### PR TITLE
Remove additional 8MB of play from 2.2 archive

### DIFF
--- a/framework/package
+++ b/framework/package
@@ -92,7 +92,7 @@ fi
 
 if [ $CLEAN -eq 0 ]
 then
-    $DIR/build clean Play-Repository:clean
+    $DIR/build clean
 fi
 
 $DIR/build -Dplay.version=${PLAY_VERSION} $PUBLISHCMD create-dist

--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -311,9 +311,9 @@ object PlayBuild extends Build {
     .settings(ApiDocs.settings: _*)
     .settings(
       libraryDependencies := (runtime ++ jdbcDeps),
-      cleanFiles ++= Seq(file("../dist"), file("../repository/local")),
       publish := {},
       generateDistTask
     )
     .aggregate(publishedProjects: _*)
+    .aggregate(RepositoryProject)
 }


### PR DESCRIPTION
The play 2.2 archive is 8MB more than it needs to be as it includes dependencies from "play" % "play" i.e. the old group id.
