### PR TITLE
Lighthouse #173: creation of zipped or unzipped distribution

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -121,6 +121,8 @@ trait PlaySettings {
 
     dist <<= distTask,
 
+    distZip <<= distZipTask,
+
     computeDependencies <<= computeDependenciesTask,
 
     playVersion := play.core.PlayVersion.current,


### PR DESCRIPTION
I never want to use the zipped version.  It's a bit of a pain for me that it's zipped because I have numerous scrips which deal with the distribution and they all need to unzip first.  Since jars are themselves zip files, zipping saves very little space and I find the inconvenience outweighs any space savings for my own use. The gradle build system has "gradle dist" for unzipped and "gradle distZip" for zipped, which I've found to be very convenient.  This change makes play behave the same way so that there is a "play dist" and "play distZip"

https://play.lighthouseapp.com/projects/82401/tickets/173-feature-request-dist-task-which-does-not-zip-output
