### PR TITLE
Removed the deprecation error. Changed all the tell to pass explicit sender when possible

### DIFF
--- a/samples/java/comet-clock/app/controllers/Application.java
+++ b/samples/java/comet-clock/app/controllers/Application.java
@@ -29,7 +29,7 @@ public class Application extends Controller {
     public static Result liveClock() {
         return ok(new Comet("parent.clockChanged") {  
             public void onConnected() {
-               clock.tell(this); 
+               clock.tell(this, null); 
             } 
         });
     }
@@ -69,7 +69,7 @@ public class Application extends Controller {
                     // Register disconnected callback 
                     cometSocket.onDisconnected(new Callback0() {
                         public void invoke() {
-                            getContext().self().tell(cometSocket);
+                            getContext().self().tell(cometSocket, null);
                         }
                     });
                     

--- a/samples/java/websocket-chat/app/models/ChatRoom.java
+++ b/samples/java/websocket-chat/app/models/ChatRoom.java
@@ -45,7 +45,7 @@ public class ChatRoom extends UntypedActor {
                public void invoke(JsonNode event) {
                    
                    // Send a Talk message to the room.
-                   defaultRoom.tell(new Talk(username, event.get("text").asText()));
+                   defaultRoom.tell(new Talk(username, event.get("text").asText()), null);
                    
                } 
             });
@@ -55,7 +55,7 @@ public class ChatRoom extends UntypedActor {
                public void invoke() {
                    
                    // Send a Quit message to the room.
-                   defaultRoom.tell(new Quit(username));
+                   defaultRoom.tell(new Quit(username), null);
                    
                }
             });
@@ -85,11 +85,11 @@ public class ChatRoom extends UntypedActor {
             
             // Check if this username is free.
             if(members.containsKey(join.username)) {
-                getSender().tell("This username is already used");
+                getSender().tell("This username is already used", getSelf());
             } else {
                 members.put(join.username, join.channel);
                 notifyAll("join", join.username, "has entered the room");
-                getSender().tell("OK");
+                getSender().tell("OK", getSelf());
             }
             
         } else if(message instanceof Talk)  {

--- a/samples/java/websocket-chat/app/models/Robot.java
+++ b/samples/java/websocket-chat/app/models/Robot.java
@@ -30,7 +30,7 @@ public class Robot {
         };
         
         // Join the room
-        chatRoom.tell(new ChatRoom.Join("Robot", robotChannel));
+        chatRoom.tell(new ChatRoom.Join("Robot", robotChannel), null);
         
         // Make the robot talk every 30 seconds
         Akka.system().scheduler().schedule(

--- a/samples/java/websocket-chat/project/Build.scala
+++ b/samples/java/websocket-chat/project/Build.scala
@@ -12,7 +12,8 @@ object ApplicationBuild extends Build {
     )
 
     val main = play.Project(appName, appVersion, appDependencies).settings(
-      // Add your own project settings here      
+      // Add your own project settings here 
+      javacOptions += "-Xlint:deprecation"     
     )
 
 }


### PR DESCRIPTION
Akka 2.1 deprecated the old tell method and the new one requires you to send the actorref of the sender explicitly. Changed all the java samples to use the new API and remove deprecation warning
