### PR TITLE
Fix default parameters support of javascript reverse router

### DIFF
--- a/framework/src/play/src/main/scala/play/core/router/Router.scala
+++ b/framework/src/play/src/main/scala/play/core/router/Router.scala
@@ -446,7 +446,7 @@ object Router {
                                     queryParams.map { p =>
                                       ("(\"\"\" + implicitly[QueryStringBindable[" + p.typeName + "]].javascriptUnbind + \"\"\")" + """("""" + p.name + """", """ + localNames.get(p.name).getOrElse(p.name) + """)""") -> p
                                     }.map {
-                                      case (u, Parameter(name, typeName, None, Some(default))) => """(""" + localNames.get(name).getOrElse(name) + " == \"\"\" +  implicitly[JavascriptLitteral[" + typeName + "]].to(" + default + ") + \"\"\" ? null : " + u + ")"
+                                      case (u, Parameter(name, typeName, None, Some(default))) => """(""" + localNames.get(name).getOrElse(name) + " == null ? \"\"\" +  implicitly[JavascriptLitteral[" + typeName + "]].to(" + default + ") + \"\"\" : " + u + ")"
                                       case (u, Parameter(name, typeName, None, None)) => u
                                     }.mkString(", "))
 


### PR DESCRIPTION
Provided the following route:

```
GET  /foo    controllers.App.foo(bar ?= "baz")
```

This patch fix the behavior of the generated javascript reverse router so one can write the following:

``` javascript
routes.controllers.App.foo().url;      // '/foo?bar=baz'
routes.controllers.App.foo(null).url;  // '/foo?bar=baz'
routes.controllers.App.foo('bah').url; // '/foo?bar=bah'
```
