### PR TITLE
corrected Json warnings except 1

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/json/JsValue.scala
@@ -86,6 +86,7 @@ sealed trait JsValue {
 
 /**
  * Represent a Json null value.
+ * with Scala 2.10-M7, this code generates WARNING : https://issues.scala-lang.org/browse/SI-6513
  */
 case object JsNull extends JsValue
 
@@ -385,6 +386,10 @@ private[json] class JsValueDeserializer(factory: TypeFactory, klass: Class[_]) e
       case (JsonToken.END_OBJECT, ReadingMap(content) :: stack) => (Some(JsObject(content)), stack)
 
       case (JsonToken.END_OBJECT, _) => throw new RuntimeException("We should have been reading an object, something got wrong")
+
+      case (JsonToken.NOT_AVAILABLE, _) => throw new RuntimeException("We should have been reading an object, something got wrong")
+
+      case (JsonToken.VALUE_EMBEDDED_OBJECT, _) => throw new RuntimeException("We should have been reading an object, something got wrong")
     }
 
     // Read ahead

--- a/framework/src/play/src/main/scala/play/api/libs/json/Writes.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/json/Writes.scala
@@ -3,6 +3,7 @@ package play.api.libs.json
 import Json._
 import scala.collection._
 import scala.annotation.implicitNotFound
+import scala.reflect.ClassTag
 
 /**
  * Json serializer: write an implicit to define a serializer for any type
@@ -147,7 +148,7 @@ trait DefaultWrites {
   /**
    * Serializer for Array[T] types.
    */
-  implicit def arrayWrites[T](implicit fmt: Writes[T], mf: Manifest[T]): Writes[Array[T]] = new Writes[Array[T]] {
+  implicit def arrayWrites[T : ClassTag](implicit fmt: Writes[T]): Writes[Array[T]] = new Writes[Array[T]] {
     def writes(ts: Array[T]) = JsArray((ts.map(t => toJson(t)(fmt))).toList)
   }
 


### PR DESCRIPTION
There is one warning left about "dead code" after a "case object"...
Apparently this is a bug in Scala-2.10.M7 so for the time being, we'll have to bear it...
https://issues.scala-lang.org/browse/SI-6513
