### PR TITLE
Added gzip filter

### DIFF
--- a/documentation/manual/Highlights22.md
+++ b/documentation/manual/Highlights22.md
@@ -47,3 +47,7 @@ The _stage_ and _dist_ tasks have been completely overhauled in order to use the
 The benefit in using the Native Packager is that many types of archive can now be supported in addition to regular zip files e.g. tar.gz, RPM, OS X disk images, Microsoft Installers (MSI) and more. In addition a Windows batch script is now provided for Play as well as a Unix one.
 
 More information can be found in the [[Creating a standalone version of your application|ProductionDist]] document.
+
+## Built in gzip support
+
+Play now has built in support for gzipping all responses.  For information on how to enable this, see [[Configuring gzip encoding|GzipEncoding]]

--- a/documentation/manual/detailledTopics/configuration/GzipEncoding.md
+++ b/documentation/manual/detailledTopics/configuration/GzipEncoding.md
@@ -1,0 +1,21 @@
+# Configuring gzip encoding
+
+Play provides a gzip filter that can be used to gzip responses.  It can be added to the applications filters using the `Global` object.
+
+## Enabling gzip in Scala
+
+The simplest way to enable the gzip filter in a Scala project is to use the `WithFilters` helper:
+
+@[global](code/GzipEncoding.scala)
+
+To control which responses are and aren't implemented, use the `shouldGzip` parameter, which accepts a function of a request header and a response header to a boolean.
+
+For example, the code below only gzips HTML responses:
+
+@[should-gzip](code/GzipEncoding.scala)
+
+## Enabling GZIP in Java
+
+To enable gzip in Java, add it to the list of filters in the `Global` object:
+
+@[global](code/detailedtopics/configuration/gzipencoding/Global.java)

--- a/documentation/manual/detailledTopics/configuration/_Sidebar.md
+++ b/documentation/manual/detailledTopics/configuration/_Sidebar.md
@@ -4,6 +4,7 @@
 - [[Configuring the JDBC connection pool | SettingsJDBC]]
 - [[Configuring Play's thread pools | ThreadPools]]
 - [[Configuring logging | SettingsLogger]]
+- [[Configuring gzip encoding|GzipEncoding]]
 
 ### Getting started
 

--- a/documentation/manual/detailledTopics/configuration/code/GzipEncoding.scala
+++ b/documentation/manual/detailledTopics/configuration/code/GzipEncoding.scala
@@ -1,0 +1,57 @@
+package detailedtopics.configuration.gzipencoding
+
+import play.api.test._
+import play.filters.gzip.GzipFilter
+import play.api.templates.Html
+import play.api.mvc.Results
+import play.core.j.JavaGlobalSettingsAdapter
+
+object GzipEncoding extends PlaySpecification {
+
+  "gzip filter" should {
+    "be possible to configure in play" in {
+      //#global
+      import play.api._
+      import play.api.mvc._
+      import play.filters.gzip.GzipFilter
+
+      object Global extends WithFilters(new GzipFilter()) with GlobalSettings {
+        // onStart, onStop etc...
+      }
+      //#global
+
+      running(FakeApplication()) {
+        header(CONTENT_ENCODING,
+          Global.doFilter(Action(Results.Ok))(gzipRequest).run
+        ) must beSome("gzip")
+      }
+    }
+
+    "allow custom strategies for when to gzip" in {
+      val filter =
+        //#should-gzip
+        new GzipFilter(shouldGzip = (request, response) =>
+          response.headers.get("Content-Type").exists(_.startsWith("text/html")))
+        //#should-gzip
+
+      import play.api.mvc._
+      running(FakeApplication()) {
+        header(CONTENT_ENCODING,
+          filter(Action(Results.Ok("foo")))(gzipRequest).run
+        ) must beNone
+      }
+    }
+
+    "be possible to configure in a play java project" in {
+      import play.api.mvc._
+      running(FakeApplication()) {
+        val global = new JavaGlobalSettingsAdapter(new Global())
+        header(CONTENT_ENCODING,
+          global.doFilter(Action(Results.Ok))(gzipRequest).run
+        ) must beSome("gzip")
+      }
+    }
+  }
+
+  def gzipRequest = FakeRequest().withHeaders(ACCEPT_ENCODING -> "gzip")
+}

--- a/documentation/manual/detailledTopics/configuration/code/detailedtopics/configuration/gzipencoding/Global.java
+++ b/documentation/manual/detailledTopics/configuration/code/detailedtopics/configuration/gzipencoding/Global.java
@@ -1,0 +1,13 @@
+package detailedtopics.configuration.gzipencoding;
+
+//#global
+import play.GlobalSettings;
+import play.api.mvc.EssentialFilter;
+import play.filters.gzip.GzipFilter;
+
+public class Global extends GlobalSettings {
+    public <T extends EssentialFilter> Class<T>[] filters() {
+        return new Class[]{GzipFilter.class};
+    }
+}
+//#global

--- a/documentation/project/Build.scala
+++ b/documentation/project/Build.scala
@@ -5,7 +5,6 @@ import sbt.Keys._
 import play.Keys._
 import play.core.{ SBTDocHandler, SBTLink, PlayVersion }
 import play.PlaySourceGenerators._
-import scala.Some
 
 object ApplicationBuild extends Build {
 

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Concurrent.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Concurrent.scala
@@ -773,4 +773,66 @@ object Concurrent {
 
     }
   }
+
+  /**
+   * Create a joined iteratee enumerator pair.
+   *
+   * When the enumerator is applied to an iteratee, the iteratee subsequently consumes whatever the iteratee in the pair
+   * is applied to.  Consequently the enumerator is "one shot", applying it to subsequent iteratees will throw an
+   * exception.
+   */
+  def joined[A]: (Iteratee[A, Unit], Enumerator[A]) = {
+    val promisedIteratee = Promise[Iteratee[A, Unit]]()
+    val enumerator = new Enumerator[A] {
+      def apply[B](i: Iteratee[A, B]) = {
+        val doneIteratee = Promise[Iteratee[A, B]]()
+
+        // Equivalent to map, but allows us to handle failures
+        def wrap(delegate: Iteratee[A, B]): Iteratee[A, B] = new Iteratee[A, B] {
+          def fold[C](folder: (Step[A, B]) => Future[C])(implicit ec: ExecutionContext) = {
+            val toReturn = delegate.fold {
+              case done @ Step.Done(a, in) => {
+                doneIteratee.success(done.it)
+                folder(done)
+              }
+              case Step.Cont(k) => {
+                folder(Step.Cont(k.andThen(wrap)))
+              }
+              case err => folder(err)
+            }(ec)
+            toReturn.onFailure {
+              case e => doneIteratee.failure(e)
+            }(dec)
+            toReturn
+          }
+        }
+
+        if (promisedIteratee.trySuccess(wrap(i).map(_ => ())(dec))) {
+          doneIteratee.future
+        } else {
+          throw new IllegalStateException("Joined enumerator may only be applied once")
+        }
+      }
+    }
+    (Iteratee.flatten(promisedIteratee.future), enumerator)
+  }
+
+  /**
+   * Run the enumerator, and produce the remaining enumerator as part the result.
+   *
+   * The result will be the result of the iteratee, and an enumerator containing the remaining input.
+   */
+  def runPartial[E, A](enumerator: Enumerator[E], iteratee: Iteratee[E, A]): Future[(A, Enumerator[E])] = {
+    val result = Promise[(A, Enumerator[E])]()
+
+    (enumerator |>>> iteratee.flatMap { a =>
+      val (consumeRemaining, remaining) = Concurrent.joined[E]
+      result.success((a, remaining))
+      consumeRemaining
+    }(dec)).onFailure {
+      case e => result.tryFailure(e)
+    }(dec)
+
+    result.future
+  }
 }

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/ConcurrentSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/ConcurrentSpec.scala
@@ -204,6 +204,46 @@ object ConcurrentSpec extends Specification
       }
     }
   }
