### PR TITLE
Refactored computer-database sample to move database access out of the view

### DIFF
--- a/samples/scala/computer-database/app/controllers/Application.scala
+++ b/samples/scala/computer-database/app/controllers/Application.scala
@@ -61,7 +61,7 @@ object Application extends Controller {
    */
   def edit(id: Long) = Action {
     Computer.findById(id).map { computer =>
-      Ok(html.editForm(id, computerForm.fill(computer)))
+      Ok(html.editForm(id, computerForm.fill(computer), Company.options))
     }.getOrElse(NotFound)
   }
   
@@ -72,7 +72,7 @@ object Application extends Controller {
    */
   def update(id: Long) = Action { implicit request =>
     computerForm.bindFromRequest.fold(
-      formWithErrors => BadRequest(html.editForm(id, formWithErrors)),
+      formWithErrors => BadRequest(html.editForm(id, formWithErrors, Company.options)),
       computer => {
         Computer.update(id, computer)
         Home.flashing("success" -> "Computer %s has been updated".format(computer.name))
@@ -84,7 +84,7 @@ object Application extends Controller {
    * Display the 'new computer form'.
    */
   def create = Action {
-    Ok(html.createForm(computerForm))
+    Ok(html.createForm(computerForm, Company.options))
   }
   
   /**
@@ -92,7 +92,7 @@ object Application extends Controller {
    */
   def save = Action { implicit request =>
     computerForm.bindFromRequest.fold(
-      formWithErrors => BadRequest(html.createForm(formWithErrors)),
+      formWithErrors => BadRequest(html.createForm(formWithErrors, Company.options)),
       computer => {
         Computer.insert(computer)
         Home.flashing("success" -> "Computer %s has been created".format(computer.name))

--- a/samples/scala/computer-database/app/views/createForm.scala.html
+++ b/samples/scala/computer-database/app/views/createForm.scala.html
@@ -1,4 +1,4 @@
-@(computerForm: Form[Computer])
+@(computerForm: Form[Computer], companies: Seq[(String, String)])
 
 @import helper._
 
@@ -18,7 +18,7 @@
 
             @select(
                 computerForm("company"), 
-                Company.options, 
+                companies, 
                 '_label -> "Company", '_default -> "-- Choose a company --",
                 '_showConstraints -> false
             )

--- a/samples/scala/computer-database/app/views/editForm.scala.html
+++ b/samples/scala/computer-database/app/views/editForm.scala.html
@@ -1,4 +1,4 @@
-@(id: Long, computerForm: Form[Computer])
+@(id: Long, computerForm: Form[Computer], companies : Seq[(String, String)])
 
 @import helper._
 
@@ -18,7 +18,7 @@
             
             @select(
                 computerForm("company"), 
-                Company.options, 
+                companies, 
                 '_label -> "Company", '_default -> "-- Choose a company --",
                 '_showConstraints -> false
             )


### PR DESCRIPTION
In the computer-database example there is code in the view to fetch something from the database. This is IMHO a bad thing since it makes the view function side effecting. 
