### PR TITLE
fixed java.io.File handling in less compiler

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/less/LessCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/less/LessCompiler.scala
@@ -115,8 +115,8 @@ object LessCompiler {
       val dependencies = ScriptableObject.getProperty(result, "dependencies").asInstanceOf[NativeArray]
 
       css -> (0 until dependencies.getLength.toInt).map(ScriptableObject.getProperty(dependencies, _) match {
-        case f: File => f
-        case o: NativeJavaObject => o.unwrap.asInstanceOf[File]
+        case f: File => f.getCanonicalFile
+        case o: NativeJavaObject => o.unwrap.asInstanceOf[File].getCanonicalFile
       })
     }
   }


### PR DESCRIPTION
Problem:
Changes to lib.less will be ignored by play in dev mode.

``` css
# File "test.less"
@import "lib.less"

#File "lib.less"
body {
    color: red;
}
```

The fix:
The lesscompiler returns relative pathes. My fixed converts relative paths to absolutes paths. The dependencies variable in the AssetCompiler does not work with mixed relative/absolute pathes.
scala shell example (path "/var/share/man" choosen by random):

``` text
scala> val absolute = new java.io.File("/var/share/man")
absolute: java.io.File = /var/share/man
scala> absolute.equals(absolute)
res0: Boolean = true
scala> val relative = new java.io.File("/var/share/doc/../man")
relative: java.io.File = /var/share/doc/../man
scala> absolute.equals(relative)
res1: Boolean = false
scala> absolute.equals(relative.getCanonicalFile)
res2: Boolean = true
```
