### PR TITLE
Don’t double URL decode query string

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -144,7 +144,7 @@ object QueryStringBindable {
    * QueryString binder for String.
    */
   implicit def bindableString = new QueryStringBindable[String] {
-    def bind(key: String, params: Map[String, Seq[String]]) = params.get(key).flatMap(_.headOption).map(v => Right(URLDecoder.decode(v, "utf-8")))
+    def bind(key: String, params: Map[String, Seq[String]]) = params.get(key).flatMap(_.headOption).map(Right(_)) // No need to URL decode from query string since netty already does that
     def unbind(key: String, value: String) = key + "=" + (URLEncoder.encode(value, "utf-8"))
   }
 

--- a/framework/test/integrationtest/app/controllers/Application.scala
+++ b/framework/test/integrationtest/app/controllers/Application.scala
@@ -78,4 +78,7 @@ object Application extends Controller {
     Ok(Jsonp(callback, json))
   }
 
+  def urldecode(fromPath: String, fromQueryString: String) = Action {
+    Ok("fromPath=%s fromQueryString=%s".format(fromPath, fromQueryString))
+  }
 }

--- a/framework/test/integrationtest/conf/routes
+++ b/framework/test/integrationtest/conf/routes
@@ -31,6 +31,8 @@ GET     /take-list-java         controllers.JavaApi.takeList(x: java.util.List[j
 GET     /jsonp                  controllers.Application.jsonp(callback)
 GET     /jsonp-java             controllers.JavaApi.jsonpJava(callback)
 
+GET     /urldecode/:p           controllers.Application.urldecode(p, q)
+
 # Map static resources from the /public folder to the /public path
 GET     /public/*file           controllers.Assets.at(path="/public", file)
 

--- a/framework/test/integrationtest/test/ApplicationSpec.scala
+++ b/framework/test/integrationtest/test/ApplicationSpec.scala
@@ -151,6 +151,14 @@ class ApplicationSpec extends Specification {
       }
     }
 
+    "urldecode correctly parameters from path and query string" in {
+      running(FakeApplication()) {
+        val Some(result) = routeAndCall(FakeRequest(GET, "/urldecode/2%2B2?q=2%2B2"))
+        contentAsString(result) must contain ("fromPath=2+2")
+        contentAsString(result) must contain ("fromQueryString=2+2")
+      }
+    }
+
   }
 
 }


### PR DESCRIPTION
Hope this fixes [#285](https://play.lighthouseapp.com/projects/82401/tickets/285-2b-in-querystring-param-is-being-double-decoded-as-a-space)

(For remind, query string parameters are retrieved [here](https://github.com/playframework/Play20/blob/master/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala#L49), calling this method: http://netty.io/docs/stable/api/org/jboss/netty/handler/codec/http/QueryStringDecoder.html#getParameters())
