### PR TITLE
WS: Split ConnectionTimeout and RequestTimeout properties

### DIFF
--- a/documentation/manual/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/scalaGuide/main/ws/ScalaWS.md
@@ -55,5 +55,24 @@ Use the following properties to configure the WS client
 
 You can also get access to the underlying client using `def client` method  
  
+### Timeouts
+
+There is 3 different timeouts in WS. Reaching a timeout causes the WS request to interrupt.
+
+* **Connection Timeout**: The maximum time to wait when connecting to the remote host *(default is **120 seconds**)*.
+* **Connection Idle Timeout**: The maximum time the request can stay idle (connexion is established but waiting for more data) *(default is **120 seconds**)*.
+* **Request Timeout**: The total time you accept a request to take (it will be interrupted, whatever if the remote host is still sending data) *(default is **none**, to allow stream consuming)*.
+
+You can define each timeout in `application.conf` with respectively: `ws.timeout.connection`, `ws.timeout.idle`, `ws.timeout.request`.
+
+Alternatively, `ws.timeout` can be defined to target both *Connection Timeout* and *Connection Idle Timeout*.
+
+The request timeout can be specified for a given connection with `withRequestTimeout`.
+
+Example:
+
+```scala
+WS.url("http://playframework.org/").withRequestTimeout(10000 /* in milliseconds */)
+```
 
 > **Next:** [[OpenID Support in Play | ScalaOpenID]]


### PR DESCRIPTION
Today we can define a "timeout" in a WS request. We can use it both with the configuration `"ws.timeout"` and with `WS.url(..).withTimeout(timeout)`. The default timeout is set to 120 seconds.

Unfortunately, in the current implementation, this timeout determines both the time to wait before the remote host to respond (ConnectionTimeout) and the maximum time we accept to consuming a response (RequestTimeout).

However, in [AsyncHttpClientConfig.Builder](http://www.jarvana.com/jarvana/view/com/ning/async-http-client/1.0.0/async-http-client-1.0.0-javadoc.jar!/com/ning/http/client/AsyncHttpClientConfig.Builder.html), there are `setConnectionTimeoutInMs` and `setRequestTimeoutInMs`.

And, in fact, those are totally different.

This pull request propose to split these 2 different properties.

ConnectionTimeout => "ws.timeout" as before to keep compatibility (it is what we except a timeout to be: the time the request can wait when connecting to a remote host)

RequestTimeout => "ws.timeout.request" which is set to "-1" to make it "Infinite" by default.
IHMO, and especially for Play 2, it doesn't make sense to interrupt a WS consumption after 120 seconds. 
For instance, you except to consume a stream forever (see for instance the Twitter example, any stream example would have this issue btw).

[edit] I'm looking forward to your idea on this, It seems to be a matter of taste / use case here, but IHMO the max time you want to retrieve a resource should always be explicit (not the contrary): like the -max-time in curl, if you don't provide it, you will consume it until the remote server says it's done. In other words, IMO, default behavior should be no timeout for the RequestTimeout (but of course it can still be override with conf).
