### PR TITLE
Error with javadoc not finding inner class Field in DynamicForm.java

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java/src/main/java/play/data/DynamicForm.java
@@ -107,7 +107,9 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      * @param key field name
      * @return the field - even if the field does not exist you get a field
      */
-    public Field field(String key) {
+    public Form.Field field(String key) {
+        // #1310: We specify inner class as Form.Field rather than Field because otherwise,
+        // javadoc cannot find the static inner class.
         Field field = super.field(asDynamicKey(key));
         return new Field(this, key, field.constraints(), field.format(), field.errors(),
             field.value() == null ? get(key) : field.value()


### PR DESCRIPTION
[info] Generating Scala API documentation for main sources to /Users/wsargent/work/Play20/framework/src/play-java/target/scala-2.10/api...
[error] /Users/wsargent/work/Play20/framework/src/play-java/src/main/java/play/data/DynamicForm.java:110: not found: type Field
[error]     public Field field(String key) {
[error]            ^
model contains 28 documentable templates
[error] one error found

It looks like this is a bug in javadoc where it is unable to find inner classes correctly. as using Form.Field as the return type works correctly.  Will attach a PR.
