### PR TITLE
Log request method and URI in exception logs

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -157,11 +157,11 @@ class Application(val path: File, val classloader: ClassLoader, val sources: Opt
       Logger.error(
         """
         |
-        |! %sInternal server error, for request [%s] ->
+        |! %sInternal server error, for (%s) [%s] ->
         |""".stripMargin.format(e match {
           case p: PlayException => "@" + p.id + " - "
           case _ => ""
-        }, request),
+        }, request.method, request.uri),
         e)
 
       global.onError(request, e)

--- a/framework/src/play/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play/src/main/scala/play/core/server/Server.scala
@@ -72,11 +72,11 @@ trait Server {
       Logger.error(
         """
         |
-        |! %sInternal server error, for request [%s] ->
+        |! %sInternal server error, for (%s) [%s] ->
         |""".stripMargin.format(e match {
           case p: PlayException => "@" + p.id + " - "
           case _ => ""
-        }, request),
+        }, request.method, request.uri),
         e)
 
       DefaultGlobal.onError(request, e)


### PR DESCRIPTION
It's very hard to tell what caused errors today because only the request path is logged.  It would be extremely useful to log the query parameters
