### PR TITLE
update netty to 3.6.6.Final

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -62,7 +62,7 @@ object Dependencies {
     specsBuild % "test")
 
   val runtime = Seq(
-    "io.netty" % "netty" % "3.6.3.Final",
+    "io.netty" % "netty" % "3.6.6.Final",
 
     "com.typesafe.netty" % "netty-http-pipelining" % "1.0.0",
 


### PR DESCRIPTION
netty 3.6.4 and 3.6.5 were bad releases, but 3.6.6 has been stable for a while now.

See
https://github.com/netty/netty/issues?milestone=44&page=1&state=closed
https://github.com/netty/netty/issues?milestone=49&page=1&state=closed
https://github.com/netty/netty/issues?milestone=50&page=1&state=closed
for details of the issues that have been closed since the 3.6.3 release.

This update to 3.6.6 passes ./runtests and other usage.
