### PR TITLE
Fix wrong inputDate documentation. Related to #852

### DIFF
--- a/framework/src/play/src/main/scala/views/helper/inputDate.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputDate.scala.html
@@ -3,7 +3,7 @@
  *
  * Example:
  * {{{
- * @inputText(field = myForm("name"), args = 'size -> 10)
+ * @inputDate(field = myForm("releaseDate"), args = 'size -> 10)
  * }}}
  *
  * @param field The form field.


### PR DESCRIPTION
This pull request covers https://play.lighthouseapp.com/projects/82401-play-20/tickets/852-inputdate-documentation-wrongly-describes-inputtext-usage
