### PR TITLE
Ensured Logger API doesn't cache stale log config

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Logger.scala
+++ b/framework/src/play/src/main/scala/play/api/Logger.scala
@@ -21,27 +21,27 @@ trait LoggerLike {
   /**
    * `true` if the logger instance is enabled for the `TRACE` level.
    */
-  lazy val isTraceEnabled = logger.isTraceEnabled
+  def isTraceEnabled = logger.isTraceEnabled
 
   /**
    * `true` if the logger instance is enabled for the `DEBUG` level.
    */
-  lazy val isDebugEnabled = logger.isDebugEnabled
+  def isDebugEnabled = logger.isDebugEnabled
 
   /**
    * `true` if the logger instance is enabled for the `INFO` level.
    */
-  lazy val isInfoEnabled = logger.isInfoEnabled
+  def isInfoEnabled = logger.isInfoEnabled
 
   /**
    * `true` if the logger instance is enabled for the `WARN` level.
    */
-  lazy val isWarnEnabled = logger.isWarnEnabled
+  def isWarnEnabled = logger.isWarnEnabled
 
   /**
    * `true` if the logger instance is enabled for the `ERROR` level.
    */
-  lazy val isErrorEnabled = logger.isErrorEnabled
+  def isErrorEnabled = logger.isErrorEnabled
 
   /**
    * Logs a message with the `TRACE` level.
@@ -49,7 +49,7 @@ trait LoggerLike {
    * @param message the message to log
    */
   def trace(message: => String) {
-    if (isTraceEnabled) logger.trace(message)
+    if (logger.isTraceEnabled) logger.trace(message)
   }
 
   /**
@@ -59,7 +59,7 @@ trait LoggerLike {
    * @param error the associated exception
    */
   def trace(message: => String, error: => Throwable) {
-    if (isTraceEnabled) logger.trace(message, error)
+    if (logger.isTraceEnabled) logger.trace(message, error)
   }
 
   /**
@@ -68,7 +68,7 @@ trait LoggerLike {
    * @param message the message to log
    */
   def debug(message: => String) {
-    if (isDebugEnabled) logger.debug(message)
+    if (logger.isDebugEnabled) logger.debug(message)
   }
 
   /**
@@ -78,7 +78,7 @@ trait LoggerLike {
    * @param error the associated exception
    */
   def debug(message: => String, error: => Throwable) {
-    if (isDebugEnabled) logger.debug(message, error)
+    if (logger.isDebugEnabled) logger.debug(message, error)
   }
 
   /**
@@ -87,7 +87,7 @@ trait LoggerLike {
    * @param message the message to log
    */
   def info(message: => String) {
-    if (isInfoEnabled) logger.info(message)
+    if (logger.isInfoEnabled) logger.info(message)
   }
 
   /**
@@ -97,7 +97,7 @@ trait LoggerLike {
    * @param error the associated exception
    */
   def info(message: => String, error: => Throwable) {
-    if (isInfoEnabled) logger.info(message, error)
+    if (logger.isInfoEnabled) logger.info(message, error)
   }
 
   /**
@@ -106,7 +106,7 @@ trait LoggerLike {
    * @param message the message to log
    */
   def warn(message: => String) {
-    if (isWarnEnabled) logger.warn(message)
+    if (logger.isWarnEnabled) logger.warn(message)
   }
 
   /**
@@ -116,7 +116,7 @@ trait LoggerLike {
    * @param error the associated exception
    */
   def warn(message: => String, error: => Throwable) {
-    if (isWarnEnabled) logger.warn(message, error)
+    if (logger.isWarnEnabled) logger.warn(message, error)
   }
 
   /**
@@ -125,7 +125,7 @@ trait LoggerLike {
    * @param message the message to log
    */
   def error(message: => String) {
-    if (isErrorEnabled) logger.error(message)
+    if (logger.isErrorEnabled) logger.error(message)
   }
 
   /**
@@ -135,7 +135,7 @@ trait LoggerLike {
    * @param error the associated exception
    */
   def error(message: => String, error: => Throwable) {
-    if (isErrorEnabled) logger.error(message, error)
+    if (logger.isErrorEnabled) logger.error(message, error)
   }
 
 }


### PR DESCRIPTION
See https://play.lighthouseapp.com/projects/82401/tickets/892-the-lazy-vals-in-playapilogger-may-cause-it-to-stop-logging
