### PR TITLE
[doc] More WS documentation, worked examples

### DIFF
--- a/documentation/manual/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/scalaGuide/main/ws/ScalaWS.md
@@ -1,29 +1,108 @@
 # The Play WS API
 
-Sometimes we would like to call other HTTP services from within a Play application. Play supports this via its `play.api.libs.ws.WS` library, which provides a way to make asynchronous HTTP calls.
+Sometimes we would like to call other HTTP services from within a Play application. Play supports this via its [WS library](api/scala/index.html#play.api.libs.ws.package), which provides a way to make asynchronous HTTP calls.
 
-Any calls made by `play.api.libs.ws.WS` should return a `scala.concurrent.Future[play.api.libs.ws.Response]` which we can later handle with Play’s asynchronous mechanisms.
+## Imports
+
+To use WS, import the following:
+
+```scala
+import play.api.libs.ws._
+import scala.concurrent.Future
+```
 
 ## Making an HTTP call
 
-To send an HTTP request you start with `WS.url()` to specify the URL. Then you get a builder that you can use to specify various HTTP options, such as setting headers. You end by calling a final method corresponding to the HTTP method you want to use. For example:
+To send an HTTP request you start with `WS.url()` to specify the URL.  This returns an object called [WSRequestHolder](api/scala/index.html#play.api.libs.ws.WS$$WSRequestHolder) that you can use to specify various HTTP options, such as setting headers. You end by calling a final method corresponding to the HTTP method you want to use.
+
+For example:
 
 ```scala
-val homePage: Future[play.api.libs.ws.Response] = WS.url("http://mysite.com").get()
+WS.url("http://mysite.com").get()
 ```
 
 Or:
 
 ```scala
-val result: Future[ws.Response] = {
-  WS.url("http://localhost:9001/post").post("content")
-}
+WS.url("http://localhost:9001/post").post("content")
 ```
 
+### Calling with authentication
 
-## Retrieving the HTTP response result
+If you need to use HTTP authentication, you can specify it in the builder, using a username, password, and an [AuthScheme](http://sonatype.github.io/async-http-client/apidocs/reference/com/ning/http/client/Realm.AuthScheme.html).  Options for the AuthScheme are `BASIC`, `DIGEST`, `KERBEROS`, `NONE`, `NTLM`, and `SPNEGO`.
 
-The call is asynchronous and you need to manipulate it as a `Future[ws.Response]` to get the actual content. You can compose several promises and end with a `Future[Result]` that can be handled directly by the Play server:
+```scala
+import com.ning.http.client.Realm.AuthScheme
+WS.url("http://example.com/protectedfile").withAuth(user, password, AuthScheme.BASIC).get()
+```
+
+### Calling with redirects
+
+If an HTTP call results in a 302 or a 301 redirect, you can automatically follow the redirect without having to make another call.
+
+```scala
+WS.url("http://example.com/returns302").withFollowRedirects(true).get()
+```
+
+### Calling with query parameters
+
+Parameters can be specified as a series of key/value tuples.
+
+```scala
+WS.url("http://localhost:9000").withQueryString("paramKey" -> "paramValue").get()
+```
+
+### Calling with additional headers
+
+Headers can be specified as a series of key/value tuples.
+
+```scala
+WS.url("http://localhost:9000").withHeaders("headerKey" -> "headerValue").get()
+```
+
+### Calling with virtual host
+
+A virtual host can be specified as a string.
+
+```scala
+WS.url("http://localhost:9000").withVirtualHost("192.168.1.1").get()
+```
+
+### Calling with time out
+
+If you need to give a server more time to process, you can use `withTimeout` to set a value in milliseconds.  You may want to use this for extremely large files.
+
+```scala
+WS.url(dataUrl).withTimeout(1000).get()
+```
+
+### Using POST with url-form-encoded data
+
+To post url-form-encoded data a `Map[String, Seq[String]]` needs to be passed into `post`.
+
+```scala
+WS.url(url).post(Map("key" -> Seq("value")))
+```
+
+### Using POST with JSON data
+
+???
+
+```scala
+WS.url(url).post()
+```
+
+## Retrieving the HTTP response
+
+Any calls made by `WS` should return a `Future[Response]` which we can later handle with Play’s asynchronous mechanisms.
+
+### Processing a response as JSON or XML
+
+???
+
+### Processing a response to a controller
+
+You can compose several promises and end with a `Future[Result]` that can be handled directly by the Play server, using the `Async` method
 
 ```scala
 def feedTitle(feedUrl: String) = Action {
@@ -35,15 +114,63 @@ def feedTitle(feedUrl: String) = Action {
 }
 ```
 
-## Post url-form-encoded data
+### Processing large responses
 
-To post url-form-encoded data a `Map[String, Seq[String]]` needs to be passed into post()
+Calling `get` or `post` by default will cause the body of the request to be loaded into memory before the response is made available.  When you are downloading with large, multi-gigabyte files, this may result in unwelcome garbage collection or even out of memory errors.  `WS` lets you deal with the download as a stream using [[iteratees|Iteratees]].
+
+@[scalaws-fileupload](code/ScalaWSSpec.scala)
+
+POST and PUT use a slightly different API: instead of `post`, you call `postAndRetrieveStream`:
 
 ```scala
-WS.url(url).post(Map("key" -> Seq("value")))
+WS.url("http://example.com/largedata").postAndRetrieveStream(body) { headers =>
+  Iteratee.foreach { bytes => logger.info("Received bytes: " + bytes.length) }
+}
 ```
 
-## Configuring WS client
+## Common Patterns and Use Cases
+
+### Chaining WS calls
+
+Using for comprehensions is a good way to chain conversations of WS calls.
+
+```scala
+  for {
+    jsonPayload <- WS.url("http://example.com/first").get()
+    reply = constructReply(jsonPayload)
+    response <- WS.url("http://example.com/post").post(reply)
+  } yield response
+```
+
+### Using Recover
+
+Recover is technically part of the Future, but is widely used to return values.
+
+```
+  WS.url("http://example.com").get().recover {
+    WS.url("http://backup.example.com").get()
+  }
+```
+
+??? How to use with for comprehensions?
+
+## Advanced Usage
+
+You can also get access to the underlying [async client](http://sonatype.github.io/async-http-client/apidocs/reference/com/ning/http/client/AsyncHttpClient.html).
+
+```scala
+import com.ning.http.client.AsyncHttpClient
+
+val client:AsyncHttpClient = WS.client
+```
+
+## Limitations
+
+* `WS` does not support multi part form upload directly.  You can use the underlying client.
+* `WS` does not support mutual TLS.
+* `WS` does not support faking a user agent.
+
+## Configuring WS 
 
 Use the following properties to configure the WS client
 
@@ -53,7 +180,6 @@ Use the following properties to configure the WS client
 * `ws.useragent` to configure the User-Agent header field
 * `ws.acceptAnyCertificate` set it to false to use the default SSLContext
 
-You can also get access to the underlying client using `def client` method  
  
 
 > **Next:** [[OpenID Support in Play | ScalaOpenID]]

--- a/documentation/manual/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -1,0 +1,81 @@
+package scalaguide.ws.scalaws {
+
+import play.api.libs.ws._
+import play.api.libs.iteratee._
+import scala.concurrent.{ExecutionContext, Future}
+
+import play.api.mvc._
+import play.api.test._
+import play.api.test.Helpers._
+
+import java.io._
+
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+import play.api.libs.Files.TemporaryFile
+
+@RunWith(classOf[JUnitRunner])
+class ScalaWSSpec extends PlaySpecification with Results {
+
+  "WS get" should {
+
+    // Create a route that will lead us to a file we'll download in chunks.
+    val fakeApplication: FakeApplication = FakeApplication(withRoutes = {
+      case ("GET", "/") =>
+        Action {
+          // Create an input stream of lots of null bytes.
+          val inputStream: InputStream = new InputStream() {
+            private var count = 0
+            private val numBytes = 4096
+
+            def read(): Int = {
+              count = count + 1
+              if (count > numBytes) -1 else 0
+            }
+          }
+          implicit val context = scala.concurrent.ExecutionContext.Implicits.global
+
+          Ok.chunked(Enumerator.fromStream(inputStream))
+        }
+      case (_, _) =>
+        Action {
+          BadRequest("no binding found")
+        }
+    })
+
+    "work with an iteratee" in new WithServer(fakeApplication, 3333) {
+      implicit val context = scala.concurrent.ExecutionContext.Implicits.global
+
+      val file = File.createTempFile("scalaws", "")
+      try {
+        // #scalaws-fileupload
+        val timeout = 3000
+        val outputStream: OutputStream = new BufferedOutputStream(new FileOutputStream(file))
+        val futureResponse = WS.url("http://localhost:3333/").withTimeout(timeout).get({
+          headers =>
+            Iteratee.fold[Array[Byte], OutputStream](outputStream) {
+              (stream, bytes) =>
+                stream.write(bytes)
+                stream
+            }
+        }).map {
+          iteratee =>
+            outputStream.flush()
+            outputStream.close()
+            iteratee
+        }
+        // #scalaws-fileupload
+        await(futureResponse, 4000)
+
+        file.exists() should beTrue
+        file.length() should beEqualTo(4096)
+      } finally {
+        file.delete()
+      }
+    }
+  }
+
+}
+
+}
+


### PR DESCRIPTION
Need to do some follow up work on http://www.playframework.com/documentation/2.2-SNAPSHOT/ScalaWS to match http://www.playframework.com/documentation/2.2-SNAPSHOT/JavaWS and provide more examples for both JavaWS and ScalaWS (some work already done in #1475).

https://groups.google.com/forum/#!searchin/play-framework/WS/play-framework/UylCl0mAa00/Wyq4_uUt9cEJ
https://groups.google.com/forum/#!searchin/play-framework/WS/play-framework/BYeyBuannGs/oxdssGDoVOkJ

Examples:
- Using recover
- Using for comprehensions for futures
- Using withAuth()
- Providing toJson and toXML formatting.
