### PR TITLE
#275 Remove log settings from reference.conf to stop them overriding user's logger.xml

### DIFF
--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -1,14 +1,5 @@
 # Reference configuration for Play 2.0 
 
-# Root logger
-logger.root=ERROR
-
-# Logger used by the framework:
-logger.play=INFO
-
-# Logger provided to your application:
-logger.application=DEBUG
-
 play {
     
     akka {


### PR DESCRIPTION
As per ticket #275, these defaults end up overriding user settings.  They are unnecessary, since Play will fall back on the default logger.xml if the user doesn't specify any logging config.
