### PR TITLE
Helper to retrieve the first value of a query string parameter

### DIFF
--- a/framework/src/play/src/main/java/play/data/Form.java
+++ b/framework/src/play/src/main/java/play/data/Form.java
@@ -11,6 +11,7 @@ import static java.lang.annotation.RetentionPolicy.*;
 
 import play.libs.F;
 import play.mvc.Http;
+import play.mvc.Http.QueryString;
 import static play.libs.F.*;
 
 import play.data.validation.*;
@@ -104,7 +105,7 @@ public class Form<T> {
             );
         }
         
-        Map<String,String[]> queryString = play.mvc.Controller.request().queryString();
+        QueryString queryString = play.mvc.Controller.request().queryString();
         
         Map<String,String> data = new HashMap<String,String>();
         
@@ -127,10 +128,7 @@ public class Form<T> {
         }
         
         for(String key: queryString.keySet()) {
-            String[] value = queryString.get(key);
-            if(value.length > 0) {
-                data.put(key, value[0]);
-            }
+            data.put(key, queryString.getString(key));
         }
         
         return data;

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -184,7 +184,7 @@ public class Http {
         /**
          * The query string content.
          */
-        public abstract Map<String,String[]> queryString();
+        public abstract QueryString queryString();
         
         /**
          * The request body.
@@ -240,6 +240,37 @@ public class Http {
         }
         
     }
+    
+
+    /**
+     * The request query string
+     */
+    @SuppressWarnings("serial")
+    public static class QueryString extends HashMap<String, String[]> {
+
+        /**
+         * @param m query string data
+         */
+        public QueryString(Map<? extends String, ? extends String[]> m) {
+            super(m);
+        }
+
+        /**
+         * Retrieve a parameter value as a <code>String</code>.
+         * @param key name of the parameter to retrieve
+         * @return the first value for the given <code>key</code>, if found, otherwise <code>null</code>.
+         */
+        public String getString(String key) {
+            String[] values = get(key);
+            if (values == null || values.length == 0) {
+                return null;
+            } else {
+                return values[0];
+            }
+        }
+
+    }
+
     
     /**
      * Handle the request body a raw bytes data.

--- a/framework/src/play/src/main/scala/play/api/libs/Jsonp.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Jsonp.scala
@@ -32,7 +32,7 @@ import play.api.mvc.Codec
  * {{{
  *   def myService = Action { implicit request =>
  *     val json = ...
- *     request.queryString.get("callback").flatMap(_.headOption) match {
+ *     request.queryString.getString("callback") match {
  *       case Some(callback) => Ok(Jsonp(callback, json))
  *       case None => Ok(json)
  *     }

--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -230,11 +230,13 @@ object JavascriptLitteral {
  */
 object QueryStringBindable {
 
+  import play.api.mvc.QueryString.getString
+
   /**
    * QueryString binder for String.
    */
   implicit def bindableString = new QueryStringBindable[String] {
-    def bind(key: String, params: Map[String, Seq[String]]) = params.get(key).flatMap(_.headOption).map(Right(_)) // No need to URL decode from query string since netty already does that
+    def bind(key: String, params: Map[String, Seq[String]]) = getString(params, key).map(Right(_)) // No need to URL decode from query string since netty already does that
     def unbind(key: String, value: String) = key + "=" + (URLEncoder.encode(value, "utf-8"))
   }
 
@@ -242,7 +244,7 @@ object QueryStringBindable {
    * QueryString binder for Int.
    */
   implicit def bindableInt = new QueryStringBindable[Int] {
-    def bind(key: String, params: Map[String, Seq[String]]) = params.get(key).flatMap(_.headOption).map { i =>
+    def bind(key: String, params: Map[String, Seq[String]]) = getString(params, key).map { i =>
       try {
         Right(java.lang.Integer.parseInt(i))
       } catch {
@@ -256,7 +258,7 @@ object QueryStringBindable {
    * QueryString binder for Long.
    */
   implicit def bindableLong = new QueryStringBindable[Long] {
-    def bind(key: String, params: Map[String, Seq[String]]) = params.get(key).flatMap(_.headOption).map { i =>
+    def bind(key: String, params: Map[String, Seq[String]]) = getString(params, key).map { i =>
       try {
         Right(java.lang.Long.parseLong(i))
       } catch {
@@ -270,7 +272,7 @@ object QueryStringBindable {
    * QueryString binder for Integer.
    */
   implicit def bindableInteger = new QueryStringBindable[java.lang.Integer] {
-    def bind(key: String, params: Map[String, Seq[String]]) = params.get(key).flatMap(_.headOption).map { i =>
+    def bind(key: String, params: Map[String, Seq[String]]) = getString(params, key).map { i =>
       try {
         Right(java.lang.Integer.parseInt(i))
       } catch {
@@ -284,7 +286,7 @@ object QueryStringBindable {
    * QueryString binder for Boolean.
    */
   implicit def bindableBoolean = new QueryStringBindable[Boolean] {
-    def bind(key: String, params: Map[String, Seq[String]]) = params.get(key).flatMap(_.headOption).map { i =>
+    def bind(key: String, params: Map[String, Seq[String]]) = getString(params, key).map { i =>
       try {
         java.lang.Integer.parseInt(i) match {
           case 0 => Right(false)

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -247,6 +247,39 @@ package play.api.mvc {
   }
 
   /**
+   * Helpers to deal with query string values
+   */
+  object QueryString {
+
+    /**
+     * @param params query string data
+     * @key name of the parameter to retrieve
+     * @return the first value for the given `key`, if found, otherwise `None`.
+     */
+    def getString(params: Map[String, Seq[String]], key: String): Option[String] = params.get(key).flatMap(_.headOption)
+
+    object implicits {
+
+      class QueryString(params: Map[String, Seq[String]]) {
+        def getString(key: String) = QueryString.getString(params, key)
+      }
+
+      /**
+       * Pimps a map of query string data to add it the helpers as methods, allowing a more object idiomatic notation.
+       * Example:
+       * 
+       * {{{
+       *   import play.api.mvc.QueryString.implicits._
+       *   def index = Action { request =>
+       *     request.queryString.getString("foo").map(Ok(_)).getOrElse(BadRequest)
+       *   }
+       * }}}
+       */
+      implicit def toQueryString(params: Map[String, Seq[String]]) = new QueryString(params)
+    }
+  }
+
+  /**
    * Trait that should be extended by the Cookie helpers.
    */
   trait CookieBaker[T <: AnyRef] {

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -2,7 +2,7 @@ package play.core.j
 
 import play.api.mvc._
 import play.mvc.{ Action => JAction, Result => JResult }
-import play.mvc.Http.{ Context => JContext, Request => JRequest, RequestBody => JBody, Cookies => JCookies, Cookie => JCookie }
+import play.mvc.Http.{ Context => JContext, Request => JRequest, QueryString => JQueryString, RequestBody => JBody, Cookies => JCookies, Cookie => JCookie }
 
 import scala.collection.JavaConverters._
 
@@ -68,8 +68,8 @@ trait JavaHelpers {
 
       def acceptLanguages = req.acceptLanguages.map(new play.i18n.Lang(_)).asJava
 
-      def queryString = {
-        req.queryString.mapValues(_.toArray).asJava
+      lazy val queryString = {
+        new JQueryString(req.queryString.mapValues(_.toArray).asJava)
       }
 
       def accept = req.accept.asJava
@@ -123,8 +123,8 @@ trait JavaHelpers {
 
       def accepts(mediaType: String) = req.accepts(mediaType)
 
-      def queryString = {
-        req.queryString.mapValues(_.toArray).asJava
+      lazy val queryString = {
+        new JQueryString(req.queryString.mapValues(_.toArray).asJava)
       }
 
       def cookies = new JCookies {

--- a/framework/src/play/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/data/FormSpec.scala
@@ -2,7 +2,7 @@ package play.data
 
 import org.specs2.mutable._
 import play.mvc._
-import play.mvc.Http.Context
+import play.mvc.Http.{Context, QueryString}
 import scala.collection.JavaConverters._
 
 class DummyRequest(data: Map[String, Array[String]]) extends play.mvc.Http.Request {
@@ -25,7 +25,7 @@ class DummyRequest(data: Map[String, Array[String]]) extends play.mvc.Http.Reque
   def cookies() = new play.mvc.Http.Cookies {
     def get(name: String) = null
   }
-  def queryString: java.util.Map[String, Array[String]] = new java.util.HashMap()
+  def queryString = new QueryString(new java.util.HashMap[String, Array[String]])
   setUsername("peter")
 }
 


### PR DESCRIPTION
## Summary
### Scala API
- Add [`QueryString.getString(params: Map[String, Seq[String]]): Option[String]`](https://github.com/playframework/Play20/pull/269/files#L5R259), a helper method retrieving the first value of a given query string parameter. Example:

``` scala
import play.api.mvc.QueryString.getString
def index = Action { request =>
  val foo: Option[String] = getString(request.queryString, "foo")
  Ok
}
```
- Add an implicit conversion pimping a `Map[String, Seq[String]]` value, adding it a `getString(key: String): Option[String]` method, allowing to use a more object idiomatic style. Example:

``` scala
import play.api.mvc.QueryString.implicits._
def index = Action { request =>
  val foo: Option[String] = request.queryString.getString("foo")
  Ok
}
```
### Java API
- Define a `QueryString` class, subclassing `HashMap<String, String[]>` so it is fully backward source compatible.
- Define a `public String getString(String key)` method to the `QueryString` class. Example:

``` java
public static Result index() {
  String foo = request().queryString().getString("foo");
  return ok();
}
```
