### PR TITLE
Fix a broken link in the 2.1.x docs

### DIFF
--- a/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide2.md
+++ b/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide2.md
@@ -286,7 +286,7 @@ Edit the `conf/test-data.yml` file and start to describe a User:
 ...
 ```
 
-Notice that this object is defined as part of a root object that is a list.  We can now define more objects to be a part of that, however, our dataset is a little large, so you can download a full dataset [here](javaGuide/tutorials/zentasks/files/test-data.yml).
+Notice that this object is defined as part of a root object that is a list.  We can now define more objects to be a part of that, however, our dataset is a little large, so you can download a full dataset [here](resources/manual/javaGuide/tutorials/zentasks/files/test-data.yml).
 
 Now we create a test case that loads this data and runs some assertions over it:
 


### PR DESCRIPTION
I'm assuming this fixes it since this is what the link looks like in master where it works
