### PR TITLE
Applied patch to fix requirejs path escaping problem in windows. #865

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/jscompile/JavascriptCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/jscompile/JavascriptCompiler.scala
@@ -124,9 +124,8 @@ object JavascriptCompiler {
     val scope = ctx.initStandardObjects(global)
     val writer = new java.io.StringWriter()
     try {
-      val defineArguments = """arguments = ['-o', '""" + source.getAbsolutePath + "']"
-      ctx.evaluateString(scope, defineArguments, null,
-        1, null)
+      var argsArray = ctx.newArray(scope, Array[Object]("-o", source.getAbsolutePath))
+      scope.put("arguments", scope, argsArray)
       val r = ctx.evaluateReader(scope, new InputStreamReader(
         this.getClass.getClassLoader.getResource("r.js").openConnection().getInputStream()),
         "r.js", 1, null)


### PR DESCRIPTION
As stated in https://play.lighthouseapp.com/projects/82401/tickets/865-requirejs-support-broken-on-windows I created a small pull request for the provided path. Problem was fixed for me on Win 7. 
