### PR TITLE
Improve Cache object docs and added a way to pass a Duration object.

### DIFF
--- a/framework/src/play/src/main/scala/play/api/cache/Cache.scala
+++ b/framework/src/play/src/main/scala/play/api/cache/Cache.scala
@@ -4,6 +4,8 @@ import play.api._
 
 import reflect.{ ClassTag, ClassManifest }
 import org.apache.commons.lang3.reflect.TypeUtils
+
+import scala.concurrent.duration.Duration
 /**
  * API for a Cache plugin.
  */
@@ -46,16 +48,26 @@ object Cache {
   }
 
   /**
-   * Sets a value without expiration
+   * Set a value into the cache.
    *
    * @param key Item key.
    * @param value Item value.
-   * @param expiration expiration period in seconds.
+   * @param expiration Expiration time in seconds (0 second means eternity).
    */
-  def set(key: String, value: Any, expiration: Int = 0)(implicit app: Application) = {
+  def set(key: String, value: Any, expiration: Int = 0)(implicit app: Application): Unit = {
     cacheAPI.set(key, value, expiration)
   }
 
+  /**
+   * Set a value into the cache.
+   *
+   * @param key Item key.
+   * @param value Item value.
+   * @param expiration Expiration time as a [[scala.concurrent.duration.Duration]].
+   */
+  def set(key: String, value: Any, expiration: Duration)(implicit app: Application): Unit = {
+    set(key, value, expiration.toSeconds.toInt)
+  }
   /**
    * Retrieve a value from the cache.
    *


### PR DESCRIPTION
Note that the actual scaladocs say:

> > Sets a value without expiration

which is false since one of the parameters sets the expiration in seconds.

Using always seconds as a unit is cumbersome, specially for longer periods (hours or days) so I included a way to pass in a duration object to be able to do:

``` scala
Cache.set("key", "value", 3.hours)
```
