### PR TITLE
Better 304 Handling

### DIFF
--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -138,12 +138,12 @@ object Assets extends Controller {
         case "file" => Some(dateFormatter.format(new java.util.Date(new java.io.File(resource.getPath).lastModified)))
         case "jar" => {
             resource.getPath.split('!').drop(1).headOption.flatMap { fileNameInJar =>
-	      Option(resource.openConnection)
-		.collect { case c: JarURLConnection => c }
-		.flatMap(c => Option(c.getJarFile.getJarEntry(fileNameInJar.drop(1))))
-		.map(_.getTime)
-		.filterNot(_ == 0)
-		.map(lastModified => dateFormatter.format(new java.util.Date(lastModified))) 
+              Option(resource.openConnection)
+               .collect { case c: JarURLConnection => c }
+               .flatMap(c => Option(c.getJarFile.getJarEntry(fileNameInJar.drop(1))))
+               .map(_.getTime)
+               .filterNot(_ == 0)
+               .map(lastModified => dateFormatter.format(new java.util.Date(lastModified))) 
             }
         }
         case _ => None


### PR DESCRIPTION
1) `Last-Modified` and `If-Modified-Since` are used to determine a possible 304 if etag didn't match
2) `Date` header added to support better 304 handling with proxies
3) Timestamps for static assets inside of JAR files are determined by the actual file (in the JAR) instead of just the JAR file iteself.
