### PR TITLE
Which scala version is used? Contradictory information reported at command line.

### DIFF
--- a/framework/src/console/src/main/scala/Console.scala
+++ b/framework/src/console/src/main/scala/Console.scala
@@ -22,10 +22,10 @@ object Console {
            ||_|            |__/
            |
            |""".stripMargin) +
-    ("play! " + play.core.PlayVersion.current +
-      " (using Java " + System.getProperty("java.version") +
-      " and Scala " + scala.util.Properties.scalaPropOrElse("version.number", "unknown") +
-      "), http://www.playframework.com")
+    ("play! " + play.core.PlayVersion.current  +
+      " built with Scala " + play.core.PlayVersion.scalaVersion +
+      " (running Java " + System.getProperty("java.version") + ")," +
+      " http://www.playframework.com")
 
   // -- Commands
 


### PR DESCRIPTION
I edited `project/Build.scala`, setting `Keys.scalaVersion := "2.10.1"` . Now when I fire up `play`, it still tells me it is `using ... Scala 2.10.0`, but then `scala-version` will report `2.10.1`. What is the meaning of this?

```
$play
[info] blahblah
       _            _
 _ __ | | __ _ _  _| |
| '_ \| |/ _' | || |_|
|  __/|_|\____|\__ (_)
|_|            |__/

play! 2.1.0 (using Java 1.6.0_43 and Scala 2.10.0), http://www.playframework.org

> Type "help play" or "license" for more information.
> Type "exit" or use Ctrl+D to leave this console.

[dev_portal] $ scala-version
[info] 2.10.1
```

@gissues:{"order":99.21875,"status":"inprogress"}
