### PR TITLE
Fixed oauth document

### DIFF
--- a/documentation/manual/scalaGuide/main/ws/ScalaOAuth.md
+++ b/documentation/manual/scalaGuide/main/ws/ScalaOAuth.md
@@ -38,7 +38,7 @@ object Twitter extends Controller {
     "https://api.twitter.com/oauth/request_token",
     "https://api.twitter.com/oauth/access_token",
     "https://api.twitter.com/oauth/authorize", KEY),
-    false)
+    true)
 
   def authenticate = Action { request =>
     request.getQueryString("oauth_verifier").map { verifier =>


### PR DESCRIPTION
The previous code snippet doesn't work no longer because Twitter doesn't support OAuth1.0 and require to use OAuth1.0a. 

This link is discussions form of twitter oauth spec.
https://dev.twitter.com/discussions/16443
