### PR TITLE
Update documentation/manual/detailledTopics/configuration/SettingsLogger.md

### DIFF
--- a/documentation/manual/detailledTopics/configuration/SettingsLogger.md
+++ b/documentation/manual/detailledTopics/configuration/SettingsLogger.md
@@ -29,7 +29,7 @@ logger.org.springframework=TRACE
 
 The default is to define two appenders, one dispatched to the standard out stream, and the other to the `logs/application.log` file.
 
-If you want to fully customize logback, just define a `conf/application-logger.xml` configuration file. Here is the default configuration file used by Play:
+If you want to fully customize logback, just define a `conf/application-logger.xml` or `conf/logger.xml` configuration file. Here is the default configuration file used by Play:
 
 ```xml
 <configuration>


### PR DESCRIPTION
Today, I found my application does not add any log entry into `logs/application.log`, while it normally prints logs to stdout. To figure out the reason, I read `SettingLogger` document. The document said:

"If you want to fully customize logback, just define a `conf/application-logger.xml` configuration file. Here is the default configuration file used by Play:"

But I didn't have `conf/application-logger.xml`. After minutes of struggle, I finally found that `conf/logger.xml` also works as a configuration file for logging.

So, now I believe the sentence in the document should be changed:

"If you want to fully customize logback, just define a `conf/application-logger.xml`  or `conf/logger.xml`  configuration file. Here is the default configuration file used by Play:"
