### PR TITLE
replaced folder app/views/html/... by app/views/... in "Improving the La...

### DIFF
--- a/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide3.md
+++ b/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide3.md
@@ -194,7 +194,7 @@ Edit the `app/views/main.scala.html` file:
 </html>
 ```
 
-Like with the rendering of each `Task` in our index page, we have made the rendering of a group of projects its own template, for later reuse.  Let's implement that template now, open `app/views/html/projects/group.scala.html`:
+Like with the rendering of each `Task` in our index page, we have made the rendering of a group of projects its own template, for later reuse.  Let's implement that template now, open `app/views/projects/group.scala.html`:
 
 ```html
 @(group: String, projects: List[Project])
@@ -218,7 +218,7 @@ Like with the rendering of each `Task` in our index page, we have made the rende
 </li>
 ```
 
-And again, the individual project items are implemented using their own template, `app/views/html/projects/item.scala.html`:
+And again, the individual project items are implemented using their own template, `app/views/projects/item.scala.html`:
 
 ```html
 @(project: Project)
@@ -236,7 +236,7 @@ Refresh the page.
 
 [[images/dashboard2.png]]
 
-Uh oh!  We have a compile error.  We haven't updated the call to the `main` template from our `index` template to pass a list of projects instead of a string.  Let's fix that now, by editing `app/views/html/index.scala.html`:
+Uh oh!  We have a compile error.  We haven't updated the call to the `main` template from our `index` template to pass a list of projects instead of a string.  Let's fix that now, by editing `app/views/index.scala.html`:
 
 ```html
 @(projects: List[Project], todoTasks: List[Task])


### PR DESCRIPTION
...yout"

Seems like this is a typo. The folder for projects/group.scala.html, projects/item.scala.html, and main.scala.html should be just views instead of views/html.

At least in my case the tutorial didn't work when putting, for example, the projects folder into app/views/html.
(Doing the tutorial with play! 2.1.2 (using Java 1.6.0_51 and Scala 2.10.0)).
