### PR TITLE
Handle fully qualified type names of querystring route parameters having a default value

### DIFF
--- a/framework/src/play/src/main/scala/play/core/router/Router.scala
+++ b/framework/src/play/src/main/scala/play/core/router/Router.scala
@@ -445,7 +445,7 @@ object Router {
                                     queryParams.map { p =>
                                       ("(\"\"\" + implicitly[QueryStringBindable[" + p.typeName + "]].javascriptUnbind + \"\"\")" + """("""" + p.name + """", """ + localNames.get(p.name).getOrElse(p.name) + """)""") -> p
                                     }.map {
-                                      case (u, Parameter(name, typeName, None, Some(default))) => """(""" + localNames.get(name).getOrElse(name) + " == \"\"\" +  implicitly[JavascriptLitteral[" + typeName.replace(".", "_") + "]].to(" + default + ") + \"\"\" ? null : " + u + ")"
+                                      case (u, Parameter(name, typeName, None, Some(default))) => """(""" + localNames.get(name).getOrElse(name) + " == \"\"\" +  implicitly[JavascriptLitteral[" + typeName + "]].to(" + default + ") + \"\"\" ? null : " + u + ")"
                                       case (u, Parameter(name, typeName, None, None)) => u
                                     }.mkString(", "))
 


### PR DESCRIPTION
[#447](https://play.lighthouseapp.com/projects/82401/tickets/447-default-values-for-querystring-parameters-with-package-name)
