### PR TITLE
fix F.Option.toArray

### DIFF
--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.Arrays;
 
 import play.api.libs.concurrent.PlayPromise;
 import play.core.j.FPromiseHelper;
@@ -717,13 +718,14 @@ public class F {
         }
 
         @Override
-        public T[] toArray() {
-            return (T[])(new Object[0]);
+        public Object[] toArray() {
+            return new Object[0];
         }
 
         @Override
         public <R> R[] toArray(R[] r) {
-            return (R[])(new Object[0]);
+            Arrays.fill(r, null);
+            return r;
         }
 
         @Override
@@ -774,17 +776,23 @@ public class F {
         }
 
         @Override
-        public T[] toArray() {
-            T[] result = (T[])new Object[1];
+        public Object[] toArray() {
+            Object[] result = new Object[1];
             result[0] = value;
             return result;
         }
 
         @Override
         public <R> R[] toArray(R[] r) {
-            Object[] result = new Object[1];
-            result[0] = value;
-            return (R[])result;
+            if(r.length == 0){
+                 R[] array = (R[])Arrays.copyOf(r, 1);
+                 array[0] = (R)value;
+                 return array;
+            }else{
+                 Arrays.fill(r, 1, r.length, null);
+                 r[0] = (R)value;
+                 return r;
+            }
         }
 
         @Override

--- a/framework/src/play/src/test/java/play/OptionTest.java
+++ b/framework/src/play/src/test/java/play/OptionTest.java
@@ -1,0 +1,40 @@
+package play;
+
+import org.junit.Test;
+
+import play.libs.F;
+import play.libs.F.Option;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+// see http://docs.oracle.com/javase/7/docs/api/java/util/Collection.html#toArray(T[])
+public class OptionTest {
+
+    @Test
+    public void testSomeToArray() {
+        F.Option<String> a = Option.Some("a");
+        assertThat(a.toArray()).isEqualTo(new Object[]{"a"});
+        assertThat(a.toArray(new String[]{})).isEqualTo(new String[]{"a"});
+        assertThat(a.toArray(new CharSequence[]{})).isEqualTo(new String[]{"a"});
+        String[] b = {null, "b", null , "c"};
+        assertThat(a.toArray(b)).isEqualTo(new String[]{"a", null, null, null});
+    }
+
+    @Test
+    public void testNoneToArray() {
+        F.Option<String> a = Option.<String>None();
+        assertThat(a.toArray()).isEqualTo(new Object[]{});
+        assertThat(a.toArray(new String[]{})).isEqualTo(new String[]{});
+        assertThat(a.toArray(new CharSequence[]{})).isEqualTo(new String[]{});
+        String[] b = {null, "b", null , "c"};
+        assertThat(a.toArray(b)).isEqualTo(new String[]{null, null, null, null});
+    }
+
+    @Test(expected=ArrayStoreException.class)
+    public void throwArrayStoreException() {
+        F.Option<String> a = Option.Some("a");
+        a.toArray(new Integer[]{});
+    }
+
+}
+


### PR DESCRIPTION
- old Implementation **ALWAYS THROWS ClassCastException**
- Java is not Scala. can not use [ClassTag](https://github.com/scala/scala/blob/v2.10.2/src/library/scala/collection/GenTraversableOnce.scala#L479). [java.util.Collection#toArray](http://bit.ly/ZGwS1m) return type **SHOULD NOT** override. can not create generic array in runtime.
- It should preserve the contracts of Collection#toArray. see javadoc http://bit.ly/11vSnzE
