### PR TITLE
Scala views generate invalid code for unmatched parenthesis inside a string

### DIFF
--- a/framework/src/templates-compiler/src/main/scala/play/templates/ScalaTemplateCompiler.scala
+++ b/framework/src/templates-compiler/src/main/scala/play/templates/ScalaTemplateCompiler.scala
@@ -302,7 +302,7 @@ package play.templates {
       }
 
       def parentheses: Parser[String] = {
-        "(" ~ (several((parentheses | not(")") ~> any))) ~ commit(")") ^^ {
+        "(" ~ several(stringLiteral | parentheses | not(")") ~> any) ~ commit(")") ^^ {
           case p1 ~ charList ~ p2 => p1 + charList.mkString + p2
         }
       }

--- a/framework/src/templates-compiler/src/test/scala/TemplateParserSpec.scala
+++ b/framework/src/templates-compiler/src/test/scala/TemplateParserSpec.scala
@@ -20,10 +20,10 @@ object TemplateParserSpec extends Specification {
       parser.parser(get(templateName))
     }
 
-    def failAt(message: String, line: Int, column: Int): PartialFunction[parser.ParseResult[ScalaTemplateCompiler.Template], Boolean] = {
-      case parser.NoSuccess(msg, rest) => {
-        message == msg && rest.pos.line == line && rest.pos.column == column
-      }
+    def parseString(template: String) = parser.parser(new CharSequenceReader(template))
+
+    def parseStringSuccess(template: String) = parseString(template) must beLike {
+      case parser.Success(_, rest) if rest.atEnd => ok
     }
 
     "succeed for" in {
@@ -40,6 +40,10 @@ object TemplateParserSpec extends Specification {
         parse("complicated.scala.html") must beLike({ case parser.Success(_, rest) => if (rest.atEnd) ok else ko })
       }
 
+      "brackets in strings" in {
+        "open" in parseStringSuccess("""@foo("(")""")
+        "close" in parseStringSuccess("""@foo(")@")""")
+      }
     }
 
     "fail for" in {


### PR DESCRIPTION
Play generates invalid Scala code when using unmatched parenthesis inside a string.

For example, this: `@Messages(")")` gives the following compilation error:
`')' expected but string literal found.`
While this works: `@Messages("()")`

Apparently, this is a long-standing bug:
https://groups.google.com/forum/#!topic/play-framework/kYm8b7CqruM
