### PR TITLE
Upgrade bonecp to 0.8.0.RELEASE

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
 
 
   val jdbcDeps = Seq(
-    "com.jolbox" % "bonecp" % "0.8.0-rc1" exclude ("com.google.guava", "guava"),
+    "com.jolbox" % "bonecp" % "0.8.0.RELEASE" exclude ("com.google.guava", "guava"),
 
     // bonecp needs it, but due to guavas stupid version numbering of older versions ("r08"), we need to explicitly
     // declare a dependency on the newer version so that ivy can know which one to include


### PR DESCRIPTION
Upgrade to the final bonecp 0.8.0 release given a number of bugs that it repairs - including problems around re-using prepared statements.
