### PR TITLE
Check for nulls in string validation

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/Forms.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Forms.scala
@@ -235,7 +235,6 @@ object Forms {
    * @param maxLength maximum text length
    */
   def text(minLength: Int = 0, maxLength: Int = Int.MaxValue): Mapping[String] = (minLength, maxLength) match {
-    case (0, Int.MaxValue) => text
     case (min, Int.MaxValue) => text verifying Constraints.minLength(min)
     case (0, max) => text verifying Constraints.maxLength(max)
     case (min, max) => text verifying (Constraints.minLength(min), Constraints.maxLength(max))

--- a/framework/src/play/src/main/scala/play/api/data/validation/Validation.scala
+++ b/framework/src/play/src/main/scala/play/api/data/validation/Validation.scala
@@ -74,7 +74,7 @@ trait Constraints {
    * '''error'''[error.required]
    */
   def nonEmpty: Constraint[String] = Constraint[String]("constraint.required") { o =>
-    if (o.trim.isEmpty) Invalid(ValidationError("error.required")) else Valid
+    if (o == null) Invalid(ValidationError("error.required")) else if (o.trim.isEmpty) Invalid(ValidationError("error.required")) else Valid
   }
 
   /**
@@ -112,7 +112,8 @@ trait Constraints {
    * '''error'''[error.minLength(length)]
    */
   def minLength(length: Int): Constraint[String] = Constraint[String]("constraint.minLength", length) { o =>
-    if (o.size >= length) Valid else Invalid(ValidationError("error.minLength", length))
+    require(length >= 0, "string minLength must not be negative")
+    if (o == null) Invalid(ValidationError("error.minLength", length)) else if (o.size >= length) Valid else Invalid(ValidationError("error.minLength", length))
   }
 
   /**
@@ -122,7 +123,8 @@ trait Constraints {
    * '''error'''[error.maxLength(length)]
    */
   def maxLength(length: Int): Constraint[String] = Constraint[String]("constraint.maxLength", length) { o =>
-    if (o.size <= length) Valid else Invalid(ValidationError("error.maxLength", length))
+    require(length >= 0, "string maxLength must not be negative")
+    if (o == null) Invalid(ValidationError("error.maxLength", length)) else if (o.size <= length) Valid else Invalid(ValidationError("error.maxLength", length))
   }
 
   /**
@@ -132,7 +134,11 @@ trait Constraints {
    * '''error'''[error.pattern(regex)] or defined by the error parameter.
    */
   def pattern(regex: => scala.util.matching.Regex, name: String = "constraint.pattern", error: String = "error.pattern"): Constraint[String] = Constraint[String](name, () => regex) { o =>
-    regex.unapplySeq(o).map(_ => Valid).getOrElse(Invalid(ValidationError(error, regex)))
+    require(regex != null, "regex must not be null")
+    require(name != null, "name must not be null")
+    require(error != null, "error must not be null")
+
+    if (o == null) Invalid(ValidationError(error, regex)) else regex.unapplySeq(o).map(_ => Valid).getOrElse(Invalid(ValidationError(error, regex)))
   }
 
 }

--- a/framework/src/play/src/test/scala/play/api/data/validation/ValidationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/validation/ValidationSpec.scala
@@ -12,6 +12,74 @@ import play.api.data.validation.Constraints._
 
 object ValidationSpec extends Specification {
 
+  "text" should {
+    "throw an IllegalArgumentException if maxLength is negative" in {
+      {
+        Form(
+          "value" -> Forms.text(maxLength = -1)
+        ).bind(Map("value" -> "hello"))
+      }.must(throwAn[IllegalArgumentException])
+    }
+
+    "return a bound form with error if input is null, even if maxLength=0 " in {
+      Form("value" -> Forms.text(maxLength = 0)).bind(Map("value" -> null)).fold(
+        formWithErrors => { formWithErrors.errors.head.message must equalTo("error.maxLength") },
+        { textData => "The mapping should fail." must equalTo("Error") }
+      )
+    }
+
+    "throw an IllegalArgumentException if minLength is negative" in {
+      {
+        Form(
+          "value" -> Forms.text(minLength = -1)
+        ).bind(Map("value" -> "hello"))
+      }.must(throwAn[IllegalArgumentException])
+    }
+
+    "return a bound form with error if input is null, even if minLength=0" in {
+      Form("value" -> Forms.text(minLength = 0)).bind(Map("value" -> null)).fold(
+        formWithErrors => { formWithErrors.errors.head.message must equalTo("error.minLength") },
+        { textData => "The mapping should fail." must equalTo("Error") }
+      )
+    }
+  }
+
+  "nonEmptyText" should {
+    "return a bound form with error if input is null" in {
+      Form("value" -> nonEmptyText).bind(Map("value" -> null)).fold(
+        formWithErrors => { formWithErrors.errors.head.message must equalTo("error.required") },
+        { textData => "The mapping should fail." must equalTo("Error") }
+      )
+    }
+  }
+
+  "Constraints.pattern" should {
+    "throw an IllegalArgumentException if regex is null" in {
+      {
+        Form(
+          "value" -> Forms.text.verifying(Constraints.pattern(null, "nullRegex", "error"))
+        ).bind(Map("value" -> "hello"))
+      }.must(throwAn[IllegalArgumentException])
+    }
+
+    "throw an IllegalArgumentException if name is null" in {
+      {
+        Form(
+          "value" -> Forms.text.verifying(Constraints.pattern(".*".r, null, "error"))
+        ).bind(Map("value" -> "hello"))
+      }.must(throwAn[IllegalArgumentException])
+    }
+
+    "throw an IllegalArgumentException if error is null" in {
+      {
+        Form(
+          "value" -> Forms.text.verifying(pattern(".*".r, "nullRegex", null))
+        ).bind(Map("value" -> "hello"))
+      }.must(throwAn[IllegalArgumentException])
+    }
+
+  }
+
   "Min and max constraint on an Int" should {
     "5 must be a valid number(1,10)" in {
       Form( "value" -> number(1,10) ).bind( Map( "value" -> "5") ).fold(


### PR DESCRIPTION
Fix for #1742

Add checks to ensure that a null string always fails validation on nonEmpty, minLength, maxLength and pattern constraints.
Add requires() to parameters on text, minLength, maxLength and pattern to ensure that parameters are valid and non-null.
Add specs for above.
