### PR TITLE
Fix updating of Firefox extensions hosted by Play

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
@@ -392,6 +392,7 @@ object MimeTypes {
         rar=application/x-rar-compressed
         ras=application/x-cmu-raster
         rast=image/cmu-raster
+        rdf=text/xml
         rexx=text/x-scriptrexx
         rf=image/vndrn-realflash
         rgb=image/x-rgb
@@ -551,6 +552,7 @@ object MimeTypes {
         xm=audio/xm
         xml=text/xml
         xmz=xgl/movie
+        xpi=application/x-xpinstall
         xpix=application/x-vndls-xpix
         xpm=image/x-xpixmap
         xsr=video/x-amt-showrun


### PR DESCRIPTION
Would love love love to get this into Play 2.1-RC2.  It's a very small change and would be a huge help to me.  Thanks!
