### PR TITLE
Improved migration from 2.0.x to 2.1.x through adding some additional information

### DIFF
--- a/documentation/manual/Migration21.md
+++ b/documentation/manual/Migration21.md
@@ -61,7 +61,7 @@ object ApplicationBuild extends Build {
     val appVersion      = "1.0"
 
     val appDependencies = Seq(
-       javaCore, javaJdbc, javaEbean
+       javaCore, javaJdbc, javaEbean,
        "extern_app" %% "information" % "version_number",
        "extern_app2" %% "information" % "version_number"
     )
@@ -73,7 +73,7 @@ object ApplicationBuild extends Build {
 }
 ```
 
-The `mainLang` parameter for the project is not required anymore. The main language is determined based on the dependencies added to the project. If dependencies contains `javaCore` then the language is set to `JAVA` otherwise `SCALA`.Notice the modularized dependencies in the `appDependencies` section. Furthermore you have to add a comma after every dependency, also the extern ones, where it wasn't required in **play 2.0.x**.
+The `mainLang` parameter for the project is not required anymore. The main language is determined based on the dependencies added to the project. If dependencies contains `javaCore` then the language is set to `JAVA` otherwise `SCALA`.Notice the modularized dependencies in the `appDependencies` section.
 
 ## play.mvc.Controller.form() renamed to play.data.Form.form()
 


### PR DESCRIPTION
I added the information that the new form import has to be static and you need now a comma after every app dependency
