### PR TITLE
[#573] Fall back to less specific locale for missing keys

### DIFF
--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -230,9 +230,13 @@ case class MessagesApi(messages: Map[String, Map[String, String]]) {
    * @return the formatted message, if this key was defined
    */
   def translate(key: String, args: Seq[Any])(implicit lang: Lang): Option[String] = {
-    messages.get(lang.code).flatMap(_.get(key)).orElse(messages.get("default").flatMap(_.get(key))).map { pattern =>
-      new MessageFormat(pattern, lang.toLocale).format(args.map(_.asInstanceOf[java.lang.Object]).toArray)
-    }
+    val langsToTry: List[Lang] =
+      List(lang, Lang(lang.language, ""), Lang("default", ""))
+    val pattern: Option[String] =
+      langsToTry.foldLeft[Option[String]](None)((res, lang) =>
+        res.orElse(messages.get(lang.code).flatMap(_.get(key))))
+    pattern.map(pattern =>
+      new MessageFormat(pattern, lang.toLocale).format(args.map(_.asInstanceOf[java.lang.Object]).toArray))
   }
 
 }

--- a/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
@@ -1,0 +1,41 @@
+package play.api.i18n
+
+import org.specs2.mutable._
+
+object MessagesSpec extends Specification {
+  val testMessages = Map(
+      "default" -> Map(
+          "title" -> "English Title",
+          "foo" -> "English foo",
+          "bar" -> "English pub"),
+      "fr" -> Map(
+          "title" -> "Titre francais",
+          "foo" -> "foo francais"),
+      "fr-CH" -> Map(
+          "title" -> "Titre suisse"))
+  val api = new MessagesApi(testMessages)
+
+  def translate(msg: String, lang: String, reg: String): Option[String] =
+    api.translate(msg, Nil)(Lang(lang, reg))
+
+  "MessagesApi" should {
+    "fall back to less specific translation" in {
+      // Direct lookups
+      translate("title", "fr", "CH") must be equalTo Some("Titre suisse")
+      translate("title", "fr", "") must be equalTo Some("Titre francais")
+      
+      // Region that is missing
+      translate("title", "fr", "FR") must be equalTo Some("Titre francais")
+      
+      // Translation missing in the given region
+      translate("foo", "fr", "CH") must be equalTo Some("foo francais")
+      translate("bar", "fr", "CH") must be equalTo Some("English pub")
+      
+      // Unrecognized language
+      translate("title", "bo", "GO") must be equalTo Some("English Title")
+      
+      // Missing translation
+      translate("garbled", "fr", "CH") must be equalTo None
+    }
+  }
+}


### PR DESCRIPTION
Implements #573 (https://play.lighthouseapp.com/projects/82401/tickets/573).

If this is accepted, then it would be good to update the documentation. The following sentence might be added to "Externalizing Messages" for both the Scala and Java APIs:

"If there is no message for the requested key and language, the Messages API will fall back on looking in the same language but with no region; if it's not there, either, it will look in the "default" messages."
