### PR TITLE
make ExecutionContext-s configurable

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -564,7 +564,9 @@ object PlayBuild extends Build {
 
         val iterateesDependencies = Seq(
             "org.scala-stm"                     %    "scala-stm_2.10.0-RC1"     %   "0.6",
+            "com.typesafe"                      %    "config"                   %   "1.0.0",
             "com.github.scala-incubator.io"     %    "scala-io-file_2.10.0-RC1" %   "0.4.1" exclude("javax.transaction", "jta")
+
         )
 
 

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/package.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/package.scala
@@ -13,9 +13,12 @@ package play.api.libs {
 
 package play.api.libs.iteratee {
 
-  object internal {
-    private[iteratee] implicit lazy val defaultExecutionContext: scala.concurrent.ExecutionContext =
-      scala.concurrent.ExecutionContext.Implicits.global
+  private[iteratee] object internal {
+    implicit lazy val defaultExecutionContext: scala.concurrent.ExecutionContext = {
+      val numberOfThreads = try { com.typesafe.config.ConfigFactory.load().getInt("iteratee-threadpool-size") } 
+                            catch {case e: com.typesafe.config.ConfigException.Missing => Runtime.getRuntime.availableProcessors}
+      scala.concurrent.ExecutionContext.fromExecutorService(java.util.concurrent.Executors.newFixedThreadPool(numberOfThreads))
+   }
   }
 
 }

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Execution.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Execution.scala
@@ -8,7 +8,7 @@ object Execution {
       play.core.Invoker.executionContext: scala.concurrent.ExecutionContext
   }
 
-  val defaultContext = play.core.Invoker.executionContext: scala.concurrent.ExecutionContext
+  val defaultContext = Implicits.defaultContext
 
 }
 

--- a/framework/src/play/src/main/scala/play/core/system/Execution.scala
+++ b/framework/src/play/src/main/scala/play/core/system/Execution.scala
@@ -1,9 +1,11 @@
 package play.core
 
 
-object Execution {
+private[play] object Execution {
 
-  lazy val internalContext: scala.concurrent.ExecutionContext =
-    scala.concurrent.ExecutionContext.Implicits.global: scala.concurrent.ExecutionContext //FIXME use a proper ThreadPool for Play from Conf
+  lazy val internalContext: scala.concurrent.ExecutionContext = {
+     val numberOfThreads = play.api.Play.maybeApplication.map(_.configuration.getInt("internal-threadpool-size")).flatten.getOrElse(Runtime.getRuntime.availableProcessors)
+  	 scala.concurrent.ExecutionContext.fromExecutorService(java.util.concurrent.Executors.newFixedThreadPool(numberOfThreads))
+  }
 
 }

--- a/framework/src/play/src/main/scala/play/core/system/Invoker.scala
+++ b/framework/src/play/src/main/scala/play/core/system/Invoker.scala
@@ -8,9 +8,9 @@ import com.typesafe.config._
 /**
  * provides Play's internal actor system and the corresponding actor instances
  */
-object Invoker {
+private[play] object Invoker {
 
-  val system: ActorSystem = ActorSystem("play") //TODO make sure this is configurable
+  val system: ActorSystem = ActorSystem("play")
 
   val executionContext: scala.concurrent.ExecutionContext = system.dispatcher
 


### PR DESCRIPTION
- change `play.core.Invoker`'s visibility to `private[play]`
- change `play.core.Execution`'s visibility to `private[play]`
- make `play.core.Execution.internalContext` threadpool's size configurable (defaults to number of available processors)
- make `play.api.libs.iteratee.internal.defaultExecutionContext` threadpool's size configurable (defaults to number of available processors)
- add `typesafe config` dependency to iteratee (it was needed for the configuration)

I was evaluating both `scala.concurrent.forkjoin.ForkJoinPool` and `java.util.concurrent.Executors.newCachedThreadPool` as backends for the thread pools and my conclusion was that a simple fixed size pool is providing the best overall solution (predictable, simple, configurable etc.)
