### PR TITLE
Handle runtime errors of async results

### DIFF
--- a/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -92,8 +92,10 @@ private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: De
               case AsyncResult(p) => p.extend1 {
                 case Redeemed(v) => handle(v)
                 case Thrown(e) => {
-                  Logger("play").error("Waiting for a promise, but got an error: " + e.getMessage, e)
-                  handle(Results.InternalServerError)
+                  server.applicationProvider.get match {
+                    case Right(app) => handle(app.handleError(requestHeader, e))
+                    case Left(_) => handle(Results.InternalServerError)
+                  }
                 }
               }
 

--- a/framework/src/play/src/main/scala/play/core/system/Invoker.scala
+++ b/framework/src/play/src/main/scala/play/core/system/Invoker.scala
@@ -114,45 +114,11 @@ class ActionInvoker extends Actor {
     case Invoker.HandleAction(request, response: Response, action, app: Application) => {
 
       val result = try {
-        try {
-          Threads.withContextClassLoader(app.classloader) {
-            action(request)
-          }
-        } catch {
-          case e: PlayException.UsefulException => throw e
-          case e: Throwable => {
-
-            val source = app.sources.flatMap(_.sourceFor(e))
-
-            throw new PlayException(
-              "Execution exception",
-              "[%s: %s]".format(e.getClass.getSimpleName, e.getMessage),
-              Some(e)) with PlayException.ExceptionSource {
-              def line = source.map(_._2)
-              def position = None
-              def input = source.map(_._1).map(scalax.file.Path(_))
-              def sourceName = source.map(_._1.getAbsolutePath)
-            }
-
-          }
+        Threads.withContextClassLoader(app.classloader) {
+          action(request)
         }
       } catch {
-        case e => try {
-
-          Logger.error(
-            """
-            |
-            |! %sInternal server error, for request [%s] ->
-            |""".stripMargin.format(e match {
-              case p: PlayException => "@" + p.id + " - "
-              case _ => ""
-            }, request),
-            e)
-
-          app.global.onError(request, e)
-        } catch {
-          case e => DefaultGlobal.onError(request, e)
-        }
+        case e => app.handleError(request, e)
       }
 
       response.handle {

--- a/framework/test/integrationtest/app/Global.scala
+++ b/framework/test/integrationtest/app/Global.scala
@@ -1,0 +1,11 @@
+
+import play.api.GlobalSettings
+import play.api.mvc.{RequestHeader, Result}
+import play.api.mvc.Results.InternalServerError
+import play.api.Logger
+
+object Global extends GlobalSettings {
+  override def onError(r: RequestHeader, e: Throwable): Result = {
+    InternalServerError("Something went wrong.")
+  }
+}

--- a/framework/test/integrationtest/app/controllers/Application.scala
+++ b/framework/test/integrationtest/app/controllers/Application.scala
@@ -8,6 +8,7 @@ import play.api.cache.Cache
 import play.api.libs.json._
 import play.api.libs.json.Json._
 import play.api.libs.Jsonp
+import play.api.libs.concurrent.Promise
 
 import models._
 import models.Protocol._
@@ -116,5 +117,16 @@ object Application extends Controller {
     import java.io.File
     val file = new File(filepath)
     Ok.sendFile(file, onClose = () => { file.delete() })
+  }
+
+  def syncError = Action {
+    sys.error("Error")
+    Ok
+  }
+
+  def asyncError = Action {
+    Async {
+      Promise.pure[Result](sys.error("Error"))
+    }
   }
 }

--- a/framework/test/integrationtest/conf/routes
+++ b/framework/test/integrationtest/conf/routes
@@ -44,6 +44,9 @@ GET     /accept-java            controllers.JavaApi.accept()
 
 GET     /onCloseSendFile/*fp    controllers.Application.onCloseSendFile(fp)
 
+GET     /sync-error             controllers.Application.syncError()
+GET     /async-error            controllers.Application.asyncError()
+
 # Map static resources from the /public folder to the /public path
 GET     /public/*file           controllers.Assets.at(path="/public", file)
 

--- a/framework/test/integrationtest/test/FunctionalSpec.scala
+++ b/framework/test/integrationtest/test/FunctionalSpec.scala
@@ -148,6 +148,21 @@ class FunctionalSpec extends Specification {
       }
     }
 
+    "Provide a hook to handle errors" in {
+      "Synchronous results" in {
+        running(TestServer(9000), HTMLUNIT) { browser =>
+          browser.goTo("http://localhost:9000/sync-error")
+          browser.pageSource must equalTo ("Something went wrong.")
+        }
+      }
+      "Asynchronous results" in {
+        running(TestServer(9000), HTMLUNIT) { browser =>
+          browser.goTo("http://localhost:9000/async-error")
+          browser.pageSource must equalTo ("Something went wrong.")
+        }
+      }
+    }
+
   }
   
 }


### PR DESCRIPTION
Fixes [#496](https://play.lighthouseapp.com/projects/82401/tickets/496-201-scala-globalonerror-isnt-called-when-an-exception-occurs-in-an-akkafuture): runtime errors occuring in an async result are hooked to the `Global.onError` handler.

Notes:
- I think it should be fixed in a better way: async results and sync results should be unified (sync results could be lifted to an async result, for example) at some point earlier so we would **not** have to handle the errors at two different places in the code (`PlayDefaultUpstreamHandler` for async results and `Invoker` for sync results) ;
- I was unable to write tests running in a fake application (runtime exceptions of sync results are not caught by the fake application, and runtime exception of async results gave me the following error: “RuntimeException: Cannot extract the body content from a result of type play.api.mvc.AsyncResult”).
