### PR TITLE
Allow to define multiple message keys in ValidationError

### DIFF
--- a/framework/src/play-datacommons/src/main/scala/play/api/data/validation/ValidationError.scala
+++ b/framework/src/play-datacommons/src/main/scala/play/api/data/validation/ValidationError.scala
@@ -9,5 +9,14 @@ package play.api.data.validation
  * @param message the error message
  * @param args the error message arguments
  */
-case class ValidationError(message: String, args: Any*)
+case class ValidationError(messages: Seq[String], args: Any*) {
 
+  lazy val message = messages.last
+
+}
+
+object ValidationError {
+
+  def apply(message: String, args: Any*) = new ValidationError(Seq(message), args: _*)
+
+}

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsResult.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsResult.scala
@@ -40,31 +40,27 @@ object JsError {
     JsError(merge(e1.errors, e2.errors))
   }
 
-  //def toJson: JsValue = original // TODO
+  def toJson(e: JsError): JsObject = toJson(e.errors, false)
+  def toJson(errors: Seq[(JsPath, Seq[ValidationError])]): JsObject = toJson(errors, false)
   //def toJsonErrorsOnly: JsValue = original // TODO
   def toFlatForm(e: JsError): Seq[(String, Seq[ValidationError])] = e.errors.map { case (path, seq) => path.toJsonString -> seq }
-  def toFlatJson(e: JsError): JsObject = toFlatJson(e.errors)
-  def toFlatJson(errors: Seq[(JsPath, Seq[ValidationError])]): JsObject =
+
+  @deprecated("Use toJson which include alternative message keys", "2.3")
+  def toFlatJson(e: JsError): JsObject = toJson(e.errors, true)
+  @deprecated("Use toJson which include alternative message keys", "2.3")
+  def toFlatJson(errors: Seq[(JsPath, Seq[ValidationError])]): JsObject = toJson(errors, true)
+
+  private def toJson(errors: Seq[(JsPath, Seq[ValidationError])], flat: Boolean): JsObject = {
+    val argsWrite = Writes.traversableWrites[Any](Writes.anyWrites)
     errors.foldLeft(Json.obj()) { (obj, error) =>
       obj ++ Json.obj(error._1.toJsonString -> error._2.foldLeft(Json.arr()) { (arr, err) =>
         arr :+ Json.obj(
-          "msg" -> err.message,
-          "args" -> err.args.foldLeft(Json.arr()) { (arr, arg) =>
-            arr :+ (arg match {
-              case s: String => JsString(s)
-              case nb: Int => JsNumber(nb)
-              case nb: Short => JsNumber(nb)
-              case nb: Long => JsNumber(nb)
-              case nb: Double => JsNumber(nb)
-              case nb: Float => JsNumber(nb)
-              case b: Boolean => JsBoolean(b)
-              case js: JsValue => js
-              case x => JsString(x.toString)
-            })
-          }
+          "msg" -> (if (flat) err.message else Json.toJson(err.messages)),
+          "args" -> Json.toJson(err.args)(argsWrite)
         )
       })
     }
+  }
 }
 
 sealed trait JsResult[+A] { self =>

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
@@ -286,4 +286,20 @@ trait DefaultWrites {
     def writes(value: E#Value): JsValue = JsString(value.toString)
   }
 
+  /**
+   * Serializer for Any, used for the args of ValidationErrors.
+   */
+  private[json] object anyWrites extends Writes[Any] {
+    def writes(a: Any): JsValue = a match {
+      case s: String => JsString(s)
+      case nb: Int => JsNumber(nb)
+      case nb: Short => JsNumber(nb)
+      case nb: Long => JsNumber(nb)
+      case nb: Double => JsNumber(nb)
+      case nb: Float => JsNumber(nb)
+      case b: Boolean => JsBoolean(b)
+      case js: JsValue => js
+      case x => JsString(x.toString)
+    }
+  }
 }

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
@@ -761,10 +761,10 @@ object JsonValidSpec extends Specification {
       js0.validate(myReads) must beEqualTo(JsError(__ \ 'field2, "error.path.missing") ++ JsError(__ \ 'field3, "error.path.missing"))
     }
 
-    "serialize JsError to flat json" in {
+    "serialize JsError to json" in {
       val jserr = JsError(Seq(
         (__ \ 'field1 \ 'field11) -> Seq(
-          ValidationError("msg1.msg11", "arg11", 123L, 123.456F),
+          ValidationError(Seq("msg1.msg11", "msg1.msg12"), "arg11", 123L, 123.456F),
           ValidationError("msg2.msg21.msg22", 456, 123.456, true, 123)
         ),
         (__ \ 'field2 \ 'field21) -> Seq(
@@ -773,30 +773,30 @@ object JsonValidSpec extends Specification {
         )
       ))
 
-      val flatJson = Json.obj(
+      val json = Json.obj(
         "obj.field1.field11" -> Json.arr(
           Json.obj(
-            "msg" -> "msg1.msg11",
+            "msg" -> Json.arr("msg1.msg11", "msg1.msg12"),
             "args" -> Json.arr("arg11", 123, 123.456F)
           ),
           Json.obj(
-            "msg" -> "msg2.msg21.msg22",
+            "msg" -> Json.arr("msg2.msg21.msg22"),
             "args" -> Json.arr(456, 123.456, true, 123)
           )
         ),
         "obj.field2.field21" -> Json.arr(
           Json.obj(
-            "msg" -> "msg1.msg21",
+            "msg" -> Json.arr("msg1.msg21"),
             "args" -> Json.arr("arg1", Json.obj("test" -> "test2"))
           ),
           Json.obj(
-            "msg" -> "msg2",
+            "msg" -> Json.arr("msg2"),
             "args" -> Json.arr("arg1", "arg2")
           )
         )
       )
 
-      JsError.toFlatJson(jserr) should beEqualTo(flatJson)
+      JsError.toJson(jserr) should beEqualTo(json)
     }
 
     "prune json" in {

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -556,7 +556,7 @@ trait Mapping[T] {
   protected def collectErrors(t: T): Seq[FormError] = {
     constraints.map(_(t)).collect {
       case Invalid(errors) => errors.toSeq
-    }.flatten.map(ve => FormError(key, ve.message, ve.args))
+    }.flatten.map(ve => FormError(key, ve.messages, ve.args))
   }
 
 }


### PR DESCRIPTION
Follow up on the pull request [https://github.com/playframework/Play20/pull/1140].

I missed adding multiple keys in the scala object ValidationErrors.

To limit the impact i didn't change the serialization of the JsError, the Json generated contain only the last key.
For reference the plugin https://github.com/julienrf/play-jsmessages support alternative message keys.