### PR TITLE
Made Global handlers return futures

### DIFF
--- a/documentation/manual/javaGuide/main/global/JavaGlobal.md
+++ b/documentation/manual/javaGuide/main/global/JavaGlobal.md
@@ -4,96 +4,28 @@
 
 Defining a `Global` object in your project allows you to handle global settings for your application. This object must be defined in the root package.
 
-```java
-import play.*;
-
-public class Global extends GlobalSettings {
-
-}
-```
+@[global](code/javaguide/global/simple/Global.java)
 
 ## Intercepting application start-up and shutdown
 
 You can override the `onStart` and `onStop` operation to be notified of the corresponding application lifecycle events:
 
-```java
-import play.*;
-
-public class Global extends GlobalSettings {
-
-  @Override
-  public void onStart(Application app) {
-    Logger.info("Application has started");
-  }  
-  
-  @Override
-  public void onStop(Application app) {
-    Logger.info("Application shutdown...");
-  }  
-    
-}
-```
+@[global](code/javaguide/global/startstop/Global.java)
 
 ## Providing an application error page
 
 When an exception occurs in your application, the `onError` operation will be called. The default is to use the internal framework error page. You can override this:
 
-```java
-import play.*;
-import play.mvc.*;
-
-import static play.mvc.Results.*;
-
-public class Global extends GlobalSettings {
-
-  @Override
-  public Result onError(RequestHeader request, Throwable t) {
-    return internalServerError(
-      views.html.errorPage(t)
-    );
-  }  
-    
-}
-```
+@[global](code/javaguide/global/onerror/Global.java)
 
 ## Handling action not found
 
 If the framework doesn’t find an action method for a request, the `onHandlerNotFound` operation will be called:
 
-```java
-import play.*;
-import play.mvc.*;
-
-import static play.mvc.Results.*;
-
-public class Global extends GlobalSettings {
-
-  @Override
-  public Result onHandlerNotFound(RequestHeader request) {
-    return Results.notFound(
-      views.html.pageNotFound(request.uri())
-    );
-  }  
-    
-}
-```
+@[global](code/javaguide/global/notfound/Global.java)
 
 The `onBadRequest` operation will be called if a route was found, but it was not possible to bind the request parameters:
 
-```java
-import play.*;
-import play.mvc.*;
-
-import static play.mvc.Results.*;
-
-public class Global extends GlobalSettings {
-
-  @Override
-  public Result onBadRequest(RequestHeader request, String error) {
-    return Results.badRequest("Don't try to hack the URI!");
-  }  
-    
-}
-```
+@[global](code/javaguide/global/badrequest/Global.java)
 
 > **Next:** [[Intercepting requests | JavaInterceptors]]

--- a/documentation/manual/javaGuide/main/global/JavaInterceptors.md
+++ b/documentation/manual/javaGuide/main/global/JavaInterceptors.md
@@ -6,22 +6,7 @@ One important aspect of  the ```GlobalSettings``` class is that it provides a wa
 
 For example:
 
-```java
-import play.*;
-import play.mvc.Action;
-import play.mvc.Http.Request;
-import java.lang.reflect.Method;
-
-public class Global extends GlobalSettings {
-
-@Override
-public Action onRequest(Request request, Method actionMethod) {
-   System.out.println("before each request..." + request.toString());
-   return super.onRequest(request, actionMethod);
-}
-
-}
-```
+@[global](code/javaguide/global/intercept/Global.java)
 
 It’s also possible to intercept a specific action method. This can be achieved via [[Action composition| JavaActionsComposition]].
 

