### PR TITLE
Document Lang.forCode return value

### DIFF
--- a/framework/src/play/src/main/java/play/i18n/Lang.java
+++ b/framework/src/play/src/main/java/play/i18n/Lang.java
@@ -55,6 +55,8 @@ public class Lang extends play.api.i18n.Lang {
     
     /**
      * Create a Lang value from a code (such as fr or en-US).
+     * Returns null if the code is not recognized.
+     *
      */
     public static Lang forCode(String code) {
         try {


### PR DESCRIPTION
When the language code is not recognized, Lang.forCode returns null.
