### PR TITLE
[#925] Ensured routes files with only includes still compile

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
@@ -318,14 +318,6 @@ object RoutesCompiler {
    */
   private def check(file: java.io.File, routes: List[Route]) {
 
-    if(routes.isEmpty) {
-      throw RoutesCompilationError(
-        file,
-        "Empty routes file",
-        None,
-        None)
-    }
-
     routes.foreach { route =>
 
       if (route.call.packageName.isEmpty) {
@@ -945,7 +937,7 @@ object RoutesCompiler {
         )
     }.mkString("\n") +
       """|
-         |def documentation = List(%s).foldLeft(List.empty[(String,String,String)]) { (s,e) => e match {
+         |def documentation = List(%s).foldLeft(List.empty[(String,String,String)]) { (s,e) => e.asInstanceOf[Any] match {
          |  case r @ (_,_,_) => s :+ r.asInstanceOf[(String,String,String)]
          |  case l => s ++ l.asInstanceOf[List[(String,String,String)]] 
          |}}


### PR DESCRIPTION
First of all, I removed the validation for an empty routes file, then the problem was that the compiler was inferring that the type of the list was of type `List[(String, String, String)]` when the routes file only contained includes, so pattern matching on (_, _, _) was a compile error.  So I cast it to Any (because that's what it is).

Would be nice if we could find a better way to solve merging the documentation from sub modules.
