### PR TITLE
MySQL Connector/J has the ability to execute a lightweight ping against ...

### DIFF
--- a/framework/play/src/main/scala/play/api/db/DB.scala
+++ b/framework/play/src/main/scala/play/api/db/DB.scala
@@ -121,6 +121,10 @@ object DBApi {
         case e => throw conf.reportError("driver", "Driver not found: [" + driver + "]", Some(e))
       }
     }
+    
+    if (conf.getString("db.driver") contains "mysql") {
+      datasource.setConnectionTestStatement("/* ping */ SELECT 1")
+    }
 
     val autocommit = conf.getBoolean("autocommit").getOrElse(true)
     val isolation = conf.getString("isolation").getOrElse("READ_COMMITTED") match {


### PR DESCRIPTION
...a server, in order to validate the connection. In the case of load-balanced connections, this is performed against all active pooled internal connections that are retained. This is beneficial to Java applications using connection pools, as the pool can use this feature to validate connections.

See http://dev.mysql.com/doc/refman/5.1/en/connector-j-usagenotes-j2ee.html
