### PR TITLE
Extracted java code samples for async

### DIFF
--- a/documentation/manual/javaGuide/main/async/JavaComet.md
+++ b/documentation/manual/javaGuide/main/async/JavaComet.md
@@ -5,26 +5,8 @@
 An useful usage of **Chunked responses** is to create Comet sockets. A Comet socket is just a chunked `text/html` response containing only `<script>` elements. For each chunk, we write a `<script>` tag containing JavaScript that is immediately executed by the web browser. This way we can send events live to the web browser from the server: for each message, wrap it into a `<script>` tag that calls a JavaScript callback function, and write it to the chunked response.
     
 Let’s write a first proof-of-concept: create an enumerator generating `<script>` tags calling the browser `console.log` function:
-    
-```
-public static Result index() {
-  // Prepare a chunked text stream
-  Chunks<String> chunks = new StringChunks() {
 
-    // Called when the stream is ready
-    public void onReady(Chunks.Out<String> out) {
-      out.write("<script>console.log('kiki')</script>");
-      out.write("<script>console.log('foo')</script>");
-      out.write("<script>console.log('bar')</script>");
-      out.close();
-    }
-
-  };
-
-  response().setContentType("text/html");
-  return ok(chunks);
-}
-```
+@[manual](code/javaguide/async/JavaComet.java)
 
 If you run this action from a web browser, you will see the three events logged in the browser console.
 
@@ -36,39 +18,13 @@ We provide a Comet helper to handle these comet chunked streams that does almost
 
 Let’s just rewrite the previous example to use it:
 
-```
-public static Result index() {
-  Comet comet = new Comet("console.log") {
-    public void onConnected() {
-      sendMessage("kiki");
-      sendMessage("foo");
-      sendMessage("bar");
-      close();
-    }
-  };
-  
-  return ok(comet);
-}
-```
+@[comet](code/javaguide/async/JavaComet.java)
 
 ## The forever iframe technique
 
 The standard technique to write a Comet socket is to load an infinite chunked comet response in an iframe and to specify a callback calling the parent frame:
 
-```
-public static Result index() {
-  Comet comet = new Comet("parent.cometMessage") {
-    public void onConnected() {
-      sendMessage("kiki");
-      sendMessage("foo");
-      sendMessage("bar");
-      close();
-    }
-  };
-  
-  return ok(comet);
-}
-```
+@[forever-iframe](code/javaguide/async/JavaComet.java)
 
 With an HTML page like:
 

--- a/documentation/manual/javaGuide/main/async/JavaStream.md
+++ b/documentation/manual/javaGuide/main/async/JavaStream.md
@@ -6,11 +6,7 @@ Since HTTP 1.1, to keep a single connection open to serve several HTTP requests 
 
 By default, when you send a simple result, such as:
 
-```
-public static Result index() {
-  return ok("Hello World")
-}
-```
+@[by-default](code/javaguide/async/JavaStream.java)
 
 You are not specifying a `Content-Length` header. Of course, because the content you are sending is well known, Play is able to compute the content size for you and to generate the appropriate header.
 
@@ -24,11 +20,7 @@ If it’s not a problem to load the whole content into memory for simple content
 
 Play provides easy to use helpers to this common task of serving a local file:
 
-```
-public static Result index() {
-  return ok(new java.io.File("/tmp/fileToServe.pdf"));
-}
-```
+@[serve-file](code/javaguide/async/JavaStream.java)
 
 Additionally this helper will also compute the `Content-Type` header from the file name. And it will also add the `Content-Disposition` header to specify how the web browser should handle this response. The default is to ask the web browser to download this file by using `Content-Disposition: attachment; filename=fileToServe.pdf`.
 
@@ -48,44 +40,17 @@ The advantage is that we can serve data **live**, meaning that we send chunks of
 
 Let’s say that we have a service somewhere that provides a dynamic `InputStream` that computes some data. We can ask Play to stream this content directly using a chunked response:
 
-```
-public static Result index() {
-  InputStream is = getDynamicStreamSomewhere();
-  return ok(is);
-}
-```
+@[input-stream](code/javaguide/async/JavaStream.java)
 
 You can also set up your own chunked response builder. The Play Java API supports both text and binary chunked streams (via `String` and `byte[]`):
 
