### PR TITLE
Allow for overriding configuration based on the application mode

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -47,7 +47,8 @@ object Configuration {
   def load(appPath: File, mode: Mode.Mode = Mode.Dev) = {
     try {
       val currentMode = Play.maybeApplication.map(_.mode).getOrElse(mode)
-      if (currentMode == Mode.Prod) Configuration(ConfigFactory.load()) else Configuration(loadDev(appPath))
+      val configuration = if (currentMode == Mode.Prod) Configuration(ConfigFactory.load()) else Configuration(loadDev(appPath))
+      configuration.getConfig(currentMode.toString.toLowerCase).map(_ ++ configuration).getOrElse(configuration)
     } catch {
       case e: ConfigException => throw configError(e.origin, e.getMessage, Some(e))
       case e => throw e


### PR DESCRIPTION
Currently it is kind of hard to configure your application differently for e.g. the dev and production environment.
This fix improves the situation so that one can write in application.conf:

```
db.default.user=su
db.default.password=

prod {
  db.default.user=myAccount
  db.default.password=secret
}
```
