### PR TITLE
Add ActionBuilder trait

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -146,9 +146,9 @@ object BodyParser {
 }
 
 /**
- * Helper object to create `Action` values.
+ * Provides helpers for creating `Action` values.
  */
-object Action {
+trait ActionBuilder {
 
   /**
    * Constructs an `Action`.
@@ -183,9 +183,7 @@ object Action {
    * @param block the action code
    * @return an action
    */
-  def apply(block: Request[AnyContent] => Result): Action[AnyContent] = {
-    Action(BodyParsers.parse.anyContent)(block)
-  }
+  def apply(block: Request[AnyContent] => Result): Action[AnyContent] = apply(BodyParsers.parse.anyContent)(block)
 
   /**
    * Constructs an `Action` with default content, and no request parameter.
@@ -200,8 +198,11 @@ object Action {
    * @param block the action code
    * @return an action
    */
-  def apply(block: => Result): Action[AnyContent] = {
-    this.apply(_ => block)
-  }
+  def apply(block: => Result): Action[AnyContent] = apply(_ => block)
 
 }
+
+/**
+ * Helper object to create `Action` values.
+ */
+object Action extends ActionBuilder


### PR DESCRIPTION
Move the capabilities of the `Action` helper object to a trait which the `Action` helper object then extends.

This allows easy creation of additional helper objects where only the implementation of `apply[A <: AnyContent](bodyParser: BodyParser[A])(block: Request[A] => Result)` needs to be changed. This can be an alternative to using case classes for custom actions.

It would be convenient when wanting to override the default behavior of `Action`, turning

``` scala
trait ControllerMagic {
  def layout: Layouts.Layout

  val BareAction = play.api.mvc.Action

  object Action {
    def apply[A <: AnyContent](bodyParser: BodyParser[A])(block: Request[A] => Result): Action[A] = {
      new Layouts.WithLayout(layout)(new Action[A] {
        def parser = bodyParser
        def apply(ctx: Request[A]) = block(ctx)
      })
    }

    def apply(block: Request[AnyContent] => Result): Action[AnyContent] = apply(BodyParsers.parse.anyContent)(block)

    def apply(block: => Result): Action[AnyContent] = apply(_ => block)
  }
}
```

into

``` scala
trait ControllerMagic {
  def layout: Layouts.Layout

  object BareAction extends play.api.mvc.ActionBuilder

  object Action extends play.api.mvc.ActionBuilder {
    def apply[A <: AnyContent](bodyParser: BodyParser[A])(block: Request[A] => Result): Action[A] = {
      new Layouts.WithLayout(layout)(new Action[A] {
        def parser = bodyParser
        def apply(ctx: Request[A]) = block(ctx)
      })
    }
  }
}
```
