### PR TITLE
Uploading files bigger than 2GB does not work 

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -59,7 +59,7 @@ object Dependencies {
     specsBuild % "test")
 
   val runtime = Seq(
-    "io.netty" % "netty" % "3.5.9.Final",
+    "io.netty" % "netty" % "3.6.3.Final",
 
     "org.slf4j" % "slf4j-api" % "1.6.6",
     "org.slf4j" % "jul-to-slf4j" % "1.6.6",

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -61,8 +61,8 @@ object ResultsSpec extends Specification {
       setCookies("session").maxAge must beNone
       setCookies("preferences").value must be_==("blue")
       setCookies("lang").value must be_==("fr")
-      // Should be beSome(-1) once https://github.com/netty/netty/issues/712 is fixed
-      setCookies("logged").maxAge must beSome(0)
+      setCookies("logged").maxAge must beSome
+      setCookies("logged").maxAge.get must be_<=(1)
     }
 
 
@@ -99,8 +99,8 @@ object ResultsSpec extends Specification {
       setCookies("session").value must be_==("items2")
       setCookies("preferences").value must be_==("blue")
       setCookies("lang").value must be_==("fr")
-      // Should be beSome(-1) once https://github.com/netty/netty/issues/712 is fixed
-      setCookies("logged").maxAge must beSome(0)
+      setCookies("logged").maxAge must beSome
+      setCookies("logged").maxAge.get must be_<=(1)
       val playSession = Session.decodeFromCookie(setCookies.get(Session.COOKIE_NAME))
       playSession.data.size must be_==(2)
       playSession.data must havePair("user" -> "kiki")


### PR DESCRIPTION
According to James Roper, this seems to be a bug in Netty which is already fixed in Netty 3.6.1:
https://github.com/netty/netty/issues/845

Please see this mailing list thread for a detailed description of the error that occurs when trying to upload files bigger than 2GB:
https://groups.google.com/forum/?hl=de&fromgroups=#!topic/play-framework/bNNxZyoobwU

To reproduce this issue, I put a simple Play 2.1 file upload application on Github:
https://github.com/heiflo/play21-file-upload-streaming
Just upload a 2GB (or bigger) file and the upload will fail.

@gissues:{"order":75,"status":"notstarted"}
