### PR TITLE
Migration docs for F.Promise and OrderedExecutionContext.

### DIFF
--- a/documentation/manual/Migration22.md
+++ b/documentation/manual/Migration22.md
@@ -145,6 +145,37 @@ Iteratee.foreach[String] { msg =>
 }
 ```
 
+## Concurrent F.Promise execution
+
+The way that the [`F.Promise`](api/java/play/libs/F.Promise.html) class executes user-supplied code has changed in Play 2.2.
+
+In Play 2.1, the `F.Promise` class restricted how user code was executed. Promise operations for a given HTTP request would execute in the order that they were submitted, essentially running sequentially.
+
+With Play 2.2, this restriction on ordering has been removed so that promise operations can execute concurrently. Work executed by the `F.Promise` class now uses [[Play's default thread pool|ThreadPools]] without placing any additional restrictions on execution.
+
+However, for those who still want it, Play 2.1's legacy behavior has been captured in the `OrderedExecutionContext` class. The legacy behavior of Play 2.1 can be easily recreated by supplying an `OrderedExecutionContext` as an argument to any of `F.Promise`'s methods.
+
+The following code shows how to recreate Play 2.1's behaviour in Play 2.2. Note that this example uses the same settings as Play 2.1: a pool of 64 actors running within Play's default `ActorSystem`.
+
+````java
+import play.core.j.OrderedExecutionContext;
+import play.libs.Akka;
+import play.libs.F.*;
+import scala.concurrent.ExecutionContext;
+
+ExecutionContext orderedExecutionContext = new OrderedExecutionContext(Akka.system(), 64);
+Promise<Double> pi = Promise.promise(new Function0<Double>() {
+  Double apply() {
+    return Math.PI;
+  }
+}, orderedExecutionContext);
+Promise<Double> mappedPi = pi.map(new Function<Double, Double>() {
+  Double apply(x Double) {
+    return 2 * x;
+  }
+}, orderedExecutionContext);
+````
+
 ## Jackson Json
 We have upgraded Jackson to version 2 which means that the package name is now `com.fasterxml.jackson.core` instead of `org.codehaus.jackson`.
 

--- a/documentation/manual/detailledTopics/configuration/ThreadPools.md
+++ b/documentation/manual/detailledTopics/configuration/ThreadPools.md
@@ -50,7 +50,7 @@ The default thread pool can be configured using standard Akka configuration in `
 
 @[default-config](code/ThreadPools.scala)
 
-This configuration instructs Akka to create one thread per available processor, with a maximum of 24 threads in the pool.  The full configuration options available to you can be found [here](http://doc.akka.io/docs/akka/2.1.0/general/configuration.html#Listing_of_the_Reference_Configuration).
+This configuration instructs Akka to create one thread per available processor, with a maximum of 24 threads in the pool.  The full configuration options available to you can be found [here](http://doc.akka.io/docs/akka/2.2.0/general/configuration.html#Listing_of_the_Reference_Configuration).
 
 > Note that this configuration is separate from the configuration that the Play Akka plugin uses.  The Play Akka plugin is configured separately, by configuring akka in the root namespace (without the play { } surrounding it).
 


### PR DESCRIPTION
Some docs about changes to F.Promise semantics.

I'll backport this to 2.2 so the docs are there in our final 2.2 release.
