### PR TITLE
Fixes for AuthenticatedBuilder ScalaDoc

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
@@ -1,8 +1,10 @@
 package play.it.auth
 
 import play.api.test._
-import play.api.mvc.Security.AuthenticatedBuilder
-import play.api.mvc.Results
+import play.api.mvc.Security.{AuthenticatedRequest, AuthenticatedBuilder}
+import play.api.mvc._
+import scala.concurrent.Future
+import play.api.test.FakeApplication
 
 object SecuritySpec extends PlaySpecification {
 
@@ -20,9 +22,39 @@ object SecuritySpec extends PlaySpecification {
       contentAsString(result) must_== "john"
     }
 
+    "allow use as an ActionBuilder" in withApplication {
+      val result = Authenticated { req =>
+        Results.Ok(s"${req.conn.name}:${req.user.name}")
+      }(FakeRequest().withSession("user" -> "Phil"))
+      status(result) must_== OK
+      contentAsString(result) must_== "fake:Phil"
+    }
   }
 
   val TestAction = AuthenticatedBuilder()
+
+  case class User(name: String)
+  def getUserFromRequest(req: RequestHeader) = req.session.get("user") map (User(_))
+
+  class AuthenticatedDbRequest[A](val user: User, val conn: Connection, request: Request[A]) extends WrappedRequest[A](request)
+
+  object Authenticated extends ActionBuilder[AuthenticatedDbRequest] {
+    def invokeBlock[A](request: Request[A], block: (AuthenticatedDbRequest[A]) => Future[SimpleResult]) = {
+      AuthenticatedBuilder(req => getUserFromRequest(req)).authenticate(request, { authRequest: AuthenticatedRequest[A, User] =>
+        DB.withConnection { conn =>
+          block(new AuthenticatedDbRequest[A](authRequest.user, conn, request))
+        }
+      })
+    }
+  }
+
+  object DB {
+    def withConnection[A](block: Connection => A) = {
+      block(FakeConnection)
+    }
+  }
+  object FakeConnection extends Connection("fake")
+  case class Connection(name: String)
 
   def withApplication[T](block: => T) =
     running(FakeApplication(additionalConfiguration = Map("application.secret" -> "foobar")))(block)

--- a/framework/src/play/src/main/scala/play/api/mvc/Security.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Security.scala
@@ -113,11 +113,11 @@ object Security {
    *
    * object Authenticated extends ActionBuilder[AuthenticatedDbRequest] {
    *   def invokeBlock[A](request: Request[A], block: (AuthenticatedDbRequest[A]) => Future[SimpleResult]) = {
-   *     AuthenticatedBuilder(req => getUserFromRequest(req)).authenticate(request, { authRequest =>
+   *     AuthenticatedBuilder(req => getUserFromRequest(req)).authenticate(request, { authRequest: AuthenticatedRequest[A, User] =>
    *       DB.withConnection { conn =>
-   *         new AuthenticatedDbRequest(authRequest.user, conn, request)
-   *       })
-   *     }
+   *         block(new AuthenticatedDbRequest[A](authRequest.user, conn, request))
+   *       }
+   *     })
    *   }
    * }
    * }}}
@@ -168,11 +168,11 @@ object Security {
    *
    * object Authenticated extends ActionBuilder[AuthenticatedDbRequest] {
    *   def invokeBlock[A](request: Request[A], block: (AuthenticatedDbRequest[A]) => Future[SimpleResult]) = {
-   *     AuthenticatedBuilder(req => getUserFromRequest(req)).authenticate(request, { authRequest =>
+   *     AuthenticatedBuilder(req => getUserFromRequest(req)).authenticate(request, { authRequest: AuthenticatedRequest[A, User] =>
    *       DB.withConnection { conn =>
-   *         new AuthenticatedDbRequest(authRequest.user, conn, request)
-   *       })
-   *     }
+   *         block(new AuthenticatedDbRequest[A](authRequest.user, conn, request))
+   *       }
+   *     })
    *   }
    * }
    * }}}


### PR DESCRIPTION
I'm not entirely sure this is the desired correct usage, but it does compile and behave in a way which seems reasonable, whereas I couldn't see any way to make the existing example compile.
