### PR TITLE
Show in the browser compilation errors only

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
@@ -346,13 +346,17 @@ trait PlayReloader {
                 Incomplete.allExceptions(incomplete).headOption.map {
                   case e: PlayException => e
                   case e: xsbti.CompileFailed => {
-                    getProblems(incomplete).headOption.map(CompilationException(_)).getOrElse {
-                      UnexpectedException(Some("Compilation failed without reporting any problem!?"), Some(e))
-                    }
+                    getProblems(incomplete)
+                      .filter(_.severity == xsbti.Severity.Error)
+                      .headOption
+                      .map(CompilationException(_))
+                      .getOrElse {
+                        UnexpectedException(Some("The compilation failed without reporting any problem!"), Some(e))
+                      }
                   }
                   case e: Exception => UnexpectedException(unexpected = Some(e))
                 }.getOrElse {
-                  UnexpectedException(Some("Compilation task failed without any exception!?"))
+                  UnexpectedException(Some("The compilation task failed without any exception!"))
                 }
               }
               .right.map { compilationResult =>


### PR DESCRIPTION
By filtering SBT "problems" based on their severity, we can tell
Play to show in the browser compilation errors only.

Thanks to this fix, if the compiler indicates a warning followed
by an exception, the developer won't see the warning instead of
the exception in his browser.

Thanks to @baloo for his help.
