### PR TITLE
providing a simple way to create a custom Assets controller 

### DIFF
--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -33,7 +33,9 @@ import collection.JavaConverters._
  * GET     /assets/\uFEFF*file               controllers.Assets.at(path="/public", file)
  * }}}
  */
-object Assets extends Controller {
+object Assets extends AssetsBuilder
+
+class AssetsBuilder extends Controller {
 
   private val timeZoneCode = "GMT"
 
@@ -49,11 +51,11 @@ object Assets extends Controller {
 
   private lazy val defaultCharSet = Play.configuration.getString("default.charset").getOrElse("utf-8")
 
-  private def addCharsetIfNeeded(mimeType: String): String = 
+  private def addCharsetIfNeeded(mimeType: String): String =
     if (MimeTypes.isText(mimeType))
-      "; charset="+defaultCharSet
-    else ""  
-  
+      "; charset=" + defaultCharSet
+    else ""
+
   /**
    * Generates an `Action` that serves a static resource.
    *
@@ -109,18 +111,15 @@ object Assets extends Controller {
               request.headers.get(IF_MODIFIED_SINCE).flatMap(parseDate).flatMap { ifModifiedSince =>
                 lastModifiedFor(url).flatMap(parseDate).filterNot(lastModified => lastModified.after(ifModifiedSince))
               }.map(_ => NotModified.withHeaders(
-                DATE -> df.print({ new java.util.Date }.getTime)
-              )).getOrElse {
+                DATE -> df.print({ new java.util.Date }.getTime))).getOrElse {
 
                 // Prepare a streamed response
                 val response = SimpleResult(
                   header = ResponseHeader(OK, Map(
                     CONTENT_LENGTH -> length.toString,
                     CONTENT_TYPE -> MimeTypes.forFileName(file).map(m => m + addCharsetIfNeeded(m)).getOrElse(BINARY),
-                    DATE -> df.print({ new java.util.Date }.getTime)
-                  )),
-                  resourceData
-                )
+                    DATE -> df.print({ new java.util.Date }.getTime))),
+                  resourceData)
 
                 // If there is a gzipped version, even if the client isn't accepting gzip, we need to specify the
                 // Vary header so proxy servers will cache both the gzip and the non gzipped version

--- a/framework/test/integrationtest/app/controllers/my/JavaAssets.java
+++ b/framework/test/integrationtest/app/controllers/my/JavaAssets.java
@@ -1,0 +1,5 @@
+package controllers.my;
+
+public class JavaAssets {
+	public static controllers.AssetsBuilder delegate = new controllers.AssetsBuilder();
+}

--- a/framework/test/integrationtest/app/controllers/my/ScalaAssets.scala
+++ b/framework/test/integrationtest/app/controllers/my/ScalaAssets.scala
@@ -1,0 +1,3 @@
+package controllers.my 
+object ScalaAssets extends controllers.AssetsBuilder
+

--- a/framework/test/integrationtest/test/AssetsBuilderSpec.scala
+++ b/framework/test/integrationtest/test/AssetsBuilderSpec.scala
@@ -1,0 +1,17 @@
+package test 
+import org.specs2.mutable._
+
+
+class AssetsBuilderSpec extends Specification {
+
+    "Custom Assets" should {
+      "work with Scala API" in {
+         controllers.my.ScalaAssets.at("sdfd","dsfd").toString must equalTo ("Action(parser=BodyParser(anyContent))")
+      }
+      "work with Java API" in {
+         controllers.my.JavaAssets.delegate.at("sdfd","dsfd").toString must equalTo ("Action(parser=BodyParser(anyContent))")
+      }
+      
+    }
+  }
+


### PR DESCRIPTION
The main idea is to create `Assets` object from `AssetsBuilder` class, instead of extending `Controller`directly. This intermediate type could be then used both from Scala and Java in sub projects.

The benefits of this approach are:
- nothing has changed regarding `controllers.Assets`, ie no extra companion object is created (which means `controllers.Assets` can be called from a java controller)
- scala types are hidden from java users
- both API-s look fairly simple now

Examples:
- scala:

```
package controllers.my
object Assets extends controllers.AssetsBuilder
```
- java:

```
package controllers.my;
public class Assets {
    public static controllers.AssetsBuilder delegate = new controllers.AssetsBuilder();
}
```
