### PR TITLE
Allow routing to inherited Java controller actions

### DIFF
--- a/framework/src/play/src/main/scala/play/core/router/Router.scala
+++ b/framework/src/play/src/main/scala/play/core/router/Router.scala
@@ -1092,7 +1092,7 @@ object Router {
         new play.core.j.JavaAction {
           def invocation = call
           def controller = handler.getControllerClass
-          def method = controller.getDeclaredMethod(handler.method, handler.parameterTypes.map {
+          def method = controller.getMethod(handler.method, handler.parameterTypes.map {
             case c if c == classOf[Long] => classOf[java.lang.Long]
             case c => c
           }: _*)


### PR DESCRIPTION
This is a fix for this bug I filed:

  https://play.lighthouseapp.com/projects/82401/tickets/376-cannot-route-to-inherited-methods-in-java-controllers
