### PR TITLE
WS is not interrupt even if the iteratee has end

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
@@ -274,7 +274,7 @@ object WS {
           } else {
             iteratee = null
             // Must close underlying connection, otherwise async http client will drain the stream
-            bodyPart.closeUnderlyingConnection()
+            bodyPart.markUnderlyingConnectionAsClosed()
             STATE.ABORT
           }
         }


### PR DESCRIPTION
Considering this simple example:
It allows to re-stream an OGG web radio (by consequence this stream is "infinite").

``` scala
  def webRadioWithEcho = Action {
    val src = "http://radio.hbr1.com:19800/ambient.ogg"
    Ok.stream((socket: Socket.Out[Array[Byte]]) => WS.url(src).get(headers => socket))
      .withHeaders(CONTENT_TYPE -> "audio/ogg")
  }
```

If I open a lot of connections to the url of webRadioWithEcho in different tab, it will of-course create one WS stream for each tab. And theorically, when I close each tab, The stream should stop downloading, because the socket Iteratee has reach the Done state.

BTW, the implementation (here: https://github.com/playframework/Play20/blob/master/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala#L252 ) seems right and the STATE.ABORT is sent (I have logged it with success) when each time I closed one tab.

However, if I look to my computer stats, the streams are still downloading (see my attached screenshot of the bandwidth graph, a lot of opening/closing (with curl) has been done, and a kill of the server at the end).

Are we sure sending STATE.ABORT is enough to AsyncHttpClient to kill the request?

Migrated from http://play.lighthouseapp.com/projects/82401/tickets/921-ws-is-not-interrupt-even-if-the-iteratee-has-end
@gissues:{"order":58.97435897435891,"status":"backlog"}
