### PR TITLE
Configurable HTTP request parameters - max request length, max header size, chunk size

### DIFF
--- a/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
@@ -52,9 +52,9 @@ class NettyServer(appProvider: ApplicationProvider, port: Int, sslPort: Option[I
           newPipeline.addLast("ssl", new SslHandler(sslEngine))
         }
       }
-      val maxInitialLineLength = Option(System.getProperty("http.maxInitialLineLength")).map(Integer.parseInt(_)).getOrElse(4096)
-      val maxHeaderSize = Option(System.getProperty("http.maxHeaderSize")).map(Integer.parseInt(_)).getOrElse(8192)
-      val maxChunkSize = Option(System.getProperty("http.maxChunkSize")).map(Integer.parseInt(_)).getOrElse(8192)
+      val maxInitialLineLength = Option(System.getProperty("http.netty.maxInitialLineLength")).map(Integer.parseInt(_)).getOrElse(4096)
+      val maxHeaderSize = Option(System.getProperty("http.netty.maxHeaderSize")).map(Integer.parseInt(_)).getOrElse(8192)
+      val maxChunkSize = Option(System.getProperty("http.netty.maxChunkSize")).map(Integer.parseInt(_)).getOrElse(8192)
       newPipeline.addLast("decoder", new HttpRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize))
       newPipeline.addLast("encoder", new HttpResponseEncoder())
       newPipeline.addLast("decompressor", new HttpContentDecompressor())


### PR DESCRIPTION
Add ability to override default HTTP request details:
- request line length - default 4096
- header size - default 8192
- chunk size - default 8192

Add use of system properties:
- http.netty.maxInitialLineLength
- http.netty.maxHeaderSize
- http.netty.maxChunkSize
  (each to be defined as int value in bytes)

These values are passed in to constructor for org.jboss.netty.handler.codec.http.HttpRequestDecoder
If the system properties are not defined, the current default value is used,
