### PR TITLE
Upgrade netty to 3.7.0

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -68,7 +68,7 @@ object Dependencies {
     specsBuild % "test")
 
   val runtime = Seq(
-    "io.netty" % "netty" % "3.6.6.Final",
+    "io.netty" % "netty" % "3.7.0.Final",
 
     "com.typesafe.netty" % "netty-http-pipelining" % "1.1.2",
 


### PR DESCRIPTION
Upgrade netty to get people using Play 2.2.0-SNAPSHOT testing Play with the netty 3.7.x branch. Will need to upgrade to netty 3.7.1 when it is released to fix SSL deadlocking issue.
