### PR TITLE
Update to documentation/manual/javaGuide/main/i18n/JavaI18N.md

### DIFF
--- a/documentation/manual/javaGuide/main/i18n/JavaI18N.md
+++ b/documentation/manual/javaGuide/main/i18n/JavaI18N.md
@@ -25,7 +25,7 @@ String title = Messages.get("home.title")
 You can also specify the language explicitly:
 
 ```
-String title = Messages.get(new Lang("fr"), "home.title")
+String title = Messages.get(new Lang(Lang.forCode("fr")), "home.title")
 ```
 
 > **Note:** If you have a `Request` in the scope, it will provide a default `Lang` value corresponding to the preferred language extracted from the `Accept-Language` header and matching one of the application’s supported languages. You should also add a `Lang` implicit parameter to your template like this: `@()(implicit lang: Lang)`.


### PR DESCRIPTION
I've noticed that you're using a constructor that is undefined for the class `play.i18n.Lang` in the **Externalizing messages** chapter.
As it's undefined i've made an example that uses the constructor `Lang(Lang)` taking advantage of the static method `Lang.forCode(String)`.
