### PR TITLE
Add additional HTTP status codes.

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -901,6 +901,7 @@ public class Http {
         int UPGRADE_REQUIRED = 426;
         int PRECONDITION_REQUIRED = 428;
         int TOO_MANY_REQUESTS = 429;
+        int REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
         int INTERNAL_SERVER_ERROR = 500;
         int NOT_IMPLEMENTED = 501;
         int BAD_GATEWAY = 502;


### PR DESCRIPTION
While I'm trying to implement the adapters to make DAV Servlets to work on PlayFramework 2.0, I found some HTTP status codes are not added in the framework.
- 207, 422, 423, 424 and 507 defined by RFC 2518
- 510 defined by RFC 2774
- 426 defined by RFC 2817
- 226 defined by RFC 3229
- 428, 429, 431 and 511 defined by RFC 6585
