### PR TITLE
Cleaned up SBT logging

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayLogger.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayLogger.scala
@@ -2,25 +2,6 @@ package sbt
 
 import xsbti.{ Maybe, Position }
 
-object InPlaceLogger {
-
-  private var lastMessage: String = null
-
-  def log(message: String) {
-    val logged = "[info] " + message + "\r"
-    print(logged)
-    lastMessage = logged
-  }
-
-  def clear() {
-    if (lastMessage != null) {
-      print(" " * lastMessage.size + "\r")
-      lastMessage = null
-    }
-  }
-
-}
-
 object PlayLogManager {
 
   def default(playPositionMapper: Position => Option[Position])(extra: ScopedKey[_] => Seq[AbstractLogger]) =
@@ -29,40 +10,20 @@ object PlayLogManager {
 }
 
 class PlayLogManager(extra: ScopedKey[_] => Seq[AbstractLogger], playPositionMapper: Position => Option[Position]) extends LogManager {
-  //reintroduce missing methods
-  def defaultScreen: AbstractLogger = ConsoleLogger()
-  //reintroduce missing methods
-  def defaultBacked(useColor: Boolean = ConsoleLogger.formatEnabled): java.io.PrintWriter => ConsoleLogger =
-    to => ConsoleLogger(ConsoleLogger.printWriterOut(to), useColor = useColor)
 
-  val screen = defaultScreen
-  val backed = defaultBacked()
+  val screen = MainLogging.defaultScreen(StandardMain.console)
+  val backed = MainLogging.defaultBacked()
   val sourcePositionFilter = new PlaySourcePositionFilter(playPositionMapper)
 
   def apply(data: Settings[Scope], state: State, task: ScopedKey[_], to: java.io.PrintWriter): Logger = {
     new FilterLogger(
       delegate = LogManager.defaultLogger(data, state, task, screen, backed(to), extra(task).toList).asInstanceOf[AbstractLogger]
     ) {
-
       override def log(level: Level.Value, message: => String): Unit = {
         if (atLevel(level)) {
-          sourcePositionFilter.filter(level, message) { (level, message) =>
-            InPlaceLogger.clear()
-            if (!message.contains("Running java with options -classpath")) {
-              if (filtered(message)) {
-                InPlaceLogger.log(message)
-              } else {
-                super.log(level, message)
-              }
-            }
-          }
+          sourcePositionFilter.filter(level, message)(super.log)
         }
       }
-
-      def filtered(message: String) = {
-        message.startsWith("Resolving ") && message.endsWith("...")
-      }
-
     }
   }
 }


### PR DESCRIPTION
SBT 0.12 implemented the feature where carriage returns (not newlines)
are added after the resolving messages, previously Play was using
regular expressions to implement these itself.  It's about time we let
SBT 0.12 do it for us.
