### PR TITLE
Clean up PlayWS documentation for 2.2

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,0 +1,77 @@
+# Build documentation
+
+This is the Play documentation project.  It does not build with the rest of the Play document, and has its own sbt
+project.
+
+## Dependencies
+
+This project depends on [play-doc](http://github.com/playframework/play-doc].  If you want to tweak the format or change the includes, you should do so there.
+
+## Output
+
+The output from this project is pushed to [play-doc](http://github.com/playframework/play-generated-docs], and eventually appears on http://www.playframework.com/documentation/2.2-SNAPSHOT/Home
+(depending on the Play version).
+
+## Existing Docs
+
+All the documentation is under the /manual folder, and is in [Markdown](http://daringfireball.net/projects/markdown/syntax) format with an extension that looks like this
+
+    @[label](some/relative/path)
+
+Code snippets are identified using the hash symbol prepended to the label, like this:
+
+    //#label
+    println("Hello world")
+    //#label
+
+As an example, if you open up `main/akka/JavaAkka.md` then you'll see:
+
+    @[actor-for](code/javaguide/akka/JavaAkka.java)
+
+which refers to the code snippet in the file code/javaguide/JavaAkka.java (note it is relative to the akka directory):
+
+    //#actor-for
+    ActorRef myActor = Akka.system().actorOf(new Props(MyActor.class));
+    //#actor-for
+
+And this code snippet is included in the generated documentation.
+
+## Code
+
+Any directory under /manual called "code" is treated as a root of a test directory.  You can put configuration files, Java files, or Scala files in there.  Source files do not have to be part of a test suite, but it is highly encouraged to ensure that all included code snippets both compile and pass.
+
+## IDE integration
+
+There is no out of the box integration, but you can use the [sbt-idea](https://github.com/mpeltonen/sbt-idea) plugin or the [Eclipse](https://github.com/typesafehub/sbteclipse) plugin to generate a project for you.
+
+NOTE: if you use sbt-idea, the generated project defines "com.typesafe.play" and other libraries as "runtime" and so does not expose the included libraries to the IDE.  Setting them to "test" manually makes everything work.
+
+## Testing
+
+You can run the test suite for the documentation using:
+
+```
+./build
+> test
+```
+
+## Packaging
+
+```
+./build package
+```
+
+## Publishing
+
+```
+./build publish-local
+```
+
+## Running
+
+You can run a built-in documentation server.  This will give you quick access to the documentation without having
+to build everything.  It is available at http://localhost:9000 by default.
+
+```
+./build run
+```

--- a/documentation/manual/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/javaGuide/main/ws/JavaWS.md
@@ -2,85 +2,47 @@
 
 Sometimes you want to call other HTTP services from within a Play application. Play supports this via its `play.libs.WS` library, which provides a way to make asynchronous HTTP calls.
 
-A call made by `play.libs.WS` should return a `Promise<Ws.Response>`, which you can handle later with Play’s asynchronous mechanisms.
+A call made by `play.libs.WS` should return a `Promise<WS.Response>`, which you can handle later with Play’s asynchronous mechanisms.
+
+## Imports
+
+To use WS, first import the following packages:
+
+@[ws-imports](code/javaguide/ws/JavaWS.java)
 
 ## Making HTTP calls
 
 To make an HTTP request, you start with `WS.url()` to specify the URL. Then you get a builder that you can use to specify HTTP options, such as setting headers. You end by calling a method corresponding to the HTTP method you want to use:
 
-```
-Promise<WS.Response> homePage = WS.url("http://mysite.com").get();
-```
+@[get-call](code/javaguide/ws/JavaWS.java)
 
 Alternatively:
 
-```
-Promise<WS.Response> result = WS.url("http://localhost:9001").post("content");
-```
+@[post-call](code/javaguide/ws/JavaWS.java)
+
+## Recovery
+
+If you want to recover from an error in the call transparently, you can use `recover` to substitute a response:
+
+@[get-call-and-recover](code/javaguide/ws/JavaWS.java)
 
 ## Retrieving the HTTP response result
 
 The call is made asynchronously and you need to manipulate it as a `Promise<WS.Response>` to get the actual content. You can compose several promises and end up with a `Promise<Result>` that can be handled directly by the Play server:
 
-```
-import play.libs.F.Function;
-import play.libs.WS;
-import play.mvc.*;
+@[simple-call](code/javaguide/ws/JavaWS.java)
 
-public class Controller extends Controller {
-
-  public static Result feedTitle(String feedUrl) {
-    return async(
-      WS.url(feedUrl).get().map(
-        new Function<WS.Response, Result>() {
-          public Result apply(WS.Response response) {
-            return ok("Feed title:" + response.asJson().findPath("title"));
-          }
-        }
-      )
-    );
-  }
-  
-}
-```
 
 ## Composing results
 
 If you want to make multiple calls in sequence, this can be achieved using `flatMap`:
 
-```
-  public static Result feedComments(String feedUrl) {
-    return async(
-      WS.url(feedUrl).get().flatMap(
-        new Function<WS.Response, Promise<Result>>() {
-          public Promise<Result> apply(WS.Response response) {
-            return WS.url(response.asJson().findPath("commentsUrl").get().map(
-              new Function<WS.Response, Result>() {
-                public Result apply(WS.Response response) {
-                  return ok("Number of comments: " + response.asJson().findPath("count"));
-                }
-              }
-            );
-          }
-        }
-      )
-    );
-  }
-```
+@[composed-call](code/javaguide/ws/JavaWS.java)
 
 ## Configuring the HTTP client
 
 The HTTP client can be configured globally in `application.conf` via a few properties:
 
-```
-# Follow redirects (default true)
-ws.followRedirects=true
-# Connection timeout in ms (default 120000)
-ws.timeout=120000
-# Whether to use http.proxy* JVM system properties (default true)
-ws.useProxyProperties=true
-# A user agent string to set on each request (default none)
-ws.useragent="My Play Application"
-```
+@[application](code/javaguide/ws/application.conf)
 
 > **Next:** [[Integrating with Akka | JavaAkka]]

--- a/documentation/manual/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -1,0 +1,76 @@
+package javaguide.ws;
+
+import javaguide.testhelpers.MockJavaAction;
+
+// #ws-imports
+import play.libs.WS;
+import play.mvc.Result;
+
+import static play.libs.F.Function;
+import static play.libs.F.Promise;
+// #ws-imports
+
+public class JavaWS {
+    private static String feedUrl = "http://localhost:3333/feed";
+
+    public static class Controller1 extends MockJavaAction {
+
+        public static void getCallAndRecover() {
+            final int timeout = 5000;
+            // #get-call
+            Promise<WS.Response> homePage = WS.url("http://example.com").get();
+            // #get-call
+            // #get-call-and-recover
+            Promise<WS.Response> callWithRecover = homePage.recover(new Function<Throwable, WS.Response>() {
+                @Override
+                public WS.Response apply(Throwable throwable) throws Throwable {
+                    return WS.url("http://backup.example.com").get().get(timeout);
+                }
+            });
+            // #get-call-and-recover
+        }
+
+        public static void postCall() {
+            // #post-call
+            Promise<WS.Response> result = WS.url("http://example.com").post("content");
+            // #post-call
+        }
+
+        // #simple-call
+        public static Promise<Result> index() {
+            final Promise<Result> resultPromise = WS.url(feedUrl).get().map(
+                    new Function<WS.Response, Result>() {
+                        public Result apply(WS.Response response) {
+                            return ok("Feed title:" + response.asJson().findPath("title"));
+                        }
+                    }
+            );
+            return resultPromise;
+        }
+        // #simple-call
+    }
+
+    public static class Controller2 extends MockJavaAction {
+
+        // #composed-call
+        public static Promise<Result> index() {
+            final Promise<Result> resultPromise = WS.url(feedUrl).get().flatMap(
+                    new Function<WS.Response, Promise<Result>>() {
+                        public Promise<Result> apply(WS.Response response) {
+                            return WS.url(response.asJson().findPath("commentsUrl").asText()).get().map(
+                                    new Function<WS.Response, Result>() {
+                                        public Result apply(WS.Response response) {
+                                            return ok("Number of comments: " + response.asJson().findPath("count").asInt());
+                                        }
+                                    }
+                            );
+                        }
+                    }
+            );
+            return resultPromise;
+        }
+        // #composed-call
+    }
+
+
+}

--- a/documentation/manual/javaGuide/main/ws/code/javaguide/ws/JavaWSSpec.scala
+++ b/documentation/manual/javaGuide/main/ws/code/javaguide/ws/JavaWSSpec.scala
@@ -1,0 +1,55 @@
+package javaguide.ws
+
+import org.specs2.mutable._
+import play.api.test._
+
+import play.api.mvc._
+import play.api.libs.json._
+
+import play.api.test.Helpers._
+
+import play.api.test.FakeApplication
+import play.api.libs.json.JsObject
+
+object JavaWSSpec extends Specification with Results {
+  // It's much easier to test this in Scala because we need to set up a
+  // fake application with routes.
+
+  val fakeApplication = FakeApplication(withRoutes = {
+    case ("GET", "/feed") =>
+      Action {
+        val obj: JsObject = Json.obj(
+          "title" -> "foo",
+          "commentsUrl" -> "http://localhost:3333/comments"
+        )
+        Ok(obj)
+      }
+    case ("GET", "/comments") =>
+         Action {
+           val obj: JsObject = Json.obj(
+             "count" -> "10"
+           )
+           Ok(obj)
+         }
+    case (_, _) =>
+      Action {
+        BadRequest("no binding found")
+      }
+  })
+
+  "The Java WS class" should {
+    "call WS correctly" in new WithServer(app = fakeApplication, port = 3333) {
+      val result= JavaWS.Controller1.index().get(5000).getWrappedResult
+
+      status(result) must equalTo(OK)
+    }
+
+    "compose WS calls successfully" in new WithServer(app = fakeApplication, port = 3333) {
+      val result = JavaWS.Controller2.index().get(5000).getWrappedResult
+
+      status(result) must equalTo(OK)
+      contentAsString(result) must beEqualTo("Number of comments: 10")
+    }
+  }
+
+}

--- a/documentation/manual/javaGuide/main/ws/code/javaguide/ws/application.conf
+++ b/documentation/manual/javaGuide/main/ws/code/javaguide/ws/application.conf
@@ -1,0 +1,10 @@
+# #application
+# Follow redirects (default true)
+ws.followRedirects=true
+# Connection timeout in ms (default 120000)
+ws.timeout=120000
+# Whether to use http.proxy* JVM system properties (default true)
+ws.useProxyProperties=true
+# A user agent string to set on each request (default none)
+ws.useragent="My Play Application"
+# #application


### PR DESCRIPTION
The documentation for PlayWS @ http://www.playframework.com/documentation/2.2-SNAPSHOT/JavaWS uses old style async and has inline code examples.

It'd be nice to break this out into external referenced code examples and tests, and make it use "modern style" async calls.