-```
-public static index() {
-  // Prepare a chunked text stream
-  Chunks<String> chunks = new StringChunks() {
-    
-    // Called when the stream is ready
-    public void onReady(Chunks.Out<String> out) {
-      registerOutChannelSomewhere(out);
-    }
-    
-  };
-  
-  // Serves this stream with 200 OK
-  return ok(chunks);
-}
-```
+@[chunked](code/javaguide/async/JavaStream.java)
 
 The `onReady` method is called when it is safe to write to this stream. It gives you a `Chunks.Out` channel you can write to.
 
 Let’s say we have an asynchronous process (like an `Actor`) somewhere pushing to this stream:
 
-```
-public void registerOutChannelSomewhere(Chunks.Out<String> out) {
-  out.write("kiki");
-  out.write("foo");
-  out.write("bar");
-  out.close();
-}
-```
+@[register-out-channel](code/javaguide/async/JavaStream.java)
 
 We can inspect the HTTP response sent by the server:
 

--- a/documentation/manual/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/javaGuide/main/async/JavaWebSockets.md
@@ -18,40 +18,7 @@ Until now we were using a simple action method to handle standard HTTP requests 
 
 To handle a WebSocket your method must return a `WebSocket` instead of a `Result`:
 
-```
-public static WebSocket<String> index() {
-  return new WebSocket<String>() {
-      
-    // Called when the Websocket Handshake is done.
-    public void onReady(WebSocket.In<String> in, WebSocket.Out<String> out) {
-      
-      // For each event received on the socket,
-      in.onMessage(new Callback<String>() {
-         public void invoke(String event) {
-             
-           // Log events to the console
-           println(event);  
-             
-         } 
-      });
-      
-      // When the socket is closed.
-      in.onClose(new Callback0() {
-         public void invoke() {
-             
-           println("Disconnected");
-             
-         }
-      });
-      
-      // Send a single 'Hello!' message
-      out.write("Hello!");
-      
-    }
-    
-  }
-}
-```
+@[websocket](code/javaguide/async/JavaWebSockets.java)
 
 A WebSocket has access to the request headers (from the HTTP request that initiates the WebSocket connection) allowing you to retrieve standard headers and session data. But it doesn't have access to any request body, nor to the HTTP response.
 
@@ -63,17 +30,6 @@ It this example, we print each message to console and we send a single **Hello!*
 
 Let’s write another example that totally discards the input data and closes the socket just after sending the **Hello!** message:
 
-```
-public static WebSocket<String> index() {
-  return new WebSocket<String>() {
-      
-    public void onReady(WebSocket.In<String> in, WebSocket.Out<String> out) {
-      out.write("Hello!");
-      out.close();
-    }
-    
-  };
-}
-```
+@[discard-input](code/javaguide/async/JavaWebSockets.java)
 
 > **Next:** [[The template engine | JavaTemplates]]

