### PR TITLE
Upgrade to sbt idea 1.5.1 final

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -154,7 +154,7 @@ object Dependencies {
 
     // Once we upgrade to SBT 0.13.0, we can use the build version of SBT here
     "com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0" extra("sbtVersion" -> "0.13", "scalaVersion" -> BuildSettings.buildScalaBinaryVersionForSbt),
-    "com.github.mpeltonen" % "sbt-idea" % "1.5.0-SNAPSHOT" extra("sbtVersion" -> "0.13", "scalaVersion" -> BuildSettings.buildScalaBinaryVersionForSbt),
+    "com.github.mpeltonen" % "sbt-idea" % "1.5.1" extra("sbtVersion" -> "0.13", "scalaVersion" -> BuildSettings.buildScalaBinaryVersionForSbt),
     "com.typesafe.sbt" % "sbt-native-packager" % "0.6.0" extra("sbtVersion" ->  "0.13", "scalaVersion" -> BuildSettings.buildScalaBinaryVersionForSbt),
 
     specsSbt


### PR DESCRIPTION
The sbt idea plugin has now been released as final. This PR accommodates the event. More information on the release:

http://notes.implicit.ly/post/56635172083/sbt-idea-1-5-1
