### PR TITLE
Set compatibility with Javascript < 1.6 for javascriptUnbindList

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -410,7 +410,7 @@ object QueryStringBindable {
     }).mkString("&")
   }
 
-  private def javascriptUnbindList(jsUnbindT: String) = "function(k,vs){return vs.map(function(v){return (" + jsUnbindT + ")(k, v)}).join('&')}"
+  private def javascriptUnbindList(jsUnbindT: String) = "function(k,vs){var l=vs&&vs.length,r=[],i=0;for(;i<l;i++){r[i]=(" + jsUnbindT + ")(k,vs[i])}return r.join('&')}"
 
   /**
    * QueryString binder for QueryStringBindable.


### PR DESCRIPTION
- Compatibility for browsers not supporting JavaScript 1.6 (Internet Explorer < 9) ;
- Don’t crash if the route is called with no argument or `null`.

Examples:

``` javascript
routes.controllers.Application.takeList().url;          // '/take-list'
routes.controllers.Application.takeList([]).url;        // '/take-list'
routes.controllers.Application.takeList([1, 2, 3]).url; // '/take-list?x=1&x=2&x=3'
```
