### PR TITLE
Added explicit dependency on jansi 1.11 for repository

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -298,7 +298,8 @@ object PlayBuild extends Build {
         "org.scala-lang" % "jline" % BuildSettings.buildScalaVersion % "master",
         "org.scala-lang" % "scala-compiler" % BuildSettings.buildScalaVersionForSbt % "master",
         "org.scala-lang" % "jline" % BuildSettings.buildScalaVersionForSbt % "master",
-        "org.scala-sbt" % "sbt" % BuildSettings.buildSbtVersion
+        "org.scala-sbt" % "sbt" % BuildSettings.buildSbtVersion,
+        "org.fusesource.jansi" % "jansi" % "1.11" % "master"
       )
     )
 


### PR DESCRIPTION
This ensures that play can be used on Windows with no internet connection, since SBT magically adds a dependency on jansi 1.11 for Windows.
