### PR TITLE
Add support of JSON templates

### DIFF
--- a/framework/src/play/src/main/scala/play/api/templates/Templates.scala
+++ b/framework/src/play/src/main/scala/play/api/templates/Templates.scala
@@ -167,6 +167,64 @@ object XmlFormat extends Format[Xml] {
 
 }
 
+/**
+ * Content type used in default JSON templates.
+ *
+ * @param text The JSON text.
+ */
+case class Json(text: String) extends Appendable[Json] with Content with play.mvc.Content {
+  val buffer = new StringBuilder(text)
+
+  /**
+   * Appends this json fragment to another.
+   */
+  def +(other: Json): this.type = {
+    buffer.append(other.buffer)
+    this
+  }
+
+  override def toString = buffer.toString
+
+  /**
+   * Content type of text (`text/json`).
+   */
+  def contentType = "text/json"
+
+  def body = toString
+
+}
+
+/**
+ * Helper for utilities JSON methods.
+ */
+object Json {
+
+  /**
+   * Creates an empty JSON fragment.
+   */
+  def empty = Json("")
+
+}
+
+/**
+ * Formatter for text content.
+ */
+object JsonFormat extends Format[Json] {
+
+  /**
+   * Create a text fragment.
+   */
+  def raw(text: String) = Json(text)
+
+  /**
+   * Create a safe (escaped) text fragment.
+   */
+  def escape(text: String) = Json(org.apache.commons.lang3.StringEscapeUtils.escapeEcmaScript(text))
+
+}
+
+
+
 /** Defines a magic helper for Play templates. */
 object PlayMagic {
 

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -199,6 +199,7 @@ trait PlaySettings {
       case "html" => ("play.api.templates.Html", "play.api.templates.HtmlFormat")
       case "txt" => ("play.api.templates.Txt", "play.api.templates.TxtFormat")
       case "xml" => ("play.api.templates.Xml", "play.api.templates.XmlFormat")
+      case "json" => ("play.api.templates.Json", "play.api.templates.JsonFormat")
     })
 
 }


### PR DESCRIPTION
Currently the framework enables by default only HTML, XML and Txt
templates. JSON is widely used and ability to generates JSON with
templates is really useful, enabling one to keep a clean architecture
with separation of concerns.
This commit introduces the necessary classes and utility objects to
generate JSON and activate by default JSON templates.
