### PR TITLE
Added ability to use Scala Durations as cache expiration periods

### DIFF
--- a/framework/src/play/src/main/scala/play/api/cache/Cached.scala
+++ b/framework/src/play/src/main/scala/play/api/cache/Cached.scala
@@ -2,10 +2,11 @@ package play.api.cache
 
 import play.api._
 import play.api.mvc._
+import scala.concurrent.duration.Duration
 import reflect.ClassTag
 
 /**
- * Cache an action.
+ * Cache an action, with duration in seconds.
  *
  * @param key Compute a key from the request header
  * @param duration Cache duration (in seconds)
@@ -46,7 +47,18 @@ object Cached {
   }
 
   /**
-   * Cache an action.
+   * Cache an action.  Use Duration.Inf for infinite cache.
+   *
+   * @param key Cache key
+   * @param duration Cache duration (as a Scala Duration, rounded to seconds)
+   * @param action Action to cache
+   */
+  def apply[A](key: String, duration: Duration)(action: Action[A])(implicit app: Application): Cached[A] = {
+    apply(key, duration = Cache.durationToExpiration(duration) )(action)
+  }
+
+  /**
+   * Cache an action.  Duration of 0 is Infinite
    *
    * @param key Cache key
    * @param duration Cache duration (in seconds)


### PR DESCRIPTION
Basically adding the ability for the Cache to take Durations, in addition to integer seconds.  Durations end up being converted to Integers.

Durations smaller than 1s are rounded up to 1s, and Duration.Inf is used for infinite cache duration.  

In Lighthouse it's https://play.lighthouseapp.com/projects/82401/tickets/980
