### PR TITLE
Multiple directory support in source generators

### DIFF
--- a/documentation/project/Build.scala
+++ b/documentation/project/Build.scala
@@ -39,17 +39,17 @@ object ApplicationBuild extends Build {
 
     // Need to ensure that templates in the Java docs get Java imports, and in the Scala docs get Scala imports
     sourceGenerators in Test <+= (state, javaManualSourceDirectories, sourceManaged in Test, templatesTypes) map { (s, ds, g, t) =>
-      ds.flatMap(d => ScalaTemplates(s, d, g, t, defaultTemplatesImport ++ defaultJavaTemplatesImport))
+      ScalaTemplates(s, ds, g, t, defaultTemplatesImport ++ defaultJavaTemplatesImport)
     },
     sourceGenerators in Test <+= (state, scalaManualSourceDirectories, sourceManaged in Test, templatesTypes) map { (s, ds, g, t) =>
-      ds.flatMap(d => ScalaTemplates(s, d, g, t, defaultTemplatesImport ++ defaultScalaTemplatesImport))
+      ScalaTemplates(s, ds, g, t, defaultTemplatesImport ++ defaultScalaTemplatesImport)
     },
 
     sourceGenerators in Test <+= (state, javaManualSourceDirectories, sourceManaged in Test) map  { (s, ds, g) =>
-      ds.flatMap(d => RouteFiles(s, d, g, Seq("play.libs.F"), true, true))
+      RouteFiles(s, ds, g, Seq("play.libs.F"), true, true)
     },
     sourceGenerators in Test <+= (state, scalaManualSourceDirectories, sourceManaged in Test) map  { (s, ds, g) =>
-      ds.flatMap(d => RouteFiles(s, d, g, Seq(), true, true))
+      RouteFiles(s, ds, g, Seq(), true, true)
     },
 
     templatesTypes := Map(

--- a/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
@@ -251,12 +251,12 @@ object RoutesCompiler {
   case class GeneratedSource(file: File) {
 
     val lines = if (file.exists) Path(file).string.split('\n').toList else Nil
-    val source = lines.headOption.filter(_.startsWith("// @SOURCE:")).map(m => Path.fromString(m.trim.drop(11)))
+    val source = lines.find(_.startsWith("// @SOURCE:")).map(m => Path.fromString(m.trim.drop(11)))
 
     def isGenerated: Boolean = source.isDefined
 
     def sync(): Boolean = {
-      if (!source.get.exists) file.delete() else false
+      if (!source.exists(_.exists)) file.delete() else false
     }
 
     def needsRecompilation(imports: Seq[String]): Boolean = {

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -94,12 +94,14 @@ trait Settings {
 
     namespaceReverseRouter := false,
 
-    sourceGenerators in Compile <+= (state, confDirectory, sourceManaged in Compile, routesImport, generateReverseRouter, namespaceReverseRouter) map RouteFiles,
+    sourceGenerators in Compile <+= (state, confDirectory, sourceManaged in Compile, routesImport, generateReverseRouter, namespaceReverseRouter) map { (s, cd, sm, ri, grr, nrr) =>
+      RouteFiles(s, Seq(cd), sm, ri, grr, nrr)
+    },
 
     // Adds config directory's source files to continuous hot reloading
     watchSources <+= confDirectory map { all => all },
 
-    sourceGenerators in Compile <+= (state, sourceDirectory in Compile, sourceManaged in Compile, templatesTypes, templatesImport) map ScalaTemplates,
+    sourceGenerators in Compile <+= (state, unmanagedSourceDirectories in Compile, sourceManaged in Compile, templatesTypes, templatesImport) map ScalaTemplates,
 
     // Adds app directory's source files to continuous hot reloading
     watchSources <++= baseDirectory map { path => ((path / "app") ** "*" --- (path / "app/assets") ** "*").get },


### PR DESCRIPTION
Routes and templates source generators previously could only generate sources for one directory at a time.  The problem is, if there were multiple source directories, there would only be one generated directory, and they always scanned the generated directory in order to delete generated files that no longer had source equivalents.  This meant there was a race condition, because source generators run in parallel, if a generated file was found but the header hadn't been written, it would be deleted.

This fixes it to ensure that each source generator only needs to run once, so projects with multple source directories (eg, the documentation project) don't have this race condition.

Also made routes generated source handling more robust.
