### PR TITLE
JSONP Support

### DIFF
--- a/framework/src/play/src/main/java/play/libs/Jsonp.java
+++ b/framework/src/play/src/main/java/play/libs/Jsonp.java
@@ -1,0 +1,59 @@
+package play.libs;
+
+import org.codehaus.jackson.JsonNode;
+
+import play.mvc.Content;
+import play.libs.Json;
+
+/**
+ * The JSONP Content renders a JavaScript call of a JSON object.<br />
+ * Example of use, provided the following route definition:
+ * <pre>
+ *   GET  /my-service        Application.myService(callback: String)
+ * </pre>
+ * The following action definition:
+ * <pre>
+ *   public static Result myService(String callback) {
+ *     JsonNode json = ...
+ *     return ok(jsonp(callback, json));
+ *   }
+ * </pre>
+ * And the following request:
+ * <pre>
+ *   GET  /my-service?callback=foo
+ * </pre>
+ * The response will have content type “text/javascript” and will look like the following:
+ * <pre>
+ *   foo({...});
+ * </pre>
+ */
+public class Jsonp implements Content {
+
+    public Jsonp(String padding, JsonNode json) {
+        this.padding = padding;
+        this.json = json;
+    }
+
+    @Override
+    public String body() {
+        return padding + "(" + Json.stringify(json) + ");";
+    }
+
+    @Override
+    public String contentType() {
+        return "text/javascript";
+    }
+
+    private final String padding;
+    private final JsonNode json;
+
+    /**
+     * @param padding Name of the callback
+     * @param json Json content
+     * @return A JSONP Content using padding and json.
+     */
+    public static Jsonp jsonp(String padding, JsonNode json) {
+        return new Jsonp(padding, json);
+    }
+
+}

--- a/framework/src/play/src/main/scala/play/api/libs/Jsonp.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Jsonp.scala
@@ -1,0 +1,52 @@
+package play.api.libs
+
+import play.api.libs.json.JsValue
+import play.api.http.{ContentTypeOf, ContentTypes, Writeable}
+import play.api.mvc.Codec
+
+/**
+ * JSONP helper.
+ * 
+ * Example of use, provided the following route definition:
+ * {{{
+ *   GET  /my-service       Application.myService(callback: String)
+ * }}}
+ * The following action definition:
+ * {{{
+ *   def myService(callback: String) = Action {
+ *     val json = ...
+ *     Ok(Jsonp(callback, json))
+ *   }
+ * }}}
+ * And the following request:
+ * {{{
+ *   GET /my-service?callback=foo
+ * }}}
+ * The response will have content type “text/javascript” and will look like the following:
+ * {{{
+ *   foo({...});
+ * }}}
+ * 
+ * Another example, showing how to serve either JSON or JSONP from the same action, according to the presence of
+ * a “callback” parameter in the query string:
+ * {{{
+ *   def myService = Action { implicit request =>
+ *     val json = ...
+ *     request.queryString.get("callback").flatMap(_.headOption) match {
+ *       case Some(callback) => Ok(Jsonp(callback, json))
+ *       case None => Ok(json)
+ *     }
+ *   }
+ * }}}
+ */
+case class Jsonp(padding: String, json: JsValue)
+
+object Jsonp {
+
+  implicit val contentTypeOf_Jsonp = ContentTypeOf[Jsonp](Some(ContentTypes.JAVASCRIPT))
+
+  implicit def writeableOf_Jsonp(implicit codec: Codec) = Writeable[Jsonp] { jsonp =>
+    codec.encode("%s(%s);".format(jsonp.padding, jsonp.json))
+  }
+
+}

--- a/framework/test/integrationtest/app/controllers/Application.scala
+++ b/framework/test/integrationtest/app/controllers/Application.scala
@@ -7,6 +7,7 @@ import play.api.Configuration
 import play.api.cache.Cache
 import play.api.libs.json._
 import play.api.libs.json.Json._
+import play.api.libs.Jsonp
 
 import models._
 import models.Protocol._
@@ -71,4 +72,10 @@ object Application extends Controller {
   def takeList(xs: List[Int]) = Action {
     Ok(xs.mkString)
   }
+
+  def jsonp(callback: String) = Action {
+    val json = JsObject(List("foo" -> JsString("bar")))
+    Ok(Jsonp(callback, json))
+  }
+
 }

