### PR TITLE
updated websockets Readme with an example utilizing Concurrent.broadcast

### DIFF
--- a/documentation/manual/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/scalaGuide/main/async/ScalaWebSockets.md
@@ -64,4 +64,25 @@ def index = WebSocket.using[String] { request =>
 }
 ```
 
+Here is another example in which the input data is logged to standard out and broadcast by to the client utilizing 'Concurrent.broadcast'.
+
+```scala
+//This shows an updated websocket example for play 2.2.0 utilizing Concurrent.broadcast vs Enumerator.imperative, which is now deprecated.
+
+ def index =  WebSocket.using[String] { request =>
+ 
+   //Concurernt.broadcast returns (Enumerator, Concurrent.Channel)
+    val (out,channel) = Concurrent.broadcast[String]
+ 
+    //log the message to stdout and send response back to client
+    val in = Iteratee.foreach[String] {
+      msg => println(msg)
+             //the Enumerator returned by Concurrent.broadcast subscribes to the channel and will 
+             //receive the pushed messages
+             channel push("RESPONSE: " + msg)
+    }
+    (in,out)
+}
+```
+
 > **Next:** [[The template engine | ScalaTemplates]]


### PR DESCRIPTION
A simple WebSocket example that utilizes Concurrent.broadcast, which now replaces the deprecated Enumerator.imperative method for play 2.2.0. 
