### PR TITLE
Forbids access to assets directories (lighthouse issue 166)

### DIFF
--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -54,6 +54,8 @@ object Assets extends Controller {
 
       resource.map {
 
+        case (url, _) if new File(url.toURI).isDirectory => Forbidden
+
         case (url, isGzipped) => {
 
           lazy val (length, resourceData) = {

--- a/framework/test/integrationtest/test/ApplicationSpec.scala
+++ b/framework/test/integrationtest/test/ApplicationSpec.scala
@@ -45,6 +45,13 @@ class ApplicationSpec extends Specification {
 
       }
     }
+    
+    "not serve asset directories" in {
+      running(FakeApplication()) {
+        val Some(result) = routeAndCall(FakeRequest(GET, "/public//"))
+        status(result) must equalTo (FORBIDDEN)
+      }
+    }
    
   }
    


### PR DESCRIPTION
Fixes [#166](https://play.lighthouseapp.com/projects/82401/tickets/166-security-flaw-wildcard-route-serves-directory-listing)
