### PR TITLE
field constructor template has been adjusted to bootstrap2 for .form-horizontal form class

### DIFF
--- a/framework/src/play/src/main/scala/views/helper/twitterBootstrap/twitterBootstrapFieldConstructor.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/twitterBootstrap/twitterBootstrapFieldConstructor.scala.html
@@ -7,11 +7,11 @@
 * Generate input according twitter bootsrap rules *
 **************************************************@
 
-<div class="clearfix @elements.args.get('_class) @if(elements.hasErrors) {error}" id="@elements.args.get('_id).getOrElse(elements.id + "_field")">
-    <label for="@elements.id">@elements.label(elements.lang)</label>
-    <div class="input">
+<div class="control-group @elements.args.get('_class) @if(elements.hasErrors) {error}" id="@elements.args.get('_id).getOrElse(elements.id + "_field")">
+    <label class="control-label" for="@elements.id">@elements.label(elements.lang)</label>
+    <div class="controls">
         @elements.input
         <span class="help-inline">@elements.errors(elements.lang).mkString(", ")</span>
-        <span class="help-block">@elements.infos(elements.lang).mkString(", ")</span> 
+        <p class="help-block">@elements.infos(elements.lang).mkString(", ")</p> 
     </div>
 </div>


### PR DESCRIPTION
Referring to this ticket I chose to update the form helper for bootstrap2-code.
https://play.lighthouseapp.com/projects/82401-play-20/tickets/248-support-bootstrap2x#ticket-248-2

In order to get comparable results to the bootstrap 1.4 code I chode the layout for the .form-horizontal class (see http://twitter.github.com/bootstrap/base-css.html#forms).
