### PR TITLE
Fix bad link in "Using Google Closure Compiler"

### DIFF
--- a/documentation/manual/detailledTopics/assets/AssetsGoogleClosureCompiler.md
+++ b/documentation/manual/detailledTopics/assets/AssetsGoogleClosureCompiler.md
@@ -36,4 +36,4 @@ javascriptEntryPoints <<= (sourceDirectory in Compile)(base =>
 )
 ```
 
-> **Next:** [[Using require.js to manage dependencies | requirejs]]
+> **Next:** [[Using require.js to manage dependencies | RequireJS-support]]


### PR DESCRIPTION
This should fix the link "Using require.js to manage dependencies" which is at the bottom of the page. 
