### PR TITLE
Test improvements

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/TestBrowser.java
+++ b/framework/src/play-test/src/main/java/play/test/TestBrowser.java
@@ -14,8 +14,6 @@ import java.util.concurrent.TimeUnit;
  */
 public class TestBrowser extends FluentAdapter {
 
-    private final String baseUrl;
-
     /**
      * A test browser (Using Selenium WebDriver) with the FluentLenium API (https://github.com/Fluentlenium/FluentLenium).
      *
@@ -35,7 +33,7 @@ public class TestBrowser extends FluentAdapter {
      */
     public TestBrowser(WebDriver webDriver, String baseUrl) {
         super(webDriver);
-        this.baseUrl = baseUrl;
+        withDefaultUrl(baseUrl);
     }
 
     /**
@@ -84,18 +82,5 @@ public class TestBrowser extends FluentAdapter {
      */
     public WebDriver.Options manage() {
         return super.getDriver().manage();
-    }
-
-    @Override
-    public <T extends FluentPage> T createPage(Class<T> classOfPage) {
-        // Work around a bug in FluentLenium
-        T page = super.createPage(classOfPage);
-        page.withDefaultUrl(getDefaultBaseUrl());
-        return page;
-    }
-
-    @Override
-    public String getDefaultBaseUrl() {
-        return baseUrl;
     }
 }

--- a/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
@@ -1,7 +1,5 @@
 package play.api.test
 
-import java.io._
-
 import play.api._
 
 import org.openqa.selenium._
@@ -10,7 +8,6 @@ import org.openqa.selenium.htmlunit._
 
 import org.fluentlenium.core._
 
-import collection.JavaConverters._
 import java.util.concurrent.TimeUnit
 import com.google.common.base.Function
 import org.openqa.selenium.support.ui.FluentWait
@@ -19,7 +16,9 @@ import org.openqa.selenium.support.ui.FluentWait
  *
  * @param webDriver The WebDriver instance to use.
  */
