### PR TITLE
Lighthouse bug 64 - delegate is misspelled

### DIFF
--- a/framework/src/play/src/main/java/play/db/ebean/TransactionalAction.java
+++ b/framework/src/play/src/main/java/play/db/ebean/TransactionalAction.java
@@ -14,7 +14,7 @@ public class TransactionalAction extends Action<Transactional> {
         return Ebean.execute(new TxCallable<Result>() {  
             public Result call() {
                 try {
-                    return deleguate.call(ctx);
+                    return delegate.call(ctx);
                 } catch(RuntimeException e) {
                     throw e;
                 } catch(Throwable t) {

--- a/framework/src/play/src/main/java/play/db/jpa/TransactionalAction.java
+++ b/framework/src/play/src/main/java/play/db/jpa/TransactionalAction.java
@@ -24,7 +24,7 @@ public class TransactionalAction extends Action<Transactional> {
                 tx.begin();
             }
             
-            Result result = deleguate.call(ctx);
+            Result result = delegate.call(ctx);
             
             if(tx != null) {
                 if(tx.getRollbackOnly()) {

--- a/framework/src/play/src/main/java/play/mvc/Action.java
+++ b/framework/src/play/src/main/java/play/mvc/Action.java
@@ -17,7 +17,7 @@ public abstract class Action<T> extends Results {
     /**
      * The wrapped action.
      */
-    public Action<?> deleguate;
+    public Action<?> delegate;
     
     /**
      * Executes this action with the give HTTP context and returns the result.

--- a/framework/src/play/src/main/java/play/mvc/Security.java
+++ b/framework/src/play/src/main/java/play/mvc/Security.java
@@ -36,7 +36,7 @@ public class Security {
                 } else {
                     try {
                         ctx.request().setUsername(username);
-                        return deleguate.call(ctx);
+                        return delegate.call(ctx);
                     } finally {
                         ctx.request().setUsername(null);
                     }

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -45,10 +45,10 @@ trait JavaAction extends Action[play.mvc.Http.RequestBody] with JavaHelpers {
     }
 
     val finalAction = actionMixins.foldLeft(rootAction) {
-      case (deleguate, (annotation, actionClass)) => {
+      case (delegate, (annotation, actionClass)) => {
         val action = actionClass.newInstance().asInstanceOf[JAction[Any]]
         action.configuration = annotation
-        action.deleguate = deleguate
+        action.delegate = delegate
         action
       }
     }


### PR DESCRIPTION
Action.delegate is misspelled. It is currently deleguate, but should be delegate. This is misspelling means that the example in the documentation (https://github.com/playframework/Play20/wiki/JavaControllers) will not compile.

https://play.lighthouseapp.com/projects/82401/tickets/64-actiondelegate-is-misspelled-actiondeleguate
