### PR TITLE
Quoted filename in content disposition header

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -627,7 +627,7 @@ trait Results {
         header = ResponseHeader(OK, Map(
           CONTENT_LENGTH -> content.length.toString,
           CONTENT_TYPE -> play.api.libs.MimeTypes.forFileName(content.getName).getOrElse(play.api.http.ContentTypes.BINARY)
-        ) ++ (if (inline) Map.empty else Map(CONTENT_DISPOSITION -> ("attachment; filename=" + fileName(content))))),
+        ) ++ (if (inline) Map.empty else Map(CONTENT_DISPOSITION -> ("""attachment; filename="%s"""".format(fileName(content)))))),
         Enumerator.fromFile(content) &> Enumeratee.onIterateeDone(onClose)
       )
     }


### PR DESCRIPTION
Simple fix for a simple bug, we should be quoting the filename in the content disposition header, otherwise Firefox will truncate the filename at the first space:

http://kb.mozillazine.org/Filenames_with_spaces_are_truncated_upon_download
