### PR TITLE
Force http1.1 for nginx to enable play streaming capabilities

### DIFF
--- a/documentation/manual/detailedTopics/production/HTTPServer.md
+++ b/documentation/manual/detailedTopics/production/HTTPServer.md
@@ -53,7 +53,9 @@ http {
   proxy_set_header   X-Scheme $scheme;
   proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header   Host $http_host;
- 
+  # proxy_http_version appeared in nginx 1.1.4
+  proxy_http_version 1.1;
+
   upstream my-backend {
     server 127.0.0.1:9000;
   }


### PR DESCRIPTION
By default nginx proxies with http1.0 which is wrong if you want to use
chunking or any streaming capabilities of play

see http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version
