### PR TITLE
Support for changing the name of the FLASH-cookie

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -472,7 +472,7 @@ package play.api.mvc {
    */
   object Flash extends CookieBaker[Flash] {
 
-    val COOKIE_NAME = "PLAY_FLASH"
+    val COOKIE_NAME = Play.maybeApplication.flatMap(_.configuration.getString("flash.cookieName")).getOrElse("PLAY_FLASH")
     val emptyCookie = new Flash
 
     def deserialize(data: Map[String, String]) = new Flash(data)


### PR DESCRIPTION
Added support for changing the name of the FLASH-cookie as requested in ticket #416.
