### PR TITLE
HTML5 - client side validation attributes

### DIFF
--- a/framework/src/play/src/main/scala/play/api/templates/Templates.scala
+++ b/framework/src/play/src/main/scala/play/api/templates/Templates.scala
@@ -180,6 +180,21 @@ object PlayMagic {
    */
   def toHtmlArgs(args: Map[Symbol, Any]) = Html(args.map(a => a._1.name + "=\"" + a._2 + "\"").mkString(" "))
 
+  /**
+   * Generates form validation attributes
+   */
+  def toValidation(field: play.api.data.Field) = {
+    val out = Html.empty
+    field.constraints.foreach(
+      constraint => constraint._1 match {
+        case "constraint.required" => out + Html(" required")
+        case "constraint.minLength" => out + Html(" minlength=\"" + constraint._2.head + "\"")
+        case "constraint.maxLength" => out + Html(" maxlength=\"" + constraint._2.head + "\"")
+        case _ => ()
+      })
+    out
+  }	
+
 }
 
 /** Defines a magic helper for Play templates in a Java context. */

--- a/framework/src/play/src/main/scala/views/helper/inputText.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputText.scala.html
@@ -13,5 +13,5 @@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, lang: play.api.i18n.Lang)
 
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
-    <input type="text" id="@id" name="@name" value="@value" @toHtmlArgs(htmlArgs)>
+    <input type="text" id="@id" name="@name" value="@value" @toHtmlArgs(htmlArgs) @toValidation(field)>
 }


### PR DESCRIPTION
Added client side validation (HTML attributes) for required and max|max length in inputText template helper,
in addition to info labels already displayed by this helpers (e.g "Maximum length: 10")
