### PR TITLE
Allow for community support of other build systems

### DIFF
--- a/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
+++ b/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
@@ -68,7 +68,7 @@ class TestApplication(application: Application) extends ApplicationProvider {
 }
 
 /**
- * represents an application that can be reloaded in Dev Mode
+ * Represents an application that can be reloaded in Dev Mode.
  */
 class ReloadableApplication(sbtLink: SBTLink, sbtDocHandler: SBTDocHandler) extends ApplicationProvider {
 

--- a/framework/src/sbt-link/src/main/java/play/core/SBTLink.java
+++ b/framework/src/sbt-link/src/main/java/play/core/SBTLink.java
@@ -14,24 +14,79 @@ import java.util.*;
  */
 public interface SBTLink {
 
-	// Will return either:
-	// - Throwable -> If something is wrong
-	// - ClassLoader -> If the classLoader changed
-	// - null -> if nothing changed
+    /**
+     * Check if anything has changed, and if so, return an updated classloader.
+     *
+     * This method is called multiple times on every request, so it is advised that change detection happens
+     * asynchronously to this call, and that this call just check a boolean.
+     *
+     * @return Either
+     * <ul>
+     *     <li>Throwable - If something went wrong (eg, a compile error).  {@link play.api.PlayException} and its sub
+     *     types can be used to provide specific details on compile errors or other exceptions.</li>
+     *     <li>ClassLoader - If the classloader has changed, and the application should be reloaded.</li>
+     *     <li>null - If nothing changed.</li>
+     * </ul>
+     */
 	public Object reload();
 
-	// Will return either:
-	// - [File, Integer]
-	// - [File, null]
-	// - null
+    /**
+     * Find the original source file for the given class name and line number.
+     *
+     * When the application throws an exception, this will be called for every element in the stack trace from top to
+     * bottom until a source file may be found, so that the browser can render the line of code that threw the
+     * exception.
+     *
+     * If the class is generated (eg a template), then the original source file should be returned, and the line number
+     * should be mapped back to the line number in the original source file, if possible.
+     *
+     * @param className The name of the class to find the source for.
+     * @param line The line number the exception was thrown at.
+     * @return Either:
+     * <ul>
+     *     <li>[File, Integer] - The source file, and the passed in line number, if the source wasn't generated, or if
+     *     it was generated, and the line number could be mapped, then the original source file and the mapped line
+     *     number.</li>
+     *     <li>[File, null] - If the source was generated but the line number couldn't be mapped, then just the original
+     *     source file and null for the unmappable line number.</li>
+     *     <li>null - If no source file could be found for the class name.</li>
+     * </ul>
+     */
 	public Object[] findSource(String className, Integer line);
 
+    /**
+     * Get the path of the project.  This is used by methods such as {@link play.api.Application#getFile}.
+     *
+     * @return The path of the project.
+     */
 	public File projectPath();
 
-	public Object runTask(String name);
-
+    /**
+     * Force the application to reload on the next invocation of reload.
+     *
+     * This is invoked by plugins for example that change something on the classpath or something about the application
+     * that requires a reload, for example, the evolutions plugin.
+     */
 	public void forceReload();
 
+    /**
+     * Returns a list of application settings configured in the build system.
+     *
+     * @return The settings.
+     */
 	public Map<String,String> settings();
 
+    /**
+     * Run a task in the build tool.
+     *
+     * This can be used by Play plugins, for example, by a test fixture plugin to run tests.  The format of the passed
+     * in task and the return value are build tool specific.
+     *
+     * For the default SBT implementation, it's a standard SBT task, and the result is the return value of that task.
+     * Note that if the return value is anything but JDK classes, the only way to access it will be using reflection.
+     *
+     * @param task The name of the task to run.
+     * @return The result of running the task.
+     */
+    public Object runTask(String task);
 }

--- a/framework/src/sbt-link/src/main/java/play/core/server/ServerWithStop.java
+++ b/framework/src/sbt-link/src/main/java/play/core/server/ServerWithStop.java
@@ -1,8 +1,20 @@
 package play.core.server;
 
+/**
+ * A server that can be stopped.
+ */
 public interface ServerWithStop {
 
+    /**
+     * Stop the server.
+     */
 	public void stop();
+
+    /**
+     * Get the address of the server.
+     *
+     * @return The address of the server.
+     */
 	public java.net.InetSocketAddress mainAddress(); 
 
 }


### PR DESCRIPTION
I would be thrilled if Pay could be decoupled from SBT. I realize Typesafe and the Play team will probably only ever support SBT, but it would be very awesome if it were easier for the community to add support for other build systems. E.g. I use Gradle to build all my other projects and it is extremely difficult to interface them with my Play project. Also, I find SBT to be very difficult to understand and would much prefer to have some choice in using it.

I'd really like for there to be a well-defined interface between Play and SBT. If there were one centralized and well-documented interface that could be implemented for any build system that would be awesome! A wiki page describing what would need to be done to add support for a new build system would be very helpful as well. With any luck, much of the logic that's now in SBT tasks/plugins could be moved to generic Scala/Java libraries and reused in other build system implementations.
