### PR TITLE
anorm.Pk case is not handled by anyParameter method

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/Anorm.scala
+++ b/framework/src/anorm/src/main/scala/anorm/Anorm.scala
@@ -330,6 +330,8 @@ object ToStatement {
         case None => stmt.setObject(index, null)
         case bd: java.math.BigDecimal => stmt.setBigDecimal(index, bd)
         case date: java.util.Date => stmt.setTimestamp(index, new java.sql.Timestamp(date.getTime()))
+        case Id(id) => stmt.setObject(index, id)
+        case NotAssigned => stmt.setObject(index, null)
         case o => stmt.setObject(index, o)
       }
       stmt


### PR DESCRIPTION
Hi,

I'm sending a pull request that fixes a little bug that happens when you want to pass a Pk object (stored as Any) as parameter to an SQL query:

val id : Any = Id(5)
SQL("SELECT \* FROM cities WHERE id = {id}").on('id -> id)

This doesn't work properly because when the parameter is of type Any, it goes through the [anyParameter](https://github.com/playframework/Play20/blob/master/framework/src/anorm/src/main/scala/anorm/Anorm.scala#L325) method which does not handle anorm.Pk objects. When the parameter is of type Pk then it's fine cause it's handled by [pkToStatement](https://github.com/playframework/Play20/blob/master/framework/src/anorm/src/main/scala/anorm/Anorm.scala#L355).

*_Note: *_ This is my first pull request so I'm not sure if I have followed all the guidelines. The code compiles & doesn't seem to be breaking any of the tests.

Thanks!
