### PR TITLE
[#888] Implemented new HTML escaping

### DIFF
--- a/framework/src/play/src/main/scala/play/api/templates/Templates.scala
+++ b/framework/src/play/src/main/scala/play/api/templates/Templates.scala
@@ -6,10 +6,11 @@ import play.templates._
 /**
  * Content type used in default HTML templates.
  *
- * @param text the HTML text
+ * @param buffer the HTML text
  */
-case class Html(text: String) extends Appendable[Html] with Content with play.mvc.Content {
-  val buffer = new StringBuilder(text)
+case class Html(buffer: StringBuilder) extends Appendable[Html] with Content with play.mvc.Content {
+
+  def this(text: String) = this(new StringBuilder(text))
 
   /**
    * Appends this HTML fragment to another.
@@ -37,7 +38,12 @@ object Html {
   /**
    * Creates an empty HTML fragment.
    */
-  def empty: Html = Html("")
+  def empty: Html = Html(new StringBuilder)
+
+  /**
+   * Create an HTML fragment for the given string.
+   */
+  def apply(text: String): Html = new Html(text)
 
 }
 
@@ -54,7 +60,20 @@ object HtmlFormat extends Format[Html] {
   /**
    * Creates a safe (escaped) HTML fragment.
    */
-  def escape(text: String): Html = Html(org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(text))
+  def escape(text: String): Html = {
+    // Using our own algorithm here because commons lang escaping wasn't designed for protecting against XSS, and there
+    // don't seem to be any other good generic escaping tools out there.
+    val sb = new StringBuilder(text.length)
+    text.foreach {
+      case '<' => sb.append("&lt;")
+      case '>' => sb.append("&gt;")
+      case '"' => sb.append("&quot;")
+      case '\'' => sb.append("&#x27;")
+      case '&' => sb.append("&amp;")
+      case c => sb += c
+    }
+    Html(sb)
+  }
 
 }
 
@@ -178,6 +197,6 @@ object PlayMagic {
    * toHtmlArgs(Seq('id -> "item", 'style -> "color:red"))
    * }}}
    */
-  def toHtmlArgs(args: Map[Symbol, Any]) = Html(args.map(a => a._1.name + "=\"" + a._2 + "\"").mkString(" "))
+  def toHtmlArgs(args: Map[Symbol, Any]) = Html(args.map(a => a._1.name + "=\"" + HtmlFormat.escape(a._2.toString).body + "\"").mkString(" "))
 
 }

--- a/framework/src/play/src/test/scala/play/api/templates/TemplatesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/templates/TemplatesSpec.scala
@@ -5,13 +5,26 @@ import org.specs2.mutable._
 object TemplatesSpec extends Specification {
   "HtmlFormat" should {
     "escape '<', '&' and '>'" in {
-      HtmlFormat.escape("foo < bar & baz >").body must equalTo("foo &lt; bar &amp; baz &gt;")
+      HtmlFormat.escape("foo < bar & baz >").body must_== "foo &lt; bar &amp; baz &gt;"
+    }
+
+    "escape single quotes" in {
+      HtmlFormat.escape("'single quotes'").body must_== "&#x27;single quotes&#x27;"
+    }
+
+    "escape double quotes" in {
+      HtmlFormat.escape("\"double quotes\"").body must_== "&quot;double quotes&quot;"
+    }
+
+    "not escape non-ASCII characters" in {
+      HtmlFormat.escape("こんにちは").body must_== "こんにちは"
     }
   }
 
-  "HtmlFormat" should {
-    "not escape non-ASCII characters" in {
-      HtmlFormat.escape("こんにちは").body must equalTo("こんにちは")
+  "toHtmlArgs" should {
+    "escape attribute values" in {
+      PlayMagic.toHtmlArgs(Map('foo -> """bar <>&"'""")).body must_== """foo="bar &lt;&gt;&amp;&quot;&#x27;""""
     }
   }
+
 }


### PR DESCRIPTION
- Implemented a new HTML escaper - commons-lang didn't escape single quote, and also escaped about 100 extra entities that don't need escaping since we are using UTF-8 everywhere.
- Fixed a potential XSS in toHtmlArgs, since the attribute values could contain user data, they should be escaped (and should be escaped for correctness anyway)
- Minor performance improvement, since when escaping we end up with a StringBuilder, and the first thing Html did was convert the String to a StringBuilder, no need to use an intermediate string between them.  The old String constructor (and companion object apply method) have been added for backwards compatibility.
