### PR TITLE
Updating documentation for ThreadPools for Akka 2.2

### DIFF
--- a/documentation/manual/detailledTopics/configuration/code/ThreadPools.scala
+++ b/documentation/manual/detailledTopics/configuration/code/ThreadPools.scala
@@ -22,7 +22,7 @@ object ThreadPoolsSpec extends PlaySpecification {
       val config = """#default-config
         play {
           akka {
-            event-handlers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jEventHandler"]
+            akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
             loglevel = WARNING
             actor {
               default-dispatcher = {
@@ -80,7 +80,7 @@ object ThreadPoolsSpec extends PlaySpecification {
       val config = ConfigFactory.parseString("""#highly-synchronous
       play {
         akka {
-          event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+          akka.loggers = ["akka.event.slf4j.Slf4jLogger"]
           loglevel = WARNING
           actor {
             default-dispatcher = {


### PR DESCRIPTION
Akka 2.2 has some updates that require changes to your configuration if you are using the 'highly synchronous' configuration pattern that Play recommends. 

I've updated the documentation for how to configure for 'highly synchronous'  per the akka migration guide: http://doc.akka.io/docs/akka/2.2-M1/project/migration-guide-2.1.x-2.2.x.html
