### PR TITLE
Serializing selective attributes of a case class to a nested JSON object discards all but last selected attribute...

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsConstraints.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsConstraints.scala
@@ -189,7 +189,7 @@ trait PathWrites {
   def jsPickBranchUpdate(path: JsPath, wrs: OWrites[JsValue]): OWrites[JsValue] =
     OWrites[JsValue]{ js => 
       JsPath.createObj(
-        path -> path(js).headOption.flatMap( js => js.asOpt[JsObject].map( obj => obj ++ wrs.writes(obj) ) ).getOrElse(JsNull)
+        path -> path(js).headOption.flatMap( js => js.asOpt[JsObject].map( obj => obj.deepMerge(wrs.writes(obj)) ) ).getOrElse(JsNull)
       )
     }
 

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
@@ -44,7 +44,7 @@ object OWrites extends PathWrites with ConstraintWrites {
 
   implicit val functionalCanBuildOWrites:FunctionalCanBuild[OWrites] = new FunctionalCanBuild[OWrites] {
 
-    def apply[A,B](wa: OWrites[A], wb: OWrites[B]):OWrites[A~B] = OWrites[A~B]{ case a ~ b => wa.writes(a) ++ wb.writes(b)}
+    def apply[A,B](wa: OWrites[A], wb: OWrites[B]):OWrites[A~B] = OWrites[A~B]{ case a ~ b => wa.writes(a).deepMerge(wb.writes(b)) }
 
   }
 

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -241,6 +241,27 @@ object JsonSpec extends Specification {
         )
       )
     }
+
+    "write in 2nd level" in {
+      case class TestCase(id: String, attr1: String, attr2: String)
+
+      val js = Json.obj(
+        "id" -> "my-id",
+        "data" -> Json.obj(
+          "attr1" -> "foo",
+          "attr2" -> "bar"
+        )
+      )
+
+      implicit val testCaseWrites: Writes[TestCase] = (
+        (__ \ "id").write[String] and
+        (__ \ "data" \ "attr1").write[String] and
+        (__ \ "data" \ "attr2").write[String]
+      )(unlift(TestCase.unapply))
+
+      Json.toJson(TestCase("my-id", "foo", "bar")) must beEqualTo(js)
+
+    }    
   }
 
 


### PR DESCRIPTION
If you want to "unflatten" a case class to a JSON object by putting certain attributes within their own nested object, only the last attribute will be written. For example:

```
case class TestCase(id: String, attr1: String, attr2: String)
```

_should_ serialize to:

```
{
   "id": "my-id",
   "data": {
      "attr1": "hello",
      "attr2": "world"
   }
}
```

The obvious way to do this would be with a Writes (or Format) that looks like:

```
implicit val testCaseWrites: Writes[TestCase] = (
  (__ \ "id").write[String] and
  (__ \ "data" \ "attr1").write[String] and
  (__ \ "data" \ "attr2").write[String]
)(unlift(TestCase.unapply))
```

However this does not work "correctly", since only "attr2" will end up in the serialized JSON:

```
{
  "id" : "id-1",
  "data" : {
    "attr2":"world"
  }
}
```

Note that doing an equivalent `Reads[TestCase]` object works correctly, so I think this is definitely unexpected behaviour.
@gissues:{"order":97.43589743589743,"status":"backlog"}
