### PR TITLE
Allowed JAVA_HOME to be set from the command line

### DIFF
--- a/framework/build
+++ b/framework/build
@@ -4,10 +4,16 @@ if [ -z "${PLAY_VERSION}" ]; then
   PLAY_VERSION="2.2-SNAPSHOT"
 fi
 
+if [ -z "$JAVA_HOME" ]; then
+  JAVA="java"
+else
+ JAVA="$JAVA_HOME/bin/java"
+fi
+
 if [ -z "${JPDA_PORT}" ]; then
   DEBUG_PARAM=""
 else
   DEBUG_PARAM="-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=${JPDA_PORT}"
 fi
 
-java ${DEBUG_PARAM} -Xms512M -Xmx1536M -Xss1M -XX:ReservedCodeCacheSize=192m -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=512M ${JAVA_OPTS} -Dfile.encoding=UTF-8 -Dplay.version="${PLAY_VERSION}" -Dplay.home=`dirname $0` -Dsbt.boot.properties=`dirname $0`/sbt/sbt.boot.properties ${PLAY_OPTS} -jar `dirname $0`/sbt/sbt-launch.jar "$@"
+"$JAVA" ${DEBUG_PARAM} -Xms512M -Xmx1536M -Xss1M -XX:ReservedCodeCacheSize=192m -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=512M ${JAVA_OPTS} -Dfile.encoding=UTF-8 -Dplay.version="${PLAY_VERSION}" -Dplay.home=`dirname $0` -Dsbt.boot.properties=`dirname $0`/sbt/sbt.boot.properties ${PLAY_OPTS} -jar `dirname $0`/sbt/sbt-launch.jar "$@"


### PR DESCRIPTION
Just as in the `play` script, allowed the JAVA_HOME to be set from the command line in the `build` script. This allows for testing and building Play and Play applications using different Java versions. It also makes sure that the `play` script behaves consistently regardless of which code path is taken in the script.
