### PR TITLE
Provide a QueryStringBindable[List[T]]

### DIFF
--- a/framework/test/integrationtest/app/controllers/Application.scala
+++ b/framework/test/integrationtest/app/controllers/Application.scala
@@ -68,4 +68,7 @@ object Application extends Controller {
     Ok(b.toString())
   }
 
+  def takeList(xs: List[Int]) = Action {
+    Ok(xs.mkString)
+  }
 }

--- a/framework/test/integrationtest/app/controllers/JavaApi.java
+++ b/framework/test/integrationtest/app/controllers/JavaApi.java
@@ -53,5 +53,9 @@ public class JavaApi extends Controller {
     public static Result intercepted() {
         return ok(Interceptor.state);
     }
+
+    public static Result takeList(List<Integer> xs) {
+        return ok(xs.size() + " elements");
+    }
 }
 

--- a/framework/test/integrationtest/conf/routes
+++ b/framework/test/integrationtest/conf/routes
@@ -20,6 +20,8 @@ GET     /index_java_cache       controllers.Application.index_java_cache()
 GET     /conf                   controllers.Application.conf()
 GET     /take-bool              controllers.Application.takeBool(b: Boolean)
 GET     /take-bool-2/:b         controllers.Application.takeBool2(b: Boolean)
+GET     /take-list              controllers.Application.takeList(x: List[Int])
+GET     /take-list-java         controllers.JavaApi.takeList(x: java.util.List[java.lang.Integer])
 # Map static resources from the /public folder to the /public path
 GET     /public/*file           controllers.Assets.at(path="/public", file)
 

--- a/framework/test/integrationtest/test/ApplicationSpec.scala
+++ b/framework/test/integrationtest/test/ApplicationSpec.scala
@@ -92,6 +92,28 @@ class ApplicationSpec extends Specification {
         }
       }
     }
+
+    "bind int parameters from the query string as a list" in {
+      running(FakeApplication()) {
+        "from a list of numbers" in {
+          val Some(result) = routeAndCall(FakeRequest(GET, controllers.routes.Application.takeList(List(1, 2, 3)).url))
+          contentAsString(result) must equalTo ("123")
+        }
+        "from a list of numbers and letters" in {
+          val Some(result) = routeAndCall(FakeRequest(GET, "/take-list?x=1&x=a&x=2"))
+          contentAsString(result) must equalTo ("12")
+        }
+        "when there is no parameter at all" in {
+          val Some(result) = routeAndCall(FakeRequest(GET, "/take-list"))
+          contentAsString(result) must equalTo ("")
+        }
+        "using the Java API" in {
+          val Some(result) = routeAndCall(FakeRequest(GET, "/take-list-java?x=1&x=2&x=3"))
+          contentAsString(result) must equalTo ("3 elements")
+        }
+      }
+    }
+
   }
    
 }


### PR DESCRIPTION
This implementation always succeed: if there is no parameter in the query string it will bind to `Nil`.

For example, given this route:

```
GET     /foo           controllers.Application.foo(x: List[Int])
```

The binding works as follows:

```
/foo?x=1&x=2&x=3   // ==> List(1, 2, 3)
/foo?x=1&x=bar     // ==> List(1)
/foo               // ==> Nil
/foo?x=bar         // ==> Nil
```

Maybe the binding should fail if at least one of the values can’t be bound to `T` (so in my examples, the 2nd and the 4th lines would fail)?
