### PR TITLE
Add views.helper.json

### DIFF
--- a/framework/src/play/src/main/scala/views/helper/package.scala
+++ b/framework/src/play/src/main/scala/views/helper/package.scala
@@ -1,5 +1,8 @@
 package views.html
 
+import play.api.libs.json.{Json, Writes}
+import play.api.templates.Html
+
 /**
  * Contains template helpers, for example for generating HTML forms.
  */
@@ -25,4 +28,19 @@ package object helper {
   def urlEncode(string: String)(implicit codec: play.api.mvc.Codec): String =
     java.net.URLEncoder.encode(string, codec.charset)
 
+  /**
+   * Generates a JavaScript value from a Scala value. This is useful when you need to generate JavaScript
+   * values in your templates:
+   *
+   * {{{
+   * @(username: String)
+   * <script>
+   *   alert(@helper.json(username));
+   * </script>
+   * }}}
+   *
+   * @param a The value to convert to JavaScript
+   * @return A JavaScript value
+   */
+  def json[A : Writes](a: A): Html = Html(Json.toJson(a).toString)
 }

--- a/framework/src/play/src/test/scala/views/helper/HelpersSpec.scala
+++ b/framework/src/play/src/test/scala/views/helper/HelpersSpec.scala
@@ -37,4 +37,26 @@ object HelpersSpec extends Specification {
       body.substring(body.indexOf(typeAttr) + typeAttr.length) must not contain(typeAttr)
     }
   }
+
+  "@json" should {
+    "Produce valid JavaScript strings" in {
+      json("foo").toString must equalTo ("\"foo\"")
+    }
+
+    "Properly escape quotes" in {
+      json("fo\"o").toString must equalTo ("\"fo\\\"o\"")
+    }
+
+    "Not escape HTML entities" in {
+      json("fo&o").toString must equalTo ("\"fo&o\"")
+    }
+
+    "Produce valid JavaScript literal objects" in {
+      json(Map("foo" -> "bar")).toString must equalTo ("{\"foo\":\"bar\"}")
+    }
+
+    "Produce valid JavaScript arrays" in {
+      json(List("foo", "bar")).toString must equalTo ("[\"foo\",\"bar\"]")
+    }
+  }
 }


### PR DESCRIPTION
Adds a `views.helper.json` function that makes it easier to generate JavaScript values.

That’s useful when your HTML templates build some JavaScript data from your template parameters.

E.g. [this line of code](https://github.com/playframework/Play20/blob/master/samples/scala/websocket-chat/app/views/chatRoom.scala.html#L60) will fail if `username` contains a quote. It could simply be replaced with:

``` javascript
if (data == @helper.json(username)) $(el).addClass('me')
```

That will properly escape literals.
