### PR TITLE
Chunked result doesn't close connection

### DIFF
--- a/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -191,7 +191,7 @@ private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: De
                     case Redeemed(_) =>
                       cleanup()
                       ctx.setAttachment(null)
-                      if (!keepAlive) Channels.close(e.getChannel)
+                      if (!keepAlive || contentLength == "-1") Channels.close(e.getChannel)
                     case Thrown(ex) =>
                       Logger("play").debug(ex.toString)
                       Channels.close(e.getChannel)

--- a/framework/test/integrationtest-scala/app/controllers/Application.scala
+++ b/framework/test/integrationtest-scala/app/controllers/Application.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import play.api._
-import libs.iteratee.Iteratee
+import libs.iteratee.{Enumerator, Iteratee}
 import libs.json.Json
 import play.api.mvc._
 
@@ -41,4 +41,11 @@ object Application extends Controller {
     Ok(request.body)
   }
 
+  def streamEnumerator = Action {
+    Ok.stream(Enumerator("a", "b", "c"))
+  }
+
+  def feedEnumerator = Action {
+    Ok.feed(Enumerator("a", "b", "c"))
+  }
 }

--- a/framework/test/integrationtest-scala/conf/routes
+++ b/framework/test/integrationtest-scala/conf/routes
@@ -6,6 +6,8 @@ GET     /                           controllers.Application.index(name = "Guest"
 GET     /key                        controllers.Application.key
 GET     /thread                     controllers.Application.thread
 GET     /bodyParserThread           controllers.Application.bodyParserThread
+GET     /streamEnumerator           controllers.Application.streamEnumerator
+GET     /feedEnumerator             controllers.Application.feedEnumerator
 GET     /:name                      controllers.Application.index(name)
 POST    /json                       controllers.Application.json
 

--- a/framework/test/integrationtest-scala/test/SimpleSpec.scala
+++ b/framework/test/integrationtest-scala/test/SimpleSpec.scala
@@ -116,6 +116,15 @@ class SimpleSpec extends Specification {
       response.body must startWith("play-akka.actor.default-dispatcher-")
     }
 
+    "support streaming using an enumerator" in new WithServer() {
+      val response = Await.result(wsCall(controllers.routes.Application.streamEnumerator()).get(), Duration.Inf)
+      response.body must_== "abc"
+    }
+
+    "support feeding using an enumerator" in new WithServer() {
+      val response = Await.result(wsCall(controllers.routes.Application.feedEnumerator()).get(), Duration.Inf)
+      response.body must_== "abc"
+    }
   }
 
 }


### PR DESCRIPTION
In play2.1.1, Ok.stream does not close connection.

``` scala
object Test extends Controller {

   def test = Action {
     import play.api.libs.iteratee.Enumerator
     Ok.stream(Enumerator("foo", "bar"))
  }   
}
```

Here is what i observe:

```
$ curl -v http://localhost:9000/test
* About to connect() to localhost port 9000 (#0)
*   Trying ::1... connected
* Connected to localhost (::1) port 9000 (#0)
> GET /test HTTP/1.1
> User-Agent: curl/7.21.4 (universal-apple-darwin11.0) libcurl/7.21.4 OpenSSL/0.9.8r zlib/1.2.5
> Host: localhost:9000
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: text/plain; charset=utf-8
< Transfer-Encoding: chunked
<
```

And curl stops here.

Here is a workaround found by @vmunier :

``` scala
object Test extends Controller {

   def test = Action {
     import play.api.libs.iteratee.Enumerator
     Ok.stream(Enumerator("foo", "bar").andThen(Enumerator.eof[String]))
  }   
}
```

which results in:

```
$ curl -v http://localhost:9000/test
* About to connect() to localhost port 9000 (#0)
*   Trying ::1... connected
* Connected to localhost (::1) port 9000 (#0)
> GET /test HTTP/1.1
> User-Agent: curl/7.21.4 (universal-apple-darwin11.0) libcurl/7.21.4 OpenSSL/0.9.8r zlib/1.2.5
> Host: localhost:9000
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: text/plain; charset=utf-8
< Transfer-Encoding: chunked
<
* Connection #0 to host localhost left intact
* Closing connection #0
foobar
```

Which is what i expect to see
