### PR TITLE
compileVirtual is added, which does the compiling on the fly

### DIFF
--- a/framework/src/templates/src/main/scala/play/api/templates/ScalaTemplateCompiler.scala
+++ b/framework/src/templates/src/main/scala/play/api/templates/ScalaTemplateCompiler.scala
@@ -580,7 +580,7 @@ object """ :+ name :+ """ extends BaseScalaTemplate[""" :+ resultType :+ """,For
       generated
     }
 
-    @deprecated("use generateFinalTemplate with 8 parameters instead", "Play 2.0.4")
+    @deprecated("use generateFinalTemplate with 8 parameters instead", "Play 2.1")
     def generateFinalTemplate(template: File, packageName: String, name: String, root: Template, resultType: String, formatterType: String, additionalImports: String): String = {
       generateFinalTemplate(template.getAbsolutePath, Path(template).slurpString, packageName, name, root, resultType, formatterType, additionalImports)
     }
@@ -761,7 +761,7 @@ object """ :+ name :+ """ extends BaseScalaTemplate[""" :+ resultType :+ """,For
             """
     }
     
-    @deprecated("use finalSource with 3 parameters instead", "Play 2.0.4")
+    @deprecated("use finalSource with 3 parameters instead", "Play 2.1")
     def finalSource(template: File, generatedTokens: Seq[Any]): String = {
       finalSource(template.getAbsolutePath, Path(template).byteArray, generatedTokens)
     }


### PR DESCRIPTION
It gets 'source: File' which is only used for generating template name and producing TemplateCompilationError, but its contents is not used. Instead 'content: String' will be used.
Now we have two kinds of GeneratedSource: 1. GeneratedSource 2. GeneratedSourceVirtual. And there is a trait AbstractGeneratedSource, which contains the common parts.
Previous interface of finalSource and generateFinalTemplate are marked as deprecated and new general interface is defined for them.
Merger should change the description of deprecated as well.
