### PR TITLE
Race Condition with Reverse Routing in multi-project projects

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -82,6 +82,9 @@ object Play {
 
     _currentApp = app
 
+    // Ensure routes are eagerly loaded, so that the reverse routers are correctly initialised before plugins are
+    // started.
+    app.routes
     Threads.withContextClassLoader(classloader(app)) {
       app.plugins.foreach(_.onStart())
     }


### PR DESCRIPTION
There is a race condition when I attempt to use a reverse router to a route in an included routes file from a sub project.

Due to the lazy initialization of a lot of Play's internals, I send an HTTP request to a special /status route to initialize the framework. If I access the reverse router of a subordinate project (the `/status` handler is common and shared between projects) in the `onStart` hook (or even after a second in a scheduled Akka thunk/anon function), it can trigger the routing to fail. One work around is to hard-code the path for the first request. Another is to (in the `onStart` hook force initialization by calling `app.routes`.

See discussion at: https://groups.google.com/forum/?fromgroups=#!topic/play-framework-dev/fulhWGWE42s

@gissues:{"order":46.1538461538461,"status":"backlog"}
