### PR TITLE
Fixed WS Java options request method to be OPTION instead of OPTIONS

### DIFF
--- a/framework/src/play-java/src/main/java/play/libs/WS.java
+++ b/framework/src/play-java/src/main/java/play/libs/WS.java
@@ -346,10 +346,10 @@ public class WS {
         }
 
         /**
-         * Perform a OPTION on the request asynchronously.
+         * Perform an OPTIONS on the request asynchronously.
          */
-        public Promise<Response> option() {
-            return execute("OPTION");
+        public Promise<Response> options() {
+            return execute("OPTIONS");
         }
 
         private Promise<Response> execute(String method) {


### PR DESCRIPTION
Typo in WS Java API, request method is OPTIONS not OPTION.  This change is backwards incompatible since the method name has changed, but that's probably ok since the method was probably not useful before anyway.
