### PR TITLE
Implemented handling for snapshot versions

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayProject.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayProject.scala
@@ -1,22 +1,23 @@
 package sbt
 
 import Keys._
-import jline._
-
 import play.api._
-import play.core._
-
+import play.core.PlayVersion
 import play.utils.Colors
+import java.util.regex.Pattern
 
 object PlayProject extends Plugin with PlayExceptions with PlayKeys with PlayReloader with PlayCommands with PlaySettings {
 
+  val SnapshotVersion = "(.*-)SNAPSHOT"r
+
   Option(System.getProperty("play.version")).map {
-    case badVersion if badVersion != play.core.PlayVersion.current => {
+    case SnapshotVersion(versionPrefix) if PlayVersion.current.matches(Pattern.quote(versionPrefix) + "[0-9]+") =>
+    case badVersion if badVersion != PlayVersion.current => {
       println(
         Colors.red("""
           |This project uses Play %s!
           |Update the Play sbt-plugin version to %s (usually in project/plugins.sbt)
-        """.stripMargin.format(play.core.PlayVersion.current, badVersion))
+        """.stripMargin.format(PlayVersion.current, badVersion))
       )
     }
     case _ =>


### PR DESCRIPTION
This just allows people to depend on specific nightly builds of Play, through updating the version in the SBT plugins file (which is checked into their source repository), without having to update the version in the play script (which is not checked into the source repository), so one person in a team can update the version, and no one else has to do anything.
