### PR TITLE
Fixed #375 "Global.onStop() is not called"

### DIFF
--- a/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
@@ -169,11 +169,19 @@ object NettyServer {
     }
 
     try {
-      Some(new NettyServer(
+      val server = new NettyServer(
         new StaticApplication(applicationPath),
         Option(System.getProperty("http.port")).map(Integer.parseInt(_)).getOrElse(9000),
         Option(System.getProperty("https.port")).map(Integer.parseInt(_)),
-        Option(System.getProperty("http.address")).getOrElse("0.0.0.0")))
+        Option(System.getProperty("http.address")).getOrElse("0.0.0.0"))
+        
+      Runtime.getRuntime.addShutdownHook(new Thread {
+        override def run {
+          server.stop()
+        }
+      })
+      
+      Some(server)
     } catch {
       case e => {
         println("Oops, cannot start the server.")


### PR DESCRIPTION
Fixed #375 ticket
https://play.lighthouseapp.com/projects/82401-play-20/tickets/375-globalonstop-is-not-invoked

If the application is started by 'play start' command, Global.onStop() is not called. 
So I attached a hooker.

Please review it.
