### PR TITLE
Add a helper to retrieve the first value of a query string parameter

### DIFF
--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -43,7 +43,7 @@ case class FakeRequest[A](method: String, uri: String, headers: FakeHeaders, bod
   /**
    * The request query String
    */
-  lazy val queryString: Map[String, Seq[String]] = play.core.parsers.FormUrlEncodedParser.parse(rawQueryString)
+  lazy val queryString: QueryString = QueryString(play.core.parsers.FormUrlEncodedParser.parse(rawQueryString))
 
   /**
    * Constructs a new request with additional headers.

--- a/framework/src/play/src/main/java/play/data/Form.java
+++ b/framework/src/play/src/main/java/play/data/Form.java
@@ -11,6 +11,7 @@ import static java.lang.annotation.RetentionPolicy.*;
 
 import play.libs.F;
 import play.mvc.Http;
+import play.mvc.Http.QueryString;
 import static play.libs.F.*;
 
 import play.data.validation.*;
@@ -104,7 +105,7 @@ public class Form<T> {
             );
         }
         
-        Map<String,String[]> queryString = play.mvc.Controller.request().queryString();
+        QueryString queryString = play.mvc.Controller.request().queryString();
         
         Map<String,String> data = new HashMap<String,String>();
         
@@ -127,10 +128,7 @@ public class Form<T> {
         }
         
         for(String key: queryString.keySet()) {
-            String[] value = queryString.get(key);
-            if(value.length > 0) {
-                data.put(key, value[0]);
-            }
+            data.put(key, queryString.getString(key));
         }
         
         return data;

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -184,7 +184,7 @@ public class Http {
         /**
          * The query string content.
          */
-        public abstract Map<String,String[]> queryString();
+        public abstract QueryString queryString();
         
         /**
          * The request body.
@@ -240,6 +240,37 @@ public class Http {
         }
         
     }
+    
+
+    /**
+     * The request query string
+     */
+    @SuppressWarnings("serial")
+    public static class QueryString extends HashMap<String, String[]> {
+
+        /**
+         * @param m query string data
+         */
+        public QueryString(Map<? extends String, ? extends String[]> m) {
+            super(m);
+        }
+
+        /**
+         * Retrieve a parameter value as a <code>String</code>.
+         * @param key name of the parameter to retrieve
+         * @return the first value for the given <code>key</code>, if found, otherwise <code>null</code>.
+         */
+        public String getString(String key) {
+            String[] values = get(key);
+            if (values == null || values.length == 0) {
+                return null;
+            } else {
+                return values[0];
+            }
+        }
+
+    }
+
     
     /**
      * Handle the request body a raw bytes data.

--- a/framework/src/play/src/main/scala/play/api/libs/Jsonp.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Jsonp.scala
@@ -32,7 +32,7 @@ import play.api.mvc.Codec
  * {{{
  *   def myService = Action { implicit request =>
  *     val json = ...
- *     request.queryString.get("callback").flatMap(_.headOption) match {
+ *     request.queryString.getString("callback") match {
  *       case Some(callback) => Ok(Jsonp(callback, json))
  *       case None => Ok(json)
  *     }

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -30,7 +30,7 @@ package play.api.mvc {
     /**
      * The parsed query string.
      */
-    def queryString: Map[String, Seq[String]]
+    def queryString: QueryString
 
     /**
      * The HTTP headers.
@@ -243,6 +243,52 @@ package play.api.mvc {
     def toSimpleMap: Map[String, String] = keys.map { headerKey =>
       (headerKey, apply(headerKey))
     }.toMap
+
+  }
+
+  /**
+   * The query string part of an URL.
+   */
+  class QueryString(private val data: Map[String, Seq[String]]) extends Map[String, Seq[String]] with collection.immutable.MapLike[String, Seq[String], QueryString] {
+
+    override def get(key: String): Option[Seq[String]] = data.get(key)
+
+    override def iterator = data.iterator
+
+    override def + [A >: Seq[String]](kv: (String, A)): Map[String, A] = data + kv
+
+    override def - (key: String): QueryString = QueryString(data - key)
+
+    override def empty: QueryString = QueryString.empty
+
+    /**
+     * @param key parameter name to retrieve
+     * @return the first value for the requested parameter, if found, otherwise `None`.
+     */
+    def getString(key: String): Option[String] = data.get(key).flatMap(_.headOption)
+
+  }
+
+  object QueryString {
+
+    import play.api.http.Writeable
+
+    /**
+     * Creates a QueryString from a map of parameters.
+     */
+    def apply(data: Map[String, Seq[String]]) = new QueryString(data)
+
+    /**
+     * Creates a QueryString from key-value pairs.
+     * Example:
+     * 
+     * {{{
+     *   QueryString("foo"->"bar", "foo"->"baz")
+     * }}}
+     */
+    def apply(params: (String, String)*) = new QueryString(params.groupBy(_._1).mapValues(_.map(_._2)))
+
+    def empty = new QueryString(Map.empty)
 
   }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -491,7 +491,7 @@ trait Results {
    * @param url the URL to redirect to
    * @param status HTTP status
    */
-  def Redirect(url: String, status: Int): SimpleResult[Results.EmptyContent] = Redirect(url, Map.empty, status)
+  def Redirect(url: String, status: Int): SimpleResult[Results.EmptyContent] = Redirect(url, QueryString.empty, status)
 
   /**
    * Generates a redirect simple result.
@@ -500,7 +500,7 @@ trait Results {
    * @param queryString queryString parameters to add to the queryString
    * @param status HTTP status
    */
-  def Redirect(url: String, queryString: Map[String, Seq[String]] = Map.empty, status: Int = SEE_OTHER) = {
+  def Redirect(url: String, queryString: QueryString = QueryString.empty, status: Int = SEE_OTHER) = {
     import java.net.URLEncoder
     val fullUrl = url + Option(queryString).filterNot(_.isEmpty).map { params =>
       (if (url.contains("?")) "&" else "?") + params.toSeq.flatMap { pair =>

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -2,7 +2,7 @@ package play.core.j
 
 import play.api.mvc._
 import play.mvc.{ Action => JAction, Result => JResult }
-import play.mvc.Http.{ Context => JContext, Request => JRequest, RequestBody => JBody, Cookies => JCookies, Cookie => JCookie }
+import play.mvc.Http.{ Context => JContext, Request => JRequest, QueryString => JQueryString, RequestBody => JBody, Cookies => JCookies, Cookie => JCookie }
 
 import scala.collection.JavaConverters._
 
@@ -68,8 +68,8 @@ trait JavaHelpers {
 
       def acceptLanguages = req.acceptLanguages.map(new play.i18n.Lang(_)).asJava
 
-      def queryString = {
-        req.queryString.mapValues(_.toArray).asJava
+      lazy val queryString = {
+        new JQueryString(req.queryString.mapValues(_.toArray).asJava)
       }
 
       def accept = req.accept.asJava
@@ -123,8 +123,8 @@ trait JavaHelpers {
 
       def accepts(mediaType: String) = req.accepts(mediaType)
 
-      def queryString = {
-        req.queryString.mapValues(_.toArray).asJava
+      lazy val queryString = {
+        new JQueryString(req.queryString.mapValues(_.toArray).asJava)
       }
 
       def cookies = new JCookies {

--- a/framework/src/play/src/main/scala/play/core/router/Router.scala
+++ b/framework/src/play/src/main/scala/play/core/router/Router.scala
@@ -1037,7 +1037,7 @@ object Router {
 
   case class Param[T](name: String, value: Either[String, T])
 
-  case class RouteParams(path: Map[String, String], queryString: Map[String, Seq[String]]) {
+  case class RouteParams(path: Map[String, String], queryString: QueryString) {
 
     def fromPath[T](key: String, default: Option[T] = None)(implicit binder: PathBindable[T]): Param[T] = {
       Param(key, path.get(key).map(binder.bind(key, _)).getOrElse {

--- a/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -77,7 +77,7 @@ private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: De
           def uri = nettyHttpRequest.getUri
           def path = nettyUri.getPath
           def method = nettyHttpRequest.getMethod.getName
-          def queryString = parameters
+          def queryString = QueryString(parameters)
           def headers = rHeaders
           lazy val remoteAddress = rRemoteAddress
           def username = None
@@ -296,7 +296,7 @@ private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: De
                       def uri = nettyHttpRequest.getUri
                       def path = nettyUri.getPath
                       def method = nettyHttpRequest.getMethod.getName
-                      def queryString = parameters
+                      def queryString = QueryString(parameters)
                       def headers = rHeaders
                       lazy val remoteAddress = rRemoteAddress
                       def username = None

--- a/framework/src/play/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/data/FormSpec.scala
@@ -2,7 +2,7 @@ package play.data
 
 import org.specs2.mutable._
 import play.mvc._
-import play.mvc.Http.Context
+import play.mvc.Http.{Context, QueryString}
 import scala.collection.JavaConverters._
 
 class DummyRequest(data: Map[String, Array[String]]) extends play.mvc.Http.Request {
@@ -25,7 +25,7 @@ class DummyRequest(data: Map[String, Array[String]]) extends play.mvc.Http.Reque
   def cookies() = new play.mvc.Http.Cookies {
     def get(name: String) = null
   }
-  def queryString: java.util.Map[String, Array[String]] = new java.util.HashMap()
+  def queryString = new QueryString(new java.util.HashMap[String, Array[String]])
   setUsername("peter")
 }
 


### PR DESCRIPTION
## Summary
### Scala API
- Add `QueryString` class, extending `Map[String, Seq[String]]`, with a method `getString` retrieving the first value of a given query string parameter. Example:

``` scala
import play.api.mvc.QueryString.getString
def index = Action { request =>
  val foo: Option[String] = equest.queryString.getString("foo")
  Ok
}
```
### Java API
- Define a `QueryString` class, subclassing `HashMap<String, String[]>` so it is fully backward source compatible.
- Define a `public String getString(String key)` method to the `QueryString` class. Example:

``` java
public static Result index() {
  String foo = request().queryString().getString("foo");
  return ok();
}
```
