### PR TITLE
Fixed error message when stopping NettyServer.

### DIFF
--- a/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
@@ -168,7 +168,7 @@ class NettyServer(appProvider: ApplicationProvider, port: Option[Int], sslPort: 
     try {
       super.stop()
     } catch {
-      case NonFatal(e) => Play.logger.error("Error while stopping akka", e)
+      case NonFatal(e) => Play.logger.error("Error while stopping logger", e)
     }
 
     mode match {


### PR DESCRIPTION
Akka(Invoker) had already been removed by this commit.
https://github.com/playframework/Play20/commit/767ba2f
Now, only Logger is stopped here.
