### PR TITLE
Use re-released scala-io-file 0.4.1 for Scala 2.10

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -406,8 +406,8 @@ object PlayBuild extends Build {
 
       // Some common dependencies here so they don't need to be declared over and over
       val specsBuild = "org.specs2" %% "specs2" % "1.12.3"
-      // The 2.10 version of scala-io-file 0.4.1 doesn't work with 2.10.0.
-      val scalaIoFileBuild = "com.github.scala-incubator.io" % "scala-io-file_2.10.0-RC1" % "0.4.1" exclude("javax.transaction", "jta")
+      // The 2.10 version of scala-io-file 0.4.1 was released on 6th Jan 2013, now works with 2.10.0.
+      val scalaIoFileBuild = "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.1" exclude("javax.transaction", "jta")
 
 
       val jdbcDeps = Seq(


### PR DESCRIPTION
The scala-io-file 0.4.1 for Scala 2.10 was re-released on Jan 6th 2013, I believe it works now! I've seen errors that indicate using the pre-release (RC1) version may be problematic (see exception below).

http://search.maven.org/#artifactdetails%7Ccom.github.scala-incubator.io%7Cscala-io-file_2.10%7C0.4.1%7Cjar

```
Exception in thread "main" java.lang.NoSuchMethodError: scala.Predef$.any2stringadd(Ljava/lang/Object;)Lscala/runtime/StringAdd;
    at scalax.io.ScalaIOException$.scalax$io$ScalaIOException$$throwableString(ScalaIOException.scala:6)
    at scalax.io.ScalaIOException.<init>(ScalaIOException.scala:11)
    at scalax.io.ResourceContext$class.errorHandler(ResourceContext.scala:58)
    at scalax.io.Resource$$anon$3.errorHandler(Resource.scala:520)
    at scalax.io.CloseableIterator$.withIterator(CloseableIterator.scala:129)
    at scalax.io.traversable.ByteResourceTraversable.toArray(ByteResourceTraversable.scala:48)
    at scalax.io.Input$class.byteArray(Input.scala:81)
    at scalax.io.managed.InputStreamResource.byteArray(InputStreamResource.scala:14)
    at scalax.io.Input$class.string(Input.scala:136)
    at scalax.io.managed.InputStreamResource.string(InputStreamResource.scala:14)
    at play.api.WithDefaultPlugins$$anonfun$pluginClasses$1.apply(Application.scala:100)
    at play.api.WithDefaultPlugins$$anonfun$pluginClasses$1.apply(Application.scala:99)
    at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
    at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
    at scala.collection.immutable.List.foreach(List.scala:309)
    at scala.collection.TraversableLike$class.map(TraversableLike.scala:244)
    at scala.collection.AbstractTraversable.map(Traversable.scala:105)
    at play.api.WithDefaultPlugins$class.pluginClasses(Application.scala:99)
    at play.api.DefaultApplication.pluginClasses(Application.scala:383)
...
```

I have completed the TypeSafe CLA
