### PR TITLE
Add a helper to url-encode in templates

### DIFF
--- a/framework/src/play/src/main/scala/views/helper/package.scala
+++ b/framework/src/play/src/main/scala/views/helper/package.scala
@@ -19,4 +19,10 @@ package object helper {
    */
   val defaultField = defaultFieldConstructor.f
 
+  /**
+   * @return The url-encoded value of `string` using the charset provided by `codec`
+   */
+  def urlEncode(string: String)(implicit codec: play.api.mvc.Codec): String =
+    java.net.URLEncoder.encode(string, codec.charset)
+
 }


### PR DESCRIPTION
[#439](https://play.lighthouseapp.com/projects/82401/tickets/439-helper-for-url-encoding-in-template-missing#ticket-439-1)
# Usage

In templates:

```
  @helper.urlEncode("foo bar")
```
