### PR TITLE
Update SBT launch properties for console

### DIFF
--- a/framework/sbt/play.boot.properties
+++ b/framework/sbt/play.boot.properties
@@ -1,12 +1,12 @@
 [scala]
-  version: 2.10.1
+  version: 2.10.2
 
 [app]
   org: com.typesafe.play
   name: console
   version: 2.2-SNAPSHOT
   class: play.console.Console
-  cross-versioned: true
+  cross-versioned: binary
 
 [repositories]
   local


### PR DESCRIPTION
- Update Scala version.
- Use binary cross-versioning to use console_2.10 rather than console_2.10.x.
