### PR TITLE
[#929] Backport the correction of Enumeratee.grouped to stop dropping elements

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/iteratee/Iteratee.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/iteratee/Iteratee.scala
@@ -601,7 +601,13 @@ object Enumeratee {
         case in @ (Input.El(_) | Input.Empty) =>
 
           Iteratee.flatten(f.feed(in)).pureFlatFold(
-            (a, _) => new CheckDone[From, To] { def continue[A](k: K[To, A]) = Cont(step(folder)(k)) } &> k(Input.El(a)),
+            (a, left) => new CheckDone[From, To] {
+              def continue[A](k: K[To, A]) =
+                (left match {
+                  case Input.El(_) => step(folder)(k)(left)
+                  case _ => Cont(step(folder)(k))
+                })
+            } &> k(Input.El(a)),
             kF => Cont(step(Cont(kF))(k)),
             (msg, e) => Error(msg, in))
 

--- a/framework/src/play/src/test/scala/play/iteratee/EnumerateesSpec.scala
+++ b/framework/src/play/src/test/scala/play/iteratee/EnumerateesSpec.scala
@@ -123,7 +123,15 @@ object EnumerateesSpec extends Specification {
         Enumeratee.map(List(_)) |>>
         Iteratee.consume()
       result.flatMap(_.run).value.get must equalTo(List("Hello","World","!"))
+    }
 
+    "Not drop elements" in {
+      val result =
+        Enumerator(Range(1,10):_*) &>
+        Enumeratee.map[Int](List(_)) ><>
+        Enumeratee.grouped( Traversable.take[List[Int]](2) &>> Iteratee.consume() ) |>>
+        Iteratee.consume()
+      result.flatMap(_.run).value.get must equalTo(List(Range(1,10):_*))
     }
 
   }


### PR DESCRIPTION
Correction from the current implementation of Enumeratee from master :

https://github.com/playframework/Play20/blob/master/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
