### PR TITLE
[2.1.0] JPA: Parameter value [*] was not matching type [java.util.Map]

### DIFF
--- a/framework/test/integrationtest-java/app/controllers/Application.java
+++ b/framework/test/integrationtest-java/app/controllers/Application.java
@@ -66,4 +66,12 @@ public class Application extends Controller {
     public static Result thread() {
         return ok(Thread.currentThread().getName());
     }
+
+    public static Result classLoader(String resource) {
+        if (Thread.currentThread().getContextClassLoader().getResource(resource) == null) {
+            return notFound();
+        } else {
+            return ok();
+        }
+    }
 }

--- a/framework/test/integrationtest-java/conf/routes
+++ b/framework/test/integrationtest-java/conf/routes
@@ -11,6 +11,7 @@ POST    /json                       controllers.Application.getIdenticalJson()
 GET     /paged                      controllers.Application.paged(p: controllers.Pager)
 GET     /user/:user                 controllers.Application.user(user: models.User)
 GET     /thread                     controllers.Application.thread
+GET     /classLoader/:resource      controllers.Application.classLoader(resource)
 
 POST    /parsers/json               controllers.BodyParsers.json()
 POST    /parsers/limitedjson        controllers.BodyParsers.limitedJson()


### PR DESCRIPTION
When fetching a list of models and getting it by a '.setParameter()', instead of getting the list something throws an exception about a not matching type. Here is the code that i used in the sample project: 

``` java
 @Transactional
    public static Result index() {
        Company company = Company.findById(1l);
        List<Computer> data = JPA.em()
                .createQuery("from Computer where company = :company")
                .setParameter("company", company)
                .getResultList();

        return GO_HOME;

    }
```

This is the exception that gets thrown.

```
play.api.Application$$anon$1: Execution exception[[IllegalArgumentException: Parameter value [models.Company@f321da3] was not matching type [java.util.Map]]]
    at play.api.Application$class.handleError(Application.scala:289) ~[play_2.10-2.1.0.jar:2.1.0]
    at play.api.DefaultApplication.handleError(Application.scala:383) [play_2.10-2.1.0.jar:2.1.0]
    at play.core.server.netty.PlayDefaultUpstreamHandler$$anon$2$$anonfun$handle$1.apply(PlayDefaultUpstreamHandler.scala:132) [play_2.10-2.1.0.jar:2.1.0]
    at play.core.server.netty.PlayDefaultUpstreamHandler$$anon$2$$anonfun$handle$1.apply(PlayDefaultUpstreamHandler.scala:128) [play_2.10-2.1.0.jar:2.1.0]
    at play.api.libs.concurrent.PlayPromise$$anonfun$extend1$1.apply(Promise.scala:113) [play_2.10-2.1.0.jar:2.1.0]
    at play.api.libs.concurrent.PlayPromise$$anonfun$extend1$1.apply(Promise.scala:113) [play_2.10-2.1.0.jar:2.1.0]
java.lang.IllegalArgumentException: Parameter value [models.Company@f321da3] was not matching type [java.util.Map]
    at org.hibernate.ejb.AbstractQueryImpl.registerParameterBinding(AbstractQueryImpl.java:360) ~[hibernate-entitymanager-3.6.9.Final.jar:3.6.9.Final]
    at org.hibernate.ejb.QueryImpl.setParameter(QueryImpl.java:364) ~[hibernate-entitymanager-3.6.9.Final.jar:3.6.9.Final]
    at org.hibernate.ejb.QueryImpl.setParameter(QueryImpl.java:72) ~[hibernate-entitymanager-3.6.9.Final.jar:3.6.9.Final]
    at controllers.Application.index(Application.java:37) ~[na:na]
    at Routes$$anonfun$routes$1$$anonfun$applyOrElse$1$$anonfun$apply$1.apply(routes_routing.scala:73) ~[na:na]
    at Routes$$anonfun$routes$1$$anonfun$applyOrElse$1$$anonfun$apply$1.apply(routes_routing.scala:73) ~[na:na]
```

@gissues:{"order":33.333333333333286,"status":"backlog"}
