### PR TITLE
Don't include compiled assets in "watchSources" by default

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -127,7 +127,7 @@ trait PlaySettings {
     sourceGenerators in Compile <+= (state, sourceDirectory in Compile, sourceManaged in Compile, templatesTypes, templatesImport) map ScalaTemplates,
 
     // Adds app directory's source files to continuous hot reloading
-    watchSources <++= baseDirectory map { path => ((path / "app") ** "*").get },
+    watchSources <++= baseDirectory map { path => ((path / "app") ** "*" --- (path / "app/assets") ** "*").get },
 
     commands ++= Seq(shCommand, playCommand, playRunCommand, playStartCommand, h2Command, classpathCommand, licenseCommand, computeDependenciesCommand),
 


### PR DESCRIPTION
Having the `app/assets/*` files in the `watchSources` settings, cause an application reload each time one of this file is modified.