-  
 
+  "Concurrent.joined" should {
+    "join the iteratee and enumerator if the enumerator is applied first" in {
+      val (iteratee, enumerator) = Concurrent.joined[String]
+      val result = enumerator |>>> Iteratee.getChunks[String]
+      val unitResult = Enumerator("foo", "bar") |>>> iteratee
+      await(result) must_== Seq("foo", "bar")
+      await(unitResult) must_== ()
+    }
+    "join the iteratee and enumerator if the iteratee is applied first" in {
+      val (iteratee, enumerator) = Concurrent.joined[String]
+      val unitResult = Enumerator("foo", "bar") |>>> iteratee
+      val result = enumerator |>>> Iteratee.getChunks[String]
+      await(result) must_== Seq("foo", "bar")
+      await(unitResult) must_== ()
+    }
+    "join the iteratee and enumerator if the enumerator is applied during the iteratees run" in {
+      val (iteratee, enumerator) = Concurrent.joined[String]
+      val (broadcast, channel) = Concurrent.broadcast[String]
+      val unitResult = broadcast |>>> iteratee
+      channel.push("foo")
+      Thread.sleep(10)
+      val result = enumerator |>>> Iteratee.getChunks[String]
+      channel.push("bar")
+      channel.end()
+      await(result) must_== Seq("foo", "bar")
+      await(unitResult) must_== ()
+    }
+  }
+
+  "Concurrent.runPartial" should {
+    "redeem the iteratee with the result and the partial enumerator" in {
+      val (a, remaining) = await(Concurrent.runPartial(Enumerator("foo", "bar"), Iteratee.head[String]))
+      a must beSome("foo")
+      await(remaining |>>> Iteratee.getChunks[String]) must_== Seq("bar")
+    }
+    "work when there is no input left in the enumerator" in {
+      val (a, remaining) = await(Concurrent.runPartial(Enumerator("foo", "bar"), Iteratee.getChunks[String]))
+      a must_== Seq("foo", "bar")
+      await(remaining |>>> Iteratee.getChunks[String]) must_== Nil
+    }
+  }
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/Gzip.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/Gzip.scala
@@ -1,0 +1,396 @@
+package play.filters.gzip
+
+import play.api.libs.iteratee._
+import play.api.libs.iteratee.Enumeratee.CheckDone
+import java.util.zip._
+import play.api.libs.concurrent.Execution.Implicits._
+
+/**
+ * Enumeratees for dealing with gzip streams
+ */
+object Gzip {
+  private type Bytes = Array[Byte]
+  private type CheckDoneBytes = CheckDone[Bytes, Bytes]
+  private val GzipMagic = 0x8b1f
+  // Gzip flags
+  private val HeaderCrc = 2
+  private val ExtraField = 4
+  private val FileName = 8
+  private val FileComment = 16
+
+  /**
+   * Create a gzip enumeratee.
+   *
+   * This enumeratee is not purely functional, it uses the high performance native deflate implementation provided by
+   * Java, which is stateful.  However, this state is created each time the enumeratee is applied, so it is fine to
+   * reuse the enumeratee returned by this function.
+   *
+   * @param bufferSize The size of the output buffer
+   */
+  def gzip(bufferSize: Int = 512): Enumeratee[Array[Byte], Array[Byte]] = {
+
+    /*
+     * State consists of 4 parts, a deflater (high performance native zlib implementation), a crc32 calculator, required
+     * by gzip to be at the end of the stream, a buffer in which we accumulate the compressed bytes, and the current
+     * position of that buffer.
+     */
+    class State {
+      val deflater = new Deflater(Deflater.DEFAULT_COMPRESSION, true)
+      val crc = new CRC32
+      @volatile var buffer = new Bytes(bufferSize)
+      @volatile var pos = 0
+
+      def reset() {
+        pos = 0
+        buffer = new Bytes(bufferSize)
+      }
+    }
+
+    new CheckDoneBytes {
+
+      def step[A](state: State, k: K[Bytes, A]): K[Bytes, Iteratee[Bytes, A]] = {
+        case Input.EOF => {
+          state.deflater.finish()
+          deflateUntilFinished(state, k)
+        }
+
+        case Input.El(bytes) => {
+          state.crc.update(bytes)
+          state.deflater.setInput(bytes)
+          deflateUntilNeedsInput(state, k)
+        }
+
+        case in @ Input.Empty => feedEmpty(state, k)
+      }
+
+      def continue[A](k: K[Bytes, A]) = {
+        feedHeader(k).pureFlatFold {
+          case Step.Cont(k2) => Cont(step(new State, k2))
+          case step => Done(step.it, Input.Empty)
+        }
+      }
+
+      def deflateUntilNeedsInput[A](state: State, k: K[Bytes, A]): Iteratee[Bytes, Iteratee[Bytes, A]] = {
+        // Deflate some bytes
+        val numBytes = state.deflater.deflate(state.buffer, state.pos, bufferSize - state.pos)
+        if (numBytes == 0) {
+          if (state.deflater.needsInput()) {
+            // Deflater needs more input, so continue
+            Cont(step(state, k))
+          } else {
+            deflateUntilNeedsInput(state, k)
+          }
+        } else {
+          state.pos += numBytes
+          if (state.pos < bufferSize) {
+            deflateUntilNeedsInput(state, k)
+          } else {
+            // We've filled our buffer, feed it into the k function
+            val buffer = state.buffer
+            state.reset()
+            new CheckDoneBytes {
+              def continue[B](k: K[Bytes, B]) = deflateUntilNeedsInput(state, k)
+            } &> k(Input.El(buffer))
+          }
+        }
+      }
+
+      def deflateUntilFinished[A](state: State, k: K[Bytes, A]): Iteratee[Bytes, Iteratee[Bytes, A]] = {
+        val numBytes = state.deflater.deflate(state.buffer, state.pos, bufferSize - state.pos)
+        if (numBytes == 0) {
+          if (state.deflater.finished()) {
+            // Deflater is finished, send the trailer
+            feedTrailer(state, k)
+          } else {
+            deflateUntilFinished(state, k)
+          }
+        } else {
+          state.pos += numBytes
+          if (state.pos < bufferSize) {
+            deflateUntilFinished(state, k)
+          } else {
+            val buffer = state.buffer
+            state.reset()
+            new CheckDoneBytes {
+              def continue[B](k: K[Bytes, B]) = deflateUntilFinished(state, k)
+            } &> k(Input.El(buffer))
+          }
+        }
+      }
+
+      def feedEmpty[A](state: State, k: K[Bytes, A]) = new CheckDoneBytes {
+        def continue[B](k: K[Bytes, B]) = Cont(step(state, k))
+      } &> k(Input.Empty)
+
+      def feedHeader[A](k: K[Bytes, A]) = {
+        // First need to write the Gzip header
+        val zero = 0.asInstanceOf[Byte]
+        val header = Array(
+          GzipMagic.asInstanceOf[Byte], // Magic number (2 bytes)
+          (GzipMagic >> 8).asInstanceOf[Byte],
+          Deflater.DEFLATED.asInstanceOf[Byte], // Compression method
+          zero, // Flags
+          zero, // Modification time (4 bytes)
+          zero,
+          zero,
+          zero,
+          zero, // Extra flags
+          zero // Operating system
+        )
+        k(Input.El(header))
+      }
+
+      def feedTrailer[A](state: State, k: K[Bytes, A]): Iteratee[Bytes, Iteratee[Bytes, A]] = {
+        def writeTrailer(buffer: Bytes, pos: Int) {
+          val crc = state.crc.getValue
+          val length = state.deflater.getTotalIn
+          state.deflater.end()
+          // CRC followed by length, little endian
+          intToLittleEndian(crc.asInstanceOf[Int], buffer, pos)
+          intToLittleEndian(length, buffer, pos + 4)
+        }
+
+        // Try to just append to the existing buffer if there's enough room
+        val finalIn = if (state.pos + 8 <= bufferSize) {
+          writeTrailer(state.buffer, state.pos)
+          state.pos = state.pos + 8
+          val buffer = if (state.pos == bufferSize) state.buffer else state.buffer.take(state.pos)
+          Seq(buffer)
+        } else {
+          // Create a new buffer for the trailer
+          val buffer = if (state.pos == bufferSize) state.buffer else state.buffer.take(state.pos)
+          val trailer = new Bytes(8)
+          writeTrailer(trailer, 0)
+          Seq(buffer, trailer)
+        }
+        Iteratee.flatten(Enumerator.enumerate(finalIn) >>> Enumerator.eof |>> Cont(k)).map(it => Done(it, Input.EOF))
+      }
+    }
+  }
+
+  /**
+   * Create a gunzip enumeratee.
+   *
+   * This enumeratee is not purely functional, it uses the high performance native deflate implementation provided by
+   * Java, which is stateful.  However, this state is created each time the enumeratee is applied, so it is fine to
+   * reuse the enumeratee returned by this function.
+   *
+   * @param bufferSize The size of the output buffer
+   */
+  def gunzip(bufferSize: Int = 512): Enumeratee[Array[Byte], Array[Byte]] = {
+
+    /*
+     * State consists of 4 parts, an inflater (high performance native zlib implementation), a crc32 calculator, required
+     * by gzip to be at the end of the stream, a buffer in which we accumulate the compressed bytes, and the current
+     * position of that buffer.
+     */
+    class State {
+      val inflater = new Inflater(true)
+      val crc = new CRC32
+      @volatile var buffer = new Bytes(bufferSize)
+      @volatile var pos = 0
+
+      def reset() {
+        pos = 0
+        buffer = new Bytes(bufferSize)
+      }
+    }
+
+    case class Header(magic: Short, compressionMethod: Byte, flags: Byte) {
+      def hasCrc = (flags & HeaderCrc) == HeaderCrc
+      def hasExtraField = (flags & ExtraField) == ExtraField
+      def hasFilename = (flags & FileName) == FileName
+      def hasComment = (flags & FileComment) == FileComment
+    }
+
+    new CheckDoneBytes {
+
+      def step[A](state: State, k: K[Bytes, A]): K[Bytes, Iteratee[Bytes, A]] = {
+        case Input.EOF => {
+          Error("Premature end of gzip stream", Input.EOF)
+        }
+
+        case Input.El(bytes) => {
+          state.inflater.setInput(bytes)
+          inflateUntilNeedsInput(state, k, bytes)
+        }
+
+        case in @ Input.Empty => feedEmpty(state, k)
+      }
+
+      def continue[A](k: K[Bytes, A]) = {
+        for {
+          state <- readHeader
+          step <- Cont(step(state, k))
+        } yield step
+      }
+
+      def maybeEmpty(bytes: Bytes) = if (bytes.isEmpty) Input.Empty else Input.El(bytes)
+
+      def inflateUntilNeedsInput[A](state: State, k: K[Bytes, A], input: Bytes): Iteratee[Bytes, Iteratee[Bytes, A]] = {
+        // Inflate some bytes
+        val numBytes = state.inflater.inflate(state.buffer, state.pos, bufferSize - state.pos)
+        if (numBytes == 0) {
+          if (state.inflater.finished()) {
+            // Feed the current buffer
+            val buffer = if (state.buffer.length > state.pos) {
+              state.buffer.take(state.pos)
+            } else {
+              state.buffer
+            }
+            state.crc.update(buffer)
+            new CheckDoneBytes {
+              def continue[B](k: K[Bytes, B]) = finish(state, k, input)
+            } &> k(Input.El(buffer))
+
+          } else if (state.inflater.needsInput()) {
+            // Inflater needs more input, so continue
+            Cont(step(state, k))
+          } else {
+            inflateUntilNeedsInput(state, k, input)
+          }
+        } else {
+          state.pos += numBytes
+          if (state.pos < bufferSize) {
+            inflateUntilNeedsInput(state, k, input)
+          } else {
+            // We've filled our buffer, feed it into the k function
+            val buffer = state.buffer
+            state.crc.update(buffer)
+            state.reset()
+            new CheckDoneBytes {
+              def continue[B](k: K[Bytes, B]) = inflateUntilNeedsInput(state, k, input)
+            } &> k(Input.El(buffer))
+          }
+        }
+      }
+
+      def feedEmpty[A](state: State, k: K[Bytes, A]) = new CheckDoneBytes {
+        def continue[B](k: K[Bytes, B]) = Cont(step(state, k))
+      } &> k(Input.Empty)
+
+      def done[A](a: A = Unit): Iteratee[Bytes, A] = Done[Bytes, A](a)
+
+      def finish[A](state: State, k: K[Bytes, A], input: Bytes): Iteratee[Bytes, Iteratee[Bytes, A]] = {
+        // Get the left over bytes from the inflater
+        val leftOver = if (input.length > state.inflater.getRemaining) {
+          Done(Unit, Input.El(input.takeRight(state.inflater.getRemaining)))
+        } else {
+          done()
+        }
+
+        // Read the trailer, before sending an EOF
+        for {
+          _ <- leftOver
+          _ <- readTrailer(state)
+          done <- Done(k(Input.EOF), Input.EOF)
+        } yield done
+      }
+
+      def readHeader: Iteratee[Bytes, State] = {
+        // Parse header
+        val crc = new CRC32
+        for {
+          headerBytes <- take(10, "Not enough bytes for gzip file", crc)
+          header <- done(Header(littleEndianToShort(headerBytes), headerBytes(2), headerBytes(3)))
+          _ <- if (header.magic != GzipMagic.asInstanceOf[Short]) Error("Not a gzip file, found header" + headerBytes.take(2).map(b => "%02X".format(b)).mkString("(", ", ", ")"), Input.El(headerBytes)) else done()
+          _ <- if (header.compressionMethod != Deflater.DEFLATED) Error("Unsupported compression method", Input.El(headerBytes)) else done()
+          efLength <- if (header.hasExtraField) readShort(crc) else done(0)
+          _ <- if (header.hasExtraField) drop(efLength, "Not enough bytes for extra field", crc) else done()
+          _ <- if (header.hasFilename) dropWhile(_ != 0x00, "EOF found in middle of file name", crc) else done()
+          _ <- if (header.hasComment) dropWhile(_ != 0x00, "EOF found in middle of comment", crc) else done()
+          headerCrc <- if (header.hasCrc) readShort(new CRC32) else done(0)
+          _ <- if (header.hasCrc && (crc.getValue & 0xffff) != headerCrc) Error[Bytes]("Header CRC failed", Input.Empty) else done()
+        } yield new State()
+      }
+
+      /**
+       * Read and validate the trailer.  Returns a done iteratee if the trailer is valid, or error if not.
+       */
+      def readTrailer(state: State): Iteratee[Bytes, Unit] = {
+        val dummy = new CRC32
+        for {
+          crc <- readInt("Premature EOF before gzip CRC", dummy)
+          _ <- if (crc != state.crc.getValue.asInstanceOf[Int]) Error("CRC failed, was %X, expected %X".format(state.crc.getValue.asInstanceOf[Int], crc), Input.El(intToLittleEndian(crc))) else done()
+          length <- readInt("Premature EOF before gzip total length", dummy)
+          _ <- if (length != state.inflater.getTotalOut) Error("Length check failed", Input.El(intToLittleEndian(length))) else done()
+        } yield {
+          state.inflater.end()
+          done()
+        }
+      }
+
+      def readShort(crc: CRC32): Iteratee[Bytes, Int] = for {
+        bytes <- take(2, "Not enough bytes for extra field length", crc)
+      } yield {
+        littleEndianToShort(bytes)
+      }
+
+      def readInt(error: String, crc: CRC32): Iteratee[Bytes, Int] = for {
+        bytes <- take(4, error, crc)
+      } yield {
+        littleEndianToInt(bytes)
+      }
+
+      def take(n: Int, error: String, crc: CRC32, bytes: Bytes = new Bytes(0)): Iteratee[Bytes, Bytes] = Cont {
+        case Input.EOF => Error(error, Input.EOF)
+        case Input.Empty => take(n, error, crc, bytes)
+        case Input.El(b) => {
+          val splitted = b.splitAt(n)
+          crc.update(splitted._1)
+          splitted match {
+            case (needed, left) if needed.length == n => Done(bytes ++ needed, maybeEmpty(left))
+            case (partial, _) => take(n - partial.length, error, crc, bytes ++ partial)
+          }
+        }
+      }
+
+      def drop(n: Int, error: String, crc: CRC32): Iteratee[Bytes, Unit] = Cont {
+        case Input.EOF => Error(error, Input.EOF)
+        case Input.Empty => drop(n, error, crc)
+        case Input.El(b) => if (b.length >= n) {
+          val splitted = b.splitAt(n)
+          crc.update(splitted._1)
+          Done(Unit, maybeEmpty(splitted._2))
+        } else {
+          crc.update(b)
+          drop(b.length - n, error, crc)
+        }
+      }
+
+      def dropWhile(p: Byte => Boolean, error: String, crc: CRC32): Iteratee[Bytes, Unit] = Cont {
+        case Input.EOF => Error(error, Input.EOF)
+        case Input.Empty => dropWhile(p, error, crc)
+        case Input.El(b) => {
+          val dropped = b.dropWhile(p)
+          crc.update(b, 0, b.length - dropped.length)
+          dropped match {
+            case all if all.length == b.length => dropWhile(p, error, crc)
+            case left if left.isEmpty => Done(Unit, Input.Empty)
+            case left => Done(Unit, Input.El(left))
+          }
+        }
+      }
+    }
+  }
+
+  private def intToLittleEndian(i: Int, out: Bytes = new Bytes(4), offset: Int = 0): Bytes = {
+    out(offset) = (i & 0xff).asInstanceOf[Byte]
+    out(offset + 1) = (i >> 8 & 0xff).asInstanceOf[Byte]
+    out(offset + 2) = (i >> 16 & 0xff).asInstanceOf[Byte]
+    out(offset + 3) = (i >> 24 & 0xff).asInstanceOf[Byte]
+    out
+  }
+
+  private def littleEndianToShort(bytes: Bytes, offset: Int = 0): Short = {
+    ((bytes(offset + 1) & 0xff) << 8 | bytes(offset) & 0xff).asInstanceOf[Short]
+  }
+
+  private def littleEndianToInt(bytes: Bytes, offset: Int = 0): Int = {
+    (bytes(offset + 3) & 0xff) << 24 |
+      (bytes(offset + 2) & 0xff) << 16 |
+      (bytes(offset + 1) & 0xff) << 8 |
+      (bytes(offset) & 0xff)
+  }
+}
+

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -1,0 +1,186 @@
+package play.filters.gzip
+
+import play.api.libs.iteratee._
+import play.api.mvc._
+import scala.concurrent.Future
+import play.api.mvc.SimpleResult
+import play.api.mvc.ResponseHeader
+import org.jboss.netty.handler.codec.http.HttpHeaders.Names
+import play.api.http.{ Status, MimeTypes }
+import play.api.libs.concurrent.Execution.Implicits._
+
+/**
+ * A gzip filter.
+ *
+ * This filter may gzip the responses for any requests that aren't HEAD requests and specify an accept encoding of gzip.
+ *
+ * It will only gzip non chunked responses.  Chunked responses are often comet responses, gzipping will interfere in
+ * that case.  If you want to gzip a chunked response, you can apply the gzip enumeratee manually to the enumerator.
+ *
+ * For non chunked responses, it won't gzip under the following conditions:
+ *
+ * - The response code is 204 or 304 (these codes MUST NOT contain a body, and an empty gzipped response is 20 bytes
+ * long)
+ * - The response already defines a Content-Encoding header
+ * - The response content type is text/event-stream
+ * - A custom shouldGzip function is supplied and it returns false
+ *
+ * Since gzipping changes the content length of the response, this filter may do some buffering.  If a content length
+ * is sent by the action, that content length is filtered out and ignored.  If the connection flag on the result is
+ * Close, the filter will not attempt to buffer, and will simply rely on the closing the response to signify the end
+ * of the response.  Otherwise, it will buffer up to the configured chunkedThreshold, which defaults to 100kb.  If the
+ * response fits in that buffer, the filter will send the content length, otherwise it falls back to sending a chunked
+ * response, or if the protocol is HTTP/1.0, it closes the connection at the end of the response.
+ *
+ * You can use this filter in your project simply by including it in the Global filters, like this:
+ *
+ * {{{
+ * object Global extends WithFilters(new GzipFilter()) {
+ *   ...
+ * }
+ * }}}
+ *
+ * @param gzip The gzip enumeratee to use.
+ * @param chunkedThreshold The content length threshold, after which the filter will switch to chunking the result.
+ * @param shouldGzip Whether the given request/result should be gzipped.  This can be used, for example, to implement
+ *                   black/white lists for gzipping by content type.
+ */
+class GzipFilter(gzip: Enumeratee[Array[Byte], Array[Byte]] = Gzip.gzip(GzipFilter.DefaultChunkSize),
+    chunkedThreshold: Int = GzipFilter.DefaultChunkedThreshold,
+    shouldGzip: (RequestHeader, ResponseHeader) => Boolean = (_, _) => true) extends EssentialFilter {
+
+  import play.api.http.HeaderNames._
+  import play.api.http.HttpProtocol._
+
+  /**
+   * Allows use with a custom chunked threshold from Java
+   */
+  def this(chunkedThreshold: Int) = this(Gzip.gzip(GzipFilter.DefaultChunkSize), chunkedThreshold, (_, _) => true)
+
+  /**
+   * This allows it to be used from Java
+   */
+  def this() = this(GzipFilter.DefaultChunkedThreshold)
+
+  def apply(next: EssentialAction) = new EssentialAction {
+    def apply(request: RequestHeader) = {
+      if (mayCompress(request)) {
+        next(request).mapM(result => handleResult(request, result))
+      } else {
+        next(request)
+      }
+    }
+  }
+
+  private def handleResult(request: RequestHeader, result: SimpleResult): Future[SimpleResult] = {
+    if (shouldCompress(result.header) && shouldGzip(request, result.header)) {
+      // If connection is close, don't bother buffering it, we can send it without a content length
+      if (result.connection == HttpConnection.Close) {
+        Future.successful(SimpleResult(
+          header = result.header.copy(headers = setupHeader(result.header.headers)),
+          body = result.body &> gzip,
+          connection = result.connection
+        ))
+      } else {
+
+        // Attempt to buffer it
+        // left means we didn't buffer the whole thing before reaching the threshold, and contains the chunks that we did buffer
+        // right means we did buffer it before reaching the threshold, and contains the chunks and the length of data
+        def buffer(chunks: List[Array[Byte]], count: Int): Iteratee[Array[Byte], Either[List[Array[Byte]], (List[Array[Byte]], Int)]] = {
+          Cont {
+            case Input.EOF => Done(Right((chunks.reverse, count)))
+            // If we have 10 or less bytes already, then we have so far only seen the gzip header
+            case Input.El(data) if count <= GzipFilter.GzipHeaderLength || count + data.length < chunkedThreshold =>
+              buffer(data :: chunks, count + data.length)
+            case Input.El(data) => Done(Left((data :: chunks).reverse))
+            case Input.Empty => buffer(chunks, count)
+          }
+        }
+
+        // Run the enumerator partially (means we get an enumerator that contains the rest of the input)
+        Concurrent.runPartial(result.body &> gzip, buffer(Nil, 0)).map {
+          // We successfully buffered the whole thing, so we have a content length
+          case (Right((chunks, contentLength)), _) =>
+            SimpleResult(
+              header = result.header.copy(headers = setupHeader(result.header.headers)
+                + (CONTENT_LENGTH -> Integer.toString(contentLength))),
+              body = Enumerator.enumerate(chunks),
+              connection = result.connection
+            )
+          // We still had some input remaining
+          case (Left(chunks), remaining) => {
+            if (request.version == HTTP_1_0) {
+              // Don't chunk for HTTP/1.0
+              SimpleResult(
+                header = result.header.copy(headers = setupHeader(result.header.headers)),
+                body = Enumerator.enumerate(chunks) >>> remaining,
+                connection = HttpConnection.Close
+              )
+            } else {
+              // Otherwise chunk
+              SimpleResult(
+                header = result.header.copy(headers = setupHeader(result.header.headers)
+                  + (TRANSFER_ENCODING -> CHUNKED)),
+                body = (Enumerator.enumerate(chunks) >>> remaining) &> Results.chunk,
+                connection = result.connection
+              )
+            }
+          }
+        }
+      }
+    } else {
+      Future.successful(result)
+    }
+  }
+
+  /**
+   * Whether this request may be compressed.
+   */
+  private def mayCompress(request: RequestHeader) = request.method != "HEAD" &&
+    request.headers.get(Names.ACCEPT_ENCODING).flatMap(_.split(',').find(_ == "gzip")).isDefined
+
+  /**
+   * Whether this response should be compressed.  Responses that may not contain content won't be compressed, nor will
+   * responses that already define a content encoding, server sent event responses will not be compressed, and chunked
+   * responses won't be compressed.
+   */
+  private def shouldCompress(header: ResponseHeader) = isAllowedContent(header) &&
+    isNotAlreadyCompressed(header) &&
+    isNotServerSentEvents(header) &&
+    isNotChunked(header)
+
+  /**
+   * We don't compress chunked responses because this is often used for comet events, and because we would have to
+   * dechunk them first if we did.
+   */
+  private def isNotChunked(header: ResponseHeader) = !header.headers.get(TRANSFER_ENCODING).exists(_ == CHUNKED)
+
+  /**
+   * We don't compress server sent events because these must be pushed immediately, and compressing buffers.
+   */
+  private def isNotServerSentEvents(header: ResponseHeader) = !header.headers.get(CONTENT_TYPE).exists(_ == MimeTypes.EVENT_STREAM)
+
+  /**
+   * Certain response codes are forbidden by the HTTP spec to contain content, but a gzipped response always contains
+   * a minimum of 20 bytes, even for empty responses.
+   */
+  private def isAllowedContent(header: ResponseHeader) = header.status != Status.NO_CONTENT && header.status != Status.NOT_MODIFIED
+
+  /**
+   * Of course, we don't want to double compress responses
+   */
+  private def isNotAlreadyCompressed(header: ResponseHeader) = header.headers.get(Names.CONTENT_ENCODING).isEmpty
+
+  private def setupHeader(header: Map[String, String]): Map[String, String] = {
+    header.filter(_._1 == Names.CONTENT_LENGTH) + (Names.CONTENT_ENCODING -> "gzip") + (Names.VARY -> Names.ACCEPT_ENCODING)
+  }
+}
+
+object GzipFilter {
+  /** Default threshold before chunking happens is 100kb */
+  private val DefaultChunkedThreshold = 102400
+  /** The default buffer for gzip chunk size to use, 8kb matches plays default chunking size when streaming */
+  private val DefaultChunkSize = 8192
+  /** The GZIP header length */
+  private val GzipHeaderLength = 10
+}

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -1,0 +1,104 @@
+package play.filters.gzip
+
+import play.api.test._
+import play.api.mvc.{ResponseHeader, Action, SimpleResult}
+import play.api.mvc.Results._
+import java.util.zip.GZIPInputStream
+import java.io.ByteArrayInputStream
+import org.apache.commons.io.IOUtils
+import scala.concurrent.Future
+import play.api.libs.iteratee.{Iteratee, Enumeratee, Enumerator}
+import scala.concurrent.ExecutionContext.Implicits._
+import scala.util.Random
+
+object GzipFilterSpec extends PlaySpecification {
+
+  sequential
+
+  "The GzipFilter" should {
+
+    "gzip responses" in withApplication(Ok("hello")) {
+      checkGzippedBody(makeGzipRequest, "hello")
+    }
+
+    "not gzip responses when not requested" in withApplication(Ok("hello")) {
+      checkNotGzipped(route(FakeRequest()).get, "hello")
+    }
+
+    "not gzip HEAD requests" in withApplication(Ok) {
+      checkNotGzipped(route(FakeRequest("HEAD", "/").withHeaders(ACCEPT_ENCODING -> "gzip")).get, "")
+    }
+
+    "not gzip no content responses" in withApplication(NoContent) {
+      checkNotGzipped(makeGzipRequest, "")
+    }
+
+    "not gzip not modified responses" in withApplication(NotModified) {
+      checkNotGzipped(makeGzipRequest, "")
+    }
+
+    "not gzip chunked responses" in withApplication(Ok.chunked(Enumerator("foo", "bar"))) {
+      val result = makeGzipRequest
+      header(CONTENT_ENCODING, result) must beNone
+      header(CONTENT_LENGTH, result) must beNone
+      header(TRANSFER_ENCODING, result) must beSome("chunked")
+      new String(await(await(result).body &> dechunk |>>> Iteratee.consume[Array[Byte]]()), "UTF-8") must_== "foobar"
+    }
+
+    "not gzip event stream responses" in withApplication(Ok.feed(Enumerator("foo", "bar")).as("text/event-stream")) {
+      checkNotGzipped(makeGzipRequest, "foobar")
+    }
+
+    "filter content length headers" in withApplication(Ok("hello").withHeaders(CONTENT_LENGTH -> Integer.toString(328974))) {
+      checkGzippedBody(makeGzipRequest, "hello")
+    }
+
+    val body = Random.nextString(1000)
+
+    "not buffer more than the configured threshold" in withApplication(Ok(body)) {
+      val result = makeGzipRequest
+      checkGzipped(result)
+      header(CONTENT_LENGTH, result) must beNone
+      header(TRANSFER_ENCODING, result) must beSome("chunked")
+      gunzip(await(await(result).body &> dechunk |>>> Iteratee.consume[Array[Byte]]())) must_== body
+    }
+
+    "buffer the first chunk even if it exceeds the threshold" in withApplication(Ok("foobarblah"), 15) {
+      checkGzippedBody(makeGzipRequest, "foobarblah")
+    }
+  }
+
+  def withApplication[T](result: SimpleResult, buffer: Int = 1024)(block: => T): T = {
+    running(FakeApplication(withRoutes = {
+      case _ => new GzipFilter(gzip = Gzip.gzip(512), chunkedThreshold = buffer).apply(Action(result))
+    }))(block)
+  }
+
+  def gzipRequest = FakeRequest().withHeaders(ACCEPT_ENCODING -> "gzip")
+
+  def makeGzipRequest = route(gzipRequest).get
+
+  def gunzip(bytes: Array[Byte]): String = {
+    val is = new GZIPInputStream(new ByteArrayInputStream(bytes))
+    val result = IOUtils.toString(is)
+    is.close()
+    result
+  }
+
+  def checkGzipped(result: Future[SimpleResult]) = {
+    header(CONTENT_ENCODING, result) must beSome("gzip")
+  }
+
+  def checkGzippedBody(result: Future[SimpleResult], body: String) = {
+    checkGzipped(result)
+    val resultBody = contentAsBytes(result)
+    header(CONTENT_LENGTH, result) must beSome(Integer.toString(resultBody.length))
+    gunzip(resultBody) must_== body
+  }
+
+  def checkNotGzipped(result: Future[SimpleResult], body: String) = {
+    header(CONTENT_ENCODING, result) must beNone
+    contentAsString(result) must_== body
+  }
+
+}

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipSpec.scala
@@ -1,0 +1,110 @@
+package play.filters.gzip
+
+import concurrent.Await
+import play.api.libs.iteratee.{Iteratee, Enumeratee, Enumerator}
+import concurrent.duration.Duration
+import org.specs2.mutable.Specification
+import scala.concurrent.ExecutionContext.Implicits._
+
+object GzipSpec extends Specification {
+
+  "gzip" should {
+
+    /**
+     * Uses both Java's GZIPOutputStream and GZIPInputStream to verify correctness.
+     */
+    def test(values: String*) = {
+      import java.io._
+      import java.util.zip._
+
+      val valuesBytes = values.map(_.getBytes("utf-8"))
+
+      val result: Array[Byte] = Await.result(Enumerator.enumerate(valuesBytes) &> Gzip.gzip() |>>> Iteratee.consume[Array[Byte]](), Duration.Inf)
+
+      // Check that it exactly matches the gzip output stream
+      val baos = new ByteArrayOutputStream()
+      val os = new GZIPOutputStream(baos)
+      valuesBytes.foreach(bytes => os.write(bytes))
+      os.close()
+      val baosResult = baos.toByteArray
+
+      for (i <- 0 until result.length) {
+        if (result(i) != baosResult(i)) {
+          result(i) must_== baosResult(i)
+        }
+      }
+
+      result must_== baos.toByteArray
+
+      // Check that it can be unzipped
+      val bais = new ByteArrayInputStream(result)
+      val is = new GZIPInputStream(bais)
+      val check: Array[Byte] = Await.result(Enumerator.fromStream(is) |>>> Iteratee.consume[Array[Byte]](), Duration.Inf)
+      values.mkString("") must_== new String(check, "utf-8")
+    }
+
+    "gzip simple input" in {
+      test("Hello world")
+    }
+
+    "gzip multiple inputs" in {
+      test("Hello", " ", "world")
+    }
+
+    "gzip large repeating input" in {
+      val bigString = Seq.fill(1000)("Hello world").mkString("")
+      test(bigString)
+    }
+
+    "gzip multiple large repeating inputs" in {
+      val bigString = Seq.fill(1000)("Hello world").mkString("")
+      test(bigString, bigString, bigString)
+    }
+
+    "gzip large random input" in {
+      test(scala.util.Random.nextString(10000))
+    }
+
+    "gzip multiple large random inputs" in {
+      test(scala.util.Random.nextString(10000),
+        scala.util.Random.nextString(10000),
+        scala.util.Random.nextString(10000))
+    }
+  }
+
+  "gunzip" should {
+
+    /**
+     * Uses the gzip enumeratee to verify correctness.
+     */
+    def test(value: String, gunzip: Enumeratee[Array[Byte], Array[Byte]] = Gzip.gunzip(), gzip: Enumeratee[Array[Byte], Array[Byte]] = Gzip.gzip()) = {
+      val future = Enumerator(value.getBytes("utf-8")) &> gzip &> gunzip |>>> Iteratee.consume[Array[Byte]]()
+      val result = new String(Await.result(future, Duration.Inf), "utf-8")
+      result must_== value
+    }
+
+    "gunzip simple input" in {
+      test("Hello world")
+    }
+
+    "gunzip simple input in small chunks" in {
+      test("Hello world", gzip = Gzip.gzip(5))
+    }
+
+    "gunzip large repeating input" in {
+      test(Seq.fill(1000)("Hello world").mkString(""))
+    }
+
+    "gunzip large repeating input in small chunks" in {
+      test(Seq.fill(1000)("Hello world").mkString(""), gzip = Gzip.gzip(10))
+    }
+
+    "gunzip large random input" in {
+      test(scala.util.Random.nextString(10000))
+    }
+
+    "gunzip large random input in small chunks" in {
+      test(scala.util.Random.nextString(10000), gzip = Gzip.gzip(10))
+    }
+  }
+}

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -364,6 +364,7 @@ trait ResultExtractors {
 object Helpers extends PlayRunners
   with HeaderNames
   with Status
+  with HttpProtocol
   with DefaultAwaitTimeout
   with ResultExtractors
   with Writeables

--- a/framework/src/play-test/src/main/scala/play/api/test/PlaySpecification.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/PlaySpecification.scala
@@ -2,7 +2,7 @@ package play.api.test
 
 import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
-import play.api.http.{ Status, HeaderNames }
+import play.api.http.{ HttpProtocol, Status, HeaderNames }
 
 /**
  * Play specs2 specification.
@@ -15,6 +15,7 @@ trait PlaySpecification extends Specification
     with PlayRunners
     with HeaderNames
     with Status
+    with HttpProtocol
     with DefaultAwaitTimeout
     with ResultExtractors
     with Writeables

--- a/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
@@ -242,7 +242,6 @@ trait HeaderNames {
   val TE = "Te"
   val TRAILER = "Trailer"
   val TRANSFER_ENCODING = "Transfer-Encoding"
-  val CHUNKED = "chunked"
 
   val UPGRADE = "Upgrade"
   val USER_AGENT = "User-Agent"
@@ -268,4 +267,21 @@ trait HeaderNames {
   val ORIGIN = "Origin"
   val ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method"
   val ACCESS_CONTROL_REQUEST_HEADERS = "Access-Control-Request-Headers"
+}
+
+/**
+ * Defines HTTP protocol constants
+ */
+object HttpProtocol extends HttpProtocol
+
+/**
+ * Defines HTTP protocol constants
+ */
+trait HttpProtocol {
+  // Versions
+  val HTTP_1_0 = "HTTP/1.0"
+  val HTTP_1_1 = "HTTP/1.1"
+
+  // Other HTTP protocol values
+  val CHUNKED = "chunked"
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
@@ -18,7 +18,7 @@ import play.api.Play
  * }
  * }}}
  */
