### PR TITLE
Enable back markdown rendering for the /@documentation link

### DIFF
--- a/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
+++ b/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
@@ -254,30 +254,12 @@ class ReloadableApplication(sbtLink: SBTLink) extends ApplicationProvider {
 
           pageWithSidebar.map {
             case (pageSource, maybeSidebar) => {
-
-              val linkRender: (String => (String, String)) = _ match {
-                case link if link.contains("|") => {
-                  val parts = link.split('|')
-                  (parts.tail.head, parts.head)
-                }
-                case image if image.endsWith(".png") => {
-                  val link = image match {
-                    case full if full.startsWith("http://") => full
-                    case absolute if absolute.startsWith("/") => "resources/manual" + absolute
-                    case relative => "resources/" + pageSource.parent.get.relativize(Path(documentationHome.get)).path + "/" + relative
-                  }
-                  (link, """<img src="""" + link + """"/>""")
-                }
-                case link => {
-                  (link, link)
-                }
-              }
-
+              val relativePath = pageSource.parent.get.relativize(Path(documentationHome.get)).path
               Ok(
                 views.html.play20.manual(
                   page,
-                  Some(sbtLink.markdownToHtml(pageSource.string/*, linkRender*/)),
-                  maybeSidebar.map(s => sbtLink.markdownToHtml(s.string/*, linkRender*/))
+                  Some(sbtLink.markdownToHtml(pageSource.string, relativePath)),
+                  maybeSidebar.map(s => sbtLink.markdownToHtml(s.string, relativePath))
                 )
               )
             }

--- a/framework/src/sbt-link/src/main/java/play/core/SBTLink.java
+++ b/framework/src/sbt-link/src/main/java/play/core/SBTLink.java
@@ -28,6 +28,6 @@ public interface SBTLink {
 
 	public void forceReload();
 
-	public String markdownToHtml(String markdown);
+	public String markdownToHtml(String markdown, String pagePath);
 
 }

--- a/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
@@ -22,7 +22,7 @@ import java.lang.{ ProcessBuilder => JProcessBuilder }
 trait PlayCommands extends PlayAssetsCompiler with PlayEclipse {
   this: PlayReloader =>
 
-  //alerts  
+  // ~~ Alerts  
   if(Option(System.getProperty("play.debug.classpath")).filter(_ == "true").isDefined) {
     println()
     this.getClass.getClassLoader.asInstanceOf[sbt.PluginManagement.PluginClassLoader].getURLs.foreach { el =>


### PR DESCRIPTION
It was broken after the SbtLink refactoring. 

Because I don't want to make a Markdown renderer a dependency of Play runtime, and because we can't share anymore a function between Scala 2.9.2 (Build components) and Scala 2.10 (Runtime components), some documentation rendering logic moved to the PlayReloader.

This is probably not the best place to solve it, and we need to think about the whole Sbt plugin composition for the next release (2.2) 
