### PR TITLE
Change HelloWorld sample app - allow repeat to take default value matching placeholder from template

### DIFF
--- a/samples/scala/helloworld/app/controllers/Application.scala
+++ b/samples/scala/helloworld/app/controllers/Application.scala
@@ -15,7 +15,7 @@ object Application extends Controller {
   val helloForm = Form(
     tuple(
       "name" -> nonEmptyText,
-      "repeat" -> number(min = 1, max = 100),
+      "repeat" -> optional(number(min = 1, max = 100)),
       "color" -> optional(text)
     )
   )
@@ -35,7 +35,7 @@ object Application extends Controller {
   def sayHello = Action { implicit request =>
     helloForm.bindFromRequest.fold(
       formWithErrors => BadRequest(html.index(formWithErrors)),
-      {case (name, repeat, color) => Ok(html.hello(name, repeat.toInt, color))}
+      {case (name, repeat, color) => Ok(html.hello(name, repeat.getOrElse(10).toInt, color))}
     )
   }
 

--- a/samples/scala/helloworld/app/views/index.scala.html
+++ b/samples/scala/helloworld/app/views/index.scala.html
@@ -1,4 +1,4 @@
-@(helloForm: Form[(String,Int,Option[String])])
+@(helloForm: Form[(String,Option[Int],Option[String])])
 
 @import helper._
 


### PR DESCRIPTION
The placeholder attribute in the template for the value of the "repeat" option is 10, yet I was unable to submit with that value as empty. Originally I was expecting it to take the value of 10, and I was looking through the code to figure out how that default was set. After I tried it, I was surprised to find out that it didn't take 10 as the default value at all and the form validation failed if it was empty. I just modified this to show how to setup a default value that matches the placeholder on the front end. 

If this isn't the direction that you want to go with the default option in this sample application, then maybe I could change the placeholder text to not be an integer, but rather leave it empty or add explanatory text. 
