### PR TITLE
[fix #386] Respond to HTTP HEAD request if there is a matching GET route

### DIFF
--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -175,7 +175,7 @@ object Helpers extends Status with HeaderNames {
    */
   def routeAndCall[T, ROUTER <: play.core.Router.Routes](router: Class[ROUTER], request: FakeRequest[T]): Option[Result] = {
     val routes = router.getClassLoader.loadClass(router.getName + "$").getDeclaredField("MODULE$").get(null).asInstanceOf[play.core.Router.Routes]
-    routes.routes.lift(request).map {
+    routes.handlerFor(request).map {
       case action: Action[_] => action.asInstanceOf[Action[T]](request)
     }
   }

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -152,15 +152,21 @@ package play.api.mvc {
   /**
    * Wrap an existing request. Useful to extend a request.
    */
-  class WrappedRequest[A](request: Request[A]) extends Request[A] {
+  class WrappedRequest[A](request: Request[A]) extends WrappedRequestHeader(request) with Request[A] {
     def body = request.body
-    def headers = request.headers
-    def queryString = request.queryString
-    def path = request.path
-    def uri = request.uri
-    def method = request.method
-    def remoteAddress = request.remoteAddress
   }
+
+  /**
+   * Wrap an existing request header. Useful to extend or override a request header
+   */
+   class WrappedRequestHeader(requestHeader: RequestHeader) extends RequestHeader {
+     def uri = requestHeader.uri
+     def path = requestHeader.uri
+     def method = requestHeader.method
+     def queryString = requestHeader.queryString
+     def headers = requestHeader.headers
+     def remoteAddress = requestHeader.remoteAddress
+   }
 
   /**
    * The HTTP response.

--- a/framework/src/play/src/main/scala/play/core/router/Router.scala
+++ b/framework/src/play/src/main/scala/play/core/router/Router.scala
@@ -1260,7 +1260,15 @@ object Router {
     }
 
     def handlerFor(request: RequestHeader): Option[Handler] = {
-      routes.lift(request)
+      routes.lift(request) match {
+        case None if "HEAD" == request.method =>
+          // Check if there is a handler for a GET request instead
+          routes.lift(new WrappedRequestHeader(request) {
+            override def method = "GET"
+          })
+        case None => None
+        case opt@Some(e) => opt
+      }
     }
 
     def invokeHandler[T](call: => T, handler: HandlerDef)(implicit d: HandlerInvoker[T]): Handler = {

--- a/framework/test/integrationtest-scala/conf/routes
+++ b/framework/test/integrationtest-scala/conf/routes
@@ -4,7 +4,7 @@
 
 GET     /                           controllers.Application.index(name = "Guest")
 GET     /key                        controllers.Application.key
-GET     /:name                      controllers.Application.index(name)
+GET     /name/:name                 controllers.Application.index(name)
 POST    /json                       controllers.Application.json
 
 # Map static resources from the /public folder to the /assets URL path

--- a/framework/test/integrationtest-scala/test/SimpleSpec.scala
+++ b/framework/test/integrationtest-scala/test/SimpleSpec.scala
@@ -37,16 +37,30 @@ class SimpleSpec extends Specification {
       
       result must equalTo(None)
     }
-    
+
     "respond to the GET /Kiki request" in {
-      val Some(result) = routeAndCall(FakeRequest(GET, "/Kiki"))
+      val Some(result) = routeAndCall(FakeRequest(GET, "/name/Kiki"))
       
       status(result) must equalTo(OK)
       contentType(result) must equalTo(Some("text/html"))
       charset(result) must equalTo(Some("utf-8"))
       contentAsString(result) must contain("Hello Kiki")
     }
-    
+
+    "do not respond to HEAD request to a route for which no HEAD method is defined" in {
+      val result = routeAndCall(FakeRequest(HEAD, "/json"))
+
+      result must equalTo(None)
+    }
+
+    "respond to the HEAD /Kiki request if there is a corresponding GET route defined" in {
+      val Some(result) = routeAndCall(FakeRequest(HEAD, "/name/Kiki"))
+
+      status(result) must equalTo(OK)
+      contentType(result) must equalTo(Some("text/html"))
+      charset(result) must equalTo(Some("utf-8"))
+    }
+
     "respond to the key Action" in {
       running(FakeApplication()) {
         val result = controllers.Application.key(FakeRequest())
@@ -66,7 +80,7 @@ class SimpleSpec extends Specification {
         
         browser.$("a").click()
         
-        browser.url must equalTo("http://localhost:3333/Coco")
+        browser.url must equalTo("http://localhost:3333/name/Coco")
         browser.$("#title").getTexts().get(0) must equalTo("Hello Coco")
 
       }


### PR DESCRIPTION
This is a fix for #386.

This changeset includes:
- Looking up a handler for a HEAD request if there is a matching handler for a GET request
- Updating the Helpers.roundAndCall method to use the handler lookup method
- Updating the integrationtest-scala application to distinguish between dynamic GET
  requests and non-existing routes by introducing a /name path element.
- Adding a WrappedRequestHeader class that allows to easily wrap RequestHeaders
