### PR TITLE
Fixed Issue #1111: Broken image link in docs

### DIFF
--- a/documentation/manual/scalaGuide/main/templates/ScalaTemplates.md
+++ b/documentation/manual/scalaGuide/main/templates/ScalaTemplates.md
@@ -22,7 +22,7 @@ Play 2.0 comes with a new and really powerful Scala-based template engine, whose
 
 Templates are compiled, so you will see any errors in your browser:
 
-![tempaltesyntax](https://raw.github.com/wiki/playframework/Play20/javaGuide/main/templates/images/templatesError.png)
+[[images/templatesError.png]]
 
 ## Overview
 


### PR DESCRIPTION
Hi,

This is my first pull request ever.

I replaced the image source with the correct raw URL from GitHub.
I payed attention to refer the one from the 2.1.x branch.

Could you please review it?

Thanks,
Hunor Kovács
