### PR TITLE
Remove dependency on org.apache.ws.commons

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -237,7 +237,6 @@ object PlayBuild extends Build {
             "org.joda"                          %    "joda-convert"             %   "1.2",
             "org.javassist"                     %    "javassist"                %   "3.16.1-GA",
             "org.apache.commons"                %    "commons-lang3"            %   "3.1",
-            "org.apache.ws.commons"             %    "ws-commons-util"          %   "1.0.1",
             
             ("com.ning"                         %    "async-http-client"        %   "1.7.0" notTransitive())
               .exclude("org.jboss.netty", "netty")

--- a/framework/src/play/src/main/java/play/libs/XPath.java
+++ b/framework/src/play/src/main/java/play/libs/XPath.java
@@ -3,14 +3,12 @@ package play.libs;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.namespace.NamespaceContext;
 import javax.xml.xpath.*;
+
+import org.springframework.util.xml.SimpleNamespaceContext;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
-
-import org.apache.ws.commons.util.NamespaceContextImpl;
-
 
 
 /**
@@ -27,17 +25,14 @@ public class XPath {
      * prefix and the value the namespace URI
      * @return
      */
-    @SuppressWarnings("unchecked")
     public static NodeList selectNodes(String path, Object node, Map<String, String> namespaces) {
         try {
             XPathFactory factory = XPathFactory.newInstance();
             javax.xml.xpath.XPath xpath = factory.newXPath();
             
             if (namespaces != null) {
-                NamespaceContextImpl nsContext = new NamespaceContextImpl();
-                for (Map.Entry<String, String> namespace : namespaces.entrySet()) {
-                    nsContext.startPrefixMapping(namespace.getKey(), namespace.getValue());                    
-                }
+                SimpleNamespaceContext nsContext = new SimpleNamespaceContext();
+                nsContext.setBindings(namespaces);
                 xpath.setNamespaceContext(nsContext);
             }
 
@@ -64,10 +59,8 @@ public class XPath {
             javax.xml.xpath.XPath xpath = factory.newXPath();
             
             if (namespaces != null) {
-                NamespaceContextImpl nsContext = new NamespaceContextImpl();
-                for (Map.Entry<String, String> namespace : namespaces.entrySet()) {
-                    nsContext.startPrefixMapping(namespace.getKey(), namespace.getValue());                    
-                }
+                SimpleNamespaceContext nsContext = new SimpleNamespaceContext();
+                nsContext.setBindings(namespaces);
                 xpath.setNamespaceContext(nsContext);
             }
 
@@ -92,10 +85,8 @@ public class XPath {
             javax.xml.xpath.XPath xpath = factory.newXPath();
 
             if (namespaces != null) {
-                NamespaceContextImpl nsContext = new NamespaceContextImpl();
-                for (Map.Entry<String, String> namespace : namespaces.entrySet()) {
-                    nsContext.startPrefixMapping(namespace.getKey(), namespace.getValue());                    
-                }
+                SimpleNamespaceContext nsContext = new SimpleNamespaceContext();
+                nsContext.setBindings(namespaces);
                 xpath.setNamespaceContext(nsContext);
             }
 


### PR DESCRIPTION
This makes the dependencies a bit lighter.  org.apache.ws.commons has not been updated in at least a few years and was putting junit 3 on my main classpath (not even in test scope) and causing me some difficulty since junit 4 is also on my classpath and Eclipse was auto-importing a mix of the two.
