### PR TITLE
#310 - Added withJsonBody support to the FakeRequest

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/FakeRequest.java
+++ b/framework/src/play-test/src/main/java/play/test/FakeRequest.java
@@ -1,9 +1,12 @@
 package play.test;
 
+import org.codehaus.jackson.JsonNode;
+import play.api.mvc.AnyContentAsJson;
 import play.libs.*;
 import play.mvc.*;
 
 import java.util.*;
+import scala.collection.Seq;
 
 /**
  * Fake HTTP request implementation.
@@ -32,6 +35,39 @@ public class FakeRequest {
     @SuppressWarnings(value = "unchecked")
     public FakeRequest withHeader(String name, String value) {
         fake = fake.withHeaders(Scala.varargs(Scala.Tuple(name, value)));
+        return this;
+    }
+
+    /**
+     * Set a Json Body to this request.
+     * The <tt>Content-Type</tt> header of the request is set to <tt>application/json</tt>.
+     * The method is set to <tt>POST</tt>.
+     * @param node the Json Node
+     * @return the Fake Request
+     */
+    public FakeRequest withJsonBody(JsonNode node) {
+        Map<String, Seq<String>> map = new HashMap(Scala.asJava(fake.headers().toMap()));
+        map.put("Content-Type", Scala.toSeq(new String[] {"application/json"}));
+        AnyContentAsJson content = new AnyContentAsJson(play.api.libs.json.Json.parse(node.toString()));
+        fake = new play.api.test.FakeRequest(Helpers.POST, fake.path(), new play.api.test.FakeHeaders(Scala.asScala(map)), content);
+        return this;
+    }
+
+    /**
+     * Set a Json Body to this request.
+     * The <tt>Content-Type</tt> header of the request is set to <tt>application/json</tt>.
+     * @param node the Json Node
+     * @param method the HTTP method. <tt>POST</tt> if set to <code>null</code>
+     * @return the Fake Request
+     */
+    public FakeRequest withJsonBody(JsonNode node, String method) {
+        if (method == null) {
+            method = Helpers.POST;
+        }
+        Map<String, Seq<String>> map = new HashMap(Scala.asJava(fake.headers().toMap()));
+        map.put("Content-Type", Scala.toSeq(new String[] {"application/json"}));
+        AnyContentAsJson content = new AnyContentAsJson(play.api.libs.json.Json.parse(node.toString()));
+        fake = new play.api.test.FakeRequest(method, fake.path(), new play.api.test.FakeHeaders(Scala.asScala(map)), content);
         return this;
     }
 

--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -1,6 +1,8 @@
 package play.api.test;
 
 import play.api.mvc._
+import org.codehaus.jackson.JsonNode
+import play.api.libs.json.JsValue
 
 /**
  * Fake HTTP headers implementation.
@@ -87,6 +89,20 @@ case class FakeRequest[A](method: String, uri: String, headers: FakeHeaders, bod
    */
   def withFormUrlEncodedBody(data: (String, String)*): FakeRequest[AnyContentAsFormUrlEncoded] = {
     copy(body = AnyContentAsFormUrlEncoded(data.groupBy(_._1).mapValues(_.map(_._2))))
+  }
+
+  /**
+   * Sets a JSON body to this request.
+   * The content type is set to <tt>application/json</tt>.
+   * The method is set to <tt>POST</tt>.
+   *
+   * @param node the JSON Node.
+   * @param _method The request HTTP method, <tt>POST</tt> by default.
+   * @return the current fake request
+   */
+  def withJsonBody(node: JsValue,  _method: String = Helpers.POST): FakeRequest[AnyContentAsJson] = {
+    copy(method = _method, body = AnyContentAsJson(node))
+        .withHeaders(play.api.http.HeaderNames.CONTENT_TYPE -> "application/json")
   }
 
 }

--- a/framework/test/integrationtest-java/app/controllers/Application.java
+++ b/framework/test/integrationtest-java/app/controllers/Application.java
@@ -1,5 +1,6 @@
 package controllers;
 
+import org.codehaus.jackson.JsonNode;
 import play.*;
 import play.mvc.*;
 
@@ -15,6 +16,11 @@ public class Application extends Controller {
     
     public static Result key() {
         return ok("Key=" + Play.application().configuration().getString("key"));
+    }
+
+    public static Result getIdenticalJson() {
+        JsonNode node = request().body().asJson();
+        return ok(node);
     }
   
 }

