### PR TITLE
Add column aliases support to Anorm

### DIFF
--- a/framework/src/anorm/src/main/scala/Anorm.scala
+++ b/framework/src/anorm/src/main/scala/Anorm.scala
@@ -493,7 +493,7 @@ package anorm {
             meta.getTableName(i)
           }
 
-        } + "." + meta.getColumnName(i)),
+        } + "." + meta.getColumnLabel(i)),
           nullable = meta.isNullable(i) == columnNullable,
           clazz = meta.getColumnClassName(i))))
     }


### PR DESCRIPTION
This patch makes it possible to use column aliases with Anorm.

For example:

``` sql
select id as user_id from users;
```

can be then parsed with 

``` scala
get[Long]("user_id")
```
