### PR TITLE
to include javascript min files

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayAssetsCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayAssetsCompiler.scala
@@ -58,7 +58,7 @@ trait PlayAssetsCompiler {
               (dependencies ++ Seq(sourceFile)).toSet[File].map(_ -> out) ++ min.map { minified =>
                 val outMin = new File(resources, "public/" + naming(name, true))
                 IO.write(outMin, minified)
-                dependencies.map(_ -> outMin)
+                Seq(sourceFile).map(_ -> outMin)
               }.getOrElse(Nil)
             } else {
               previousRelation.filter((original, compiled) => original == sourceFile)._2s.map(sourceFile -> _)


### PR DESCRIPTION
Sometime dependencies could be Nil and if that is the case then min files doesn't get copied to the classes/public/... folder. Question is whether should we map that to dependencies as well?
