### PR TITLE
Fix the Javascript Reverse router. Problem with default values.

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
@@ -596,7 +596,7 @@ object RoutesCompiler {
                             queryParams.map { p =>
                               ("(\"\"\" + implicitly[QueryStringBindable[" + p.typeName + "]].javascriptUnbind + \"\"\")" + """("""" + p.name + """", """ + localNames.get(p.name).getOrElse(p.name) + """)""") -> p
                             }.map {
-                              case (u, Parameter(name, typeName, None, Some(default))) => """(""" + localNames.get(name).getOrElse(name) + " == null ? \"\"\" +  implicitly[JavascriptLitteral[" + typeName + "]].to(" + default + ") + \"\"\" : " + u + ")"
+                              case (u, Parameter(name, typeName, None, Some(default))) => """(""" + localNames.get(name).getOrElse(name) + " == null ? null : " + u + ")"
                               case (u, Parameter(name, typeName, None, None)) => u
                             }.mkString(", "))
 


### PR DESCRIPTION
The code generated in the Javascript reverse router in wrong for arguments with a default value.

Try:

```
GET  /       controllers.Application.index(limit: Int =? 10)
```

And try Js reverse router for this call:

``` javascript
Router.controllers.Application.index()
```

It gives

```
/?10
```

Because anyway the default values are fixed server side, the client doesn't need to repeat the value. The simplest fix is to omit completely non-specified arguments that have a default value server side. 
