### PR TITLE
Support application/xml, and prefer it over text/xml

### DIFF
--- a/documentation/manual/javaGuide/main/http/JavaBodyParsers.md
+++ b/documentation/manual/javaGuide/main/http/JavaBodyParsers.md
@@ -51,7 +51,7 @@ If you don't specify your own body parser, Play will use the default one guessin
 
 - **text/plain**: `String`, accessible via `asText()`
 - **application/json**: `JsonNode`, accessible via `asJson()`
-- **text/xml**: `org.w3c.Document`, accessible via `asXml()`
+- **application/xml**, **text/xml** or **application/XXX+xml**: `org.w3c.Document`, accessible via `asXml()`
 - **application/form-url-encoded**: `Map<String, String[]>`, accessible via `asFormUrlEncoded()`
 - **multipart/form-data**: `Http.MultipartFormData`, accessible via `asMultipartFormData()`
 - Any other content type: `Http.RawBuffer`, accessible via `asRaw()`

--- a/documentation/manual/javaGuide/main/xml/JavaXmlRequests.md
+++ b/documentation/manual/javaGuide/main/xml/JavaXmlRequests.md
@@ -2,7 +2,7 @@
 
 ## Handling an XML request
 
-An XML request is an HTTP request using a valid XML payload as request body. It must specify the `text/xml` MIME type in its `Content-Type` header.
+An XML request is an HTTP request using a valid XML payload as request body. It must specify the `application/xml` or `text/xml` MIME type in its `Content-Type` header.
 
 By default, an action uses an **any content** body parser, which you can use to retrieve the body as XML (actually as a `org.w3c.Document`):
 
@@ -42,7 +42,7 @@ You can test it with **cURL** on the command line:
 
 ```
 curl 
-  --header "Content-type: text/xml" 
+  --header "Content-type: application/xml" 
   --request POST 
   --data '<name>Guillaume</name>' 
   http://localhost:9000/sayHello
@@ -78,7 +78,7 @@ Now it replies with:
 
 ```
 HTTP/1.1 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 Content-Length: 46
 
 <message status="OK">Hello Guillaume</message>

--- a/documentation/manual/scalaGuide/main/http/ScalaBodyParsers.md
+++ b/documentation/manual/scalaGuide/main/http/ScalaBodyParsers.md
@@ -48,7 +48,7 @@ This body parser checks the `Content-Type` header and decides what kind of body 
 
 - **text/plain**: `String`
 - **application/json**: `JsValue`
-- **text/xml**: `NodeSeq`
+- **application/xml**, **text/xml** or **application/XXX+xml**: `NodeSeq`
 - **application/form-url-encoded**: `Map[String, Seq[String]]`
 - **multipart/form-data**: `MultipartFormData[TemporaryFile]`
 - any other content type: `RawBuffer`

--- a/documentation/manual/scalaGuide/main/http/ScalaResults.md
+++ b/documentation/manual/scalaGuide/main/http/ScalaResults.md
@@ -16,7 +16,7 @@ Will automatically set the `Content-Type` header to `text/plain`, while:
 val xmlResult = Ok(<message>Hello World!</message>)
 ```
 
-will set the Content-Type header to `text/xml`.
+will set the Content-Type header to `application/xml`.
 
 > **Tip:** this is done via the `play.api.http.ContentTypeOf` type class.
 

--- a/documentation/manual/scalaGuide/main/xml/ScalaXmlRequests.md
+++ b/documentation/manual/scalaGuide/main/xml/ScalaXmlRequests.md
@@ -2,7 +2,7 @@
 
 ## Handling an XML request
 
-An XML request is an HTTP request using a valid XML payload as the request body. It must specify the `text/xml` MIME type in its `Content-Type` header.
+An XML request is an HTTP request using a valid XML payload as the request body. It must specify the `application/xml` or `text/xml` MIME type in its `Content-Type` header.
 
 By default an `Action` uses a **any content** body parser, which lets you retrieve the body as XML (actually as a `NodeSeq`):
 
@@ -38,7 +38,7 @@ You can test it with **cURL** from a command line:
 
 ```
 curl 
-  --header "Content-type: text/xml" 
+  --header "Content-type: application/xml" 
   --request POST 
   --data '<name>Guillaume</name>' 
   http://localhost:9000/sayHello
