### PR TITLE
Fix #374 (access request Header in onError, onHandlerNotFound, onBadRequest in java defined Global)

### DIFF
--- a/framework/src/play/src/main/java/play/GlobalSettings.java
+++ b/framework/src/play/src/main/java/play/GlobalSettings.java
@@ -36,10 +36,11 @@ public class GlobalSettings {
      * Returns a Result that could be a custom error page.
      * The default implementation returns <code>null</code>, so that the Scala engine handles the excepetion and show an error page.
      *
+     * @param request The HTTP Request
      * @param t is any throwable
      * @return null as the default implementation
      */
-    public Result onError(Throwable t) {
+    public Result onError(play.api.mvc.RequestHeader request, Throwable t) {
         return null;
     }
     
@@ -77,11 +78,10 @@ public class GlobalSettings {
     /**
      * Triggered when a resource was requested but not found. The default implementation returns <code>null</code>, so that
      * the Scala engine handles the <code>onActionNotFound</code>.
-     *
-     * @param uri the request URI
+     * @param request the RequestHeader
      * @return null in the default implementation, you can return your own custom Result in your Global class.
      */
-    public Result onHandlerNotFound(String uri) {
+    public Result onHandlerNotFound(play.api.mvc.RequestHeader request) {
         return null;
     }
     
@@ -89,10 +89,10 @@ public class GlobalSettings {
      * Triggered when a resource was requested but not found, the default implementation returns <code>null</code>, so that
      * the Scala engine handles the <code>onBadRequest</code>.
      *
-     * @param uri the request URI
+     * @param request the RequestHeader
      * @return null in the default implementation, you can return your own custom Result in your Global class.
      */
-    public Result onBadRequest(String uri, String error) {
+    public Result onBadRequest(play.api.mvc.RequestHeader request, String error) {
         return null;
     }
 }

--- a/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
@@ -24,15 +24,15 @@ class JavaGlobalSettingsAdapter(val underlying: play.GlobalSettings) extends Glo
   }
 
   override def onError(request: RequestHeader, ex: Throwable): Result = {
-    Option(underlying.onError(ex)).map(_.getWrappedResult).getOrElse(super.onError(request, ex))
+    Option(underlying.onError(request, ex)).map(_.getWrappedResult).getOrElse(super.onError(request, ex))
   }
 
   override def onHandlerNotFound(request: RequestHeader): Result = {
-    Option(underlying.onHandlerNotFound(request.path)).map(_.getWrappedResult).getOrElse(super.onHandlerNotFound(request))
+    Option(underlying.onHandlerNotFound(request)).map(_.getWrappedResult).getOrElse(super.onHandlerNotFound(request))
   }
 
   override def onBadRequest(request: RequestHeader, error: String): Result = {
-    Option(underlying.onBadRequest(request.path, error)).map(_.getWrappedResult).getOrElse(super.onBadRequest(request, error))
+    Option(underlying.onBadRequest(request, error)).map(_.getWrappedResult).getOrElse(super.onBadRequest(request, error))
   }
 
 }


### PR DESCRIPTION
It's breaking the backward compatibility for people using Gloval in java, and overloading onError, onHandlerNotFound, or onBadRequest.
