### PR TITLE
Added an option for 'play start' to start an application as a background process

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
@@ -637,13 +637,22 @@ exec java $* -cp "`dirname $0`/lib/*" """ + customFileName.map(fn => "-Dconfig.f
             }
           }.start()
 
-          println(Colors.green(
-            """|
-               |(Starting server. Type Ctrl+D to exit logs, the server will remain in background)
-               |""".stripMargin))
+          properties.find { p => p._1 == "background" && p._2 == "true"} match {
+          	case Some(_) =>
+          	  println(Colors.green(
+			    """|
+			       |(Starting server. The server will remain in background)
+			       |""".stripMargin))				  
+  
+			case _ => 
+			  println(Colors.green(
+				"""|
+				   |(Starting server. Type Ctrl+D to exit logs, the server will remain in background)
+				   |""".stripMargin))
 
-          waitForKey()
-
+              waitForKey()
+          }
+					
           println()
 
           state.copy(remainingCommands = Seq.empty)


### PR DESCRIPTION
Hello.

I needed an option to start an application as a background process rather than Type 'Ctrl + D' manually.
More details on my needs at https://groups.google.com/forum/?fromgroups#!topic/play-framework/BlV4c3q8hxE

And I issued a ticket, #457
https://play.lighthouseapp.com/projects/82401-play-20/tickets/457-start-an-application-as-background-process

Please kindly review the code.
