### PR TITLE
Added a convenient helper function to the Scala cache api to deal futures

### DIFF
--- a/documentation/manual/scalaGuide/main/cache/ScalaCache.md
+++ b/documentation/manual/scalaGuide/main/cache/ScalaCache.md
@@ -21,6 +21,10 @@ There is also a convenient helper to retrieve from cache or set the value in cac
 
 @[retrieve-missing](code/ScalaCache.scala)
 
+If you want to cache a Future response there is a convenient helper to prevent Future failures from being cached for example if you are caching a Play WS result:
+
+@[retrieve-missing-future](code/ScalaCache.scala)
+
 
 To remove an item from the cache use the `remove` method:
 

--- a/documentation/manual/scalaGuide/main/cache/code/ScalaCache.scala
+++ b/documentation/manual/scalaGuide/main/cache/code/ScalaCache.scala
@@ -6,6 +6,7 @@ import org.specs2.runner.JUnitRunner
 
 import play.api.Play.current
 import play.api.test._
+import play.api.test.Helpers._
 import play.api.cache.{Cached, Cache}
 import play.api.mvc._
 import scala.concurrent.Future
@@ -48,6 +49,20 @@ class ScalaCacheSpec extends PlaySpecification with Controller {
         }
         //#retrieve-missing
         user must beEqualTo(User(connectedUser))
+      }
+    }
+
+    "a cache or get user with future" in {
+      implicit val execContext = play.api.libs.concurrent.Execution.defaultContext
+
+      running(FakeApplication()) {
+        val connectedUser = "xfasync"
+        //#retrieve-missing-future
+        val user: Future[User] = Cache.futureGetOrElse[User]("item.key") {
+          User.findAsync(connectedUser)
+        }
+        //#retrieve-missing-future
+        await(user) must beEqualTo(User(connectedUser))
       }
     }
 
@@ -119,6 +134,8 @@ object User {
   def findById(userId: String) = User(userId)
 
   def find(user: String) = User(user)
+
+  def findAsync(user: String) = Future.successful(User(user))
 }
 
 }


### PR DESCRIPTION
Added a convenient helper function to the Scala cache api to deal futures caching futures. Any future which has a failure will not be cached, this is extremely useful when working with Play WS and we don't want to cache exceptions such as timeouts.
