### PR TITLE
[#1542] Quote shell variables JAVA and JAVA_HOME to deal with spaces

### DIFF
--- a/play
+++ b/play
@@ -7,10 +7,10 @@ done
 
 dir=`dirname $PRG`
 
-if [ -z $JAVA_HOME ]; then
+if [ -z "$JAVA_HOME" ]; then
     JAVA="java"
 else
-    JAVA=$JAVA_HOME/bin/java
+    JAVA="$JAVA_HOME/bin/java"
 fi
 
 if [ -f conf/application.conf -o -f conf/reference.conf ] || [ -d project ]; then
@@ -61,5 +61,5 @@ if [ -f conf/application.conf -o -f conf/reference.conf ] || [ -d project ]; the
   fi
   
 else
-  $JAVA -Dsbt.ivy.home=$dir/repository -Dplay.home=$dir/framework -Dsbt.boot.properties=$dir/framework/sbt/play.boot.properties -jar $dir/framework/sbt/sbt-launch.jar "$@"
+  "$JAVA" -Dsbt.ivy.home=$dir/repository -Dplay.home=$dir/framework -Dsbt.boot.properties=$dir/framework/sbt/play.boot.properties -jar $dir/framework/sbt/sbt-launch.jar "$@"
 fi


### PR DESCRIPTION
Quote some shell variables to deal with spaces in the location of JAVA_HOME.
This is probably most likely on OSX using a developer preview of JDK 1.7.

This doesn't deal with other possibilities of spaces in the path (e.g. spaces in the path to the play code).
