### PR TITLE
Fix for DynamicForm values being set to null

### DIFF
--- a/framework/src/play/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play/src/main/java/play/data/DynamicForm.java
@@ -78,7 +78,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
             Map<String,String> newData = new HashMap<String,String>();
             for(String key: data.keySet()) {
                 String dkey = asDynamicKey(key);
-                newData.put(dkey, data.get(dkey));
+                newData.put(dkey, data.get(key));
             }
             data = newData;
         }


### PR DESCRIPTION
The dynamic form values are all being set to null because of the introduction of the new dynamic key in the bind method. 

The dynamic key shouldn't be used for pulling out the form values, as they wont exist.
