### PR TITLE
Support custom TimeZone for date formatter

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/Forms.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Forms.scala
@@ -385,8 +385,9 @@ object Forms {
    * }}}
    *
    * @param pattern the date pattern, as defined in `java.text.SimpleDateFormat`
+   * @param timeZone the `java.util.TimeZone` to use for parsing and formatting
    */
-  def date(pattern: String): Mapping[java.util.Date] = of[java.util.Date] as dateFormat(pattern)
+  def date(pattern: String, timeZone: java.util.TimeZone = java.util.TimeZone.getDefault): Mapping[java.util.Date] = of[java.util.Date] as dateFormat(pattern, timeZone)
 
   /**
    * Constructs a simple mapping for a date field (mapped as `sql.Date type`).
@@ -407,8 +408,9 @@ object Forms {
    * }}}
    *
    * @param pattern the date pattern, as defined in `java.text.SimpleDateFormat`
+   * @param timeZone the `java.util.TimeZone` to use for parsing and formatting
    */
-  def sqlDate(pattern: String): Mapping[java.sql.Date] = of[java.sql.Date] as sqlDateFormat(pattern)
+  def sqlDate(pattern: String, timeZone: java.util.TimeZone = java.util.TimeZone.getDefault): Mapping[java.sql.Date] = of[java.sql.Date] as sqlDateFormat(pattern, timeZone)
 
   /**
    * Constructs a simple mapping for a date field (mapped as `org.joda.time.DateTime type`).
@@ -429,8 +431,9 @@ object Forms {
    * }}}
    *
    * @param pattern the date pattern, as defined in `org.joda.time.format.DateTimeFormat`
+   * @param timeZone the `org.joda.time.DateTimeZone` to use for parsing and formatting
    */
-  def jodaDate(pattern: String): Mapping[org.joda.time.DateTime] = of[org.joda.time.DateTime] as jodaDateTimeFormat(pattern)
+  def jodaDate(pattern: String, timeZone: org.joda.time.DateTimeZone = org.joda.time.DateTimeZone.getDefault): Mapping[org.joda.time.DateTime] = of[org.joda.time.DateTime] as jodaDateTimeFormat(pattern, timeZone)
 
   /**
    * Constructs a simple mapping for a date field (mapped as `org.joda.time.LocalDatetype`).

--- a/framework/src/play/src/test/scala/play/api/data/format/FormatSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/format/FormatSpec.scala
@@ -1,0 +1,20 @@
+package play.api.data.format
+
+import org.specs2.mutable.Specification
+import java.util.{Date, TimeZone}
+
+object FormatSpec extends Specification {
+  "dateFormat" should {
+    "support custom time zones" << {
+      val data = Map("date" -> "00:00")
+
+      val format = Formats.dateFormat("HH:mm", TimeZone.getTimeZone("America/Los_Angeles"))
+      format.bind("date", data).right.map(_.getTime) should beRight (28800000L)
+      format.unbind("date", new Date(28800000L)) should equalTo (data)
+
+      val format2 = Formats.dateFormat("HH:mm", TimeZone.getTimeZone("GMT+0000"))
+      format2.bind("date", data).right.map(_.getTime) should beRight (0L)
+      format2.unbind("date", new Date(0L)) should equalTo (data)
+    }
+  }
+}


### PR DESCRIPTION
Adds an additional `tz` parameter to the `date` form mapping and the `dateFormat` formatter, so users can set a custom `TimeZone` when parsing and formatting form dates. Example:

``` scala
Form(single("time" -> date("HH:mm", TimeZone.getTimeZone("Europe/Paris"))))
```

The patch breaks binary compatibility since it changes the `date` and `dateFormat` signatures. However it does not break source compatibility because the `tz` parameter is set a default value (which is the JVM default timezone).
