### PR TITLE
Allow user code supplied to iteratees and enumerators to run in an ExecutionContext (#807)

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/TraversableIteratee.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/TraversableIteratee.scala
@@ -1,5 +1,7 @@
 package play.api.libs.iteratee
 
+import scala.concurrent.ExecutionContext
+
 object Traversable {
 
   @scala.deprecated("use Enumeratee.passAlong instead", "2.1.x")
@@ -32,7 +34,7 @@ object Traversable {
                 case (toPush, left) => Done(k(Input.El(toPush)), Input.El(left))
               }
               case _ => Done(inner, in)
-            }
+            }(ExecutionContext.global)
 
           case Input.EOF => Done(inner, Input.EOF)
 
@@ -56,9 +58,9 @@ object Traversable {
                 case Step.Done(_, _) => Cont(step(inner, (leftToTake - all.size)))
                 case Step.Cont(k) => Cont(step(k(Input.El(all)), (leftToTake - all.size)))
                 case Step.Error(_, _) => Cont(step(inner, (leftToTake - all.size)))
-              }
+              }(ExecutionContext.global)
               case (x, left) if x.isEmpty => Done(inner, Input.El(left))
-              case (toPush, left) => Done(inner.pureFlatFold{ case Step.Cont(k) => k(Input.El(toPush)); case _ => inner }, Input.El(left))
+              case (toPush, left) => Done(inner.pureFlatFold{ case Step.Cont(k) => k(Input.El(toPush)); case _ => inner }(ExecutionContext.global), Input.El(left))
             }
 
           case Input.EOF => Done(inner, Input.EOF)
