### PR TITLE
Set Vary header when doing content negotiation based on the Accept header (#1105)

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Render.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Render.scala
@@ -27,8 +27,10 @@ trait Rendering {
     }
 
     // “If no Accept header field is present, then it is assumed that the client accepts all media types.”
-    if (request.acceptedTypes.isEmpty) _render(Seq(MediaRange("*", "*", None)))
-    else _render(request.acceptedTypes)
+    val result =
+      if (request.acceptedTypes.isEmpty) _render(Seq(MediaRange("*", "*", None)))
+      else _render(request.acceptedTypes)
+    result.withHeaders(VARY -> ACCEPT)
   }
 
 }

--- a/framework/test/integrationtest/test/ApplicationSpec.scala
+++ b/framework/test/integrationtest/test/ApplicationSpec.scala
@@ -217,6 +217,7 @@ class ApplicationSpec extends Specification {
 
         val Some(result) = route(FakeRequest(GET, url).withHeaders(ACCEPT -> "text/html"))
         contentType(result) must equalTo (Some("text/html"))
+        header(VARY, result) must equalTo (Some(ACCEPT))
 
         val Some(result2) = route(FakeRequest(GET, url).withHeaders(ACCEPT -> "text/html;q=0.5,application/*"))
         contentType(result2) must equalTo (Some("application/json"))


### PR DESCRIPTION
Fixes #1105

I think I should not completely replace the `Vary` header value, but update it by just adding the `Accept` item. But that’s not currently easy to do with `Result` (it will be better with `SimpleResult`).
