### PR TITLE
Fixed typo in migration guide for Play 2.2

### DIFF
--- a/documentation/manual/Migration22.md
+++ b/documentation/manual/Migration22.md
@@ -138,7 +138,7 @@ The signature of the `call` method in `play.mvc.Action` has changed to now retur
 Iteratees, enumeratees and enumerators that execute application supplied code now require an implicit execution context.  For example:
 
 ```scala
-import play.api.libs.concurrent.Exceution.Implicits._
+import play.api.libs.concurrent.Execution.Implicits._
 
 Iteratee.foreach[String] { msg =>
   println(msg)


### PR DESCRIPTION
Simple fix in Play 2.2 migration guide
