### PR TITLE
Add application/javascript to text types

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
@@ -608,6 +608,7 @@ object MimeTypes {
     lazy val additionalText =
     """
         application/json
+        application/javascript
     """.split('\n').map(_.trim).filter(_.size > 0).filter(_(0) != '#')
 
 }


### PR DESCRIPTION
Javascript code also needs charset HTTP header to correctly use UTF-8 strings. This patch adds 'application/javascript' to list of additional text types in MimeTypes class

I signed CLA.