--- a/framework/test/integrationtest-java/conf/routes
+++ b/framework/test/integrationtest-java/conf/routes
@@ -6,5 +6,8 @@ GET     /                           controllers.Application.index(name = "Guest"
 GET     /key                        controllers.Application.key
 GET     /:name                      controllers.Application.index(name)
 
+POST    /json                       controllers.Application.getIdenticalJson()
+
+
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.at(path="/public", file)

--- a/framework/test/integrationtest-java/test/SimpleTest.java
+++ b/framework/test/integrationtest-java/test/SimpleTest.java
@@ -5,9 +5,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import controllers.routes;
 import org.codehaus.jackson.JsonNode;
 import org.junit.*;
 
+import play.libs.Json;
 import play.mvc.*;
 import play.test.*;
 import play.data.DynamicForm;
@@ -101,6 +103,57 @@ public class SimpleTest {
                 
                 JsonNode jsonErrors = form.errorsAsJson(lang);
                 assertThat(jsonErrors.findPath("foo").iterator().next().asText()).isEqualTo(play.i18n.Messages.get(lang, RequiredValidator.message));
+            }
+        });
+    }
+
+    /**
+     * Checks that we can build fake request with a json body.
+     * In this test, we use the default method (POST).
+     */
+    @Test
+    public void withJsonBody() {
+        running(fakeApplication(), new Runnable() {
+            @Override
+            public void run() {
+                Map map = new HashMap();
+                map.put("key1", "val1");
+                map.put("key2", 2);
+                map.put("key3", true);
+                JsonNode node = Json.toJson(map);
+                Result result = routeAndCall(fakeRequest("POST", "/json").withJsonBody(node));
+                assertThat(status(result)).isEqualTo(OK);
+                assertThat(contentType(result)).isEqualTo("application/json");
+                JsonNode node2 = Json.parse(contentAsString(result));
+                assertThat(node2.get("key1").asText()).isEqualTo("val1");
+                assertThat(node2.get("key2").asInt()).isEqualTo(2);
+                assertThat(node2.get("key3").asBoolean()).isTrue();
+            }
+        });
+    }
+
+    /**
+     * Checks that we can build fake request with a json body.
+     * In this test we specify the method to use (DELETE)
+     */
+    @Test
+    public void withJsonBodyAndSpecifyMethod() {
+        running(fakeApplication(), new Runnable() {
+            @Override
+            public void run() {
+                Map map = new HashMap();
+                map.put("key1", "val1");
+                map.put("key2", 2);
+                map.put("key3", true);
+                JsonNode node = Json.toJson(map);
+                Result result = callAction(routes.ref.Application.getIdenticalJson(),
+                        fakeRequest().withJsonBody(node, "DELETE"));
+                assertThat(status(result)).isEqualTo(OK);
+                assertThat(contentType(result)).isEqualTo("application/json");
+                JsonNode node2 = Json.parse(contentAsString(result));
+                assertThat(node2.get("key1").asText()).isEqualTo("val1");
+                assertThat(node2.get("key2").asInt()).isEqualTo(2);
+                assertThat(node2.get("key3").asBoolean()).isTrue();
             }
         });
     }

--- a/framework/test/integrationtest-scala/app/controllers/Application.scala
+++ b/framework/test/integrationtest-scala/app/controllers/Application.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import play.api._
+import libs.json.Json
 import play.api.mvc._
 
 import play.api.Play.current
@@ -15,6 +16,15 @@ object Application extends Controller {
     Play.configuration.getString("key").map {
       key => Ok("Key=" + key)
     }.getOrElse(InternalServerError("Configuration missing"))
+  }
+
+  def json = Action { request =>
+    request.body.asJson.map { json =>
+      Ok(json)
+    }.getOrElse(
+        Ok(Json.toJson(Map("status" -> "KO", "message" -> "JSON Body missing")))
+    )
+
   }
   
 }

--- a/framework/test/integrationtest-scala/conf/routes
+++ b/framework/test/integrationtest-scala/conf/routes
@@ -5,6 +5,7 @@
 GET     /                           controllers.Application.index(name = "Guest")
 GET     /key                        controllers.Application.key
 GET     /:name                      controllers.Application.index(name)
+POST    /json                       controllers.Application.json
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.at(path="/public", file)

--- a/framework/test/integrationtest-scala/test/SimpleSpec.scala
+++ b/framework/test/integrationtest-scala/test/SimpleSpec.scala
@@ -4,6 +4,7 @@ import org.specs2.mutable._
 
 import play.api.test._
 import play.api.test.Helpers._
+import play.api.libs.json.{JsValue, Json, JsObject}
 
 class SimpleSpec extends Specification {
   
@@ -68,6 +69,34 @@ class SimpleSpec extends Specification {
         browser.url must equalTo("http://localhost:3333/Coco")
         browser.$("#title").getTexts().get(0) must equalTo("Hello Coco")
 
+      }
+    }
+
+    "response to the json Action using default (POST) method" in {
+      running(FakeApplication()) {
+        val node = Json.toJson(Map("key1" -> "val1", "key2" -> "2", "key3" -> "true"))
+        val result = controllers.Application.json(FakeRequest().withJsonBody(node))
+
+        status(result) must equalTo(OK)
+        contentType(result) must equalTo(Some("application/json"))
+        val node2 = Json.parse(contentAsString(result))
+        (node2 \ "key1").as[String] must equalTo("val1")
+        (node2 \ "key2").as[String] must equalTo("2")
+        (node2 \ "key3").as[String] must equalTo("true")
+      }
+    }
+
+    "response to the json Action when specifying the method (DELETE)" in {
+      running(FakeApplication()) {
+        val node = Json.toJson(Map("key1" -> "val1", "key2" -> "2", "key3" -> "true"))
+        val result = controllers.Application.json(FakeRequest().withJsonBody(node, "DELETE"))
+
+        status(result) must equalTo(OK)
+        contentType(result) must equalTo(Some("application/json"))
+        val node2 = Json.parse(contentAsString(result))
+        (node2 \ "key1").as[String] must equalTo("val1")
+        (node2 \ "key2").as[String] must equalTo("2")
+        (node2 \ "key3").as[String] must equalTo("true")
       }
     }
     


### PR DESCRIPTION
This pull request is just the aggregation of the commits discussed on https://github.com/playframework/Play20/pull/218. 

It provides the fix for the ticket #310 - Added withJsonBody support to the FakeRequest.

---

Added the withJsonBody in FakeRequest.

This method is used to build fake requests sending a Json Body. In Java this method receives a JsonNode; in Scala the method receives a JSValue.

The method can be used with or without a method parameter. If not set, POST is used.
