### PR TITLE
Allow creating fake requests from calls

### DIFF
--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -171,8 +171,8 @@ object FakeRequest {
     FakeRequest(method, path, FakeHeaders(), AnyContentAsEmpty)
   }
 
-  def apply(method: String, call: Call): FakeRequest[AnyContentAsEmpty.type] = {
-    apply(method, call.url)
+  def apply(call: Call): FakeRequest[AnyContentAsEmpty.type] = {
+    apply(call.method, call.url)
   }
 }
 


### PR DESCRIPTION
Useful because it allows me to write less fragile test code like:

```
route(FakeRequest(GET, routes.Application.index))
```

instead of:

```
route(FakeRequest(GET, "/"))
```

or the more verbose:

```
route(FakeRequest(GET, routes.Application.index.url))
```
