### PR TITLE
Added carriage returns (\r) to lines written to DDL file.

### DIFF
--- a/framework/src/play-java-ebean/src/main/java/play/db/ebean/EbeanPlugin.java
+++ b/framework/src/play-java-ebean/src/main/java/play/db/ebean/EbeanPlugin.java
@@ -111,15 +111,15 @@ public class EbeanPlugin extends Plugin {
         }
         
         return (
-            "# --- Created by Ebean DDL\n" +
-            "# To stop Ebean DDL generation, remove this comment and start using Evolutions\n" +
-            "\n" + 
-            "# --- !Ups\n" +
-            "\n" + 
+            "# --- Created by Ebean DDL\r\n" +
+            "# To stop Ebean DDL generation, remove this comment and start using Evolutions\r\n" +
+            "\r\n" + 
+            "# --- !Ups\r\n" +
+            "\r\n" + 
             ups +
-            "\n" + 
-            "# --- !Downs\n" +
-            "\n" +
+            "\r\n" + 
+            "# --- !Downs\r\n" +
+            "\r\n" +
             downs
         );
     }


### PR DESCRIPTION
DDL generated by Ebean uses \r\n. This patch makes Play also use \r\n so the file will have consistent line endings.
More details at https://groups.google.com/forum/#!topic/play-framework/-H0MgRPFd60

Review by @jroper
Backport to 2.0.x
