### PR TITLE
Less compiler error reporting broken for imported files

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -239,7 +239,11 @@ object PlayBuild extends Build {
           d.organization + ":" + d.name + ":" + d.revision
         }.sorted.foreach(println)
       },
-      publishTo := Some(publishingIvyRepository)
+      publishTo := Some(publishingIvyRepository),
+      // Must be false, because due to the way SBT integrates with test libraries, and the way SBT uses Java object
+      // serialisation to communicate with forked processes, and because this plugin will have SBT 0.13 on the forked
+      // processes classpath while it's actually being run by SBT 0.12... if it forks you get serialVersionUID errors.
+      fork in Test := false
     ).settings(scriptedSettings: _*)
     .settings(
       scriptedLaunchOpts <++= (baseDirectory in ThisBuild) { baseDir =>

--- a/framework/src/sbt-plugin/src/main/scala/less/LessCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/less/LessCompiler.scala
@@ -84,9 +84,6 @@ object LessCompiler {
                             contents:env.contents,
                             dumpLineNumbers:window.less.dumpLineNumbers
                         }).parse(input, function (e, root) {
-                            if(e instanceof Object) {
-                                throw e;
-                            }
                             fn(e, root, input);
 
                             context.pop();
@@ -94,7 +91,7 @@ object LessCompiler {
                     }
 
                     new(window.less.Parser)({optimization:3, filename:String(source.getCanonicalPath())}).parse(String(LessCompiler.readContent(source)), function (e,root) {
-                        if(e instanceof Object) {
+                        if (e) {
                             throw e;
                         }
                         compiled = root.toCSS({compress: """ + (if (minify) "true" else "false") + """})

--- a/framework/src/sbt-plugin/src/test/resources/importinvalid.less
+++ b/framework/src/sbt-plugin/src/test/resources/importinvalid.less
@@ -1,0 +1,1 @@
+@import "invalid.less";

--- a/framework/src/sbt-plugin/src/test/resources/importparseerror.less
+++ b/framework/src/sbt-plugin/src/test/resources/importparseerror.less
@@ -1,0 +1,1 @@
+@import "parseerror.less";

--- a/framework/src/sbt-plugin/src/test/resources/importvalid.less
+++ b/framework/src/sbt-plugin/src/test/resources/importvalid.less
@@ -1,0 +1,1 @@
+@import "valid.less";

--- a/framework/src/sbt-plugin/src/test/resources/invalid.less
+++ b/framework/src/sbt-plugin/src/test/resources/invalid.less
@@ -1,0 +1,15 @@
+@base: #f938ab;
+
+.box-shadow(@style, @c) when (iscolor(@c)) {
+  box-shadow:         @style @c;
+  -webkit-box-shadow: @style @c;
+  -moz-box-shadow:    @style @c;
+}
+.box-shadow(@style, @alpha: 50%) when (isnumber(@alpha)) {
+  .box-shadow(@style, rgba(0, 0, 0, @alpha));
+}
+.box {
+  color: saturate(@base, 5%);
+  border-color: lighten(@doesnotexist, 30%);
+  div { .box-shadow(0 0 5px, 30%) }
+}

--- a/framework/src/sbt-plugin/src/test/resources/parseerror.less
+++ b/framework/src/sbt-plugin/src/test/resources/parseerror.less
@@ -1,0 +1,6 @@
+.foo {
+  .bar {
+    color: red
+    border: 1px
+  }
+}

--- a/framework/src/sbt-plugin/src/test/resources/valid.less
+++ b/framework/src/sbt-plugin/src/test/resources/valid.less
@@ -1,0 +1,15 @@
+@base: #f938ab;
+
+.box-shadow(@style, @c) when (iscolor(@c)) {
+  box-shadow:         @style @c;
+  -webkit-box-shadow: @style @c;
+  -moz-box-shadow:    @style @c;
+}
+.box-shadow(@style, @alpha: 50%) when (isnumber(@alpha)) {
+  .box-shadow(@style, rgba(0, 0, 0, @alpha));
+}
+.box {
+  color: saturate(@base, 5%);
+  border-color: lighten(@base, 30%);
+  div { .box-shadow(0 0 5px, 30%) }
+}

--- a/framework/src/sbt-plugin/src/test/scala/less/LessCompilerSpec.scala
+++ b/framework/src/sbt-plugin/src/test/scala/less/LessCompilerSpec.scala
@@ -1,0 +1,75 @@
+package play.core.less
+
+import org.specs2.mutable.Specification
+import java.io.File
+import play.PlayExceptions.AssetCompilationException
+
+object LessCompilerSpec extends Specification {
+
+  sequential
+
+  "the less compiler" should {
+    "compile a valid less file" in {
+      val result = LessCompiler.compile(getFile("valid.less"))
+      // debug
+      result._1 must contain(".box")
+      // minified
+      result._2 must beSome.like {
+        case css =>
+          css must contain(".box")
+      }
+    }
+
+    "support imports" in {
+      val result = LessCompiler.compile(getFile("importvalid.less"))
+      result._1 must contain(".box")
+    }
+
+    "correctly handle errors in an invalid less file" in {
+      val file = getFile("invalid.less")
+      LessCompiler.compile(file) must throwAn[AssetCompilationException].like {
+        case e: AssetCompilationException =>
+          e.atLine must beSome(13)
+          e.column must beSome(24)
+          e.message must_== "variable @doesnotexist is undefined"
+          e.source must beSome(file)
+      }
+    }
+
+    "correctly handle errors in an imported invalid less file" in {
+      LessCompiler.compile(getFile("importinvalid.less")) must throwAn[AssetCompilationException].like {
+        case e: AssetCompilationException =>
+          e.atLine must beSome(13)
+          e.column must beSome(24)
+          e.message must_== "variable @doesnotexist is undefined"
+          e.source must beSome(getFile("invalid.less"))
+      }
+    }
+
+    "correctly handle errors in a less file with a parse error" in {
+      val file = getFile("parseerror.less")
+      LessCompiler.compile(file) must throwAn[AssetCompilationException].like {
+        case e: AssetCompilationException =>
+          e.atLine must beSome(3)
+          e.column must beSome(4)
+          e.message must_== "Unrecognised input"
+          e.source must beSome(file)
+      }
+    }
+
+    "correctly handle errors in an imported less file with a parse error" in {
+      LessCompiler.compile(getFile("importparseerror.less")) must throwAn[AssetCompilationException].like {
+        case e: AssetCompilationException =>
+          e.atLine must beSome(3)
+          e.column must beSome(4)
+          e.message must_== "Unrecognised input"
+          e.source must beSome(getFile("parseerror.less"))
+      }
+    }
+
+  }
+
+  def getFile(fileName: String):File = {
+    new File(this.getClass.getClassLoader.getResource(fileName).toURI)
+  }
+}


### PR DESCRIPTION
https://github.com/playframework/playframework/commit/cacfb8475109720c6e3ab1b3057983348bc97495 broke error reporting for Less compilation in master. I very much would like to see Less upgraded to 1.4.1 (or actually 1.4.2), but it looks like there's some problems still

```
play.PlayExceptions$UnexpectedException: Unexpected exception[EcmaError: TypeError: Cannot call method "toCSS" of undefined (compiler.js#40)]
    at play.PlayReloader$$anon$1$$anonfun$reload$2$$anonfun$apply$14.apply(PlayReloader.scala:309) ~[na:na]
    at play.PlayReloader$$anon$1$$anonfun$reload$2$$anonfun$apply$14.apply(PlayReloader.scala:298) ~[na:na]
    at scala.Option.map(Option.scala:145) ~[scala-library.jar:na]
    at play.PlayReloader$$anon$1$$anonfun$reload$2.apply(PlayReloader.scala:298) ~[na:na]
    at play.PlayReloader$$anon$1$$anonfun$reload$2.apply(PlayReloader.scala:296) ~[na:na]
    at scala.util.Either$LeftProjection.map(Either.scala:377) ~[scala-library.jar:na]
org.mozilla.javascript.EcmaError: TypeError: Cannot call method "toCSS" of undefined (compiler.js#40)
    at org.mozilla.javascript.ScriptRuntime.constructError(ScriptRuntime.java:3687) ~[na:na]
    at org.mozilla.javascript.ScriptRuntime.constructError(ScriptRuntime.java:3665) ~[na:na]
    at org.mozilla.javascript.ScriptRuntime.typeError(ScriptRuntime.java:3693) ~[na:na]
    at org.mozilla.javascript.ScriptRuntime.typeError2(ScriptRuntime.java:3712) ~[na:na]
    at org.mozilla.javascript.ScriptRuntime.undefCallError(ScriptRuntime.java:3731) ~[na:na]
    at org.mozilla.javascript.ScriptRuntime.getPropFunctionAndThisHelper(ScriptRuntime.java:2258) ~[na:na]
```
