### PR TITLE
no sources published for sbt-plugin

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -106,7 +106,7 @@ object BuildSettings {
         scalaBinaryVersion := CrossVersion.binaryScalaVersion(buildScalaVersionForSbt),
         publishTo := Some(publishingMavenRepository),
         publishArtifact in packageDoc := false,
-        publishArtifact in (Compile, packageSrc) := false,
+        publishArtifact in (Compile, packageSrc) := true,
         scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint", "-deprecation", "-unchecked"))
   }
 }


### PR DESCRIPTION
with idea with-sources=yes sbt-classifiers i get no sources for sbt-plugin
looking here http://repo.typesafe.com/typesafe/ivy-releases/com.typesafe.play/sbt-plugin/scala_2.10/sbt_0.13/2.2.0/ they are indeed missing
They were published for play 2.1, so that's kinda frustrating.
