### PR TITLE
Add more methods in the Form APIs to deal with errors

### DIFF
--- a/framework/src/play/src/main/java/play/data/Form.java
+++ b/framework/src/play/src/main/java/play/data/Form.java
@@ -213,7 +213,7 @@ public class Form<T> {
                 }
                 errors.get(key).add(new ValidationError(key, error.isBindingFailure() ? "error.invalid" : error.getDefaultMessage(), arguments));                    
             }
-            return new Form(rootName, backedType, data, errors, None());
+            return new Form<T>(rootName, backedType, data, errors, None());
         } else {
             Object globalError = null;
             if(result.getTarget() != null) {
@@ -235,9 +235,9 @@ public class Form<T> {
                 } else if(globalError instanceof Map) {
                     errors = (Map<String,List<ValidationError>>)globalError;
                 }
-                return new Form(rootName, backedType, data, errors, None());
+                return new Form<T>(rootName, backedType, data, errors, None());
             }
-            return new Form(rootName, backedType, new HashMap<String,String>(data), new HashMap<String,List<ValidationError>>(errors), Some((T)result.getTarget()));
+            return new Form<T>(rootName, backedType, new HashMap<String,String>(data), new HashMap<String,List<ValidationError>>(errors), Some((T)result.getTarget()));
         }
     }
     
@@ -269,7 +269,7 @@ public class Form<T> {
         if(value == null) {
             throw new RuntimeException("Cannot fill a form with a null value");
         }
-        return new Form(rootName, backedType, new HashMap<String,String>(), new HashMap<String,ValidationError>(), Some(value));
+        return new Form<T>(rootName, backedType, new HashMap<String,String>(), new HashMap<String,List<ValidationError>>(), Some(value));
     }
     
     /**
@@ -397,7 +397,7 @@ public class Form<T> {
      * @param error the error message
      */    
     public void reject(String key, String error) {
-        reject(key, error, new ArrayList());
+        reject(key, error, new ArrayList<Object>());
     }
     
     /**
@@ -416,9 +416,16 @@ public class Form<T> {
      * @param error the error message.
      */    
     public void reject(String error) {
-        reject("", error, new ArrayList());
+        reject("", error, new ArrayList<Object>());
     }
-    
+
+    /**
+     * Discard errors of this form
+     */
+    public void discardErrors() {
+        errors.clear();
+    }
+
     /**
      * Retrieve a field.
      *

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -216,6 +216,35 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
 
   }
 
+  /**
+   * Adds an error to this form
+   * @param error Error to add
+   * @returns a copy of this form with the added error
+   */
+  def withError(error: FormError): Form[T] = this.copy(errors = errors :+ error)
+
+  /**
+   * Convenient overloaded method adding an error to this form
+   * @param key Key of the field having the error
+   * @param message Error message
+   * @param args Error message arguments
+   * @returns a copy of this form with the added error
+   */
+  def withError(key: String, message: String, args: Any*): Form[T] = withError(FormError(key, message, args))
+
+  /**
+   * Adds a global error to this form
+   * @param message Error message
+   * @param args Error message arguments
+   * @return a copy of this form with the added global error
+   */
+  def withGlobalError(message: String, args: Any*): Form[T] = withError(FormError("", message, args))
+
+  /**
+   * Discards this form’s errors
+   * @returns a copy of this form without errors
+   */
+  def discardingErrors: Form[T] = this.copy(errors = Seq.empty)
 }
 
 /**


### PR DESCRIPTION
Add the following methods to the Scala `Form[T]` API:

``` scala
  def withError(error: FormError): Form[T]
  def withError(key: String, message: String, args: Any*): Form[T]
  def withGlobalError(message: String, args: Any*): Form[T]
  def discardingErrors: Form[T]
```

Add the following method to the Java `Form<T>` API:

``` java
  public void discardErrors();
```

(The equivalent of Scala’s `withError` already exists in Java API under the name “`reject`”)
