### PR TITLE
#274 fix Closure Compiler broken in Windows

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/jscompile/JavascriptCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/jscompile/JavascriptCompiler.scala
@@ -29,7 +29,7 @@ object JavascriptCompiler {
       val defaultOptions = new CompilerOptions()
       defaultOptions.closurePass = true
       defaultOptions.setProcessCommonJSModules(true)
-      defaultOptions.setCommonJSModulePathPrefix(source.getParent() + "/")
+      defaultOptions.setCommonJSModulePathPrefix(source.getParent() + File.separator)
       defaultOptions.setManageClosureDependencies(Seq(toModuleName(source.getName())).asJava)
       simpleCompilerOptions.foreach(_ match {
         case "advancedOptimizations" => CompilationLevel.ADVANCED_OPTIMIZATIONS.setOptionsForCompilationLevel(defaultOptions)


### PR DESCRIPTION
The end of Path in windows should be "\\" but not "/"
