### PR TITLE
Java: OpenID identification always null

### DIFF
--- a/framework/src/play/src/main/java/play/libs/OpenID.java
+++ b/framework/src/play/src/main/java/play/libs/OpenID.java
@@ -81,6 +81,7 @@ public class OpenID {
             this.attributes = new HashMap<String, String>();
         }
         public UserInfo(String id, Map<String, String> attributes) {
+            this.id = id;
             this.attributes = attributes;
         }
     }


### PR DESCRIPTION
Fix the OpenID identification always being null when using the Play! Java OpenID API
