### PR TITLE
Minor cleaning in json lib

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/json/JsPath.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/json/JsPath.scala
@@ -124,16 +124,7 @@ case class IdxPathNode(idx: Int) extends PathNode {
 
 }
 
-object __ extends JsPath
-
-object JsPath {
-  def \(child: String) = JsPath() \ child
-  def \(child: Symbol) = JsPath() \ child
-
-  def \\(child: String) = JsPath() \\ child
-  def \\(child: Symbol) = JsPath() \\ child
-
-  def apply(idx: Int): JsPath = JsPath()(idx)
+object JsPath extends JsPath(List.empty) {
 
   // TODO implement it correctly (doesn't merge )
   def createObj(pathValues: (JsPath, JsValue)*) = {

--- a/framework/src/play/src/main/scala/play/api/libs/json/package.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/json/package.scala
@@ -33,4 +33,9 @@ package play.api.libs
  */
 package object json {
 
+  /**
+   * Alias for `JsPath` companion object
+   */
+  val __ = JsPath
+
 }


### PR DESCRIPTION
- Remove duplicated code between `JsPath` companion object and class
- Make `__` an alias of `JsPath`
