### PR TITLE
Upgrade junit-interface to 0.10.

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -107,7 +107,7 @@ object Dependencies {
     specsBuild % "test",
 
     "org.mockito" % "mockito-all" % "1.9.5" % "test",
-    "com.novocode" % "junit-interface" % "0.10-M4" % "test",
+    "com.novocode" % "junit-interface" % "0.10" % "test",
 
     ("org.fluentlenium" % "fluentlenium-festassert" % "0.9.0" % "test")
       .exclude("org.jboss.netty", "netty")
@@ -187,7 +187,7 @@ object Dependencies {
   val testDependencies = Seq(
     "junit" % "junit" % "4.11",
     specsBuild,
-    "com.novocode" % "junit-interface" % "0.10-M4",
+    "com.novocode" % "junit-interface" % "0.10",
     guava,
     findBugs,
     ("org.fluentlenium" % "fluentlenium-festassert" % "0.8.0")


### PR DESCRIPTION
Fixes several bugs compared to 0.9 such as swallowed test failure information and problems with junit runners
