### PR TITLE
Update "Building From Source" to 2.2-SNAPSHOT

### DIFF
--- a/documentation/manual/hacking/BuildingFromSource.md
+++ b/documentation/manual/hacking/BuildingFromSource.md
@@ -31,9 +31,7 @@ $ ./build doc
 ```
 If done properly, once you run a project, you should be able to see documentation available locally at [http://localhost:9000/@documentation](http://localhost:9000/@documentation)
 
-You can also refer to [this stackoverflow question](http://stackoverflow.com/questions/10525791/build-play2-0-documentation-from-source-so-that-it-is-available-from-documentat).
-
-## Running tests
+## Run tests
 
 You can run basic tests from the sbt console using the `test` task:
 
@@ -47,13 +45,13 @@ We are also using several Play applications to test the framework. To run this c
 $ ./runtests
 ```
 
-## Creating projects
+## Use in projects
 
 Creating projects using the Play version you have built from source works much the same as a regular Play application.
 
 export PATH=$PATH:<projdir>/Play20
 
-If you have an existing Play application that you are upgrading from Play Beta to edge, please add 
+If you have an existing Play application that you are upgrading, please add
 
 ```
 resolvers ++= Seq(
@@ -67,6 +65,6 @@ addSbtPlugin("play" % "sbt-plugin" % "2.2-SNAPSHOT")
 
 to project/plugins.sbt. 
 
-## Using Code in Eclipse.
+## Using Code in Eclipse
 
 You can find at [Stackoverflow](http://stackoverflow.com/questions/10053201/how-to-setup-eclipse-ide-work-on-the-playframework-2-0/10055419#10055419) some information how to setup eclipse to work on the code.


### PR DESCRIPTION
Remove the references to old SBT version.
Remove the reference to Play20.wiki.git (documentation is inline).
Change references to "Play 2.0" to be just "Play".
Fix the SBT plugin to say 2.2-SNAPSHOT
