### PR TITLE
add build.properties file forcing sbt to 0.11.0

### DIFF
--- a/framework/project/build.properties
+++ b/framework/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.11.0


### PR DESCRIPTION
Otherwise if people run a different sbt version, it probably
won't work, for example because some plugins might not
be published for that sbt version. They have to guess
which sbt version the build is intended to work with.

With the build.properties then any 0.11.x should work.
