### PR TITLE
Fix PathBindable#javascriptUnbind for some instances

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -580,17 +580,7 @@ object PathBindable {
   }
 
   /**
-   * Path binder for Option.
-   */
-  implicit def bindableOption[T: PathBindable] = new PathBindable[Option[T]] {
-    def bind(key: String, value: String) = {
-      implicitly[PathBindable[T]].bind(key, value).right.map(Some(_))
-    }
-    def unbind(key: String, value: Option[T]) = value.map(v => implicitly[PathBindable[T]].unbind(key, v)).getOrElse("")
-  }
-
-  /**
-   * Path binder for Java Option.
+   * Path binder for Java PathBindable
    */
   implicit def javaPathBindable[T <: play.mvc.PathBindable[T]](implicit m: Manifest[T]) = new PathBindable[T] {
     def bind(key: String, value: String) = {


### PR DESCRIPTION
This commit fixes the javascript reverse router so it can now be used with routes taking `Option`, `Boolean` or `List` parameters.

Provided the following routes definitions:

```
GET  /foo    controllers.App.list(x: List[Int])
GET  /bar    controllers.App.bool(b: Boolean)
GET  /baz    controllers.App.option(x: Option[Boolean])
```

The javascript reverse router now allows to write the following code:

``` javascript
routes.controllers.App.list([1, 2, 3]).url; // '/foo?x=1&x=2&x=3'
routes.controllers.App.bool(true).url; // '/bar?b=1'
```

Binders can be composed so the following works as expected:

``` javascript
routes.controllers.App.option(null).url; // '/baz'
routes.controllers.App.option().url; // '/baz'
routes.controllers.App.option(false).url; // '/baz?x=0'
routes.controllers.App.option(true).url; // '/baz?x=1'
```

BTW I removed again `PathBindable[Option]` instances which have been accidentally re-inserted by merging a pull request.
