### PR TITLE
Don't publish RepositoryBuilder project

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -285,7 +285,8 @@ object PlayBuild extends Build {
         "org.scala-lang" % "scala-compiler" % BuildSettings.buildScalaVersion,
         "org.scala-lang" % "scala-compiler" % BuildSettings.buildScalaVersionForSbt,
         "org.scala-sbt" % "sbt" % BuildSettings.buildSbtVersion
-      )
+      ),
+      publish := {}
     )
     
   lazy val publishedProjects = Seq[ProjectReference](


### PR DESCRIPTION
This fixes an error with publishing Play. Since db8e8d7932f0c05aaa5ea15d05d14dbdac642c60, RepositoryBuilder has been aggregated into the Root project, but we don't want RepositoryBuilder to be published when the rest of Play is published.

This PR makes RepositoryBuilder's publish task into a no-op. The Root project already has a no-op publish task. I am applying the same idea to the RepositoryBuilder project.

```
> publish
...
[trace] Stack trace suppressed: run last Play-Repository/*:publish-configuration for the full output.
[error] (Play-Repository/*:publish-configuration) Repository for publishing is not specified.
[error] Total time: 337 s, completed 9/08/2013 8:38:20 PM
...
> last
java.lang.RuntimeException: Repository for publishing is not specified.
        at scala.sys.package$.error(package.scala:27)
        at sbt.Classpaths$$anonfun$getPublishTo$1.apply(Defaults.scala:997)
        at sbt.Classpaths$$anonfun$getPublishTo$1.apply(Defaults.scala:997)
...
```
