### PR TITLE
Modified Java waitAll promise generics to work with promises of different sub types

### DIFF
--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -78,7 +78,7 @@ public class F {
          * @param promises The promises to combine
          * @return A single promise whose methods act on the list of redeemed promises
          */
-        public static <A> Promise<List<A>> waitAll(Promise<A>... promises){
+        public static <A> Promise<List<A>> waitAll(Promise<? extends A>... promises){
             return new Promise<List<A>>(play.core.j.JavaPromise.<A>sequence(java.util.Arrays.asList(promises)));
         }
         
@@ -109,9 +109,9 @@ public class F {
          * @param promises The promises to combine
          * @return A single promise whose methods act on the list of redeemed promises
          */
-        public static <A> Promise<List<A>> waitAll(Iterable<Promise<A>> promises){
-            ArrayList<Promise<A>> ps = new ArrayList<Promise<A>>();
-            for(Promise<A> p : promises){
+        public static <A> Promise<List<A>> waitAll(Iterable<Promise<? extends A>> promises){
+            ArrayList<Promise<? extends A>> ps = new ArrayList<Promise<? extends A>>();
+            for(Promise<? extends A> p : promises){
                 ps.add(p);
             }
             return new Promise<List<A>>(play.core.j.JavaPromise.<A>sequence(ps));
@@ -128,7 +128,7 @@ public class F {
 
         /**
          * Create a new promise throwing an exception.
-         * @param a Value to throw
+         * @param throwable Value to throw
          */
         public static <A> Promise<A> throwing(Throwable throwable) {
             return new Promise<A>(play.core.j.JavaPromise.<A>throwing(throwable));

--- a/framework/src/play/src/main/scala/play/core/j/JavaPromise.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaPromise.scala
@@ -7,7 +7,7 @@ import play.libs.F
 
 object JavaPromise {
 
-  def sequence[A](promises: JList[F.Promise[A]]): Promise[JList[A]] = {
+  def sequence[A](promises: JList[F.Promise[_ <: A]]): Promise[JList[A]] = {
     Promise.sequence(JavaConverters.asScalaBufferConverter(promises).asScala.map(_.getWrappedPromise))
       .map(az => JavaConverters.bufferAsJavaListConverter(az).asJava)
   }


### PR DESCRIPTION
This change makes waiting on multiple promises with a common super type possible, without the boiler plate of casting to a ungenerified type.  For example:

```
public interface Fruit {}
public class Apple implements Fruit {}
public class Orange implements Fruit {}
...
Promise<Apple> apple = ...;
Promise<Orange> orange = ...;
Promise<List<Fruit>> fruits = Promise.waitAll(apple, orange);
```

The above code would be a compiler error without the change in this pull request, with the change, it is a compiler warning, but because of the limitations of Java generics, the only way to achieve it without a compiler warning is to map each promise to be a promise of type Ingredient, which is overkill.
