### PR TITLE
Upgrade to Scala 2.10.3-RC3 and check iteratee memory leak is fixed

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -27,9 +27,9 @@ object BuildSettings {
   val buildVersion = propOr("play.version", "2.3-SNAPSHOT")
   val buildWithDoc = boolProp("generate.doc")
   val previousVersion = "2.1.0"
-  val buildScalaVersion = propOr("scala.version", "2.10.2")
+  val buildScalaVersion = propOr("scala.version", "2.10.3-RC3")
   // TODO - Try to compute this from SBT... or not.
-  val buildScalaVersionForSbt = propOr("play.sbt.scala.version", "2.10.2")
+  val buildScalaVersionForSbt = propOr("play.sbt.scala.version", "2.10.3-RC3")
   val buildScalaBinaryVersionForSbt = CrossVersion.binaryScalaVersion(buildScalaVersionForSbt)
   val buildSbtVersion = propOr("play.sbt.version", "0.13.0")
   val buildSbtMajorVersion = "0.13"

--- a/framework/sbt/play.boot.properties
+++ b/framework/sbt/play.boot.properties
@@ -2,7 +2,7 @@
 # Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
 #
 [scala]
-  version: 2.10.2
+  version: 2.10.3-RC3
 
 [app]
   org: com.typesafe.play

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/IterateesSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/IterateesSpec.scala
@@ -308,4 +308,17 @@ object IterateesSpec extends Specification
 
   }
 
+  "Iteratee.ignore" should {
+
+    "never throw an OutOfMemoryError when consuming large input" in {
+      // Work out how many arrays we'd need to create to trigger an OutOfMemoryError
+      val arraySize = 1000000
+      val tooManyArrays = (Runtime.getRuntime.maxMemory / arraySize).toInt + 1
+      val iterator = Iterator.range(0, tooManyArrays).map(_ => new Array[Byte](arraySize))
+      import play.api.libs.iteratee.Execution.Implicits.defaultExecutionContext
+      await(Enumerator.enumerate(iterator) |>>> Iteratee.ignore[Array[Byte]]) must_== ()
+    }
+
+  }
+
 }


### PR DESCRIPTION
Scala 2.10.3 inclues a fix that allows memory to be freed when chaining
Future.flatMap calls (SI-7336). Iteratees make extensive use of
Future.flatMap, so upgrading to Scala 2.10.3 allows us to avoid memory
leaks when using iteratees (#1084). Memory leaks can occur when
processing large amounts of data or when working with connections that
can remain open for a long time.
