### PR TITLE
Allow user SBT settings to override play default settings

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/Project.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/Project.scala
@@ -31,7 +31,7 @@ object Project extends Plugin with PlayExceptions with PlayKeys with PlayReloade
 
   // ----- Create a Play project with default settings
  
-  def apply(name: String, applicationVersion: String = "1.0", dependencies: Seq[ModuleID] = Nil, path: File = file("."), settings: => Seq[Setting[_]] = Defaults.defaultSettings): sbt.Project = {
+  def apply(name: String, applicationVersion: String = "1.0", dependencies: Seq[ModuleID] = Nil, path: File = file("."), settings: => Seq[Setting[_]] = Seq()): sbt.Project = {
     val mainLang = if (dependencies.contains(javaCore)) JAVA else SCALA
 
     lazy val playSettings =
@@ -42,9 +42,9 @@ object Project extends Plugin with PlayExceptions with PlayKeys with PlayReloade
         libraryDependencies ++= dependencies
       )
 
-    lazy val allSettings = settings ++ playSettings
-
-    sbt.Project(name, path, settings = allSettings)
+    sbt.Project(name, path)
+      .settings(playSettings: _*)
+      .settings(settings: _*)
 
   }
 }


### PR DESCRIPTION
The way we currently handle SBT settings is actually really bad, and causes a number of issues such as users not being able to override Play defaults.  Instead, we should use the standard SBT mechanism of chaining .settings() calls on Project to allow things to override settings.
