### PR TITLE
Fix for bug Bug 452, Evolution does not handle SQL script larger than 64kb

### DIFF
--- a/framework/src/play/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/framework/src/play/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -163,8 +163,8 @@ object Evolutions {
                     create table play_evolutions (
                         id int not null primary key, hash varchar(255) not null, 
                         applied_at timestamp not null, 
-                        apply_script text, 
-                        revert_script text, 
+                        apply_script mediumtext,
+                        revert_script mediumtext,
                         state varchar(255), 
                         last_problem text
                     )


### PR DESCRIPTION
I updated the default column from "text" to "mediumtext"
