### PR TITLE
Update Mozilla Rhino to 1.7R4

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -533,7 +533,7 @@ object PlayBuild extends Build {
 
         val sbtDependencies = Seq(
             "com.typesafe"                      %    "config"                   %   "1.0.0",
-            "rhino"                             %    "js"                       %   "1.7R2",
+            "org.mozilla"                       %    "rhino"                    %   "1.7R4",
 
             ("com.google.javascript"            %    "closure-compiler"         %   "rr2079.1" notTransitive())
               .exclude("args4j", "args4j")


### PR DESCRIPTION
https://play.lighthouseapp.com/projects/82401/tickets/949-update-rhino-to-17r4

We are at the moment running 1.7R2 but since then mozilla have changed the namespace.

The newest version is "org.mozilla" % "rhino" % "1.7R4"

The reason I wan't to upgrade is that 1.7R4 has better support for ecmascript 5 and I was not successful when trying to compile ember.js with 1.7R2
But as soon as I switched to 1.7R4 it worked like a charm. Why you might ask? Primarily it seems to boil down to ember.js using a lot of ecmascript 3's reserved keywords such as volatile, char, string... but in ecmascript 5 they have released these keywords into the wild.
