### PR TITLE
Add constants for standard HTTP proxy headers

### DIFF
--- a/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
@@ -191,6 +191,9 @@ trait HeaderNames {
   val WWW_AUTHENTICATE = "WWW-Authenticate"
 
   val X_FORWARDED_FOR = "X-Forwarded-For"
+  val X_FORWARDED_HOST = "X-Forwarded-Host"
+  val X_FORWARDED_PORT = "X-Forwarded-Port"
+  val X_FORWARDED_PROTO = "X-Forwarded-Proto"
   
   val ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin"
   val ACCESS_CONTROL_EXPOSE_HEADERS = "Access-Control-Expose-Headers"


### PR DESCRIPTION
Since Apache mod_proxy[1], these headers have been used by http
proxies to pass on information about the original request url:
  \* X-Forwarded-Host
  \* X-Forwarded-Port
  \* X-Forwarded-Proto

Their support is widespread [2][3], so play framework should
include constants for them.

[1] http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#x-headers
[2] https://github.com/jaswope/rack-reverse-proxy/pull/12
[3] https://github.com/nodejitsu/node-http-proxy/issues/53
