### PR TITLE
Replace unsafe calls to Option.get with a for comprehension

### DIFF
--- a/samples/scala/zentasks/app/controllers/Projects.scala
+++ b/samples/scala/zentasks/app/controllers/Projects.scala
@@ -18,13 +18,17 @@ object Projects extends Controller with Secured {
    * Display the dashboard.
    */
   def index = Action { request =>
-    Ok(
-      html.dashboard(
-        Project.findInvolving(request.username.get), 
-        Task.findTodoInvolving(request.username.get), 
-        User.findByEmail(request.username.get).get
+    val response = for {
+      username <- request.username
+      user <- User.findByEmail(username)
+    } yield Ok(
+        html.dashboard(
+          Project.findInvolving(username),
+          Task.findTodoInvolving(username),
+          user
+        )
       )
-    )
+    response getOrElse Unauthorized
   }
 
   // -- Projects


### PR DESCRIPTION
Option.get shoud be avoided when possible. The language provides
tools to safely deal with Option in a nice, scalaish way.

An alternative using flatMap and map would be:

``` scala
  /**
   * Display the dashboard.
   */
  def index = Action { request =>
    request.username flatMap { username =>
      User.findByEmail(username) map { user =>
        Ok(
          html.dashboard(
            Project.findInvolving(username),
            Task.findTodoInvolving(username),
            user
          )
        )
      }
    } getOrElse Unauthorized
  }
```

But I find the for comprehension more readable.