--- a/documentation/manual/javaGuide/main/async/code/javaguide/async/JavaComet.java
+++ b/documentation/manual/javaGuide/main/async/code/javaguide/async/JavaComet.java
@@ -1,0 +1,97 @@
+package javaguide.async;
+
+import javaguide.testhelpers.MockJavaAction;
+import org.junit.Before;
+import org.junit.Test;
+import play.libs.Comet;
+import play.mvc.Result;
+import play.test.WithApplication;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static play.test.Helpers.*;
+
+public class JavaComet extends WithApplication {
+    @Before
+    public void setUp() {
+        start();
+    }
+
+    @Test
+    public void manual() {
+        String content = contentAsString(MockJavaAction.call(new Controller1(), fakeRequest()));
+        // Wait until results refactoring is merged, then this will work
+        // assertThat(content, containsString("<script>console.log('kiki')</script>"));
+    }
+
+    public static class Controller1 extends MockJavaAction {
+        //#manual
+        public static Result index() {
+            // Prepare a chunked text stream
+            Chunks<String> chunks = new StringChunks() {
+
+                // Called when the stream is ready
+                public void onReady(Chunks.Out<String> out) {
+                    out.write("<script>console.log('kiki')</script>");
+                    out.write("<script>console.log('foo')</script>");
+                    out.write("<script>console.log('bar')</script>");
+                    out.close();
+                }
+
+            };
+
+            response().setContentType("text/html");
+            return ok(chunks);
+        }
+        //#manual
+    }
+
+    @Test
+    public void comet() {
+        String content = contentAsString(MockJavaAction.call(new Controller2(), fakeRequest()));
+        // Wait until results refactoring is merged, then this will work
+        // assertThat(content, containsString("<script type=\"text/javascript\">console.log(\"kiki\");</script>"));
+    }
+
+    public static class Controller2 extends MockJavaAction {
+        //#comet
+        public static Result index() {
+            Comet comet = new Comet("console.log") {
+                public void onConnected() {
+                    sendMessage("kiki");
+                    sendMessage("foo");
+                    sendMessage("bar");
+                    close();
+                }
+            };
+
+            return ok(comet);
+        }
+        //#comet
+    }
+
+    @Test
+    public void foreverIframe() {
+        String content = contentAsString(MockJavaAction.call(new Controller3(), fakeRequest()));
+        // Wait until results refactoring is merged, then this will work
+        // assertThat(content, containsString("<script type=\"text/javascript\">parent.cometMessage(\"kiki\");</script>"));
+    }
+
+    public static class Controller3 extends MockJavaAction {
+        //#forever-iframe
+        public static Result index() {
+            Comet comet = new Comet("parent.cometMessage") {
+                public void onConnected() {
+                    sendMessage("kiki");
+                    sendMessage("foo");
+                    sendMessage("bar");
+                    close();
+                }
+            };
+
+            return ok(comet);
+        }
+        //#forever-iframe
+    }
+
+}

--- a/documentation/manual/javaGuide/main/async/code/javaguide/async/JavaStream.java
+++ b/documentation/manual/javaGuide/main/async/code/javaguide/async/JavaStream.java
@@ -1,0 +1,115 @@
+package javaguide.async;
+
+import javaguide.testhelpers.MockJavaAction;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+import play.mvc.Result;
+import play.mvc.Results.Chunks;
+import play.test.WithApplication;
+
+import java.io.*;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static play.test.Helpers.*;
+
+public class JavaStream extends WithApplication {
+    @Before
+    public void setUp() {
+        start();
+    }
+
+    @Test
+    public void byDefault() {
+        assertThat(contentAsString(MockJavaAction.call(new Controller1(), fakeRequest())), equalTo("Hello World"));
+    }
+
+    public static class Controller1 extends MockJavaAction {
+        //#by-default
+        public static Result index() {
+            return ok("Hello World");
+        }
+        //#by-default
+    }
+
+    @Test
+    public void serveFile() throws Exception {
+        File file = new File("/tmp/fileToServe.pdf");
+        file.deleteOnExit();
+        OutputStream os = new FileOutputStream(file);
+        try {
+            IOUtils.write("hi", os);
+        } finally {
+            os.close();
+        }
+        Result result = MockJavaAction.call(new Controller2(), fakeRequest());
+        assertThat(contentAsString(result), equalTo("hi"));
+        assertThat(header(CONTENT_LENGTH, result), equalTo("2"));
+        file.delete();
+    }
+
+    public static class Controller2 extends MockJavaAction {
+        //#serve-file
+        public static Result index() {
+            return ok(new java.io.File("/tmp/fileToServe.pdf"));
+        }
+        //#serve-file
+    }
+
+    @Test
+    public void inputStream() {
+        String content = contentAsString(MockJavaAction.call(new Controller3(), fakeRequest()));
+        // Wait until results refactoring is merged, then this will work
+        // assertThat(content, containsString("hello"));
+    }
+
+    private static InputStream getDynamicStreamSomewhere() {
+        return new ByteArrayInputStream("hello".getBytes());
+    }
+
+    public static class Controller3 extends MockJavaAction {
+        //#input-stream
+        public static Result index() {
+            InputStream is = getDynamicStreamSomewhere();
+            return ok(is);
+        }
+        //#input-stream
+    }
+
+    @Test
+    public void chunked() {
+        String content = contentAsString(MockJavaAction.call(new Controller4(), fakeRequest()));
+        // Wait until results refactoring is merged, then this will work
+        // assertThat(content, containsString("kikifoobar"));
+    }
+
+    public static class Controller4 extends MockJavaAction {
+        //#chunked
+        public static Result index() {
+            // Prepare a chunked text stream
+            Chunks<String> chunks = new StringChunks() {
+
+                // Called when the stream is ready
+                public void onReady(Chunks.Out<String> out) {
+                    registerOutChannelSomewhere(out);
+                }
+
+            };
+
+            // Serves this stream with 200 OK
+            return ok(chunks);
+        }
+        //#chunked
+    }
+
+    //#register-out-channel
+    public static void registerOutChannelSomewhere(Chunks.Out<String> out) {
+        out.write("kiki");
+        out.write("foo");
+        out.write("bar");
+        out.close();
+    }
+    //#register-out-channel
+
+}

