### PR TITLE
Cleanup the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Play Framework combines productivity and performance making it easy to build
 - [Get Started with Java](http://www.playframework.com/documentation/latest/JavaTodoList)
 - [Get Started with Scala](http://www.playframework.com/documentation/latest/ScalaTodoList)
 - [Build from source](http://www.playframework.com/documentation/latest/BuildingFromSource)
-- [Search or create issues](https://github.com/playframework/play20/issues)
+- [Search or create issues](https://github.com/playframework/playframework/issues)
 - [Get help](http://stackoverflow.com/questions/tagged/playframework)
 - [Contribute](http://www.playframework.com/documentation/latest/Guidelines)
 


### PR DESCRIPTION
The existing README is confusing and duplicates information from the docs.  This change points people to the docs and changes some wording to be consistent with the official branding.  The links and verbiage are all version agnostic to avoid this page from becoming out of date.  However, the links use use the `latest` qualifier which takes the user to the latest official docs.  In the future it would be better to have a `master` qualifier that would take them to the newest `SNAPSHOT`.
