### PR TITLE
Add Enumeratee.flatten

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
@@ -88,6 +88,16 @@ object Enumeratee {
         case _ => Done(it, Input.Empty)
       }
   }
+  
+  /**
+   * flatten a [[scala.concurrent.Future]] of [[play.api.libs.iteratee.Enumeratee]]] into an Enumeratee
+   *
+   * @param futureOfEnumeratee a future of enumeratee
+   */
+  def flatten[From, To](futureOfEnumeratee: Future[Enumeratee[From, To]]) = new Enumeratee[From, To] {
+    def applyOn[A](it: Iteratee[To, A]): Iteratee[From, Iteratee[To,A]] = 
+      Iteratee.flatten(futureOfEnumeratee map(_.applyOn[A](it)))
+  }
 
   /**
    * Create an Enumeratee that zips two Iteratees together.

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumerateesSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumerateesSpec.scala
@@ -117,6 +117,22 @@ object EnumerateesSpec extends Specification {
     }
 
   }
+  
+  "Enumeratee.flatten" should {
+
+    "passAlong a future enumerator" in {
+
+      val passAlongFuture = Enumeratee.flatten {
+        concurrent.future { 
+          Enumeratee.passAlong[Int]
+        }
+      }
+      val sum = Iteratee.fold[Int, Int](0)(_+_)
+      val enumerator = Enumerator(1,2,3,4,5,6,7,8,9)
+      Await.result(enumerator |>>> passAlongFuture &>> sum, Duration.Inf) must equalTo(45)
+    }
+
+  }
 
   "Enumeratee.filter" should {
 


### PR DESCRIPTION
Iteratee and Enumerator companion objects have both the `flatten` function to flatten a Future of _ into a _.

This pull request propose to also have the `Enumeratee.flatten` function.

Exemple:

``` scala
val someFutureObject = future { 1 }
val myEnumeratee = Enumeratee.flatten {
  someFutureObject map { value =>
    Enumeratee.map { (i: Int) => i + value }
  }
}
```
