### PR TITLE
Using Action.async with Rendering.render requires downcast

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/action/ContentNegotiationSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/ContentNegotiationSpec.scala
@@ -1,0 +1,34 @@
+package play.it.action
+
+import play.api.test.{FakeRequest, PlaySpecification}
+import play.api.mvc.{SimpleResult, Action, Controller}
+import scala.concurrent.Future
+
+object ContentNegotiationSpec extends PlaySpecification with Controller {
+
+  "rendering" should {
+    "work with simple results" in {
+      status(Action { implicit req =>
+        render {
+          case Accepts.Json() => Ok
+        }
+      }(FakeRequest().withHeaders(ACCEPT -> "application/json"))) must_== 200
+    }
+
+    "work with simple results in an async action" in {
+      status(Action.async { implicit req =>
+        Future.successful(render {
+          case Accepts.Json() => Ok
+        })
+      }(FakeRequest().withHeaders(ACCEPT -> "application/json"))) must_== 200
+    }
+
+    "work with async results" in {
+      status(Action.async { implicit req =>
+        render.async {
+          case Accepts.Json() => Future.successful(Ok)
+        }
+      }(FakeRequest().withHeaders(ACCEPT -> "application/json"))) must_== 200
+    }
+  }
+}

--- a/framework/src/play/src/main/scala/play/api/mvc/Render.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Render.scala
@@ -1,36 +1,73 @@
 package play.api.mvc
 
-import play.api.http.{ Writeable, MediaRange }
+import play.api.http.MediaRange
 import play.api.mvc.Results._
 import play.api.http.HeaderNames._
+import scala.concurrent.Future
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 trait Rendering {
 
-  /**
-   * Tries to render the most acceptable result according to the request’s Accept header value.
-   * {{{
-   *   render {
-   *     case Accepts.Html() => Ok(views.html.show(value))
-   *     case Accepts.Json() => Ok(Json.toJson(value))
-   *   }
-   * }}}
-   *
-   * @param f A partial function returning a `Result` for a given request media range
-   * @return A result provided by `f`, if it is defined for the current request media ranges, otherwise NotAcceptable
-   */
-  def render(f: PartialFunction[MediaRange, Result])(implicit request: RequestHeader): Result = {
-    def _render(ms: Seq[MediaRange]): Result = ms match {
-      case Nil => NotAcceptable
-      case Seq(m, ms @ _*) =>
-        if (f.isDefinedAt(m)) f(m)
-        else _render(ms)
+  object render {
+
+    /**
+     * Tries to render the most acceptable result according to the request’s Accept header value.
+     * {{{
+     * def myAction = Action { implicit req =>
+     *   val value = ...
+     *   render {
+     *     case Accepts.Html() => Ok(views.html.show(value))
+     *     case Accepts.Json() => Ok(Json.toJson(value))
+     *   }
+     * }
+     * }}}
+     *
+     * @param f A partial function returning a `SimpleResult` for a given request media range
+     * @return A result provided by `f`, if it is defined for the current request media ranges, otherwise NotAcceptable
+     */
+    def apply(f: PartialFunction[MediaRange, SimpleResult])(implicit request: RequestHeader): SimpleResult = {
+      def _render(ms: Seq[MediaRange]): SimpleResult = ms match {
+        case Nil => NotAcceptable
+        case Seq(m, ms @ _*) =>
+          f.applyOrElse(m, (m: MediaRange) => _render(ms))
+      }
+
+      // “If no Accept header field is present, then it is assumed that the client accepts all media types.”
+      val result =
+        if (request.acceptedTypes.isEmpty) _render(Seq(new MediaRange("*", "*", Nil, None, Nil)))
+        else _render(request.acceptedTypes)
+      result.withHeaders(VARY -> ACCEPT)
     }
 
-    // “If no Accept header field is present, then it is assumed that the client accepts all media types.”
-    val result =
-      if (request.acceptedTypes.isEmpty) _render(Seq(new MediaRange("*", "*", Nil, None, Nil)))
-      else _render(request.acceptedTypes)
-    result.withHeaders(VARY -> ACCEPT)
-  }
+    /**
+     * Tries to render the most acceptable result according to the request’s Accept header value.
+     *
+     * This function can be used if you want to do asynchronous processing in your render function.
+     * {{{
+     * def myAction = Action.async { implicit req =>
+     *   val value = ...
+     *   render.async {
+     *     case Accepts.Html() => loadData.map(data => Ok(views.html.show(value, data))))
+     *     case Accepts.Json() => Future.successful(Ok(Json.toJson(value)))
+     *   }
+     * }
+     * }}}
+     *
+     * @param f A partial function returning a `Future[SimpleResult]` for a given request media range
+     * @return A result provided by `f`, if it is defined for the current request media ranges, otherwise NotAcceptable
+     */
+    def async(f: PartialFunction[MediaRange, Future[SimpleResult]])(implicit request: RequestHeader): Future[SimpleResult] = {
+      def _render(ms: Seq[MediaRange]): Future[SimpleResult] = ms match {
+        case Nil => Future.successful(NotAcceptable)
+        case Seq(m, ms @ _*) =>
+          f.applyOrElse(m, (m: MediaRange) => _render(ms))
+      }
 
+      // “If no Accept header field is present, then it is assumed that the client accepts all media types.”
+      val result =
+        if (request.acceptedTypes.isEmpty) _render(Seq(new MediaRange("*", "*", Nil, None, Nil)))
+        else _render(request.acceptedTypes)
+      result.map(_.withHeaders(VARY -> ACCEPT))
+    }
+  }
 }


### PR DESCRIPTION
The Rendering trait has not been updated to reflect recent API changes. Specifically, the "render" method returns a Result, which has been deprecated in favor of SimpleResult. This has the unfortunate effect of requiring downcast when used with Action.async, which expects a function that returns a Future[SimpleResult]. 

As far as I can tell, fixing this should just be a matter of changing the return type of Rendering.render.
