### PR TITLE
Fix thread pools regression

### DIFF
--- a/documentation/manual/detailledTopics/configuration/code/ThreadPools.scala
+++ b/documentation/manual/detailledTopics/configuration/code/ThreadPools.scala
@@ -1,0 +1,176 @@
+package detailedtopics.configuration.threadpools
+
+import org.specs2.mutable.Specification
+import play.api.libs.ws.WS
+import play.api.mvc._
+import play.api.mvc.Results._
+import play.api.test.Helpers._
+import play.api.test._
+import play.api._
+import com.typesafe.config.ConfigFactory
+import akka.actor.ActorSystem
+import play.api.libs.concurrent.Akka
+import scala.concurrent.{Future, ExecutionContext}
+import java.io.File
+
+object ThreadPoolsSpec extends Specification {
+  "Play's thread pools" should {
+
+    "make a global thread pool available" in new WithApplication() {
+      contentAsString(Samples.someAsyncAction(FakeRequest())) must startWith("The response code was")
+    }
+
+    "have a global configuration" in {
+      val config = """#default-config
+        play {
+          akka {
+            event-handlers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jEventHandler"]
+            loglevel = WARNING
+            actor {
+              default-dispatcher = {
+                fork-join-executor {
+                  parallelism-factor = 1.0
+                  parallelism-max = 24
+                }
+              }
+            }
+          }
+        }
+      #default-config """
+      val parsed = ConfigFactory.parseString(config)
+      val actorSystem = ActorSystem("test", parsed.getConfig("play"))
+      actorSystem.shutdown()
+    }
+
+    "allow configuring a custom thread pool" in runningWithConfig(
+      """#my-context-config
+        my-context {
+          fork-join-executor {
+            parallelism-factor = 20.0
+            parallelism-max = 200
+          }
+        }
+      #my-context-config """
+    ) { implicit app =>
+      //#my-context-usage
+      object Contexts {
+        implicit val myExecutionContext: ExecutionContext = Akka.system.dispatchers.lookup("my-context")
+      }
+      //#my-context-usage
+      await(Future(Thread.currentThread().getName)(Contexts.myExecutionContext)) must startWith("application-my-context")
+
+      //#my-context-explicit
+      Future {
+        // Some blocking or expensive code here
+      }(Contexts.myExecutionContext)
+      //#my-context-explicit
+
+      {
+        //#my-context-implicit
+        import Contexts.myExecutionContext
+
+        Future {
+          // Some blocking or expensive code here
+        }
+        //#my-context-implicit
+      }
+      pass
+    }
+
+    "allow changing the default thread pool" in {
+      val config = ConfigFactory.parseString("""#highly-synchronous
+      play {
+        akka {
+          event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+          loglevel = WARNING
+          actor {
+            default-dispatcher = {
+              fork-join-executor {
+                parallelism-min = 300
+                parallelism-max = 300
+              }
+            }
+          }
+        }
+      }
+      #highly-synchronous """)
+
+      val actorSystem = ActorSystem("test", config.getConfig("play"))
+      actorSystem.shutdown()
+    }
+
+    "allow configuring many custom thread pools" in runningWithConfig(
+    """ #many-specific-config
+      contexts {
+        simple-db-lookups {
+          fork-join-executor {
+            parallelism-factor = 10.0
+          }
+        }
+        expensive-db-lookups {
+          fork-join-executor {
+            parallelism-max = 4
+          }
+        }
+        db-write-operations {
+          fork-join-executor {
+            parallelism-factor = 2.0
+          }
+        }
+        expensive-cpu-operations {
+          fork-join-executor {
+            parallelism-max = 2
+          }
+        }
+      }
+    #many-specific-config """
+    ) { implicit app =>
+      //#many-specific-contexts
+      object Contexts {
+        implicit val simpleDbLookups: ExecutionContext = Akka.system.dispatchers.lookup("contexts.simple-db-lookups")
+        implicit val expensiveDbLookups: ExecutionContext = Akka.system.dispatchers.lookup("contexts.expensive-db-lookups")
+        implicit val dbWriteOperations: ExecutionContext = Akka.system.dispatchers.lookup("contexts.db-write-operations")
+        implicit val expensiveCpuOperations: ExecutionContext = Akka.system.dispatchers.lookup("contexts.expensive-cpu-operations")
+      }
+      //#many-specific-contexts
+      def test(context: ExecutionContext, name: String) = {
+        await(Future(Thread.currentThread().getName)(context)) must startWith("application-contexts." + name)
+      }
+      test(Contexts.simpleDbLookups, "simple-db-lookups")
+      test(Contexts.expensiveDbLookups, "expensive-db-lookups")
+      test(Contexts.dbWriteOperations, "db-write-operations")
+      test(Contexts.expensiveCpuOperations, "expensive-cpu-operations")
+    }
+
+  }
+
+  def runningWithConfig[T](config: String )(block: Application => T) {
+    val parsed = ConfigFactory.parseString(config)
+    val app = FakeApplication(withGlobal = Some(new GlobalSettings {
+      override def onLoadConfig(config: Configuration, path: File, classloader: ClassLoader, mode: Mode.Mode) = {
+        config ++ Configuration(parsed)
+      }
+    }))
+    running(app)(block(app))
+  }
+
+  def pass = true must_== true
+}
+
+// since specs provides defaultContext, implicitly importing it doesn't work
+object Samples {
+
+  //#global-thread-pool
+  import play.api.libs.concurrent.Execution.Implicits._
+
+  def someAsyncAction = Action.async {
+    WS.url("http://www.playframework.com").get().map { response =>
+      // This code block is executed in the imported default execution context
+      // which happens to be the same thread pool in which the outer block of
+      // code in this action will be executed.
+      Ok("The response code was " + response.status)
+    }
+  }
+  //#global-thread-pool
+
+}

