### PR TITLE
Unwrap ExecutionException in handleError (e.g. to enable AssertionError to be displayed)

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -15,7 +15,7 @@ import annotation.implicitNotFound
 import java.lang.reflect.InvocationTargetException
 import reflect.ClassTag
 import scala.util.control.NonFatal
-import scala.concurrent.{Future, ExecutionException}
+import scala.concurrent.{ Future, ExecutionException }
 
 trait WithDefaultGlobal {
   self: Application with WithDefaultConfiguration =>


### PR DESCRIPTION
Currently when assertion error is thrown in the application, it's displayed as Boxed Error. This changes enables the assertion error to be displayed correctly.
