### PR TITLE
[FIXFOR: #676] Upgraded com.typesafe.config library to 0.5.0

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -266,7 +266,7 @@ object PlayBuild extends Build {
         )
 
         val sbtDependencies = Seq(
-            "com.typesafe.config"               %    "config"                   %   "0.2.1",
+            "com.typesafe"                      %    "config"                   %   "0.5.0",
             "rhino"                             %    "js"                       %   "1.7R2",
             
             ("com.google.javascript"            %    "closure-compiler"         %   "r2079" notTransitive())


### PR DESCRIPTION
The release 0.5.0 of the Typesafe config library introduces possibility to quote multiline strings without the need of escaping it. I think it is a desirable feature.
