### PR TITLE
[#921] Ensured WS closes the stream when iteratee is done early

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
@@ -273,6 +273,8 @@ object WS {
             STATE.CONTINUE
           } else {
             iteratee = null
+            // Must close underlying connection, otherwise async http client will drain the stream
+            bodyPart.closeUnderlyingConnection()
             STATE.ABORT
           }
         }


### PR DESCRIPTION
By default, if you abort consuming the response in async http client, the client will drain the response so that it can put the connection back into the pool.  This obviously causes problems with very large bodies, or infinite streams.  This ensures that if the iteratee is done early, we close the connection rather than drain it.
