### PR TITLE
Configuration constructor to make working with Java Configuration object easier.

### DIFF
--- a/framework/src/play/src/main/java/play/Configuration.java
+++ b/framework/src/play/src/main/java/play/Configuration.java
@@ -1,6 +1,8 @@
 package play;
 
 import java.util.*;
+
+import com.typesafe.config.Config;
 import scala.collection.JavaConverters;
 
 import play.libs.Scala;
@@ -26,12 +28,19 @@ public class Configuration {
     private final play.api.Configuration conf;
 
     /**
+     * Creates a new configuration from a Typesafe Config object.
+     */
+    public Configuration(Config conf) {
+        this(new play.api.Configuration(conf));
+    }
+
+    /**
      * Creates a new configuration from a Scala-based configuration.
      */
     public Configuration(play.api.Configuration conf) {
         this.conf = conf;
     }
-    
+
     // --
 
     /**


### PR DESCRIPTION
I've had to create a Configuration object myself in a few places now.  E.g. in tests.  It's kind of a pain to do in Java today as you first have to make a typesafe config, then a scala configuration, then a Java configuration.  This helper constructor will make that a bit nicer.
