### PR TITLE
java.sql.Date changed to java.util.Date in Anorm.scala

### DIFF
--- a/framework/src/anorm/src/main/scala/Anorm.scala
+++ b/framework/src/anorm/src/main/scala/Anorm.scala
@@ -314,7 +314,7 @@ package anorm {
           case Some(o) => stmt.setObject(index, o)
           case None => stmt.setObject(index, null)
           case bd: java.math.BigDecimal => stmt.setBigDecimal(index, bd)
-          case date: java.util.Date => stmt.setDate(index, new java.sql.Date(date.getTime()))
+          case date: java.util.Date => stmt.setDate(index, new java.util.Date(date.getTime()))
           case o => stmt.setObject(index, o)
         }
         stmt
@@ -324,7 +324,7 @@ package anorm {
     }
 
     implicit val dateToStatement = new ToStatement[java.util.Date] {
-      def set(s: java.sql.PreparedStatement, index: Int, aValue: java.util.Date): Unit = s.setDate(index, new java.sql.Date(aValue.getTime()))
+      def set(s: java.sql.PreparedStatement, index: Int, aValue: java.util.Date): Unit = s.setDate(index, new java.util.Date(aValue.getTime()))
 
     }
 


### PR DESCRIPTION
Anorm is dropping time when passed dates as sql parameters.  java.sql.Date does not support time.

See

https://play.lighthouseapp.com/projects/82401/tickets/96-anorm-removes-time-from-date-being-passed
