### PR TITLE
Use a mutable structure during JSON deserialization of arrays and objects

### DIFF
--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonPerformanceTest.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonPerformanceTest.scala
@@ -23,6 +23,14 @@ object JsonPerformanceTest extends App {
   println("Deserialization run 2: " + testDeserialization() + "ms")
   println("Deserialization run 3: " + testDeserialization() + "ms")
 
+  println("Large Array Deserialization run 1: " + testLargeArrayDeserialization() + "ms")
+  println("Large Array Deserialization run 2: " + testLargeArrayDeserialization() + "ms")
+  println("Large Array Deserialization run 3: " + testLargeArrayDeserialization() + "ms")
+  
+  println("Large Object Deserialization run 1: " + testLargeObjectDeserialization() + "ms")
+  println("Large Object Deserialization run 2: " + testLargeObjectDeserialization() + "ms")
+  println("Large Object Deserialization run 3: " + testLargeObjectDeserialization() + "ms")
+  
   lazy val jsvalue = Json.obj(
     "f1" -> Json.obj(
       "f1" -> "string",
@@ -54,6 +62,16 @@ object JsonPerformanceTest extends App {
 
   lazy val json = Json.stringify(jsvalue)
 
+  lazy val largeArrayJsValue = Json.obj(
+    "f1" -> Json.toJson((1 to 65536))
+  )
+
+  lazy val largeArrayJson = Json.stringify(largeArrayJsValue)
+
+  lazy val largeObjectJsValue = (1 to 8192).map(i => Json.obj("f" + i -> "obj")).reduce(_++_)
+
+  lazy val largeObjectJson = Json.stringify(largeObjectJsValue)
+
   def testSerialization(times: Int = 10000000, threads: Int = 100): Long = {
     runTest(times, threads) {
       Json.stringify(jsvalue)
@@ -63,6 +81,18 @@ object JsonPerformanceTest extends App {
   def testDeserialization(times: Int = 1000000, threads: Int = 100): Long = {
     runTest(times, threads) {
       Json.parse(json)
+    }
+  }
+
+  def testLargeArrayDeserialization(times: Int = 100, threads: Int = 10): Long = {
+    runTest(times, threads) {
+      Json.parse(largeArrayJson)
+    }
+  }
+
+  def testLargeObjectDeserialization(times: Int = 100, threads: Int = 100): Long = {
+    runTest(times, threads) {
+      Json.parse(largeObjectJson)
     }
   }
 
@@ -90,3 +120,5 @@ object JsonPerformanceTest extends App {
   }
 
 }
+
+


### PR DESCRIPTION
This pull request changes the deserialization process within JsValue to use a mutable structure internally during deserialization.  The current immutable process does not offer adequate performance when deserializing very large arrays or objects.

This implementation does not leak mutable state outside the deserialization process: once done, the ListBuffer is converted back to an immutable structure.

Performance tests are also provided.
