### PR TITLE
 Corrected play building from source steps documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You first need to build Play:
 ```bash
 $ cd framework/
 $ ./build
-> build-repository
+> publish-local
 ```
 
 Then, for convenience, add the framework installation directory to your system PATH.  


### PR DESCRIPTION
In https://github.com/playframework/Play20/wiki/BuildingFromSource the next step after running ./build script is  running publish-local task instead of build-repository.
