### PR TITLE
Routes parameters unboxing

### DIFF
--- a/framework/src/play/src/main/scala/play/core/router/Router.scala
+++ b/framework/src/play/src/main/scala/play/core/router/Router.scala
@@ -2,6 +2,7 @@ package play.core
 
 import play.api.mvc._
 import play.api.mvc.Results._
+import org.apache.commons.lang3.reflect.MethodUtils
 
 /**
  * provides Play's router implementation
@@ -1169,10 +1170,7 @@ object Router {
         new play.core.j.JavaAction {
           def invocation = call
           def controller = handler.getControllerClass
-          def method = controller.getMethod(handler.method, handler.parameterTypes.map {
-            case c if c == classOf[Long] => classOf[java.lang.Long]
-            case c => c
-          }: _*)
+          def method = MethodUtils.getMatchingAccessibleMethod(controller, handler.method, handler.parameterTypes: _*)
         }
       }
     }


### PR DESCRIPTION
Fixes [#282](https://play.lighthouseapp.com/projects/82401/tickets/282-unboxing-in-route-parameters-fails-silently)

The problem came from the fact that `Class#getMethod` doesn’t do unboxing, so a `NoSuchMethodException` was thrown when one wrote a route calling an action `foo(n: Long)` if this action was defined as `public static Result foo(long n)`.

I used `MethodUtils.getMatchingAccessibleMethod` to solve the problem.

See the following references for more information:
http://stackoverflow.com/questions/1894740/any-solution-for-class-getmethod-reflection-and-autoboxing
http://commons.apache.org/lang/api-3.1/org/apache/commons/lang3/reflect/MethodUtils.html#getMatchingAccessibleMethod(java.lang.Class,%20java.lang.String,%20java.lang.Class...)

I tested with long, int and doubles. Let me know if you think I should add a test to the pull request.
