### PR TITLE
Add text for fakeGlobal() option already in JavaGuide3.md

### DIFF
--- a/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide3.md
+++ b/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide3.md
@@ -36,7 +36,16 @@ Now this will be called whenever play starts up.
 
 You have to create an `initial-data.yml` in the `conf` directory.  You can of course reuse the `test-data.yml` content that we just used for tests previously.
 
-Now run the application using `play run` and display the <http://localhost:9000> page in the browser.
+Since the database now always contains data, the model tests you wrote [earlier](JavaGuide2) are currently broken. To get them back working, all you need to do is adding a call to `fakeGlobal()` to the test setup for overriding the default behavior when using a fake application:
+
+```java
+@Before
+public void setUp() {
+	start(fakeApplication(inMemoryDatabase(), fakeGlobal()));
+}
+```
+
+After verifying with `play test` that all tests are fine again, run the application using `play run` and display the <http://localhost:9000> page in the browser.
 
 ## The dashboard
 


### PR DESCRIPTION
The `fakeGlobal()` option is currently introduced in JavaGuide4.md which is too late as the tests fail already here. Therefore, I added a piece of text at the corresponding position for all people like me who run `play test` after each chapter of the tutorial.
