### PR TITLE
Fix sh scripts tests to have a wider compatibility

### DIFF
--- a/play
+++ b/play
@@ -1,7 +1,7 @@
 #! /usr/bin/env sh
 
 if [ -f conf/application.conf ]; then
-  if [ "$1" == "clean" ]; then
+  if test "$1" = "clean"; then
     `dirname $0`/framework/cleanIvyCache
   fi
   if [ -n "$1" ]; then


### PR DESCRIPTION
On my system (Linux/Debian) I got the following error when running the `play` command:
```julien@ju:~/Workspace/testapp$ play2
/home/julien/Install/dev/play2/play: 4: [: unexpected operator

```

This commit fixes this issue on my system. It should be fully bash compatible.
```
