### PR TITLE
Removed explicit ExecutionContext args

### DIFF
--- a/framework/src/play-cache/src/main/scala/play/api/cache/Cached.scala
+++ b/framework/src/play-cache/src/main/scala/play/api/cache/Cached.scala
@@ -6,6 +6,8 @@ import play.api.libs.iteratee.{ Iteratee, Done }
 import play.api.http.HeaderNames.{ IF_NONE_MATCH, ETAG, EXPIRES }
 import play.api.mvc.Results.NotModified
 
+import play.core.Execution.Implicits.internalContext
+
 /**
  * Cache an action.
  *
@@ -46,7 +48,7 @@ case class Cached(key: RequestHeader => String, duration: Int)(action: Essential
         iterateeResult.map { result =>
           Cache.set(etagKey, etag, duration) // Cache the new ETAG of the resource
           result.withHeaders(ETAG -> etag, EXPIRES -> expirationDate)
-        }(play.core.Execution.internalContext)
+        }
       }
     }
   }

--- a/framework/src/play-filters-helpers/src/main/scala/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/csrf.scala
@@ -226,10 +226,10 @@ package play.filters.csrf {
             _.fold(_ => checkRequest(request), body => checkRequest(request, Some(extractor(body))))
               .fold(
                 result => Done(result, Input.Empty: Input[Array[Byte]]),
-                r => Iteratee.flatten(Enumerator(b).apply(next(addRequestToken(r, token)))).map(result => addResponseToken(request, result, token))(defaultContext)
+                r => Iteratee.flatten(Enumerator(b).apply(next(addRequestToken(r, token)))).map(result => addResponseToken(request, result, token))
               )
           })
-      }(defaultContext)
+      }
     }
 
     def checkFormUrlEncodedBody = checkBody[Map[String, Seq[String]]](tolerantFormUrlEncoded, identity) _
@@ -269,7 +269,7 @@ package play.filters.csrf {
             checkTextBody(request, token, next)
           case None if request.method == "GET" =>
             filterLogger.trace("[CSRF] GET request, adding the token")
-            next(addRequestToken(request, token)).map(result => addResponseToken(request, result, token))(defaultContext)
+            next(addRequestToken(request, token)).map(result => addResponseToken(request, result, token))
           case ct =>
             filterLogger.trace("[CSRF] bypass the request (%s)".format(ct.toString))
             next(request)

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
@@ -140,7 +140,7 @@ object Json {
    * }}}
    */
   def fromJson[A: Reads]: Enumeratee[JsValue, A] =
