### PR TITLE
Filters should be executed on every single request

### DIFF
--- a/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
+++ b/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
@@ -75,17 +75,14 @@ trait GlobalSettings {
    * Default is: route, tag request, then apply filters
    */
   def onRequestReceived(request: RequestHeader): (RequestHeader, Handler) = {
-    onRouteRequest(request)
-      .map {
-        case handler: RequestTaggingHandler => (handler.tagRequest(request), handler)
-        case handler => (request, handler)
-      }
-      .map {
-        case (taggedRequest, handler) => (taggedRequest, doFilter(rh => handler)(taggedRequest))
-      }
-      .getOrElse {
-        (request, Action.async(BodyParsers.parse.empty)(_ => this.onHandlerNotFound(request)))
-      }
+    val (routedRequest, handler) = onRouteRequest(request) map {
+      case handler: RequestTaggingHandler => (handler.tagRequest(request), handler)
+      case otherHandler => (request, otherHandler)
+    } getOrElse {
+      (request, Action.async(BodyParsers.parse.empty)(_ => this.onHandlerNotFound(request)))
+    }
+
+    (routedRequest, doFilter(rh => handler)(routedRequest))
   }
 
   /**

--- a/framework/test/integrationtest/test/FiltersSpec.scala
+++ b/framework/test/integrationtest/test/FiltersSpec.scala
@@ -15,8 +15,10 @@ object FiltersSpec extends Specification {
   "filters should" should {
     "be able to access request tags" in {
 
+      val notFoundText = "MockGlobal returned 404"
+      
       object MockGlobal extends WithFilters(Filter { (f, rh) =>
-        Future.successful(rh.tags.get(Routes.ROUTE_VERB).map(verb => Results.Ok(verb)).getOrElse(Results.NotFound))
+        Future.successful(rh.tags.get(Routes.ROUTE_VERB).map(verb => Results.Ok(verb)).getOrElse(Results.NotFound(notFoundText)))
       })
 
       "helpers routing" in new WithApplication(FakeApplication(withGlobal = Some(MockGlobal))) {
@@ -29,6 +31,12 @@ object FiltersSpec extends Specification {
         val response = Await.result(wsCall(controllers.routes.Application.index()).get(), Duration.Inf)
         response.status must_== 200
         response.body must_== "GET"
+      }
+
+      "filters fire for every single request, even those not matching a route" in new WithServer(FakeApplication(withGlobal = Some(MockGlobal))) {
+        val response = Await.result(wsUrl("/not-a-real-route").get(), Duration.Inf)
+        response.status must_== 404
+        response.body must_== notFoundText
       }
 
       object MockGlobal2 extends play.api.GlobalSettings {


### PR DESCRIPTION
This is a fix for #1856: execute `doFilter` on every single request, even if `onRouteRequest` returns `None`. This makes it possible to write filters that act on requests no in the routes file, such as an access log filter, or a filter that tracks stats on all response types (2xx, 3xx, 4xx, 5xx).
