### PR TITLE
[#462] BatchSql natively accepts collections. Fix quadratic time issue.

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/Anorm.scala
+++ b/framework/src/anorm/src/main/scala/anorm/Anorm.scala
@@ -365,8 +365,10 @@ package anorm
 
   case class BatchSql(sql: SqlQuery, params: Seq[Seq[(String, ParameterValue[_])]]) {
 
+    def addBatch(args: (String, ParameterValue[_])*): BatchSql = this.copy(params = (this.params) :+ args)
     def addBatchList(paramsMapList: TraversableOnce[Seq[(String, ParameterValue[_])]]) : BatchSql = this.copy(params = (this.params) ++ paramsMapList)
 
+    def addBatchParams(args: ParameterValue[_]*): BatchSql = this.copy(params = (this.params) :+ sql.argsInitialOrder.zip(args))
     def addBatchParamsList(paramsSeqList: TraversableOnce[Seq[ParameterValue[_]]]): BatchSql = this.copy(params = (this.params) ++ paramsSeqList.map(paramsSeq => sql.argsInitialOrder.zip(paramsSeq)))
 
     def getFilledStatement(connection: java.sql.Connection, getGeneratedKeys: Boolean = false) = {


### PR DESCRIPTION
Ticket:
https://play.lighthouseapp.com/projects/82401-play-20/tickets/462-anorm-sql-batch-is-quadratic-complexity-and-counterintuitive

Branch:
https://github.com/tommycli/Play20/tree/lighthouse-462-patch
