### PR TITLE
make EmailValidator.regex public

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/validation/Constraints.java
+++ b/framework/src/play-java/src/main/java/play/data/validation/Constraints.java
@@ -358,7 +358,7 @@ public class Constraints {
     public static class EmailValidator extends Validator<String> implements ConstraintValidator<Email, String> {
         
         final static public String message = "error.email";
-        final static java.util.regex.Pattern regex = java.util.regex.Pattern.compile("\\b[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*\\b");
+        final static public java.util.regex.Pattern regex = java.util.regex.Pattern.compile("\\b[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*\\b");
         
         public EmailValidator() {}
         


### PR DESCRIPTION
Sometimes we need to use same regex that validation's uses. it's better than duplicate it in code ...
