### PR TITLE
Tidy up SBTDocLink

### DIFF
--- a/documentation/project/Build.scala
+++ b/documentation/project/Build.scala
@@ -3,7 +3,7 @@ import play.core.server.ServerWithStop
 import sbt._
 import sbt.Keys._
 import PlayKeys._
-import play.core.{ SBTDocLink, SBTLink, PlayVersion }
+import play.core.{ SBTDocHandler, SBTLink, PlayVersion }
 import PlaySourceGenerators._
 import scala.Some
 
@@ -82,7 +82,7 @@ object ApplicationBuild extends Build {
       val classloader = new java.net.URLClassLoader(classpath.map(_.data.toURI.toURL).toArray, null /* important here, don't depend of the sbt classLoader! */) {
         val sharedClasses = Seq(
           classOf[play.core.SBTLink].getName,
-          classOf[play.core.SBTDocLink].getName,
+          classOf[play.core.SBTDocHandler].getName,
           classOf[play.core.server.ServerWithStop].getName,
           classOf[play.api.UsefulException].getName,
           classOf[play.api.PlayException].getName,
@@ -101,15 +101,15 @@ object ApplicationBuild extends Build {
       }
 
       val projectPath = extracted.get(baseDirectory)
-      val sbtDocLink = {
-        val docLinkFactoryClass = classloader.loadClass("play.docs.SBTDocLinkFactory")
-        val fromDirectoryMethod = docLinkFactoryClass.getMethod("fromDirectory", classOf[java.io.File])
+      val sbtDocHandler = {
+        val docHandlerFactoryClass = classloader.loadClass("play.docs.SBTDocHandlerFactory")
+        val fromDirectoryMethod = docHandlerFactoryClass.getMethod("fromDirectory", classOf[java.io.File])
         fromDirectoryMethod.invoke(null, projectPath)
       }
 
       val clazz = classloader.loadClass("play.docs.DocumentationServer")
-      val constructor = clazz.getConstructor(classOf[File], classOf[SBTDocLink], classOf[java.lang.Integer])
-      val server = constructor.newInstance(projectPath, sbtDocLink, new java.lang.Integer(port)).asInstanceOf[ServerWithStop]
+      val constructor = clazz.getConstructor(classOf[File], classOf[SBTDocHandler], classOf[java.lang.Integer])
+      val server = constructor.newInstance(projectPath, sbtDocHandler, new java.lang.Integer(port)).asInstanceOf[ServerWithStop]
 
       println()
       println(Colors.green("Documentation server started, you can now view the docs by going to http://localhost:" + port))

--- a/framework/src/play-docs/src/main/java/play/docs/SBTDocHandlerFactory.java
+++ b/framework/src/play-docs/src/main/java/play/docs/SBTDocHandlerFactory.java
@@ -4,57 +4,47 @@ import java.io.File;
 import java.util.jar.JarFile;
 
 import play.api.mvc.RequestHeader;
-import play.core.SBTDocLink;
+import play.core.SBTDocHandler;
 import play.doc.FileRepository;
 import play.doc.FilesystemRepository;
 import play.doc.JarRepository;
 import scala.Option;
 
 /**
- * Provides a way for SBT code to create SBTDocLink objects.
+ * Provides a way for SBT code to create SBTDocHandler objects.
  *
  * <p>This class is used by the Play SBT plugin run command (to serve
  * documentation from a JAR) and by the Play documentation project (to
- * server documentation from the filesystem).
+ * serve documentation from the filesystem).
  *
  * <p>This class is written in Java and uses only Java types so that
  * communication can work even when the SBT code and the play-docs project
  * are built with different versions of Scala.
  */
-public class SBTDocLinkFactory {
+public class SBTDocHandlerFactory {
 
   /**
-   * Create an SBTDocLink that serves documentation from a given directory by
+   * Create an SBTDocHandler that serves documentation from a given directory by
    * wrapping a FilesystemRepository.
    *
    * @param directory The directory to serve the documentation from.
    */
-  public static SBTDocLink fromDirectory(File directory) {
+  public static SBTDocHandler fromDirectory(File directory) {
     FileRepository repo = new FilesystemRepository(directory);
-    final DocumentationHandler handler = new DocumentationHandler(repo);
-    return new SBTDocLink() {
-      public Object maybeHandleDocRequest(Object request) {
-        return handler.maybeHandleRequest((RequestHeader) request);
-      }
-    };
+    return new DocumentationHandler(repo);
   }
 
   /**
-   * Create an SBTDocLink that serves documentation from a given JAR file by
+   * Create an SBTDocHandler that serves documentation from a given JAR file by
    * wrapping a JarRepository.
    *
    * @param jarFile The JAR file to server the documentation from.
    * @param base The directory within the JAR file to serve the documentation from, or null if the
    *    documentation should be served from the root of the JAR.
    */
-  public static SBTDocLink fromJar(final JarFile jarFile, String base) {
+  public static SBTDocHandler fromJar(JarFile jarFile, String base) {
     FileRepository repo = new JarRepository(jarFile, Option.apply(base));
-    final DocumentationHandler handler = new DocumentationHandler(repo);
-    return new SBTDocLink() {
-      public Object maybeHandleDocRequest(Object request) {
-        return handler.maybeHandleRequest((RequestHeader) request);
-      }
-    };
+    return new DocumentationHandler(repo);
   }
 
 }

--- a/framework/src/play-docs/src/main/scala/play/docs/DocumentationApplication.scala
+++ b/framework/src/play-docs/src/main/scala/play/docs/DocumentationApplication.scala
@@ -9,7 +9,7 @@ import scala.util.Success
 /**
  * Provides a very simple application that renders Play documentation.
  */
-case class DocumentationApplication(projectPath: File, sbtDocLink: SBTDocLink) extends ApplicationProvider {
+case class DocumentationApplication(projectPath: File, sbtDocHandler: SBTDocHandler) extends ApplicationProvider {
 
   val application = new Application with WithDefaultConfiguration {
     def path = projectPath
@@ -26,7 +26,7 @@ case class DocumentationApplication(projectPath: File, sbtDocLink: SBTDocLink) e
   override def path = projectPath
   override def get = Success(application)
   override def handleWebCommand(request: RequestHeader) =
-    sbtDocLink.maybeHandleDocRequest(request).asInstanceOf[Option[SimpleResult]].orElse(
+    sbtDocHandler.maybeHandleDocRequest(request).asInstanceOf[Option[SimpleResult]].orElse(
       Some(Results.Redirect("/@documentation"))
     )
 }

--- a/framework/src/play-docs/src/main/scala/play/docs/DocumentationHandler.scala
+++ b/framework/src/play-docs/src/main/scala/play/docs/DocumentationHandler.scala
@@ -7,7 +7,7 @@ import play.api.http.HeaderNames
 import play.api.libs.concurrent.Execution
 import play.api.libs.iteratee.Enumerator
 import play.api.libs.iteratee.Enumeratee
-import play.core.PlayVersion
+import play.core.{ PlayVersion, SBTDocHandler }
 import play.doc.{ FileRepository, PlayDoc }
 import org.apache.commons.io.IOUtils
 
@@ -16,14 +16,20 @@ import org.apache.commons.io.IOUtils
  * Documentation is located in the given repository - either a JAR file or directly from
  * the filesystem.
  */
-class DocumentationHandler(repo: FileRepository) {
+class DocumentationHandler(repo: FileRepository) extends SBTDocHandler {
 
   val markdownRenderer = new PlayDoc(repo, repo, "resources", PlayVersion.current)
+
+  // Method without Scala types. Required by SBTDocHandler to allow communication
+  // between code compiled by different versions of Scala
+  override def maybeHandleDocRequest(request: AnyRef): AnyRef = {
+    this.maybeHandleDocRequest(request.asInstanceOf[RequestHeader])
+  }
 
   /**
    * Handle the given request if it is a request for documentation content.
    */
-  def maybeHandleRequest(request: RequestHeader): Option[SimpleResult] = {
+  def maybeHandleDocRequest(request: RequestHeader): Option[SimpleResult] = {
 
     // Assumes caller consumes result, closing entry
     def sendFileInline(path: String): Option[SimpleResult] = {

--- a/framework/src/play-docs/src/main/scala/play/docs/DocumentationServer.scala
+++ b/framework/src/play-docs/src/main/scala/play/docs/DocumentationServer.scala
@@ -2,7 +2,7 @@ package play.docs
 
 import java.io.File
 import play.api.Mode
-import play.core.SBTDocLink
+import play.core.SBTDocHandler
 import play.core.server.NettyServer
 
 /**
@@ -11,6 +11,6 @@ import play.core.server.NettyServer
  * to create a server that embeds both the user application and the Play documentation
  * application.
  */
-class DocumentationServer(projectPath: File, sbtDocLink: SBTDocLink, port: java.lang.Integer) extends NettyServer(DocumentationApplication(projectPath, sbtDocLink), Some(port),
+class DocumentationServer(projectPath: File, sbtDocHandler: SBTDocHandler, port: java.lang.Integer) extends NettyServer(DocumentationApplication(projectPath, sbtDocHandler), Some(port),
   mode = Mode.Dev
 )

--- a/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
@@ -283,8 +283,8 @@ object NettyServer {
    * <p>This method uses simple Java types so that it can be used with reflection by code
    * compiled with different versions of Scala.
    */
-  def mainDevOnlyHttpsMode(sbtLink: SBTLink, sbtDocLink: SBTDocLink, httpsPort: Int): NettyServer = {
-    mainDev(sbtLink, sbtDocLink, None, Some(httpsPort))
+  def mainDevOnlyHttpsMode(sbtLink: SBTLink, sbtDocHandler: SBTDocHandler, httpsPort: Int): NettyServer = {
+    mainDev(sbtLink, sbtDocHandler, None, Some(httpsPort))
   }
 
   /**
@@ -293,14 +293,14 @@ object NettyServer {
    * <p>This method uses simple Java types so that it can be used with reflection by code
    * compiled with different versions of Scala.
    */
-  def mainDevHttpMode(sbtLink: SBTLink, sbtDocLink: SBTDocLink, httpPort: Int): NettyServer = {
-    mainDev(sbtLink, sbtDocLink, Some(httpPort), Option(System.getProperty("https.port")).map(Integer.parseInt(_)))
+  def mainDevHttpMode(sbtLink: SBTLink, sbtDocHandler: SBTDocHandler, httpPort: Int): NettyServer = {
+    mainDev(sbtLink, sbtDocHandler, Some(httpPort), Option(System.getProperty("https.port")).map(Integer.parseInt(_)))
   }
 
-  private def mainDev(sbtLink: SBTLink, sbtDocLink: SBTDocLink, httpPort: Option[Int], httpsPort: Option[Int]): NettyServer = {
+  private def mainDev(sbtLink: SBTLink, sbtDocHandler: SBTDocHandler, httpPort: Option[Int], httpsPort: Option[Int]): NettyServer = {
     play.utils.Threads.withContextClassLoader(this.getClass.getClassLoader) {
       try {
-        val appProvider = new ReloadableApplication(sbtLink, sbtDocLink)
+        val appProvider = new ReloadableApplication(sbtLink, sbtDocHandler)
         new NettyServer(appProvider, httpPort,
           httpsPort,
           mode = Mode.Dev)

--- a/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
+++ b/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
@@ -70,7 +70,7 @@ class TestApplication(application: Application) extends ApplicationProvider {
 /**
  * represents an application that can be reloaded in Dev Mode
  */
-class ReloadableApplication(sbtLink: SBTLink, sbtDocLink: SBTDocLink) extends ApplicationProvider {
+class ReloadableApplication(sbtLink: SBTLink, sbtDocHandler: SBTDocHandler) extends ApplicationProvider {
 
   // Use plain Java call here in case of scala classloader mess
   {
@@ -168,7 +168,7 @@ class ReloadableApplication(sbtLink: SBTLink, sbtDocLink: SBTDocLink) extends Ap
 
   override def handleWebCommand(request: play.api.mvc.RequestHeader): Option[SimpleResult] = {
 
-    sbtDocLink.maybeHandleDocRequest(request).asInstanceOf[Option[SimpleResult]].orElse(
+    sbtDocHandler.maybeHandleDocRequest(request).asInstanceOf[Option[SimpleResult]].orElse(
       for {
         app <- Play.maybeApplication
         result <- app.plugins.foldLeft(Option.empty[SimpleResult]) {

--- a/framework/src/sbt-link/src/main/java/play/core/SBTDocHandler.java
+++ b/framework/src/sbt-link/src/main/java/play/core/SBTDocHandler.java
@@ -1,17 +1,17 @@
 package play.core;
 
 /**
- * Interface used by the Play SBT code to communicate with an embedded DocumentationApplication.
- * This occurs happens when SBT runs a Play server in development mode and from within the
- * Play documentation project.
+ * Interface used by the Play SBT code to call a DocumentationHandler. We don't use
+ * a DocumentationHandler directly because Play's SBT and application code can be compiled
+ * with different versions of Scala and there can be binary compatibility problems.
  *
- * <p>SBTLink objects are created by calling the static methods on SBTDocLinkFactory.
+ * <p>SBTDocHandler objects can created by calling the static methods on SBTDocHandlerFactory.
  *
  * <p>This interface is written in Java and uses only Java types so that
  * communication can work even when the calling code and the play-docs project
  * are built with different versions of Scala.
  */
-public interface SBTDocLink {
+public interface SBTDocHandler {
 
   /**
    * Given a request, either handle it and return some result, or don't, and return none.

--- a/framework/src/sbt-plugin/src/main/scala/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayRun.scala
@@ -2,7 +2,7 @@ package sbt
 
 import sbt.Keys._
 import sbt.PlayKeys._
-import play.core.{ SBTLink, SBTDocLink }
+import play.core.{ SBTLink, SBTDocHandler }
 import play.console.Colors
 import annotation.tailrec
 import scala.collection.JavaConverters._
@@ -160,7 +160,7 @@ trait PlayRun extends PlayInternalKeys {
 
           private val sbtSharedClasses = Seq(
             classOf[play.core.SBTLink].getName,
-            classOf[play.core.SBTDocLink].getName,
+            classOf[play.core.SBTDocHandler].getName,
             classOf[play.core.server.ServerWithStop].getName,
             classOf[play.api.UsefulException].getName,
             classOf[play.api.PlayException].getName,
@@ -219,20 +219,20 @@ trait PlayRun extends PlayInternalKeys {
           val f = docsAppClasspath.map(_.data).filter(_.getName.startsWith("play-docs")).head
           new JarFile(f)
         }
-        val sbtDocLink = {
-          val docLinkFactoryClass = docsLoader.loadClass("play.docs.SBTDocLinkFactory")
-          val factoryMethod = docLinkFactoryClass.getMethod("fromJar", classOf[JarFile], classOf[String])
-          factoryMethod.invoke(null, docsJarFile, "play/docs/content").asInstanceOf[SBTDocLink]
+        val sbtDocHandler = {
+          val docHandlerFactoryClass = docsLoader.loadClass("play.docs.SBTDocHandlerFactory")
+          val factoryMethod = docHandlerFactoryClass.getMethod("fromJar", classOf[JarFile], classOf[String])
+          factoryMethod.invoke(null, docsJarFile, "play/docs/content").asInstanceOf[SBTDocHandler]
         }
 
         val server = {
           val mainClass = applicationLoader.loadClass("play.core.server.NettyServer")
           if (httpPort.isDefined) {
-            val mainDev = mainClass.getMethod("mainDevHttpMode", classOf[SBTLink], classOf[SBTDocLink], classOf[Int])
-            mainDev.invoke(null, reloader, sbtDocLink, httpPort.get: java.lang.Integer).asInstanceOf[play.core.server.ServerWithStop]
+            val mainDev = mainClass.getMethod("mainDevHttpMode", classOf[SBTLink], classOf[SBTDocHandler], classOf[Int])
+            mainDev.invoke(null, reloader, sbtDocHandler, httpPort.get: java.lang.Integer).asInstanceOf[play.core.server.ServerWithStop]
           } else {
-            val mainDev = mainClass.getMethod("mainDevOnlyHttpsMode", classOf[SBTLink], classOf[SBTDocLink], classOf[Int])
-            mainDev.invoke(null, reloader, sbtDocLink, httpsPort.get: java.lang.Integer).asInstanceOf[play.core.server.ServerWithStop]
+            val mainDev = mainClass.getMethod("mainDevOnlyHttpsMode", classOf[SBTLink], classOf[SBTDocHandler], classOf[Int])
+            mainDev.invoke(null, reloader, sbtDocHandler, httpsPort.get: java.lang.Integer).asInstanceOf[play.core.server.ServerWithStop]
           }
         }
 


### PR DESCRIPTION
#1444 needed a little more polish before it was merged.
- Rename SBTDocLink -> SBTDocHandler
- Change DocumentationHandler to implement this interface.
- Change SBTDocLinkFactory to SBTDocHandlerFactory and have it return a DocumentationHandler directly.
