### PR TITLE
Removed space from application full name in Project Creation

### DIFF
--- a/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide1.md
+++ b/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide1.md
@@ -46,7 +46,7 @@ Open a new command line and type:
 
     ~$ play new zentasks
 
-It will prompt you for the application full name.  Type **'Zen Tasks'**.  It will then prompt you for a template to use.  We are creating a Java application, so type **2**.
+It will prompt you for the application full name.  Type **'ZenTasks'**.  It will then prompt you for a template to use.  We are creating a Java application, so type **2**.
 
 > Whether you select Java or Scala now, you can always change it later.
 


### PR DESCRIPTION
If typing 'Zen Tasks', you'll get an error "Application name may only contain letters, digits, '_' and '-', and it must start with a letter."

This is already fixed in master, but should also appear in the documentation for 2.1.x, I think.
