### PR TITLE
CSS tweak: make file and line number more readable on dev error pages.

### DIFF
--- a/framework/src/play/src/main/scala/views/defaultpages/devError.scala.html
+++ b/framework/src/play/src/main/scala/views/defaultpages/devError.scala.html
@@ -53,11 +53,11 @@
 		    h2 {
 		        margin: 0;
 		        padding: 5px 45px;
-		        font-size: 12px;
-		        background: #333;
-		        color: #fff;
-		        text-shadow: 1px 1px 1px rgba(0,0,0,.3);
-		        border-top: 4px solid #2a2a2a;
+		        font-size: 18px;
+		        font-family: monospace;
+		        background: #fff;
+		        color: #666;
+		        border-top: 4px solid #cdcdcd;
 		    }
 			pre {
 				margin: 0;
@@ -109,18 +109,18 @@
 
 		<p id="detail">
 		    @error match {
-		        
+
 		        case description:play.api.PlayException.RichDescription => {
 		            @play.api.templates.Html(description.htmlDescription)
 		        }
-		        
+
 		        case _ => {
 		            @error.description
     			}
-		        
+
 		    }
 		</p>
-		
+
 		@error match {
 
 			case source:play.api.PlayException.ExceptionSource => {
@@ -133,11 +133,11 @@
 					</h2>
 
                     <div>
-    					@source.interestingLines().map { 
+    					@source.interestingLines().map {
 
     						case (first,lines,errorIndex) => {
 
-    							@lines.zipWithIndex.map { 
+    							@lines.zipWithIndex.map {
 
     								case (line,index) if index == errorIndex => {
     									<pre class="error"><span class="line">@(first+index)</span><span class="code">@(source.position.map(pos => (line+" ").zipWithIndex.map{ case (c,i) if i == pos => Html("""<span class="marker">""" + c + """</span>"""); case (c,_) => c}).getOrElse(line))</span></pre>
@@ -157,38 +157,38 @@
 				}
 
 			}
-			
+
 			case attachment:play.api.PlayException.ExceptionAttachment => {
-			    
+
 			    <h2>@attachment.subTitle</h2>
-			    
+
 			    <div>
 			        @attachment.content.split("\n").zipWithIndex.map {
-			            
+
 			            case (line,index) => {
 			                <pre><span class="line">@(index+1)</span><span class="code">@line</span></pre>
 			            }
-			            
+
 			        }
 			    </div>
-			    
+
 			}
-			
+
 			case play.api.PlayException(_, _ , Some(throwable)) => {
-			    
+
 			    <h2>
 			        No source available, here is the exception stack trace:
 			    </h2>
-			    
+
 			    <div>
-			        
+
 			        <pre class="error"><span class="line">-></span><span class="code">@throwable.getClass.getName: @throwable.getMessage</span></pre>
-			        
+
 			        @throwable.getStackTrace.map { line =>
 						<pre><span class="line">&nbsp;</span><span class="code">    @line</span></pre>
 			        }
 			    </div>
-			    
+
 			}
 
 			case _ => {

--- a/framework/src/play/src/main/scala/views/defaultpages/devNotFound.scala.html
+++ b/framework/src/play/src/main/scala/views/defaultpages/devNotFound.scala.html
@@ -38,11 +38,11 @@
 		    h2 {
 		        margin: 0;
 		        padding: 5px 45px;
-		        font-size: 12px;
-		        background: #333;
-		        color: #fff;
-		        text-shadow: 1px 1px 1px rgba(0,0,0,.3);
-		        border-top: 4px solid #2a2a2a;
+		        font-size: 18px;
+		        font-family: monospace;
+		        background: #fff;
+		        color: #666;
+		        border-top: 4px solid #cdcdcd;
 		    }
 			pre {
 				margin: 0;
@@ -107,11 +107,11 @@
 		<p id="detail">
 			For request '@request'
 		</p>
-		
+
 		@router match {
 
 			case Some(routes) => {
-			    
+
 			    <h2>
         			These routes have been tried, in this order:
         		</h2>
@@ -129,7 +129,7 @@
         			No router defined.
         		</h2>
 			}
-		
+
         }
 
 	</body>


### PR DESCRIPTION
It turns out my text editor also took the liberty to remove trailing whitespaces, which I believe is a good thing.
