### PR TITLE
deprecated the waitAll API

### DIFF
--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -99,8 +99,20 @@ public class F {
          * @param promises The promises to combine
          * @return A single promise whose methods act on the list of redeemed promises
          */
-        public static <A> Promise<List<A>> waitAll(Promise<? extends A>... promises){
+        public static <A> Promise<List<A>> sequence(Promise<? extends A>... promises){
             return new Promise<List<A>>(play.core.j.JavaPromise.<A>sequence(java.util.Arrays.asList(promises)));
+        }
+
+        /**
+         * Combine the given promises into a single promise for the list of results.
+         *
+         * @param promises The promises to combine
+         * @return A single promise whose methods act on the list of redeemed promises
+         * @deprecated As of release 2.1, replaced by {@link #sequence}
+         */
+
+        @Deprecated public static <A> Promise<List<A>> waitAll(Promise<? extends A>... promises){
+            return sequence(promises);
         }
 
         /**
@@ -142,12 +154,24 @@ public class F {
          * @param promises The promises to combine
          * @return A single promise whose methods act on the list of redeemed promises
          */
-        public static <A> Promise<List<A>> waitAll(Iterable<Promise<? extends A>> promises){
+        public static <A> Promise<List<A>> sequence(Iterable<Promise<? extends A>> promises){
             ArrayList<Promise<? extends A>> ps = new ArrayList<Promise<? extends A>>();
             for(Promise<? extends A> p : promises){
                 ps.add(p);
             }
             return new Promise<List<A>>(play.core.j.JavaPromise.<A>sequence(ps));
+        }
+
+
+        /**
+         * Combine the given promises into a single promise for the list of results.
+         *
+         * @param promises The promises to combine
+         * @return A single promise whose methods act on the list of redeemed promises
+         * @deprecated As of release 2.1, replaced by {@link #sequence}
+         */
+        @Deprecated public static <A> Promise<List<A>> waitAll(Iterable<Promise<? extends A>> promises){
+            return sequence(promises);
         }
 
         /**


### PR DESCRIPTION
waitAll name is little confusing. Even though I don't there any waiting involved. I changed to sequence to match the Scala Promise API
