### PR TITLE
Application.path points to wrong place

### DIFF
--- a/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
@@ -8,7 +8,7 @@ import org.jboss.netty.channel.group._
 import org.jboss.netty.handler.ssl._
 
 import java.security._
-import java.net.{ InetSocketAddress }
+import java.net.InetSocketAddress
 import javax.net.ssl._
 import java.util.concurrent._
 
@@ -269,11 +269,17 @@ object NettyServer {
    * @param args
    */
   def main(args: Array[String]) {
-    args.headOption.orElse(
-      Option(System.getProperty("user.dir"))).map(new File(_)).filter(p => p.exists && p.isDirectory).map { applicationPath =>
-        createServer(applicationPath).getOrElse(System.exit(-1))
+    args.headOption
+      .orElse(Option(System.getProperty("user.dir")))
+      .map { applicationPath =>
+        val applicationFile = new File(applicationPath)
+        if (!(applicationFile.exists && applicationFile.isDirectory)) {
+          println("Bad application path: " + applicationPath)
+        } else {
+          createServer(applicationFile).getOrElse(System.exit(-1))
+        }
       }.getOrElse {
-        println("Not a valid Play application")
+        println("No application path supplied")
       }
   }
 

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -5,6 +5,7 @@ import sbt.Keys._
 import Keys._
 import PlayEclipse._
 import com.typesafe.sbt.SbtNativePackager._
+import com.typesafe.sbt.packager.Keys._
 
 trait Settings {
   this: PlayCommands with PlayPositionMapper with PlayRun with PlaySourceGenerators =>
@@ -251,7 +252,10 @@ trait Settings {
           readmeFile: File =>
             readmeFile -> readmeFile.getName
         }
-    }
+    },
+
+    // Adds the Play application directory to the command line args passed to Play
+    bashScriptExtraDefines += "addJava \"-Duser.dir=$(cd \"${app_home}/..\"; pwd -P)\"\n"
 
   )
 }


### PR DESCRIPTION
`Application.path` no longer points to the application dir when running the native packager start script, I think it points to the current working directory.
