### PR TITLE
Added NaN Json parsing support

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/json/JsValue.scala
@@ -237,7 +237,10 @@ private[json] class JsValueDeserializer(factory: TypeFactory, klass: Class[_]) e
 
       case (JsonToken.VALUE_NUMBER_INT, c) => (Some(JsNumber(jp.getLongValue)), c)
 
-      case (JsonToken.VALUE_NUMBER_FLOAT, c) => (Some(JsNumber(jp.getDoubleValue)), c)
+      case (JsonToken.VALUE_NUMBER_FLOAT, c) => jp.getDoubleValue match {
+        case v if(v.isNaN) => (Some(JsNull), c)
+        case v             => (Some(JsNumber(v)), c)
+      }
 
       case (JsonToken.VALUE_STRING, c) => (Some(JsString(jp.getText)), c)
 
@@ -325,6 +328,6 @@ private[json] object JerksonJson extends com.codahale.jerkson.Json {
       context.addSerializers(new PlaySerializers)
     }
   }
+  factory.enable(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS)
   mapper.registerModule(module)
-
 }

--- a/framework/src/play/src/test/scala/play/api/JsonSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/JsonSpec.scala
@@ -92,7 +92,7 @@ object JsonSpec extends Specification {
       (jsonM \ "timestamp").as[Long] must equalTo(t)
       (jsonM.toString must equalTo("{\"timestamp\":1330950829160}"))
     }
-    
+
     "Serialize and deserialize BigDecimals" in {
       val n = BigDecimal("12345678901234567890.42")
       val json = toJson(n)
@@ -137,6 +137,14 @@ object JsonSpec extends Specification {
       val parsedJson = Json.parse(postJson)
       val expectedJson = JsArray(List(JsNull))
       parsedJson must equalTo(expectedJson)
+    }
+    "Can parse Array containing NaN as null" in {
+      val js = Json.parse("""[1.0, 2.0, NaN]""")
+      js === JsArray(JsNumber(1.0) :: JsNumber(2.0) :: JsNull :: Nil)
+    }
+    "Can parse bare NaN as null" in {
+      val js = Json.parse("""NaN""")
+      js === JsNull
     }
   }
 


### PR DESCRIPTION
Updated Jerkson/Jackson parser features to include JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS.  In the token parser I convert NaN doubles to JsNull.
