### PR TITLE
changed documentation to create custom Assets

### DIFF
--- a/documentation/manual/detailledTopics/build/SBTSubProjects.md
+++ b/documentation/manual/detailledTopics/build/SBTSubProjects.md
@@ -214,10 +214,13 @@ object Assets extends controllers.AssetsBuilder
 
 ```java
 // Assets.java
-package controllers.my;
+package controllers.admin;
+import play.api.mvc.*;
+
 public class Assets {
-//can be referenced as `controllers.my.Assets.delegate.at` in the route file
-public static controllers.AssetsBuilder delegate = new controllers.AssetsBuilder();
+  public static Action<AnyContent> at(String path, String file) {
+    return controllers.Assets.at(path, file);
+  }
 }
 ```
 


### PR DESCRIPTION
Please look at the issue http://play.lighthouseapp.com/projects/82401-play-20/tickets/1003-Routes-compiler-cant-handle-routes-file-name-that-has-more-than-6-dots for the details. 

As it stands right now if you are creating subprojects with custom assets you have to do something like following:

``` java
// Assets.java
package controllers.admin;
import play.api.mvc.*;

public class Assets {
  public static Action<AnyContent> at(String path, String file) {
    return controllers.Assets.at(path, file);
  }
}
```

The delegate approach doesn't work because RoutesCompiler will parse a.b.c.Assets.delegate.at(...) as:

package name: a.b.c.Assets
class name: delegate
method: at

And this results in compilation error. As of now I changed the doc but let me know if you guys can think of a better way to handle this issue.
