### PR TITLE
don't ignore NotImplementedError exceptions

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -52,6 +52,7 @@ trait WithDefaultGlobal {
       javaGlobal.map(new j.JavaGlobalSettingsAdapter(_)).getOrElse(scalaGlobal)
     } catch {
       case e: PlayException => throw e
+      case e: ThreadDeath => throw e
       case e: VirtualMachineError => throw e
       case e: Throwable => throw new PlayException(
         "Cannot init the Global object",
@@ -135,6 +136,7 @@ trait WithDefaultPlugins {
           } catch {
             case e: PlayException => throw e
             case e: VirtualMachineError => throw e
+            case e: ThreadDeath => throw e
             case e: Throwable => throw new PlayException(
               "Cannot load plugin",
               "Plugin [" + className + "] cannot been instantiated.",
@@ -146,6 +148,7 @@ trait WithDefaultPlugins {
           "An exception occurred during Plugin [" + className + "] initialization",
           e.getTargetException)
         case e: PlayException => throw e
+        case e: ThreadDeath => throw e
         case e: VirtualMachineError => throw e
         case e: Throwable => throw new PlayException(
           "Cannot load plugin",

--- a/framework/src/play/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play/src/main/scala/play/core/server/Server.scala
@@ -58,8 +58,9 @@ trait Server {
           (maybeAction.getOrElse(Action(BodyParsers.parse.empty)(_ => application.global.onHandlerNotFound(request))), application)
         }
       } catch {
+        case e: ThreadDeath => throw e
         case e: VirtualMachineError => throw e
-        case e : Throwable => Left(e)
+        case e: Throwable => Left(e)
       }
     }
 


### PR DESCRIPTION
NotImplementedError can occur when we use reflection to create a plugin or when we instantiate a controller.
Letting this exception propagate can result in a bad user experience i.e. failing silently
