### PR TITLE
Allow JS routes ajax call to accept no parameters

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Routes.scala
+++ b/framework/src/play/src/main/scala/play/api/Routes.scala
@@ -43,7 +43,7 @@ package play.api {
              |})(%s)
           """.stripMargin.format(
         name,
-        ajaxMethod.map("ajax:function(c){c.url=r.url;c.type=r.method;return " + _ + "(c)},").getOrElse(""),
+        ajaxMethod.map("ajax:function(c){c=c||{};c.url=r.url;c.type=r.method;return " + _ + "(c)},").getOrElse(""),
         host,
         host,
         routes.map { route =>


### PR DESCRIPTION
Fixes https://play.lighthouseapp.com/projects/82401-play-20/tickets/542-js-routes-ajax-call-fails-if-no-parameters-are-provided
