### PR TITLE
Accept all WebSocket subprotocols.

### DIFF
--- a/framework/src/play/src/main/scala/play/core/server/websocket/WebSocketHandshake.scala
+++ b/framework/src/play/src/main/scala/play/core/server/websocket/WebSocketHandshake.scala
@@ -31,7 +31,7 @@ object WebSocketHandshake {
 
   def shake(ctx: ChannelHandlerContext, req: HttpRequest): Unit = {
     val factory = new WebSocketServerHandshakerFactory(getWebSocketLocation(req),
-      null, /* subprotocols */
+      "*", /* wildcard to accept all subprotocols */
       true /* allowExtensions */ )
 
     val shaker = factory.newHandshaker(req)


### PR DESCRIPTION
Now that Play uses Netty 3.7.0+ we can use the wildcard WebSocket subprotocol. This allows Play to accept arbitrary WebSocket subprotocols like 'wamp' used by the WAMP WebSocket RPC/Pubsub JavaScript library. Before Netty would just throw an exception.

This PR will also finally close #1101 and #800.

I've compiled this PR and it works as expected with the WAMPlay library.

Thanks!
