### PR TITLE
[#767] Fix default empty database password for sample projects.

### DIFF
--- a/framework/skeletons/empty-skel/conf/application.conf
+++ b/framework/skeletons/empty-skel/conf/application.conf
@@ -36,7 +36,7 @@ application.langs="en"
 # db.default.driver=org.h2.Driver
 # db.default.url="jdbc:h2:mem:play"
 # db.default.user=sa
-# db.default.password=
+# db.default.password=""
 
 # Evolutions
 # ~~~~~

--- a/framework/test/integrationtest-java/conf/application.conf
+++ b/framework/test/integrationtest-java/conf/application.conf
@@ -23,7 +23,7 @@ application.secret="k_tL/LsWE^h:El?=@>I0RLZA>[HfjfTsqNk@H7<FEXuc@?:t`IiLt[KUY6q0
 db.default.driver=org.h2.Driver
 db.default.url="jdbc:h2:mem:play"
 # db.default.user=sa
-# db.default.password=
+# db.default.password=""
 
 # Ebean configuration
 # ~~~~~

--- a/framework/test/integrationtest-scala/conf/application.conf
+++ b/framework/test/integrationtest-scala/conf/application.conf
@@ -23,7 +23,7 @@ application.secret="I_B4ueh2Gd1teu0OUCbjxsCwNPb1:A4ASEanTe1JjrqjkxGFT/50DlNZAeQc
 # db.default.driver=org.h2.Driver
 # db.default.url="jdbc:h2:mem:play"
 # db.default.user=sa
-# db.default.password=
+# db.default.password=""
 
 # Logger
 # ~~~~~

--- a/samples/java/comet-clock/conf/application.conf
+++ b/samples/java/comet-clock/conf/application.conf
@@ -21,7 +21,7 @@ application.secret="LXkI?<qeo`6mfj2fIWZ[>::Ryc?YK?<Ek=7EqWED@?nFmNsHIaWc]>XL^Mo?
 # db.default.driver=org.h2.Driver
 # db.default.url="jdbc:h2:mem:play"
 # db.default.user=sa
-# db.default.password=
+# db.default.password=""
 #
 # You can expose this datasource via JNDI if needed (Useful for JPA)
 # db.default.jndiName=DefaultDS

--- a/samples/java/forms/conf/application.conf
+++ b/samples/java/forms/conf/application.conf
@@ -21,7 +21,7 @@ application.secret="UM/[gm4bL4=i5f<:Be]aYCBaQ[TWKAI[wqDoraFY8LBHSAZLvP:n9y/`?yA0
 # db.default.driver=org.h2.Driver
 # db.default.url="jdbc:h2:mem:play"
 # db.default.user=sa
-# db.default.password=
+# db.default.password=""
 #
 # You can expose this datasource via JNDI if needed (Useful for JPA)
 # db.default.jndiName=DefaultDS

--- a/samples/java/helloworld/conf/application.conf
+++ b/samples/java/helloworld/conf/application.conf
@@ -15,7 +15,7 @@ application.secret="TsLWj4[^1N<7nrI/>EkyPDTO[dnh<7_R[j;cN0:lGK6Mm`0048C@3PK]4KR6
 # db.default.driver=org.h2.Driver
 # db.default.url="jdbc:h2:mem:play"
 # db.default.user=sa
-# db.default.password=
+# db.default.password=""
 
 # Logger
 # ~~~~~

--- a/samples/java/websocket-chat/conf/application.conf
+++ b/samples/java/websocket-chat/conf/application.conf
@@ -21,7 +21,7 @@ application.secret="G]IT8?InJi]pm]IUsvJBrIeJH8HWhDQdTb3]xQTD@g<Nka9hvhk9S]jnMh0d
 # db.default.driver=org.h2.Driver
 # db.default.url="jdbc:h2:mem:play"
 # db.default.user=sa
-# db.default.password=
+# db.default.password=""
 #
 # You can expose this datasource via JNDI if needed (Useful for JPA)
 # db.default.jndiName=DefaultDS

--- a/samples/scala/comet-clock/conf/application.conf
+++ b/samples/scala/comet-clock/conf/application.conf
@@ -21,7 +21,7 @@ application.secret="RXd?[5P43DQ<NXXX/6Y@F2`cifo<8FbotAR]?w4LWJWU3l]E31iTghaA8mNn
 # db.default.driver=org.h2.Driver
 # db.default.url="jdbc:h2:mem:play"
 # db.default.user=sa
-# db.default.password=
+# db.default.password=""
 
 # Evolutions
 # ~~~~~

--- a/samples/scala/comet-live-monitoring/conf/application.conf
+++ b/samples/scala/comet-live-monitoring/conf/application.conf
@@ -21,7 +21,7 @@ application.secret="bP>HHHl3QoSBko;]osOLQ8Aphe?6]nQCZN@IswBb]u04aSuu4oAWAkS[ba:D
 # db.default.driver=org.h2.Driver
 # db.default.url="jdbc:h2:mem:play"
 # db.default.user=sa
-# db.default.password=
+# db.default.password=""
 
 # Evolutions
 # ~~~~~

--- a/samples/scala/forms/conf/application.conf
+++ b/samples/scala/forms/conf/application.conf
@@ -21,7 +21,7 @@ application.secret="HaD4G7mboGeN=dyx=^KxRaj4oVTsGxbM>P;xHg]^uu[l/JxjHQR^fqsMQYTS
 # db.default.driver=org.h2.Driver
 # db.default.url="jdbc:h2:mem:play"
 # db.default.user=sa
-# db.default.password=
+# db.default.password=""
 #
 # You can expose this datasource via JNDI if needed (Useful for JPA)
 # db.default.jndiName=DefaultDS

--- a/samples/scala/helloworld/conf/application.conf
+++ b/samples/scala/helloworld/conf/application.conf
@@ -15,7 +15,7 @@ application.secret="TsLWj4[^1N<7nrI/>EkyPDTO[dnh<7_R[j;cN0:lGK6Mm`0048C@3PK]4KR6
 # db.default.driver=org.h2.Driver
 # db.default.url="jdbc:h2:mem:play"
 # db.default.user=sa
-# db.default.password=
+# db.default.password=""
 
 # Logger
 # ~~~~~

--- a/samples/scala/websocket-chat/conf/application.conf
+++ b/samples/scala/websocket-chat/conf/application.conf
@@ -21,7 +21,7 @@ application.secret="fXYT0c[h_gT_ZtlDbpJESb=22p;R62HO5nvwgN3RI<3ZsIVu04UsP;HiMeFb
 # db.default.driver=org.h2.Driver
 # db.default.url="jdbc:h2:mem:play"
 # db.default.user=sa
-# db.default.password=
+# db.default.password=""
 
 # Evolutions
 # ~~~~~

--- a/samples/workinprogress/akka-chat/conf/application.conf
+++ b/samples/workinprogress/akka-chat/conf/application.conf
@@ -21,7 +21,7 @@ application.global=MyGlobal
 # db.default.driver=org.h2.Driver
 # db.default.url="jdbc:h2:mem:play"
 # db.default.user=sa
-# db.default.password=
+# db.default.password=""
 
 # Logger
 # ~~~~~

--- a/samples/workinprogress/pi-calculator/conf/application.conf
+++ b/samples/workinprogress/pi-calculator/conf/application.conf
@@ -17,7 +17,7 @@ application.global=MyGlobal
 # db.default.driver=org.h2.Driver
 # db.default.url="jdbc:h2:mem:play"
 # db.default.user=sa
-# db.default.password=
+# db.default.password=""
 
 # Logger
 # ~~~~~

--- a/samples/workinprogress/twitterstream/conf/application.conf
+++ b/samples/workinprogress/twitterstream/conf/application.conf
@@ -15,7 +15,7 @@ application.secret="FuqsIcSJlLppP8s?UpVYb5CvX1v55PVgHQ1Pk<x^Hp6XCRX^:9cvBKXsL49k
 # db.default.driver=org.h2.Driver
 # db.default.url=jdbc:h2:mem:play
 # db.default.user=sa
-# db.default.password=
+# db.default.password=""
 
 # Logger
 # ~~~~~


### PR DESCRIPTION
This patch fixes the default database password for all sample projects.  The empty password needs to be specified as a quoted empty string, otherwise a configuration error will be thrown when the database definition is uncommented.
