### PR TITLE
Add a JSONP Filter

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -346,7 +346,7 @@ object PlayBuild extends Build {
             resolvers += typesafe
         )
     ).settings(com.typesafe.sbtscalariform.ScalariformPlugin.defaultScalariformSettings: _*)
-    .dependsOn(PlayProject)
+    .dependsOn(PlayProject, PlayTestProject)
 
     val Root = Project(
         "Root",

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -6,5 +6,5 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.3")
 
 addSbtPlugin( "com.typesafe.sbtscalariform" % "sbtscalariform" % "0.5.1") 
 
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.1.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.2.0")
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/Jsonp.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/Jsonp.scala
@@ -1,0 +1,47 @@
+package play.filters
+
+import play.api.mvc._
+import play.api.http.HeaderNames.CONTENT_TYPE
+import play.api.http.ContentTypes.{JSON, JAVASCRIPT}
+import concurrent.ExecutionContext
+import play.api.libs.iteratee.Enumerator
+
+/**
+ * Transforms JSON responses into JavaScript responses if there is a `paramName` parameter in the request’s query string.
+ *
+ * See [[http://www.json-p.org/]] for more information about JSONP.
+ *
+ * @param paramName Name of the query string parameter containing the callback name.
+ * @param codec Codec used to serialize the response body
+ * @param ex Execution context to use in case of asynchronous results
+ */
+class Jsonp(paramName: String = "callback")(implicit codec: Codec, ex: ExecutionContext) extends EssentialFilter {
+
+  def apply(action: EssentialAction) = EssentialAction { request =>
+    val resultProducer = action(request)
+    request.getQueryString(paramName) match {
+      case Some(callback) => resultProducer.map(jsonpify(callback))
+      case None => resultProducer
+    }
+  }
+
+  /**
+   * Tries to transform a response into a JavaScript expression.
+   * @param callback JavaScript callback name
+   * @param result Result to transform
+   */
+  def jsonpify(callback: String)(result: Result): Result = result match {
+    case result: SimpleResult[_] =>
+      result.header.headers.get(CONTENT_TYPE) match {
+        case Some(ct) if ct == JSON =>
+          SimpleResult(
+            result.header,
+            Enumerator(codec.encode(s"$callback(")) >>> result.body.map(body => result.writeable.transform(body)) >>> Enumerator(codec.encode(");"))
+          ).as(JAVASCRIPT)
+        case _ => result
+      }
+    case AsyncResult(result) => AsyncResult(result.map(jsonpify(callback)))
+    case _ => result // ChunkedResult is not supported and PlainResult have no body
+  }
+
+}

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/JsonpSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/JsonpSpec.scala
@@ -1,0 +1,60 @@
+package play.filters
+
+import org.specs2.mutable.Specification
+import play.api.mvc.{AsyncResult, Result, EssentialAction}
+import play.api.mvc.Codec.utf_8
+import play.api.mvc.Results.Ok
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import concurrent.{Future, Await}
+import concurrent.duration.Duration
+import play.api.http.MimeTypes._
+import play.api.libs.iteratee.Done
+import play.api.libs.json.Json
+
+object JsonpSpec extends Specification {
+
+  "Jsonp filter" should {
+
+    val filter = new Jsonp()(utf_8, play.api.libs.concurrent.Execution.Implicits.defaultContext)
+
+    val textAction = EssentialAction(_ => Done(Ok("foo")))
+
+    val jsonAction = EssentialAction(_ => Done(Ok(Json.obj("bar" -> "baz"))))
+
+    val asyncAction = EssentialAction(_ => Done(AsyncResult(Future.successful(Ok(Json.obj("bar" -> "baz"))))))
+
+    def run(uri: String)(action: EssentialAction): Result =
+      Await.result(filter(action)(FakeRequest("GET", uri)).run, Duration.Inf)
+
+    "leave non-JSON results untouched" in {
+      val result = run("/")(textAction)
+      contentType(result) must equalTo (Some(TEXT))
+      contentAsString(result) must equalTo ("foo")
+    }
+
+    "leave JSON results untouched if there is no callback parameter in the query string" in {
+      val result = run("/")(jsonAction)
+      contentType(result) must equalTo (Some(JSON))
+      contentAsJson(result) must equalTo (Json.obj("bar" -> "baz"))
+    }
+
+    "transform JSON results into JavaScript if there is a callback parameter in the query string" in {
+      val result = run("/?callback=foo")(jsonAction)
+      contentType(result) must equalTo (Some(JAVASCRIPT))
+      contentAsString(result) must equalTo ("""foo({"bar":"baz"});""")
+    }
+
+    "leave non-JSON results untouched even if there is a callback parameter in the query string" in {
+      val result = run("/?callback=foo")(textAction)
+      contentType(result) must equalTo (Some(TEXT))
+      contentAsString(result) must equalTo ("foo")
+    }
+
+    "support async results" in {
+      val result = run("/?callback=foo")(asyncAction)
+      contentType(result) must equalTo (Some(JAVASCRIPT))
+      contentAsString(result) must equalTo ("""foo({"bar":"baz"});""")
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds a `Jsonp` filter in the `play-filters-helpers` project. This filter transforms JSON results into JavaScript results made of the JSON result preceeded by a padding, if the request query string contains a parameter providing the padding to use.

Note: I don’t handle `ChunkedResult`, I found no way to handle them. By the way, do we really need this type? It looks like everything could be expressed using `SimpleResult`.
