### PR TITLE
#374 Create a RequestHeader for the Java API Global

### DIFF
--- a/framework/src/play/src/main/java/play/GlobalSettings.java
+++ b/framework/src/play/src/main/java/play/GlobalSettings.java
@@ -39,7 +39,7 @@ public class GlobalSettings {
      * @param t is any throwable
      * @return null as the default implementation
      */
-    public Result onError(Throwable t) {
+    public Result onError(RequestHeader request, Throwable t) {
         return null;
     }
     
@@ -70,7 +70,7 @@ public class GlobalSettings {
     * @param request the HTTP request header as seen by the core framework (the body has not been parsed yet)
     * @return an action to handle this request - if no action is returned, a 404 not found result will be sent to client
     */
-    public play.api.mvc.Handler onRouteRequest(play.api.mvc.RequestHeader request) {
+    public play.api.mvc.Handler onRouteRequest(RequestHeader request) {
         return null;
     }
 
@@ -78,10 +78,10 @@ public class GlobalSettings {
      * Triggered when a resource was requested but not found. The default implementation returns <code>null</code>, so that
      * the Scala engine handles the <code>onActionNotFound</code>.
      *
-     * @param uri the request URI
+     * @param request the HTTP request
      * @return null in the default implementation, you can return your own custom Result in your Global class.
      */
-    public Result onHandlerNotFound(String uri) {
+    public Result onHandlerNotFound(RequestHeader request) {
         return null;
     }
     
@@ -89,10 +89,10 @@ public class GlobalSettings {
      * Triggered when a resource was requested but not found, the default implementation returns <code>null</code>, so that
      * the Scala engine handles the <code>onBadRequest</code>.
      *
-     * @param uri the request URI
+     * @param request the HTTP request
      * @return null in the default implementation, you can return your own custom Result in your Global class.
      */
-    public Result onBadRequest(String uri, String error) {
+    public Result onBadRequest(RequestHeader request, String error) {
         return null;
     }
 }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -135,11 +135,7 @@ public class Http {
         
     }
     
-    /**
-     * An HTTP request.
-     */
-    public abstract static class Request {
-        
+    public abstract static class RequestHeader {
         /**
          * The complete request URI, containing both path and query string.
          */
@@ -185,12 +181,7 @@ public class Http {
          * The query string content.
          */
         public abstract Map<String,String[]> queryString();
-        
-        /**
-         * The request body.
-         */
-        public abstract RequestBody body();
-        
+
         /**
          * @return the request cookies
          */
@@ -219,6 +210,18 @@ public class Http {
             }
             return headers[0];
         }
+
+    }
+    
+    /**
+     * An HTTP request.
+     */
+    public abstract static class Request extends RequestHeader {
+
+        /**
+         * The request body.
+         */
+        public abstract RequestBody body();
 
         // -- username
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
@@ -2,6 +2,7 @@ package play.core.j
 
 import play.api._
 import play.api.mvc._
+import play.mvc.Http.{RequestHeader => JRequestHeader}
 
 /** Adapter that holds the Java `GlobalSettings` and acts as a Scala `GlobalSettings` for the framework. */
 class JavaGlobalSettingsAdapter(val underlying: play.GlobalSettings) extends GlobalSettings {
@@ -20,19 +21,23 @@ class JavaGlobalSettingsAdapter(val underlying: play.GlobalSettings) extends Glo
   }
 
   override def onRouteRequest(request: RequestHeader): Option[Handler] = {
-    Option(underlying.onRouteRequest(request)).map(Some(_)).getOrElse(super.onRouteRequest(request))
+    val r = JavaHelpers.createJavaRequest(request)
+    Option(underlying.onRouteRequest(r)).map(Some(_)).getOrElse(super.onRouteRequest(request))
   }
 
   override def onError(request: RequestHeader, ex: Throwable): Result = {
-    Option(underlying.onError(ex)).map(_.getWrappedResult).getOrElse(super.onError(request, ex))
+    val r = JavaHelpers.createJavaRequest(request)
+    Option(underlying.onError(r, ex)).map(_.getWrappedResult).getOrElse(super.onError(request, ex))
   }
 
   override def onHandlerNotFound(request: RequestHeader): Result = {
-    Option(underlying.onHandlerNotFound(request.path)).map(_.getWrappedResult).getOrElse(super.onHandlerNotFound(request))
+    val r = JavaHelpers.createJavaRequest(request)
+    Option(underlying.onHandlerNotFound(r)).map(_.getWrappedResult).getOrElse(super.onHandlerNotFound(request))
   }
 
   override def onBadRequest(request: RequestHeader, error: String): Result = {
-    Option(underlying.onBadRequest(request.path, error)).map(_.getWrappedResult).getOrElse(super.onBadRequest(request, error))
+    val r = JavaHelpers.createJavaRequest(request)
+    Option(underlying.onBadRequest(r, error)).map(_.getWrappedResult).getOrElse(super.onBadRequest(request, error))
   }
 
 }


### PR DESCRIPTION
@see https://play.lighthouseapp.com/projects/82401/tickets/374-play-java-globalsettings-api-allows-no-access-to-request-object-for-onerror-onhandlernotfound-onbadrequest
