### PR TITLE
Make FormUrlEncoded Data Preserve Parameter Order. Fixes #1814

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FormFieldOrderSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FormFieldOrderSpec.scala
@@ -9,7 +9,6 @@ import play.api.test.TestServer
 import play.api.libs.ws.WS
 import play.api.libs.ws.WS.WSRequestHolder
 import play.api.test.FakeApplication
-import scala.collection.immutable.ListMap
 
 
 object FormFieldOrderSpec extends PlaySpecification {
@@ -34,7 +33,7 @@ object FormFieldOrderSpec extends PlaySpecification {
       // Check precondition. This needs to be an x-www-form-urlencoded request body
       request.headers.get("Content-Type").getOrElse("") must equalTo(content_type)
       // The following just ingests the request body and converts it to a sequnce of strings of the form name=value
-      val pairs: Seq[String] = { request.body.asFormUrlEncoded map { params: ListMap[String,Seq[String]] =>
+      val pairs: Seq[String] = { request.body.asFormUrlEncoded map { params: Map[String,Seq[String]] =>
         {for ( (key:String,value:Seq[String]) <- params ) yield key + "=" + value.mkString }.toSeq
       }}.getOrElse(Seq.empty[String])
       // And now this just puts it all back into one string separated by & to reincarnate, hopefully, the

--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -10,7 +10,6 @@ import xml.NodeSeq
 import play.core.Router
 import scala.runtime.AbstractPartialFunction
 import play.api.libs.Files.TemporaryFile
-import scala.collection.immutable.ListMap
 
 /**
  * Fake HTTP headers implementation.
@@ -55,7 +54,7 @@ case class FakeRequest[A](method: String, uri: String, headers: FakeHeaders, bod
   /**
    * The request query String
    */
-  lazy val queryString: ListMap[String, Seq[String]] =
+  lazy val queryString: Map[String, Seq[String]] =
     play.core.parsers.FormUrlEncodedParser.parse(rawQueryString)
 
   /**

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -15,7 +15,6 @@ import play.api.libs.iteratee.Parsing._
 import play.api.libs.Files.TemporaryFile
 import MultipartFormData._
 import scala.collection.mutable.ListBuffer
-import scala.collection.immutable.ListMap
 import scalax.io.Resource
 import java.util.Locale
 import scala.util.control.NonFatal
@@ -28,7 +27,7 @@ sealed trait AnyContent {
   /**
    * application/form-url-encoded
    */
-  def asFormUrlEncoded: Option[ListMap[String, Seq[String]]] = this match {
+  def asFormUrlEncoded: Option[Map[String, Seq[String]]] = this match {
     case AnyContentAsFormUrlEncoded(data) => Some(data)
     case _ => None
   }
@@ -88,7 +87,7 @@ case class AnyContentAsText(txt: String) extends AnyContent
 /**
  * AnyContent - Form url encoded body
  */
-case class AnyContentAsFormUrlEncoded(data: ListMap[String, Seq[String]]) extends AnyContent
+case class AnyContentAsFormUrlEncoded(data: Map[String, Seq[String]]) extends AnyContent
 
 /**
  * AnyContent - Raw body (give access to the raw data as bytes).
@@ -509,7 +508,7 @@ trait BodyParsers {
      *
      * @param maxLength Max length allowed or returns EntityTooLarge HTTP response.
      */
-    def tolerantFormUrlEncoded(maxLength: Int): BodyParser[ListMap[String, Seq[String]]] =
+    def tolerantFormUrlEncoded(maxLength: Int): BodyParser[Map[String, Seq[String]]] =
       tolerantBodyParser("urlFormEncoded", maxLength, "Error parsing application/x-www-form-urlencoded") { (request, bytes) =>
         import play.core.parsers._
         FormUrlEncodedParser.parse(new String(bytes, request.charset.getOrElse("utf-8")),
@@ -519,14 +518,14 @@ trait BodyParsers {
     /**
      * Parse the body as form url encoded without checking the Content-Type.
      */
-    def tolerantFormUrlEncoded: BodyParser[ListMap[String, Seq[String]]] = tolerantFormUrlEncoded(DEFAULT_MAX_TEXT_LENGTH)
+    def tolerantFormUrlEncoded: BodyParser[Map[String, Seq[String]]] = tolerantFormUrlEncoded(DEFAULT_MAX_TEXT_LENGTH)
 
     /**
      * Parse the body as form url encoded if the Content-Type is application/x-www-form-urlencoded.
      *
      * @param maxLength Max length allowed or returns EntityTooLarge HTTP response.
      */
-    def urlFormEncoded(maxLength: Int): BodyParser[ListMap[String, Seq[String]]] = when(
+    def urlFormEncoded(maxLength: Int): BodyParser[Map[String, Seq[String]]] = when(
       _.contentType.exists(_.equalsIgnoreCase("application/x-www-form-urlencoded")),
       tolerantFormUrlEncoded(maxLength),
       createBadResult("Expecting application/x-www-form-urlencoded body")
@@ -535,7 +534,7 @@ trait BodyParsers {
     /**
      * Parse the body as form url encoded if the Content-Type is application/x-www-form-urlencoded.
      */
-    def urlFormEncoded: BodyParser[ListMap[String, Seq[String]]] = urlFormEncoded(DEFAULT_MAX_TEXT_LENGTH)
+    def urlFormEncoded: BodyParser[Map[String, Seq[String]]] = urlFormEncoded(DEFAULT_MAX_TEXT_LENGTH)
 
     // -- Magic any content
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaParsers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaParsers.scala
@@ -9,7 +9,6 @@ import play.api.libs.Files.{ TemporaryFile }
 
 import scala.xml._
 import scala.collection.JavaConverters._
-import scala.collection.immutable.ListMap
 
 /**
  * provides Java centric BodyParsers
@@ -19,7 +18,7 @@ object JavaParsers extends BodyParsers {
   import play.mvc.Http.{ RequestBody }
 
   case class DefaultRequestBody(
-      urlFormEncoded: Option[ListMap[String, Seq[String]]] = None,
+      urlFormEncoded: Option[Map[String, Seq[String]]] = None,
       raw: Option[RawBuffer] = None,
       text: Option[String] = None,
       json: Option[JsValue] = None,

--- a/framework/src/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
@@ -28,7 +28,7 @@ object FormUrlEncodedParser {
    * @param encoding The character encoding of data
    * @return A ListMap of keys to the sequence of values for that key
    */
-  def parse(data: String, encoding: String = "utf-8"): ListMap[String, Seq[String]] = {
+  def parse(data: String, encoding: String = "utf-8"): Map[String, Seq[String]] = {
 
     // Generate the pairs of values from the string.
     val pairs: Seq[(String, String)] = parseToPairs(data, encoding)

--- a/framework/src/play/src/main/scala/play/utils/OrderPreserving.scala
+++ b/framework/src/play/src/main/scala/play/utils/OrderPreserving.scala
@@ -8,7 +8,7 @@ import scala.collection.mutable
 
 object OrderPreserving {
 
-  def groupBy[K, V](seq: Seq[(K, V)])(f: ((K, V)) => K): ListMap[K, Seq[V]] = {
+  def groupBy[K, V](seq: Seq[(K, V)])(f: ((K, V)) => K): Map[K, Seq[V]] = {
     // This mutable map will not retain insertion order for the seq, but it is fast for retrieval. The value is
     // a builder for the desired Seq[String] in the final result.
     val m = mutable.Map.empty[K, mutable.Builder[V, Seq[V]]]

--- a/framework/src/play/src/test/scala/play/core/parsers/FormUrlEncodedParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/parsers/FormUrlEncodedParserSpec.scala
@@ -4,7 +4,6 @@
 package play.core.parsers
 
 import org.specs2.mutable.Specification
-import scala.collection.immutable.ListMap
 
 object FormUrlEncodedParserSpec extends Specification {
   "FormUrlEncodedParser" should {
@@ -19,7 +18,7 @@ object FormUrlEncodedParserSpec extends Specification {
     }
     "ensure field order is retained, when requested" in {
       val url_encoded = "Zero=zero&One=one&Two=two&Three=three&Four=four&Five=five&Six=six&Seven=seven"
-      val result: ListMap[String, Seq[String]] = FormUrlEncodedParser.parse(url_encoded)
+      val result: Map[String, Seq[String]] = FormUrlEncodedParser.parse(url_encoded)
       val strings = ( for ( k <- result.keysIterator ) yield "&" + k + "=" + result(k).head ).mkString
       val reconstructed = strings.substring(1)
       reconstructed must equalTo(url_encoded)


### PR DESCRIPTION
- Write play.utils.OrderPreserving.groupBy to abstractly do groupBy while preserving order
- Created a separate module because there might be a need for other OrderPreserving things later.
- Utilize OrderPreserving.groupBy in FormUrlEncodedParser.scala so that it can return ListMap instead of Map
- Adjust ContentTypes, Fakes, and JavaParsers to use ListMap instead of Map for FormUrlEncoded bodies
- Write new test case for validating FormFieldOrder being received correctly out of the pipeline
- Extend test case for FormUrlEncodedParser to ensure it maintains parameter order.

I previously submitted this under pull request #1910 which is now closed. This is the replacement pull request .. just botched some commits on my end, all fixed now. This commit incorporates all previous commits including fixes James Roper requested in #1910
