### PR TITLE
Ticket-944: Make lookup of scala-library.jar and scala-compiler.jar more robust

### DIFF
--- a/framework/src/templates-compiler/src/main/scala/play/templates/ScalaTemplateCompiler.scala
+++ b/framework/src/templates-compiler/src/main/scala/play/templates/ScalaTemplateCompiler.scala
@@ -645,8 +645,10 @@ object """ :+ name :+ """ extends BaseScalaTemplate[""" :+ resultType :+ """,For
 
           // is null in Eclipse/OSGI but luckily we don't need it there
           if (scalaObjectSource != null) {
-            val compilerPath = Class.forName("scala.tools.nsc.Interpreter").getProtectionDomain.getCodeSource.getLocation.getFile
-            val libPath = scalaObjectSource.getLocation.getFile
+            import java.security.CodeSource
+            def toAbsolutePath(cs: CodeSource) = new File(cs.getLocation.toURI).getAbsolutePath
+            val compilerPath = toAbsolutePath(Class.forName("scala.tools.nsc.Interpreter").getProtectionDomain.getCodeSource)
+            val libPath = toAbsolutePath(scalaObjectSource)
             val pathList = List(compilerPath, libPath)
             val origBootclasspath = settings.bootclasspath.value
             settings.bootclasspath.value = ((origBootclasspath :: pathList) ::: additionalClassPathEntry.toList) mkString File.pathSeparator


### PR DESCRIPTION
This patch fixes a bug that causes `TemplateCompiler` to fail to load `scala-library.jar` and `scala-compiler.jar` on Windows 2003.
The corresponding lighthouse ticket is [944](https://play.lighthouseapp.com/projects/82401-play-20/tickets/944-scalatemplatecompiler-fails-to-lookup-scala-libraryjar-on-windows-xp).

I already signed the Typesafe CLA.
