### PR TITLE
JLine command history broken on Windows

### DIFF
--- a/framework/build.bat
+++ b/framework/build.bat
@@ -10,7 +10,7 @@ set p=%~dp0
 set p=%p:\=/%
 set fp=file:///!p: =%%20!
 
-java -Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M %DEBUG_PARAM% %JAVA_OPTS% -Dfile.encoding=UTF-8 -Dplay.version="%PLAY_VERSION%" -Dsbt.ivy.home="%~dp0..\repository" -Dplay.home="%~dp0." -Dsbt.boot.properties="%fp%sbt/sbt.boot.properties" %PLAY_OPTS% -jar "%~dp0sbt\sbt-launch.jar" %*
+java -Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M %DEBUG_PARAM% %JAVA_OPTS% -Dfile.encoding=UTF-8 -Dinput.encoding=Cp1252 -Dplay.version="%PLAY_VERSION%" -Dsbt.ivy.home="%~dp0..\repository" -Dplay.home="%~dp0." -Dsbt.boot.properties="%fp%sbt/sbt.boot.properties" %PLAY_OPTS% -jar "%~dp0sbt\sbt-launch.jar" %*
 
 :end
 endlocal


### PR DESCRIPTION
This behaviour can be reproduced on Windows with vanilla SBT 0.13.0 by providing `file.encoding=UTF-8` as an option:

```
>set JAVA_OPTS=-Dfile.encoding=UTF-8
>sbt
[info] Set current project to project (in build file:/C:/p/ansi/ansi2/project/)
> ∩┐╜
```

It does _not_ occur with SBT 0.12.4, which is why this wasn't a problem for Play 2.1.

Removing the `file.encoding` option from Play's build.bat resolves the problem, but I guess we need that option for some reason, e.g. Scala compilation.

A quick search for "jline file.encoding" showed me:

http://jline.sourceforge.net/apidocs/src-html/jline/WindowsTerminal.html

```
192        String encoding = System.getProperty("jline.WindowsTerminal.input.encoding", System.getProperty("file.encoding"));
193        ReplayPrefixOneCharInputStream replayStream = new ReplayPrefixOneCharInputStream(encoding);
```

So there is an option to set the JLine encoding directly, but how can you set it to `null` while still setting `file.encoding`?

It looks like Spring Roo couldn't find a solution to the problem when they tried to solve it in 2009.
https://jira.springsource.org/browse/ROO-439

Definitely needs more investigation.
