### PR TITLE
Support multiple message keys in ValidationError and FormError

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -225,14 +225,13 @@ object PlayBuild extends Build {
   lazy val PlayJavaProject = PlayRuntimeProject("Play-Java", "play-java")
     .settings(libraryDependencies := javaDeps)
     .dependsOn(PlayProject)
-    .dependsOn(PlayTestProject % "test")
 
   lazy val PlayDocsProject = PlayRuntimeProject("Play-Docs", "play-docs")
     .settings(Docs.settings: _*)
     .settings(
       libraryDependencies := playDocsDependencies
     ).dependsOn(PlayProject)
-  
+
   import ScriptedPlugin._
 
   lazy val SbtPluginProject = PlaySbtProject("SBT-Plugin", "sbt-plugin")
@@ -370,7 +369,7 @@ object PlayBuild extends Build {
     PlayFiltersHelpersProject,
     PlayIntegrationTestProject
   )
-    
+
   lazy val Root = Project(
     "Root",
     file("."))

--- a/framework/src/play-java/src/main/java/play/data/validation/ValidationError.java
+++ b/framework/src/play-java/src/main/java/play/data/validation/ValidationError.java
@@ -13,7 +13,7 @@ import com.google.common.collect.ImmutableList;
 public class ValidationError {
     
     private String key;
-    private String message;
+    private List<String> messages;
     private List<Object> arguments;
 
     /**
@@ -35,22 +35,42 @@ public class ValidationError {
      */
     public ValidationError(String key, String message, List<Object> arguments) {
         this.key = key;
-        this.message = message;
+        this.arguments = arguments;
+        this.messages = ImmutableList.of(message);
+    }
+
+    /**
+     * Constructs a new <code>ValidationError</code>.
+     *
+     * @param key the error key
+     * @param messages the list of error messages
+     * @param arguments the error message arguments
+     */
+    public ValidationError(String key, List<String> messages, List<Object> arguments) {
+        this.key = key;
+        this.messages = messages;
         this.arguments = arguments;
     }
-    
+
     /**
      * Returns the error key.
      */
     public String key() {
         return key;
     }
-    
+
     /**
      * Returns the error message.
      */
     public String message() {
-        return message;
+        return messages.get(messages.size()-1);
+    }
+
+    /**
+     * Returns the error messages.
+     */
+    public List<String> messages() {
+        return messages;
     }
 
     /**
@@ -59,9 +79,9 @@ public class ValidationError {
     public List<Object> arguments() {
         return arguments;
     }
-    
+
     public String toString() {
-        return "ValidationError(" + key + "," + message + "," + arguments + ")";
+        return "ValidationError(" + key + "," + messages + "," + arguments + ")";
     }
-    
+
 }

--- a/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
+++ b/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
@@ -41,7 +41,7 @@ object PlayMagicForJava {
       jField.errors.asScala.map { jE =>
         play.api.data.FormError(
           jE.key,
-          jE.message,
+          jE.messages.asScala,
           jE.arguments.asScala)
       },
       Option(jField.value)) {

--- a/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
@@ -4,7 +4,6 @@
 package play.data
 
 import org.specs2.mutable.Specification
-import play.api.test.WithApplication
 import play.mvc._
 import play.mvc.Http.Context
 import scala.collection.JavaConverters._
@@ -12,35 +11,35 @@ import scala.collection.JavaConverters._
 object FormSpec extends Specification {
 
   "a java form" should {
-    "be valid" in new WithApplication{
+    "be valid" in {
       val req = new DummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "done" -> Array("true"), "dueDate" -> Array("15/12/2009")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = Form.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
     }
-    "be valid with mandatory params passed" in new WithApplication{
+    "be valid with mandatory params passed" in {
       val req = new DummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = Form.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
     }
-    "have an error due to baldy formatted date" in new WithApplication{
+    "have an error due to baldy formatted date" in {
       val req = new DummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = Form.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(true)
-      myForm.errors.get("dueDate").get(0).message() must beEqualTo("error.invalid.java.util.Date")
+      myForm.errors.get("dueDate").get(0).messages().asScala must contain("error.invalid.java.util.Date")
     }
-    "have an error due to bad value in Id field" in new WithApplication{
+    "have an error due to bad value in Id field" in {
       val req = new DummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter"), "dueDate" -> Array("12/12/2009")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = Form.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(true)
-      myForm.errors.get("id").get(0).message() must beEqualTo("error.invalid")
+      myForm.errors.get("id").get(0).messages().asScala must contain("error.invalid")
     }
 
     "support repeated values for Java binding" in {

--- a/framework/src/play/src/main/java/play/i18n/Messages.java
+++ b/framework/src/play/src/main/java/play/i18n/Messages.java
@@ -6,6 +6,7 @@ package play.i18n;
 import scala.collection.mutable.Buffer;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import play.api.i18n.Lang;
 
@@ -13,21 +14,6 @@ import play.api.i18n.Lang;
  * High-level internationalisation API.
  */
 public class Messages {
-
-    /**
-    * Translates a message.
-    *
-    * Uses `java.text.MessageFormat` internally to format the message.
-    *
-    * @param lang the message lang
-    * @param key the message key
-    * @param args the message arguments
-    * @return the formatted message or a default rendering if the key wasn't defined
-    */
-    public static String get(Lang lang, String key, Object... args) {
-        Buffer<Object> scalaArgs = scala.collection.JavaConverters.asScalaBufferConverter(Arrays.asList(args)).asScala();
-        return play.api.i18n.Messages.apply(key, scalaArgs, lang);
-    }
 
     private static Lang getLang(){
         Lang lang = null;
@@ -45,6 +31,37 @@ public class Messages {
     *
     * Uses `java.text.MessageFormat` internally to format the message.
     *
+    * @param lang the message lang
+    * @param key the message key
+    * @param args the message arguments
+    * @return the formatted message or a default rendering if the key wasn't defined
+    */
+    public static String get(Lang lang, String key, Object... args) {
+        Buffer<Object> scalaArgs = scala.collection.JavaConverters.asScalaBufferConverter(Arrays.asList(args)).asScala();
+        return play.api.i18n.Messages.apply(key, scalaArgs, lang);
+    }
+
+    /**
+    * Translates the first defined message.
+    *
+    * Uses `java.text.MessageFormat` internally to format the message.
+    *
+    * @param lang the message lang
+    * @param key the messages keys
+    * @param args the message arguments
+    * @return the formatted message or a default rendering if the key wasn't defined
+    */
+    public static String get(Lang lang, List<String> keys, Object... args) {
+        Buffer<String> keyArgs = scala.collection.JavaConverters.asScalaBufferConverter(keys).asScala();
+        Buffer<Object> scalaArgs = scala.collection.JavaConverters.asScalaBufferConverter(Arrays.asList(args)).asScala();
+        return play.api.i18n.Messages.apply(keyArgs.toSeq(), scalaArgs, lang);
+    }
+
+    /**
+    * Translates a message.
+    *
+    * Uses `java.text.MessageFormat` internally to format the message.
+    *
     * @param key the message key
     * @param args the message arguments
     * @return the formatted message or a default rendering if the key wasn't defined
@@ -52,6 +69,21 @@ public class Messages {
     public static String get(String key, Object... args) {
         Buffer<Object> scalaArgs = scala.collection.JavaConverters.asScalaBufferConverter(Arrays.asList(args)).asScala();
         return play.api.i18n.Messages.apply(key, scalaArgs, getLang());
+    }
+
+    /**
+    * Translates the first defined message.
+    *
+    * Uses `java.text.MessageFormat` internally to format the message.
+    *
+    * @param key the messages keys
+    * @param args the message arguments
+    * @return the formatted message or a default rendering if the key wasn't defined
+    */
+    public static String get(List<String> keys, Object... args) {
+        Buffer<String> keyArgs = scala.collection.JavaConverters.asScalaBufferConverter(keys).asScala();
+        Buffer<Object> scalaArgs = scala.collection.JavaConverters.asScalaBufferConverter(Arrays.asList(args)).asScala();
+        return play.api.i18n.Messages.apply(keyArgs.toSeq(), scalaArgs, getLang());
     }
 
     /**

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -386,7 +386,13 @@ private[data] object FormUtils {
  * @param message The form message (often a simple message key needing to be translated).
  * @param args Arguments used to format the message.
  */
-case class FormError(key: String, message: String, args: Seq[Any] = Nil) {
+case class FormError(key: String, messages: Seq[String], args: Seq[Any] = Nil) {
+
+  def this(key: String, message: String) = this(key, Seq(message), Nil)
+
+  def this(key: String, message: String, args: Seq[Any]) = this(key, Seq(message), args)
+
+  lazy val message = messages.last
 
   /**
    * Copy this error with a new Message.
@@ -394,6 +400,13 @@ case class FormError(key: String, message: String, args: Seq[Any] = Nil) {
    * @param message The new message.
    */
   def withMessage(message: String): FormError = FormError(key, message)
+}
+
+object FormError {
+
+  def apply(key: String, message: String) = new FormError(key, message)
+
+  def apply(key: String, message: String, args: Seq[Any]) = new FormError(key, message, args)
 
 }
 

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -146,6 +146,26 @@ object Messages {
   }
 
   /**
+   * Translates the first defined message.
+   *
+   * Uses `java.text.MessageFormat` internally to format the message.
+   *
+   * @param key the message key
+   * @param args the message arguments
+   * @return the formatted message or a default rendering if the key wasn’t defined
+   */
+  def apply(keys: Seq[String], args: Any*)(implicit lang: Lang): String = {
+    Play.maybeApplication.flatMap { app =>
+      app.plugin[MessagesPlugin].map { plugin =>
+        keys.foldLeft[Option[String]](None) {
+          case (None, key) => plugin.api.translate(key, args)
+          case (acc, _) => acc
+        }
+      }.getOrElse(throw new Exception("this plugin was not registered or disabled"))
+    }.getOrElse(noMatch(keys(keys.length - 1), args))
+  }
+
+  /**
    * Check if a message key is defined.
    * @param key the message key
    * @return a boolean

--- a/framework/test/integrationtest/test/ApplicationSpec.scala
+++ b/framework/test/integrationtest/test/ApplicationSpec.scala
@@ -25,14 +25,14 @@ class ApplicationSpec extends PlaySpecification {
       contentAsString(result) must contain("Hello world")
     }
 
-    "tess custom validator failure" in new WithApplication() {
+    "test custom validator failure" in new WithApplication() {
       import play.data._
        val userForm = new Form(classOf[JUser])
        val anyData = new java.util.HashMap[String,String]
        anyData.put("email", "")
-       userForm.bind(anyData).errors.toString must contain("ValidationError(email,error.invalid,[class validator.NotEmpty]")
+       userForm.bind(anyData).errors.toString must contain("ValidationError(email,[error.invalid],[class validator.NotEmpty]")
     }
-    "tess custom validator passing" in new WithApplication() {
+    "test custom validator passing" in new WithApplication() {
       import play.data._
        val userForm = new Form(classOf[JUser])
        val anyData = new java.util.HashMap[String,String]


### PR DESCRIPTION
Follow up on the pull request [https://github.com/playframework/Play20/pull/1098].

I tried to add the possibility to have multiple error message keys without breaking the api. 
The main breaking point will be the change in return type of the FormError unapply method.
