### PR TITLE
[fixes #43] changed play script so it can be run through multiple symlinks

### DIFF
--- a/play
+++ b/play
@@ -2,7 +2,9 @@
 
 PRG="$0"
 while [ -h "$PRG" ] ; do
-    PRG=`readlink "$PRG"`
+  LINK=`readlink "$PRG"`
+  BASE_DIR=`dirname "$PRG"`
+  PRG="$BASE_DIR/$LINK"
 done
 dir=`dirname $PRG`
 


### PR DESCRIPTION
Readlink gives a relative path to the file a symlink points to.  You need
to add the base directory in order to get an absolute path.  Otherwise
you cannot resolve the appropriate path through a second symlink.
