### PR TITLE
Throw an Exception if Configuration is not found

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -2,7 +2,7 @@ package play.api
 
 import java.io._
 
-import com.typesafe.config.{ Config, ConfigFactory, ConfigList, ConfigParseOptions, ConfigSyntax, ConfigObject, ConfigOrigin, ConfigException }
+import com.typesafe.config.{ Config, ConfigFactory, ConfigList, ConfigParseOptions, ConfigSyntax, ConfigObject, ConfigOrigin, ConfigException, ConfigResolveOptions }
 
 import scala.collection.JavaConverters._
 
@@ -26,11 +26,16 @@ object Configuration {
   private[play] def loadDev(appPath: File) = {
     try {
       val file = Option(System.getProperty("config.file")).map(f => new File(f)).getOrElse(new File(appPath, "conf/application.conf"))
-      ConfigFactory.load(ConfigFactory.parseFileAnySyntax(file))
+      ConfigFactory.load(ConfigFactory.parseFileAnySyntax(file, parseOpts))
     } catch {
+      case e: ConfigException.IO => 
+        throw configError(e.origin, """application.conf not found. If you're running tests using FakeApplication or TestServer, add the path parameter: FakeApplication(path = new java.io.File("path/to/application/folder"))""", Some(e))
       case e: ConfigException => throw configError(e.origin, e.getMessage, Some(e))
     }
   }
+
+  private val parseOpts = ConfigParseOptions.defaults().setAllowMissing(false)
+  private val resolveOpts = ConfigResolveOptions.defaults()
 
   /**
    * Loads a new `Configuration` either from the classpath or from
@@ -47,7 +52,7 @@ object Configuration {
   def load(appPath: File, mode: Mode.Mode = Mode.Dev) = {
     try {
       val currentMode = Play.maybeApplication.map(_.mode).getOrElse(mode)
-      if (currentMode == Mode.Prod) Configuration(ConfigFactory.load()) else Configuration(loadDev(appPath))
+      if (currentMode == Mode.Prod) Configuration(ConfigFactory.load("application", parseOpts, resolveOpts)) else Configuration(loadDev(appPath))
     } catch {
       case e: ConfigException => throw configError(e.origin, e.getMessage, Some(e))
       case e => throw e


### PR DESCRIPTION
For now play fails silently when application.conf is not found (fallback to a default config).
This patch makes it throw an Exception.

The main problem it solves is configuration being ignored silently in Tests (using FakeApplication or TestServer) when the app does not live in "." (current sbt folder), which leads to unpredictable, hard to trace bugs.
