### PR TITLE
 fixed incorrect entry for root logger

### DIFF
--- a/framework/skeletons/empty-skel/conf/application.conf
+++ b/framework/skeletons/empty-skel/conf/application.conf
@@ -27,7 +27,7 @@ application.secret="%APPLICATION_SECRET%"
 # You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
 
 # Root logger:
-logger=ERROR
+logger.root=ERROR
 
 # Logger used by the framework:
 logger.play=INFO


### PR DESCRIPTION
Tiny and trivial error:  incorrect entry for root logger level in empty application.conf skeleton
