### PR TITLE
Manage Java ObjectMapper lifecycle via a plugin

### DIFF
--- a/framework/src/play-java/src/main/resources/play.plugins
+++ b/framework/src/play-java/src/main/resources/play.plugins
@@ -1,0 +1,1 @@
+100:play.core.ObjectMapperPlugin

--- a/framework/src/play-java/src/main/scala/play/core/ObjectMapperPlugin.scala
+++ b/framework/src/play-java/src/main/scala/play/core/ObjectMapperPlugin.scala
@@ -1,0 +1,23 @@
+package play.core
+
+import play.api.Plugin
+import play.api.Application
+import play.libs.Json
+import com.fasterxml.jackson.databind.ObjectMapper
+
+/**
+ * Plugin that injects an object mapper to the JSON library on start and on stop.
+ *
+ * This solves the issue of the ObjectMapper cache from holding references to the application class loader between
+ * reloads.
+ */
+class ObjectMapperPlugin(app: Application) extends Plugin {
+
+  override def onStart() {
+    Json.setObjectMapper(new ObjectMapper())
+  }
+
+  override def onStop() {
+    Json.setObjectMapper(null)
+  }
+}


### PR DESCRIPTION
The Java ObjectMapper lifecycle should be managed via a plugin, to prevent OOMEs caused by the Jackson cache.
