### PR TITLE
Lighthouse bug 50 - Don't hardcode models directory

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
@@ -351,8 +351,18 @@ trait PlayCommands {
       val t = new Transformer(cp, "debug=-1")
 
       val ft = new OfflineFileTransform(t, cl, classes.getAbsolutePath, classes.getAbsolutePath)
-      ft.process("models/**")
 
+      var packages = ""
+      for(line <- scala.io.Source.fromFile("conf/application.conf").getLines()) {
+        if (line.startsWith("ebean.")) {
+          if (!packages.isEmpty()) {
+            packages += ","
+          }
+          packages += line.split("=")(1).replaceAll("\"", "")
+        }
+      }
+
+      ft.process(packages)
     } catch {
       case _ =>
     }


### PR DESCRIPTION
Multiple people have been affected by this.  It would be good to fix as it makes porting from Play 1 to Play 2 much more difficult for some users.
