### PR TITLE
Allow user code supplied to iteratees and enumerators to run in an ExecutionContext (#807 part 2)

### DIFF
--- a/documentation/manual/scalaGuide/main/async/code/ScalaComet.scala
+++ b/documentation/manual/scalaGuide/main/async/code/ScalaComet.scala
@@ -2,6 +2,7 @@ package scalaguide.async.scalacomet
 
 import org.specs2.mutable.Specification
 import play.api.mvc._
+import play.api.libs.concurrent.Execution.Implicits.{ defaultContext => dec }
 import play.api.libs.iteratee.{Enumeratee, Iteratee, Enumerator}
 import play.api.test._
 import play.api.test.Helpers._

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
@@ -1,6 +1,7 @@
 package play.api.libs.iteratee
 
-import play.api.libs.iteratee.internal.{ defaultExecutionContext => dec, executeIteratee, executeFuture }
+import play.api.libs.iteratee.Execution.Implicits.{ defaultExecutionContext => dec }
+import play.api.libs.iteratee.internal.{ executeIteratee, executeFuture }
 import scala.language.reflectiveCalls
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -54,7 +55,7 @@ trait Enumeratee[From, To] {
   def ><>[To2](other: Enumeratee[To, To2]): Enumeratee[From, To2] = compose(other)
 
   /**
-   * Compose this Enumeratee with another Enumeratee, concatinating any input left by both Enumeratees when they
+   * Compose this Enumeratee with another Enumeratee, concatenating any input left by both Enumeratees when they
    * are done.
    */
   def composeConcat[X](other: Enumeratee[To, To])(implicit p: To => scala.collection.TraversableLike[X, To], bf: scala.collection.generic.CanBuildFrom[To, X, To]): Enumeratee[From, To] = {
@@ -72,6 +73,10 @@ trait Enumeratee[From, To] {
 
 }
 
+/**
+ * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
+ * @define paramEcMultiple @param ec The context to execute the supplied functions with. The context is prepared on the calling thread before being used.
+ */
 object Enumeratee {
 
   /**
@@ -113,8 +118,14 @@ object Enumeratee {
   /**
    * Create an Enumeratee that zips two Iteratees together, using the passed in zipper function to combine the results
    * of the two.
+   *
+   * @param inner1 The first Iteratee to combine.
+   * @param inner2 The second Iteratee to combine.
+   * @param zipper Used to combine the results of each Iteratee.
+   * $paramEcSingle
    */
-  def zipWith[E, A, B, C](inner1: Iteratee[E, A], inner2: Iteratee[E, B])(zipper: (A, B) => C)(ec: ExecutionContext): Iteratee[E, C] = {
+  def zipWith[E, A, B, C](inner1: Iteratee[E, A], inner2: Iteratee[E, B])(zipper: (A, B) => C)(implicit ec: ExecutionContext): Iteratee[E, C] = {
+    val pec = ec.prepare()
 
     def getNext(it1: Iteratee[E, A], it2: Iteratee[E, B]): Iteratee[E, C] = {
       import ExecutionContext.Implicits.global
@@ -125,9 +136,9 @@ object Enumeratee {
         ) yield checkDone(a1, a2) match {
           case Left((msg, in)) => Error(msg, in)
           case Right(None) => Cont(step(it1_, it2_))
-          case Right(Some(Left(Left(a)))) => it2_.map(b => zipper(a, b))(ec)
-          case Right(Some(Left(Right(b)))) => it1_.map(a => zipper(a, b))(ec)
-          case Right(Some(Right(((a, b), e)))) => executeIteratee(Done(zipper(a, b), e))(ec)
+          case Right(Some(Left(Left(a)))) => it2_.map(b => zipper(a, b))(pec)
+          case Right(Some(Left(Right(b)))) => it1_.map(a => zipper(a, b))(pec)
+          case Right(Some(Right(((a, b), e)))) => executeIteratee(Done(zipper(a, b), e))(pec)
         }
 
       Iteratee.flatten(eventuallyIter)
@@ -173,11 +184,17 @@ object Enumeratee {
    * iteratee before EOF is encountered.
    */
   def mapInput[From] = new {
-    def apply[To](f: Input[From] => Input[To]) = new CheckDone[From, To] {
+    /**
+     * @param f Used to transform each input element.
+     * $paramEcSingle
+     */
+    def apply[To](f: Input[From] => Input[To])(implicit ec: ExecutionContext) = new CheckDone[From, To] {
+      val pec = ec.prepare()
 
       def step[A](k: K[To, A]): K[From, Iteratee[To, A]] = {
-        case in @ (Input.El(_) | Input.Empty) =>
-          new CheckDone[From, To] { def continue[A](k: K[To, A]) = Cont(step(k)) } &> k(f(in))
+        case in @ (Input.El(_) | Input.Empty) => new CheckDone[From, To] {
+          def continue[A](k: K[To, A]) = Cont(step(k))
+        } &> Iteratee.flatten(Future(f(in))(pec).map(in => k(in))(dec))
 
         case Input.EOF => Done(Cont(k), Input.EOF)
       }
@@ -190,25 +207,38 @@ object Enumeratee {
    * Create an enumeratee that transforms its input into a sequence of inputs for the target iteratee.
    */
   def mapConcatInput[From] = new {
-    def apply[To](f: From => Seq[Input[To]]) = mapFlatten[From](in => Enumerator.enumerateSeq2(f(in)))
+    /**
+     * @param f Used to transform each input element into a sequence of inputs.
+     * $paramEcSingle
+     */
+    def apply[To](f: From => Seq[Input[To]])(implicit ec: ExecutionContext) = mapFlatten[From](in => Enumerator.enumerateSeq2(f(in)))(ec)
   }
 
   /**
    * Create an Enumeratee that transforms its input elements into a sequence of input elements for the target Iteratee.
    */
   def mapConcat[From] = new {
-    def apply[To](f: From => Seq[To]) = mapFlatten[From](in => Enumerator.enumerateSeq1(f(in)))
+    /**
+     * @param f Used to transform each input element into a sequence of input elements.
+     * $paramEcSingle
+     */
+    def apply[To](f: From => Seq[To])(implicit ec: ExecutionContext) = mapFlatten[From](in => Enumerator.enumerateSeq1(f(in)))(ec)
   }
 
   /**
    * Create an Enumeratee that transforms its input elements into an Enumerator that is fed into the target Iteratee.
    */
   def mapFlatten[From] = new {
-    def apply[To](f: From => Enumerator[To]) = new CheckDone[From, To] {
+    /**
+     * @param f Used to transform each input element into an Enumerator.
+     * $paramEcSingle
+     */
+    def apply[To](f: From => Enumerator[To])(implicit ec: ExecutionContext) = new CheckDone[From, To] {
+      val pec = ec.prepare()
 
       def step[A](k: K[To, A]): K[From, Iteratee[To, A]] = {
         case Input.El(e) =>
-          new CheckDone[From, To] { def continue[A](k: K[To, A]) = Cont(step(k)) } &> Iteratee.flatten(f(e)(Cont(k)))
+          new CheckDone[From, To] { def continue[A](k: K[To, A]) = Cont(step(k)) } &> Iteratee.flatten(Future(f(e))(pec).flatMap(_(Cont(k)))(dec))
 
         case in @ Input.Empty =>
           new CheckDone[From, To] { def continue[A](k: K[To, A]) = Cont(step(k)) } &> k(in)
@@ -224,6 +254,10 @@ object Enumeratee {
    * Create an Enumeratee that transforms its input into an Enumerator that is fed into the target Iteratee.
    */
   def mapInputFlatten[From] = new {
+    /**
+     * @param f Used to transform each input into an Enumerator.
+     * $paramEcSingle
+     */
     def apply[To](f: Input[From] => Enumerator[To]) = new CheckDone[From, To] {
 
       def step[A](k: K[To, A]): K[From, Iteratee[To, A]] = {
@@ -239,11 +273,16 @@ object Enumeratee {
    * Like `mapInput`, but allows the map function to asynchronously return the mapped input.
    */
   def mapInputM[From] = new {
-    def apply[To](f: Input[From] => Future[Input[To]]) = new CheckDone[From, To] {
+    /**
+     * @param f Used to transform each input.
+     * $paramEcSingle
+     */
+    def apply[To](f: Input[From] => Future[Input[To]])(implicit ec: ExecutionContext) = new CheckDone[From, To] {
+      val pec = ec.prepare()
 
       def step[A](k: K[To, A]): K[From, Iteratee[To, A]] = {
         case in @ (Input.El(_) | Input.Empty) =>
-          new CheckDone[From, To] { def continue[A](k: K[To, A]) = Cont(step(k)) } &> Iteratee.flatten(f(in).map(k(_))(dec))
+          new CheckDone[From, To] { def continue[A](k: K[To, A]) = Cont(step(k)) } &> Iteratee.flatten(executeFuture(f(in))(pec).map(k(_))(dec))
 
         case Input.EOF => Done(Cont(k), Input.EOF)
       }
@@ -256,18 +295,26 @@ object Enumeratee {
    * Like `map`, but allows the map function to asynchronously return the mapped element.
    */
   def mapM[E] = new {
-    def apply[NE](f: E => Future[NE]): Enumeratee[E, NE] = mapInputM[E] {
+    /**
+     * @param f Used to transform each input element.
+     * $paramEcSingle
+     */
+    def apply[NE](f: E => Future[NE])(implicit ec: ExecutionContext): Enumeratee[E, NE] = mapInputM[E] {
       case Input.Empty => Future.successful(Input.Empty)
       case Input.EOF => Future.successful(Input.EOF)
       case Input.El(e) => f(e).map(Input.El(_))(dec)
-    }
+    }(ec)
   }
 
   /**
    * Create an Enumeratee which transforms its input using a given function
    */
   def map[E] = new {
-    def apply[NE](f: E => NE): Enumeratee[E, NE] = mapInput[E](in => in.map(f))
+    /**
+     * @param f A function to transform input elements.
+     * $paramEcSingle
+     */
+    def apply[NE](f: E => NE)(implicit ec: ExecutionContext): Enumeratee[E, NE] = mapInput[E](in => in.map(f))(ec)
   }
 
   /**
@@ -367,15 +414,18 @@ object Enumeratee {
 
   /**
    * Create an Enumeratee that filters the inputs using the given predicate
+   *
+   * @param predicate A function to filter the input elements.
+   * $paramEcSingle
    */
-  def filter[E](predicate: E => Boolean): Enumeratee[E, E] = new CheckDone[E, E] {
+  def filter[E](predicate: E => Boolean)(implicit ec: ExecutionContext): Enumeratee[E, E] = new CheckDone[E, E] {
+    val pec = ec.prepare()
 
     def step[A](k: K[E, A]): K[E, Iteratee[E, A]] = {
 
-      case in @ Input.El(e) if predicate(e) =>
-        new CheckDone[E, E] { def continue[A](k: K[E, A]) = Cont(step(k)) } &> k(in)
-
-      case in @ Input.El(e) => Cont(step(k))
+      case in @ Input.El(e) => Iteratee.flatten(Future(predicate(e))(pec).map { b =>
+        if (b) (new CheckDone[E, E] { def continue[A](k: K[E, A]) = Cont(step(k)) } &> k(in)) else Cont(step(k))
+      }(dec))
 
       case in @ Input.Empty =>
         new CheckDone[E, E] { def continue[A](k: K[E, A]) = Cont(step(k)) } &> k(in)
@@ -390,19 +440,34 @@ object Enumeratee {
 
   /**
    * Create an Enumeratee that filters the inputs using the negation of the given predicate
+   *
+   * @param predicate A function to filter the input elements.
+   * $paramEcSingle
    */
-  def filterNot[E](predicate: E => Boolean): Enumeratee[E, E] = filter(e => !predicate(e))
+  def filterNot[E](predicate: E => Boolean)(implicit ec: ExecutionContext): Enumeratee[E, E] = filter[E](e => !predicate(e))(ec)
 
+  /**
+   * Create an Enumeratee that both filters and transforms its input. The input is transformed by the given
+   * PartialFunction. If the PartialFunction isn't defined for an input element then that element is discarded.
+   */
   def collect[From] = new {
 
-    def apply[To](transformer: PartialFunction[From, To]): Enumeratee[From, To] = new CheckDone[From, To] {
+    /**
+     * @param transformer A function to transform and filter the input elements with.
+     * $paramSingleEc
+     */
+    def apply[To](transformer: PartialFunction[From, To])(implicit ec: ExecutionContext): Enumeratee[From, To] = new CheckDone[From, To] {
+      val pec = ec.prepare()
 
       def step[A](k: K[To, A]): K[From, Iteratee[To, A]] = {
 
-        case in @ Input.El(e) if transformer.isDefinedAt(e) =>
-          new CheckDone[From, To] { def continue[A](k: K[To, A]) = Cont(step(k)) } &> k(in.map(transformer))
-
-        case in @ Input.El(e) => Cont(step(k))
+        case in @ Input.El(e) => Iteratee.flatten(Future {
+          if (transformer.isDefinedAt(e)) {
+            new CheckDone[From, To] { def continue[A](k: K[To, A]) = Cont(step(k)) } &> k(Input.El(transformer(e)))
+          } else {
+            Cont(step(k))
+          }
+        }(pec))
 
         case in @ Input.Empty =>
           new CheckDone[From, To] { def continue[A](k: K[To, A]) = Cont(step(k)) } &> k(in)
@@ -436,46 +501,73 @@ object Enumeratee {
 
   }
 
-  def dropWhile[E](p: E => Boolean)(ec: ExecutionContext): Enumeratee[E, E] = new CheckDone[E, E] {
+  /**
+   * Create an Enumeratee that drops input until a predicate is satisfied.
+   *
+   * @param f A predicate to test the input with.
+   * $paramEcSingle
+   */
+  def dropWhile[E](p: E => Boolean)(implicit ec: ExecutionContext): Enumeratee[E, E] = {
+    val pec = ec.prepare()
+    new CheckDone[E, E] {
 
-    def step[A](k: K[E, A]): K[E, Iteratee[E, A]] = {
+      def step[A](k: K[E, A]): K[E, Iteratee[E, A]] = {
 
-      case in @ Input.El(e) => Iteratee.flatten(Future(p(e))(ec).map {
-        b => if (b) Cont(step(k)) else (passAlong[E] &> k(in))
-      }(dec))
+        case in @ Input.El(e) => Iteratee.flatten(Future(p(e))(pec).map {
+          b => if (b) Cont(step(k)) else (passAlong[E] &> k(in))
+        }(dec))
 
-      case in @ Input.Empty => Cont(step(k))
+        case in @ Input.Empty => Cont(step(k))
 
-      case Input.EOF => Done(Cont(k), Input.EOF)
+        case Input.EOF => Done(Cont(k), Input.EOF)
+
+      }
+
+      def continue[A](k: K[E, A]) = Cont(step(k))
 
     }
-
-    def continue[A](k: K[E, A]) = Cont(step(k))
-
   }
 
-  def takeWhile[E](p: E => Boolean)(ec: ExecutionContext): Enumeratee[E, E] = new CheckDone[E, E] {
+  /**
+   * Create an Enumeratee that passes input through while a predicate is satisfied. Once the predicate
+   * fails, no more input is passed through.
+   *
+   * @param f A predicate to test the input with.
+   * $paramEcSingle
+   */
+  def takeWhile[E](p: E => Boolean)(implicit ec: ExecutionContext): Enumeratee[E, E] = {
+    val pec = ec.prepare()
+    new CheckDone[E, E] {
 
-    def step[A](k: K[E, A]): K[E, Iteratee[E, A]] = {
+      def step[A](k: K[E, A]): K[E, Iteratee[E, A]] = {
 
-      case in @ Input.El(e) => Iteratee.flatten(Future(p(e))(ec).map {
-        b => if (b) (new CheckDone[E, E] { def continue[A](k: K[E, A]) = Cont(step(k)) } &> k(in)) else Done(Cont(k), in)
-      }(dec))
+        case in @ Input.El(e) => Iteratee.flatten(Future(p(e))(pec).map {
+          b => if (b) (new CheckDone[E, E] { def continue[A](k: K[E, A]) = Cont(step(k)) } &> k(in)) else Done(Cont(k), in)
+        }(dec))
 
-      case in @ Input.Empty =>
-        new CheckDone[E, E] { def continue[A](k: K[E, A]) = Cont(step(k)) } &> k(in)
+        case in @ Input.Empty =>
+          new CheckDone[E, E] { def continue[A](k: K[E, A]) = Cont(step(k)) } &> k(in)
 
-      case Input.EOF => Done(Cont(k), Input.EOF)
+        case Input.EOF => Done(Cont(k), Input.EOF)
+      }
+
+      def continue[A](k: K[E, A]) = Cont(step(k))
+
     }
-
-    def continue[A](k: K[E, A]) = Cont(step(k))
-
   }
 
-  def breakE[E](p: E => Boolean)(ec: ExecutionContext) = new Enumeratee[E, E] {
+  /**
+   * Create an Enumeratee that passes input through until a predicate is satisfied. Once the predicate
+   * is satisfied, no more input is passed through.
+   *
+   * @param f A predicate to test the input with.
+   * $paramEcSingle
+   */
+  def breakE[E](p: E => Boolean)(implicit ec: ExecutionContext) = new Enumeratee[E, E] {
+    val pec = ec.prepare()
     def applyOn[A](inner: Iteratee[E, A]): Iteratee[E, Iteratee[E, A]] = {
       def step(inner: Iteratee[E, A])(in: Input[E]): Iteratee[E, Iteratee[E, A]] = in match {
-        case Input.El(e) => Iteratee.flatten(Future(p(e))(ec).map(b => if (b) Done(inner, in) else stepNoBreak(inner)(in))(dec))
+        case Input.El(e) => Iteratee.flatten(Future(p(e))(pec).map(b => if (b) Done(inner, in) else stepNoBreak(inner)(in))(dec))
         case _ => stepNoBreak(inner)(in)
       }
       def stepNoBreak(inner: Iteratee[E, A])(in: Input[E]): Iteratee[E, Iteratee[E, A]] =
@@ -521,19 +613,32 @@ object Enumeratee {
     def continue[A](k: K[M, A]) = Cont(step(k))
   }
 
-  def onIterateeDone[E](action: () => Unit)(ec: ExecutionContext): Enumeratee[E, E] = new Enumeratee[E, E] {
+  /**
+   * Create an Enumeratee that performs an action when its Iteratee is done.
+   *
+   * @param action The action to perform.
+   * $paramEcSingle
+   */
+  def onIterateeDone[E](action: () => Unit)(implicit ec: ExecutionContext): Enumeratee[E, E] = new Enumeratee[E, E] {
+    val pec = ec.prepare()
 
-    def applyOn[A](iteratee: Iteratee[E, A]): Iteratee[E, Iteratee[E, A]] = passAlong[E](iteratee).map(_.map { a => action(); a }(ec))(dec)
+    def applyOn[A](iteratee: Iteratee[E, A]): Iteratee[E, Iteratee[E, A]] = passAlong[E](iteratee).map(_.map { a => action(); a }(pec))(dec)
 
   }
 
-  def onEOF[E](action: () => Unit): Enumeratee[E, E] = new CheckDone[E, E] {
+  /**
+   * Create an Enumeratee that performs an action on EOF.
+   *
+   * @param action The action to perform.
+   * $paramEcSingle
+   */
+  def onEOF[E](action: () => Unit)(implicit ec: ExecutionContext): Enumeratee[E, E] = new CheckDone[E, E] {
+    val pec = ec.prepare()
 
     def step[A](k: K[E, A]): K[E, Iteratee[E, A]] = {
 
       case Input.EOF =>
-        action()
-        Done(Cont(k), Input.EOF)
+        Iteratee.flatten(Future(action())(pec).map(_ => Done[E, Iteratee[E, A]](Cont(k), Input.EOF))(dec))
 
       case in =>
         new CheckDone[E, E] { def continue[A](k: K[E, A]) = Cont(step(k)) } &> k(in)
@@ -557,34 +662,40 @@ object Enumeratee {
    *  } |>>> Iteratee.getChunks // => List(4, 2)
    * }}}
    *
+   * @param f Called when an error occurs with the cause of the error and the input associated with the error.
+   * $paramEcSingle
    */
-  def recover[E](f: (Throwable, Input[E]) => Unit = (_: Throwable, _: Input[E]) => ())(implicit executionContext: ExecutionContext): Enumeratee[E, E] = new Enumeratee[E, E] {
-    def applyOn[A](it: Iteratee[E, A]): Iteratee[E, Iteratee[E, A]] = {
+  def recover[E](f: (Throwable, Input[E]) => Unit = (_: Throwable, _: Input[E]) => ())(implicit ec: ExecutionContext): Enumeratee[E, E] = {
+    val pec = ec.prepare()
+    new Enumeratee[E, E] {
 
-      def step(it: Iteratee[E, A])(input: Input[E]): Iteratee[E, Iteratee[E, A]] = input match {
-        case in @ (Input.El(_) | Input.Empty) =>
-          val next: Future[Iteratee[E, Iteratee[E, A]]] = it.pureFlatFold[E, Iteratee[E, A]] {
-            case Step.Cont(k) =>
-              val n = k(in)
-              n.pureFlatFold[E, Iteratee[E, A]] {
-                case Step.Cont(k) => Cont(step(n))
-                case _ => Done(n, Input.Empty)
-              }(dec)
-            case other => Done(other.it, in)
-          }(dec).unflatten.map({ s =>
-            s.it
-          })(dec).recover({
-            case e: Throwable =>
-              f(e, in)
-              Cont(step(it))
-          })(executionContext)
-          Iteratee.flatten(next)
-        case Input.EOF =>
-          Done(it, Input.Empty)
+      def applyOn[A](it: Iteratee[E, A]): Iteratee[E, Iteratee[E, A]] = {
+
+        def step(it: Iteratee[E, A])(input: Input[E]): Iteratee[E, Iteratee[E, A]] = input match {
+          case in @ (Input.El(_) | Input.Empty) =>
+            val next: Future[Iteratee[E, Iteratee[E, A]]] = it.pureFlatFold[E, Iteratee[E, A]] {
+              case Step.Cont(k) =>
+                val n = k(in)
+                n.pureFlatFold[E, Iteratee[E, A]] {
+                  case Step.Cont(k) => Cont(step(n))
+                  case _ => Done(n, Input.Empty)
+                }(dec)
+              case other => Done(other.it, in)
+            }(dec).unflatten.map({ s =>
+              s.it
+            })(dec).recover({
+              case e: Throwable =>
+                f(e, in)
+                Cont(step(it))
+            })(pec)
+            Iteratee.flatten(next)
+          case Input.EOF =>
+            Done(it, Input.Empty)
+        }
+
+        Cont(step(it))
+
       }
-
-      Cont(step(it))
-
     }
   }
 

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Execution.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Execution.scala
@@ -1,0 +1,21 @@
+package play.api.libs.iteratee
+
+import scala.concurrent.ExecutionContext
+
+/**
+ * Contains the default ExecutionContext used by Iteratees.
+ */
+private[play] object Execution {
+
+  def defaultExecutionContext: ExecutionContext = Implicits.defaultExecutionContext
+
+  object Implicits {
+    implicit lazy val defaultExecutionContext: ExecutionContext = scala.concurrent.ExecutionContext.fromExecutor(null)
+  }
+
+  val sameThreadExecutionContext: ExecutionContext = new ExecutionContext {
+    def execute(runnable: Runnable): Unit = runnable.run()
+    def reportFailure(t: Throwable): Unit = t.printStackTrace()
+  }
+
+}

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/package.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/package.scala
@@ -14,28 +14,38 @@ package play.api.libs {
 package play.api.libs.iteratee {
 
   private[iteratee] object internal {
-    import java.util.concurrent.{ Executors, ThreadFactory }
-    import java.util.concurrent.atomic.AtomicInteger
     import play.api.libs.iteratee.Iteratee
     import scala.concurrent.{ ExecutionContext, Future }
     import scala.util.control.NonFatal
 
-    val defaultExecutionContext: ExecutionContext = ExecutionContext.global
-
-    object Implicits {
-      def defaultExecutionContext: ExecutionContext = internal.defaultExecutionContext
-    }
-
-    def sameThreadExecutionContext: ExecutionContext = new ExecutionContext {
-      def execute(runnable: Runnable): Unit = runnable.run()
-      def reportFailure(t: Throwable): Unit = t.printStackTrace()
-    }
-
+    /**
+     * Executes code immediately on the current thread, returning a successful or failed Future depending on
+     * the result.
+     */
     def eagerFuture[A](body: => A): Future[A] = try Future.successful(body) catch { case NonFatal(e) => Future.failed(e) }
 
-    def executeFuture[A](body: => Future[A])(ec: ExecutionContext): Future[A] = Future(body)(ec).flatMap(x => x)(sameThreadExecutionContext)
+    /**
+     * Executes code in the given ExecutionContext, flattening the resulting Future.
+     */
+    def executeFuture[A](body: => Future[A])(implicit ec: ExecutionContext): Future[A] = Future(body)(ec).flatMap(identity)(Execution.sameThreadExecutionContext)
 
-    def executeIteratee[A, E](body: => Iteratee[A, E])(ec: ExecutionContext): Iteratee[A, E] = Iteratee.flatten(Future(body)(ec))
+    /**
+     * Executes code in the given ExecutionContext, flattening the resulting Iteratee.
+     */
+    def executeIteratee[A, E](body: => Iteratee[A, E])(implicit ec: ExecutionContext): Iteratee[A, E] = Iteratee.flatten(Future(body)(ec))
 
+    /**
+     * Prepare an ExecutionContext and pass it to the given function, returning the result of
+     * the function.
+     *
+     * Makes it easy to write single line functions with a prepared ExecutionContext, eg:
+     * {{{
+     * def myFunc(implicit ec: ExecutionContext) = prepared(ec)(pec => ...)
+     * }}}
+     */
+    def prepared[A](ec: ExecutionContext)(f: ExecutionContext => A): A = {
+      val pec = ec.prepare()
+      f(pec)
+    }
   }
 }

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/ConcurrentSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/ConcurrentSpec.scala
@@ -1,13 +1,15 @@
 package play.api.libs.iteratee
 
-import org.specs2.mutable._
-import scala.concurrent.ExecutionContext.Implicits.global
-import concurrent._
-import concurrent.duration.Duration
-import scala.language.reflectiveCalls
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit._
+import java.util.concurrent.atomic.AtomicInteger
+import org.specs2.mutable._
+import scala.concurrent._
+import scala.concurrent.duration.Duration
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.language.reflectiveCalls
 
-object ConcurrentSpec extends Specification {
+object ConcurrentSpec extends Specification with IterateeSpecification {
 
   val timer = new java.util.Timer
   def timeout[A](a: => A, d: Duration)(implicit e: ExecutionContext): Future[A] = {
@@ -20,55 +22,69 @@ object ConcurrentSpec extends Specification {
     p.future
   }
 
+  "Concurrent.broadcast (0-arg)" should {
+    "broadcast the same to already registered iteratees" in {
+      mustExecute(38) { foldEC =>
+        val (broadcaster, pushHere) = Concurrent.broadcast[String]
+        val results = Future.sequence(Range(1, 20).map(_ => Iteratee.fold[String, String]("") { (s, e) => s + e }(foldEC)).map(broadcaster.apply).map(_.flatMap(_.run)))
+        pushHere.push("beep")
+        pushHere.push("beep")
+        pushHere.eofAndEnd()
+        Await.result(results, Duration.Inf) must equalTo(Range(1, 20).map(_ => "beepbeep"))
+      }
+    }
+  }
+
   "Concurrent.buffer" should {
 
     def now = System.currentTimeMillis()
 
     "not slow down the enumerator if the iteratee is slow" in {
-      val foldMEC = TestExecutionContext()
-      val slowIteratee = Iteratee.foldM(List[Long]()){ (s,e:Long) => timeout(s :+ e, Duration(100, MILLISECONDS)) }(foldMEC)
-      val fastEnumerator = Enumerator[Long](1,2,3,4,5,6,7,8,9,10)
-      val result = 
-        fastEnumerator &>
-        Enumeratee.scanLeft((now,0L)){ case ((s,v),_) => val ms = now;  (ms,(ms - s)) } &>
-        Enumeratee.map(_._2) &>
-        Concurrent.buffer(20) |>>>
-        slowIteratee
+      mustExecute(10, 10, 10) { (foldEC, mapEC, bufferEC) =>
+        val slowIteratee = Iteratee.foldM(List[Long]()) { (s, e: Long) => timeout(s :+ e, Duration(100, MILLISECONDS)) }(foldEC)
+        val fastEnumerator = Enumerator[Long](1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        val result =
+          fastEnumerator &>
+            Enumeratee.scanLeft((now, 0L)) { case ((s, v), _) => val ms = now; (ms, (ms - s)) } &>
+            Enumeratee.map((_: (Long, Long))._2)(mapEC) &>
+            Concurrent.buffer(20, (_: Input[Long]) => 1)(bufferEC) |>>>
+            slowIteratee
 
-      Await.result(result, Duration.Inf).max must beLessThan (1000L)
-      foldMEC.executionCount must equalTo(10)
-      
+        Await.result(result, Duration.Inf).max must beLessThan(1000L)
+      }
     }
 
     "throw an exception when buffer is full" in {
-      val foldMEC = TestExecutionContext()
-      val foldCount = new java.util.concurrent.atomic.AtomicInteger()
-      val p = Promise[List[Long]]()
-      val stuckIteratee = Iteratee.foldM(List[Long]()){ (s,e:Long) => foldCount.incrementAndGet(); p.future }(foldMEC)
-      val fastEnumerator = Enumerator[Long](1,2,3,4,5,6,7,8,9,10)
-      val result = 
-        fastEnumerator &>
-        Concurrent.buffer(7) |>>>
-        stuckIteratee
+      testExecution { foldEC =>
+        val foldCount = new AtomicInteger()
+        val p = Promise[List[Long]]()
+        val stuckIteratee = Iteratee.foldM(List[Long]()) { (s, e: Long) => foldCount.incrementAndGet(); p.future }(foldEC)
+        val fastEnumerator = Enumerator[Long](1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        val result =
+          fastEnumerator &>
+            Concurrent.buffer(7) |>>>
+            stuckIteratee
 
-      Await.result(result, Duration.Inf) must throwAn[Exception]("buffer overflow")
-      foldMEC.executionCount must equalTo(foldCount.get())
+        Await.result(result, Duration.Inf) must throwAn[Exception]("buffer overflow")
+        foldEC.executionCount must equalTo(foldCount.get())
+      }
     }
 
     "drop intermediate unused input, swallow even the unused eof forcing u to pass it twice" in {
-      val p = Promise[List[Long]]()
-      val slowIteratee = Iteratee.flatten(timeout(Cont[Long,List[Long]]{case Input.El(e) => Done(List(e),Input.Empty)}, Duration(100, MILLISECONDS)))
-      val fastEnumerator = Enumerator[Long](1,2,3,4,5,6,7,8,9,10) >>> Enumerator.eof
-      val flatMapEC = TestExecutionContext()
-      val mapEC = TestExecutionContext()
-      val result = 
-        fastEnumerator |>>>
-        (Concurrent.buffer(20) &>>
-        slowIteratee).flatMap{ l => println(l); Iteratee.getChunks.map(l ++ (_: List[Long]))(mapEC)}(flatMapEC)
+      testExecution { (flatMapEC, mapEC) =>
+        val p = Promise[List[Long]]()
+        val slowIteratee = Iteratee.flatten(timeout(Cont[Long, List[Long]] { case Input.El(e) => Done(List(e), Input.Empty) }, Duration(100, MILLISECONDS)))
+        val fastEnumerator = Enumerator[Long](1, 2, 3, 4, 5, 6, 7, 8, 9, 10) >>> Enumerator.eof
+        val preparedMapEC = mapEC.prepare()
+        val result =
+          fastEnumerator |>>>
+            (Concurrent.buffer(20) &>>
+              slowIteratee).flatMap { l => println(l); Iteratee.getChunks.map(l ++ (_: List[Long]))(preparedMapEC) }(flatMapEC)
 
-      Await.result(result, Duration.Inf) must not equalTo (List(1,2,3,4,5,6,7,8,9,10))
-      flatMapEC.executionCount must beGreaterThan(0)
-      mapEC.executionCount must equalTo(flatMapEC.executionCount)
+        Await.result(result, Duration.Inf) must not equalTo (List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+        flatMapEC.executionCount must beGreaterThan(0)
+        mapEC.executionCount must equalTo(flatMapEC.executionCount)
+      }
     }
 
   }
@@ -88,62 +104,105 @@ object ConcurrentSpec extends Specification {
 
   "Concurrent.unicast" should {
     "allow to push messages and end" in {
-      val unicastEC = TestExecutionContext()
-      val a = "FOO"
-      val b = "bar"
-      val enumerator = Concurrent.unicast[String] { c =>
-        c.push(a)
-        c.push(b)
-        c.eofAndEnd()
-      }(unicastEC)
-      val foldEC = TestExecutionContext()
-      val promise = (enumerator |>> Iteratee.fold[String, String]("")(_ ++ _)(foldEC)).flatMap(_.run)
+      mustExecute(2, 2) { (unicastEC, foldEC) =>
+        val a = "FOO"
+        val b = "bar"
+        val startCount = new AtomicInteger()
+        val completeCount = new AtomicInteger()
+        val errorCount = new AtomicInteger()
+        val enumerator = Concurrent.unicast[String](
+          c => {
+            startCount.incrementAndGet()
+            c.push(a)
+            c.push(b)
+            c.eofAndEnd()
+          },
+          () => completeCount.incrementAndGet(),
+          (_: String, _: Input[String]) => errorCount.incrementAndGet())(unicastEC)
+        val promise = (enumerator |>> Iteratee.fold[String, String]("")(_ ++ _)(foldEC)).flatMap(_.run)
 
-      Await.result(promise, Duration.Inf) must equalTo (a + b)
-      unicastEC.executionCount must equalTo(2) // onStart/onComplete
-      foldEC.executionCount must equalTo(2) // once for each string
+        Await.result(promise, Duration.Inf) must equalTo(a + b)
+        startCount.get() must equalTo(1)
+        completeCount.get() must equalTo(0)
+        errorCount.get() must equalTo(0)
+      }
     }
 
     "call the onComplete callback when the iteratee is done" in {
-      val completed = Promise[String]
-      val unicastEC = TestExecutionContext()
+      mustExecute(2) { unicastEC =>
+        val completed = Promise[String]
 
-      val enumerator = Concurrent.unicast[String](onStart = { c =>
-        c.push("foo")
-        c.push("bar")
-      }, onComplete = {
-        completed.success("called")
-      })(unicastEC)
+        val enumerator = Concurrent.unicast[String](onStart = { c =>
+          c.push("foo")
+          c.push("bar")
+        }, onComplete = {
+          completed.success("called")
+        })(unicastEC)
 
-      val future = enumerator |>>> Cont {
-        case Input.El(data) => Done(data)
-        case _ => Done("didn't get data")
+        val future = enumerator |>>> Cont {
+          case Input.El(data) => Done(data)
+          case _ => Done("didn't get data")
+        }
+
+        Await.result(future, Duration.Inf) must_== "foo"
+        Await.result(completed.future, Duration.Inf) must_== "called"
       }
-
-      Await.result(future, Duration.Inf) must_== "foo"
-      Await.result(completed.future, Duration.Inf) must_== "called"
-      unicastEC.executionCount must equalTo(2) // onStart/onComplete
     }
 
     "call the onError callback when the iteratee encounters an error" in {
-      val error = Promise[String]
-      val unicastEC = TestExecutionContext()
+      mustExecute(2) { unicastEC =>
+        val error = Promise[String]
 
-      val enumerator = Concurrent.unicast[String](onStart = { c =>
-        c.push("foo")
-        c.push("bar")
-      }, onError = { (err, input) =>
-        error.success(err)
-      })(unicastEC)
+        val enumerator = Concurrent.unicast[String](onStart = { c =>
+          c.push("foo")
+          c.push("bar")
+        }, onError = { (err, input) =>
+          error.success(err)
+        })(unicastEC)
 
-      enumerator |>> Cont {
-        case Input.El(data) => Error(data, Input.Empty)
-        case in => Error("didn't get data", in)
+        enumerator |>> Cont {
+          case Input.El(data) => Error(data, Input.Empty)
+          case in => Error("didn't get data", in)
+        }
+
+        Await.result(error.future, Duration.Inf) must_== "foo"
       }
-
-      Await.result(error.future, Duration.Inf) must_== "foo"
-      unicastEC.executionCount must equalTo(2) // onStart/onError
     }
   }
+
+  "Concurrent.broadcast (2-arg)" should {
+    "call callback in the correct ExecutionContext" in {
+      mustExecute(1) { callbackEC =>
+        val (e0, c) = Concurrent.broadcast[Int]
+        val interestCount = new AtomicInteger()
+        val interestDone = new CountDownLatch(1)
+        val (e2, b) = Concurrent.broadcast(e0, { f =>
+          interestCount.incrementAndGet()
+          interestDone.countDown()
+          })(callbackEC)
+        val i = e2 |>>> Iteratee.getChunks[Int]
+        c.push(1)
+        c.push(2)
+        c.push(3)
+        c.eofAndEnd()
+        Await.result(i, Duration.Inf) must equalTo(List(1, 2, 3))
+        interestDone.await(5, SECONDS)
+        interestCount.get() must equalTo(1)
+      }
+    }
+  } 
+  
+  "Concurrent.patchPanel" should {
+
+    "perform patching in the correct ExecutionContext" in {
+      mustExecute(1) { ppEC =>
+        val e = Concurrent.patchPanel[Int] { pp =>
+          pp.patchIn(Enumerator.eof)
+        }(ppEC)
+        Await.result(e |>>> Iteratee.getChunks[Int], Duration.Inf) must equalTo(Nil)
+      }
+    }
+  }
+  
 
 }

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumerateesSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumerateesSpec.scala
@@ -1,13 +1,92 @@
 package play.api.libs.iteratee
 
+import play.api.libs.iteratee.Execution.Implicits.{ defaultExecutionContext => dec }
 import scala.concurrent._
 import scala.concurrent.duration.Duration
 import scala.language.reflectiveCalls
 
 import org.specs2.mutable._
 
-object EnumerateesSpec extends Specification {
+object EnumerateesSpec extends Specification with IterateeSpecification {
 
+  "Enumeratee.zip" should {
+    
+    "combine the final results into a pair" in {
+      Await.result(Enumeratee.zip(Done[Int, Int](2), Done[Int, Int](3)).unflatten, Duration.Inf) must equalTo(Step.Done((2, 3), Input.Empty))
+    }
+    
+  }
+
+  "Enumeratee.zipWith" should {
+    
+    "combine the final results" in {
+      mustExecute(1) { zipEC =>
+        Await.result(Enumeratee.zipWith(Done[Int, Int](2), Done[Int, Int](3))(_ * _)(zipEC).unflatten, Duration.Inf) must equalTo(Step.Done(6, Input.Empty))
+      }
+    }
+    
+  }
+
+  "Enumeratee.mapInput" should {
+    
+    "transform each input" in {
+      mustExecute(2) { mapEC =>
+        mustTransformTo(1, 2)(2, 4)(Enumeratee.mapInput[Int](_.map(_ * 2))(mapEC))
+      }
+    }
+    
+  }
+
+  "Enumeratee.mapConcatInput" should {
+    
+    "transform each input element into a sequence of inputs" in {
+      mustExecute(2) { mapEC =>
+        mustTransformTo(1, 2)(1, 1, 2, 2)(Enumeratee.mapConcatInput[Int](x => List(Input.El(x), Input.Empty, Input.El(x)))(mapEC))
+      }
+    }
+    
+  }
+
+  "Enumeratee.mapConcat" should {
+    
+    "transform each input element into a sequence of input elements" in {
+      mustExecute(2) { mapEC =>
+        mustTransformTo(1, 2)(1, 1, 2, 2)(Enumeratee.mapConcat[Int](x => List(x, x))(mapEC))
+      }
+    }
+    
+  }
+
+  "Enumeratee.mapFlatten" should {
+    
+    "transform each input element into the output of an enumerator" in {
+      mustExecute(2) { mapFlattenEC =>
+        mustTransformTo(1, 2)(1, 1, 2, 2)(Enumeratee.mapFlatten[Int](x => Enumerator(x, x))(mapFlattenEC))
+      }
+    }
+    
+  }
+
+  "Enumeratee.mapInputM" should {
+    
+    "transform each input" in {
+      mustExecute(2) { mapEC =>
+        mustTransformTo(1, 2)(2, 4)(Enumeratee.mapInputM[Int]((i: Input[Int]) => Future.successful(i.map(_ * 2)))(mapEC))
+      }
+    }
+    
+  }
+
+  "Enumeratee.mapM" should {
+    
+    "transform each input element" in {
+      mustExecute(2) { mapEC =>
+        mustTransformTo(1, 2)(2, 4)(Enumeratee.mapM[Int]((x: Int) => Future.successful(x * 2))(mapEC))
+      }
+    }
+    
+  }
+  
   "Enumeratee.drop" should {
 
     "ignore 3 chunkes when applied with 3" in {
@@ -22,14 +101,12 @@ object EnumerateesSpec extends Specification {
 
   "Enumeratee.dropWhile" should {
 
-    "ignore chunkes while predicate is valid" in {
-      
-      val dropWhileEC = TestExecutionContext()
-      val drop3AndConsume = Enumeratee.dropWhile[String](_ != "4")(dropWhileEC) &>>  Iteratee.consume[String]()
-      val enumerator = Enumerator(Range(1,20).map(_.toString) :_*)
-      Await.result(enumerator |>>> drop3AndConsume, Duration.Inf) must equalTo(Range(4,20).map(_.toString).mkString)
-      dropWhileEC.executionCount must equalTo(4)
-
+    "ignore chunks while predicate is valid" in {
+      mustExecute(4) { dropWhileEC =>
+        val drop3AndConsume = Enumeratee.dropWhile[String](_ != "4")(dropWhileEC) &>> Iteratee.consume[String]()
+        val enumerator = Enumerator(Range(1, 20).map(_.toString): _*)
+        Await.result(enumerator |>>> drop3AndConsume, Duration.Inf) must equalTo(Range(4, 20).map(_.toString).mkString)
+      }
     }
 
   }
@@ -45,26 +122,23 @@ object EnumerateesSpec extends Specification {
     }
 
     "passes along what's left of chunks after taking 3" in {
-      val tec = TestExecutionContext()
-      val take3AndConsume = (Enumeratee.take[String](3) &>>  Iteratee.consume()).flatMap(_ => Iteratee.consume())(tec)
-      val enumerator = Enumerator(Range(1,20).map(_.toString) :_*)
-      Await.result(enumerator |>>> take3AndConsume, Duration.Inf) must equalTo(Range(4,20).map(_.toString).mkString)
-      tec.executionCount must equalTo(1)
-
+      mustExecute(1) { flatMapEC =>
+        val take3AndConsume = (Enumeratee.take[String](3) &>> Iteratee.consume()).flatMap(_ => Iteratee.consume())(flatMapEC)
+        val enumerator = Enumerator(Range(1, 20).map(_.toString): _*)
+        Await.result(enumerator |>>> take3AndConsume, Duration.Inf) must equalTo(Range(4, 20).map(_.toString).mkString)
+      }
     }
 
     "not execute callback on take 0" in {
-      val generateEC = TestExecutionContext()
-      val foldEC = TestExecutionContext()
-      var triggered = false
-      val enumerator = Enumerator.generateM {
+      mustExecute(0, 0) { (generateEC, foldEC) =>
+        var triggered = false
+        val enumerator = Enumerator.generateM {
           triggered = true
-          Future(Some(1))(generateEC)
+          Future(Some(1))(dec)
+        }(generateEC)
+        Await.result(enumerator &> Enumeratee.take(0) |>>> Iteratee.fold(0)((_: Int) + (_: Int))(foldEC), Duration.Inf) must equalTo(0)
+        triggered must beFalse
       }
-      Await.result(enumerator &> Enumeratee.take(0) |>>> Iteratee.fold(0)((_: Int) + (_: Int))(foldEC), Duration.Inf) must equalTo(0)
-      triggered must beFalse
-      generateEC.executionCount must equalTo(0)
-      foldEC.executionCount must equalTo(0)
     }
 
   }
@@ -72,27 +146,56 @@ object EnumerateesSpec extends Specification {
   "Enumeratee.takeWhile" should {
 
     "pass chunks until condition is not met" in {
-      val takeWhileEC = TestExecutionContext()
-      val take3AndConsume = Enumeratee.takeWhile[String](_ != "4" )(takeWhileEC) &>>  Iteratee.consume()
-      val enumerator = Enumerator(Range(1,20).map(_.toString) :_*)  
-      Await.result(enumerator |>>> take3AndConsume, Duration.Inf) must equalTo(List(1,2,3).map(_.toString).mkString)
-      takeWhileEC.executionCount must equalTo(4)
+      mustExecute(4) { takeWhileEC =>
+        val take3AndConsume = Enumeratee.takeWhile[String](_ != "4")(takeWhileEC) &>> Iteratee.consume()
+        val enumerator = Enumerator(Range(1, 20).map(_.toString): _*)
+        Await.result(enumerator |>>> take3AndConsume, Duration.Inf) must equalTo(List(1, 2, 3).map(_.toString).mkString)
+      }
     }
 
     "passes along what's left of chunks after taking" in {
-      val takeWhileEC = TestExecutionContext()
-      val consumeFlatMapEC = TestExecutionContext()
-      val generateEC = TestExecutionContext()
-      val take3AndConsume = (Enumeratee.takeWhile[String](_ != "4")(takeWhileEC) &>>  Iteratee.consume()).flatMap(_ => Iteratee.consume())(consumeFlatMapEC)
-      val enumerator = Enumerator(Range(1,20).map(_.toString) :_*)  
-      Await.result(enumerator |>>> take3AndConsume, Duration.Inf) must equalTo(Range(4,20).map(_.toString).mkString)
-      takeWhileEC.executionCount must equalTo(4)
-      consumeFlatMapEC.executionCount must equalTo(1)
-
+      mustExecute(4, 1, 0) { (takeWhileEC, consumeFlatMapEC, generateEC) =>
+        val take3AndConsume = (Enumeratee.takeWhile[String](_ != "4")(takeWhileEC) &>> Iteratee.consume()).flatMap(_ => Iteratee.consume())(consumeFlatMapEC)
+        val enumerator = Enumerator(Range(1, 20).map(_.toString): _*)
+        Await.result(enumerator |>>> take3AndConsume, Duration.Inf) must equalTo(Range(4, 20).map(_.toString).mkString)
+      }
     }
 
   }
 
+  "Enumeratee.breakE" should {
+    
+    "pass input through until the predicate is met" in {
+      mustExecute(3) { breakEC =>
+        mustTransformTo(1, 2, 3, 2, 1)(1, 2)(Enumeratee.breakE[Int](_ > 2)(breakEC))
+      }
+    }
+    
+  }
+
+  "Enumeratee.onIterateeDone" should {
+
+    "call the callback when the iteratee is done" in {
+      mustExecute(1) { doneEC =>
+        val count = new java.util.concurrent.atomic.AtomicInteger()
+        mustTransformTo(1, 2, 3)(1, 2, 3)(Enumeratee.onIterateeDone(() => count.incrementAndGet())(doneEC))
+        count.get() must equalTo(1)
+      }
+    }
+
+  }
+
+  "Enumeratee.onEOF" should {
+
+    "call the callback on EOF" in {
+      mustExecute(1) { eofEC =>
+        val count = new java.util.concurrent.atomic.AtomicInteger()
+        mustTransformTo(1, 2, 3)(1, 2, 3)(Enumeratee.onEOF(() => count.incrementAndGet())(eofEC))
+        count.get() must equalTo(1)
+      }
+    }
+
+  }
 
   "Traversable.take" should {
 
@@ -105,13 +208,11 @@ object EnumerateesSpec extends Specification {
     }
 
     "pass along what's left after taking 3 elements" in {
-
-      val consumeFlatMapEC = TestExecutionContext()
-      val take3AndConsume = (Traversable.take[String](3) &>>  Iteratee.consume()).flatMap(_ => Iteratee.consume())(consumeFlatMapEC)
-      val enumerator = Enumerator("he","ybbb","bbb")  
-      Await.result(enumerator |>>> take3AndConsume, Duration.Inf) must equalTo("bbbbbb")
-      consumeFlatMapEC.executionCount must equalTo(1)
-
+      mustExecute(1) { consumeFlatMapEC =>
+        val take3AndConsume = (Traversable.take[String](3) &>> Iteratee.consume()).flatMap(_ => Iteratee.consume())(consumeFlatMapEC)
+        val enumerator = Enumerator("he", "ybbb", "bbb")
+        Await.result(enumerator |>>> take3AndConsume, Duration.Inf) must equalTo("bbbbbb")
+      }
     }
 
   }
@@ -119,26 +220,28 @@ object EnumerateesSpec extends Specification {
   "Enumeratee.map" should {
 
     "add one to each of the ints enumerated" in {
-      
-      val add1AndConsume = Enumeratee.map[Int](i => List(i+1)) &>>  Iteratee.consume()
-      val enumerator = Enumerator(1,2,3,4)  
-      Await.result(enumerator |>>> add1AndConsume, Duration.Inf) must equalTo(Seq(2,3,4,5))
-
+      mustExecute(4) { mapEC =>
+        val add1AndConsume = Enumeratee.map[Int](i => List(i+1))(mapEC) &>>  Iteratee.consume()
+        val enumerator = Enumerator(1,2,3,4)  
+        Await.result(enumerator |>>> add1AndConsume, Duration.Inf) must equalTo(Seq(2,3,4,5))
+      }
     }
 
 
     "infer its types correctly from previous enumeratee" in {
-      
-      val add1AndConsume = Enumeratee.map[Int](i => i+1) ><> Enumeratee.map(i => List(i)) &>>  Iteratee.consume()
-      add1AndConsume : Iteratee[Int,List[Int]]
-      true //this test is about compilation and if it compiles it means we got it right
+      mustExecute(0, 0) { (map1EC, map2EC) =>
+        val add1AndConsume = Enumeratee.map[Int](i => i+1)(map1EC) ><> Enumeratee.map[Int](i => List(i))(map2EC) &>>  Iteratee.consume()
+        add1AndConsume : Iteratee[Int,List[Int]]
+        true //this test is about compilation and if it compiles it means we got it right
+      }
     }
 
     "infer its types correctly from the preceeding enumerator" in {
-      
-      val addOne = Enumerator(1,2,3,4) &> Enumeratee.map(i => i+1) 
-      addOne : Enumerator[Int]
-      true //this test is about compilation and if it compiles it means we got it right
+      mustExecute(0) { mapEC =>
+        val addOne = Enumerator(1,2,3,4) &> Enumeratee.map[Int](i => i+1)(mapEC)
+        addOne : Enumerator[Int]
+        true //this test is about compilation and if it compiles it means we got it right
+      }
     }
 
   }
@@ -146,29 +249,36 @@ object EnumerateesSpec extends Specification {
   "Enumeratee.flatten" should {
 
     "passAlong a future enumerator" in {
-
-      val passAlongFuture = Enumeratee.flatten {
-        concurrent.future { 
-          Enumeratee.passAlong[Int]
-        } (ExecutionContext.global)
+      mustExecute(9) { sumEC =>
+        val passAlongFuture = Enumeratee.flatten {
+          concurrent.future {
+            Enumeratee.passAlong[Int]
+          }(ExecutionContext.global)
+        }
+        val sum = Iteratee.fold[Int, Int](0)(_ + _)(sumEC)
+        val enumerator = Enumerator(1, 2, 3, 4, 5, 6, 7, 8, 9)
+        Await.result(enumerator |>>> passAlongFuture &>> sum, Duration.Inf) must equalTo(45)
       }
-      val sumEC = TestExecutionContext()
-      val sum = Iteratee.fold[Int, Int](0)(_+_)(sumEC)
-      val enumerator = Enumerator(1,2,3,4,5,6,7,8,9)
-      Await.result(enumerator |>>> passAlongFuture &>> sum, Duration.Inf) must equalTo(45)
-      sumEC.executionCount must equalTo(9)
     }
 
   }
 
   "Enumeratee.filter" should {
 
-    "ignore input that doesn't satisfy the predicate" in {
-      
-      val takesOnlyStringsWithLessThan4Chars = Enumeratee.filter[String](_.length < 4) &>>  Iteratee.consume()
-      val enumerator = Enumerator("One","Two","Three","Four", "Five", "Six")
-      Await.result(enumerator |>>> takesOnlyStringsWithLessThan4Chars, Duration.Inf) must equalTo("OneTwoSix")
+    "only enumerate input that satisfies the predicate" in {
+      mustExecute(6) { filterEC =>
+        mustTransformTo("One", "Two", "Three", "Four", "Five", "Six")("One", "Two", "Six")(Enumeratee.filter[String](_.length < 4)(filterEC))
+      }
+    }
 
+  }
+
+  "Enumeratee.filterNot" should {
+
+    "only enumerate input that doesn't satisfy the predicate" in {
+      mustExecute(6) { filterEC =>
+        mustTransformTo("One", "Two", "Three", "Four", "Five", "Six")("Three", "Four", "Five")(Enumeratee.filterNot[String](_.length < 4)(filterEC))
+      }
     }
 
   }
@@ -176,11 +286,9 @@ object EnumerateesSpec extends Specification {
   "Enumeratee.collect" should {
 
     "ignores input that doesn't satisfy the predicate and transform the input when matches" in {
-      
-      val takesOnlyStringsWithLessThan4Chars = Enumeratee.collect[String]{ case e@("One" | "Two" | "Six") => e.toUpperCase } &>>  Iteratee.consume()
-      val enumerator = Enumerator("One","Two","Three","Four", "Five", "Six")  
-      Await.result(enumerator |>>> takesOnlyStringsWithLessThan4Chars, Duration.Inf) must equalTo("ONETWOSIX")
-
+      mustExecute(6) { collectEC =>
+        mustTransformTo("One", "Two", "Three", "Four", "Five", "Six")("ONE", "TWO", "SIX")(Enumeratee.collect[String]{ case e@("One" | "Two" | "Six") => e.toUpperCase }(collectEC))
+      }
     }
 
   }
@@ -188,45 +296,48 @@ object EnumerateesSpec extends Specification {
   "Enumeratee.grouped" should {
 
     "group input elements according to a folder iteratee" in {
-      val foldEC = TestExecutionContext()
-      val folderIteratee = 
-        Enumeratee.mapInput[String]{ 
-          case Input.El("Concat") => Input.EOF;
-          case other => other } &>>
-        Iteratee.fold[String, String]("")((s,e) => s + e)(foldEC)
+      mustExecute(9, 7, 3) { (mapInputEC, foldEC, mapEC) =>
+        val folderIteratee =
+          Enumeratee.mapInput[String] {
+            case Input.El("Concat") => Input.EOF;
+            case other => other
+          }(mapInputEC) &>>
+            Iteratee.fold[String, String]("")((s, e) => s + e)(foldEC)
 
-      val result = 
-        Enumerator("He","ll","o","Concat", "Wo", "r", "ld", "Concat","!") &>
-        Enumeratee.grouped(folderIteratee) ><>
-        Enumeratee.map(List(_)) |>>>
-        Iteratee.consume()
-      Await.result(result, Duration.Inf) must equalTo(List("Hello","World","!"))
-      foldEC.executionCount must equalTo(7)
+        val result =
+          Enumerator("He", "ll", "o", "Concat", "Wo", "r", "ld", "Concat", "!") &>
+            Enumeratee.grouped(folderIteratee) ><>
+            Enumeratee.map[String](List(_))(mapEC) |>>>
+            Iteratee.consume()
+        Await.result(result, Duration.Inf) must equalTo(List("Hello", "World", "!"))
+      }
     }
 
   }
 
   "Enumeratee.grouped" should {
     "pass along what is consumed by the last folder iteratee on EOF" in {
+      mustExecute(4, 3) { (splitEC, mapEC) =>
+        val upToSpace = Traversable.splitOnceAt[String, Char](c => c != '\n')(implicitly[String => scala.collection.TraversableLike[Char, String]], splitEC) &>> Iteratee.consume()
 
-      val upToSpace = Traversable.splitOnceAt[String,Char](c => c != '\n')  &>> Iteratee.consume()
-
-      val result = (Enumerator("dasdasdas ", "dadadasda\nshouldb\neinnext") &> Enumeratee.grouped(upToSpace) ><> Enumeratee.map(_+"|")) |>>> Iteratee.consume[String]()
-      Await.result(result, Duration.Inf) must equalTo("dasdasdas dadadasda|shouldb|einnext|")
+        val result = (Enumerator("dasdasdas ", "dadadasda\nshouldb\neinnext") &> Enumeratee.grouped(upToSpace) ><> Enumeratee.map[String](_ + "|")(mapEC)) |>>> Iteratee.consume[String]()
+        Await.result(result, Duration.Inf) must equalTo("dasdasdas dadadasda|shouldb|einnext|")
+      }
     }
   }
 
   "Enumeratee.scanLeft" should {
 
     "transform elements using a sate" in {
-      val result = 
-        Enumerator(1,2,3,4) &> 
-        Enumeratee.scanLeft[Int](0)(_ + _) ><>
-        Enumeratee.map(List(_)) |>>>
-        Iteratee.consume()
+      mustExecute(4) { mapEC =>
+        val result =
+          Enumerator(1, 2, 3, 4) &>
+            Enumeratee.scanLeft[Int](0)(_ + _) ><>
+            Enumeratee.map[Int](List(_))(mapEC) |>>>
+            Iteratee.consume()
 
-      Await.result(result, Duration.Inf) must equalTo(List(1,3,6,10))
-
+        Await.result(result, Duration.Inf) must equalTo(List(1, 3, 6, 10))
+      }
     }
 
   }
@@ -234,16 +345,17 @@ object EnumerateesSpec extends Specification {
   "Enumeratee.recover" should {
 
     "perform computations and log errors" in {
-      val eventuallyInput = Promise[Input[Int]]()
-      val recoverEC = TestExecutionContext()
-      val result = Enumerator(0, 2, 4) &> Enumeratee.recover[Int] { (_, input) =>
-        eventuallyInput.success(input)
-      }(recoverEC) &> Enumeratee.map { i =>
+      mustExecute(3, 3) { (recoverEC, mapEC) =>
+        val eventuallyInput = Promise[Input[Int]]()
+        val result = Enumerator(0, 2, 4) &> Enumeratee.recover[Int] { (_, input) =>
+          eventuallyInput.success(input)
+        }(recoverEC) &> Enumeratee.map[Int] { i =>
           8 / i
-      } |>>> Iteratee.getChunks // => List(4, 2)
+        }(mapEC) |>>> Iteratee.getChunks // => List(4, 2)
 
-      Await.result(result, Duration.Inf) must equalTo(List(4, 2))
-      Await.result(eventuallyInput.future, Duration.Inf) must equalTo(Input.El(0))
+        Await.result(result, Duration.Inf) must equalTo(List(4, 2))
+        Await.result(eventuallyInput.future, Duration.Inf) must equalTo(Input.El(0))
+      }
     }
   }
 

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumeratorsSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumeratorsSpec.scala
@@ -4,102 +4,102 @@ import org.specs2.mutable._
 
 import java.io.OutputStream
 import java.util.concurrent.{CountDownLatch, TimeUnit}
-import scala.concurrent.ExecutionContext.Implicits.global
+import java.util.concurrent.atomic.AtomicInteger
+import play.api.libs.iteratee.Execution.Implicits.{ defaultExecutionContext => dec }
 import scala.concurrent.{Promise, Future, Await}
 import scala.concurrent.duration.Duration
 import scala.language.reflectiveCalls
 
-object EnumeratorsSpec extends Specification {
+object EnumeratorsSpec extends Specification with IterateeSpecification {
 
+  "Enumerator's interleave" should {
 
-"Enumerator's interleave" should {
-
-  "mix it with another enumerator into one" in {
-      val e1 = Enumerator(List(1),List(3),List(5),List(7))
-      val e2 = Enumerator(List(2),List(4),List(6),List(8))
-      val e = e1 interleave e2
-      val foldEC = TestExecutionContext()
-      val kk = e |>>> Iteratee.fold(List.empty[Int])((r, e: List[Int]) => r ++ e)(foldEC)
-      val result = Await.result(kk, Duration.Inf)
-      println("interleaved enumerators result is: "+result)
-      result.diff(Seq(1,2,3,4,5,6,7,8)) must equalTo (Seq())
-      foldEC.executionCount must equalTo(8)
+    "mix it with another enumerator into one" in {
+      mustExecute(8) { foldEC =>
+        val e1 = Enumerator(List(1), List(3), List(5), List(7))
+        val e2 = Enumerator(List(2), List(4), List(6), List(8))
+        val e = e1 interleave e2
+        val kk = e |>>> Iteratee.fold(List.empty[Int])((r, e: List[Int]) => r ++ e)(foldEC)
+        val result = Await.result(kk, Duration.Inf)
+        println("interleaved enumerators result is: " + result)
+        result.diff(Seq(1, 2, 3, 4, 5, 6, 7, 8)) must equalTo(Seq())
+      }
     }
 
-  "yield when both enumerators EOF" in {
-      val e1 = Enumerator(List(1),List(3),List(5),List(7)) >>> Enumerator.enumInput(Input.EOF)
-      val e2 = Enumerator(List(2),List(4),List(6),List(8))  >>> Enumerator.enumInput(Input.EOF)
-      val e = e1 interleave e2
-      val foldEC = TestExecutionContext()
-      val kk = e |>>> Iteratee.fold(List.empty[Int])((r, e: List[Int]) => r ++ e)(foldEC)
-      val result = Await.result(kk, Duration.Inf)
-      result.diff(Seq(1,2,3,4,5,6,7,8)) must equalTo (Seq())
-      foldEC.executionCount must equalTo(8)
+    "yield when both enumerators EOF" in {
+      mustExecute(8) { foldEC =>
+        val e1 = Enumerator(List(1), List(3), List(5), List(7)) >>> Enumerator.enumInput(Input.EOF)
+        val e2 = Enumerator(List(2), List(4), List(6), List(8)) >>> Enumerator.enumInput(Input.EOF)
+        val e = e1 interleave e2
+        val kk = e |>>> Iteratee.fold(List.empty[Int])((r, e: List[Int]) => r ++ e)(foldEC)
+        val result = Await.result(kk, Duration.Inf)
+        result.diff(Seq(1, 2, 3, 4, 5, 6, 7, 8)) must equalTo(Seq())
+      }
     }
 
-  "yield when iteratee is done!" in {
-      val e1 = Enumerator(List(1),List(3),List(5),List(7))
-      val e2 = Enumerator(List(2),List(4),List(6),List(8))
-      val e = e1 interleave e2
-      val foldEC = TestExecutionContext()
-      val kk = e |>>> Enumeratee.take(7) &>> Iteratee.fold(List.empty[Int])((r, e: List[Int]) => r ++ e)(foldEC)
-      val result = Await.result(kk, Duration.Inf)
-      result.length must equalTo (7)
-      foldEC.executionCount must equalTo(7)
+    "yield when iteratee is done!" in {
+      mustExecute(7) { foldEC =>
+        val e1 = Enumerator(List(1), List(3), List(5), List(7))
+        val e2 = Enumerator(List(2), List(4), List(6), List(8))
+        val e = e1 interleave e2
+        val kk = e |>>> Enumeratee.take(7) &>> Iteratee.fold(List.empty[Int])((r, e: List[Int]) => r ++ e)(foldEC)
+        val result = Await.result(kk, Duration.Inf)
+        result.length must equalTo(7)
+      }
     }
 
-  "not necessarily go alternatively between two enumerators" in {
-    val firstDone = Promise[Unit]
-    val onDoneEC = TestExecutionContext()
-    val e1 = Enumerator(1, 2, 3, 4).onDoneEnumerating(firstDone.success(Unit))(onDoneEC)
-    val e2 = Enumerator.unfoldM[Boolean, Int](true) { first => if (first) firstDone.future.map(_ => Some(false, 5)) else Future.successful(None)}
-    val result = Await.result((e1 interleave e2) |>>> Iteratee.getChunks[Int], Duration.Inf)
-    result must_== Seq(1, 2, 3, 4, 5)
-    onDoneEC.executionCount must equalTo(1)
+    "not necessarily go alternatively between two enumerators" in {
+      mustExecute(1, 2) { (onDoneEC, unfoldEC) =>
+        val firstDone = Promise[Unit]
+        val e1 = Enumerator(1, 2, 3, 4).onDoneEnumerating(firstDone.success(Unit))(onDoneEC)
+        val e2 = Enumerator.unfoldM[Boolean, Int](true) { first => if (first) firstDone.future.map(_ => Some(false, 5)) else Future.successful(None) }(unfoldEC)
+        val result = Await.result((e1 interleave e2) |>>> Iteratee.getChunks[Int], Duration.Inf)
+        result must_== Seq(1, 2, 3, 4, 5)
+      }
+    }
+
   }
 
-}
+  "Enumerator.enumerate " should {
+    "generate an Enumerator from a singleton Iterator" in {
+      mustExecute(1) { foldEC =>
+        val iterator = scala.collection.Iterator.single[Int](3)
+        val futureOfResult = Enumerator.enumerate(iterator) |>>>
+          Enumeratee.take(1) &>>
+          Iteratee.fold(List.empty[Int])((r, e: Int) => e :: r)(foldEC)
+        val result = Await.result(futureOfResult, Duration.Inf)
+        result(0) must equalTo(3)
+        result.length must equalTo(1)
+      }
+    }
 
-"Enumerator.enumerate " should {
-  "generate an Enumerator from a singleton Iterator" in {
-    val iterator = scala.collection.Iterator.single[Int](3)
-    val foldEC = TestExecutionContext()
-    val futureOfResult = Enumerator.enumerate(iterator) |>>> 
-                         Enumeratee.take(1) &>> 
-                         Iteratee.fold(List.empty[Int])((r, e: Int) => e::r)(foldEC)
-    val result = Await.result(futureOfResult, Duration.Inf)
-    result(0) must equalTo(3)
-    result.length must equalTo(1)
-    foldEC.executionCount must equalTo(1)
+    "take as much element as in the iterator in the right order" in {
+      mustExecute(50) { foldEC =>
+        val iterator = scala.collection.Iterator.range(0, 50)
+        val futureOfResult = Enumerator.enumerate(iterator) |>>>
+          Enumeratee.take(100) &>>
+          Iteratee.fold(Seq.empty[Int])((r, e: Int) => r :+ e)(foldEC)
+        val result = Await.result(futureOfResult, Duration.Inf)
+        result.length must equalTo(50)
+        result(0) must equalTo(0)
+        result(49) must equalTo(49)
+      }
+    }
+    "work with Seq too" in {
+      mustExecute(6) { foldEC =>
+        val seq = List(1, 2, 3, 7, 42, 666)
+        val futureOfResult = Enumerator.enumerate(seq) |>>>
+          Enumeratee.take(100) &>>
+          Iteratee.fold(Seq.empty[Int])((r, e: Int) => r :+ e)(foldEC)
+        val result = Await.result(futureOfResult, Duration.Inf)
+        result.length must equalTo(6)
+        result(0) must equalTo(1)
+        result(4) must equalTo(42)
+      }
+    }
   }
 
-  "take as much element as in the iterator in the right order" in {
-    val iterator = scala.collection.Iterator.range(0, 50)
-    val foldEC = TestExecutionContext()
-    val futureOfResult = Enumerator.enumerate(iterator) |>>> 
-                         Enumeratee.take(100) &>> 
-                         Iteratee.fold(Seq.empty[Int])((r, e: Int) => r :+ e)(foldEC)
-    val result = Await.result(futureOfResult, Duration.Inf)
-    result.length must equalTo(50)
-    result(0) must equalTo(0)
-    result(49) must equalTo(49)
-    foldEC.executionCount must equalTo(50)
-  }
-  "work with Seq too" in {
-    val seq = List(1, 2, 3, 7, 42, 666)
-    val foldEC = TestExecutionContext()
-    val futureOfResult = Enumerator.enumerate(seq) |>>> 
-                         Enumeratee.take(100) &>> 
-                         Iteratee.fold(Seq.empty[Int])((r, e: Int) => r :+ e)(foldEC)
-    val result = Await.result(futureOfResult, Duration.Inf)
-    result.length must equalTo(6)
-    result(0) must equalTo(1)
-    result(4) must equalTo(42)
-    foldEC.executionCount must equalTo(6)
-  }
-}
-
-/*"Enumerator's PatchPanel" should {
+  /*"Enumerator's PatchPanel" should {
 
   "allow to patch in different Enumerators" in {
       import play.api.libs.concurrent.Promise
@@ -114,113 +114,232 @@ object EnumeratorsSpec extends Specification {
   }
 
 }*/
-
-"Enumerator" should {
-  "be transformed to another Enumerator using flatMap" in {
-    val flatMapEC = TestExecutionContext()
-    val foldEC = TestExecutionContext()
-    val e = Enumerator(10, 20, 30).flatMap(i => Enumerator((i until i + 10): _*))(flatMapEC)
-    val it = Iteratee.fold[Int, Int](0)((sum, x) => sum + x)(foldEC)
-    Await.result(e |>>> it, Duration.Inf) must equalTo ((10 until 40).sum)
-    flatMapEC.executionCount must equalTo(3)
-    foldEC.executionCount must equalTo(30)
-  }
-}
-
-"Enumerator.generateM" should {
-  "generate a stream of values until the expression is None" in {
-
-    val a = (0 to 10).toList
-    val it = a.iterator
-
-    val enumerator = Enumerator.generateM(Future(if(it.hasNext) Some(it.next()) else None))
-
-    val foldEC = TestExecutionContext()
-    Await.result(enumerator |>>> Iteratee.fold[Int,String]("")(_ + _)(foldEC), Duration.Inf) must equalTo ("012345678910")
-    foldEC.executionCount must equalTo(11)
-
-  }
-
-}
-
-"Enumerator.generateM" should {
-  "Can be composed with another enumerator (doesn't send EOF)" in {
-
-    val a = (0 to 10).toList
-    val it = a.iterator
-
-    val enumerator = Enumerator.generateM(Future(if(it.hasNext) Some(it.next()) else None)) >>> Enumerator(12)
-
-    val foldEC = TestExecutionContext()
-    Await.result(enumerator |>>> Iteratee.fold[Int,String]("")(_ + _)(foldEC), Duration.Inf) must equalTo ("01234567891012")
-    foldEC.executionCount must equalTo(12)
-
-  }
-
-}
-
-"Enumerator.unfoldM" should {
-  "Can be composed with another enumerator (doesn't send EOF)" in {
-
-    val enumerator = Enumerator.unfoldM[Int,Int](0)( s => Future(if(s > 10) None else Some((s+1,s+1)))) >>> Enumerator(12)
-
-    val foldEC = TestExecutionContext()
-    Await.result(enumerator |>>> Iteratee.fold[Int,String]("")(_ + _)(foldEC), Duration.Inf) must equalTo ("123456789101112")
-    foldEC.executionCount must equalTo(12)
-
-  }
-
-}
-
-"Enumerator.broadcast" should {
-  "broadcast the same to already registered iteratees" in {
-
-    val (broadcaster,pushHere) = Concurrent.broadcast[String]
-    val foldEC = TestExecutionContext()
-    val results = Future.sequence(Range(1,20).map(_ => Iteratee.fold[String,String](""){(s,e) => s + e }(foldEC)).map(broadcaster.apply).map(_.flatMap(_.run)))
-    pushHere.push("beep")
-    pushHere.push("beep")
-    pushHere.eofAndEnd()
-    Await.result(results, Duration.Inf) must equalTo (Range(1,20).map(_ => "beepbeep"))
-    foldEC.executionCount must equalTo(38)
-
-  }
-}
-
-"Enumerator.outputStream" should {
-  "produce the same value written in the OutputStream" in {
-    val a = "FOO"
-    val b = "bar"
-    val enumerator = Enumerator.outputStream { outputStream =>
-      outputStream.write(a.toArray.map(_.toByte))
-      outputStream.write(b.toArray.map(_.toByte))
-      outputStream.close()
+  
+  "Enumerator" should {
+    
+    "call onDoneEnumerating callback" in {
+      mustExecute(1) { onDoneEC =>
+        val count = new java.util.concurrent.atomic.AtomicInteger()
+        mustEnumerateTo(1, 2, 3)(Enumerator(1, 2, 3).onDoneEnumerating(count.incrementAndGet())(onDoneEC))
+        count.get() must equalTo(1)
+      }
     }
-    val foldEC = TestExecutionContext()
-    val promise = (enumerator |>>> Iteratee.fold[Array[Byte],Array[Byte]](Array[Byte]())(_ ++ _)(foldEC))
+    
+    "transform input elements with map" in {
+      mustExecute(3) { mapEC =>
+        mustEnumerateTo(2, 4, 6)(Enumerator(1, 2, 3).map(_ * 2)(mapEC))
+      }
+    }
+    
+    "transform input with map" in {
+      mustExecute(3) { mapEC =>
+        mustEnumerateTo(2, 4, 6)(Enumerator(1, 2, 3).mapInput(_.map(_ * 2))(mapEC))
+      }
+    }
+    
+    "be transformed to another Enumerator using flatMap" in {
+      mustExecute(3, 30) { (flatMapEC, foldEC) =>
+        val e = Enumerator(10, 20, 30).flatMap(i => Enumerator((i until i + 10): _*))(flatMapEC)
+        val it = Iteratee.fold[Int, Int](0)((sum, x) => sum + x)(foldEC)
+        Await.result(e |>>> it, Duration.Inf) must equalTo((10 until 40).sum)
+      }
+    }
 
-    Await.result(promise, Duration.Inf).map(_.toChar).foldLeft("")(_+_) must equalTo (a+b)
-    foldEC.executionCount must equalTo(2)
   }
 
-  "not block" in {
-    var os: OutputStream = null
-    val osReady = new CountDownLatch(1)
-    val enumerator = Enumerator.outputStream { o => os = o; osReady.countDown() }
-    val promiseIteratee = Promise[Iteratee[Array[Byte], Array[Byte]]]
-    val future = enumerator |>>> Iteratee.flatten(promiseIteratee.future)
-    osReady.await(5, TimeUnit.SECONDS)
-    // os should now be set
-    os.write("hello".getBytes)
-    os.write(" ".getBytes)
-    os.write("world".getBytes)
-    os.close()
-    promiseIteratee.success(Iteratee.consume[Array[Byte]]())
-    Await.result(future, Duration("10s")) must_== "hello world".getBytes
+  "Enumerator.generateM" should {
+    "generate a stream of values until the expression is None" in {
+      mustExecute(12, 11) { (generateEC, foldEC) =>
+        val a = (0 to 10).toList
+        val it = a.iterator
+
+        val enumerator = Enumerator.generateM(Future(if (it.hasNext) Some(it.next()) else None))(generateEC)
+
+        Await.result(enumerator |>>> Iteratee.fold[Int, String]("")(_ + _)(foldEC), Duration.Inf) must equalTo("012345678910")
+      }
+    }
+
+    "Can be composed with another enumerator (doesn't send EOF)" in {
+      mustExecute(12, 12) { (generateEC, foldEC) =>
+        val a = (0 to 10).toList
+        val it = a.iterator
+
+        val enumerator = Enumerator.generateM(Future(if (it.hasNext) Some(it.next()) else None))(generateEC) >>> Enumerator(12)
+
+        Await.result(enumerator |>>> Iteratee.fold[Int, String]("")(_ + _)(foldEC), Duration.Inf) must equalTo("01234567891012")
+      }
+    }
+
   }
+
+  "Enumerator.callback1" should {
+    "generate a stream of values until the expression is None" in {
+      mustExecute(5) { callbackEC =>
+        val it = (1 to 3).iterator // FIXME: Probably not thread-safe
+        val completeCount = new AtomicInteger(0)
+        val completeDone = new CountDownLatch(1)
+        val errorCount = new AtomicInteger(0)
+        val enumerator = Enumerator.fromCallback1(
+            b => Future(if (it.hasNext) Some((b, it.next())) else None),
+            () => {
+              completeCount.incrementAndGet()
+              completeDone.countDown()
+            },
+            (_: String, _: Input[(Boolean, Int)]) => errorCount.incrementAndGet())(callbackEC)
+        mustEnumerateTo((true, 1), (false, 2), (false, 3))(enumerator)
+        completeDone.await(5, TimeUnit.SECONDS)
+        completeCount.get() must equalTo(1)
+        errorCount.get() must equalTo(0)
+      }
+    }
+  }
+
+  "Enumerator.unfoldM" should {
+    "Can be composed with another enumerator (doesn't send EOF)" in {
+      mustExecute(12, 12) { (foldEC, unfoldEC) =>
+        val enumerator = Enumerator.unfoldM[Int, Int](0)(s => Future(if (s > 10) None else Some((s + 1, s + 1))))(unfoldEC) >>> Enumerator(12)
+
+        Await.result(enumerator |>>> Iteratee.fold[Int, String]("")(_ + _)(foldEC), Duration.Inf) must equalTo("123456789101112")
+      }
+    }
+
+  }
+  
+  "Enumerator.repeat" should {
+    "supply input from a by-name arg" in {
+      mustExecute(3) { repeatEC =>
+        val count = new AtomicInteger(0)
+        val fut = Enumerator.repeat(count.incrementAndGet())(repeatEC) |>>> (Enumeratee.take(3) &>> Iteratee.getChunks[Int])
+        Await.result(fut, Duration.Inf) must equalTo(List(1, 2, 3))
+      }
+    }
+  }
+
+  "Enumerator.repeatM" should {
+    "supply input from a by-name arg" in {
+      mustExecute(3) { repeatEC =>
+        val count = new AtomicInteger(0)
+        val fut = Enumerator.repeatM(Future.successful(count.incrementAndGet()))(repeatEC) |>>> (Enumeratee.take(3) &>> Iteratee.getChunks[Int])
+        Await.result(fut, Duration.Inf) must equalTo(List(1, 2, 3))
+      }
+    }
+  }
+
+  "Enumerator.imperative" should {
+    "allow input to be pushed" in {
+      mustExecute(1) { (callbackEC) =>
+        val startCount = new AtomicInteger()
+        val completeCount = new AtomicInteger()
+        val errorCount = new AtomicInteger()
+        val allPushesReceived = new CountDownLatch(3)
+        @volatile
+        var pushed = List[Int]()
+
+        val e = Enumerator.imperative(
+            () => startCount.incrementAndGet(),
+            () => completeCount.incrementAndGet(),
+            (_: String, _: Input[Int]) => errorCount.incrementAndGet()) (callbackEC)
+            
+        val i = Iteratee.foreach[Int] { e =>
+          pushed = pushed :+ e
+          allPushesReceived.countDown()
+        }(dec)
+
+        val waitTime = scala.concurrent.duration.Duration(5, scala.concurrent.duration.SECONDS)
+        Await.result(Future(e(i))(dec), waitTime)
+
+        e.push(1) must equalTo(true)
+        e.push(2) must equalTo(true)
+        e.push(3) must equalTo(true)
+        e.close()
+        allPushesReceived.await()
+        pushed must equalTo(List(1, 2, 3))
+        startCount.get() must equalTo(1)
+        completeCount.get() must equalTo(0) // Only called if Iteratee is done
+        errorCount.get() must equalTo(0)
+      }
+    }
+  }
+
+  "Enumerator.pushee" should {
+    "allow input to be pushed" in {
+      mustExecute(1) { (callbackEC) =>
+        val startCount = new AtomicInteger()
+        val completeCount = new AtomicInteger()
+        val errorCount = new AtomicInteger()
+        val startDone = new CountDownLatch(1)
+        @volatile
+        var pushee: Enumerator.Pushee[Int] = null
+        @volatile
+        var pushed = List[Int]()
+        val allPushesReceived = new CountDownLatch(3)
+
+        val e = Enumerator.pushee(
+          (p: Enumerator.Pushee[Int]) => {
+            startCount.incrementAndGet()
+            pushee = p
+            startDone.countDown()
+          },
+          () => {
+            completeCount.incrementAndGet()
+          },
+          (_: String, _: Input[Int]) => errorCount.incrementAndGet())(callbackEC)
+
+        val i = Iteratee.foreach[Int] { e =>
+          pushed = pushed :+ e
+          allPushesReceived.countDown()
+        }(dec)
+
+        startDone.await(5, TimeUnit.SECONDS)
+        val waitTime = scala.concurrent.duration.Duration(5, scala.concurrent.duration.SECONDS)
+        Await.result(Future(e(i))(dec), waitTime)
+
+        pushee.push(1)
+        pushee.push(2)
+        pushee.push(3)
+        pushee.close()
+
+        allPushesReceived.await(5, TimeUnit.SECONDS)
+        pushed must equalTo(List(1, 2, 3))
+        startCount.get() must equalTo(1)
+        completeCount.get() must equalTo(0) // Only called if Iteratee is done
+        errorCount.get() must equalTo(0)
+      }
+    }
+  }
+
+  "Enumerator.outputStream" should {
+    "produce the same value written in the OutputStream" in {
+      mustExecute(1, 2) { (outputEC, foldEC) =>
+        val a = "FOO"
+        val b = "bar"
+        val enumerator = Enumerator.outputStream { outputStream =>
+          outputStream.write(a.toArray.map(_.toByte))
+          outputStream.write(b.toArray.map(_.toByte))
+          outputStream.close()
+        }(outputEC)
+        val promise = (enumerator |>>> Iteratee.fold[Array[Byte], Array[Byte]](Array[Byte]())(_ ++ _)(foldEC))
+        Await.result(promise, Duration.Inf).map(_.toChar).foldLeft("")(_ + _) must equalTo(a + b)
+      }
+    }
+
+    "not block" in {
+      mustExecute(1) { outputEC =>
+        var os: OutputStream = null
+        val osReady = new CountDownLatch(1)
+        val enumerator = Enumerator.outputStream { o => os = o; osReady.countDown() }(outputEC)
+        val promiseIteratee = Promise[Iteratee[Array[Byte], Array[Byte]]]
+        val future = enumerator |>>> Iteratee.flatten(promiseIteratee.future)
+        osReady.await(5, TimeUnit.SECONDS)
+        // os should now be set
+        os.write("hello".getBytes)
+        os.write(" ".getBytes)
+        os.write("world".getBytes)
+        os.close()
+        promiseIteratee.success(Iteratee.consume[Array[Byte]]())
+        Await.result(future, Duration("10s")) must_== "hello world".getBytes
+      }
+    }
+  }
+
 }
-
-
-
-}
-

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/IterateeSpecification.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/IterateeSpecification.scala
@@ -1,0 +1,60 @@
+package play.api.libs.iteratee
+
+import play.api.libs.iteratee.internal.executeFuture
+import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.concurrent.duration.{ Duration, SECONDS }
+
+/**
+ * Common functionality for iteratee tests.
+ */
+trait IterateeSpecification {
+  self: org.specs2.mutable.SpecificationLike =>
+
+  val waitTime = Duration(5, SECONDS)
+  def await[A](f: Future[A]): A = Await.result(f, waitTime)
+  def ready[A](f: Future[A]): Future[A] = Await.ready(f, waitTime)
+
+  def testExecution[A](f: TestExecutionContext => A): A = {
+    val ec = TestExecutionContext()
+    val result = ec.preparable(f(ec))
+    result
+  }
+
+  def testExecution[A](f: (TestExecutionContext, TestExecutionContext) => A): A = {
+    testExecution(ec1 => testExecution(ec2 => f(ec1, ec2)))
+  }
+
+  def testExecution[A](f: (TestExecutionContext, TestExecutionContext, TestExecutionContext) => A): A = {
+    testExecution(ec1 => testExecution(ec2 => testExecution(ec3 => f(ec1, ec2, ec3))))
+  }
+
+  def mustExecute[A](expectedCount: => Int)(f: ExecutionContext => A): A = {
+    testExecution { tec =>
+      val result = f(tec)
+      tec.executionCount must equalTo(expectedCount)
+      result
+    }
+  }
+
+  def mustExecute[A](expectedCount1: Int, expectedCount2: Int)(f: (ExecutionContext, ExecutionContext) => A): A = {
+    mustExecute(expectedCount1)(ec1 => mustExecute(expectedCount2)(ec2 => f(ec1, ec2)))
+  }
+
+  def mustExecute[A](expectedCount1: Int, expectedCount2: Int, expectedCount3: Int)(f: (ExecutionContext, ExecutionContext, ExecutionContext) => A): A = {
+    mustExecute(expectedCount1)(ec1 => mustExecute(expectedCount2)(ec2 => mustExecute(expectedCount3)(ec3 => f(ec1, ec2, ec3))))
+  }
+
+  def mustTransformTo[E, A](in: E*)(out: A*)(e: Enumeratee[E, A]): Unit = {
+    val f = Future(Enumerator(in: _*) |>>> e &>> Iteratee.getChunks[A])(Execution.defaultExecutionContext).flatMap[List[A]](x => x)(Execution.defaultExecutionContext)
+    Await.result(f, Duration.Inf) must equalTo(List(out: _*))
+  }
+
+  def enumeratorChunks[E](e: Enumerator[E]): Future[List[E]] = {
+    executeFuture(e |>>> Iteratee.getChunks[E])(Execution.defaultExecutionContext)
+  }
+
+  def mustEnumerateTo[E, A](out: A*)(e: Enumerator[E]): Unit = {
+    Await.result(enumeratorChunks(e), Duration.Inf) must equalTo(List(out: _*))
+  }
+
+}

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/IterateesSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/IterateesSpec.scala
@@ -1,0 +1,295 @@
+package play.api.libs.iteratee
+
+import scala.language.reflectiveCalls
+
+import org.specs2.mutable._
+import java.io.OutputStream
+import java.util.concurrent.{ CountDownLatch, TimeUnit }
+import scala.concurrent.{ ExecutionContext, Promise, Future, Await }
+import scala.util.{ Failure, Success, Try }
+
+object IterateesSpec extends Specification with IterateeSpecification {
+
+  def checkFoldResult[A, E](i: Iteratee[A, E], expected: Step[A, E]) = {
+    mustExecute(1) { foldEC =>
+      await(i.fold(s => Future.successful(s))(foldEC)) must equalTo(expected)
+    }
+  }
+
+  def checkImmediateFoldFailure[A, E](i: Iteratee[A, E]) = {
+    mustExecute(1) { foldEC =>
+      val e = new Exception("exception")
+      val result = ready(i.fold(_ => throw e)(foldEC))
+      result.value must equalTo(Some(Failure(e)))
+    }
+  }
+
+  def checkFutureFoldFailure[A, E](i: Iteratee[A, E]) = {
+    mustExecute(1, 1) { (foldEC, folderEC) =>
+      val e = new Exception("exception")
+      val preparedFolderEC = folderEC.prepare()
+      val result = ready(i.fold(_ => Future(throw e)(preparedFolderEC))(foldEC))
+      result.value must equalTo(Some(Failure(e)))
+    }
+  }
+
+  def mustTranslate3To(x: Int)(f: Iteratee[Int, Int] => Iteratee[Int, Int]): Unit = {
+    await(f(Done(3)).unflatten) must equalTo(Step.Done(x, Input.Empty))
+  }
+
+  "Flattened iteratees" should {
+
+    val i = Iteratee.flatten(Future.successful(Done(1, Input.El("x"))))
+
+    "delegate folding to their promised iteratee" in {
+      checkFoldResult(i, Step.Done(1, Input.El("x")))
+    }
+
+    "return immediate fold errors in promise" in {
+      checkImmediateFoldFailure(i)
+    }
+
+    "return future fold errors in promise" in {
+      checkFutureFoldFailure(i)
+    }
+
+  }
+
+  "Done iteratees" should {
+
+    val i = Done(1, Input.El("x"))
+
+    "fold with their result and unused input" in {
+      checkFoldResult(i, Step.Done(1, Input.El("x")))
+    }
+
+    "return immediate fold errors in promise" in {
+      checkImmediateFoldFailure(i)
+    }
+
+    "return future fold errors in promise" in {
+      checkFutureFoldFailure(i)
+    }
+
+    "fold input with fold1" in {
+      mustExecute(1) { foldEC =>
+        mustTranslate3To(5)(it => Iteratee.flatten(it.fold1(
+          (a, i) => Future.successful(Done(a + 2, i)),
+          _ => ???,
+          (_, _) => ???)(foldEC)))
+      }
+    }
+
+    "fold input with pureFold" in {
+      mustExecute(1) { foldEC =>
+        mustTranslate3To(9)(it => Iteratee.flatten(it.pureFold(_ => Done[Int, Int](9))(foldEC)))
+      }
+    }
+
+    "fold input with pureFlatFold" in {
+      mustExecute(1) { foldEC =>
+        mustTranslate3To(9)(_.pureFlatFold(_ => Done[Int, Int](9))(foldEC))
+      }
+    }
+
+    "fold input with flatFold0" in {
+      mustExecute(1) { foldEC =>
+        mustTranslate3To(9)(_.flatFold0(_ => Future.successful(Done[Int, Int](9)))(foldEC))
+      }
+    }
+
+    "fold input with flatFold" in {
+      mustExecute(1) { foldEC =>
+        mustTranslate3To(9)(_.flatFold(
+          (_, _) => Future.successful(Done[Int, Int](9)),
+          _ => ???,
+          (_, _) => ???)(foldEC))
+      }
+    }
+
+    "flatMap directly to result when no remaining input" in {
+      mustExecute(1) { flatMapEC =>
+        await(Done(3).flatMap((x: Int) => Done[Int, Int](x * 2))(flatMapEC).unflatten) must equalTo(Step.Done(6, Input.Empty))
+      }
+    }
+
+    "flatMap result and process remaining input with Done" in {
+      mustExecute(1) { flatMapEC =>
+        await(Done(3, Input.El("remaining")).flatMap((x: Int) => Done[String, Int](x * 2))(flatMapEC).unflatten) must equalTo(Step.Done(6, Input.El("remaining")))
+      }
+    }
+
+    "flatMap result and process remaining input with Cont" in {
+      mustExecute(1) { flatMapEC =>
+        await(Done(3, Input.El("remaining")).flatMap((x: Int) => Cont(in => Done[String, Int](x * 2, in)))(flatMapEC).unflatten) must equalTo(Step.Done(6, Input.El("remaining")))
+      }
+    }
+
+    "flatMap result and process remaining input with Error" in {
+      mustExecute(1) { flatMapEC =>
+        await(Done(3, Input.El("remaining")).flatMap((x: Int) => Error("error", Input.El("bad")))(flatMapEC).unflatten) must equalTo(Step.Error("error", Input.El("bad")))
+      }
+    }
+
+    "flatMap result with flatMapM" in {
+      mustExecute(1) { flatMapEC =>
+        mustTranslate3To(6)(_.flatMapM((x: Int) => Future.successful(Done[Int, Int](x * 2)))(flatMapEC))
+      }
+    }
+
+    "fold result with flatMapInput" in {
+      mustExecute(1) { flatMapEC =>
+        mustTranslate3To(1)(_.flatMapInput(_ => Done(1))(flatMapEC))
+      }
+    }
+
+    "concatenate unused input with flatMapTraversable" in {
+      mustExecute(1) { flatMapEC =>
+        await(Done(3, Input.El(List(1, 2))).flatMapTraversable(_ => Done[List[Int], Int](4, Input.El(List(3, 4))))(
+          implicitly[List[Int] => scala.collection.TraversableLike[Int, List[Int]]],
+          implicitly[scala.collection.generic.CanBuildFrom[List[Int], Int, List[Int]]],
+          flatMapEC).unflatten) must equalTo(Step.Done(4, Input.El(List(1, 2, 3, 4))))
+      }
+    }
+
+  }
+
+  "Cont iteratees" should {
+
+    val k: Input[String] => Iteratee[String, Int] = x => ???
+    val i = Cont(k)
+
+    "fold with their continuation" in {
+      checkFoldResult(i, Step.Cont(k))
+    }
+
+    "return immediate fold errors in promise" in {
+      checkImmediateFoldFailure(i)
+    }
+
+    "return future fold errors in promise" in {
+      checkFutureFoldFailure(i)
+    }
+
+    "flatMap recursively" in {
+      mustExecute(1) { flatMapEC =>
+        await(Iteratee.flatten(Cont[Int, Int](_ => Done(3)).flatMap((x: Int) => Done[Int, Int](x * 2))(flatMapEC).feed(Input.El(11))).unflatten) must equalTo(Step.Done(6, Input.Empty))
+      }
+    }
+
+  }
+
+  "Error iteratees" should {
+
+    val i = Error("msg", Input.El("x"))
+
+    "fold with their message and the input that caused the error" in {
+      checkFoldResult(i, Step.Error("msg", Input.El("x")))
+    }
+
+    "return immediate fold errors in promise" in {
+      checkImmediateFoldFailure(i)
+    }
+
+    "return future fold errors in promise" in {
+      checkFutureFoldFailure(i)
+    }
+
+    "flatMap to an error" in {
+      mustExecute(0) { flatMapEC =>
+        await(Error("msg", Input.El("bad")).flatMap((x: Int) => Done("done"))(flatMapEC).unflatten) must equalTo(Step.Error("msg", Input.El("bad")))
+      }
+    }
+
+  }
+
+  "Iteratees fed multiple inputs" should {
+
+    "map the final iteratee's result (with mapDone)" in {
+      mustExecute(4, 1) { (foldEC, mapEC) =>
+        await(Enumerator(1, 2, 3, 4) |>>> Iteratee.fold[Int, Int](0)(_ + _)(foldEC).mapDone(_ * 2)(mapEC)) must equalTo(20)
+      }
+    }
+
+    "map the final iteratee's result (with map)" in {
+      mustExecute(4, 1) { (foldEC, mapEC) =>
+        await(Enumerator(1, 2, 3, 4) |>>> Iteratee.fold[Int, Int](0)(_ + _)(foldEC).map(_ * 2)(mapEC)) must equalTo(20)
+      }
+    }
+
+    "map the final iteratee's result (with mapM)" in {
+      mustExecute(4, 1) { (foldEC, mapEC) =>
+        await(Enumerator(1, 2, 3, 4) |>>> Iteratee.fold[Int, Int](0)(_ + _)(foldEC).mapM(x => Future.successful(x * 2))(mapEC)) must equalTo(20)
+      }
+    }
+
+  }
+
+  "Iteratee.fold" should {
+
+    "fold input" in {
+      mustExecute(4) { foldEC =>
+        await(Enumerator(1, 2, 3, 4) |>>> Iteratee.fold[Int, Int](0)(_ + _)(foldEC)) must equalTo(10)
+      }
+    }
+
+  }
+
+  "Iteratee.foldM" should {
+
+    "fold input" in {
+      mustExecute(4) { foldEC =>
+        await(Enumerator(1, 2, 3, 4) |>>> Iteratee.foldM[Int, Int](0)((x, y) => Future.successful(x + y))(foldEC)) must equalTo(10)
+      }
+    }
+
+  }
+
+  "Iteratee.fold2" should {
+
+    "fold input" in {
+      mustExecute(4) { foldEC =>
+        val folder = (x: Int, y: Int) => Future.successful((x + y, false))
+        await(Enumerator(1, 2, 3, 4) |>>> Iteratee.fold2[Int, Int](0)(folder)(foldEC)) must equalTo(10)
+      }
+    }
+
+    "fold input, stopping early" in {
+      mustExecute(3) { foldEC =>
+        val folder = (x: Int, y: Int) => Future.successful((x + y, (y > 2)))
+        await(Enumerator(1, 2, 3, 4) |>>> Iteratee.fold2[Int, Int](0)(folder)(foldEC)) must equalTo(6)
+      }
+    }
+
+  }
+
+  "Iteratee.foldM" should {
+
+    "fold input" in {
+      mustExecute(4) { foldEC =>
+        await(Enumerator(1, 2, 3, 4) |>>> Iteratee.fold1[Int, Int](Future.successful(0))((x, y) => Future.successful(x + y))(foldEC)) must equalTo(10)
+      }
+    }
+
+  }
+
+  "Iteratee.consume" should {
+
+    "return its concatenated input" in {
+      val s = List(List(1, 2), List(3), List(4, 5))
+      val r = List(1, 2, 3, 4, 5)
+      await(Enumerator.enumerateSeq1(s) |>>> Iteratee.consume[List[Int]]()) must equalTo(r)
+    }
+
+  }
+
+  "Iteratee.getChunks" should {
+
+    "return its input as a list" in {
+      val s = List(1, 2, 3, 4, 5)
+      await(Enumerator.enumerateSeq1(s) |>>> Iteratee.getChunks[Int]) must equalTo(s)
+    }
+
+  }
+
+}

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/ParsingSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/ParsingSpec.scala
@@ -7,42 +7,38 @@ import org.specs2.mutable._
 import concurrent.duration.Duration
 import concurrent.Await
 
-object ParsingSpec extends Specification {
+object ParsingSpec extends Specification with IterateeSpecification {
 
   "Parsing" should {
 
     "split case 1" in {
+      mustExecute(10) { foldEC =>
+        val data = Enumerator(List("xx", "kxckikixckikio", "cockik", "isdodskikisd", "ksdloii").map(_.getBytes): _*)
+        val parsed = data |>>> Parsing.search("kiki".getBytes).transform(Iteratee.fold(List.empty[MatchInfo[Array[Byte]]]) { (s, c: MatchInfo[Array[Byte]]) => s :+ c }(foldEC))
 
-      val foldEC = TestExecutionContext()
-      val data = Enumerator(List("xx", "kxckikixckikio", "cockik", "isdodskikisd", "ksdloii").map(_.getBytes): _*)
-      val parsed = data |>>> Parsing.search("kiki".getBytes).transform(Iteratee.fold(List.empty[MatchInfo[Array[Byte]]]) { (s, c: MatchInfo[Array[Byte]]) => s :+ c }(foldEC))
+        val result = Await.result(parsed, Duration.Inf).map {
+          case Matched(kiki) => "Matched(" + new String(kiki) + ")"
+          case Unmatched(data) => "Unmatched(" + new String(data) + ")"
+        }.mkString(", ")
 
-      val result = Await.result(parsed, Duration.Inf).map {
-        case Matched(kiki) => "Matched(" + new String(kiki) + ")"
-        case Unmatched(data) => "Unmatched(" + new String(data) + ")"
-      }.mkString(", ")
-
-      result must equalTo (
-        "Unmatched(xxkxc), Matched(kiki), Unmatched(xc), Matched(kiki), Unmatched(ococ), Matched(kiki), Unmatched(sdods), Matched(kiki), Unmatched(sdks), Unmatched(dloii)")
-      foldEC.executionCount must equalTo(10)
-
+        result must equalTo(
+          "Unmatched(xxkxc), Matched(kiki), Unmatched(xc), Matched(kiki), Unmatched(ococ), Matched(kiki), Unmatched(sdods), Matched(kiki), Unmatched(sdks), Unmatched(dloii)")
+      }
     }
 
     "split case 1" in {
+      mustExecute(11) { foldEC =>
+        val data = Enumerator(List("xx", "kxckikixcki", "k", "kicockik", "isdkikodskikisd", "ksdlokiikik", "i").map(_.getBytes): _*)
+        val parsed = data |>>> Parsing.search("kiki".getBytes).transform(Iteratee.fold(List.empty[MatchInfo[Array[Byte]]]) { (s, c: MatchInfo[Array[Byte]]) => s :+ c }(foldEC))
 
-      val data = Enumerator(List("xx", "kxckikixcki", "k", "kicockik", "isdkikodskikisd", "ksdlokiikik", "i").map(_.getBytes): _*)
-      val foldEC = TestExecutionContext()
-      val parsed = data |>>> Parsing.search("kiki".getBytes).transform(Iteratee.fold(List.empty[MatchInfo[Array[Byte]]]) { (s, c: MatchInfo[Array[Byte]]) => s :+ c }(foldEC))
+        val result = Await.result(parsed, Duration.Inf).map {
+          case Matched(kiki) => "Matched(" + new String(kiki) + ")"
+          case Unmatched(data) => "Unmatched(" + new String(data) + ")"
+        }.mkString(", ")
 
-      val result = Await.result(parsed, Duration.Inf).map {
-        case Matched(kiki) => "Matched(" + new String(kiki) + ")"
-        case Unmatched(data) => "Unmatched(" + new String(data) + ")"
-      }.mkString(", ")
-
-      result must equalTo(
-        "Unmatched(xxkxc), Matched(kiki), Unmatched(xckikkico), Unmatched(c), Matched(kiki), Unmatched(sdkikods), Matched(kiki), Unmatched(sdksdlok), Unmatched(ii), Matched(kiki), Unmatched()")
-      foldEC.executionCount must equalTo(11)
-
+        result must equalTo(
+          "Unmatched(xxkxc), Matched(kiki), Unmatched(xckikkico), Unmatched(c), Matched(kiki), Unmatched(sdkikods), Matched(kiki), Unmatched(sdksdlok), Unmatched(ii), Matched(kiki), Unmatched()")
+      }
     }
 
   }

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/TestExecutionContext.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/TestExecutionContext.scala
@@ -7,7 +7,7 @@ object TestExecutionContext {
   /**
    * Create a `TestExecutionContext` that delegates to the iteratee package's default `ExecutionContext`.
    */
-  def apply(): TestExecutionContext = new TestExecutionContext(internal.defaultExecutionContext)
+  def apply(): TestExecutionContext = new TestExecutionContext(Execution.defaultExecutionContext)
 
 }
 
@@ -17,16 +17,40 @@ object TestExecutionContext {
  * @param delegate The underlying `ExecutionContext` to delegate execution to.
  */
 class TestExecutionContext(delegate: ExecutionContext) extends ExecutionContext {
+  top =>
+
   val count = new java.util.concurrent.atomic.AtomicInteger()
+
+  val local = new ThreadLocal[java.lang.Boolean]
+  
+  def preparable[A](body: => A): A = {
+    local.set(true)
+    try body finally local.set(null)
+  }
+
   def execute(runnable: Runnable): Unit = {
-    count.getAndIncrement()
-    delegate.prepare().execute(runnable)
+    throw new RuntimeException("Cannot execute unprepared TestExecutionContext")
   }
   
   def reportFailure(t: Throwable): Unit = delegate.reportFailure(t)
   
-  override def prepare(): ExecutionContext = this
+  override def prepare(): ExecutionContext = {
+    val isLocal = Option(local.get()).getOrElse(false: java.lang.Boolean)
+    if (!isLocal) throw new RuntimeException("Can only prepare TestExecutionContext within 'preparable' scope")
+    val preparedDelegate = delegate.prepare()
+    return new ExecutionContext {
+
+      def execute(runnable: Runnable): Unit = {
+	    count.getAndIncrement()
+	    preparedDelegate.execute(runnable)
+	  }
+	  
+	  def reportFailure(t: Throwable): Unit = preparedDelegate.reportFailure(t)
+      
+    }
+  }
   
   def executionCount: Int = count.get()
   
 }
+

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/TraversableIterateesSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/TraversableIterateesSpec.scala
@@ -1,0 +1,21 @@
+package play.api.libs.iteratee
+
+import org.specs2.mutable._
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration.Duration
+
+object TraversableIterateesSpec extends Specification with IterateeSpecification {
+
+  "Traversable.splitOnceAt" should {
+
+    "yield input while predicate is satisfied" in {
+      mustExecute(1) { splitEC =>
+        val e = Traversable.splitOnceAt[String, Char] { c => c != 'e' }(
+          implicitly[String => scala.collection.TraversableLike[Char, String]],
+          splitEC)
+        mustTransformTo("hello", "there")("h")(e)
+      }
+    }
+
+  }
+}

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
@@ -2,6 +2,8 @@ package play.api.libs.json
 
 import scala.language.reflectiveCalls
 
+import play.api.libs.iteratee.Execution.Implicits.defaultExecutionContext
+
 /**
  * Helper functions to handle JsValues.
  */
@@ -129,7 +131,7 @@ object Json {
    *   val jsonStream: Enumerator[JsValue] = fooStream &> Json.toJson
    * }}}
    */
-  def toJson[A: Writes]: Enumeratee[A, JsValue] = Enumeratee.map(Json.toJson(_))
+  def toJson[A: Writes]: Enumeratee[A, JsValue] = Enumeratee.map[A](Json.toJson(_))
   /**
    * Transform a stream of JsValue to a stream of A, keeping only successful results
    * {{{
@@ -138,7 +140,7 @@ object Json {
    * }}}
    */
   def fromJson[A: Reads]: Enumeratee[JsValue, A] =
-    Enumeratee.map((json: JsValue) => Json.fromJson(json)) ><> Enumeratee.collect { case JsSuccess(value, _) => value }
+    Enumeratee.map[JsValue]((json: JsValue) => Json.fromJson(json)) ><> Enumeratee.collect[JsResult[A]] { case JsSuccess(value, _) => value }(defaultExecutionContext)
 
   /**
    * Experimental JSON extensions to replace asProductXXX by generating

--- a/framework/src/play/src/main/scala/play/api/libs/Comet.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Comet.scala
@@ -53,7 +53,7 @@ object Comet {
     def applyOn[A](inner: Iteratee[Html, A]): Iteratee[E, Iteratee[Html, A]] = {
 
       val fedWithInitialChunk = Iteratee.flatten(Enumerator(initialChunk) |>> inner)
-      val eToScript = Enumeratee.map[E](data => Html("""<script type="text/javascript">""" + callback + """(""" + encoder.toJavascriptMessage(data) + """);</script>"""))
+      val eToScript = Enumeratee.map[E](data => Html("""<script type="text/javascript">""" + callback + """(""" + encoder.toJavascriptMessage(data) + """);</script>"""))(play.core.Execution.internalContext)
       eToScript.applyOn(fedWithInitialChunk)
     }
   }

--- a/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
@@ -36,6 +36,6 @@ object EventSource {
     eventNameExtractor.eventName(chunk).map("event: " + _ + "\r\n").getOrElse("") +
       eventIdExtractor.eventId(chunk).map("id: " + _ + "\r\n").getOrElse("") +
       "data: " + encoder.toJavascriptMessage(chunk) + "\r\n\r\n"
-  }
+  }(play.core.Execution.internalContext)
 
 }

--- a/framework/src/play/src/main/scala/play/core/j/JavaResults.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaResults.scala
@@ -74,7 +74,7 @@ object JavaResultExtractor {
   def getBody(result: play.mvc.Result): Array[Byte] = result.getWrappedResult match {
     case r: AsyncResult => getBody(new ResultWrapper(r.result.await.get))
     case r @ SimpleResult(_, bodyEnumerator) => {
-      var readAsBytes = Enumeratee.map[r.BODY_CONTENT](r.writeable.transform(_)).transform(Iteratee.consume[Array[Byte]]())
+      var readAsBytes = Enumeratee.map[r.BODY_CONTENT](r.writeable.transform(_))(play.core.Execution.internalContext).transform(Iteratee.consume[Array[Byte]]())
       bodyEnumerator(readAsBytes).flatMap(_.run)(play.core.Execution.internalContext).value1.get
     }
     case r: PlainResult => Array.empty[Byte]

--- a/framework/src/play/src/main/scala/play/core/j/JavaWebSocket.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaWebSocket.scala
@@ -38,7 +38,7 @@ object JavaWebSocket extends JavaHelpers {
       val socketIn = new play.mvc.WebSocket.In[A]
 
       in |>> {
-        Iteratee.foreach[A](msg => socketIn.callbacks.asScala.foreach(_.invoke(msg)))(play.core.Execution.internalContext).mapDone { _ =>
+        Iteratee.foreach[A](msg => socketIn.callbacks.asScala.foreach(_.invoke(msg)))(play.core.Execution.internalContext).map { _ =>
           socketIn.closeCallbacks.asScala.foreach(_.invoke())
         }(play.core.Execution.internalContext)
       }

--- a/framework/test/integrationtest-scala/app/controllers/Application.scala
+++ b/framework/test/integrationtest-scala/app/controllers/Application.scala
@@ -3,6 +3,7 @@ package controllers
 import play.api._
 import libs.iteratee.Iteratee
 import libs.json.Json
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.mvc._
 
 import play.api.Play.current
@@ -35,7 +36,7 @@ object Application extends Controller {
   def bodyParserThread = Action(new BodyParser[String] {
     def apply(request: RequestHeader) = {
       val threadName = Thread.currentThread.getName
-      Iteratee.ignore[Array[Byte]].map(_ => Right(threadName))(play.api.libs.concurrent.Execution.defaultContext)
+      Iteratee.ignore[Array[Byte]].map(_ => Right(threadName))
     }
   }) { request =>
     Ok(request.body)

--- a/framework/test/integrationtest/test/FunctionalSpec.scala
+++ b/framework/test/integrationtest/test/FunctionalSpec.scala
@@ -45,7 +45,7 @@ class FunctionalSpec extends Specification {
         hdrs.get("CONTENT-TYpe").isDefined must equalTo(true)
         hdrs.keys.find(header => header == "Content-Type" ).isDefined must equalTo(true)
         hdrs.keys.find(header => header == "CONTENT-TYpe" ).isDefined must equalTo(false)
-        Iteratee.fold[Array[Byte],StringBuffer](new StringBuffer){ (buf,array) => { buf.append(array); buf }}(global)
+        Iteratee.fold[Array[Byte],StringBuffer](new StringBuffer){ (buf,array) => { buf.append(array); buf }}
       }
 
       await(hp.map(_.run)).map(buf => buf.toString must contain("""{"Accept":"application/json"}""") )

--- a/samples/scala/comet-clock/app/controllers/Application.scala
+++ b/samples/scala/comet-clock/app/controllers/Application.scala
@@ -8,7 +8,7 @@ import play.api.libs.iteratee._
 import play.api.libs.concurrent._
 
 import scala.concurrent.duration._
-import play.api.libs.concurrent.Execution.Implicits._ 
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 object Application extends Controller {
   
@@ -25,7 +25,7 @@ object Application extends Controller {
     
     Enumerator.fromCallback { () =>
       Promise.timeout(Some(dateFormat.format(new Date)), 100 milliseconds)
-    }(defaultContext)
+    }
   }
   
   def index = Action {

--- a/samples/scala/comet-live-monitoring/app/controllers/Application.scala
+++ b/samples/scala/comet-live-monitoring/app/controllers/Application.scala
@@ -41,13 +41,13 @@ object Streams {
       val currentMillis = java.lang.System.currentTimeMillis()
       Some(SpeedOMeter.getSpeed +":rps") },
       100, TimeUnit.MILLISECONDS )
-    }(defaultContext)
+    }
 
   val getHeap = Enumerator.fromCallback{ () =>
     Promise.timeout(
       Some((Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / (1024*1024) + ":memory"),
       100, TimeUnit.MILLISECONDS)
-  }(defaultContext)
+  }
 
   val cpu = new models.CPU()
 

--- a/samples/scala/websocket-chat/app/models/ChatRoom.scala
+++ b/samples/scala/websocket-chat/app/models/ChatRoom.scala
@@ -19,7 +19,7 @@ object Robot {
   def apply(chatRoom: ActorRef) {
     
     // Create an Iteratee that logs all messages to the console.
-    val loggerIteratee = Iteratee.foreach[JsValue](event => Logger("robot").info(event.toString))(defaultContext)
+    val loggerIteratee = Iteratee.foreach[JsValue](event => Logger("robot").info(event.toString))
     
     implicit val timeout = Timeout(1 second)
     // Make the robot join the room
@@ -62,9 +62,9 @@ object ChatRoom {
         // Create an Iteratee to consume the feed
         val iteratee = Iteratee.foreach[JsValue] { event =>
           default ! Talk(username, (event \ "text").as[String])
-        }(defaultContext).mapDone { _ =>
+        }.map { _ =>
           default ! Quit(username)
-        }(defaultContext)
+        }
 
         (iteratee,enumerator)
         

--- a/samples/workinprogress/akka-chat/app/controllers/Actors.scala
+++ b/samples/workinprogress/akka-chat/app/controllers/Actors.scala
@@ -7,6 +7,7 @@ import akka.actor.Actor._
 
 import play.api.libs.iteratee._
 import play.api.libs.concurrent._
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 class ChatRoomActor extends Actor {
   
@@ -19,7 +20,7 @@ class ChatRoomActor extends Actor {
     case Join() => {
       lazy val channel: PushEnumerator[String] =  Enumerator.imperative[String](
         onComplete = ()=> self ! Quit(channel) 
-      )(Execution.defaultContext)
+      )
       members = members :+ channel
       Logger.info("New member joined")
       sender ! channel

--- a/samples/workinprogress/twitterstream/app/controllers/Application.scala
+++ b/samples/workinprogress/twitterstream/app/controllers/Application.scala
@@ -9,6 +9,7 @@ import play.api.libs.oauth._
 import play.api.mvc._
 import play.api.libs._
 import play.api.libs.concurrent._
+import play.api.libs.concurrent.Execution.Implicits._
 import play.api.libs.iteratee._
 import com.ning.http.client.Realm.AuthScheme
 


### PR DESCRIPTION
This is the second part of #807. The first part was in PR #996.
- Coverage of _all_ iteratee/enumeratee/enumerator methods that accept user functions. (The previous PR didn't get everything.)
- All EC arguments are now implicit. I've removed explicit EC params from the sample apps, but I still need to go through Play to remove any unneeded explicit passing of ECs.
- ECs are prepared before use. This allows ECs to capture any important thread local information so that the information can be available when the user function is executed.
- More scaladoc.
- Lots of tests.
- Deprecated `mapDone` since it is the same as `map`.

Next steps:
- Go through Play and audit the EC usage there. Add EC args to the Play API where necessary.
- Remove any explicit EC usage that can now be determined implicitly.
- Think more about the default iteratee EC: make it configurable, tie in to other ECs in Play. I will raise a ticket for this.
- Tidying up deprecated methods - https://github.com/playframework/Play20/issues/1077