--- a/documentation/project/Build.scala
+++ b/documentation/project/Build.scala
@@ -23,9 +23,11 @@ object ApplicationBuild extends Build {
 
     unmanagedSourceDirectories in Test <++= javaManualSourceDirectories,
     unmanagedSourceDirectories in Test <++= scalaManualSourceDirectories,
+    unmanagedSourceDirectories in Test <++= (baseDirectory)(base => (base / "manual" / "detailledTopics" ** "code").get),
 
     unmanagedResourceDirectories in Test <++= javaManualSourceDirectories,
     unmanagedResourceDirectories in Test <++= scalaManualSourceDirectories,
+    unmanagedResourceDirectories in Test <++= (baseDirectory)(base => (base / "manual" / "detailledTopics" ** "code").get),
 
     parallelExecution in Test := false,
 

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -52,7 +52,7 @@ class AkkaPlugin(app: Application) extends Plugin {
 
   lazy val applicationSystem: ActorSystem = {
     applicationSystemEnabled = true
-    val system = ActorSystem("application", app.configuration.underlying.getConfig("play"), app.classloader)
+    val system = ActorSystem("application", app.configuration.underlying, app.classloader)
     Play.logger.info("Starting application default Akka system.")
     system
   }

--- a/framework/test/integrationtest/test/FunctionalSpec.scala
+++ b/framework/test/integrationtest/test/FunctionalSpec.scala
@@ -79,7 +79,7 @@ class FunctionalSpec extends Specification {
       browser.goTo("/conf")
       browser.pageSource must contain("This value comes from complex-app's complex1.conf")
       browser.pageSource must contain("override akka:2 second")
-      browser.pageSource must contain("akka-loglevel:WARNING")
+      browser.pageSource must contain("akka-loglevel:DEBUG")
       browser.pageSource must contain("promise-timeout:7000")
       browser.pageSource must contain("None")
       browser.title must beNull


### PR DESCRIPTION
There is a regression in 2.1.1 that causes Akka to use the same config.  This fixes that regression, and also verifies that the documentation is correct.
