### PR TITLE
Adding support for byte type on anorm

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/Anorm.scala
+++ b/framework/src/anorm/src/main/scala/anorm/Anorm.scala
@@ -88,6 +88,14 @@ package anorm
       }
     }
 
+    implicit def rowToByte: Column[Byte] = Column.nonNull { (value, meta) =>
+      val MetaDataItem(qualified, nullable, clazz) = meta
+      value match {
+        case byte: Byte => Right(byte)
+        case _ => Left(TypeDoesNotMatch("Cannot convert " + value + ":" + value.asInstanceOf[AnyRef].getClass + " to Byte for column " + qualified))
+      }
+    }
+
     implicit def rowToBoolean: Column[Boolean] = Column.nonNull { (value, meta) =>
       val MetaDataItem(qualified, nullable, clazz) = meta
       value match {


### PR DESCRIPTION
Just adding a rowToByte function so its possible to use byte type in anorm.  As discussed here:

http://groups.google.com/group/play-framework/browse_thread/thread/e036768731503572/1a9dda3e6114eb0a
