### PR TITLE
Better error reporting when the initialization of a plugin fails

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -11,6 +11,8 @@ import scala.collection.JavaConverters._
 
 import annotation.implicitNotFound
 
+import java.lang.reflect.InvocationTargetException
+
 /**
  * A Play application.
  *
@@ -174,6 +176,10 @@ class Application(val path: File, val classloader: ClassLoader, val sources: Opt
               Some(e))
           }
         }
+        case e: InvocationTargetException => throw PlayException(
+          "Cannot load plugin",
+          "An exception occurred during Plugin [" + className + "] initialization",
+          Some(e.getTargetException))
         case e: PlayException => throw e
         case e => throw PlayException(
           "Cannot load plugin",


### PR DESCRIPTION
When a plugin instanciation fails due to an exception thrown in its constructor, this exception is caught by `java.lang.reflect.Constructor.newInstance()` and wrapped in an `InvocationTargetException`.

This patch provides a more useful error message in such cases by showing the stack trace of the underlying exception rather than the `InvocationTargetException`.
