### PR TITLE
Path and query string bindables for java.util.UUID.

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -5,6 +5,7 @@ import scala.annotation._
 import play.api.mvc._
 
 import java.net.{ URLEncoder, URLDecoder }
+import java.util.UUID
 import scala.annotation._
 
 import scala.collection.JavaConverters._
@@ -342,6 +343,13 @@ object QueryStringBindable {
     bindableBoolean.transform(b => b, b => b)
 
   /**
+   * Path binder for java.util.UUID.
+   */
+  implicit object bindableUUID extends Parsing[UUID](
+    UUID.fromString(_), _.toString, (key: String, e: Exception) => "Cannot parse parameter %s as UUID: %s".format(key, e.getMessage)
+  )
+
+  /**
    * QueryString binder for Option.
    */
   implicit def bindableOption[T: QueryStringBindable] = new QueryStringBindable[Option[T]] {
@@ -531,6 +539,13 @@ object PathBindable {
    */
   implicit def bindableJavaBoolean: PathBindable[java.lang.Boolean] = 
     bindableBoolean.transform(b => b, b => b)
+
+  /**
+   * Path binder for java.util.UUID.
+   */
+  implicit object bindableUUID extends Parsing[UUID](
+    UUID.fromString(_), _.toString, (key: String, e: Exception) => "Cannot parse parameter %s as UUID: %s".format(key, e.getMessage)
+  )
 
   /**
    * Path binder for Java PathBindable

--- a/framework/src/play/src/test/scala/play/mvc/BindersSpec.scala
+++ b/framework/src/play/src/test/scala/play/mvc/BindersSpec.scala
@@ -1,0 +1,37 @@
+package play.api.mvc
+
+import java.util.UUID
+import org.specs2.mutable._
+
+object BindersSpec extends Specification {
+
+  val uuid = UUID.randomUUID
+
+  "UUID path binder" should {
+    val subject = implicitly[PathBindable[UUID]]
+
+    "Unbind UUID as string" in {
+      subject.unbind("key", uuid) must be_==(uuid.toString)
+    }
+    "Bind parameter to UUID" in {
+      subject.bind("key", uuid.toString) must be_==(Right(uuid))
+    }
+    "Fail on unparseable UUID" in {
+      subject.bind("key", "bad-uuid") must be_==(Left("Cannot parse parameter key as UUID: Invalid UUID string: bad-uuid"))
+    }
+  }
+
+  "UUID query string binder" should {
+    val subject = implicitly[QueryStringBindable[UUID]]
+
+    "Unbind UUID as string" in {
+      subject.unbind("key", uuid) must be_==("key=" + uuid.toString)
+    }
+    "Bind parameter to UUID" in {
+      subject.bind("key", Map("key" -> Seq(uuid.toString))) must be_==(Some(Right(uuid)))
+    }
+    "Fail on unparseable UUID" in {
+      subject.bind("key", Map("key" -> Seq("bad-uuid"))) must be_==(Some(Left("Cannot parse parameter key as UUID: Invalid UUID string: bad-uuid")))
+    }
+  }
+}


### PR DESCRIPTION
These allow UUID parameters to be used in controller actions.
