### PR TITLE
Normalize Lang: lowercase lang, uppercase country.

### DIFF
--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -50,8 +50,16 @@ case class Lang(language: String, country: String = "") {
   /**
    * The Lang code (such as fr or en-US).
    */
-  lazy val code = language + Option(country).filterNot(_.isEmpty).map("-" + _).getOrElse("")
+  lazy val code = language.toLowerCase(java.util.Locale.ENGLISH) + Option(country).filterNot(_.isEmpty).map("-" + _.toUpperCase(java.util.Locale.ENGLISH)).getOrElse("")
 
+  override def equals(that: Any) = {
+    that match {
+      case lang: Lang => code == lang.code
+      case _ => false
+    }
+  }
+
+  override def hashCode: Int = code.hashCode
 }
 
 /**

--- a/framework/src/play/src/test/scala/play/api/i18n/LangSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/i18n/LangSpec.scala
@@ -39,7 +39,47 @@ class LangSpec extends Specification {
       "in order" in {
         Lang.preferred(Seq(esEs, enUs)) must_== esEs
       }
+    }
+
+    "normalize before comparsion" in {
+      Lang.get("en-us") must_== Lang.get("en-US")
+      Lang.get("EN-us") must_== Lang.get("en-US")
+      Lang.get("ES-419") must_== Lang.get("es-419")
+      Lang.get("en-us").hashCode must_== Lang.get("en-US").hashCode
+      Lang("en-us").code must_== "en-US"
+      Lang("EN-us").code must_== "en-US"
+      Lang("EN").code must_== "en"
+
+      "even with locales with different caseness" in trLocaleContext {
+        Lang.get("ii-ii") must_== Lang.get("ii-II")
+      }
 
     }
+
+    "forbid instantiation of lanague code" in {
+
+      "with wrong format" in {
+        Lang.get("en-UUS") must_== None
+        Lang.get("een-US") must_== None
+        Lang.get("en_US") must_== None
+      }
+
+      "with extraneous characters" in {
+        Lang.get("en-ÚS") must_== None
+      }
+
+    }
+
   }
 }
+
+object trLocaleContext extends org.specs2.mutable.Around {
+  def around[T : org.specs2.execute.AsResult](t: =>T) = {
+    val defaultLocale = java.util.Locale.getDefault
+    java.util.Locale.setDefault(new java.util.Locale("tr"))
+    val result = org.specs2.execute.AsResult(t)
+    java.util.Locale.setDefault(defaultLocale)
+    result
+  }
+}
+


### PR DESCRIPTION
I ran into a problem when comparing two Lang objects for equality and getting false because one had uppercase country code and the other had a lowercase one. This is an unnecessary inconvenience when we deal with language codes that come from case insensitive source (e.g. a domain name).

So I think it would be good to have the caseness of Langs normalized on object creation. This is also more consistent with `java.util.Locale`:

```
scala> Locale.forLanguageTag("en-US").equals(Locale.forLanguageTag("en-us"))
res1: Boolean = true
```

Please: Note that this commit is untested.
