### PR TITLE
Refactor Json serializers and deserializers

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/json/Reads.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/json/Reads.scala
@@ -10,7 +10,7 @@ import scala.annotation.implicitNotFound
 @implicitNotFound(
   "No Json deserializer found for type ${T}. Try to implement an implicit Reads or Format for this type."
 )
-trait Reads[+T] {
+trait Reads[T] {
 
   /**
    * Convert the JsValue into a T
@@ -110,38 +110,6 @@ trait DefaultReads {
   }
 
   /**
-   * Deserializer for List[T] types.
-   */
-  implicit def listReads[T](implicit fmt: Reads[T]): Reads[List[T]] = new Reads[List[T]] {
-    def reads(json: JsValue) = json match {
-      case JsArray(ts) => ts.map(t => fromJson(t)(fmt)).toList
-      case _ => throw new RuntimeException("List expected")
-    }
-  }
-
-  /**
-   * Deserializer for Seq[T] types.
-   */
-  implicit def seqReads[T](implicit fmt: Reads[T]): Reads[Seq[T]] = new Reads[Seq[T]] {
-    def reads(json: JsValue) = json match {
-      case JsArray(ts) => ts.map(t => fromJson(t)(fmt))
-      case _ => throw new RuntimeException("Seq expected")
-    }
-  }
-
-  /**
-   * Deserializer for Array[T] types.
-   */
-  implicit def arrayReads[T](implicit fmt: Reads[T], mf: Manifest[T]): Reads[Array[T]] = new Reads[Array[T]] {
-    def reads(json: JsValue) = json match {
-      case JsArray(ts) => listToArray(ts.map(t => fromJson(t)(fmt)).toList)
-      case _ => throw new RuntimeException("Array expected")
-    }
-  }
-
-  private[this] def listToArray[T: Manifest](ls: List[T]): Array[T] = ls.toArray
-
-  /**
    * Deserializer for Map[String,V] types.
    */
   implicit def mapReads[V](implicit fmtv: Reads[V]): Reads[collection.immutable.Map[String, V]] = new Reads[collection.immutable.Map[String, V]] {
@@ -152,38 +120,32 @@ trait DefaultReads {
   }
 
   /**
-   * Deserializer for Set[T] types.
+   * Generic deserializer for collections types.
    */
-  implicit def mutableSetReads[T](implicit fmt: Reads[T]): Reads[mutable.Set[T]] = {
-    viaSeq((x: Seq[T]) => mutable.Set(x: _*))
-  }
-
-  /**
-   * Deserializer for Set[T] types.
-   */
-  implicit def immutableSetReads[T](implicit fmt: Reads[T]): Reads[immutable.Set[T]] = {
-    viaSeq((x: Seq[T]) => immutable.Set(x: _*))
-  }
-
-  /**
-   * Deserializer for SortedSet[T] types.
-   */
-  implicit def immutableSortedSetReads[S](implicit ord: S => Ordered[S], binS: Reads[S]): Reads[immutable.SortedSet[S]] = {
-    viaSeq((x: Seq[S]) => immutable.TreeSet[S](x: _*))
-  }
-
-  private def viaSeq[S <: Iterable[T], T](f: Seq[T] => S)(implicit fmt: Reads[T]): Reads[S] = new Reads[S] {
+  implicit def traversableReads[F[_], A](implicit bf: generic.CanBuildFrom[F[_], A, F[A]], ra: Reads[A]) = new Reads[F[A]] {
     def reads(json: JsValue) = json match {
-      case JsArray(ts) => f(ts.map(t => fromJson[T](t)))
+      case JsArray(ts) => {
+        val builder = bf()
+        for (a <- ts.map(fromJson[A](_))) {
+          builder += a
+        }
+        builder.result()
+      }
       case _ => throw new RuntimeException("Collection expected")
     }
+  }
+
+  /**
+   * Deserializer for Array[T] types.
+   */
+  implicit def arrayReads[T : Reads : Manifest]: Reads[Array[T]] = new Reads[Array[T]] {
+    def reads(json: JsValue) = json.as[List[T]].toArray
   }
 
   /**
    * Deserializer for JsValue.
    */
   implicit object JsValueReads extends Reads[JsValue] {
-    def writes(o: JsValue) = o
     def reads(json: JsValue) = json
   }
 
@@ -192,7 +154,7 @@ trait DefaultReads {
    */
   implicit object JsObjectReads extends Reads[JsObject] {
     def reads(json: JsValue) = json match {
-      case o @ JsObject(_) => o
+      case o: JsObject => o
       case _ => throw new RuntimeException("JsObject expected")
     }
   }

--- a/framework/src/play/src/main/scala/play/api/libs/json/Writes.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/json/Writes.scala
@@ -86,27 +86,11 @@ trait DefaultWrites {
   }
 
   /**
-   * Serializer for List[T] types.
-   */
-  implicit def listWrites[T](implicit fmt: Writes[T]): Writes[List[T]] = new Writes[List[T]] {
-    def writes(ts: List[T]) = JsArray(ts.map(t => toJson(t)(fmt)))
-  }
-
-  /**
-   * Serializer for Seq[T] types.
-   */
-  implicit def seqWrites[T](implicit fmt: Writes[T]): Writes[Seq[T]] = new Writes[Seq[T]] {
-    def writes(ts: Seq[T]) = JsArray(ts.toList.map(t => toJson(t)(fmt)))
-  }
-
-  /**
    * Serializer for Array[T] types.
    */
   implicit def arrayWrites[T](implicit fmt: Writes[T], mf: Manifest[T]): Writes[Array[T]] = new Writes[Array[T]] {
     def writes(ts: Array[T]) = JsArray((ts.map(t => toJson(t)(fmt))).toList)
   }
-
-  private def listToArray[T: Manifest](ls: List[T]): Array[T] = ls.toArray
 
   /**
    * Serializer for Map[String,V] types.
@@ -116,28 +100,10 @@ trait DefaultWrites {
   }
 
   /**
-   * Serializer for Set[T] types.
+   * Serializer for Traversables types.
    */
-  implicit def mutableSetWrites[T](implicit fmt: Writes[T]): Writes[mutable.Set[T]] = {
-    viaSeq((x: Seq[T]) => mutable.Set(x: _*))
-  }
-
-  /**
-   * Serializer for Set[T] types.
-   */
-  implicit def immutableSetWrites[T](implicit fmt: Writes[T]): Writes[immutable.Set[T]] = {
-    viaSeq((x: Seq[T]) => immutable.Set(x: _*))
-  }
-
-  /**
-   * Serializer for Set[T] types.
-   */
-  implicit def immutableSortedSetWrites[S](implicit ord: S => Ordered[S], binS: Writes[S]): Writes[immutable.SortedSet[S]] = {
-    viaSeq((x: Seq[S]) => immutable.TreeSet[S](x: _*))
-  }
-
-  private def viaSeq[S <: Iterable[T], T](f: Seq[T] => S)(implicit fmt: Writes[T]): Writes[S] = new Writes[S] {
-    def writes(ts: S) = JsArray(ts.map(t => toJson(t)(fmt)).toList)
+  implicit def traversableWrites[A : Writes] = new Writes[Traversable[A]] {
+    def writes(as: Traversable[A]) = JsArray(as.map(toJson(_)).toSeq)
   }
 
   /**
@@ -145,7 +111,6 @@ trait DefaultWrites {
    */
   implicit object JsValueWrites extends Writes[JsValue] {
     def writes(o: JsValue) = o
-    def reads(json: JsValue) = json
   }
 
   /**

--- a/framework/src/play/src/test/scala/play/api/JsonSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/JsonSpec.scala
@@ -100,6 +100,13 @@ object JsonSpec extends Specification {
       fromJson[BigDecimal](json) must equalTo (n)
     }
 
+    "Serialize and deserialize Lists" in {
+      val xs: List[Int] = (1 to 5).toList
+      val json = arr(1, 2, 3, 4, 5)
+      toJson(xs) must equalTo (json)
+      fromJson[List[Int]](json) must equalTo (xs)
+    }
+
     "Map[String,String] should be turned into JsValue" in {
       val f = toJson(Map("k"->"v"))
       f.toString must equalTo("{\"k\":\"v\"}")


### PR DESCRIPTION
- Removes `Writes[List[T]]`, `Writes[Seq[T]]`, and other `Writes` instances for collections. `Writes[Traversable[T]]` is enough now that `Writes[-T]` is contravariant.
- Removes `Reads[List[T]]`, `Reads[Seq[T]]`, and other `Reads` specialized instances for collections, provides instead a generic instance using `CanBuildFrom`. BTW I removed covariance on `Reads[T]` because it seems not to be appropriate.
