### PR TITLE
Play 2.2.0-RC1 - Json Bodyparser returns incorrect error message when fed invalid Json

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -819,7 +819,7 @@ trait BodyParsers {
     }
 
     private def createBadResult(msg: String): RequestHeader => Future[SimpleResult] = { request =>
-      Play.maybeApplication.map(_.global.onBadRequest(request, "Expecting xml body"))
+      Play.maybeApplication.map(_.global.onBadRequest(request, msg))
         .getOrElse(Future.successful(Results.BadRequest))
     }
 


### PR DESCRIPTION
Tested using java @BodyParser.Of(BodyParser.Json.class)

body of incoming message contains invalid /badly formed json, error response indicates that xml body is expected:

For request 'POST /xyz' [Expecting xml body]
