### PR TITLE
Typo in EmailValidator pattern

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/validation/Constraints.java
+++ b/framework/src/play-java/src/main/java/play/data/validation/Constraints.java
@@ -358,7 +358,7 @@ public class Constraints {
     public static class EmailValidator extends Validator<String> implements ConstraintValidator<Email, String> {
         
         final static public String message = "error.email";
-        final static java.util.regex.Pattern regex = java.util.regex.Pattern.compile("\\b[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*\\b");
+        final static java.util.regex.Pattern regex = java.util.regex.Pattern.compile("\\b[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*\\b");
         
         public EmailValidator() {}
         

--- a/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
@@ -6,7 +6,88 @@ import play.mvc._
 import play.mvc.Http.Context
 import scala.collection.JavaConverters._
 
-import play.data.{ Form => JForm }
+object FormSpec extends Specification {
+
+  "a java form" should {
+    "be valid" in new WithApplication{
+      val req = new DummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "done" -> Array("true"), "dueDate" -> Array("15/12/2009")))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
+
+      val myForm = Form.form(classOf[play.data.models.Task]).bindFromRequest()
+      myForm hasErrors () must beEqualTo(false)
+    }
+    "be valid with mandatory params passed" in new WithApplication{
+      val req = new DummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009")))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
+
+      val myForm = Form.form(classOf[play.data.models.Task]).bindFromRequest()
+      myForm hasErrors () must beEqualTo(false)
+    }
+    "have an error due to baldy formatted date" in new WithApplication{
+      val req = new DummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
+
+      val myForm = Form.form(classOf[play.data.models.Task]).bindFromRequest()
+      myForm hasErrors () must beEqualTo(true)
+      myForm.errors.get("dueDate").get(0).message() must beEqualTo("error.invalid.java.util.Date")
+    }
+    "have an error due to bad value in Id field" in new WithApplication{
+      val req = new DummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter"), "dueDate" -> Array("12/12/2009")))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
+
+      val myForm = Form.form(classOf[play.data.models.Task]).bindFromRequest()
+      myForm hasErrors () must beEqualTo(true)
+      myForm.errors.get("id").get(0).message() must beEqualTo("error.invalid")
+    }
+
+    "support repeated values for Java binding" in {
+
+      val user1 = Form.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki")))).get
+      user1.getName must beEqualTo("Kiki")
+      user1.getEmails.size must beEqualTo(0)
+
+      val user2 = Form.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki"), "emails[0]" -> Array("kiki@gmail.com")))).get
+      user2.getName must beEqualTo("Kiki")
+      user2.getEmails.size must beEqualTo(1)
+
+      val user3 = Form.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki"), "emails[0]" -> Array("kiki@gmail.com"), "emails[1]" -> Array("kiki@zen.com")) )).get
+      user3.getName must beEqualTo("Kiki")
+      user3.getEmails.size must beEqualTo(2)
+
+      val user4 = Form.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki"), "emails[]" -> Array("kiki@gmail.com")) )).get
+      user4.getName must beEqualTo("Kiki")
+      user4.getEmails.size must beEqualTo(1)
+
+      val user5 = Form.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki"), "emails[]" -> Array("kiki@gmail.com", "kiki@zen.com")) )).get
+      user5.getName must beEqualTo("Kiki")
+      user5.getEmails.size must beEqualTo(2)
+
+    }
+
+    "support option deserialization" in {
+      val user1 = Form.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki")))).get
+      user1.getCompany.isDefined must beEqualTo(false)
+
+      val user2 = Form.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki"), "company" -> Array("Acme")))).get
+      user2.getCompany.get must beEqualTo("Acme")
+    }
+
+    "bind when valid" in {
+      val userForm: Form[MyUser] = Form.form(classOf[MyUser])
+      val user = userForm.bind(new java.util.HashMap[String, String]()).get()
+      userForm.hasErrors() must equalTo(false)
+      (user == null) must equalTo(false)
+    }
+
+    "support email validation" in {
+      val userEmail = Form.form(classOf[UserEmail])
+      userEmail.bind(Map("email" -> "john@example.com").asJava).errors().asScala must beEmpty
+      userEmail.bind(Map("email" -> "o'flynn@example.com").asJava).errors().asScala must beEmpty
+      userEmail.bind(Map("email" -> "john@ex'ample.com").asJava).errors().asScala must not beEmpty
+    }
+  }
+
+}
 
 class DummyRequest(data: Map[String, Array[String]]) extends play.mvc.Http.Request {
   def uri() = "/test"
@@ -34,289 +115,4 @@ class DummyRequest(data: Map[String, Array[String]]) extends play.mvc.Http.Reque
   setUsername("peter")
 }
 
