### PR TITLE
HTTP response codes can only be 3 digits by RFC standards.

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
@@ -496,7 +496,11 @@ case class Response(ahcResponse: AHCResponse) {
 /**
  * An HTTP response header (the body has not been retrieved yet)
  */
-case class ResponseHeaders(status: Int, headers: Map[String, Seq[String]])
+case class ResponseHeaders(status: Int, headers: Map[String, Seq[String]]) {
+  if (status < 100 || status > 999) {
+    throw new IllegalArgumentException("Http status must be 3 digits.")
+  }
+}
 
 /**
  * Sign a WS call.

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -19,6 +19,9 @@ import play.core.Execution.internalContext
  * @param headers the HTTP headers
  */
 case class ResponseHeader(status: Int, headers: Map[String, String] = Map.empty) {
+  if (status < 100 || status > 999) {
+    throw new IllegalArgumentException("Http status must be 3 digits.")
+  }
 
   override def toString = {
     status + ", " + headers

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -11,6 +11,20 @@ object ResultsSpec extends Specification {
 
   sequential
 
+  "Status" should {
+
+    "have status with 3 digits" in {
+      // RFC 1945 6.1.1 (http://www.w3.org/Protocols/rfc1945/rfc1945)
+      //  states that status codes must be 3 digits
+      new Status(700) // should throw no exceptions
+
+      new Status(-200) must throwA[IllegalArgumentException]
+      new Status(99) must throwA[IllegalArgumentException]
+      new Status(1000) must throwA[IllegalArgumentException]
+    }
+
+  }
+
   "SimpleResult" should {
 
     "have status" in {

--- a/framework/src/play/src/test/scala/play/ws/WSSpec.scala
+++ b/framework/src/play/src/test/scala/play/ws/WSSpec.scala
@@ -2,6 +2,7 @@ package play.ws
 
 import org.specs2.mutable.Specification
 import play.api.libs.ws.WS
+import play.api.libs.ws.ResponseHeaders
 
 object WSSpec extends Specification {
 
@@ -16,4 +17,15 @@ object WSSpec extends Specification {
     }
   }
 
+  "ResponseHeaders" should {
+    "have status with 3 digits" in {
+      // RFC 1945 6.1.1 (http://www.w3.org/Protocols/rfc1945/rfc1945)
+      //  states that status codes must be 3 digits
+      ResponseHeaders(700, Map()) // should throw no exceptions
+
+      ResponseHeaders(-200, Map()) must throwA[IllegalArgumentException]
+      ResponseHeaders(99, Map()) must throwA[IllegalArgumentException]
+      ResponseHeaders(1000, Map()) must throwA[IllegalArgumentException]
+    }
+  }
 }


### PR DESCRIPTION
I opened a ticket for this which I am offering a simple fix for.

https://play.lighthouseapp.com/projects/82401-play-20/tickets/871-http-result-status-codes-not-always-rfc-compliant
