### PR TITLE
Should work with Content-Type header like: text/xml; charset="utf-8"

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -161,7 +161,7 @@ package play.api.mvc {
     /**
      * Returns the charset of the request for text-based body
      */
-    lazy val charset: Option[String] = headers.get(play.api.http.HeaderNames.CONTENT_TYPE).flatMap(_.split(';').tail.headOption).map(_.toLowerCase.trim).filter(_.startsWith("charset=")).flatMap(_.split('=').tail.headOption)
+    lazy val charset: Option[String] = headers.get(play.api.http.HeaderNames.CONTENT_TYPE).flatMap(_.split(';').tail.headOption).map(_.toLowerCase.trim).filter(_.startsWith("charset=")).flatMap(_.split('=').tail.headOption.map(_.replaceAll("""^"|"$""", "")))
 
     /**
      * Copy the request.

--- a/framework/src/play/src/test/scala/play/api/mvc/HttpSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/HttpSpec.scala
@@ -35,4 +35,18 @@ class HttpSpec extends Specification {
       headers.toSimpleMap must be_==(Map("a" -> "a1", "b" -> "b1"))
     }
   }
+
+  "RequestHeader" should {
+    "parse quoted and unquoted charset" in {
+      case class TestRequestHeader(headers: Headers, method: String = "GET", uri: String = "/", path: String = "", remoteAddress: String = "127.0.0.1", version: String = "HTTP/1.1", id: Long = 666, tags: Map[String, String] = Map.empty[String, String], queryString: Map[String, Seq[String]] = Map()) extends RequestHeader
+
+      TestRequestHeader(headers = new Headers {
+        val data = Seq(play.api.http.HeaderNames.CONTENT_TYPE -> Seq("""text/xml; charset="utf-8""""))
+      }).charset must beSome("utf-8")
+
+      TestRequestHeader(headers = new Headers {
+        val data = Seq(play.api.http.HeaderNames.CONTENT_TYPE -> Seq("text/xml; charset=utf-8"))
+      }).charset must beSome("utf-8")
+    }
+  }
 }


### PR DESCRIPTION
this is the same issue you had for Play 1.0:
http://play.lighthouseapp.com/projects/57987/tickets/1361-error-parsing-quoted-charset-in-http-header

In that ticket they say that "spec does not include quote in charset definition" but that is not true in my opinion:
    media-type     = type "/" subtype *( ";" parameter )
( http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7 )

where parameter is defined as
    parameter            = attribute "=" value
    attribute               = token
    value                    = token | quoted-string
( http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.6 )

So both 
    text/xml; charset="utf-8" 
and 
    text/xml; charset=utf-8 
should be accepted as Content-Type:

https://github.com/playframework/Play20/blob/master/framework/src/play/src/main/scala/play/api/mvc/Http.scala#L164

thanks
