### PR TITLE
Update Production.md

### DIFF
--- a/documentation/manual/detailledTopics/production/Production.md
+++ b/documentation/manual/detailledTopics/production/Production.md
@@ -18,7 +18,7 @@ The easiest way to start an application in production mode is to use the `start`
 
 When you run the `start` command, Play forks a new JVM and runs the default Netty HTTP server. The standard output stream is redirected to the Play console, so you can monitor its status.
 
-> The server’s process id is displayed at bootstrap and written to the `RUNNING_PID` file. To kill a running Play server, it is enough to send a `SIGTERM` to the process to properly shutdown the application.
+> The server’s process id is displayed at bootstrap and written to the `RUNNING_PID` file. To kill a running Play server, it is enough to send a `SIGTERM` to the process to properly shutdown the application. If you are on Windows, you can run `taskkill /PID <PID_of_play_server> /F` to stop the application.
 
 If you type `Ctrl+D`, the Play console will quit, but the created server process will continue running in background. The forked JVM’s standard output stream is then closed, and logging can be read from the `logs/application.log` file.
 


### PR DESCRIPTION
Added instructions for stopping a Play application that has been started using the start command on Windows. Confirmed working in version 2.1.3
