### PR TITLE
Use version of Signpost with better error handling

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -234,9 +234,9 @@ object PlayBuild extends Build {
               .exclude("org.jboss.netty", "netty")
             ,
             
-            "oauth.signpost"                    %    "signpost-core"            %   "1.2.1.1",
-            "oauth.signpost"                    %    "signpost-commonshttp4"    %   "1.2.1.1",
-            "com.codahale"                      %   "jerkson_2.9.1"             %   "0.5.0",
+            "oauth.signpost"                    %    "signpost-core"            %   "1.2.1.2",
+            "oauth.signpost"                    %    "signpost-commonshttp4"    %   "1.2.1.2",
+            "com.codahale"                      %%   "jerkson"                  %   "0.5.0",
             
             ("org.reflections"                  %    "reflections"              %   "0.9.7" notTransitive())
               .exclude("com.google.guava", "guava")


### PR DESCRIPTION
OAuth errors can be a bit tricky to debug.  This will make it slightly better.  See this commit from four months ago on Signpost:
https://github.com/kaeppler/signpost/commit/102db23377192cd4563a00e6d46cfdaff84a137c