--- a/documentation/manual/javaGuide/main/global/code/JavaGlobalSpec.scala
+++ b/documentation/manual/javaGuide/main/global/code/JavaGlobalSpec.scala
@@ -1,0 +1,52 @@
+package javaguide.global
+
+import play.api.test._
+import play.api.mvc._
+import play.GlobalSettings
+import play.core.j.JavaGlobalSettingsAdapter
+import play.api.libs.ws.WS
+
+object JavaGlobalSpec extends PlaySpecification {
+
+  "java Global support" should {
+    "allow defining a custom global object" in testGlobal(new simple.Global())
+    "allow defining on start and on stop methods" in testGlobal(new startstop.Global())
+    "allow defining a custom error handler" in {
+      val content = contentOf("/error", new onerror.Global())
+      content must contain("Custom error page")
+      content must contain("foobar")
+    }
+    "allow defining a custom not found handler" in {
+      val content = contentOf("/notfound", new notfound.Global())
+      content must contain("Custom not found page")
+      content must contain("/notfound")
+    }
+    "allow defining a custom bad request handler" in {
+      val content = contentOf("/withInt/notint", new badrequest.Global())
+      content must_== "Don't try to hack the URI!"
+    }
+    "allow intercepting requests" in {
+      val content = contentOf("/normal", new intercept.Global())
+      content must_== "hi"
+    }
+  }
+
+  def testGlobal(global: GlobalSettings) = running(FakeApplication(
+    withGlobal = Some(new JavaGlobalSettingsAdapter(global))
+  ))(success)
+
+  def contentOf(url: String, global: GlobalSettings) = running(new TestServer(testServerPort, new FakeApplication(
+    withGlobal = Some(new JavaGlobalSettingsAdapter(global))) {
+    override protected def loadRoutes = Some(Routes)
+  })) {
+    await(WS.url("http://localhost:" + testServerPort + url).get()).body
+  }
+}
+
+package object controllers {
+  object Application {
+    def withInt(i: Int) = Action(Results.Ok)
+    def normal = Action(Results.Ok("hi"))
+    def error = Action(req => throw new RuntimeException("foobar"))
+  }
+}

--- a/documentation/manual/javaGuide/main/global/code/javaguide.global.routes
+++ b/documentation/manual/javaGuide/main/global/code/javaguide.global.routes
@@ -1,0 +1,3 @@
+GET        /withInt/:i        controllers.Application.withInt(i: Int)
+GET        /normal            controllers.Application.normal
+GET        /error             controllers.Application.error

--- a/documentation/manual/javaGuide/main/global/code/javaguide/global/badrequest/Global.java
+++ b/documentation/manual/javaGuide/main/global/code/javaguide/global/badrequest/Global.java
@@ -1,0 +1,19 @@
+package javaguide.global.badrequest;
+
+//#global
+import play.*;
+import play.mvc.*;
+import play.mvc.Http.*;
+import play.libs.F.*;
+
+import static play.mvc.Results.*;
+
+public class Global extends GlobalSettings {
+
+    public Promise<SimpleResult> onBadRequest(RequestHeader request, String error) {
+        return Promise.<SimpleResult>pure(badRequest("Don't try to hack the URI!"));
+    }
+
+}
+//#global
+

--- a/documentation/manual/javaGuide/main/global/code/javaguide/global/errorPage.scala.html
+++ b/documentation/manual/javaGuide/main/global/code/javaguide/global/errorPage.scala.html
@@ -1,0 +1,3 @@
+@(ex:Throwable)
+Custom error page
+@ex.getMessage

--- a/documentation/manual/javaGuide/main/global/code/javaguide/global/intercept/Global.java
+++ b/documentation/manual/javaGuide/main/global/code/javaguide/global/intercept/Global.java
@@ -1,0 +1,17 @@
+package javaguide.global.intercept;
+
+//#global
+import play.*;
+import play.mvc.Action;
+import play.mvc.Http.Request;
+import java.lang.reflect.Method;
+
+public class Global extends GlobalSettings {
+
+    public Action onRequest(Request request, Method actionMethod) {
+        System.out.println("before each request..." + request.toString());
+        return super.onRequest(request, actionMethod);
+    }
+
+}
+//#global

--- a/documentation/manual/javaGuide/main/global/code/javaguide/global/notFoundPage.scala.html
+++ b/documentation/manual/javaGuide/main/global/code/javaguide/global/notFoundPage.scala.html
@@ -1,0 +1,3 @@
+@(path:String)
+Custom not found page
+@path

--- a/documentation/manual/javaGuide/main/global/code/javaguide/global/notfound/Global.java
+++ b/documentation/manual/javaGuide/main/global/code/javaguide/global/notfound/Global.java
@@ -1,0 +1,22 @@
+package javaguide.global.notfound;
+
+import javaguide.global.views;
+
+//#global
+import play.*;
+import play.mvc.*;
+import play.mvc.Http.*;
+import play.libs.F.*;
+
+import static play.mvc.Results.*;
+
+public class Global extends GlobalSettings {
+
+    public Promise<SimpleResult> onHandlerNotFound(RequestHeader request) {
+        return Promise.<SimpleResult>pure(notFound(
+            views.html.notFoundPage.render(request.uri())
+        ));
+    }
+
+}
+//#global

