### PR TITLE
[#834] Allow arbitrary methods in WS API

### DIFF
--- a/framework/src/play-java/src/main/java/play/libs/WS.java
+++ b/framework/src/play-java/src/main/java/play/libs/WS.java
@@ -352,7 +352,12 @@ public class WS {
             return execute("OPTION");
         }
 
-        private Promise<Response> execute(String method) {
+        /**
+         * Execute an arbitrary method on the request asynchronously.
+         *
+         * @param method The method to execute
+         */
+        public Promise<Response> execute(String method) {
             WSRequest req = new WSRequest(method).setUrl(url)
                     .setHeaders(headers)
                     .setQueryParameters(new FluentStringsMap(queryParameters));

--- a/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
@@ -399,6 +399,13 @@ object WS {
      */
     def options(): Future[Response] = prepare("OPTIONS").execute
 
+    /**
+     * Execute an arbitrary method on the request asynchronously.
+     *
+     * @param method The method to execute
+     */
+    def execute(method: String): Future[Response] = prepare(method).execute
+
     private[play] def prepare(method: String) = {
       val request = new WSRequest(method, auth, calc).setUrl(url)
         .setHeaders(headers)


### PR DESCRIPTION
This ticket came in:

https://play.lighthouseapp.com/projects/82401/tickets/834-ws-should-support-creating-http-patch-requests

I thought maybe it'd be best to support arbitrary methods.
