### PR TITLE
Pass Signpost an InputStream rather than null to avoid NPE

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/oauth/OAuth.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/oauth/OAuth.scala
@@ -124,7 +124,7 @@ case class OAuthCalculator(consumerKey: ConsumerKey, token: RequestToken) extend
 
     override def getContentType(): String = getHeader("Content-Type")
 
-    override def getMessagePayload() = null
+    override def getMessagePayload() = new java.io.ByteArrayInputStream(request.getStringData.getBytes)
 
     override def getMethod(): String = this.request.method
 

--- a/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
@@ -66,6 +66,10 @@ object WS {
 
     import scala.collection.JavaConverters._
 
+    def getStringData = body.getOrElse("")
+    protected var body: Option[String] = None
+    override def setBody(s: String) = { this.body = Some(s); super.setBody(s)}
+
     protected var calculator: Option[SignatureCalculator] = _calc
 
     protected var headers: Map[String, Seq[String]] = Map()


### PR DESCRIPTION
When signing a POST request constructed with `WS.url(...).post(Map(...))`, Play's `WSRequestAdapter.getMessagePayload()` returns null, causing signpost to throw an NPE: https://gist.github.com/3193633.

Demonstration code: https://gist.github.com/3193621
