### PR TITLE
Less compiler error handling is broken

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/coffeescript/CoffeescriptCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/coffeescript/CoffeescriptCompiler.scala
@@ -30,7 +30,7 @@ object CoffeescriptCompiler {
           val options = ctx.newObject(scope)
           options.put("bare", options, bare)
           compilerFunction.call(ctx, scope, scope, Array(coffeeCode, options))
-        }.asInstanceOf[String]
+        }.toString
       }
 
   }
@@ -83,7 +83,7 @@ object CoffeescriptCompiler {
         val line = """.*on line ([0-9]+).*""".r
         val error = e.getValue.asInstanceOf[Scriptable]
 
-        throw ScriptableObject.getProperty(error, "message").asInstanceOf[String] match {
+        throw ScriptableObject.getProperty(error, "message").toString match {
           case msg @ line(l) => AssetCompilationException(Some(source), msg, Some(Integer.parseInt(l)), None)
           case msg => AssetCompilationException(Some(source), msg, None, None)
         }

--- a/framework/src/sbt-plugin/src/main/scala/less/LessCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/less/LessCompiler.scala
@@ -134,10 +134,10 @@ object LessCompiler {
       case e: JavaScriptException => {
 
         val error = e.getValue.asInstanceOf[Scriptable]
-        val filename = ScriptableObject.getProperty(error, "filename").asInstanceOf[String]
+        val filename = ScriptableObject.getProperty(error, "filename").toString
         val file = new File(filename)
         throw AssetCompilationException(Some(file),
-          ScriptableObject.getProperty(error, "message").asInstanceOf[String],
+          ScriptableObject.getProperty(error, "message").toString,
           Some(ScriptableObject.getProperty(error, "line").asInstanceOf[Double].intValue),
           Some(ScriptableObject.getProperty(error, "column").asInstanceOf[Double].intValue))
       }


### PR DESCRIPTION
This is with 2.2.0-M2

```
sbt.PlayExceptions$UnexpectedException: Unexpected exception[ClassCastException: org.mozilla.javascript.ConsString cannot be cast to java.lang.String]
    at sbt.PlayReloader$$anon$2$$anonfun$reload$2$$anonfun$apply$14.apply(PlayReloader.scala:323) ~[na:na]
    at sbt.PlayReloader$$anon$2$$anonfun$reload$2$$anonfun$apply$14.apply(PlayReloader.scala:312) ~[na:na]
    at scala.Option.map(Option.scala:145) ~[scala-library.jar:na]
    at sbt.PlayReloader$$anon$2$$anonfun$reload$2.apply(PlayReloader.scala:312) ~[na:na]
    at sbt.PlayReloader$$anon$2$$anonfun$reload$2.apply(PlayReloader.scala:310) ~[na:na]
    at scala.util.Either$LeftProjection.map(Either.scala:377) ~[scala-library.jar:na]
java.lang.ClassCastException: org.mozilla.javascript.ConsString cannot be cast to java.lang.String
    at play.core.less.LessCompiler$.compile(LessCompiler.scala:140) ~[na:na]
    at sbt.PlayAssetsCompiler$$anonfun$6.apply(PlayAssetsCompiler.scala:88) ~[na:na]
    at sbt.PlayAssetsCompiler$$anonfun$6.apply(PlayAssetsCompiler.scala:88) ~[na:na]
    at sbt.PlayAssetsCompiler$$anonfun$AssetsCompiler$1$$anonfun$3.liftedTree1$1(PlayAssetsCompiler.scala:52) ~[na:na]
    at sbt.PlayAssetsCompiler$$anonfun$AssetsCompiler$1$$anonfun$3.apply(PlayAssetsCompiler.scala:51) ~[na:na]
    at sbt.PlayAssetsCompiler$$anonfun$AssetsCompiler$1$$anonfun$3.apply(PlayAssetsCompiler.scala:48) ~[na:na]
```
