### PR TITLE
Add WAMP to the list of allowed websocket subprotocols.

### DIFF
--- a/framework/src/play/src/main/scala/play/core/server/websocket/WebSocketHandshake.scala
+++ b/framework/src/play/src/main/scala/play/core/server/websocket/WebSocketHandshake.scala
@@ -31,7 +31,7 @@ object WebSocketHandshake {
 
   def shake(ctx: ChannelHandlerContext, req: HttpRequest): Unit = {
     val factory = new WebSocketServerHandshakerFactory(getWebSocketLocation(req),
-      null, /* subprotocols */
+      "wamp", /* subprotocol CSV list */
       true /* allowExtensions */ )
 
     val shaker = factory.newHandshaker(req)


### PR DESCRIPTION
This request allows libraries like https://github.com/blopker/WAMPlay to use AutobahnJS for websocket RPC/PubSub.

Originally the subprotocol list was `null`. This tells Netty to reject any header with the "Sec-WebSocket-Protocol" field set. Setting the string to `"wamp"` allows AutobahnJS to connect to Play without using ugly workarounds. To add further protocols (though I'm not aware of others) just set the string to `"wamp,otherprotocol"`.
