### PR TITLE
Fixed success handler in chatroom sample

### DIFF
--- a/samples/workinprogress/chatroom/app/views/room.scala.html
+++ b/samples/workinprogress/chatroom/app/views/room.scala.html
@@ -19,7 +19,7 @@
         
         $("#say").click(function() {
             jsRoutes.controllers.Application.say($('#msg').val()).ajax({
-                sucess: function() {
+                success: function() {
                     
                 }
             })


### PR DESCRIPTION
"sucess:" changed to "success:" in /samples/workinprogress/chatroom/app/views/room.scala.html
