### PR TITLE
Issue #1907 - Correct conf and share/doc/api directory packaging in zip 

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -241,7 +241,7 @@ trait Settings {
         val pathFinder = confDirectory ** ("*" -- "routes")
         pathFinder.get map {
           confFile: File =>
-            confFile -> ("conf" + confFile.getCanonicalPath.substring(confDirectoryLen).replace("\\","/"))
+            confFile -> ("conf" + confFile.getCanonicalPath.substring(confDirectoryLen).replace("\\", "/"))
         }
     },
 
@@ -251,7 +251,7 @@ trait Settings {
         val pathFinder = docDirectory ** "*"
         pathFinder.get map {
           docFile: File =>
-            docFile -> ("share/doc/api" + docFile.getCanonicalPath.substring(docDirectoryLen).replace("\\","/"))
+            docFile -> ("share/doc/api" + docFile.getCanonicalPath.substring(docDirectoryLen).replace("\\", "/"))
         }
     },
 


### PR DESCRIPTION
When packaged on a windows system a blank directory would be setup in the zip file under the conf and share/doc/api directories. Windows explorer unzipping would prompt for a password entry when extracting these files. 7-zip would display these are a blank directory. ie, for the logging.xml file, it would display (in 7-zip) as conf\logging.xml
When extracting on a non-Windows based system, the files under the conf and api doc directory would be preceded with a backslash () and would not extract correctly.

Tested on Windows, don't have a linux based system to try the packaging on.
