### PR TITLE
[#358] Remove compiler warning when using Option in routes

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
@@ -900,7 +900,7 @@ object RoutesCompiler {
                                 markLines((route +: routes): _*),
                                 route.call.method,
                                 reverseSignature,
-                                reverseParameters.map(_._1.name).mkString(", "),
+                                reverseParameters.map(_._1.name + ": @unchecked").mkString(", "),
 
                                 // route selection
                                 (route +: routes).map { route =>


### PR DESCRIPTION
This fixes a compiler warning when using Option (and any other sealed class) parameter types in routes.  For example, the following routes:

```
GET     /t                          controllers.Application.t(p: Option[Int] = None)
GET     /t/a                        controllers.Application.t(p: Option[Int])
```

would result in a compiler warning in the reverse routes file saying that the match was not exhaustive, because the Scala compiler isn't smart enough to work out that

```
case (p) if true =>
```

matches everything, and so is exhaustive.  Of course, the "if true" is needed for cases where two routes point to the same method, otherwise you get an unreachable code compiler error.  So, using this workaround:

http://www.scala-lang.org/node/123

we tell the compiler not to do the exhaustive check by adding @unchecked to the match statement.
