### PR TITLE
Introduce new filter API in Global that works for any Handler

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
@@ -31,6 +31,7 @@ trait Filter extends EssentialFilter {
       import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
       def apply(rh: RequestHeader): Iteratee[Array[Byte], SimpleResult] = {
+
         // Promised result, that is returned to the filter when it invokes the wrapped function
         val promisedResult = Promise[SimpleResult]
         // Promised iteratee, that we return to the framework

--- a/framework/src/play/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play/src/main/scala/play/core/server/Server.scala
@@ -47,15 +47,16 @@ trait Server {
 
   def mode: Mode.Mode
 
-  def getHandlerFor(request: RequestHeader): Either[SimpleResult, (Handler, Application)] = {
+  def getHandlerFor(request: RequestHeader): Either[SimpleResult, (RequestHeader, Handler, Application)] = {
 
     import scala.util.control.Exception
 
-    def sendHandler: Either[Throwable, (Handler, Application)] = {
+    def sendHandler: Either[Throwable, (RequestHeader, Handler, Application)] = {
       try {
         applicationProvider.get.right.map { application =>
-          val maybeAction = application.global.onRouteRequest(request)
-          (maybeAction.getOrElse(Action(BodyParsers.parse.empty)(_ => application.global.onHandlerNotFound(request))), application)
+          application.global.onRequestReceived(request) match {
+            case (requestHeader, handler) => (requestHeader, handler, application)
+          }
         }
       } catch {
         case e: ThreadDeath => throw e

--- a/framework/test/integrationtest/app/controllers/Application.scala
+++ b/framework/test/integrationtest/app/controllers/Application.scala
@@ -18,6 +18,10 @@ import play.api.i18n._
 
 object Application extends Controller {
 
+  def plainHelloWorld = Action {
+    Ok("Hello World")
+  }
+
   def index = Action {
     if (Messages("home.title")(Lang("fr")) != "ffff" ) throw new RuntimeException("i18n does not work")
     if (Messages("constraint.required") != "Hijacked" ) throw new RuntimeException("can not override default message")

--- a/framework/test/integrationtest/conf/routes
+++ b/framework/test/integrationtest/conf/routes
@@ -13,6 +13,8 @@ GET     /cookie                 controllers.JavaApi.setCookie()
 GET     /read/:name             controllers.JavaApi.readCookie(name)
 GET     /clear/:name            controllers.JavaApi.clearCookie(name)
 
+GET     /helloWorld 			controllers.Application.plainHelloWorld()
+
 GET     /json_java_instance     @controllers.JavaControllerInstance.index()
 GET     /json_scala_instance    @controllers.ScalaControllerInstance.index()
 


### PR DESCRIPTION
Introduce a new filter method in `Global` that works for any `Handler`:

```
def doFilter(next: RequestHeader => Handler): (RequestHeader => Handler)
```

It allows to filter at a higher level that the current `doFilter`, for example to filter WebSockets.

This pull request also contains some refactoring that moves out from the core the low level routing, request tagging and filtering tasks. These tasks are now defined in the Global object in `onMessageReceived(rh: RequestHeader): (RequestHeader, Handler)` and can be overridden by the application or by a plugin if needed.
