### PR TITLE
Simplify extending Actions with custom requests

### DIFF
--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -196,8 +196,8 @@ object Helpers extends Status with HeaderNames {
   def routeAndCall[T, ROUTER <: play.core.Router.Routes](router: Class[ROUTER], request: FakeRequest[T]): Option[Result] = {
     val routes = router.getClassLoader.loadClass(router.getName + "$").getDeclaredField("MODULE$").get(null).asInstanceOf[play.core.Router.Routes]
     routes.routes.lift(request).map {
-      case a: Action[_] =>
-        val action = a.asInstanceOf[Action[T]]
+      case a: Action[_, _] =>
+        val action = a.asInstanceOf[Action[T, Request]]
         val parsedBody: Option[Either[play.api.mvc.Result, T]] = action.parser(request).fold1(
           (a, in) => Promise.pure(Some(a)),
           k => Promise.pure(None),

--- a/framework/src/play/src/main/scala/play/api/cache/Cached.scala
+++ b/framework/src/play/src/main/scala/play/api/cache/Cached.scala
@@ -10,9 +10,11 @@ import play.api.mvc._
  * @param duration Cache duration (in seconds)
  * @param action Action to cache
  */
-case class Cached[A](key: RequestHeader => String, duration: Int)(action: Action[A])(implicit app: Application) extends Action[A] {
+case class Cached[A](key: RequestHeader => String, duration: Int)(action: Action[A, Request])(implicit app: Application) extends Action[A, Request] {
 
   lazy val parser = action.parser
+
+  def req[A] = (rh: RequestHeader, a:A) => Request(rh,a)
 
   def apply(request: Request[A]): Result = {
     Cache.getOrElse[Result](key(request), duration) {
@@ -30,7 +32,7 @@ object Cached {
    * @param key Compute a key from the request header
    * @param action Action to cache
    */
-  def apply[A](key: RequestHeader => String)(action: Action[A])(implicit app: Application): Cached[A] = {
+  def apply[A](key: RequestHeader => String)(action: Action[A, Request])(implicit app: Application): Cached[A] = {
     apply(key, duration = 0)(action)
   }
 
@@ -40,7 +42,7 @@ object Cached {
    * @param key Cache key
    * @param action Action to cache
    */
-  def apply[A](key: String)(action: Action[A])(implicit app: Application): Cached[A] = {
+  def apply[A](key: String)(action: Action[A, Request])(implicit app: Application): Cached[A] = {
     apply(key, duration = 0)(action)
   }
 
@@ -51,7 +53,7 @@ object Cached {
    * @param duration Cache duration (in seconds)
    * @param action Action to cache
    */
-  def apply[A](key: String, duration: Int)(action: Action[A])(implicit app: Application): Cached[A] = {
+  def apply[A](key: String, duration: Int)(action: Action[A, Request])(implicit app: Application): Cached[A] = {
     Cached(_ => key, duration)(action)
   }
 

--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -53,7 +53,7 @@ object Assets extends Controller {
    * @param path the root folder for searching the static resource files, such as `"/public"`
    * @param file the file part extracted from the URL
    */
-  def at(path: String, file: String): Action[AnyContent] = Action { request =>
+  def at(path: String, file: String): Action[AnyContent, Request] = Action { request =>
     // -- LastModified handling
 
     def parseDate(date: String): Option[java.util.Date] = try {

--- a/framework/src/play/src/main/scala/play/api/controllers/Default.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Default.scala
@@ -25,7 +25,7 @@ object Default extends Controller {
    * GET   /admin           controllers.Default.todo
    * }}}
    */
-  def todo: Action[AnyContent] = TODO
+  def todo: Action[AnyContent, Request] = TODO
 
   /**
    * Returns a 404 NotFound response.
@@ -35,7 +35,7 @@ object Default extends Controller {
    * GET   /favicon.ico     controllers.Default.notFound
    * }}}
    */
-  def notFound: Action[AnyContent] = Action {
+  def notFound: Action[AnyContent, Request] = Action {
     NotFound
   }
 
@@ -47,7 +47,7 @@ object Default extends Controller {
    * GET   /google          controllers.Default.redirect(to = "http://www.google.com")
    * }}}
    */
-  def redirect(to: String): Action[AnyContent] = Action {
+  def redirect(to: String): Action[AnyContent, Request] = Action {
     Redirect(to)
   }
 
@@ -59,7 +59,7 @@ object Default extends Controller {
    * GET   /xxx             controllers.Default.error
    * }}}
    */
-  def error: Action[AnyContent] = Action {
+  def error: Action[AnyContent, Request] = Action {
     InternalServerError
   }
 

--- a/framework/src/play/src/main/scala/play/api/controllers/ExternalAssets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/ExternalAssets.scala
@@ -33,10 +33,10 @@ object ExternalAssets extends Controller {
   /**
    * Generates an `Action` that serves a static resource from an external folder
    *
-   * @param absoluteRootPath the root folder for searching the static resource files such as `"/home/peter/public"`, `C:\external` or `relativeToYourApp`
+   * @param rootPath the root folder for searching the static resource files such as `"/home/peter/public"`, `C:\external` or `relativeToYourApp`
    * @param file the file part extracted from the URL
    */
-  def at(rootPath: String, file: String): Action[AnyContent] = Action { request =>
+  def at(rootPath: String, file: String): Action[AnyContent, Request] = Action { request =>
     Play.mode match {
       case Mode.Prod => NotFound
       case _ => {

--- a/framework/src/play/src/main/scala/play/api/mvc/Security.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Security.scala
@@ -38,7 +38,7 @@ object Security {
    */
   def Authenticated[A](
     username: RequestHeader => Option[String],
-    onUnauthorized: RequestHeader => Result)(action: String => Action[A]): Action[(Action[A], A)] = {
+    onUnauthorized: RequestHeader => Result)(action: String => Action[A, Request]): Action[(Action[A, Request], A), Request] = {
 
     val authenticatedBodyParser = BodyParser { request =>
       username(request).map { user =>
@@ -86,7 +86,7 @@ object Security {
    * @tparam A the type of the request body
    * @param action the action to wrap
    */
-  def Authenticated[A](action: String => Action[A]): Action[(Action[A], A)] = Authenticated(
+  def Authenticated[A](action: String => Action[A, Request]): Action[(Action[A, Request], A), Request] = Authenticated(
     req => req.session.get(username),
     _ => Unauthorized(views.html.defaultpages.unauthorized()))(action)
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -7,7 +7,7 @@ import play.mvc.Http.{ Context => JContext, Request => JRequest, RequestBody => 
 /*
  * An action that's handling Java requests
  */
-trait JavaAction extends Action[play.mvc.Http.RequestBody] with JavaHelpers {
+trait JavaAction extends Action[play.mvc.Http.RequestBody, Request] with JavaHelpers {
 
   def parser: BodyParser[play.mvc.Http.RequestBody] = {
     Seq(method.getAnnotation(classOf[play.mvc.BodyParser.Of]), controller.getAnnotation(classOf[play.mvc.BodyParser.Of]))

--- a/framework/src/play/src/main/scala/play/core/router/Router.scala
+++ b/framework/src/play/src/main/scala/play/core/router/Router.scala
@@ -8,7 +8,7 @@ import org.apache.commons.lang3.reflect.MethodUtils
  * provides Play's router implementation
  */
 object Router {
-  
+
    object Route {
 
     trait ParamsExtractor {
@@ -102,6 +102,7 @@ object Router {
           def invocation = call
           def controller = handler.getControllerClass
           def method = MethodUtils.getMatchingAccessibleMethod(controller, handler.method, handler.parameterTypes: _*)
+          def req[A] = (rh: RequestHeader, a:A) => Request(rh,a)
         }
       }
     }
@@ -286,6 +287,8 @@ object Router {
           override def apply(req: Request[play.mvc.Http.RequestBody]): Result = {
             javaAction(Request(tagRequest(req, handler), req.body))
           }
+
+          def req[A] = (rh: RequestHeader, a:A) => Request(rh,a)
         }
         case action: EssentialAction => new EssentialAction {
           def apply(rh: RequestHeader) = action(tagRequest(rh, handler))

--- a/framework/test/integrationtest/app/controllers/Application.scala
+++ b/framework/test/integrationtest/app/controllers/Application.scala
@@ -44,7 +44,7 @@ object Application extends Controller {
     val overrideAkka = play.api.libs.concurrent.Akka.system.settings.config.getString("akka.loglevel")
     Ok(s + " no key: " + c +" - override akka:"+ overrideConfig+" akka-loglevel:"+ overrideAkka+ " promise-timeout:"+ timeout)
   }
-  
+
   def post = Action { request =>
     val content: String = request.body.toString
     Ok(views.html.index(content))
@@ -53,9 +53,9 @@ object Application extends Controller {
   def json = Action {
     Ok(toJson(User(1, "Sadek", List("tea"))))
   }
-  
+
   def jsonFromJsObject = Action {
-    Ok(toJson(JsObject(List("blah" -> JsString("foo"))))) 
+    Ok(toJson(JsObject(List("blah" -> JsString("foo")))))
   }
 
   def jsonWithContentType = Action { request =>
@@ -91,7 +91,7 @@ object Application extends Controller {
   def takeBool2(b: Boolean) = Action {
     Ok(b.toString())
   }
-  
+
   def javascriptRoutes = Action { implicit request =>
     import play.api.Routes
     Ok(Routes.javascriptRouter("routes")(routes.javascript.Application.javascriptTest)).as("text/javascript")
@@ -137,5 +137,9 @@ object Application extends Controller {
     Async {
       Promise.pure[Result](sys.error("Error"))
     }
+  }
+
+  def customAction = CustomAction { req =>
+    Ok(req.token)
   }
 }

--- a/framework/test/integrationtest/app/controllers/CustomAction.scala
+++ b/framework/test/integrationtest/app/controllers/CustomAction.scala
@@ -1,0 +1,16 @@
+package controllers
+
+import play.api.mvc._
+
+/**
+ *
+ * @author blake
+ *
+ */
+object CustomAction extends ActionBuilder[CustomRequest] {
+  def request[A] = (rh: RequestHeader, a:A) => CustomRequest("XXX",Request(rh,a))
+}
+
+case class CustomRequest[A](token: String, request: Request[A]) extends WrappedRequest(request)
+
+

--- a/framework/test/integrationtest/conf/routes
+++ b/framework/test/integrationtest/conf/routes
@@ -31,6 +31,8 @@ GET     /conf                   controllers.Application.conf()
 GET     /take-bool              controllers.Application.takeBool(b: Boolean)
 GET     /take-bool-2/:b         controllers.Application.takeBool2(b: Boolean)
 
+GET     /customAction           controllers.Application.customAction()
+
 GET     /take-list              controllers.Application.takeList(x: List[Int])
 GET     /take-list-java         controllers.JavaApi.takeList(x: java.util.List[java.lang.Integer])
 

--- a/framework/test/integrationtest/test/ApplicationSpec.scala
+++ b/framework/test/integrationtest/test/ApplicationSpec.scala
@@ -10,14 +10,14 @@ import play.api.mvc.AnyContentAsEmpty
 class ApplicationSpec extends Specification {
 
   "an Application" should {
-  
+
     "execute index" in {
-      
+
       running(FakeApplication()) {
-        
+
         val action = controllers.Application.index()
         val result = action(FakeRequest())
-        
+
         status(result) must equalTo(OK)
         contentType(result) must equalTo(Some("text/html"))
         charset(result) must equalTo(Some("utf-8"))
@@ -43,20 +43,20 @@ class ApplicationSpec extends Specification {
          userForm.bind(anyData).get.toString must contain ("")
       }
     }
-  
+
     "execute index again" in {
-      
+
       running(FakeApplication()) {
         val action = controllers.Application.index()
         val result = action(FakeRequest())
-        
+
         status(result) must equalTo(OK)
         contentType(result) must equalTo(Some("text/html"))
         charset(result) must equalTo(Some("utf-8"))
         contentAsString(result) must contain("Hello world")
       }
     }
-    
+
     "execute json" in {
     running(FakeApplication()) {
       val Some(result) = route(FakeRequest(GET, "/json"))
@@ -103,7 +103,7 @@ class ApplicationSpec extends Specification {
         status(result) must equalTo (NOT_FOUND)
       }
     }
-   
+
     "remove cache elements" in {
       running(FakeApplication()) {
         import play.api.Play.current
@@ -151,7 +151,7 @@ class ApplicationSpec extends Specification {
     }
 
     "bind int parameters from the query string as a list" in {
-     
+
         "from a list of numbers" in {
            running(FakeApplication()) {
              val Some(result) = route(FakeRequest(GET, controllers.routes.Application.takeList(List(1, 2, 3)).url))
@@ -217,6 +217,13 @@ class ApplicationSpec extends Specification {
         val Some(result) = route(FakeRequest(GET, "/urldecode/2%2B2?q=2%2B2"))
         contentAsString(result) must contain ("fromPath=2+2")
         contentAsString(result) must contain ("fromQueryString=2+2")
+      }
+    }
+
+    "do custom generic actions" in {
+      running(FakeApplication()) {
+        val Some(result) = route(FakeRequest(GET, "/customAction"))
+        contentAsString(result) must contain ("XXX")
       }
     }
 


### PR DESCRIPTION
My use case is that I want to be able to extend an Action with a custom request in a simple manner. After looking at this [discussion](https://groups.google.com/d/topic/play-framework/ZBLeUTo9aMk/discussion) I figured that there should be a simpler way of implementing this.

In my pull request there are some modifications to Action[A] and ActionBuilder - both of these traits are now parameterized by Request as well. All a user has to do now is to either extend Action[T, R], and supply an implementation of a request, or extend ActionBuilder[R] and do the same there. 

This change shouldn't be too disruptive, although if a user has custom actions or explicitly depends on the return type somehow, stuff will break.  

Here's the Lighthouse [ticket](https://play.lighthouseapp.com/projects/82401-play-20/tickets/799-simplify-extending-actions-with-custom-requests).
