### PR TITLE
Adds an additional ecmascript5 ClosureCompilerOption.

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/jscompile/JavascriptCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/jscompile/JavascriptCompiler.scala
@@ -41,6 +41,7 @@ object JavascriptCompiler {
         case "checkControlStructures" => defaultOptions.setCheckControlStructures(true)
         case "checkTypes" => defaultOptions.setCheckTypes(true)
         case "checkSymbols" => defaultOptions.setCheckSymbols(true)
+        case "ecmascript5" => defaultOptions.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT5)
         case _ => Unit // Unknown option
       })
       defaultOptions


### PR DESCRIPTION
Adds an additional ecmascript5 option for the ClosureCompiler. ECMAScript5 is required by several modern javascript libraries, such as Three.JS.
