### PR TITLE
Cookie discard may not discard the cookie for the next request

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -654,7 +654,7 @@ public class Http {
          * @param secure Whether the cookie to discard is secure
          */
         public void discardCookie(String name, String path, String domain, boolean secure) {
-            cookies.add(new Cookie(name, "", -1, path, domain, secure, false));
+            cookies.add(new Cookie(name, "", -86400, path, domain, secure, false));
         }
 
         // FIXME return a more convenient type? e.g. Map<String, Cookie>

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -641,7 +641,7 @@ import scala.util.control.NonFatal
    * @param secure whether this cookie is secured
    */
   case class DiscardingCookie(name: String, path: String = "/", domain: Option[String] = None, secure: Boolean = false) {
-    def toCookie = Cookie(name, "", Some(-1), path, domain, secure)
+    def toCookie = Cookie(name, "", Some(-86400), path, domain, secure)
   }
 
   /**

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -62,7 +62,7 @@ object ResultsSpec extends Specification {
       setCookies("preferences").value must be_==("blue")
       setCookies("lang").value must be_==("fr")
       setCookies("logged").maxAge must beSome
-      setCookies("logged").maxAge.get must be_<=(1)
+      setCookies("logged").maxAge.get must be_<=(-86000)
     }
 
 
@@ -100,7 +100,7 @@ object ResultsSpec extends Specification {
       setCookies("preferences").value must be_==("blue")
       setCookies("lang").value must be_==("fr")
       setCookies("logged").maxAge must beSome
-      setCookies("logged").maxAge.get must be_<=(1)
+      setCookies("logged").maxAge.get must be_<=(-86000)
       val playSession = Session.decodeFromCookie(setCookies.get(Session.COOKIE_NAME))
       playSession.data.size must be_==(2)
       playSession.data must havePair("user" -> "kiki")


### PR DESCRIPTION
The code response().discardCookie("cookieName"); will generate a response HTTP header like this :
Set-Cookie: cookieName=; Expires=Sat, 30-Mar-2013 15:26:<b>51</b> GMT; Path=/

However, if the server is slow to execute the response (eg on a raspberry pi :), it could generate a "wrong" date header :
Date: Sat, 30 Mar 2013 15:26:<b>50</b> GMT

This means that for the next request, the client will believe the cookie is still alive :
GET /page HTTP/1.1
Cookie: cookieName=

Maybe in order to discard a cookie Play should use a fixed expire date, eg :
Set-Cookie: cookieName=; Expires=Thu, 01-Jan-1970 00:00:01 GMT; Path=/

@gissues:{"order":96.875,"status":"notstarted"}
