### PR TITLE
Allowed @inputText helper to use custom types

### DIFF
--- a/framework/src/play/src/main/scala/views/helper/inputText.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputText.scala.html
@@ -12,6 +12,8 @@
  *@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, lang: play.api.i18n.Lang)
 
-@input(field, args:_*) { (id, name, value, htmlArgs) =>
-    <input type="text" id="@id" name="@name" value="@value" @toHtmlArgs(htmlArgs)>
+@inputType = @{ args.toMap.get('type).map(_.toString).getOrElse("text") }
+
+@input(field, args.filter(_._1 != 'type):_*) { (id, name, value, htmlArgs) =>
+    <input type="@inputType" id="@id" name="@name" value="@value" @toHtmlArgs(htmlArgs)>
 }

--- a/framework/src/play/src/test/scala/views/helper/HelpersSpec.scala
+++ b/framework/src/play/src/test/scala/views/helper/HelpersSpec.scala
@@ -10,7 +10,7 @@ object HelpersSpec extends Specification {
   import FieldConstructor.defaultField
   import Lang.defaultLang
 
-  "inputText" should {
+  "@inputText" should {
 
     "allow setting a custom id" in {
 
@@ -23,5 +23,18 @@ object HelpersSpec extends Specification {
       body.substring(body.indexOf(idAttr) + idAttr.length) must not contain(idAttr)
     }
 
+    "default to a type of text" in {
+      inputText.apply(Form(single("foo" -> Forms.text))("foo")).body must contain("type=\"text\"")
+    }
+
+    "allow setting a custom type" in {
+      val body = inputText.apply(Form(single("foo" -> Forms.text))("foo"), 'type -> "email").body
+
+      val typeAttr = "type=\"email\""
+      body must contain(typeAttr)
+
+      // Make sure it doesn't contain it twice
+      body.substring(body.indexOf(typeAttr) + typeAttr.length) must not contain(typeAttr)
+    }
   }
 }


### PR DESCRIPTION
This allows users to use the standard @inputText helper with HTML5 input types.
