### PR TITLE
Add the host to the Java API

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -134,9 +134,14 @@ public class Http {
         public abstract String uri();
         
         /**
-         * The HTTP Method.
+         * The HTTP method.
          */
         public abstract String method();
+
+        /**
+         * The request host.
+         */
+        public abstract String host();
         
         /**
          * The URI path.

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -54,6 +54,7 @@ trait JavaHelpers {
 
       def uri = req.uri
       def method = req.method
+      def host = req.host
       def path = req.path
 
       def body = null
@@ -85,6 +86,7 @@ trait JavaHelpers {
 
       def uri = req.uri
       def method = req.method
+      def host = req.host
       def path = req.path
 
       def body = req.body


### PR DESCRIPTION
It was added to the Scala API last week and still needs to be added to the Java API:
https://github.com/playframework/Play20/commit/c69f6a6477ada907ff937ee028a8279e9b3fb87d
