### PR TITLE
Bugfix for incompatible evolutions between Play 1.2.x and 2.0

### DIFF
--- a/framework/src/play/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/framework/src/play/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -28,7 +28,7 @@ private[evolutions] case class Evolution(revision: Int, sql_up: String = "", sql
   /**
    * Revision hash, automatically computed from the SQL content.
    */
-  val hash = sha1(sql_down + sql_up)
+  val hash = sha1(sql_down.trim + sql_up.trim)
 
 }
 


### PR DESCRIPTION
See https://play.lighthouseapp.com/projects/82401-play-20/tickets/306-evolutions-not-compatible-between-play-123-and-20
