### PR TITLE
Implement a Formatter[Float] and a Formatter[Double]

### DIFF
--- a/framework/src/play/src/main/resources/messages
+++ b/framework/src/play/src/main/resources/messages
@@ -11,11 +11,13 @@ constraint.email=Email
 # --- Formats
 format.date=Date (''{0}'')
 format.numeric=Numeric
+format.real=Real
 
 # --- Errors
 error.invalid=Invalid value
 error.required=This field is required
 error.number=Numeric value expected
+error.real=Real number value expected
 error.min=Must be greater or equal to {0}
 error.max=Must be less or equal to {0}
 error.minLength=Minimum length is {0}

--- a/framework/src/play/src/main/scala/play/api/data/format/Format.scala
+++ b/framework/src/play/src/main/scala/play/api/data/format/Format.scala
@@ -58,19 +58,29 @@ object Formats {
   }
 
   /**
+   * Helper for formatters binders
+   * @param parse Function parsing a String value into a T value, throwing an exception in case of failure
+   * @param error Error to set in case of parsing failure
+   * @param key Key name of the field to parse
+   * @param data Field data
+   */
+  private def parsing[T](parse: String => T, errMsg: String, errArgs: Seq[Any])(key: String, data: Map[String, String]): Either[Seq[FormError], T] = {
+    stringFormat.bind(key, data).right.flatMap { s =>
+      util.control.Exception.allCatch[T]
+        .either(parse(s))
+        .left.map(e => Seq(FormError(key, errMsg, errArgs)))
+    }
+  }
+
+  /**
    * Default formatter for the `Long` type.
    */
   implicit def longFormat: Formatter[Long] = new Formatter[Long] {
 
     override val format = Some("format.numeric", Nil)
 
-    def bind(key: String, data: Map[String, String]) = {
-      stringFormat.bind(key, data).right.flatMap { s =>
-        scala.util.control.Exception.allCatch[Long]
-          .either(java.lang.Long.parseLong(s))
-          .left.map(e => Seq(FormError(key, "error.number", Nil)))
-      }
-    }
+    def bind(key: String, data: Map[String, String]) =
+      parsing(_.toLong, "error.number", Nil)(key, data)
 
     def unbind(key: String, value: Long) = Map(key -> value.toString)
   }
@@ -82,15 +92,36 @@ object Formats {
 
     override val format = Some("format.numeric", Nil)
 
-    def bind(key: String, data: Map[String, String]) = {
-      stringFormat.bind(key, data).right.flatMap { s =>
-        scala.util.control.Exception.allCatch[Int]
-          .either(Integer.parseInt(s))
-          .left.map(e => Seq(FormError(key, "error.number", Nil)))
-      }
-    }
+    def bind(key: String, data: Map[String, String]) =
+      parsing(_.toInt, "error.number", Nil)(key, data)
 
     def unbind(key: String, value: Int) = Map(key -> value.toString)
+  }
+
+  /**
+   * Default formatter for the `Float` type.
+   */
+  implicit def floatFormat: Formatter[Float] = new Formatter[Float] {
+
+    override val format = Some("format.real", Nil)
+
+    def bind(key: String, data: Map[String, String]) =
+      parsing(_.toFloat, "error.real", Nil)(key, data)
+
+    def unbind(key: String, value: Float) = Map(key -> value.toString)
+  }
+
+  /**
+   * Default formatter for the `Double` type.
+   */
+  implicit def doubleFormat: Formatter[Double] = new Formatter[Double] {
+
+    override val format = Some("format.real", Nil)
+
+    def bind(key: String, data: Map[String, String]) =
+      parsing(_.toDouble, "error.real", Nil)(key, data)
+
+    def unbind(key: String, value: Double) = Map(key -> value.toString)
   }
 
   /**
@@ -124,16 +155,12 @@ object Formats {
     override val format = Some("format.date", Seq(pattern))
 
     def bind(key: String, data: Map[String, String]) = {
-      stringFormat.bind(key, data).right.flatMap { s =>
-        scala.util.control.Exception.allCatch[Date]
-          .either({
-            val sdf = new SimpleDateFormat(pattern)
-            sdf.setLenient(false)
-            sdf.parse(s)
-          }
-          )
-          .left.map(e => Seq(FormError(key, "error.date", Nil)))
+      def dateParser = { s: String =>
+        val sdf = new SimpleDateFormat(pattern)
+        sdf.setLenient(false)
+        sdf.parse(s)
       }
+      parsing(dateParser, "error.date", Nil)(key, data)
     }
 
     def unbind(key: String, value: Date) = Map(key -> new SimpleDateFormat(pattern).format(value))


### PR DESCRIPTION
Allow to define form fields containing `Float` or `Double` values. E.g.:

``` scala
Form("price"->of[Float])
```

Note: I didn’t understand why the “default” formatters are defined in a `Formats` object rather than being in the companion object `Formatter` (so that they wouldn’t need to be explicitly imported).
Note2: I didn’t define an alias for these formatters (as opposed to `number` and `longNumber` which are aliases for `of[Int]` and `of[Long]`).
