### PR TITLE
Fixed bug specifying port number when running play cmd in Windows

### DIFF
--- a/play.bat
+++ b/play.bat
@@ -28,7 +28,8 @@ if exist "dist" rmdir /s /q dist
 
 shift
 set additionalArgs=%additionalArgs:*clean-all=%
-if "%1" == "" goto endWithMessage
+
+if "%~1" == "" goto endWithMessage
 
 :runCommand
 if "%~1" == "" goto enterConsole
@@ -41,7 +42,7 @@ set JPDA_PORT=9999
 shift
 set additionalArgs=%additionalArgs:*debug=%
 
-if "%1" == "" goto enterConsole
+if "%~1" == "" goto enterConsole
 
 :enterConsoleWithCommands
 


### PR DESCRIPTION
Running cmd: play "run PORT NUMBER" or: play debug "run PORT NUMBER" has been fixed.
