### PR TITLE
Create an Enumeratee that recovers an iteratee in Error state.

### DIFF
--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumerateesSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumerateesSpec.scala
@@ -190,16 +190,16 @@ object EnumerateesSpec extends Specification {
   "Enumeratee.recover" should {
 
     "perform computations and log errors" in {
-      var shouldBecomeTrue = false
+      val eventuallyInput = Promise[Input[Int]]()
 
-      val result = Enumerator(0, 2, 4) &> Enumeratee.recover { _ =>
-        shouldBecomeTrue = true
+      val result = Enumerator(0, 2, 4) &> Enumeratee.recover { (_, input) =>
+        eventuallyInput.success(input)
       } &> Enumeratee.map { i =>
           8 / i
       } |>>> Iteratee.getChunks // => List(4, 2)
 
       Await.result(result, Duration.Inf) must equalTo(List(4, 2))
-      shouldBecomeTrue must equalTo(true)
+      Await.result(eventuallyInput.future, Duration.Inf) must equalTo(Input.El(0))
     }
   }
 


### PR DESCRIPTION
This enumeratee will ignore the input that caused the iteratee's error state and use the previous state of the iteratee to handle the next input.

``` scala
Enumerator(0, 2, 4) &> Enumeratee.recover { error =>
   Logger.error("oops failure occured", error)
} &> Enumeratee.map { i =>
   8 / i
} |>>> Iteratee.getChunks // => List(4, 2)
```
