### PR TITLE
Headers in multipart are not correctly converted to String

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -595,7 +595,7 @@ trait BodyParsers {
             val collectHeaders = maxHeaderBuffer.map { buffer =>
               val (headerBytes, rest) = Option(buffer.drop(2)).map(b => b.splitAt(b.indexOfSlice(CRLFCRLF))).get
 
-              val headerString = new String(headerBytes)
+              val headerString = new String(headerBytes, "utf-8")
               val headers = headerString.lines.map { header =>
                 val key :: value = header.trim.split(":").toList
                 (key.trim.toLowerCase, value.mkString.trim)


### PR DESCRIPTION
This results e.g. in broken filenames for multipart fileuploads that contain special characters (e.g. german umlauts)

see: `play.api.mvc.ContentTypes`:

adding "utf-8" should do the trick
`val headerString = new String(headerBytes)`
