### PR TITLE
enumeratee.take(0) should not trigger any callbacks

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
@@ -291,7 +291,7 @@ object Enumeratee {
       case in => Done(Cont(k), in)
     }
 
-    def continue[A](k: K[E, A]) = Cont(step(count)(k))
+    def continue[A](k: K[E, A]) = if (count <= 0) Done(Cont(k), Input.EOF) else Cont(step(count)(k))
 
   }
 

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumerateesSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumerateesSpec.scala
@@ -50,6 +50,17 @@ object EnumerateesSpec extends Specification {
 
     }
 
+    "not trigger callback on take 0" in {
+      var triggered = false
+      val enumerator = Enumerator.fromCallback {
+        () =>
+          triggered = true
+          Future(Some(1))
+      }
+      Await.result(enumerator &> Enumeratee.take(0) |>>> Iteratee.fold(0)(_ + _), Duration.Inf) must equalTo(0)
+      triggered must beFalse
+    }
+
   }
 
   "Enumeratee.takeWhile" should {


### PR DESCRIPTION
The test I added fails without this change. I think this is a clean way to implement it but I'm open to other suggestions as well.
