### PR TITLE
Set Mode in a logical order

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -10,10 +10,10 @@ import java.io._
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
-/** Application mode, either `DEV` or `PROD`. */
+/** Application mode, either `DEV`, `TEST`, or `PROD`. */
 object Mode extends Enumeration {
   type Mode = Value
-  val Dev, Prod, Test = Value
+  val Dev, Test, Prod = Value
 }
 
 /**


### PR DESCRIPTION
The application mode is an Enumeration, which are ordered. However for Mode this order was not logical:

```
scala> Mode.Dev < Mode.Prod
res0: Boolean = true

scala> Mode.Test < Mode.Prod
res1: Boolean = false
```

Test should be less than Prod, so one could write code like:

``` scala
object Global extends GlobalSettings {
  override def onStart(app: Application) =
    if (app.mode < Mode.Prod) { seedMockData() }
}
```