--- a/documentation/manual/javaGuide/main/global/code/javaguide/global/onerror/Global.java
+++ b/documentation/manual/javaGuide/main/global/code/javaguide/global/onerror/Global.java
@@ -1,0 +1,21 @@
+package javaguide.global.onerror;
+
+import javaguide.global.views;
+//#global
+import play.*;
+import play.mvc.*;
+import play.mvc.Http.*;
+import play.libs.F.*;
+
+import static play.mvc.Results.*;
+
+public class Global extends GlobalSettings {
+
+    public Promise<SimpleResult> onError(RequestHeader request, Throwable t) {
+        return Promise.<SimpleResult>pure(internalServerError(
+            views.html.errorPage.render(t)
+        ));
+    }
+
+}
+//#global

--- a/documentation/manual/javaGuide/main/global/code/javaguide/global/simple/Global.java
+++ b/documentation/manual/javaGuide/main/global/code/javaguide/global/simple/Global.java
@@ -1,0 +1,9 @@
+package javaguide.global.simple;
+
+//#global
+import play.*;
+
+public class Global extends GlobalSettings {
+
+}
+//#global

--- a/documentation/manual/javaGuide/main/global/code/javaguide/global/startstop/Global.java
+++ b/documentation/manual/javaGuide/main/global/code/javaguide/global/startstop/Global.java
@@ -1,0 +1,17 @@
+package javaguide.global.startstop;
+
+//#global
+import play.*;
+
+public class Global extends GlobalSettings {
+
+    public void onStart(Application app) {
+        Logger.info("Application has started");
+    }
+
+    public void onStop(Application app) {
+        Logger.info("Application shutdown...");
+    }
+
+}
+//#global

--- a/documentation/manual/javaGuide/main/global/code/javaguide/global/views.java
+++ b/documentation/manual/javaGuide/main/global/code/javaguide/global/views.java
@@ -1,0 +1,12 @@
+package javaguide.global;
+
+// Hack to allow example Globals to refer to templates in the views.html package without them actually being in that
+// package.
+public class views {
+    public static HtmlField html = new HtmlField();
+
+    public static class HtmlField {
+        public static javaguide.global.html.errorPage$ errorPage = javaguide.global.html.errorPage$.MODULE$;
+        public static javaguide.global.html.notFoundPage$ notFoundPage = javaguide.global.html.notFoundPage$.MODULE$;
+    }
+}

