### PR TITLE
[2.1.x] Templates-Compiler project is missing a dependency on scala-compiler

### DIFF
--- a/framework/src/templates-compiler/src/main/scala/play/templates/ScalaTemplateCompiler.scala
+++ b/framework/src/templates-compiler/src/main/scala/play/templates/ScalaTemplateCompiler.scala
@@ -302,7 +302,7 @@ package play.templates {
       }
 
       def parentheses: Parser[String] = {
-        "(" ~ (several((parentheses | not(")") ~> any))) ~ commit(")") ^^ {
+        "(" ~ several(stringLiteral | parentheses | not(")") ~> any) ~ commit(")") ^^ {
           case p1 ~ charList ~ p2 => p1 + charList.mkString + p2
         }
       }

--- a/framework/src/templates-compiler/src/test/scala/TemplateParserSpec.scala
+++ b/framework/src/templates-compiler/src/test/scala/TemplateParserSpec.scala
@@ -20,10 +20,10 @@ object TemplateParserSpec extends Specification {
       parser.parser(get(templateName))
     }
 
-    def failAt(message: String, line: Int, column: Int): PartialFunction[parser.ParseResult[ScalaTemplateCompiler.Template], Boolean] = {
-      case parser.NoSuccess(msg, rest) => {
-        message == msg && rest.pos.line == line && rest.pos.column == column
-      }
+    def parseString(template: String) = parser.parser(new CharSequenceReader(template))
+
+    def parseStringSuccess(template: String) = parseString(template) must beLike {
+      case parser.Success(_, rest) if rest.atEnd => ok
     }
 
     "succeed for" in {
@@ -40,6 +40,10 @@ object TemplateParserSpec extends Specification {
         parse("complicated.scala.html") must beLike({ case parser.Success(_, rest) => if (rest.atEnd) ok else ko })
       }
 
+      "brackets in strings" in {
+        "open" in parseStringSuccess("""@foo("(")""")
+        "close" in parseStringSuccess("""@foo(")@")""")
+      }
     }
 
     "fail for" in {


### PR DESCRIPTION
While looking for a solution for Issue #1419 I tried to compile and test the Templates-Compiler project as follows:

```
$ sbt
$ project Templates-Compiler
$ test
```

Compilation failed because of missing `scala.tools.nsc` package. So it seems that `templatesCompilerDependencies` in `Build.scala` is missing the following dependency:

```
"org.scala-lang"                    %    "scala-compiler"           %   buildScalaVersion,
```
