### PR TITLE
add scala 2.10 feature imports, also enable `feature` compiler flag

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -82,7 +82,7 @@ object PlayBuild extends Build {
         settings = buildSettingsWithMIMA ++ Seq(
             previousArtifact := Some("play" % {"anorm_"+previousScalaVersion} % previousVersion),
             publishTo := Some(playRepository),
-            scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked"),
+            scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked", "-feature"),
             publishArtifact in packageDoc := buildWithDoc,
             publishArtifact in (Compile, packageSrc) := true
         )
@@ -95,7 +95,7 @@ object PlayBuild extends Build {
             previousArtifact := Some("play" % {"play-iteratees_"+previousScalaVersion} % previousVersion),
             libraryDependencies := iterateesDependencies,
             publishTo := Some(playRepository),
-            scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked"),
+            scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked", "-feature"),
             publishArtifact in packageDoc := buildWithDoc,
             publishArtifact in (Compile, packageSrc) := true
         )
@@ -124,7 +124,7 @@ object PlayBuild extends Build {
             libraryDependencies := runtime,
             sourceGenerators in Compile <+= sourceManaged in Compile map PlayVersion,
             publishTo := Some(playRepository),
-            scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked"),
+            scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked", "-feature"),
             javacOptions ++= Seq("-source","1.6","-target","1.6", "-encoding", "UTF-8"),
             javacOptions in doc := Seq("-source", "1.6"),
             publishArtifact in packageDoc := buildWithDoc,
@@ -143,7 +143,7 @@ object PlayBuild extends Build {
             previousArtifact := Some("play" % {"play-jdbc_"+previousScalaVersion} % previousVersion),
             libraryDependencies := jdbcDeps,
             publishTo := Some(playRepository),
-            scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked"),
+            scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked", "-feature"),
             javacOptions ++= Seq("-source","1.6","-target","1.6", "-encoding", "UTF-8"),
             javacOptions in doc := Seq("-source", "1.6"),
             publishArtifact in packageDoc := buildWithDoc,
@@ -159,7 +159,7 @@ object PlayBuild extends Build {
         settings = buildSettingsWithMIMA ++ Seq(
             previousArtifact := Some("play" % {"play-java-jdbc_"+previousScalaVersion} % previousVersion),
             publishTo := Some(playRepository),
-            scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked"),
+            scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked", "-feature"),
             javacOptions ++= Seq("-source","1.6","-target","1.6", "-encoding", "UTF-8"),
             javacOptions in doc := Seq("-source", "1.6"),
             publishArtifact in packageDoc := buildWithDoc,
@@ -176,7 +176,7 @@ object PlayBuild extends Build {
             previousArtifact := Some("play" % {"play-java-ebean_"+previousScalaVersion} % previousVersion),
             libraryDependencies := ebeanDeps ++ jpaDeps,
             publishTo := Some(playRepository),
-            scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked"),
+            scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked", "-feature"),
             javacOptions ++= Seq("-source","1.6","-target","1.6", "-encoding", "UTF-8"),
             javacOptions in doc := Seq("-source", "1.6"),
             publishArtifact in packageDoc := buildWithDoc,
@@ -243,7 +243,7 @@ object PlayBuild extends Build {
             previousArtifact := Some("play" % {"play-test_"+previousScalaVersion} % previousVersion),
             libraryDependencies := testDependencies,
             publishTo := Some(playRepository),
-            scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked"),
+            scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked", "-feature"),
             javacOptions ++= Seq("-source","1.6","-target","1.6", "-encoding", "UTF-8"),
             javacOptions in doc := Seq("-source", "1.6"),
             publishArtifact in packageDoc := buildWithDoc,
@@ -299,7 +299,7 @@ object PlayBuild extends Build {
             previousArtifact := Some("play" % {"play_"+previousScalaVersion} % previousVersion),
             libraryDependencies := runtime,
             publishTo := Some(playRepository),
-            scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked"),
+            scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked", "-feature"),
             javacOptions ++= Seq("-source","1.6","-target","1.6", "-encoding", "UTF-8"),
             javacOptions in doc := Seq("-source", "1.6"),
             publishArtifact in packageDoc := buildWithDoc,

--- a/framework/src/anorm/src/main/scala/anorm/Anorm.scala
+++ b/framework/src/anorm/src/main/scala/anorm/Anorm.scala
@@ -1,5 +1,7 @@
 package anorm
 
+import scala.language.{postfixOps,reflectiveCalls}
+
 import MayErr._
 import java.util.Date
 import collection.TraversableOnce

--- a/framework/src/anorm/src/main/scala/anorm/SqlStatementParser.scala
+++ b/framework/src/anorm/src/main/scala/anorm/SqlStatementParser.scala
@@ -1,5 +1,7 @@
 package anorm
 
+import scala.language.postfixOps
+
 import scala.util.parsing.combinator._
 
 object SqlStatementParser extends JavaTokenParsers {

--- a/framework/src/anorm/src/main/scala/anorm/Utils.scala
+++ b/framework/src/anorm/src/main/scala/anorm/Utils.scala
@@ -20,6 +20,7 @@ case class MayErr[+E, +A](e: Either[E, A]) {
 }
 
 object MayErr {
+  import scala.language.implicitConversions
   implicit def eitherToError[E, EE >: E, A, AA >: A](e: Either[E, A]): MayErr[EE, AA] = MayErr[E, A](e)
   implicit def errorToEither[E, EE >: E, A, AA >: A](e: MayErr[E, A]): Either[EE, AA] = e.e
 }

--- a/framework/src/anorm/src/main/scala/anorm/package.scala
+++ b/framework/src/anorm/src/main/scala/anorm/package.scala
@@ -11,6 +11,7 @@
  * }}}
  */
 package object anorm {
+  import scala.language.implicitConversions	
 
   implicit def sqlToSimple(sql: SqlQuery): SimpleSql[Row] = sql.asSimple
   implicit def sqlToBatch(sql: SqlQuery): BatchSql = sql.asBatch

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
@@ -1,5 +1,7 @@
 package play.api.libs.iteratee
 
+import scala.language.reflectiveCalls
+
 import scala.concurrent.Future
 import play.api.libs.iteratee.internal.defaultExecutionContext
 

--- a/framework/src/play-filters-helpers/src/main/scala/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/csrf.scala
@@ -1,4 +1,6 @@
 package play.filters.csrf {
+  
+  import scala.language.reflectiveCalls
 
   import play.api.mvc._
   import Results._

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
@@ -1,5 +1,7 @@
 package play.api.db
 
+import scala.language.reflectiveCalls
+
 import play.api._
 import play.api.libs._
 

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -1,5 +1,7 @@
 package play.api.test
 
+import scala.language.reflectiveCalls
+
 import play.api._
 import play.api.mvc._
 import play.api.http._

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -1,5 +1,7 @@
 package play.api.data
 
+import scala.language.existentials
+
 import format._
 import validation._
 

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -1,5 +1,7 @@
 package play.api.i18n
 
+import scala.language.postfixOps
+
 import play.api._
 import play.core._
 

--- a/framework/src/play/src/main/scala/play/api/libs/Comet.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Comet.scala
@@ -1,5 +1,7 @@
 package play.api.libs
 
+import scala.language.reflectiveCalls
+
 import play.api.mvc._
 import play.api.libs.iteratee._
 import play.api.templates._

--- a/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
@@ -1,5 +1,7 @@
 package play.api.libs
 
+import scala.language.reflectiveCalls
+
 import play.api.mvc._
 import play.api.libs.iteratee._
 import play.api.templates._

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Promise.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Promise.scala
@@ -1,5 +1,7 @@
 package play.api.libs.concurrent
 
+import scala.language.higherKinds
+
 import play.core._
 import play.api._
 

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/package.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/package.scala
@@ -12,6 +12,7 @@ import scala.concurrent.{ Future }
  */
 package object concurrent {
 
+  import scala.language.implicitConversions	
 
   implicit def futureToPlayPromise[A](fu: scala.concurrent.Future[A]): PlayPromise[A] = new PlayPromise[A](fu)
 

--- a/framework/src/play/src/main/scala/play/api/libs/functional/Util.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/functional/Util.scala
@@ -1,5 +1,8 @@
 package play.api.libs.functional
 
+import scala.language.higherKinds
+import scala.language.implicitConversions
+
 trait LazyHelper[M[_], T] {
   def lazyStuff: M[T]
 }

--- a/framework/src/play/src/main/scala/play/api/libs/json/Json.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/json/Json.scala
@@ -1,10 +1,12 @@
 package play.api.libs.json
 
+import scala.language.reflectiveCalls
+
 /**
  * Helper functions to handle JsValues.
  */
 object Json {
-
+  
   /**
    * Parse a String representing a json, and return it as a JsValue.
    *
@@ -58,6 +60,8 @@ object Json {
   sealed trait JsValueWrapper extends NotNull
 
   private case class JsValueWrapperImpl(field: JsValue) extends JsValueWrapper
+
+  import scala.language.implicitConversions
 
   implicit def toJsFieldJsValueWrapper[T](field: T)(implicit w: Writes[T]): JsValueWrapper = JsValueWrapperImpl(w.writes(field))
 

--- a/framework/src/play/src/main/scala/play/api/libs/json/Reads.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/json/Reads.scala
@@ -1,5 +1,7 @@
 package play.api.libs.json
 
+import scala.language.higherKinds
+
 import scala.collection._
 import Json._
 import scala.annotation.implicitNotFound

--- a/framework/src/play/src/main/scala/play/api/libs/json/Util.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/json/Util.scala
@@ -1,5 +1,7 @@
 package play.api.libs.json.util
 
+import scala.language.higherKinds
+
 trait LazyHelper[M[_], T] {
   def lazyStuff: M[T]
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -1,5 +1,7 @@
 package play.api.mvc
 
+import scala.language.reflectiveCalls
+
 import java.io._
 
 import scala.xml._

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -1,5 +1,7 @@
 package play.core.j
 
+import scala.language.existentials
+
 import play.api.mvc._
 import play.mvc.{ Action => JAction, Result => JResult }
 import play.mvc.Http.{ Context => JContext, Request => JRequest, RequestBody => JBody, Cookies => JCookies, Cookie => JCookie }

--- a/framework/src/play/src/main/scala/play/core/j/JavaResults.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaResults.scala
@@ -1,5 +1,7 @@
 package play.core.j
 
+import scala.language.reflectiveCalls
+
 import play.api.mvc._
 import play.api.http._
 import play.api.libs.iteratee._

--- a/framework/src/play/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play/src/main/scala/play/core/server/Server.scala
@@ -1,5 +1,7 @@
 package play.core.server
 
+import scala.language.postfixOps
+
 import play.api._
 import play.core._
 import play.api.mvc._

--- a/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -1,5 +1,7 @@
 package play.core.server.netty
 
+import scala.language.reflectiveCalls
+
 import org.jboss.netty.buffer._
 import org.jboss.netty.channel._
 import org.jboss.netty.bootstrap._

--- a/framework/src/play/src/main/scala/play/core/server/netty/WebSocketHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/WebSocketHandler.scala
@@ -1,5 +1,7 @@
 package play.core.server.netty
 
+import scala.language.reflectiveCalls
+
 import org.jboss.netty.buffer._
 import org.jboss.netty.channel._
 import org.jboss.netty.bootstrap._

--- a/framework/src/play/src/main/scala/views/helper/Helpers.scala
+++ b/framework/src/play/src/main/scala/views/helper/Helpers.scala
@@ -1,5 +1,7 @@
 import play.api.templates._
 
+import scala.language.implicitConversions
+
 import scala.collection.JavaConverters._
 
 package views.html.helper {

--- a/framework/test/integrationtest/test/TestHelperSpec.scala
+++ b/framework/test/integrationtest/test/TestHelperSpec.scala
@@ -1,5 +1,7 @@
 package test
 
+import scala.language.reflectiveCalls
+
 import play.api.test._
 import play.api.test.Helpers._
 import java.util.concurrent.CountDownLatch


### PR DESCRIPTION
- add scala 2.10 feature imports:
  these imports get rid of the warnings but more importantly act as a reminder that in the given source file we are using a (potentially) dangerous language feature
- enable `feature` compile flag on scala 2.10 projects:
  this change allows us to see the actual warnings in the future
