### PR TITLE
Make the MockitoSpec actually display

### DIFF
--- a/documentation/manual/scalaGuide/main/tests/code/ExampleMockitoSpec.scala
+++ b/documentation/manual/scalaGuide/main/tests/code/ExampleMockitoSpec.scala
@@ -5,29 +5,29 @@ import org.specs2.mutable._
 
 import java.util._
 
+case class Data(retrievalDate: java.util.Date)
+
+trait DataService {
+  def findData: Data
+}
+
+class MyService {
+  def dataService: DataService = null // implementation reference...
+
+  def isDailyData: Boolean = {
+    val retrievalDate = Calendar.getInstance
+    retrievalDate.setTime(dataService.findData.retrievalDate)
+
+    val today = Calendar.getInstance()
+
+    (retrievalDate.get(Calendar.YEAR) == today.get(Calendar.YEAR)
+      && retrievalDate.get(Calendar.DAY_OF_YEAR) == today.get(Calendar.DAY_OF_YEAR))
+  }
+}
+
+// #scalaws-mockito
 class ExampleMockitoSpec extends Specification with Mockito {
 
-  case class Data(retrievalDate: java.util.Date)
-
-  trait DataService {
-    def findData: Data
-  }
-
-  class MyService {
-    def dataService: DataService = null // implementation reference...
-
-    def isDailyData: Boolean = {
-      val retrievalDate = Calendar.getInstance
-      retrievalDate.setTime(dataService.findData.retrievalDate)
-
-      val today = Calendar.getInstance()
-
-      (retrievalDate.get(Calendar.YEAR) == today.get(Calendar.YEAR)
-        && retrievalDate.get(Calendar.DAY_OF_YEAR) == today.get(Calendar.DAY_OF_YEAR))
-    }
-  }
-
-  // #scalaws-mockito
   "MyService#isDailyData" should {
     "return true if the data is from today" in {
       val mockDataService = mock[DataService]
@@ -41,5 +41,5 @@ class ExampleMockitoSpec extends Specification with Mockito {
       actual must equalTo(true)
     }
   }
-  // #scalaws-mockito
 }
+// #scalaws-mockito


### PR DESCRIPTION
The MockitoSpec code example does not include the Mockito trait that is necessary for the code example to actually work.

This patch makes the example show the entire spec:

``` scala
object ExampleMockitoSpec extends Specification with Mockito
```

so that it's clearer.
