### PR TITLE
Fix eclipsify command

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
@@ -169,7 +169,7 @@ trait PlayCommands {
         new EclipseClasspathEntryTransformerFactory {
           override def createTransformer(ref: ProjectRef, state: State) =
             setting(crossTarget in ref)(state) map (ct =>
-              (entries: Seq[EclipseClasspathEntry]) => entries :+ EclipseClasspathEntry.Lib(ct + "/classes_managed")
+              (entries: Seq[EclipseClasspathEntry]) => entries :+ EclipseClasspathEntry.Lib("target/scala-2.9.1/classes_managed")
             )
         }
     EclipsePlugin.eclipseSettings ++ Seq(EclipseKeys.commandName := "eclipsify",


### PR DESCRIPTION
Fix eclipsify command: change "classes_managed" classpath entry to a relative path.

Without this fix, Eclipse will not recognize the classpath entry when running on Windows (only verified for Windows 7).
The relative path will also prevent trouble when moving the project to a different location.
