### PR TITLE
Accept dashes in i18n messages' keys

### DIFF
--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -160,7 +160,7 @@ object Messages {
 
     def comment = """#.*""".r ^^ { case s => Comment(s) }
 
-    def messageKey = namedError("""[a-zA-Z0-9_.]+""".r, "Message key expected")
+    def messageKey = namedError("""[a-zA-Z0-9_.-]+""".r, "Message key expected")
 
     def messagePattern = namedError(
       rep(


### PR DESCRIPTION
Underscores are accepted, why not dashes? 
Is there any reason for this? 

Regards, 
Samy
