### PR TITLE
Do not compile any assets that are in folders with names starting from '_'

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
@@ -318,7 +318,7 @@ trait PlayCommands {
         // Delete previous generated files
         previousRelation._2s.foreach(IO.delete)
 
-        val generated = ((sourceFiles --- ((src / "assets") ** "_*")) x relativeTo(Seq(src / "assets"))).flatMap {
+        val generated = ((sourceFiles --- ((src / "assets") ** "_*" ***)) x relativeTo(Seq(src / "assets"))).flatMap {
           case (sourceFile, name) => {
             val (debug, min, dependencies) = compile(sourceFile)
             val out = new File(resources, "public/" + naming(name, false))


### PR DESCRIPTION
Without this, it is very difficult to use any lesscss or coffeescript libraries that consist of several files. E.g., twitter bootstrap consists of several .less files that import each other by name, so renaming them to start with an underscore is not an option. With the fix I propose, one could just put all the files as is under assets/stylesheets/_twitter_bootstrap and the assets compiler will ignore them all.
