### PR TITLE
Exclude junit-dep as it is deprecated

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -107,7 +107,7 @@ object Dependencies {
     specsBuild % "test",
 
     "org.mockito" % "mockito-all" % "1.9.5" % "test",
-    "com.novocode" % "junit-interface" % "0.10" % "test",
+    "com.novocode" % "junit-interface" % "0.10" % "test" exclude("junit", "junit-dep"),
 
     ("org.fluentlenium" % "fluentlenium-festassert" % "0.9.0" % "test")
       .exclude("org.jboss.netty", "netty")
@@ -190,7 +190,7 @@ object Dependencies {
   val testDependencies = Seq(
     "junit" % "junit" % "4.11",
     specsBuild,
-    "com.novocode" % "junit-interface" % "0.10",
+    "com.novocode" % "junit-interface" % "0.10" exclude("junit", "junit-dep"),
     guava,
     findBugs,
     ("org.fluentlenium" % "fluentlenium-festassert" % "0.8.0")

--- a/framework/src/play/src/test/scala/play/core/server/ServerBenchmark.scala
+++ b/framework/src/play/src/test/scala/play/core/server/ServerBenchmark.scala
@@ -35,7 +35,7 @@ class ServerBenchmark {
   @Test
   @PerfTest(threads = 1, duration = 35000, warmUp = 30000)
   def makeHelloWordRequest() {
-    for (i <- 1 until 100) {
+    for (i <- 1 to 100) {
       val f = withDefaultUpstreamHandler(SimpleRequest)
       Await.ready(f, 2 seconds)
     }


### PR DESCRIPTION
Excluding junit-dep from junit-interface as it is deprecated by the JUnit project. JUnit 4.11 now brings in a minimal number of dependencies.

This change also supplies a fix to the reason why pt:test had stopped working. pt:test requires JUnit 4.11.
