### PR TITLE
Typo in Form.reject(String key, String error, List<Object> args) Javadoc

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/Form.java
+++ b/framework/src/play-java/src/main/java/play/data/Form.java
@@ -559,7 +559,7 @@ public class Form<T> {
      *
      * @param key the error key
      * @param error the error message
-     * @param args the errot arguments
+     * @param args the error arguments
      */
     public void reject(String key, String error, List<Object> args) {
         reject(new ValidationError(key, error, args));


### PR DESCRIPTION
Typo in Form.reject(String key, String error, List<Object> args) Javadoc. "error" spelled as "errot"