--- a/documentation/manual/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
+++ b/documentation/manual/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
@@ -1,0 +1,61 @@
+package javaguide.async;
+
+import play.libs.F.*;
+import play.mvc.WebSocket;
+
+public class JavaWebSockets {
+
+    // No simple way to test websockets yet
+
+    public static class Controller1 {
+        //#websocket
+        public static WebSocket<String> index() {
+            return new WebSocket<String>() {
+
+                // Called when the Websocket Handshake is done.
+                public void onReady(WebSocket.In<String> in, WebSocket.Out<String> out) {
+
+                    // For each event received on the socket,
+                    in.onMessage(new Callback<String>() {
+                        public void invoke(String event) {
+
+                            // Log events to the console
+                            System.out.println(event);
+
+                        }
+                    });
+
+                    // When the socket is closed.
+                    in.onClose(new Callback0() {
+                        public void invoke() {
+
+                            System.out.println("Disconnected");
+
+                        }
+                    });
+
+                    // Send a single 'Hello!' message
+                    out.write("Hello!");
+
+                }
+
+            };
+        }
+        //#websocket
+    }
+
+    public static class Controller2 {
+        //#discard-input
+        public static WebSocket<String> index() {
+            return new WebSocket<String>() {
+
+                public void onReady(WebSocket.In<String> in, WebSocket.Out<String> out) {
+                    out.write("Hello!");
+                    out.close();
+                }
+
+            };
+        }
+        //#discard-input
+    }
+}

--- a/framework/src/play/src/main/java/play/mvc/Results.java
+++ b/framework/src/play/src/main/java/play/mvc/Results.java
@@ -2,6 +2,7 @@ package play.mvc;
 
 import play.api.mvc.*;
 
+import play.core.j.JavaResults;
 import play.libs.*;
 import play.libs.F.*;
 
