### PR TITLE
[#745] Fixed escaping issue for routes that contain regex escapes

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
@@ -712,7 +712,7 @@ object RoutesCompiler {
                     """
                           |%s
                           |def %s(%s): play.api.mvc.HandlerRef[_] = new play.api.mvc.HandlerRef(
-                          |   %s, HandlerDef(this, "%s", "%s", %s, "%s", "%s",  Routes.prefix + "%s")
+                          |   %s, HandlerDef(this, "%s", "%s", %s, "%s", %s,  Routes.prefix + %s)
                           |)
                       """.stripMargin.format(
                       markLines(route),
@@ -724,7 +724,7 @@ object RoutesCompiler {
                       "Seq(" + { parameters.map("classOf[" + _.typeName + "]").mkString(", ") } + ")",
                       route.verb,
                       "\"\"\""+route.comments.map(_.comment).mkString("\n")+"\"\"\"",
-                      route.path
+                      "\"\"\""+route.path+"\"\"\""
                       )
 
                 }.mkString("\n")
@@ -990,7 +990,7 @@ object RoutesCompiler {
           // definition
           """HandlerDef(this, """" + r.call.packageName + "." + r.call.controller + """", """" + r.call.method + """", """ + r.call.parameters.filterNot(_.isEmpty).map { params =>
             params.map("classOf[" + _.typeName + "]").mkString(", ")
-          }.map("Seq(" + _ + ")").getOrElse("Nil") + ""","""" + r.verb + """", """ +"\"\"\""+ r.comments.map(_.comment).mkString("\n")+"\"\"\""+ """ , Routes.prefix + """" + r.path + """")""")
+          }.map("Seq(" + _ + ")").getOrElse("Nil") + ""","""" + r.verb + """", """ +"\"\"\""+ r.comments.map(_.comment).mkString("\n")+"\"\"\", Routes.prefix + \"\"\"" + r.path + "\"\"\")")
     }.mkString("\n")).filterNot(_.isEmpty).getOrElse {
 
       """Map.empty""" // Empty partial function

--- a/framework/test/integrationtest/app/controllers/Application.scala
+++ b/framework/test/integrationtest/app/controllers/Application.scala
@@ -84,6 +84,10 @@ object Application extends Controller {
     Ok(views.html.index(Cache.get("hello").map(_.toString).getOrElse("oh noooz")))
   }
 
+  def takeInt(i: Int) = Action {
+    Ok(i.toString)
+  }
+
   def takeBool(b: Boolean) = Action {
     Ok(b.toString())
   }

--- a/framework/test/integrationtest/conf/routes
+++ b/framework/test/integrationtest/conf/routes
@@ -27,6 +27,9 @@ GET     /jsonWithCharset        controllers.Application.jsonWithContentTypeAndCh
 GET     /index_java_cache       controllers.Application.index_java_cache()
 GET     /conf                   controllers.Application.conf()
 
+# Test that the regex is properly escaped in the generated code
+GET     /escapes/$i<\d+>        controllers.Application.takeInt(i: Int)
+
 GET     /take-bool              controllers.Application.takeBool(b: Boolean)
 GET     /take-bool-2/:b         controllers.Application.takeBool2(b: Boolean)
 


### PR DESCRIPTION
Routes like this:

```
GET    /foo/$bar<\d+>      controllers.Foo.bar(bar: Int)
```

generate a compile error, because the \d is included in single quoted strings.  This puts it in triple quoted strings.

Also fixed a small bug where comments had extra quotes around them in the ref router.