-object ScalaForms {
-   import play.api.data.validation.Constraints._
-   import play.api.data._
-   import play.api.data.Forms._
-   import format.Formats._
-
-   case class User(name: String, age: Int)
-
-    val userForm = Form(
-      mapping(
-        "name" -> of[String].verifying(nonEmpty),
-        "age" -> of[Int].verifying(min(0), max(100))
-      )(User.apply)(User.unapply)
-    )
-
-    val loginForm = Form(
-      tuple(
-        "email" -> of[String],
-        "password" -> of[Int]
-      )
-    )
-
-    val defaultValuesForm = Form(
-      tuple(
-        "pos" -> default(number, 42),
-        "name" -> default(text, "default text")
-      )
-    )
-
-    val helloForm = Form(
-      tuple(
-        "name" -> nonEmptyText,
-        "repeat" -> number(min = 1, max = 100),
-        "color" -> optional(text),
-        "still works" -> optional(text),
-        "1" -> optional(text),
-        "2" -> optional(text),
-        "3" -> optional(text),
-        "4" -> optional(text),
-        "5" -> optional(text),
-        "6" -> optional(text),
-        "7" -> optional(text),
-        "8" -> optional(text),
-        "9" -> optional(text),
-        "10" -> optional(text),
-        "11" -> optional(text),
-        "12" -> optional(text),
-        "13" -> optional(text),
-        "14" -> optional(text)
-      )
-    )
-
-    val repeatedForm = Form(
-      tuple(
-        "name" -> nonEmptyText,
-        "emails" -> list(nonEmptyText)
-      )
-    )
-
-    val form = Form(
-          "foo" -> Forms.text.verifying("first.digit", s => (s.headOption map {_ == '3'}) getOrElse false)
-                     .transform[Int](Integer.parseInt _, _.toString).verifying("number.42", _ < 42)
-    )
-
-    val emailForm = Form(
-      tuple(
-        "email" -> email,
-        "name" -> of[String]
-      )
-    )
-
-    val longNumberForm = Form("longNumber" -> longNumber(10, 42))
-}
-
-object FormSpec extends Specification {
-
-  sequential
-
-  "A form" should {
-    "be valid" in new WithApplication{
-      val req = new DummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "done" -> Array("true"), "dueDate" -> Array("15/12/2009")))
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
-
-      val myForm = JForm.form(classOf[play.data.models.Task]).bindFromRequest()
-      myForm hasErrors () must beEqualTo(false)
-    }
-    "be valid with mandatory params passed" in new WithApplication{
-      val req = new DummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009")))
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
-
-      val myForm = JForm.form(classOf[play.data.models.Task]).bindFromRequest()
-      myForm hasErrors () must beEqualTo(false)
-    }
-    "have an error due to baldy formatted date" in new WithApplication{
-      val req = new DummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
-
-      val myForm = JForm.form(classOf[play.data.models.Task]).bindFromRequest()
-      myForm hasErrors () must beEqualTo(true)
-      myForm.errors.get("dueDate").get(0).message() must beEqualTo("error.invalid.java.util.Date")
-    }
-    "have an error due to bad value in Id field" in new WithApplication{
-      val req = new DummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter"), "dueDate" -> Array("12/12/2009")))
-      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
-
-      val myForm = JForm.form(classOf[play.data.models.Task]).bindFromRequest()
-      myForm hasErrors () must beEqualTo(true)
-      myForm.errors.get("id").get(0).message() must beEqualTo("error.invalid")
-    }
-    "have an error due to a malformed email" in {
-      val f5 = ScalaForms.emailForm.fillAndValidate("john@", "John")
-      f5.errors.size must equalTo (1)
-      f5.errors.find(_.message == "error.email") must beSome
-
-      val f6 = ScalaForms.emailForm.fillAndValidate("john@zen.....com", "John")
-      f6.errors.size must equalTo (1)
-      f6.errors.find(_.message == "error.email") must beSome
-    }
-
-    "be valid with a well-formed email" in {
-      val f7 = ScalaForms.emailForm.fillAndValidate("john@zen.com", "John")
-      f7.errors.size must equalTo (0)
-
-      val f8 = ScalaForms.emailForm.fillAndValidate("john@zen.museum", "John")
-      f8.errors.size must equalTo (0)
-
-      val f9 = ScalaForms.emailForm.fillAndValidate("john@mail.zen.com", "John")
-      f9.errors.size must equalTo(0)
-    }
-
-    "apply constraints on wrapped mappings" in {
-      "when it binds data" in {
-        val f1 = ScalaForms.form.bind(Map("foo"->"0"))
-        f1.errors.size must equalTo (1)
-        f1.errors.find(_.message == "first.digit") must beSome
-
-        val f2 = ScalaForms.form.bind(Map("foo"->"3"))
-        f2.errors.size must equalTo (0)
-
-        val f3 = ScalaForms.form.bind(Map("foo"->"50"))
-        f3.errors.size must equalTo (1) // Only one error because "number.42" can’t be applied since wrapped bind failed
-        f3.errors.find(_.message == "first.digit") must beSome
-
-        val f4 = ScalaForms.form.bind(Map("foo"->"333"))
-        f4.errors.size must equalTo (1)
-        f4.errors.find(_.message == "number.42") must beSome
-      }
-
-      "when it is filled with data" in {
-        val f1 = ScalaForms.form.fillAndValidate(0)
-        f1.errors.size must equalTo (1)
-        f1.errors.find(_.message == "first.digit") must beSome
-
-        val f2 = ScalaForms.form.fillAndValidate(3)
-        f2.errors.size must equalTo (0)
-
-        val f3 = ScalaForms.form.fillAndValidate(50)
-        f3.errors.size must equalTo (2)
-        f3.errors.find(_.message == "first.digit") must beSome
-        f3.errors.find(_.message == "number.42") must beSome
-
-        val f4 = ScalaForms.form.fillAndValidate(333)
-        f4.errors.size must equalTo (1)
-        f4.errors.find(_.message == "number.42") must beSome
-      }
-    }
-
-    "apply constraints on longNumber fields" in {
-      val f1 = ScalaForms.longNumberForm.fillAndValidate(0);
-      f1.errors.size must equalTo(1)
-      f1.errors.find(_.message == "error.min") must beSome
-
-      val f2 = ScalaForms.longNumberForm.fillAndValidate(9000);
-      f2.errors.size must equalTo(1)
-      f2.errors.find(_.message == "error.max") must beSome
-
-      val f3 = ScalaForms.longNumberForm.fillAndValidate(10);
-      f3.errors.size must equalTo(0)
-
-      val f4 = ScalaForms.longNumberForm.fillAndValidate(42);
-      f3.errors.size must equalTo(0)
-    }
-  }
-
-  "render form using field[Type] syntax" in {
-    val anyData = Map("email" -> "bob@gmail.com", "password" -> "123")
-    ScalaForms.loginForm.bind(anyData).get.toString must equalTo("(bob@gmail.com,123)")
-  }
-
-  "support default values" in {
-    ScalaForms.defaultValuesForm.bindFromRequest( Map() ).get must equalTo(42, "default text")
-    ScalaForms.defaultValuesForm.bindFromRequest( Map("name" -> Seq("another text") ) ).get must equalTo(42, "another text")
-    ScalaForms.defaultValuesForm.bindFromRequest( Map("pos" -> Seq("123")) ).get must equalTo(123, "default text")
-    ScalaForms.defaultValuesForm.bindFromRequest( Map("pos" -> Seq("123"), "name" -> Seq("another text")) ).get must equalTo(123, "another text")
-
-    val f1 = ScalaForms.defaultValuesForm.bindFromRequest( Map("pos" -> Seq("abc")) )
-    f1.errors.size must equalTo (1)
-  }
-
-  "support repeated values" in {
-    ScalaForms.repeatedForm.bindFromRequest( Map("name" -> Seq("Kiki")) ).get must equalTo(("Kiki", Seq()))
-    ScalaForms.repeatedForm.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[0]" -> Seq("kiki@gmail.com")) ).get must equalTo(("Kiki", Seq("kiki@gmail.com")))
-    ScalaForms.repeatedForm.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[0]" -> Seq("kiki@gmail.com"), "emails[1]" -> Seq("kiki@zen.com")) ).get must equalTo(("Kiki", Seq("kiki@gmail.com", "kiki@zen.com")))
-    ScalaForms.repeatedForm.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[0]" -> Seq(), "emails[1]" -> Seq("kiki@zen.com")) ).hasErrors must equalTo(true)
-    ScalaForms.repeatedForm.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[]" -> Seq("kiki@gmail.com")) ).get must equalTo(("Kiki", Seq("kiki@gmail.com")))
-    ScalaForms.repeatedForm.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[]" -> Seq("kiki@gmail.com", "kiki@zen.com")) ).get must equalTo(("Kiki", Seq("kiki@gmail.com", "kiki@zen.com")))
-  }
-
-  "support repeated values for Java binding" in {
-
-    val user1 = JForm.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki")))).get
-    user1.getName must beEqualTo("Kiki")
-    user1.getEmails.size must beEqualTo(0)
-
-    val user2 = JForm.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki"), "emails[0]" -> Array("kiki@gmail.com")))).get
-    user2.getName must beEqualTo("Kiki")
-    user2.getEmails.size must beEqualTo(1)
-
-    val user3 = JForm.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki"), "emails[0]" -> Array("kiki@gmail.com"), "emails[1]" -> Array("kiki@zen.com")) )).get
-    user3.getName must beEqualTo("Kiki")
-    user3.getEmails.size must beEqualTo(2)
-
-    val user4 = JForm.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki"), "emails[]" -> Array("kiki@gmail.com")) )).get
-    user4.getName must beEqualTo("Kiki")
-    user4.getEmails.size must beEqualTo(1)
-
-    val user5 = JForm.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki"), "emails[]" -> Array("kiki@gmail.com", "kiki@zen.com")) )).get
-    user5.getName must beEqualTo("Kiki")
-    user5.getEmails.size must beEqualTo(2)
-
-  }
-
-  "support option deserialization" in {
-    val user1 = JForm.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki")))).get
-    user1.getCompany.isDefined must beEqualTo(false)
-
-    val user2 = JForm.form(classOf[play.data.AnotherUser]).bindFromRequest(new DummyRequest(Map("name" -> Array("Kiki"), "company" -> Array("Acme")))).get
-    user2.getCompany.get must beEqualTo("Acme")
-  }
-
-  "render a form with max 18 fields" in {
-    ScalaForms.helloForm.bind(Map("name" -> "foo", "repeat" -> "1")).get.toString must equalTo("(foo,1,None,None,None,None,None,None,None,None,None,None,None,None,None,None,None,None)")
-  }
-
-  "render a from using java" in {
-    import play.data._
-    val userForm: Form[MyUser] = JForm.form(classOf[MyUser])
-    val user = userForm.bind(new java.util.HashMap[String, String]()).get()
-    userForm.hasErrors() must equalTo(false)
-    (user == null) must equalTo(false)
-  }
-
-  "render form using jodaDate" in {
-    import play.api.data._
-    import play.api.data.Forms._
-    import play.api.data.format.Formats.jodaDateTimeFormat
-    import org.joda.time.DateTime
-
-    val dateForm = Form(("date" -> jodaDate))
-    val data = Map("date" -> "2012-01-01")
-    dateForm.bind(data).get mustEqual(new DateTime(2012,1,1,0,0))
-  }
-
-  "render form using jodaDate with format(30/1/2012)" in {
-    import play.api.data._
-    import play.api.data.Forms._
-    import play.api.data.format.Formats.jodaDateTimeFormat
-    import org.joda.time.DateTime
-
-    val dateForm = Form(("date" -> jodaDate("dd/MM/yyyy")))
-    val data = Map("date" -> "30/1/2012")
-    dateForm.bind(data).get mustEqual(new DateTime(2012,1,30,0,0))
-  }
-
-  "render form using jodaLocalDate with format(30/1/2012)" in {
-    import play.api.data._
-    import play.api.data.Forms._
-    import play.api.data.format.Formats.jodaLocalDateFormat
-    import org.joda.time.LocalDate
-
-    val dateForm = Form(("date" -> jodaLocalDate("dd/MM/yyyy")))
-    val data = Map("date" -> "30/1/2012")
-    dateForm.bind(data).get mustEqual(new LocalDate(2012,1,30))
-  }
-}
 

