### PR TITLE
[#954] Ensured requests are tagged before filters are applied

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -11,6 +11,13 @@ import scala.concurrent.Future
 trait Handler
 
 /**
+ * A handler that is able to tag requests
+ */
+trait RequestTaggingHandler extends Handler {
+  def tagRequest(request: RequestHeader): RequestHeader
+}
+
+/**
  * Reference to an Handler.
  */
 class HandlerRef[T](callValue: => T, handlerDef: play.core.Router.HandlerDef)(implicit handlerInvoker: play.core.Router.HandlerInvoker[T]) extends play.mvc.HandlerRef {

--- a/framework/test/integrationtest/test/FiltersSpec.scala
+++ b/framework/test/integrationtest/test/FiltersSpec.scala
@@ -1,0 +1,32 @@
+package test
+
+import org.specs2.mutable.Specification
+import play.api.mvc._
+import play.api.Routes
+import play.api.test._
+import play.api.test.Helpers._
+import scala.concurrent.duration.Duration
+import scala.concurrent.Await
+
+object FiltersSpec extends Specification {
+  "filters should" should {
+    "be able to access request tags" in {
+
+      object MockGlobal extends WithFilters(Filter { (f, rh) =>
+        rh.tags.get(Routes.ROUTE_VERB).map(verb => Results.Ok(verb)).getOrElse(Results.NotFound)
+      })
+
+      "helpers routing" in new WithApplication(FakeApplication(withGlobal = Some(MockGlobal))) {
+        val result = route(FakeRequest("GET", "/")).get
+        status(result) must_== 200
+        contentAsString(result) must_== "GET"
+      }
+
+      "running server" in new WithServer(FakeApplication(withGlobal = Some(MockGlobal))) {
+        val response = Await.result(wsCall(controllers.routes.Application.index()).get(), Duration.Inf)
+        response.status must_== 200
+        response.body must_== "GET"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Request tags are added to the request inside the Handler, but filters are applied a level above that, that means filters can never see request tags.  This is not really desirable, since request tags are most useful in filters.

This is one possible solution to the problem.
