### PR TITLE
Add support for client-side cache to the Cached action combinator

### DIFF
--- a/framework/src/play/src/main/scala/play/api/cache/Cached.scala
+++ b/framework/src/play/src/main/scala/play/api/cache/Cached.scala
@@ -2,23 +2,53 @@ package play.api.cache
 
 import play.api._
 import play.api.mvc._
-import reflect.ClassTag
+import play.api.libs.iteratee.{Iteratee, Done}
+import play.api.http.HeaderNames.{IF_NONE_MATCH, ETAG, EXPIRES}
+import play.api.mvc.Results.NotModified
 
 /**
  * Cache an action.
  *
+ * Uses both server and client caches:
+ *
+ *  - Adds an `Expires` header to the response, so clients can cache response content ;
+ *  - Adds an `Etag` header to the response, so clients can cache response content and ask the server for freshness ;
+ *  - Cache the result on the server, so the underlying action is not computed at each call.
+ *
  * @param key Compute a key from the request header
- * @param duration Cache duration (in seconds)
+ * @param duration Cache duration (in seconds, 0 means eternity)
  * @param action Action to cache
  */
-case class Cached[A](key: RequestHeader => String, duration: Int)(action: Action[A])(implicit app: Application) extends Action[A] {
+case class Cached(key: RequestHeader => String, duration: Int)(action: EssentialAction)(implicit app: Application) extends EssentialAction {
 
-  lazy val parser = action.parser
+  def apply(request: RequestHeader): Iteratee[Array[Byte], Result] = {
 
-  def apply(request: Request[A]): Result = {
-    Cache.getOrElse[Result](key(request), duration) {
-      action(request)
-    }(app, implicitly[ClassTag[Result]])
+    val resultKey = key(request)
+    val etagKey = s"$resultKey-etag"
+
+    // Has the client a version of the resource as fresh as the last one we served?
+    val notModified = for {
+      requestEtag <- request.headers.get(IF_NONE_MATCH)
+      etag <- Cache.getAs[String](etagKey)
+      if etag == requestEtag
+    } yield Done[Array[Byte], Result](NotModified)
+
+    notModified.getOrElse {
+      // Otherwise try to serve the resource from the cache, if it has not yet expired
+      Cache.getOrElse(resultKey, duration) {
+        // The resource was not in the cache, we have to run the underlying action
+        val iterateeResult = action(request)
+        val durationMilliseconds = if (duration == 0) 1000 * 60 * 60 * 24 * 365 else duration * 1000 // Set client cache expiration to one year for “eternity” duration
+        val expirationDate = http.dateFormat.print(System.currentTimeMillis() + durationMilliseconds)
+        // Generate a fresh ETAG for it
+        val etag = expirationDate // Use the expiration date as ETAG
+        // Add cache information to the response, so clients can cache its content
+        iterateeResult.map { result =>
+          Cache.set(etagKey, etag, duration) // Cache the new ETAG of the resource
+          result.withHeaders(ETAG -> etag, EXPIRES -> expirationDate)
+        }
+      }
+    }
   }
 
 }
@@ -31,7 +61,7 @@ object Cached {
    * @param key Compute a key from the request header
    * @param action Action to cache
    */
-  def apply[A](key: RequestHeader => String)(action: Action[A])(implicit app: Application): Cached[A] = {
+  def apply(key: RequestHeader => String)(action: EssentialAction)(implicit app: Application): Cached = {
     apply(key, duration = 0)(action)
   }
 
@@ -41,7 +71,7 @@ object Cached {
    * @param key Cache key
    * @param action Action to cache
    */
-  def apply[A](key: String)(action: Action[A])(implicit app: Application): Cached[A] = {
+  def apply(key: String)(action: EssentialAction)(implicit app: Application): Cached = {
     apply(key, duration = 0)(action)
   }
 
@@ -52,7 +82,7 @@ object Cached {
    * @param duration Cache duration (in seconds)
    * @param action Action to cache
    */
-  def apply[A](key: String, duration: Int)(action: Action[A])(implicit app: Application): Cached[A] = {
+  def apply(key: String, duration: Int)(action: EssentialAction)(implicit app: Application): Cached = {
     Cached(_ => key, duration)(action)
   }
 

--- a/framework/src/play/src/main/scala/play/api/http/package.scala
+++ b/framework/src/play/src/main/scala/play/api/http/package.scala
@@ -1,5 +1,8 @@
 package play.api
 
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.DateTimeZone
+
 /**
  * Contains standard HTTP constants.
  * For example:
@@ -9,4 +12,7 @@ package play.api
  * val accept = HeaderNames.ACCEPT
  * }}}
  */
-package object http
+package object http {
+  /** HTTP date formatter, compliant to RFC 1123 */
+  val dateFormat = DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'").withLocale(java.util.Locale.ENGLISH).withZone(DateTimeZone.forID("GMT"))
+}

--- a/framework/test/integrationtest/test/play/api/cache/CachedSpec.scala
+++ b/framework/test/integrationtest/test/play/api/cache/CachedSpec.scala
@@ -1,0 +1,56 @@
+package play.api.cache
+
+import org.specs2.mutable.Specification
+
+import play.api.test._
+import play.api.test.Helpers._
+import java.util.concurrent.TimeUnit
+
+object CachedSpec extends Specification {
+
+  "Cached combinator" should {
+
+    "Cache result on server-side and client-side" in new WithApplication() {
+
+      import play.api.Play.current
+      import play.api.mvc.Results.Ok
+      import play.api.mvc.Action
+      import scala.concurrent.ExecutionContext.Implicits.global
+
+      var count = 0
+      val action = Action {
+        count = count + 1
+        Ok(count.toString)
+      }
+
+      val cachedAction = Cached(_.uri, 1)(action)
+
+      val request = FakeRequest(GET, "/")
+
+      val result1 = await(cachedAction(request).run)
+
+      // Result has been cached, so we’ll get the same as `result1`
+      val result2 = await(cachedAction(request).run)
+      contentAsString(result2) must equalTo (contentAsString(result1))
+      header(EXPIRES, result1) must equalTo (header(EXPIRES, result2))
+
+      // Ask for freshness
+      val etag = header(ETAG, result1).get
+      val result3 = await(cachedAction(request.withHeaders(IF_NONE_MATCH -> etag)).run)
+      status(result3) must equalTo (NOT_MODIFIED)
+
+      await(play.api.libs.concurrent.Promise.timeout((), 1, TimeUnit.SECONDS)) // Let the resource expire
+
+      // Now we get a new result
+      val result4 = await(cachedAction(request).run)
+      contentAsString(result4) must not equalTo (contentAsString(result1))
+
+      // Even using `If-None-Match`, we get the new version of the resource
+      val result5 = await(cachedAction(request.withHeaders(IF_NONE_MATCH -> etag)).run)
+      status(result5) must not equalTo (NOT_MODIFIED)
+      contentAsString(result5) must equalTo (contentAsString(result4))
+    }
+
+  }
+
+}


### PR DESCRIPTION
Server-side cache is usually used to save computation time while client-side cache is usually used to save bandwidth. These two properties are not always related but I think it makes sense to make the `Cached` combinator support both client-side and server-side caches.

I’m not sure of two things in this pull request:
- I generate two cache keys from the single `key: RequestHeader => String` function. The second key is used to save the resource `Etag`.
- I used `Iteratee#map` instead of `Iteratee#mapDone`. What the difference between those? The type signatures are the same.
