### PR TITLE
ETag's should be a quoted-string

### DIFF
--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -147,7 +147,7 @@ object Assets extends Controller {
 
   private def etagFor(resource: java.net.URL)(implicit dateFormatter: SimpleDateFormat): Option[String] = {
     etags.get(resource.toExternalForm).filter(_ => Play.isProd).orElse {
-      val maybeEtag = lastModifiedFor(resource).map(_ + " -> " + resource.toExternalForm).map(Codecs.sha1)
+      val maybeEtag = lastModifiedFor(resource).map(_ + " -> " + resource.toExternalForm).map(Codecs.sha1).map("\""+_+"\"")
       maybeEtag.foreach(etags.put(resource.toExternalForm, _))
       maybeEtag
     }


### PR DESCRIPTION
The ETag http header should be a quoted string, for example;

Etag: 8408afbdccb80c2b8a8b340b5fa6ca442a5cdfd2

=>

Etag: "8408afbdccb80c2b8a8b340b5fa6ca442a5cdfd2"

Relevant RFC;
http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.19
http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.11
http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.2
