### PR TITLE
Allow to stop the HTTP connection when using an Iteratee as a consumer

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
@@ -270,6 +270,13 @@ object WS {
                 it
               }
             }(play.core.Execution.internalContext)
+
+            iteratee = iteratee.mapDone { a =>
+              bodyPart.markUnderlyingConnectionAsClosed()
+              Option(iteratee).map(iterateeP.success(_))
+              a
+            }(play.core.Execution.internalContext)
+
             STATE.CONTINUE
           } else {
             iteratee = null


### PR DESCRIPTION
When connecting to a never ending HTTP stream, sometimes you want to gracefully stop the connection. Since the only control you have with the current implementation of WS is the Iteratee you build to consume the byte arrays, putting this Iteratee in Done state is the naturally way to halt the flow of bytes.

Currently, the Done state is checked only in the next round of onBodyPartReceived, but not all streams are frequently putting bytes in the stream (like the twitter stream). This commit fix this scenario in my tests.

Putting this in a unit test will requiere quite a difficult simulation.
