### PR TITLE
[#873] Fixed bugs in route includes reverse routing

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
@@ -411,7 +411,7 @@ exec java $* -cp $classpath """ + customFileName.map(fn => "-Dconfig.file=`dirna
 
     ((generatedDir ** "routes.java").get ++ (generatedDir ** "routes_*.scala").get).map(GeneratedSource(_)).foreach(_.sync())
     try {
-      { (confDirectory * "*.routes").get ++ (confDirectory * "routes").get }.headOption.map { routesFile =>
+      { (confDirectory * "*.routes").get ++ (confDirectory * "routes").get }.map { routesFile =>
         compile(routesFile, generatedDir, additionalImports)
       }
     } catch {

--- a/framework/test/integrationtest/app/controllers/module/ModuleController.scala
+++ b/framework/test/integrationtest/app/controllers/module/ModuleController.scala
@@ -1,0 +1,9 @@
+package controllers.module
+
+import play.api.mvc._
+
+object ModuleController extends Controller {
+  def index = Action {
+    Ok
+  }
+}

--- a/framework/test/integrationtest/conf/module.routes
+++ b/framework/test/integrationtest/conf/module.routes
@@ -1,0 +1,1 @@
+GET     /index          controllers.module.ModuleController.index

--- a/framework/test/integrationtest/conf/routes
+++ b/framework/test/integrationtest/conf/routes
@@ -59,6 +59,8 @@ GET     /ident/:è27             controllers.πø$7ß.ôü65$t(è27: Int)
 GET     /hello                  controllers.Application.hello()
 GET     /setLang                controllers.Application.setLang(lang)
 
+->      /module                 module.Routes
+
 # Map static resources from the /public folder to the /public path
 GET     /public/*file           controllers.Assets.at(path="/public", file)
 

--- a/framework/test/integrationtest/test/ApplicationSpec.scala
+++ b/framework/test/integrationtest/test/ApplicationSpec.scala
@@ -6,6 +6,7 @@ import play.api.test.Helpers._
 import org.specs2.mutable._
 import models._
 import play.api.mvc.AnyContentAsEmpty
+import module.Routes
 
 class ApplicationSpec extends Specification {
 
@@ -253,6 +254,12 @@ class ApplicationSpec extends Specification {
         Lang("en-gb"),
         Lang("en")
       ))
+    }
+
+    "allow reverse routing of routes includes" in new WithApplication() {
+      // Force the router to bootstrap the prefix
+      app.routes
+      controllers.module.routes.ModuleController.index().url must_== "/module/index"
     }
   }
 


### PR DESCRIPTION
This fixes a few bugs with reverse routing when using route includes:
- Two controllers/routes.java classes might be generated, one for the included routes, one for the main routes.  This class is now placed in its own package.
- The Routes.prefix mechanism was broken for reverse routing, since Routes is defined in the root package, and hence was hiding import inc.Routes, so the prefix was always the prefix for the main routes file.  This was interesting to fix, since there were all sorts of issues with having classes in the root package (eg, you can't alias a class in the root package, neither import {Routes => MyRoutes} or import _root_.{Routes => MyRoutes} would work).  I ended up going with import Routes.{prefix => _prefix, defaultPrefix => _defaultPrefix}.
- Defining two routes files in one project didn't work, since they both generated the same routes_routing.scala and routes_reverseRouting.scala files.  These are now generated in a directory that matches the package.
