### PR TITLE
Fix broken link in documentation (Java ZenTasks)

### DIFF
--- a/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide2.md
+++ b/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide2.md
@@ -286,7 +286,7 @@ Edit the `conf/test-data.yml` file and start to describe a User:
 ...
 ```
 
-Notice that this object is defined as part of a root object that is a list.  We can now define more objects to be a part of that, however, our dataset is a little large, so you can download a full dataset [here](resources/manual/javaGuide/tutorials/zentasks/files/test-data.yml).
+Notice that this object is defined as part of a root object that is a list.  We can now define more objects to be a part of that, however, our dataset is a little large, so you can download a full dataset [here](https://github.com/playframework/Play20/blob/master/documentation/manual/javaGuide/tutorials/zentasks/files/test-data.yml).
 
 Now we create a test case that loads this data and runs some assertions over it:
 


### PR DESCRIPTION
Solves this issue: https://github.com/playframework/Play20/issues/1325
Now it links to a github file; it's not perfect but it's a workaround.
