### PR TITLE
add support for relative symbolic link to play launch script. Fixes tick...

### DIFF
--- a/play
+++ b/play
@@ -1,16 +1,22 @@
 #! /usr/bin/env sh
 
 PRG="$0"
+# resolve relative/absolute symlinks
 while [ -h "$PRG" ] ; do
-  PRG=`readlink "$PRG"`
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG="`dirname "$PRG"`/$link"
+  fi
 done
-
 dir=`dirname $PRG`
 
 if [ -z "$JAVA_HOME" ]; then
-    JAVA="java"
+  JAVA="java"
 else
-    JAVA="$JAVA_HOME/bin/java"
+ JAVA="$JAVA_HOME/bin/java"
 fi
 
 if [ -f conf/application.conf -o -f conf/reference.conf ] || [ -d project ]; then


### PR DESCRIPTION
...et #194.

Symbolic link resolution derived from Apache Maven mvn launch script (http://maven.apache.org/license.html)
