### PR TITLE
Remove not needed import statements from test code in JavaGuide4.md

### DIFF
--- a/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide4.md
+++ b/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide4.md
@@ -242,11 +242,8 @@ Play already comes with a built in authenticator action, which we will extend to
 ```java
 package controllers;
 
-import play.*;
 import play.mvc.*;
 import play.mvc.Http.*;
-
-import models.*;
 
 public class Secured extends Security.Authenticator {
 


### PR DESCRIPTION
The two removed packages are not needed in this context. In fact, it would be even enough to just have the following three lines:

```
import play.mvc.Result;
import play.mvc.Security;
import play.mvc.Http.Context;
```
