### PR TITLE
[2.1.3-scala], Problem with fillAndValidate on Form

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -6,7 +6,7 @@ package play.api.data
 import scala.language.existentials
 
 import format._
-import validation._
+import play.api.data.validation._
 
 /**
  * Helper to manage HTML form description, submission and validation.
@@ -589,11 +589,7 @@ case class WrappedMapping[A, B](wrapped: Mapping[A], f1: A => B, f2: B => A, val
   /**
    * The constraints associated with this field.
    */
-  val constraints: Seq[Constraint[B]] = wrapped.constraints.map { constraintOfT =>
-    Constraint[B](constraintOfT.name, constraintOfT.args) { b =>
-      constraintOfT(f2(b))
-    }
-  } ++ additionalConstraints
+  val constraints: Seq[Constraint[B]] = additionalConstraints
 
   /**
    * Binds this field, i.e. construct a concrete value from submitted data.
@@ -620,7 +616,8 @@ case class WrappedMapping[A, B](wrapped: Mapping[A], f1: A => B, f2: B => A, val
    * @return the plain data and any errors in the plain data
    */
   def unbindAndValidate(value: B): (Map[String, String], Seq[FormError]) = {
-    (wrapped.unbindAndValidate(f2(value))._1, collectErrors(value))
+    val (data, errors) = wrapped.unbindAndValidate(f2(value))
+    (data, errors ++ collectErrors(value))
   }
 
   /**
@@ -689,7 +686,7 @@ case class RepeatedMapping[T](wrapped: Mapping[T], val key: String = "", val con
    *   Form("phonenumber" -> text.verifying(required) )
    * }}}
    *
-   * @param constraints the constraints to add
+   * @param addConstraints the constraints to add
    * @return the new mapping
    */
   def verifying(addConstraints: Constraint[List[T]]*): Mapping[List[T]] = {


### PR DESCRIPTION
When I do a fold on my form after I have done a fillAndValidate the error function isn't called.

``` scala
"The form mapping" should {

    import play.api.data._
    import play.api.data.Forms._

    "fold on error after fillAndValidate" in {
      case class Item(text: String)
      val itemForm = Form(mapping("text" -> nonEmptyText)(Item)(Item.unapply))
      val filled = itemForm.fillAndValidate(Item(""))

      val result = filled.fold(
        errors => false,
        success => true
      )
      result should beFalse
    }

    "find nested error on unbind" in {
      case class Item(text: String)
      case class Items(seq: Seq[Item])
      val itemForm = Form[Items](
        mapping(
          "seq" -> seq(
            mapping("text" -> nonEmptyText)(Item)(Item.unapply)
          )
        )(Items)(Items.unapply)
      )

      val result = itemForm.mapping.unbind(Items(Seq(Item(""))))
      result._2 must haveSize(1)
    }
  }
```
