### PR TITLE
Generalize authentication wrapper code

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -292,23 +292,23 @@ public class Http {
          */
         public abstract RequestBody body();
 
-        // -- username
+        // -- user
 
-        private String username = null;
+        private Object user = null;
         
         /**
-         * The user name for this request, if defined.
+         * The user for this request, if defined.
          * This is usually set by annotating your Action with <code>@Authenticated</code>.
          */
-        public String username() {
-            return username;
+        public Object user() {
+            return user;
         }
         
         /**
-         * Defines the user name for this request.
+         * Defines the user for this request.
          */
-        public void setUsername(String username) {
-            this.username = username;
+        public void setUser(Object user) {
+            this.user = user;
         }
         
     }

--- a/framework/src/play/src/main/java/play/mvc/Security.java
+++ b/framework/src/play/src/main/java/play/mvc/Security.java
@@ -23,22 +23,22 @@ public class Security {
      * Wraps another action, allowing only authenticated HTTP requests.
      * <p>
      * The user name is retrieved from the session cookie, and added to the HTTP request's
-     * <code>username</code> attribute.
+     * <code>user</code> attribute.
      */
     public static class AuthenticatedAction extends Action<Authenticated> {
         
         public Result call(Context ctx) {
             try {
                 Authenticator authenticator = configuration.value().newInstance();
-                String username = authenticator.getUsername(ctx);
-                if(username == null) {
+                Object user = authenticator.getUser(ctx);
+                if(user == null) {
                     return authenticator.onUnauthorized(ctx);
                 } else {
                     try {
-                        ctx.request().setUsername(username);
+                        ctx.request().setUser(user);
                         return delegate.call(ctx);
                     } finally {
-                        ctx.request().setUsername(null);
+                        ctx.request().setUser(null);
                     }
                 }
             } catch(RuntimeException e) {
@@ -56,11 +56,11 @@ public class Security {
     public static class Authenticator extends Results {
         
         /**
-         * Retrieves the username from the HTTP context; the default is to read from the session cookie.
+         * Retrieves the user from the HTTP context; the default is to retrieve the username read from the session cookie.
          *
          * @return null if the user is not authenticated.
          */
-        public String getUsername(Context ctx) {
+        public String getUser(Context ctx) {
             return ctx.session().get("username");
         }
         

--- a/framework/src/play/src/main/scala/play/api/mvc/Security.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Security.scala
@@ -12,36 +12,37 @@ object Security {
 
   /**
    * Wraps another action, allowing only authenticated HTTP requests.
-   * Furthermore, it lets users to configure where to retrieve the username from
+   * Furthermore, it lets users to configure where to retrieve the user from
    * and what to do in case unsuccessful authentication
    *
    * For example:
    * {{{
    *  //in a Security trait
-   *  def username(request: RequestHeader) = request.session.get("email")
+   *  def user(request: RequestHeader) = request.session.get("email")
    *  def onUnauthorized(request: RequestHeader) = Results.Redirect(routes.Application.login)
    *  def isAuthenticated(f: => String => Request[AnyContent] => Result) = {
-   *    Authenticated(username, onUnauthorized) { user =>
+   *    Authenticated(user, onUnauthorized) { user =>
    *      Action(request => f(user)(request))
    *    }
    *  }
    * //then in a controller
-   * def index = isAuthenticated { username => implicit request =>
-   *     Ok("Hello " + username)
+   * def index = isAuthenticated { user => implicit request =>
+   *     Ok("Hello " + user)
    * }
    * }}}
    *
    * @tparam A the type of the request body
-   * @param username function used to retrieve the user name from the request header - the default is to read from session cookie
+   * @tparam B the type of the user
+   * @param user function used to retrieve the user from the request header - the default is to read from session cookie
    * @param onUnauthorized function used to generate alternative result if the user is not authenticated - the default is a simple 401 page
    * @param action the action to wrap
    */
-  def Authenticated[A](
-    username: RequestHeader => Option[String],
-    onUnauthorized: RequestHeader => Result)(action: String => Action[A]): Action[(Action[A], A)] = {
+  def Authenticated[A, B](
+    user: RequestHeader => Option[B],
+    onUnauthorized: RequestHeader => Result)(action: B => Action[A]): Action[(Action[A], A)] = {
 
     val authenticatedBodyParser = BodyParser { request =>
-      username(request).map { user =>
+      user(request).map { user =>
         val innerAction = action(user)
         innerAction.parser(request).mapDone { body =>
           body.right.map(innerBody => (innerAction, innerBody))


### PR DESCRIPTION
Current authentication wrapper code associates authentication to a username.
That is not very flexible, as one may need to retrieve from the authenticated
user more information than only his name.
This commit generalizes the code by associating authentication to a user instead
of a username.
