### PR TITLE
Modification to retrieve external properties for JPA EMF

### DIFF
--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAPlugin.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAPlugin.java
@@ -32,7 +32,20 @@ public class JPAPlugin extends Plugin {
         if(jpaConf != null) {
             for(String key: jpaConf.keys()) {
                 String persistenceUnit = jpaConf.getString(key);
-                emfs.put(key, Persistence.createEntityManagerFactory(persistenceUnit));
+
+                // Check if there are properties for PU
+                Configuration puConf = application.configuration().getConfig(persistenceUnit);
+                if (puConf != null) {
+                    Map<String, String> puProperties = new HashMap<String, String>();
+                    for (String keyPu : puConf.keys()) {
+                        puProperties.put(keyPu, puConf.getString(keyPu));
+                    }
+
+                    // EMF created with external properties
+                    emfs.put(key, Persistence.createEntityManagerFactory(persistenceUnit, puProperties));
+                } else {
+                    emfs.put(key, Persistence.createEntityManagerFactory(persistenceUnit));
+                }
             }
         }
         


### PR DESCRIPTION
Add possibility to use external properties to instantiate a JPA EntityManagerFactory

Ex (for kundera properties) : 
# JPA PersistenceUnit

jpa.default=mongoPU

mongoPU.kundera.nodes="127.0.0.1"
mongoPU.kundera.port=27017
mongoPU.kundera.keyspace=MyDataStore
