### PR TITLE
Remote address support

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/FakeRequest.java
+++ b/framework/src/play-test/src/main/java/play/test/FakeRequest.java
@@ -50,7 +50,7 @@ public class FakeRequest {
         Map<String, Seq<String>> map = new HashMap(Scala.asJava(fake.headers().toMap()));
         map.put("Content-Type", Scala.toSeq(new String[] {"application/json"}));
         AnyContentAsJson content = new AnyContentAsJson(play.api.libs.json.Json.parse(node.toString()));
-        fake = new play.api.test.FakeRequest(Helpers.POST, fake.path(), new play.api.test.FakeHeaders(Scala.asScala(map)), content);
+        fake = new play.api.test.FakeRequest(Helpers.POST, fake.path(), new play.api.test.FakeHeaders(Scala.asScala(map)), content, "127.0.0.1");
         return this;
     }
 
@@ -69,7 +69,7 @@ public class FakeRequest {
         Map<String, Seq<String>> map = new HashMap(Scala.asJava(fake.headers().toMap()));
         map.put("Content-Type", Scala.toSeq(new String[] {"application/json"}));
         AnyContentAsJson content = new AnyContentAsJson(play.api.libs.json.Json.parse(node.toString()));
-        fake = new play.api.test.FakeRequest(method, fake.path(), new play.api.test.FakeHeaders(Scala.asScala(map)), content);
+        fake = new play.api.test.FakeRequest(method, fake.path(), new play.api.test.FakeHeaders(Scala.asScala(map)), content, "127.0.0.1");
         return this;
     }
 

--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -31,8 +31,9 @@ case class FakeHeaders(data: Map[String, Seq[String]] = Map.empty) extends Heade
  * @param uri The request uri.
  * @param headers The request HTTP headers.
  * @param body The request body.
+ * @param remoteAddress The client IP.
  */
-case class FakeRequest[A](method: String, uri: String, headers: FakeHeaders, body: A) extends Request[A] {
+case class FakeRequest[A](method: String, uri: String, headers: FakeHeaders, body: A, remoteAddress: String = "127.0.0.1") extends Request[A] {
 
   /**
    * The request path.

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -149,6 +149,12 @@ public class Http {
          * The HTTP Method.
          */
         public abstract String method();
+
+        /**
+         * The client IP address.
+         */
+        public abstract String remoteAddress();
+
         
         /**
          * The request host.

--- a/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
@@ -190,5 +190,6 @@ trait HeaderNames {
   val WARNING = "Warning"
   val WWW_AUTHENTICATE = "WWW-Authenticate"
 
+  val X_FORWARDED_FOR = "X-Forwarded-For"
 }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -38,6 +38,11 @@ package play.api.mvc {
     def headers: Headers
 
     /**
+     * The client IP address.
+     */
+    def remoteAddress: String
+
+    /**
      * The HTTP host (domain, optionally port)
      */
     lazy val host: String = headers.get(play.api.http.HeaderNames.HOST).getOrElse("")
@@ -138,6 +143,7 @@ package play.api.mvc {
       def method = self.method
       def queryString = self.queryString
       def headers = self.headers
+      def remoteAddress = self.remoteAddress
       lazy val body = f(self.body)
     }
 
@@ -153,6 +159,7 @@ package play.api.mvc {
     def path = request.path
     def uri = request.uri
     def method = request.method
+    def remoteAddress = request.remoteAddress
   }
 
   /**

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -56,6 +56,8 @@ trait JavaHelpers {
 
       def method = req.method
 
+      def remoteAddress = req.remoteAddress
+
       def host = req.host
 
       def path = req.path
@@ -104,6 +106,8 @@ trait JavaHelpers {
       def uri = req.uri
 
       def method = req.method
+
+      def remoteAddress = req.remoteAddress
 
       def host = req.host
 

--- a/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -10,18 +10,16 @@ import org.jboss.netty.handler.stream._
 import org.jboss.netty.handler.codec.http.HttpHeaders._
 import org.jboss.netty.handler.codec.http.HttpHeaders.Names._
 import org.jboss.netty.handler.codec.http.HttpHeaders.Values._
-
 import org.jboss.netty.channel.group._
 import java.util.concurrent._
-
 import play.core._
 import server.Server
 import play.api._
 import play.api.mvc._
+import play.api.http.HeaderNames.X_FORWARDED_FOR
 import play.api.libs.iteratee._
 import play.api.libs.iteratee.Input._
 import play.api.libs.concurrent._
-
 import scala.collection.JavaConverters._
 
 private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: DefaultChannelGroup) extends SimpleChannelUpstreamHandler with Helpers with WebSocketHandler with RequestBodyHandler {
@@ -51,6 +49,18 @@ private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: De
         val rHeaders = getHeaders(nettyHttpRequest)
         val rCookies = getCookies(nettyHttpRequest)
 
+        def rRemoteAddress = e.getRemoteAddress match {
+          case ra: java.net.InetSocketAddress => {
+            val remoteAddress = ra.getAddress.getHostAddress
+            (for {
+              xff <- rHeaders.get(X_FORWARDED_FOR)
+              app <- server.applicationProvider.get.right.toOption
+              trustxforwarded <- app.configuration.getBoolean("trustxforwarded").orElse(Some(false))
+              if remoteAddress == "127.0.0.1" || trustxforwarded
+            } yield xff).getOrElse(remoteAddress)
+          }
+        }
+
         import org.jboss.netty.util.CharsetUtil;
 
         //mapping netty request to Play's
@@ -61,6 +71,7 @@ private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: De
           def method = nettyHttpRequest.getMethod.getName
           def queryString = parameters
           def headers = rHeaders
+          lazy val remoteAddress = rRemoteAddress
           def username = None
         }
 
@@ -288,6 +299,7 @@ private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: De
                       def method = nettyHttpRequest.getMethod.getName
                       def queryString = parameters
                       def headers = rHeaders
+                      lazy val remoteAddress = rRemoteAddress
                       def username = None
                       val body = b
                     })

--- a/framework/src/play/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/data/FormSpec.scala
@@ -14,6 +14,7 @@ class DummyRequest(data: Map[String, Array[String]]) extends play.mvc.Http.Reque
   def accept = List("text/html").asJava
   def accepts(mediaType: String) = false
   def headers() = new java.util.HashMap[String, Array[String]]()
+  val remoteAddress = "127.0.0.1"
   def body() = new Http.RequestBody {
     override def asFormUrlEncoded = data.asJava
     override def asRaw = null


### PR DESCRIPTION
I started with the code of this [pull request](https://github.com/playframework/Play20/pull/200) and tried to add support for `X-Forwarded-For` header: if there is an `X-Forwarded-For` header and either the client IP is `127.0.0.1` or a configuration key `trustxforwarded` is defined and equal to `true`, the value of the header is used. Otherwise, the remote address provided by Netty is used.

Some things to mention:
- **I didn’t test** behind a reverse proxy
- I wasn’t sure of the way to retrieve the `Application`: I could have used `play.api.Play.current` but wasn’t sure it’s the better way to retrieve it from the netty handler, so I went through `server.applicationProvider`
- I didn’t create an entry for the `X-Forwarded-For` header name in `play.api.http.HeaderNames` since that’s not a real “standard” header, but maybe I was wrong
- Very often, in the existing code, `def`s are used where `val`s could be used to improve performance (unless I’m wrong?). Is there a reason to have chosen `def`s? In doubt I let the existing code as is.
