### PR TITLE
Made Play assets just be ordinary resources

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayKeys.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayKeys.scala
@@ -50,8 +50,6 @@ trait Keys {
   /** A hook to configure how play blocks on user input while running. */
   val playInteractionMode = SettingKey[play.PlayInteractionMode]("play-interaction-mode")
 
-  val playAssetsDirectories = SettingKey[Seq[File]]("play-assets-directories")
-
   val playExternalAssets = SettingKey[Seq[(File, File => PathFinder, String)]]("play-external-assets")
 
   val confDirectory = SettingKey[File]("play-conf")

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -58,7 +58,12 @@ trait Settings {
 
     confDirectory <<= baseDirectory / "conf",
 
-    resourceDirectory in Compile <<= baseDirectory / "conf",
+    // Everything is a resource
+    unmanagedResourceDirectories in Compile <+= baseDirectory / "conf",
+    unmanagedResourceDirectories in Compile <+= baseDirectory / "app",
+    unmanagedResourceDirectories in Compile <+= baseDirectory / "public",
+    // Except for java and scala sources
+    excludeFilter in unmanagedResources <<= (excludeFilter in unmanagedResources).apply(_ || GlobFilter("*.scala") || GlobFilter("*.java")),
 
     scalaSource in Compile <<= baseDirectory / "app",
     scalaSource in Test <<= baseDirectory / "test",
@@ -184,11 +189,7 @@ trait Settings {
 
     // Assets
 
-    playAssetsDirectories := Seq.empty[File],
-
     playExternalAssets := Seq.empty[(File, File => PathFinder, String)],
-
-    playAssetsDirectories <+= baseDirectory / "public",
 
     requireJs := Nil,
 


### PR DESCRIPTION
With the Play web driver strategy, we are looking at making all resources just resources, using SBTs managedResources and unmanagedResources.  This will ensure Play can better play in the SBT ecosystem, get better resuse etc.
