### PR TITLE
Utilise memory usage conservation of the pipelining library

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -63,7 +63,7 @@ object Dependencies {
   val runtime = Seq(
     "io.netty" % "netty" % "3.6.3.Final",
 
-    "com.typesafe.netty" % "netty-http-pipelining" % "1.1.0",
+    "com.typesafe.netty" % "netty-http-pipelining" % "1.1.1",
 
     "org.slf4j" % "slf4j-api" % "1.6.6",
     "org.slf4j" % "jul-to-slf4j" % "1.6.6",


### PR DESCRIPTION
Upgraded the pipelining the library in order to circumvent a large use of memory given its initial capacity declaration.
