### PR TITLE
Fix code references to ScalaFormsHelper

### DIFF
--- a/documentation/manual/scalaGuide/main/forms/ScalaFormHelpers.md
+++ b/documentation/manual/scalaGuide/main/forms/ScalaFormHelpers.md
@@ -70,7 +70,7 @@ It supports the same set of options as the default field constructor (see below)
 
 Often you will need to write your own field constructor. Start by writing a template like:
 
-@[form-myfield](code/scalaguide/forms/scalaformhelper/views/user.scala.html)
+@[form-myfield](code/scalaguide/forms/scalaformhelper/views/myFieldConstructorTemplate.scala.html)
 
 
 > **Note:** This is just a sample. You can make it as complicated as you need. You also have access to the original field using `@elements.field`.

--- a/documentation/manual/scalaGuide/main/forms/code/scalaguide/forms/scalaformhelper/views/user.scala.html
+++ b/documentation/manual/scalaGuide/main/forms/code/scalaguide/forms/scalaformhelper/views/user.scala.html
@@ -46,15 +46,15 @@
 
 }
 
-@* #import-myhelper-implicit*@
+@* #import-myhelper-implicit *@
 @implicitField = @{ FieldConstructor(myFieldConstructorTemplate.f) }
-@* #import-myhelper-implicit*@
+@* #import-myhelper-implicit *@
 
 @helper.form(action = routes.Application.submit) {
 
-@* #form-myfield-helper*@
+@* #form-myfield-helper *@
 @helper.inputText(myForm("username"))
-@* #form-myfield-helper*@
+@* #form-myfield-helper *@
 
 @helper.inputPassword(myForm("password"))
 


### PR DESCRIPTION
Fix for https://github.com/playframework/playframework/issues/1764

Needs to be backported to 2.2.x.

Changes in play-doc and a reference to user.scala.html that should have been myFieldConstructor.scala.html.
