### PR TITLE
#844: The evolutions web command shouldn't use OfflineEvolutions

### DIFF
--- a/framework/test/integrationtest/app/Global.scala
+++ b/framework/test/integrationtest/app/Global.scala
@@ -2,10 +2,25 @@
 import play.api.GlobalSettings
 import play.api.mvc.{RequestHeader, Result}
 import play.api.mvc.Results.InternalServerError
-import play.api.Logger
+import play.api.{Logger, Configuration}
+import com.typesafe.config.ConfigFactory
 
 object Global extends GlobalSettings {
   override def onError(r: RequestHeader, e: Throwable): Result = {
     InternalServerError("Something went wrong.")
   }
+
+  // Ensure that the Evolutions code uses the same configuration as the running application
+  // See: https://play.lighthouseapp.com/projects/82401-play-20/tickets/844
+  override def configuration = {
+    
+    val extraConfig = 
+      """
+        |applyEvolutions.mock=false
+        |db.mock.driver=org.h2.Driver
+        |db.mock.url="jdbc:h2:mem:mock"
+      """.stripMargin
+    
+    Configuration(ConfigFactory.parseString(extraConfig))
+  }  
 }


### PR DESCRIPTION
Fix for [#844](https://play.lighthouseapp.com/projects/82401-play-20/tickets/844).

This pull request makes the Evolutions web commands use `Evolutions.applyScript` and `Evolutions.resolve` directly instead of going through the `OfflineEvolutions` code. 

The primary motivator is that the `OfflineEvolutions` code (by design) does not take into account any configuration that can come in through `Global.configuration`. On the other hand, the `EvolutionsPlugin.onStart` code _does_ take it into account. If the `Global.configuration` has an DB config in it, you may repeatedly get prompted to apply evolutions, but it'll never actually work.

As a test, I added db config data to the `configuration` method of `Global.scala` in `integrationtest`. Before the patch, the web UI would prompt you to apply evolutions, but wouldn't actually be able to do it when you click the button, so you'd just get stuck in an infinite loop in that page. After the patch, it applies evolutions as expected.