-    Enumeratee.map[JsValue]((json: JsValue) => Json.fromJson(json)) ><> Enumeratee.collect[JsResult[A]] { case JsSuccess(value, _) => value }(defaultExecutionContext)
+    Enumeratee.map[JsValue]((json: JsValue) => Json.fromJson(json)) ><> Enumeratee.collect[JsResult[A]] { case JsSuccess(value, _) => value }
 
   /**
    * Experimental JSON extensions to replace asProductXXX by generating

--- a/framework/src/play/src/main/scala/play/api/controllers/ExternalAssets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/ExternalAssets.scala
@@ -47,7 +47,7 @@ object ExternalAssets extends Controller {
         }
 
         if (fileToServe.exists) {
-          Ok.sendFile(fileToServe, inline = true)(play.api.libs.concurrent.Execution.defaultContext).withHeaders(CACHE_CONTROL -> "max-age=3600")
+          Ok.sendFile(fileToServe, inline = true).withHeaders(CACHE_CONTROL -> "max-age=3600")
         } else {
           NotFound
         }

--- a/framework/src/play/src/main/scala/play/api/http/Writeable.scala
+++ b/framework/src/play/src/main/scala/play/api/http/Writeable.scala
@@ -8,6 +8,8 @@ import scala.language.reflectiveCalls
 import play.api.libs.iteratee.Enumeratee
 import play.api.libs.concurrent.Execution
 
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
 /**
  * Transform a value of type A to a Byte Array.
  *
@@ -18,7 +20,7 @@ import play.api.libs.concurrent.Execution
 )
 case class Writeable[-A](transform: (A => Array[Byte]), contentType: Option[String]) {
   def map[B](f: B => A): Writeable[B] = Writeable(b => transform(f(b)), contentType)
-  def toEnumeratee[E <: A]: Enumeratee[E, Array[Byte]] = Enumeratee.map[E](transform)(Execution.defaultContext)
+  def toEnumeratee[E <: A]: Enumeratee[E, Array[Byte]] = Enumeratee.map[E](transform)
 }
 
 /**

--- a/framework/src/play/src/main/scala/play/api/libs/Comet.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Comet.scala
@@ -2,11 +2,12 @@ package play.api.libs
 
 import scala.language.reflectiveCalls
 
+import org.apache.commons.lang3.StringEscapeUtils
 import play.api.mvc._
 import play.api.libs.iteratee._
 import play.api.templates._
 
-import org.apache.commons.lang3.{ StringEscapeUtils }
+import play.core.Execution.Implicits.internalContext
 
 /**
  * Helper function to produce a Comet Enumeratee.
@@ -53,7 +54,7 @@ object Comet {
     def applyOn[A](inner: Iteratee[Html, A]): Iteratee[E, Iteratee[Html, A]] = {
 
       val fedWithInitialChunk = Iteratee.flatten(Enumerator(initialChunk) |>> inner)
-      val eToScript = Enumeratee.map[E](data => Html("""<script type="text/javascript">""" + callback + """(""" + encoder.toJavascriptMessage(data) + """);</script>"""))(play.core.Execution.internalContext)
+      val eToScript = Enumeratee.map[E](data => Html("""<script type="text/javascript">""" + callback + """(""" + encoder.toJavascriptMessage(data) + """);</script>"""))
       eToScript.applyOn(fedWithInitialChunk)
     }
   }

--- a/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
@@ -6,6 +6,8 @@ import play.api.mvc._
 import play.api.libs.iteratee._
 import play.api.templates._
 
+import play.core.Execution.Implicits.internalContext
+
 object EventSource {
 
   case class EventNameExtractor[E](eventName: E => Option[String])
@@ -36,6 +38,6 @@ object EventSource {
     eventNameExtractor.eventName(chunk).map("event: " + _ + "\r\n").getOrElse("") +
       eventIdExtractor.eventId(chunk).map("id: " + _ + "\r\n").getOrElse("") +
       "data: " + encoder.toJavascriptMessage(chunk) + "\r\n\r\n"
-  }(play.core.Execution.internalContext)
+  }
 
 }

--- a/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
@@ -20,6 +20,8 @@ import collection.immutable.TreeMap
 import play.core.utils.CaseInsensitiveOrdered
 import com.ning.http.util.AsyncHttpProviderUtils
 
+import play.core.Execution.Implicits.internalContext
+
 /**
  * Asynchronous API to to query web services, as an http client.
  *
@@ -269,7 +271,7 @@ object WS {
                 iterateeP.success(it)
                 it
               }
-            }(play.core.Execution.internalContext)
+            }
             STATE.CONTINUE
           } else {
             iteratee = null

--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -5,6 +5,8 @@ import play.api._
 import scala.concurrent._
 import scala.language.higherKinds
 
+import play.core.Execution.Implicits.internalContext
+
 /**
  * An Handler handles a request.
  */
