### PR TITLE
Enables JavaScript support by default for HtmlUnitDriver

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -335,7 +335,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * Creates a Test Browser.
      */
     public static TestBrowser testBrowser() {
-        return new TestBrowser(new HtmlUnitDriver());
+        return testBrowser(HTMLUNIT);
     }
     
     /**

--- a/framework/src/play-test/src/main/java/play/test/TestBrowser.java
+++ b/framework/src/play-test/src/main/java/play/test/TestBrowser.java
@@ -19,7 +19,7 @@ public class TestBrowser extends Fluent {
      * @param webDriver The WebDriver instance to use.
      */
     public TestBrowser(Class<? extends WebDriver> webDriver) throws Exception {
-        this(webDriver.newInstance());
+        this(play.api.test.WebDriverFactory.apply(webDriver));
     }
     
     /**

--- a/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
@@ -63,18 +63,35 @@ object TestBrowser {
   /**
    * Creates an in-memory WebBrowser (using HtmlUnit)
    */
-  def default() = TestBrowser(new HtmlUnitDriver)
+  def default() = of(classOf[HtmlUnitDriver])
 
   /**
    * Creates a firefox WebBrowser.
    */
-  def firefox() = TestBrowser(new FirefoxDriver)
+  def firefox() = of(classOf[FirefoxDriver])
 
   /**
    * Creates a WebBrowser of the specified class name.
    */
-  def of[WEBDRIVER <: WebDriver](webDriver: Class[WEBDRIVER]) = TestBrowser(webDriver.newInstance)
+  def of[WEBDRIVER <: WebDriver](webDriver: Class[WEBDRIVER]) = TestBrowser(WebDriverFactory(webDriver))
 
+}
+
+object WebDriverFactory {
+  /**
+   * Creates a Selenium Web Driver and configures it
+   * @param clazz Type of driver to create
+   * @return The driver instance
+   */
+  def apply[D <: WebDriver](clazz: Class[D]): WebDriver = {
+    val driver = clazz.newInstance
+    // Driver-specific configuration
+    driver match {
+      case htmlunit: HtmlUnitDriver => htmlunit.setJavascriptEnabled(true)
+      case _ =>
+    }
+    driver
+  }
 }
 
 /**


### PR DESCRIPTION
Calls `setJavascriptEnabled(true)` on `HtmlUnitDriver` driver creation.
