### PR TITLE
[#752] Support discarding cookies on a particular path, domain and ensure Session/Flash cookies use this

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -152,7 +152,8 @@ object PlayBuild extends Build {
             publishArtifact in (Compile, packageSrc) := true,
             resolvers += typesafe,
             sourceGenerators in Compile <+= (dependencyClasspath in TemplatesCompilerProject in Runtime, packageBin in TemplatesCompilerProject in Compile, scalaSource in Compile, sourceManaged in Compile, streams) map ScalaTemplates,
-            compile in (Compile) <<= PostCompile
+            compile in (Compile) <<= PostCompile,
+            parallelExecution in Test := false
         )
     ).settings(com.typesafe.sbtscalariform.ScalariformPlugin.defaultScalariformSettings: _*)
     .dependsOn({

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -499,7 +499,6 @@ public class Http {
 
         private final Map<String,String> headers = new HashMap<String,String>();
         private final List<Cookie> cookies = new ArrayList<Cookie>();
-        private final List<String> discardedCookies = new ArrayList<String>();
 
         /**
          * Adds a new header to the response.
@@ -591,16 +590,26 @@ public class Http {
          * @param names Names of the cookies to discard
          */
         public void discardCookies(String... names) {
-            discardedCookies.addAll(Arrays.asList(names));
+            for (String name: names) {
+                discardCookie(name, "/", null, false);
+            }
+        }
+
+        /**
+         * Discard a cookie in this result
+         *
+         * @param name The name of the cookie to discard
+         * @param path The path of the cookie te discard, may be null
+         * @param domain The domain of the cookie to discard, may be null
+         * @param secure Whether the cookie to discard is secure
+         */
+        public void discardCookie(String name, String path, String domain, boolean secure) {
+            cookies.add(new Cookie(name, "", 0, path, domain, secure, false));
         }
 
         // FIXME return a more convenient type? e.g. Map<String, Cookie>
         public Iterable<Cookie> cookies() {
             return cookies;
-        }
-
-        public Iterable<String> discardedCookies() {
-            return discardedCookies;
         }
 
     }

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -68,7 +68,7 @@ sealed trait WithHeaders[+A <: Result] {
    * @param cookies the cookies to discard along to this result
    * @return the new result
    */
-  def discardingCookies(names: String*): A
+  def discardingCookies(cookies: DiscardingCookie*): A
 
   /**
    * Sets a new session for this result.
@@ -203,8 +203,8 @@ trait PlainResult extends Result with WithHeaders[PlainResult] {
    * @param cookies the cookies to discard along to this result
    * @return the new result
    */
-  def discardingCookies(names: String*): PlainResult = {
-    withHeaders(SET_COOKIE -> Cookies.merge(header.headers.get(SET_COOKIE).getOrElse(""), Nil, discard = names))
+  def discardingCookies(cookies: DiscardingCookie*): PlainResult = {
+    withHeaders(SET_COOKIE -> Cookies.merge(header.headers.get(SET_COOKIE).getOrElse(""), cookies.map(_.toCookie)))
   }
 
   /**
@@ -219,7 +219,7 @@ trait PlainResult extends Result with WithHeaders[PlainResult] {
    * @return the new result
    */
   def withSession(session: Session): PlainResult = {
-    if (session.isEmpty) discardingCookies(Session.COOKIE_NAME) else withCookies(Session.encodeAsCookie(session))
+    if (session.isEmpty) discardingCookies(Session.discard) else withCookies(Session.encodeAsCookie(session))
   }
 
   /**
@@ -420,8 +420,8 @@ case class AsyncResult(result: Future[Result]) extends Result with WithHeaders[A
    * @param cookies the cookies to discard along to this result
    * @return the new result
    */
-  def discardingCookies(names: String*): AsyncResult = {
-    map(_.discardingCookies(names: _*))
+  def discardingCookies(cookies: DiscardingCookie*): AsyncResult = {
+    map(_.discardingCookies(cookies: _*))
   }
 
   /**

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -33,7 +33,6 @@ trait JavaHelpers {
     case result: PlainResult => {
       val wResult = result.withHeaders(javaContext.response.getHeaders.asScala.toSeq: _*)
         .withCookies((javaContext.response.cookies.asScala.toSeq map { c => Cookie(c.name, c.value, c.maxAge, c.path, Option(c.domain), c.secure, c.httpOnly) }): _*)
-        .discardingCookies(javaContext.response.discardedCookies.asScala.toSeq: _*)
 
       if (javaContext.session.isDirty && javaContext.flash.isDirty) {
         wResult.withSession(Session(javaContext.session.asScala.toMap)).flashing(Flash(javaContext.flash.asScala.toMap))

--- a/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -272,7 +272,7 @@ private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: De
             .map(Cookies.decode(_))
             .flatMap(_.find(_.name == Flash.COOKIE_NAME)).orElse {
               Option(requestHeader.flash).filterNot(_.isEmpty).map { _ =>
-                play.api.mvc.Cookie(Flash.COOKIE_NAME, "", 0)
+                Flash.discard.toCookie
               }
             }
           }

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -53,7 +53,7 @@ object ResultsSpec extends Specification {
         Ok("hello").as("text/html")
           .withCookies(Cookie("session", "items"), Cookie("preferences", "blue"))
           .withCookies(Cookie("lang", "fr"), Cookie("session", "items2"))
-          .discardingCookies("logged")
+          .discardingCookies(DiscardingCookie("logged"))
 
       val setCookies = Cookies.decode(headers("Set-Cookie")).map(c => c.name -> c).toMap
       setCookies.size must be_==(4)
@@ -78,7 +78,7 @@ object ResultsSpec extends Specification {
         Ok("hello").as("text/html")
           .withSession("user" -> "kiki", "langs" -> "fr:en:de")
           .withCookies(Cookie("session", "items"), Cookie("preferences", "blue"))
-          .discardingCookies("logged")
+          .discardingCookies(DiscardingCookie("logged"))
           .withSession("user" -> "kiki", "langs" -> "fr:en:de")
           .withCookies(Cookie("lang", "fr"), Cookie("session", "items2"))
 
@@ -102,16 +102,59 @@ object ResultsSpec extends Specification {
       val decodedSession = Session.decode(maliciousSession)
       decodedSession must beEmpty
     }
+
+    "support a custom application context" in {
+      "set session on right path" in new WithFooPath {
+        Cookies.decode(Ok.withSession("user" -> "alice").header.headers("Set-Cookie")).head.path must_== "/foo"
+      }
+
+      "discard session on right path" in new WithFooPath {
+        Cookies.decode(Ok.withNewSession.header.headers("Set-Cookie")).head.path must_== "/foo"
+      }
+
+      "set flash on right path" in new WithFooPath {
+        Cookies.decode(Ok.flashing("user" -> "alice").header.headers("Set-Cookie")).head.path must_== "/foo"
+      }
+
+      // flash cookie is discarded in PlayDefaultUpstreamHandler
+    }
+
+    "support a custom session domain" in {
+      "set session on right domain" in new WithFooDomain {
+        Cookies.decode(Ok.withSession("user" -> "alice").header.headers("Set-Cookie")).head.domain must beSome(".foo.com")
+      }
+
+      "discard session on right domain" in new WithFooDomain {
+        Cookies.decode(Ok.withNewSession.header.headers("Set-Cookie")).head.domain must beSome(".foo.com")
+      }
+    }
+
+    "support a secure session" in {
+      "set session as secure" in new WithSecureSession {
+        Cookies.decode(Ok.withSession("user" -> "alice").header.headers("Set-Cookie")).head.secure must_== true
+      }
+
+      "discard session as secure" in new WithFooDomain {
+        Cookies.decode(Ok.withNewSession.header.headers("Set-Cookie")).head.secure must_== true
+      }
+    }
+
   }
 
-  trait WithApplication extends Around with Scope {
+  abstract class WithFooPath extends WithApplication("application.context" -> "/foo")
+
+  abstract class WithFooDomain extends WithApplication("session.domain" -> ".foo.com")
+
+  abstract class WithSecureSession extends WithApplication("session.secure" -> true)
+
+  abstract class WithApplication(config: (String, Any)*) extends Around with Scope {
     import play.api._
     import java.io.File
 
-    implicit val app: Application =
+    implicit lazy val app: Application =
       new DefaultApplication(new File("./src/play/src/test"), Thread.currentThread.getContextClassLoader, None, play.api.Mode.Test){
         override lazy val configuration = Configuration.from(Map("application.secret" -> "pass",
-          "ehcacheplugin" -> "disabled"))
+          "ehcacheplugin" -> "disabled") ++ config.toMap)
       }
 
     def around[T <% SpecsResult](t: => T) = {


### PR DESCRIPTION
This is a backwards incompatible change, because it means discardingCookies now accepts a list of DiscardingCookie, which gives the developer the ability to discard cookies that were set on a particular domain, path or with secure set.

It fixes a bug in that when application.context, session.domain or session.secure was set, it was impossible to clear the session, and flash cookies were completely screwed.

Also in this request I changed some vals to defs in CookieBaker, Session and Flash objects, so that I could test with different configurations.
