### PR TITLE
Add scala template for radio groups

### DIFF
--- a/framework/play/src/main/scala/views/helper/Helpers.scala
+++ b/framework/play/src/main/scala/views/helper/Helpers.scala
@@ -5,10 +5,14 @@ import scala.collection.JavaConverters._
 package views.html.helper {
 
   case class InputElements(label: Html, input: Html, errors: Seq[String], infos: Seq[String])
+  case class RadioElements(input: Html, label: Html)
 
-  trait InputConstructor extends NotNull {
-    def apply(elts: InputElements): Html
+  trait ElementsConstructor[A] extends NotNull {
+    def apply(elts: A): Html
   }
+
+  trait InputConstructor extends ElementsConstructor[InputElements]
+  trait RadioConstructor extends ElementsConstructor[RadioElements]
 
   object InputConstructor {
 
@@ -20,6 +24,19 @@ package views.html.helper {
 
     implicit def inlineInputConstructor(f: (InputElements) => Html) = InputConstructor(f)
     implicit def templateAsInputConstructor(t: Template1[InputElements, Html]) = InputConstructor(t.render)
+
+  }
+
+  object RadioConstructor {
+
+    implicit val defaultRadio = RadioConstructor(views.html.helper.defaultRadioHandler.f)
+
+    def apply(f: (RadioElements) => Html): RadioConstructor = new RadioConstructor {
+      def apply(elts: RadioElements) = f(elts)
+    }
+
+    implicit def inlineRadioConstructor(f: (RadioElements) => Html) = RadioConstructor(f)
+    implicit def templateAsRadioConstructor(t: Template1[RadioElements, Html]) = RadioConstructor(t.render)
 
   }
 

--- a/framework/play/src/main/scala/views/helper/defaultRadioHandler.scala.html
+++ b/framework/play/src/main/scala/views/helper/defaultRadioHandler.scala.html
@@ -1,0 +1,6 @@
+@(el: RadioElements)
+
+<p>
+@el.input
+@el.label
+</p>

--- a/framework/play/src/main/scala/views/helper/package.scala
+++ b/framework/play/src/main/scala/views/helper/package.scala
@@ -6,7 +6,7 @@ package views.html
 package object helper {
 
   /**
-   * Default inpout structure.
+   * Default input structure.
    *
    * {{{
    * <dl>
@@ -18,5 +18,17 @@ package object helper {
    * }}}
    */
   val defaultInput = defaultInputHandler.f
+
+  /**
+   * Default radio structure.
+   *
+   * {{{
+   * <p>
+   *   <input type="radio" name="country" id="country" value="germany">
+   *   <label for="germany">Germany</label>
+   * </p>
+   * }}}
+   */
+  val defaultRadio = defaultRadioHandler.f
 
 }

--- a/framework/play/src/main/scala/views/helper/radio.scala.html
+++ b/framework/play/src/main/scala/views/helper/radio.scala.html
@@ -1,0 +1,10 @@
+@(id:String, value:String, label:Option[String])(inputDef: (String,String) => Html)(implicit handler: RadioConstructor)
+
+@labelRendering = {
+    <label for="@value">@label</label> 
+}
+
+@handler(RadioElements(
+    inputDef(id,value),
+    labelRendering
+))

--- a/framework/play/src/main/scala/views/helper/radioGroup.scala.html
+++ b/framework/play/src/main/scala/views/helper/radioGroup.scala.html
@@ -1,0 +1,11 @@
+@(field:play.api.data.Field, options:Seq[(String,String)], args:(Symbol,Any)*)(implicit handler: InputConstructor, innerHandler: RadioConstructor = defaultRadio)
+
+@defining(Utils.filter(args, 'id -> field.id, 'label -> field.name, 'default -> null)) { args =>
+    @input(field, args._1('id), Some(args._1('label)), showInfo = false) { (id,name,value) =>
+        @options.map { v =>
+            @radio(field.name, v._1, Some(v._2)) { (id2,value2) =>
+                <input type="radio" value="@value2" id="@id2" name="@id2" @(if(value == Some(value2) || (!value.isDefined && args._1('default) == value2)) Html("checked=\"checked\"") else "") @toHtmlArgs(args._2)>
+            }(innerHandler)
+        }
+    }(handler)
+}


### PR DESCRIPTION
I added a Scala template for radio groups, so you can do something like the following in your view:

```
@form(routes.Application.myAction()) {
  @radioGroup(
    myForm("document"),
    documents.map { d => d.id -> d.name }
  )
}
```

This will create a list of <input type="radio"> elements with all of them having the same id.
