### PR TITLE
too many files open bug

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
@@ -98,7 +98,12 @@ trait Enumerator[E] {
   }
 
   /**
-   * Creates an Enumerator which calls the given callback when its final input has been consumed.
+   * Creates an Enumerator which calls the given callback when a passed in iteratee has either entered the done state,
+   * or if an error is returned.
+   *
+   * This is equivalent to a finally call, and can be used to clean up any resources used by this enumerator.  Note that
+   * if the callback throws an exception, then the future returned by the enumerator will be completed with that
+   * exception.
    *
    * @param callback The callback to call
    * $paramEcSingle
@@ -106,7 +111,11 @@ trait Enumerator[E] {
   def onDoneEnumerating(callback: => Unit)(implicit ec: ExecutionContext) = new Enumerator[E] {
     val pec = ec.prepare()
 
-    def apply[A](it: Iteratee[E, A]): Future[Iteratee[E, A]] = parent.apply(it).map { a => callback; a }(pec)
+    def apply[A](it: Iteratee[E, A]): Future[Iteratee[E, A]] = parent.apply(it).andThen {
+      case someTry =>
+        callback
+        someTry.get
+    }(pec)
 
   }
 

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumeratorsSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumeratorsSpec.scala
@@ -139,6 +139,16 @@ object EnumeratorsSpec extends Specification
         count.get() must equalTo(1)
       }
     }
+
+    "call onDoneEnumerating callback when an error is encountered" in {
+      mustExecute(1) { onDoneEC =>
+        val count = new java.util.concurrent.atomic.AtomicInteger()
+        mustPropagateFailure(
+          Enumerator(1, 2, 3).onDoneEnumerating(count.incrementAndGet())(onDoneEC)
+        )
+        count.get() must_== 1
+      }
+    }
     
     "transform input elements with map" in {
       mustExecute(3) { mapEC =>
@@ -215,6 +225,30 @@ object EnumeratorsSpec extends Specification
         val s = "hello"
         val enumerator = Enumerator.fromStream(new ByteArrayInputStream(s.getBytes))(fromStreamEC).map(new String(_))
         mustEnumerateTo(s)(enumerator)
+      }
+    }
+    "close the stream" in {
+      class CloseableByteArrayInputStream(bytes: Array[Byte]) extends ByteArrayInputStream(bytes) {
+        @volatile var closed = false
+
+        override def close() = {
+          closed = true
+        }
+      }
+
+      "when done normally" in {
+        val stream = new CloseableByteArrayInputStream(Array.empty)
+        mustExecute(2) { fromStreamEC =>
+          Await.result(Enumerator.fromStream(stream)(fromStreamEC)(Iteratee.ignore), Duration.Inf)
+          stream.closed must beTrue
+        }
+      }
+      "when completed abnormally" in {
+        val stream = new CloseableByteArrayInputStream("hello".getBytes)
+        mustExecute(2) { fromStreamEC =>
+          mustPropagateFailure(Enumerator.fromStream(stream)(fromStreamEC))
+          stream.closed must beTrue
+        }
       }
     }
   }

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/IterateeSpecification.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/IterateeSpecification.scala
@@ -7,6 +7,7 @@ import play.api.libs.iteratee.internal.executeFuture
 import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration.{ Duration, SECONDS }
 import org.specs2.mutable.SpecificationLike
+import scala.util.Try
 
 /**
  * Common functionality for iteratee tests.
@@ -29,6 +30,13 @@ trait IterateeSpecification {
 
   def mustEnumerateTo[E, A](out: A*)(e: Enumerator[E]) = {
     Await.result(enumeratorChunks(e), Duration.Inf) must equalTo(List(out: _*))
+  }
+
+  def mustPropagateFailure[E](e: Enumerator[E]) = {
+    Try(Await.result(
+      e(Cont { case _ => throw new RuntimeException() }),
+      Duration.Inf
+    )) must beAFailedTry
   }
 
 }


### PR DESCRIPTION
Hi guys.
    I use play! deployment several projects.when my project running in product env.
running after a period of,the will throw 'Too many files open' exception!
so check my source code,confirm input/output stream all closed.
after a period of groping,I found a bug in play! source code in : 
\play-2.1.1\framework\src\iteratees\src\main\scala\play\api\libs\iteratee\Enumerator.scala  603 line.
the mothod:

``` scala
  def fromStream(input: java.io.InputStream, chunkSize: Int = 1024 * 8) = {
    fromCallback(() => {
      val buffer = new Array[Byte](chunkSize)
      val chunk = input.read(buffer) match {
        case -1 => None
        case read =>
          val input = new Array[Byte](read)
          System.arraycopy(buffer, 0, input, 0, read)
          Some(input)
      }
      Future.successful(chunk)
    }, input.close)
  }
```

the code not closed input stream,when the exception throwed.
so i change the code to:

``` scala
  def fromStream(input: java.io.InputStream, chunkSize: Int = 1024 * 8) = {
    fromCallback(() => {
      val buffer = new Array[Byte](chunkSize)
      val chunk = input.read(buffer) match {
        case -1 => None
        case read =>
          val input = new Array[Byte](read)
          System.arraycopy(buffer, 0, input, 0, read)
          Some(input)
      }
      Future.successful(chunk)
    }, input.close,(_:String,_:Input[_]) => input.close)
  }
```

the change just only close input stream when socket communication exceptin.

there has been the latest version.
