### PR TITLE
Add note on move of Controller.form() helper methods to migration guide

### DIFF
--- a/documentation/manual/Migration.md
+++ b/documentation/manual/Migration.md
@@ -259,4 +259,4 @@ More information about this feature can be found on the [[RequireJS documentatio
 
 ## Form helper methods moved to Form
 
-The form() family of helper methods have moved from Controller to Form. Please update your imports/references accordingly.
+The form() family of helper methods have moved from `play.mvc.Controller` to `play.data.Form`. Please update your imports/references accordingly.


### PR DESCRIPTION
I had to dig through the Play commit history to understand how to upgrade my project for 2.1-RC1.

I'm happy to update the main documentation too e.g. tutorial examples for Java if that would be welcome?
