### PR TITLE
Fix for #472

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -84,7 +84,7 @@ trait QueryStringBindable[A] {
   /**
    * Javascript function to unbind in the Javascript router.
    */
-  def javascriptUnbind: String = """function(k,v) {return k+'='+v}"""
+  def javascriptUnbind: String = """function(k,v) {return encodeURIComponent(k)+'='+encodeURIComponent(v)}"""
 
 }
 


### PR DESCRIPTION
Fix for: https://play.lighthouseapp.com/projects/82401/tickets/472-url-encoding-for-javascript-routing-brokennon-existent#ticket-472-1
Discussion is here: https://github.com/playframework/Play20/pull/318 - new branch because of squashing fails :(
