### PR TITLE
Allow to define custom binding message for java form

### DIFF
--- a/documentation/manual/javaGuide/main/forms/JavaForms.md
+++ b/documentation/manual/javaGuide/main/forms/JavaForms.md
@@ -78,4 +78,10 @@ For an object like JodaTime's `LocalTime` it could look like this:
 
 @[register-formatter](code/javaguide/forms/JavaForms.java)
 
+When the binding fail an array of errors keys is created, the first one defined in the messages file will be used. This array will generally contain :
+
+    ["error.invalid.<fieldName>", "error.invalid.<type>", "error.invalid"]
+
+The errors keys are created by [Spring DefaultMessageCodesResolver](http://static.springsource.org/spring/docs/3.0.7.RELEASE/javadoc-api/org/springframework/validation/DefaultMessageCodesResolver.html), the root "typeMismatch" is replaced by "error.invalid".
+
 > **Next:** [[Using the form template helpers | JavaFormHelpers]]

--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -185,15 +185,16 @@ object PlayBuild extends Build {
     .settings(libraryDependencies := jpaDeps)
     .dependsOn(PlayJavaJdbcProject)
 
-  lazy val PlayJavaProject = PlayRuntimeProject("Play-Java", "play-java")
-    .settings(libraryDependencies := javaDeps)
-    .dependsOn(PlayProject)
-
   lazy val PlayTestProject = PlayRuntimeProject("Play-Test", "play-test")
     .settings(
       libraryDependencies := testDependencies,
       parallelExecution in Test := false
     ).dependsOn(PlayProject)
+
+  lazy val PlayJavaProject = PlayRuntimeProject("Play-Java", "play-java")
+    .settings(libraryDependencies := javaDeps)
+    .dependsOn(PlayProject)
+    .dependsOn(PlayTestProject % "test")
 
   lazy val SbtPluginProject = PlaySbtProject("SBT-Plugin", "sbt-plugin")
     .settings(

--- a/framework/src/play-java/src/main/java/play/data/Form.java
+++ b/framework/src/play-java/src/main/java/play/data/Form.java
@@ -361,9 +361,23 @@ public class Form<T> {
                     }                    
                 }
                 if(!errors.containsKey(key)) {
-                   errors.put(key, new ArrayList<ValidationError>()); 
+                   errors.put(key, new ArrayList<ValidationError>());
                 }
-                errors.get(key).add(new ValidationError(key, error.isBindingFailure() ? "error.invalid" : error.getDefaultMessage(), arguments));                    
+
+                String message = "error.invalid";
+                if( error.isBindingFailure() ){
+                    for(String code : error.getCodes() ){
+                        code = code.replace("typeMismatch", "error.invalid");
+                        if( play.i18n.Messages.isDefined(code) ){
+                            message = code;
+                            break;
+                        }
+                    }
+                }else{
+                    message = error.getDefaultMessage();
+                }
+
+                errors.get(key).add(new ValidationError(key, message, arguments));
             }
             return new Form(rootName, backedType, data, errors, None(), groups);
         } else {

--- a/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
@@ -1,6 +1,7 @@
 package play.data
 
 import org.specs2.mutable.Specification
+import play.api.test.WithApplication
 import play.mvc._
 import play.mvc.Http.Context
 import scala.collection.JavaConverters._
@@ -109,36 +110,38 @@ object ScalaForms {
 
 object FormSpec extends Specification {
 
+  sequential
+
   "A form" should {
-    "be valid" in {
+    "be valid" in new WithApplication{
       val req = new DummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "done" -> Array("true"), "dueDate" -> Array("15/12/2009")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = JForm.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
     }
-    "be valid with mandatory params passed" in {
+    "be valid with mandatory params passed" in new WithApplication{
       val req = new DummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = JForm.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
     }
-    "have an error due to baldy formatted date" in {
+    "have an error due to baldy formatted date" in new WithApplication{
       val req = new DummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = JForm.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(true)
-
+      myForm.errors.get("dueDate").get(0).message() must beEqualTo("error.invalid.java.util.Date")
     }
-    "have an error due to bad value in Id field" in {
+    "have an error due to bad value in Id field" in new WithApplication{
       val req = new DummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter"), "dueDate" -> Array("12/12/2009")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = JForm.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(true)
-
+      myForm.errors.get("id").get(0).message() must beEqualTo("error.invalid")
     }
     "have an error due to a malformed email" in {
       val f5 = ScalaForms.emailForm.fillAndValidate("john@", "John")

--- a/framework/src/play/src/main/java/play/i18n/Messages.java
+++ b/framework/src/play/src/main/java/play/i18n/Messages.java
@@ -25,7 +25,18 @@ public class Messages {
         Buffer<Object> scalaArgs = scala.collection.JavaConverters.asScalaBufferConverter(Arrays.asList(args)).asScala();
         return play.api.i18n.Messages.apply(key, scalaArgs, lang);
     }
-    
+
+    private static Lang getLang(){
+        Lang lang = null;
+        if(play.mvc.Http.Context.current.get() != null) {
+            lang = play.mvc.Http.Context.current().lang();
+        } else {
+            Locale defaultLocale = Locale.getDefault();
+            lang = new Lang(defaultLocale.getLanguage(), defaultLocale.getCountry());
+        }
+        return lang;
+    }
+
     /**
     * Translates a message.
     *
@@ -37,13 +48,26 @@ public class Messages {
     */
     public static String get(String key, Object... args) {
         Buffer<Object> scalaArgs = scala.collection.JavaConverters.asScalaBufferConverter(Arrays.asList(args)).asScala();
-        Lang lang = null;
-        if(play.mvc.Http.Context.current.get() != null) {
-            lang = play.mvc.Http.Context.current().lang();
-        } else {
-            Locale defaultLocale = Locale.getDefault();
-            lang = new Lang(defaultLocale.getLanguage(), defaultLocale.getCountry());
-        }
-        return play.api.i18n.Messages.apply(key, scalaArgs, lang);
+        return play.api.i18n.Messages.apply(key, scalaArgs, getLang());
+    }
+
+    /**
+    * Check if a message key is defined.
+    * @param lang the message lang
+    * @param key the message key
+    * @return a Boolean
+    */
+    public static Boolean isDefined(Lang lang, String key) {
+        return play.api.i18n.Messages.isDefinedAt(key, lang);
+    }
+
+    /**
+    * Check if a message key is defined.
+    * @param lang the message lang
+    * @param key the message key
+    * @return a Boolean
+    */
+    public static Boolean isDefined(String key) {
+        return play.api.i18n.Messages.isDefinedAt(key, getLang());
     }
 }

--- a/framework/src/play/src/main/resources/messages
+++ b/framework/src/play/src/main/resources/messages
@@ -15,6 +15,7 @@ format.real=Real
 
 # --- Errors
 error.invalid=Invalid value
+error.invalid.java.util.Date=Invalid date value
 error.required=This field is required
 error.number=Numeric value expected
 error.real=Real number value expected

--- a/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
@@ -18,24 +18,34 @@ object MessagesSpec extends Specification {
   def translate(msg: String, lang: String, reg: String): Option[String] =
     api.translate(msg, Nil)(Lang(lang, reg))
 
+  def isDefinedAt(msg: String, lang: String, reg: String): Boolean =
+    api.isDefinedAt(msg)(Lang(lang, reg))
+
   "MessagesApi" should {
     "fall back to less specific translation" in {
       // Direct lookups
       translate("title", "fr", "CH") must be equalTo Some("Titre suisse")
       translate("title", "fr", "") must be equalTo Some("Titre francais")
-      
+      isDefinedAt("title", "fr", "CH") must be equalTo true
+      isDefinedAt("title", "fr", "") must be equalTo true
+
       // Region that is missing
       translate("title", "fr", "FR") must be equalTo Some("Titre francais")
-      
+      isDefinedAt("title", "fr", "FR") must be equalTo true
+
       // Translation missing in the given region
       translate("foo", "fr", "CH") must be equalTo Some("foo francais")
       translate("bar", "fr", "CH") must be equalTo Some("English pub")
-      
+      isDefinedAt("foo", "fr", "CH") must be equalTo true
+      isDefinedAt("bar", "fr", "CH") must be equalTo true
+
       // Unrecognized language
       translate("title", "bo", "GO") must be equalTo Some("English Title")
-      
+      isDefinedAt("title", "bo", "GO") must be equalTo true
+
       // Missing translation
       translate("garbled", "fr", "CH") must be equalTo None
+      isDefinedAt("garbled", "fr", "CH") must be equalTo false
     }
   }
 }


### PR DESCRIPTION
Right now when a java form binding fail the error message returned is always : error.invalid.

In the SpringValidator when the binding fail a FieldError is returned, this class implements the interface of MessageSourceResolvable which define mutiple message code to be tried in specific order.

Those messages look like : 
 [typeMismatch.target.client.dateNaissance, typeMismatch.client.dateNaissance, typeMismatch.dateNaissance, typeMismatch.org.joda.time.DateTime, typeMismatch] 

This pull request add a similar comportement in order to be able to define a specific error message for each binding.

The root of each error message key (typeMismatch) is replaced by : error.invalid.
