### PR TITLE
Remove note about incrementalAssetsCompilation

### DIFF
--- a/documentation/manual/detailledTopics/assets/Assets.md
+++ b/documentation/manual/detailledTopics/assets/Assets.md
@@ -126,11 +126,6 @@ Usually, using Etag is enough to have proper caching. However if you want to spe
 
 By default play compiles all managed assets that are kept in the ```app/assets``` folder. The compilation process will clean and recompile all managed assets regardless of the change. This is the safest strategy since tracking dependencies can be very tricky with front end technologies. 
 
->Note if you are dealing with a lot of managed assets this strategy can be very slow. For this reason there is a way to recompile only the change file and its supposed dependencies. You can turn on this experimental feature by adding the following to your settings:
-```
-incrementalAssetsCompilation := true
-```
-
 You will learn more about managed assets on the next few pages.
 
 


### PR DESCRIPTION
Remove the note about using incrementalAssetsCompilation flag for Assets. The flag no
longer exists.

CLA signed.
