### PR TITLE
make skeleton spacing more consistent with language norms

### DIFF
--- a/framework/skeletons/java-skel/app/controllers/Application.java
+++ b/framework/skeletons/java-skel/app/controllers/Application.java
@@ -7,8 +7,8 @@ import views.html.*;
 
 public class Application extends Controller {
   
-  public static Result index() {
-    return ok(index.render("Your new application is ready."));
-  }
+    public static Result index() {
+        return ok(index.render("Your new application is ready."));
+    }
   
 }

--- a/framework/skeletons/java-skel/project/Build.scala
+++ b/framework/skeletons/java-skel/project/Build.scala
@@ -4,18 +4,18 @@ import play.Project._
 
 object ApplicationBuild extends Build {
 
-    val appName         = "%APPLICATION_NAME%"
-    val appVersion      = "1.0-SNAPSHOT"
+  val appName         = "%APPLICATION_NAME%"
+  val appVersion      = "1.0-SNAPSHOT"
 
-    val appDependencies = Seq(
-       // Add your project dependencies here,
-       javaCore,
-       javaJdbc,
-       javaEbean
-    )
+  val appDependencies = Seq(
+    // Add your project dependencies here,
+    javaCore,
+    javaJdbc,
+    javaEbean
+  )
 
-    val main = play.Project(appName, appVersion, appDependencies).settings(
-      // Add your own project settings here      
-    )
+  val main = play.Project(appName, appVersion, appDependencies).settings(
+    // Add your own project settings here      
+  )
 
 }

--- a/framework/skeletons/scala-skel/project/Build.scala
+++ b/framework/skeletons/scala-skel/project/Build.scala
@@ -4,18 +4,18 @@ import play.Project._
 
 object ApplicationBuild extends Build {
 
-    val appName         = "%APPLICATION_NAME%"
-    val appVersion      = "1.0-SNAPSHOT"
+  val appName         = "%APPLICATION_NAME%"
+  val appVersion      = "1.0-SNAPSHOT"
 
-    val appDependencies = Seq(
-      // Add your project dependencies here,
-      jdbc,
-      anorm
-    )
+  val appDependencies = Seq(
+    // Add your project dependencies here,
+    jdbc,
+    anorm
+  )
 
 
-    val main = play.Project(appName, appVersion, appDependencies).settings(
-      // Add your own project settings here      
-    )
+  val main = play.Project(appName, appVersion, appDependencies).settings(
+    // Add your own project settings here      
+  )
 
 }


### PR DESCRIPTION
Since Scala usually is 2 spaces and Java is 4 spaces lets make the spacing in these files consistent with their languages.
