### PR TITLE
Added HTTP pipelining support

### DIFF
--- a/framework/src/play/src/main/java/play/core/server/netty/HttpPipeliningChannel.java
+++ b/framework/src/play/src/main/java/play/core/server/netty/HttpPipeliningChannel.java
@@ -1,0 +1,278 @@
+package play.core.server.netty;
+
+import org.jboss.netty.channel.*;
+
+import java.net.SocketAddress;
+import java.util.concurrent.Callable;
+
+/**
+ * Delegates operations to the underlying channel, but only when the channel is allowed to do those operations.
+ *
+ * Some operations are not supported.
+ */
+class HttpPipeliningChannel implements Channel {
+
+    private final Channel delegate;
+    private final ChannelFuture future;
+    private Object attachment;
+    private boolean allowReading = true;
+    private boolean allowWriting = true;
+
+    HttpPipeliningChannel(Channel delegate) {
+        this(delegate, false);
+    }
+
+    HttpPipeliningChannel(Channel delegate, boolean proceed) {
+        this.delegate = delegate;
+        if (proceed) {
+            this.future = new SucceededChannelFuture(this);
+        } else {
+            this.future = new DefaultChannelFuture(this, false);
+        }
+    }
+
+    /**
+     * The channel must stop reading, since there is another request in the pipeline.
+     *
+     * After this is called, any call to register interest or not in reading will fail.
+     */
+    public void stopReading() {
+        allowReading = false;
+    }
+
+    /**
+     * The channel must stop writing, since it's the next request in the pipelines turn to write.
+     *
+     * After this is called, all write operations will fail.
+     */
+    public void stopWriting() {
+        allowWriting = false;
+    }
+
+    /**
+     * The chanel is allowed to start writing.  Any queued up futures will be made successful.
+     */
+    public void startWriting() {
+        future.setSuccess();
+    }
+
+    /**
+     * The channel has been cancelled.
+     */
+    public void cancel() {
+        future.cancel();
+    }
+
+    /**
+     * The channel has failed.  This will be called if the previous pipelined response has failed.
+     */
+    public void fail(Throwable cause) {
+        future.setFailure(cause);
+    }
+
+    @Override
+    public Integer getId() {
+        return delegate.getId();
+    }
+
+    @Override
+    public ChannelFactory getFactory() {
+        return delegate.getFactory();
+    }
+
+    @Override
+    public Channel getParent() {
+        return delegate.getParent();
+    }
+
+    @Override
+    public ChannelConfig getConfig() {
+        return delegate.getConfig();
+    }
+
+    @Override
+    public ChannelPipeline getPipeline() {
+        return delegate.getPipeline();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return delegate.isOpen();
+    }
+
+    @Override
+    public boolean isBound() {
+        return delegate.isBound();
+    }
+
+    @Override
+    public boolean isConnected() {
+        return delegate.isConnected();
+    }
+
+    @Override
+    public SocketAddress getLocalAddress() {
+        return delegate.getLocalAddress();
+    }
+
+    @Override
+    public SocketAddress getRemoteAddress() {
+        return delegate.getRemoteAddress();
+    }
+
+    @Override
+    public ChannelFuture write(final Object message) {
+        if (allowWriting) {
+            // Small optimisation
+            if (future.isSuccess()) {
+                return delegate.write(message);
+            } else {
+                return chainFutureTo(new Callable<ChannelFuture>() {
+                    @Override
+                    public ChannelFuture call() throws Exception {
+                        return delegate.write(message);
+                    }
+                });
+            }
+        } else {
+            return new FailedChannelFuture(this, new IllegalStateException("Not allowed to write to pipelined channel after response is finished."));
+        }
+    }
+
+    @Override
+    public ChannelFuture write(final Object message, final SocketAddress remoteAddress) {
+        return new FailedChannelFuture(this, new UnsupportedOperationException("Cannot write to an address on a pipelined channel."));
+    }
+
+    @Override
+    public ChannelFuture bind(final SocketAddress localAddress) {
+        return new FailedChannelFuture(this, new UnsupportedOperationException("Cannot bind a pipelined channel."));
+    }
+
+    @Override
+    public ChannelFuture connect(final SocketAddress remoteAddress) {
+        return new FailedChannelFuture(this, new UnsupportedOperationException("Cannot connect a pipelined channel."));
+    }
+
+    @Override
+    public ChannelFuture disconnect() {
+        return chainFutureTo(new Callable<ChannelFuture>() {
+            @Override
+            public ChannelFuture call() throws Exception {
+                return delegate.disconnect();
+            }
+        });
+    }
+
+    @Override
+    public ChannelFuture unbind() {
+        return new FailedChannelFuture(this, new UnsupportedOperationException("Cannot unbind a pipelined channel"));
+    }
+
+    @Override
+    public ChannelFuture close() {
+        if (future.isSuccess()) {
+            return delegate.close();
+        } else {
+            return chainFutureTo(new Callable<ChannelFuture>() {
+                @Override
+                public ChannelFuture call() throws Exception {
+                    return delegate.close();
+                }
+            });
+        }
+    }
+
+    @Override
+    public ChannelFuture getCloseFuture() {
+        if (future.isSuccess()) {
+            return delegate.getCloseFuture();
+        } else {
+            return chainFutureTo(new Callable<ChannelFuture>() {
+                @Override
+                public ChannelFuture call() throws Exception {
+                    return delegate.getCloseFuture();
+                }
+            });
+        }
+    }
+
+    @Override
+    public int getInterestOps() {
+        return delegate.getInterestOps();
+    }
+
+    @Override
+    public boolean isReadable() {
+        return allowReading && delegate.isReadable();
+    }
+
+    @Override
+    public boolean isWritable() {
+        return allowWriting && future.isDone() && delegate.isWritable();
+    }
+
+    @Override
+    public ChannelFuture setInterestOps(final int interestOps) {
+        if (allowReading) {
+            return delegate.setInterestOps(interestOps);
+        } else {
+            return new FailedChannelFuture(this, new IllegalStateException("Cannot set interested ops on a pipelined channel once the request is finished"));
+        }
+    }
+
+    @Override
+    public ChannelFuture setReadable(final boolean readable) {
+        if (allowReading) {
+            return delegate.setReadable(readable);
+        } else {
+            return new FailedChannelFuture(this, new IllegalStateException("Cannot read from a pipelined channel once the current request has finished"));
+        }
+    }
+
+    @Override
+    public Object getAttachment() {
+        return attachment;
+    }
+
+    @Override
+    public void setAttachment(Object attachment) {
+        this.attachment = attachment;
+    }
+
+    @Override
+    public int compareTo(Channel channel) {
+        return delegate.compareTo(channel);
+    }
+
+    /**
+     * Basically makes the ChannelFuture a monad of sorts.
+     */
+    private ChannelFuture chainFutureTo(final Callable<ChannelFuture> op) {
+        final ChannelFuture chained = new DefaultChannelFuture(this, true);
+        future.addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) throws Exception {
+                if (future.isCancelled()) {
+                    chained.cancel();
+                } else if (future.isSuccess()) {
+                    op.call().addListener(new ChannelFutureListener() {
+                        @Override
+                        public void operationComplete(ChannelFuture future) throws Exception {
+                            if (future.isSuccess()) {
+                                chained.setSuccess();
+                            } else if (future.isCancelled()) {
+                                chained.cancel();
+                            } else {
+                                chained.setFailure(future.getCause());
+                            }
+                        }
+                    });
+                } else {
+                    chained.setFailure(future.getCause());
+                }
+            }
+        });
+        return chained;
+    }
+}

