### PR TITLE
Generated templates can now be typed as a Scala function

### DIFF
--- a/framework/src/templates-compiler/src/main/scala/play/templates/ScalaTemplateCompiler.scala
+++ b/framework/src/templates-compiler/src/main/scala/play/templates/ScalaTemplateCompiler.scala
@@ -1,4 +1,31 @@
+//Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+import java.io.File
+import java.security.CodeSource
+import java.security.MessageDigest
+
+import scala.Array.canBuildFrom
+import scala.Option.option2Iterable
+import scala.annotation.migration
+import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
+import scala.io.Codec
+import scala.language.postfixOps
+import scala.language.reflectiveCalls
+import scala.reflect.internal.Flags
+import scala.reflect.internal.util.BatchSourceFile
+import scala.reflect.internal.util.Position
+import scala.reflect.internal.util.SourceFile
+import scala.tools.nsc.Settings
+import scala.tools.nsc.interactive.Global
+import scala.tools.nsc.interactive.Response
+import scala.tools.nsc.reporters.ConsoleReporter
+import scala.util.parsing.combinator.JavaTokenParsers
+import scala.util.parsing.input.CharSequenceReader
+import scala.util.parsing.input.NoPosition
 import scala.util.parsing.input.OffsetPosition
+import scala.util.parsing.input.Positional
+
+import scalax.file.Path
 
 package play.templates {
 
@@ -51,56 +78,35 @@ package play.templates {
             }
           }.toMap
         } catch {
-          case _ => Map.empty[String, String]
+          case _: Throwable => Map.empty[String, String]
         }
       }
     }
 
-    lazy val matrix: Seq[(Int, Int)] = {
-      for (pos <- meta("MATRIX").split('|'); val c = pos.split("->"))
+    private def parseMeta(name: String) =
+      for (pos <- meta(name).split('|'); c = pos.split("->"))
         yield try {
         Integer.parseInt(c(0)) -> Integer.parseInt(c(1))
       } catch {
-        case _ => (0, 0) // Skip if MATRIX meta is corrupted
+        case _: Throwable => (0, 0) // Skip if meta is corrupted
       }
-    }
 
-    lazy val lines: Seq[(Int, Int)] = {
-      for (pos <- meta("LINES").split('|'); val c = pos.split("->"))
-        yield try {
-        Integer.parseInt(c(0)) -> Integer.parseInt(c(1))
-      } catch {
-        case _ => (0, 0) // Skip if LINES meta is corrupted
-      }
-    }
+    lazy val matrix: Seq[(Int, Int)] = parseMeta("MATRIX")
+    lazy val lines: Seq[(Int, Int)] = parseMeta("LINES")
 
-    def mapPosition(generatedPosition: Int): Int = {
-      matrix.indexWhere(p => p._1 > generatedPosition) match {
+    private def correctIndex(meta: Seq[(Int, Int)])(generatedIndex: Int): Int =
+      meta.indexWhere(p => p._1 > generatedIndex) match {
         case 0 => 0
-        case i if i > 0 => {
-          val pos = matrix(i - 1)
-          pos._2 + (generatedPosition - pos._1)
-        }
-        case _ => {
-          val pos = matrix.takeRight(1)(0)
-          pos._2 + (generatedPosition - pos._1)
-        }
+        case i if i > 0 =>
+          val pos = meta(i - 1)
+          pos._2 + (generatedIndex - pos._1)
+        case _ =>
+          val pos = meta.takeRight(1)(0)
+          pos._2 + (generatedIndex - pos._1)
       }
-    }
 
-    def mapLine(generatedLine: Int): Int = {
-      lines.indexWhere(p => p._1 > generatedLine) match {
-        case 0 => 0
-        case i if i > 0 => {
-          val line = lines(i - 1)
-          line._2 + (generatedLine - line._1)
-        }
-        case _ => {
-          val line = lines.takeRight(1)(0)
-          line._2 + (generatedLine - line._1)
-        }
-      }
-    }
+    val mapPosition = correctIndex(matrix) _
+    val mapLine = correctIndex(lines) _
   }
 
   case class GeneratedSource(file: File) extends AbstractGeneratedSource {
@@ -119,7 +125,7 @@ package play.templates {
         val line = Path(source.get).string.substring(0, targetMarker).split('\n').size
         (line, targetMarker)
       } catch {
-        case _ => (0, 0)
+        case _: Throwable => (0, 0)
       }
     }
 
@@ -148,28 +154,10 @@ package play.templates {
     def content = _content
   }
 
