### PR TITLE
OpenID: fix typo (change openid.claimedId -> openid.claimed_id)

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/openid/OpenID.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/openid/OpenID.scala
@@ -22,7 +22,7 @@ object UserInfo {
 
   def apply(queryString: Map[String, Seq[String]]): UserInfo = {
     val axAttribute = new Regex("^openid[.].+[.]value[.]([^.]+)([.]\\d+)?$")
-    val id = queryString.get("openid.claimedId").flatMap(_.headOption)
+    val id = queryString.get("openid.claimed_id").flatMap(_.headOption)
       .orElse(queryString.get("openid.identity").flatMap(_.headOption))
       .getOrElse(throw Errors.BAD_RESPONSE)
     val attributes = queryString.toSeq.map(pair => (axAttribute.findFirstMatchIn(pair._1).map(_.group(1)), pair._2.headOption))
@@ -73,7 +73,7 @@ object OpenID {
 
   private def verifiedId(queryString: Map[String, Seq[String]]): Promise[UserInfo] = {
     (queryString.get("openid.mode").flatMap(_.headOption),
-      queryString.get("openid.claimedId").flatMap(_.headOption).orElse(queryString.get("openid.identity").flatMap(_.headOption)),
+      queryString.get("openid.claimed_id").flatMap(_.headOption).orElse(queryString.get("openid.identity").flatMap(_.headOption)),
       queryString.get("openid.op_endpoint").flatMap(_.headOption)) match {
         case (Some("id_res"), Some(id), endPoint) => {
           val server: Promise[String] = endPoint.map(PurePromise(_)).getOrElse(discoverServer(id).map(_.url))

--- a/framework/src/play/src/test/scala/play/api/libs/OpenIDSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/OpenIDSpec.scala
@@ -1,0 +1,42 @@
+package play.api.libs
+
+import openid.UserInfo
+import org.specs2.mutable.Specification
+import scala.Predef._
+
+object OpenIDSpec extends Specification {
+
+  val claimedId = "http://example.com/openid?id=C123"
+  val identity = "http://example.com/openid?id=C123&id"
+
+  "UserInfo" should {
+    "successfully be created for the default response using the value of the openid.claimed_id field" in {
+      val userInfo = UserInfo(createDefaultResponse)
+      userInfo.id must be equalTo claimedId
+      userInfo.attributes must beEmpty
+    }
+    "successfully be created for the default response using the value of the openid.identity field" in {
+      // For testing the claimed_id is removed to check that id contains the identity value.
+      val userInfo = UserInfo(createDefaultResponse - "openid.claimed_id")
+      userInfo.id must be equalTo identity
+      userInfo.attributes must beEmpty
+    }
+  }
+
+  // See 10.1 - Positive Assertions
+  // http://openid.net/specs/openid-authentication-2_0.html#positive_assertions
+  private def createDefaultResponse: Map[String, Seq[String]] = Map(
+    "openid.ns" -> "http://specs.openid.net/auth/2.0",
+    "openid.mode" -> "id_res",
+    "openid.op_endpoint" -> "https://www.google.com/a/example.com/o8/ud?be=o8",
+    "openid.claimed_id" -> claimedId,
+    "openid.identity" -> identity,
+    "openid.return_to" -> "https://example.com/openid?abc=false",
+    "openid.response_nonce" -> "2012-05-25T06:47:55ZEJvRv76xQcWbTG",
+    "openid.assoc_handle" -> "AMlYA9VC8_UIj4-y4K_X2E_mdv-123-ABC",
+    "openid.signed" -> "op_endpoint,claimed_id,identity,return_to,response_nonce,assoc_handle",
+    "openid.sig" -> "MWRsJZ/9AOMQt9gH6zTZIfIjk6g="
+  )
+
+  private implicit def stringToSeq(s: String): Seq[String] = Seq(s)
+}


### PR DESCRIPTION
Fixed typo in the UserInfo#apply method, added basic spec for the UserInfo creation.
