### PR TITLE
Cache Bug when getting typed data (with autoboxing types for ex)

### DIFF
--- a/framework/src/play/src/main/scala/play/api/cache/Cache.scala
+++ b/framework/src/play/src/main/scala/play/api/cache/Cache.scala
@@ -3,6 +3,7 @@ package play.api.cache
 import play.api._
 
 import reflect.ClassManifest
+import org.apache.commons.lang3.reflect.TypeUtils
 /**
  * API for a Cache plugin.
  */
@@ -87,12 +88,7 @@ object Cache {
    */
   def getAs[T](key: String)(implicit app: Application, m: ClassManifest[T]): Option[T] = {
     get(key)(app).map { item =>
-      try {
-        //if (m.erasure.isAssignableFrom(item.getClass)) Some(item.asInstanceOf[T]) else None
-        Some(item.asInstanceOf[T])
-      }catch{
-        case e:ClassCastException => None
-      }
+      if (TypeUtils.isInstance(item, m.erasure)) Some(item.asInstanceOf[T]) else None
     }.getOrElse(None)
   }
 


### PR DESCRIPTION
Correct following Cache type bug:
Cache.set("long", 12345L)
Cache.getAs[Long]("long") == None

Uses org.apache.commons.lang3 to go around parameterized types limitation due to erasure (Option[T]).
