### PR TITLE
added allHeaders to play.api.libs.ws.Response

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala
@@ -720,6 +720,14 @@ case class Response(ahcResponse: AHCResponse) {
   def header(key: String): Option[String] = Option(ahcResponse.getHeader(key))
 
   /**
+   * Get all response headers.
+   */
+  def allHeaders: Map[String, Seq[String]] = {
+    import scala.collection.JavaConverters._
+    mapAsScalaMapConverter(ahcResponse.getHeaders()).asScala.map(e => e._1 -> e._2.asScala.toSeq).toMap
+  }
+
+  /**
    * Get all the cookies.
    */
   def cookies: Seq[Cookie] = {

--- a/framework/src/play/src/test/scala/play/api/libs/ws/WSSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/ws/WSSpec.scala
@@ -7,6 +7,7 @@ import org.specs2.mutable._
 import org.specs2.mock.Mockito
 
 import com.ning.http.client.{
+  FluentCaseInsensitiveStringsMap,
   Response => AHCResponse,
   Cookie => AHCCookie
 }
@@ -90,6 +91,20 @@ object WSSpec extends Specification with Mockito {
         cookie.maxAge must ===(1000)
         cookie.secure must beFalse
       }
+    }
+
+    "get headers from an AHC response" in {
+      val ahcResponse : AHCResponse = mock[AHCResponse]
+      val javaHeaders = new FluentCaseInsensitiveStringsMap()
+      javaHeaders.put("header", util.Arrays.asList("value1","value2"))
+
+      ahcResponse.getHeaders returns javaHeaders
+      
+      val response = Response(ahcResponse)
+
+      val headers = response.allHeaders
+
+      headers must beEqualTo(Map("header" -> Seq("value1", "value2")))
     }
   }
 


### PR DESCRIPTION
This is a mirror of functionality already on play.api.libs.ws.Request
