### PR TITLE
 added optional creation of Lang obect is one if correct.

### DIFF
--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -52,7 +52,7 @@ object Lang {
    *  throw exception if language is unrecognized
    */
   def apply(code: String): Lang = {
-    option(code).getOrElse(
+    get(code).getOrElse(
                    sys.error("Unrecognized language: %s".format(code))
     )
   }
@@ -61,7 +61,7 @@ object Lang {
    * Create a Lang value from a code (such as fr or en-US) or none
    * if language is unrecognized.
    */
-  def option(code: String): Option[Lang] = {
+  def get(code: String): Option[Lang] = {
     code match {
       case SimpleLocale(language) => Some(Lang(language, ""))
       case CountryLocale(language, country) => Some(Lang(language, country))


### PR DESCRIPTION
It would be good to have in API  ability to create language from string only if string can represent correct language.  This is needed when you want to have explicit localization be available (for example when language is set as part or url).   So, I added `optional` method to Lang object, with typical usage:

```
Lang.optional(slang).getOrElse(Lang.prefferedLanguage) 
```
