### PR TITLE
Make Security.Authenticated return EssentialAction instead of Action[(Action[A], A)]

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Security.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Security.scala
@@ -53,7 +53,7 @@ object Security {
   /**
    * Key of the username attribute stored in session.
    */
-  lazy val username: String = Play.maybeApplication map (_.configuration.getString("session.username")) flatMap (e => e) getOrElse ("username")
+  lazy val username: String = Play.maybeApplication.flatMap(_.configuration.getString("session.username")) getOrElse ("username")
 
   /**
    * Wraps another action, allowing only authenticated HTTP requests.


### PR DESCRIPTION
I’m not sure it is the right way to do that but I wanted to remove the weird `Action[(Action[A], A)]` return type of the `Security.Authenticated` helper.

This patch has the advantage that the API change is small (the zentask sample still compiles), however I’m not sure the `Security` object is so useful in its current shape. Actually each time I start a Play project I rewrite my own security helper. I prefer a signature (for the `Authenticated` function) that takes a function that returns a `Result` rather than an `Action[_]`:

``` scala
def Authenticated[A](result: String => Request[A] => Result): Action[A]
```

And I often need something different that a `String` to identify the user (sometimes I use an `Int`, sometimes both an id and a username). Maybe we should abstract over it:

``` scala
def Authenticated[A, B](result: B => Request[A] => Result): Action[A]
```

What do you think?
