### PR TITLE
Display exception text as preformatted text

### DIFF
--- a/framework/src/play/src/main/scala/views/defaultpages/devError.scala.html
+++ b/framework/src/play/src/main/scala/views/defaultpages/devError.scala.html
@@ -37,7 +37,8 @@
 		    }
 		    p#detail.pre {
 		    	white-space: pre;
-		    	font-size: 12px;
+		    	font-size: 13px;
+		    	overflow: auto;
 		    }
 		    p#detail input {
 		        background: -webkit-gradient(linear, 0% 0%, 0% 100%, from(#AE1113), to(#A31012));


### PR DESCRIPTION
So that the error marker (^) points to the correct position. Also make the font size smaller to reduce wrapping/clipping caused by very long Type name (e.g. mapping type).
