### PR TITLE
Fix result enumerator stream and feed

### DIFF
--- a/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -246,7 +246,7 @@ private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: De
                         })
                 }
 
-                chunks apply bodyIteratee.map { _ =>
+                chunks(bodyIteratee).map { _ =>
                   play.api.Play.maybeApplication.foreach(_.global.onRequestCompletion(requestHeader))
                   if (e.getChannel.isConnected()) {
                     val f = e.getChannel.write(HttpChunk.LAST_CHUNK);

--- a/framework/test/integrationtest-scala/app/controllers/Application.scala
+++ b/framework/test/integrationtest-scala/app/controllers/Application.scala
@@ -48,4 +48,10 @@ object Application extends Controller {
   def feedEnumerator = Action {
     Ok.feed(Enumerator("a", "b", "c"))
   }
+
+  def streamIteratee = Action {
+    Ok.stream({ it: Iteratee[String, Unit] =>
+      Enumerator("a", "b", "c") |>>> it
+    })
+  }
 }

--- a/framework/test/integrationtest-scala/conf/routes
+++ b/framework/test/integrationtest-scala/conf/routes
@@ -8,6 +8,7 @@ GET     /thread                     controllers.Application.thread
 GET     /bodyParserThread           controllers.Application.bodyParserThread
 GET     /streamEnumerator           controllers.Application.streamEnumerator
 GET     /feedEnumerator             controllers.Application.feedEnumerator
+GET     /streamIteratee             controllers.Application.streamIteratee
 GET     /:name                      controllers.Application.index(name)
 POST    /json                       controllers.Application.json
 

--- a/framework/test/integrationtest-scala/test/SimpleSpec.scala
+++ b/framework/test/integrationtest-scala/test/SimpleSpec.scala
@@ -121,6 +121,11 @@ class SimpleSpec extends Specification {
       response.body must_== "abc"
     }
 
+    "support streaming using a callback for an iteratee" in new WithServer() {
+      val response = Await.result(wsCall(controllers.routes.Application.streamIteratee()).get(), Duration.Inf)
+      response.body must_== "abc"
+    }
+
     "support feeding using an enumerator" in new WithServer() {
       val response = Await.result(wsCall(controllers.routes.Application.feedEnumerator()).get(), Duration.Inf)
       response.body must_== "abc"


### PR DESCRIPTION
This fixes two bugs, one in Status.feed, and one in Status.stream, both completely different problems, but both with the same effect, the server never terminated the response when the enumerator was done.

With Status.stream, the enumerator was being fed into the response iteratee using `|>>` instead of `|>>>`.

With Status.feed, since no content length header was being set, the only way to terminate the response is to close the connection, but the connection was only being closed if keep alive wasn't set (keep alive is the default for HTTP/1.1).

Two trivial tests have been added to test these scenarios.
