### PR TITLE
play-2.2.1-RC1 - BoneCPConfig - releaseHelperThreads has been deprecated

### DIFF
--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
@@ -379,10 +379,6 @@ private[db] class BoneCPApi(configuration: Configuration, classloader: ClassLoad
     datasource.setDisableJMX(conf.getBoolean("disableJMX").getOrElse(true))
     datasource.setStatisticsEnabled(conf.getBoolean("statisticsEnabled").getOrElse(false))
     datasource.setIdleConnectionTestPeriod(conf.getMilliseconds("idleConnectionTestPeriod").getOrElse(1000 * 60), java.util.concurrent.TimeUnit.MILLISECONDS)
-    // Release helper threads has caused users issues, and the feature has been removed altogether from BoneCP 0.8.0
-    // (which is yet to be released) because it offered no real performance advantage.  Once we upgrade to BoneCP 0.8.x,
-    // we can remove this line.  https://play.lighthouseapp.com/projects/82401/tickets/754-cannot-set-important-bonecp-parameter-in-configuration
-    datasource.setReleaseHelperThreads(0)
 
     conf.getString("initSQL").map(datasource.setInitSQL)
     conf.getBoolean("logStatements").map(datasource.setLogStatementsEnabled)


### PR DESCRIPTION
A new warning has appeared with play-2.2.1-RC1:

[warn] c.j.b.BoneCPConfig - releaseHelperThreads has been deprecated -- it tends to slow down your application more.
