### PR TITLE
Update documentation/manual/javaGuide/tutorials/zentasks/JavaGuide2.md

### DIFF
--- a/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide2.md
+++ b/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide2.md
@@ -286,7 +286,7 @@ Edit the `conf/test-data.yml` file and start to describe a User:
 ...
 ```
 
-Notice that this object is defined as part of a root object that is a list.  We can now define more objects to be a part of that, however, our dataset is a little large, so you can download a full dataset [here](javaGuide/tutorials/zentasks/files/test-data.yml).
+Notice that this object is defined as part of a root object that is a list.  We can now define more objects to be a part of that, however, our dataset is a little large, so you can download a full dataset [here](files/test-data.yml).
 
 Now we create a test case that loads this data and runs some assertions over it:
 


### PR DESCRIPTION
(documentation) Incorrect (relative) link to the test-data.yml file in the Java Zentasks tutorial. The file is needed for the subsequent test "fullTest" to pass correctly.
