### PR TITLE
Make the CommonJs functionality optional

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/jscompile/JavascriptCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/jscompile/JavascriptCompiler.scala
@@ -23,24 +23,24 @@ object JavascriptCompiler {
   def compile(source: File, simpleCompilerOptions: Seq[String], fullCompilerOptions: Option[CompilerOptions]): (String, Option[String], Seq[File]) = {
     import scala.util.control.Exception._
 
-    val simpleCheck = simpleCompilerOptions.contains("rjs")
+    val requireJsMode = simpleCompilerOptions.contains("rjs")
 
     val origin = Path(source).string
 
     val options = fullCompilerOptions.getOrElse {
       val defaultOptions = new CompilerOptions()
       defaultOptions.closurePass = true
-      if (!simpleCheck) {
-        defaultOptions.setProcessCommonJSModules(true)
-        defaultOptions.setCommonJSModulePathPrefix(source.getParent() + File.separator)
-        defaultOptions.setManageClosureDependencies(Seq(toModuleName(source.getName())).asJava)
-      }
       simpleCompilerOptions.foreach(_ match {
         case "advancedOptimizations" => CompilationLevel.ADVANCED_OPTIMIZATIONS.setOptionsForCompilationLevel(defaultOptions)
         case "checkCaja" => defaultOptions.setCheckCaja(true)
         case "checkControlStructures" => defaultOptions.setCheckControlStructures(true)
         case "checkTypes" => defaultOptions.setCheckTypes(true)
         case "checkSymbols" => defaultOptions.setCheckSymbols(true)
+        case "commonJs" if !requireJsMode =>
+          defaultOptions.setProcessCommonJSModules(true)
+          // The compiler always expects forward slashes even on Windows.
+          defaultOptions.setCommonJSModulePathPrefix((source.getParent() + File.separator).replaceAll("\\\\", "/"))
+          defaultOptions.setManageClosureDependencies(Seq(toModuleName(source.getName())).asJava)
         case "ecmascript5" => defaultOptions.setLanguageIn(CompilerOptions.LanguageMode.ECMASCRIPT5)
         case _ => Unit // Unknown option
       })
@@ -49,10 +49,10 @@ object JavascriptCompiler {
 
     val compiler = new Compiler()
     lazy val all = allSiblings(source)
-    val input = if (!simpleCheck) all.map(f => JSSourceFile.fromFile(f)).toArray else Array(JSSourceFile.fromFile(source))
+    val input = if (!requireJsMode) all.map(f => JSSourceFile.fromFile(f)).toArray else Array(JSSourceFile.fromFile(source))
 
     catching(classOf[Exception]).either(compiler.compile(Array[JSSourceFile](), input, options).success) match {
-      case Right(true) => (origin, { if (!simpleCheck) Some(compiler.toSource()) else None }, Nil)
+      case Right(true) => (origin, { if (!requireJsMode) Some(compiler.toSource()) else None }, Nil)
       case Right(false) => {
         val error = compiler.getErrors().head
         val errorFile = all.find(f => f.getAbsolutePath() == error.sourceName)


### PR DESCRIPTION
The Common/Js functionality of the JS compiler is supported by default when the RequireJs functionality isn't required. This PR changes that so that Common/Js functionality has to be explicitly enabled given that it causes problems on Windows. This behaviour is also inline with the closure compiler where Common/Js handling has to be explicitly enabled.

The PR is aimed at 2.2.1 given that something has changed and js compilation is failing consistently on Windows. I'm personally unsure how it ever worked on Windows when used in conjunction with Common/Js.
