### PR TITLE
Path pattern not decoding middle path part

### DIFF
--- a/framework/src/play/src/test/scala/play/core/router/RouterSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/router/RouterSpec.scala
@@ -25,8 +25,10 @@ object RouterSpec extends Specification {
 
 
   "PathPattern" should {
+    // /path/to/:foo
     val pathPatternWithDynamicLastPart = PathPattern(Seq(StaticPart("/path/"), StaticPart("to/"), DynamicPart("foo", "[^/]+", true)))
-    val pathPatternWithDynamicMiddlePart = PathPattern(Seq(StaticPart("/path/"), DynamicPart("foo", "[^/]+", true), StaticPart("to/")))
+    // /path/:foo/to
+    val pathPatternWithDynamicMiddlePart = PathPattern(Seq(StaticPart("/path/"), DynamicPart("foo", "[^/]+", true), StaticPart("/to")))
     val pathStringWithEncodedLastPart = "/path/to/some%20file"
     val pathStringWithEncodedMiddlePart = "/path/some%20file/to"
     val pathNonEncodedString1 = "/path/to/bar:baz"


### PR DESCRIPTION
URI decoding of path parts works fine if dynamic part is
at the end but does not work in the middle.

I could not figure out how to fix it but the pull request contains a failing test.

Please let me know if there is anything else that you need.
