### PR TITLE
using application.context to set the path for session and flash cookie

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -302,6 +302,11 @@ package play.api.mvc {
     val secure = false
 
     /**
+     *  The cookie path. 
+     */
+    val path = "/"
+
+    /**
      * Encodes the data as a `String`.
      */
     def encode(data: Map[String, String]): String = {
@@ -339,7 +344,7 @@ package play.api.mvc {
      */
     def encodeAsCookie(data: T): Cookie = {
       val cookie = encode(serialize(data))
-      Cookie(COOKIE_NAME, cookie, maxAge, "/", None, secure, httpOnly)
+      Cookie(COOKIE_NAME, cookie, maxAge, path, None, secure, httpOnly)
     }
 
     /**
@@ -427,6 +432,7 @@ package play.api.mvc {
     override val secure = Play.maybeApplication.flatMap(_.configuration.getBoolean("session.secure")).getOrElse(false)
     override val maxAge = Play.maybeApplication.flatMap(_.configuration.getInt("session.maxAge")).getOrElse(-1)
     override val httpOnly = Play.maybeApplication.flatMap(_.configuration.getBoolean("session.httpOnly")).getOrElse(true)
+    override val path = Play.maybeApplication.flatMap(_.configuration.getString("application.context")).getOrElse("/")
 
     def deserialize(data: Map[String, String]) = new Session(data)
 
@@ -489,6 +495,8 @@ package play.api.mvc {
   object Flash extends CookieBaker[Flash] {
 
     val COOKIE_NAME = Play.maybeApplication.flatMap(_.configuration.getString("flash.cookieName")).getOrElse("PLAY_FLASH")
+    override val path = Play.maybeApplication.flatMap(_.configuration.getString("application.context")).getOrElse("/")
+
     val emptyCookie = new Flash
 
     def deserialize(data: Map[String, String]) = new Flash(data)


### PR DESCRIPTION
Fix to use the value of application.context to set the path property of both session and flash cookie. 
