### PR TITLE
Fix lighthouse bug #136 (Play2's anorm can't work on postgresql)

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -285,6 +285,7 @@ object PlayBuild extends Build {
         )
 
         val anormDependencies = Seq(
+            "postgresql"                        %    "postgresql"               %   "8.4-702.jdbc4"
         )
 
         val testDependencies = Seq(


### PR DESCRIPTION
This patch works around postgresql's behaviour to return the empty string on getTableName().
It calls getBaseTableName() instead if the ResultSetMetaData is a PGResultSetMetaData.

Disadvantage:
- adds a dependency on the postgresql JDBC driver

(bug report: https://play.lighthouseapp.com/projects/82401/tickets/136-play2s-anorm-cant-work-on-postgresql)
