### PR TITLE
Clean up structural types definitions in Enumeratee

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
@@ -4,7 +4,6 @@ import play.api.libs.iteratee.Execution.Implicits.{ defaultExecutionContext => d
 import play.api.libs.iteratee.internal.{ eagerFuture, executeFuture }
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.{ Try, Success, Failure }
-import scala.language.reflectiveCalls
 
 /**
  * A producer which pushes input to an [[play.api.libs.iteratee.Iteratee]].

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
@@ -1,7 +1,5 @@
 package play.api.libs.json
 
-import scala.language.reflectiveCalls
-
 import play.api.libs.iteratee.Execution.Implicits.defaultExecutionContext
 
 /**

--- a/framework/src/play/src/main/scala/play/api/http/Writeable.scala
+++ b/framework/src/play/src/main/scala/play/api/http/Writeable.scala
@@ -4,7 +4,6 @@ import play.api.mvc._
 import play.api.libs.json._
 
 import scala.annotation._
-import scala.language.reflectiveCalls
 import play.api.libs.iteratee.Enumeratee
 import play.api.libs.concurrent.Execution
 

--- a/framework/src/play/src/main/scala/play/api/libs/Comet.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Comet.scala
@@ -1,7 +1,5 @@
 package play.api.libs
 
-import scala.language.reflectiveCalls
-
 import org.apache.commons.lang3.StringEscapeUtils
 import play.api.mvc._
 import play.api.libs.iteratee._

--- a/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -1,7 +1,5 @@
 package play.core.server.netty
 
-import scala.language.reflectiveCalls
-
 import org.jboss.netty.channel._
 import org.jboss.netty.handler.codec.http._
 import org.jboss.netty.handler.codec.http.HttpHeaders._


### PR DESCRIPTION
The structural types used in Enumeratee significantly raise the complexity of understanding the use of Enumeratees.

This commit moves the structural types out into type definitions, and, more importantly, hides the internals of the return types.
