### PR TITLE
Implement XPath lib with XPath standard API

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -237,6 +237,7 @@ object PlayBuild extends Build {
             "org.joda"                          %    "joda-convert"             %   "1.2",
             "org.javassist"                     %    "javassist"                %   "3.16.1-GA",
             "org.apache.commons"                %    "commons-lang3"            %   "3.1",
+            "org.apache.ws.commons"             %    "ws-commons-util"          %   "1.0.1",
             
             ("com.ning"                         %    "async-http-client"        %   "1.7.0" notTransitive())
               .exclude("org.jboss.netty", "netty")

--- a/framework/src/play/src/main/java/play/libs/XPath.java
+++ b/framework/src/play/src/main/java/play/libs/XPath.java
@@ -3,9 +3,15 @@ package play.libs;
 import java.util.List;
 import java.util.Map;
 
+import javax.xml.namespace.NamespaceContext;
 import javax.xml.xpath.*;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
+
+import org.apache.ws.commons.util.NamespaceContextImpl;
+
+
 
 /**
  * XPath for parsing
@@ -22,13 +28,23 @@ public class XPath {
      * @return
      */
     @SuppressWarnings("unchecked")
-    public static List<Node> selectNodes(String path, Object node, Map<String, String> namespaces) {
-        /*try {
-            return getDOMXPath(path, namespaces).selectNodes(node);
+    public static NodeList selectNodes(String path, Object node, Map<String, String> namespaces) {
+        try {
+            XPathFactory factory = XPathFactory.newInstance();
+            javax.xml.xpath.XPath xpath = factory.newXPath();
+            
+            if (namespaces != null) {
+                NamespaceContextImpl nsContext = new NamespaceContextImpl();
+                for (Map.Entry<String, String> namespace : namespaces.entrySet()) {
+                    nsContext.startPrefixMapping(namespace.getKey(), namespace.getValue());                    
+                }
+                xpath.setNamespaceContext(nsContext);
+            }
+
+            return (NodeList) xpath.evaluate(path, node, XPathConstants.NODESET);
         } catch (Exception e) {
             throw new RuntimeException(e);
-        }*/
-        return null;
+        }
     }
 
     /**
@@ -38,27 +54,31 @@ public class XPath {
      * @param node
      * @return
      */
-    public static List<Node> selectNodes(String path, Object node) {
-        /*return selectNodes(path, node, null);*/
-        return null;
+    public static NodeList selectNodes(String path, Object node) {
+        return selectNodes(path, node, null);
     }
 
     public static Node selectNode(String path, Object node, Map<String, String> namespaces) {
-        /*try {
-            List<Node> nodes = selectNodes(path, node, namespaces);
-            if (nodes.size() == 0) {
-                return null;
+        try {
+            XPathFactory factory = XPathFactory.newInstance();
+            javax.xml.xpath.XPath xpath = factory.newXPath();
+            
+            if (namespaces != null) {
+                NamespaceContextImpl nsContext = new NamespaceContextImpl();
+                for (Map.Entry<String, String> namespace : namespaces.entrySet()) {
+                    nsContext.startPrefixMapping(namespace.getKey(), namespace.getValue());                    
+                }
+                xpath.setNamespaceContext(nsContext);
             }
-            return nodes.get(0);
+
+            return (Node) xpath.evaluate(path, node, XPathConstants.NODE);
         } catch (Exception e) {
             throw new RuntimeException(e);
-        }*/
-        return null;
+        }
     }
 
     public static Node selectNode(String path, Object node) {
-        /*return selectNode(path, node, null);*/
-        return null;
+        return selectNode(path, node, null);
     }
 
     /**
@@ -67,22 +87,22 @@ public class XPath {
      * @param node the node, node-set or Context object for evaluation. This value can be null.
      */
     public static String selectText(String path, Object node, Map<String, String> namespaces) {
-        /*try {
-            Node rnode = (Node) getDOMXPath(path, namespaces).selectSingleNode(node);
-            if (rnode == null) {
-                return null;
+        try {
+            XPathFactory factory = XPathFactory.newInstance();
+            javax.xml.xpath.XPath xpath = factory.newXPath();
+
+            if (namespaces != null) {
+                NamespaceContextImpl nsContext = new NamespaceContextImpl();
+                for (Map.Entry<String, String> namespace : namespaces.entrySet()) {
+                    nsContext.startPrefixMapping(namespace.getKey(), namespace.getValue());                    
+                }
+                xpath.setNamespaceContext(nsContext);
             }
-            if (!(rnode instanceof Text)) {
-                rnode = rnode.getFirstChild();
-            }
-            if (!(rnode instanceof Text)) {
-                return null;
-            }
-            return ((Text) rnode).getData();
+
+            return (String) xpath.evaluate(path, node, XPathConstants.STRING);
         } catch (Exception e) {
             throw new RuntimeException(e);
-        }*/
-        return null;
+        }
     }
 
     /**
@@ -91,8 +111,7 @@ public class XPath {
      * @param node the node, node-set or Context object for evaluation. This value can be null.
      */
     public static String selectText(String path, Object node) {
-        /*return selectText(path, node, null);*/
-        return null;
+        return selectText(path, node, null);
     }
 
 }


### PR DESCRIPTION
 Rewrite of XPath lib to use the standard API instead of Jaxen. It introduces a small dependency to org.apache.ws.commons.util to have a simple implementation of NamespaceContext. We could avoid the
dependency by copying their implementation.
