### PR TITLE
Upgrade to sbt eclipse plugin 2.1-M2 to allow setting of target directory

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -74,7 +74,7 @@ object PlayBuild extends Build {
         sbtPlugin := true,
         publishMavenStyle := false,
         libraryDependencies := sbtDependencies,
-        addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-core" % "2.0.0"),
+        addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-core" % "2.1.0-M2"),
         addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.1.0-M1-TYPESAFE"),
         unmanagedJars in Compile ++= sbtJars,
         publishTo := Some(playIvyRepository),

--- a/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
@@ -220,9 +220,9 @@ exec java $* -cp "`dirname $0`/lib/*" """ + customFileName.map(fn => "-Dconfig.f
     import com.typesafe.sbteclipse.core._
     import com.typesafe.sbteclipse.core.EclipsePlugin._
     def transformerFactory =
-      new EclipseClasspathEntryTransformerFactory {
+      new EclipseTransformerFactory[Seq[EclipseClasspathEntry] => Seq[EclipseClasspathEntry]] {
         override def createTransformer(ref: ProjectRef, state: State) =
-          setting(crossTarget in ref)(state) map (ct =>
+          setting(crossTarget in ref, state) map (ct =>
             (entries: Seq[EclipseClasspathEntry]) => entries :+ EclipseClasspathEntry.Lib(ct + java.io.File.separator + "classes_managed")
           )
       }


### PR DESCRIPTION
This is necessary for fixing the Eclipse integration.  I believe someone filed a lighthouse issue for this, but I can't find it at the moment.
