### PR TITLE
fixes issue #200: distDirectory setting is not used so is not  used when overridden

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
@@ -141,11 +141,10 @@ trait PlayCommands {
   }
 
   val dist = TaskKey[File]("dist", "Build the standalone application package")
-  val distTask = (baseDirectory, playPackageEverything, dependencyClasspath in Runtime, target, normalizedName, version) map { (root, packaged, dependencies, target, id, version) =>
+  val distTask = (distDirectory, baseDirectory, playPackageEverything, dependencyClasspath in Runtime, target, normalizedName, version) map { (dist, root, packaged, dependencies, target, id, version) =>
 
     import sbt.NameFilter._
 
-    val dist = root / "dist"
     val packageName = id + "-" + version
     val zip = dist / (packageName + ".zip")
 


### PR DESCRIPTION
Reproduction steps:
In project/Build.scala insert the setting:

distDirectory <<= baseDirectory / "myown"
//startup play2 in console then execute:

dist
//observe that the dist directory "myown" is not used

This pull request addresses this issue
