### PR TITLE
Anorm: add some type conversions

### DIFF
--- a/framework/src/anorm/src/main/scala/Anorm.scala
+++ b/framework/src/anorm/src/main/scala/Anorm.scala
@@ -94,7 +94,7 @@ package anorm {
       }
     }
 
-    implicit def rowToAny: Column[Any] = Column.nonNull { (value, meta) => Right(value) }
+    implicit def rowToAnyType[T]: Column[T] = Column.nonNull { (value, meta) => Right(value.asInstanceOf[T]) }
 
     implicit def rowToInt: Column[Int] = Column.nonNull { (value, meta) =>
       val MetaDataItem(qualified, nullable, clazz) = meta


### PR DESCRIPTION
BUG: Instead of just `row[Long](columnName)` one has to write `row[BigDecimal](columnName).longValue()` if the column datatype is (for example) Oracle NUMBER. Otherwise one would get RuntimeException: TypeDoesNotMatch(Cannot convert 1:BigDecimal to Long for column .ID). 

The attached pull request fixes it for cases when `rs.getObject(columnName)` is a numeric type, String or Boolean, providing conversions to String, Boolean, Int, Long, Short, Double, java.math.BigDecimal, java.math.BigInteger. 
It also adds fallback (asInstanceOf[T]) conversion, to enable `row[T](columnName)` to get the original column value as type T: the same as plain JDBC `rs.getObject(columnName).asInstanceOf[T]`
