### PR TITLE
Fix 100-continue support

### DIFF
--- a/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -17,9 +17,9 @@ import play.api.http.HeaderNames.X_FORWARDED_FOR
 import play.api.libs.iteratee._
 import play.api.libs.iteratee.Input._
 import scala.collection.JavaConverters._
-import scala.util.{ Failure, Success }
 import scala.util.control.Exception
 import com.typesafe.netty.http.pipelining.{OrderedDownstreamMessageEvent, OrderedUpstreamMessageEvent}
+import scala.concurrent.Future
 
 
 private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: DefaultChannelGroup) extends SimpleChannelUpstreamHandler with WebSocketHandler with RequestBodyHandler {
@@ -175,21 +175,16 @@ private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: De
         def handleAction(action: EssentialAction, app: Option[Application]){
           Play.logger.trace("Serving this request with: " + action)
 
-          val eventuallyBodyParser = Iteratee.flatten(
-            scala.concurrent.Future(action(requestHeader))(play.api.libs.concurrent.Execution.defaultContext))
+          val bodyParser = Iteratee.flatten(
+            scala.concurrent.Future(action(requestHeader))(play.api.libs.concurrent.Execution.defaultContext)
+          )
 
-          requestHeader.headers.get("Expect").filter(_ == "100-continue").foreach { _ =>
-            eventuallyBodyParser.unflatten.map {
-              case Step.Cont(k) =>
-                sendDownstream(0, true, new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE))
-              case _ =>
-            }(internalExecutionContext)
-          }
+          val expectContinue: Option[_] = requestHeader.headers.get("Expect").filter(_.equalsIgnoreCase("100-continue"))
 
-          val eventuallyResultIteratee = if (nettyHttpRequest.isChunked) {
+          def feedBody[A](bodyParser: Iteratee[Array[Byte], A]) = if (nettyHttpRequest.isChunked) {
 
             val p: ChannelPipeline = ctx.getChannel().getPipeline()
-            val result = newRequestBodyUpstreamHandler(eventuallyBodyParser, { handler =>
+            val result = newRequestBodyUpstreamHandler(bodyParser, { handler =>
               p.replace("handler", "handler", handler)
             }, {
               p.replace("handler", "handler", this)
@@ -209,8 +204,24 @@ private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: De
               Enumerator(body).andThen(Enumerator.enumInput(EOF))
             }
 
-            bodyEnumerator |>> eventuallyBodyParser
+            bodyEnumerator |>> bodyParser
+          }
 
+          // This is an iteratee containing the result, and and the sequence number, which will be 1 if 100 continue
+          // was sent
+          val eventuallyResultIteratee = expectContinue match {
+            case Some(_) => {
+              bodyParser.unflatten.flatMap {
+                case c @ Step.Cont(k) =>
+                  sendDownstream(0, false, new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE))
+                  feedBody(bodyParser.map((_, 1)))
+                case _ => {
+                  // Ignore the body
+                  Future.successful(bodyParser.map((_, 0)))
+                }
+              }
+            }
+            case None => feedBody(bodyParser.map((_, 0)))
           }
 
           val eventuallyResult = eventuallyResultIteratee.flatMap(it => it.run)(internalExecutionContext)
@@ -219,9 +230,10 @@ private[server] class PlayDefaultUpstreamHandler(server: Server, allChannels: De
             case error =>
               Play.logger.error("Cannot invoke the action, eventually got an error: " + error)
               e.getChannel.setReadable(true)
-              app.map(_.handleError(requestHeader, error)).getOrElse(DefaultGlobal.onError(requestHeader, error))
-          }(internalExecutionContext).flatMap { result =>
-            NettyResultStreamer.sendResult(cleanFlashCookie(result), !keepAlive, nettyVersion)
+              (app.map(_.handleError(requestHeader, error)).getOrElse(DefaultGlobal.onError(requestHeader, error)), 0)
+          }(internalExecutionContext).flatMap {
+            case (result, sequence) =>
+              NettyResultStreamer.sendResult(cleanFlashCookie(result), !keepAlive, nettyVersion, sequence)
           }
 
           // Finally, clean up

--- a/framework/src/play/src/main/scala/play/core/server/netty/RequestBodyHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/RequestBodyHandler.scala
@@ -21,24 +21,24 @@ private[server] trait RequestBodyHandler {
    * @param finish a function to handle the de-registration of the handler i.e. when the chunked request is complete.
    * @return a future of an iteratee that will return the result.
    */
-  def newRequestBodyUpstreamHandler(firstIteratee: Iteratee[Array[Byte], SimpleResult],
+  def newRequestBodyUpstreamHandler[A](firstIteratee: Iteratee[Array[Byte], A],
     start: SimpleChannelUpstreamHandler => Unit,
-    finish: => Unit): Future[Iteratee[Array[Byte], SimpleResult]] = {
+    finish: => Unit): Future[Iteratee[Array[Byte], A]] = {
 
     implicit val internalContext = play.core.Execution.internalContext
     import scala.concurrent.stm._
-    var p = Promise[Iteratee[Array[Byte], SimpleResult]]()
+    var p = Promise[Iteratee[Array[Byte], A]]()
     val MaxMessages = 10
     val MinMessages = 10
     val counter = Ref(0)
 
-    var iteratee: Ref[Iteratee[Array[Byte], SimpleResult]] = Ref(firstIteratee)
+    var iteratee: Ref[Iteratee[Array[Byte], A]] = Ref(firstIteratee)
 
     def pushChunk(ctx: ChannelHandlerContext, chunk: Input[Array[Byte]]) {
       if (counter.single.transformAndGet { _ + 1 } > MaxMessages && ctx.getChannel.isOpen() && !p.isCompleted)
         ctx.getChannel.setReadable(false)
 
-      val itPromise = Promise[Iteratee[Array[Byte], SimpleResult]]()
+      val itPromise = Promise[Iteratee[Array[Byte], A]]()
       val current = atomic { implicit txn =>
         if (!p.isCompleted)
           Some(iteratee.single.swap(Iteratee.flatten(itPromise.future)))
@@ -60,13 +60,13 @@ private[server] trait RequestBodyHandler {
         }
       }
 
-      def continue(it: Iteratee[Array[Byte], SimpleResult]) {
+      def continue(it: Iteratee[Array[Byte], A]) {
         if (counter.single.transformAndGet { _ - 1 } <= MinMessages && ctx.getChannel.isOpen())
           ctx.getChannel.setReadable(true)
         itPromise.success(it)
       }
 
-      def finish(it: Iteratee[Array[Byte], SimpleResult]) {
+      def finish(it: Iteratee[Array[Byte], A]) {
         if (!p.trySuccess(it)) {
           iteratee = null; p = null;
           if (ctx.getChannel.isOpen()) ctx.getChannel.setReadable(true)


### PR DESCRIPTION
When Play sends a 100 continue response, it sends it as the 0th message (for HTTP pipelining).  It then sends the main response as the 0th message too, which is not allowed.  Sending a 100 continue response should cause the main response to be the 1st message.
