### PR TITLE
(documentation) Fixed broken link to Spring documentation

### DIFF
--- a/documentation/manual/javaGuide/main/forms/JavaForms.md
+++ b/documentation/manual/javaGuide/main/forms/JavaForms.md
@@ -15,7 +15,7 @@ public class User {
 Form<User> userForm = form(User.class);
 ```
 
-> **Note:** The underlying binding is done using [[Spring data binder| http://static.springsource.org/spring/docs/3.0.7.RELEASE/reference/html/validation.html]].
+> **Note:** The underlying binding is done using [[Spring data binder| http://static.springsource.org/spring/docs/3.0.7.RELEASE/reference/validation.html]].
 
 This form can generate a `User` result value from `HashMap<String,String>` data:
 


### PR DESCRIPTION
Fixed broken link to Spring documentation at static.springsource.org (old path contained /html/, removed).

(It still links to 3.0.7.RELEASE, maybe it should link to newer version? Play 2.1-RC1 uses 3.1.2.RELEASE)
