### PR TITLE
Documentation Error in ScalaActionsComposition

### DIFF
--- a/documentation/manual/scalaGuide/main/http/ScalaActionsComposition.md
+++ b/documentation/manual/scalaGuide/main/http/ScalaActionsComposition.md
@@ -236,7 +236,7 @@ def Authenticated[A](p: BodyParser[A])(f: AuthenticatedRequest[A] => Result) = {
     val result = for {
       id <- request.session.get("user")
       user <- User.find(id)
-    } yield f(Authenticated(user, request))
+    } yield f(AuthenticatedRequest(user, request))
     result getOrElse Unauthorized
   }
 }


### PR DESCRIPTION
Fix to the last example in Action Composition (Scala).

It references Authenticated while it's supposed to reference AuthenticatedRequest
