### PR TITLE
[java / 2.1.2] play.core.router.Router#queryString causes an error against a parameter named "queryString" in routes

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
@@ -19,7 +19,9 @@ object RoutesCompiler {
     "super", "then", "this", "throw",
     "trait", "try", "true", "type",
     "val", "var", "while", "with",
-    "yield"
+    "yield",
+    // Not scala keywords, but are used in the router
+    "queryString"
   )
 
   case class HttpVerb(value: String) {

--- a/framework/test/integrationtest/app/controllers/Application.scala
+++ b/framework/test/integrationtest/app/controllers/Application.scala
@@ -170,6 +170,10 @@ object Application extends Controller {
   def routetest(parameter: String) = Action {
     Ok("")
   }
+  
+  def route2(parameter: String) = Action {
+    Ok("")
+  }
 
   def anyXml = Action { request =>
     request.body.asXml.map(xml => Ok(xml)).getOrElse(NotFound("Not XML"))

--- a/framework/test/integrationtest/conf/routes
+++ b/framework/test/integrationtest/conf/routes
@@ -106,6 +106,8 @@ GET     /routes                 controllers.Application.route(while)
 GET     /routestest             controllers.Application.routetest(with)
 GET     /routestest             controllers.Application.routetest(yield)
 
+GET     /routes2                controllers.Application.route2(queryString)
+
 # Map static resources from the /public folder to the /public path
 GET     /public/*file           controllers.Assets.at(path="/public", file)
 


### PR DESCRIPTION
If I have a parameter named "queryString" in routes as below, I encounter an error.
- routes:

`GET     /                           controllers.Application.index()
GET     /hello                      controllers.Application.hello(queryString: String ?= null)
GET     /assets/*file               controllers.Assets.at(path="/public", file)`
- error:

`[info] Compiling 4 Scala sources and 2 Java sources to /home/elisa/repos/mine/play212Test/target/scala-2.10/classes...
[error] /home/elisa/repos/mine/play212Test/conf/routes:8: type mismatch;
[error]  found   : List[Option[String]]
[error]  required: Int
[error] GET     /hello                      controllers.Application.hello(queryString: String ?= null)
[error] one error found
[error] (compile:compile) Compilation failed
[error] application -`

It turned out that play.core.router.Router#queryString caused that error.

Can it be fixed?
