### PR TITLE
adding @head tag in the html <head> to the java default template

### DIFF
--- a/framework/skeletons/java-skel/app/views/main.scala.html
+++ b/framework/skeletons/java-skel/app/views/main.scala.html
@@ -1,4 +1,4 @@
-@(title: String)(content: Html)
+@(title: String, head: Html = Html(""))(content: Html)
 
 <!DOCTYPE html>
 
@@ -8,6 +8,7 @@
         <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/main.css")">
         <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
         <script src="@routes.Assets.at("javascripts/jquery-1.7.1.min.js")" type="text/javascript"></script>
+        @head
     </head>
     <body>
         @content


### PR DESCRIPTION
I thought that it would make sense to have a @head variable in the default template in order to add stylesheets or additional javascript in the html document <head> from a specific view.

Here is an example how it could be called from a view:

@head = {
    <script type="text/javascript">alert("hello !");</script>
}

@main("Title", head){

   Html Header Tag content here ...

}
