### PR TITLE
XPath.selectText regression

### DIFF
--- a/framework/src/play-java/src/main/java/play/libs/XPath.java
+++ b/framework/src/play-java/src/main/java/play/libs/XPath.java
@@ -32,7 +32,7 @@ public class XPath {
             
             if (namespaces != null) {
                 SimpleNamespaceContext nsContext = new SimpleNamespaceContext();
-                nsContext.setBindings(namespaces);
+                bindUnboundedNamespaces(nsContext, namespaces);
                 xpath.setNamespaceContext(nsContext);
             }
 
@@ -60,7 +60,7 @@ public class XPath {
             
             if (namespaces != null) {
                 SimpleNamespaceContext nsContext = new SimpleNamespaceContext();
-                nsContext.setBindings(namespaces);
+                bindUnboundedNamespaces(nsContext, namespaces);
                 xpath.setNamespaceContext(nsContext);
             }
 
@@ -72,6 +72,15 @@ public class XPath {
 
     public static Node selectNode(String path, Object node) {
         return selectNode(path, node, null);
+    }
+
+    private static void bindUnboundedNamespaces(SimpleNamespaceContext nsContext, Map<String, String> namespaces) {
+        for (Map.Entry<String, String> entry : namespaces.entrySet()) {
+            //making sure that namespace is not already bound. Otherwise UnsupportedException happens
+            if(nsContext.getPrefix(entry.getValue()) == null) {
+                nsContext.bindNamespaceUri(entry.getKey(), entry.getValue());
+            }
+        }
     }
 
     /**
@@ -86,7 +95,7 @@ public class XPath {
 
             if (namespaces != null) {
                 SimpleNamespaceContext nsContext = new SimpleNamespaceContext();
-                nsContext.setBindings(namespaces);
+                bindUnboundedNamespaces(nsContext, namespaces);
                 xpath.setNamespaceContext(nsContext);
             }
 

--- a/framework/src/play-java/src/test/scala/play/libs/XPathSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/libs/XPathSpec.scala
@@ -1,0 +1,40 @@
+package play.libs
+
+import org.specs2.mutable.Specification
+import scala.collection.JavaConverters._
+
+
+object XPathSpec extends Specification {
+  //XPathFactory.newInstance() used internally by XPath is not thread safe so forcing sequential execution
+  sequential
+
+  val xmlWithNamespace = XML.fromString("""<x:foo xmlns:x="http://foo.com/"><x:bar><x:baz>hey</x:baz></x:bar></x:foo>""")
+  val xmlWithoutNamespace = XML.fromString("""<foo><bar><baz>hey</baz></bar><bizz></bizz><bizz></bizz></foo>""")
+
+  "XPath" should {
+    "ignore already bound namespaces" in {
+      val ns = Map("x" -> "http://foo.com/", "ns" -> "http://www.w3.org/XML/1998/namespace", "y" -> "http://foo.com/")
+      XPath.selectText("//x:baz", xmlWithNamespace, ns.asJava) must not(throwAn[UnsupportedOperationException])
+    }
+
+    "find text with namespace" in {
+      val text = XPath.selectText("//x:baz", xmlWithNamespace, Map("ns" -> "http://www.w3.org/XML/1998/namespace", "x" -> "http://foo.com/").asJava)
+      text must_== "hey"
+    }
+
+    "find text without namespace" in {
+      val text = XPath.selectText("//baz", xmlWithoutNamespace, null)
+      text must_== "hey"
+    }
+
+    "find node with namespace" in {
+      val node = XPath.selectNode("//x:baz", xmlWithNamespace, Map("ns" -> "http://www.w3.org/XML/1998/namespace", "x" -> "http://foo.com/").asJava)
+      node.getNodeName must_== "x:baz"
+    }
+
+    "find nodes" in {
+      val nodeList = XPath.selectNodes("//bizz", xmlWithoutNamespace, null)
+      nodeList.getLength === 2
+    }
+  }
+}


### PR DESCRIPTION
There appears to be a regression in regards to the play.libs.XPath#selectText method:

```
java.lang.RuntimeException: java.lang.UnsupportedOperationException
  at play.libs.XPath.selectText(XPath.java:95) ~[play-java_2.10.jar:2.1-SNAPSHOT]
  ...
Caused by: java.lang.UnsupportedOperationException: null
  at java.util.AbstractList.add(AbstractList.java:131) ~[na:1.6.0_37]
  at java.util.AbstractList.add(AbstractList.java:91) ~[na:1.6.0_37]
  at org.springframework.util.xml.SimpleNamespaceContext.bindNamespaceUri(SimpleNamespaceContext.java:106) ~[spring-core-3.1.2.RELEASE.jar:3.1.2.RELEASE]
  at org.springframework.util.xml.SimpleNamespaceContext.setBindings(SimpleNamespaceContext.java:79) ~[spring-core-3.1.2.RELEASE.jar:3.1.2.RELEASE]
  at play.libs.XPath.selectText(XPath.java:89) ~[play-java_2.10.jar:2.1-SNAPSHOT]
```
