### PR TITLE
Added a Concurrent.joined spec

### DIFF
--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/ConcurrentSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/ConcurrentSpec.scala
@@ -232,6 +232,14 @@ object ConcurrentSpec extends Specification
       await(result) must_== Seq("foo", "bar")
       await(unitResult) must_== ()
     }
+    "break early from infinite enumerators" in {
+      val (iteratee, enumerator) = Concurrent.joined[String]
+      val infinite = Enumerator.repeat("foo")
+      val unitResult = infinite |>>> iteratee
+      val head = enumerator |>>> Iteratee.head
+      await(head) must beSome("foo")
+      await(unitResult) must_== ()
+    }
   }
 
   "Concurrent.runPartial" should {


### PR DESCRIPTION
The new spec proves that Concurrent.joined iteratee breaks early from infinite enumerators when the target iteratee is done.

Someone was saying that this didn't happen, so I added the test to prove that it did.
