### PR TITLE
Fix typo in documentation example.

### DIFF
--- a/framework/src/play/src/main/scala/views/helper/javascriptRouter.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/javascriptRouter.scala.html
@@ -4,8 +4,8 @@
  * Example:
  * {{{
  * @javascriptRouter("jsRoutes")(
- *   routes.javascripts.Users.list,
- *   routes.javascripts.Application.index
+ *   routes.javascript.Users.list,
+ *   routes.javascript.Application.index
  * )
  * }}}
  *


### PR DESCRIPTION
This commit updates the documentation example, which actually does not compile, due to a trailing 's'.
See https://groups.google.com/d/topic/play-framework/oVEls_dlNeA/discussion for details
