### PR TITLE
configuring actor system and dispatchers

### DIFF
--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -6,35 +6,11 @@ promise.akka.actor.typed.timeout=5s
 play {
     
     akka {
-        event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+        event-handlers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jEventHandler"]
         loglevel = WARNING
         
         actor {
-            
-            deployment {
-
-                /actions {
-                    router = round-robin
-                    nr-of-instances = 24
-                }
-
-            }
-            
             retrieveBodyParserTimeout = 1 second
-            
-            actions-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 1.0
-                    parallelism-max = 24
-                }
-            }
-
-            websockets-dispatcher = {
-                fork-join-executor {
-                    parallelism-factor = 1.0
-                    parallelism-max = 24
-                }
-            }
 
             default-dispatcher = {
                 fork-join-executor {

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -59,7 +59,7 @@ class AkkaPlugin(app: Application) extends Plugin {
 
   lazy val applicationSystem: ActorSystem = {
     applicationSystemEnabled = true
-    val system = ActorSystem("application", app.configuration.underlying, app.classloader)
+    val system = ActorSystem("application", app.configuration.underlying.getConfig("play"), app.classloader)
     Logger("play").info("Starting application default Akka system.")
     system
   }

--- a/framework/test/integrationtest/test/FunctionalSpec.scala
+++ b/framework/test/integrationtest/test/FunctionalSpec.scala
@@ -79,7 +79,7 @@ class FunctionalSpec extends Specification {
       browser.goTo("/conf")
       browser.pageSource must contain("This value comes from complex-app's complex1.conf")
       browser.pageSource must contain("override akka:2 second")
-      browser.pageSource must contain("akka-loglevel:DEBUG")
+      browser.pageSource must contain("akka-loglevel:WARNING")
       browser.pageSource must contain("promise-timeout:7000")
       browser.pageSource must contain("None")
       browser.title must beNull


### PR DESCRIPTION
The "application" actor system is now created using the config under play. I think its a right thing to do so that actor system doesn't get created with some other config in the path. 

One the bigger note I think it makes sense to have only one actor system for entire application with specific dispatcher for play vs. application code. 
