### PR TITLE
[2.1.1-scala] MediaRange implementation assumes that there is no additional "/" except range separator.

### DIFF
--- a/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
@@ -16,7 +16,7 @@ class DummyRequest(data: Map[String, Array[String]]) extends play.mvc.Http.Reque
   def host() = "localhost"
   def acceptLanguages = new java.util.ArrayList[play.i18n.Lang]
   def accept = List("text/html").asJava
-  def acceptedTypes = List(play.api.http.MediaRange("text/html")).asJava
+  def acceptedTypes = List(play.api.http.MediaRange("text", "html", None)).asJava
   def accepts(mediaType: String) = false
   def headers() = new java.util.HashMap[String, Array[String]]()
   val remoteAddress = "127.0.0.1"

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -105,7 +105,9 @@ package play.api.mvc {
      * @return The media types list of the request’s Accept header, sorted by preference (preferred first).
      */
     lazy val acceptedTypes: Seq[play.api.http.MediaRange] = {
-      val mediaTypes = acceptHeader(HeaderNames.ACCEPT).map(item => (item._1, MediaRange(item._2)))
+      val mediaTypes = acceptHeader(HeaderNames.ACCEPT).collect {
+        case (q, MediaRange.parse(mediaRange)) => (q, mediaRange)
+      }
       mediaTypes.sorted.map(_._2).reverse
     }
 

--- a/framework/src/play/src/test/scala/play/api/http/MediaRangeSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/MediaRangeSpec.scala
@@ -6,22 +6,37 @@ object MediaRangeSpec extends Specification {
 
   "A MediaRange" should {
     "accept all media types" in {
-      val mediaRange = MediaRange("*/*")
+      val mediaRange = parse("*/*")
       mediaRange.accepts("text/html") must beTrue
       mediaRange.accepts("application/json") must beTrue
       mediaRange.accepts("foo/bar") must beTrue
     }
     "accept a range of media types" in {
-      val mediaRange = MediaRange("text/*")
+      val mediaRange = parse("text/*")
       mediaRange.accepts("text/html") must beTrue
       mediaRange.accepts("text/plain") must beTrue
       mediaRange.accepts("application/json") must beFalse
     }
     "accept a media type" in {
-      val mediaRange = MediaRange("text/html")
+      val mediaRange = parse("text/html")
       mediaRange.accepts("text/html") must beTrue
       mediaRange.accepts("text/plain") must beFalse
       mediaRange.accepts("application/json") must beFalse
+    }
+    "allow media types with slashes in the parameters" in {
+      val mediaRange = parse("application/ld+json;profile=\"http://www.w3.org/ns/json-ld#compacted\"")
+      mediaRange.mediaType must_== "application"
+      mediaRange.mediaSubType must_== "ld+json"
+      mediaRange.parameters must beSome("profile=\"http://www.w3.org/ns/json-ld#compacted\"")
+    }
+    "not choke on invalid media ranges" in {
+      MediaRange.parse("foo") must beNone
+    }
+
+    def parse(mediaRange: String): MediaRange = {
+      val parsed = MediaRange.parse(mediaRange)
+      parsed must beSome
+      parsed.get
     }
   }
 


### PR DESCRIPTION
Because of this bug I can't use JSON-LD media type with profile(http://json-ld.org/spec/latest/json-ld/#application-ld-json), for example:

application/ld+json;profile="http://www.w3.org/ns/json-ld#compacted"

The cause is in MediaRange.apply method.
