### PR TITLE
Fix the code formatting for the iteratees documentation

### DIFF
--- a/documentation/manual/scalaGuide/advanced/iteratees/Iteratees.md
+++ b/documentation/manual/scalaGuide/advanced/iteratees/Iteratees.md
@@ -26,7 +26,9 @@ An iteratee has one of three states, `Cont` meaning accepting more input, `Error
 ```scala
 def fold[B](folder: Step[E, A] => Future[B]): Future[B]
 ```
-where `Step`  object has 3 states :
+
+where the `Step` object has 3 states :
+
 ```scala
 object Step {
   case class Done[+A, E](a: A, remaining: Input[E]) extends Step[E, A]


### PR DESCRIPTION
Backport doc fix to 2.1.x. Fixes https://github.com/playframework/playframework/issues/1030
