### PR TITLE
Fix 'play' command when building from source after organisation change.

### DIFF
--- a/framework/sbt/play.boot.properties
+++ b/framework/sbt/play.boot.properties
@@ -2,7 +2,7 @@
   version: 2.9.2
 
 [app]
-  org: play
+  org: com.typesafe.play
   name: console
   version: 2.2-SNAPSHOT
   class: play.console.Console
@@ -16,7 +16,7 @@
 
 [boot]
   directory: ${play.home}/sbt/boot
- 
+
 [ivy]
   ivy-home: ${sbt.ivy.home-${play.home}/../repository}
-  
+


### PR DESCRIPTION
It seems the play command might have been broken when building play from source and after the recent organisation change.

```
$ play
Getting play console_2.9.2 2.2-SNAPSHOT ...

:: problems summary ::
:::: WARNINGS
        module not found: play#console_2.9.2;2.2-SNAPSHOT
```
