### PR TITLE
Fix the incremental Assets compilation

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayAssetsCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayAssetsCompiler.scala
@@ -18,7 +18,7 @@ trait PlayAssetsCompiler {
     naming: (String, Boolean) => String,
     compile: (File, Seq[String]) => (String, Option[String], Seq[File]),
     optionsSettings: sbt.SettingKey[Seq[String]]) =
-    (state, sourceDirectory in Compile, resourceManaged in Compile, cacheDirectory, optionsSettings, filesSetting, incrementalAssetsCompilation, requireJs) map { (state, src, resources, cache, options, files, incrementalAssetsCompilation, requireJs) =>
+    (state, sourceDirectory in Compile, resourceManaged in Compile, cacheDirectory, optionsSettings, filesSetting, requireJs) map { (state, src, resources, cache, options, files, requireJs) =>
 
       val requireSupport = if (!requireJs.isEmpty) {
         Seq("rjs")
@@ -36,19 +36,18 @@ trait PlayAssetsCompiler {
         //a changed file can be either a new file, a deleted file or a modified one
         lazy val changedFiles: Seq[File] = currentInfos.filter(e => !previousInfo.get(e._1).isDefined || previousInfo(e._1).lastModified < e._2.lastModified).map(_._1).toSeq ++ previousInfo.filter(e => !currentInfos.get(e._1).isDefined).map(_._1).toSeq
 
-        //erease dependencies that belong to changed files (when incremental compilation is turned on, otherwise delete everything for given compiler)
-        val dependencies = previousRelation.filter((original, compiled) => !incrementalAssetsCompilation || changedFiles.contains(original))._2s
+        //erease dependencies that belong to changed files
+        val dependencies = previousRelation.filter((original, compiled) => changedFiles.contains(original))._2s
         dependencies.foreach(IO.delete)
 
         /**
-         * process each file if it's not incremental compilation
-         * or if the given file was changed or
+         * If the given file was changed or
          * if the given file was a dependency,
          * otherwise calculate dependencies based on previous relation graph
          */
         val generated: Seq[(File, java.io.File)] = (files x relativeTo(Seq(src / "assets"))).flatMap {
           case (sourceFile, name) => {
-            if (!incrementalAssetsCompilation || changedFiles.contains(sourceFile) || dependencies.contains(new File(resources, "public/" + naming(name, false)))) {
+            if (changedFiles.contains(sourceFile) || dependencies.contains(new File(resources, "public/" + naming(name, false)))) {
               val (debug, min, dependencies) = try {
                 compile(sourceFile, options ++ requireSupport)
               } catch {

--- a/framework/src/sbt-plugin/src/main/scala/PlayKeys.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayKeys.scala
@@ -36,8 +36,6 @@ trait PlayKeys {
 
   val playAssetsDirectories = SettingKey[Seq[File]]("play-assets-directories")
 
-  val incrementalAssetsCompilation = SettingKey[Boolean]("play-incremental-assets-compilation")
-
   val playExternalAssets = SettingKey[Seq[(File, File => PathFinder, String)]]("play-external-assets")
 
   val confDirectory = SettingKey[File]("play-conf")

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -201,8 +201,6 @@ trait PlaySettings {
     coffeescriptOptions := Seq.empty[String],
     closureCompilerOptions := Seq.empty[String],
 
-    incrementalAssetsCompilation := true,
-
     // Templates
 
     templatesImport := Seq("play.api.templates._", "play.api.templates.PlayMagic._"),

--- a/framework/src/sbt-plugin/src/main/scala/jscompile/JavascriptCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/jscompile/JavascriptCompiler.scala
@@ -51,7 +51,7 @@ object JavascriptCompiler {
     val input = if (!simpleCheck) all.map(f => JSSourceFile.fromFile(f)).toArray else Array(JSSourceFile.fromFile(source))
 
     catching(classOf[Exception]).either(compiler.compile(Array[JSSourceFile](), input, options).success) match {
-      case Right(true) => (origin, { if (!simpleCheck) Some(compiler.toSource()) else None }, all)
+      case Right(true) => (origin, { if (!simpleCheck) Some(compiler.toSource()) else None }, Nil)
       case Right(false) => {
         val error = compiler.getErrors().head
         val errorFile = all.find(f => f.getAbsolutePath() == error.sourceName)


### PR DESCRIPTION
The incremental Assets compilation is already managed by the `PlayAssetsCompiler`:
- Remove the `incrementalAssetsCompilation` setting
- Fix the JavascriptCompiler to not manage dependencies

The main issue was that the JavascriptCompiler was defining all files in the same directory (including sub-directories) as dependencies. I don't think it is useful at all, especially because now the javascript dependency tracking is done by RequireJS and Google closure compiler is only used to check the Javascript syntax.
