### PR TITLE
Update documentation/manual/scalaGuide/main/cache/ScalaCache.md

### DIFF
--- a/documentation/manual/scalaGuide/main/cache/ScalaCache.md
+++ b/documentation/manual/scalaGuide/main/cache/ScalaCache.md
@@ -23,7 +23,7 @@ val maybeUser: Option[User] = Cache.getAs[User]("item.key")
 There is also a convenient helper to retrieve from cache or set the value in cache if it was missing:
 
 ```
-val user: User = Cache.getOrElseAs[User]("item.key") {
+val user: User = Cache.getOrElse[User]("item.key") {
   User.findById(connectedUser)
 }
 ```


### PR DESCRIPTION
The method `Cache.getOrElseAs` does not exist, it is actually `Cache.getOrElse`

see https://github.com/playframework/Play20/blob/master/framework/src/play/src/main/scala/play/api/cache/Cache.scala#L75

I have already signed the Typesafe CLA.
