### PR TITLE
In Request.map, only map one time and store the result

### DIFF
--- a/framework/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/play/src/main/scala/play/api/mvc/Http.scala
@@ -68,7 +68,7 @@ package play.api.mvc {
       def queryString = self.queryString
       def headers = self.headers
       def cookies = self.cookies
-      def body = f(self.body)
+      val body = f(self.body)
     }
 
   }


### PR DESCRIPTION
`def body = f(self.body)` runs f() on every access to body
`val body = f(self.body)` runs f() only once
