### PR TITLE
Unnecessary XML validation

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -102,6 +102,8 @@ object Dependencies {
     "com.fasterxml.jackson.core" % "jackson-annotations" % "2.2.2",
     "com.fasterxml.jackson.core" % "jackson-databind" % "2.2.2",
 
+    "xerces" % "xercesImpl" % "2.11.0",
+
     "javax.transaction" % "jta" % "1.1",
 
     specsBuild % "test",

--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -9,6 +9,8 @@ import java.io._
 
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
+import javax.xml.parsers.SAXParserFactory
+import org.apache.xerces.impl.Constants
 
 /** Application mode, either `DEV`, `TEST`, or `PROD`. */
 object Mode extends Enumeration {
@@ -31,6 +33,22 @@ object Play {
    * A general purpose logger for Play. Intended for internal usage.
    */
   private[play] val logger = Logger("play")
+
+  /*
+   * We want control over the sax parser used so we specify the factory required explicitly. We know that
+   * SAXParserFactoryImpl will yield a SAXParser having looked at its source code, despite there being
+   * no explicit doco stating this is the case. That said, there does not appear to be any other way than
+   * declaring a factory in order to yield a parser of a specific type.
+   */
+  private[play] val xercesSaxParserFactory =
+    SAXParserFactory.newInstance("org.apache.xerces.jaxp.SAXParserFactoryImpl", Play.getClass.getClassLoader)
+  xercesSaxParserFactory.setFeature(Constants.SAX_FEATURE_PREFIX + Constants.EXTERNAL_GENERAL_ENTITIES_FEATURE, false)
+  xercesSaxParserFactory.setFeature(Constants.XERCES_FEATURE_PREFIX + Constants.DISALLOW_DOCTYPE_DECL_FEATURE, false)
+
+  /*
+   * A parser to be used that is configured to ensure that no schemas are loaded.
+   */
+  private[play] def XML = scala.xml.XML.withSAXParser(xercesSaxParserFactory.newSAXParser())
 
   /**
    * Returns the currently running application, or `null` if not defined.

--- a/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
@@ -23,6 +23,7 @@ import play.core.utils.CaseInsensitiveOrdered
 import com.ning.http.util.AsyncHttpProviderUtils
 
 import play.core.Execution.Implicits.internalContext
+import play.api.Play
 
 /**
  * Asynchronous API to to query web services, as an http client.
@@ -659,7 +660,7 @@ case class Response(ahcResponse: AHCResponse) {
   /**
    * The response body as Xml.
    */
-  lazy val xml: Elem = XML.loadString(body)
+  lazy val xml: Elem = Play.XML.loadString(body)
 
   /**
    * The response body as Json.

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -419,7 +419,7 @@ trait BodyParsers {
         ).foreach { charset =>
             inputSource.setEncoding(charset)
           }
-        XML.load(inputSource)
+        Play.XML.load(inputSource)
       }
 
     /**


### PR DESCRIPTION
XML validation against a schema is not required within Play and could present an unnecessary performance overhead. Places where XML validation is performed are:
- L422 of ContentTypes.scala
- L662 of WS.scala

Recommendation in terms of establishing a loader:

```
val f = javax.xml.parsers.SAXParserFactory.newInstance()
f.setValidating(false)
val p = f.newSAXParser()
val nonValidatingXml = xml.XML.withSAXParser(p)
```

...and when required

```
val doc = nonValidatingXml.load(url)
```
