### PR TITLE
Updated Fluentlenium (and Selenium)

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -550,7 +550,7 @@ object PlayBuild extends Build {
             "org.mockito"                       %    "mockito-all"              %   "1.9.0"    %  "test",
             "com.novocode"                      %    "junit-interface"          %   "0.10-M2"  %  "test",
 
-            "org.fluentlenium"                  %    "fluentlenium-festassert"  %   "0.7.3"    %  "test" exclude("org.jboss.netty", "netty"),
+            "org.fluentlenium"                  %    "fluentlenium-festassert"  %   "0.7.6"    %  "test" exclude("org.jboss.netty", "netty"),
             "org.scala-lang"                    %    "scala-reflect"            %   "2.10.0"
         )
 


### PR DESCRIPTION
It's important to get the latest Selenium version because a few of the major browser already don't work anymore with 2.28.0 (currently used in Play 2.1.0).
@gissues:{"order":48.71794871794866,"status":"backlog"}
