### PR TITLE
Fixing [#709] max length calculation errors

### DIFF
--- a/framework/src/play/src/main/java/play/libs/WS.java
+++ b/framework/src/play/src/main/java/play/libs/WS.java
@@ -34,7 +34,9 @@ import org.codehaus.jackson.map.ObjectMapper;
  */
 public class WS {
 
-    private static AsyncHttpClient client = play.api.libs.ws.WS.client();
+    private static AsyncHttpClient client() {
+        return play.api.libs.ws.WS.client();
+    }
 
     /**
      * Prepare a new request. You can then construct it by chaining calls.
@@ -140,7 +142,7 @@ public class WS {
         private Promise<Response> execute() {
             final scala.concurrent.Promise<Response> scalaPromise = scala.concurrent.Promise$.MODULE$.<Response>apply();
             try {
-                WS.client.executeRequest(request, new AsyncCompletionHandler<com.ning.http.client.Response>() {
+                WS.client().executeRequest(request, new AsyncCompletionHandler<com.ning.http.client.Response>() {
                     @Override
                     public com.ning.http.client.Response onCompleted(com.ning.http.client.Response response) {
                         final com.ning.http.client.Response ahcResponse = response;

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -16,7 +16,7 @@ public interface BodyParser {
     @Retention(RetentionPolicy.RUNTIME)
     public @interface Of {
         Class<? extends BodyParser> value();
-        int maxLength() default Integer.MAX_VALUE;
+        int maxLength() default -1;
     }
 
     /**

--- a/framework/src/play/src/main/scala/play/core/j/JavaParsers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaParsers.scala
@@ -81,7 +81,7 @@ object JavaParsers extends BodyParsers {
 
   }
 
-  def anyContent(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(maxLength, parse.anyContent).map { body =>
+  def anyContent(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.anyContent).map { body =>
     body
       .left.map(_ => DefaultRequestBody(isMaxSizeExceeded = true))
       .right.map { anyContent =>
@@ -95,7 +95,7 @@ object JavaParsers extends BodyParsers {
       }.fold(identity, identity)
   }
 
-  def json(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(maxLength, parse.json).map { body =>
+  def json(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.json(Integer.MAX_VALUE)).map { body =>
     body
       .left.map(_ => DefaultRequestBody(isMaxSizeExceeded = true))
       .right.map { json =>
@@ -103,7 +103,7 @@ object JavaParsers extends BodyParsers {
       }.fold(identity, identity)
   }
 
-  def tolerantJson(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(maxLength, parse.tolerantJson).map { body =>
+  def tolerantJson(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.tolerantJson(Integer.MAX_VALUE)).map { body =>
     body
       .left.map(_ => DefaultRequestBody(isMaxSizeExceeded = true))
       .right.map { json =>
@@ -111,7 +111,7 @@ object JavaParsers extends BodyParsers {
       }.fold(identity, identity)
   }
 
-  def xml(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(maxLength, parse.xml).map { body =>
+  def xml(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.xml(Integer.MAX_VALUE)).map { body =>
     body
       .left.map(_ => DefaultRequestBody(isMaxSizeExceeded = true))
       .right.map { xml =>
@@ -119,7 +119,7 @@ object JavaParsers extends BodyParsers {
       }.fold(identity, identity)
   }
 
-  def tolerantXml(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(maxLength, parse.tolerantXml).map { body =>
+  def tolerantXml(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.tolerantXml(Integer.MAX_VALUE)).map { body =>
     body
       .left.map(_ => DefaultRequestBody(isMaxSizeExceeded = true))
       .right.map { xml =>
@@ -127,7 +127,7 @@ object JavaParsers extends BodyParsers {
       }.fold(identity, identity)
   }
 
-  def text(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(maxLength, parse.text).map { body =>
+  def text(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.text(Integer.MAX_VALUE)).map { body =>
     body
       .left.map(_ => DefaultRequestBody(isMaxSizeExceeded = true))
       .right.map { text =>
@@ -135,7 +135,7 @@ object JavaParsers extends BodyParsers {
       }.fold(identity, identity)
   }
 
-  def tolerantText(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(maxLength, parse.tolerantText).map { body =>
+  def tolerantText(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.tolerantText(Integer.MAX_VALUE)).map { body =>
     body
       .left.map(_ => DefaultRequestBody(isMaxSizeExceeded = true))
       .right.map { text =>
@@ -143,7 +143,7 @@ object JavaParsers extends BodyParsers {
       }.fold(identity, identity)
   }
 
-  def formUrlEncoded(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(maxLength, parse.urlFormEncoded).map { body =>
+  def formUrlEncoded(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.urlFormEncoded(Integer.MAX_VALUE)).map { body =>
     body
       .left.map(_ => DefaultRequestBody(isMaxSizeExceeded = true))
       .right.map { urlFormEncoded =>
@@ -151,7 +151,7 @@ object JavaParsers extends BodyParsers {
       }.fold(identity, identity)
   }
 
-  def multipartFormData(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(maxLength, parse.multipartFormData).map { body =>
+  def multipartFormData(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.multipartFormData).map { body =>
     body
       .left.map(_ => DefaultRequestBody(isMaxSizeExceeded = true))
       .right.map { multipart =>
@@ -159,12 +159,14 @@ object JavaParsers extends BodyParsers {
       }.fold(identity, identity)
   }
 
-  def raw(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(maxLength, parse.raw).map { body =>
+  def raw(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.raw(Integer.MAX_VALUE)).map { body =>
     body
       .left.map(_ => DefaultRequestBody(isMaxSizeExceeded = true))
       .right.map { raw =>
         DefaultRequestBody(raw = Some(raw))
       }.fold(identity, identity)
   }
+
+  private def orDefault(maxLength: Int) = if (maxLength < 0) BodyParsers.parse.DEFAULT_MAX_TEXT_LENGTH else maxLength
 
 }

--- a/framework/test/integrationtest-java/app/controllers/BodyParsers.java
+++ b/framework/test/integrationtest-java/app/controllers/BodyParsers.java
@@ -1,0 +1,21 @@
+package controllers;
+
+import play.mvc.BodyParser;
+import play.mvc.Controller;
+import play.mvc.Result;
+
+public class BodyParsers extends Controller {
+    @BodyParser.Of(BodyParser.Json.class)
+    public static Result json() {
+        if (request().body().isMaxSizeExceeded()) {
+            return status(413);
+        } else {
+            return ok(request().body().asJson());
+        }
+    }
+
+    @BodyParser.Of(value = BodyParser.Json.class, maxLength = 120 * 1024)
+    public static Result limitedJson() {
+        return json();
+    }
+}

--- a/framework/test/integrationtest-java/conf/routes
+++ b/framework/test/integrationtest-java/conf/routes
@@ -7,10 +7,12 @@ GET     /key                        controllers.Application.key
 GET     /async                      controllers.Application.asyncResult
 GET     /lang/:code                 controllers.Application.setLang(code)
 GET     /hello                      controllers.Application.hello()
-GET     /:name                      controllers.Application.index(name)
-
 POST    /json                       controllers.Application.getIdenticalJson()
 
+POST    /parsers/json               controllers.BodyParsers.json()
+POST    /parsers/limitedjson        controllers.BodyParsers.limitedJson()
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.at(path="/public", file)
+
+GET     /:name                      controllers.Application.index(name)

--- a/framework/test/integrationtest-java/test/controllers/BodyParsersTest.java
+++ b/framework/test/integrationtest-java/test/controllers/BodyParsersTest.java
@@ -1,0 +1,80 @@
+package controllers;
+
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.node.ObjectNode;
+import org.junit.Test;
+import play.libs.Json;
+import play.libs.WS;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static play.test.Helpers.*;
+
+public class BodyParsersTest {
+    @Test
+    public void testJson() {
+        JsonNode json = createJson(100);
+        WS.Response response = runJsonTest(json, "/parsers/json");
+        System.out.println(response.getBodyAsStream());
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat((Object) response.asJson()).isEqualTo(json);
+    }
+
+    @Test
+    public void testJsonExceedsDefaultLength() {
+        JsonNode json = createJson(110 * 1024);
+        WS.Response response = runJsonTest(json, "/parsers/json");
+        assertThat(response.getStatus()).isEqualTo(413);
+    }
+
+    @Test
+    public void testLimitedJson() {
+        JsonNode json = createJson(100);
+        WS.Response response = runJsonTest(json, "/parsers/limitedjson");
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat((Object) response.asJson()).isEqualTo(json);
+    }
+
+    @Test
+    public void testLimitedJsonExceedsDefaultLengthButLessThanLimit() {
+        JsonNode json = createJson(110 * 1024);
+        WS.Response response = runJsonTest(json, "/parsers/limitedjson");
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat((Object) response.asJson()).isEqualTo(json);
+    }
+
+    @Test
+    public void testLimitedJsonExceedsLimit() {
+        JsonNode json = createJson(130 * 1024);
+        WS.Response response = runJsonTest(json, "/parsers/limitedjson");
+        assertThat(response.getStatus()).isEqualTo(413);
+    }
+
+    private WS.Response runJsonTest(final JsonNode json, final String url) {
+        final AtomicReference<WS.Response> response = new AtomicReference<WS.Response>();
+        running(testServer(9001), new Runnable() {
+            @Override
+            public void run() {
+                WS.Response r = WS.url("http://localhost:9001" + url).setHeader("Content-Type", "application/json")
+                        .post(Json.stringify(json)).get();
+                r.getBody();
+                response.set(r);
+            }
+        });
+        return response.get();
+    }
+
+    private static JsonNode createJson(int length) {
+        StringBuilder sb = new StringBuilder(length);
+        String text = "The quick brown fox jumps over the lazy dog. Why? I don't know. I guess it just uses every letter.";
+        while (length > 0) {
+            int toAppend = Math.min(length, text.length());
+            sb.append(text.substring(0, toAppend));
+            length -= toAppend;
+        }
+        ObjectNode json = Json.newObject();
+        json.put("string", sb.toString());
+        return json;
+    }
+}


### PR DESCRIPTION
A few bugs fixed in this commit:
- Global default max length overrides per action max length in Java actions, rather than being the default
- WS Java API not reset properly between testServer runs
- -1 is now the indication that the default maxLength should be used in the BodyParser.Of.maxLength annotation value, rather than Integer.MAX_INT
