### PR TITLE
Add Enumerator.outputStream

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
@@ -541,26 +541,26 @@ object Enumerator {
   }
 
   /** Create an Enumerator of bytes with an OutputStream.
-   * @example val (enumerator, outputStream) = Enumerator.outputStream
    */
-  def outputStream: (Enumerator[Array[Byte]], java.io.OutputStream) = {
-    val (enumerator, channel) = Concurrent.broadcast[Array[Byte]]
-    val os = new java.io.OutputStream(){
-      override def close() {
-        channel.end()
+  def outputStream(a: java.io.OutputStream => Unit): Enumerator[Array[Byte]] = {
+    Concurrent.unicast[Array[Byte]] { channel =>
+      val outputStream = new java.io.OutputStream(){
+        override def close() {
+          //channel.end() // FIXME, NPE triggered when consuming the Enumerator
+        }
+        override def flush() {}
+        override def write(value: Int) {
+          channel.push(Array(value.toByte))
+        }
+        override def write(buffer: Array[Byte]) {
+          write(buffer, 0, buffer.length)
+        }
+        override def write(buffer: Array[Byte], start: Int, count: Int) {
+          channel.push(buffer.slice(start, start+count))
+        }
       }
-      override def flush() {}
-      override def write(value: Int) {
-        channel.push(Array(value.toByte))
-      }
-      override def write(buffer: Array[Byte]) {
-        write(buffer, 0, buffer.length)
-      }
-      override def write(buffer: Array[Byte], start: Int, count: Int) {
-        channel.push(buffer.slice(start, start+count))
-      }
+      a(outputStream)
     }
-    (enumerator, os)
   }
 
   def eof[A] = enumInput[A](Input.EOF)

--- a/framework/src/play/src/test/scala/play/iteratee/EnumeratorsSpec.scala
+++ b/framework/src/play/src/test/scala/play/iteratee/EnumeratorsSpec.scala
@@ -152,18 +152,16 @@ object EnumeratorsSpec extends Specification {
 
 "Enumerator.outputStream" should {
   "produce the same value written in the OutputStream" in {
-    val (enumerator, outputStream) = Enumerator.outputStream
     val a = "FOO"
     val b = "bar"
-
+    val enumerator = Enumerator.outputStream { outputStream =>
+      outputStream.write(a.toArray.map(_.toByte))
+      outputStream.write(b.toArray.map(_.toByte))
+      outputStream.close()
+    }
     val promise = (enumerator |>> Iteratee.fold[Array[Byte],Array[Byte]](Array[Byte]())(_ ++ _)).flatMap(_.run)
 
-    outputStream.write(a.toArray.map(_.toByte))
-    outputStream.write(b.toArray.map(_.toByte))
-    outputStream.close()
-
     promise.await.get.map(_.toChar).foldLeft("")(_+_) must equalTo(a+b)
-
   }
 }
 


### PR DESCRIPTION
Enumerator.outputStream creates an Enumerator of bytes with an OutputStream.
**Exemple:** `val (enumerator, outputStream) = Enumerator.outputStream`

It's very useful to work with Java APIs.

Here is a use case:

```
def zip = Action {
  val (enumerator, os) = Enumerator.outputStream
    val zip = new ZipOutputStream(os)
    zip.putNextEntry(new ZipEntry("file1.txt"))
    zip.write("hello world".map(_.toByte).toArray)
    zip.closeEntry()
    zip.close()
  Ok(enumerator)
}
```
