### PR TITLE
Small fixes for Java F library

### DIFF
--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -112,6 +112,15 @@ public class F {
         }
 
         /**
+         * Create a new pure promise, that is, a promise with a constant value from the start.
+         *
+         * @param a the value for the promise
+         */
+        public Promise(A a) {
+            this(play.api.libs.concurrent.Promise$.MODULE$.pure(a));
+        }
+
+        /**
          * Awaits for the promise to get the result using the default timeout (5000 milliseconds).
          *
          * @return The promised object


### PR DESCRIPTION
Two things here, one is to provide a constructor to construct a pure promise, as suggested here:

https://groups.google.com/forum/?fromgroups#!topic/play-framework/trasgTs_zdU

The other was a bug, where Option.map is not passing the caught exception to the new RuntimeException when it attempts to wrap it, this ensures the cause is passed to the wrapping RuntimeException
