### PR TITLE
[#329] Made Java WSRequest.execute public

### DIFF
--- a/framework/src/play/src/main/java/play/libs/WS.java
+++ b/framework/src/play/src/main/java/play/libs/WS.java
@@ -139,7 +139,7 @@ public class WS {
             return this.url;
         }
 
-        private Promise<Response> execute() {
+        public Promise<Response> execute() {
             final scala.concurrent.Promise<Response> scalaPromise = scala.concurrent.Promise$.MODULE$.<Response>apply();
             try {
                 WS.client().executeRequest(request, new AsyncCompletionHandler<com.ning.http.client.Response>() {


### PR DESCRIPTION
This is a very small pull request, but I wanted to get some feedback first, is this ok?  Basically it allows access to the full (and powerful) Ning RequestBuilderBase API, for doing practically anything required, instead of hiding this from users.  The only other option users have if Plays WSRequestHolder doesn't provide something they need is to not use the WS API (and hence they lose easy access to Promise).

To give an example of where I have needed this before, we had a case where we were talking to a third party server that was gzipping all responses, whether gzip was in the Accept header or not, so we needed to add some custom handling to the client.  We had to resort to using a different HTTP client lib to do this.
