### PR TITLE
Support for setting pid-file path using system property

### DIFF
--- a/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
@@ -150,7 +150,8 @@ object NettyServer {
 
     // Manage RUNNING_PID file
     java.lang.management.ManagementFactory.getRuntimeMXBean.getName.split('@').headOption.map { pid =>
-      val pidFile = new File(applicationPath, "RUNNING_PID")
+      val pidPath = Option(System.getProperty("pidfile.path")).getOrElse(applicationPath.getAbsolutePath())
+      val pidFile = new File(pidPath, "RUNNING_PID")
 
       if (pidFile.exists) {
         println("This application is already running (Or delete the RUNNING_PID file).")


### PR DESCRIPTION
Added support for setting the pid-file location. (Using a system propertie)

Do we want it this way or do we want a possibility to name the the file like:

-Dpidfile.path=/tmp

or

-Dpidfile=/tmp/mypid

I implemented the -Dpidfile.path=/tmp solution.

(This replaces the old pull request from my master-branch.)