-  object ScalaTemplateCompiler {
+  object ScalaTemplateCompiler extends TemplateParser with TemplateElements with TemplateGenerator {
 
-    import scala.util.parsing.input.Positional
     import scala.util.parsing.input.CharSequenceReader
     import scala.util.parsing.combinator.JavaTokenParsers
-
-    abstract class TemplateTree
-    abstract class ScalaExpPart
-
-    case class Params(code: String) extends Positional
-    case class Template(name: PosString, comment: Option[Comment], params: PosString, imports: Seq[Simple], defs: Seq[Def], sub: Seq[Template], content: Seq[TemplateTree]) extends Positional
-    case class PosString(str: String) extends Positional {
-      override def toString = str
-    }
-    case class Def(name: PosString, params: PosString, code: Simple) extends Positional
-    case class Plain(text: String) extends TemplateTree with Positional
-    case class Display(exp: ScalaExp) extends TemplateTree with Positional
-    case class Comment(msg: String) extends TemplateTree with Positional
-    case class ScalaExp(parts: Seq[ScalaExpPart]) extends TemplateTree with Positional
-    case class Simple(code: String) extends ScalaExpPart with Positional
-    case class Block(whitespace: String, args: Option[PosString], content: Seq[TemplateTree]) extends ScalaExpPart with Positional
-    case class Value(ident: PosString, block: Block) extends Positional
 
     def compile(source: File, sourceDirectory: File, generatedDirectory: File, formatterType: String, additionalImports: String = "") = {
       val resultType = formatterType + ".Appendable"
@@ -241,482 +229,6 @@ package play.templates {
     }
 
     val templateParser = new TemplateParser
-
-    class TemplateParser extends JavaTokenParsers {
-
-      def as[T](parser: Parser[T], error: String) = {
-        Parser(in => parser(in) match {
-          case s @ Success(_, _) => s
-          case Failure(_, next) => Failure("`" + error + "' expected but `" + next.first + "' found", next)
-          case Error(_, next) => Error(error, next)
-        })
-      }
-
-      def several[T](p: => Parser[T]): Parser[List[T]] = Parser { in =>
-        import scala.collection.mutable.ListBuffer
-        val elems = new ListBuffer[T]
-        def continue(in: Input): ParseResult[List[T]] = {
-          val p0 = p // avoid repeatedly re-evaluating by-name parser
-          @tailrec
-          def applyp(in0: Input): ParseResult[List[T]] = p0(in0) match {
-            case Success(x, rest) => elems += x; applyp(rest)
-            case Failure(_, _) => Success(elems.toList, in0)
-            case err: Error => err
-          }
-          applyp(in)
-        }
-        continue(in)
-      }
-
-      def at = "@"
-
-      def eof = """\Z""".r
-
-      def newLine = (("\r"?) ~> "\n")
-
-      def identifier = as(ident, "identifier")
-
-      def whiteSpaceNoBreak = """[ \t]+""".r
-
-      def escapedAt = at ~> at
-
-      def any = {
-        Parser(in => if (in.atEnd) {
-          Failure("end of file", in)
-        } else {
-          Success(in.first, in.rest)
-        })
-      }
-
-      def plain: Parser[Plain] = {
-        positioned(
-          ((escapedAt | (not(at) ~> (not("{" | "}") ~> any))) +) ^^ {
-            case charList => Plain(charList.mkString)
-          })
-      }
-
-      def squareBrackets: Parser[String] = {
-        "[" ~ (several((squareBrackets | not("]") ~> any))) ~ commit("]") ^^ {
-          case p1 ~ charList ~ p2 => p1 + charList.mkString + p2
-        }
-      }
-
-      def parentheses: Parser[String] = {
-        "(" ~ several(stringLiteral | parentheses | not(")") ~> any) ~ commit(")") ^^ {
-          case p1 ~ charList ~ p2 => p1 + charList.mkString + p2
-        }
-      }
-
-      def comment: Parser[Comment] = {
-        positioned((at ~ "*") ~> ((not("*@") ~> any *) ^^ { case chars => Comment(chars.mkString) }) <~ ("*" ~ at))
-      }
-
-      def brackets: Parser[String] = {
-        ensureMatchedBrackets((several((brackets | not("}") ~> any)))) ^^ {
-          case charList => "{" + charList.mkString + "}"
-        }
-      }
-
-      def ensureMatchedBrackets[T](p: Parser[T]): Parser[T] = Parser { in =>
-        val pWithBrackets = "{" ~> p <~ ("}" | eof ~ err("EOF"))
-        pWithBrackets(in) match {
-          case s @ Success(_, _) => s
-          case f @ Failure(_, _) => f
-          case Error("EOF", _) => Error("Unmatched bracket", in)
-          case e: Error => e
-        }
-      }
-
-      def block: Parser[Block] = {
-        positioned(
-          (whiteSpaceNoBreak?) ~ ensureMatchedBrackets((blockArgs?) ~ several(mixed)) ^^ {
-            case w ~ (args ~ content) => Block(w.getOrElse(""), args, content.flatten)
-          })
-      }
-
-      def blockArgs: Parser[PosString] = positioned((not("=>" | newLine) ~> any *) ~ "=>" ^^ { case args ~ arrow => PosString(args.mkString + arrow) })
-
-      def methodCall: Parser[String] = identifier ~ (squareBrackets?) ~ (parentheses?) ^^ {
-        case methodName ~ types ~ args => methodName + types.getOrElse("") + args.getOrElse("")
-      }
-
-      def expression: Parser[Display] = {
-        at ~> commit(positioned(methodCall ^^ { case code => Simple(code) })) ~ several(expressionPart) ^^ {
-          case first ~ parts => Display(ScalaExp(first :: parts))
-        }
-      }
-
-      def expressionPart: Parser[ScalaExpPart] = {
-        chainedMethods | block | (whiteSpaceNoBreak ~> scalaBlockChained) | elseCall | positioned[Simple]((parentheses ^^ { case code => Simple(code) }))
-      }
-
-      def chainedMethods: Parser[Simple] = {
-        positioned(
-          "." ~> rep1sep(methodCall, ".") ^^ {
-            case calls => Simple("." + calls.mkString("."))
-          })
-      }
-
-      def elseCall: Parser[Simple] = {
-        (whiteSpaceNoBreak?) ~> positioned("else" ^^ { case e => Simple(e) }) <~ (whiteSpaceNoBreak?)
-      }
-
-      def safeExpression: Parser[Display] = {
-        at ~> positioned(parentheses ^^ { case code => Simple(code) }) ^^ {
-          case code => Display(ScalaExp(code :: Nil))
-        }
-      }
-
-      def matchExpression: Parser[Display] = {
-        val simpleExpr: Parser[List[ScalaExpPart]] = positioned(methodCall ^^ { Simple(_) }) ~ several(expressionPart) ^^ {
-          case first ~ parts => first :: parts
-        }
-        val complexExpr = positioned(parentheses ^^ { expr => (Simple(expr)) }) ^^ { List(_) }
-
-        at ~> ((simpleExpr | complexExpr) ~ positioned((whiteSpaceNoBreak ~ "match" ^^ { case w ~ m => Simple(w + m) })) ^^ {
-          case e ~ m => e ++ Seq(m)
-        }) ~ block ^^ {
-          case expr ~ block => Display(ScalaExp(expr ++ Seq(block)))
-        }
-      }
-
-      def forExpression: Parser[Display] = {
-        at ~> positioned("for" ~ parentheses ^^ { case f ~ p => Simple(f + p + " yield ") }) ~ block ^^ {
-          case expr ~ block => {
-            Display(ScalaExp(List(expr, block)))
-          }
-        }
-      }
-
-      def caseExpression: Parser[ScalaExp] = {
-        (whiteSpace?) ~> positioned("""case (.+)=>""".r ^^ { case c => Simple(c) }) ~ block <~ (whiteSpace?) ^^ {
-          case pattern ~ block => ScalaExp(List(pattern, block))
-        }
-      }
-
-      def importExpression: Parser[Simple] = {
-        at ~> positioned("""import .*(\r)?\n""".r ^^ {
-          case stmt => Simple(stmt)
-        })
-      }
-
-      def scalaBlock: Parser[Simple] = {
-        at ~> positioned(
-          brackets ^^ { case code => Simple(code) })
-      }
-
-      def scalaBlockChained: Parser[Block] = {
-        scalaBlock ^^ {
-          case code => Block("", None, ScalaExp(code :: Nil) :: Nil)
-        }
-      }
-
-      def scalaBlockDisplayed: Parser[Display] = {
-        scalaBlock ^^ {
-          case code => Display(ScalaExp(code :: Nil))
-        }
-      }
-
-      def positionalLiteral(s: String): Parser[Plain] = new Parser[Plain] {
-        def apply(in: Input) = {
-          val offset = in.offset
-          val result = literal(s)(in)
-          result match {
-            case Success(s, r) => {
-              val plainString = Plain(s)
-              plainString.pos = new OffsetPosition(in.source, offset)
-              Success(plainString, r)
-            }
-            case Failure(s, t) => Failure(s, t)
-          }
-        }
-      }
-
-      def mixed: Parser[Seq[TemplateTree]] = {
-        ((comment | scalaBlockDisplayed | caseExpression | matchExpression | forExpression | safeExpression | plain | expression) ^^ { case t => List(t) }) |
-          (positionalLiteral("{") ~ several(mixed) ~ positionalLiteral("}")) ^^ { case p1 ~ content ~ p2 => { p1 +: content.flatten :+ p2 } }
-      }
-
-      def template: Parser[Template] = {
-        templateDeclaration ~ """[ \t]*=[ \t]*[{]""".r ~ templateContent <~ "}" ^^ {
-          case declaration ~ assign ~ content => {
-            Template(declaration._1, None, declaration._2, content._1, content._2, content._3, content._4)
-          }
-        }
-      }
-
-      def localDef: Parser[Def] = {
-        templateDeclaration ~ """[ \t]*=[ \t]*""".r ~ scalaBlock ^^ {
-          case declaration ~ w ~ code => {
-            Def(declaration._1, declaration._2, code)
-          }
-        }
-      }
-
-      def templateDeclaration: Parser[(PosString, PosString)] = {
-        at ~> positioned(identifier ^^ { case s => PosString(s) }) ~ positioned(opt(squareBrackets) ~ several(parentheses) ^^ { case t ~ p => PosString(t.getOrElse("") + p.mkString) }) ^^ {
-          case name ~ params => name -> params
-        }
-      }
-
-      def templateContent: Parser[(List[Simple], List[Def], List[Template], List[TemplateTree])] = {
-        (several(importExpression | localDef | template | mixed)) ^^ {
-          case elems => {
-            elems.foldLeft((List[Simple](), List[Def](), List[Template](), List[TemplateTree]())) { (s, e) =>
-              e match {
-                case i: Simple => (s._1 :+ i, s._2, s._3, s._4)
-                case d: Def => (s._1, s._2 :+ d, s._3, s._4)
-                case v: Template => (s._1, s._2, s._3 :+ v, s._4)
-                case c: Seq[_] => (s._1, s._2, s._3, s._4 ++ c.asInstanceOf[Seq[TemplateTree]])
-              }
-            }
-          }
-        }
-      }
-
-      def parser: Parser[Template] = {
-        opt(comment) ~ opt(whiteSpace) ~ opt(at ~> positioned((parentheses+) ^^ { case s => PosString(s.mkString) })) ~ templateContent ^^ {
-          case comment ~ _ ~ args ~ content => {
-            Template(PosString(""), comment, args.getOrElse(PosString("()")), content._1, content._2, content._3, content._4)
-          }
-        }
-      }
-
-      override def skipWhitespace = false
-
-    }
-
-    def visit(elem: Seq[TemplateTree], previous: Seq[Any]): Seq[Any] = {
-      elem match {
-        case head :: tail =>
-          val tripleQuote = "\"\"\""
-          visit(tail, head match {
-            case p @ Plain(text) => (if (previous.isEmpty) Nil else previous :+ ",") :+ "format.raw" :+ Source("(", p.pos) :+ tripleQuote :+ text :+ tripleQuote :+ ")"
-            case Comment(msg) => previous
-            case Display(exp) => (if (previous.isEmpty) Nil else previous :+ ",") :+ "_display_(Seq[Any](" :+ visit(Seq(exp), Nil) :+ "))"
-            case ScalaExp(parts) => previous :+ parts.map {
-              case s @ Simple(code) => Source(code, s.pos)
-              case b @ Block(whitespace, args, content) if (content.forall(_.isInstanceOf[ScalaExp])) => Nil :+ Source(whitespace + "{" + args.getOrElse(""), b.pos) :+ visit(content, Nil) :+ "}"
-              case b @ Block(whitespace, args, content) => Nil :+ Source(whitespace + "{" + args.getOrElse(""), b.pos) :+ "_display_(Seq[Any](" :+ visit(content, Nil) :+ "))}"
-            }
-          })
-        case Nil => previous
-      }
-    }
-
-    def templateCode(template: Template, resultType: String): Seq[Any] = {
-
-      val defs = (template.sub ++ template.defs).map { i =>
-        i match {
-          case t: Template if t.name == "" => templateCode(t, resultType)
-          case t: Template => {
-            Nil :+ (if (t.name.str.startsWith("implicit")) "implicit def " else "def ") :+ Source(t.name.str, t.name.pos) :+ Source(t.params.str, t.params.pos) :+ ":" :+ resultType :+ " = {_display_(" :+ templateCode(t, resultType) :+ ")};"
-          }
-          case Def(name, params, block) => {
-            Nil :+ (if (name.str.startsWith("implicit")) "implicit def " else "def ") :+ Source(name.str, name.pos) :+ Source(params.str, params.pos) :+ " = {" :+ block.code :+ "};"
-          }
-        }
-      }
-
-      val imports = template.imports.map(_.code).mkString("\n")
-
-      Nil :+ imports :+ "\n" :+ defs :+ "\n" :+ "Seq[Any](" :+ visit(template.content, Nil) :+ ")"
-    }
-
-    def generateCode(packageName: String, name: String, root: Template, resultType: String, formatterType: String, additionalImports: String) = {
-      val extra = TemplateAsFunctionCompiler.getFunctionMapping(
-        root.params.str,
-        resultType)
-
-      val generated = {
-        Nil :+ """
-package """ :+ packageName :+ """
-
-import play.templates._
-import play.templates.TemplateMagic._
-
-""" :+ additionalImports :+ """
-/*""" :+ root.comment.map(_.msg).getOrElse("") :+ """*/
-object """ :+ name :+ """ extends BaseScalaTemplate[""" :+ resultType :+ """,Format[""" :+ resultType :+ """]](""" :+ formatterType :+ """) with """ :+ extra._3 :+ """ {
-
-    /*""" :+ root.comment.map(_.msg).getOrElse("") :+ """*/
-    def apply""" :+ Source(root.params.str, root.params.pos) :+ """:""" :+ resultType :+ """ = {
-        _display_ {""" :+ templateCode(root, resultType) :+ """}
-    }
-    
-    """ :+ extra._1 :+ """
-    
-    """ :+ extra._2 :+ """
-    
-    def ref: this.type = this
-
-}"""
-      }
-      generated
-    }
-
-    @deprecated("use generateFinalTemplate with 8 parameters instead", "Play 2.1")
-    def generateFinalTemplate(template: File, packageName: String, name: String, root: Template, resultType: String, formatterType: String, additionalImports: String): String = {
-      generateFinalTemplate(template.getAbsolutePath, Path(template).byteArray, packageName, name, root, resultType, formatterType, additionalImports)
-    }
-
-    def generateFinalTemplate(absolutePath: String, contents: Array[Byte], packageName: String, name: String, root: Template, resultType: String, formatterType: String, additionalImports: String): String = {
-      val generated = generateCode(packageName, name, root, resultType, formatterType, additionalImports)
-
-      Source.finalSource(absolutePath, contents, generated, Hash(contents, additionalImports))
-    }
-
-    object TemplateAsFunctionCompiler {
-
-      // Note, the presentation compiler is not thread safe, all access to it must be synchronized.  If access to it
-      // is not synchronized, then weird things happen like FreshRunReq exceptions are thrown when multiple sub projects
-      // are compiled (done in parallel by default by SBT).  So if adding any new methods to this object, make sure you
-      // make them synchronized.
-
-      import java.io.File
-      import scala.tools.nsc.interactive.{ Response, Global }
-      import scala.tools.nsc.io.AbstractFile
-      import scala.tools.nsc.util.{ SourceFile, Position, BatchSourceFile }
-      import scala.tools.nsc.Settings
-      import scala.tools.nsc.reporters.ConsoleReporter
-
-      def getFunctionMapping(signature: String, returnType: String): (String, String, String) = synchronized {
-
-        type Tree = PresentationCompiler.global.Tree
-        type DefDef = PresentationCompiler.global.DefDef
-        type TypeDef = PresentationCompiler.global.TypeDef
-        type ValDef = PresentationCompiler.global.ValDef
-
-        def filterType(t: String) = t match {
-          case vararg if vararg.startsWith("_root_.scala.<repeated>") => vararg.replace("_root_.scala.<repeated>", "Array")
-          case synthetic if synthetic.contains("<synthetic>") => synthetic.replace("<synthetic>", "")
-          case t => t
-        }
-
-        def findSignature(tree: Tree): Option[DefDef] = {
-          tree match {
-            case t: DefDef if t.name.toString == "signature" => Some(t)
-            case t: Tree => t.children.flatMap(findSignature).headOption
-          }
-        }
-
-        // For some reason they got rid of mods.isByNameParam
-        object ByNameParam {
-          def unapply(param: ValDef): Option[(String, String)] = if (param.mods.hasFlag(Flags.BYNAMEPARAM)) {
-            Some((param.name.toString, param.tpt.children(1).toString))
-          } else None
-        }
-
-        val params = findSignature(
-          PresentationCompiler.treeFrom("object FT { def signature" + signature + " }")).get.vparamss
-
-        val functionType = "(" + params.map(group => "(" + group.map {
-          case ByNameParam(_, paramType) => " => " + paramType
-          case a => filterType(a.tpt.toString)
-        }.mkString(",") + ")").mkString(" => ") + " => " + returnType + ")"
-
-        val renderCall = "def render%s: %s = apply%s".format(
-          "(" + params.flatten.map {
-            case ByNameParam(name, paramType) => name + ":" + paramType
-            case a => a.name.toString + ":" + filterType(a.tpt.toString)
-          }.mkString(",") + ")",
-          returnType,
-          params.map(group => "(" + group.map { p =>
-            p.name.toString + Option(p.tpt.toString).filter(_.startsWith("_root_.scala.<repeated>")).map(_ => ":_*").getOrElse("")
-          }.mkString(",") + ")").mkString)
-
-        val templateType = "play.api.templates.Template%s[%s%s]".format(
-          params.flatten.size,
-          params.flatten.map {
-            case ByNameParam(_, paramType) => paramType
-            case a => filterType(a.tpt.toString)
-          }.mkString(","),
-          (if (params.flatten.isEmpty) "" else ",") + returnType)
-
-        val f = "def f:%s = %s => apply%s".format(
-          functionType,
-          params.map(group => "(" + group.map(_.name.toString).mkString(",") + ")").mkString(" => "),
-          params.map(group => "(" + group.map { p =>
-            p.name.toString + Option(p.tpt.toString).filter(_.startsWith("_root_.scala.<repeated>")).map(_ => ":_*").getOrElse("")
-          }.mkString(",") + ")").mkString)
-
-        (renderCall, f, templateType)
-      }
-
-      class CompilerInstance {
-
-        def additionalClassPathEntry: Option[String] = None
-
-        lazy val compiler = {
-
-          val settings = new Settings
-
-          val scalaObjectSource = Class.forName("scala.ScalaObject").getProtectionDomain.getCodeSource
-
-          // is null in Eclipse/OSGI but luckily we don't need it there
-          if (scalaObjectSource != null) {
-            import java.security.CodeSource
-            def toAbsolutePath(cs: CodeSource) = new File(cs.getLocation.toURI).getAbsolutePath
-            val compilerPath = toAbsolutePath(Class.forName("scala.tools.nsc.Interpreter").getProtectionDomain.getCodeSource)
-            val libPath = toAbsolutePath(scalaObjectSource)
-            val pathList = List(compilerPath, libPath)
-            val origBootclasspath = settings.bootclasspath.value
-            settings.bootclasspath.value = ((origBootclasspath :: pathList) ::: additionalClassPathEntry.toList) mkString File.pathSeparator
-          }
-
-          val compiler = new Global(settings, new ConsoleReporter(settings) {
-            override def printMessage(pos: Position, msg: String) = ()
-          })
-
-          // Everything must be done on the compiler thread, because the presentation compiler is a fussy piece of work.
-          compiler.ask(() => new compiler.Run)
-
-          compiler
-        }
-      }
-
-      trait TreeCreationMethods {
-
-        val global: scala.tools.nsc.interactive.Global
-
-        val randomFileName = {
-          val r = new java.util.Random
-          () => "file" + r.nextInt
-        }
-
-        def treeFrom(src: String): global.Tree = {
-          val file = new BatchSourceFile(randomFileName(), src)
-          treeFrom(file)
-        }
-
-        def treeFrom(file: SourceFile): global.Tree = {
-          import tools.nsc.interactive.Response
-
-          type Scala29Compiler = {
-            def askParsedEntered(file: SourceFile, keepLoaded: Boolean, response: Response[global.Tree]): Unit
-            def askType(file: SourceFile, forceReload: Boolean, respone: Response[global.Tree]): Unit
-          }
-
-          val newCompiler = global.asInstanceOf[Scala29Compiler]
-
-          val r1 = new Response[global.Tree]
-          newCompiler.askParsedEntered(file, true, r1)
-          r1.get.left.toOption.getOrElse(throw r1.get.right.get)
-        }
-
-      }
-
-      object CompilerInstance extends CompilerInstance
-
-      object PresentationCompiler extends TreeCreationMethods {
-        val global = CompilerInstance.compiler
-
-        def shutdown() {
-          global.askShutdown()
-        }
-      }
-
-    }
 
   }
 

--- a/framework/src/templates-compiler/src/main/scala/play/templates/TemplateElements.scala
+++ b/framework/src/templates-compiler/src/main/scala/play/templates/TemplateElements.scala
@@ -1,0 +1,24 @@
+//Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+package play.templates
+
+import scala.util.parsing.input.Positional
+
+trait TemplateElements {
+
+  abstract class TemplateTree
+  abstract class ScalaExpPart
+
+  case class Params(code: String) extends Positional
+  case class Template(name: PosString, comment: Option[Comment], params: PosString, imports: Seq[Simple], defs: Seq[Def], sub: Seq[Template], content: Seq[TemplateTree]) extends Positional
+  case class PosString(str: String) extends Positional {
+    override def toString = str
+  }
+  case class Def(name: PosString, params: PosString, code: Simple) extends Positional
+  case class Plain(text: String) extends TemplateTree with Positional
+  case class Display(exp: ScalaExp) extends TemplateTree with Positional
+  case class Comment(msg: String) extends TemplateTree with Positional
+  case class ScalaExp(parts: Seq[ScalaExpPart]) extends TemplateTree with Positional
+  case class Simple(code: String) extends ScalaExpPart with Positional
+  case class Block(whitespace: String, args: Option[PosString], content: Seq[TemplateTree]) extends ScalaExpPart with Positional
+  case class Value(ident: PosString, block: Block) extends Positional
+}

--- a/framework/src/templates-compiler/src/main/scala/play/templates/TemplateGenerator.scala
+++ b/framework/src/templates-compiler/src/main/scala/play/templates/TemplateGenerator.scala
@@ -1,0 +1,325 @@
+package play.templates
+
+//Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+import java.io.File
+import java.security.CodeSource
+
+import scala.Option.option2Iterable
+import scala.language.postfixOps
+import scala.language.reflectiveCalls
+import scala.reflect.internal.Flags
+import scala.reflect.internal.util.BatchSourceFile
+import scala.reflect.internal.util.Position
+import scala.reflect.internal.util.SourceFile
+import scala.tools.nsc.Settings
+import scala.tools.nsc.interactive.Global
+import scala.tools.nsc.interactive.Response
+import scala.tools.nsc.reporters.ConsoleReporter
+
+import scalax.file.Path
+
+trait TemplateGenerator { self: TemplateElements =>
+
+  def generateCode(packageName: String, name: String, root: Template, resultType: String, formatterType: String, additionalImports: String) = {
+    val (functionType, renderMethod, fMethod, toFunctionImplicitMethods, templateType) =
+      TemplateAsFunctionCompiler.getFunctionMapping(name, root.params.str, resultType)
+
+    val generated =
+      Nil :+
+        s"""|package $packageName
+		    |
+            |import scala.language.implicitConversions
+		    |import play.templates._
+		    |import play.templates.TemplateMagic._
+		    |
+		    |$additionalImports
+		    |/*${root.comment.map(_.msg).getOrElse("")}*/
+		    |object $name extends BaseScalaTemplate[$resultType, Format[$resultType]]($formatterType) with $templateType {
+		    |
+		    |  /*${root.comment.map(_.msg).getOrElse("")}*/
+		    |  def apply""" :+ Source(root.params.str, root.params.pos) :+ s""":$resultType = {
+		    |    _display_ {""" :+ templateCode(root, resultType) :+ s"""}
+		    |  }
+		    |
+		    |  $toFunctionImplicitMethods
+		    |    
+		    |  $renderMethod
+		    |
+		    |  @scala.deprecated("The template itself now be typed as a function", "2.2.1")
+		    |  $fMethod
+		    |
+		    |  def ref: this.type = this
+		    |}"""
+
+    generated.map {
+      case string: String => string.stripMargin
+      case other => other
+    }
+  }
+
+  def templateCode(template: Template, resultType: String): Seq[Any] = {
+
+    val defs = (template.sub ++ template.defs).map { i =>
+      i match {
+        case t: Template if t.name == "" => templateCode(t, resultType)
+        case t: Template => {
+          Nil :+ (if (t.name.str.startsWith("implicit")) "implicit def " else "def ") :+ Source(t.name.str, t.name.pos) :+ Source(t.params.str, t.params.pos) :+ ":" :+ resultType :+ " = {_display_(" :+ templateCode(t, resultType) :+ ")};"
+        }
+        case Def(name, params, block) => {
+          Nil :+ (if (name.str.startsWith("implicit")) "implicit def " else "def ") :+ Source(name.str, name.pos) :+ Source(params.str, params.pos) :+ " = {" :+ block.code :+ "};"
+        }
+      }
+    }
+
+    val imports = template.imports.map(_.code).mkString("\n")
+
+    Nil :+ imports :+ "\n" :+ defs :+ "\n" :+ "Seq[Any](" :+ visit(template.content, Nil) :+ ")"
+  }
+
+  @deprecated("use generateFinalTemplate with 8 parameters instead", "Play 2.1")
+  def generateFinalTemplate(template: File, packageName: String, name: String, root: Template, resultType: String, formatterType: String, additionalImports: String): String = {
+    generateFinalTemplate(template.getAbsolutePath, Path(template).byteArray, packageName, name, root, resultType, formatterType, additionalImports)
+  }
+
+  def generateFinalTemplate(absolutePath: String, contents: Array[Byte], packageName: String, name: String, root: Template, resultType: String, formatterType: String, additionalImports: String): String = {
+    val generated = generateCode(packageName, name, root, resultType, formatterType, additionalImports)
+
+    Source.finalSource(absolutePath, contents, generated, Hash(contents, additionalImports))
+  }
+
+  def visit(elem: Seq[TemplateTree], previous: Seq[Any]): Seq[Any] = {
+    elem match {
+      case head :: tail =>
+        val tripleQuote = "\"\"\""
+        visit(tail, head match {
+          case p @ Plain(text) => (if (previous.isEmpty) Nil else previous :+ ",") :+ "format.raw" :+ Source("(", p.pos) :+ tripleQuote :+ text :+ tripleQuote :+ ")"
+          case Comment(msg) => previous
+          case Display(exp) => (if (previous.isEmpty) Nil else previous :+ ",") :+ "_display_(Seq[Any](" :+ visit(Seq(exp), Nil) :+ "))"
+          case ScalaExp(parts) => previous :+ parts.map {
+            case s @ Simple(code) => Source(code, s.pos)
+            case b @ Block(whitespace, args, content) if (content.forall(_.isInstanceOf[ScalaExp])) => Nil :+ Source(whitespace + "{" + args.getOrElse(""), b.pos) :+ visit(content, Nil) :+ "}"
+            case b @ Block(whitespace, args, content) => Nil :+ Source(whitespace + "{" + args.getOrElse(""), b.pos) :+ "_display_(Seq[Any](" :+ visit(content, Nil) :+ "))}"
+          }
+        })
+      case Nil => previous
+    }
+  }
+
+  object TemplateAsFunctionCompiler {
+
+    // Note, the presentation compiler is not thread safe, all access to it must be synchronized.  If access to it
+    // is not synchronized, then weird things happen like FreshRunReq exceptions are thrown when multiple sub projects
+    // are compiled (done in parallel by default by SBT).  So if adding any new methods to this object, make sure you
+    // make them synchronized.
+
+    import java.io.File
+    import scala.tools.nsc.interactive.{ Response, Global }
+    import scala.tools.nsc.io.AbstractFile
+    import scala.tools.nsc.Settings
+    import scala.tools.nsc.reporters.ConsoleReporter
+
+    def getFunctionMapping(name: String, signature: String, returnType: String): (String, String, String, String, String) = synchronized {
+
+      type Tree = PresentationCompiler.global.Tree
+      type DefDef = PresentationCompiler.global.DefDef
+      type TypeDef = PresentationCompiler.global.TypeDef
+      type ValDef = PresentationCompiler.global.ValDef
+
+      def findSignature(tree: Tree): Option[DefDef] = {
+        tree match {
+          case t: DefDef if t.name.toString == "signature" => Some(t)
+          case t: Tree => t.children.flatMap(findSignature).headOption
+        }
+      }
+
+      case class Param(name: String, tpe: String, isImplicit: Boolean, isByName: Boolean, defaultValue: String) {
+        private val REPEATED = raw"^_root_\.scala\.<repeated>\[(.+?)\]$$".r
+        private val SYNTHETIC = "<synthetic>"
+
+        val hasDefaultValue = defaultValue != "<empty>"
+
+        val (varargs, cleanType) =
+          tpe.replaceAll(SYNTHETIC, "") match {
+            case REPEATED(cleanType) => (true, cleanType)
+            case cleanType => (false, cleanType)
+          }
+
+        val normalizedType =
+          if (varargs) s"Array[$cleanType]"
+          else cleanType
+
+        val nameForCall = name + (if (varargs) ":_*" else "")
+        val fullType =
+          (if (isByName) " => " else "") +
+            cleanType +
+            (if (varargs) " *" else "")
+        val nameAndNormalizedType = name + ":" + normalizedType
+        val fullParam = name + ":" + fullType + (if (hasDefaultValue) " = " + defaultValue else "")
+      }
+
+      def toParam(param: ValDef): Param = {
+        val defaultValue = param.rhs.toString
+        val isByName = param.mods.hasFlag(Flags.BYNAMEPARAM)
+        val isImplicit = param.mods.hasFlag(Flags.IMPLICIT)
+        val tpe =
+          if (isByName) param.tpt.children(1).toString
+          else param.tpt.toString
+        Param(param.name.toString, tpe, isImplicit, isByName, defaultValue)
+      }
+
+      val params =
+        findSignature(
+          PresentationCompiler.treeFrom("object FT { def signature" + signature + " }"))
+          .get
+          .vparamss
+          .map(_.map(toParam))
+
+      val allParams = params.flatten
+
+      val functionType =
+        "(" + params.map("(" + _.map(_.fullType).mkString(",") + ")").mkString(" => ") + " => " + returnType + ")"
+
+      val parametersForCall =
+        params.map("(" + _.map(_.nameForCall).mkString(",") + ")").mkString
+
+      val renderMethod = {
+        val singleParameterList =
+          "(" + allParams.map(_.nameAndNormalizedType).mkString(",") + ")"
+
+        s"def render$singleParameterList: $returnType = apply$parametersForCall"
+      }
+
+      val templateType = {
+        val parameterCount = allParams.size
+        val argumentTypes = allParams.map(_.normalizedType)
+        val typeParameters = (argumentTypes :+ returnType).mkString(",")
+
+        s"play.api.templates.Template$parameterCount[$typeParameters]"
+      }
+
+      val fMethod = {
+        val closureParameters =
+          params.map(group => "(" + group.map(_.name).mkString(",") + ")").mkString(" => ")
+        s"def f:$functionType = $closureParameters => apply$parametersForCall"
+      }
+
+      val toFunctionImplicitMethods = {
+        val hasImplicits = params.lastOption.map(_.headOption.map(_.isImplicit).getOrElse(false)).getOrElse(false)
+
+        if (hasImplicits) {
+
+          val applyParameters =
+            params.map("(" + _.map(_.nameForCall).mkString(",") + ")").mkString
+
+          val withoutImplicits = {
+
+            val closureParameters =
+              params.map("(" + _.map(_.name).mkString(",") + ")").mkString(" => ")
+
+            s"""|implicit def toFunction(template:$name.type):$functionType = 
+                |  { $closureParameters => apply$applyParameters }
+                |""".stripMargin
+          }
+
+          val withImplicits = {
+            val implicitParams =
+              "(implicit " + params.last.map(_.fullParam).mkString(",") + ")"
+            val typeWithoutImplicits =
+              params.dropRight(1).map("(" + _.map(_.fullType).mkString(",") + ")")
+
+            val onlyImplicits = typeWithoutImplicits.isEmpty
+            val functionTypeWithoutImplicits =
+              if (onlyImplicits) returnType
+              else "(" + typeWithoutImplicits.mkString(" => ") + " => " + returnType + ")"
+
+            val applyCall =
+              if (onlyImplicits) "apply" + applyParameters
+              else "apply _"
+
+            s"""|implicit def toFunction(template:$name.type)$implicitParams:$functionTypeWithoutImplicits = 
+            	|  $applyCall
+                |""".stripMargin
+          }
+
+          withoutImplicits + withImplicits
+        } else
+          s"implicit def toFunction(template:$name.type):$functionType = apply _"
+      }
+
+      (functionType, renderMethod, fMethod, toFunctionImplicitMethods, templateType)
+    }
+
+    class CompilerInstance {
+
+      def additionalClassPathEntry: Option[String] = None
+
+      lazy val compiler = {
+
+        val settings = new Settings
+
+        val scalaObjectSource = Class.forName("scala.ScalaObject").getProtectionDomain.getCodeSource
+
+        // is null in Eclipse/OSGI but luckily we don't need it there
+        if (scalaObjectSource != null) {
+          import java.security.CodeSource
+          def toAbsolutePath(cs: CodeSource) = new File(cs.getLocation.toURI).getAbsolutePath
+          val compilerPath = toAbsolutePath(Class.forName("scala.tools.nsc.Interpreter").getProtectionDomain.getCodeSource)
+          val libPath = toAbsolutePath(scalaObjectSource)
+          val pathList = List(compilerPath, libPath)
+          val origBootclasspath = settings.bootclasspath.value
+          settings.bootclasspath.value = ((origBootclasspath :: pathList) ::: additionalClassPathEntry.toList) mkString File.pathSeparator
+        }
+
+        val compiler = new Global(settings, new ConsoleReporter(settings) {
+          override def printMessage(pos: Position, msg: String) = ()
+        })
+
+        // Everything must be done on the compiler thread, because the presentation compiler is a fussy piece of work.
+        compiler.ask(() => new compiler.Run)
+
+        compiler
+      }
+    }
+
+    trait TreeCreationMethods {
+
+      val global: scala.tools.nsc.interactive.Global
+
+      val randomFileName = {
+        val r = new java.util.Random
+        () => "file" + r.nextInt
+      }
+
+      def treeFrom(src: String): global.Tree = {
+        val file = new BatchSourceFile(randomFileName(), src)
+        treeFrom(file)
+      }
+
+      def treeFrom(file: SourceFile): global.Tree = {
+        import tools.nsc.interactive.Response
+
+        type Scala29Compiler = {
+          def askParsedEntered(file: SourceFile, keepLoaded: Boolean, response: Response[global.Tree]): Unit
+          def askType(file: SourceFile, forceReload: Boolean, respone: Response[global.Tree]): Unit
+        }
+
+        val newCompiler = global.asInstanceOf[Scala29Compiler]
+
+        val r1 = new Response[global.Tree]
+        newCompiler.askParsedEntered(file, true, r1)
+        r1.get.left.toOption.getOrElse(throw r1.get.right.get)
+      }
+
+    }
+
+    object CompilerInstance extends CompilerInstance
+
+    object PresentationCompiler extends TreeCreationMethods {
+      val global = CompilerInstance.compiler
+
+      def shutdown() {
+        global.askShutdown()
+      }
+    }
+  }
+}

--- a/framework/src/templates-compiler/src/main/scala/play/templates/TemplateParser.scala
+++ b/framework/src/templates-compiler/src/main/scala/play/templates/TemplateParser.scala
@@ -1,0 +1,258 @@
+//Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+package play.templates
+
+import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
+import scala.language.postfixOps
+import scala.language.reflectiveCalls
+import scala.util.parsing.combinator.JavaTokenParsers
+import scala.util.parsing.input.OffsetPosition
+
+trait TemplateParser { self: TemplateElements =>
+
+  class TemplateParser extends JavaTokenParsers {
+
+    def as[T](parser: Parser[T], error: String) = {
+      Parser(in => parser(in) match {
+        case s @ Success(_, _) => s
+        case Failure(_, next) => Failure("`" + error + "' expected but `" + next.first + "' found", next)
+        case Error(_, next) => Error(error, next)
+      })
+    }
+
+    def several[T](p: => Parser[T]): Parser[List[T]] = Parser { in =>
+      import scala.collection.mutable.ListBuffer
+      val elems = new ListBuffer[T]
+      def continue(in: Input): ParseResult[List[T]] = {
+        val p0 = p // avoid repeatedly re-evaluating by-name parser
+        @tailrec
+        def applyp(in0: Input): ParseResult[List[T]] = p0(in0) match {
+          case Success(x, rest) =>
+            elems += x; applyp(rest)
+          case Failure(_, _) => Success(elems.toList, in0)
+          case err: Error => err
+        }
+        applyp(in)
+      }
+      continue(in)
+    }
+
+    def at = "@"
+
+    def eof = """\Z""".r
+
+    def newLine = (("\r"?) ~> "\n")
+
+    def identifier = as(ident, "identifier")
+
+    def whiteSpaceNoBreak = """[ \t]+""".r
+
+    def escapedAt = at ~> at
+
+    def any = {
+      Parser(in => if (in.atEnd) {
+        Failure("end of file", in)
+      } else {
+        Success(in.first, in.rest)
+      })
+    }
+
+    def plain: Parser[Plain] = {
+      positioned(
+        ((escapedAt | (not(at) ~> (not("{" | "}") ~> any))) +) ^^ {
+          case charList => Plain(charList.mkString)
+        })
+    }
+
+    def squareBrackets: Parser[String] = {
+      "[" ~ (several((squareBrackets | not("]") ~> any))) ~ commit("]") ^^ {
+        case p1 ~ charList ~ p2 => p1 + charList.mkString + p2
+      }
+    }
+
+    def parentheses: Parser[String] = {
+      "(" ~ several(stringLiteral | parentheses | not(")") ~> any) ~ commit(")") ^^ {
+        case p1 ~ charList ~ p2 => p1 + charList.mkString + p2
+      }
+    }
+
+    def comment: Parser[Comment] = {
+      positioned((at ~ "*") ~> ((not("*@") ~> any *) ^^ { case chars => Comment(chars.mkString) }) <~ ("*" ~ at))
+    }
+
+    def brackets: Parser[String] = {
+      ensureMatchedBrackets((several((brackets | not("}") ~> any)))) ^^ {
+        case charList => "{" + charList.mkString + "}"
+      }
+    }
+
+    def ensureMatchedBrackets[T](p: Parser[T]): Parser[T] = Parser { in =>
+      val pWithBrackets = "{" ~> p <~ ("}" | eof ~ err("EOF"))
+      pWithBrackets(in) match {
+        case s @ Success(_, _) => s
+        case f @ Failure(_, _) => f
+        case Error("EOF", _) => Error("Unmatched bracket", in)
+        case e: Error => e
+      }
+    }
+
+    def block: Parser[Block] = {
+      positioned(
+        (whiteSpaceNoBreak?) ~ ensureMatchedBrackets((blockArgs?) ~ several(mixed)) ^^ {
+          case w ~ (args ~ content) => Block(w.getOrElse(""), args, content.flatten)
+        })
+    }
+
+    def blockArgs: Parser[PosString] = positioned((not("=>" | newLine) ~> any *) ~ "=>" ^^ { case args ~ arrow => PosString(args.mkString + arrow) })
+
+    def methodCall: Parser[String] = identifier ~ (squareBrackets?) ~ (parentheses?) ^^ {
+      case methodName ~ types ~ args => methodName + types.getOrElse("") + args.getOrElse("")
+    }
+
+    def expression: Parser[Display] = {
+      at ~> commit(positioned(methodCall ^^ { case code => Simple(code) })) ~ several(expressionPart) ^^ {
+        case first ~ parts => Display(ScalaExp(first :: parts))
+      }
+    }
+
+    def expressionPart: Parser[ScalaExpPart] = {
+      chainedMethods | block | (whiteSpaceNoBreak ~> scalaBlockChained) | elseCall | positioned[Simple]((parentheses ^^ { case code => Simple(code) }))
+    }
+
+    def chainedMethods: Parser[Simple] = {
+      positioned(
+        "." ~> rep1sep(methodCall, ".") ^^ {
+          case calls => Simple("." + calls.mkString("."))
+        })
+    }
+
+    def elseCall: Parser[Simple] = {
+      (whiteSpaceNoBreak?) ~> positioned("else" ^^ { case e => Simple(e) }) <~ (whiteSpaceNoBreak?)
+    }
+
+    def safeExpression: Parser[Display] = {
+      at ~> positioned(parentheses ^^ { case code => Simple(code) }) ^^ {
+        case code => Display(ScalaExp(code :: Nil))
+      }
+    }
+
+    def matchExpression: Parser[Display] = {
+      val simpleExpr: Parser[List[ScalaExpPart]] = positioned(methodCall ^^ { Simple(_) }) ~ several(expressionPart) ^^ {
+        case first ~ parts => first :: parts
+      }
+      val complexExpr = positioned(parentheses ^^ { expr => (Simple(expr)) }) ^^ { List(_) }
+
+      at ~> ((simpleExpr | complexExpr) ~ positioned((whiteSpaceNoBreak ~ "match" ^^ { case w ~ m => Simple(w + m) })) ^^ {
+        case e ~ m => e ++ Seq(m)
+      }) ~ block ^^ {
+        case expr ~ block => Display(ScalaExp(expr ++ Seq(block)))
+      }
+    }
+
+    def forExpression: Parser[Display] = {
+      at ~> positioned("for" ~ parentheses ^^ { case f ~ p => Simple(f + p + " yield ") }) ~ block ^^ {
+        case expr ~ block => {
+          Display(ScalaExp(List(expr, block)))
+        }
+      }
+    }
+
+    def caseExpression: Parser[ScalaExp] = {
+      (whiteSpace?) ~> positioned("""case (.+)=>""".r ^^ { case c => Simple(c) }) ~ block <~ (whiteSpace?) ^^ {
+        case pattern ~ block => ScalaExp(List(pattern, block))
+      }
+    }
+
+    def importExpression: Parser[Simple] = {
+      at ~> positioned("""import .*(\r)?\n""".r ^^ {
+        case stmt => Simple(stmt)
+      })
+    }
+
+    def scalaBlock: Parser[Simple] = {
+      at ~> positioned(
+        brackets ^^ { case code => Simple(code) })
+    }
+
+    def scalaBlockChained: Parser[Block] = {
+      scalaBlock ^^ {
+        case code => Block("", None, ScalaExp(code :: Nil) :: Nil)
+      }
+    }
+
+    def scalaBlockDisplayed: Parser[Display] = {
+      scalaBlock ^^ {
+        case code => Display(ScalaExp(code :: Nil))
+      }
+    }
+
+    def positionalLiteral(s: String): Parser[Plain] = new Parser[Plain] {
+      def apply(in: Input) = {
+        val offset = in.offset
+        val result = literal(s)(in)
+        result match {
+          case Success(s, r) => {
+            val plainString = Plain(s)
+            plainString.pos = new OffsetPosition(in.source, offset)
+            Success(plainString, r)
+          }
+          case Failure(s, t) => Failure(s, t)
+          case Error(s, t) => Failure(s, t)
+        }
+      }
+    }
+
+    def mixed: Parser[Seq[TemplateTree]] = {
+      ((comment | scalaBlockDisplayed | caseExpression | matchExpression | forExpression | safeExpression | plain | expression) ^^ { case t => List(t) }) |
+        (positionalLiteral("{") ~ several(mixed) ~ positionalLiteral("}")) ^^ { case p1 ~ content ~ p2 => { p1 +: content.flatten :+ p2 } }
+    }
+
+    def template: Parser[Template] = {
+      templateDeclaration ~ """[ \t]*=[ \t]*[{]""".r ~ templateContent <~ "}" ^^ {
+        case declaration ~ assign ~ content => {
+          Template(declaration._1, None, declaration._2, content._1, content._2, content._3, content._4)
+        }
+      }
+    }
+
+    def localDef: Parser[Def] = {
+      templateDeclaration ~ """[ \t]*=[ \t]*""".r ~ scalaBlock ^^ {
+        case declaration ~ w ~ code => {
+          Def(declaration._1, declaration._2, code)
+        }
+      }
+    }
+
+    def templateDeclaration: Parser[(PosString, PosString)] = {
+      at ~> positioned(identifier ^^ { case s => PosString(s) }) ~ positioned(opt(squareBrackets) ~ several(parentheses) ^^ { case t ~ p => PosString(t.getOrElse("") + p.mkString) }) ^^ {
+        case name ~ params => name -> params
+      }
+    }
+
+    def templateContent: Parser[(List[Simple], List[Def], List[Template], List[TemplateTree])] = {
+      (several(importExpression | localDef | template | mixed)) ^^ {
+        case elems => {
+          elems.foldLeft((List[Simple](), List[Def](), List[Template](), List[TemplateTree]())) { (s, e) =>
+            e match {
+              case i: Simple => (s._1 :+ i, s._2, s._3, s._4)
+              case d: Def => (s._1, s._2 :+ d, s._3, s._4)
+              case v: Template => (s._1, s._2, s._3 :+ v, s._4)
+              case c: Seq[_] => (s._1, s._2, s._3, s._4 ++ c.asInstanceOf[Seq[TemplateTree]])
+            }
+          }
+        }
+      }
+    }
+
+    def parser: Parser[Template] = {
+      opt(comment) ~ opt(whiteSpace) ~ opt(at ~> positioned((parentheses+) ^^ { case s => PosString(s.mkString) })) ~ templateContent ^^ {
+        case comment ~ _ ~ args ~ content => {
+          Template(PosString(""), comment, args.getOrElse(PosString("()")), content._1, content._2, content._3, content._4)
+        }
+      }
+    }
+
+    override def skipWhitespace = false
+
+  }
+}

--- a/framework/src/templates-compiler/src/test/scala/FakeRuntime.scala
+++ b/framework/src/templates-compiler/src/test/scala/FakeRuntime.scala
@@ -1,4 +1,5 @@
 // TODO Get rid of this file which just demonstrates how harmful copy-pasting is.
+import scala.language.implicitConversions
 
 package play.api.templates {
 
@@ -46,7 +47,7 @@ package play.templates {
 
     def _display_(o: Any)(implicit m: Manifest[T]): T = {
       o match {
-        case escaped if escaped != null && escaped.getClass == m.erasure => escaped.asInstanceOf[T]
+        case escaped if escaped != null && escaped.getClass == m.runtimeClass => escaped.asInstanceOf[T]
         case () => format.raw("")
         case None => format.raw("")
         case Some(v) => _display_(v)

--- a/framework/src/templates-compiler/src/test/templates/defaultValue.scala.html
+++ b/framework/src/templates-compiler/src/test/templates/defaultValue.scala.html
@@ -1,0 +1,2 @@
+@(arg: String = Math.max(0, 1).toString())
+@arg

--- a/framework/src/templates-compiler/src/test/templates/forSomeType.scala.html
+++ b/framework/src/templates-compiler/src/test/templates/forSomeType.scala.html
@@ -1,0 +1,2 @@
+@(seq: Seq[_])
+@seq.mkString(",")

--- a/framework/src/templates-compiler/src/test/templates/function.scala.html
+++ b/framework/src/templates-compiler/src/test/templates/function.scala.html
@@ -1,0 +1,2 @@
+@(arg1:String, arg2: => String, arg3:String *)(arg4:String, arg5: => String, arg6:String *)(arg7:List[String], arg8: => List[String], arg9:List[String] *)(implicit arg10:String)
+@arg1,@arg2,@arg3.mkString(","),@arg4,@arg5,@arg6.mkString(","),@arg7.mkString,@arg8.mkString,@arg9.map(_.mkString).mkString(","),@arg10

--- a/framework/src/templates-compiler/src/test/templates/onlyImplicit.scala.html
+++ b/framework/src/templates-compiler/src/test/templates/onlyImplicit.scala.html
@@ -1,0 +1,2 @@
+@(implicit test:String)
+@test


### PR DESCRIPTION
- Refactored parsing of LINES and MATRIX meta, the code was very similar
- Refactored mapPosition and mapLine, the code was very similar
- Removed some compiler warnings
  - Added `:Throwable` in catch clauses
  - Added missing `Error` case in `positionalLiteral` of parser
  - Added language feature imports
- Moved big chunks of the `ScalaTemplateCompiler` file to traits
- Refactored `getFunctionMapping` to remove some duplicate code and make it more readable
- Updated `generateCode`
  - making use of string interpolation where possible
  - added an `@scala.deprecated` annotation for the `f` method (not sure about the version that's in there)
  - added implicit `toFunction` methods that can convert the template object to the correct function type
- Cleanup of the `TestCompilerSpec`
  - introduced a `Context` for compiling
  - moved the separate template tests into their own examples
  - compiler helper now returns the template object itself instead of `f`
  - cast is done to structural types
