### PR TITLE
Add a Date header to 304 responses

### DIFF
--- a/framework/test/integrationtest/test/FunctionalSpec.scala
+++ b/framework/test/integrationtest/test/FunctionalSpec.scala
@@ -36,6 +36,9 @@ class FunctionalSpec extends Specification {
         
         val secondRequest = await(WS.url("http://localhost:9001/public/stylesheets/main.css").withHeaders("If-Modified-Since"-> format.format(startDate)).get)
         secondRequest.status must equalTo(304)
+
+        // return Date header with 304 response
+        secondRequest.header(DATE) must beSome
        
         val localCal = cal
         val f = new java.io.File("public/stylesheets/main.css")


### PR DESCRIPTION
This change adds a Date header to 304 responses and fixes an issue with CloudFront getting stuck in a RefreshHit cycle after hitting the TTL.

More information about why the Date header is required on 304 responses can be found at:
http://stackoverflow.com/questions/1587667/should-http-304-not-modified-responses-contain-cache-control-headers

Also, since a Date header should always be returned (not just for requests that have a Last-Modified header) the Date header is now set when a 200 response is constructed.

The FunctionalSpec has been added to test for the Date header on a 304 response.
