### PR TITLE
Added support for symlinking play using relative paths

### DIFF
--- a/play
+++ b/play
@@ -2,7 +2,13 @@
 
 PRG="$0"
 while [ -h "$PRG" ] ; do
-    PRG=`readlink "$PRG"`
+  TARGET=`readlink "$PRG"`
+  TARGET_BASE=`basename "$TARGET"`
+  TARGET_DIR=`dirname "$TARGET"`
+  LINK_DIR=`dirname "$PRG"`
+
+  ABS_DIR=`cd $LINK_DIR; cd $TARGET_DIR; pwd`
+  PRG="$ABS_DIR/$TARGET_BASE"
 done
 dir=`dirname $PRG`
 


### PR DESCRIPTION
I noticed that the last set of changes I added to fix this were pulled out.  I also noticed that those changes broke symlinking the play script using absolute paths.  I assume this is why they were removed.  Sorry about that.  I should have been more careful.  

Here is a new version that supports both relative and absolute symlinks.  Let me know if there are other issues.
