### PR TITLE
Replace strange " by regular "

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -177,7 +177,7 @@ public class Http {
         /**
          * @return the request cookies
          */
-        public abstract Cookies cookies(); // FIXME Provide a “Cookie cookie(String name)” function instead of this one?
+        public abstract Cookies cookies(); // FIXME Provide a "Cookie cookie(String name)" function instead of this one?
         
         /**
          * Retrieves all headers.
@@ -425,7 +425,7 @@ public class Http {
         }
         
         /**
-         * Set a new transient cookie with path “/”<br />
+         * Set a new transient cookie with path "/"<br />
          * For example:
          * <pre>
          * response().setCookie("theme", "blue");
@@ -438,7 +438,7 @@ public class Http {
         }
         
         /**
-         * Set a new cookie with path “/”
+         * Set a new cookie with path "/"
          * @param name Cookie name
          * @param value Cookie value
          * @param maxAge Cookie duration (-1 for a transient cookie and 0 for a cookie that expires now)

--- a/framework/src/play/src/main/scala/play/api/libs/iteratee/Iteratee.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/iteratee/Iteratee.scala
@@ -317,7 +317,7 @@ trait Iteratee[E, +A] {
 
 object Done {
   /**
-   * Create an [[play.api.libs.iteratee.Iteratee]] in the “done” state.
+   * Create an [[play.api.libs.iteratee.Iteratee]] in the "done" state.
    * @param a Result
    * @param e Remaining unused input
    */
@@ -332,7 +332,7 @@ object Done {
 
 object Cont {
   /**
-   * Create an [[play.api.libs.iteratee.Iteratee]] in the “cont” state.
+   * Create an [[play.api.libs.iteratee.Iteratee]] in the "cont" state.
    * @param k Continuation which will compute the next Iteratee state according to an input
    */
   def apply[E, A](k: Input[E] => Iteratee[E, A]): Iteratee[E, A] = new Iteratee[E, A] {
@@ -344,7 +344,7 @@ object Cont {
 }
 object Error {
   /**
-   * Create an [[play.api.libs.iteratee.Iteratee]] in the “error” state.
+   * Create an [[play.api.libs.iteratee.Iteratee]] in the "error" state.
    * @param msg Error message
    * @param e The input that caused the error
    */


### PR DESCRIPTION
When developing Play2 on Windows (cp1252), strange ” (double quotes) can break scala compiler. I just replaced them by regular ".
