### PR TITLE
[#377] Fixes the bug, allowing the use of properties in MySQL connections

### DIFF
--- a/framework/src/play/src/main/scala/play/api/db/DB.scala
+++ b/framework/src/play/src/main/scala/play/api/db/DB.scala
@@ -334,11 +334,11 @@ private[db] class BoneCPApi(configuration: Configuration, classloader: ClassLoad
         datasource.setUsername(username)
         datasource.setPassword(password)
       case Some(MysqlFullUrl(username, password, host, dbname, params)) =>
-		if (params.startsWith("?"))
-		  datasource.setJdbcUrl("jdbc:mysql://%s/%s?%suseUnicode=yes&characterEncoding=UTF-8&connectionCollation=utf8_general_ci".format(host, dbname, params))
-		else
-		  datasource.setJdbcUrl("jdbc:mysql://%s/%s?useUnicode=yes&characterEncoding=UTF-8&connectionCollation=utf8_general_ci".format(host, dbname))
-		datasource.setUsername(username)
+        if (params.startsWith("?"))
+          datasource.setJdbcUrl("jdbc:mysql://%s/%s?%suseUnicode=yes&characterEncoding=UTF-8&connectionCollation=utf8_general_ci".format(host, dbname, params))
+        else
+          datasource.setJdbcUrl("jdbc:mysql://%s/%s?useUnicode=yes&characterEncoding=UTF-8&connectionCollation=utf8_general_ci".format(host, dbname))
+        datasource.setUsername(username)
         datasource.setPassword(password)
       case Some(s: String) =>
         datasource.setJdbcUrl(s)


### PR DESCRIPTION
see https://play.lighthouseapp.com/projects/82401-play-20/tickets/377-mysql-database-url-with-properties-leads-to-connection-failure for details
