### PR TITLE
Throw a better exception when user tries to set null cookie value

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -518,7 +518,10 @@ package play.api.mvc {
      * @param kv the key-value pair to add
      * @return the modified session
      */
-    def +(kv: (String, String)) = copy(data + kv)
+    def +(kv: (String, String)) = {
+      require(kv._2 != null, "Cookie values cannot be null")
+      copy(data + kv)
+    }
 
     /**
      * Removes any value from the session.
@@ -586,7 +589,10 @@ package play.api.mvc {
      * @param kv the key-value pair to add
      * @return the modified flash scope
      */
-    def +(kv: (String, String)) = copy(data + kv)
+    def +(kv: (String, String)) = {
+      require(kv._2 != null, "Cookie values cannot be null")
+      copy(data + kv)
+    }
 
     /**
      * Removes a value from the flash scope.

--- a/framework/src/play/src/test/scala/play/api/mvc/FlashCookieSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/FlashCookieSpec.scala
@@ -88,5 +88,9 @@ object FlashCookieSpec extends Specification {
       val m = Flash.decode(es)
       m.size must_== 0
     }
+    "put disallows null values" in {
+      val c = Flash(Map("foo" -> "bar"))
+      c + (("x", null)) must throwA(new IllegalArgumentException("requirement failed: Cookie values cannot be null"))
+    }
   }
 }


### PR DESCRIPTION
null values are typically allowed in Java maps so it is confusing that they are not allowed here, but no error is given to indicate that
