### PR TITLE
Allow PLAY_VERSION to be set from command line when building

### DIFF
--- a/framework/build
+++ b/framework/build
@@ -1,6 +1,8 @@
 #! /usr/bin/env sh
 
-PLAY_VERSION="2.2-SNAPSHOT"
+if [ -z "${PLAY_VERSION}" ]; then
+  PLAY_VERSION="2.2-SNAPSHOT"
+fi
 
 if [ -z "${JPDA_PORT}" ]; then
   DEBUG_PARAM=""


### PR DESCRIPTION
This comes in handy when releasing Play.
