### PR TITLE
Add a deleteManyToManyAssociations method to Model

### DIFF
--- a/framework/src/play/src/main/java/play/db/ebean/Model.java
+++ b/framework/src/play/src/main/java/play/db/ebean/Model.java
@@ -101,6 +101,16 @@ public class Model {
         Ebean.getServer(server).saveManyToManyAssociations(this, path);
     }    
     
+    
+    /**
+     * Deletes a many-to-many association
+     * 
+     * @parama path name of the many-to-many association we want to delete
+     */
+    public void deleteManyToManyAssociations(String path) {
+        Ebean.deleteManyToManyAssociations(this, path);
+    }
+    
     /**
      * Updates this entity.
      */


### PR DESCRIPTION
It would be nice to have the deleteManyToManyAssociations method in the Model Object. This makes it more intuitive to handle with ManyToMany associations with a model instead of calling the Ebean.deleteManyToManyAssociations method.