-trait Controller extends Results with BodyParsers with Status with HeaderNames with ContentTypes with RequestExtractors with Rendering {
+trait Controller extends Results with BodyParsers with HttpProtocol with Status with HeaderNames with ContentTypes with RequestExtractors with Rendering {
 
   /**
    * Provides an empty `Action` implementation: the result is a standard ‘Not implemented yet’ result page.

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -3,6 +3,7 @@ package play.api.mvc
 import play.api.libs.iteratee._
 import play.api.http._
 import play.api.http.HeaderNames._
+import play.api.http.HttpProtocol._
 import play.api.{ Application, Play }
 import play.api.i18n.Lang
 
@@ -648,7 +649,6 @@ object Results extends Results {
 trait Results {
 
   import play.api.http.Status._
-  import play.api.http.HeaderNames._
 
   /**
    * Generates default `SimpleResult` from a content type, headers and content.


### PR DESCRIPTION
- Added gzip/gunzip enumeratees, with tests
- Added gzip filter, with tests
- Added two new iteratee concurrent facilities, a joined iteratee/enumerator, and a partial run of an enumerator that returns a future with the iteratee result and an enumerator that links up to the enumerators remaining input.  With tests.
- Documented how to use the gzip filter in Scala and Java, and added it to the 2.2 highlights.
