### PR TITLE
Make the Assets controller specializable

### DIFF
--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -11,26 +11,9 @@ import java.io._
 import scalax.io.{ Resource }
 import java.text.SimpleDateFormat
 
-/**
- * Controller that serves static resources.
- *
- * Resources are searched in the classpath.
- *
- * It handles Last-Modified and ETag header automatically.
- * If a gzipped version of a resource is found (Same resource name with the .gz suffix), it is served instead.
- *
- * You can set a custom Cache directive for a particular resource if needed. For example in your application.conf file:
- *
- * {{{
- * "assets.cache./public/images/logo.png" = "max-age=3600"
- * }}}
- *
- * You can use this controller in any application, just by declaring the appropriate route. For example:
- * {{{
- * GET     /assets/\uFEFF*file               controllers.Assets.at(path="/public", file)
- * }}}
- */
-object Assets extends Controller {
+
+trait Assets {
+  this: Controller =>
 
   /**
    * Generates an `Action` that serves a static resource.
@@ -155,3 +138,23 @@ object Assets extends Controller {
 
 }
 
+/**
+ * Controller that serves static resources.
+ *
+ * Resources are searched in the classpath.
+ *
+ * It handles Last-Modified and ETag header automatically.
+ * If a gzipped version of a resource is found (Same resource name with the .gz suffix), it is served instead.
+ *
+ * You can set a custom Cache directive for a particular resource if needed. For example in your application.conf file:
+ *
+ * {{{
+ * "assets.cache./public/images/logo.png" = "max-age=3600"
+ * }}}
+ *
+ * You can use this controller in any application, just by declaring the appropriate route. For example:
+ * {{{
+ * GET     /assets/\uFEFF*file               controllers.Assets.at(path="/public", file)
+ * }}}
+ */
+object Assets extends Controller with Assets


### PR DESCRIPTION
Allows one to write custom Assets controllers things such as follows:

``` scala
object CustomAssets extends Controller with Assets {
  override def at(path: String, file: String): Action[AnyContent] = Action { implicit request =>
    if (somethingDependingOnTheRequestOrTheSession) {
      super.at(path, file)
    } else {
      NotFound
    }
  }
}
```

As requested [here](https://groups.google.com/d/topic/play-framework/BkdAM8DqT_I/discussion).
