### PR TITLE
Fix problem where Guava was not allowing ClassLoaders to be garbage collected (See Guava issue 92)

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -186,7 +186,8 @@ object PlayBuild extends Build {
             "com.typesafe.akka"                 %    "akka-actor"               %   "2.0.2",
             "com.typesafe.akka"                 %    "akka-slf4j"               %   "2.0.2",
             
-            ("com.google.guava"                 %    "guava"                    %   "10.0.1" notTransitive())
+            ("com.google.guava"                 %    "guava"                    %   "12.0" notTransitive())
+              // Note: this exclusion will no longer be needed with Guava 13
               .exclude("com.google.code.findbugs", "jsr305")
             ,
             


### PR DESCRIPTION
./runtests shows all tests pass.  I've been using guava 12 with my own project for the past few weeks with no issues
