### PR TITLE
Make test browser implicitly available

### DIFF
--- a/framework/src/play-test/src/main/scala/play/api/test/Specs.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Specs.scala
@@ -50,7 +50,7 @@ abstract class WithBrowser[WEBDRIVER <: WebDriver](
   implicit def implicitApp = app
   implicit def implicitPort: Port = port
 
-  lazy val browser: TestBrowser = TestBrowser.of(webDriver, Some("http://localhost:" + port))
+  implicit lazy val browser: TestBrowser = TestBrowser.of(webDriver, Some("http://localhost:" + port))
 
   override def around[T: AsResult](t: => T): Result = {
     try {

--- a/framework/src/play-test/src/test/scala/play/api/test/SpecsSpec.scala
+++ b/framework/src/play-test/src/test/scala/play/api/test/SpecsSpec.scala
@@ -19,4 +19,15 @@ object SpecsSpec extends Specification {
       Play.maybeApplication must beSome(app)
     }
   }
+
+  "WithBrowser context" should {
+
+    def doBrowserStuff()(implicit browser: TestBrowser) = {
+      browser.goTo("/")
+    }
+
+    "make the browser available implicitly" in new WithBrowser {
+      doBrowserStuff()
+    }
+  }
 }


### PR DESCRIPTION
When writing integration specs using a browser, it is hard to reuse code because you need to pass the browser with each method call. This changes therefor makes the test browser reference implicit.

Now I can write code like:

``` scala
def login(username: String, password: String)(implicit browser: Testbrowser) = ...

"My admin area" should {
  "be available for admins" in new WithBrowser {
    login("admin@domain.com", "foo")
    browser.url must beSome("/admin")
  }
}
```
