### PR TITLE
doc/javaform: Fix a dead link to Spring Validation.

### DIFF
--- a/documentation/manual/javaGuide/main/forms/JavaForms.md
+++ b/documentation/manual/javaGuide/main/forms/JavaForms.md
@@ -8,7 +8,7 @@ The `play.data` package contains several helpers to handle HTTP form data submis
 
 @[create](code/javaguide/forms/JavaForms.java)
 
-> **Note:** The underlying binding is done using [Spring data binder](http://static.springsource.org/spring/docs/3.0.7.RELEASE/reference/validation.html).
+> **Note:** The underlying binding is done using [Spring data binder](http://static.springsource.org/spring/docs/3.0.x/reference/validation.html).
 
 This form can generate a `User` result value from `HashMap<String,String>` data:
 


### PR DESCRIPTION
In JavaForms.md, the link to Spring Validation page is broken.
