### PR TITLE
Play ticket75

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
@@ -265,34 +265,34 @@ trait PlayCommands {
           case (sourceFile, name) => sourceFile -> ("public/" + naming(name))
         }.flatMap {
           case (sourceFile, name) => {
-	    //do intermediary js closure compile if we have coffeescript, else just do compile action
-	     val compileTuple = compileName match{
-	      case "coffeescript" => {
-		val (preClosureSource, deps) = compile(sourceFile, min)
-		val splitPath = name.split("/")
-		val preClosureFile = new File(IO.temporaryDirectory.name+"/"+splitPath(splitPath.length-1))
-		IO.write(preClosureFile, preClosureSource, IO.utf8)
+            //do intermediary js closure compile if we have coffeescript, else just do compile action
+             val compileTuple = compileName match{
+              case "coffeescript" => {
+                val (preClosureSource, deps) = compile(sourceFile, min)
+                val splitPath = name.split("/")
+                val preClosureFile = new File(IO.temporaryDirectory.name+"/"+splitPath(splitPath.length-1))
+                IO.write(preClosureFile, preClosureSource, IO.utf8)
 
-		val jsSourceFiles = IO.copy(
-		  (
-		    (src / "assets") ** "*.js"
-		  ).get.map(
-		    file=>
-		      file->new File(
-			IO.temporaryDirectory.name+"/"+file.name
-		      )
-		  ), true
-		)
-		val (fullSource, minified, jsDeps) = play.core.jscompile.JavascriptCompiler.compile(preClosureFile)
-		(if (min) minified else fullSource, jsDeps++deps)->new File(resources, name)
-	      }
-	      // less or js compile action
-	      case _ => {
-		compile(sourceFile, min) -> new File(resources, name)
-	      } // end match
-	    }
-	    val ((css, dependencies), out) = compileTuple
-	    // write out
+                val jsSourceFiles = IO.copy(
+                  (
+                    (src / "assets") ** "*.js"
+                  ).get.map(
+                    file=>
+                      file->new File(
+                        IO.temporaryDirectory.name+"/"+file.name
+                      )
+                  ), true
+                )
+                val (fullSource, minified, jsDeps) = play.core.jscompile.JavascriptCompiler.compile(preClosureFile)
+                (if (min) minified else fullSource, jsDeps++deps)->new File(resources, name)
+              }
+              // less or js compile action
+              case _ => {
+                compile(sourceFile, min) -> new File(resources, name)
+              } // end match
+            }
+            val ((css, dependencies), out) = compileTuple
+            // write out
             IO.write(out, css)
             dependencies.map(_ -> out)
           }


### PR DESCRIPTION
Fix for Play 2.0 Ticket 75 Coffescript generated javascripts not parsed by Google Closure Compiler:

https://play.lighthouseapp.com/projects/82401/tickets/75
### Description

Coffescript generated javascript files are not parsed by the google closure compiler. A require statement in the Coffeescript does not include the necessary code from required scripts.  This pull request fixes the issue by writing the Coffeescript generated javascript to the IO.temporaryDirectory, copying all JS files in the assets/javascripts src folder into the IO.temporaryDirectory, and passing the Coffescript generated javascript file in the IO.temporaryDirectory to the play *jscompile.JavascriptCompiler. The source generated by the JavascriptCompiler is then returned as the generated js from the Coffeescript.
### Remaining Issues

This pull request merely passes the Coffeescript generated javascript to the Google Closure Compiler. It does not fix play ticket 45 (https://play.lighthouseapp.com/projects/82401/tickets/75).
This pull request does not fix the issue that Coffeescript generated javascript files can not require other Coffeescript generated javascript files.
