### PR TITLE
[#722] Made email validation compliant with W3C spec

### DIFF
--- a/framework/src/play/src/main/java/play/data/validation/Constraints.java
+++ b/framework/src/play/src/main/java/play/data/validation/Constraints.java
@@ -358,7 +358,7 @@ public class Constraints {
     public static class EmailValidator extends Validator<String> implements ConstraintValidator<Email, String> {
         
         final static public String message = "error.email";
-        final static java.util.regex.Pattern regex = java.util.regex.Pattern.compile("\\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}\\b");
+        final static java.util.regex.Pattern regex = java.util.regex.Pattern.compile("\\b[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*\\b");
         
         public EmailValidator() {}
         

--- a/framework/src/play/src/main/scala/play/api/data/Forms.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Forms.scala
@@ -423,7 +423,7 @@ object Forms {
    * }}}
    */
   val email: Mapping[String] = of[String] verifying Constraints.pattern(
-    """\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}\b""".r,
+    """\b[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\b""".r,
     "constraint.email",
     "error.email")
 

--- a/framework/src/play/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/data/FormSpec.scala
@@ -93,6 +93,13 @@ object ScalaForms {
           "foo" -> Forms.text.verifying("first.digit", s => (s.headOption map {_ == '3'}) getOrElse false)
                      .transform[Int](Integer.parseInt _, _.toString).verifying("number.42", _ < 42)
     )
+    
+    val emailForm = Form(
+      tuple(
+        "email" -> email,
+        "name" -> of[String]
+      )
+    )
 }
 
 object FormSpec extends Specification {
@@ -127,6 +134,26 @@ object FormSpec extends Specification {
       val myForm = Controller.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(true)
 
+    }
+    "have an error due to a malformed email" in {
+      val f5 = ScalaForms.emailForm.fillAndValidate("john@", "John")
+      f5.errors.size must equalTo (1)
+      f5.errors.find(_.message == "error.email") must beSome
+      
+      val f6 = ScalaForms.emailForm.fillAndValidate("john@zen.....com", "John")
+      f6.errors.size must equalTo (1)
+      f6.errors.find(_.message == "error.email") must beSome
+    }
+    
+    "be valid with a well-formed email" in {
+      val f7 = ScalaForms.emailForm.fillAndValidate("john@zen.com", "John")
+      f7.errors.size must equalTo (0)
+      
+      val f8 = ScalaForms.emailForm.fillAndValidate("john@zen.museum", "John")
+      f8.errors.size must equalTo (0)
+      
+      val f9 = ScalaForms.emailForm.fillAndValidate("john@mail.zen.com", "John")
+      f9.errors.size must equalTo(0)
     }
     
     "apply constraints on wrapped mappings" in {


### PR DESCRIPTION
see
http://www.w3.org/TR/html-markup/datatypes.html#form.data.emailaddress

The regex was changed in the Validator classes to conform to the specification referenced above. The new regex allows for TLD's that are longer than four characters, like .museum.

Also included unit tests for the Scala API in FormSpec
