### PR TITLE
Ticket #801 implementation requiring specific enabling of Down Evolutions

### DIFF
--- a/documentation/manual/detailledTopics/evolutions/Evolutions.md
+++ b/documentation/manual/detailledTopics/evolutions/Evolutions.md
@@ -198,6 +198,21 @@ Play detects this new evolution that replaces the previous 3 one, and will run t
 
 Evolutions are stored in your database in a table called PLAY_EVOLUTIONS.  A Text column stores the actual evolution script.  Your database probably has a 64kb size limit on a text column.  To work around the 64kb limitation you could: manually alter the play_evolutions table structure changing the column type or (prefered) create multiple evolutions scripts less than 64kb in size.
 
-### Evolutions and multiple hosts
+## Running Evolutions in Production
+
+The appropriate up and down scripts are run in dev mode when you click 'Apply Evolutions' in the play console. To use evolutions in PROD mode there are two things to consier.
+
+If you want to apply UP evolutions automatically, you should set the system property `-DapplyEvolutions.<database>=true` or set `applyEvolutions.<database>=true` in application.conf.
+If the evolution script calculated by Play only contains UP evolutions and this property is set, then Play will apply them and start the server.
+
+If you want to run UP and DOWN evolutions automatically,  you should set the system property `-DapplyDownEvolutions.<database>=true`. It is not recommended to have this setting in your application.conf.
+If the evolution script calculated by Play only contains DOWN evolutions and this property is NOT set, Play will NOT apply them and will NOT start the server.
+
+### Evolutions and multiple hosts using Postgres or Oracle
+
+If your application is running on several hosts, you must set the config property evolutions.use.locks=true. If this property is set, database locks are used to ensure that only
+one host applies any Evolutions. Play will create a table called PLAY_EVOLUTIONS_LOCKS which will be used with SELECT FOR UPDATE NOWAIT to perform locking.
+
+### Evolutions and multiple hosts NOT using Postgres or Oracle
 
 If your application is running on several hosts, evolutions should be switched off. Multiple hosts may try to apply the evolutions scripts concurrently, with a risk of one of them failing and leaving the database in an inconsistent state.

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -6,3 +6,5 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.3")
 
 addSbtPlugin( "com.typesafe.sbtscalariform" % "sbtscalariform" % "0.5.1") 
 
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.1.0")
+

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -423,11 +423,21 @@ class EvolutionsPlugin(app: Application) extends Plugin with HandleWebCommandSup
       case (ds, db) => {
         withLock(ds) {
           val script = evolutionScript(api, app.path, app.classloader, db)
+          val hasDown = script.find(_.isInstanceOf[DownScript]).isDefined
           if (!script.isEmpty) {
             app.mode match {
               case Mode.Test => Evolutions.applyScript(api, db, script)
               case Mode.Dev if app.configuration.getBoolean("applyEvolutions." + db).filter(_ == true).isDefined => Evolutions.applyScript(api, db, script)
-              case Mode.Prod if app.configuration.getBoolean("applyEvolutions." + db).filter(_ == true).isDefined => Evolutions.applyScript(api, db, script)
+              case Mode.Prod if !hasDown && app.configuration.getBoolean("applyEvolutions." + db).filter(_ == true).isDefined => Evolutions.applyScript(api, db, script)
+              case Mode.Prod if hasDown &&
+                app.configuration.getBoolean("applyEvolutions." + db).filter(_ == true).isDefined &&
+                app.configuration.getBoolean("applyDownEvolutions." + db).filter(_ == true).isDefined => Evolutions.applyScript(api, db, script)
+              case Mode.Prod if hasDown => {
+                Logger("play").warn("Your production database [" + db + "] needs evolutions! \n\n" + toHumanReadableScript(script))
+                Logger("play").warn("Run with -DapplyEvolutions." + db + "=true and -DapplyDownEvolutions." + db + "=true if you want to run them automatically (be careful)")
+
+                throw InvalidDatabaseRevision(db, toHumanReadableScript(script))
+              }
               case Mode.Prod => {
                 Logger("play").warn("Your production database [" + db + "] needs evolutions! \n\n" + toHumanReadableScript(script))
                 Logger("play").warn("Run with -DapplyEvolutions." + db + "=true if you want to run them automatically (be careful)")


### PR DESCRIPTION
https://play.lighthouseapp.com/projects/82401/tickets/801-ups-only-mode-for-evolutions

This is implemented as requiring Down evolutions to be turned on explicitly with `-DapplyDownEvolutions.db=true` , and Up-Only evolutions to function with the existing `-DapplyEvolutions.db=true`

evolutions docs updated. Also added a missing section on Evolutions with Multihosts using Locking.
