### PR TITLE
Cookie encoding issues

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -8,6 +8,7 @@ package play.api.mvc {
 
   import scala.annotation._
   import scala.util.control.NonFatal
+  import java.net.{ URLDecoder, URLEncoder }
 
   /**
    * The HTTP request header. Note that it doesn’t contain the request body yet.
@@ -402,7 +403,9 @@ package play.api.mvc {
      * Encodes the data as a `String`.
      */
     def encode(data: Map[String, String]): String = {
-      val encoded = java.net.URLEncoder.encode(data.filterNot(_._1.contains(":")).map(d => d._1 + ":" + d._2).mkString("\u0000"), "UTF-8")
+      val encoded = data.map {
+        case (k, v) => URLEncoder.encode(k, "UTF-8") + "=" + URLEncoder.encode(v, "UTF-8")
+      }.mkString("&")
       if (isSigned)
         Crypto.sign(encoded) + "-" + encoded
       else
@@ -414,7 +417,13 @@ package play.api.mvc {
      */
     def decode(data: String): Map[String, String] = {
 
-      def urldecode(data: String) = java.net.URLDecoder.decode(data, "UTF-8").split("\u0000").map(_.split(":")).map(p => p(0) -> p.drop(1).mkString(":")).toMap
+      def urldecode(data: String) = {
+        data
+          .split("&")
+          .map(_.split("=", 2))
+          .map(p => URLDecoder.decode(p(0), "UTF-8") -> URLDecoder.decode(p(1), "UTF-8"))
+          .toMap
+      }
 
       // Do not change this unless you understand the security issues behind timing attacks.
       // This method intentionally runs in constant time if the two strings have the same length.
@@ -433,7 +442,7 @@ package play.api.mvc {
 
       try {
         if (isSigned) {
-          val splitted = data.split("-")
+          val splitted = data.split("-", 2)
           val message = splitted.tail.mkString("-")
           if (safeEquals(splitted(0), Crypto.sign(message)))
             urldecode(message)

--- a/framework/src/play/src/test/scala/play/api/mvc/FlashCookieSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/FlashCookieSpec.scala
@@ -1,0 +1,45 @@
+package play.api.mvc
+
+import org.specs2.mutable._
+
+object FlashCookieSpec extends Specification {
+
+  "Flash cookies" should {
+    "bake in a header and value" in {
+      val es = Flash.encode(Map("a" -> "b"))
+      val m = Flash.decode(es)
+      m.size must_== 1
+      m("a") must_== "b"
+    }
+    "encode values such that no extra keys can be created" in {
+      val es = Flash.encode(Map("a" -> "b&c=d"))
+      val m = Flash.decode(es)
+      m.size must_== 1
+      m("a") must_== "b&c=d"
+    }
+    "specifically exclude control chars" in {
+      for (i <- 0 until 32) {
+        val s = Character.toChars(i).toString
+        val es = Flash.encode(Map("a" -> s))
+        es must not contain s
+
+        val m = Flash.decode(es)
+        m.size must_== 1
+        m("a") must_== s
+      }
+      success
+    }
+    "specifically exclude special cookie chars" in {
+      val es = Flash.encode(Map("a" -> " \",;\\"))
+      es must not contain " "
+      es must not contain "\""
+      es must not contain ","
+      es must not contain ";"
+      es must not contain "\\"
+
+      val m = Flash.decode(es)
+      m.size must_== 1
+      m("a") must_== " \",;\\"
+    }
+  }
+}


### PR DESCRIPTION
Map key and values are encoded directly instead of having the entire key value concatenation encoded. This permits special characters to be used in key and value values. Test coverage is provided.

In addition the delimiters used for encoding have been changed to '=' and '&' given that these are permissible characters to appear as cookie values according to RFC 6265: http://www.rfc-editor.org/rfc/rfc6265.txt
