### PR TITLE
Update documentation/manual/detailledTopics/assets/RequireJS-support.md

### DIFF
--- a/documentation/manual/detailledTopics/assets/RequireJS-support.md
+++ b/documentation/manual/detailledTopics/assets/RequireJS-support.md
@@ -62,7 +62,7 @@ After rendering the page in Dev mode you should see: ```9``` popping up in an al
 
 ## When running stage, dist or start
 
-your application's jar file should contain (```public/javascript/main.js```):
+your application's jar file should contain (```public/javascripts-min/main.js```):
 
 ```js
 define("helper/lib",[],function(){return{sum:function(e,t){return e+t}}}),require(["helper/lib"],function(e){var t=e.sum(5,4);alert(t)}),define("main",function(){})


### PR DESCRIPTION
The combined and minified main.js is in public/javascripts-min, public/javascripts contains the original file.

Maybe https://github.com/schleichardt/play-2.1-features/tree/requirejs (branch requirejs) helps to reproduce.
