### PR TITLE
Fix for Evolutions diffing doesn't notice changes other than the most recent one

### DIFF
--- a/framework/src/play-jdbc/src/test/scala/play/api/db/evolutions/ScriptSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/evolutions/ScriptSpec.scala
@@ -42,10 +42,70 @@ object ScriptSpec extends Specification {
       scriptStatements.toList must beEqualTo(List(statement))
     }
 
-  }
+  }  
 
 
   private case class ScriptSansEvolution(sql: String) extends Script {
     override val evolution = Evolution(0, "", "")
+  }
+
+
+  "Conflicts" should {
+
+    "not be noticed if there aren't any" in {
+
+      val downRest = (9 to 1).reverse.map(i=> Evolution(i, s"DummySQLUP$i",s"DummySQLDOWN$i"))
+      val upRest = downRest        
+
+      val (conflictingDowns, conflictingUps) = Evolutions.conflictings(downRest, upRest)
+
+      conflictingDowns.size must beEqualTo(0)
+      conflictingUps.size must beEqualTo(0)
+    }
+
+    "be noticed on the most recent one" in {
+
+      val downRest = (1 to 9).reverse.map(i=> Evolution(i, s"DummySQLUP$i",s"DummySQLDOWN$i"))
+      val upRest = Evolution(9, "DifferentDummySQLUP", "DifferentDummySQLDOWN") +: (1 to 8).reverse.map(i=> Evolution(i, s"DummySQLUP$i",s"DummySQLDOWN$i"))  
+      
+      val (conflictingDowns, conflictingUps) = Evolutions.conflictings(downRest, upRest)
+
+
+      conflictingDowns.size must beEqualTo(1)
+      conflictingUps.size must beEqualTo(1)
+      conflictingDowns(0).revision must beEqualTo(9)
+      conflictingUps(0).revision must beEqualTo(9)
+    }
+
+    "be noticed in the middle" in {
+
+      val downRest = (1 to 9).reverse.map(i=> Evolution(i, s"DummySQLUP$i",s"DummySQLDOWN$i"))
+      val upRest = (6 to 9).reverse.map(i=> Evolution(i, s"DummySQLUP$i",s"DummySQLDOWN$i")) ++: Evolution(5, "DifferentDummySQLUP", "DifferentDummySQLDOWN") +: (1 to 4).reverse.map(i=> Evolution(i, s"DummySQLUP$i",s"DummySQLDOWN$i"))  
+      
+      val (conflictingDowns, conflictingUps) = Evolutions.conflictings(downRest, upRest)
+
+      conflictingDowns.size must beEqualTo(5)
+      conflictingUps.size must beEqualTo(5)
+      conflictingDowns(0).revision must beEqualTo(9)
+      conflictingUps(0).revision must beEqualTo(9)
+      conflictingDowns(4).revision must beEqualTo(5)
+      conflictingUps(4).revision must beEqualTo(5)
+    }
+
+    "be noticed on the first" in {
+
+      val downRest = (1 to 9).reverse.map(i=> Evolution(i, s"DummySQLUP$i",s"DummySQLDOWN$i"))
+      val upRest = (2 to 9).reverse.map(i=> Evolution(i, s"DummySQLUP$i",s"DummySQLDOWN$i")) ++: List(Evolution(1, "DifferentDummySQLUP", "DifferentDummySQLDOWN"))
+      
+      val (conflictingDowns, conflictingUps) = Evolutions.conflictings(downRest, upRest)
+
+      conflictingDowns.size must beEqualTo(9)
+      conflictingUps.size must beEqualTo(9)
+      conflictingDowns(0).revision must beEqualTo(9)
+      conflictingUps(0).revision must beEqualTo(9)
+      conflictingDowns(8).revision must beEqualTo(1)
+      conflictingUps(8).revision must beEqualTo(1)
+    }
+
   }
 }


### PR DESCRIPTION
This change makes it possible for Play to detect changes in evolutions at any stages. Check new tests for further explanation.
