### PR TITLE
provide an option to override sbt.ivy.home

### DIFF
--- a/framework/build
+++ b/framework/build
@@ -8,4 +8,4 @@ else
   DEBUG_PARAM="-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=${JPDA_PORT}"
 fi
 
-java ${DEBUG_PARAM} -Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=384M ${JAVA_OPTS} -Dfile.encoding=UTF-8 -Dplay.version="${PLAY_VERSION}" -Dsbt.ivy.home=`dirname $0`/../repository -Dplay.home=`dirname $0` -Dsbt.boot.properties=`dirname $0`/sbt/sbt.boot.properties -jar `dirname $0`/sbt/sbt-launch.jar "$@"
+java ${DEBUG_PARAM} -Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=384M ${JAVA_OPTS} -Dfile.encoding=UTF-8 -Dplay.version="${PLAY_VERSION}" -Dplay.home=`dirname $0` -Dsbt.boot.properties=`dirname $0`/sbt/sbt.boot.properties -jar `dirname $0`/sbt/sbt-launch.jar "$@"

--- a/framework/sbt/play.boot.properties
+++ b/framework/sbt/play.boot.properties
@@ -18,5 +18,5 @@
   directory: ${play.home}/sbt/boot
  
 [ivy]
-  ivy-home: ${play.home}/../repository
+  ivy-home: ${sbt.ivy.home-${play.home}/../repository}
   

--- a/framework/sbt/sbt.boot.properties
+++ b/framework/sbt/sbt.boot.properties
@@ -19,4 +19,4 @@
   directory: ${play.home}/sbt/boot
 
 [ivy]
-  ivy-home: ${play.home}/../repository
+  ivy-home: ${sbt.ivy.home-${play.home}/../repository}

--- a/play
+++ b/play
@@ -61,5 +61,5 @@ if [ -f conf/application.conf -o -f conf/reference.conf ] || [ -d project ]; the
   fi
   
 else
-  "$JAVA" -Dsbt.ivy.home=$dir/repository -Dplay.home=$dir/framework -Dsbt.boot.properties=$dir/framework/sbt/play.boot.properties -jar $dir/framework/sbt/sbt-launch.jar "$@"
+  "$JAVA" -Dplay.home=$dir/framework -Dsbt.boot.properties=$dir/framework/sbt/play.boot.properties -jar $dir/framework/sbt/sbt-launch.jar "$@"
 fi


### PR DESCRIPTION
Problem: 
Want to override the sbt.ivy.home so that I can use same ivy home for my Play and SBT projects.  But once you hardcode the ivy-home in the sbt.boot.properties file you cannot override it any more. SBT will ignore -Dsbt.ivy.home property you pass from command line

One way to tackle this problem is to use `${sbt.ivy.home-${play.home}/../repository}`. In this case SBT will try to read the sbt.ivy.home property and if not specified use the ${play.home}../repository. This will allow developers to configure the sbt.ivy.home and default to play.home repository.
