### PR TITLE
JSON BigDecimal precision loss when parsing

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
@@ -366,9 +366,7 @@ private[json] class JsValueDeserializer(factory: TypeFactory, klass: Class[_]) e
 
     val (maybeValue, nextContext) = (jp.getCurrentToken, parserContext) match {
 
-      case (JsonToken.VALUE_NUMBER_INT, c) => (Some(JsNumber(jp.getLongValue)), c)
-
-      case (JsonToken.VALUE_NUMBER_FLOAT, c) => (Some(JsNumber(jp.getDoubleValue)), c)
+      case (JsonToken.VALUE_NUMBER_INT | JsonToken.VALUE_NUMBER_FLOAT, c) => (Some(JsNumber(jp.getDecimalValue)), c)
 
       case (JsonToken.VALUE_STRING, c) => (Some(JsString(jp.getText)), c)
 

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -146,12 +146,27 @@ object JsonSpec extends Specification {
       (jsonM \ "timestamp").as[Long] must equalTo(t)
       (jsonM.toString must equalTo("{\"timestamp\":1330950829160}"))
     }
-    
+
     "Serialize and deserialize BigDecimals" in {
       val n = BigDecimal("12345678901234567890.42")
       val json = toJson(n)
       json must equalTo (JsNumber(n))
       fromJson[BigDecimal](json) must equalTo(JsSuccess(n))
+    }
+
+    "Not lose precision when parsing BigDecimals" in {
+      val n = BigDecimal("12345678901234567890.123456789")
+      val json = toJson(n)
+      parse(stringify(json)) must equalTo(json)
+
+    }
+
+    "Not lose precision when parsing big integers" in {
+      // By big integers, we just mean integers that overflow long, since Jackson has different code paths for them
+      // from decimals
+      val i = BigDecimal("123456789012345678901234567890")
+      val json = toJson(i)
+      parse(stringify(json)) must equalTo(json)
     }
 
     "Serialize and deserialize Lists" in {


### PR DESCRIPTION
I'm using a locally built snapshot (today's master branch) of Play-Json, I have the following problem:

```
fred@fred:~/play/framework$ sbt
[info] Loading project definition from /home/fred/play/framework/project
[info] Set current project to Root (in build file:/home/fred/play/framework/)
> project Play-Json
[info] Set current project to Play-Json (in build file:/home/fred/play/framework/)
> console
[info] Starting scala interpreter...
[info] 
Welcome to Scala version 2.10.0 (OpenJDK 64-Bit Server VM, Java 1.7.0_21).
Type in expressions to have them evaluated.
Type :help for more information.

scala> import play.api.libs.json._
import play.api.libs.json._

scala> val bd = BigDecimal(Long.MaxValue) * BigDecimal("1234.5678901")
bd: scala.math.BigDecimal = 11386878955147140008156.5148107

scala> println(Json.parse(Json.toJson(bd).toString()) == Json.toJson(bd))
false

scala> println(Json.parse(Json.toJson(bd).toString).toString == Json.toJson(bd).toString)
false

scala> println(Json.toJson(bd))
11386878955147140008156.5148107

scala> println(Json.parse(Json.toJson(bd).toString))
1.1386878955147141E+22

```

I'm expecting true and true, but get false and false, then the 2 println clearly illustrate that parsing BigDecimal leads to a precision loss.