-case class TestBrowser(webDriver: WebDriver) extends FluentAdapter(webDriver) {
+case class TestBrowser(webDriver: WebDriver, baseUrl: Option[String]) extends FluentAdapter(webDriver) {
+
+  baseUrl.map(baseUrl => withDefaultUrl(baseUrl))
 
   /**
    * Repeatedly applies this instance's input value to the given block until one of the following occurs:
@@ -28,7 +27,7 @@ case class TestBrowser(webDriver: WebDriver) extends FluentAdapter(webDriver) {
    * the timeout expires
    *
    * @param timeout
-   * @param timeunit duration
+   * @param timeUnit duration
    * @param block code to be executed
    */
   def waitUntil[T](timeout: Int, timeUnit: TimeUnit)(block: => T): T = {
@@ -56,7 +55,6 @@ case class TestBrowser(webDriver: WebDriver) extends FluentAdapter(webDriver) {
    * to set cookies, manage timeouts among other things
    */
   def manage: WebDriver.Options = super.getDriver.manage
-
 }
 
 /**
@@ -66,18 +64,24 @@ object TestBrowser {
 
   /**
    * Creates an in-memory WebBrowser (using HtmlUnit)
+   *
+   * @param baseUrl The default base URL that will be used for relative URLs
    */
-  def default() = of(classOf[HtmlUnitDriver])
+  def default(baseUrl: Option[String] = None) = of(classOf[HtmlUnitDriver], baseUrl)
 
   /**
    * Creates a firefox WebBrowser.
+   *
+   * @param baseUrl The default base URL that will be used for relative URLs
    */
-  def firefox() = of(classOf[FirefoxDriver])
+  def firefox(baseUrl: Option[String] = None) = of(classOf[FirefoxDriver], baseUrl)
 
   /**
    * Creates a WebBrowser of the specified class name.
+   *
+   * @param baseUrl The default base URL that will be used for relative URLs
    */
-  def of[WEBDRIVER <: WebDriver](webDriver: Class[WEBDRIVER]) = TestBrowser(WebDriverFactory(webDriver))
+  def of[WEBDRIVER <: WebDriver](webDriver: Class[WEBDRIVER], baseUrl: Option[String] = None) = TestBrowser(WebDriverFactory(webDriver), baseUrl)
 
 }
 

--- a/framework/test/integrationtest/test/ApplicationSpec.scala
+++ b/framework/test/integrationtest/test/ApplicationSpec.scala
@@ -11,60 +11,46 @@ class ApplicationSpec extends Specification {
 
   "an Application" should {
   
-    "execute index" in {
-      
-      running(FakeApplication()) {
-        
-        val action = controllers.Application.index()
-        val result = action(FakeRequest())
-        
-        status(result) must equalTo(OK)
-        contentType(result) must equalTo(Some("text/html"))
-        charset(result) must equalTo(Some("utf-8"))
-        contentAsString(result) must contain("Hello world")
-      }
+    "execute index" in new WithApplication() {
+      val action = controllers.Application.index()
+      val result = action(FakeRequest())
+
+      status(result) must equalTo(OK)
+      contentType(result) must equalTo(Some("text/html"))
+      charset(result) must equalTo(Some("utf-8"))
+      contentAsString(result) must contain("Hello world")
     }
 
-    "tess custom validator failure" in {
+    "tess custom validator failure" in new WithApplication() {
       import play.data._
-      running(FakeApplication()) {
-         val userForm = new Form(classOf[JUser])
-         val anyData = new java.util.HashMap[String,String]
-         anyData.put("email", "")
-         userForm.bind(anyData).errors.toString must contain("ValidationError(email,error.invalid,[class validator.NotEmpty]")
-      }
+       val userForm = new Form(classOf[JUser])
+       val anyData = new java.util.HashMap[String,String]
+       anyData.put("email", "")
+       userForm.bind(anyData).errors.toString must contain("ValidationError(email,error.invalid,[class validator.NotEmpty]")
     }
-    "tess custom validator passing" in {
+    "tess custom validator passing" in new WithApplication() {
       import play.data._
-      running(FakeApplication()) {
-         val userForm = new Form(classOf[JUser])
-         val anyData = new java.util.HashMap[String,String]
-         anyData.put("email", "peter.hausel@yay.com")
-         userForm.bind(anyData).get.toString must contain ("")
-      }
+       val userForm = new Form(classOf[JUser])
+       val anyData = new java.util.HashMap[String,String]
+       anyData.put("email", "peter.hausel@yay.com")
+       userForm.bind(anyData).get.toString must contain ("")
     }
   
-    "execute index again" in {
-      
-      running(FakeApplication()) {
-        val action = controllers.Application.index()
-        val result = action(FakeRequest())
-        
-        status(result) must equalTo(OK)
-        contentType(result) must equalTo(Some("text/html"))
-        charset(result) must equalTo(Some("utf-8"))
-        contentAsString(result) must contain("Hello world")
-      }
+    "execute index again" in new WithApplication() {
+      val action = controllers.Application.index()
+      val result = action(FakeRequest())
+
+      status(result) must equalTo(OK)
+      contentType(result) must equalTo(Some("text/html"))
+      charset(result) must equalTo(Some("utf-8"))
+      contentAsString(result) must contain("Hello world")
     }
     
-    "execute json" in {
-    running(FakeApplication()) {
+    "execute json" in new WithApplication() {
       val Some(result) = route(FakeRequest(GET, "/json"))
       status(result) must equalTo(OK)
       contentType(result) must equalTo(Some("application/json"))
       contentAsString(result) must contain("{\"id\":1,\"name\":\"Sadek\",\"favThings\":[\"tea\"]}")
-
-      }
     }
 
     def javaResult(result: play.api.mvc.Result) =
@@ -72,47 +58,39 @@ class ApplicationSpec extends Specification {
         def getWrappedResult = result
       }
 
-    "execute json with content type" in {
-     running(FakeApplication()) {
-       // here we just test the case insensitivity of FakeHeaders, which is not that
-       // interesting, ...
-         val Some(result) = route(FakeRequest(GET, "/jsonWithContentType",
-           FakeHeaders(Seq("Accept"-> Seq("application/json"))), AnyContentAsEmpty))
-         status(result) must equalTo(OK)
-         contentType(result) must equalTo(Some("application/json"))
-         charset(result) must equalTo(None)
-         contentAsString(result) must contain("""{"Accept":"application/json"}""")
-         play.test.Helpers.charset(javaResult(result)) must equalTo(null)
-       }
-     }
+    "execute json with content type" in new WithApplication() {
+      // here we just test the case insensitivity of FakeHeaders, which is not that
+      // interesting, ...
+      val Some(result) = route(FakeRequest(GET, "/jsonWithContentType",
+        FakeHeaders(Seq("Accept" -> Seq("application/json"))), AnyContentAsEmpty))
+      status(result) must equalTo(OK)
+      contentType(result) must equalTo(Some("application/json"))
+      charset(result) must equalTo(None)
+      contentAsString(result) must contain( """{"Accept":"application/json"}""")
+      play.test.Helpers.charset(javaResult(result)) must equalTo(null)
+    }
 
 
-    "execute json with content type and charset" in {
-     running(FakeApplication()) {
-         val Some(result) = route(FakeRequest(GET, "/jsonWithCharset"))
-         status(result) must equalTo(OK)
-         contentType(result) must equalTo(Some("application/json"))
-         charset(result) must equalTo(Some("utf-8"))
-         play.test.Helpers.charset(javaResult(result)) must equalTo("utf-8")
-       }
-     }
+    "execute json with content type and charset" in new WithApplication() {
+      val Some(result) = route(FakeRequest(GET, "/jsonWithCharset"))
+      status(result) must equalTo(OK)
+      contentType(result) must equalTo(Some("application/json"))
+      charset(result) must equalTo(Some("utf-8"))
+      play.test.Helpers.charset(javaResult(result)) must equalTo("utf-8")
+    }
 
-    "not serve asset directories" in {
-      running(FakeApplication()) {
-        val Some(result) = route(FakeRequest(GET, "/public//"))
-        status(result) must equalTo (NOT_FOUND)
-      }
+    "not serve asset directories" in new WithApplication() {
+      val Some(result) = route(FakeRequest(GET, "/public//"))
+      status(result) must equalTo (NOT_FOUND)
     }
    
-    "remove cache elements" in {
-      running(FakeApplication()) {
-        import play.api.Play.current
-        import play.api.cache.Cache
-        Cache.set("foo", "bar")
-        Cache.get("foo") must equalTo (Some("bar"))
-        Cache.remove("foo")
-        Cache.get("foo") must equalTo (None)
-    }}
+    "remove cache elements" in new WithApplication() {
+      import play.api.cache.Cache
+      Cache.set("foo", "bar")
+      Cache.get("foo") must equalTo (Some("bar"))
+      Cache.remove("foo")
+      Cache.get("foo") must equalTo (None)
+    }
 
     "reverse routes containing boolean parameters" in {
       "in the query string" in {
@@ -126,136 +104,108 @@ class ApplicationSpec extends Specification {
     }
 
     "bind boolean parameters" in {
-      "from the query string" in {
-        running(FakeApplication()) {
-          val Some(result) = route(FakeRequest(GET, "/take-bool?b=true"))
-          contentAsString(result) must equalTo ("true")
-          val Some(result2) = route(FakeRequest(GET, "/take-bool?b=false"))
-          contentAsString(result2) must equalTo ("false")
-          // Bind boolean values from 1 and 0 integers too
-          contentAsString(route(FakeRequest(GET, "/take-bool?b=1")).get) must equalTo ("true")
-          contentAsString(route(FakeRequest(GET, "/take-bool?b=0")).get) must equalTo ("false")
-        }
+      "from the query string" in new WithApplication() {
+        val Some(result) = route(FakeRequest(GET, "/take-bool?b=true"))
+        contentAsString(result) must equalTo ("true")
+        val Some(result2) = route(FakeRequest(GET, "/take-bool?b=false"))
+        contentAsString(result2) must equalTo ("false")
+        // Bind boolean values from 1 and 0 integers too
+        contentAsString(route(FakeRequest(GET, "/take-bool?b=1")).get) must equalTo ("true")
+        contentAsString(route(FakeRequest(GET, "/take-bool?b=0")).get) must equalTo ("false")
       }
-      "from the path" in {
-        running(FakeApplication()) {
-          val Some(result) = route(FakeRequest(GET, "/take-bool-2/true"))
-          contentAsString(result) must equalTo ("true")
-          val Some(result2) = route(FakeRequest(GET, "/take-bool-2/false"))
-          contentAsString(result2) must equalTo ("false")
-          // Bind boolean values from 1 and 0 integers too
-          contentAsString(route(FakeRequest(GET, "/take-bool-2/1")).get) must equalTo ("true")
-          contentAsString(route(FakeRequest(GET, "/take-bool-2/0")).get) must equalTo ("false")
-        }
+      "from the path" in new WithApplication() {
+        val Some(result) = route(FakeRequest(GET, "/take-bool-2/true"))
+        contentAsString(result) must equalTo ("true")
+        val Some(result2) = route(FakeRequest(GET, "/take-bool-2/false"))
+        contentAsString(result2) must equalTo ("false")
+        // Bind boolean values from 1 and 0 integers too
+        contentAsString(route(FakeRequest(GET, "/take-bool-2/1")).get) must equalTo ("true")
+        contentAsString(route(FakeRequest(GET, "/take-bool-2/0")).get) must equalTo ("false")
       }
     }
 
     "bind int parameters from the query string as a list" in {
-     
-        "from a list of numbers" in {
-           running(FakeApplication()) {
-             val Some(result) = route(FakeRequest(GET, controllers.routes.Application.takeList(List(1, 2, 3)).url))
-             contentAsString(result) must equalTo ("123")
-           }
-        }
-        "from a list of numbers and letters" in {
-          running(FakeApplication()) {
-            val Some(result) = route(FakeRequest(GET, "/take-list?x=1&x=a&x=2"))
-            contentAsString(result) must equalTo ("12")
-          }
-        }
-        "when there is no parameter at all" in {
-          running(FakeApplication()) {
-            val Some(result) = route(FakeRequest(GET, "/take-list"))
-            contentAsString(result) must equalTo ("")
-          }
-        }
-        "using the Java API" in {
-          running(FakeApplication()) {
-            val Some(result) = route(FakeRequest(GET, "/take-list-java?x=1&x=2&x=3"))
-            contentAsString(result) must equalTo ("3 elements")
-          }
-        }
+
+      "from a list of numbers" in new WithApplication() {
+        val Some(result) = route(FakeRequest(GET, controllers.routes.Application.takeList(List(1, 2, 3)).url))
+        contentAsString(result) must equalTo("123")
+      }
+      "from a list of numbers and letters" in new WithApplication() {
+        val Some(result) = route(FakeRequest(GET, "/take-list?x=1&x=a&x=2"))
+        contentAsString(result) must equalTo("12")
+      }
+      "when there is no parameter at all" in new WithApplication() {
+        val Some(result) = route(FakeRequest(GET, "/take-list"))
+        contentAsString(result) must equalTo("")
+      }
+      "using the Java API" in new WithApplication() {
+        val Some(result) = route(FakeRequest(GET, "/take-list-java?x=1&x=2&x=3"))
+        contentAsString(result) must equalTo("3 elements")
+      }
     }
 
     "return jsonp" in {
-      "Scala API" in {
-        running(FakeApplication()) {
-          val Some(result) = route(FakeRequest(GET, controllers.routes.Application.jsonp("baz").url))
-          contentAsString(result) must equalTo ("baz({\"foo\":\"bar\"});")
-          contentType(result) must equalTo (Some("text/javascript"))
-        }
+      "Scala API" in new WithApplication() {
+        val Some(result) = route(FakeRequest(GET, controllers.routes.Application.jsonp("baz").url))
+        contentAsString(result) must equalTo ("baz({\"foo\":\"bar\"});")
+        contentType(result) must equalTo (Some("text/javascript"))
       }
-      "Java API" in {
-        running(FakeApplication()) {
-          val Some(result) = route(FakeRequest(GET, controllers.routes.JavaApi.jsonpJava("baz").url))
-          contentAsString(result) must equalTo ("baz({\"foo\":\"bar\"});")
-          contentType(result) must equalTo (Some("text/javascript"))
-        }
+      "Java API" in new WithApplication() {
+        val Some(result) = route(FakeRequest(GET, controllers.routes.JavaApi.jsonpJava("baz").url))
+        contentAsString(result) must equalTo("baz({\"foo\":\"bar\"});")
+        contentType(result) must equalTo(Some("text/javascript"))
       }
     }
 
     "instantiate controllers" in {
-      "Java controller instance" in {
-        running(FakeApplication()) {
-          val Some(result) = route(FakeRequest(GET, controllers.routes.JavaControllerInstance.index().url))
-          contentAsString(result) must equalTo ("{\"peter\":\"foo\",\"yay\":\"value\"}")
-          contentType(result) must equalTo (Some("application/json"))
-        }
+      "Java controller instance" in new WithApplication() {
+        val Some(result) = route(FakeRequest(GET, controllers.routes.JavaControllerInstance.index().url))
+        contentAsString(result) must equalTo("{\"peter\":\"foo\",\"yay\":\"value\"}")
+        contentType(result) must equalTo(Some("application/json"))
       }
-      "Scala controller instance" in {
-        running(FakeApplication()) {
-          val Some(result) = route(FakeRequest(GET, controllers.routes.ScalaControllerInstance.index().url))
-          contentAsString(result) must equalTo ("{\"peter\":\"foo\",\"yay\":\"value\"}")
-          contentType(result) must equalTo (Some("application/json"))
-        }
+      "Scala controller instance" in new WithApplication() {
+        val Some(result) = route(FakeRequest(GET, controllers.routes.ScalaControllerInstance.index().url))
+        contentAsString(result) must equalTo("{\"peter\":\"foo\",\"yay\":\"value\"}")
+        contentType(result) must equalTo(Some("application/json"))
       }
     }
 
-    "urldecode correctly parameters from path and query string" in {
-      running(FakeApplication()) {
-        val Some(result) = route(FakeRequest(GET, "/urldecode/2%2B2?q=2%2B2"))
-        contentAsString(result) must contain ("fromPath=2+2")
-        contentAsString(result) must contain ("fromQueryString=2+2")
-      }
+    "urldecode correctly parameters from path and query string" in new WithApplication() {
+      val Some(result) = route(FakeRequest(GET, "/urldecode/2%2B2?q=2%2B2"))
+      contentAsString(result) must contain("fromPath=2+2")
+      contentAsString(result) must contain("fromQueryString=2+2")
     }
 
     "test Accept header mime-types" in {
       import play.api.http.HeaderNames._
-      "Scala API" in {
-        running(FakeApplication()) {
-          val url = controllers.routes.Application.accept().url
-          val Some(result) = route(FakeRequest(GET, url).withHeaders(ACCEPT -> "text/html,application/xml;q=0.5"))
-          contentAsString(result) must equalTo ("html")
+      "Scala API" in new WithApplication() {
+        val url = controllers.routes.Application.accept().url
+        val Some(result) = route(FakeRequest(GET, url).withHeaders(ACCEPT -> "text/html,application/xml;q=0.5"))
+        contentAsString(result) must equalTo("html")
 
-          val Some(result2) = route(FakeRequest(GET, url).withHeaders(ACCEPT -> "text/*"))
-          contentAsString(result2) must equalTo ("html")
+        val Some(result2) = route(FakeRequest(GET, url).withHeaders(ACCEPT -> "text/*"))
+        contentAsString(result2) must equalTo("html")
 
-          val Some(result3) = route(FakeRequest(GET, url).withHeaders(ACCEPT -> "application/json"))
-          contentAsString(result3) must equalTo ("json")
-        }
+        val Some(result3) = route(FakeRequest(GET, url).withHeaders(ACCEPT -> "application/json"))
+        contentAsString(result3) must equalTo("json")
       }
-      "Java API" in {
-        running(FakeApplication()) {
-          val url = controllers.routes.JavaApi.accept().url
-          val Some(result) = route(FakeRequest(GET, url).withHeaders(ACCEPT -> "text/html,application/xml;q=0.5"))
-          contentAsString(result) must equalTo ("html")
+      "Java API" in new WithApplication() {
+        val url = controllers.routes.JavaApi.accept().url
+        val Some(result) = route(FakeRequest(GET, url).withHeaders(ACCEPT -> "text/html,application/xml;q=0.5"))
+        contentAsString(result) must equalTo("html")
 
-          val Some(result2) = route(FakeRequest(GET, url).withHeaders(ACCEPT -> "text/*"))
-          contentAsString(result2) must equalTo ("html")
+        val Some(result2) = route(FakeRequest(GET, url).withHeaders(ACCEPT -> "text/*"))
+        contentAsString(result2) must equalTo("html")
 
-          val Some(result3) = route(FakeRequest(GET, url).withHeaders(ACCEPT -> "application/json"))
-          contentAsString(result3) must equalTo ("json")
-        }
+        val Some(result3) = route(FakeRequest(GET, url).withHeaders(ACCEPT -> "application/json"))
+        contentAsString(result3) must equalTo("json")
       }
     }
 
-    "support all valid Java identifiers in router" in {
-      running(FakeApplication()) {
-        val Some(result) = route(FakeRequest(GET, "/ident/3"))
-        status(result) must equalTo(OK)
-        contentAsString(result) must_== "3"
-      }
+    "support all valid Java identifiers in router" in new WithApplication() {
+      val Some(result) = route(FakeRequest(GET, "/ident/3"))
+      status(result) must equalTo(OK)
+      contentAsString(result) must_== "3"
     }
 
   }

--- a/framework/test/integrationtest/test/ApplicationTest.java
+++ b/framework/test/integrationtest/test/ApplicationTest.java
@@ -11,93 +11,74 @@ import static org.fest.assertions.Assertions.*;
 import java.util.concurrent.Callable;
 import java.util.*;
 
-public class ApplicationTest {
+public class ApplicationTest extends WithApplication {
     
     @Test 
     public void compute() {
         assertThat(1 + 1).isEqualTo(2);
     }
 
-      
-    @Test 
-    public void cache() {
-        running(fakeApplication(), new Runnable() {
-            public void run() {
-               try{
-                   Callable<String> c = new Callable<String>() {
-                   public String call() {
-                     return "world";
-                   }
-                  };
-                  Callable<String> overrideC = new Callable<String>() {
-                   public String call() {
-                     return "override";
-                   }
-                  };
-                  assertThat(play.cache.Cache.get("key")).isEqualTo(null);
-                  play.cache.Cache.getOrElse("key", c,0);
-                  assertThat(play.cache.Cache.get("key")).isEqualTo("world");
-                  String j = play.cache.Cache.getOrElse("key", overrideC,0);
-                  assertThat(j).isEqualTo("world");
-               } catch (Exception e) {assertThat(e).hasNoCause();}
+
+    @Test
+    public void cache() throws Exception {
+        start();
+        Callable<String> c = new Callable<String>() {
+            public String call() {
+                return "world";
             }
-        });
+        };
+        Callable<String> overrideC = new Callable<String>() {
+            public String call() {
+                return "override";
+            }
+        };
+        assertThat(play.cache.Cache.get("key")).isEqualTo(null);
+        play.cache.Cache.getOrElse("key", c, 0);
+        assertThat(play.cache.Cache.get("key")).isEqualTo("world");
+        String j = play.cache.Cache.getOrElse("key", overrideC, 0);
+        assertThat(j).isEqualTo("world");
     }
 
     @Test 
-    public void testAdditionPlugin() {
-        List<String> plugins = new ArrayList<String>();
-        plugins.add("test.DummyPlugin");
-        running(fakeApplication(new HashMap<String,String>(),plugins), new Runnable() {
-          public void run() {
-            assertThat(play.Play.application().plugin(test.DummyPlugin.class).foo()).isEqualTo("yay");
-          }
-        });
+    public void testAdditionPlugin() throws Exception {
+        start(fakeApplication(Collections.<String, String>emptyMap(), Arrays.asList("test.DummyPlugin")));
+        assertThat(play.Play.application().plugin(test.DummyPlugin.class).foo()).isEqualTo("yay");
     }
 
     @Test 
     public void test() {
-        running(fakeApplication(), new Runnable() {
-            public void run() {
-                Result result = callAction(
-                    controllers.routes.ref.JavaApi.headers(),
-                    fakeRequest().withHeader(HOST, "playframework.org")
-                );
-                assertThat(contentAsString(result)).isEqualTo("playframework.org");
-            }
-        });
+        start();
+        Result result = callAction(
+            controllers.routes.ref.JavaApi.headers(),
+            fakeRequest().withHeader(HOST, "playframework.org")
+        );
+        assertThat(contentAsString(result)).isEqualTo("playframework.org");
     }
     @Test 
     public void testCookie() {
+        start();
         final Http.Cookie c = new Http.Cookie("testcookie", "value", -1, "/", "localhost", true, true);
-        running(fakeApplication(), new Runnable() {
-            public void run() {
-                Result result = callAction(
-                    controllers.routes.ref.JavaApi.cookietest(),
-                    fakeRequest().withCookies(c)
-                );
-                assertThat(cookie("testcookie",result).name()).isEqualTo("testcookie");
-                assertThat(contentAsString(result)).isEqualTo("testcookie");
-            }
-        });
+        Result result = callAction(
+            controllers.routes.ref.JavaApi.cookietest(),
+            fakeRequest().withCookies(c)
+        );
+        assertThat(cookie("testcookie",result).name()).isEqualTo("testcookie");
+        assertThat(contentAsString(result)).isEqualTo("testcookie");
     }
 
     @Test
     public void interceptors() {
-        running(fakeApplication(), new Runnable() {
-            public void run() {
-                Interceptor.state = "";
-                Result result = callAction(controllers.routes.ref.JavaApi.notIntercepted());
-                assertThat(contentAsString(result)).isEqualTo("");
-                
-                Interceptor.state = "";
-                result = callAction(controllers.routes.ref.JavaApi.interceptedUsingWith());
-                assertThat(contentAsString(result)).isEqualTo("intercepted");
-                
-                Interceptor.state = "";
-                result = callAction(controllers.routes.ref.JavaApi.intercepted());
-                assertThat(contentAsString(result)).isEqualTo("intercepted");
-      }});
-    
+        start();
+        Interceptor.state = "";
+        Result result = callAction(controllers.routes.ref.JavaApi.notIntercepted());
+        assertThat(contentAsString(result)).isEqualTo("");
+
+        Interceptor.state = "";
+        result = callAction(controllers.routes.ref.JavaApi.interceptedUsingWith());
+        assertThat(contentAsString(result)).isEqualTo("intercepted");
+
+        Interceptor.state = "";
+        result = callAction(controllers.routes.ref.JavaApi.intercepted());
+        assertThat(contentAsString(result)).isEqualTo("intercepted");
     }
 }

--- a/framework/test/integrationtest/test/EvolutionsSpec.scala
+++ b/framework/test/integrationtest/test/EvolutionsSpec.scala
@@ -3,21 +3,20 @@ import org.specs2.mutable._
 import play.api.db.DB
 import play.api.db.evolutions.Evolutions
 import play.api.test.Helpers._
-import play.api.test.FakeApplication
-import play.api.Play.current
+import play.api.test.{WithApplication, FakeApplication}
 
 class EvolutionsSpec extends Specification {
 
   "Evolutions" should {
-    "be run against the configured database in fake application when testing" in {
-      running(FakeApplication(additionalConfiguration = inMemoryDatabase("mock"))) {
-        Evolutions.applyFor("mock")
-        DB.withConnection("mock") { implicit conn =>
-          SQL("insert into Mock (value) values ('foobar')").executeUpdate()
-          val first = SQL("select * from Mock where value = 'foobar'").apply().head
-          first[String]("value") must_== "foobar"
-          first[Int]("id") must_!= null
-        }
+    "be run against the configured database in fake application when testing" in new WithApplication(
+      FakeApplication(additionalConfiguration = inMemoryDatabase("mock"))
+    ) {
+      Evolutions.applyFor("mock")
+      DB.withConnection("mock") { implicit conn =>
+        SQL("insert into Mock (value) values ('foobar')").executeUpdate()
+        val first = SQL("select * from Mock where value = 'foobar'").apply().head
+        first[String]("value") must_== "foobar"
+        first[Int]("id") must_!= null
       }
     }
   }

--- a/framework/test/integrationtest/test/FunctionalSpec.scala
+++ b/framework/test/integrationtest/test/FunctionalSpec.scala
@@ -6,11 +6,9 @@ import play.api.libs.ws._
 import org.specs2.mutable._
 import models._
 import models.Protocol._
-import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import java.util.Calendar
 import java.util.Locale
-import play.api.libs.iteratee.{Iteratee, Cont, Input, Done}
-import play.api.test.TestServer
+import play.api.libs.iteratee.Iteratee
 import play.api.libs.ws.ResponseHeaders
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -22,180 +20,167 @@ class FunctionalSpec extends Specification {
 
     val startDate = cal.getTime()
 
-    "charset should be defined" in {
-      running(TestServer(9003), HTMLUNIT) { browser =>
-        val h = await(WS.url("http://localhost:9003/public/stylesheets/main.css").get)
-        h.header("Content-Type").get must equalTo("text/css; charset=utf-8")
-      }
-    } 
-    "call onClose for Ok.sendFile responses" in {
+    "charset should be defined" in new WithServer() {
+      val h = await(WS.url("http://localhost:" + port + "/public/stylesheets/main.css").get)
+      h.header("Content-Type").get must equalTo("text/css; charset=utf-8")
+    }
+    "call onClose for Ok.sendFile responses" in new WithBrowser() {
       import java.io.File
-      running(TestServer(9003), HTMLUNIT) { browser =>
-        def file = new File("onClose.tmp")
-        file.createNewFile()
-        file.exists() must equalTo(true)
+      def file = new File("onClose.tmp")
+      file.createNewFile()
+      file.exists() must equalTo(true)
 
-        browser.goTo("http://localhost:9003/onCloseSendFile/" + file.getCanonicalPath)
-        Thread.sleep(1000)
-        file.exists() must equalTo(false)
-      }
+      browser.goTo("/onCloseSendFile/" + file.getCanonicalPath)
+      Thread.sleep(1000)
+      file.exists() must equalTo(false)
     }
 
-    "pass functional test with two browsers" in {
-      running(TestServer(9002), HTMLUNIT) { browser =>
-        browser.goTo("http://localhost:9002")
-        browser.pageSource must contain("Hello world")
+    "pass functional test with two browsers" in new WithBrowser() {
+      browser.goTo("/")
+      browser.pageSource must contain("Hello world")
+    }
+    "pass functional test" in new WithBrowser() {
+      // -- Etags
+      val format = new java.text.SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH)
+      format.setTimeZone(java.util.TimeZone.getTimeZone("GMT"))
+      val h = await(WS.url("http://localhost:" + port + "/public/stylesheets/main.css").get)
+      h.header("Last-Modified").isDefined must equalTo(true)
+      h.header("LAST-MODIFIED").isDefined must equalTo(true)   //test case insensitivity of hashmap keys
+      h.header("Etag").get.startsWith("\"") must equalTo(true)
+      h.header("Etag").get.endsWith("\"") must equalTo(true)
+      h.header("ETAG").get.endsWith("\"") must equalTo(true)
+      //the map queries are case insensitive, but the underlying map still contains the original headers
+      val keys = h.getAHCResponse.getHeaders().keySet()
+      keys.contains("Etag")  must equalTo(true)
+      keys.contains("ETAG") must equalTo(false)
+
+      val hp = WS.url("http://localhost:" + port + "/jsonWithContentType").
+        withHeaders("Accept"-> "application/json").
+        get{ header: ResponseHeaders =>
+         val hdrs = header.headers
+         hdrs.get("Content-Type").isDefined must equalTo(true)
+         hdrs.get("CONTENT-TYpe").isDefined must equalTo(true)
+         hdrs.keys.find(header => header == "Content-Type" ).isDefined must equalTo(true)
+         hdrs.keys.find(header => header == "CONTENT-TYpe" ).isDefined must equalTo(false)
+         Iteratee.fold[Array[Byte],StringBuffer](new StringBuffer){ (buf,array) => { buf.append(array); buf }}
       }
-    } 
-    "pass functional test" in {
-      running(TestServer(9001), HTMLUNIT) { browser =>
-        // -- Etags
 
-        val format = new java.text.SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH)
-        format.setTimeZone(java.util.TimeZone.getTimeZone("GMT"))
-        val h = await(WS.url("http://localhost:9001/public/stylesheets/main.css").get)
-        h.header("Last-Modified").isDefined must equalTo(true)
-        h.header("LAST-MODIFIED").isDefined must equalTo(true)   //test case insensitivity of hashmap keys
-        h.header("Etag").get.startsWith("\"") must equalTo(true)
-        h.header("Etag").get.endsWith("\"") must equalTo(true)
-        h.header("ETAG").get.endsWith("\"") must equalTo(true)
-        //the map queries are case insensitive, but the underlying map still contains the original headers
-        val keys = h.getAHCResponse.getHeaders().keySet()
-        keys.contains("Etag")  must equalTo(true)
-        keys.contains("ETAG") must equalTo(false)
+      await(hp.map(_.run)).map(buf => buf.toString must contain("""{"Accept":"application/json"}""") )
 
-        val hp = WS.url("http://localhost:9001/jsonWithContentType").
-          withHeaders("Accept"-> "application/json").
-          get{ header: ResponseHeaders =>
-           val hdrs = header.headers
-           hdrs.get("Content-Type").isDefined must equalTo(true)
-           hdrs.get("CONTENT-TYpe").isDefined must equalTo(true)
-           hdrs.keys.find(header => header == "Content-Type" ).isDefined must equalTo(true)
-           hdrs.keys.find(header => header == "CONTENT-TYpe" ).isDefined must equalTo(false)
-           Iteratee.fold[Array[Byte],StringBuffer](new StringBuffer){ (buf,array) => { buf.append(array); buf }}
-        }
+      val secondRequest = await(WS.url("http://localhost:" + port + "/public/stylesheets/main.css").withHeaders("If-Modified-Since"-> format.format(startDate)).get)
+      secondRequest.status must equalTo(304)
 
-        await(hp.map(_.run)).map(buf => buf.toString must contain("""{"Accept":"application/json"}""") )
+      // return Date header with 304 response
+      secondRequest.header(DATE) must beSome
 
-        val secondRequest = await(WS.url("http://localhost:9001/public/stylesheets/main.css").withHeaders("If-Modified-Since"-> format.format(startDate)).get)
-        secondRequest.status must equalTo(304)
+      val localCal = cal
+      val f = new java.io.File("public/stylesheets/main.css")
+      localCal.setTime(new java.util.Date(f.lastModified))
+      localCal.add(Calendar.HOUR, -1)
+      val earlierDate =  localCal.getTime
 
-        // return Date header with 304 response
-        secondRequest.header(DATE) must beSome
-       
-        val localCal = cal
-        val f = new java.io.File("public/stylesheets/main.css")
-        localCal.setTime(new java.util.Date(f.lastModified))
-        localCal.add(Calendar.HOUR, -1)
-        val earlierDate =  localCal.getTime
+      val third = await(WS.url("http://localhost:" + port + "/public/stylesheets/main.css").withHeaders("If-Modified-Since"-> format.format(earlierDate)).get)
+      third.header("Last-Modified").isDefined must equalTo(true)
+      third.status must equalTo(200)
 
-        val third = await(WS.url("http://localhost:9001/public/stylesheets/main.css").withHeaders("If-Modified-Since"-> format.format(earlierDate)).get)
-        third.header("Last-Modified").isDefined must equalTo(true)
-        third.status must equalTo(200)
+      val fourth = await(WS.url("http://localhost:" + port + "/public/stylesheets/main.css").withHeaders("If-Modified-Since" -> "Not a date").get)
+      fourth.header("Last-Modified").isDefined must equalTo(true)
+      fourth.status must equalTo(200)
 
-        val fourth = await(WS.url("http://localhost:9001/public/stylesheets/main.css").withHeaders("If-Modified-Since" -> "Not a date").get)
-        fourth.header("Last-Modified").isDefined must equalTo(true)
-        fourth.status must equalTo(200)
-
-        val content: String = await(WS.url("http://localhost:9001/post").post("param1=foo")).body
-        content must contain ("param1")
-        content must contain("AnyContentAsText")
-        content must contain ("foo")
+      val content: String = await(WS.url("http://localhost:" + port + "/post").post("param1=foo")).body
+      content must contain ("param1")
+      content must contain("AnyContentAsText")
+      content must contain ("foo")
 
 
-        val contentForm: String = await(WS.url("http://localhost:9001/post").post(Map("param1"->Seq("foo")))).body
-        contentForm must contain ("AnyContentAsFormUrlEncoded")
-        contentForm must contain ("foo")
+      val contentForm: String = await(WS.url("http://localhost:" + port + "/post").post(Map("param1"->Seq("foo")))).body
+      contentForm must contain ("AnyContentAsFormUrlEncoded")
+      contentForm must contain ("foo")
 
-         val jpromise: play.libs.F.Promise[play.libs.WS.Response] = play.libs.WS.url("http://localhost:9001/post").setHeader("Content-Type","application/x-www-form-urlencoded").post("param1=foo")
-        val contentJava: String = jpromise.get().getBody()
-        contentJava must contain ("param1")
-        contentJava must contain ("AnyContentAsFormUrlEncoded")
-        contentJava must contain ("foo")
+       val jpromise: play.libs.F.Promise[play.libs.WS.Response] = play.libs.WS.url("http://localhost:" + port + "/post").setHeader("Content-Type","application/x-www-form-urlencoded").post("param1=foo")
+      val contentJava: String = jpromise.get().getBody()
+      contentJava must contain ("param1")
+      contentJava must contain ("AnyContentAsFormUrlEncoded")
+      contentJava must contain ("foo")
 
-        browser.goTo("http://localhost:9001/form")
-        browser.pageSource must contain("input type=\"radio\" id=\"gender_M\" name=\"gender\" value=\"M\" checked")
+      browser.goTo("/form")
+      browser.pageSource must contain("input type=\"radio\" id=\"gender_M\" name=\"gender\" value=\"M\" checked")
 
-        browser.goTo("http://localhost:9001")
-        browser.pageSource must contain("Hello world")
+      browser.goTo("/")
+      browser.pageSource must contain("Hello world")
 
-        await(WS.url("http://localhost:9001").get()).body must contain ("Hello world")
+      await(WS.url("http://localhost:" + port + "").get()).body must contain ("Hello world")
 
-        await(WS.url("http://localhost:9001/json").get()).json.as[User] must equalTo(User(1, "Sadek", List("tea")))
+      await(WS.url("http://localhost:" + port + "/json").get()).json.as[User] must equalTo(User(1, "Sadek", List("tea")))
 
-        browser.goTo("http://localhost:9001/conf")
-        browser.pageSource must contain("This value comes from complex-app's complex1.conf")
-        browser.pageSource must contain("override akka:2 second")
-        browser.pageSource must contain("akka-loglevel:DEBUG")
-        browser.pageSource must contain("promise-timeout:7000")
-        browser.pageSource must contain("None")
-        browser.title must beNull
+      browser.goTo("/conf")
+      browser.pageSource must contain("This value comes from complex-app's complex1.conf")
+      browser.pageSource must contain("override akka:2 second")
+      browser.pageSource must contain("akka-loglevel:DEBUG")
+      browser.pageSource must contain("promise-timeout:7000")
+      browser.pageSource must contain("None")
+      browser.title must beNull
 
-        browser.goTo("http://localhost:9001/json_java")
-        browser.pageSource must contain ("{\"peter\":\"foo\",\"yay\":\"value\"}")
+      browser.goTo("/json_java")
+      browser.pageSource must contain ("{\"peter\":\"foo\",\"yay\":\"value\"}")
 
-        browser.goTo("http://localhost:9001/json_from_jsobject")
-        browser.pageSource must contain ("{\"blah\":\"foo\"}")
+      browser.goTo("/json_from_jsobject")
+      browser.pageSource must contain ("{\"blah\":\"foo\"}")
 
-        browser.goTo("http://localhost:9001/headers")
-        browser.pageSource must contain("localhost:9001")
+      browser.goTo("/headers")
+      browser.pageSource must contain("localhost:" + port)
 
-        // --- Cookies
+      // --- Cookies
 
-        browser.goTo("http://localhost:9001/json_java")
-        browser.getCookies.size must equalTo(0)
+      browser.goTo("/json_java")
+      browser.getCookies.size must equalTo(0)
 
-        browser.goTo("http://localhost:9001/cookie")
-        browser.getCookie("foo").getValue must equalTo("bar")
+      browser.goTo("/cookie")
+      browser.getCookie("foo").getValue must equalTo("bar")
 
-        browser.goTo("http://localhost:9001/read/foo")
-        browser.pageSource must contain("Cookie foo has value: bar")
+      browser.goTo("/read/foo")
+      browser.pageSource must contain("Cookie foo has value: bar")
 
-        browser.goTo("http://localhost:9001/read/bar")
-        browser.pageSource must equalTo("")
+      browser.goTo("/read/bar")
+      browser.pageSource must equalTo("")
 
-        browser.goTo("http://localhost:9001/clear/foo")
-        browser.getCookies.size must equalTo(0)
+      browser.goTo("/clear/foo")
+      browser.getCookies.size must equalTo(0)
 
-        // --- Javascript Reverse Router
+      // --- Javascript Reverse Router
 
-        browser.goTo("http://localhost:9001/javascript-test?name=guillaume")
+      browser.goTo("/javascript-test?name=guillaume")
 
-        browser.$("#route-url").click()
-        browser.$("#result").getTexts().get(0) must equalTo ("/javascript-test?name=world")
+      browser.$("#route-url").click()
+      browser.$("#result").getTexts().get(0) must equalTo ("/javascript-test?name=world")
 
-        browser.$("#route-abs-url").click()
-        browser.$("#result").getTexts().get(0) must equalTo ("http://localhost:9001/javascript-test?name=world")
+      browser.$("#route-abs-url").click()
+      browser.$("#result").getTexts().get(0) must equalTo ("http://localhost:" + port + "/javascript-test?name=world")
 
-        browser.$("#route-abs-secure-url").click()
-        browser.$("#result").getTexts().get(0) must equalTo ("https://localhost:9001/javascript-test?name=world")
+      browser.$("#route-abs-secure-url").click()
+      browser.$("#result").getTexts().get(0) must equalTo ("https://localhost:" + port + "/javascript-test?name=world")
 
-        browser.$("#route-abs-secure-url2").click()
-        browser.$("#result").getTexts().get(0) must equalTo ("https://localhost:9001/javascript-test?name=world")
+      browser.$("#route-abs-secure-url2").click()
+      browser.$("#result").getTexts().get(0) must equalTo ("https://localhost:" + port + "/javascript-test?name=world")
 
-        browser.$("#route-ws-url").click()
-        browser.$("#result").getTexts().get(0) must equalTo ("ws://localhost:9001/javascript-test?name=world")
+      browser.$("#route-ws-url").click()
+      browser.$("#result").getTexts().get(0) must equalTo ("ws://localhost:" + port + "/javascript-test?name=world")
 
-        browser.$("#route-ws-secure-url").click()
-        browser.$("#result").getTexts().get(0) must equalTo ("wss://localhost:9001/javascript-test?name=world")
+      browser.$("#route-ws-secure-url").click()
+      browser.$("#result").getTexts().get(0) must equalTo ("wss://localhost:" + port + "/javascript-test?name=world")
 
-        browser.$("#route-ws-secure-url2").click()
-        browser.$("#result").getTexts().get(0) must equalTo ("wss://localhost:9001/javascript-test?name=world")
-      }
+      browser.$("#route-ws-secure-url2").click()
+      browser.$("#result").getTexts().get(0) must equalTo ("wss://localhost:" + port + "/javascript-test?name=world")
     }
 
     "Provide a hook to handle errors" in {
-      "Synchronous results" in {
-        running(TestServer(9000), HTMLUNIT) { browser =>
-          browser.goTo("http://localhost:9000/sync-error")
-          browser.pageSource must equalTo ("Something went wrong.")
-        }
+      "Synchronous results" in new WithBrowser() {
+        browser.goTo("/sync-error")
+        browser.pageSource must equalTo ("Something went wrong.")
       }
-      "Asynchronous results" in {
-        running(TestServer(9000), HTMLUNIT) { browser =>
-          browser.goTo("http://localhost:9000/async-error")
-          browser.pageSource must equalTo ("Something went wrong.")
-        }
+      "Asynchronous results" in new WithBrowser() {
+        browser.goTo("/async-error")
+        browser.pageSource must equalTo ("Something went wrong.")
       }
     }
 

--- a/framework/test/integrationtest/test/SslSpec.scala
+++ b/framework/test/integrationtest/test/SslSpec.scala
@@ -34,10 +34,7 @@ class SslSpec extends Specification {
                      password: Option[String] = None,
                      trustStore: Option[String] = None) extends Around with Scope {
 
-    implicit lazy val app = FakeApplication(withoutPlugins = Seq(
-      "play.api.db.BoneCPPlugin",
-      "play.api.db.evolutions.EvolutionsPlugin"
-    ))
+    implicit lazy val app = FakeApplication()
 
     def around[T](t: => T)(implicit evidence: (T) => Result) = {
       val props = System.getProperties


### PR DESCRIPTION
- Fixed bug in WithApplication/Server/Browser around scopes where the around() method was being invoked twice
- Modified integrationtest to use WithApplication/Server/Browser
- Modified TestBrowser so that it would set a default base URL for relative URLs in Fluentlenium, and made it use the one provided by WithBrowser
