### PR TITLE
Use scala-io-file v0.4.2 for Scala 2.10

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -407,8 +407,7 @@ object PlayBuild extends Build {
 
       // Some common dependencies here so they don't need to be declared over and over
       val specsBuild = "org.specs2" %% "specs2" % "1.13"
-      // The 2.10 version of scala-io-file 0.4.1 doesn't work with 2.10.0.
-      val scalaIoFileBuild = "com.github.scala-incubator.io" % "scala-io-file_2.10.0-RC1" % "0.4.1" exclude("javax.transaction", "jta")
+      val scalaIoFileBuild = "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.2"
 
 
       val jdbcDeps = Seq(


### PR DESCRIPTION
This has been compiled against Scala 2.10.0 final (as has it's dependency scala-arm v1.3) so the problems from PR #676 are finally laid to rest :)

Happily, it's no longer necessary to add the `javax.transaction` exclusion, as that's been dropped from the list of dependencies of scala-io.

scala-io v0.4.2 was _only_ published against Scala v2.10 so far as I can see, so I haven't updated the other build deps of scala-io to it, as they are still running within SBT at Scala 2.9.2.
