### PR TITLE
Akka should use application's configuration, not load it's own.

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -110,7 +110,7 @@ class AkkaPlugin(app: Application) extends Plugin {
 
   lazy val applicationSystem: ActorSystem = {
     applicationSystemEnabled = true
-    val system = ActorSystem("application", Configuration.load(app.path, app.mode).underlying)
+    val system = ActorSystem("application", app.configuration.underlying)
     Logger("play").info("Starting application default Akka system.")
     system
   }


### PR DESCRIPTION
Minor issue, but it doesn't allow changes in GlobalSettings to configurations to be available to Akka.

See on lighthouse: https://play.lighthouseapp.com/projects/82401-play-20/tickets/267
