### PR TITLE
Update framework/src/routes-compiler/src/main/scala/play/router/RoutesCo...

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
@@ -145,7 +145,7 @@ object RoutesCompiler {
       }
     }
 
-    def httpVerb: Parser[HttpVerb] = namedError("GET" | "POST" | "PUT" | "PATCH" | "HEAD" | "DELETE" | "OPTIONS" | "MKCOL" | "CONNECT" | "COPY" | "LOCK" | "MOVE" | "PROPFIND" | "PROPPATCH" | "TRACE" | "UNLOCK", "HTTP Verb expected") ^^ {
+    def httpVerb: Parser[HttpVerb] = namedError("GET" | "POST" | "PUT" | "PATCH" | "HEAD" | "DELETE" | "OPTIONS" | "MKCOL" | "SEARCH" | "COPY" | "LOCK" | "MOVE" | "PROPFIND" | "PROPPATCH" | "TRACE" | "UNLOCK", "HTTP Verb expected") ^^ {
       case v => HttpVerb(v)
     }
 


### PR DESCRIPTION
...mpiler.scala

I only really need MKCOL at present for work at W3C LDP WG, 
but since I'd rather not have to come back in case I need the 
other HTTP METHODS I added all the other ones I found on the web site 
http://restpatterns.org/HTTP_Methods/MKCOL
