### PR TITLE
Stopped using Typesafe fork of SBT IDEA plugin

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -201,7 +201,7 @@ object PlayBuild extends Build {
       publishMavenStyle := false,
       libraryDependencies := sbtDependencies,
       libraryDependencies += "com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.1" extra("sbtVersion" -> buildSbtVersionBinaryCompatible, "scalaVersion" -> buildScalaVersionForSbt),
-      libraryDependencies += "com.typesafe.sbtidea" % "sbt-idea" % "1.1.1" extra("sbtVersion" -> buildSbtVersionBinaryCompatible, "scalaVersion" -> buildScalaVersionForSbt),
+      libraryDependencies += "com.github.mpeltonen" % "sbt-idea" % "1.4.0" extra("sbtVersion" -> buildSbtVersionBinaryCompatible, "scalaVersion" -> buildScalaVersionForSbt),
       libraryDependencies += "org.specs2" %% "specs2" % "1.12.3" % "test" exclude("javax.transaction", "jta"),
       libraryDependencies += "org.scala-sbt" % "sbt" % buildSbtVersion % "provided",
       publishTo := Some(publishingIvyRepository)

--- a/framework/src/sbt-plugin/src/main/scala/play/Project.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/Project.scala
@@ -34,7 +34,7 @@ object Project extends Plugin with PlayExceptions with PlayKeys with PlayReloade
     val mainLang = if (dependencies.contains(javaCore)) JAVA else SCALA
 
     lazy val playSettings =
-      Project.defaultSettings ++ eclipseCommandSettings(mainLang) ++ intellijCommandSettings(mainLang) ++ Seq(testListeners += testListener) ++ whichLang(mainLang) ++ Seq(
+      Project.defaultSettings ++ eclipseCommandSettings(mainLang) ++ intellijCommandSettings ++ Seq(testListeners += testListener) ++ whichLang(mainLang) ++ Seq(
         scalacOptions ++= Seq("-deprecation", "-unchecked", "-encoding", "utf8"),
         javacOptions in Compile ++= Seq("-encoding", "utf8", "-g"),
         version := applicationVersion,


### PR DESCRIPTION
Now uses 1.4.0 of the main SBT IDEA plugin, and wraps it in a command
that supplies the same interface as the Typesafe fork.  Still compatible
with gen-idea.
