### PR TITLE
[#836] Use eventIdExtractor

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
@@ -31,7 +31,8 @@ object EventSource {
   object EventIdExtractor extends LowPriorityEventIdExtractor
 
   def apply[E]()(implicit encoder: Comet.CometMessage[E], eventNameExtractor: EventNameExtractor[E], eventIdExtractor: EventIdExtractor[E]) = Enumeratee.map[E] { chunk =>
-    eventNameExtractor.eventName(chunk).map("event: " + _ + "\n").getOrElse("") +
+    eventNameExtractor.eventName(chunk).map("event: " + _ + "\r\n").getOrElse("") +
+    eventIdExtractor.eventId(chunk).map("id: " + _ + "\r\n").getOrElse("") +
       "data: " + encoder.toJavascriptMessage(chunk) + "\r\n\r\n"
   }
 


### PR DESCRIPTION
I think this is what was meant to be done with the eventIdExtractor.  I also changed the event: line to be ended with crlf instead of just lf, because the data line ends with crlf and although both are valid according to the spec, probably better to be consistent.
