### PR TITLE
Add query parameters to the URL used for OAuthCalculator signing.

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/oauth/OAuth.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/oauth/OAuth.scala
@@ -132,7 +132,11 @@ case class OAuthCalculator(consumerKey: ConsumerKey, token: RequestToken) extend
       request.setHeader(name, value)
     }
 
-    override def getRequestUrl() = request.url
+    /**
+     * Returns the full URL with query string for correct signing.
+     * @return a URL with query string attached.
+     */
+    override def getRequestUrl() = request.urlWithQueryString
 
     override def setRequestUrl(url: String) {
       request.setUrl(url)

--- a/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
@@ -160,6 +160,8 @@ object WS {
      */
     def url: String = _url
 
+    def urlWithQueryString: String = request.asInstanceOf[com.ning.http.client.Request].getUrl
+
     private def ningHeadersToMap(headers: java.util.Map[String, java.util.Collection[String]]) =
       mapAsScalaMapConverter(headers).asScala.map(e => e._1 -> e._2.asScala.toSeq).toMap
 


### PR DESCRIPTION
Fix for #1759.  This is only applicable against 2.2.x.

The underlying RequestBuilderBase has a getURL method that constructs a URL plus query string internally, so I exposed it.  No tests: had to write an application against twitter to verify this, modified from the Java source code.

``` scala
package controllers

import play.api._
import play.api.mvc._

import play.api.libs.oauth._
import play.api.libs.ws._

import com.typesafe.config.Config
import com.typesafe.config.ConfigFactory

object Application extends Controller {

  implicit val context = scala.concurrent.ExecutionContext.Implicits.global

  private final val config: Config = ConfigFactory.load
  private final val consumerKey: ConsumerKey = new ConsumerKey(config.getString("twitter.consumer_key"), config.getString("twitter.consumer_secret"))
  private final val requestToken: RequestToken = new RequestToken(config.getString("twitter.access_token_key"), config.getString("twitter.access_token_secret"))

  def index = Action {
    Ok(views.html.index())
  }

  def parameters_in_url = Action.async {
    val url: String = "https://api.twitter.com/1.1/users/show.json?screen_name=playframework&include_entities=true"

    val calculator = OAuthCalculator(consumerKey, requestToken)
    WS.url(url).sign(calculator).get().map {
      response => Ok(response.json)
    }
  }

  def parameters_in_ws = Action.async {
    val url: String = "https://api.twitter.com/1.1/users/show.json"
    val calculator = OAuthCalculator(consumerKey, requestToken)
    WS.url(url).withQueryString("screen_name" -> "playframework", "include_entities" -> "true").sign(calculator).get().map {
      response => Ok(response.json)
    }
  }

  def parameters_in_both = Action.async {
    val url: String = "https://api.twitter.com/1.1/users/show.json?screen_name=playframework&include_entities=true"
    val calculator = OAuthCalculator(consumerKey, requestToken)

    WS.url(url).withQueryString("screen_name" -> "playframework", "include_entities" -> "true").sign(calculator).get().map {
      response => Ok(response.json)
    }
  }
}
```

Easy way to tell if it's working --  have System.setProperty("debug", "true") and look at Signpost:

WORKING:

[SIGNPOST] Request URL: https://api.twitter.com/1.1/users/show.json?screen_name=playframework&include_entities=true

NOT WORKING:

[SIGNPOST] Request URL: https://api.twitter.com/1.1/users/show.json
