### PR TITLE
Ok.sendFile(inline = false) now quotes the file name - Fixes #941

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -627,7 +627,7 @@ trait Results {
         header = ResponseHeader(OK, Map(
           CONTENT_LENGTH -> content.length.toString,
           CONTENT_TYPE -> play.api.libs.MimeTypes.forFileName(content.getName).getOrElse(play.api.http.ContentTypes.BINARY)
-        ) ++ (if (inline) Map.empty else Map(CONTENT_DISPOSITION -> ("attachment; filename=" + fileName(content))))),
+        ) ++ (if (inline) Map.empty else Map(CONTENT_DISPOSITION -> ("attachment; filename=\"" + fileName(content) + "\"")))),
         Enumerator.fromFile(content) &> Enumeratee.onIterateeDone(onClose)
       )
     }


### PR DESCRIPTION
I spotted an issue downloading files in Firefox that I was serving with Ok.sendFile(inline=false) when there were spaces in the file name - because thefile name (in the header) was not quoted.

So I've created an issue to track this https://play.lighthouseapp.com/projects/82401-play-20/tickets/941-oksendfile-with-inlinefalse-and-a-space-in-the-filename-does-not-download-on-firefox-correctly and have fixed in in my branch.

It's a very simple change, as you can see.
