### PR TITLE
Upgrade to Netty 3.5.3

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -184,7 +184,7 @@ object PlayBuild extends Build {
     object Dependencies {
 
         val runtime = Seq(
-            "io.netty"                          %    "netty"                    %   "3.5.0.Final",
+            "io.netty"                          %    "netty"                    %   "3.5.3.Final",
             "org.slf4j"                         %    "slf4j-api"                %   "1.6.4",
             "org.slf4j"                         %    "jul-to-slf4j"             %   "1.6.4",
             "org.slf4j"                         %    "jcl-over-slf4j"           %   "1.6.4",


### PR DESCRIPTION
In order to resolve the Netty issue with the reserved cookie names (https://github.com/netty/netty/issues/397), upgrade to the latest version of Netty.
