### PR TITLE
Fix Promise#filter

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Promise.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Promise.scala
@@ -125,13 +125,10 @@ class STMPromise[A] extends Promise[A] with Redeemable[A] {
 
   def filter(p: A => Boolean): Promise[A] = {
     val result = new STMPromise[A]()
-    onRedeem(a => if (p(a)) result.redeem(a))
-    result
-  }
-
-  def collect[B](p: PartialFunction[A, B]) = {
-    val result = new STMPromise[B]()
-    onRedeem(a => p.lift(a).foreach(result.redeem(_)))
+    this.addAction(_.value match {
+      case Redeemed(a) => if (p(a)) result.redeem(a) else result.redeem(throw new NoSuchElementException)
+      case Thrown(t) => result.redeem(throw t)
+    })
     result
   }
 

--- a/framework/src/play/src/test/scala/play/concurrent/PromiseSpec.scala
+++ b/framework/src/play/src/test/scala/play/concurrent/PromiseSpec.scala
@@ -1,0 +1,32 @@
+package play.concurrent
+
+import org.specs2.mutable.Specification
+import play.api.libs.concurrent._
+import org.specs2.execute.Result
+
+class PromiseSpec extends Specification {
+
+  "Promise" can {
+
+    "filter" in {
+
+      "Redeemed values" << {
+        val p = Promise.timeout(42, 100)
+        p.filter(_ == 42).value.get must equalTo (42)
+      }
+
+      "Redeemed values not matching the predicate" << {
+        val p = Promise.timeout(42, 100)
+        p.filter(_ != 42).value.get must throwA [NoSuchElementException]
+      }
+
+      "Thrown values" << {
+        val p = Promise.timeout(42, 100).map[Int]{ _ => throw new Exception("foo") }
+        p.filter(_ => true).value.get must throwAn [Exception](message = "foo")
+      }
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
[#459](https://play.lighthouseapp.com/projects/82401/tickets/459-play-server-does-not-respond-when-i-use-promisefilter)
- Fix `Promise#filter` so it never leads to an unredeemable promise ;
- Follow the [Scala standard `Future#filter`](http://www.scala-lang.org/archives/downloads/distrib/files/nightly/docs/library/index.html#scala.concurrent.Future) behavior when the predicate fails: throw a `NoSuchElementException` ;
- Remove `STMPromise#collect` which was wrong and anyway not expose at the `Promise` interface level.
