### PR TITLE
Fix regression - recently fixed Lighthouse bug 66 was reintroduced

### DIFF
--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -72,8 +72,8 @@ trait JavaHelpers {
       override def toString = req.toString
 
     },
-      req.session.data.asJava,
-      req.flash.data.asJava)
+    req.session.data.asJava,
+    req.flash.data.asJava)
   }
 
   /**
@@ -85,7 +85,7 @@ trait JavaHelpers {
 
       def uri = req.uri
       def method = req.method
-      def path = req.method
+      def path = req.path
 
       def body = req.body
 
@@ -103,8 +103,8 @@ trait JavaHelpers {
       override def toString = req.toString
 
     },
-      req.session.data.asJava,
-      req.flash.data.asJava)
+    req.session.data.asJava,
+    req.flash.data.asJava)
   }
 
 }


### PR DESCRIPTION
This was recently fixed:
https://github.com/playframework/Play20/pull/46

However, it appears someone did not merge correctly while doing a refactoring and the bug was reintroduced.