--- a/framework/src/play-java/src/test/scala/play/data/UserEmail.java
+++ b/framework/src/play-java/src/test/scala/play/data/UserEmail.java
@@ -1,0 +1,17 @@
+package play.data;
+
+import play.data.validation.Constraints;
+
+public class UserEmail {
+
+    @Constraints.Email
+    public String email;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/framework/src/play/src/main/scala/play/api/data/Forms.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Forms.scala
@@ -490,7 +490,7 @@ object Forms {
    * }}}
    */
   val email: Mapping[String] = of[String] verifying Constraints.pattern(
-    """\b[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\b""".r,
+    """\b[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\b""".r,
     "constraint.email",
     "error.email")
 

--- a/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
@@ -1,18 +1,213 @@
 package play.api.data
 
-import Forms._
+import play.api.data.Forms._
+import play.api.data.validation.Constraints._
+import play.api.data.format.Formats._
 import org.specs2.mutable.Specification
+import org.joda.time.{DateTime, LocalDate}
 
 object FormSpec extends Specification {
+  "A form" should {
+    "have an error due to a malformed email" in {
+      val f5 = ScalaForms.emailForm.fillAndValidate("john@", "John")
+      f5.errors.size must equalTo (1)
+      f5.errors.find(_.message == "error.email") must beSome
 
-  "Form" should {
-
-    "reject input if it contains global errors" in {
-      Form( "value" -> nonEmptyText ).withGlobalError("some.error").bind( Map("value" -> "some value") ).fold(
-        formWithErrors => { formWithErrors.errors.head.message must equalTo("some.error") },
-        { data => "The mapping should fail." must equalTo("Error") }
-      )
+      val f6 = ScalaForms.emailForm.fillAndValidate("john@zen.....com", "John")
+      f6.errors.size must equalTo (1)
+      f6.errors.find(_.message == "error.email") must beSome
     }
 
+    "be valid with a well-formed email" in {
+      val f7 = ScalaForms.emailForm.fillAndValidate("john@zen.com", "John")
+      f7.errors.size must equalTo (0)
+
+      val f8 = ScalaForms.emailForm.fillAndValidate("john@zen.museum", "John")
+      f8.errors.size must equalTo (0)
+
+      val f9 = ScalaForms.emailForm.fillAndValidate("john@mail.zen.com", "John")
+      f9.errors.size must equalTo(0)
+
+      ScalaForms.emailForm.fillAndValidate("o'flynn@example.com", "O'Flynn").errors must beEmpty
+    }
+
+    "apply constraints on wrapped mappings" in {
+      "when it binds data" in {
+        val f1 = ScalaForms.form.bind(Map("foo"->"0"))
+        f1.errors.size must equalTo (1)
+        f1.errors.find(_.message == "first.digit") must beSome
+
+        val f2 = ScalaForms.form.bind(Map("foo"->"3"))
+        f2.errors.size must equalTo (0)
+
+        val f3 = ScalaForms.form.bind(Map("foo"->"50"))
+        f3.errors.size must equalTo (1) // Only one error because "number.42" can’t be applied since wrapped bind failed
+        f3.errors.find(_.message == "first.digit") must beSome
+
+        val f4 = ScalaForms.form.bind(Map("foo"->"333"))
+        f4.errors.size must equalTo (1)
+        f4.errors.find(_.message == "number.42") must beSome
+      }
+
+      "when it is filled with data" in {
+        val f1 = ScalaForms.form.fillAndValidate(0)
+        f1.errors.size must equalTo (1)
+        f1.errors.find(_.message == "first.digit") must beSome
+
+        val f2 = ScalaForms.form.fillAndValidate(3)
+        f2.errors.size must equalTo (0)
+
+        val f3 = ScalaForms.form.fillAndValidate(50)
+        f3.errors.size must equalTo (2)
+        f3.errors.find(_.message == "first.digit") must beSome
+        f3.errors.find(_.message == "number.42") must beSome
+
+        val f4 = ScalaForms.form.fillAndValidate(333)
+        f4.errors.size must equalTo (1)
+        f4.errors.find(_.message == "number.42") must beSome
+      }
+    }
+
+    "apply constraints on longNumber fields" in {
+      val f1 = ScalaForms.longNumberForm.fillAndValidate(0);
+      f1.errors.size must equalTo(1)
+      f1.errors.find(_.message == "error.min") must beSome
+
+      val f2 = ScalaForms.longNumberForm.fillAndValidate(9000);
+      f2.errors.size must equalTo(1)
+      f2.errors.find(_.message == "error.max") must beSome
+
+      val f3 = ScalaForms.longNumberForm.fillAndValidate(10);
+      f3.errors.size must equalTo(0)
+
+      val f4 = ScalaForms.longNumberForm.fillAndValidate(42);
+      f3.errors.size must equalTo(0)
+    }
   }
+
+  "render form using field[Type] syntax" in {
+    val anyData = Map("email" -> "bob@gmail.com", "password" -> "123")
+    ScalaForms.loginForm.bind(anyData).get.toString must equalTo("(bob@gmail.com,123)")
+  }
+
+  "support default values" in {
+    ScalaForms.defaultValuesForm.bindFromRequest( Map() ).get must equalTo(42, "default text")
+    ScalaForms.defaultValuesForm.bindFromRequest( Map("name" -> Seq("another text") ) ).get must equalTo(42, "another text")
+    ScalaForms.defaultValuesForm.bindFromRequest( Map("pos" -> Seq("123")) ).get must equalTo(123, "default text")
+    ScalaForms.defaultValuesForm.bindFromRequest( Map("pos" -> Seq("123"), "name" -> Seq("another text")) ).get must equalTo(123, "another text")
+
+    val f1 = ScalaForms.defaultValuesForm.bindFromRequest( Map("pos" -> Seq("abc")) )
+    f1.errors.size must equalTo (1)
+  }
+
+  "support repeated values" in {
+    ScalaForms.repeatedForm.bindFromRequest( Map("name" -> Seq("Kiki")) ).get must equalTo(("Kiki", Seq()))
+    ScalaForms.repeatedForm.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[0]" -> Seq("kiki@gmail.com")) ).get must equalTo(("Kiki", Seq("kiki@gmail.com")))
+    ScalaForms.repeatedForm.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[0]" -> Seq("kiki@gmail.com"), "emails[1]" -> Seq("kiki@zen.com")) ).get must equalTo(("Kiki", Seq("kiki@gmail.com", "kiki@zen.com")))
+    ScalaForms.repeatedForm.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[0]" -> Seq(), "emails[1]" -> Seq("kiki@zen.com")) ).hasErrors must equalTo(true)
+    ScalaForms.repeatedForm.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[]" -> Seq("kiki@gmail.com")) ).get must equalTo(("Kiki", Seq("kiki@gmail.com")))
+    ScalaForms.repeatedForm.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[]" -> Seq("kiki@gmail.com", "kiki@zen.com")) ).get must equalTo(("Kiki", Seq("kiki@gmail.com", "kiki@zen.com")))
+  }
+
+
+  "render a form with max 18 fields" in {
+    ScalaForms.helloForm.bind(Map("name" -> "foo", "repeat" -> "1")).get.toString must equalTo("(foo,1,None,None,None,None,None,None,None,None,None,None,None,None,None,None,None,None)")
+  }
+
+  "render form using jodaDate" in {
+    val dateForm = Form(("date" -> jodaDate))
+    val data = Map("date" -> "2012-01-01")
+    dateForm.bind(data).get mustEqual(new DateTime(2012,1,1,0,0))
+  }
+
+  "render form using jodaDate with format(30/1/2012)" in {
+    val dateForm = Form(("date" -> jodaDate("dd/MM/yyyy")))
+    val data = Map("date" -> "30/1/2012")
+    dateForm.bind(data).get mustEqual(new DateTime(2012,1,30,0,0))
+  }
+
+  "render form using jodaLocalDate with format(30/1/2012)" in {
+    val dateForm = Form(("date" -> jodaLocalDate("dd/MM/yyyy")))
+    val data = Map("date" -> "30/1/2012")
+    dateForm.bind(data).get mustEqual(new LocalDate(2012,1,30))
+  }
+
+  "reject input if it contains global errors" in {
+    Form( "value" -> nonEmptyText ).withGlobalError("some.error")
+      .bind( Map("value" -> "some value"))
+      .errors.headOption must beSome.like {
+        case error => error.message must equalTo("some.error")
+      }
+  }
+
+}
+
+object ScalaForms {
+
+  case class User(name: String, age: Int)
+
+  val userForm = Form(
+    mapping(
+      "name" -> of[String].verifying(nonEmpty),
+      "age" -> of[Int].verifying(min(0), max(100))
+    )(User.apply)(User.unapply)
+  )
+
+  val loginForm = Form(
+    tuple(
+      "email" -> of[String],
+      "password" -> of[Int]
+    )
+  )
+
+  val defaultValuesForm = Form(
+    tuple(
+      "pos" -> default(number, 42),
+      "name" -> default(text, "default text")
+    )
+  )
+
+  val helloForm = Form(
+    tuple(
+      "name" -> nonEmptyText,
+      "repeat" -> number(min = 1, max = 100),
+      "color" -> optional(text),
+      "still works" -> optional(text),
+      "1" -> optional(text),
+      "2" -> optional(text),
+      "3" -> optional(text),
+      "4" -> optional(text),
+      "5" -> optional(text),
+      "6" -> optional(text),
+      "7" -> optional(text),
+      "8" -> optional(text),
+      "9" -> optional(text),
+      "10" -> optional(text),
+      "11" -> optional(text),
+      "12" -> optional(text),
+      "13" -> optional(text),
+      "14" -> optional(text)
+    )
+  )
+
+  val repeatedForm = Form(
+    tuple(
+      "name" -> nonEmptyText,
+      "emails" -> list(nonEmptyText)
+    )
+  )
+
+  val form = Form(
+    "foo" -> Forms.text.verifying("first.digit", s => (s.headOption map {_ == '3'}) getOrElse false)
+      .transform[Int](Integer.parseInt _, _.toString).verifying("number.42", _ < 42)
+  )
+
+  val emailForm = Form(
+    tuple(
+      "email" -> email,
+      "name" -> of[String]
+    )
+  )
+
+  val longNumberForm = Form("longNumber" -> longNumber(10, 42))
 }


### PR DESCRIPTION
I found a typo in the regular expression pattern of EmailValidator.

The pattern contains a multibyte single quote `’` (= \xE280 \u2019) character, but it should be an ASCII apostrophe `'` (= \x27).

Scala API `play.api.data.Forms.email`

```
"""\b[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\b""".r
```

Also, Java API `play.data.validation.Constraints.EmailValidator`

```
"\\b[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*\\b"
```
