### PR TITLE
[328] Contraints.Pattern value not available in models constraint map

### DIFF
--- a/framework/src/play/src/main/java/play/data/validation/Constraints.java
+++ b/framework/src/play/src/main/java/play/data/validation/Constraints.java
@@ -394,9 +394,9 @@ public class Constraints {
     @Target({FIELD})
     @Retention(RUNTIME)
     @Constraint(validatedBy = PatternValidator.class)
-    @play.data.Form.Display(name="constraint.pattern", attributes={})
+    @play.data.Form.Display(name="constraint.pattern", attributes={"value"})
     public static @interface Pattern {
-        String message() default EmailValidator.message;
+        String message() default PatternValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
         String value();


### PR DESCRIPTION
When we define a pattern value with `@Pattern` annotation, the "constraint.pattern" entry was present in forms constraint map, but it had no value. With this change it's fixed, and the error.pattern message in message file can be used (this message was already existing). 
This is also useful for module development, for example to use this validation values to do some HTML5 client side validation.
