### PR TITLE
Support for F.Option in Java form bindings

### DIFF
--- a/framework/src/play-java/src/test/scala/play/data/AnotherUser.java
+++ b/framework/src/play-java/src/test/scala/play/data/AnotherUser.java
@@ -1,22 +1,32 @@
 package play.data;
 
 import java.util.*;
+import play.libs.F;
 
 public class AnotherUser {
 
-	private String name;
+    private String name;
     private List<String> emails = new ArrayList<String>();
+    private F.Option<String> company = new F.None();
 
     public void setName(String name) {
-    	this.name = name;
+        this.name = name;
     }
 
     public String getName() {
-    	return name;
+        return name;
+    }
+
+    public void setCompany(F.Option<String> company) {
+        this.company = company;
+    }
+
+    public F.Option<String> getCompany() {
+        return this.company;
     }
 
     public List<String> getEmails() {
-    	return emails;
+        return emails;
     }
 
 }

--- a/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
@@ -245,7 +245,7 @@ object FormSpec extends Specification {
     user1.getName must beEqualTo("Kiki")
     user1.getEmails.size must beEqualTo(0)
 
-    val user2 = JForm.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki"), "emails[0]" -> Array("kiki@gmail.com")) )).get
+    val user2 = JForm.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki"), "emails[0]" -> Array("kiki@gmail.com")))).get
     user2.getName must beEqualTo("Kiki")
     user2.getEmails.size must beEqualTo(1)
 
@@ -261,6 +261,14 @@ object FormSpec extends Specification {
     user5.getName must beEqualTo("Kiki")
     user5.getEmails.size must beEqualTo(2)
 
+  }
+
+  "support option deserialization" in {
+    val user1 = JForm.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki")))).get
+    user1.getCompany.isDefined must beEqualTo(false)
+
+    val user2 = JForm.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki"), "company" -> Array("Acme")))).get
+    user2.getCompany.get must beEqualTo("Acme")
   }
 
   "render a form with max 18 fields" in {
@@ -296,7 +304,7 @@ object FormSpec extends Specification {
     val data = Map("date" -> "30/1/2012")
     dateForm.bind(data).get mustEqual(new DateTime(2012,1,30,0,0))
   }
-  
+
   "render form using jodaLocalDate with format(30/1/2012)" in {
     import play.api.data._
     import play.api.data.Forms._

--- a/framework/src/play-java/src/test/scala/play/data/MyUser.java
+++ b/framework/src/play-java/src/test/scala/play/data/MyUser.java
@@ -1,5 +1,7 @@
 package play.data;
 
+import play.libs.F.Option;
+
 public class MyUser {
     public String email;
     public String password;

--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -1,6 +1,7 @@
 package play.libs;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Iterator;
@@ -446,7 +447,7 @@ public class F {
     /**
      * Represents optional values. Instances of <code>Option</code> are either an instance of <code>Some</code> or the object <code>None</code>.
      */
-    public static abstract class Option<T> implements Iterable<T> {
+    public static abstract class Option<T> implements Collection<T> {
 
         /**
          * Is the value of this option defined?
@@ -454,6 +455,11 @@ public class F {
          * @return <code>true</code> if the value is defined, otherwise <code>false</code>.
          */
         public abstract boolean isDefined();
+
+        @Override
+        public boolean isEmpty() {
+            return !isDefined();
+        }
 
         /**
          * Returns the value if defined.
@@ -518,6 +524,36 @@ public class F {
             }
         }
 
+        @Override
+        public void clear() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean retainAll(Collection<?> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean add(Object o) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean removeAll(Collection<?> c) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean addAll(Collection<? extends T> c) {
+            throw new UnsupportedOperationException();
+        }
+
     }
 
     /**
@@ -550,6 +586,11 @@ public class F {
         }
 
         @Override
+        public int size() {
+            return 0;
+        }
+
+        @Override
         public T get() {
             throw new IllegalStateException("No value");
         }
@@ -559,9 +600,30 @@ public class F {
         }
 
         @Override
+        public boolean contains(Object o) {
+            return false;
+        }
+
+        @Override
+        public boolean containsAll(Collection<?> c) {
+            return c.size() == 0;
+        }
+
+        @Override
+        public T[] toArray() {
+            return (T[])(new Object[0]);
+        }
+
+        @Override
+        public <R> R[] toArray(R[] r) {
+            return (R[])(new Object[0]);
+        }
+
+        @Override
         public String toString() {
             return "None";
         }
+
     }
 
     /**
@@ -581,12 +643,41 @@ public class F {
         }
 
         @Override
+        public int size() {
+            return 1;
+        }
+
+        @Override
         public T get() {
             return value;
         }
 
         public Iterator<T> iterator() {
             return Collections.singletonList(value).iterator();
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            return o != null && o.equals(value);
+        }
+
+        @Override
+        public boolean containsAll(Collection<?> c) {
+            return (c.size() == 1) && (c.toArray()[0].equals(value));
+        }
+
+        @Override
+        public T[] toArray() {
+            T[] result = (T[])new Object[1];
+            result[0] = value;
+            return result;
+        }
+
+        @Override
+        public <R> R[] toArray(R[] r) {
+            Object[] result = new Object[1];
+            result[0] = value;
+            return (R[])result;
         }
 
         @Override


### PR DESCRIPTION
Note that it was necessary to have Option implement Collection, otherwise TypeDescriptor.getElementTypeDescriptor() wouldn't work.

Collection is a super-interface of Iterable so Option still implements it.
