### PR TITLE
Use the renamed version of Typesafe's sbt-idea plugin (fixes #804)

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -263,7 +263,7 @@ object PlayBuild extends Build {
             publishMavenStyle := false,
             libraryDependencies := sbtDependencies,
             libraryDependencies += "com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0" extra("sbtVersion" -> buildSbtVersionBinaryCompatible, "scalaVersion" -> buildScalaVersionForSbt),
-            libraryDependencies += "com.github.mpeltonen" % "sbt-idea" % "1.1.0-TYPESAFE" extra("sbtVersion" -> buildSbtVersionBinaryCompatible, "scalaVersion" -> buildScalaVersionForSbt),
+            libraryDependencies += "com.typesafe.sbtidea" % "sbt-idea" % "1.1.1" extra("sbtVersion" -> buildSbtVersionBinaryCompatible, "scalaVersion" -> buildScalaVersionForSbt),
             unmanagedJars in Compile <++= (baseDirectory) map { b => sbtJars(b / "../..") },
             publishTo := Some(playIvyRepository),
             scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint","-deprecation", "-unchecked"),

--- a/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
@@ -279,11 +279,10 @@ exec java $* -cp $classpath """ + customFileName.map(fn => "-Dconfig.file=`dirna
   }
 
   def intellijCommandSettings(mainLang: String) = {
-    import org.sbtidea.SbtIdeaPlugin
+    import com.typesafe.sbtidea.SbtIdeaPlugin
     SbtIdeaPlugin.ideaSettings ++
       Seq(
         SbtIdeaPlugin.commandName := "idea",
-        SbtIdeaPlugin.addGeneratedClasses := true,
         SbtIdeaPlugin.includeScalaFacet := { mainLang == SCALA },
         SbtIdeaPlugin.defaultClassifierPolicy := false
       )


### PR DESCRIPTION
Updates to the latest version of the sbt-idea plugin which no longer clashes with the original version.

https://play.lighthouseapp.com/projects/82401/tickets/804-namespace-collisions-of-incompatible-typesafe-sbt-idea-fork

Original pull-request on plugin: https://github.com/typesafehub/sbt-idea/pull/1

The SbtIdeaPlugin.addGeneratedClasses setting removed here as it was recently removed from the Typesafe fork of sbt-idea: https://github.com/typesafehub/sbt-idea/commit/0beff7ca824c7d417c843d06aff18ee06a242c7a#L1L30

(I have signed the Typesafe CLA)
