### PR TITLE
[#754] Disable bonecp release helper threads

### DIFF
--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
@@ -370,6 +370,10 @@ private[db] class BoneCPApi(configuration: Configuration, classloader: ClassLoad
     datasource.setMaxConnectionAge(conf.getMilliseconds("maxConnectionAge").getOrElse(1000 * 60 * 60), java.util.concurrent.TimeUnit.MILLISECONDS)
     datasource.setDisableJMX(conf.getBoolean("disableJMX").getOrElse(true))
     datasource.setIdleConnectionTestPeriod(conf.getMilliseconds("idleConnectionTestPeriod").getOrElse(1000 * 60), java.util.concurrent.TimeUnit.MILLISECONDS)
+    // Release helper threads has caused users issues, and the feature has been removed altogether from BoneCP 0.8.0
+    // (which is yet to be released) because it offered no real performance advantage.  Once we upgrade to BoneCP 0.8.x,
+    // we can remove this line.  https://play.lighthouseapp.com/projects/82401/tickets/754-cannot-set-important-bonecp-parameter-in-configuration
+    datasource.setReleaseHelperThreads(0)
 
     conf.getString("initSQL").map(datasource.setInitSQL(_))
     conf.getBoolean("logStatements").map(datasource.setLogStatementsEnabled(_))


### PR DESCRIPTION
See https://play.lighthouseapp.com/projects/82401-play-20/tickets/754-cannot-set-important-bonecp-parameter-in-configuration
