### PR TITLE
New integration test project

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -217,6 +217,9 @@ object PlayBuild extends Build {
   lazy val PlayFiltersHelpersProject = PlayRuntimeProject("Filters-Helpers", "play-filters-helpers")
     .dependsOn(PlayProject)
 
+  // This project is just for testing Play, not really a public artifact
+  lazy val PlayIntegrationTestProject = PlayRuntimeProject("Play-Integration-Test", "play-integration-test")
+    .dependsOn(PlayProject, PlayTestProject)
 
   import RepositoryBuilder._
   lazy val RepositoryProject = Project(
@@ -253,7 +256,8 @@ object PlayBuild extends Build {
     ConsoleProject,
     PlayTestProject,
     PlayExceptionsProject,
-    PlayFiltersHelpersProject
+    PlayFiltersHelpersProject,
+    PlayIntegrationTestProject
   )
     
   lazy val Root = Project(

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JAction.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JAction.scala
@@ -1,0 +1,39 @@
+package play.it.http
+
+import play.api.mvc.EssentialAction
+import play.core.j.JavaAction
+import play.mvc.{Results, Http, Controller, Result}
+
+/**
+ * Use this to mock Java actions, eg:
+ *
+ * {{{
+ *   new FakeApplication(
+ *     withRouter = {
+ *       case _ => JAction(new MockController() {
+ *         @Security.Authenticated
+ *         def action = ok
+ *       })
+ *     }
+ *   }
+ * }}}
+ */
+object JAction {
+  def apply(c: MockController): EssentialAction = {
+    new JavaAction {
+      def method = c.getClass.getMethod("action")
+      def controller: Class[_] = c.getClass
+      def invocation = c.action
+    }
+  }
+}
+
+abstract class MockController {
+  def action: Result
+
+  def ctx = Http.Context.current()
+  def response = ctx.response()
+  def request = ctx.request()
+  def session = ctx.session()
+  def flash = ctx.flash()
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -1,0 +1,60 @@
+package play.it.http
+
+import play.api.test.Helpers._
+import play.api.libs.ws.Response
+import play.api.test.{FakeApplication, TestServer}
+import play.mvc.Results
+import play.mvc.Results.Chunks
+
+import org.specs2.mutable.Specification
+
+object JavaResultsHandlingSpec extends Specification {
+
+  "java body handling" should {
+    def makeRequest[T](controller: MockController)(block: Response => T) = {
+      implicit val port = testServerPort
+      running(TestServer(port, FakeApplication(
+        withRoutes = {
+          case _ => JAction(controller)
+        }
+      ))) {
+        val response = await(wsUrl("/").get())
+        block(response)
+      }
+    }
+
+    "buffer results with no content length" in makeRequest(new MockController {
+      def action = Results.ok("Hello world")
+    }) { response =>
+      response.header(CONTENT_LENGTH) must beSome("11")
+      response.body must_== "Hello world"
+    }
+
+    "send results as is with a content length" in makeRequest(new MockController {
+      def action = {
+        response.setHeader(CONTENT_LENGTH, "5")
+        Results.ok("Hello world")
+      }
+    }) { response =>
+      response.header(CONTENT_LENGTH) must beSome("5")
+      response.body must_== "Hello"
+    }
+
+    "chunk results that are streamed" in makeRequest(new MockController {
+      def action = {
+        Results.ok(new Results.StringChunks() {
+          def onReady(out: Chunks.Out[String]) {
+            out.write("a")
+            out.write("b")
+            out.write("c")
+            out.close()
+          }
+        })
+      }
+    }) { response =>
+      response.header(TRANSFER_ENCODING) must beSome("chunked")
+      response.header(CONTENT_LENGTH) must beNone
+      response.body must_== "abc"
+    }
+  }
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -1,0 +1,57 @@
+package play.it.http
+
+import org.specs2.mutable._
+import play.api.mvc.{Result, Results, Action}
+import play.api.test.Helpers._
+import play.api.test._
+import play.api.libs.ws.Response
+import play.api.libs.iteratee.Enumerator
+
+object ScalaResultsHandlingSpec extends Specification {
+
+
+  "scala body handling" should {
+
+    def makeRequest[T](result: Result)(block: Response => T) = {
+      implicit val port = testServerPort
+      running(TestServer(port, FakeApplication(
+        withRoutes = {
+          case _ => Action(result)
+        }
+      ))) {
+        val response = await(wsUrl("/").get())
+        block(response)
+      }
+    }
+
+    "buffer results with no content length" in makeRequest(Results.Ok("Hello world")) { response =>
+      response.header(CONTENT_LENGTH) must beSome("11")
+      response.body must_== "Hello world"
+    }
+
+    "send results as is with a content length" in makeRequest(Results.Ok("Hello world")
+      .withHeaders(CONTENT_LENGTH -> "5")) { response =>
+      response.header(CONTENT_LENGTH) must beSome("5")
+      response.body must_== "Hello"
+    }
+
+    "chunk results that are streamed" in makeRequest(
+      Results.Ok.stream(Enumerator("a", "b", "c") >>> Enumerator.eof)
+    ) { response =>
+      response.header(TRANSFER_ENCODING) must beSome("chunked")
+      response.header(CONTENT_LENGTH) must beNone
+      response.body must_== "abc"
+    }
+
+    /* Skipped until feeding bug is fixed
+    "close the connection for streamed results that are not chunked" in makeRequest(
+      Results.Ok.feed(Enumerator("a", "b", "c"))
+    ) { response =>
+      response.header(TRANSFER_ENCODING) must beNone
+      response.header(CONTENT_LENGTH) must beNone
+      response.body must_== "abc"
+    }
+    */
+  }
+
+}

--- a/framework/src/play-test/src/main/java/play/test/FakeApplication.java
+++ b/framework/src/play-test/src/main/java/play/test/FakeApplication.java
@@ -3,7 +3,11 @@ package play.test;
 import java.io.*;
 import java.util.*;
 
+import play.api.mvc.Handler;
 import play.libs.*;
+import scala.PartialFunction;
+import scala.PartialFunction$;
+import scala.Tuple2;
 
 /**
  * A Fake application.
@@ -31,7 +35,8 @@ public class FakeApplication {
                 Scala.toSeq(additionalPlugins),
                 Scala.<String>emptySeq(),
                 Scala.asScala((Map<String, Object>)additionalConfiguration),
-                scala.Option.apply(g)
+                scala.Option.apply(g),
+                PartialFunction$.MODULE$.<Tuple2<String, String>, Handler>empty()
                 );
     }
 

--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -6,6 +6,8 @@ import play.api.libs.concurrent.Promise
 import collection.immutable.TreeMap
 import play.core.utils.CaseInsensitiveOrdered
 import xml.NodeSeq
+import play.core.Router
+import scala.runtime.AbstractPartialFunction
 
 /**
  * Fake HTTP headers implementation.
@@ -183,6 +185,7 @@ object FakeRequest {
  * @param additionalPlugins Additional plugins class names loaded by this application
  * @param withoutPlugins Plugins class names to disable
  * @param additionalConfiguration Additional configuration
+ * @param withRoutes A partial function of method name and path to a handler for handling the request
  */
 
 import play.api.{ Application, WithDefaultConfiguration, WithDefaultGlobal, WithDefaultPlugins }
@@ -192,7 +195,8 @@ case class FakeApplication(
   val additionalPlugins: Seq[String] = Nil,
   val withoutPlugins: Seq[String] = Nil,
   val additionalConfiguration: Map[String, _ <: Any] = Map.empty,
-  val withGlobal: Option[play.api.GlobalSettings] = None) extends {
+  val withGlobal: Option[play.api.GlobalSettings] = None,
+  val withRoutes: PartialFunction[(String, String), Handler] = PartialFunction.empty) extends {
   override val sources = None
   override val mode = play.api.Mode.Test
 } with Application with WithDefaultConfiguration with WithDefaultGlobal with WithDefaultPlugins {
@@ -205,4 +209,25 @@ case class FakeApplication(
   }
 
   override lazy val global = withGlobal.getOrElse(super.global)
+
+  override lazy val routes: Option[Router.Routes] = {
+    val parentRoutes = loadRoutes
+    Some(new Router.Routes() {
+      def documentation = parentRoutes.map(_.documentation).getOrElse(Nil)
+      // Use withRoutes first, then delegate to the parentRoutes if no route is defined
+      val routes = new AbstractPartialFunction[RequestHeader, Handler] {
+        override def applyOrElse[A <: RequestHeader, B >: Handler](rh: A, default: A => B) =
+          withRoutes.applyOrElse((rh.method, rh.path), (_: (String, String)) => default(rh))
+        def isDefinedAt(rh: RequestHeader) = withRoutes.isDefinedAt((rh.method, rh.path))
+      } orElse new AbstractPartialFunction[RequestHeader, Handler] {
+        override def applyOrElse[A <: RequestHeader, B >: Handler](rh: A, default: A => B) =
+          parentRoutes.map(_.routes.applyOrElse(rh, default)).getOrElse(default(rh))
+        def isDefinedAt(x: RequestHeader) = parentRoutes.map(_.routes.isDefinedAt(x)).getOrElse(false)
+      }
+      def setPrefix(prefix: String) {
+        parentRoutes.foreach(_.setPrefix(prefix))
+      }
+      def prefix = parentRoutes.map(_.prefix).getOrElse("")
+    })
+  }
 }

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -1,7 +1,6 @@
 package play.api.test
 
 import scala.language.reflectiveCalls
-import scala.xml.NodeSeq
 
 import play.api._
 import libs.ws.WS

--- a/framework/src/play-test/src/test/scala/play/api/test/FakesSpec.scala
+++ b/framework/src/play-test/src/test/scala/play/api/test/FakesSpec.scala
@@ -1,0 +1,26 @@
+package play.api.test
+
+import org.specs2.mutable.Specification
+import play.api.mvc._
+import play.api.test.Helpers._
+
+object FakesSpec extends Specification {
+
+  "FakeApplication" should {
+
+    "allow adding routes inline" in {
+      val app = new FakeApplication(
+        withRoutes = {
+          case ("GET", "/inline") => Action { Results.Ok("inline route") }
+        }
+      )
+      running(app) {
+        val result = route(app, FakeRequest("GET", "/inline"))
+        result must beSome
+        contentAsString(result.get) must_== "inline route"
+        route(app, FakeRequest("GET", "/foo")) must beNone
+      }
+    }
+  }
+
+}

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -236,7 +236,9 @@ trait Application {
   /**
    * The router used by this application (if defined).
    */
-  lazy val routes: Option[Router.Routes] = try {
+  lazy val routes: Option[Router.Routes] = loadRoutes
+
+  protected def loadRoutes: Option[Router.Routes] = try {
     Some(classloader.loadClass(configuration.getString("application.router").map(_ + "$").getOrElse("Routes$")).getDeclaredField("MODULE$").get(null).asInstanceOf[Router.Routes]).map { router =>
       router.setPrefix(configuration.getString("application.context").map { prefix =>
         if (!prefix.startsWith("/")) {


### PR DESCRIPTION
The idea here is to move test code closer to the code that's being tested.  This makes it easy to write, run, debug and maintain tests, since everything is in the one SBT project.

In this change specifically, I've done:
- Added easy way to define embedded routes in a FakeApplication
- Created a new integration test project
- Implemented some integration tests that demonstrates the usefulness of this
