### PR TITLE
Sending a request to Play application throws "NoClassDefFoundError: com/google/common/base/Function" error

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -6,12 +6,15 @@ object Dependencies {
   val specsBuild = "org.specs2" %% "specs2" % "1.14"
   val scalaIoFileBuild = "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.2"
   val scalaIoFileSbt = "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.1" exclude ("javax.transaction", "jta")
+  val guava = "com.google.guava" % "guava" % "13.0.1"
 
 
   val jdbcDeps = Seq(
-    ("com.jolbox" % "bonecp" % "0.7.1.RELEASE" notTransitive ())
-      .exclude("com.google.guava", "guava")
-      .exclude("org.slf4j", "slf4j-api"),
+    "com.jolbox" % "bonecp" % "0.7.1.RELEASE" exclude ("com.google.guava", "guava"),
+
+    // bonecp needs it, but due to guavas stupid version numbering of older versions ("r08"), we need to explicitly
+    // declare a dependency on the newer version so that ivy can know which one to include
+    guava,
 
     "com.h2database" % "h2" % "1.3.168",
 
@@ -50,7 +53,7 @@ object Dependencies {
       .exclude("com.google.guava", "guava")
       .exclude("javassist", "javassist"),
 
-    "com.google.guava" % "guava" % "13.0.1",
+    guava,
 
     "com.google.code.findbugs" % "jsr305" % "2.0.1",
 


### PR DESCRIPTION
This is an application that was previously working from an earlier pull of Play2 code.

Went into the directory for the application, issued "play clean", "play compile", then "play run"

Until this point - all goes well.  When I point my browser to localhost:9000, I get the following error thrown;

NoClassDefFoundError: com/google/common/base/Function
No source available, here is the exception stack trace:
->java.lang.NoClassDefFoundError: com/google/common/base/Function
     play.api.db.BoneCPApi.play$api$db$BoneCPApi$$createDataSource(DB.scala:291)
     play.api.db.BoneCPApi$$anonfun$6.apply(DB.scala:407)
     play.api.db.BoneCPApi$$anonfun$6.apply(DB.scala:402)
     scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
     scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
     scala.collection.immutable.Set$Set1.foreach(Set.scala:74)
     scala.collection.TraversableLike$class.map(TraversableLike.scala:244)
     scala.collection.AbstractSet.scala$collection$SetLike$$super$map(Set.scala:47)
     scala.collection.SetLike$class.map(SetLike.scala:93)
     scala.collection.AbstractSet.map(Set.scala:47)
     play.api.db.BoneCPApi.<init>(DB.scala:402)
     play.api.db.BoneCPPlugin.play$api$db$BoneCPPlugin$$dbApi$lzycompute(DB.scala:214)
     play.api.db.BoneCPPlugin.play$api$db$BoneCPPlugin$$dbApi(DB.scala:214)
     play.api.db.BoneCPPlugin.onStart(DB.scala:242)
     play.api.Play$$anonfun$start$1$$anonfun$apply$mcV$sp$1.apply(Play.scala:63)
     play.api.Play$$anonfun$start$1$$anonfun$apply$mcV$sp$1.apply(Play.scala:63)
     scala.collection.immutable.List.foreach(List.scala:309)
     play.api.Play$$anonfun$start$1.apply$mcV$sp(Play.scala:63)
     play.api.Play$$anonfun$start$1.apply(Play.scala:63)
     play.api.Play$$anonfun$start$1.apply(Play.scala:63)
     play.utils.Threads$.withContextClassLoader(Threads.scala:18)
     play.api.Play$.start(Play.scala:62)
     play.core.ReloadableApplication$$anonfun$get$1$$anonfun$1.apply(ApplicationProvider.scala:133)
     play.core.ReloadableApplication$$anonfun$get$1$$anonfun$1.apply(ApplicationProvider.scala:106)
     scala.Option.map(Option.scala:145)
     play.core.ReloadableApplication$$anonfun$get$1.apply(ApplicationProvider.scala:106)
     play.core.ReloadableApplication$$anonfun$get$1.apply(ApplicationProvider.scala:104)
     scala.util.Either$RightProjection.flatMap(Either.scala:523)
     play.core.ReloadableApplication.get(ApplicationProvider.scala:104)
     play.core.server.Server$class.sendHandler$1(Server.scala:56)
     play.core.server.Server$$anonfun$getHandlerFor$4.apply(Server.scala:88)
     play.core.server.Server$$anonfun$getHandlerFor$4.apply(Server.scala:87)
     scala.util.Either$RightProjection.flatMap(Either.scala:523)
     play.core.server.Server$class.getHandlerFor(Server.scala:87)
     play.core.server.NettyServer.getHandlerFor(NettyServer.scala:34)
     play.core.server.netty.PlayDefaultUpstreamHandler$$anonfun$6.apply(PlayDefaultUpstreamHandler.scala:115)
     play.core.server.netty.PlayDefaultUpstreamHandler$$anonfun$6.apply(PlayDefaultUpstreamHandler.scala:115)
     scala.util.Either.fold(Either.scala:98)
     play.core.server.netty.PlayDefaultUpstreamHandler.messageReceived(PlayDefaultUpstreamHandler.scala:109)
     org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:70)
     org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:560)
     org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:787)
     org.jboss.netty.handler.codec.http.HttpContentDecoder.messageReceived(HttpContentDecoder.java:108)
     org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:70)
     org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:560)
     org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:787)
     org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:296)
     org.jboss.netty.handler.codec.frame.FrameDecoder.unfoldAndFireMessageReceived(FrameDecoder.java:459)
     org.jboss.netty.handler.codec.replay.ReplayingDecoder.callDecode(ReplayingDecoder.java:536)
     org.jboss.netty.handler.codec.replay.ReplayingDecoder.messageReceived(ReplayingDecoder.java:435)
     org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:70)
     org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:560)
     org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:555)
     org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:268)
     org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:255)
     org.jboss.netty.channel.socket.nio.NioWorker.read(NioWorker.java:88)
     org.jboss.netty.channel.socket.nio.AbstractNioWorker.process(AbstractNioWorker.java:107)
     org.jboss.netty.channel.socket.nio.AbstractNioSelector.run(AbstractNioSelector.java:312)
     org.jboss.netty.channel.socket.nio.AbstractNioWorker.run(AbstractNioWorker.java:88)
     org.jboss.netty.channel.socket.nio.NioWorker.run(NioWorker.java:178)
     org.jboss.netty.util.ThreadRenamingRunnable.run(ThreadRenamingRunnable.java:108)
     org.jboss.netty.util.internal.DeadLockProofWorker$1.run(DeadLockProofWorker.java:42)
     java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
     java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
     java.lang.Thread.run(Thread.java:722)

There are no external plugins used - everything is used that comes with Play.
