### PR TITLE
[#1106] FakeRequest method should not be overriden in withBody* methods

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/FakeRequest.java
+++ b/framework/src/play-test/src/main/java/play/test/FakeRequest.java
@@ -66,7 +66,6 @@ public class FakeRequest {
     /**
      * Set a Json Body to this request.
      * The <tt>Content-Type</tt> header of the request is set to <tt>application/json</tt>.
-     * The method is set to <tt>POST</tt>.
      * @param node the Json Node
      * @return the Fake Request
      */
@@ -78,12 +77,11 @@ public class FakeRequest {
     /**
      * Set a Json Body to this request.
      * The <tt>Content-Type</tt> header of the request is set to <tt>application/json</tt>.
-     * The method is set to <tt>POST</tt>.
      * @param json the JsValue
      * @return the Fake Request
      */
     public FakeRequest withJsonBody(JsValue json) {
-        return withAnyContent(new AnyContentAsJson(json), "application/json", Helpers.POST);
+        return withAnyContent(new AnyContentAsJson(json), "application/json", this.fake.getMethod());
     }
 
     /**
@@ -181,34 +179,31 @@ public class FakeRequest {
     /**
      * Set a Binary Data to this request.
      * The <tt>Content-Type</tt> header of the request is set to <tt>application/octet-stream</tt>.
-     * The method is set to <tt>POST</tt>.
      * @param data the Binary Data
      * @return the Fake Request
      */
     public FakeRequest withRawBody(byte[] data) {
-        return withAnyContent(new AnyContentAsRaw(new RawBuffer(data.length, data)), "application/octet-stream", Helpers.POST);
+        return withAnyContent(new AnyContentAsRaw(new RawBuffer(data.length, data)), "application/octet-stream", this.fake.getMethod());
     }
 
     /**
      * Set a XML to this request.
      * The <tt>Content-Type</tt> header of the request is set to <tt>application/xml</tt>.
-     * The method is set to <tt>POST</tt>.
      * @param xml the XML
      * @return the Fake Request
      */
     public FakeRequest withXmlBody(InputSource xml) {
-        return withAnyContent(new AnyContentAsXml(scala.xml.XML.load(xml)), "application/xml", Helpers.POST);
+        return withAnyContent(new AnyContentAsXml(scala.xml.XML.load(xml)), "application/xml", this.fake.getMethod());
     }
 
     /**
      * Set a Text to this request.
      * The <tt>Content-Type</tt> header of the request is set to <tt>text/plain</tt>.
-     * The method is set to <tt>POST</tt>.
      * @param xml the XML
      * @return the Fake Request
      */
     public FakeRequest withTextBody(String text) {
-        return withAnyContent(new AnyContentAsText(text), "text/plain", Helpers.POST);
+        return withAnyContent(new AnyContentAsText(text), "text/plain", this.fake.getMethod());
     }
 
     /**

--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -166,6 +166,11 @@ case class FakeRequest[A](method: String, uri: String, headers: FakeHeaders, bod
   def withBody[B](body: B): FakeRequest[B] = {
     _copy(body = body)
   }
+
+  /**
+   * Returns the current method
+   */
+  def getMethod: String = method
 }
 
 /**

--- a/framework/src/play-test/src/test/java/play/test/FakeRequestSpec.scala
+++ b/framework/src/play-test/src/test/java/play/test/FakeRequestSpec.scala
@@ -1,0 +1,28 @@
+package play.test
+
+import org.specs2.mutable._
+import play.mvc.Result
+import scala.concurrent.Future
+import play.api.mvc.{Cookie, Results, SimpleResult}
+
+import play.api.libs.json._
+
+
+/**
+ *
+ */
+object FakeRequestSpec extends Specification {
+
+  "FakeRequest" should {
+
+    "Not override method in with* methods" in {
+
+      val req = new FakeRequest("PUT", "/path")
+        .withJsonBody(JsString("blah"))
+        .withRawBody(JsString("blah").toString.toCharArray.map(_.toByte))
+        .withTextBody(JsString("blah").toString)
+
+      req.fake.method must be equalTo("PUT")
+    }
+  }
+}


### PR DESCRIPTION
see #1106.

Even GET request might have a body, there is no excuses for overriding method.
