### PR TITLE
stop plugins in reverse order that they were started

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -75,8 +75,8 @@ object Play {
   def stop() {
     Option(_currentApp).map { app =>
       Threads.withContextClassLoader(classloader(app)) {
-        app.plugins.foreach { p =>
-          try { p.onStop } catch { case _ => }
+        app.plugins.reverse.foreach { p =>
+          try { p.onStop } catch { case e => Logger("play").error("error while stopping plugin " + p, e) }
         }
       }
     }


### PR DESCRIPTION
This allows for more graceful cleanup in case plugins depend on each other.  In addition, we report any errors that happen during stop so that these do not get lost.
