### PR TITLE
Provide empty string default for bindableString.unbind

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -271,7 +271,8 @@ object QueryStringBindable {
    */
   implicit def bindableString = new QueryStringBindable[String] {
     def bind(key: String, params: Map[String, Seq[String]]) = params.get(key).flatMap(_.headOption).map(Right(_)) // No need to URL decode from query string since netty already does that
-    def unbind(key: String, value: String) = key + "=" + (URLEncoder.encode(value, "utf-8"))
+    // Use an option here in case users call index(null) in the routes -- see #818
+    def unbind(key: String, value: String) = key + "=" + URLEncoder.encode(Option(value).getOrElse(""), "utf-8")
   }
 
   /**

--- a/framework/src/play/src/test/scala/play/api/mvc/BindersSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/BindersSpec.scala
@@ -50,4 +50,13 @@ object BindersSpec extends Specification {
       subject.bind("key", pathString) must equalTo(Right(pathString))
     }
   }
+
+  "QueryStringBindable.bindableString" should {
+    "unbind with null values" in {
+      import QueryStringBindable._
+      val boundValue = bindableString.unbind("key", null)
+      boundValue must beEqualTo("key=")
+    }
+  }
+
 }


### PR DESCRIPTION
Fixes #818. 

Made QueryStringBindable.bindableString.unbind("key", null) map to "key=" (empty value)