@@ -110,7 +112,7 @@ object Traversable {
                 it.pureFlatFold {
                   case Step.Cont(k) => Enumeratee.passAlong.applyOn(k(toPass))
                   case _ => Done(it, toPass)
-                }
+                }(ExecutionContext.global)
             }
           case Input.Empty => Cont(step(it, leftToDrop))
 

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/ParsingSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/ParsingSpec.scala
@@ -13,8 +13,9 @@ object ParsingSpec extends Specification {
 
     "split case 1" in {
 
+      val foldEC = TestExecutionContext()
       val data = Enumerator(List("xx", "kxckikixckikio", "cockik", "isdodskikisd", "ksdloii").map(_.getBytes): _*)
-      val parsed = data |>>> Parsing.search("kiki".getBytes).transform(Iteratee.fold(List.empty[MatchInfo[Array[Byte]]]) { (s, c) => s :+ c })
+      val parsed = data |>>> Parsing.search("kiki".getBytes).transform(Iteratee.fold(List.empty[MatchInfo[Array[Byte]]]) { (s, c: MatchInfo[Array[Byte]]) => s :+ c }(foldEC))
 
       val result = Await.result(parsed, Duration.Inf).map {
         case Matched(kiki) => "Matched(" + new String(kiki) + ")"
@@ -23,13 +24,15 @@ object ParsingSpec extends Specification {
 
       result must equalTo (
         "Unmatched(xxkxc), Matched(kiki), Unmatched(xc), Matched(kiki), Unmatched(ococ), Matched(kiki), Unmatched(sdods), Matched(kiki), Unmatched(sdks), Unmatched(dloii)")
+      foldEC.executionCount must equalTo(10)
 
     }
 
     "split case 1" in {
 
       val data = Enumerator(List("xx", "kxckikixcki", "k", "kicockik", "isdkikodskikisd", "ksdlokiikik", "i").map(_.getBytes): _*)
-      val parsed = data |>>> Parsing.search("kiki".getBytes).transform(Iteratee.fold(List.empty[MatchInfo[Array[Byte]]]) { (s, c) => s :+ c })
+      val foldEC = TestExecutionContext()
+      val parsed = data |>>> Parsing.search("kiki".getBytes).transform(Iteratee.fold(List.empty[MatchInfo[Array[Byte]]]) { (s, c: MatchInfo[Array[Byte]]) => s :+ c }(foldEC))
 
       val result = Await.result(parsed, Duration.Inf).map {
         case Matched(kiki) => "Matched(" + new String(kiki) + ")"
@@ -38,6 +41,7 @@ object ParsingSpec extends Specification {
 
       result must equalTo(
         "Unmatched(xxkxc), Matched(kiki), Unmatched(xckikkico), Unmatched(c), Matched(kiki), Unmatched(sdkikods), Matched(kiki), Unmatched(sdksdlok), Unmatched(ii), Matched(kiki), Unmatched()")
+      foldEC.executionCount must equalTo(11)
 
     }
 

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/TestExecutionContext.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/TestExecutionContext.scala
@@ -1,0 +1,32 @@
+package play.api.libs.iteratee
+
+import scala.concurrent.ExecutionContext
+
+object TestExecutionContext {
+  
+  /**
+   * Create a `TestExecutionContext` that delegates to the iteratee package's default `ExecutionContext`.
+   */
+  def apply(): TestExecutionContext = new TestExecutionContext(internal.defaultExecutionContext)
+
+}
+
+/**
+ * An `ExecutionContext` that counts its executions.
+ * 
+ * @param delegate The underlying `ExecutionContext` to delegate execution to.
+ */
+class TestExecutionContext(delegate: ExecutionContext) extends ExecutionContext {
+  val count = new java.util.concurrent.atomic.AtomicInteger()
+  def execute(runnable: Runnable): Unit = {
+    count.getAndIncrement()
+    delegate.prepare().execute(runnable)
+  }
+  
+  def reportFailure(t: Throwable): Unit = delegate.reportFailure(t)
+  
+  override def prepare(): ExecutionContext = this
+  
+  def executionCount: Int = count.get()
+  
+}

--- a/framework/src/play-filters-helpers/src/main/scala/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/csrf.scala
@@ -234,9 +234,9 @@ package play.filters.csrf {
               _.fold(_ => checkRequest(request), body => checkRequest(request, Some(extractor(body))))
                 .fold(
                   result => Done(result, Input.Empty: Input[Array[Byte]]),
-                  r => Iteratee.flatten(Enumerator(b).apply(next(addRequestToken(r, token)))).map(result => addResponseToken(request, result, token))
+                  r => Iteratee.flatten(Enumerator(b).apply(next(addRequestToken(r, token)))).map(result => addResponseToken(request, result, token))(defaultContext)
                 )})
-        }
+        }(defaultContext)
     }
 
     def checkFormUrlEncodedBody = checkBody[Map[String, Seq[String]]](tolerantFormUrlEncoded, identity) _
@@ -276,7 +276,7 @@ package play.filters.csrf {
             checkTextBody(request, token, next)
           case None if request.method == "GET" => 
             logger.trace("[CSRF] GET request, adding the token")
-            next(addRequestToken(request, token)).map(result => addResponseToken(request, result, token))
+            next(addRequestToken(request, token)).map(result => addResponseToken(request, result, token))(defaultContext)
           case ct => 
             logger.trace("[CSRF] bypass the request (%s)".format(ct.toString))
             next(request)

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -210,7 +210,7 @@ object Helpers extends Status with HeaderNames {
         val parsedBody: Option[Either[play.api.mvc.Result, T]] = action.parser(request).fold1(
           (a, in) => Promise.pure(Some(a)),
           k => Promise.pure(None),
-          (msg, in) => Promise.pure(None)).await.get
+          (msg, in) => Promise.pure(None))(global).await.get
         parsedBody.map { resultOrT =>
           resultOrT.right.toOption.map { innerBody =>
             action(FakeRequest(request.method, request.uri, request.headers, innerBody))

--- a/framework/src/play/src/main/scala/play/api/cache/Cached.scala
+++ b/framework/src/play/src/main/scala/play/api/cache/Cached.scala
@@ -46,7 +46,7 @@ case class Cached(key: RequestHeader => String, duration: Int)(action: Essential
         iterateeResult.map { result =>
           Cache.set(etagKey, etag, duration) // Cache the new ETAG of the resource
           result.withHeaders(ETAG -> etag, EXPIRES -> expirationDate)
-        }
+        }(play.core.Execution.internalContext)
       }
     }
   }

--- a/framework/src/play/src/main/scala/play/api/controllers/ExternalAssets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/ExternalAssets.scala
@@ -47,7 +47,7 @@ object ExternalAssets extends Controller {
         }
 
         if (fileToServe.exists) {
-          Ok.sendFile(fileToServe, inline = true).withHeaders(CACHE_CONTROL -> "max-age=3600")
+          Ok.sendFile(fileToServe, inline = true)(play.api.libs.concurrent.Execution.defaultContext).withHeaders(CACHE_CONTROL -> "max-age=3600")
         } else {
           NotFound
         }

--- a/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
@@ -269,7 +269,7 @@ object WS {
                 iterateeP.success(it)
                 it
               }
-            }
+            }(play.core.Execution.internalContext)
             STATE.CONTINUE
           } else {
             iteratee = null

--- a/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
@@ -34,7 +34,7 @@ trait Filter extends EssentialFilter {
       def apply(rh:RequestHeader):Iteratee[Array[Byte],Result] = {
         val it = scala.concurrent.Promise[Iteratee[Array[Byte],Result]]()
         val result = self.apply({(rh:RequestHeader) => it.success(next(rh)) ; AsyncResult(p.future)})(rh)
-        val i = it.future.map(_.map({r => p.success(r); result}))
+        val i = it.future.map(_.map({r => p.success(r); result})(defaultContext))
         result match {
           case r:AsyncResult => Iteratee.flatten( r.unflatten.map(Done(_,Input.Empty: Input[Array[Byte]])).or(i).map(_.fold(identity, identity)))
           case r:PlainResult => Done(r)

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -622,13 +622,13 @@ trait Results {
      * @param inline Use Content-Disposition inline or attachment.
      * @param fileName function to retrieve the file name (only used for Content-Disposition attachment)
      */
-    def sendFile(content: java.io.File, inline: Boolean = false, fileName: java.io.File => String = _.getName, onClose: () => Unit = () => ()): SimpleResult[Array[Byte]] = {
+    def sendFile(content: java.io.File, inline: Boolean = false, fileName: java.io.File => String = _.getName, onClose: () => Unit = () => ())(ec: ExecutionContext): SimpleResult[Array[Byte]] = {
       SimpleResult(
         header = ResponseHeader(OK, Map(
           CONTENT_LENGTH -> content.length.toString,
           CONTENT_TYPE -> play.api.libs.MimeTypes.forFileName(content.getName).getOrElse(play.api.http.ContentTypes.BINARY)
         ) ++ (if (inline) Map.empty else Map(CONTENT_DISPOSITION -> ("""attachment; filename="%s"""".format(fileName(content)))))),
-        Enumerator.fromFile(content) &> Enumeratee.onIterateeDone(onClose)
+        Enumerator.fromFile(content) &> Enumeratee.onIterateeDone(onClose)(ec)
       )
     }
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaResults.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaResults.scala
@@ -27,7 +27,7 @@ object JavaResults extends Results with DefaultWriteables with DefaultContentTyp
   def async(p: scala.concurrent.Future[Result]) = AsyncResult(p)
   def chunked[A](onDisconnected: () => Unit): play.libs.F.Tuple[Enumerator[A], Channel[A]] = {
     val (enumerator, channel) = Concurrent.broadcast[A]
-    play.libs.F.Tuple(enumerator.onDoneEnumerating(onDisconnected()), channel)
+    play.libs.F.Tuple(enumerator.onDoneEnumerating(onDisconnected())(play.core.Execution.internalContext), channel)
   }
   //play.api.libs.iteratee.Enumerator.imperative[A](onComplete = onDisconnected)
   def chunked(stream: java.io.InputStream, chunkSize: Int): Enumerator[Array[Byte]] = Enumerator.fromStream(stream, chunkSize)

--- a/framework/src/play/src/main/scala/play/core/j/JavaWebSocket.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaWebSocket.scala
@@ -38,9 +38,9 @@ object JavaWebSocket extends JavaHelpers {
       val socketIn = new play.mvc.WebSocket.In[A]
 
       in |>> {
-        Iteratee.foreach[A](msg => socketIn.callbacks.asScala.foreach(_.invoke(msg))).mapDone { _ =>
+        Iteratee.foreach[A](msg => socketIn.callbacks.asScala.foreach(_.invoke(msg)))(play.core.Execution.internalContext).mapDone { _ =>
           socketIn.closeCallbacks.asScala.foreach(_.invoke())
-        }
+        }(play.core.Execution.internalContext)
       }
 
       enumerator |>> out

--- a/framework/src/play/src/main/scala/play/core/server/netty/Helpers.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/Helpers.scala
@@ -24,7 +24,7 @@ private[netty] trait Helpers {
         case Empty => Cont(step(future))
       }
 
-    Enumeratee.breakE[A](_ => !channel.isConnected()).transform(Cont(step(None)))
+    Enumeratee.breakE[A](_ => !channel.isConnected())(play.core.Execution.internalContext).transform(Cont(step(None)))
   }
 
   def getHeaders(nettyRequest: HttpRequest): Headers = {

--- a/framework/src/play/src/main/scala/play/core/server/netty/WebSocketHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/WebSocketHandler.scala
@@ -60,9 +60,9 @@ private[server] trait WebSocketHandler {
 
                 case Step.Cont(_) => Promise.pure(next)
                 case Step.Error(msg, e) => { /* deal with error, maybe close the socket */ Promise.pure(next) }
-              }
+              }(play.core.Execution.internalContext)
             },
-            (err, e) => /* handle error, maybe close the socket */ Promise.pure(current))
+            (err, e) => /* handle error, maybe close the socket */ Promise.pure(current))(play.core.Execution.internalContext)
         eventuallyNext.success(next)
       }
     }

--- a/framework/src/play/src/main/scala/play/core/system/DocumentationApplication.scala
+++ b/framework/src/play/src/main/scala/play/core/system/DocumentationApplication.scala
@@ -4,6 +4,7 @@ import play.api.mvc._
 import java.io.File
 import play.core._
 import play.api._
+import play.api.libs.concurrent.Execution
 import libs.iteratee.Iteratee
 import com.typesafe.config.ConfigFactory
 import server.NettyServer
@@ -56,7 +57,7 @@ class DocumentationHandler(markdownRenderer: (String, String, File) => String) {
           documentationHome.flatMap { home =>
             Option(new java.io.File(home, "api/" + page)).filter(f => f.exists && f.isFile)
           }.map { file =>
-            Ok.sendFile(file, inline = true)
+            Ok.sendFile(file, inline = true)(Execution.defaultContext)
           }.getOrElse {
             NotFound(views.html.play20.manual(page, None, None))
           }
@@ -70,7 +71,7 @@ class DocumentationHandler(markdownRenderer: (String, String, File) => String) {
           documentationHome.flatMap { home =>
             Option(new java.io.File(home, path)).filter(_.exists)
           }.map { file =>
-            Ok.sendFile(file, inline = true)
+            Ok.sendFile(file, inline = true)(Execution.defaultContext)
           }.getOrElse(NotFound("Resource not found [" + path + "]"))
         }
 

--- a/framework/test/integrationtest-java/test/test/JavaCometTest.java
+++ b/framework/test/integrationtest-java/test/test/JavaCometTest.java
@@ -51,7 +51,7 @@ public class JavaCometTest {
         });
         comet.close();
         try {
-          latch.await(5, java.util.concurrent.TimeUnit.MILLISECONDS);
+          latch.await(5, java.util.concurrent.TimeUnit.SECONDS);
         } catch(Throwable t) {}
         assertEquals(1, callbackCalled.get());
       }

--- a/framework/test/integrationtest-scala/app/controllers/Application.scala
+++ b/framework/test/integrationtest-scala/app/controllers/Application.scala
@@ -35,7 +35,7 @@ object Application extends Controller {
   def bodyParserThread = Action(new BodyParser[String] {
     def apply(request: RequestHeader) = {
       val threadName = Thread.currentThread.getName
-      Iteratee.ignore[Array[Byte]].map(_ => Right(threadName))
+      Iteratee.ignore[Array[Byte]].map(_ => Right(threadName))(play.api.libs.concurrent.Execution.defaultContext)
     }
   }) { request =>
     Ok(request.body)

--- a/framework/test/integrationtest/app/controllers/Application.scala
+++ b/framework/test/integrationtest/app/controllers/Application.scala
@@ -145,7 +145,7 @@ object Application extends Controller {
   def onCloseSendFile(filepath: String) = Action {
     import java.io.File
     val file = new File(filepath)
-    Ok.sendFile(file, onClose = () => { file.delete() })
+    Ok.sendFile(file, onClose = () => { file.delete() })(play.api.libs.concurrent.Execution.defaultContext)
   }
 
   def syncError = Action {

--- a/framework/test/integrationtest/test/FunctionalSpec.scala
+++ b/framework/test/integrationtest/test/FunctionalSpec.scala
@@ -45,7 +45,7 @@ class FunctionalSpec extends Specification {
         hdrs.get("CONTENT-TYpe").isDefined must equalTo(true)
         hdrs.keys.find(header => header == "Content-Type" ).isDefined must equalTo(true)
         hdrs.keys.find(header => header == "CONTENT-TYpe" ).isDefined must equalTo(false)
-        Iteratee.fold[Array[Byte],StringBuffer](new StringBuffer){ (buf,array) => { buf.append(array); buf }}
+        Iteratee.fold[Array[Byte],StringBuffer](new StringBuffer){ (buf,array) => { buf.append(array); buf }}(global)
       }
 
       await(hp.map(_.run)).map(buf => buf.toString must contain("""{"Accept":"application/json"}""") )

--- a/samples/scala/comet-clock/app/controllers/Application.scala
+++ b/samples/scala/comet-clock/app/controllers/Application.scala
@@ -25,7 +25,7 @@ object Application extends Controller {
     
     Enumerator.fromCallback { () =>
       Promise.timeout(Some(dateFormat.format(new Date)), 100 milliseconds)
-    }
+    }(defaultContext)
   }
   
   def index = Action {

--- a/samples/scala/comet-live-monitoring/app/controllers/Application.scala
+++ b/samples/scala/comet-live-monitoring/app/controllers/Application.scala
@@ -41,13 +41,13 @@ object Streams {
       val currentMillis = java.lang.System.currentTimeMillis()
       Some(SpeedOMeter.getSpeed +":rps") },
       100, TimeUnit.MILLISECONDS )
-    }
+    }(defaultContext)
 
   val getHeap = Enumerator.fromCallback{ () =>
     Promise.timeout(
       Some((Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / (1024*1024) + ":memory"),
       100, TimeUnit.MILLISECONDS)
-  }
+  }(defaultContext)
 
   val cpu = new models.CPU()
 
@@ -55,7 +55,7 @@ object Streams {
     Promise.timeout(
       Some((cpu.getCpuUsage()*1000).round / 10.0 + ":cpu"),
       100, TimeUnit.MILLISECONDS)
-  }
+  }(defaultContext)
 
 }
 

--- a/samples/scala/websocket-chat/app/models/ChatRoom.scala
+++ b/samples/scala/websocket-chat/app/models/ChatRoom.scala
@@ -19,7 +19,7 @@ object Robot {
   def apply(chatRoom: ActorRef) {
     
     // Create an Iteratee that logs all messages to the console.
-    val loggerIteratee = Iteratee.foreach[JsValue](event => Logger("robot").info(event.toString))
+    val loggerIteratee = Iteratee.foreach[JsValue](event => Logger("robot").info(event.toString))(defaultContext)
     
     implicit val timeout = Timeout(1 second)
     // Make the robot join the room
@@ -62,9 +62,9 @@ object ChatRoom {
         // Create an Iteratee to consume the feed
         val iteratee = Iteratee.foreach[JsValue] { event =>
           default ! Talk(username, (event \ "text").as[String])
-        }.mapDone { _ =>
+        }(defaultContext).mapDone { _ =>
           default ! Quit(username)
-        }
+        }(defaultContext)
 
         (iteratee,enumerator)
         

--- a/samples/workinprogress/akka-chat/app/controllers/Actors.scala
+++ b/samples/workinprogress/akka-chat/app/controllers/Actors.scala
@@ -19,7 +19,7 @@ class ChatRoomActor extends Actor {
     case Join() => {
       lazy val channel: PushEnumerator[String] =  Enumerator.imperative[String](
         onComplete = ()=> self ! Quit(channel) 
-      )
+      )(Execution.defaultContext)
       members = members :+ channel
       Logger.info("New member joined")
       sender ! channel


### PR DESCRIPTION
This is the first part of #807.

This PR updates the iteratee library so that user code can be run in its own `ExecutionContext`. Many methods have been updated to accept an `ExecutionContext` argument. For example, `map` now accepts an `ExecutionContext`, and the function passed to `map` will run in that context. The ability to run code in a different context will be used by the Play framework to isolate the execution of user code from internal Play code.

All built-in iteratee code runs in the default Scala `ExecutionContext` (`ExecutionContext.global`). Only user code runs in the `ExecutionContext`s passed in as arguments.

Before merging this PR I additionally plan to:
- [ ] Update scaladoc.
- [ ] Write tests for iteratee package methods I've changed that currently lack tests.
  (I'll do this while the PR is being reviewed.)

But please review in the meantime!
#### Code removed

I removed some deprecated code, to reduce the work of updating the iteratee module.
- Removed deprecated `Concurrent.hub` and associated `Hub` trait.
- Removed deprecated `Enumerator.imperative` and `Enumerator.pushee`.
- Removed deprecated `Enumerator.callback` method.
- Removed deprecated `PushEnumerator` class.

More controversially, I also removed some code that _wasn't_ deprecated. I did this when the code had a strong relationship to the deprecated code and I felt it may have been mistakenly left un-deprecated. The code I removed wasn't used anywhere else in the Play framework and also had errors or other issues.

We may want to discuss this. :) I'll understand if any of the code I removed needs to be reinstated.
- Removed _non-deprecated_ `Enumerator.callback1` method (related to deprecated `callback` method; unused; untested; `onError` argument not called).
- Removed _non-deprecated_ `Concurrent.broadcast` method (basically wraps deprecated `hub` method; unused; untested).
#### Next PR

I haven't completed #807 with this PR, more work will be required.

First we'll want to update the Play framework to use this code.
- Work out how to structure threadpools in Iteratees and in Play for both internal and user code.
- Change code outside Iteratee package to run user code in the correct `ExecutionContext`, e.g. user actions, filters, etc.

Then we'll want to finish off the iteratee module changes to close the issue.
- Audit Iteratee package to make sure all user code runs in a user-supplied `ExecutionContext`, e.g. will need to update `joinI`.
- Add tests for these methods if needed.
- Make all `ExecutionContext` params and values implicit, once we're sure everything is wired together properly.
- Once `ExecutionContext`s are implicit, remove any now-unneeded explicit `ExecutionContext`s.

There are a few other changes we could consider too:
- Make `Concurrent.patchPanel`'s `isClosed` var `@volatile` annotation? Need to get commented-out test working first.
- Make an `ExecutionContext` that executes immediately in the same thread, to use for in certain cases, e.g. the simple nop function in `Iteratee.ignore.`
- Perf test before and after to identify impact of changes.
