### PR TITLE
Add a convenience constructor for ValidationError

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/validation/ValidationError.java
+++ b/framework/src/play-java/src/main/java/play/data/validation/ValidationError.java
@@ -2,6 +2,8 @@ package play.data.validation;
 
 import java.util.*;
 
+import com.google.common.collect.ImmutableList;
+
 /**
  * A form validation error.
  */
@@ -10,6 +12,16 @@ public class ValidationError {
     private String key;
     private String message;
     private List<Object> arguments;
+
+    /**
+     * Constructs a new <code>ValidationError</code>.
+     *
+     * @param key the error key
+     * @param message the error message
+     */
+    public ValidationError(String key, String message) {
+        this(key, message, ImmutableList.of());
+    }
     
     /**
      * Constructs a new <code>ValidationError</code>.


### PR DESCRIPTION
The last constructor parameter of ValidationError is normally just an empty list. This makes it easier to call and can also save memory since ImmutableList.of() uses the same empty list instance internally (as opposed to creating a new empty list instance causing extra memory usage and garbage collection)
