### PR TITLE
Keep connections alive during long running requests that produce an AsyncResult

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ framework/project/boot/
 documentation/api
 workspace/
 framework/sbt/boot
+framework/.idea
+framework/.idea_modules
 

--- a/framework/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/framework/play/src/main/scala/play/api/http/StandardValues.scala
@@ -12,6 +12,7 @@ trait Status {
 
   val CONTINUE = 100
   val SWITCHING_PROTOCOLS = 101
+  val PROCESSING = 102
 
   val OK = 200
   val CREATED = 201


### PR DESCRIPTION
This adds optional sending of http 102 processing interim responses during long running requests that produce an AsyncResult.  

The goal is to keep connections alive on Heroku and platforms like it that will time out a connection if no bytes are sent within a given time window.