@@ -109,7 +110,7 @@ public class Results {
      * Generates a chunked result.
      */
     public static Status status(int status, File content) {
-        return status(status, content, defaultChunkSize);
+        return new Status(play.core.j.JavaResults.Status(status), content);
     }
 
     /**
@@ -199,15 +200,40 @@ public class Results {
     }
 
     /**
-     * Generates a 200 OK chunked result.
+     * Generates a 200 OK file result as an attachment.
+     *
+     * @param content The file to send.
      */
     public static Status ok(File content) {
-        return ok(content, defaultChunkSize);
+        return new Status(play.core.j.JavaResults.Ok(), content);
     }
 
     /**
-     * Generates a 200 OK simple result.
+     * Generates a 200 OK file result.
+     *
+     * @param content The file to send.
+     * @param inline Whether the file should be sent inline, or as an attachment.
      */
+    public static Status ok(File content, boolean inline) {
+        return new Status(JavaResults.Ok(), content, inline);
+    }
+
+    /**
+     * Generates a 200 OK file result as an attachment.
+     *
+     * @param content The file to send.
+     * @param filename The name to send the file as.
+     */
+    public static Status ok(File content, String filename) {
+        return new Status(JavaResults.Ok(), content, true, filename);
+    }
+
+    /**
+     * Generates a 200 OK file result, sent as a chunked response.
+     *
+     * @deprecated Since the length of the file is known, there is little reason to send a file as chunked.
+     */
+    @Deprecated
     public static Status ok(File content, int chunkSize) {
         return new Status(play.core.j.JavaResults.Ok(), content, chunkSize);
     }
@@ -292,15 +318,40 @@ public class Results {
     }
 
     /**
-     * Generates a 201 CREATED chunked result.
+     * Generates a 201 CREATED file result as an attachment.
+     *
+     * @param content The file to send.
      */
     public static Status created(File content) {
-        return created(content, defaultChunkSize);
+        return new Status(play.core.j.JavaResults.Created(), content);
     }
 
     /**
-     * Generates a 201 CREATED simple result.
+     * Generates a 201 CREATED file result.
+     *
+     * @param content The file to send.
+     * @param inline Whether the file should be sent inline, or as an attachment.
      */
+    public static Status created(File content, boolean inline) {
+        return new Status(JavaResults.Created(), content, inline);
+    }
+
+    /**
+     * Generates a 201 CREATED file result as an attachment.
+     *
+     * @param content The file to send.
+     * @param filename The name to send the file as.
+     */
+    public static Status created(File content, String filename) {
+        return new Status(JavaResults.Created(), content, true, filename);
+    }
+
+    /**
+     * Generates a 201 CREATED file result, sent as a chunked response.
+     *
+     * @deprecated Since the length of the file is known, there is little reason to send a file as chunked.
+     */
+    @Deprecated
     public static Status created(File content, int chunkSize) {
         return new Status(play.core.j.JavaResults.Created(), content, chunkSize);
     }
@@ -394,15 +445,40 @@ public class Results {
     }
 
     /**
-     * Generates a 500 INTERNAL_SERVER_ERROR chunked result.
+     * Generates a 500 INTERNAL_SERVER_ERROR file result as an attachment.
+     *
+     * @param content The file to send.
      */
     public static Status internalServerError(File content) {
-        return internalServerError(content, defaultChunkSize);
+        return new Status(play.core.j.JavaResults.InternalServerError(), content);
     }
 
     /**
-     * Generates a 500 INTERNAL_SERVER_ERROR simple result.
+     * Generates a 500 INTERNAL_SERVER_ERROR file result.
+     *
+     * @param content The file to send.
+     * @param inline Whether the file should be sent inline, or as an attachment.
      */
+    public static Status internalServerError(File content, boolean inline) {
+        return new Status(JavaResults.InternalServerError(), content, inline);
+    }
+
+    /**
+     * Generates a 500 INTERNAL_SERVER_ERROR file result as an attachment.
+     *
+     * @param content The file to send.
+     * @param filename The name to send the file as.
+     */
+    public static Status internalServerError(File content, String filename) {
+        return new Status(JavaResults.InternalServerError(), content, true, filename);
+    }
+
+    /**
+     * Generates a 500 INTERNAL_SERVER_ERROR file result, sent as a chunked response.
+     *
+     * @deprecated Since the length of the file is known, there is little reason to send a file as chunked.
+     */
+    @Deprecated
     public static Status internalServerError(File content, int chunkSize) {
         return new Status(play.core.j.JavaResults.InternalServerError(), content, chunkSize);
     }
@@ -487,15 +563,40 @@ public class Results {
     }
 
     /**
-     * Generates a 404 NOT_FOUND chunked result.
+     * Generates a 404 NOT_FOUND file result as an attachment.
+     *
+     * @param content The file to send.
      */
     public static Status notFound(File content) {
-        return notFound(content, defaultChunkSize);
+        return new Status(play.core.j.JavaResults.NotFound(), content);
     }
 
     /**
-     * Generates a 404 NOT_FOUND simple result.
+     * Generates a 404 NOT_FOUND file result.
+     *
+     * @param content The file to send.
+     * @param inline Whether the file should be sent inline, or as an attachment.
      */
+    public static Status notFound(File content, boolean inline) {
+        return new Status(JavaResults.NotFound(), content, inline);
+    }
+
+    /**
+     * Generates a 404 NOT_FOUND file result as an attachment.
+     *
+     * @param content The file to send.
+     * @param filename The name to send the file as.
+     */
+    public static Status notFound(File content, String filename) {
+        return new Status(JavaResults.NotFound(), content, true, filename);
+    }
+
+    /**
+     * Generates a 404 NOT_FOUND file result, sent as a chunked response.
+     *
+     * @deprecated Since the length of the file is known, there is little reason to send a file as chunked.
+     */
+    @Deprecated
     public static Status notFound(File content, int chunkSize) {
         return new Status(play.core.j.JavaResults.NotFound(), content, chunkSize);
     }
@@ -580,15 +681,40 @@ public class Results {
     }
 
     /**
-     * Generates a 403 FORBIDDEN chunked result.
+     * Generates a 403 FORBIDDEN file result as an attachment.
+     *
+     * @param content The file to send.
      */
     public static Status forbidden(File content) {
-        return forbidden(content, defaultChunkSize);
+        return new Status(play.core.j.JavaResults.Forbidden(), content);
     }
 
     /**
-     * Generates a 403 FORBIDDEN simple result.
+     * Generates a 403 FORBIDDEN file result.
+     *
+     * @param content The file to send.
+     * @param inline Whether the file should be sent inline, or as an attachment.
      */
+    public static Status forbidden(File content, boolean inline) {
+        return new Status(JavaResults.Forbidden(), content, inline);
+    }
+
+    /**
+     * Generates a 403 FORBIDDEN file result as an attachment.
+     *
+     * @param content The file to send.
+     * @param filename The name to send the file as.
+     */
+    public static Status forbidden(File content, String filename) {
+        return new Status(JavaResults.Forbidden(), content, true, filename);
+    }
+
+    /**
+     * Generates a 403 FORBIDDEN file result, sent as a chunked response.
+     *
+     * @deprecated Since the length of the file is known, there is little reason to send a file as chunked.
+     */
+    @Deprecated
     public static Status forbidden(File content, int chunkSize) {
         return new Status(play.core.j.JavaResults.Forbidden(), content, chunkSize);
     }
@@ -673,15 +799,40 @@ public class Results {
     }
 
     /**
-     * Generates a 401 UNAUTHORIZED chunked result.
+     * Generates a 401 UNAUTHORIZED file result as an attachment.
+     *
+     * @param content The file to send.
      */
     public static Status unauthorized(File content) {
-        return unauthorized(content, defaultChunkSize);
+        return new Status(play.core.j.JavaResults.Unauthorized(), content);
     }
 
     /**
-     * Generates a 401 UNAUTHORIZED simple result.
+     * Generates a 401 UNAUTHORIZED file result.
+     *
+     * @param content The file to send.
+     * @param inline Whether the file should be sent inline, or as an attachment.
      */
+    public static Status unauthorized(File content, boolean inline) {
+        return new Status(JavaResults.Unauthorized(), content, inline);
+    }
+
+    /**
+     * Generates a 401 UNAUTHORIZED file result as an attachment.
+     *
+     * @param content The file to send.
+     * @param filename The name to send the file as.
+     */
+    public static Status unauthorized(File content, String filename) {
+        return new Status(JavaResults.Unauthorized(), content, true, filename);
+    }
+
+    /**
+     * Generates a 401 UNAUTHORIZED file result, sent as a chunked response.
+     *
+     * @deprecated Since the length of the file is known, there is little reason to send a file as chunked.
+     */
+    @Deprecated
     public static Status unauthorized(File content, int chunkSize) {
         return new Status(play.core.j.JavaResults.Unauthorized(), content, chunkSize);
     }
@@ -766,15 +917,40 @@ public class Results {
     }
 
     /**
-     * Generates a 400 BAD_REQUEST chunked result.
+     * Generates a 400 BAD_REQUEST file result as an attachment.
+     *
+     * @param content The file to send.
      */
     public static Status badRequest(File content) {
-        return badRequest(content, defaultChunkSize);
+        return new Status(play.core.j.JavaResults.BadRequest(), content);
     }
 
     /**
-     * Generates a 400 BAD_REQUEST simple result.
+     * Generates a 400 BAD_REQUEST file result.
+     *
+     * @param content The file to send.
+     * @param inline Whether the file should be sent inline, or as an attachment.
      */
+    public static Status badRequest(File content, boolean inline) {
+        return new Status(JavaResults.BadRequest(), content, inline);
+    }
+
+    /**
+     * Generates a 400 BAD_REQUEST file result as an attachment.
+     *
+     * @param content The file to send.
+     * @param filename The name to send the file as.
+     */
+    public static Status badRequest(File content, String filename) {
+        return new Status(JavaResults.BadRequest(), content, true, filename);
+    }
+
+    /**
+     * Generates a 400 BAD_REQUEST file result, sent as a chunked response.
+     *
+     * @deprecated Since the length of the file is known, there is little reason to send a file as chunked.
+     */
+    @Deprecated
     public static Status badRequest(File content, int chunkSize) {
         return new Status(play.core.j.JavaResults.BadRequest(), content, chunkSize);
     }
@@ -1112,6 +1288,21 @@ public class Results {
                     content,
                     play.core.j.JavaResults.writeBytes()
                     );
+        }
+
+        public Status(play.api.mvc.Results.Status status, File content) {
+            this(status, content, false);
+        }
+
+        public Status(play.api.mvc.Results.Status status, File content, boolean inline) {
+            this(status, content, inline, content.getName());
+        }
+
+        public Status(play.api.mvc.Results.Status status, File content, boolean inline, String filename) {
+            if(content == null) {
+                throw new NullPointerException("null content");
+            }
+            wrappedResult = play.core.j.JavaResults.sendFile(status, content, inline, filename);
         }
 
         public Status(play.api.mvc.Results.Status status, File content, int chunkSize) {

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -621,11 +621,12 @@ trait Results {
      * @param fileName function to retrieve the file name (only used for Content-Disposition attachment)
      */
     def sendFile(content: java.io.File, inline: Boolean = false, fileName: java.io.File => String = _.getName, onClose: () => Unit = () => ())(ec: ExecutionContext): SimpleResult[Array[Byte]] = {
+      val name = fileName(content)
       SimpleResult(
         header = ResponseHeader(OK, Map(
           CONTENT_LENGTH -> content.length.toString,
-          CONTENT_TYPE -> play.api.libs.MimeTypes.forFileName(content.getName).getOrElse(play.api.http.ContentTypes.BINARY)
-        ) ++ (if (inline) Map.empty else Map(CONTENT_DISPOSITION -> ("""attachment; filename="%s"""".format(fileName(content)))))),
+          CONTENT_TYPE -> play.api.libs.MimeTypes.forFileName(name).getOrElse(play.api.http.ContentTypes.BINARY)
+        ) ++ (if (inline) Map.empty else Map(CONTENT_DISPOSITION -> ("""attachment; filename="%s"""".format(name))))),
         Enumerator.fromFile(content) &> Enumeratee.onIterateeDone(onClose)(ec)
       )
     }

--- a/framework/src/play/src/main/scala/play/core/j/JavaResults.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaResults.scala
@@ -34,6 +34,7 @@ object JavaResults extends Results with DefaultWriteables with DefaultContentTyp
   //play.api.libs.iteratee.Enumerator.imperative[A](onComplete = onDisconnected)
   def chunked(stream: java.io.InputStream, chunkSize: Int): Enumerator[Array[Byte]] = Enumerator.fromStream(stream, chunkSize)
   def chunked(file: java.io.File, chunkSize: Int) = Enumerator.fromFile(file, chunkSize)
+  def sendFile(status: play.api.mvc.Results.Status, file: java.io.File, inline: Boolean, filename: String) = status.sendFile(file, inline, _ => filename)(play.core.Execution.internalContext)
 }
 object JavaResultExtractor {
 


### PR DESCRIPTION
Also ensured that files in Java are served as the docs say they are served,
as attachments, with a content length, not chunked.
