### PR TITLE
JSON Enumeration support

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/json/Reads.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/json/Reads.scala
@@ -110,6 +110,26 @@ trait DefaultReads {
   }
 
   /**
+   * Deserializer for Enumeration types.
+   *
+   * {{{
+   * (Json \ "status").as(enum(Status))
+   * }}}
+   */
+  def enum[E <: Enumeration](enum: E): Reads[E#Value] = new Reads[E#Value] {
+    def reads(json: JsValue) = json match {
+      case JsString(s) => {
+        try {
+          enum.withName(s)
+        } catch {
+          case _ => throw new RuntimeException("Enumeration expected")
+        }
+      }
+      case _ => throw new RuntimeException("String expected")
+    }
+  }
+
+  /**
    * Deserializer for List[T] types.
    */
   implicit def listReads[T](implicit fmt: Reads[T]): Reads[List[T]] = new Reads[List[T]] {

--- a/framework/src/play/src/main/scala/play/api/libs/json/Writes.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/json/Writes.scala
@@ -86,6 +86,13 @@ trait DefaultWrites {
   }
 
   /**
+   * Serializer for Enumeration types.
+   */
+  implicit object EnumWrites extends Writes[Enumeration#Value] {
+    def writes(o: Enumeration#Value) = JsString(o.toString)
+  }
+
+  /**
    * Serializer for List[T] types.
    */
   implicit def listWrites[T](implicit fmt: Writes[T]): Writes[List[T]] = new Writes[List[T]] {

--- a/framework/src/play/src/test/scala/play/api/JsonSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/JsonSpec.scala
@@ -131,6 +131,17 @@ object JsonSpec extends Specification {
       val expectedJson = JsArray(List(JsNull))
       parsedJson must equalTo(expectedJson)
     }
+    "Serialize and deserialize Enumerations" in {
+      import play.api.libs.json.Reads.enum
+      object Status extends Enumeration {
+        val Free = Value("free")
+      }
+
+      val e = Status.Free
+      val m = Map("status" -> e)
+      val jsonM = toJson(m)
+      (jsonM \ "status").as(enum(Status)) must equalTo(e)
+    }
   }
 
 }


### PR DESCRIPTION
To support Enumerations when deserializing JSON we need to specify the type of the enum.

It's the same problem as with the form enum support.

I've added a spec from the start this time, and squashed the commits :)

```
  import play.api.libs.json.Reads.enum
  object Status extends Enumeration {
    val Free = Value("free")
  }

  val e = Status.Free
  val m = Map("status" -> e)
  val jsonM = toJson(m)
  (jsonM \ "status").as(enum(Status)) must equalTo(e)
```
