### PR TITLE
Fix WSRequestHolder#setQueryParameter

### DIFF
--- a/framework/src/play/src/main/java/play/libs/WS.java
+++ b/framework/src/play/src/main/java/play/libs/WS.java
@@ -133,7 +133,7 @@ public class WS {
          */
         public WSRequestHolder setQueryParameter(String name, String value) {
             if (queryParameters.containsKey(name)) {
-                Collection<String> values = headers.get(name);
+                Collection<String> values = queryParameters.get(name);
                 values.add(value);
             } else {
                 List<String> values = new ArrayList<String>();


### PR DESCRIPTION
See [#360](https://play.lighthouseapp.com/projects/82401/tickets/360-bug-in-wsjava-setqueryparameter-leads-to-npe-when-adding-a-query-parameter-twice)
