### PR TITLE
Log uncatched exceptions

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -206,7 +206,10 @@ trait ActionBuilder {
    */
   def apply[A](bodyParser: BodyParser[A])(block: Request[A] => Result): Action[A] = new Action[A] {
     def parser = bodyParser
-    def apply(ctx: Request[A]) = block(ctx)
+    def apply(ctx: Request[A]) = {
+      try block(ctx)
+      catch { case e: Throwable => Logger.error("Uncatched exception", e) ; throw e }
+    }
   }
 
   /**


### PR DESCRIPTION
Uncatched exceptions thrown in a Action block kill the current request (the client waits until timeout) without any warning.

I propose to (at least) log the exception stacktrace, in order to _know_ that there was something wrong.

This PR does not change the current request workflow nor API.