--- a/documentation/manual/scalaGuide/main/global/code/ScalaGlobal.scala
+++ b/documentation/manual/scalaGuide/main/global/code/ScalaGlobal.scala
@@ -1,16 +1,14 @@
 package scalaguide.global.scalaglobal {
 
-import play.api.mvc._
 import play.api.test._
 import play.api.test.Helpers._
 import org.specs2.mutable.Specification
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import play.core.Router
-import play.api.GlobalSettings
 
 @RunWith(classOf[JUnitRunner])
-class ScalaGlobalSpec extends Specification with Controller {
+class ScalaGlobalSpec extends Specification {
 
   "A scala global" should {
 
@@ -45,14 +43,15 @@ class ScalaGlobalSpec extends Specification with Controller {
       //#global-hooking-error
       import play.api._
       import play.api.mvc._
-      //import play.api.mvc.Results._
+      import play.api.mvc.Results._
+      import scala.concurrent.Future
 
       object Global extends GlobalSettings {
 
         override def onError(request: RequestHeader, ex: Throwable) = {
-          InternalServerError(
+          Future.successful(InternalServerError(
             views.html.errorPage(ex)
-          )
+          ))
         }
 
       }
@@ -70,14 +69,15 @@ class ScalaGlobalSpec extends Specification with Controller {
       //#global-hooking-notfound
       import play.api._
       import play.api.mvc._
-      //import play.api.mvc.Results._
+      import play.api.mvc.Results._
+      import scala.concurrent.Future
 
       object Global extends GlobalSettings {
 
-        override def onHandlerNotFound(request: RequestHeader): SimpleResult = {
-          NotFound(
+        override def onHandlerNotFound(request: RequestHeader) = {
+          Future.successful(NotFound(
             views.html.notFoundPage(request.path)
-          )
+          ))
         }
 
       }
@@ -93,12 +93,13 @@ class ScalaGlobalSpec extends Specification with Controller {
       //#global-hooking-bad-request
       import play.api._
       import play.api.mvc._
-      //import play.api.mvc.Results._
+      import play.api.mvc.Results._
+      import scala.concurrent.Future
 
       object Global extends GlobalSettings {
 
         override def onBadRequest(request: RequestHeader, error: String) = {
-          BadRequest("Bad Request: " + error)
+          Future.successful(BadRequest("Bad Request: " + error))
         }
 
       }
@@ -111,10 +112,14 @@ class ScalaGlobalSpec extends Specification with Controller {
 
   }
 
-  def contentOf(rh: RequestHeader, router: Router.Routes = Routes,g:GlobalSettings) = running(FakeApplication(withGlobal=Some(g)))(contentAsString(router.routes(rh) match {
+  import play.api.mvc._
+  import play.api.GlobalSettings
+
+  def contentOf(rh: RequestHeader, router: Router.Routes = Routes,g:GlobalSettings) = running(
+    FakeApplication(withGlobal=Some(g))
+  )(contentAsString(router.routes(rh) match {
     case e: EssentialAction => e(rh).run
   }))
-
 
 }
 

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipSpec.scala
@@ -96,7 +96,7 @@ object GzipSpec extends Specification {
     }
 
     "gunzip large repeating input in small chunks" in {
-      test(Seq.fill(1000)("Hello world").mkString(""), gzip = Gzip.gzip(10))
+      test(Seq.fill(1000)("Hello world").mkString(""), gzip = Gzip.gzip(100))
     }
 
     "gunzip large random input" in {
@@ -104,7 +104,7 @@ object GzipSpec extends Specification {
     }
 
     "gunzip large random input in small chunks" in {
-      test(scala.util.Random.nextString(10000), gzip = Gzip.gzip(10))
+      test(scala.util.Random.nextString(10000), gzip = Gzip.gzip(100))
     }
   }
 }

--- a/framework/src/play/src/main/java/play/GlobalSettings.java
+++ b/framework/src/play/src/main/java/play/GlobalSettings.java
@@ -45,7 +45,7 @@ public class GlobalSettings {
      * @param t is any throwable
      * @return null as the default implementation
      */
-    public SimpleResult onError(RequestHeader request, Throwable t) {
+    public F.Promise<SimpleResult> onError(RequestHeader request, Throwable t) {
         return null;
     }
     
@@ -92,7 +92,7 @@ public class GlobalSettings {
      * @param request the HTTP request
      * @return null in the default implementation, you can return your own custom Result in your Global class.
      */
-    public SimpleResult onHandlerNotFound(RequestHeader request) {
+    public F.Promise<SimpleResult> onHandlerNotFound(RequestHeader request) {
         return null;
     }
     
@@ -107,7 +107,7 @@ public class GlobalSettings {
      * @param request the HTTP request
      * @return null in the default implementation, you can return your own custom Result in your Global class.
      */
-    public SimpleResult onBadRequest(RequestHeader request, String error) {
+    public F.Promise<SimpleResult> onBadRequest(RequestHeader request, String error) {
         return null;
     }
 
@@ -133,6 +133,9 @@ public class GlobalSettings {
         return null;
     }
 
+    /**
+     * Get the filters that should be used to handle each request.
+     */
     public <T extends play.api.mvc.EssentialFilter> Class<T>[] filters() {
         return new Class[0];
     }

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -7,13 +7,12 @@ import play.api.mvc._
 
 import java.io._
 
-import scala.collection.JavaConverters._
-
 import annotation.implicitNotFound
 
 import java.lang.reflect.InvocationTargetException
 import reflect.ClassTag
 import scala.util.control.NonFatal
+import scala.concurrent.Future
 
 trait WithDefaultGlobal {
   self: Application with WithDefaultConfiguration =>
@@ -284,7 +283,7 @@ trait Application {
   /**
    * Handle a runtime error during the execution of an action
    */
-  private[play] def handleError(request: RequestHeader, e: Throwable): SimpleResult = try {
+  private[play] def handleError(request: RequestHeader, e: Throwable): Future[SimpleResult] = try {
     e match {
       case e: UsefulException => throw e
       case e: Throwable => {

--- a/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
+++ b/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
@@ -3,6 +3,7 @@ package play.api
 import play.api.mvc._
 import java.io.File
 import scala.util.control.NonFatal
+import scala.concurrent.Future
 
 /**
  * Defines an application’s global settings.
@@ -80,7 +81,7 @@ trait GlobalSettings {
         case (taggedRequest, handler) => (taggedRequest, doFilter(rh => handler)(taggedRequest))
       }
       .getOrElse {
-        (request, Action(BodyParsers.parse.empty)(_ => this.onHandlerNotFound(request)))
+        (request, Action.async(BodyParsers.parse.empty)(_ => this.onHandlerNotFound(request)))
       }
   }
 
@@ -124,9 +125,9 @@ trait GlobalSettings {
    * @param ex The exception
    * @return The result to send to the client
    */
-  def onError(request: RequestHeader, ex: Throwable): SimpleResult = {
+  def onError(request: RequestHeader, ex: Throwable): Future[SimpleResult] = {
     try {
-      InternalServerError(Play.maybeApplication.map {
+      Future.successful(InternalServerError(Play.maybeApplication.map {
         case app if app.mode != Mode.Prod => views.html.defaultpages.devError.f
         case app => views.html.defaultpages.error.f
       }.getOrElse(views.html.defaultpages.devError.f) {
@@ -134,11 +135,11 @@ trait GlobalSettings {
           case e: UsefulException => e
           case NonFatal(e) => UnexpectedException(unexpected = Some(e))
         }
-      })
+      }))
     } catch {
       case e: Throwable => {
         Logger.error("Error while rendering default error page", e)
-        InternalServerError
+        Future.successful(InternalServerError)
       }
     }
   }
@@ -151,11 +152,11 @@ trait GlobalSettings {
    * @param request the HTTP request header
    * @return the result to send to the client
    */
-  def onHandlerNotFound(request: RequestHeader): SimpleResult = {
-    NotFound(Play.maybeApplication.map {
+  def onHandlerNotFound(request: RequestHeader): Future[SimpleResult] = {
+    Future.successful(NotFound(Play.maybeApplication.map {
       case app if app.mode != Mode.Prod => views.html.defaultpages.devNotFound.f
       case app => views.html.defaultpages.notFound.f
-    }.getOrElse(views.html.defaultpages.devNotFound.f)(request, Play.maybeApplication.flatMap(_.routes)))
+    }.getOrElse(views.html.defaultpages.devNotFound.f)(request, Play.maybeApplication.flatMap(_.routes))))
   }
 
   /**
@@ -166,8 +167,8 @@ trait GlobalSettings {
    * @param request the HTTP request header
    * @return the result to send to the client
    */
-  def onBadRequest(request: RequestHeader, error: String): SimpleResult = {
-    BadRequest(views.html.defaultpages.badRequest(request, error))
+  def onBadRequest(request: RequestHeader, error: String): Future[SimpleResult] = {
+    Future.successful(BadRequest(views.html.defaultpages.badRequest(request, error)))
   }
 
   def onRequestCompletion(request: RequestHeader) {

--- a/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
@@ -2,8 +2,9 @@ package play.core.j
 
 import play.api._
 import play.api.mvc._
-import play.mvc.Http.{ RequestHeader => JRequestHeader }
 import java.io.File
+import scala.concurrent.Future
+import play.api.libs.iteratee._
 
 /** Adapter that holds the Java `GlobalSettings` and acts as a Scala `GlobalSettings` for the framework. */
 class JavaGlobalSettingsAdapter(val underlying: play.GlobalSettings) extends GlobalSettings {
@@ -26,17 +27,17 @@ class JavaGlobalSettingsAdapter(val underlying: play.GlobalSettings) extends Glo
     Option(underlying.onRouteRequest(r)).map(Some(_)).getOrElse(super.onRouteRequest(request))
   }
 
-  override def onError(request: RequestHeader, ex: Throwable): SimpleResult = {
+  override def onError(request: RequestHeader, ex: Throwable): Future[SimpleResult] = {
     JavaHelpers.invokeWithContext(request, req => Option(underlying.onError(req, ex)))
       .getOrElse(super.onError(request, ex))
   }
 
-  override def onHandlerNotFound(request: RequestHeader): SimpleResult = {
+  override def onHandlerNotFound(request: RequestHeader): Future[SimpleResult] = {
     JavaHelpers.invokeWithContext(request, req => Option(underlying.onHandlerNotFound(req)))
       .getOrElse(super.onHandlerNotFound(request))
   }
 
-  override def onBadRequest(request: RequestHeader, error: String): SimpleResult = {
+  override def onBadRequest(request: RequestHeader, error: String): Future[SimpleResult] = {
     JavaHelpers.invokeWithContext(request, req => Option(underlying.onBadRequest(req, error)))
       .getOrElse(super.onBadRequest(request, error))
   }
@@ -55,7 +56,10 @@ class JavaGlobalSettingsAdapter(val underlying: play.GlobalSettings) extends Glo
     try {
       Filters(super.doFilter(a), underlying.filters.map(_.newInstance: play.api.mvc.EssentialFilter): _*)
     } catch {
-      case e: Throwable => EssentialAction(req => play.api.libs.iteratee.Done(onError(req, e)))
+      case e: Throwable => {
+        import play.api.libs.iteratee.Execution.Implicits.trampoline
+        EssentialAction(req => Iteratee.flatten(onError(req, e).map(result => Done(result, Input.Empty))))
+      }
     }
   }
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -1,11 +1,11 @@
 package play.core.j
 
-import play.api.mvc._
 import play.mvc.{ SimpleResult => JSimpleResult }
-import play.mvc.Http.{ Context => JContext, Request => JRequest, RequestBody => JBody, Cookies => JCookies, Cookie => JCookie }
+import play.mvc.Http.{ Context => JContext, Request => JRequest, Cookies => JCookies, Cookie => JCookie }
 
-import scala.collection.JavaConverters._
 import play.libs.F
+import scala.concurrent.Future
+import play.api.libs.iteratee.Execution.trampoline
 
 class EitherToFEither[A, B]() extends play.libs.F.Function[Either[A, B], play.libs.F.Either[A, B]] {
 
@@ -170,11 +170,11 @@ trait JavaHelpers {
    * @param f The function to invoke
    * @return The result
    */
-  def invokeWithContext(request: RequestHeader, f: JRequest => Option[JSimpleResult]): Option[SimpleResult] = {
+  def invokeWithContext(request: RequestHeader, f: JRequest => Option[F.Promise[JSimpleResult]]): Option[Future[SimpleResult]] = {
     val javaContext = createJavaContext(request)
     try {
       JContext.current.set(javaContext)
-      f(javaContext.request()).map(result => createResult(javaContext, result))
+      f(javaContext.request()).map(_.wrapped.map(createResult(javaContext, _))(trampoline))
     } finally {
       JContext.current.remove()
     }

--- a/framework/src/play/src/main/scala/play/core/router/Router.scala
+++ b/framework/src/play/src/main/scala/play/core/router/Router.scala
@@ -227,7 +227,7 @@ object Router {
 
     //
 
-    def badRequest(error: String) = Action { request =>
+    def badRequest(error: String) = Action.async { request =>
       play.api.Play.maybeApplication.map(_.global.onBadRequest(request, error)).getOrElse(play.api.DefaultGlobal.onBadRequest(request, error))
     }
 

--- a/framework/test/integrationtest-java/app/Global.java
+++ b/framework/test/integrationtest-java/app/Global.java
@@ -2,13 +2,14 @@ import play.GlobalSettings;
 import play.mvc.Http;
 import play.mvc.SimpleResult;
 import play.mvc.Results;
+import play.libs.F;
 
 public class Global extends GlobalSettings {
     @Override
-    public SimpleResult onHandlerNotFound(Http.RequestHeader requestHeader) {
+    public F.Promise<SimpleResult> onHandlerNotFound(Http.RequestHeader requestHeader) {
         // This is here to make sure that the context is set, there is a test that asserts
         // that this is true
         Http.Context.current().session().put("onHandlerNotFound", "true");
-        return Results.notFound();
+        return F.Promise.<SimpleResult>pure(Results.notFound());
     }
 }

--- a/framework/test/integrationtest/app/Global.scala
+++ b/framework/test/integrationtest/app/Global.scala
@@ -4,10 +4,11 @@ import play.api.mvc.{RequestHeader, SimpleResult}
 import play.api.mvc.Results.InternalServerError
 import play.api.{Logger, Configuration}
 import com.typesafe.config.ConfigFactory
+import scala.concurrent.Future
 
 object Global extends GlobalSettings {
-  override def onError(r: RequestHeader, e: Throwable): SimpleResult = {
-    InternalServerError("Something went wrong.")
+  override def onError(r: RequestHeader, e: Throwable): Future[SimpleResult] = {
+    Future.successful(InternalServerError("Something went wrong."))
   }
 
   // Ensure that the Evolutions code uses the same configuration as the running application


### PR DESCRIPTION
The results refactoring ended with Global handlers, such as onError, onHandlerNotFound etc, returning SimpleResult, which meant they couldn't be asynchronous.  This changes the type to Future[SimpleResult].

Also extracted code samples out of Java Global docs, and updated all docs for this.