--- a/framework/src/play/src/main/java/play/core/server/netty/HttpPipeliningHandler.java
+++ b/framework/src/play/src/main/java/play/core/server/netty/HttpPipeliningHandler.java
@@ -1,0 +1,136 @@
+package play.core.server.netty;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.channel.*;
+import org.jboss.netty.handler.codec.http.*;
+
+import java.util.LinkedList;
+
+/**
+ * Implements HTTP pipelining ordering, ensuring that responses are completely served in the same order as their
+ * corresponding requests.
+ *
+ * @author James Roper
+ */
+public class HttpPipeliningHandler implements ChannelUpstreamHandler, ChannelDownstreamHandler {
+
+    // The queue of pipelined channels
+    private final LinkedList<HttpPipeliningChannel> channelQueue = new LinkedList<HttpPipeliningChannel>();
+
+    // These two variables are used to store data about the response currently being sent.
+    // Remaining content is -1 if there was no Content-Length header
+    private long remainingContentLength = -1;
+    private boolean isChunked;
+
+    @Override
+    public void handleDownstream(ChannelHandlerContext ctx, ChannelEvent e) throws Exception {
+        if (e instanceof MessageEvent) {
+            MessageEvent msgEvent = (MessageEvent) e;
+            Object message = msgEvent.getMessage();
+            if (message instanceof HttpResponse) {
+                // It's an http response, setup the
+                HttpResponse response = (HttpResponse) message;
+                if (response.getStatus() == HttpResponseStatus.NO_CONTENT || response.getStatus() == HttpResponseStatus.NOT_MODIFIED) {
+                    remainingContentLength = 0;
+                } else {
+                    remainingContentLength = HttpHeaders.getContentLength(response, -1);
+                }
+                // If a content length was specified, the Netty HTTP encoder ignores is chunked
+                isChunked = remainingContentLength == -1 && response.isChunked();
+                if (!isChunked) {
+                    observeContent(response.getContent(), e.getFuture());
+                }
+            } else if (message instanceof HttpChunk) {
+                HttpChunk chunk = (HttpChunk) message;
+                if (isChunked) {
+                    // If the response is actually chunked, then we just need to pop the channel queue on the last chunk
+                    if (chunk.isLast()) {
+                        popChannelQueue(e.getFuture());
+                    }
+                } else {
+                    // Otherwise just look at the content
+                    observeContent(chunk.getContent(), e.getFuture());
+                }
+            } else if (message instanceof ChannelBuffer) {
+                observeContent((ChannelBuffer) message, e.getFuture());
+            }
+        }
+        ctx.sendDownstream(e);
+    }
+
+    /**
+     * Decrements remainingContentLength by the content length in the buffer, and when 0 is reached, pops the channel
+     * off the queue
+     */
+    private void observeContent(ChannelBuffer buffer, ChannelFuture future) {
+        if (remainingContentLength >= 0) {
+            remainingContentLength -= buffer.readableBytes();
+            if (remainingContentLength <= 0) {
+                popChannelQueue(future);
+                remainingContentLength = -1;
+            }
+        }
+    }
+
+    /**
+     * Pop the channel off the queue, once the current operation is complete.  If there is another channel on the queue,
+     * tell it to proceed.
+     */
+    private void popChannelQueue(ChannelFuture future) {
+        future.addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) throws Exception {
+                HttpPipeliningChannel next;
+                synchronized (channelQueue) {
+                    channelQueue.pop().stopWriting();
+                    next = channelQueue.peek();
+                }
+                if (future.isCancelled()) {
+                    next.cancel();
+                } else if (future.isSuccess()) {
+                    next.startWriting();
+                } else {
+                    next.fail(new RuntimeException("Previous request in pipeline failed", future.getCause()));
+                }
+            }
+        });
+    }
+
+    @Override
+    public void handleUpstream(ChannelHandlerContext ctx, ChannelEvent e) throws Exception {
+        // A message has come from upstream (ie, part of a request)
+        if (e instanceof MessageEvent) {
+            MessageEvent msgEvent = (MessageEvent) e;
+            Object msg = msgEvent.getMessage();
+            if (msg instanceof HttpRequest) {
+                synchronized (channelQueue) {
+                    if (channelQueue.size() > 0) {
+                        // This request is pipelined behind another.
+                        channelQueue.getLast().stopReading();
+                        channelQueue.add(new HttpPipeliningChannel(e.getChannel()));
+                    } else {
+                        // No pipelining, so tell the channel to proceed immediately
+                        channelQueue.add(new HttpPipeliningChannel(e.getChannel(), true));
+                    }
+                }
+            }
+            ctx.sendUpstream(new UpstreamMessageEvent(channelQueue.getLast(), msg, msgEvent.getRemoteAddress()));
+        } else if (e instanceof ChannelStateEvent) {
+            ChannelStateEvent event = (ChannelStateEvent) e;
+            if (event.getState() == ChannelState.OPEN && event.getValue() == Boolean.FALSE) {
+                // The channel is closed.  Send upstream, and for each pipelining channel in the queue we need to tell
+                // them to proceed so they can fail if necessary.
+                // But pop the first one cos it should already have proceeded.
+                if (!channelQueue.isEmpty()) {
+                    channelQueue.pop();
+                }
+                for (HttpPipeliningChannel channel : channelQueue) {
+                    channel.startWriting();
+                }
+            }
+            ctx.sendUpstream(e);
+        } else {
+            ctx.sendUpstream(e);
+        }
+    }
+}

--- a/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
@@ -53,6 +53,7 @@ class NettyServer(appProvider: ApplicationProvider, port: Int, sslPort: Option[I
       }
       newPipeline.addLast("decoder", new HttpRequestDecoder(4096, 8192, 8192))
       newPipeline.addLast("encoder", new HttpResponseEncoder())
+      newPipeline.addLast("pipelining", new HttpPipeliningHandler())
       newPipeline.addLast("decompressor", new HttpContentDecompressor())
       newPipeline.addLast("handler", defaultUpStreamHandler)
       newPipeline


### PR DESCRIPTION
Netty does not, out of the box support HTTP pipelining.  This adds
support for it, by holding off any writes by a pipelined request until
all requests before it have finished writing their responses.

It is written in Java because it will be contributed to Netty, in the
mean time it can live in Play.
@gissues:{"order":87.5,"status":"inprogress"}
