### PR TITLE
Removal of the sonatype snapshot repo from sbt.boot.properties

### DIFF
--- a/framework/sbt/sbt.boot.properties
+++ b/framework/sbt/sbt.boot.properties
@@ -13,8 +13,6 @@
   local
   maven-local
   typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
-  # temporarily while the IDE plugins are snapshots. URL can be removed once Play itself is upgraded to 0.13.0
-  sonatype-oss-snapshots: http://oss.sonatype.org/content/repositories/snapshots/
   maven-central
 
 [boot]


### PR DESCRIPTION
Removal of the sonatype snapshot repo as the code was a hangover from when sbt 0.13 wasn't released.
