### PR TITLE
default value for optional fields

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/Forms.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Forms.scala
@@ -319,6 +319,19 @@ object Forms {
    * @param mapping The mapping to make optional.
    */
   def optional[A](mapping: Mapping[A]): Mapping[Option[A]] = OptionalMapping(mapping)
+  /**
+   * Defines an optional mapping, with a default value.
+   *
+   * {{{
+   * Form(
+   *   "name" -> optional(text, "The default text")
+   * )
+   * }}}
+   *
+   * @param mapping The mapping to make optional.
+   * @param defValue The default value when mapping and the field is not present.
+   */
+  def optional[A](mapping: Mapping[A], defValue:A): Mapping[A] = OptionalMapping(mapping).transform(_.getOrElse(defValue), Some(_))
 
   /**
    * Defines a repeated mapping.


### PR DESCRIPTION
I would like to propose this change about the optional mapping to reduce the amount of user code required to define default values

```
def test = Action {
  implicit request =>

  case class CData(top:Int)

  val p = Form(
    mapping(
      "top" -> optional(number)
    )((top) => CData(top.getOrElse(42))) ((cdata:CData) => Some(Some(cdata.top)))
  ).bindFromRequest()

  Ok("all done. " + p.get.toString)
}
```

with the new feature

```
def test = Action {
  implicit request =>

  case class CData(top:Int)

  val p = Form(
    mapping(
      "top" -> optional(number, 2)
    ) (CData.apply) (Cdata.unapply)
  ).bindFromRequest()

  Ok("all done. " + p.get.toString)
}
```
