### PR TITLE
Add Enumerator.outputStream

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
@@ -540,6 +540,29 @@ object Enumerator {
     fromStream(new java.io.FileInputStream(file), chunkSize)
   }
 
+  /** Create an Enumerator of bytes with an OutputStream.
+   */
+  def outputStream(a: java.io.OutputStream => Unit): Enumerator[Array[Byte]] = {
+    Concurrent.unicast[Array[Byte]] { channel =>
+      val outputStream = new java.io.OutputStream(){
+        override def close() {
+          channel.end()
+        }
+        override def flush() {}
+        override def write(value: Int) {
+          channel.push(Array(value.toByte))
+        }
+        override def write(buffer: Array[Byte]) {
+          write(buffer, 0, buffer.length)
+        }
+        override def write(buffer: Array[Byte], start: Int, count: Int) {
+          channel.push(buffer.slice(start, start+count))
+        }
+      }
+      a(outputStream)
+    }
+  }
+
   def eof[A] = enumInput[A](Input.EOF)
 
   /**

--- a/framework/src/play/src/test/scala/play/iteratee/EnumeratorsSpec.scala
+++ b/framework/src/play/src/test/scala/play/iteratee/EnumeratorsSpec.scala
@@ -149,5 +149,23 @@ object EnumeratorsSpec extends Specification {
 
   }
 }
+
+"Enumerator.outputStream" should {
+  "produce the same value written in the OutputStream" in {
+    val a = "FOO"
+    val b = "bar"
+    val enumerator = Enumerator.outputStream { outputStream =>
+      outputStream.write(a.toArray.map(_.toByte))
+      outputStream.write(b.toArray.map(_.toByte))
+      outputStream.close()
+    }
+    val promise = (enumerator |>> Iteratee.fold[Array[Byte],Array[Byte]](Array[Byte]())(_ ++ _)).flatMap(_.run)
+
+    promise.await.get.map(_.toChar).foldLeft("")(_+_) must equalTo(a+b)
+  }
+}
+
+
+
 }
 


### PR DESCRIPTION
Here is a clean one commit pull request of Enumerator.outputStream
See https://github.com/playframework/Play20/pull/487

Use case:

```
  def zip = Action {
    import play.api.libs.iteratee._
    import java.util.zip._

    val enumerator = Enumerator.outputStream { os =>
      var zip = new ZipOutputStream(os);
      zip.putNextEntry(new ZipEntry("README.txt"))
      zip.write("~~~ This README file contained in a zip has been generated with Play2 Enumerator.outputStream combined with java's ZipOutputStream ~~~".map(_.toByte).toArray)
      zip.closeEntry()
      zip.close()
    }
    Ok.stream(enumerator >>> Enumerator.eof).withHeaders(
      "Content-Type"->"application/zip", 
      "Content-Disposition"->("attachment; filename=test.zip")
    )
  }
```
