### PR TITLE
Fix race condition in WS.client and WS.resetClient

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
@@ -46,7 +46,7 @@ object WS {
   /**
    * resets the underlying AsyncHttpClient
    */
-  def resetClient(): Unit = {
+  private[play] def resetClient(): Unit = {
     val oldClient = clientHolder.getAndSet(None)
     oldClient.map { clientRef =>
       clientRef.close()


### PR DESCRIPTION
The original implementation of `WS.client` was a `lazy val`, which is thread-safe. But in commit ead15b9, when `WS.resetClient` was added, the implementation was changed, and is no longer thread-safe.
