### PR TITLE
NullPointerException when using parse.maxLength

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
@@ -14,17 +14,18 @@ object BasicHttpClient {
    *
    * @param port The port to connect to
    * @param checkClosed Whether to check if the channel is closed after receiving the responses
+   * @param trickleFeed A timeout to use between sending request body chunks
    * @param requests The requests to make
    * @return The parsed number of responses.  This may be more than the number of requests, if continue headers are sent.
    */
-  def makeRequests(port: Int, checkClosed: Boolean, requests: BasicRequest*): Seq[BasicResponse] = {
+  def makeRequests(port: Int, checkClosed: Boolean = false, trickleFeed: Option[Long] = None)(requests: BasicRequest*): Seq[BasicResponse] = {
     val client = new BasicHttpClient(port)
 
     try {
       var requestNo = 0
       val responses = requests.flatMap { request =>
         requestNo += 1
-        client.sendRequest(request, requestNo.toString, waitForResponses = true)
+        client.sendRequest(request, requestNo.toString, trickleFeed = trickleFeed)
       }
 
       if (checkClosed) {
@@ -70,10 +71,13 @@ class BasicHttpClient(port: Int) {
    *
    * @param request The request to send
    * @param waitForResponses Whether we should wait for responses
+   * @param trickleFeed Whether bodies should be trickle fed.  Trickle feeding will simulate a more realistic network
+   *                    environment.
    * @return The responses (may be more than one if Expect: 100-continue header is present) if requested to wait for
    *         them
    */
-  def sendRequest(request: BasicRequest, requestDesc: String, waitForResponses: Boolean): Seq[BasicResponse] = {
+  def sendRequest(request: BasicRequest, requestDesc: String, waitForResponses: Boolean = true,
+                  trickleFeed: Option[Long] = None): Seq[BasicResponse] = {
     out.write(s"${request.method} ${request.uri} ${request.version}\r\n")
     out.write("Host: localhost\r\n")
     request.headers.foreach { header =>
@@ -81,9 +85,18 @@ class BasicHttpClient(port: Int) {
     }
     out.write("\r\n")
 
-    def writeBody = {
+    def writeBody() = {
       if (request.body.length > 0) {
-        out.write(request.body)
+        trickleFeed match {
+          case Some(timeout) =>
+            request.body.grouped(8192).foreach { chunk =>
+              out.write(chunk)
+              out.flush()
+              Thread.sleep(timeout)
+            }
+          case None =>
+            out.write(request.body)
+        }
       }
       out.flush()
     }
@@ -93,17 +106,17 @@ class BasicHttpClient(port: Int) {
         out.flush()
         val response = readResponse(requestDesc + " continue")
         if (response.status == 100) {
-          writeBody
+          writeBody()
           Seq(response, readResponse(requestDesc))
         } else {
           Seq(response)
         }
       } getOrElse {
-        writeBody
+        writeBody()
         Seq(readResponse(requestDesc))
       }
     } else {
-      writeBody
+      writeBody()
       Nil
     }
   }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/Expect100ContinueSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/Expect100ContinueSpec.scala
@@ -21,7 +21,7 @@ object Expect100ContinueSpec extends PlaySpecification {
     }
 
     "honour 100 continue" in withServer(Action(Results.Ok)) { port =>
-      val responses = BasicHttpClient.makeRequests(port, false,
+      val responses = BasicHttpClient.makeRequests(port)(
         BasicRequest("POST", "/", "HTTP/1.1", Map("Expect" -> "100-continue", "Content-Length" -> "10"), "abcdefghij")
       )
       responses.length must_== 2
@@ -32,7 +32,7 @@ object Expect100ContinueSpec extends PlaySpecification {
     "not read body when expecting 100 continue but action iteratee is done" in withServer(
       EssentialAction(_ => Done(Results.Ok))
     ) { port =>
-      val responses = BasicHttpClient.makeRequests(port, false,
+      val responses = BasicHttpClient.makeRequests(port)(
         BasicRequest("POST", "/", "HTTP/1.1", Map("Expect" -> "100-continue", "Content-Length" -> "100000"), "foo")
       )
       responses.length must_== 1
@@ -49,7 +49,7 @@ object Expect100ContinueSpec extends PlaySpecification {
     "close the connection after rejecting a Expect: 100-continue body" in withServer(
       EssentialAction(_ => Done(Results.Ok))
     ) { port =>
-      val responses = BasicHttpClient.makeRequests(port, true,
+      val responses = BasicHttpClient.makeRequests(port, checkClosed = true)(
         BasicRequest("POST", "/", "HTTP/1.1", Map("Expect" -> "100-continue", "Content-Length" -> "100000"), "foo")
       )
       responses.length must_== 1
@@ -59,7 +59,7 @@ object Expect100ContinueSpec extends PlaySpecification {
     "leave the Netty pipeline in the right state after accepting a 100 continue request" in withServer(
       Action(Results.Ok)
     ) { port =>
-      val responses = BasicHttpClient.makeRequests(port, false,
+      val responses = BasicHttpClient.makeRequests(port)(
         BasicRequest("POST", "/", "HTTP/1.1", Map("Expect" -> "100-continue", "Content-Length" -> "10"), "abcdefghij"),
         BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
       )

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
@@ -1,0 +1,54 @@
+package play.it.http
+
+import play.api.mvc._
+import play.api.test._
+import play.api.test.TestServer
+import play.api.libs.iteratee._
+import scala.concurrent.ExecutionContext.Implicits._
+import scala.util.Random
+
+object RequestBodyHandlingSpec extends PlaySpecification {
+
+  "Play request body handling" should {
+
+    def withServer[T](action: EssentialAction)(block: Port => T) = {
+      val port = testServerPort
+      running(TestServer(port, FakeApplication(
+        withRoutes = {
+          case _ => action
+        }
+      ))) {
+        block(port)
+      }
+    }
+
+    "handle large bodies" in withServer(EssentialAction { rh =>
+      Iteratee.ignore[Array[Byte]].map(_ => Results.Ok)
+    }) { port =>
+      val body = new String(Random.alphanumeric.take(50 * 1024).toArray)
+      val responses = BasicHttpClient.makeRequests(port, trickleFeed = Some(100L))(
+        BasicRequest("POST", "/", "HTTP/1.1", Map("Content-Length" -> body.length.toString), body),
+        // Second request ensures that Play switches back to its normal handler
+        BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+      )
+      responses.length must_== 2
+      responses(0).status must_== 200
+      responses(1).status must_== 200
+    }
+
+    "gracefully handle early body parser termination" in withServer(EssentialAction { rh =>
+      Traversable.takeUpTo[Array[Byte]](20 * 1024) &>> Iteratee.ignore[Array[Byte]].map(_ => Results.Ok)
+    }) { port =>
+      val body = new String(Random.alphanumeric.take(50 * 1024).toArray)
+      // Trickle feed is important, otherwise it won't switch to ignoring the body.
+      val responses = BasicHttpClient.makeRequests(port, trickleFeed = Some(100L))(
+        BasicRequest("POST", "/", "HTTP/1.1", Map("Content-Length" -> body.length.toString), body),
+        // Second request ensures that Play switches back to its normal handler
+        BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+      )
+      responses.length must_== 2
+      responses(0).status must_== 200
+      responses(1).status must_== 200
+    }
+  }
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -65,7 +65,7 @@ object ScalaResultsHandlingSpec extends PlaySpecification {
     "close the connection when the connection close header is present" in withServer(
       Results.Ok
     ) { port =>
-      BasicHttpClient.makeRequests(port, true,
+      BasicHttpClient.makeRequests(port, checkClosed = true)(
         BasicRequest("GET", "/", "HTTP/1.1", Map("Connection" -> "close"), "")
       )(0).status must_== 200
     }
@@ -73,7 +73,7 @@ object ScalaResultsHandlingSpec extends PlaySpecification {
     "close the connection when the connection when protocol is HTTP 1.0" in withServer(
       Results.Ok
     ) { port =>
-      BasicHttpClient.makeRequests(port, true,
+      BasicHttpClient.makeRequests(port, checkClosed = true)(
         BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
       )(0).status must_== 200
     }
@@ -81,7 +81,7 @@ object ScalaResultsHandlingSpec extends PlaySpecification {
     "honour the keep alive header for HTTP 1.0" in withServer(
       Results.Ok
     ) { port =>
-      val responses = BasicHttpClient.makeRequests(port, false,
+      val responses = BasicHttpClient.makeRequests(port)(
         BasicRequest("GET", "/", "HTTP/1.0", Map("Connection" -> "keep-alive"), ""),
         BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
       )
@@ -92,7 +92,7 @@ object ScalaResultsHandlingSpec extends PlaySpecification {
     "keep alive HTTP 1.1 connections" in withServer(
       Results.Ok
     ) { port =>
-      val responses = BasicHttpClient.makeRequests(port, false,
+      val responses = BasicHttpClient.makeRequests(port)(
         BasicRequest("GET", "/", "HTTP/1.1", Map(), ""),
         BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
       )
@@ -104,7 +104,7 @@ object ScalaResultsHandlingSpec extends PlaySpecification {
       Results.Ok.chunked(Enumerator("a", "b", "c"))
     ) { port =>
       // will timeout if not closed
-      BasicHttpClient.makeRequests(port, true,
+      BasicHttpClient.makeRequests(port, checkClosed = true)(
         BasicRequest("GET", "/", "HTTP/1.1", Map("Connection" -> "close"), "")
       )(0).status must_== 200
     }
@@ -112,7 +112,7 @@ object ScalaResultsHandlingSpec extends PlaySpecification {
     "keep chunked connections alive by default" in withServer(
       Results.Ok.chunked(Enumerator("a", "b", "c"))
     ) { port =>
-      val responses = BasicHttpClient.makeRequests(port, false,
+      val responses = BasicHttpClient.makeRequests(port)(
         BasicRequest("GET", "/", "HTTP/1.1", Map(), ""),
         BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
       )
@@ -127,7 +127,7 @@ object ScalaResultsHandlingSpec extends PlaySpecification {
           .map(count => Seq("Chunks" -> count.toString))(ec)
       )))
     ) { port =>
-      val response = BasicHttpClient.makeRequests(port, false,
+      val response = BasicHttpClient.makeRequests(port)(
         BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
       )(0)
 
@@ -141,7 +141,7 @@ object ScalaResultsHandlingSpec extends PlaySpecification {
     "fall back to simple streaming when more than one chunk is sent and protocol is HTTP 1.0" in withServer(
       SimpleResult(ResponseHeader(200, Map()), Enumerator("abc", "def", "ghi") &> Enumeratee.map[String](_.getBytes)(ec))
     ) { port =>
-      val response = BasicHttpClient.makeRequests(port, false,
+      val response = BasicHttpClient.makeRequests(port)(
         BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
       )(0)
       response.headers.keySet must not contain TRANSFER_ENCODING

--- a/framework/src/play/src/main/scala/play/core/server/netty/RequestBodyHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/RequestBodyHandler.scala
@@ -4,108 +4,157 @@ import org.jboss.netty.channel._
 import org.jboss.netty.handler.codec.http._
 
 import play.api._
-import play.api.mvc._
 import play.api.libs.iteratee._
 import play.api.libs.iteratee.Input._
 
 import scala.concurrent.{ Future, Promise }
-import scala.util.{ Failure, Success }
+import scala.util.{ Try, Success }
 
 private[server] trait RequestBodyHandler {
 
   /**
    * Creates a new upstream handler for the purposes of receiving chunked requests. Requests are buffered as an
    * optimization.
-   * @param firstIteratee the iteratee to be used to process the first chunk
-   * @param start a function to handle the registration of the handler. A handler is passed as a param.
-   * @param finish a function to handle the de-registration of the handler i.e. when the chunked request is complete.
+   *
+   * @param bodyHandler the iteratee used to handle the body.
+   * @param replaceHandler a function to handle the registration of a new handler. A handler is passed as a param.
+   * @param handlerFinished a function to handle the de-registration of the handler i.e. when the chunked request is complete.
    * @return a future of an iteratee that will return the result.
    */
-  def newRequestBodyUpstreamHandler[A](firstIteratee: Iteratee[Array[Byte], A],
-    start: SimpleChannelUpstreamHandler => Unit,
-    finish: => Unit): Future[A] = {
+  def newRequestBodyUpstreamHandler[A](bodyHandler: Iteratee[Array[Byte], A],
+    replaceHandler: ChannelUpstreamHandler => Unit,
+    handlerFinished: => Unit): Future[A] = {
 
     implicit val internalContext = play.core.Execution.internalContext
     import scala.concurrent.stm._
-    var p = Promise[Iteratee[Array[Byte], A]]()
+
+    // A promise for the result of the body handler.  This will be returned to the caller immediately.
+    val bodyHandlerResult = Promise[Iteratee[Array[Byte], A]]()
+
+    // Constants for how many messages we're prepared to allow to be in flight.
     val MaxMessages = 10
     val MinMessages = 10
+
+    // How messages we currently have "in flight" that the bodyHandler hasn't acknowledged.
     val counter = Ref(0)
 
-    var iteratee: Ref[Iteratee[Array[Byte], A]] = Ref(firstIteratee)
+    // An STM reference to the body handler.
+    // I don't think STM is needed here, since Netty won't give us two chunks at once.
+    // But I don't want to remove it, in case I've misunderstood.
+    // TODO: Work out whether STM is needed.
+    val iteratee: Ref[Iteratee[Array[Byte], A]] = Ref(bodyHandler)
 
     def pushChunk(ctx: ChannelHandlerContext, chunk: Input[Array[Byte]]) {
-      if (counter.single.transformAndGet { _ + 1 } > MaxMessages && ctx.getChannel.isOpen() && !p.isCompleted)
+
+      // If we have more messages in flight than the maximum, ensure that we have told upstream that
+      // we don't want to received more.  But only if the channel is still open and we haven't finished handling it.
+      if (counter.single.transformAndGet { _ + 1 } > MaxMessages && ctx.getChannel.isOpen && !bodyHandlerResult.isCompleted)
         ctx.getChannel.setReadable(false)
 
+      // Promise for the next iteratee
       val itPromise = Promise[Iteratee[Array[Byte], A]]()
+
+      // Update our body handler iteratee to be the next iteratee, and get the current one atomically
       val current = atomic { implicit txn =>
-        if (!p.isCompleted)
+        if (!bodyHandlerResult.isCompleted) {
           Some(iteratee.single.swap(Iteratee.flatten(itPromise.future)))
-        else None
+        } else {
+          // We already have a result, but we're not at the end of the stream yet.  Replace the handler with one that
+          // will simply ignore the rest of the body.
+          // This means we can free up resources that this handler holds, namely, the promise for the parsed body,
+          // which could be large, while the rest of the body comes.
+          if (chunk != Input.EOF) {
+            replaceHandler(new IgnoreBodyHandler(handlerFinished))
+          }
+          None
+        }
       }
 
-      current.foreach { i =>
-        i.feed(chunk).flatMap(_.unflatten).onComplete {
+      current.foreach { currentIteratee =>
+        // Feed the chunk
+        currentIteratee.feed(chunk).flatMap(_.unflatten).onComplete {
           case Success(c @ Step.Cont(k)) =>
             continue(c.it)
-          case Success(finished) =>
-            finish(finished.it)
-          case Failure(e) =>
-            if (!p.tryFailure(e)) {
-              iteratee = null; p = null;
-              if (ctx.getChannel.isOpen()) ctx.getChannel.setReadable(true)
-            }
-            itPromise.failure(e)
+          case done =>
+            finish(done.map(_.it))
         }
       }
 
       def continue(it: Iteratee[Array[Byte], A]) {
-        if (counter.single.transformAndGet { _ - 1 } <= MinMessages && ctx.getChannel.isOpen())
+        // If we have less messages in flight than the minimum, ensure that we have told upstream that
+        // we are ready to receive more.
+        if (counter.single.transformAndGet { _ - 1 } <= MinMessages && ctx.getChannel.isOpen)
           ctx.getChannel.setReadable(true)
         itPromise.success(it)
       }
 
-      def finish(it: Iteratee[Array[Byte], A]) {
-        if (!p.trySuccess(it)) {
-          iteratee = null; p = null;
-          if (ctx.getChannel.isOpen()) ctx.getChannel.setReadable(true)
+      def finish(result: Try[Iteratee[Array[Byte], A]]) {
+        // Redeem the body handler result
+        if (!bodyHandlerResult.tryComplete(result)) {
+          if (ctx.getChannel.isOpen) ctx.getChannel.setReadable(true)
         }
-        itPromise.success(it)
+        itPromise.complete(result)
       }
     }
 
-    start(new SimpleChannelUpstreamHandler {
+    replaceHandler(new SimpleChannelUpstreamHandler {
       override def messageReceived(ctx: ChannelHandlerContext, e: MessageEvent) {
         e.getMessage match {
 
-          case chunk: HttpChunk if !chunk.isLast() =>
-            val cBuffer = chunk.getContent()
+          case chunk: HttpChunk if !chunk.isLast =>
+            val cBuffer = chunk.getContent
             val bytes = new Array[Byte](cBuffer.readableBytes())
             cBuffer.readBytes(bytes)
             pushChunk(ctx, El(bytes))
 
-          case chunk: HttpChunk if chunk.isLast() => {
+          case chunk: HttpChunk if chunk.isLast => {
             pushChunk(ctx, EOF)
-            finish
+            handlerFinished
           }
 
-          case unexpected => Play.logger.error("Oops, unexpected message received in NettyServer/ChunkHandler (please report this problem): " + unexpected)
+          case unexpected =>
+            Play.logger.error("Oops, unexpected message received in NettyServer/RequestBodyHandler" +
+              " (please report this problem): " + unexpected)
 
         }
       }
 
       override def exceptionCaught(ctx: ChannelHandlerContext, e: ExceptionEvent) {
-        e.getCause().printStackTrace();
-        e.getChannel().close(); /*really? */
+        Play.logger.error("Exception caught in RequestBodyHandler", e.getCause)
+        e.getChannel.close()
       }
+
       override def channelDisconnected(ctx: ChannelHandlerContext, e: ChannelStateEvent) {
         pushChunk(ctx, EOF)
       }
 
     })
 
-    p.future.flatMap(_.run)
+    bodyHandlerResult.future.flatMap(_.run)
   }
 
+  /**
+   * Ignores the body, but calls finish when finished.
+   */
+  private class IgnoreBodyHandler(handlerFinished: => Unit) extends SimpleChannelUpstreamHandler {
+    override def messageReceived(ctx: ChannelHandlerContext, e: MessageEvent) {
+      e.getMessage match {
+        case chunk: HttpChunk => {
+          // Ignore, and invoke the callback if it's the last chunk.
+          if (chunk.isLast) handlerFinished
+        }
+
+        // Even though this handler essentially ignores everything it receives, it should only be handling HTTP chunks,
+        // so if it gets something else log it so that we can know there's a bug.
+        case unexpected =>
+          Play.logger.error("Oops, unexpected message received in NettyServer/IgnoreBodyHandler" +
+            " (please report this problem): " + unexpected)
+      }
+    }
+
+    override def exceptionCaught(ctx: ChannelHandlerContext, e: ExceptionEvent) {
+      Play.logger.error("Exception caught in IgnoreBodyHandler", e.getCause)
+      e.getChannel.close()
+    }
+  }
 }


### PR DESCRIPTION
When using parse.maxLength to limit the incoming body size, a NullPointerException is thrown if the body exceeds this size.  In my isolated test the intended response still gets back to the user, but in my larger application the user receives a 500 rather than the intended message.

Example action:

```
def maxlen = Action(parse.maxLength(5, parser = parse.anyContent)) { implicit request =>
  request.body match {
    case Left(maxSize) => BadRequest("exceeded maxSize " + maxSize)
    case Right(body) => Ok("accepted")
  }
}
```

Triggering the bug:

```
curl -X POST http://localhost:9000/maxlen -d @conf/application.conf
```

Project that demonstrates this bug: https://github.com/varju/play-maxlength-bug

Reproduced using 2.1.2 and with 2.1.x c447be8
