### PR TITLE
Add OpenID realm parameter

### DIFF
--- a/framework/src/play/src/main/java/play/libs/OpenID.java
+++ b/framework/src/play/src/main/java/play/libs/OpenID.java
@@ -21,26 +21,35 @@ public class OpenID {
      * Retrieve the URL where the user should be redirected to start the OpenID authentication process
      */
     public static F.Promise<String> redirectURL(String openID, String callbackURL) {
-        return redirectURL(openID, callbackURL, null, null);
+        return redirectURL(openID, callbackURL, null, null, null);
     }
 
     /**
      * Retrieve the URL where the user should be redirected to start the OpenID authentication process
      */
     public static F.Promise<String> redirectURL(String openID, String callbackURL, Map<String, String> axRequired) {
-        return redirectURL(openID, callbackURL, axRequired, null);
+        return redirectURL(openID, callbackURL, axRequired, null, null);
     }
 
     /**
      * Retrieve the URL where the user should be redirected to start the OpenID authentication process
      */
     public static F.Promise<String> redirectURL(String openID, String callbackURL, Map<String, String> axRequired, Map<String, String> axOptional) {
+        return redirectURL(openID, callbackURL, axRequired, axOptional, null);
+    }
+
+    /**
+     * Retrieve the URL where the user should be redirected to start the OpenID authentication process
+     */
+    public static F.Promise<String> redirectURL(String openID, String callbackURL, Map<String, String> axRequired, Map<String, String> axOptional, String realm) {
         if (axRequired == null) axRequired = new HashMap<String, String>();
         if (axOptional == null) axOptional = new HashMap<String, String>();
+        scala.Option<java.lang.String> realmOpt = realm == null ? scala.None$.MODULE$ : new scala.Some(realm);
         return new F.Promise<String>(play.api.libs.openid.OpenID.redirectURL(openID,
                                                                              callbackURL,
                                                                              JavaConversions.mapAsScalaMap(axRequired).toSeq(),
-                                                                             JavaConversions.mapAsScalaMap(axOptional).toSeq()));
+                                                                             JavaConversions.mapAsScalaMap(axOptional).toSeq(),
+                                                                             realmOpt));
     }
 
     /**

--- a/framework/src/play/src/main/scala/play/api/libs/openid/OpenID.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/openid/OpenID.scala
@@ -42,7 +42,8 @@ object OpenID {
   def redirectURL(openID: String,
     callbackURL: String,
     axRequired: Seq[(String, String)] = Seq.empty,
-    axOptional: Seq[(String, String)] = Seq.empty): Promise[String] = {
+    axOptional: Seq[(String, String)] = Seq.empty,
+    realm: Option[String] = None): Promise[String] = {
     val claimedId = normalize(openID)
     discoverServer(claimedId).map(server => {
       val parameters = Seq(
@@ -51,7 +52,7 @@ object OpenID {
         "openid.claimed_id" -> claimedId,
         "openid.identity" -> server.delegate.getOrElse(claimedId),
         "openid.return_to" -> callbackURL
-      ) ++ axParameters(axRequired, axOptional)
+      ) ++ realm.map("openid.realm" -> _).toList ++ axParameters(axRequired, axOptional)
       val separator = if (server.url.contains("?")) "&" else "?"
       server.url + separator + parameters.map(pair => pair._1 + "=" + URLEncoder.encode(pair._2, "UTF-8")).mkString("&")
     })


### PR DESCRIPTION
Google/Gmail OpenID login uses the OpenID realm to determine the value of a
user's ID. So if your website uses different host names, the same Gmail
user will have different OpenIDs at each host — unless you specify the
realm parameter and set it to `http://*.yourdomain.com`.
