### PR TITLE
Play 2.2 Bash/Shell Bug

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/PlayInteractionMode.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/PlayInteractionMode.scala
@@ -51,9 +51,8 @@ object PlayConsoleInteractionMode extends PlayInteractionMode {
   def doWithoutEcho(f: => Unit): Unit = {
     withConsoleReader { consoleReader =>
       val terminal = consoleReader.getTerminal
-      val oldEcho = terminal.isEchoEnabled
       terminal.setEchoEnabled(false)
-      try f finally terminal.setEchoEnabled(oldEcho)
+      try f finally terminal.restore()
     }
   }
   override def waitForCancel(): Unit = waitForKey()


### PR DESCRIPTION
As someone else in the Play Google group has confirmed this issue and was able to reproduce it, I am reporting it as a bug:

I've noticed a problem on several of my machines since my most recent Play upgrade to version 2.2.  After issuing either the "play start" or "play run" commands and hitting "ctrl + d" to return to the prompt, I lose the ability to see any further input in the shell command line.  I've verified this happening on Ubuntu 13.04 directly, remote access to a Linux box using Putty, and in Mac OSX terminal.  Windows command prompt seems unaffected as far as I know.

Steps to reproduce:

issue the command play run or play start
hit control+D to return to the prompt after the server starts

You should notice that you no longer have the ability to view your input (text) in the terminal and have to start a new session to get it back.  Line breaks are also missing.
