### PR TITLE
Asset versioning

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -490,12 +490,15 @@ object PlayBuild extends Build {
             "org.joda"                          %    "joda-convert"             %   "1.2",
 
             "org.apache.commons"                %    "commons-lang3"            %   "3.1",
+            "commons-codec"                     %    "commons-codec"            %   "1.7",
 
             ("com.ning"                         %    "async-http-client"        %   "1.7.6" notTransitive())
               .exclude("org.jboss.netty", "netty")
             ,
 
-            "oauth.signpost"                    %    "signpost-core"            %   "1.2.1.2",
+            ("oauth.signpost"                    %    "signpost-core"            %   "1.2.1.2" notTransitive())
+              .exclude("commons-codec", "commons-codec")
+            ,
             "oauth.signpost"                    %    "signpost-commonshttp4"    %   "1.2.1.2",
 
             "org.codehaus.jackson"              %    "jackson-core-asl"         %   "1.9.10",

--- a/samples/scala/websocket-chat/app/views/main.scala.html
+++ b/samples/scala/websocket-chat/app/views/main.scala.html
@@ -6,9 +6,9 @@
     <head>
         <title>Websocket Chat-Room</title>
         <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/bootstrap.css")">
-        <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/main.css")">
+        <link rel="stylesheet" media="screen" href="@routes.Assets.versionedAt(Asset("stylesheets/main.css"))">
         <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
-        <script src="@routes.Assets.at("javascripts/jquery-1.7.1.min.js")" type="text/javascript"></script>
+        <script src="@routes.Assets.versionedAt("javascripts/jquery-1.7.1.min.js")" type="text/javascript"></script>
     </head>
     <body>
         

--- a/samples/scala/websocket-chat/conf/routes
+++ b/samples/scala/websocket-chat/conf/routes
@@ -9,3 +9,4 @@ GET     /room/chat                  controllers.Application.chat(username)
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.at(path="/public", file)
+GET     /assetsVersionned/*file     controllers.Assets.versionedAt(path="/public", file: controllers.Asset)


### PR DESCRIPTION
ticket 842 https://play.lighthouseapp.com/projects/82401/tickets/842-proper-asset-versioning

When doing a reverse routing on an `Asset` we insert a hash of the content into the generated url.
So in a template : `@routes.Assets.versionedAt("javascripts/jquery-1.7.1.min.js")` will be transformed to `/assetsVersionned/javascripts/jquery-1.7.1.min-9eb9ac595e9b5544e2dc79fff7cd2d0b4b5ef71f.js`

todo : javascript reverse router
