### PR TITLE
Allow for overriding default Ebean startup config

### DIFF
--- a/framework/src/play/src/main/java/play/Application.java
+++ b/framework/src/play/src/main/java/play/Application.java
@@ -87,6 +87,23 @@ public class Application {
     }
     
     /**
+     * Scans the application classloader to retrieve all types within a specific package.
+     * <p>
+     * This method is useful for some plug-ins, for example the EBean plugin will automatically detect all types
+     * within the models package.
+     * <p>
+     * Note that it is better to specify a very specific package to avoid expensive searches.
+     *
+     * @param packageName the root package to scan
+     * @return a set of types names satisfying the condition
+     */
+    public Set<String> getTypes(String packageName) {
+        return scala.collection.JavaConverters.setAsJavaSetConverter(
+            application.getTypes(packageName)
+        ).asJava();
+    }
+    
+    /**
      * Scans the application classloader to retrieve all types annotated with a specific annotation.
      * <p>
      * This method is useful for some plug-ins, for example the EBean plugin will automatically detect all types

--- a/framework/src/play/src/main/java/play/Configuration.java
+++ b/framework/src/play/src/main/java/play/Configuration.java
@@ -257,6 +257,15 @@ public class Configuration {
     }
     
     /**
+     * Retrieves the set of direct sub-keys available in this configuration.
+     *
+     * @return the set of direct sub-keys available in this configuration
+     */
+    public Set<String> subKeys() {
+        return JavaConverters.setAsJavaSetConverter(conf.subKeys()).asJava();
+    }
+    
+    /**
      * Creates a configuration error for a specific congiguration key.
      *
      * @param key the configuration key, related to this error

--- a/framework/src/play/src/main/java/play/db/ebean/EbeanPlugin.java
+++ b/framework/src/play/src/main/java/play/db/ebean/EbeanPlugin.java
@@ -40,6 +40,7 @@ public class EbeanPlugin extends Plugin {
                 
                 ServerConfig config = new ServerConfig();
                 config.setName(key);
+                config.loadFromProperties();
                 try {
                     config.setDataSource(new WrappingDatasource(DB.getDataSource(key)));
                 } catch(Exception e) {
@@ -58,8 +59,7 @@ public class EbeanPlugin extends Plugin {
                 for(String load: toLoad) {
                     load = load.trim();
                     if(load.endsWith(".*")) {
-                        classes.addAll(application.getTypesAnnotatedWith(load.substring(0, load.length()-2), javax.persistence.Entity.class));
-                        classes.addAll(application.getTypesAnnotatedWith(load.substring(0, load.length()-2), javax.persistence.Embeddable.class));
+                        classes.addAll(application.getTypes(load.substring(0, load.length()-2)));
                     } else {
                         classes.add(load);
                     }

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -300,6 +300,29 @@ class Application(val path: File, val classloader: ClassLoader, val sources: Opt
   def getExistingFile(relativePath: String): Option[File] = Option(getFile(relativePath)).filter(_.exists)
 
   /**
+   * Scans the application classloader to retrieve all types within a specific package.
+   *
+   * This method is useful for some plugins, for example the EBean plugin will automatically detect all types
+   * within the models package, using:
+   * {{{
+   * val entities = application.getTypes("models")
+   * }}}
+   *
+   * Note that it is better to specify a very specific package to avoid expensive searches.
+   *
+   * @param packageName the root package to scan
+   * @return a set of types names specifying the condition
+   */
+  def getTypes(packageName: String): Set[String] = {
+    import org.reflections._
+    new Reflections(
+      new util.ConfigurationBuilder()
+        .addUrls(util.ClasspathHelper.forPackage(packageName, classloader))
+        .filterInputsBy(new util.FilterBuilder().include(util.FilterBuilder.prefix(packageName + ".")))
+        .setScanners(new scanners.TypesScanner())).getStore.get(classOf[scanners.TypesScanner]).keySet.asScala.toSet
+  }
+
+  /**
    * Scans the application classloader to retrieve all types annotated with a specific annotation.
    *
    * This method is useful for some plugins, for example the EBean plugin will automatically detect all types


### PR DESCRIPTION
There are occasions when overriding the default Ebean ServerConfig is absolutely essential.

This patch provides for 2 solutions to this problem.

1) Provides for a static `ebean.properties` file in your conf directory.
2) Provides a hook for programmatically overriding the Ebean `ServerConfig` instance at startup (available since the recently upgraded Ebean 2.7.5, which includes the new `ServerConfigStartup` interface)

Please refer to [Lighthouse ticket 156](https://play.lighthouseapp.com/projects/82401-play-20/tickets/156) for further information
