### PR TITLE
make sure we output the original file in AssetsCompiler

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayAssetsCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayAssetsCompiler.scala
@@ -55,7 +55,7 @@ trait PlayAssetsCompiler {
               }
               val out = new File(resources, "public/" + naming(name, false))
               IO.write(out, debug)
-              dependencies.map(_ -> out) ++ min.map { minified =>
+              (dependencies ++ Seq(sourceFile)).toSet[File].map(_ -> out) ++ min.map { minified =>
                 val outMin = new File(resources, "public/" + naming(name, true))
                 IO.write(outMin, minified)
                 dependencies.map(_ -> outMin)


### PR DESCRIPTION
Since we don't return anything from the javascriptCompiler as a dependency anymore https://github.com/playframework/Play20/blob/ac19b2802753b7d8419c1cbf45ac6c4fd8b7c55c/framework/src/sbt-plugin/src/main/scala/jscompile/JavascriptCompiler.scala#L54
we stopped outputting the original javascript files.

This change fixes this problem by making sure the original file appears in the list of files being written to the target location
