### PR TITLE
Json.parse("null") returns null instead of JsNull

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
@@ -420,6 +420,9 @@ private[json] class JsValueDeserializer(factory: TypeFactory, klass: Class[_]) e
     }
 
   }
+
+  // This is used when the root object is null, ie when deserialising "null"
+  override def getNullValue = JsNull
 }
 
 private[json] class PlayDeserializers(classLoader: ClassLoader) extends Deserializers.Base {

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -224,6 +224,10 @@ object JsonSpec extends Specification {
   "key3" : [ 1, "tutu" ]
 }""")
     }
+
+    "null root object should be parsed as JsNull" in {
+      parse("null") must_== JsNull
+    }
   }
 
   "JSON Writes" should {


### PR DESCRIPTION
 The play.api.libs.json.Json.parse("null") returns null instad of expected JsNull.

Play version: 2.1.1
OS: Darwin zz.local 12.4.0 Darwin Kernel Version 12.4.0: Wed May  1 17:57:12 PDT 2013; root:xnu-2050.24.15~1/RELEASE_X86_64 x86_64
Java: java version "1.7.0_17"
Java(TM) SE Runtime Environment (build 1.7.0_17-b02)
Java HotSpot(TM) 64-Bit Server VM (build 23.7-b01, mixed mode)

```
scala> import play.api.libs.json._
import play.api.libs.json._
scala> Json.parse("true") == JsBoolean(true)
res0: Boolean = true
scala> Json.parse("true") == true
res1: Boolean = false
scala> Json.parse("[]") == JsArray()
res2: Boolean = true
scala> Json.parse("null") == JsNull
res3: Boolean = false
scala> Json.parse("null") == null
res4: Boolean = true
```

Funny result of this behavior is result of `scala> scala.util.control.Exception.nonFatalCatch.opt`:

```
scala> scala.util.control.Exception.nonFatalCatch.opt { Json.parse("null") }
res5: Option[play.api.libs.json.JsValue] = Some(null)
```
