### PR TITLE
Bad return type in Java async example

### DIFF
--- a/documentation/manual/javaGuide/main/async/JavaAsync.md
+++ b/documentation/manual/javaGuide/main/async/JavaAsync.md
@@ -5,9 +5,9 @@
 
 Until now, we have been able to compute the result to send to the web client directly. This is not always the case: the result may depend on an expensive computation or on a long web service call.
 
-Because of the way Play works, action code must be as fast as possible (i.e. non blocking). So what should we return as result if we are not yet able to compute it? The response should be a promise of a result!
+Because of the way Play works, action code must be as fast as possible (i.e. non blocking). So what should we return from our action if we are not yet able to compute the result? We should return the *promise* of a result!
 
-A `Promise<Result>` will eventually be redeemed with a value of type `Result`. By giving a `Promise<Result>` instead of a normal `Result`, we are able to compute the result quickly without blocking anything. Play will then serve this result as soon as the promise is redeemed. 
+A `Promise<Result>` will eventually be redeemed with a value of type `Result`. By using a `Promise<Result>` instead of a normal `Result`, we are able to return from our action quickly without blocking anything. Play will then serve the result as soon as the promise is redeemed.
 
 The web client will be blocked while waiting for the response but nothing will be blocked on the server, and server resources can be used to serve other clients.
 
@@ -27,9 +27,9 @@ A simple way to execute a block of code asynchronously and to get a `Promise` is
 
 > **Note:** Here, the intensive computation will just be run on another thread. It is also possible to run it remotely on a cluster of backend servers using Akka remote.
 
-## AsyncResult
+## Async results
 
-While we have been simply returning `Result` until now, to send an asynchronous result we need to return `Promise<Result>` from our action:
+We have been returning `Result` up until now. To send an asynchronous result our action needs to return a `Promise<Result>`:
 
 @[async](code/javaguide/async/Application.java)
 

--- a/documentation/manual/javaGuide/main/async/code/javaguide/async/Application.java
+++ b/documentation/manual/javaGuide/main/async/code/javaguide/async/Application.java
@@ -3,7 +3,7 @@
  */
 package javaguide.async;
 
-import play.mvc.SimpleResult;
+import play.mvc.Result;
 import play.libs.F.Function;
 import play.libs.F.Function0;
 import play.libs.F.Promise;
@@ -11,7 +11,7 @@ import play.mvc.Controller;
 
 public class Application extends Controller {
     //#async
-    public static Promise<SimpleResult> index() {
+    public static Promise<Result> index() {
       Promise<Integer> promiseOfInt = Promise.promise(
         new Function0<Integer>() {
           public Integer apply() {
@@ -20,8 +20,8 @@ public class Application extends Controller {
         }
       );
       return promiseOfInt.map(
-          new Function<Integer, SimpleResult>() {
-            public SimpleResult apply(Integer i) {
+          new Function<Integer, Result>() {
+            public Result apply(Integer i) {
               return ok("Got result: " + i);
             } 
           }

--- a/framework/test/integrationtest/app/controllers/JavaApi.java
+++ b/framework/test/integrationtest/app/controllers/JavaApi.java
@@ -8,6 +8,7 @@ import java.util.*;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import play.*;
+import play.libs.F.Promise;
 import play.libs.Json;
 import play.mvc.*;
 import play.mvc.Http.Cookie;
@@ -83,5 +84,9 @@ public class JavaApi extends Controller {
             return badRequest();
         }
     }
-}
 
+    public static Promise<Result> promised() {
+        return Promise.<Result>pure(ok("x"));
+    }
+
+}

--- a/framework/test/integrationtest/app/controllers/JavaControllerInstance.java
+++ b/framework/test/integrationtest/app/controllers/JavaControllerInstance.java
@@ -6,6 +6,7 @@ package controllers;
 import java.util.*;
 
 import play.*;
+import play.libs.F.Promise;
 import play.mvc.*;
 
 import static play.libs.Json.toJson;
@@ -17,6 +18,10 @@ public class JavaControllerInstance extends Controller {
     d.put("peter", "foo");
     d.put("yay", "value");
     return ok(toJson(d));
+  }
+
+  public Promise<Result> promised() {
+    return Promise.<Result>pure(ok("x"));
   }
 
 }

--- a/framework/test/integrationtest/conf/routes
+++ b/framework/test/integrationtest/conf/routes
@@ -32,6 +32,9 @@ GET     /jsonWithCharset        controllers.Application.jsonWithContentTypeAndCh
 GET     /index_java_cache       controllers.Application.index_java_cache()
 GET     /conf                   controllers.Application.conf()
 
+GET     /promised               controllers.JavaApi.promised()
+GET     /promisedInstance       @controllers.JavaControllerInstance.promised()
+
 # Test that the regex is properly escaped in the generated code
 GET     /escapes/$i<\d+>        controllers.Application.takeInt(i: Int)
 

--- a/framework/test/integrationtest/test/ApplicationSpec.scala
+++ b/framework/test/integrationtest/test/ApplicationSpec.scala
@@ -334,7 +334,17 @@ class ApplicationSpec extends PlaySpecification {
         await(wsUrl("/xml").withHeaders("Content-Type" -> "application/xml").post(<foo>bar</foo>)).header("Content-Type").get must startWith("application/xml")
       }
     }
-    
+
+    "execute Java Promise" in new WithApplication() {
+      val Some(result) = route(FakeRequest(GET, "/promised"))
+      status(result) must equalTo(OK)
+    }
+
+    "execute Java Promise in controller instance" in new WithApplication() {
+      val Some(result) = route(FakeRequest(GET, "/promisedInstance"))
+      status(result) must equalTo(OK)
+    }
+
   }
 
 }


### PR DESCRIPTION
According to a thread on the mailing list (https://groups.google.com/d/msg/play-framework/G1wbM0EATsQ/QzYoCp0HD2IJ) the return type in the Java async example maybe should be:

```
Promise<Result>
```

instead of

```
Promise<SimpleResult>
```

? I'm not sure, so maybe someone else could confirm which way it should be.

http://www.playframework.com/documentation/2.2.x/JavaAsync
