### PR TITLE
Fix dead link to requirejs "Next" page.

### DIFF
--- a/documentation/manual/detailledTopics/assets/AssetsGoogleClosureCompiler.md
+++ b/documentation/manual/detailledTopics/assets/AssetsGoogleClosureCompiler.md
@@ -36,4 +36,4 @@ javascriptEntryPoints <<= (sourceDirectory in Compile)(base =>
 )
 ```
 
-> **Next:** [[Using require.js to manage dependencies | requirejs]]
+> **Next:** [[Using require.js to manage dependencies | RequireJS-support]]


### PR DESCRIPTION
This is already fixed in master, but adding to 2.1 branch.
