### PR TITLE
Fix WS timeout configuration

### DIFF
--- a/documentation/manual/javaGuide/main/ws/code/javaguide/ws/application.conf
+++ b/documentation/manual/javaGuide/main/ws/code/javaguide/ws/application.conf
@@ -2,7 +2,7 @@
 # Follow redirects (default true)
 ws.followRedirects=true
 # Connection timeout in ms (default 120000)
-ws.timeout=120000
+ws.timeout.connection=120000
 # Whether to use http.proxy* JVM system properties (default true)
 ws.useProxyProperties=true
 # A user agent string to set on each request (default none)

--- a/documentation/manual/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/scalaGuide/main/ws/ScalaWS.md
@@ -204,7 +204,6 @@ This is important in a couple of cases.  WS has a couple of limitations that req
 
 Use the following properties to configure the WS client
 
-* `ws.timeout` sets both the connection and request timeout in milliseconds
 * `ws.followRedirects` configures the client to follow 301 and 302 redirects
 * `ws.useProxyProperties`to use the system http proxy settings(http.proxyHost, http.proxyPort) 
 * `ws.useragent` to configure the User-Agent header field
@@ -220,8 +219,6 @@ There ore 3 different timeouts in WS. Reaching a timeout causes the WS request t
 * **Request Timeout**: The total time you accept a request to take (it will be interrupted, whatever if the remote host is still sending data) *(default is **none**, to allow stream consuming)*.
 
 You can define each timeout in `application.conf` with respectively: `ws.timeout.connection`, `ws.timeout.idle`, `ws.timeout.request`.
-
-Alternatively, `ws.timeout` can be defined to target both *Connection Timeout* and *Connection Idle Timeout*.
 
 The request timeout can be specified for a given connection with `withRequestTimeout`.
 

--- a/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
@@ -50,10 +50,9 @@ object WS {
 
   private[play] def newClient(): AsyncHttpClient = {
     val playConfig = play.api.Play.maybeApplication.map(_.configuration)
-    val wsTimeout = playConfig.flatMap(_.getMilliseconds("ws.timeout"))
     val asyncHttpConfig = new AsyncHttpClientConfig.Builder()
-      .setConnectionTimeoutInMs(playConfig.flatMap(_.getMilliseconds("ws.timeout.connection")).orElse(wsTimeout).getOrElse(120000L).toInt)
-      .setIdleConnectionTimeoutInMs(playConfig.flatMap(_.getMilliseconds("ws.timeout.idle")).orElse(wsTimeout).getOrElse(120000L).toInt)
+      .setConnectionTimeoutInMs(playConfig.flatMap(_.getMilliseconds("ws.timeout.connection")).getOrElse(120000L).toInt)
+      .setIdleConnectionTimeoutInMs(playConfig.flatMap(_.getMilliseconds("ws.timeout.idle")).getOrElse(120000L).toInt)
       .setRequestTimeoutInMs(playConfig.flatMap(_.getMilliseconds("ws.timeout.request")).getOrElse(120000L).toInt)
       .setFollowRedirects(playConfig.flatMap(_.getBoolean("ws.followRedirects")).getOrElse(true))
       .setUseProxyProperties(playConfig.flatMap(_.getBoolean("ws.useProxyProperties")).getOrElse(true))


### PR DESCRIPTION
Before this commit, any tentative to configure a timeout results in a
runtime exception `Configuration error[/../conf/application.conf:
31: ws.timeout has type STRING rather than OBJECT]`.

Because WS was trying to read `ws.timeout` as a duration value:
`val wsTimeout = playConfig.flatMap(_.getMilliseconds("ws.timeout"))`
Then was treating it as an object:
`playConfig.flatMap(_.getMilliseconds("ws.timeout.connection"))`

As a result, as soon as `ws.timeout` was set, be it a value or an
object, WS was unusable.

This commit removes the `ws.timeout` shortcut and only forces the user
to use `ws.timeout.connection`, `ws.timeout.idle` and
`ws.timeout.request`. `ws.timeout` is no more treatead as a value.
