### PR TITLE
don't ignore NotImplementedError exceptions

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -52,7 +52,8 @@ trait WithDefaultGlobal {
       javaGlobal.map(new j.JavaGlobalSettingsAdapter(_)).getOrElse(scalaGlobal)
     } catch {
       case e: PlayException => throw e
-      case NonFatal(e) => throw new PlayException(
+      case e: VirtualMachineError => throw e
+      case e: Throwable => throw new PlayException(
         "Cannot init the Global object",
         e.getMessage,
         e
@@ -133,7 +134,8 @@ trait WithDefaultPlugins {
             if (plugin.enabled) Some(plugin) else { Logger("play").warn("Plugin [" + className + "] is disabled"); None }
           } catch {
             case e: PlayException => throw e
-            case NonFatal(e) => throw new PlayException(
+            case e: VirtualMachineError => throw e
+            case e: Throwable => throw new PlayException(
               "Cannot load plugin",
               "Plugin [" + className + "] cannot been instantiated.",
               e)
@@ -144,7 +146,8 @@ trait WithDefaultPlugins {
           "An exception occurred during Plugin [" + className + "] initialization",
           e.getTargetException)
         case e: PlayException => throw e
-        case NonFatal(e) => throw new PlayException(
+        case e: VirtualMachineError => throw e
+        case e: Throwable => throw new PlayException(
           "Cannot load plugin",
           "Plugin [" + className + "] cannot been instantiated.",
           e)

--- a/framework/src/play/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play/src/main/scala/play/core/server/Server.scala
@@ -58,7 +58,8 @@ trait Server {
           (maybeAction.getOrElse(Action(BodyParsers.parse.empty)(_ => application.global.onHandlerNotFound(request))), application)
         }
       } catch {
-        case NonFatal(e) => Left(e)
+        case e: VirtualMachineError => throw e
+        case e : Throwable => Left(e)
       }
     }
 


### PR DESCRIPTION
NotImplementedError can occur when we use reflection to create a plugin or when we instantiate a controller.
Letting this exception propagate can result in a bad user experience i.e. failing silently
