### PR TITLE
Fix play versions conflict when using play plugins

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayKeys.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayKeys.scala
@@ -44,5 +44,7 @@ trait PlayKeys {
 
   val javascriptEntryPoints = SettingKey[PathFinder]("play-javascript-entry-points")
 
+  val playPlugin = SettingKey[Boolean]("play-plugin")
+
 }
 object PlayKeys extends PlayKeys

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -59,6 +59,8 @@ trait PlaySettings {
 
   lazy val defaultSettings = Seq[Setting[_]](
 
+    playPlugin := false,
+
     resolvers ++= Seq(
       "Typesafe Releases Repository" at "http://repo.typesafe.com/typesafe/releases/",
       "Typesafe Snapshots Repository" at "http://repo.typesafe.com/typesafe/snapshots/"
@@ -81,7 +83,13 @@ trait PlaySettings {
 
     distDirectory <<= baseDirectory / "dist",
 
-    libraryDependencies += "play" %% "play" % play.core.PlayVersion.current,
+    libraryDependencies <+= (playPlugin) { isPlugin =>
+      val d = "play" %% "play" % play.core.PlayVersion.current
+      if(isPlugin)
+         d % "provided"
+      else
+        d
+    },
 
     libraryDependencies += "play" %% "play-test" % play.core.PlayVersion.current % "test",
 
@@ -110,7 +118,7 @@ trait PlaySettings {
 
     sourceGenerators in Compile <+= (confDirectory, sourceManaged in Compile, routesImport) map RouteFiles,
 
-    // Adds config directory's source files to continuous hot reloading 
+    // Adds config directory's source files to continuous hot reloading
     watchSources <+= confDirectory map { all => all },
 
     sourceGenerators in Compile <+= (sourceDirectory in Compile, sourceManaged in Compile, templatesTypes, templatesImport) map ScalaTemplates,


### PR DESCRIPTION
Add a new setting to PlayProject called playPlugin

``` scala
lazy val plugin = PlayProject(appName, appVersion, pluginDependencies, mainLang = SCALA).settings(
      playPlugin := true,
    )
```

When set to true, dependency on Play is marked as provided, which avoid conflicts between Play from your app, and Play from a plugin.