@@ -141,7 +143,7 @@ trait BodyParser[+A] extends Function1[RequestHeader, Iteratee[Array[Byte], Eith
    * Transform this BodyParser[A] to a BodyParser[B]
    */
   def map[B](f: A => B): BodyParser[B] = new BodyParser[B] {
-    def apply(request: RequestHeader) = self(request).map(_.right.map(f(_)))(play.core.Execution.internalContext)
+    def apply(request: RequestHeader) = self(request).map(_.right.map(f(_)))
     override def toString = self.toString
   }
 
@@ -152,7 +154,7 @@ trait BodyParser[+A] extends Function1[RequestHeader, Iteratee[Array[Byte], Eith
     def apply(request: RequestHeader) = self(request).flatMap {
       case Left(e) => Done(Left(e), Input.Empty)
       case Right(a) => f(a)(request)
-    }(play.core.Execution.internalContext)
+    }
     override def toString = self.toString
   }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
@@ -56,7 +56,7 @@ trait Filter extends EssentialFilter {
         Iteratee.flatten(bodyIteratee.future.map(_.mapM({ simpleResult =>
           promisedResult.success(simpleResult)
           result
-        })(defaultContext)))
+        })))
       }
 
     }

--- a/framework/src/play/src/main/scala/play/api/mvc/WebSocket.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/WebSocket.scala
@@ -5,7 +5,8 @@ import play.api.libs.iteratee._
 import play.api.libs.concurrent._
 
 import scala.concurrent.Future
-import play.core.Execution.internalContext
+
+import play.core.Execution.Implicits.internalContext
 
 /**
  * A WebSocket handler.
@@ -87,8 +88,8 @@ object WebSocket {
   def async[A](f: RequestHeader => Future[(Iteratee[A, _], Enumerator[A])])(implicit frameFormatter: FrameFormatter[A]): WebSocket[A] = {
     using { rh =>
       val p = f(rh)
-      val it = Iteratee.flatten(p.map(_._1)(internalContext))
-      val enum = Enumerator.flatten(p.map(_._2)(internalContext))
+      val it = Iteratee.flatten(p.map(_._1))
+      val enum = Enumerator.flatten(p.map(_._2))
       (it, enum)
     }
   }

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -9,6 +9,8 @@ import play.libs.F.{ Promise => JPromise }
 import scala.concurrent.Future
 import play.libs.F
 
+import play.core.Execution.Implicits.internalContext
+
 /**
  * Retains and evaluates what is otherwise expensive reflection work on call by call basis.
  * @param controller The controller to be evaluated
@@ -87,7 +89,7 @@ trait JavaAction extends Action[play.mvc.Http.RequestBody] with JavaHelpers {
 
       play.libs.F.Promise.pure("").flatMap(new play.libs.F.Function[String, play.libs.F.Promise[JSimpleResult]] {
         def apply(nothing: String) = finalAction.call(javaContext)
-      }).wrapped.map(result => createResult(javaContext, result))(play.core.Execution.internalContext)
+      }).wrapped.map(result => createResult(javaContext, result))
 
     } finally {
       JContext.current.remove()

--- a/framework/src/play/src/main/scala/play/core/j/JavaWebSocket.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaWebSocket.scala
@@ -5,6 +5,8 @@ import play.mvc.{ Action => JAction, Result => JResult }
 import play.mvc.Http.{ Context => JContext, Request => JRequest, RequestBody => JBody, Cookies => JCookies, Cookie => JCookie }
 import scala.collection.JavaConverters._
 
+import play.core.Execution.Implicits.internalContext
+
 /**
  * handles a scala websocket in a Java Context
  */
