### PR TITLE
Perf issue: KeyPathNode.apply method may compute expensive value which it ignores

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsPath.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsPath.scala
@@ -16,11 +16,11 @@ sealed trait PathNode {
 case class RecursiveSearch(key: String) extends PathNode {
   def apply(json: JsValue): List[JsValue] = json match {
     case obj: JsObject => (json \\ key).toList.filterNot {
-      case JsUndefined(_) => true
+      case JsUndefined() => true
       case _ => false
     }
     case arr: JsArray => (json \\ key).toList.filterNot {
-      case JsUndefined(_) => true
+      case JsUndefined() => true
       case _ => false
     }
     case _ => List()
@@ -63,7 +63,7 @@ case class KeyPathNode(key: String) extends PathNode {
 
   def apply(json: JsValue): List[JsValue] = json match {
     case obj: JsObject => List(json \ key).filterNot {
-      case JsUndefined(_) => true
+      case JsUndefined() => true
       case _ => false
     }
     case _ => List()

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -368,7 +368,7 @@ private[data] object FormUtils {
       values.zipWithIndex.map { case (value, i) => fromJson(prefix + "[" + i + "]", value) }.foldLeft(Map.empty[String, String])(_ ++ _)
     }
     case JsNull => Map.empty
-    case JsUndefined(_) => Map.empty
+    case JsUndefined() => Map.empty
     case JsBoolean(value) => Map(prefix -> value.toString)
     case JsNumber(value) => Map(prefix -> value.toString)
     case JsString(value) => Map(prefix -> value.toString)


### PR DESCRIPTION
While profiling our play app looking for performance issues, I found that a not-insignificant amount of time is spent in the Json.stringify method. Tracing the source, I found that KeyPathNode.apply calls JsObject.\, which may call JsValue.. JsValue.\ calls this.toString, which calls Json.stringify as part of creating a human-friendly error message for JsUndefined. However, we can see that in KeyPathNode.apply, that message is ignored. This call sequence accounts for 99% of our app's calls to the Json.stringify method.
