### PR TITLE
Fix Guava compatibility issues

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -234,10 +234,10 @@ object PlayBuild extends Build {
               .exclude("org.jboss.netty", "netty")
             ,
             
-            "oauth.signpost"                    %    "signpost-core"            %   "1.2.1.1",
-            "com.codahale"                      %   "jerkson_2.9.1"                  %   "0.5.0",
+            "oauth.signpost"                    %   "signpost-core"             %   "1.2.1.1",
+            "com.codahale"                      %   "jerkson_2.9.1"             %   "0.5.0",
             
-            ("org.reflections"                  %    "reflections"              %   "0.9.6" notTransitive())
+            ("org.reflections"                  %    "reflections"              %   "0.9.7" notTransitive())
               .exclude("com.google.guava", "guava")
               .exclude("javassist", "javassist")
             ,


### PR DESCRIPTION
We are currently unable to use Google Guava 11 or Guava 12 because of an issue with reflections 0.9.6.  This is very frustrating since other libraries often pull in Guava.
