### PR TITLE
Fixes for the CSRF filter

### DIFF
--- a/documentation/manual/javaGuide/main/forms/JavaCsrf.md
+++ b/documentation/manual/javaGuide/main/forms/JavaCsrf.md
@@ -86,5 +86,15 @@ The second action is the `play.filters.csrf.AddCSRFToken` action, it generates a
 
 @[csrf-add-token](code/javaguide/forms/JavaCsrf.java)
 
+## CSRF configuration options
+
+The following options can be configured in `application.conf`:
+
+* `csrf.token.name` - The name of the token to use both in the session and in the request body/query string. Defaults to `csrfToken`.
+* `csrf.cookie.name` - If configured, Play will store the CSRF token in a cookie with the given name, instead of in the session.
+* `csrf.cookie.secure` - If `csrf.cookie.name` is set, whether the CSRF cookie should have the secure flag set.  Defaults to the same value as `session.secure`.
+* `csrf.body.bufferSize` - In order to read tokens out of the body, Play must first buffer the body and potentially parse it.  This sets the maximum buffer size that will be used to buffer the body.  Defaults to 100k.
+* `csrf.sign.tokens` - Whether Play should use signed CSRF tokens.  Signed CSRF tokens ensure that the token value is randomised per request, thus defeating BREACH style attacks.
+
 > **Next:** [[Working with JSON| JavaJsonRequests]]
 

--- a/documentation/manual/scalaGuide/main/forms/ScalaCsrf.md
+++ b/documentation/manual/scalaGuide/main/forms/ScalaCsrf.md
@@ -100,4 +100,14 @@ Then you can minimise the boiler plate code necessary to write actions:
 
 @[csrf-actions](code/ScalaCsrf.scala)
 
+## CSRF configuration options
+
+The following options can be configured in `application.conf`:
+
+* `csrf.token.name` - The name of the token to use both in the session and in the request body/query string. Defaults to `csrfToken`.
+* `csrf.cookie.name` - If configured, Play will store the CSRF token in a cookie with the given name, instead of in the session.
+* `csrf.cookie.secure` - If `csrf.cookie.name` is set, whether the CSRF cookie should have the secure flag set.  Defaults to the same value as `session.secure`.
+* `csrf.body.bufferSize` - In order to read tokens out of the body, Play must first buffer the body and potentially parse it.  This sets the maximum buffer size that will be used to buffer the body.  Defaults to 100k.
+* `csrf.sign.tokens` - Whether Play should use signed CSRF tokens.  Signed CSRF tokens ensure that the token value is randomised per request, thus defeating BREACH style attacks.
+
 > **Next:** [[Working with JSON|ScalaJson]]

