### PR TITLE
add throws annotation FPromiseHelper#get

### DIFF
--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -276,6 +276,7 @@ public class F {
          *
          * @param timeout A user defined timeout
          * @param unit timeout for timeout
+         * @throws PromiseTimeoutException when the promise did timeout.
          * @return The promised result
          *
          */
@@ -288,6 +289,7 @@ public class F {
          * Throws a Throwable if the calculation providing the promise threw an exception
          *
          * @param timeout A user defined timeout in milliseconds
+         * @throws PromiseTimeoutException when the promise did timeout.
          * @return The promised result
          */
         public A get(long timeout) {
@@ -640,6 +642,15 @@ public class F {
         }
     }
 
+
+    /**
+     * exception for to notify of timeout of promise without api change.
+     */
+    public static class PromiseTimeoutException extends RuntimeException {
+        public PromiseTimeoutException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
 
     /**
      * Represents optional values. Instances of <code>Option</code> are either an instance of <code>Some</code> or the object <code>None</code>.

--- a/framework/src/play/src/test/scala/play/libs/FSpec.scala
+++ b/framework/src/play/src/test/scala/play/libs/FSpec.scala
@@ -301,10 +301,10 @@ object FSpec extends Specification
       F.Promise.timeout(1, 2, MILLISECONDS).get(1, SECONDS) must equalTo(1)
     }
 
-    "throw a timeout exception" in {
+    "throw a promise timeout exception" in {
       //F.Promise.timeout().get(15, SECONDS) must throwA[TimeoutException] // Too slow to run for normal testing
-      F.Promise.timeout(2).get(1, SECONDS) must throwA[TimeoutException]
-      F.Promise.timeout(2, MILLISECONDS).get(1, SECONDS) must throwA[TimeoutException]
+      F.Promise.timeout(2).get(1, SECONDS) must throwA[F.PromiseTimeoutException]
+      F.Promise.timeout(2, MILLISECONDS).get(1, SECONDS) must throwA[F.PromiseTimeoutException]
     }
 
     "combine a sequence of promises from a vararg" in {


### PR DESCRIPTION
add throws annotation.
`Promise#get()` throws TimeoutException, but can't know it from java api.
excepion handling is inconvenience.
