### PR TITLE
Allow shell scripts to run under cygwin

### DIFF
--- a/framework/build
+++ b/framework/build
@@ -8,4 +8,21 @@ else
   DEBUG_PARAM="-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=${JPDA_PORT}"
 fi
 
-java ${DEBUG_PARAM} -Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=384M -Dfile.encoding=UTF8 -Dplay.version="${PLAY_VERSION}" -Dsbt.ivy.home=`dirname $0`/../repository -Dplay.home=`dirname $0` -Dsbt.boot.properties=`dirname $0`/sbt/sbt.boot.properties -jar `dirname $0`/sbt/sbt-launch.jar "$@"
+dir=`dirname $0`
+if [ `uname -o` == "Cygwin" ]
+then
+  SBT_IVY_HOME=$(cygpath -w -a $dir/../repository)
+  PLAY_HOME=$(cygpath -w -a $dir)
+  SBT_LAUNCH_JAR=$(cygpath -w -a $dir/sbt/sbt-launch.jar)
+  SBT_BOOT_PROPS=file:///$(cygpath -m -a $dir/sbt/sbt.boot.properties)
+  JLINE_TERMINAL=-Djline.terminal=jline.UnixTerminal
+else 
+  SBT_IVY_HOME=$dir/../repository
+  PLAY_HOME=$dir
+  SBT_LAUNCH_JAR=$PLAY_HOME/sbt/sbt-launch.jar
+  SBT_BOOT_PROPS=$PLAY_HOME/sbt/sbt.boot.properties
+fi
+
+JAVA_ARGS="-Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=384M $JLINE_TERMINAL -Dfile.encoding=UTF8 -Dplay.version="${PLAY_VERSION}" -Dsbt.ivy.home=$SBT_IVY_HOME -Dplay.home=$PLAY_HOME -Dsbt.boot.properties=$SBT_BOOT_PROPS"
+
+java ${DEBUG_PARAM} ${JAVA_ARGS} -jar $SBT_LAUNCH_JAR "$@"

--- a/play
+++ b/play
@@ -4,7 +4,26 @@ PRG="$0"
 while [ -h "$PRG" ] ; do
     PRG=`readlink "$PRG"`
 done
+
 dir=`dirname $PRG`
+
+if [ `uname -o` == "Cygwin" ]
+then
+  SBT_IVY_HOME=$(cygpath -w -a $dir/repository)
+  PLAY_HOME=$(cygpath -w -a $dir/framework)
+  SBT_LAUNCH_JAR=$(cygpath -w -a $dir/framework/sbt/sbt-launch.jar)
+  SBT_BOOT_PROPS=file:///$(cygpath -m -a $dir/framework/sbt/sbt.boot.properties)
+  JLINE_TERMINAL=-Djline.terminal=jline.UnixTerminal
+  BUILD=$(cygpath -m -a $dir/framework/build)
+else 
+  SBT_IVY_HOME=$dir/repository
+  PLAY_HOME=$dir/framework
+  SBT_LAUNCH_JAR=$PLAY_HOME/sbt/sbt-launch.jar
+  SBT_BOOT_PROPS=$PLAY_HOME/sbt/sbt.boot.properties
+  BUILD=$dir/framework/build
+fi
+
+JAVA_ARGS="$JLINE_TERMINAL -Dsbt.ivy.home=$SBT_IVY_HOME -Dplay.home=$PLAY_HOME -Dsbt.boot.properties=$SBT_BOOT_PROPS"
 
 if [ -f conf/application.conf ]; then
   if test "$1" = "clean-all"; then
@@ -48,11 +67,11 @@ if [ -f conf/application.conf ]; then
   fi
 
   if [ -n "$1" ]; then
-    JPDA_PORT="${JPDA_PORT}" $dir/framework/build "$@"
+    JPDA_PORT="${JPDA_PORT}" $BUILD "$@"
   else
-    JPDA_PORT="${JPDA_PORT}" $dir/framework/build play
+    JPDA_PORT="${JPDA_PORT}" $BUILD play
   fi
   
 else
-  java -Dsbt.ivy.home=$dir/repository -Dplay.home=$dir/framework -Dsbt.boot.properties=$dir/framework/sbt/play.boot.properties -jar $dir/framework/sbt/sbt-launch.jar "$@"
+  java ${DEBUG_PARAM} ${JAVA_ARGS} -jar $SBT_LAUNCH_JAR "$@"
 fi


### PR DESCRIPTION
This modifies the shell scripts (play and build) to resolve paths to windows absolute ones when running under cygwin so that the JVM can handle them.  Also forces the jline terminator for unix style which stops the console ignoring enter.  Could do with somebody giving it a onceover on a non cygwin shell.
