### PR TITLE
Make Promises covariant

### DIFF
--- a/framework/play/src/main/scala/play/api/libs/Promise.scala
+++ b/framework/play/src/main/scala/play/api/libs/Promise.scala
@@ -20,7 +20,7 @@ case class Thrown(e: scala.Throwable) extends NotWaiting[Nothing]
 case class Redeemed[+A](a: A) extends NotWaiting[A]
 case object Waiting extends PromiseValue[Nothing]
 
-trait Promise[A] {
+trait Promise[+A] {
 
   def onRedeem(k: A => Unit): Unit
 


### PR DESCRIPTION
Allows to give a Promise[Some] where a Promise[Option] is expected, for example.
