### PR TITLE
NoSuchElementException in FormUrlEncodedParser on common input (usually from MSIE)

### DIFF
--- a/framework/src/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
@@ -11,24 +11,17 @@ object FormUrlEncodedParser {
   def parse(data: String, encoding: String = "utf-8"): Map[String, Seq[String]] = {
 
     import java.net._
-    import scala.collection.mutable.{ HashMap }
 
-    var params = HashMap.empty[String, Seq[String]]
-
-    data.split('&').foreach { param =>
-
-      if (param.contains('=')) {
-
-        val parts = param.split('=')
+    data.split("&").flatMap { param =>
+      if (param.contains("=") && !param.startsWith("=")) {
+        val parts = param.split("=")
         val key = URLDecoder.decode(parts.head, encoding)
         val value = URLDecoder.decode(parts.tail.headOption.getOrElse(""), encoding)
-
-        params += key -> (params.get(key).getOrElse(Seq.empty) :+ value)
-
+        Seq(key -> value)
+      } else {
+        Nil
       }
-    }
-
-    params.toMap
+    }.toSeq.groupBy(_._1).map(param => param._1 -> param._2.map(_._2)).toMap
   }
 
 }

--- a/framework/src/play/src/test/scala/play/core/parsers/FormUrlEncodedParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/parsers/FormUrlEncodedParserSpec.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.core.parsers
+
+import org.specs2.mutable.Specification
+
+object FormUrlEncodedParserSpec extends Specification {
+  "FormUrlEncodedParser" should {
+    "decode forms" in {
+      FormUrlEncodedParser.parse("foo1=bar1&foo2=bar2") must_== Map("foo1" -> List("bar1"), "foo2" -> List("bar2"))
+    }
+    "decode form elements with multiple values" in {
+      FormUrlEncodedParser.parse("foo=bar1&foo=bar2") must_== Map("foo" -> List("bar1", "bar2"))
+    }
+    "decode fields with empty names" in {
+      FormUrlEncodedParser.parse("foo=bar&=") must_== Map("foo" -> List("bar"))
+    }
+  }
+}


### PR DESCRIPTION
In Play 2.0.4 --

Steps to reproduce:

```
FormUrlEncodedParser.parse("email=fred@example.com&password=asd&=", "utf-8")
```

MSIE seems fond of sending parameters with empty names -- see a couple of cases where this happened in http://stackoverflow.com/questions/13914481/play-framework-internet-explorer-parser-error

It may be nonsensical and not standards-compliant (the standard says that form elements without a name should not be sent), but it's even happening in MSIE10, and it is horribly difficult to diagnose & fix -- specially if the specific version(s) of MSIE you're testing with don't do that particular one (as was my case).
