### PR TITLE
Fixing race conditions in tests and removing static access to things

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -118,8 +118,9 @@ object PlayBuild extends Build {
             publishArtifact in (Compile, packageSrc) := true,
             resolvers += typesafe,
             sourceGenerators in Compile <+= (dependencyClasspath in TemplatesCompilerProject in Runtime, packageBin in TemplatesCompilerProject in Compile, scalaSource in Compile, sourceManaged in Compile, streams) map ScalaTemplates,
-            compile in (Compile) <<= PostCompile
-        )
+            compile in (Compile) <<= PostCompile,
+            parallelExecution in Test := false
+  )
     ).settings(com.typesafe.sbtscalariform.ScalariformPlugin.defaultScalariformSettings: _*)
     .dependsOn({
         Seq[sbt.ClasspathDep[sbt.ProjectReference]](SbtLinkProject, PlayExceptionsProject, TemplatesProject, AnormProject)

--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -341,7 +341,8 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * Starts a new application.
      */
     public static void start(FakeApplication fakeApplication) {
-
+        play.core.Invoker$.MODULE$.start();
+        play.api.libs.concurrent.Promise$.MODULE$.start();
         play.api.Play.start(fakeApplication.getWrappedApplication());
     }
 
@@ -350,6 +351,9 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      */
     public static void stop(FakeApplication fakeApplication) {
         play.api.Play.stop();
+        play.api.libs.concurrent.Promise$.MODULE$.resetSystem();
+        play.core.Invoker$.MODULE$.reset();
+        play.api.libs.ws.WS$.MODULE$.resetClient();
     }
 
     /**
@@ -357,13 +361,14 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      */
     public static synchronized void running(FakeApplication fakeApplication, final Runnable block) {
         try {
+            play.core.Invoker$.MODULE$.start();
+            play.api.libs.concurrent.Promise$.MODULE$.start();
             start(fakeApplication);
             block.run();
         } finally {
             stop(fakeApplication);
             play.api.libs.concurrent.Promise$.MODULE$.resetSystem();
-            play.core.Invoker$.MODULE$.system().shutdown();
-            play.core.Invoker$.MODULE$.uninit();
+            play.core.Invoker$.MODULE$.reset();
             play.api.libs.ws.WS$.MODULE$.resetClient();
         }
     }
@@ -416,7 +421,6 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
         TestBrowser browser = null;
         TestServer startedServer = null;
         try {
-            play.core.Invoker.uninit();
             start(server);
             startedServer = server;
             browser = testBrowser(webDriver);

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -35,13 +35,14 @@ object Helpers extends Status with HeaderNames {
   def running[T](fakeApp: FakeApplication)(block: => T): T = {
     synchronized {
       try {
+        play.core.Invoker.start()
+        play.api.libs.concurrent.Promise.start()
         Play.start(fakeApp)
         block
       } finally {
         Play.stop()
         play.api.libs.concurrent.Promise.resetSystem()
-        play.core.Invoker.system.shutdown()
-        play.core.Invoker.uninit()
+        play.core.Invoker.reset()
         play.api.libs.ws.WS.resetClient()
       }
     }

--- a/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
@@ -115,27 +115,24 @@ case class TestServer(port: Int, application: FakeApplication = FakeApplication(
     if (server != null) {
       sys.error("Server already started!")
     }
-    play.core.Invoker.uninit()
-    try {
-      server = new play.core.server.NettyServer(new play.core.TestApplication(application), port, sslPort = sslPort, mode = Mode.Test)
-    } catch {
-      case t: Throwable =>
-        t.printStackTrace
-        throw new RuntimeException(t)
-    }
+    server = new play.core.server.NettyServer(new play.core.TestApplication(application), port, sslPort = sslPort, mode = Mode.Test)
   }
 
   /**
    * Stops this server.
    */
   def stop() {
-    if (server == null) {
-      sys.error("Server is not started!");
+    try {
+      if (server != null) {
+        Logger("play").warn("Server not started")
+        server.stop()
+        server = null
+      }
+    } finally {
+      play.core.Invoker.reset()
+      play.api.libs.concurrent.Promise.resetSystem()
+      play.api.libs.ws.WS.resetClient()
     }
-    server.stop()
-    server = null
-    play.api.libs.concurrent.Promise.resetSystem()
-    play.api.libs.ws.WS.resetClient()
   }
 
 }

--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -345,11 +345,9 @@ public class F {
         static List<akka.actor.ActorRef> actors() {
             synchronized(Promise.class) {
                 if(actors == null) {
-                    synchronized(Promise.class) {
-                        actors = new ArrayList<akka.actor.ActorRef>(nb);
-                        for(int i=0; i<nb; i++) {
-                            actors.add(play.api.libs.concurrent.Promise$.MODULE$.system().actorOf(new akka.actor.Props(PromiseActor.class), "promise-actor-" + i));
-                        }
+                    actors = new ArrayList<akka.actor.ActorRef>(nb);
+                    for(int i=0; i<nb; i++) {
+                        actors.add(play.api.libs.concurrent.Promise$.MODULE$.system().actorOf(new akka.actor.Props(PromiseActor.class), "promise-actor-" + i));
                     }
                 }
             }

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Promise.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Promise.scala
@@ -16,6 +16,7 @@ import scala.collection.generic.CanBuildFrom
 import java.util.concurrent.TimeoutException
 
 import play.api.libs.concurrent.execution.defaultContext
+import javax.annotation.concurrent.GuardedBy
 
 /**
  * The state of a promise; it's waiting, contains a value, or contains an exception.
@@ -258,30 +259,38 @@ object PurePromise {
  */
 object Promise {
 
-  private var underlyingSystem: Option[ActorSystem] = Some(ActorSystem("promise"))
+  @volatile
+  private var underlyingSystem: Option[ActorSystem] = None
 
-  private[concurrent] lazy val defaultTimeout =
-    Duration(system.settings.config.getMilliseconds("promise.akka.actor.typed.timeout"), TimeUnit.MILLISECONDS).toMillis
+  private[concurrent] lazy val defaultTimeout: Long =
+    Play.maybeApplication.flatMap(_.configuration.getMilliseconds("promise.akka.actor.typed.timeout")).getOrElse(5000l)
 
   /**
    * actor system for Promises
    */
   private[concurrent] def system = underlyingSystem.getOrElse {
-    val a = ActorSystem("promise")
-    underlyingSystem = Some(a)
-    a
+    throw new IllegalStateException("Promise system not started")
+  }
+
+  def start() {
+    synchronized {
+      underlyingSystem = underlyingSystem match {
+        case Some(_) => throw new IllegalStateException("Promise system already started")
+        case None => Some(ActorSystem("promise"))
+      }
+    }
   }
 
   /**
    * resets the underlying promise Actor System and clears Java actor references
    */
-  def resetSystem(): Unit = {
+  def resetSystem(): Unit = synchronized {
     underlyingSystem.filter(_.isTerminated == false).map { s =>
       s.shutdown()
       s.awaitTermination()
     }.getOrElse(play.api.Logger.debug("trying to reset Promise actor system that was not started yet"))
-    play.libs.F.Promise.resetActors()
     underlyingSystem = None
+    play.libs.F.Promise.resetActors()
   }
 
   /**

--- a/framework/src/play/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play/src/main/scala/play/core/server/Server.scala
@@ -44,9 +44,10 @@ trait Server {
 
   // store the invoker in a global variable
   Invoker.init(invoker)
+  Promise.start()
 
   val bodyParserTimeout = {
-    Configuration(Invoker.system.settings.config).getMilliseconds("akka.actor.retrieveBodyParserTimeout").map(_ milliseconds).getOrElse(1 second)
+    Configuration(invoker.system.settings.config).getMilliseconds("akka.actor.retrieveBodyParserTimeout").map(_ milliseconds).getOrElse(1 second)
   }
 
   def mode: Mode.Mode
@@ -143,8 +144,9 @@ import play.api.http.HeaderNames._
   def applicationProvider: ApplicationProvider
 
   def stop() {
-    Invoker.uninit()
-    invoker.stop()
+    Promise.resetSystem()
+    Invoker.reset()
+    play.api.libs.ws.WS.resetClient()
     Logger.shutdown()
   }
 

--- a/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -26,7 +26,7 @@ import scala.collection.JavaConverters._
 
 import play.api.libs.concurrent.execution.defaultContext
 
-private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: DefaultChannelGroup) extends SimpleChannelUpstreamHandler with Helpers with WebSocketHandler with RequestBodyHandler {
+private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: DefaultChannelGroup) extends SimpleChannelUpstreamHandler with Helpers with WebSocketHandler with RequestBodyHandler with WithInvoker {
 
   private val requestIDs = new java.util.concurrent.atomic.AtomicLong(0)
 
@@ -378,4 +378,5 @@ private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: De
     }
   }
 
+  def invoker = server.invoker
 }

--- a/framework/src/play/src/main/scala/play/core/server/netty/WebSocketHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/WebSocketHandler.scala
@@ -23,12 +23,13 @@ import play.api.libs.concurrent._
 import scala.collection.JavaConverters._
 
 private[server] trait WebSocketHandler {
+  self: WithInvoker =>
   def newWebSocketInHandler[A](frameFormatter: play.api.mvc.WebSocket.FrameFormatter[A]) = {
 
     val nettyFrameFormatter = frameFormatter.asInstanceOf[play.core.server.websocket.FrameFormatter[A]]
 
     val enumerator = new Enumerator[A] {
-      val iterateeAgent = Agent[Option[Iteratee[A, Any]]](None)
+      val iterateeAgent = Agent[Option[Iteratee[A, Any]]](invoker, None)
       private val promise: scala.concurrent.Promise[Iteratee[A, Any]] = Promise[Iteratee[A, Any]]()
 
       def apply[R](i: Iteratee[A, R]) = {

--- a/framework/src/play/src/main/scala/play/core/server/netty/WithInvoker.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/WithInvoker.scala
@@ -1,0 +1,7 @@
+package play.core.server.netty
+
+import play.core.Invoker
+
+trait WithInvoker {
+  def invoker: Invoker
+}

--- a/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
+++ b/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
@@ -9,6 +9,7 @@ import scala.concurrent.util.duration._
 
 import play.api._
 import play.api.mvc._
+import akka.actor.ActorSystem
 
 /**
  * provides source code to be displayed on error pages
@@ -63,7 +64,9 @@ class TestApplication(application: Application) extends ApplicationProvider {
 /**
  * represents an application that can be reloaded in Dev Mode
  */
-class ReloadableApplication(sbtLink: SBTLink) extends ApplicationProvider {
+class ReloadableApplication(sbtLink: SBTLink, reloaderActorSystem: ActorSystem) extends ApplicationProvider {
+
+
 
   // Use plain Java call here in case of scala classloader mess
   {
@@ -92,7 +95,7 @@ class ReloadableApplication(sbtLink: SBTLink) extends ApplicationProvider {
       // Because we are on DEV mode here, it doesn't really matter
       // but it's more coherent with the way it works in PROD mode.
 
-      implicit def dispatcher: scala.concurrent.ExecutionContext = play.core.Invoker.system.dispatcher
+      implicit def dispatcher: scala.concurrent.ExecutionContext = reloaderActorSystem.dispatcher
 
       Await.result(Future {
 

--- a/framework/src/play/src/main/scala/play/core/system/Invoker.scala
+++ b/framework/src/play/src/main/scala/play/core/system/Invoker.scala
@@ -13,6 +13,7 @@ import play.api.libs.iteratee._
 import play.api.http.HeaderNames._
 
 import play.utils._
+import javax.annotation.concurrent.GuardedBy
 
 /**
  * holds Play's internal invokers
@@ -48,13 +49,10 @@ object Invoker {
    */
   //case class HandleAction[A](request: Request[A], response: Response, action: Action[A], app: Application)
 
-  private var invokerOption: Option[Invoker] = None
+  private var invokerOption: Option[(Invoker, Array[StackTraceElement])] = None
 
-  private def invoker: Invoker = invokerOption.getOrElse {
-    val default = new Invoker()
-    invokerOption = Some(default)
-    Logger.info("Invoker was created outside of Invoker#init - this potentially could lead to initialization problems in production mode")
-    default
+  private def invoker: Invoker = invokerOption.map(_._1).getOrElse {
+    throw new IllegalStateException("Invoker system not started or inited")
   }
 
   private def appProviderActorSystem(applicationProvider: ApplicationProvider) = {
@@ -69,18 +67,32 @@ object Invoker {
   def apply(applicationProvider: ApplicationProvider): Invoker = new Invoker(Some(applicationProvider))
 
   /**
+   * Start an invoker in the global scope, used by tests
+   */
+  def start() {
+    synchronized {
+      init(new Invoker())
+    }
+  }
+
+  /**
    * saves invoker instance in global scope
    */
-  def init(invoker: Invoker): Unit = {
-    if (invokerOption.isDefined)
-      throw new IllegalStateException("Invoker was initialized twice without an intervening uninit; two Server created at once?")
-    invokerOption = Some(invoker)
+  def init(invoker: => Invoker) {
+    synchronized {
+      invokerOption = invokerOption match {
+        case Some(existing) => throw new IllegalStateException(existing._2.dropWhile(_.getClassName == "play.core.Invoker$").mkString(
+            "Invoker initialised twice, first invocation was: ", "\n\tat ", "\nMake sure you call Invoker.reset() after using it.\n"))
+        case None => Some((invoker, new Exception().getStackTrace))
+      }
+    }
   }
 
   /**
    * removes invoker instance from global scope
    */
-  def uninit(): Unit = {
+  def reset(): Unit = synchronized {
+    invokerOption.map(_._1.stop())
     invokerOption = None
   }
 
@@ -98,9 +110,9 @@ object Agent {
     def close(): Unit = c
   }
 
-  def apply[A](a: A): Operations[A] = {
-    val actor: ActorRef = Invoker.system.actorOf(Props(new Agent[A](a)).withDispatcher("akka.actor.websockets-dispatcher"))
-    new Operations[A](actor, Invoker.system.stop(actor))
+  def apply[A](invoker: Invoker, a: A): Operations[A] = {
+    val actor: ActorRef = invoker.system.actorOf(Props(new Agent[A](a)).withDispatcher("akka.actor.websockets-dispatcher"))
+    new Operations[A](actor, invoker.system.stop(actor))
   }
 
   private class Agent[A](var a: A) extends Actor {

--- a/framework/src/play/src/test/scala/play/concurrent/PromiseSpec.scala
+++ b/framework/src/play/src/test/scala/play/concurrent/PromiseSpec.scala
@@ -1,16 +1,18 @@
 package play.concurrent
 
-import org.specs2.mutable.Specification
+import org.specs2.mutable.{Around, Specification}
 import play.api.libs.concurrent._
 import org.specs2.execute.Result
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.specs2.specification.Scope
+import play.core.Invoker
 
 
 class PromiseSpec extends Specification {
 
   "Promise" can {
 
-    "filter" in {
+    "filter" in new WithInvokerSystem {
 
       "Redeemed values" << {
         val p = Promise.timeout(42, 100)
@@ -29,6 +31,17 @@ class PromiseSpec extends Specification {
 
     }
 
+  }
+
+  trait WithInvokerSystem extends Around with Scope {
+    def around[T <% Result](t: => T) = {
+      Invoker.start()
+      try {
+        t
+      } finally {
+        Invoker.reset()
+      }
+    }
   }
 
 }

--- a/framework/test/integrationtest-java/test/test/SimpleTest.java
+++ b/framework/test/integrationtest-java/test/test/SimpleTest.java
@@ -64,11 +64,15 @@ public class SimpleTest {
   
     @Test
     public void callIndex() {
-        Result result = callAction(controllers.routes.ref.Application.index("Kiki"));   
-        assertThat(status(result)).isEqualTo(OK);
-        assertThat(contentType(result)).isEqualTo("text/html");
-        assertThat(charset(result)).isEqualTo("utf-8");
-        assertThat(contentAsString(result)).contains("Hello Kiki");
+        running(fakeApplication(), new Runnable() {
+            public void run() {
+                Result result = callAction(controllers.routes.ref.Application.index("Kiki"));   
+                assertThat(status(result)).isEqualTo(OK);
+                assertThat(contentType(result)).isEqualTo("text/html");
+                assertThat(charset(result)).isEqualTo("utf-8");
+                assertThat(contentAsString(result)).contains("Hello Kiki");
+            }
+        });
     }
     
     @Test
@@ -79,11 +83,15 @@ public class SimpleTest {
     
     @Test
     public void routeIndex() {
-        Result result = routeAndCall(fakeRequest(GET, "/Kiki"));
-        assertThat(status(result)).isEqualTo(OK);
-        assertThat(contentType(result)).isEqualTo("text/html");
-        assertThat(charset(result)).isEqualTo("utf-8");
-        assertThat(contentAsString(result)).contains("Hello Kiki");
+        running(fakeApplication(), new Runnable() {
+            public void run() {
+                Result result = routeAndCall(fakeRequest(GET, "/Kiki"));
+                assertThat(status(result)).isEqualTo(OK);
+                assertThat(contentType(result)).isEqualTo("text/html");
+                assertThat(charset(result)).isEqualTo("utf-8");
+                assertThat(contentAsString(result)).contains("Hello Kiki");
+            }
+        });
     }
     
     @Test

--- a/framework/test/integrationtest/project/Build.scala
+++ b/framework/test/integrationtest/project/Build.scala
@@ -7,7 +7,9 @@ object ApplicationBuild extends Build {
 
     val appDependencies = Nil 
 
-    val main = PlayProject(appName, appVersion, appDependencies)
+    val main = PlayProject(appName, appVersion, appDependencies).settings(
+      parallelExecution in Test := false
+    )
 
 }
             

--- a/framework/test/integrationtest/test/FunctionalSpec.scala
+++ b/framework/test/integrationtest/test/FunctionalSpec.scala
@@ -17,7 +17,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class FunctionalSpec extends Specification {
   "an Application" should {
-    
+    sequential
     def cal = Calendar.getInstance()
 
     val startDate = cal.getTime()
@@ -182,6 +182,7 @@ class FunctionalSpec extends Specification {
     }
 
     "Provide a hook to handle errors" in {
+      sequential
       "Synchronous results" in {
         running(TestServer(9000), HTMLUNIT) { browser =>
           browser.goTo("http://localhost:9000/sync-error")

--- a/framework/test/integrationtest/test/SslSpec.scala
+++ b/framework/test/integrationtest/test/SslSpec.scala
@@ -16,9 +16,8 @@ class SslSpec extends Specification {
 
   val SslPort = 19443
 
-  sequential
-
   "SSL support" should {
+    sequential
     "generate a self signed certificate when no keystore configuration is provided" in new Ssl {
       val conn = createConn
       conn.getResponseCode must_== 200


### PR DESCRIPTION
This commit does the following:
- Removes race conditions in Promise.system and Invoker.system that were causing Play to leak threads and our builds to hang
- Cleans up Invoker shutdown, so it can be just shutdown by calling reset()
- Removes unnecessary static access of Invoker.system() in WebSocketHandler, since the class that implements it already has non static access to an invoker
- Looks up defaultTimeout direct from Play configuration, rather than going indirectly to play configuration through loading an actor system
- Gives ReloadableApplication its own actor system, so that it doesn't reload in the actor system of the application that it's reloading
