### PR TITLE
[#450] Enabled namespace aware XML parsing

### DIFF
--- a/framework/src/play/src/main/java/play/libs/XML.java
+++ b/framework/src/play/src/main/java/play/libs/XML.java
@@ -1,6 +1,6 @@
 package play.libs;
 
-import java.util.Iterator;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
@@ -36,26 +36,24 @@ public class XML {
      * Parse an InputStream as DOM.
      */
     public static Document fromInputStream(InputStream in, String encoding) {
-       DocumentBuilderFactory factory = null;
-       DocumentBuilder builder = null;
-       Document ret = null;
-       
        try {
-           factory = DocumentBuilderFactory.newInstance();
-           builder = factory.newDocumentBuilder();
-       } catch (ParserConfigurationException e) {
-           throw new RuntimeException(e);
-       }
-       
-       try {
+
+           DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+           factory.setNamespaceAware(true);
+           DocumentBuilder builder = factory.newDocumentBuilder();
+
            InputSource is = new InputSource(in);
            is.setEncoding(encoding);
-           ret = builder.parse(is);
-       } catch (Exception e) {
+           
+           return builder.parse(is);
+
+       } catch (ParserConfigurationException e) {
+           throw new RuntimeException(e);
+       } catch (SAXException e) {
+           throw new RuntimeException(e);
+       } catch (IOException e) {
            throw new RuntimeException(e);
        }
-       
-       return ret;
     }
 
 }


### PR DESCRIPTION
See https://play.lighthouseapp.com/projects/82401-play-20/tickets/450-play-20-asxml-using-setnamespaceawaretrue#ticket-450-5

My biggest question was why document builder factories aren't namespace aware by default.  The only thing I could find about this was:

https://jira.springsource.org/browse/INT-310

Where Spring integration had the same issue.  They decided it was safe to enable it by default, so it's probably safe for us to do so too.

We may also want to provide a mechanism for configuring the DocumentBuilderFactory, but I think that's beyond the scope of this ticket, having it namespace aware is a good default.
