### PR TITLE
Removed MissingFilePart

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -109,7 +109,7 @@ case class AnyContentAsMultipartFormData(mdf: MultipartFormData[TemporaryFile]) 
 /**
  * Multipart form data body.
  */
-case class MultipartFormData[A](dataParts: Map[String, Seq[String]], files: Seq[FilePart[A]], badParts: Seq[BadPart], missingFileParts: Seq[MissingFilePart]) {
+case class MultipartFormData[A](dataParts: Map[String, Seq[String]], files: Seq[FilePart[A]], badParts: Seq[BadPart]) {
 
   /**
    * Extract the data parts as Form url encoded.
@@ -141,11 +141,6 @@ object MultipartFormData {
    * A file part.
    */
   case class FilePart[A](key: String, filename: String, contentType: Option[String], ref: A) extends Part
-
-  /**
-   * A file part with no content provided.
-   */
-  case class MissingFilePart(key: String) extends Part
 
   /**
    * A part that has not been properly parsed.
@@ -553,7 +548,6 @@ trait BodyParsers {
     def multipartFormData[A](filePartHandler: Multipart.PartHandler[FilePart[A]]): BodyParser[MultipartFormData[A]] = BodyParser("multipartFormData") { request =>
       val handler: Multipart.PartHandler[Either[Part, FilePart[A]]] =
         Multipart.handleDataPart.andThen(_.map(Left(_)))
-          .orElse({ case Multipart.FileInfoMatcher(partName, fileName, _) if fileName.trim.isEmpty => Done(Left(MissingFilePart(partName)), Input.Empty) }: Multipart.PartHandler[Either[Part, FilePart[A]]])
           .orElse(filePartHandler.andThen(_.map(Right(_))))
           .orElse { case headers => Done(Left(BadPart(headers)), Input.Empty) }
 
@@ -562,8 +556,7 @@ trait BodyParsers {
           val data = parts.collect { case Left(DataPart(key, value)) => (key, value) }.groupBy(_._1).mapValues(_.map(_._2))
           val az = parts.collect { case Right(a) => a }
           val bad = parts.collect { case Left(b @ BadPart(_)) => b }
-          val missing = parts.collect { case Left(missing @ MissingFilePart(_)) => missing }
-          MultipartFormData(data, az, bad, missing)
+          MultipartFormData(data, az, bad)
 
         }
       }
@@ -709,7 +702,6 @@ trait BodyParsers {
 
       def handlePart(fileHandler: PartHandler[FilePart[File]]): PartHandler[Part] = {
         handleDataPart
-          .orElse({ case FileInfoMatcher(partName, fileName, _) if fileName.trim.isEmpty => Done(MissingFilePart(partName), Input.Empty) }: PartHandler[Part])
           .orElse(fileHandler)
           .orElse({ case headers => Done(BadPart(headers), Input.Empty) })
       }


### PR DESCRIPTION
MissingFilePart was confusing and unnecessary:
- The name and its associated comment (A file part with no content provided) made it seem like there was a file part specified, but the content was missing from the transmission.  In fact, the only time it was returned is if the file name was blank.
- RFC-1867 (Form-based File Upload in HTML) makes it clear that filename is optional, and makes no statement as to whether it may or may not be a blank string.
- Play itself has no dependence on the filename (when we store a temporary file we generate our own file name with no relation to the filename passed in by the user).
- Users have reported problems where they upload a file, but the filename was blank, and so Play was reporting this misleading error - https://groups.google.com/d/msg/play-framework/eoYBJq-18Sc/2fVHO2you-8J

Generally, the browser will send a filename, only in some cases (as described by the user in the forum post above) will an empty filename be sent, so rather than Play heavy handedly deciding not to parse the content in that case, I think we should parse the content and pass the empty file name to the user, and let them decide how it should be handled.
