### PR TITLE
Improved plugins docs

### DIFF
--- a/framework/src/play/src/main/java/play/Plugin.java
+++ b/framework/src/play/src/main/java/play/Plugin.java
@@ -2,6 +2,20 @@ package play;
 
 /**
  * A Play plugin.
+ *
+ * A plugin must define a single argument constructor that accepts an {@link play.Application}, for example:
+ *
+ * <pre>
+ * public class MyPlugin extends Plugin {
+ *     private final Application app;
+ *     public MyPlugin(Application app) {
+ *         this.app = app;
+ *     }
+ *     public void onStart() {
+ *         Logger.info("Plugin started!");
+ *     }
+ * }
+ * </pre>
  */
 public class Plugin implements play.api.Plugin {
     

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -136,6 +136,11 @@ trait WithDefaultPlugins {
             val plugin = classloader.loadClass(className).getConstructor(classOf[play.Application]).newInstance(new play.Application(this)).asInstanceOf[Plugin]
             if (plugin.enabled) Some(plugin) else { Play.logger.warn("Plugin [" + className + "] is disabled"); None }
           } catch {
+            case e: java.lang.NoSuchMethodException =>
+              throw new PlayException("Cannot load plugin",
+                "Could not find an appropriate constructor to instantiate plugin [" + className +
+                  "]. All Play plugins must define a constructor that accepts a single argument either of type " +
+                  "play.Application for Java plugins or play.api.Application for Scala plugins.")
             case e: PlayException => throw e
             case e: VirtualMachineError => throw e
             case e: ThreadDeath => throw e

--- a/framework/src/play/src/main/scala/play/api/Plugins.scala
+++ b/framework/src/play/src/main/scala/play/api/Plugins.scala
@@ -1,13 +1,15 @@
 package play.api
 
-import play.api.mvc._
-
 /**
  * A Play plugin.
  *
- * You can define a Play plugin this way:
+ * A plugin must define a single argument constructor that accepts an [[play.api.Application]].  For example:
  * {{{
- * class MyPlugin(app: Application) extends Plugin
+ * class MyPlugin(app: Application) extends Plugin {
+ *   override def onStart() = {
+ *     Logger.info("Plugin started!")
+ *   }
+ * }
  * }}}
  *
  * The plugin class must be declared in a play.plugins file available in the classpath root:


### PR DESCRIPTION
Improved the plugins docs to make it clear that plugins must declare a single argument constructor that accepts an application, and improved the error message that is thrown when they don't.
