### PR TITLE
Allow to inject some configuration from the Build file to the application in DEV mode

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -71,7 +71,10 @@ trait WithDefaultConfiguration {
   self: Application =>
 
   protected lazy val initialConfiguration = Threads.withContextClassLoader(self.classloader) {
-    Configuration.load(path, mode)
+    Configuration.load(path, mode, this match {
+      case dev: DevSettings => dev.devSettings
+      case _ => Map.empty
+    })
   }
 
   private lazy val fullConfiguration = global.onLoadConfig(initialConfiguration, path, classloader, mode)

--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -27,10 +27,15 @@ object Configuration {
    * loads `Configuration` from 'conf/application.conf' in Dev mode
    * @return  configuration to be used
    */
-  private[play] def loadDev(appPath: File) = {
+  private[play] def loadDev(appPath: File, devSettings: Map[String,String]): Config = {
     try {
-      val file = Option(System.getProperty("config.file")).map(f => new File(f)).getOrElse(new File(appPath, "conf/application.conf"))
-      ConfigFactory.load(ConfigFactory.parseFileAnySyntax(file))
+      val file = {
+        devSettings.get("config.file").orElse(Option(System.getProperty("config.file")))
+          .map(f => new File(f)).getOrElse(new File(appPath, "conf/application.conf"))
+      }
+      ConfigFactory.parseMap(devSettings.asJava).withFallback(
+        ConfigFactory.load(ConfigFactory.parseFileAnySyntax(file))
+      )
     } catch {
       case e: ConfigException => throw configError(e.origin, e.getMessage, Some(e))
     }
@@ -48,10 +53,10 @@ object Configuration {
    * @param mode Application mode.
    * @return a `Configuration` instance
    */
-  def load(appPath: File, mode: Mode.Mode = Mode.Dev) = {
+  def load(appPath: File, mode: Mode.Mode = Mode.Dev, devSettings: Map[String,String] = Map.empty) = {
     try {
       val currentMode = Play.maybeApplication.map(_.mode).getOrElse(mode)
-      if (currentMode == Mode.Prod) Configuration(dontAllowMissingConfig) else Configuration(loadDev(appPath))
+      if (currentMode == Mode.Prod) Configuration(dontAllowMissingConfig) else Configuration(loadDev(appPath, devSettings))
     } catch {
       case e: ConfigException => throw configError(e.origin, e.getMessage, Some(e))
       case e : Throwable => throw e

--- a/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
+++ b/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
@@ -26,6 +26,10 @@ trait SourceMapper {
 
 }
 
+trait DevSettings {
+  def devSettings: Map[String,String]
+}
+
 /**
  * generic layout for initialized Applications
  */
@@ -121,7 +125,10 @@ class ReloadableApplication(sbtLink: SBTLink) extends ApplicationProvider {
                     case _ => None
                   }
                 }
-              }),Mode.Dev)
+              }), Mode.Dev) with DevSettings {
+                import scala.collection.JavaConverters._
+                lazy val devSettings: Map[String,String] = sbtLink.settings.asScala.toMap
+              }
 
               Play.start(newApplication)
 

--- a/framework/src/sbt-link/src/main/java/play/core/SBTLink.java
+++ b/framework/src/sbt-link/src/main/java/play/core/SBTLink.java
@@ -1,6 +1,7 @@
 package play.core;
 
 import java.io.*;
+import java.util.*;
 
 /**
  * Generic interface that helps the communication between a Play Application
@@ -29,5 +30,7 @@ public interface SBTLink {
 	public void forceReload();
 
 	public String markdownToHtml(String markdown, String pagePath);
+
+	public Map<String,String> settings();
 
 }

--- a/framework/src/sbt-plugin/src/main/scala/PlayKeys.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayKeys.scala
@@ -62,5 +62,7 @@ trait PlayKeys {
 
   val playPlugin = SettingKey[Boolean]("play-plugin")
 
+  val devSettings = SettingKey[Seq[(String,String)]]("play-dev-settings")
+
 }
 object PlayKeys extends PlayKeys

--- a/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
@@ -129,7 +129,7 @@ trait PlayReloader {
       var fileTimestamps = calculateTimestamps
 
       def hasChangedFiles: Boolean = monitoredFiles.exists{ f =>
-        val fileChanged = fileTimestamps.get(f.getAbsolutePath).map{ timestamp =>
+        val fileChanged = fileTimestamps.get(f.getAbsolutePath).map { timestamp =>
           f.lastModified != timestamp
         }.getOrElse{
           state.log.debug("Did not find expected timestamp of file: " + f.getAbsolutePath + " in timestamps. Marking it as changed...")
@@ -142,6 +142,11 @@ trait PlayReloader {
       }
 
       val watchChanges: Seq[Int] = monitoredDirs.map( f => jnotify.addWatch(f.getAbsolutePath) )
+
+      lazy val settings = {
+        import scala.collection.JavaConverters._
+        extracted.get(PlayKeys.devSettings).toMap.asJava
+      }
 
       // --- Utils
 

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -201,6 +201,10 @@ trait PlaySettings {
     coffeescriptOptions := Seq.empty[String],
     closureCompilerOptions := Seq.empty[String],
 
+    // Settings
+
+    devSettings := Nil,
+
     // Templates
 
     templatesImport := Seq("play.api.templates._", "play.api.templates.PlayMagic._"),


### PR DESCRIPTION
As reported in https://play.lighthouseapp.com/projects/82401-play-20/tickets/794-for-discussion-expose-a-new-way-to-get-settings-from-the-build-system-to-a-running-play-app#ticket-794-2, using global Java system properties to override some settings is painful with multi-projects organization.

Let's introduce a new Build setting `devSettings: Seq[(String, String)]` to inject some configuration into the Play application at **Dev** time. These values are seen as standard configuration values.

Here is the priority order:
- A global Java system property always override any value set in `application.conf`
- A value injected via `devSettings` always override both, the value set in  `application.conf` or set via a global Java system property.

The special setting `config.file` can be used to specify another main application configuration file (the same way the global `-Dconfig.file=xxx` does it currently).

Here is a sample:

``` scala
val main = play.Project(appName, appVersion, appDependencies).settings(

  , devSettings +=  ("config.file" -> "conf/my.conf")
  , devSettings +=  ("application.context" -> "/youhou")
  , devSettings +=  ("application.version" -> appVersion)
  , devSettings <+= (baseDirectory) { root => "application.root" -> root.getAbsolutePath }

)
```
