### PR TITLE
Promise.timeout doesn't handle exceptions correctly

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/concurrent/PromiseSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/concurrent/PromiseSpec.scala
@@ -29,4 +29,18 @@ class PromiseSpec extends PlaySpecification {
 
   }
 
+  "Promise timeouts" should {
+
+    "yield their message" in new WithApplication() {
+      val future = Promise.timeout("hello", 10)
+      await(future) must_== "hello"
+    }
+
+    "yield any exceptions thrown when generating a message" in new WithApplication() {
+      val future = Promise.timeout[Unit](throw new Exception("error!"), 10)
+      await(future) must throwAn[Exception](message = "error!")
+    }
+
+  }
+
 }

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Promise.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Promise.scala
@@ -18,6 +18,7 @@ import scala.collection._
 import scala.collection.generic.CanBuildFrom
 import java.util.concurrent.TimeoutException
 import play.core.Execution.internalContext
+import scala.util.Try
 import scala.util.control.NonFatal
 
 /**
@@ -310,7 +311,7 @@ object Promise {
     val p = SPromise[A]()
     import play.api.Play.current
     Akka.system.scheduler.scheduleOnce(FiniteDuration(duration, unit)) {
-      p.success(message)
+      p.complete(Try(message))
     }
     p.future
   }


### PR DESCRIPTION
In Play 2.2, the `Promise.timeout` method takes in a `message` parameter by name:

``` scala
def timeout[A](message: => A, duration: Long, unit: TimeUnit = TimeUnit.MILLISECONDS)(implicit ec: ExecutionContext): Future[A] = {
  val p = SPromise[A]()
  import play.api.Play.current
  Akka.system.scheduler.scheduleOnce(FiniteDuration(duration, unit)) {
    p.success(message)
  }
  p.future
}
```

The `message` parameter is resolved inside of the `scheduleOnce` call, which means it happens on another thread. If resolving that parameter throws an exception, there is no way for the client to catch the exception and the `Future` returned by the `timeout` method will never redeem. 

This is a regression from Play 2.0.x, where the [`timeout` method](https://github.com/playframework/playframework/blob/2.0.3/framework/src/play/src/main/scala/play/api/libs/concurrent/Promise.scala#L235) was using `play.api.libs.concurrent.Promise` and its `redeem` method:

``` scala
def redeem(body: => A): Unit = {
  val result = scala.util.control.Exception.allCatch[A].either(body)
  atomic { implicit txn =>
    if (redeemed().isDefined) sys.error("already redeemed")
    redeemed() = result.fold(Thrown(_), Redeemed(_))
  }
  actions.single.swap(List()).foreach(invoke(this, _))
}
```

Note that the `body` parameter is passed by name, all exceptions are caught when resolving it, and the Promise will set itself to failed status if any exception was thrown. 

In Play 2.2.x, Play is using `scala.concurrent.Promise` and its `success` method:

``` scala
def success(value: T): this.type = complete(Success(value))
```

Here, the `value` parameter is based by value, so if resolving the `message` used in the `timeout` method threw an Exception, it would leave the client code in a broken state.