--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -1,7 +1,8 @@
 import sbt._
 import Keys._
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
-import com.typesafe.tools.mima.plugin.MimaKeys.previousArtifact
+import com.typesafe.tools.mima.plugin.MimaKeys.{previousArtifact, binaryIssueFilters}
+import com.typesafe.tools.mima.core._
 import com.typesafe.sbt.SbtScalariform.defaultScalariformSettings
 
 object BuildSettings {
@@ -272,7 +273,41 @@ object PlayBuild extends Build {
     )
 
   lazy val PlayFiltersHelpersProject = PlayRuntimeProject("Filters-Helpers", "play-filters-helpers")
-    .dependsOn(PlayProject, PlayTestProject % "test", PlayJavaProject % "test")
+    .settings(
+      binaryIssueFilters ++= Seq(
+        // When we upgrade to mima with SBT 0.13 we can filter by package...
+        // Basically we had to change CSRFFilter to use by name parameters, which meant it could no
+        // longer be a case class, which is why there's so much breakage here.
+        ProblemFilters.exclude[MissingTypesProblem]("play.filters.csrf.CSRFFilter"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.copy$default$3"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.copy"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.copy$default$1"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.copy$default$2"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.toString"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.productPrefix"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.createIfNotFound"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.productArity"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.this"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.canEqual"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.equals"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.tokenName"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.productElement"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.cookieName"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.hashCode"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.copy$default$4"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.secureCookie"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.productIterator"),
+        ProblemFilters.exclude[MissingTypesProblem]("play.filters.csrf.CSRFFilter$"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.apply"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.apply"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.unapply"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFFilter.toString"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFAction.this"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFAddToken#CSRFAddTokenAction.this"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFCheck#CSRFCheckAction.this")
+      ),
+      parallelExecution in Test := false
+    ).dependsOn(PlayProject, PlayTestProject % "test", PlayJavaProject % "test")
 
   // This project is just for testing Play, not really a public artifact
   lazy val PlayIntegrationTestProject = PlayRuntimeProject("Play-Integration-Test", "play-integration-test")

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -1,6 +1,5 @@
 package play.filters.csrf;
 
-import play.api.libs.Crypto;
 import play.api.mvc.RequestHeader;
 import play.api.mvc.Session;
 import play.libs.F;
@@ -17,6 +16,7 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
     private final boolean secureCookie = CSRFConf$.MODULE$.SecureCookie();
     private final String requestTag = CSRF.Token$.MODULE$.RequestTag();
     private final CSRFAction$ CSRFAction = CSRFAction$.MODULE$;
+    private final CSRF.TokenProvider tokenProvider = CSRFConf$.MODULE$.defaultTokenProvider();
 
     @Override
     public F.Promise<SimpleResult> call(Http.Context ctx) throws Throwable {
@@ -24,7 +24,7 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
 
         if (CSRFAction.getTokenFromHeader(request, tokenName, cookieName).isEmpty()) {
             // No token in header and we have to create one if not found, so create a new token
-            String newToken = Crypto.generateSignedToken();
+            String newToken = tokenProvider.generateToken();
 
             // Place this token into the context
             ctx.args.put(requestTag, newToken);
@@ -41,7 +41,7 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
                     ctx.args);
             Http.Context.current.set(newCtx);
 
-            // Also add it to the repsonse
+            // Also add it to the response
             if (cookieName.isDefined()) {
                 Option<String> domain = Session.domain();
                 ctx.response().setCookie(cookieName.get(), newToken, null, Session.path(),

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
@@ -1,6 +1,5 @@
 package play.filters.csrf;
 
-import play.api.libs.Crypto;
 import play.api.mvc.RequestHeader;
 import play.libs.F;
 import play.mvc.Action;
@@ -13,6 +12,7 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
     private final String tokenName = CSRFConf$.MODULE$.TokenName();
     private final Option<String> cookieName = CSRFConf$.MODULE$.CookieName();
     private final CSRFAction$ CSRFAction = CSRFAction$.MODULE$;
+    private final CSRF.TokenProvider tokenProvider = CSRFConf$.MODULE$.defaultTokenProvider();
 
     @Override
     public F.Promise<SimpleResult> call(Http.Context ctx) throws Throwable {
@@ -47,10 +47,7 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
                 }
 
                 if (tokenToCheck != null) {
-                    Option<String> extractedToken = Crypto.extractSignedToken(tokenToCheck);
-                    if (extractedToken.isDefined() && Crypto.constantTimeEquals(extractedToken.get(),
-                            headerToken.get())) {
-                        // Allow through
+                    if (tokenProvider.compareTokens(tokenToCheck, headerToken.get())) {
                         return delegate.call(ctx);
                     } else {
                         return F.Promise.pure((SimpleResult) forbidden("CSRF tokens don't match"));

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
@@ -1,9 +1,14 @@
 package play.filters.csrf
 
 import play.api.mvc._
+import play.filters.csrf.CSRF.TokenProvider
 
 /**
  * A filter that provides CSRF protection.
+ *
+ * These must be by name parameters because the typical use case for instantiating the filter is in Global, which
+ * happens before the application is started.  Since the default values for the parameters are loaded from config
+ * and hence depend on a started application, they must be by name.
  *
  * @param tokenName The key used to store the token in the Play session.  Defaults to csrfToken.
  * @param cookieName If defined, causes the filter to store the token in a Cookie with this name instead of the session.
@@ -11,17 +16,29 @@ import play.api.mvc._
  *                     whether the session cookie is configured to be secure.
  * @param createIfNotFound Whether a new CSRF token should be created if it's not found.  Default creates one if it's
  *                         a GET request that accepts HTML.
+ * @param tokenProvider A token provider to use.
  */
-case class CSRFFilter(tokenName: String = CSRFConf.TokenName,
-    cookieName: Option[String] = CSRFConf.CookieName,
-    secureCookie: Boolean = CSRFConf.SecureCookie,
-    createIfNotFound: (RequestHeader) => Boolean = CSRFConf.defaultCreateIfNotFound) extends EssentialFilter {
+class CSRFFilter(tokenName: => String = CSRFConf.TokenName,
+    cookieName: => Option[String] = CSRFConf.CookieName,
+    secureCookie: => Boolean = CSRFConf.SecureCookie,
+    createIfNotFound: (RequestHeader) => Boolean = CSRFConf.defaultCreateIfNotFound,
+    tokenProvider: => TokenProvider = CSRFConf.defaultTokenProvider) extends EssentialFilter {
 
   /**
    * Default constructor, useful from Java
    */
-  def this() = this(CSRFConf.TokenName, CSRFConf.CookieName, CSRFConf.SecureCookie, CSRFConf.defaultCreateIfNotFound)
+  def this() = this(CSRFConf.TokenName)
 
   def apply(next: EssentialAction): EssentialAction = new CSRFAction(next, tokenName, cookieName, secureCookie,
-    createIfNotFound)
+    createIfNotFound, tokenProvider)
+}
+
+object CSRFFilter {
+  def apply(tokenName: => String = CSRFConf.TokenName,
+    cookieName: => Option[String] = CSRFConf.CookieName,
+    secureCookie: => Boolean = CSRFConf.SecureCookie,
+    createIfNotFound: (RequestHeader) => Boolean = CSRFConf.defaultCreateIfNotFound,
+    tokenProvider: => TokenProvider = CSRFConf.defaultTokenProvider) = {
+    new CSRFFilter(tokenName, cookieName, secureCookie, createIfNotFound, tokenProvider)
+  }
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -13,6 +13,7 @@ private[csrf] object CSRFConf {
   def CookieName: Option[String] = c.getString("csrf.cookie.name")
   def SecureCookie: Boolean = c.getBoolean("csrf.cookie.secure").getOrElse(Session.secure)
   def PostBodyBuffer: Long = c.getBytes("csrf.body.bufferSize").getOrElse(102400L)
+  def SignTokens: Boolean = c.getBoolean("csrf.sign.tokens").getOrElse(true)
 
   val UnsafeMethods = Set("POST")
   val UnsafeContentTypes = Set("application/x-www-form-urlencoded", "text/plain", "multipart/form-data")
@@ -24,6 +25,13 @@ private[csrf] object CSRFConf {
     // If the request isn't accepting HTML, then it won't be rendering a form, so there's no point in generating a
     // CSRF token for it.
     request.method == "GET" && (request.accepts("text/html") || request.accepts("application/xml+xhtml"))
+  }
+  def defaultTokenProvider = {
+    if (SignTokens) {
+      CSRF.SignedTokenProvider
+    } else {
+      CSRF.UnsignedTokenProvider
+    }
   }
 }
 
@@ -52,18 +60,44 @@ object CSRF {
   /**
    * Extract token from current request
    */
-  def getToken(request: RequestHeader): Option[Token] =
+  def getToken(request: RequestHeader): Option[Token] = {
     // First check the tags, this is where tokens are added if it's added to the current request
-    request.tags.get(Token.RequestTag)
+    val token = request.tags.get(Token.RequestTag)
       // Check cookie if cookie name is defined
       .orElse(CookieName.flatMap(n => request.cookies.get(n).map(_.value)))
       // Check session
       .orElse(request.session.get(TokenName))
+    if (SignTokens) {
       // Extract the signed token, and then resign it. This makes the token random per request, preventing the BREACH
       // vulnerability
-      .flatMap(Crypto.extractSignedToken)
-      .map(token => Token(Crypto.signToken(token)))
+      token.flatMap(Crypto.extractSignedToken)
+        .map(token => Token(Crypto.signToken(token)))
+    } else {
+      token.map(Token.apply)
+    }
+  }
 
+  /**
+   * A token provider, for generating and comparing tokens.
+   *
+   * This abstraction allows the use of randomised tokens.
+   */
+  trait TokenProvider {
+    /** Generate a token */
+    def generateToken: String
+    /** Compare two tokens */
+    def compareTokens(tokenA: String, tokenB: String): Boolean
+  }
+
+  object SignedTokenProvider extends TokenProvider {
+    def generateToken = Crypto.generateSignedToken
+    def compareTokens(tokenA: String, tokenB: String) = Crypto.compareSignedTokens(tokenA, tokenB)
+  }
+
+  object UnsignedTokenProvider extends TokenProvider {
+    def generateToken = Crypto.generateToken
+    def compareTokens(tokenA: String, tokenB: String) = Crypto.constantTimeEquals(tokenA, tokenB)
+  }
 }
 
 /**

--- a/framework/src/play-filters-helpers/src/test/resources/application-logger.xml
+++ b/framework/src/play-filters-helpers/src/test/resources/application-logger.xml
@@ -1,0 +1,6 @@
+<configuration>
+
+    <root level="OFF">
+    </root>
+
+</configuration>

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -8,6 +8,7 @@ import play.api.mvc.{Handler, Session}
 import play.api.libs.Crypto
 import play.api.test.{FakeApplication, TestServer, PlaySpecification}
 import play.api.http.{ContentTypes, ContentTypeOf, Writeable}
+import org.specs2.matcher.MatchResult
 
 /**
  * Specs for functionality that each CSRF filter/action shares in common
@@ -16,18 +17,20 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
 
   import CSRFConf._
 
-  "a CSRF filter" should {
+  // This extracts the tests out into different configurations
+  def sharedTests(csrfCheckRequest: CsrfTester, csrfAddToken: CsrfTester, generate: => String,
+                  addToken: (WSRequestHolder, String) => WSRequestHolder,
+                  getToken: Response => Option[String], compareTokens: (String, String) => MatchResult[Any]) = {
     // accept/reject tokens
     "accept requests with token in query string" in {
       lazy val token = generate
-      csrfCheckRequest(_.withQueryString(TokenName -> token)
-        .withSession(TokenName -> token)
+      csrfCheckRequest(req => addToken(req.withQueryString(TokenName -> token), token)
         .post(Map("foo" -> "bar"))
       )(_.status must_== OK)
     }
     "accept requests with token in form body" in {
       lazy val token = generate
-      csrfCheckRequest(_.withSession(TokenName -> token)
+      csrfCheckRequest(req => addToken(req, token)
         .post(Map("foo" -> "bar", TokenName -> token))
       )(_.status must_== OK)
     }
@@ -41,7 +44,7 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
     */
     "accept requests with token in header" in {
       lazy val token = generate
-      csrfCheckRequest(_.withSession(TokenName -> token)
+      csrfCheckRequest(req => addToken(req, token)
         .withHeaders(HeaderName -> token)
         .post(Map("foo" -> "bar"))
       )(_.status must_== OK)
@@ -57,22 +60,12 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
       )(_.status must_== OK)
     }
     "reject requests with different token in body" in {
-      csrfCheckRequest(_.withSession(TokenName -> generate)
-        .post(Map("foo" -> "bar", TokenName -> generate))
-      )(_.status must_== FORBIDDEN)
-    }
-    "reject requests with unsigned token in body" in {
-      csrfCheckRequest(_.withSession(TokenName -> generate)
-        .post(Map("foo" -> "bar", TokenName -> "foo"))
-      )(_.status must_== FORBIDDEN)
-    }
-    "reject requests with unsigned token in session" in {
-      csrfCheckRequest(_.withSession(TokenName -> "foo")
+      csrfCheckRequest(req => addToken(req, generate)
         .post(Map("foo" -> "bar", TokenName -> generate))
       )(_.status must_== FORBIDDEN)
     }
     "reject requests with token in session but none elsewhere" in {
-      csrfCheckRequest(_.withSession(TokenName -> generate)
+      csrfCheckRequest(req => addToken(req, generate)
         .post(Map("foo" -> "bar"))
       )(_.status must_== FORBIDDEN)
     }
@@ -87,39 +80,128 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
       csrfAddToken(_.get()) { response =>
         val token = response.body
         token must not be empty
-        val session = response.cookies.find(_.name.exists(_ == Session.COOKIE_NAME)).flatMap(_.value).map(Session.decode)
-        session must beSome
-        val sessionToken = session.flatMap(_.get(TokenName))
-        sessionToken must beSome.like {
-          case s => Crypto.compareSignedTokens(s, token) must beTrue
+        val rspToken = getToken(response)
+        rspToken must beSome.like {
+          case s => compareTokens(token, s)
         }
       }
     }
     "not set the token if already set" in {
       lazy val token = generate
       Thread.sleep(2)
-      csrfAddToken(_.withSession(TokenName -> token).get()) { response =>
-        // it shouldn't be equal, to protect against BREACH vulnerability
-        response.body must_!= token
-        Crypto.compareSignedTokens(token, response.body) must beTrue
-        // Ensure that the session wasn't updated
+      csrfAddToken(req => addToken(req, token).get()) { response =>
+        getToken(response) must beNone
+        compareTokens(token, response.body)
+        // Ensure that nothing was updated
         response.cookies must beEmpty
       }
     }
   }
 
-  def generate = Crypto.generateSignedToken
+  "a CSRF filter" should {
+
+    "work with signed session tokens" in {
+      def csrfCheckRequest = buildCsrfCheckRequest()
+      def csrfAddToken = buildCsrfAddToken()
+      def generate = Crypto.generateSignedToken
+      def addToken(req: WSRequestHolder, token: String) = req.withSession(TokenName -> token)
+      def getToken(response: Response) = {
+        val session = response.cookies.find(_.name.exists(_ == Session.COOKIE_NAME)).flatMap(_.value).map(Session.decode)
+        session.flatMap(_.get(TokenName))
+      }
+      def compareTokens(a: String, b: String) = Crypto.compareSignedTokens(a, b) must beTrue
+
+      sharedTests(csrfCheckRequest, csrfAddToken, generate, addToken, getToken, compareTokens)
+
+      "reject requests with unsigned token in body" in {
+        csrfCheckRequest(req => addToken(req, generate)
+          .post(Map("foo" -> "bar", TokenName -> "foo"))
+        )(_.status must_== FORBIDDEN)
+      }
+      "reject requests with unsigned token in session" in {
+        csrfCheckRequest(req => addToken(req, "foo")
+          .post(Map("foo" -> "bar", TokenName -> generate))
+        )(_.status must_== FORBIDDEN)
+      }
+      "return a different token on each request" in {
+        lazy val token = generate
+        Thread.sleep(2)
+        csrfAddToken(req => addToken(req, token).get()) { response =>
+          // it shouldn't be equal, to protect against BREACH vulnerability
+          response.body must_!= token
+          Crypto.compareSignedTokens(token, response.body) must beTrue
+        }
+      }
+    }
+
+    "work with unsigned session tokens" in {
+      def csrfCheckRequest = buildCsrfCheckRequest("csrf.sign.tokens" -> "false")
+      def csrfAddToken = buildCsrfAddToken("csrf.sign.tokens" -> "false")
+      def generate = Crypto.generateToken
+      def addToken(req: WSRequestHolder, token: String) = req.withSession(TokenName -> token)
+      def getToken(response: Response) = {
+        val session = response.cookies.find(_.name.exists(_ == Session.COOKIE_NAME)).flatMap(_.value).map(Session.decode)
+        session.flatMap(_.get(TokenName))
+      }
+      def compareTokens(a: String, b: String) = a must_== b
+
+      sharedTests(csrfCheckRequest, csrfAddToken, generate, addToken, getToken, compareTokens)
+    }
+
+    "work with signed cookie tokens" in {
+      def csrfCheckRequest = buildCsrfCheckRequest("csrf.cookie.name" -> "csrf")
+      def csrfAddToken = buildCsrfAddToken("csrf.cookie.name" -> "csrf")
+      def generate = Crypto.generateSignedToken
+      def addToken(req: WSRequestHolder, token: String) = req.withCookies("csrf" -> token)
+      def getToken(response: Response) = response.cookies.find(_.name.exists(_ == "csrf")).flatMap(_.value)
+      def compareTokens(a: String, b: String) = Crypto.compareSignedTokens(a, b) must beTrue
+
+      sharedTests(csrfCheckRequest, csrfAddToken, generate, addToken, getToken, compareTokens)
+    }
+
+    "work with unsigned cookie tokens" in {
+      def csrfCheckRequest = buildCsrfCheckRequest("csrf.cookie.name" -> "csrf", "csrf.sign.tokens" -> "false")
+      def csrfAddToken = buildCsrfAddToken("csrf.cookie.name" -> "csrf", "csrf.sign.tokens" -> "false")
+      def generate = Crypto.generateToken
+      def addToken(req: WSRequestHolder, token: String) = req.withCookies("csrf" -> token)
+      def getToken(response: Response) = response.cookies.find(_.name.exists(_ == "csrf")).flatMap(_.value)
+      def compareTokens(a: String, b: String) = a must_== b
+
+      sharedTests(csrfCheckRequest, csrfAddToken, generate, addToken, getToken, compareTokens)
+    }
+
+    "work with secure cookie tokens" in {
+      def csrfCheckRequest = buildCsrfCheckRequest("csrf.cookie.name" -> "csrf", "csrf.cookie.secure" -> "true")
+      def csrfAddToken = buildCsrfAddToken("csrf.cookie.name" -> "csrf", "csrf.cookie.secure" -> "true")
+      def generate = Crypto.generateSignedToken
+      def addToken(req: WSRequestHolder, token: String) = req.withCookies("csrf" -> token)
+      def getToken(response: Response) = {
+        response.cookies.find(_.name.exists(_ == "csrf")).flatMap { cookie =>
+          cookie.secure must beTrue
+          cookie.value
+        }
+      }
+      def compareTokens(a: String, b: String) = Crypto.compareSignedTokens(a, b) must beTrue
+
+      sharedTests(csrfCheckRequest, csrfAddToken, generate, addToken, getToken, compareTokens)
+    }
+
+  }
+
+  trait CsrfTester {
+    def apply[T](makeRequest: WSRequestHolder => Future[Response])(handleResponse: Response => T): T
+  }
 
   /**
    * Set up a request that will go through the CSRF action. The action must return 200 OK if successful.
    */
-  def csrfCheckRequest[T](makeRequest: WSRequestHolder => Future[Response])(handleResponse: Response => T): T
+  def buildCsrfCheckRequest(configuration: (String, String)*): CsrfTester
 
   /**
    * Make a request that will have a token generated and added to the request and response if not present.  The request
    * must return the generated token in the body, accessed as if a template had accessed it.
    */
-  def csrfAddToken[T](makeRequest: WSRequestHolder => Future[Response])(handleResponse: Response => T): T
+  def buildCsrfAddToken(configuration: (String, String)*): CsrfTester
 
   implicit class EnrichedRequestHolder(request: WSRequestHolder) {
     def withSession(session: (String, String)*): WSRequestHolder = {
@@ -133,8 +215,8 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
   implicit def simpleFormWriteable: Writeable[Map[String, String]] = Writeable.writeableOf_urlEncodedForm.map[Map[String, String]](_.mapValues(v => Seq(v)))
   implicit def simpleFormContentType: ContentTypeOf[Map[String, String]] = ContentTypeOf[Map[String, String]](Some(ContentTypes.FORM))
 
-  def withServer[T](router: PartialFunction[(String, String), Handler])(block: => T) = running(TestServer(testServerPort, FakeApplication(
-    additionalConfiguration = Map("application.secret" -> "foobar"),
+  def withServer[T](config: Seq[(String, String)])(router: PartialFunction[(String, String), Handler])(block: => T) = running(TestServer(testServerPort, FakeApplication(
+    additionalConfiguration = Map(config:_*) ++ Map("application.secret" -> "foobar"),
     withRoutes = router
   )))(block)
 }

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -7,11 +7,14 @@ import play.api.mvc._
 import play.api.libs.json.Json
 import play.api.test.{FakeApplication, TestServer}
 import scala.util.Random
+import play.api.libs.Crypto
 
 /**
  * Specs for the global CSRF filter
  */
 object CSRFFilterSpec extends CSRFCommonSpecs {
+
+  sequential
 
   import CSRFConf._
 
@@ -19,26 +22,26 @@ object CSRFFilterSpec extends CSRFCommonSpecs {
 
     // conditions for adding a token
     "not add a token to non GET requests" in {
-      csrfAddToken(_.put(""))(_.status must_== NOT_FOUND)
+      buildCsrfAddToken()(_.put(""))(_.status must_== NOT_FOUND)
     }
     "not add a token to GET requests that don't accept HTML" in {
-      csrfAddToken(_.withHeaders(ACCEPT -> "application/json").get())(_.status must_== NOT_FOUND)
+      buildCsrfAddToken()(_.withHeaders(ACCEPT -> "application/json").get())(_.status must_== NOT_FOUND)
     }
     "add a token to GET requests that accept HTML" in {
-      csrfAddToken(_.withHeaders(ACCEPT -> "text/html").get())(_.status must_== OK)
+      buildCsrfAddToken()(_.withHeaders(ACCEPT -> "text/html").get())(_.status must_== OK)
     }
 
     // extra conditions for not doing a check
     "not check non form bodies" in {
-      csrfCheckRequest(_.post(Json.obj("foo" -> "bar")))(_.status must_== OK)
+      buildCsrfCheckRequest()(_.post(Json.obj("foo" -> "bar")))(_.status must_== OK)
     }
     "not check safe methods" in {
-      csrfCheckRequest(_.put(Map("foo" -> "bar")))(_.status must_== OK)
+      buildCsrfCheckRequest()(_.put(Map("foo" -> "bar")))(_.status must_== OK)
     }
 
     // other
     "feed the body once a check has been done and passes" in {
-      withServer {
+      withServer(Nil) {
         case _ => CSRFFilter()(Action(
           _.body.asFormUrlEncoded
             .flatMap(_.get("foo"))
@@ -46,7 +49,7 @@ object CSRFFilterSpec extends CSRFCommonSpecs {
             .map(Results.Ok(_))
             .getOrElse(Results.NotFound)))
       } {
-        val token = generate
+        val token = Crypto.generateSignedToken
         await(WS.url("http://localhost:" + testServerPort).withSession(TokenName -> token)
           .post(Map("foo" -> "bar", TokenName -> token))).body must_== "bar"
       }
@@ -62,7 +65,7 @@ object CSRFFilterSpec extends CSRFCommonSpecs {
             .getOrElse(Results.NotFound)))
       }
     ))) {
-      val token = generate
+      val token = Crypto.generateSignedToken
       val response = await(WS.url("http://localhost:" + testServerPort).withSession(TokenName -> token)
         .withHeaders(CONTENT_TYPE -> "application/x-www-form-urlencoded")
         .post(
@@ -78,18 +81,22 @@ object CSRFFilterSpec extends CSRFCommonSpecs {
       response.status must_== OK
       response.body must_== "bar"
     }
+    "be possible to instantiate when there is no running application" in {
+      CSRFFilter() must beAnInstanceOf[AnyRef]
+    }
   }
 
-  def csrfCheckRequest[T](makeRequest: (WSRequestHolder) => Future[Response])(handleResponse: Response => T) = {
-    withServer {
+
+  def buildCsrfCheckRequest(configuration: (String, String)*) = new CsrfTester {
+    def apply[T](makeRequest: (WSRequestHolder) => Future[Response])(handleResponse: (Response) => T) = withServer(configuration) {
       case _ => CSRFFilter()(Action(Results.Ok))
     } {
       handleResponse(await(makeRequest(WS.url("http://localhost:" + testServerPort))))
     }
   }
 
-  def csrfAddToken[T](makeRequest: (WSRequestHolder) => Future[Response])(handleResponse: Response => T) = {
-    withServer {
+  def buildCsrfAddToken(configuration: (String, String)*) = new CsrfTester {
+    def apply[T](makeRequest: (WSRequestHolder) => Future[Response])(handleResponse: (Response) => T) = withServer(configuration) {
       case _ => CSRFFilter()(Action { implicit req =>
         CSRF.getToken(req).map { token =>
           Results.Ok(token.value)

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
@@ -12,8 +12,8 @@ import play.libs.F
  */
 object JavaCSRFActionSpec extends CSRFCommonSpecs {
 
-  def csrfCheckRequest[T](makeRequest: (WSRequestHolder) => Future[Response])(handleResponse: Response => T) = {
-    withServer {
+  def buildCsrfCheckRequest(configuration: (String, String)*) = new CsrfTester {
+    def apply[T](makeRequest: (WSRequestHolder) => Future[Response])(handleResponse: (Response) => T) = withServer(configuration) {
       case _ => new JavaAction() {
         def parser = annotations.parser
         def invocation = F.Promise.pure(new MyAction().check())
@@ -24,8 +24,8 @@ object JavaCSRFActionSpec extends CSRFCommonSpecs {
     }
   }
 
-  def csrfAddToken[T](makeRequest: (WSRequestHolder) => Future[Response])(handleResponse: Response => T) = {
-    withServer {
+  def buildCsrfAddToken(configuration: (String, String)*) = new CsrfTester {
+    def apply[T](makeRequest: (WSRequestHolder) => Future[Response])(handleResponse: (Response) => T) = withServer(configuration) {
       case _ => new JavaAction() {
         def parser = annotations.parser
         def invocation = F.Promise.pure(new MyAction().add())

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/ScalaCSRFActionSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/ScalaCSRFActionSpec.scala
@@ -10,16 +10,16 @@ import play.api.mvc._
  */
 object ScalaCSRFActionSpec extends CSRFCommonSpecs {
 
-  def csrfCheckRequest[T](makeRequest: (WSRequestHolder) => Future[Response])(handleResponse: Response => T) = {
-    withServer {
+  def buildCsrfCheckRequest(configuration: (String, String)*) = new CsrfTester {
+    def apply[T](makeRequest: (WSRequestHolder) => Future[Response])(handleResponse: (Response) => T) = withServer(configuration) {
       case _ => CSRFCheck(Action(Results.Ok))
     } {
       handleResponse(await(makeRequest(WS.url("http://localhost:" + testServerPort))))
     }
   }
 
-  def csrfAddToken[T](makeRequest: (WSRequestHolder) => Future[Response])(handleResponse: Response => T) = {
-    withServer {
+  def buildCsrfAddToken(configuration: (String, String)*) = new CsrfTester {
+    def apply[T](makeRequest: (WSRequestHolder) => Future[Response])(handleResponse: (Response) => T) = withServer(configuration) {
       case _ => CSRFAddToken(Action { implicit req =>
         CSRF.getToken(req).map { token =>
           Results.Ok(token.value)
@@ -29,5 +29,4 @@ object ScalaCSRFActionSpec extends CSRFCommonSpecs {
       handleResponse(await(makeRequest(WS.url("http://localhost:" + testServerPort))))
     }
   }
-
 }


### PR DESCRIPTION
- Fixes #1734, custom token generator feature reinstatement
- Fixes #1728, ensured CSRFFilter can be instantiated without a running application
- Made token signing optional, so that a custom token generator does not need to generate signed tokens.
- Abstracted tests so they can be run on many different permutations of configuration
- Added documentation about all the different configuration options

This commit breaks binary compatibility, the CSRFFilter constructor parameters are now not lazy, and CSRFFilter is no longer a case class, so many of the methods it used to provide are no longer there.  This was deemed necessary because the intended use of CSRFFilter, ie:

```
object Global extends WithFilters(CSRFFilter()) with GlobalSettings
```

was not possible with the old constructor.  The constructor is however still source compatible for most use cases.

Since that constructor is intentionally breaking binary compatibility, new parameters that were added for custom token generation and configuration signing were added without consideration for binary compatibility, only source compatibility.
