### PR TITLE
URL decode URL form encoded parameter key. Add spec.

### DIFF
--- a/framework/src/play/src/main/scala/play/core/parsers/UrlFormEncodedParser.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/UrlFormEncodedParser.scala
@@ -5,24 +5,19 @@ object UrlFormEncodedParser {
   def parse(data: String): Map[String, Seq[String]] = {
 
     import java.net._
-    import scala.collection.mutable.{ HashMap }
 
-    var params = HashMap.empty[String, Seq[String]]
-
-    data.split('&').foreach { param =>
+    data.split('&').foldLeft(Map.empty[String, Seq[String]]) { case (params, param) =>
 
       if (param.contains('=')) {
 
-        val parts = param.split('=')
+        val parts = param.split('=').map(URLDecoder.decode(_, "utf-8"))
         val key = parts.head
-        val value = URLDecoder.decode(parts.tail.headOption.getOrElse(""), "utf-8")
+        val value = parts.tail.headOption.getOrElse("")
 
-        params += key -> (params.get(key).getOrElse(Seq.empty) :+ value)
+        params + (key -> (params.get(key).getOrElse(Seq.empty) :+ value))
 
-      }
+      } else params
     }
-
-    params.toMap
   }
 
 }

--- a/framework/src/play/src/test/scala/play/core/parsers/UrlFormEncodedParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/parsers/UrlFormEncodedParserSpec.scala
@@ -1,0 +1,15 @@
+package play.core.parsers
+
+import org.specs2.mutable.Specification
+
+object UrlFormEncodedParserSpec extends Specification {
+
+  "UrlfFormEncodedParser" should {
+    "url decode keys and values correctly" in {
+      UrlFormEncodedParser.parse("key%5B1%5D=value%5B1%5D") must_== Map("key[1]" -> Seq("value[1]"))
+    }
+    "handle multiple values of same key" in {
+      UrlFormEncodedParser.parse("key=value1&key=value2") must_== Map("key" -> Seq("value1", "value2"))
+    }
+  }
+}


### PR DESCRIPTION
Parsing of parameters with encoded characters in keys (such as key[1]=value) was broken between Beta1 and RC1.
