### PR TITLE
Upgrade Jackson JSON library

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -337,8 +337,8 @@ object PlayBuild extends Build {
 
             "oauth.signpost"                    %    "signpost-core"            %   "1.2.1.1",
             "oauth.signpost"                    %    "signpost-commonshttp4"    %   "1.2.1.1",
-            "org.codehaus.jackson"        %   "jackson-core-asl"              %   "1.9.9",
-            "org.codehaus.jackson"        %   "jackson-mapper-asl"              %   "1.9.9",
+            "com.fasterxml.jackson.core"        %    "jackson-core"             %   "2.0.6",
+            "com.fasterxml.jackson.core"        %    "jackson-databind"         %   "2.0.6",
 
             ("org.reflections"                  %    "reflections"              %   "0.9.7" notTransitive())
               .exclude("com.google.guava", "guava")

--- a/framework/skeletons/java-skel/test/ApplicationTest.java
+++ b/framework/skeletons/java-skel/test/ApplicationTest.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.codehaus.jackson.JsonNode;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.*;
 
 import play.mvc.*;

--- a/framework/src/play-test/src/main/java/play/test/FakeRequest.java
+++ b/framework/src/play-test/src/main/java/play/test/FakeRequest.java
@@ -1,6 +1,6 @@
 package play.test;
 
-import org.codehaus.jackson.JsonNode;
+import com.fasterxml.jackson.databind.JsonNode;
 import play.api.mvc.AnyContentAsJson;
 import play.libs.*;
 import play.mvc.*;

--- a/framework/src/play/src/main/java/play/data/Form.java
+++ b/framework/src/play/src/main/java/play/data/Form.java
@@ -214,7 +214,7 @@ public class Form<T> {
      * @param data data to submit
      * @return a copy of this form filled with the new data
      */
-    public Form<T> bind(org.codehaus.jackson.JsonNode data, String... allowedFields) {
+    public Form<T> bind(com.fasterxml.jackson.databind.JsonNode data, String... allowedFields) {
         return bind(
             play.libs.Scala.asJava(
                 play.api.data.FormUtils.fromJson("", 
@@ -451,14 +451,14 @@ public class Form<T> {
     /**
      * Returns the form errors serialized as Json.
      */
-    public org.codehaus.jackson.JsonNode errorsAsJson() {
+    public com.fasterxml.jackson.databind.JsonNode errorsAsJson() {
         return errorsAsJson(Http.Context.Implicit.lang());
     }
 
     /**
      * Returns the form errors serialized as Json using the given Lang.
      */
-    public org.codehaus.jackson.JsonNode errorsAsJson(play.i18n.Lang lang) {
+    public com.fasterxml.jackson.databind.JsonNode errorsAsJson(play.i18n.Lang lang) {
         Map<String, List<String>> allMessages = new HashMap<String, List<String>>();
         for (String key : errors.keySet()) {
             List<ValidationError> errs = errors.get(key);

--- a/framework/src/play/src/main/java/play/libs/Comet.java
+++ b/framework/src/play/src/main/java/play/libs/Comet.java
@@ -4,7 +4,7 @@ import play.mvc.Results.*;
 
 import play.libs.F.*;
 
-import org.codehaus.jackson.*;
+import com.fasterxml.jackson.databind.*;
 
 import java.util.*;
 

--- a/framework/src/play/src/main/java/play/libs/Json.java
+++ b/framework/src/play/src/main/java/play/libs/Json.java
@@ -1,8 +1,8 @@
 package play.libs;
 
-import org.codehaus.jackson.*;
-import org.codehaus.jackson.map.*;
-import org.codehaus.jackson.node.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Helper functions to handle JsonNode values.

--- a/framework/src/play/src/main/java/play/libs/Jsonp.java
+++ b/framework/src/play/src/main/java/play/libs/Jsonp.java
@@ -1,6 +1,6 @@
 package play.libs;
 
-import org.codehaus.jackson.JsonNode;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import play.mvc.Content;
 import play.libs.Json;

--- a/framework/src/play/src/main/java/play/libs/WS.java
+++ b/framework/src/play/src/main/java/play/libs/WS.java
@@ -24,8 +24,8 @@ import org.w3c.dom.Document;
 
 import play.libs.F.Promise;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Asynchronous API to to query web services, as an http client.
@@ -456,7 +456,7 @@ public class WS {
         }
 
         /**
-         * Get the response body as a {@link org.codehaus.jackson.JsonNode}
+         * Get the response body as a {@link com.fasterxml.jackson.JsonNode}
          * @return the json response
          */
         public JsonNode asJson() {

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -4,7 +4,7 @@ import java.io.*;
 import java.util.*;
 
 import org.w3c.dom.*;
-import org.codehaus.jackson.*;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import play.i18n.Lang;
 

--- a/framework/src/play/src/main/java/play/mvc/Results.java
+++ b/framework/src/play/src/main/java/play/mvc/Results.java
@@ -8,7 +8,7 @@ import play.libs.F.*;
 import java.io.*;
 import java.util.*;
 
-import org.codehaus.jackson.*;
+import com.fasterxml.jackson.databind.*;
 
 /**
  * Common results.

--- a/framework/src/play/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/json/JsValue.scala
@@ -1,10 +1,10 @@
 package play.api.libs.json
 
-import org.codehaus.jackson.{ JsonGenerator, JsonToken, JsonParser }
-import org.codehaus.jackson.`type`.JavaType
-import org.codehaus.jackson.map._
-import org.codehaus.jackson.map.annotate.JsonCachable
-import org.codehaus.jackson.map.`type`.{ TypeFactory, ArrayType }
+import com.fasterxml.jackson.core.{ JsonGenerator, JsonToken, JsonParser }
+import com.fasterxml.jackson.databind._
+import com.fasterxml.jackson.databind.deser.Deserializers
+import com.fasterxml.jackson.databind.ser.Serializers
+import com.fasterxml.jackson.databind.`type`.TypeFactory
 
 import scala.collection._
 
@@ -269,10 +269,9 @@ case class JsObject(fields: Seq[(String, JsValue)]) extends JsValue {
 
 // -- Serializers.
 
-@JsonCachable
 private[json] class JsValueSerializer extends JsonSerializer[JsValue] {
 
-  def serialize(value: JsValue, json: JsonGenerator, provider: SerializerProvider) {
+  override def serialize(value: JsValue, json: JsonGenerator, provider: SerializerProvider) {
     value match {
       case JsNumber(v) => json.writeNumber(v.bigDecimal)
       case JsString(v) => json.writeString(v)
@@ -323,9 +322,11 @@ private[json] case class ReadingMap(content: List[(String, JsValue)]) extends De
 
 }
 
-@JsonCachable
 private[json] class JsValueDeserializer(factory: TypeFactory, klass: Class[_]) extends JsonDeserializer[Object] {
-  def deserialize(jp: JsonParser, ctxt: DeserializationContext): JsValue = {
+
+  override def isCachable = true
+
+  override def deserialize(jp: JsonParser, ctxt: DeserializationContext): JsValue = {
     val value = deserialize(jp, ctxt, List())
 
     if (!klass.isAssignableFrom(value.getClass)) {
@@ -399,9 +400,7 @@ private[json] class JsValueDeserializer(factory: TypeFactory, klass: Class[_]) e
 }
 
 private[json] class PlayDeserializers(classLoader: ClassLoader) extends Deserializers.Base {
-  override def findBeanDeserializer(javaType: JavaType, config: DeserializationConfig,
-    provider: DeserializerProvider, beanDesc: BeanDescription,
-    property: BeanProperty) = {
+  override def findBeanDeserializer(javaType: JavaType, config: DeserializationConfig, beanDesc: BeanDescription) = {
     val klass = javaType.getRawClass
     if (classOf[JsValue].isAssignableFrom(klass) || klass == JsNull.getClass) {
       new JsValueDeserializer(config.getTypeFactory, klass)
@@ -411,7 +410,7 @@ private[json] class PlayDeserializers(classLoader: ClassLoader) extends Deserial
 }
 
 private[json] class PlaySerializers extends Serializers.Base {
-  override def findSerializer(config: SerializationConfig, javaType: JavaType, beanDesc: BeanDescription, beanProp: BeanProperty) = {
+  override def findSerializer(config: SerializationConfig, javaType: JavaType, beanDesc: BeanDescription) = {
     val ser: Object = if (classOf[JsValue].isAssignableFrom(beanDesc.getBeanClass)) {
       new JsValueSerializer
     } else {
@@ -423,9 +422,9 @@ private[json] class PlaySerializers extends Serializers.Base {
 
 private[json] object JacksonJson{
 
-  import org.codehaus.jackson.Version
-  import org.codehaus.jackson.map.module.SimpleModule
-  import org.codehaus.jackson.map.Module.SetupContext
+  import com.fasterxml.jackson.core.Version
+  import com.fasterxml.jackson.databind.module.SimpleModule
+  import com.fasterxml.jackson.databind.Module.SetupContext
 
   private[this]  val classLoader = Thread.currentThread().getContextClassLoader
 
@@ -439,7 +438,7 @@ private[json] object JacksonJson{
   }
   mapper.registerModule(module)
 
-  private[this] lazy val jsonFactory = new org.codehaus.jackson.JsonFactory(mapper)
+  private[this] lazy val jsonFactory = new com.fasterxml.jackson.core.JsonFactory(mapper)
 
   private[this] def stringJsonGenerator(out: java.io.StringWriter) = jsonFactory.createJsonGenerator(out)
   

--- a/framework/src/play/src/main/scala/play/core/j/JavaParsers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaParsers.scala
@@ -44,8 +44,8 @@ object JavaParsers extends BodyParsers {
     }
 
     override lazy val asJson = {
-      import org.codehaus.jackson._
-      import org.codehaus.jackson.map._
+      import com.fasterxml.jackson._
+      import com.fasterxml.jackson.databind._
 
       json.map { json =>
         new ObjectMapper().readValue(json.toString, classOf[JsonNode])

--- a/framework/src/play/src/main/scala/play/core/j/JavaWebSocket.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaWebSocket.scala
@@ -63,5 +63,5 @@ object JavaWebSocket extends JavaHelpers {
     play.libs.Json.stringify, play.libs.Json.parse
   )
 
-  def ofJson(retrieveWebSocket: => play.mvc.WebSocket[org.codehaus.jackson.JsonNode]): Handler = webSocketWrapper[org.codehaus.jackson.JsonNode](retrieveWebSocket)
+  def ofJson(retrieveWebSocket: => play.mvc.WebSocket[com.fasterxml.jackson.databind.JsonNode]): Handler = webSocketWrapper[com.fasterxml.jackson.databind.JsonNode](retrieveWebSocket)
 }

--- a/framework/src/play/src/main/scala/play/core/router/Router.scala
+++ b/framework/src/play/src/main/scala/play/core/router/Router.scala
@@ -168,8 +168,8 @@ object Router {
       def call(call: => play.mvc.WebSocket[String], handler: HandlerDef): Handler = play.core.j.JavaWebSocket.ofString(call)
     }
 
-    implicit def javaJsonWebSocket: HandlerInvoker[play.mvc.WebSocket[org.codehaus.jackson.JsonNode]] = new HandlerInvoker[play.mvc.WebSocket[org.codehaus.jackson.JsonNode]] {
-      def call(call: => play.mvc.WebSocket[org.codehaus.jackson.JsonNode], handler: HandlerDef): Handler = play.core.j.JavaWebSocket.ofJson(call)
+    implicit def javaJsonWebSocket: HandlerInvoker[play.mvc.WebSocket[com.fasterxml.jackson.databind.JsonNode]] = new HandlerInvoker[play.mvc.WebSocket[com.fasterxml.jackson.databind.JsonNode]] {
+      def call(call: => play.mvc.WebSocket[com.fasterxml.jackson.databind.JsonNode], handler: HandlerDef): Handler = play.core.j.JavaWebSocket.ofJson(call)
     }
 
   }

--- a/framework/test/integrationtest-java/app/controllers/Application.java
+++ b/framework/test/integrationtest-java/app/controllers/Application.java
@@ -1,7 +1,7 @@
 package controllers;
 
 import java.util.concurrent.Callable;
-import org.codehaus.jackson.JsonNode;
+import com.fasterxml.jackson.databind.JsonNode;
 import play.*;
 import play.libs.Akka;
 import play.libs.F.Function;

--- a/framework/test/integrationtest-java/test/controllers/BodyParsersTest.java
+++ b/framework/test/integrationtest-java/test/controllers/BodyParsersTest.java
@@ -1,7 +1,7 @@
 package controllers;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.ObjectNode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
 import play.libs.Json;
 import play.libs.WS;

--- a/framework/test/integrationtest-java/test/test/SimpleTest.java
+++ b/framework/test/integrationtest-java/test/test/SimpleTest.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import controllers.routes;
-import org.codehaus.jackson.JsonNode;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.*;
 
 import play.libs.Json;

--- a/framework/test/integrationtest/app/controllers/JavaApi.java
+++ b/framework/test/integrationtest/app/controllers/JavaApi.java
@@ -2,7 +2,7 @@ package controllers;
 
 import java.util.*;
 
-import org.codehaus.jackson.JsonNode;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import play.*;
 import play.libs.Json;

--- a/samples/java/websocket-chat/app/controllers/Application.java
+++ b/samples/java/websocket-chat/app/controllers/Application.java
@@ -4,7 +4,7 @@ import play.*;
 import play.mvc.*;
 import play.libs.F.*;
 
-import org.codehaus.jackson.*;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import views.html.*;
 

--- a/samples/java/websocket-chat/app/models/ChatRoom.java
+++ b/samples/java/websocket-chat/app/models/ChatRoom.java
@@ -9,8 +9,9 @@ import akka.actor.*;
 import akka.dispatch.*;
 import static akka.pattern.Patterns.ask;
 
-import org.codehaus.jackson.*;
-import org.codehaus.jackson.node.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.util.*;
 

--- a/samples/java/websocket-chat/app/models/Robot.java
+++ b/samples/java/websocket-chat/app/models/Robot.java
@@ -9,8 +9,8 @@ import akka.util.*;
 import akka.actor.*;
 import akka.dispatch.*;
 
-import org.codehaus.jackson.*;
-import org.codehaus.jackson.node.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import static java.util.concurrent.TimeUnit.*;
 


### PR DESCRIPTION
Since we're doing JSON improvements at the moment, I thought I'd send this somewhat sizable change to stop using the old version of Jackson.  I know that library upgrades are usually not helpful, but I thought this one might be different since it has so many code changes associated with it.
