### PR TITLE
anorm: Add SimpleSql.map to modify defaultParser results

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/Anorm.scala
+++ b/framework/src/anorm/src/main/scala/anorm/Anorm.scala
@@ -401,6 +401,8 @@ case class SimpleSql[T](sql: SqlQuery, params: Seq[(String, ParameterValue[_])],
 
   def using[U](p: RowParser[U]): SimpleSql[U] = SimpleSql(sql, params, p)
 
+  def map[A](f: T => A): SimpleSql[A] = this.copy(defaultParser = defaultParser.map(f))
+
   def withQueryTimeout(seconds: Option[Int]): SimpleSql[T] = this.copy(sql = sql.withQueryTimeout(seconds))
 }
 


### PR DESCRIPTION
I've found SimpleSql convenient for packaging RowParsers, and this convenience function allows easy manipulation of the defaultParser.  Other access to RowParser manipulators could be imagined, but this one fits best and is convenient.  I don't believe that it introduces any ambiguities to implicit conversions, so should be fully backwards compatible.
