### PR TITLE
Revert a minor grammar mistake just introduced

### DIFF
--- a/documentation/manual/javaGuide/tutorials/todolist/JavaTodoList.md
+++ b/documentation/manual/javaGuide/tutorials/todolist/JavaTodoList.md
@@ -94,7 +94,7 @@ You see that `controllers.Application.index()` returns a `Result`. All action me
 
 > **Note:** Read more about [[Actions|JavaActions]].
 
-Here, the action returns a **200 OK** response with a HTML response body. The HTML content is provided by a template. Play templates are compiled to standard Java methods, here as `views.html.index.render(String message)`.
+Here, the action returns a **200 OK** response with an HTML response body. The HTML content is provided by a template. Play templates are compiled to standard Java methods, here as `views.html.index.render(String message)`.
 
 This template is defined in the `app/views/index.scala.html` source file:
 
@@ -282,7 +282,7 @@ We also imported `helper._` that give us the form creation helpers, typically th
 
 ## The task form
 
-A `Form` object encapsulates a HTML form definition, including validation constraints. Let’s create a form for our `Task` class. Add this to your `Application` controller:
+A `Form` object encapsulates an HTML form definition, including validation constraints. Let’s create a form for our `Task` class. Add this to your `Application` controller:
 
 ```
 static Form<Task> taskForm = Form.form(Task.class);


### PR DESCRIPTION
This was actually correct before commit https://github.com/playframework/playframework/commit/57046be7a1078ba9108fb5cf06e61d36f9f540fa. You use "an" before a vowel sound not just before an actual vowel. When you pronounce HTML, the first sound is 'a' or 'eh'. You use "an" so as not to have two vowel sounds in a row.

The APA is one of the most authoritative source on grammar rules. School children and professionals in the social sciences in the US are often mandated to follow the APA style guide.
http://blog.apastyle.org/apastyle/2012/04/using-a-or-an-with-acronyms-and-abbreviations.html

Google also suggests that more informal language usage also prefers "an" over "a":
"an html document" -> 10,100,000 results on Google
"a html document" -> 3,510,000 results on Google.
