### PR TITLE
Execute iteratee code on same thread

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Concurrent.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Concurrent.scala
@@ -217,7 +217,7 @@ object Concurrent {
   }
 
   /**
-   * Enumeratee that times out if the iteratee it feeds to takes to long to consume available input.
+   * Enumeratee that times out if the iteratee it feeds to takes too long to consume available input.
    *
    * @param timeout The timeout period
    * @param unit the time unit

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
@@ -126,9 +126,9 @@ object Enumeratee {
    */
   def zipWith[E, A, B, C](inner1: Iteratee[E, A], inner2: Iteratee[E, B])(zipper: (A, B) => C)(implicit ec: ExecutionContext): Iteratee[E, C] = {
     val pec = ec.prepare()
+    import Execution.Implicits.{ defaultExecutionContext => ec } // Shadow ec to make this the only implicit EC in scope
 
     def getNext(it1: Iteratee[E, A], it2: Iteratee[E, B]): Iteratee[E, C] = {
-      import ExecutionContext.Implicits.global
       val eventuallyIter =
         for (
           (a1, it1_) <- getInside(it1);
@@ -145,7 +145,6 @@ object Enumeratee {
     }
 
     def step(it1: Iteratee[E, A], it2: Iteratee[E, B])(in: Input[E]) = {
-      import ExecutionContext.Implicits.global
       Iteratee.flatten(
         for (
           it1_ <- it1.feed(in);

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
@@ -141,9 +141,9 @@ trait Enumerator[E] {
    */
   def flatMap[U](f: E => Enumerator[U])(implicit ec: ExecutionContext): Enumerator[U] = {
     val pec = ec.prepare()
+    import Execution.Implicits.{ defaultExecutionContext => ec } // Shadow ec to make this the only implicit EC in scope
     new Enumerator[U] {
       def apply[A](iteratee: Iteratee[U, A]): Future[Iteratee[U, A]] = {
-        import ExecutionContext.Implicits.global
         val folder = Iteratee.fold2[E, Iteratee[U, A]](iteratee) { (it, e) =>
           for {
             en <- Future(f(e))(pec)
@@ -202,7 +202,6 @@ object Enumerator {
   def interleave[E](es: Seq[Enumerator[E]]): Enumerator[E] = new Enumerator[E] {
 
     import scala.concurrent.stm._
-    import ExecutionContext.Implicits.global
 
     def apply[A](it: Iteratee[E, A]): Future[Iteratee[E, A]] = {
 
@@ -277,7 +276,6 @@ object Enumerator {
   def interleave[E1, E2 >: E1](e1: Enumerator[E1], e2: Enumerator[E2]): Enumerator[E2] = new Enumerator[E2] {
 
     import scala.concurrent.stm._
-    import ExecutionContext.Implicits.global
 
     def apply[A](it: Iteratee[E2, A]): Future[Iteratee[E2, A]] = {
 
@@ -537,7 +535,8 @@ object Enumerator {
    * @param input The input stream
    * @param chunkSize The size of chunks to read from the stream.
    */
-  def fromStream(input: java.io.InputStream, chunkSize: Int = 1024 * 8): Enumerator[Array[Byte]] = {
+  def fromStream(input: java.io.InputStream, chunkSize: Int = 1024 * 8)(implicit ec: ExecutionContext): Enumerator[Array[Byte]] = {
+    implicit val pec = ec.prepare()
     generateM({
       val buffer = new Array[Byte](chunkSize)
       val chunk = input.read(buffer) match {
@@ -548,7 +547,7 @@ object Enumerator {
           Some(input)
       }
       Future.successful(chunk)
-    })(dec).onDoneEnumerating(input.close)(dec)
+    })(pec).onDoneEnumerating(input.close)(pec)
   }
 
   /**
@@ -559,14 +558,14 @@ object Enumerator {
    * @param file The file to create the enumerator from.
    * @param chunkSize The size of chunks to read from the file.
    */
-  def fromFile(file: java.io.File, chunkSize: Int = 1024 * 8): Enumerator[Array[Byte]] = {
-    fromStream(new java.io.FileInputStream(file), chunkSize)
+  def fromFile(file: java.io.File, chunkSize: Int = 1024 * 8)(implicit ec: ExecutionContext): Enumerator[Array[Byte]] = {
+    fromStream(new java.io.FileInputStream(file), chunkSize)(ec)
   }
 
   /**
    * Create an Enumerator of bytes with an OutputStream.
    *
-   * Not that calls to write will not block, so if the iteratee that is being fed to is slow to consume the input, the
+   * Note that calls to write will not block, so if the iteratee that is being fed to is slow to consume the input, the
    * OutputStream will not push back.  This means it should not be used with large streams since there is a risk of
    * running out of memory.
    *
@@ -607,10 +606,17 @@ object Enumerator {
    *   val enumerator: Enumerator[String] = Enumerator("kiki", "foo", "bar")
    * }}}
    */
-  def apply[E](in: E*): Enumerator[E] = new Enumerator[E] {
-
-    def apply[A](i: Iteratee[E, A]): Future[Iteratee[E, A]] = enumerateSeq(in, i)
-
+  def apply[E](in: E*): Enumerator[E] = in.length match {
+    case 0 => Enumerator.empty
+    case 1 => new Enumerator[E] {
+      def apply[A](i: Iteratee[E, A]): Future[Iteratee[E, A]] = i.pureFoldNoEC {
+        case Step.Cont(k) => k(Input.El(in.head))
+        case _ => i
+      }
+    }
+    case _ => new Enumerator[E] {
+      def apply[A](i: Iteratee[E, A]): Future[Iteratee[E, A]] = enumerateSeq(in, i)
+    }
   }
 
   /**

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Execution.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Execution.scala
@@ -1,5 +1,7 @@
 package play.api.libs.iteratee
 
+import java.util.{ ArrayDeque, Deque }
+import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 
 /**
@@ -10,12 +12,66 @@ private[play] object Execution {
   def defaultExecutionContext: ExecutionContext = Implicits.defaultExecutionContext
 
   object Implicits {
-    implicit lazy val defaultExecutionContext: ExecutionContext = scala.concurrent.ExecutionContext.fromExecutor(null)
+    implicit def defaultExecutionContext: ExecutionContext = Execution.trampoline
+    implicit def trampoline: ExecutionContext = Execution.trampoline
   }
 
-  val sameThreadExecutionContext: ExecutionContext = new ExecutionContext {
-    def execute(runnable: Runnable): Unit = runnable.run()
+  /**
+   * Executes in the current thread. Uses a thread local trampoline to make sure the stack
+   * doesn't overflow. Since this ExecutionContext executes on the current thread, it should
+   * only be used to run small bits of fast-running code. We use it here to run the internal
+   * iteratee code.
+   *
+   * Blocking should be strictly avoided as it could hog the current thread.
+   * Also, since we're running on a single thread, blocking code risks deadlock.
+   */
+  val trampoline: ExecutionContext = new ExecutionContext {
+
+    private val local = new ThreadLocal[Deque[Runnable]]
+
+    def execute(runnable: Runnable): Unit = {
+      var queue = local.get()
+      if (queue == null) {
+        // Since there is no local queue, we need to install one and
+        // start our trampolining loop.
+        try {
+          queue = new ArrayDeque(4)
+          queue.addLast(runnable)
+          local.set(queue)
+          while (!queue.isEmpty) {
+            val runnable = queue.removeFirst()
+            runnable.run()
+          }
+        } finally {
+          // We've emptied the queue, so tidy up.
+          local.set(null)
+        }
+      } else {
+        // There's already a local queue that is being executed.
+        // Just stick our runnable on the end of that queue.
+        queue.addLast(runnable)
+      }
+    }
+
     def reportFailure(t: Throwable): Unit = t.printStackTrace()
+  }
+
+  /**
+   * Executes in the current thread. Calls Runnables directly so it is possible for the
+   * stack to overflow. To avoid overflow the `trampoline`
+   * can be used instead.
+   *
+   * Blocking should be strictly avoided as it could hog the current thread.
+   * Also, since we're running on a single thread, blocking code risks deadlock.
+   */
+  val overflowingExecutionContext: ExecutionContext = new ExecutionContext {
+
+    def execute(runnable: Runnable): Unit = {
+      runnable.run()
+    }
+
+    def reportFailure(t: Throwable): Unit = t.printStackTrace()
+
   }
 
 }

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/TraversableIteratee.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/TraversableIteratee.scala
@@ -35,7 +35,7 @@ object Traversable {
                 case (toPush, left) => Done(k(Input.El(toPush)), Input.El(left))
               }
               case _ => Done(inner, in)
-            }(ExecutionContext.global)
+            }
 
           case Input.EOF => Done(inner, Input.EOF)
 
@@ -59,9 +59,9 @@ object Traversable {
                 case Step.Done(_, _) => Cont(step(inner, (leftToTake - all.size)))
                 case Step.Cont(k) => Cont(step(k(Input.El(all)), (leftToTake - all.size)))
                 case Step.Error(_, _) => Cont(step(inner, (leftToTake - all.size)))
-              }(ExecutionContext.global)
+              }
               case (x, left) if x.isEmpty => Done(inner, Input.El(left))
-              case (toPush, left) => Done(inner.pureFlatFold { case Step.Cont(k) => k(Input.El(toPush)); case _ => inner }(ExecutionContext.global), Input.El(left))
+              case (toPush, left) => Done(inner.pureFlatFold { case Step.Cont(k) => k(Input.El(toPush)); case _ => inner }, Input.El(left))
             }
 
           case Input.EOF => Done(inner, Input.EOF)
@@ -121,7 +121,7 @@ object Traversable {
                 it.pureFlatFold {
                   case Step.Cont(k) => Enumeratee.passAlong.applyOn(k(toPass))
                   case _ => Done(it, toPass)
-                }(ExecutionContext.global)
+                }
             }
           case Input.Empty => Cont(step(it, leftToDrop))
 

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/package.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/package.scala
@@ -21,13 +21,19 @@ package play.api.libs.iteratee {
     /**
      * Executes code immediately on the current thread, returning a successful or failed Future depending on
      * the result.
+     *
+     * TODO: Rename to `tryFuture`.
      */
     def eagerFuture[A](body: => A): Future[A] = try Future.successful(body) catch { case NonFatal(e) => Future.failed(e) }
 
     /**
      * Executes code in the given ExecutionContext, flattening the resulting Future.
      */
-    def executeFuture[A](body: => Future[A])(implicit ec: ExecutionContext): Future[A] = Future(body)(ec).flatMap(identity)(Execution.sameThreadExecutionContext)
+    def executeFuture[A](body: => Future[A])(implicit ec: ExecutionContext): Future[A] = {
+      Future {
+        body
+      }(ec /* Future.apply will prepare */ ).flatMap(identityFunc.asInstanceOf[Future[A] => Future[A]])(Execution.overflowingExecutionContext)
+    }
 
     /**
      * Executes code in the given ExecutionContext, flattening the resulting Iteratee.
@@ -47,5 +53,7 @@ package play.api.libs.iteratee {
       val pec = ec.prepare()
       f(pec)
     }
+
+    val identityFunc: (Any => Any) = (x: Any) => x
   }
 }

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/ExecutionSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/ExecutionSpec.scala
@@ -1,0 +1,75 @@
+package play.api.libs.iteratee
+
+import scala.language.reflectiveCalls
+
+import org.specs2.mutable._
+import java.io.OutputStream
+import java.util.concurrent.{ CountDownLatch, TimeUnit }
+import scala.concurrent.{ ExecutionContext, Promise, Future, Await }
+import scala.concurrent.duration.{ Duration, SECONDS }
+import scala.util.{ Failure, Success, Try }
+
+object ExecutionSpec extends Specification {
+  import Execution.{ trampoline, overflowingExecutionContext }
+
+  val waitTime = Duration(5, SECONDS)
+
+  "trampoline" should {
+
+    "execute code in the same thread" in {
+      val f = Future(Thread.currentThread())(trampoline)
+      Await.result(f, waitTime) must equalTo(Thread.currentThread())
+    }
+
+    "not overflow the stack" in {
+      def executeRecursively(ec: ExecutionContext, times: Int) {
+        if (times > 0) {
+          ec.execute(new Runnable {
+            def run() = executeRecursively(ec, times - 1)
+          })
+        }
+      }
+
+      // Work out how deep to go to cause an overflow
+      var overflowTimes = 1 << 10
+      try {
+        while (overflowTimes > 0) {
+          executeRecursively(overflowingExecutionContext, overflowTimes)
+          overflowTimes = overflowTimes << 1
+        }
+        sys.error("Can't get the stack to overflow")
+      } catch {
+        case _: StackOverflowError => ()
+      }
+
+      // Now verify that we don't overflow
+      Try(executeRecursively(trampoline, overflowTimes)) must beSuccessfulTry[Unit]
+    }
+
+    "execute code in the order it was submitted" in {
+      val runRecord = scala.collection.mutable.Buffer.empty[Int]
+      case class TestRunnable(id: Int, children: Runnable*) extends Runnable {
+        def run() = {
+          runRecord += id
+          for (c <- children) trampoline.execute(c)
+        }
+      }
+
+      trampoline.execute(
+        TestRunnable(0,
+          TestRunnable(1),
+          TestRunnable(2,
+            TestRunnable(4,
+              TestRunnable(6),
+              TestRunnable(7)),
+            TestRunnable(5,
+              TestRunnable(8))),
+          TestRunnable(3))
+      )
+
+      runRecord must equalTo(0 to 8)
+    }
+
+  }
+
+}

--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -15,6 +15,8 @@ import org.joda.time.DateTimeZone
 import collection.JavaConverters._
 import scala.util.control.NonFatal
 
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
 /**
  * Controller that serves static resources.
  *


### PR DESCRIPTION
Most iteratee code is configured to run in the default iteratee ExecutionContext—currently a ForkJoinPool. For trivial code, which take a small and bounded amount of time we can run them in an ExecutionContext that executes on the same thread.

But we need be careful we don't do anything too expensive when executing on the same thread, as we don't own the thread. We should also avoid executing code that could result in a stack overflow.
