### PR TITLE
"dist" command should package all jars (2)

### DIFF
--- a/framework/runtests
+++ b/framework/runtests
@@ -25,7 +25,8 @@ echo "[info]"
 echo "[info] ---- RUNNING INTEGRATION TEST"
 echo "[info]"
 
-$PLAY "$@" clean-all test
+$PLAY "$@" clean-all test test-dist
+
 cd $CURRENT
 
 cd ./test/integrationtest-java

--- a/framework/src/sbt-plugin/src/main/scala/PlayKeys.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayKeys.scala
@@ -32,6 +32,8 @@ trait PlayKeys {
 
   val distDirectory = SettingKey[File]("play-dist")
 
+  val distExcludes = SettingKey[Seq[String]]("dist-excludes")
+
   val playAssetsDirectories = SettingKey[Seq[File]]("play-assets-directories")
 
   val incrementalAssetsCompilation = SettingKey[Boolean]("play-incremental-assets-compilation")

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -93,6 +93,8 @@ trait PlaySettings {
 
     distDirectory <<= baseDirectory / "dist",
 
+    distExcludes := Seq.empty,
+
     libraryDependencies <+= (playPlugin) { isPlugin =>
       val d = "play" %% "play" % play.core.PlayVersion.current
       if(isPlugin)

--- a/framework/test/integrationtest/project/Build.scala
+++ b/framework/test/integrationtest/project/Build.scala
@@ -4,18 +4,18 @@ import play.Project._
 
 object ApplicationBuild extends Build {
 
-    val appName         = "integrationtest"
-    val appVersion      = "0.1"
+  val appName = "integrationtest"
+  val appVersion = "0.1"
 
-    val appDependencies = Seq(
-    	javaJdbc,
-    	javaCore,
-    	anorm
-    ) 
+  val appDependencies = Seq(
+    javaJdbc,
+    javaCore,
+    anorm)
 
-    val main = play.Project(appName, appVersion, appDependencies).settings(
-    	requireJs += "main.js"
-    )	
+  val distTestSettings = DistTest.makeSettings(appName, appVersion)
 
+  val main = play.Project(appName, appVersion, appDependencies).settings(
+                  requireJs += "main.js"
+             ).settings(distTestSettings: _*)
 }
             

--- a/framework/test/integrationtest/project/DistTest.scala
+++ b/framework/test/integrationtest/project/DistTest.scala
@@ -1,0 +1,76 @@
+import sbt._
+import Keys._
+import play.Project._
+import sbt.Artifact
+
+object DistTest {
+  private val MUST_DIST_ARTIFACT_NAME = "mustDist"
+  private val MUST_NOT_DIST_ARTIFACT_NAME = "mustNotDist"
+
+  private val MUST_DIST_FILENAME = "mustDistThisArtifact.jar"
+  private val MUST_NOT_DIST_FILENAME = "mustNotDistThisArtifact.jar"
+
+  private def testDistCmd(appName: String, appVersion: String) = {
+    val help = "Run the dist task and validate the output"
+    Command.command("test-dist", help, help) { (s0: State) =>
+      Project.runTask(dist, s0) match {
+        case Some((s1, Value(distFile))) =>
+          IO.withTemporaryDirectory { tmpUnzipDir =>
+            validateDistFiles(appName, appVersion, IO.unzip(distFile, tmpUnzipDir))
+            s1
+          }
+        case r @ _ => throw new RuntimeException("Unexpected result from dist task: " + r)
+      }
+    }
+  }
+
+  private val distTestArtifactsSetting =
+    packagedArtifacts <<= (packagedArtifacts, target) map {
+      (artifacts, targetDir) =>
+          val mustDistFile = targetDir / MUST_DIST_FILENAME
+          val mustNotDistFile = targetDir / MUST_NOT_DIST_FILENAME
+
+          IO.writeLines(mustDistFile, Seq("must dist this artifact"))
+          IO.writeLines(mustNotDistFile, Seq("must not dist this artifact"))
+
+          def artifact(name: String) = new Artifact(name, "jar", "jar", None,
+                                                    Seq.empty, None, Map.empty)
+
+          val mustDistArtifact = artifact(MUST_DIST_ARTIFACT_NAME)
+          val mustNotDistArtifact = artifact(MUST_NOT_DIST_ARTIFACT_NAME)
+
+          artifacts ++ Seq((mustDistArtifact, mustDistFile),
+                           (mustNotDistArtifact, mustNotDistFile))
+    }
+
+  private def validateDistFiles(appName: String, appVersion: String, files: Set[File]) {
+
+    def matches(file: File, pat: String) = file.getAbsolutePath().matches(pat)
+
+    def contains(pat: String) = files.exists(matches(_, pat))
+
+    def mustContain(pat: String) =
+      if (!contains(pat))
+        throw new RuntimeException("dist-test failed!  No dist file matched the required pattern " + pat +
+                                   "\nDist files were:\n" + files)
+
+    def mustNotContain(pat: String) =
+      if (contains(pat))
+        throw new RuntimeException("dist-test failed!  A dist file matched the forbidden pattern " + pat +
+                                   "\nDist files were:\n" + files)
+
+    val root = ".*/%s-%s" format (appName, appVersion)
+    val lib = root + "/lib/"
+    val scalaVersionPattern = "[0-9]+[.][0-9]+"
+
+    mustContain(lib + "%s_%s-%s.jar" format (appName, scalaVersionPattern, appVersion))
+    mustContain(lib + MUST_DIST_FILENAME)
+    mustNotContain(lib + MUST_NOT_DIST_FILENAME)
+  }
+
+  def makeSettings(appName: String, appVersion: String) =
+    Seq(distTestArtifactsSetting,
+        distExcludes := Seq(MUST_NOT_DIST_ARTIFACT_NAME),
+        commands += testDistCmd(appName, appVersion))
+
+}


### PR DESCRIPTION
Replacement for pull request https://github.com/playframework/Play20/pull/535 based on a more recent master commit.  Here is the original description:

This pull request addresses lighthouse ticket #851:

Play's current "dist" implementation takes its input from the packageBin task, which is defined as "produces a main artifact, such as a binary jar," and which only returns a single File. This is sometimes insufficient. For example, it does not work if a Play project wants to publish a separate jar with convenience functionality for its clients, while also consuming that separate jar itself at runtime.

I believe a better approach is for the "dist" command to take its input from the packagedArtifacts task, which is defined as "packages all artifacts for publishing and maps the Artifact definition to the generated file" and returns a Map[Artifact,File].

I have discussed this with Guillaume.
