### PR TITLE
gzip filter doesn't preserve existing response headers

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -172,7 +172,7 @@ class GzipFilter(gzip: Enumeratee[Array[Byte], Array[Byte]] = Gzip.gzip(GzipFilt
   private def isNotAlreadyCompressed(header: ResponseHeader) = header.headers.get(Names.CONTENT_ENCODING).isEmpty
 
   private def setupHeader(header: Map[String, String]): Map[String, String] = {
-    header.filter(_._1 == Names.CONTENT_LENGTH) + (Names.CONTENT_ENCODING -> "gzip") + (Names.VARY -> Names.ACCEPT_ENCODING)
+    header.filterNot(_._1 == Names.CONTENT_LENGTH) + (Names.CONTENT_ENCODING -> "gzip") + (Names.VARY -> Names.ACCEPT_ENCODING)
   }
 }
 


### PR DESCRIPTION
The gzip filter is not preserving existing response headers.
