### PR TITLE
Race condition in body handling when Expect: 100-continue

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
@@ -1,0 +1,218 @@
+package play.it.http
+
+import java.net.Socket
+import java.io.{InputStreamReader, BufferedReader, OutputStreamWriter}
+import play.api.test.Helpers._
+import org.apache.commons.io.IOUtils
+
+object BasicHttpClient {
+
+  /**
+   * Very basic HTTP client, for when we want to be very low level about our assertions.
+   *
+   * Can only work with requests that are entirely ascii, any binary or multi byte characters and it will break.
+   *
+   * @param port The port to connect to
+   * @param checkClosed Whether to check if the channel is closed after receiving the responses
+   * @param requests The requests to make
+   * @return The parsed number of responses.  This may be more than the number of requests, if continue headers are sent.
+   */
+  def makeRequests(port: Int, checkClosed: Boolean, requests: BasicRequest*): Seq[BasicResponse] = {
+    val client = new BasicHttpClient(port)
+
+    try {
+      var requestNo = 0
+      val responses = requests.flatMap { request =>
+        requestNo += 1
+        client.sendRequest(request, requestNo.toString, waitForResponses = true)
+      }
+
+      if (checkClosed) {
+        val line = client.reader.readLine()
+        if (line != null) {
+          throw new RuntimeException("Unexpected data after responses received: " + line)
+        }
+      }
+
+      responses
+
+    } finally {
+      client.close()
+    }
+  }
+
+  def pipelineRequests(port: Int, requests: BasicRequest*): Seq[BasicResponse] = {
+    val client = new BasicHttpClient(port)
+
+    try {
+      var requestNo = 0
+      requests.foreach { request =>
+        requestNo += 1
+        client.sendRequest(request, requestNo.toString, waitForResponses = false)
+      }
+      for (i <- 0 until requests.length) yield {
+        client.readResponse(requestNo.toString)
+      }
+    } finally {
+      client.close()
+    }
+  }
+}
+
+class BasicHttpClient(port: Int) {
+  val s = new Socket("localhost", port)
+  s.setSoTimeout(5000)
+  val out = new OutputStreamWriter(s.getOutputStream)
+  val reader = new BufferedReader(new InputStreamReader(s.getInputStream))
+
+  /**
+   * Send a request
+   *
+   * @param request The request to send
+   * @param waitForResponses Whether we should wait for responses
+   * @return The responses (may be more than one if Expect: 100-continue header is present) if requested to wait for
+   *         them
+   */
+  def sendRequest(request: BasicRequest, requestDesc: String, waitForResponses: Boolean): Seq[BasicResponse] = {
+    out.write(s"${request.method} ${request.uri} ${request.version}\r\n")
+    out.write("Host: localhost\r\n")
+    request.headers.foreach { header =>
+      out.write(s"${header._1}: ${header._2}\r\n")
+    }
+    out.write("\r\n")
+
+    def writeBody = {
+      if (request.body.length > 0) {
+        out.write(request.body)
+      }
+      out.flush()
+    }
+
+    if (waitForResponses) {
+      request.headers.get("Expect").filter(_ == "100-continue").map { _ =>
+        out.flush()
+        val response = readResponse(requestDesc + " continue")
+        if (response.status == 100) {
+          writeBody
+          Seq(response, readResponse(requestDesc))
+        } else {
+          Seq(response)
+        }
+      } getOrElse {
+        writeBody
+        Seq(readResponse(requestDesc))
+      }
+    } else {
+      writeBody
+      Nil
+    }
+  }
+
+  /**
+   * Read a response
+   *
+   * @param responseDesc Description of the response, for error reporting
+   * @return The response
+   */
+  def readResponse(responseDesc: String) = {
+    try {
+      // Read status line
+      val statusLine = reader.readLine()
+      val (version, status, reasonPhrase) = statusLine.split(" ", 3) match {
+        case Array(v, s, r) => (v, s.toInt, r)
+        case Array(v, s) => (v, s.toInt, "")
+        case _ => throw new RuntimeException("Invalid status line for response " + responseDesc + ": " + statusLine)
+      }
+      // Read headers
+      def readHeaders: List[(String, String)] = {
+        val header = reader.readLine()
+        if (header.length == 0) {
+          Nil
+        } else {
+          val parsed = header.split(":", 2) match {
+            case Array(name, value) => (name.trim(), value.trim())
+            case Array(name) => (name, "")
+          }
+          parsed :: readHeaders
+        }
+      }
+      val headers = readHeaders.toMap
+
+      def readCompletely(length: Int): String = {
+        if (length == 0) {
+          ""
+        } else {
+          val buf = new Array[Char](length)
+          def readFromOffset(offset: Int): Unit = {
+            val read = reader.read(buf, offset, length - offset)
+            if (read + offset < length) readFromOffset(read + offset) else ()
+          }
+          readFromOffset(0)
+          new String(buf)
+        }
+      }
+
+      // Read body
+      val body = headers.get(TRANSFER_ENCODING).filter(_ == CHUNKED).map { _ =>
+        def readChunks: List[String] = {
+          val chunkLength = Integer.parseInt(reader.readLine())
+          if (chunkLength == 0) {
+            Nil
+          } else {
+            val chunk = readCompletely(chunkLength)
+            // Ignore newline after chunk
+            reader.readLine()
+            chunk :: readChunks
+          }
+        }
+        (readChunks.toSeq, readHeaders.toMap)
+      } toRight {
+        headers.get(CONTENT_LENGTH).map { length =>
+          readCompletely(length.toInt)
+        } getOrElse {
+          if (status != CONTINUE && status != NOT_MODIFIED && status != NO_CONTENT) {
+            IOUtils.toString(reader)
+          } else {
+            ""
+          }
+        }
+      }
+
+      BasicResponse(version, status, reasonPhrase, headers, body)
+    } catch {
+      case e: Exception =>
+        throw new RuntimeException(
+          s"Exception while reading response $responseDesc ${e.getClass.getName}: ${e.getMessage}", e)
+    }
+  }
+
+  def close() = {
+    s.close()
+  }
+}
+
+
+/**
+ * A basic response
+ *
+ * @param version The HTTP version
+ * @param status The HTTP status code
+ * @param reasonPhrase The HTTP reason phrase
+ * @param headers The HTTP response headers
+ * @param body The body, left is a plain body, right is for chunked bodies, which is a sequence of chunks and a map of
+ *             trailers
+ */
+case class BasicResponse(version: String, status: Int, reasonPhrase: String, headers: Map[String, String],
+                         body: Either[String, (Seq[String], Map[String, String])])
+
+/**
+ * A basic request
+ *
+ * @param method The HTTP request method
+ * @param uri The URI
+ * @param version The HTTP version
+ * @param headers The HTTP request headers
+ * @param body The body
+ */
+case class BasicRequest(method: String, uri: String, version: String, headers: Map[String, String], body: String)
+

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/Expect100ContinueSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/Expect100ContinueSpec.scala
@@ -1,0 +1,74 @@
+package play.it.http
+
+import org.specs2.mutable.Specification
+import play.api.mvc._
+import play.api.test.Helpers._
+import play.api.test._
+import play.api.test.TestServer
+import play.api.libs.iteratee._
+
+object Expect100ContinueSpec extends Specification {
+
+  "Play" should {
+
+    def withServer[T](action: EssentialAction)(block: Port => T) = {
+      val port = testServerPort
+      running(TestServer(port, FakeApplication(
+        withRoutes = {
+          case _ => action
+        }
+      ))) {
+        block(port)
+      }
+    }
+
+    "honour 100 continue" in withServer(Action(Results.Ok)) { port =>
+      val responses = BasicHttpClient.makeRequests(port, false,
+        BasicRequest("POST", "/", "HTTP/1.1", Map("Expect" -> "100-continue", "Content-Length" -> "10"), "abcdefghij")
+      )
+      responses.length must_== 2
+      responses(0).status must_== 100
+      responses(1).status must_== 200
+    }
+
+    "not read body when expecting 100 continue but action iteratee is done" in withServer(
+      EssentialAction(_ => Done(Results.Ok))
+    ) { port =>
+      val responses = BasicHttpClient.makeRequests(port, false,
+        BasicRequest("POST", "/", "HTTP/1.1", Map("Expect" -> "100-continue", "Content-Length" -> "100000"), "foo")
+      )
+      responses.length must_== 1
+      responses(0).status must_== 200
+    }
+
+    // This is necessary due to an ambiguity in the HTTP spec.  Clients are instructed not to wait indefinitely for
+    // the 100 continue response, but rather to just send it anyway if no response is received.  If the body is
+    // rejected then, there is no way for the server to know whether the next data is the body, sent by the client
+    // because it decided to stop waiting, or if it's the next request.  The only reliable option for handling it is to
+    // close the connection.
+    //
+    // See https://issues.jboss.org/browse/NETTY-390 for more details.
+    "close the connection after rejecting a Expect: 100-continue body" in withServer(
+      EssentialAction(_ => Done(Results.Ok))
+    ) { port =>
+      val responses = BasicHttpClient.makeRequests(port, true,
+        BasicRequest("POST", "/", "HTTP/1.1", Map("Expect" -> "100-continue", "Content-Length" -> "100000"), "foo")
+      )
+      responses.length must_== 1
+      responses(0).status must_== 200
+    }
+
+    "leave the Netty pipeline in the right state after accepting a 100 continue request" in withServer(
+      Action(Results.Ok)
+    ) { port =>
+      val responses = BasicHttpClient.makeRequests(port, false,
+        BasicRequest("POST", "/", "HTTP/1.1", Map("Expect" -> "100-continue", "Content-Length" -> "10"), "abcdefghij"),
+        BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+      )
+      responses.length must_== 3
+      responses(0).status must_== 100
+      responses(1).status must_== 200
+      responses(2).status must_== 200
+    }
+  }
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/HttpPipeliningSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/HttpPipeliningSpec.scala
@@ -1,0 +1,74 @@
+package play.it.http
+
+import org.specs2.mutable.Specification
+import play.api.mvc.{Results, EssentialAction}
+import play.api.test.Helpers._
+import play.api.test._
+import play.api.test.TestServer
+import play.api.libs.concurrent.Promise
+import play.api.libs.iteratee._
+import java.util.concurrent.TimeUnit
+import scala.concurrent.Future
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object HttpPipeliningSpec extends Specification {
+
+  "Play's http pipelining support" should {
+
+    def withServer[T](action: EssentialAction)(block: Port => T) = {
+      val port = testServerPort
+      running(TestServer(port, FakeApplication(
+        withRoutes = {
+          case _ => action
+        }
+      ))) {
+        block(port)
+      }
+    }
+
+    "wait for the first response to return before returning the second" in withServer(EssentialAction { req =>
+      req.path match {
+        case "/long" => Iteratee.flatten(Promise.timeout(Done(Results.Ok("long")), 100, TimeUnit.MILLISECONDS))
+        case "/short" => Done(Results.Ok("short"))
+        case _ => Done(Results.NotFound)
+      }
+    }) { port =>
+      val responses = BasicHttpClient.pipelineRequests(port,
+        BasicRequest("GET", "/long", "HTTP/1.1", Map(), ""),
+        BasicRequest("GET", "/short", "HTTP/1.1", Map(), "")
+      )
+      responses(0).status must_== 200
+      responses(0).body must beLeft("long")
+      responses(1).status must_== 200
+      responses(1).body must beLeft("short")
+    }
+
+    "wait for the first response body to return before returning the second" in withServer(EssentialAction { req =>
+      req.path match {
+        case "/long" => Done(
+          Results.Ok.chunked(Enumerator.unfoldM[Int, String](0) { chunk =>
+            if (chunk < 3) {
+              Promise.timeout(Some((chunk + 1, chunk.toString)), 50, TimeUnit.MILLISECONDS)
+            } else {
+              Future.successful(None)
+            }
+          })
+        )
+        case "/short" => Done(Results.Ok("short"))
+        case _ => Done(Results.NotFound)
+      }
+    }) { port =>
+      val responses = BasicHttpClient.pipelineRequests(port,
+        BasicRequest("GET", "/long", "HTTP/1.1", Map(), ""),
+        BasicRequest("GET", "/short", "HTTP/1.1", Map(), "")
+      )
+      responses(0).status must_== 200
+      responses(0).body must beRight
+      responses(0).body.right.get._1 must containAllOf(Seq("0", "1", "2")).inOrder
+      responses(1).status must_== 200
+      responses(1).body must beLeft("short")
+    }
+
+  }
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -6,14 +6,10 @@ import play.api.test._
 import play.api.test.Helpers._
 import play.api.libs.ws.Response
 import play.api.libs.iteratee._
-import java.net.Socket
-import java.io.OutputStreamWriter
-import org.apache.commons.io.IOUtils
 
 import play.api.libs.concurrent.Execution.{defaultContext => ec}
 
 object ScalaResultsHandlingSpec extends Specification {
-
 
   "scala body handling" should {
 
@@ -22,36 +18,11 @@ object ScalaResultsHandlingSpec extends Specification {
       block(response)
     }
 
-    // Low level stuff, for when our WS API isn't enough
-    def makeBasicRequest(port: Int, lines: String*): Seq[String] = {
-      val s = new Socket("localhost", port)
-      try {
-        s.setSoTimeout(5000)
-        // Send request
-        val out = new OutputStreamWriter(s.getOutputStream)
-        var expectedResponses = 1
-        lines.foreach { line =>
-          out.write(line)
-          out.write("\r\n")
-        }
-        out.write("\r\n")
-        out.flush()
-
-        import scala.collection.JavaConverters._
-        IOUtils.readLines(s.getInputStream).asScala
-
-      } finally {
-        s.close()
-      }
-    }
-
-    def withServer[T](result: SimpleResult)(block: Port => T) = withServerAction(Action(result))(block)
-
-    def withServerAction[T](action: EssentialAction)(block: Port => T) = {
+    def withServer[T](result: SimpleResult)(block: Port => T) = {
       val port = testServerPort
       running(TestServer(port, FakeApplication(
         withRoutes = {
-          case _ => action
+          case _ => Action(result)
         }
       ))) {
         block(port)
@@ -96,85 +67,59 @@ object ScalaResultsHandlingSpec extends Specification {
     "close the connection when the connection close header is present" in withServer(
       Results.Ok
     ) { port =>
-      // Will only return if the connection is closed by the server
-      makeBasicRequest(port,
-        "GET / HTTP/1.1",
-        "Host: localhost",
-        "Connection: close"
-      )(0) must_== "HTTP/1.1 200 OK"
+      BasicHttpClient.makeRequests(port, true,
+        BasicRequest("GET", "/", "HTTP/1.1", Map("Connection" -> "close"), "")
+      )(0).status must_== 200
     }
 
     "close the connection when the connection when protocol is HTTP 1.0" in withServer(
       Results.Ok
     ) { port =>
-    // Will only return if the connection is closed by the server
-      makeBasicRequest(port,
-        "GET / HTTP/1.0",
-        "Host: localhost"
-      )(0) must_== "HTTP/1.0 200 OK"
+      BasicHttpClient.makeRequests(port, true,
+        BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
+      )(0).status must_== 200
     }
 
     "honour the keep alive header for HTTP 1.0" in withServer(
       Results.Ok
     ) { port =>
-      val lines = makeBasicRequest(port,
-        "GET / HTTP/1.0",
-        "Host: localhost",
-        "Connection: keep-alive",
-        "",
-        "GET / HTTP/1.0",
-        "Host: localhost"
+      val responses = BasicHttpClient.makeRequests(port, false,
+        BasicRequest("GET", "/", "HTTP/1.0", Map("Connection" -> "keep-alive"), ""),
+        BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
       )
-      // First response
-      lines(0) must_== "HTTP/1.0 200 OK"
-      // Second response will only exist if keep alive was honoured
-      lines.tail must containAllOf(Seq("HTTP/1.0 200 OK"))
+      responses(0).status must_== 200
+      responses(1).status must_== 200
     }
 
     "keep alive HTTP 1.1 connections" in withServer(
       Results.Ok
     ) { port =>
-      val lines = makeBasicRequest(port,
-        "GET / HTTP/1.1",
-        "Host: localhost",
-        "",
-        "GET / HTTP/1.1",
-        "Host: localhost",
-        "Connection: close"
+      val responses = BasicHttpClient.makeRequests(port, false,
+        BasicRequest("GET", "/", "HTTP/1.1", Map(), ""),
+        BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
       )
-      // First response
-      lines(0) must_== "HTTP/1.1 200 OK"
-      // Second response will only exist if keep alive was honoured
-      lines.tail must containAllOf(Seq("HTTP/1.1 200 OK"))
+      responses(0).status must_== 200
+      responses(1).status must_== 200
     }
 
     "close chunked connections when requested" in withServer(
       Results.Ok.chunked(Enumerator("a", "b", "c"))
     ) { port =>
       // will timeout if not closed
-      makeBasicRequest(port,
-        "GET / HTTP/1.1",
-        "Host: localhost",
-        "Connection: close"
-      )(0) must_== "HTTP/1.1 200 OK"
+      BasicHttpClient.makeRequests(port, true,
+        BasicRequest("GET", "/", "HTTP/1.1", Map("Connection" -> "close"), "")
+      )(0).status must_== 200
     }
 
     "keep chunked connections alive by default" in withServer(
       Results.Ok.chunked(Enumerator("a", "b", "c"))
     ) { port =>
-      val lines = makeBasicRequest(port,
-        "GET / HTTP/1.1",
-        "Host: localhost",
-        "",
-        "GET / HTTP/1.1",
-        "Host: localhost",
-        "Connection: close"
+      val responses = BasicHttpClient.makeRequests(port, false,
+        BasicRequest("GET", "/", "HTTP/1.1", Map(), ""),
+        BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
       )
-      // First response
-      lines(0) must_== "HTTP/1.1 200 OK"
-      // Second response will only exist if keep alive was honoured
-      lines.tail must containAllOf(Seq("HTTP/1.1 200 OK"))
-        .orSkip("There is a race condition between the socket closing and the responses received")
+      responses(0).status must_== 200
+      responses(1).status must_== 200
     }
 
     "allow sending trailers" in withServer(
@@ -184,56 +129,27 @@ object ScalaResultsHandlingSpec extends Specification {
           .map(count => Seq("Chunks" -> count.toString))(ec)
       )))
     ) { port =>
-      val lines = makeBasicRequest(port,
-        "GET / HTTP/1.1",
-        "Host: localhost",
-        "Connection: close"
-      )
-      // Assert each chunk is there
-      lines must containAllOf(Seq("aa", "bb", "cc"))
-      // Assertion on last chunk
-      lines(lines.length - 3) must_== "0"
-      lines(lines.length - 2) must_== "Chunks: 3"
-      lines(lines.length - 1) must_== ""
+      val response = BasicHttpClient.makeRequests(port, false,
+        BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+      )(0)
+
+      response.status must_== 200
+      response.body must beRight
+      val (chunks, trailers) = response.body.right.get
+      chunks must containAllOf(Seq("aa", "bb", "cc")).inOrder
+      trailers.get("Chunks") must beSome("3")
     }
 
     "fall back to simple streaming when more than one chunk is sent and protocol is HTTP 1.0" in withServer(
       SimpleResult(ResponseHeader(200, Map()), Enumerator("abc", "def", "ghi") &> Enumeratee.map[String](_.getBytes)(ec))
     ) { port =>
-      val lines = makeBasicRequest(port,
-        "GET / HTTP/1.0",
-        "Host: localhost"
-      )
-      lines.foreach { _ must not contain "Transfer-Encoding" }
-      lines.last must_== "abcdefghi"
+      val response = BasicHttpClient.makeRequests(port, false,
+        BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
+      )(0)
+      response.headers.keySet must not contain TRANSFER_ENCODING
+      response.headers.keySet must not contain CONTENT_LENGTH
+      response.body must beLeft("abcdefghi")
     }
-
-    "honour 100 continue" in withServer(
-      Results.Ok
-    ) { port =>
-      val lines = makeBasicRequest(port,
-        "POST / HTTP/1.1",
-        "Host: localhost",
-        "Expect: 100-continue",
-        "Connection: close"
-      )
-      lines(0) must_== "HTTP/1.1 100 Continue"
-      lines must containAllOf(Seq("HTTP/1.1 200 OK"))
-    }
-
-    "not read body when expecting 100 continue but action iteratee is done" in withServerAction(new EssentialAction {
-      def apply(v1: RequestHeader) = Done(Results.Ok)
-    }) { port =>
-      val lines = makeBasicRequest(port,
-        "POST / HTTP/1.1",
-        "Host: localhost",
-        "Expect: 100-continue",
-        "Connection: close",
-        "Content-Length: 10000000"
-      )
-      lines(0) must_== ("HTTP/1.1 200 OK")
-    }
-
   }
 
 }

--- a/framework/src/play/src/main/scala/play/core/server/netty/RequestBodyHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/RequestBodyHandler.scala
@@ -23,7 +23,7 @@ private[server] trait RequestBodyHandler {
    */
   def newRequestBodyUpstreamHandler[A](firstIteratee: Iteratee[Array[Byte], A],
     start: SimpleChannelUpstreamHandler => Unit,
-    finish: => Unit): Future[Iteratee[Array[Byte], A]] = {
+    finish: => Unit): Future[A] = {
 
     implicit val internalContext = play.core.Execution.internalContext
     import scala.concurrent.stm._
@@ -105,7 +105,7 @@ private[server] trait RequestBodyHandler {
 
     })
 
-    p.future
+    p.future.flatMap(_.run)
   }
 
 }


### PR DESCRIPTION
When the `Expect: 100-continue` header is present, the body handler gets set in another thread, which introduces a race condition between when the first chunk arrives and when that handler is actually set.
