### PR TITLE
[#861] Make PurePromise consistent with Future by catching NonFatal

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Promise.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Promise.scala
@@ -8,6 +8,7 @@ import scala.concurrent.duration.Duration
 import java.util.concurrent.{ TimeUnit }
 
 import scala.concurrent.{Future, ExecutionContext}
+import scala.util.control.NonFatal
 import scala.collection.mutable.Builder
 import scala.collection._
 import scala.collection.generic.CanBuildFrom
@@ -248,7 +249,7 @@ object PurePromise {
    * factory method for a pure promise
    */
   def apply[A](lazyA: => A): scala.concurrent.Future[A] = (try (scala.concurrent.Promise.successful(lazyA)) catch {
-    case e: Exception => scala.concurrent.Promise.failed(e)
+    case NonFatal(e) => scala.concurrent.Promise.failed(e)
   }).future
 
 }

--- a/framework/src/play/src/test/scala/play/api/PromiseSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/PromiseSpec.scala
@@ -14,3 +14,14 @@ object PromiseSpec extends Specification {
     }
   }
 }
+object PurePromiseSpec extends Specification {
+	class NonFatalThrowable extends Throwable
+
+	"A pure promise" should {
+		"recover after a NonFatal error" in {
+			val promise = PurePromise[String](throw new NonFatalThrowable)
+			val recovered=promise.recover{ case e: NonFatalThrowable => "NonFatalThrowable"}
+			recovered.value1.get must equalTo ("NonFatalThrowable")
+		}
+	}	
+}


### PR DESCRIPTION
Makes sure that PurePromise handles error in the same way scala.concurrent.Future does : 
catches any throwable which matches scala.util.control.NonFatal

Issue tracker: https://play.lighthouseapp.com/projects/82401/tickets/861-make-purepromise-consistent-with-future-by-catching-nonfatal

This is important to enable custom error handling for OpenID as shown in https://github.com/jeantil/xstaffing-mobile/blob/master/app/controllers/Application.scala

Thanks
