### PR TITLE
Json to form binding is broken for number and longNumber formats

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -326,8 +326,8 @@ private[data] object FormUtils {
     case JsNull => Map.empty
     case JsUndefined(_) => Map.empty
     case JsBoolean(value) => Map(prefix -> value.toString)
-    case JsNumber(value) => Map(prefix -> value.toString)
     case JsString(value) => Map(prefix -> value.toString)
+    case other => Map(prefix -> Json.stringify(other))
   }
 
 }

--- a/framework/src/play/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/json/JsValue.scala
@@ -170,6 +170,7 @@ private[json] class JsValueSerializer extends JsonSerializer[JsValue] {
 
   def serialize(value: JsValue, json: JsonGenerator, provider: SerializerProvider) {
     value match {
+      case JsNumber(v) if v.remainder(1) == BigDecimal(0) => json.writeNumber(v.longValue)
       case JsNumber(v) => json.writeNumber(v.doubleValue())
       case JsString(v) => json.writeString(v)
       case JsBoolean(v) => json.writeBoolean(v)


### PR DESCRIPTION
The Json object is deconstructed to a Map[String, String]. Numbers are represented by their double format String, which in their turn cannot be parsed as an Integer or Long.

JsNumber stores values as a BigDecimal. If the value represents a real, it should be printed to a real string representation (so the long value, not the double value).
