### PR TITLE
Upgraded to fluentlenium 0.9.0

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -110,9 +110,8 @@ object Dependencies {
 
     "org.mockito" % "mockito-all" % "1.9.5" % "test",
     "com.novocode" % "junit-interface" % "0.10" % "test" exclude("junit", "junit-dep"),
-
-    ("org.fluentlenium" % "fluentlenium-festassert" % "0.9.0" % "test")
-      .exclude("org.jboss.netty", "netty"),
+    "org.easytesting" % "fest-assert" % "1.4" % "test",
+    guava % "test",
 
     "org.scala-lang" % "scala-reflect" % BuildSettings.buildScalaVersion,
 
@@ -193,9 +192,9 @@ object Dependencies {
     "com.novocode" % "junit-interface" % "0.10" exclude("junit", "junit-dep"),
     guava,
     findBugs,
-    ("org.fluentlenium" % "fluentlenium-festassert" % "0.8.0")
+    ("org.fluentlenium" % "fluentlenium-festassert" % "0.9.0")
       .exclude("org.jboss.netty", "netty")
-      .exclude("com.google.guava","guava"))
+  )
 
   val playCacheDeps = Seq(
     "net.sf.ehcache" % "ehcache-core" % "2.6.6",


### PR DESCRIPTION
When I upgraded fluentlenium earlier, I accidentally only upgraded it for the test dependency of the Play core project, but not the play-test project. In fact, Play core should not have had a test dependency on fluentlenium, since its tests don't use selenium at all.

So, I've got rid of the unnecessary test dependency (and added in explicit dependencies on things that it brought in transitively that were needed), and also upgraded play-test to fluentlenium 0.9.0.
