### PR TITLE
stop throwing or catching Throwable

### DIFF
--- a/framework/src/play-exceptions/src/main/java/play/api/PlayException.java
+++ b/framework/src/play-exceptions/src/main/java/play/api/PlayException.java
@@ -11,14 +11,14 @@ import java.util.concurrent.atomic.AtomicLong;
 public class PlayException extends UsefulException {
 
     private final AtomicLong generator = new AtomicLong(System.currentTimeMillis());
-   
+
     /**
      * Generates a new unique exception ID.
      */
-    private String nextId() { 
+    private String nextId() {
         return java.lang.Long.toString(generator.incrementAndGet(), 26);
     }
-  
+
     public PlayException(String title, String description, Throwable cause) {
         super(title + "[" + description + "]",cause);
         this.title = title;
@@ -26,7 +26,7 @@ public class PlayException extends UsefulException {
         this.id = nextId();
         this.cause = cause;
     }
-    
+
     public PlayException(String title, String description) {
         super(title + "[" + description + "]");
         this.title = title;
@@ -34,40 +34,40 @@ public class PlayException extends UsefulException {
         this.id = nextId();
         this.cause = null;
     }
-  
+
     /**
      * Adds source attachment to a Play exception.
      */
     public static abstract class ExceptionSource extends PlayException {
-  
+
         public ExceptionSource(String title, String description, Throwable cause) {
           super(title, description,cause);
         }
-     
+
         public ExceptionSource(String title, String description) {
           super(title, description);
         }
-  
+
         /**
          * Error line number, if defined.
          */
         public abstract Integer line();
-  
+
         /**
          * Column position, if defined.
          */
         public abstract Integer position();
-  
+
         /**
          * Input stream used to read the source content.
          */
         public abstract String input();
-  
+
         /**
          * The source file name if defined.
          */
         public abstract String sourceName();
-  
+
         /**
          * Extracts interesting lines to be displayed to the user.
          *
@@ -86,7 +86,7 @@ public class PlayException extends UsefulException {
                     focusOn.add(lines[i]);
                 }
                 return new InterestingLines(firstLine + 1, focusOn.toArray(new String[focusOn.size()]), line() - firstLine - 1);
-            } catch(Throwable e) {
+            } catch(Exception e) {
                 e.printStackTrace();
                 return null;
             }
@@ -96,54 +96,54 @@ public class PlayException extends UsefulException {
             return super.toString() + " in " + sourceName() + ":" + line();
         }
     }
-  
+
     /**
      * Adds any attachment to a Play exception.
      */
     public static abstract class ExceptionAttachment extends PlayException {
-  
+
         public ExceptionAttachment(String title, String description, Throwable cause) {
             super(title, description, cause);
         }
-  
+
         public ExceptionAttachment(String title, String description) {
             super(title, description);
         }
-     
+
         /**
          * Content title.
          */
-        public abstract String subTitle(); 
-  
+        public abstract String subTitle();
+
         /**
          * Content to be displayed.
          */
         public abstract String content();
-  
+
     }
-  
+
     /**
      * Adds a rich HTML description to a Play exception.
      */
     public static abstract class RichDescription extends ExceptionAttachment {
-     
+
         public RichDescription(String title, String description, Throwable cause) {
             super(title, description, cause);
         }
-  
+
         public RichDescription(String title, String description) {
             super(title, description);
         }
-     
+
         /**
          * The new description formatted as HTML.
          */
         public abstract String htmlDescription();
-  
+
     }
 
     public static class InterestingLines {
-  
+
         public final int firstLine;
         public final int errorLine;
         public final String[] focus;
@@ -155,5 +155,5 @@ public class PlayException extends UsefulException {
         }
 
     }
-  
+
 }

--- a/framework/src/play-java-ebean/src/main/java/play/db/ebean/EbeanPlugin.java
+++ b/framework/src/play-java-ebean/src/main/java/play/db/ebean/EbeanPlugin.java
@@ -17,27 +17,27 @@ import com.avaje.ebeaninternal.api.*;
  * A Play plugin that automatically manages Ebean configuration.
  */
 public class EbeanPlugin extends Plugin {
-    
+
     private final Application application;
-    
+
     public EbeanPlugin(Application application) {
         this.application = application;
     }
-    
+
     // --
-    
+
     private final Map<String,EbeanServer> servers = new HashMap<String,EbeanServer>();
-    
+
     /**
      * Reads the configuration file and initialises required Ebean servers.
      */
     public void onStart() {
 
         Configuration ebeanConf = Configuration.root().getConfig("ebean");
-        
+
         if(ebeanConf != null) {
             for(String key: ebeanConf.keys()) {
-                
+
                 ServerConfig config = new ServerConfig();
                 config.setName(key);
                 config.loadFromProperties();
@@ -53,7 +53,7 @@ public class EbeanPlugin extends Plugin {
                 if(key.equals("default")) {
                     config.setDefaultServer(true);
                 }
-                
+
                 String[] toLoad = ebeanConf.getString(key).split(",");
                 Set<String> classes = new HashSet<String>();
                 for(String load: toLoad) {
@@ -67,7 +67,7 @@ public class EbeanPlugin extends Plugin {
                 for(String clazz: classes) {
                     try {
                         config.addClass(Class.forName(clazz, true, application.classloader()));
-                    } catch(Throwable e) {
+                    } catch(Exception e) {
                         throw ebeanConf.reportError(
                             key,
                             "Cannot register class [" + clazz + "] in Ebean server",
@@ -75,9 +75,9 @@ public class EbeanPlugin extends Plugin {
                         );
                     }
                 }
-                
+
                 servers.put(key, EbeanServerFactory.create(config));
-                
+
                 // DDL
                 if(!application.isProd()) {
                     boolean evolutionsEnabled = !"disabled".equals(application.configuration().getString("evolutionplugin"));
@@ -92,12 +92,12 @@ public class EbeanPlugin extends Plugin {
                         }
                     }
                 }
-                
+
             }
         }
-        
+
     }
-    
+
     /**
      * Helper method that generates the required evolution to properly run Ebean.
      */
@@ -105,71 +105,71 @@ public class EbeanPlugin extends Plugin {
         DdlGenerator ddl = new DdlGenerator((SpiEbeanServer)server, config.getDatabasePlatform(), config);
         String ups = ddl.generateCreateDdl();
         String downs = ddl.generateDropDdl();
-        
+
         if(ups == null || ups.trim().isEmpty()) {
             return null;
         }
-        
+
         return (
             "# --- Created by Ebean DDL\n" +
             "# To stop Ebean DDL generation, remove this comment and start using Evolutions\n" +
-            "\n" + 
+            "\n" +
             "# --- !Ups\n" +
-            "\n" + 
+            "\n" +
             ups +
-            "\n" + 
+            "\n" +
             "# --- !Downs\n" +
             "\n" +
             downs
         );
     }
-    
+
     /**
      * <code>DataSource</code> wrapper to ensure that every retrieved connection has auto-commit disabled.
      */
     static class WrappingDatasource implements javax.sql.DataSource {
-        
+
         public java.sql.Connection wrap(java.sql.Connection connection) throws java.sql.SQLException {
             connection.setAutoCommit(false);
             return connection;
         }
-        
+
         // --
-        
+
         final javax.sql.DataSource wrapped;
-        
+
         public WrappingDatasource(javax.sql.DataSource wrapped) {
             this.wrapped = wrapped;
         }
-        
+
         public java.sql.Connection getConnection() throws java.sql.SQLException {
             return wrap(wrapped.getConnection());
         }
-        
+
         public java.sql.Connection getConnection(String username, String password) throws java.sql.SQLException {
             return wrap(wrapped.getConnection(username, password));
         }
-        
+
         public int getLoginTimeout() throws java.sql.SQLException {
             return wrapped.getLoginTimeout();
         }
-        
+
         public java.io.PrintWriter getLogWriter() throws java.sql.SQLException {
             return wrapped.getLogWriter();
         }
-        
+
         public void setLoginTimeout(int seconds) throws java.sql.SQLException {
             wrapped.setLoginTimeout(seconds);
         }
-        
+
         public void setLogWriter(java.io.PrintWriter out) throws java.sql.SQLException {
             wrapped.setLogWriter(out);
         }
-        
+
         public boolean isWrapperFor(Class<?> iface) throws java.sql.SQLException {
             return wrapped.isWrapperFor(iface);
         }
-        
+
         public <T> T unwrap(Class<T> iface) throws java.sql.SQLException {
             return wrapped.unwrap(iface);
         }
@@ -177,8 +177,8 @@ public class EbeanPlugin extends Plugin {
         public java.util.logging.Logger getParentLogger() {
             return null;
         }
-        
+
     }
-    
-    
+
+
 }

--- a/framework/src/play-java-ebean/src/main/java/play/db/ebean/TransactionalAction.java
+++ b/framework/src/play-java-ebean/src/main/java/play/db/ebean/TransactionalAction.java
@@ -9,19 +9,19 @@ import com.avaje.ebean.*;
  * Wraps an action in an Ebean transaction.
  */
 public class TransactionalAction extends Action<Transactional> {
-    
-    public Result call(final Context ctx) throws Throwable {
-        return Ebean.execute(new TxCallable<Result>() {  
+
+    public Result call(final Context ctx) throws Exception {
+        return Ebean.execute(new TxCallable<Result>() {
             public Result call() {
                 try {
                     return delegate.call(ctx);
                 } catch(RuntimeException e) {
                     throw e;
-                } catch(Throwable t) {
+                } catch(Exception t) {
                     throw new RuntimeException(t);
                 }
             }
         });
     }
-    
+
 }

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
@@ -31,7 +31,7 @@ public class JPA {
         }
 
         return em;
-    } 
+    }
 
     /**
      * Get the default EntityManager for this thread.
@@ -56,7 +56,7 @@ public class JPA {
      *
      * @param block Block of code to execute.
      */
-    public static <T> T withTransaction(play.libs.F.Function0<T> block) throws Throwable {
+    public static <T> T withTransaction(play.libs.F.Function0<T> block) throws Exception {
         return withTransaction("default", false, block);
     }
 
@@ -68,12 +68,12 @@ public class JPA {
     public static void withTransaction(final play.libs.F.Callback0 block) {
         try {
             withTransaction("default", false, new play.libs.F.Function0<Void>() {
-                public Void apply() throws Throwable {
+                public Void apply() throws Exception {
                     block.invoke();
                     return null;
                 }
             });
-        } catch(Throwable t) {
+        } catch(Exception t) {
             throw new RuntimeException(t);
         }
     }
@@ -85,7 +85,7 @@ public class JPA {
      * @param readOnly Is the transaction read-only?
      * @param block Block of code to execute.
      */
-    public static <T> T withTransaction(String name, boolean readOnly, play.libs.F.Function0<T> block) throws Throwable {
+    public static <T> T withTransaction(String name, boolean readOnly, play.libs.F.Function0<T> block) throws Exception {
         EntityManager em = null;
         EntityTransaction tx = null;
         try {
@@ -110,9 +110,9 @@ public class JPA {
 
             return result;
 
-        } catch(Throwable t) {
+        } catch(Exception t) {
             if(tx != null) {
-                try { tx.rollback(); } catch(Throwable e) {}
+                try { tx.rollback(); } catch(Exception e) {}
             }
             throw t;
         } finally {

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/TransactionalAction.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/TransactionalAction.java
@@ -9,17 +9,17 @@ import javax.persistence.*;
  * Wraps an action in am JPA transaction.
  */
 public class TransactionalAction extends Action<Transactional> {
-    
-    public Result call(final Context ctx) throws Throwable {
+
+    public Result call(final Context ctx) throws Exception {
         return JPA.withTransaction(
             configuration.value(),
             configuration.readOnly(),
             new play.libs.F.Function0<Result>() {
-                public Result apply() throws Throwable {
+                public Result apply() throws Exception {
                     return delegate.call(ctx);
                 }
             }
         );
     }
-    
+
 }

--- a/framework/src/play-java/src/main/java/play/cache/CachedAction.java
+++ b/framework/src/play-java/src/main/java/play/cache/CachedAction.java
@@ -7,7 +7,7 @@ import play.mvc.Http.*;
  * Cache another action.
  */
 public class CachedAction extends Action<Cached> {
-    
+
     public Result call(Context ctx) {
         try {
             String key = configuration.key();
@@ -20,7 +20,7 @@ public class CachedAction extends Action<Cached> {
             return result;
         } catch(RuntimeException e) {
             throw e;
-        } catch(Throwable t) {
+        } catch(Exception t) {
             throw new RuntimeException(t);
         }
     }

--- a/framework/src/play-java/src/main/java/play/data/Form.java
+++ b/framework/src/play-java/src/main/java/play/data/Form.java
@@ -25,28 +25,28 @@ import org.springframework.context.support.*;
 public class Form<T> {
 
     // -- Form utilities
-    
+
     /**
      * Instantiates a dynamic form.
      */
     public static DynamicForm form() {
         return new DynamicForm();
     }
-    
+
     /**
      * Instantiates a new form that wraps the specified class.
      */
     public static <T> Form<T> form(Class<T> clazz) {
         return new Form<T>(clazz);
     }
-    
+
     /**
      * Instantiates a new form that wraps the specified class.
      */
     public static <T> Form<T> form(String name, Class<T> clazz) {
         return new Form<T>(name, clazz);
     }
-    
+
     /**
      * Instantiates a new form that wraps the specified class.
      */
@@ -62,7 +62,7 @@ public class Form<T> {
     }
 
     // ---
-    
+
     /**
      * Defines a form element's display name.
      */
@@ -145,7 +145,7 @@ public class Form<T> {
         Map<String,String> jsonData = new HashMap<String,String>();
         if(request.body().asJson() != null) {
             jsonData = play.libs.Scala.asJava(
-                play.api.data.FormUtils.fromJson("", 
+                play.api.data.FormUtils.fromJson("",
                     play.api.libs.json.Json.parse(
                         play.libs.Json.stringify(request.body().asJson())
                     )
@@ -256,7 +256,7 @@ public class Form<T> {
     public Form<T> bind(org.codehaus.jackson.JsonNode data, String... allowedFields) {
         return bind(
             play.libs.Scala.asJava(
-                play.api.data.FormUtils.fromJson("", 
+                play.api.data.FormUtils.fromJson("",
                     play.api.libs.json.Json.parse(
                         play.libs.Json.stringify(data)
                     )
@@ -358,12 +358,12 @@ public class Form<T> {
                 for(Object arg: error.getArguments()) {
                     if(!(arg instanceof org.springframework.context.support.DefaultMessageSourceResolvable)) {
                         arguments.add(arg);
-                    }                    
+                    }
                 }
                 if(!errors.containsKey(key)) {
-                   errors.put(key, new ArrayList<ValidationError>()); 
+                   errors.put(key, new ArrayList<ValidationError>());
                 }
-                errors.get(key).add(new ValidationError(key, error.isBindingFailure() ? "error.invalid" : error.getDefaultMessage(), arguments));                    
+                errors.get(key).add(new ValidationError(key, error.isBindingFailure() ? "error.invalid" : error.getDefaultMessage(), arguments));
             }
             return new Form(rootName, backedType, data, errors, None(), groups);
         } else {
@@ -373,7 +373,7 @@ public class Form<T> {
                     java.lang.reflect.Method v = result.getTarget().getClass().getMethod("validate");
                     globalError = v.invoke(result.getTarget());
                 } catch(NoSuchMethodException e) {
-                } catch(Throwable e) {
+                } catch(Exception e) {
                     throw new RuntimeException(e);
                 }
             }
@@ -532,7 +532,7 @@ public class Form<T> {
      */
     public void reject(ValidationError error) {
         if(!errors.containsKey(error.key())) {
-           errors.put(error.key(), new ArrayList<ValidationError>()); 
+           errors.put(error.key(), new ArrayList<ValidationError>());
         }
         errors.get(error.key()).add(error);
     }
@@ -553,7 +553,7 @@ public class Form<T> {
      *
      * @param key the error key
      * @param error the error message
-     */    
+     */
     public void reject(String key, String error) {
         reject(key, error, new ArrayList<Object>());
     }
@@ -572,7 +572,7 @@ public class Form<T> {
      * Add a global error to this form.
      *
      * @param error the error message.
-     */    
+     */
     public void reject(String error) {
         reject("", error, new ArrayList<Object>());
     }
@@ -757,7 +757,7 @@ public class Form<T> {
 
         /**
          * Returns the expected format for this field.
-         * 
+         *
          * @return The expected format for this field.
          */
         public Tuple<String,List<Object>> format() {

--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -269,7 +269,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
             return new String(contentAsBytes(result), charset);
         } catch(RuntimeException e) {
             throw e;
-        } catch(Throwable t) {
+        } catch(Exception t) {
             throw new RuntimeException(t);
         }
     }
@@ -285,7 +285,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
             return routeAndCall((Class<? extends play.core.Router.Routes>)FakeRequest.class.getClassLoader().loadClass("Routes"), fakeRequest);
         } catch(RuntimeException e) {
             throw e;
-        } catch(Throwable t) {
+        } catch(Exception t) {
             throw new RuntimeException(t);
         }
     }
@@ -305,7 +305,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
             }
         } catch(RuntimeException e) {
             throw e;
-        } catch(Throwable t) {
+        } catch(Exception t) {
             throw new RuntimeException(t);
         }
     }
@@ -422,7 +422,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
             startedServer = server;
             browser = testBrowser(webDriver);
             block.invoke(browser);
-        } catch(Throwable t) {
+        } catch(Exception t) {
             throw new RuntimeException(t);
         } finally {
             if(browser != null) {
@@ -463,7 +463,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
             return new TestBrowser(webDriver, "http://localhost:" + port);
         } catch(RuntimeException e) {
             throw e;
-        } catch(Throwable t) {
+        } catch(Exception t) {
             throw new RuntimeException(t);
         }
     }

--- a/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
@@ -123,7 +123,7 @@ case class TestServer(port: Int, application: FakeApplication = FakeApplication(
     try {
       server = new play.core.server.NettyServer(new play.core.TestApplication(application), port, sslPort = sslPort, mode = Mode.Test)
     } catch {
-      case t: Throwable =>
+      case t: Exception =>
         t.printStackTrace
         throw new RuntimeException(t)
     }

--- a/framework/src/play/src/main/java/play/GlobalSettings.java
+++ b/framework/src/play/src/main/java/play/GlobalSettings.java
@@ -35,8 +35,8 @@ public class GlobalSettings {
 
     /**
      * Called when an exception occurred.
-     * 
-     * The default is to send the framework's default error page. This is achieved by returning <code>null</code>, 
+     *
+     * The default is to send the framework's default error page. This is achieved by returning <code>null</code>,
      * so that the Scala engine handles the excepetion and shows an error page.
      *
      * By overriding this method one can provide an alternative error page.
@@ -47,7 +47,7 @@ public class GlobalSettings {
     public Result onError(RequestHeader request, Throwable t) {
         return null;
     }
-    
+
     /**
      * Call to create the root Action of a request for a Java application.
      * The request and actionMethod values are passed for information.
@@ -59,7 +59,7 @@ public class GlobalSettings {
     @SuppressWarnings("rawtypes")
     public Action onRequest(Request request, Method actionMethod) {
         return new Action.Simple() {
-            public Result call(Context ctx) throws Throwable {
+            public Result call(Context ctx) throws Exception {
                 return delegate.call(ctx);
             }
         };
@@ -68,11 +68,11 @@ public class GlobalSettings {
     /**
     *
     * Called when an HTTP request has been received.
-    * The default implementation (return null) means to use the application router to find the appropriate action 
-    * 
-    * By overriding this method one can provide an alternative routing mechanism. 
+    * The default implementation (return null) means to use the application router to find the appropriate action
+    *
+    * By overriding this method one can provide an alternative routing mechanism.
     * Please note, though, this API is very low level, useful for plugin/module authors only.
-    * 
+    *
     * @param request the HTTP request header as seen by the core framework (the body has not been parsed yet)
     * @return an action to handle this request - if no action is returned, a 404 not found result will be sent to client
     */
@@ -83,8 +83,8 @@ public class GlobalSettings {
     /**
      * Called when no action was found to serve a request.
      *
-     * The default behavior is to render the framework's default 404 page. This is achieved by returning <code>null</code>, 
-     * so that the Scala engine handles <code>onHandlerNotFound</code>. 
+     * The default behavior is to render the framework's default 404 page. This is achieved by returning <code>null</code>,
+     * so that the Scala engine handles <code>onHandlerNotFound</code>.
      *
      * By overriding this method one can provide an alternative 404 page.
      *
@@ -94,11 +94,11 @@ public class GlobalSettings {
     public Result onHandlerNotFound(RequestHeader request) {
         return null;
     }
-    
+
     /**
      * Called when an action has been found, but the request parsing has failed.
      *
-     * The default behavior is to render the framework's default 400 page. This is achieved by returning <code>null</code>, 
+     * The default behavior is to render the framework's default 400 page. This is achieved by returning <code>null</code>,
      * so that the Scala engine handles <code>onBadRequest</code>.
      *
      * By overriding this method one can provide an alternative 400 page.
@@ -135,5 +135,5 @@ public class GlobalSettings {
     public <T extends play.api.mvc.EssentialFilter> Class<T>[] filters() {
         return new Class[0];
     }
-    
+
 }

--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -17,56 +17,56 @@ public class F {
      * A Callback with no arguments.
      */
     public static interface Callback0 {
-        public void invoke() throws Throwable;
+        public void invoke() throws Exception;
     }
 
     /**
      * A Callback with a single argument.
      */
     public static interface Callback<A> {
-        public void invoke(A a) throws Throwable;
+        public void invoke(A a) throws Exception;
     }
 
     /**
      * A Callback with 2 arguments.
      */
     public static interface Callback2<A,B> {
-        public void invoke(A a, B b) throws Throwable;
+        public void invoke(A a, B b) throws Exception;
     }
 
     /**
      * A Callback with 3 arguments.
      */
     public static interface Callback3<A,B,C> {
-        public void invoke(A a, B b, C c) throws Throwable;
+        public void invoke(A a, B b, C c) throws Exception;
     }
 
     /**
      * A Function with no arguments.
      */
     public static interface Function0<R> {
-        public R apply() throws Throwable;
+        public R apply() throws Exception;
     }
 
     /**
      * A Function with a single argument.
      */
     public static interface Function<A,R> {
-        public R apply(A a) throws Throwable;
+        public R apply(A a) throws Exception;
     }
 
     /**
      * A Function with 2 arguments.
      */
     public static interface Function2<A,B,R> {
-        public R apply(A a, B b) throws Throwable;
+        public R apply(A a, B b) throws Exception;
     }
 
     /**
      * A Function with 3 arguments.
      */
     public static interface Function3<A,B,C,R> {
-        public R apply(A a, B b, C c) throws Throwable;
+        public R apply(A a, B b, C c) throws Exception;
     }
 
     /**
@@ -131,7 +131,7 @@ public class F {
          *
          * The returned Promise is usually combined with other Promises.
          *
-         * @return a promise without a real value 
+         * @return a promise without a real value
          *
          */
         public static Promise<scala.Unit> timeout() throws TimeoutException {
@@ -226,7 +226,7 @@ public class F {
 
         /**
          * combines the current promise with <code>another</code> promise using `or`
-         * @param another 
+         * @param another
          */
         public <B> Promise<Either<A,B>> or(Promise<B> another) {
             return (new Promise(new play.api.libs.concurrent.PlayPromise(this.promise).or(another.getWrappedPromise()))).map(
@@ -250,14 +250,14 @@ public class F {
                                     return 0;
                                 } catch(RuntimeException e) {
                                     throw e;
-                                } catch(Throwable t) {
+                                } catch(Exception t) {
                                     throw new RuntimeException(t);
                                 }
                             }
                         }, a, context);
                     } catch (RuntimeException e) {
                         throw e;
-                    } catch (Throwable t) {
+                    } catch (Exception t) {
                         throw new RuntimeException(t);
                     }
                     return null;
@@ -284,7 +284,7 @@ public class F {
                             return run(function, a, context);
                         } catch (RuntimeException e) {
                             throw e;
-                        } catch(Throwable t) {
+                        } catch(Exception t) {
                             throw new RuntimeException(t);
                         }
                     }
@@ -312,7 +312,7 @@ public class F {
                             return run(function,t, context);
                         } catch (RuntimeException e) {
                             throw e;
-                        } catch(Throwable e) {
+                        } catch(Exception e) {
                             throw new RuntimeException(e);
                         }
                     }
@@ -339,7 +339,7 @@ public class F {
                             return run(function, a, context);
                         } catch (RuntimeException e) {
                             throw e;
-                        } catch(Throwable t) {
+                        } catch(Exception t) {
                             throw new RuntimeException(t);
                         }
                     }
@@ -387,8 +387,8 @@ public class F {
                 id = context.id();
             }
             return play.core.j.JavaPromise.akkaAsk(
-                            actors().get((int)(id % actors().size())), 
-                            Tuple3(f, a, context), 
+                            actors().get((int)(id % actors().size())),
+                            Tuple3(f, a, context),
                             akka.util.Timeout.apply(60000 * 60 * 1) // Let's wait 1h here. Unfortunately we can't avoid a timeout.
                    ).map(new scala.runtime.AbstractFunction1<Object,B> () {
                         public B apply(Object o) {
@@ -401,7 +401,7 @@ public class F {
                                     throw new RuntimeException(t);
                                 }
                             }
-                           
+
                             return r.right.get();
                 }
             },Invoker.executionContext());
@@ -418,7 +418,7 @@ public class F {
                 try {
                     play.mvc.Http.Context.current.set(context);
                     getSender().tell(Either.Right(f.apply(a)));
-                } catch(Throwable t) {
+                } catch(Exception t) {
                     getSender().tell(Either.Left(t));
                 } finally {
                     play.mvc.Http.Context.current.remove();
@@ -496,7 +496,7 @@ public class F {
                     return Some(function.apply(get()));
                 } catch (RuntimeException e) {
                     throw e;
-                } catch (Throwable t) {
+                } catch (Exception t) {
                     throw new RuntimeException(t);
                 }
             } else {

--- a/framework/src/play/src/main/java/play/libs/Json.java
+++ b/framework/src/play/src/main/java/play/libs/Json.java
@@ -38,7 +38,7 @@ public class Json {
 
     /**
      * Creates a new empty ObjectNode.
-     */ 
+     */
     public static ObjectNode newObject() {
         return new ObjectMapper().createObjectNode();
     }
@@ -56,7 +56,7 @@ public class Json {
     public static JsonNode parse(String src) {
         try {
             return new ObjectMapper().readValue(src, JsonNode.class);
-        } catch(Throwable t) {
+        } catch(Exception t) {
             throw new RuntimeException(t);
         }
     }

--- a/framework/src/play/src/main/java/play/mvc/Action.java
+++ b/framework/src/play/src/main/java/play/mvc/Action.java
@@ -6,25 +6,25 @@ import play.mvc.Http.*;
  * An action acts as decorator for the action method call.
  */
 public abstract class Action<T> extends Results {
-    
+
     /**
      * The action configuration - typically the annotation used to decorate the action method.
      */
     public T configuration;
-    
+
     /**
      * The wrapped action.
      */
     public Action<?> delegate;
-    
+
     /**
      * Executes this action with the give HTTP context and returns the result.
      */
-    public abstract Result call(Context ctx) throws Throwable;
-    
+    public abstract Result call(Context ctx) throws Exception;
+
     /**
      * A simple action with no configuration.
      */
     public static abstract class Simple extends Action<Void> {}
-    
+
 }

--- a/framework/src/play/src/main/java/play/mvc/Results.java
+++ b/framework/src/play/src/main/java/play/mvc/Results.java
@@ -907,7 +907,7 @@ public class Results {
                                     for(Callback0 callback: disconnectedCallbacks) {
                                         try {
                                             callback.invoke();
-                                        } catch(Throwable e) {
+                                        } catch(Exception e) {
                                             play.Logger.of("play").error("Exception is Chunks disconnected callback", e);
                                         }
                                     }
@@ -1118,7 +1118,7 @@ public class Results {
                 throw new NullPointerException("null content");
             }
             wrappedResult = status.stream(
-                    play.core.j.JavaResults.chunked(content, chunkSize), 
+                    play.core.j.JavaResults.chunked(content, chunkSize),
                     play.core.j.JavaResults.writeBytes(Scala.orNull(play.api.libs.MimeTypes.forFileName(content.getName())))
                     );
         }
@@ -1128,7 +1128,7 @@ public class Results {
                 throw new NullPointerException("null content");
             }
             wrappedResult = status.stream(
-                    play.core.j.JavaResults.chunked(content, chunkSize), 
+                    play.core.j.JavaResults.chunked(content, chunkSize),
                     play.core.j.JavaResults.writeBytes()
                     );
         }

--- a/framework/src/play/src/main/java/play/mvc/Security.java
+++ b/framework/src/play/src/main/java/play/mvc/Security.java
@@ -8,7 +8,7 @@ import java.lang.annotation.*;
  * Defines several security helpers.
  */
 public class Security {
-    
+
     /**
      * Wraps the annotated action in an <code>AuthenticatedAction</code>.
      */
@@ -18,7 +18,7 @@ public class Security {
     public @interface Authenticated {
         Class<? extends Authenticator> value() default Authenticator.class;
     }
-    
+
     /**
      * Wraps another action, allowing only authenticated HTTP requests.
      * <p>
@@ -26,7 +26,7 @@ public class Security {
      * <code>username</code> attribute.
      */
     public static class AuthenticatedAction extends Action<Authenticated> {
-        
+
         public Result call(Context ctx) {
             try {
                 Authenticator authenticator = configuration.value().newInstance();
@@ -43,18 +43,18 @@ public class Security {
                 }
             } catch(RuntimeException e) {
                 throw e;
-            } catch(Throwable t) {
+            } catch(Exception t) {
                 throw new RuntimeException(t);
             }
         }
 
     }
-    
+
     /**
      * Handles authentication.
      */
     public static class Authenticator extends Results {
-        
+
         /**
          * Retrieves the username from the HTTP context; the default is to read from the session cookie.
          *
@@ -63,15 +63,15 @@ public class Security {
         public String getUsername(Context ctx) {
             return ctx.session().get("username");
         }
-        
+
         /**
          * Generates an alternative result if the user is not authenticated; the default a simple '401 Not Authorized' page.
          */
         public Result onUnauthorized(Context ctx) {
             return unauthorized(views.html.defaultpages.unauthorized.render());
         }
-        
+
     }
-    
-    
+
+
 }

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -54,7 +54,7 @@ trait WithDefaultGlobal {
       case e: PlayException => throw e
       case e: ThreadDeath => throw e
       case e: VirtualMachineError => throw e
-      case e: Throwable => throw new PlayException(
+      case e: Exception => throw new PlayException(
         "Cannot init the Global object",
         e.getMessage,
         e
@@ -140,7 +140,7 @@ trait WithDefaultPlugins {
             case e: PlayException => throw e
             case e: VirtualMachineError => throw e
             case e: ThreadDeath => throw e
-            case e: Throwable => throw new PlayException(
+            case e: Exception => throw new PlayException(
               "Cannot load plugin",
               "Plugin [" + className + "] cannot been instantiated.",
               e)
@@ -153,7 +153,7 @@ trait WithDefaultPlugins {
         case e: PlayException => throw e
         case e: ThreadDeath => throw e
         case e: VirtualMachineError => throw e
-        case e: Throwable => throw new PlayException(
+        case e: Exception => throw new PlayException(
           "Cannot load plugin",
           "Plugin [" + className + "] cannot been instantiated.",
           e)

--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -59,7 +59,7 @@ object Configuration {
       if (currentMode == Mode.Prod) Configuration(dontAllowMissingConfig) else Configuration(loadDev(appPath, devSettings))
     } catch {
       case e: ConfigException => throw configError(e.origin, e.getMessage, Some(e))
-      case e : Throwable => throw e
+      case e : Exception => throw e
     }
   }
 

--- a/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
+++ b/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
@@ -106,11 +106,11 @@ trait GlobalSettings {
         }
       })
     } catch {
-      case e: Throwable => {
+      case e: Exception => {
         Logger.error("Error while rendering default error page", e)
         InternalServerError
       }
-    } 
+    }
   }
 
   /**

--- a/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
@@ -55,7 +55,7 @@ class JavaGlobalSettingsAdapter(val underlying: play.GlobalSettings) extends Glo
     try {
       Filters(super.doFilter(a), underlying.filters.map(_.newInstance:play.api.mvc.EssentialFilter):_*)
     } catch {
-      case e: Throwable => EssentialAction(req => play.api.libs.iteratee.Done(onError(req, e)))
+      case e: Exception => EssentialAction(req => play.api.libs.iteratee.Done(onError(req, e)))
     }
   }
 

--- a/framework/src/play/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play/src/main/scala/play/core/server/Server.scala
@@ -60,7 +60,7 @@ trait Server {
       } catch {
         case e: ThreadDeath => throw e
         case e: VirtualMachineError => throw e
-        case e: Throwable => Left(e)
+        case e: Exception => Left(e)
       }
     }
 

--- a/framework/test/integrationtest-java/test/test/GlobalTest.java
+++ b/framework/test/integrationtest-java/test/test/GlobalTest.java
@@ -14,7 +14,7 @@ public class GlobalTest {
     public void threadLocalContextShouldBeSet() {
         running(testServer(9001), HTMLUNIT, new F.Callback<TestBrowser>() {
             @Override
-            public void invoke(TestBrowser testBrowser) throws Throwable {
+            public void invoke(TestBrowser testBrowser) throws Exception {
                 testBrowser.goTo("http://localhost:9001/this/path/not/found");
                 Cookie sessionCookie = testBrowser.getCookie(Session$.MODULE$.COOKIE_NAME());
                 assertThat(sessionCookie).isNotNull();

--- a/framework/test/integrationtest/app/controllers/Interceptor.java
+++ b/framework/test/integrationtest/app/controllers/Interceptor.java
@@ -5,11 +5,11 @@ import play.mvc.Action.Simple;
 import play.mvc.Http.Context;
 
 public class Interceptor extends Simple {
-    
+
     public static String state = "";
-    
+
     @Override
-    public Result call(Context ctx) throws Throwable {
+    public Result call(Context ctx) throws Exception {
         state = "intercepted";
         return delegate.call(ctx);
     }


### PR DESCRIPTION
This PR replaces all catched or thrown `Throwable` by an `Exception`.

Since `Error` extends `Throwable`, `Throwable` should never be catched.  ("An Error is a subclass of Throwable that indicates serious problems that a reasonable application should not try to catch") @see http://docs.oracle.com/javase/7/docs/api/java/lang/Error.html.

I did not replace `Throwable` when it's used as a method parameter, even thought this usage is questionable too.