--- a/framework/test/integrationtest/app/controllers/JavaApi.java
+++ b/framework/test/integrationtest/app/controllers/JavaApi.java
@@ -2,11 +2,15 @@ package controllers;
 
 import java.util.*;
 
+import org.codehaus.jackson.JsonNode;
+
 import play.*;
+import play.libs.Json;
 import play.mvc.*;
 import play.mvc.Http.Cookie;
 
 import static play.libs.Json.toJson;
+import static play.libs.Jsonp.jsonp;
 
 public class JavaApi extends Controller {
 
@@ -61,5 +65,11 @@ public class JavaApi extends Controller {
     public static Result takeList(List<Integer> xs) {
         return ok(xs.size() + " elements");
     }
+
+    public static Result jsonpJava(String callback) {
+        JsonNode json = Json.parse("{ \"foo\": \"bar\" }");
+        return ok(jsonp(callback, json));
+    }
+
 }
 

--- a/framework/test/integrationtest/conf/routes
+++ b/framework/test/integrationtest/conf/routes
@@ -12,17 +12,25 @@ GET     /cookietest             controllers.JavaApi.cookietest()
 GET     /cookie                 controllers.JavaApi.setCookie()
 GET     /read/:name             controllers.JavaApi.readCookie(name)
 GET     /clear/:name            controllers.JavaApi.clearCookie(name)
+
 GET     /notintercepted         controllers.JavaApi.notIntercepted()
 GET     /intercepted-with       controllers.JavaApi.interceptedUsingWith()
 GET     /intercepted            controllers.JavaApi.intercepted()
+
 GET     /json                   controllers.Application.json()
 GET     /json_from_jsobject     controllers.Application.jsonFromJsObject()
 GET     /index_java_cache       controllers.Application.index_java_cache()
 GET     /conf                   controllers.Application.conf()
+
 GET     /take-bool              controllers.Application.takeBool(b: Boolean)
 GET     /take-bool-2/:b         controllers.Application.takeBool2(b: Boolean)
+
 GET     /take-list              controllers.Application.takeList(x: List[Int])
 GET     /take-list-java         controllers.JavaApi.takeList(x: java.util.List[java.lang.Integer])
+
+GET     /jsonp                  controllers.Application.jsonp(callback)
+GET     /jsonp-java             controllers.JavaApi.jsonpJava(callback)
+
 # Map static resources from the /public folder to the /public path
 GET     /public/*file           controllers.Assets.at(path="/public", file)
 

--- a/framework/test/integrationtest/test/ApplicationSpec.scala
+++ b/framework/test/integrationtest/test/ApplicationSpec.scala
@@ -134,6 +134,23 @@ class ApplicationSpec extends Specification {
       }
     }
 
+    "return jsonp" in {
+      "Scala API" in {
+        running(FakeApplication()) {
+          val Some(result) = routeAndCall(FakeRequest(GET, controllers.routes.Application.jsonp("baz").url))
+          contentAsString(result) must equalTo ("baz({\"foo\":\"bar\"});")
+          contentType(result) must equalTo (Some("text/javascript"))
+        }
+      }
+      "Java API" in {
+        running(FakeApplication()) {
+          val Some(result) = routeAndCall(FakeRequest(GET, controllers.routes.JavaApi.jsonpJava("baz").url))
+          contentAsString(result) must equalTo ("baz({\"foo\":\"bar\"});")
+          contentType(result) must equalTo (Some("text/javascript"))
+        }
+      }
+    }
+
   }
-   
+
 }


### PR DESCRIPTION
Provides Java and Scala helpers to render JSONP content.

Scala example:

``` scala
def jsonp(callback: String) = Action {
  val json = JsObject(List("foo" -> JsString("bar")))
  Ok(Jsonp(callback, json))
}
```

Java example:

``` java
public static Result jsonpJava(String callback) {
    JsonNode json = Json.parse("{ \"foo\": \"bar\" }");
    return ok(jsonp(callback, json));
}
```

Provided the following request:

```
GET  /action?callback=foobar
```

It will render a `text/javascript` content containing:

``` javascript
foobar({"foo":"bar"});
```
