### PR TITLE
Ensured all executors that Play uses use named thread factories

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/package.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/package.scala
@@ -14,11 +14,26 @@ package play.api.libs {
 package play.api.libs.iteratee {
 
   private[iteratee] object internal {
+    import scala.concurrent.ExecutionContext
+    import java.util.concurrent.Executors
+    import java.util.concurrent.ThreadFactory
+    import java.util.concurrent.atomic.AtomicInteger
+
     implicit lazy val defaultExecutionContext: scala.concurrent.ExecutionContext = {
       val numberOfThreads = try {
         com.typesafe.config.ConfigFactory.load().getInt("iteratee-threadpool-size")
       } catch { case e: com.typesafe.config.ConfigException.Missing => Runtime.getRuntime.availableProcessors }
-      scala.concurrent.ExecutionContext.fromExecutorService(java.util.concurrent.Executors.newFixedThreadPool(numberOfThreads))
+      val threadFactory = new ThreadFactory {
+        val threadNo = new AtomicInteger()
+        val backingThreadFactory = Executors.defaultThreadFactory()
+        def newThread(r: Runnable) = {
+          val thread = backingThreadFactory.newThread(r)
+          thread.setName("iteratee-execution-context-" + threadNo.incrementAndGet())
+          thread
+        }
+      }
+
+      ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(numberOfThreads, threadFactory))
     }
   }
 }

--- a/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
@@ -37,8 +37,8 @@ class NettyServer(appProvider: ApplicationProvider, port: Int, sslPort: Option[I
 
   private def newBootstrap = new ServerBootstrap(
     new org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory(
-      Executors.newCachedThreadPool(),
-      Executors.newCachedThreadPool()))
+      Executors.newCachedThreadPool(NamedThreadFactory("netty-boss")),
+      Executors.newCachedThreadPool(NamedThreadFactory("netty-worker"))))
 
   class PlayPipelineFactory(secure: Boolean = false) extends ChannelPipelineFactory {
 

--- a/framework/src/play/src/main/scala/play/core/system/Execution.scala
+++ b/framework/src/play/src/main/scala/play/core/system/Execution.scala
@@ -1,11 +1,14 @@
 package play.core
 
+import scala.concurrent.ExecutionContext
+import java.util.concurrent.Executors
 
 private[play] object Execution {
 
-   lazy val internalContext: scala.concurrent.ExecutionContext = {
-     val numberOfThreads = play.api.Play.maybeApplication.map(_.configuration.getInt("internal-threadpool-size")).flatten.getOrElse(Runtime.getRuntime.availableProcessors)
-     scala.concurrent.ExecutionContext.fromExecutorService(java.util.concurrent.Executors.newFixedThreadPool(numberOfThreads))
+  lazy val internalContext: scala.concurrent.ExecutionContext = {
+    val numberOfThreads = play.api.Play.maybeApplication.map(_.configuration.getInt("internal-threadpool-size")).flatten.getOrElse(Runtime.getRuntime.availableProcessors)
+
+    ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(numberOfThreads, NamedThreadFactory("play-internal-execution-context")))
   }
   
 }

--- a/framework/src/play/src/main/scala/play/core/system/NamedThreadFactory.scala
+++ b/framework/src/play/src/main/scala/play/core/system/NamedThreadFactory.scala
@@ -1,0 +1,22 @@
+package play.core
+
+import java.util.concurrent.{Executors, ThreadFactory}
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Thread factory that creates threads that are named.  Threads will be named with the format:
+ *
+ * {name}-{threadNo}
+ *
+ * where threadNo is an integer starting from one.
+ */
+case class NamedThreadFactory(name: String) extends ThreadFactory {
+  val threadNo = new AtomicInteger()
+  val backingThreadFactory = Executors.defaultThreadFactory()
+
+  def newThread(r: Runnable) = {
+    val thread = backingThreadFactory.newThread(r)
+    thread.setName(name + "-" + threadNo.incrementAndGet())
+    thread
+  }
+}


### PR DESCRIPTION
This is to allow us and users to have a better understanding of what thread pools are doing what, make thread dumps meaningful, to help in debugging, etc etc etc.
