### PR TITLE
Call #asJava recursively in play.api.Configuration.from

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -72,7 +72,18 @@ object Configuration {
    * Create a ConfigFactory object from the data passed as a Map.
    */
   def from(data: Map[String, Any]) = {
-    Configuration(ConfigFactory.parseMap(data.asJava))
+
+    def asJavaRecursively[A](data: Map[A, Any]): Map[A, Any] = {
+      data.mapValues { value =>
+        value match {
+          case v: Map[_, _] => asJavaRecursively(v).asJava
+          case v: Iterable[_] => v.asJava
+          case v => v
+        }
+      }
+    }
+
+    Configuration(ConfigFactory.parseMap(asJavaRecursively[String](data).asJava))
   }
 
   private def configError(origin: ConfigOrigin, message: String, e: Option[Throwable] = None): PlayException = {

--- a/framework/src/play/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/ConfigurationSpec.scala
@@ -4,21 +4,32 @@ import org.specs2.mutable.Specification
 
 object ConfigurationSpec extends Specification {
 
-  def exampleConfig = Configuration.from(Map("foo.bar1" -> "value1", "foo.bar2" -> "value2", "blah" -> "value3"))
+  def exampleConfig = Configuration.from(
+    Map(
+      "foo.bar1" -> "value1",
+      "foo.bar2" -> "value2",
+      "blah" -> List("value3", "value4", "value5"),
+      "blah2" -> Map(
+        "blah3" -> Map(
+          "blah4" -> "value6"
+        )
+      )
+    )
+  )
 
   "Configuration" should {
 
     "be accessible as an entry set" in {
       val map = Map(exampleConfig.entrySet.toList:_*)
-      map.keySet must contain("foo.bar1", "foo.bar2", "blah").only
+      map.keySet must contain("foo.bar1", "foo.bar2", "blah", "blah2.blah3.blah4").only
     }
 
     "make all paths accessible" in {
-      exampleConfig.keys must contain("foo.bar1", "foo.bar2", "blah").only
+      exampleConfig.keys must contain("foo.bar1", "foo.bar2", "blah", "blah2.blah3.blah4").only
     }
 
     "make all sub keys accessible" in {
-      exampleConfig.subKeys must contain("foo", "blah").only
+      exampleConfig.subKeys must contain("foo", "blah", "blah2").only
     }
 
   }


### PR DESCRIPTION
Now, for example, you need to write additionalConfiguration for FakeApplication like the following when it contains List[A]...

``` scala
  FakeApplication(
    additionalConfiguration = Map("foo" -> List("a", "b", "c").asJava)
  )
```

This is a API for Scala, so it isn't cool to call #asJava in this way.
I changed Configuration.from(data: Map[String, Any]) a little,
and It now convert the value of Map[String, Any] internaly to fit with the API of typesafeconfig.
