### PR TITLE
Call onRouteRequest and doFilters in Test

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -1,5 +1,7 @@
 package play.test;
 
+import play.*;
+
 import play.mvc.*;
 import play.libs.*;
 import play.libs.F.*;
@@ -241,6 +243,8 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
 
     /**
      * Use the Router to determine the Action to call for this request and executes it.
+     * @deprecated
+     * @see #route instead
      */
     @SuppressWarnings(value = "unchecked")
     public static Result routeAndCall(FakeRequest fakeRequest) {
@@ -255,6 +259,8 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
 
     /**
      * Use the Router to determine the Action to call for this request and executes it.
+     * @deprecated
+     * @see #route instead
      */
     public static Result routeAndCall(Class<? extends play.core.Router.Routes> router, FakeRequest fakeRequest) {
         try {
@@ -269,6 +275,38 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
         } catch(Throwable t) {
             throw new RuntimeException(t);
         } 
+    }
+
+    public static Result route(FakeRequest fakeRequest) {
+      return route(play.Play.application(), fakeRequest);
+    }
+
+    public static Result route(Application app, FakeRequest fakeRequest) {
+      final play.api.mvc.Result r = play.api.test.Helpers.route(app.getWrappedApplication(), fakeRequest.getWrappedRequest()).getOrElse(null);
+      if(r != null){
+        return new Result() {
+          public play.api.mvc.Result getWrappedResult(){
+            return r;
+          }
+        };
+      }
+      return null;
+    }
+
+    public static <T> Result route(Application app, FakeRequest fakeRequest, byte[] body) {
+      final play.api.mvc.Result r = play.api.test.Helpers.jRoute(app.getWrappedApplication(), fakeRequest.getWrappedRequest(), body).getOrElse(null);
+      if(r != null){
+        return new Result() {
+          public play.api.mvc.Result getWrappedResult(){
+            return r;
+          }
+        };
+      }
+      return null;
+    }
+
+    public static <T> Result route(FakeRequest fakeRequest, byte[] body) {
+      return route(play.Play.application(), fakeRequest, body);
     }
 
     /**

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -177,7 +177,7 @@ object Helpers extends Status with HeaderNames {
   /**
    * Use the Router to determine the Action to call for this request and executes it.
    */
-  @deprecated("Use `route` instead.", "2.10.0")
+  @deprecated("Use `route` instead.", "2.1.0")
   def routeAndCall[T](request: FakeRequest[T]): Option[Result] = {
     routeAndCall(this.getClass.getClassLoader.loadClass("Routes").asInstanceOf[Class[play.core.Router.Routes]], request)
   }
@@ -185,7 +185,7 @@ object Helpers extends Status with HeaderNames {
   /**
    * Use the Router to determine the Action to call for this request and executes it.
    */
-  @deprecated("Use `route` instead.", "2.10.0")
+  @deprecated("Use `route` instead.", "2.1.0")
   def routeAndCall[T, ROUTER <: play.core.Router.Routes](router: Class[ROUTER], request: FakeRequest[T]): Option[Result] = {
     val routes = router.getClassLoader.loadClass(router.getName + "$").getDeclaredField("MODULE$").get(null).asInstanceOf[play.core.Router.Routes]
     routes.routes.lift(request).map {
@@ -220,6 +220,10 @@ object Helpers extends Status with HeaderNames {
       case _ => None
     }
   }
+
+  // Java compatibility
+  def jRoute(app: Application, rh: RequestHeader, body: Array[Byte]): Option[Result] = route(app, rh, body)(Writeable.wBytes)
+  def jRoute(rh: RequestHeader, body: Array[Byte]): Option[Result] = jRoute(Play.current, rh, body)
 
   def route[T](app: Application, rh: RequestHeader, body: T)(implicit w: Writeable[T]): Option[Result] = {
     app.global.onRouteRequest(rh).flatMap {

--- a/framework/src/play/src/main/java/play/Application.java
+++ b/framework/src/play/src/main/java/play/Application.java
@@ -15,6 +15,10 @@ public class Application {
     
     private final play.api.Application application;
     
+    public play.api.Application getWrappedApplication() {
+      return application;
+    }
+
     /**
      * Creates an application from a Scala Application value.
      */


### PR DESCRIPTION
When using FakeApplication or TestServer to run test, onRouteRequest and doFilter were not called.
This pull request deprecate routeAndCall, and provide other meths better suited to the new API, and make them call global methods.
