### PR TITLE
specs2 1.13

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -405,7 +405,7 @@ object PlayBuild extends Build {
     object Dependencies {
 
       // Some common dependencies here so they don't need to be declared over and over
-      val specsBuild = "org.specs2" %% "specs2" % "1.12.3"
+      val specsBuild = "org.specs2" %% "specs2" % "1.13"
       // The 2.10 version of scala-io-file 0.4.1 doesn't work with 2.10.0.
       val scalaIoFileBuild = "com.github.scala-incubator.io" % "scala-io-file_2.10.0-RC1" % "0.4.1" exclude("javax.transaction", "jta")
 

--- a/framework/src/play-test/src/main/scala/play/api/test/Specs.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Specs.scala
@@ -3,7 +3,7 @@ package play.api.test
 import org.specs2.mutable.Around
 import org.specs2.specification.Scope
 import org.openqa.selenium.WebDriver
-import org.specs2.execute.Result
+import org.specs2.execute.{AsResult,Result}
 
 // NOTE: Do *not* put any initialisation code in the below classes, otherwise delayedInit() gets invoked twice
 // which means around() gets invoked twice and everything is not happy.  Only lazy vals and defs are allowed, no vals
@@ -16,8 +16,8 @@ import org.specs2.execute.Result
  */
 abstract class WithApplication(val app: FakeApplication = FakeApplication()) extends Around with Scope {
   implicit def implicitApp = app
-  def around[T](t: => T)(implicit evidence: (T) => Result) = {
-    Helpers.running(app)(t)
+  override def around[T: AsResult](t: => T): Result = {
+    Helpers.running(app)(AsResult(t))
   }
 }
 
@@ -32,7 +32,7 @@ abstract class WithServer(val app: FakeApplication = FakeApplication(),
   implicit def implicitApp = app
   implicit def implicitPort: Port = port
 
-  def around[T](t: => T)(implicit evidence: (T) => Result) = Helpers.running(TestServer(port, app))(t)
+  override def around[T: AsResult](t: => T): Result = Helpers.running(TestServer(port, app))(AsResult(t))
 }
 
 /**
@@ -52,9 +52,9 @@ abstract class WithBrowser[WEBDRIVER <: WebDriver](
 
   lazy val browser: TestBrowser = TestBrowser.of(webDriver, Some("http://localhost:" + port))
 
-  def around[T](t: => T)(implicit evidence: (T) => Result) = {
+  override def around[T: AsResult](t: => T): Result = {
     try {
-      Helpers.running(TestServer(port, app))(t)
+      Helpers.running(TestServer(port, app))(AsResult(t))
     } finally {
       browser.quit()
     }

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -2,7 +2,7 @@ package play.api.mvc
 
 import org.specs2.mutable._
 import org.specs2.specification.{AroundOutside, Scope}
-import org.specs2.execute.{Result => SpecsResult}
+import org.specs2.execute.{Result => SpecsResult,AsResult}
 import play.api.Application
 
 object ResultsSpec extends Specification {
@@ -170,10 +170,10 @@ object ResultsSpec extends Specification {
           "ehcacheplugin" -> "disabled") ++ config.toMap)
       }
 
-    def around[T <% SpecsResult](t: => T) = {
+    override def around[T: AsResult](t: => T): SpecsResult = {
       Play.start(app)
       try {
-        t
+        AsResult(t)
       } finally {
         Play.stop()
       }

--- a/framework/test/integrationtest/test/SslSpec.scala
+++ b/framework/test/integrationtest/test/SslSpec.scala
@@ -4,7 +4,7 @@ import java.security.cert.X509Certificate
 import java.security.KeyStore
 import javax.net.ssl.{HttpsURLConnection, SSLSocket, SSLContext, X509TrustManager}
 import javax.security.auth.x500.X500Principal
-import org.specs2.execute.Result
+import org.specs2.execute.{Result, AsResult}
 import org.specs2.matcher.{Expectable, Matcher}
 import org.specs2.mutable.{Around, Specification}
 import org.specs2.specification.Scope
@@ -36,7 +36,7 @@ class SslSpec extends Specification {
 
     implicit lazy val app = FakeApplication()
 
-    def around[T](t: => T)(implicit evidence: (T) => Result) = {
+    override def around[T: AsResult](t: => T): Result = {
       val props = System.getProperties
 
       def setOrUnset(name: String, value: Option[String]) = value match {
@@ -54,7 +54,7 @@ class SslSpec extends Specification {
         setOrUnset("https.keyStore", keyStore)
         setOrUnset("https.keyStorePassword", password)
         setOrUnset("https.trustStore", trustStore)
-        Helpers.running(TestServer(Helpers.testServerPort, app, Some(SslPort)))(t)
+        Helpers.running(TestServer(Helpers.testServerPort, app, Some(SslPort)))(AsResult(t))
       } finally {
         props.remove("https.keyStore")
         props.remove("https.keyStorePassword")


### PR DESCRIPTION
`"specs2_2.10" % "1.12.3"` is **NOT** depends on Scala 2.10.0 final.

http://repo1.maven.org/maven2/org/specs2/specs2_2.10/1.12.3/specs2_2.10-1.12.3.pom

we should use 1.13 if use scala 2.10.0
