### PR TITLE
Specify alternative default options for `javacOptions` for the doc axe.

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -95,6 +95,8 @@ trait PlaySettings {
 
     distExcludes := Seq.empty,
 
+    javacOptions in (Compile, doc) := List("-encoding", "utf8"),
+
     libraryDependencies <+= (playPlugin) { isPlugin =>
       val d = "play" %% "play" % play.core.PlayVersion.current
       if(isPlugin)


### PR DESCRIPTION
(these options are actually passed to `javadoc`)
