### PR TITLE
Add textmate-style link to devError page

### DIFF
--- a/framework/src/play/src/main/scala/views/defaultpages/devError.scala.html
+++ b/framework/src/play/src/main/scala/views/defaultpages/devError.scala.html
@@ -59,6 +59,9 @@
 		        text-shadow: 1px 1px 1px rgba(0,0,0,.3);
 		        border-top: 4px solid #2a2a2a;
 		    }
+		    h2 a {
+		    	color: #fff;
+		    }
 			pre {
 				margin: 0;
 				border-bottom: 1px solid #DDD;
@@ -127,7 +130,9 @@
 
 				@source.sourceName.map { name =>
 					<h2>
-						In @name @source.line.map { line =>
+						In @source.line.map { line =>
+						@* URL Scheme according to: http://manual.macromates.com/en/using_textmate_from_terminal.html#url_scheme_html *@
+						<a href="txmt://open/?url=@views.html.helper.urlEncode("file://"+name)&line=@line@source.position.map{pos=>&column=@pos}">@name</a>
 							at line @line.
 						}
 					</h2>


### PR DESCRIPTION
This change adds a textmate-style link to the devError page.

This allows the developer to just click onto the filename and the file gets opened in the editor (jumps automatically to the line and if available the column the error was detected).

I uploaded a screen which shows this feature: http://cl.ly/462U3W09281I1c1D173x

Whereas this URL style was defined by textmate: http://manual.macromates.com/en/using_textmate_from_terminal.html#url_scheme_html, many other editors support this URL scheme as well now:

Emacs:
http://railsexpress.de/blog/articles/2009/01/23/how-to-open-textmate-links-in-emacs-on-os-x/

Sublime Edit:
https://github.com/hiddenbek/subl-handler

Others:
https://github.com/dolzenko/windows_protocol_handlers
