### PR TITLE
PathBindable:bindableString return Left when decoding fails

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -470,10 +470,9 @@ object PathBindable {
   /**
    * Path binder for String.
    */
-  implicit def bindableString: PathBindable[String] = new PathBindable[String] {
-    def bind(key: String, value: String) = Right(URLDecoder.decode(value, "utf-8"))
-    def unbind(key: String, value: String) = value
-  }
+  implicit object bindableString extends Parsing[String](
+    (s: String) => s, (s: String) => s, (key: String, e: Exception) => "Cannot parse parameter %s as String: %s".format(key, e.getMessage)
+  )
 
   /**
    * Path binder for Int.

--- a/framework/src/play/src/test/scala/play/mvc/BindersSpec.scala
+++ b/framework/src/play/src/test/scala/play/mvc/BindersSpec.scala
@@ -34,4 +34,21 @@ object BindersSpec extends Specification {
       subject.bind("key", Map("key" -> Seq("bad-uuid"))) must be_==(Some(Left("Cannot parse parameter key as UUID: Invalid UUID string: bad-uuid")))
     }
   }
+
+  "URL Path string binder" should {
+    val subject = implicitly[PathBindable[String]]
+    val pathString = "/path/to/some%20file"
+    val pathStringBinded = "/path/to/some file"
+    val pathStringInvalid = "/path/to/invalide%2"
+
+    "Unbind Path string as string" in {
+      subject.unbind("key", pathString) must equalTo(pathString)
+    }
+    "Bind Path string as string" in {
+      subject.bind("key", pathString) must equalTo(Right(pathStringBinded))
+    }
+    "Fail on unparseable Path string" in {
+      subject.bind("key", pathStringInvalid) must equalTo(Left("Cannot parse parameter key as String: URLDecoder: Incomplete trailing escape (%) pattern"))
+    }
+  }
 }


### PR DESCRIPTION
Test
curl "http://localhost:9000/assets/anyfile%" -i

will fail with a HTTP code 500, it should be 400
