### PR TITLE
Remove extra parenthesis on EventSource helper

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
@@ -30,7 +30,7 @@ object EventSource {
 
   object EventIdExtractor extends LowPriorityEventIdExtractor
 
-  def apply[E]()(implicit encoder: Comet.CometMessage[E], eventNameExtractor: EventNameExtractor[E], eventIdExtractor: EventIdExtractor[E]) = Enumeratee.map[E] { chunk =>
+  def apply[E](implicit encoder: Comet.CometMessage[E], eventNameExtractor: EventNameExtractor[E], eventIdExtractor: EventIdExtractor[E]) = Enumeratee.map[E] { chunk =>
     eventNameExtractor.eventName(chunk).map("event: " + _ + "\n").getOrElse("") +
       "data: " + encoder.toJavascriptMessage(chunk) + "\r\n\r\n"
   }


### PR DESCRIPTION
Allows to write

``` scala
Ok.feed(streamOfThing &> EventSource[Thing])
```

instead of

``` scala
Ok.feed(streamOfThing &> EventSource[Thing]())
```

(notice the trailing parenthesis)
