### PR TITLE
Fixed Enumerator.pushee test; wait on CountDownLatches more carefully

### DIFF
--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/ConcurrentSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/ConcurrentSpec.scala
@@ -186,7 +186,7 @@ object ConcurrentSpec extends Specification with IterateeSpecification {
         c.push(3)
         c.eofAndEnd()
         Await.result(i, Duration.Inf) must equalTo(List(1, 2, 3))
-        interestDone.await(5, SECONDS)
+        interestDone.await(30, SECONDS) must beTrue
         interestCount.get() must equalTo(1)
       }
     }

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumeratorsSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumeratorsSpec.scala
@@ -187,7 +187,7 @@ object EnumeratorsSpec extends Specification with IterateeSpecification {
             },
             (_: String, _: Input[(Boolean, Int)]) => errorCount.incrementAndGet())(callbackEC)
         mustEnumerateTo((true, 1), (false, 2), (false, 3))(enumerator)
-        completeDone.await(5, TimeUnit.SECONDS)
+        completeDone.await(30, TimeUnit.SECONDS) must beTrue
         completeCount.get() must equalTo(1)
         errorCount.get() must equalTo(0)
       }
@@ -252,7 +252,7 @@ object EnumeratorsSpec extends Specification with IterateeSpecification {
         e.push(2) must equalTo(true)
         e.push(3) must equalTo(true)
         e.close()
-        allPushesReceived.await()
+        allPushesReceived.await(30, TimeUnit.SECONDS) must beTrue
         pushed must equalTo(List(1, 2, 3))
         startCount.get() must equalTo(1)
         completeCount.get() must equalTo(0) // Only called if Iteratee is done
@@ -290,16 +290,16 @@ object EnumeratorsSpec extends Specification with IterateeSpecification {
           allPushesReceived.countDown()
         }(dec)
 
-        startDone.await(5, TimeUnit.SECONDS)
         val waitTime = scala.concurrent.duration.Duration(5, scala.concurrent.duration.SECONDS)
         Await.result(Future(e(i))(dec), waitTime)
 
+        startDone.await(30, TimeUnit.SECONDS) must beTrue
         pushee.push(1)
         pushee.push(2)
         pushee.push(3)
         pushee.close()
 
-        allPushesReceived.await(5, TimeUnit.SECONDS)
+        allPushesReceived.await(30, TimeUnit.SECONDS) must beTrue
         pushed must equalTo(List(1, 2, 3))
         startCount.get() must equalTo(1)
         completeCount.get() must equalTo(0) // Only called if Iteratee is done
@@ -330,7 +330,7 @@ object EnumeratorsSpec extends Specification with IterateeSpecification {
         val enumerator = Enumerator.outputStream { o => os = o; osReady.countDown() }(outputEC)
         val promiseIteratee = Promise[Iteratee[Array[Byte], Array[Byte]]]
         val future = enumerator |>>> Iteratee.flatten(promiseIteratee.future)
-        osReady.await(5, TimeUnit.SECONDS)
+        osReady.await(30, TimeUnit.SECONDS) must beTrue
         // os should now be set
         os.write("hello".getBytes)
         os.write(" ".getBytes)


### PR DESCRIPTION
Fixed a timing issue with waiting on a CountDownLatch too early, which always then timed out. But the code didn't detect the fact that the CountDownLatch wait failed and the test continued anyway, causing an intermittent NPE (now happening reliably on my computer too, so perhaps a change elsewhere interacted with this test?).

Moved the wait to the right place, resolving the problem. Also wait longer and check return values for all calls to CountDownLatch.await().
