### PR TITLE
Ensure only one application can run simultaneously during testing

### DIFF
--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -29,11 +29,13 @@ object Helpers extends Status with HeaderNames {
    * Executes a block of code in a running application.
    */
   def running[T](fakeApp: FakeApplication)(block: => T): T = {
-    try {
-      Play.start(fakeApp)
-      block
-    } finally {
-      Play.stop()
+    synchronized {
+      try {
+        Play.start(fakeApp)
+        block
+      } finally {
+        Play.stop()
+      }    
     }
   }
 
@@ -41,11 +43,13 @@ object Helpers extends Status with HeaderNames {
    * Executes a block of code in a running server.
    */
   def running[T](testServer: TestServer)(block: => T): T = {
-    try {
-      testServer.start()
-      block
-    } finally {
-      testServer.stop()
+    synchronized {
+      try {
+        testServer.start()
+        block
+      } finally {
+        testServer.stop()
+      }
     }
   }
 
@@ -54,15 +58,17 @@ object Helpers extends Status with HeaderNames {
    */
   def running[T, WEBDRIVER <: WebDriver](testServer: TestServer, webDriver: Class[WEBDRIVER])(block: TestBrowser => T): T = {
     var browser: TestBrowser = null
-    try {
-      testServer.start()
-      browser = TestBrowser.of(webDriver)
-      block(browser)
-    } finally {
-      if (browser != null) {
-        browser.quit()
+    synchronized {
+      try {
+        testServer.start()
+        browser = TestBrowser.of(webDriver)
+        block(browser)
+      } finally {
+        if (browser != null) {
+          browser.quit()
+        }
+        testServer.stop()
       }
-      testServer.stop()
     }
   }
 

--- a/framework/test/integrationtest/test/TestHelperSpec.scala
+++ b/framework/test/integrationtest/test/TestHelperSpec.scala
@@ -1,0 +1,52 @@
+package test
+
+import play.api.test._
+import play.api.test.Helpers._
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
+import collection.mutable
+
+import org.specs2.mutable._
+
+class TestHelperSpec extends Specification {
+
+  "a test using the 'running' helper" should {
+
+    "not run while another test is doing the same" in {
+
+      val testsRunning = new AtomicInteger(2)
+      val allTestsReady = new CountDownLatch(1)
+      val firstTestStarted = new CountDownLatch(1)
+      val allTestsFinished = new CountDownLatch(2)
+
+      val testMap = mutable.HashMap("one-more" -> -1, "no-more" -> -1)
+
+      new Thread(new RunningFakeTester(true, testsRunning, testMap, allTestsReady, firstTestStarted, allTestsFinished), "one-more").start()
+      new Thread(new RunningFakeTester(false, testsRunning, testMap, allTestsReady, firstTestStarted, allTestsFinished), "no-more").start()
+
+      allTestsReady.countDown()
+      allTestsFinished.await()
+
+      testMap("one-more") should be equalTo 1
+      testMap("no-more") should be equalTo 0
+    }
+  }
+
+  class RunningFakeTester(isFirst: Boolean, testsRunning: AtomicInteger, testMap: mutable.HashMap[String, Int], allTestsReady: CountDownLatch, firstTestStarted: CountDownLatch, allTestsFinished: CountDownLatch) extends Runnable {
+    def run() = {
+      val name = Thread.currentThread.getName()
+
+      allTestsReady.await()
+      if (!isFirst) firstTestStarted.await()
+
+      running(FakeApplication()) {
+        if (isFirst) {
+          firstTestStarted.countDown()
+          Thread.sleep(2)
+        }
+        testMap += (Thread.currentThread.getName() -> testsRunning.decrementAndGet())
+        allTestsFinished.countDown()
+      }
+    }
+  }
+}


### PR DESCRIPTION
I don't want to have to make all the examples in a Spec sequential just because two or more of them start a Play application and might stomp on each other.
- During testing, due to ALL THE STATIC THINGS, if more than one Application is started, things just break indeterminately
- Synchronize the helper "running" methods so parallel tests block and can't interfere with each other
- Interleaved multi-threaded test using latches to force a second thread to attempt to run an application while a first thread is already running one
