### PR TITLE
Fix Scala Form documentation

### DIFF
--- a/documentation/manual/scalaGuide/main/forms/ScalaForms.md
+++ b/documentation/manual/scalaGuide/main/forms/ScalaForms.md
@@ -150,7 +150,7 @@ val userForm = Form(
         "street" -> text,
         "city" -> text
     )(Address.apply)(Address.unapply)
-  )(User.apply, User.unapply)
+  )(User.apply)(User.unapply)
 )
 ```
 
@@ -167,7 +167,7 @@ val userForm = Form(
   mapping(
     "name" -> text,
     "emails" -> list(email)
-  )(User.apply, User.unapply)
+  )(User.apply)(User.unapply)
 )
 ```
 
@@ -184,7 +184,7 @@ val userForm = Form(
   mapping(
     "name" -> text,
     "email" -> optional(email)
-  )(User.apply, User.unapply)
+  )(User.apply)(User.unapply)
 )
 ```
 
@@ -202,7 +202,7 @@ val userForm = Form(
     "id" -> ignored(1234),
     "name" -> text,
     "email" -> optional(email)
-  )(User.apply, User.unapply)
+  )(User.apply)(User.unapply)
 )
 ```
 


### PR DESCRIPTION
Parameters for the `mapping` method are wrong in some examples: (A.apply, A.unapply), instead of (A.apply)( A.unapply)
