### PR TITLE
Lighthouse 453: Fix play startup script to allow for complex multi-project builds

### DIFF
--- a/play
+++ b/play
@@ -13,7 +13,7 @@ else
     JAVA=$JAVA_HOME/bin/java
 fi
 
-if [ -f conf/application.conf -o -f conf/reference.conf ]; then
+if [ -f project/Build.scala ]; then
   if test "$1" = "clean-all"; then
     rm -rf target
     rm -rf tmp

--- a/play.bat
+++ b/play.bat
@@ -9,8 +9,7 @@ set fp=file:///!p: =%%20!
 set buildScript="%~dp0framework\build.bat"
 set additionalArgs=%*
 
-if exist "conf\application.conf" goto existingApplication
-if exist "conf\reference.conf" goto existingApplication
+if exist "project\Build.scala" goto existingApplication
 
 :noApplication
 java -Dsbt.ivy.home="%~dp0repository" -Dplay.home="%~dp0framework" -Dsbt.boot.properties="%fp%framework/sbt/play.boot.properties" -jar "%~dp0framework\sbt\sbt-launch.jar" %*


### PR DESCRIPTION
Today it is totally impossible to have a sub-project that is shared by two Play projects.  This change will fix that.  See the bug report for more details and an example project which is broken without this fix and works with it.  https://play.lighthouseapp.com/projects/82401-play-20/tickets/453-need-to-be-able-to-share-a-sub-project-with-two-play-projects#ticket-453-9
