### PR TITLE
Selenium helper to submit a form with fields in one go

### DIFF
--- a/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
@@ -21,6 +21,24 @@ case class TestBrowser(webDriver: WebDriver, baseUrl: Option[String]) extends Fl
   baseUrl.map(baseUrl => withDefaultUrl(baseUrl))
 
   /**
+   * Submits a form with the given field values
+   *
+   * @example {{{
+   *   submit("#login", fields =
+   *     "email" -> email,
+   *     "password" -> password
+   *   )
+   * }}}
+   */
+  def submit(selector: String, fields: (String, String)*): Fluent = {
+    fields.foreach {
+      case (fieldName, fieldValue) =>
+        fill(s"${selector} *[name=${fieldName}]").`with`(fieldValue)
+    }
+    submit(selector)
+  }
+
+  /**
    * Repeatedly applies this instance's input value to the given block until one of the following occurs:
    * the function returns neither null nor false,
    * the function throws an unignored exception,


### PR DESCRIPTION
A convenience method to fill in a form and submit it with one call. For example:

``` scala
submit("#login", fields =
  "email" -> email,
  "password" -> password
)
```
