### PR TITLE
encoding unicode characters in url

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -548,6 +548,7 @@ object PlayBuild extends Build {
             specsBuild % "test",
 
             "org.mockito"                       %    "mockito-all"              %   "1.9.0"    %  "test",
+            "org.mozilla"                       %    "rhino"                    %   "1.7R4"    %  "test",
             "com.novocode"                      %    "junit-interface"          %   "0.10-M2"  %  "test",
 
             "org.fluentlenium"                  %    "fluentlenium-festassert"  %   "0.7.3"    %  "test" exclude("org.jboss.netty", "netty"),


### PR DESCRIPTION
This will allow unicode characters in the url path. Please look at the ticket: http://play.lighthouseapp.com/projects/82401/tickets/750-203-routes-cannot-handle-unicode-parameters

This will allow you have url like http://localhost:9000/hello/中文
Now the question is should we allow to have unicode characters in the routes file?
