### PR TITLE
Fix a documentation error that fooled me: getSub was renamed getConfig

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -246,7 +246,7 @@ case class Configuration(underlying: Config) {
    * For example:
    * {{{
    * val configuration = Configuration.load()
-   * val engineConfig = configuration.getSub("engine")
+   * val engineConfig = configuration.getConfig("engine")
    * }}}
    *
    * The root key of this new configuration will be ‘engine’, and you can access any sub-keys relatively.


### PR DESCRIPTION
Yes, I've signed the CLA.
No, I didn't create an issue for this. Its a one line change in a comment.