@@ -72,7 +72,7 @@ Now it replies with:
 
 ```
 HTTP/1.1 200 OK
-Content-Type: text/xml; charset=utf-8
+Content-Type: application/xml; charset=utf-8
 Content-Length: 46
 
 <message status="OK">Hello Guillaume</message>

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -47,7 +47,7 @@ public interface BodyParser {
     }
 
     /**
-     * Parse the body as Xml if the Content-Type is text/xml.
+     * Parse the body as Xml if the Content-Type is application/xml.
      */
     public static class Xml implements BodyParser {
         public play.api.mvc.BodyParser<Http.RequestBody> parser(int maxLength) {

--- a/framework/src/play/src/main/scala/play/api/http/ContentTypeOf.scala
+++ b/framework/src/play/src/main/scala/play/api/http/ContentTypeOf.scala
@@ -38,7 +38,7 @@ trait DefaultContentTypeOfs {
   }
 
   /**
-   * Default content type for `Xml` values (`text/xml`).
+   * Default content type for `Xml` values (`application/xml`).
    */
   implicit def contentTypeOf_Xml(implicit codec: Codec): ContentTypeOf[Xml] = {
     ContentTypeOf[Xml](Some(ContentTypes.XML))
@@ -73,14 +73,14 @@ trait DefaultContentTypeOfs {
   }
 
   /**
-   * Default content type for `NodeSeq` values (`text/xml`).
+   * Default content type for `NodeSeq` values (`application/xml`).
    */
   implicit def contentTypeOf_NodeSeq[C <: scala.xml.NodeSeq](implicit codec: Codec): ContentTypeOf[C] = {
     ContentTypeOf[C](Some(ContentTypes.XML))
   }
 
   /**
-   * Default content type for `NodeBuffer` values (`text/xml`).
+   * Default content type for `NodeBuffer` values (`application/xml`).
    */
   implicit def contentTypeOf_NodeBuffer(implicit codec: Codec): ContentTypeOf[scala.xml.NodeBuffer] = {
     ContentTypeOf[scala.xml.NodeBuffer](Some(ContentTypes.XML))

--- a/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
@@ -86,7 +86,7 @@ trait MimeTypes {
   /**
    * Content-Type of xml.
    */
-  val XML = "text/xml"
+  val XML = "application/xml"
 
   /**
    * Content-Type of css.

--- a/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
@@ -549,7 +549,7 @@ object MimeTypes {
         xlv=application/excel
         xlw=application/excel
         xm=audio/xm
-        xml=text/xml
+        xml=application/xml
         xmz=xgl/movie
         xpix=application/x-vndls-xpix
         xpm=image/x-xpixmap

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -38,7 +38,7 @@ sealed trait AnyContent {
   }
 
   /**
-   * text/xml
+   * application/xml
    */
   def asXml: Option[NodeSeq] = this match {
     case AnyContentAsXml(xml) => Some(xml)
@@ -260,6 +260,8 @@ trait BodyParsers {
      */
     val UNLIMITED: Int = Integer.MAX_VALUE
 
+    private val ApplicationXmlMatcher = """application/.*\+xml.*""".r
+
     /**
      * Default max length allowed for text based body.
      *
@@ -411,18 +413,19 @@ trait BodyParsers {
     def tolerantXml: BodyParser[NodeSeq] = tolerantXml(DEFAULT_MAX_TEXT_LENGTH)
 
     /**
-     * Parse the body as Xml if the Content-Type is text/xml.
+     * Parse the body as Xml if the Content-Type is application/xml, text/xml or application/XXX+xml.
      *
      * @param maxLength Max length allowed or returns EntityTooLarge HTTP response.
      */
     def xml(maxLength: Int): BodyParser[NodeSeq] = when(
-      _.contentType.exists(_.startsWith("text/xml")),
+      _.contentType.exists(t => t.startsWith("text/xml") || t.startsWith("application/xml")
+        || ApplicationXmlMatcher.pattern.matcher(t).matches()),
       tolerantXml(maxLength),
-      request => Play.maybeApplication.map(_.global.onBadRequest(request, "Expecting text/xml body")).getOrElse(Results.BadRequest)
+      request => Play.maybeApplication.map(_.global.onBadRequest(request, "Expecting xml body")).getOrElse(Results.BadRequest)
     )
 
     /**
-     * Parse the body as Xml if the Content-Type is text/xml.
+     * Parse the body as Xml if the Content-Type is application/xml, text/xml or application/XXX+xml.
      */
     def xml: BodyParser[NodeSeq] = xml(DEFAULT_MAX_TEXT_LENGTH)
 
@@ -515,7 +518,7 @@ trait BodyParsers {
           Logger("play").trace("Parsing AnyContent as text")
           text(request).map(_.right.map(s => AnyContentAsText(s)))
         }
-        case Some("text/xml") => {
+        case Some("text/xml") | Some("application/xml") | Some(ApplicationXmlMatcher()) => {
           Logger("play").trace("Parsing AnyContent as xml")
           xml(request).map(_.right.map(x => AnyContentAsXml(x)))
         }

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -171,7 +171,7 @@ sealed trait WithHeaders[+A <: Result] {
    *
    * For example:
    * {{{
-   * Ok("<text>Hello world</text>").as("text/xml")
+   * Ok("<text>Hello world</text>").as("application/xml")
    * }}}
    *
    * @param contentType the new content type.
@@ -312,7 +312,7 @@ trait PlainResult extends Result with WithHeaders[PlainResult] {
    *
    * For example:
    * {{{
-   * Ok("<text>Hello world</text>").as("text/xml")
+   * Ok("<text>Hello world</text>").as("application/xml")
    * }}}
    *
    * @param contentType the new content type.
@@ -534,7 +534,7 @@ case class AsyncResult(result: Future[Result]) extends Result with WithHeaders[A
    *
    * For example:
    * {{{
-   * Ok("<text>Hello world</text>").as("text/xml")
+   * Ok("<text>Hello world</text>").as("application/xml")
    * }}}
    *
    * @param contentType the new content type.

--- a/framework/src/play/src/main/scala/play/api/templates/Templates.scala
+++ b/framework/src/play/src/main/scala/play/api/templates/Templates.scala
@@ -130,9 +130,9 @@ case class Xml(text: String) extends Appendable[Xml] with Content with play.mvc.
   override def toString = buffer.toString
 
   /**
-   * Content type of XML (`text/xml`).
+   * Content type of XML (`application/xml`).
    */
-  def contentType = "text/xml"
+  def contentType = "application/xml"
 
   def body = toString
 

--- a/framework/test/integrationtest/app/controllers/Application.scala
+++ b/framework/test/integrationtest/app/controllers/Application.scala
@@ -166,4 +166,12 @@ object Application extends Controller {
   def routetest(parameter: String) = Action {
     Ok("")
   }
+
+  def anyXml = Action { request =>
+    request.body.asXml.map(xml => Ok(xml)).getOrElse(NotFound("Not XML"))
+  }
+
+  def xml = Action(parse.xml) { request =>
+    Ok(request.body)
+  }
 }

--- a/framework/test/integrationtest/conf/routes
+++ b/framework/test/integrationtest/conf/routes
@@ -59,6 +59,9 @@ GET     /ident/:è27             controllers.πø$7ß.ôü65$t(è27: Int)
 GET     /hello                  controllers.Application.hello()
 GET     /setLang                controllers.Application.setLang(lang)
 
+POST    /any-xml                controllers.Application.anyXml
+POST    /xml                    controllers.Application.xml
+
 ->      /module                 module.Routes
 
 GET     /routes                 controllers.Application.route(abstract)

--- a/framework/test/integrationtest/test/ApplicationSpec.scala
+++ b/framework/test/integrationtest/test/ApplicationSpec.scala
@@ -261,6 +261,30 @@ class ApplicationSpec extends Specification {
       app.routes
       controllers.module.routes.ModuleController.index().url must_== "/module/index"
     }
+
+    "support xml" in {
+      "detect xml when content type is application/xml" in new WithServer() {
+        await(wsUrl("/any-xml").withHeaders("Content-Type" -> "application/xml").post(<foo>bar</foo>)).status must_== 200
+      }
+      "detect xml when content type is text/xml" in new WithServer() {
+        await(wsUrl("/any-xml").withHeaders("Content-Type" -> "text/xml").post(<foo>bar</foo>)).status must_== 200
+      }
+      "detect xml when content type is application/atom+xml" in new WithServer() {
+        await(wsUrl("/any-xml").withHeaders("Content-Type" -> "application/atom+xml").post(<foo>bar</foo>)).status must_== 200
+      }
+      "accept xml when content type is application/xml" in new WithServer() {
+        await(wsUrl("/xml").withHeaders("Content-Type" -> "application/xml").post(<foo>bar</foo>)).status must_== 200
+      }
+      "accept xml when content type is text/xml" in new WithServer() {
+        await(wsUrl("/xml").withHeaders("Content-Type" -> "text/xml").post(<foo>bar</foo>)).status must_== 200
+      }
+      "accept xml when content type is application/atom+xml" in new WithServer() {
+        await(wsUrl("/xml").withHeaders("Content-Type" -> "application/atom+xml").post(<foo>bar</foo>)).status must_== 200
+      }
+      "send xml responses as application/xml" in new WithServer() {
+        await(wsUrl("/xml").withHeaders("Content-Type" -> "application/xml").post(<foo>bar</foo>)).header("Content-Type").get must startWith("application/xml")
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Currently Play uses text/xml as the default mime type for XML, and only parses XML if it is text/xml.

text/xml however is frowned upon as the mime type for XML, it's recommended that application/xml should be used instead, because text/xml introduces ambiguities in the way encoding should be handled, though it turns out no browsers actually implement text/xml handling correctly according to the RFC.  Needless to say, application/xml should be preferred.

Furthermore, many XML formats use mime types in the format application/XXX+xml, eg, application/atom+xml, application/rdf+xml, application/xhtml+xml. Play should parse these as XML too, without having to resort to using tolerantXml.

So this makes Play consider text/xml, application/xml and application/XXX+xml all as XML, and also makes Play, by default, send XML as application/xml, when it returns XML from a request or submits it in the WS API.
