### PR TITLE
Optional form mapping: added flag to respect empty values

### DIFF
--- a/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
@@ -83,6 +83,22 @@ object ScalaForms {
         "14" -> optional(text)
       )
     )
+    
+    
+    val optionalForm = Form(
+       tuple(
+    	"set" -> optional(text),
+        "empty" -> optional(text)
+      )
+    )
+    
+    val optionalFormWithFlag = Form(
+      tuple(
+        "set" -> optional(text, true),
+        "empty" -> optional(text, true)
+      )
+    )
+
 
     val repeatedForm = Form(
       tuple(
@@ -200,6 +216,14 @@ object FormSpec extends Specification {
   "render form using field[Type] syntax" in {
     val anyData = Map("email" -> "bob@gmail.com", "password" -> "123")
     ScalaForms.loginForm.bind(anyData).get.toString must equalTo("(bob@gmail.com,123)")
+  }
+  
+  "respect empty values if flag is set on optional mapping" in {
+	  ScalaForms.optionalForm.bindFromRequest( Map("set" -> Seq("hello world")) ).get must equalTo((Some("hello world"), None))
+	  ScalaForms.optionalForm.bindFromRequest( Map("set" -> Seq("hello world"), "empty" -> Seq("")) ).get must equalTo((Some("hello world"), None))
+
+	  ScalaForms.optionalFormWithFlag.bindFromRequest( Map("set" -> Seq("hello world")) ).get must equalTo((Some("hello world"), None))
+	  ScalaForms.optionalFormWithFlag.bindFromRequest( Map("set" -> Seq("hello world"), "empty" -> Seq("")) ).get must equalTo((Some("hello world"), Some("")))
   }
 
   "support default values" in {

--- a/framework/src/play/src/main/scala/play/api/data/Forms.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Forms.scala
@@ -317,8 +317,9 @@ object Forms {
    * }}}
    *
    * @param mapping The mapping to make optional.
+   * @param respectEmptyValues Avoids empty values from not beeing mapped. E.g. an empty string "" results in Some("") instead of None. Is set to false by default.
    */
-  def optional[A](mapping: Mapping[A]): Mapping[Option[A]] = OptionalMapping(mapping)
+  def optional[A](mapping: Mapping[A], respectEmptyValues: Boolean = false): Mapping[Option[A]] = OptionalMapping(mapping, respectEmptyValues = respectEmptyValues)
 
   /**
    * Defines an default mapping, if the parameter is not present, provide a default value.


### PR DESCRIPTION
Added a flag to the optional mapping which allows to change the mapping's behavior concerning empty values. 

If the flag ist set   "someField" -> ""  is mapped to Some("") instead of None.

For BC the flag ist set to false by default:

``` Scala
def optional[A](mapping: Mapping[A], respectEmptyValues: Boolean = false)
```

Test cases are included in the patch.
