### PR TITLE
Console version bumped to 2.2-SNAPSHOT

### DIFF
--- a/framework/sbt/play.boot.properties
+++ b/framework/sbt/play.boot.properties
@@ -4,7 +4,7 @@
 [app]
   org: play
   name: console
-  version: 2.1-SNAPSHOT
+  version: 2.2-SNAPSHOT
   class: play.console.Console
   cross-versioned: true
 


### PR DESCRIPTION
The requested and built version of this class is now 2.2-SNAPSHOT.
If you run play after a fresh build, it returns an error saying that version 2.1-SNAPSHOT was not found. This is true, because there's only version 2.2-SNAPSHOT.
