### PR TITLE
Introduce BodyParsers.parse.json(Reads[A])

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/JsonBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/JsonBodyParserSpec.scala
@@ -69,6 +69,15 @@ object JsonBodyParserSpec extends PlaySpecification {
       parse("""{"a":1}""", Some("application/json"), "utf-8", fooParser) must beLeft
     }
 
+    "validate json content using implicit reads" in new WithApplication() {
+      parse("""{"a":1,"b":"bar"}""", Some("application/json"), "utf-8", BodyParsers.parse.json[Foo]) must beRight.like {
+        case foo => foo must_== Foo(1, "bar")
+      }
+      parse("""{"foo":"bar"}""", Some("application/json"), "utf-8", BodyParsers.parse.json[Foo]) must beLeft
+      parse("""{"a":1}""", Some("application/json"), "utf-8", BodyParsers.parse.json[Foo]) must beLeft
+      parse("""{"foo:}""", Some("application/json"), "utf-8", BodyParsers.parse.json[Foo]) must beLeft
+    }
+
   }
 
   private case class Foo(a: Int, b: String)


### PR DESCRIPTION
This pull request introduces a BodyParser that not only validates the content type as Json and parses the body to a `JsValue`, but then goes on the validate the `JsValue` according to the implicit `Reads[A]`.

While `BodyParser.validate` can achieve something similar (from the docs),

``` scala
def validateJson[A : Reads] = parse.json.validate(
    _.validate[A].asEither.left.map(e => BadRequest(JsError.toFlatJson(e)))
  )
```

the function parameter to `BodyParser.validate[B](f: A => Either[SimpleResult, B])` means that one can’t use `Future` and thus can’t invoke `GlobalSettings.onBadRequest`.

`BodyParsers.parse.json(Reads[A])` makes use of the private helper method `BodyParsers.parse.createBadResult` to produce a response in the case of Json validation error.
