### PR TITLE
Some changes to template parser, to make it simpler to be used by IDE

### DIFF
--- a/framework/src/templates/src/main/scala/ScalaTemplates.scala
+++ b/framework/src/templates/src/main/scala/ScalaTemplates.scala
@@ -369,8 +369,8 @@ package play.templates {
         }
         val complexExpr = positioned(parentheses ^^ { expr => (Simple(expr)) }) ^^ { List(_) }
 
-        at ~> ((simpleExpr | complexExpr) ~ whiteSpaceNoBreak ~ "match" ^^ {
-          case e ~ w ~ m => e ++ Seq(Simple(w + m))
+        at ~> ((simpleExpr | complexExpr) ~ positioned((whiteSpaceNoBreak ~ "match" ^^ {case w ~ m => Simple(w + m)})) ^^ {
+          case e ~ m => e ++ Seq(m)
         }) ~ block ^^ {
           case expr ~ block => Display(ScalaExp(expr ++ Seq(block)))
         }


### PR DESCRIPTION
- Parser is an independent class, not an anonymous one.
- Every '{' '}' in plain text, did not include the position. Now by defining positionalLiteral, it includes!
- Comments did not have the position. By using positioned() they support now!
- Arguments of a block, does not have the position. The definition of Block case class has been changed and the implementation of blockArgs method is also changed.
