### PR TITLE
Update woff MIME type to match W3 recommendation

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
@@ -523,7 +523,7 @@ object MimeTypes {
         wmlc=application/vnd.wap.wmlc
         wmls=text/vnd.wap.wmlscript
         wmlsc=application/vnd.wap.wmlscriptc
-        woff=application/x-font-woff
+        woff=application/font-woff
         word=application/msword
         wp5=application/wordperfect
         wp6=application/wordperfect


### PR DESCRIPTION
The current W3 recommendation for `woff` specifies a [different MIME type](http://www.w3.org/TR/WOFF/#appendix-b) to that delivered by the Play framework at present.

This causes a warning in current versions of Chrome.

This PR updates it to use the current recommendation's MIME type.
