### PR TITLE
Properly filter Reflections output in Application.getTypesAnnotatedWith

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -315,11 +315,8 @@ class Application(val path: File, val classloader: ClassLoader, val sources: Opt
    */
   def getTypes(packageName: String): Set[String] = {
     import org.reflections._
-    new Reflections(
-      new util.ConfigurationBuilder()
-        .addUrls(util.ClasspathHelper.forPackage(packageName, classloader))
-        .filterInputsBy(new util.FilterBuilder().include(util.FilterBuilder.prefix(packageName + ".")))
-        .setScanners(new scanners.TypesScanner())).getStore.get(classOf[scanners.TypesScanner]).keySet.asScala.toSet
+    new Reflections(packageName, new scanners.TypesScanner())
+        .getStore.get(classOf[scanners.TypesScanner]).keySet.asScala.toSet
   }
 
   /**
@@ -340,10 +337,8 @@ class Application(val path: File, val classloader: ClassLoader, val sources: Opt
    */
   def getTypesAnnotatedWith[T <: java.lang.annotation.Annotation](packageName: String, annotation: Class[T]): Set[String] = {
     import org.reflections._
-    new Reflections(
-      new util.ConfigurationBuilder()
-        .addUrls(util.ClasspathHelper.forPackage(packageName, classloader))
-        .setScanners(new scanners.TypeAnnotationsScanner())).getStore.getTypesAnnotatedWith(annotation.getName).asScala.toSet
+    new Reflections(packageName, new scanners.TypeAnnotationsScanner())
+        .getStore.getTypesAnnotatedWith(annotation.getName).asScala.toSet
   }
 
   /**


### PR DESCRIPTION
Fixes a bug in `Application.getTypesAnnotatedWith()` where the Reflections query was not being properly filtered by the `packageName` specified.

The fix makes use of the `Reflections(prefix, scanners)` convenience constructor for properly specifying the prefix + scanners.

See [Lighthouse #642](https://play.lighthouseapp.com/projects/82401-play-20/tickets/642) for a report of a manifestation of the problem.
