### PR TITLE
fix DB.withTransaction

### DIFF
--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
@@ -12,7 +12,7 @@ import javax.sql._
 
 import com.jolbox.bonecp._
 import com.jolbox.bonecp.hooks._
-import scala.util.control.NonFatal
+import scala.util.control.{NonFatal, ControlThrowable}
 
 /**
  * The Play Database API manages several connection pools.
@@ -101,6 +101,7 @@ trait DBApi {
         connection.commit()
         r
       } catch {
+        case e: ControlThrowable => connection.commit(); throw e
         case NonFatal(e) => connection.rollback(); throw e
       }
     }


### PR DESCRIPTION
neither `commit` or `rollback` if use return in `withTransaction`

``` scala
withTransaction("default"){
  // something codes

  return foo; // throw ControlThrowable internally

} // neither commit or rollback
```

https://github.com/scala/scala/blob/v2.10.0/src/library/scala/util/control/NonFatal.scala
https://github.com/scala/scala/blob/v2.10.0/src/library/scala/util/control/ControlThrowable.scala
