### PR TITLE
Removed scala compiler from runtime dependencies

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -503,7 +503,7 @@ object PlayBuild extends Build {
             "com.novocode"                      %    "junit-interface"          %   "0.9"      %  "test",
 
             "org.fluentlenium"                  %    "fluentlenium-festassert"  %   "0.7.3"    %  "test",
-            "org.scala-lang"                    %    "scala-compiler"           %   "2.10.0-RC1"
+            "org.scala-lang"                    %    "scala-reflect"            %   "2.10.0-RC1"
         )
 
         val link = Seq(


### PR DESCRIPTION
scala-compiler is not needed as a runtime dependency by Play framework, only scala-reflect (which also actually may not be needed in future, see https://issues.scala-lang.org/browse/SI-5940).

scala-compiler is a 14mb jar, so including it increases the size of a small projects dist artifact by over 50%.
