### PR TITLE
Fully documented the Java Functional helpers

### DIFF
--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -318,8 +318,6 @@ public class F {
         public <A> Option<A> map(Function<T,A> function) {
             if(isDefined()) {
                 try {
-                    // fixme jroper what if function returns null? Shouldn't we then return None?  Or shouldn't we
-                    // make the function return an Option, so it can return None, rather than a value?
                     return Some(function.apply(get()));
                 } catch (RuntimeException e) {
                     throw e;


### PR DESCRIPTION
Most of this pull request is just javadocs.  However, there are a few other small changes:
- The biggest one is that everywhere that wraps throwables in RuntimeExceptions has been modified so that RuntimeExceptions don't get double wrapped.  This should mean if talking to libraries that throw RuntimeException subclasses, that things like get() should end up throwing the original exception that was thrown, instead of throwing a wrapped (possibly many times) exception.
- A few function parameters have been renamed for the purposes of better documenting them.
