### PR TITLE
Fixed Form#withError.

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -221,7 +221,7 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
    * @param error Error to add
    * @returns a copy of this form with the added error
    */
-  def withError(error: FormError): Form[T] = this.copy(errors = errors :+ error)
+  def withError(error: FormError): Form[T] = this.copy(errors = errors :+ error, value = None)
 
   /**
    * Convenient overloaded method adding an error to this form


### PR DESCRIPTION
If the value of Form[T] is Some[T], the form is viewed as with no error and Form#fold doesn't work as expected.
Form value should be None when the form is with error.
