### PR TITLE
Update documentation/manual/javaGuide/tutorials/zentasks/JavaGuide1.md

### DIFF
--- a/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide1.md
+++ b/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide1.md
@@ -46,7 +46,7 @@ Open a new command line and type:
 
     ~$ play new zentasks
 
-It will prompt you for the application full name.  Type **'Zen Tasks'**.  It will then prompt you for a template to use.  We are creating a Java application, so type **2**.
+It will prompt you for the application full name.  Type **'ZenTasks'**.  It will then prompt you for a template to use.  We are creating a Java application, so type **2**.
 
 > Whether you select Java or Scala now, you can always change it later.
 


### PR DESCRIPTION
Spaces are not allowed in Application name. Tutorial for Java incorrectly named the zentasks project 'Zen Tasks'. 
