### PR TITLE
Prefix form() with Form class in JavaGuide4.md

### DIFF
--- a/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide4.md
+++ b/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide4.md
@@ -58,7 +58,7 @@ Now we need to pass this form into our template, to render.  Modify the `login` 
 ```java
     public static Result login() {
         return ok(
-            login.render(form(Login.class))
+            login.render(Form.form(Login.class))
         );
     }
 ```
@@ -102,12 +102,12 @@ Now implement the method in `app/controllers/Application.java`:
 
 ```java
 public static Result authenticate() {
-    Form<Login> loginForm = form(Login.class).bindFromRequest();
+    Form<Login> loginForm = Form.form(Login.class).bindFromRequest();
     return ok();
 }
 ```
 
-> Make sure you add an import statement for `play.data.*` to `Application.java`
+> Make sure you add an import statement for `play.data.*` to `Application.java`.
 
 ### Validating a form
 


### PR DESCRIPTION
The ZenTask tutorial does not work if only `form()` is used. Java is not able to find the method since the `Controller` class from which `Application` is inherited does not provide such a method. To fix this, add the corresponding class (located in `play.data.*`) as a prefix to the function call.
