### PR TITLE
Fix formatting in JavaTest.md

### DIFF
--- a/documentation/manual/javaGuide/main/tests/JavaTest.md
+++ b/documentation/manual/javaGuide/main/tests/JavaTest.md
@@ -6,7 +6,7 @@ Test source files must be placed in your application’s `test` folder. You can 
 
 The default way to test a Play application is with [JUnit](http://www.junit.org/).
 
-```
+```java
 package test;
 
 import org.junit.*;
@@ -29,20 +29,21 @@ public class SimpleTest {
 }
 ```
 
-> **Note:** A new process is forked each time `test` or `test-only` is run.  The new process uses default JVM settings.  Custom settings can be added to `play.Project.settings` in `Build.scala`.  For example:  
-> ```
-> javaOptions in (Test) += "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9998",
-> javaOptions in (Test) += "-Xms512M",
-> javaOptions in (Test) += "-Xmx1536M",
-> javaOptions in (Test) += "-Xss1M",
-> javaOptions in (Test) += "-XX:MaxPermSize=384M"
-> ```
+A new process is forked each time `test` or `test-only` is run.  The new process uses default JVM settings.  Custom settings can be added to `play.Project.settings` in `Build.scala`.  For example:  
+
+```
+javaOptions in (Test) += "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9998",
+javaOptions in (Test) += "-Xms512M",
+javaOptions in (Test) += "-Xmx1536M",
+javaOptions in (Test) += "-Xss1M",
+javaOptions in (Test) += "-XX:MaxPermSize=384M"
+```
 
 ## Running in a fake application
 
 If the code you want to test depends on a running application, you can easily create a `FakeApplication` on the fly:
 
-```
+```java
 @Test
 public void findById() {
   running(fakeApplication(), new Runnable() {
@@ -61,9 +62,10 @@ You can also pass (or override) additional application configuration, or mock an
 fakeApplication(inMemoryDatabase())
 ```
 
-> **Note:** Applications using Ebean ORM may be written to rely on Play's automatic getter/setter generation.  Play also rewrites field accesses to use the generated getters/setters.  Ebean relies on calls to the setters to do dirty checking.  In order to use these patterns in JUnit tests, you will need to enable Play's field access rewriting in test by adding the following to `play.Project.settings` in `Build.scala`:
-> ```
-> compile in Test <<= PostCompile(Test)
-> ```  
+Applications using Ebean ORM may be written to rely on Play's automatic getter/setter generation.  Play also rewrites field accesses to use the generated getters/setters.  Ebean relies on calls to the setters to do dirty checking.  In order to use these patterns in JUnit tests, you will need to enable Play's field access rewriting in test by adding the following to `play.Project.settings` in `Build.scala`:
+
+```
+compile in Test <<= PostCompile(Test)
+```  
 
 > **Next:** [[Writing functional tests | JavaFunctionalTest]]


### PR DESCRIPTION
Code blocks were all mashed together in JavaTest.md in the notes section.  Cleaned up.
