### PR TITLE
[#641] Synchronized access to presentation compiler used by template compiler

### DIFF
--- a/framework/src/templates-compiler/src/main/scala/play/templates/ScalaTemplateCompiler.scala
+++ b/framework/src/templates-compiler/src/main/scala/play/templates/ScalaTemplateCompiler.scala
@@ -566,6 +566,11 @@ object """ :+ name :+ """ extends BaseScalaTemplate[""" :+ resultType :+ """,For
 
     object TemplateAsFunctionCompiler {
 
+      // Note, the presentation compiler is not thread safe, all access to it must be synchronized.  If access to it
+      // is not synchronized, then weird things happen like FreshRunReq exceptions are thrown when multiple sub projects
+      // are compiled (done in parallel by default by SBT).  So if adding any new methods to this object, make sure you
+      // make them synchronized.
+
       import java.io.File
       import scala.tools.nsc.interactive.{ Response, Global }
       import scala.tools.nsc.io.AbstractFile
@@ -573,7 +578,7 @@ object """ :+ name :+ """ extends BaseScalaTemplate[""" :+ resultType :+ """,For
       import scala.tools.nsc.Settings
       import scala.tools.nsc.reporters.ConsoleReporter
 
-      def getFunctionMapping(signature: String, returnType: String): (String, String, String) = {
+      def getFunctionMapping(signature: String, returnType: String): (String, String, String) = synchronized {
 
         type Tree = PresentationCompiler.global.Tree
         type DefDef = PresentationCompiler.global.DefDef


### PR DESCRIPTION
SBT by default compiles sub projects in parallel (unless they are dependent on each other).  This meant template compilation was done in parallel, and template compilation uses a single global presentation compiler instance, which is not thread safe.  The effect of this was intermittent FreshRunReq exceptions being thrown, as reported here:

https://play.lighthouseapp.com/projects/82401/tickets/641-202-sbt-play-project-intermittent-compile-error-with-freshrunreq

For more details, read my post and the replies by Mark on the SBT mailing list:

https://groups.google.com/d/topic/simple-build-tool/UDqhjNaC1o0/discussion

My solution is to simply synchronize all access to the presentation compiler.  This won't have any noticeable impact on single projects, I'm not sure about multi projects, but I suspect it won't be a big impact either.
