### PR TITLE
Format messages using the given lang not the JVM default

### DIFF
--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -209,7 +209,7 @@ case class MessagesApi(messages: Map[String, Map[String, String]]) {
    */
   def translate(key: String, args: Seq[Any])(implicit lang: Lang): Option[String] = {
     messages.get(lang.code).flatMap(_.get(key)).orElse(messages.get("default").flatMap(_.get(key))).map { pattern =>
-      MessageFormat.format(pattern, args.map(_.asInstanceOf[java.lang.Object]): _*)
+      new MessageFormat(pattern, lang.toLocale).format(args.toArray)
     }
   }
 


### PR DESCRIPTION
Play now formats messages using the default JVM locale, so suppose:

```
percentage.format={0,number,0.0}
@Messages("percentage.format", 1d)(Lang("NL"))
```

This now outputs 1.0 while the correct output should be 1,0

This patch should fix this behavior so that the given language is taken into account.