@@ -38,9 +40,9 @@ object JavaWebSocket extends JavaHelpers {
       val socketIn = new play.mvc.WebSocket.In[A]
 
       in |>> {
-        Iteratee.foreach[A](msg => socketIn.callbacks.asScala.foreach(_.invoke(msg)))(play.core.Execution.internalContext).map { _ =>
+        Iteratee.foreach[A](msg => socketIn.callbacks.asScala.foreach(_.invoke(msg))).map { _ =>
           socketIn.closeCallbacks.asScala.foreach(_.invoke())
-        }(play.core.Execution.internalContext)
+        }
       }
 
       enumerator |>> out

--- a/framework/src/play/src/main/scala/play/core/server/netty/WebSocketHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/WebSocketHandler.scala
@@ -24,6 +24,8 @@ import scala.collection.JavaConverters._
 import scala.concurrent.{ Future, Promise }
 import scala.concurrent.stm._
 
+import play.core.Execution.Implicits.internalContext
+
 private[server] trait WebSocketHandler {
   def newWebSocketInHandler[A](frameFormatter: play.api.mvc.WebSocket.FrameFormatter[A]) = {
 
@@ -59,9 +61,9 @@ private[server] trait WebSocketHandler {
 
               case Step.Cont(_) => Future.successful(next)
               case Step.Error(msg, e) => { /* deal with error, maybe close the socket */ Future.successful(next) }
-            }(play.core.Execution.internalContext)
+            }
           },
-          (err, e) => /* handle error, maybe close the socket */ Future.successful(current))(play.core.Execution.internalContext)
+          (err, e) => /* handle error, maybe close the socket */ Future.successful(current))
         eventuallyNext.success(next)
       }
     }

--- a/framework/src/play/src/main/scala/play/core/system/DocumentationApplication.scala
+++ b/framework/src/play/src/main/scala/play/core/system/DocumentationApplication.scala
@@ -57,7 +57,7 @@ class DocumentationHandler(markdownRenderer: (String, String, File) => String) {
           documentationHome.flatMap { home =>
             Option(new java.io.File(home, "api/" + page)).filter(f => f.exists && f.isFile)
           }.map { file =>
-            Ok.sendFile(file, inline = true)(Execution.defaultContext)
+            Ok.sendFile(file, inline = true)
           }.getOrElse {
             NotFound(views.html.play20.manual(page, None, None))
           }
@@ -71,7 +71,7 @@ class DocumentationHandler(markdownRenderer: (String, String, File) => String) {
           documentationHome.flatMap { home =>
             Option(new java.io.File(home, path)).filter(_.exists)
           }.map { file =>
-            Ok.sendFile(file, inline = true)(Execution.defaultContext)
+            Ok.sendFile(file, inline = true)
           }.getOrElse(NotFound("Resource not found [" + path + "]"))
         }
 

--- a/framework/src/play/src/main/scala/play/core/system/Execution.scala
+++ b/framework/src/play/src/main/scala/play/core/system/Execution.scala
@@ -36,4 +36,10 @@ private[play] object Execution {
       true))
 
   }
+
+  object Implicits {
+
+    implicit def internalContext = Execution.internalContext
+
+  }
 }

--- a/framework/test/integrationtest/app/controllers/Application.scala
+++ b/framework/test/integrationtest/app/controllers/Application.scala
@@ -149,7 +149,7 @@ object Application extends Controller {
   def onCloseSendFile(filepath: String) = Action {
     import java.io.File
     val file = new File(filepath)
-    Ok.sendFile(file, onClose = () => { file.delete() })(play.api.libs.concurrent.Execution.defaultContext)
+    Ok.sendFile(file, onClose = () => { file.delete() })
   }
 
   def syncError = Action {

--- a/samples/scala/comet-live-monitoring/app/controllers/Application.scala
+++ b/samples/scala/comet-live-monitoring/app/controllers/Application.scala
@@ -55,7 +55,7 @@ object Streams {
     Promise.timeout(
       Some((cpu.getCpuUsage()*1000).round / 10.0 + ":cpu"),
       100, TimeUnit.MILLISECONDS)
-  }(defaultContext)
+  }
 
 }
 


### PR DESCRIPTION
Now that ExecutionContext arguments are implicit (completed in part 2 - #1087), we can get rid of explicitly passed ExecutionContext arguments throughout the rest of Play.

I have closed PR #1133, which also removed explicit EC args, but which also removed the global iteratee EC. After some discussion it was decided that removing the global iteratee EC was a big change that needs some more thought behind it. That's why I closed that PR and provided this PR instead.

Previous parts:
- #807 part 1: #996
- #807 part 2: #1083
- #807 part 3: #1133 (closed)
