### PR TITLE
[2.2] Test results don't propagate to runner

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -89,6 +89,12 @@ trait Settings {
 
     testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "--ignore-runners=org.specs2.runner.JUnitRunner"),
 
+    // Make sure Specs2 is at the end of the list of test frameworks, so that it gets priority over
+    // JUnit. This is a hack/workaround to prevent Specs2 tests with @RunsWith annotations being
+    // picked up by JUnit. We don't want JUnit to run the tests since JUnit ignores the Specs2
+    // runnner, which means the tests run but their results are ignored by SBT.
+    testFrameworks ~= { tf => tf.filter(_ != TestFrameworks.Specs2).:+(TestFrameworks.Specs2) },
+
     testListeners <<= (target, streams).map((t, s) => Seq(new eu.henkelmann.sbt.JUnitXmlTestsListener(t.getAbsolutePath, s.log))),
 
     testResultReporter <<= testResultReporterTask,


### PR DESCRIPTION
The behaviour of the sbt `test` command has changing between Play 2.1.5 and Play 2.2. In 2.1.5 if a test failed then the command would fail. In 2.2 it passes regardless of whether the tests have passed or failed.

Simple test case:
- Download play2.2
- Create new play project
- Modify any line in tests/ApplicationSpec.scala to make a test fail
- Run the test and observe that although the test clearly fails, the sbt task is successful (in fact the test summary is not populated)

For example, this is the output I get after changing the expected mime type to something else:

```
[info] Compiling 1 Scala source to /home/shildrew/Downloads/test2.2/target/scala-2.10/test-classes...
[info] IntegrationSpec
[info] Application should
[info] + work from within a browser
[info] Total for specification IntegrationSpec
[info] Finished in 2 seconds, 410 ms
[info] 1 example, 0 failure, 0 error
[info] ApplicationSpec
[info] Application should
[info] + send 404 on a bad request
[info] x render the index page
[error]    'Some(text/html)' is Some but text/html does not satisfy the given predicate (ApplicationSpec.scala:26)
[info] Total for specification ApplicationSpec
[info] Finished in 119 ms
[info] 2 examples, 1 failure, 0 error
[info] Passed: Total 0, Failed 0, Errors 0, Passed 0
[success] Total time: 7 s, completed 16-Oct-2013 16:31:32
```
