### PR TITLE
Make Threads.withContextClassLoader more resilient to failure

### DIFF
--- a/framework/src/play/src/main/scala/play/core/utils/Threads.scala
+++ b/framework/src/play/src/main/scala/play/core/utils/Threads.scala
@@ -13,10 +13,12 @@ object Threads {
   def withContextClassLoader[T](classloader: ClassLoader)(b: => T): T = {
     val thread = Thread.currentThread
     val oldLoader = thread.getContextClassLoader
-    thread.setContextClassLoader(classloader)
-    val result = b
-    thread.setContextClassLoader(oldLoader)
-    result
+    try {
+      thread.setContextClassLoader(classloader)
+      b
+    } finally {
+      thread.setContextClassLoader(oldLoader)
+    }
   }
 
 }

--- a/framework/src/play/src/test/scala/play/core/utils/ThreadsSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/utils/ThreadsSpec.scala
@@ -1,0 +1,30 @@
+package play.core.utils
+
+import util.control.Exception._
+import org.specs2.mutable.Specification
+import play.utils.Threads
+
+object ThreadsSpec extends Specification {
+  "Threads" should {
+    "restore the correct class loader" in {
+      "if the block returns successfully" in {
+        val currentCl = Thread.currentThread.getContextClassLoader
+        Threads.withContextClassLoader(testClassLoader) {
+          Thread.currentThread.getContextClassLoader must be equalTo testClassLoader
+          "a string"
+        } must be equalTo "a string"
+        Thread.currentThread.getContextClassLoader must be equalTo currentCl
+      }
+
+      "if the block throws an exception" in {
+        val currentCl = Thread.currentThread.getContextClassLoader
+        (catching(classOf[RuntimeException]) opt Threads.withContextClassLoader(testClassLoader) {
+          Thread.currentThread.getContextClassLoader must be equalTo testClassLoader
+          throw new RuntimeException("Uh oh")
+        }) must beNone
+        Thread.currentThread.getContextClassLoader must be equalTo currentCl
+      }
+    }
+  }
+  val testClassLoader = new ClassLoader(){}
+}


### PR DESCRIPTION
`Threads.withContextClassLoader` does not restore the original context classloader properly if the function executed in the new context throws an exception.

Change `Threads.withContextClassLoader` to execute the function in a try block and restore the previous CL in the finally block (Note: finally is _not_ part of the try/catch expression so the return value is simply the return value of the function `b` execution).
