### PR TITLE
Upgrading H2 to latest version.

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
     // declare a dependency on the newer version so that ivy can know which one to include
     guava,
 
-    "com.h2database" % "h2" % "1.3.168",
+    "com.h2database" % "h2" % "1.3.171",
 
     "tyrex" % "tyrex" % "1.0.1",
 


### PR DESCRIPTION
After setting up a automated test workflow, we ran into a bug with H2. It appears the problem is solved in latest H2 version. So H2 goes from version 1.3.168 to version 1.3.171. The issue concerns H2's Mysql MODE. The charset and encoding is misinterpreted and fails.

Here is the H2 bug report : https://code.google.com/p/h2database/issues/detail?id=431
The H2 changelog : http://www.h2database.com/html/changelog.html

_Note : The framework succesfully compiled locally and has been tested against the project with succes_
_Note 2 : I have already signed the CLA_
