### PR TITLE
Provide a shorthand to retrieve the current Http.Context from templates

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -131,6 +131,13 @@ public class Http {
                 return play.i18n.Lang.preferred(Context.current().request().acceptLanguages());
             }
             
+            /**
+             * Returns the current context.
+             */
+            public static Context ctx() {
+                return Context.current();
+            }
+            
         }
         
     }


### PR DESCRIPTION
Allows to replace the following:

``` html
<div>@Http.Context.current().args.get("foo")</div>
```

With the following:

``` html
<div>@ctx().args.get("foo")</div>
```
