### PR TITLE
AbsoluteURI support in Play Framework 2.1

### DIFF
--- a/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -20,6 +20,7 @@ import scala.collection.JavaConverters._
 import scala.util.{ Failure, Success }
 import scala.util.control.Exception
 import com.typesafe.netty.http.pipelining.{OrderedDownstreamMessageEvent, OrderedUpstreamMessageEvent}
+import java.net.URI
 
 
 private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: DefaultChannelGroup) extends SimpleChannelUpstreamHandler with WebSocketHandler with RequestBodyHandler {
@@ -85,7 +86,7 @@ private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: De
             val id = requestIDs.incrementAndGet
             val tags = Map.empty[String,String]
             def uri = nettyHttpRequest.getUri
-            def path = nettyUri.getPath
+            def path = new URI(nettyUri.getPath).getRawPath //wrapping into URI to handle absoluteURI
             def method = nettyHttpRequest.getMethod.getName
             def version = nettyVersion.getText
             def queryString = parameters


### PR DESCRIPTION
Seems that play framework doesn't support absolute uri in requests which is required by standard. Issue description is below.

As stated here:
http://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html

> To allow for transition to absoluteURIs in all requests in future versions of HTTP, all HTTP/1.1 servers MUST accept the absoluteURI form in requests, even though HTTP/1.1 clients will only generate them in requests to proxies.

I have client which sends POST-requests to my play-2.1.1 server. He sends it this way:

```
POST http://172.16.1.227:9000/A8%3aF9%3a4B%3a20%3a89%3a40/1089820966/ HTTP/1.1
Content-Length: 473
Content-Type: application/json
Date: Thu, 25 Apr 2013 15:44:43 GMT
Host: 172.16.1.227:9000
User-Agent: my-client

...some data...
```

All requests are rejected with "Action not found" error. The very same request which I send using curl is just fine and the only difference between them is curl send it with relative URI:

```
POST /A8%3aF9%3a4B%3a20%3a89%3a40/1089820966/ HTTP/1.1
Accept: */*
Content-Length: 593
Content-Type: application/json
Host: 172.16.1.227:9000
User-Agent: curl/7.30.0
```

I created the following simple workaround in Global.scala:

```
override def onRouteRequest(request: RequestHeader): Option[Handler] = {
  if (request.path.startsWith("http://")) {
    super.onRouteRequest(request.copy(
      path = request.path.replace("http://"+request.host, "")
    ))
  } else super.onRouteRequest(request)
}
```

And with this workaround all requests from my client are handled correctly. 

So can it be handled more transparently for users?
