### PR TITLE
Force initialization of routes before onStart is called

### DIFF
--- a/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
+++ b/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
@@ -172,6 +172,9 @@ class GlobalPlugin(app: Application) extends Plugin {
    * Called when the application starts.
    */
   override def onStart() {
+    // Force initialization of routes
+    // https://github.com/playframework/Play20/issues/845
+    app.routes()
     app.global.onStart(app)
   }
 


### PR DESCRIPTION
Fixes #845
@gissues:{"order":43.589743589743534,"status":"backlog"}
