### PR TITLE
Update documentation/manual/scalaGuide/main/akka/ScalaAkka.md

### DIFF
--- a/documentation/manual/scalaGuide/main/akka/ScalaAkka.md
+++ b/documentation/manual/scalaGuide/main/akka/ScalaAkka.md
@@ -72,7 +72,7 @@ For example, to send a message to the `testActor` every 30 minutes:
 Akka.system.scheduler.schedule(0 seconds, 30 minutes, testActor, "tick")
 ```
 
-> **Note:** This example uses implicit conversions defined in `akka.util.duration` to convert numbers to `Duration` objects with various time units.
+> **Note:** This example uses implicit conversions defined in `scala.concurrent.duration` to convert numbers to `Duration` objects with various time units.
 
 Similarly, to run a block of code ten seconds from now:
 


### PR DESCRIPTION
Akka now uses Duration from Scala core.
