### PR TITLE
Allow to reuse existing code when extending MessagesPlugin

### DIFF
--- a/framework/src/play/src/main/resources/play.plugins
+++ b/framework/src/play/src/main/resources/play.plugins
@@ -1,4 +1,4 @@
-100:play.api.i18n.MessagesPlugin
+100:play.api.i18n.DefaultMessagesPlugin
 100:play.core.RouterCacheLifecycle
 1000:play.api.libs.concurrent.AkkaPlugin
 10000:play.api.GlobalPlugin


### PR DESCRIPTION
Extending the MessagesPlugin allow to add custom sources of messages to the application (databases or other).
But most of the methods of MessagesPlugin can't be reused and the use of the MessagesParser is restricted to the play.api.i18n package.

On a separate note adding the custom plugin with a higher priority allow it to be used in place of the original, but both are loaded. Is there anyway to unload the original MessagesPlugin ?
