### PR TITLE
Lighthouse bug 66 - request path is not set correctly

### DIFF
--- a/framework/src/play/src/main/scala/play/core/j/JavaWrapper.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaWrapper.scala
@@ -126,7 +126,7 @@ object Wrap {
 
       def uri = req.uri
       def method = req.method
-      def path = req.method
+      def path = req.path
 
       def body = null
 


### PR DESCRIPTION
The request path is not set correctly.  It is being set to the request method (GET, POST, etc.) instead.
https://play.lighthouseapp.com/projects/82401/tickets/66-requestpath-within-an-action-is-empty
