### PR TITLE
Fixed 505 body sending bug

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -151,6 +151,16 @@ object ScalaResultsHandlingSpec extends PlaySpecification {
       response.headers.keySet must not contain CONTENT_LENGTH
       response.body must beLeft("abcdefghi")
     }
+
+    "reject HTTP 1.0 requests for chunked results" in withServer(
+      Results.Ok.chunked(Enumerator("a", "b", "c"))
+    ) { port =>
+      val response = BasicHttpClient.makeRequests(port)(
+        BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
+      )(0)
+      response.status must_== HTTP_VERSION_NOT_SUPPORTED
+      response.body must beLeft("The response to this request is chunked and hence requires HTTP 1.1 to be sent, but this is a HTTP 1.0 request.")
+    }
   }
 
 }


### PR DESCRIPTION
Ensured that the original body, but rather, an error message body is sent
when a chunked result is returned for a HTTP/1.0 request.
