### PR TITLE
Fixed Akka logging config

### DIFF
--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -4,11 +4,11 @@
 promise.akka.actor.typed.timeout=5s
 
 play {
-    
+
     akka {
-        event-handlers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jEventHandler"]
+        loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
         loglevel = WARNING
-        
+
         actor {
             retrieveBodyParserTimeout = 1 second
 
@@ -18,9 +18,9 @@ play {
                     parallelism-max = 24
                 }
             }
-            
+
         }
-        
+
     }
-    
-}   
+
+}


### PR DESCRIPTION
In Akka 2.2 'event-handlers' is a deprecated config.
