### PR TITLE
Memory leak on app reload

### DIFF
--- a/framework/src/play/src/main/resources/play.plugins
+++ b/framework/src/play/src/main/resources/play.plugins
@@ -1,3 +1,4 @@
 100:play.api.i18n.MessagesPlugin
+100:play.core.RouterCacheLifecycle
 1000:play.api.libs.concurrent.AkkaPlugin
 10000:play.api.GlobalPlugin

--- a/framework/src/play/src/main/scala/play/core/router/Router.scala
+++ b/framework/src/play/src/main/scala/play/core/router/Router.scala
@@ -12,6 +12,7 @@ import scala.util.control.Exception
 import scala.collection.concurrent.TrieMap
 import play.core.j.JavaActionAnnotations
 import play.utils.UriEncoding
+import play.api.Plugin
 
 trait PathPart
 
@@ -71,12 +72,24 @@ case class PathPattern(parts: Seq[PathPart]) {
 }
 
 /**
+ * The javaActionAnnotations map holds references to Java classes.  The map is needed for performance reasons
+ * (introspecting actions on every request is very slow), but in dev mode, this causes classloader leaks.
+ *
+ * This "plugin" hooks into the Play lifecycle to clear the map when Play shuts down.
+ */
+class RouterCacheLifecycle(app: play.api.Application) extends Plugin {
+  override def onStop() {
+    Router.javaActionAnnotations.clear()
+  }
+}
+
+/**
  * provides Play's router implementation
  */
 object Router {
 
   // Cache of annotation information for improving Java performance.
-  private val javaActionAnnotations = new TrieMap[HandlerDef, JavaActionAnnotations]
+  private[core] val javaActionAnnotations = new TrieMap[HandlerDef, JavaActionAnnotations]
 
   object Route {
 


### PR DESCRIPTION
Our app gets slower and slower with each reload until it finally gets totally unresponsive or crashes. This is easy to reproduce. Create a new Play Java app, use the following example Application.java, and then type "play run". Change something minor in it like the message and refresh the page, change the message and refresh the page again, etc. until it gets worse and worse.

```
package controllers;

import java.util.*;

import play.*;
import play.mvc.*;

import views.html.*;

public class Application extends Controller {

    public static List<Integer> numbers = new ArrayList<Integer>();

    public static Result index() {
        Date start = new Date();
        boolean didWork = generateRandomData();
        String message = "Your application is ready.";
        if (didWork) {
            Date end = new Date();
            long seconds = (end.getTime() - start.getTime()) / 1000;
            message = "Your application generated " + numbers.size() + " numbers in " + seconds + " seconds.";
            System.out.println(message);
        }
        return ok(index.render(message));
    }

    private static synchronized boolean generateRandomData() {
        int num = 10_000_000;
        if (numbers.size() < num) {
            Random r = new Random();
            for (int i = 0; i < num; i++) {
                numbers.add(r.nextInt());
            }
            return true;
        }
        return false;
    }

}
```
