### PR TITLE
Enables JavaScript support by default for HtmlUnitDriver

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -23,8 +23,14 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     
     // --
     
-    public static Class<? extends WebDriver> HTMLUNIT = HtmlUnitDriver.class;
-    public static Class<? extends WebDriver> FIREFOX = FirefoxDriver.class;
+    public static WebDriver HTMLUNIT() {
+        HtmlUnitDriver driver = new HtmlUnitDriver();
+        driver.setJavascriptEnabled(true);
+        return driver;
+    }
+    public static WebDriver FIREFOX() {
+        return new FirefoxDriver();
+    }
     
     // --
     
@@ -315,7 +321,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Executes a block of code in a running server, with a test browser.
      */
-    public static void running(TestServer server, Class<? extends WebDriver> webDriver, final Callback<TestBrowser> block) {
+    public static void running(TestServer server, WebDriver webDriver, final Callback<TestBrowser> block) {
         TestBrowser browser = null;
         try {
             start(server);
@@ -335,22 +341,9 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * Creates a Test Browser.
      */
     public static TestBrowser testBrowser() {
-        return new TestBrowser(new HtmlUnitDriver());
+        return new TestBrowser(HTMLUNIT());
     }
-    
-    /**
-     * Creates a Test Browser.
-     */
-    public static TestBrowser testBrowser(Class<? extends WebDriver> webDriver) {
-        try {
-            return new TestBrowser(webDriver);
-        } catch(RuntimeException e) {
-            throw e;
-        } catch(Throwable t) {
-            throw new RuntimeException(t);
-        }
-    }
-    
+
     /**
      * Creates a Test Browser.
      */

--- a/framework/src/play-test/src/main/java/play/test/TestBrowser.java
+++ b/framework/src/play-test/src/main/java/play/test/TestBrowser.java
@@ -18,15 +18,6 @@ public class TestBrowser extends Fluent {
      *
      * @param webDriver The WebDriver instance to use.
      */
-    public TestBrowser(Class<? extends WebDriver> webDriver) throws Exception {
-        this(webDriver.newInstance());
-    }
-    
-    /**
-     * A test browser (Using Selenium WebDriver) with the FluentLenium API (https://github.com/Fluentlenium/FluentLenium).
-     *
-     * @param webDriver The WebDriver instance to use.
-     */
     public TestBrowser(WebDriver webDriver) {
         setDriver(webDriver);
     }

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -21,8 +21,8 @@ object Helpers extends Status with HeaderNames {
   val DELETE = "DELETE"
   val HEAD = "HEAD"
 
-  val HTMLUNIT = classOf[HtmlUnitDriver]
-  val FIREFOX = classOf[FirefoxDriver]
+  def HTMLUNIT() = SeleniumDrivers.htmlunit()
+  def FIREFOX() = SeleniumDrivers.firefox()
 
   /**
    * Executes a block of code in a running application.
@@ -51,11 +51,11 @@ object Helpers extends Status with HeaderNames {
   /**
    * Executes a block of code in a running server, with a test browser.
    */
-  def running[T, WEBDRIVER <: WebDriver](testServer: TestServer, webDriver: Class[WEBDRIVER])(block: TestBrowser => T): T = {
+  def running[T](testServer: TestServer, webDriver: WebDriver)(block: TestBrowser => T): T = {
     var browser: TestBrowser = null
     try {
       testServer.start()
-      browser = TestBrowser.of(webDriver)
+      browser = TestBrowser(webDriver)
       block(browser)
     } finally {
       if (browser != null) {
@@ -64,7 +64,7 @@ object Helpers extends Status with HeaderNames {
       testServer.stop()
     }
   }
-
+  
   /**
    * Apply pending evolutions for the given DB.
    */

--- a/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
@@ -63,18 +63,33 @@ object TestBrowser {
   /**
    * Creates an in-memory WebBrowser (using HtmlUnit)
    */
-  def default() = TestBrowser(new HtmlUnitDriver)
+  def default() = TestBrowser(SeleniumDrivers.htmlunit())
 
   /**
    * Creates a firefox WebBrowser.
    */
-  def firefox() = TestBrowser(new FirefoxDriver)
+  def firefox() = TestBrowser(SeleniumDrivers.firefox())
 
+}
+
+/**
+ * Helper utilities to create usual Selenium WebDriver
+ */
+object SeleniumDrivers {
+  
   /**
-   * Creates a WebBrowser of the specified class name.
+   * Creates an HtmlUnitDriver (enables JavaScript support)
    */
-  def of[WEBDRIVER <: WebDriver](webDriver: Class[WEBDRIVER]) = TestBrowser(webDriver.newInstance)
-
+  def htmlunit() = {
+    val htmlunit = new HtmlUnitDriver
+    htmlunit.setJavascriptEnabled(true)
+    htmlunit
+  }
+  
+  /**
+   * Creates a FirefoxDriver
+   */
+  def firefox() = new FirefoxDriver
 }
 
 /**

--- a/framework/test/integrationtest-java/test/SimpleTest.java
+++ b/framework/test/integrationtest-java/test/SimpleTest.java
@@ -63,7 +63,7 @@ public class SimpleTest {
     
     @Test
     public void inServer() {
-        running(testServer(3333), HTMLUNIT, new Callback<TestBrowser>() {
+        running(testServer(3333), HTMLUNIT(), new Callback<TestBrowser>() {
             public void invoke(TestBrowser browser) {
                browser.goTo("http://localhost:3333"); 
                assertThat(browser.$("#title").getTexts().get(0)).isEqualTo("Hello Guest");

--- a/framework/test/integrationtest-scala/test/SimpleSpec.scala
+++ b/framework/test/integrationtest-scala/test/SimpleSpec.scala
@@ -58,7 +58,7 @@ class SimpleSpec extends Specification {
     }
     
     "run in a browser" in {
-      running(TestServer(3333), HTMLUNIT) { browser =>
+      running(TestServer(3333), HTMLUNIT()) { browser =>
         
         browser.goTo("http://localhost:3333")
         browser.$("#title").getTexts().get(0) must equalTo("Hello Guest")

--- a/framework/test/integrationtest/test/FunctionalSpec.scala
+++ b/framework/test/integrationtest/test/FunctionalSpec.scala
@@ -16,7 +16,7 @@ class FunctionalSpec extends Specification {
   "an Application" should {
 
     "pass functional test" in {
-      running(TestServer(9001), HTMLUNIT) { browser =>
+      running(TestServer(9001), HTMLUNIT()) { browser =>
 
         val content: String = await(WS.url("http://localhost:9001/post").post("param1=foo")).body
         content must contain ("param1")

--- a/samples/java/computer-database-jpa/test/IntegrationTest.java
+++ b/samples/java/computer-database-jpa/test/IntegrationTest.java
@@ -13,7 +13,7 @@ public class IntegrationTest {
     
     @Test
     public void test() {
-        running(testServer(3333, fakeApplication(inMemoryDatabase())), HTMLUNIT, new Callback<TestBrowser>() {
+        running(testServer(3333, fakeApplication(inMemoryDatabase())), HTMLUNIT(), new Callback<TestBrowser>() {
             public void invoke(TestBrowser browser) {
                 browser.goTo("http://localhost:3333");
                 

--- a/samples/java/computer-database/test/IntegrationTest.java
+++ b/samples/java/computer-database/test/IntegrationTest.java
@@ -13,7 +13,7 @@ public class IntegrationTest {
     
     @Test
     public void test() {
-        running(testServer(3333, fakeApplication(inMemoryDatabase())), HTMLUNIT, new Callback<TestBrowser>() {
+        running(testServer(3333, fakeApplication(inMemoryDatabase())), HTMLUNIT(), new Callback<TestBrowser>() {
             public void invoke(TestBrowser browser) {
                 browser.goTo("http://localhost:3333");
                 

--- a/samples/scala/computer-database/test/IntegrationSpec.scala
+++ b/samples/scala/computer-database/test/IntegrationSpec.scala
@@ -12,7 +12,7 @@ class IntegrationSpec extends Specification {
   "Application" should {
     
     "work from within a browser" in {
-      running(TestServer(3333), HTMLUNIT) { browser =>
+      running(TestServer(3333), HTMLUNIT()) { browser =>
         browser.goTo("http://localhost:3333/")
         
         browser.$("header h1").first.getText must equalTo("Play 2.0 sample application — Computer database")

--- a/samples/scala/helloworld/test/IntegrationSpec.scala
+++ b/samples/scala/helloworld/test/IntegrationSpec.scala
@@ -10,7 +10,7 @@ class IntegrationSpec extends Specification {
   "Application" should {
     
     "work from within a browser" in {
-      running(TestServer(3333), HTMLUNIT) { browser =>
+      running(TestServer(3333), HTMLUNIT()) { browser =>
         browser.goTo("http://localhost:3333/")
         
         browser.$("h1").first.getText must equalTo("Configure your 'Hello world':")

--- a/samples/scala/zentasks/test/IntegrationSpec.scala
+++ b/samples/scala/zentasks/test/IntegrationSpec.scala
@@ -10,7 +10,7 @@ class IntegrationSpec extends Specification {
   "Application" should {
     
     "work from within a browser" in {
-      running(TestServer(3333), HTMLUNIT) { browser =>
+      running(TestServer(3333), HTMLUNIT()) { browser =>
         browser.goTo("http://localhost:3333/")
         browser.$("header a").first.getText must equalTo("Zentasks")
         browser.$("#email").text("guillaume@sample.com")

--- a/samples/workinprogress/pi-calculator/test/FunctionalSpec.scala
+++ b/samples/workinprogress/pi-calculator/test/FunctionalSpec.scala
@@ -11,7 +11,7 @@ class FunctionalSpec extends Specification {
   
     "pass functional test" in {
    
-      running(TestServer(9001), HTMLUNIT) { browser =>
+      running(TestServer(9001), HTMLUNIT()) { browser =>
         browser.goTo("http://localhost:9001")
         browser.pageSource must contain("Pi")
       }


### PR DESCRIPTION
API changes summary:
- The `running(server, webDriver) { browser => … }` helper now takes a `WebDriver` instance instead of a `Class[T <: WebDriver]` instance ;
- The `HTMLUNIT()` and `FIREXFOX()` helpers are now methods (not values) since they return a freshly created WebDriver.
