### PR TITLE
Fix so that scala-library with alternate naming can be found

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala
@@ -55,7 +55,7 @@ trait PlayEclipse {
       override def createTransformer(ref: ProjectRef, state: State): Validation[RewriteRule] = {
         evaluateTask(dependencyClasspath in Runtime, ref, state) map { classpath =>
           val scalaLib =
-            classpath.find(_.data.getAbsolutePath.endsWith("scala-library.jar")).map(_.data.getAbsolutePath)
+            classpath.find(_.data.getAbsolutePath.matches(".*scala-library[^" + `/` + "].jar")).map(_.data.getAbsolutePath)
               .getOrElse(throw new RuntimeException("could not find scala-library.jar"))
           new RewriteRule {
             override def transform(node: Node): Seq[Node] = node match {


### PR DESCRIPTION
Our team has bumped into a problem with Eclipse project generation on Play 2.2. I believe this is caused by http://www.scala-sbt.org/0.13.0/docs/Community/ChangeSummary_0.13.0.html#resolving-scala-dependencies in SBT 0.13. If we declare the scala version in sbt.boot.properties and play.boot.properties to be the same as what play is using the plugin works because scala-library.jar is used from .sbt/boot. But if we're using a different version of scala the scala-library.jar ends up in a different local repo (ivy) with a filename such as scala-library-2.10.3-RC3.jar.

This change makes the scala-library lookup more flexible so it can deal with files that include the version number in the filename.
