### PR TITLE
Give controllers.Default some meat

### DIFF
--- a/framework/src/play/src/main/scala/play/api/controllers/Default.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Default.scala
@@ -3,9 +3,7 @@
  */
 package controllers
 
-import play.api._
 import play.api.mvc._
-import play.api.libs._
 
 /**
  * Default actions ready to use as is from your routes file.
@@ -21,17 +19,107 @@ import play.api.libs._
 object Default extends Controller {
 
   /**
-   * Returns a 501 NotImplemented response.
+   * Returns a 200 OK response.
    *
    * Example:
    * {{{
-   * GET   /admin           controllers.Default.todo
+   * GET   /xxx             controllers.Default.ok("hello")
+   * GET   /xxx             controllers.Default.ok
    * }}}
    */
-  def todo: Action[AnyContent] = TODO
+  def ok(content: String): Action[AnyContent] = Action {
+    Ok(content)
+  }
+  val ok: Action[AnyContent] = ok("")
 
   /**
-   * Returns a 404 NotFound response.
+   * Returns a 204 No Content response.
+   *
+   * Example:
+   * {{{
+   * GET   /xxx             controllers.Default.noContent
+   * }}}
+   */
+  def noContent: Action[AnyContent] = Action {
+    NoContent
+  }
+
+  /**
+   * Returns a 205 Reset Content response.
+   *
+   * Example:
+   * {{{
+   * GET   /xxx             controllers.Default.resetContent
+   * }}}
+   */
+  def resetContent: Action[AnyContent] = Action {
+    ResetContent
+  }
+
+  /**
+   * Returns a 301 Moved Permanently response.
+   *
+   * Example:
+   * {{{
+   * GET   /google          controllers.Default.movedPermanently(to = "http://www.google.com")
+   * }}}
+   */
+  def movedPermanently(to: String): Action[AnyContent] = Action {
+    MovedPermanently(to)
+  }
+
+  /**
+   * Returns a 302 Found response.
+   *
+   * Example:
+   * {{{
+   * GET   /google          controllers.Default.found(to = "http://www.google.com")
+   * }}}
+   */
+  def found(to: String): Action[AnyContent] = Action {
+    Found(to)
+  }
+
+  /**
+   * Returns a 303 See Other response.
+   *
+   * Example:
+   * {{{
+   * GET   /google          controllers.Default.seeOther(to = "http://www.google.com")
+   * }}}
+   */
+  def seeOther(to: String): Action[AnyContent] = Action {
+    SeeOther(to)
+  }
+  val redirect = seeOther _
+
+  /**
+   * Returns a 307 Temporary Redirect response.
+   *
+   * Example:
+   * {{{
+   * GET   /google          controllers.Default.temporaryRedirect(to = "http://www.google.com")
+   * }}}
+   */
+  def temporaryRedirect(to: String): Action[AnyContent] = Action {
+    TemporaryRedirect(to)
+  }
+
+  /**
+   * Returns a 308 Permanent Redirect response.
+   * http://tools.ietf.org/html/draft-reschke-http-status-308 is now in experimental status
+   *
+   * Example:
+   * {{{
+   * GET   /google          controllers.Default.permanentRedirect(to = "http://www.google.com")
+   * }}}
+   */
+  def permanentRedirect(to: String): Action[AnyContent] = Action {
+    PermanentRedirect(to)
+  }
+
+  /**
+   * Returns a 404 Not Found response.
    *
    * Example:
    * {{{
@@ -43,27 +131,69 @@ object Default extends Controller {
   }
 
   /**
-   * Returns a 302 Redirect response.
+   * Returns a 410 Gone response.
    *
    * Example:
    * {{{
-   * GET   /google          controllers.Default.redirect(to = "http://www.google.com")
+   * GET   /favicon.ico     controllers.Default.gone
    * }}}
    */
-  def redirect(to: String): Action[AnyContent] = Action {
-    Redirect(to)
+  def gone: Action[AnyContent] = Action {
+    Gone
   }
 
   /**
-   * Returns a 500 InternalServerError response.
+   * Returns a 429 Too Many Requests response.
    *
    * Example:
    * {{{
-   * GET   /xxx             controllers.Default.error
+   * GET   /admin           controllers.Default.tooManyRequests
+   * GET   /admin           controllers.Default.tooManyRequests(retryAfter = "60")
    * }}}
    */
-  def error: Action[AnyContent] = Action {
+  def tooManyRequests(retryAfter: String): Action[AnyContent] = Action {
+    TooManyRequests(Option(retryAfter).map(x => Integer.parseInt(x)))
+  }
+  def tooManyRequests: Action[AnyContent] = Action {
+    TooManyRequests(None)
+  }
+
+  /**
+   * Returns a 500 Internal Server Error response.
+   *
+   * Example:
+   * {{{
+   * GET   /xxx             controllers.Default.internalServerError
+   * }}}
+   */
+  def internalServerError: Action[AnyContent] = Action {
     InternalServerError
+  }
+  val error = internalServerError
+
+  /**
+   * Returns a 501 Not Implemented response.
+   *
+   * Example:
+   * {{{
+   * GET   /admin           controllers.Default.notImplemented
+   * }}}
+   */
+  def notImplemented: Action[AnyContent] = Action {
+    NotImplemented
+  }
+  val todo = notImplemented
+
+  /**
+   * Returns a 503 Service Unavailable response.
+   *
+   * Example:
+   * {{{
+   * GET   /admin           controllers.Default.serviceUnavailable
+   * }}}
+   */
+  def serviceUnavailable: Action[AnyContent] = Action {
+    ServiceUnavailable
   }
 
 }

--- a/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
@@ -157,6 +157,7 @@ trait Status {
   val NOT_MODIFIED = 304
   val USE_PROXY = 305
   val TEMPORARY_REDIRECT = 307
+  val PERMANENT_REDIRECT = 308
 
   val BAD_REQUEST = 400
   val UNAUTHORIZED = 401
@@ -179,7 +180,8 @@ trait Status {
   val UNPROCESSABLE_ENTITY = 422
   val LOCKED = 423
   val FAILED_DEPENDENCY = 424
-  val TOO_MANY_REQUEST = 429
+  val TOO_MANY_REQUESTS = 429
+  val TOO_MANY_REQUEST = 429 //backwards-compatible for poor spelling
 
   val INTERNAL_SERVER_ERROR = 500
   val NOT_IMPLEMENTED = 501

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -967,6 +967,14 @@ trait Results {
    */
   def TemporaryRedirect(url: String): SimpleResult = Redirect(url, TEMPORARY_REDIRECT)
 
+  /**
+   * Generates a ‘308 PERMANENT_REDIRECT’ simple result.
+   * http://tools.ietf.org/html/draft-reschke-http-status-308 is now in experimental status.
+   *
+   * @param url the URL to redirect to
+   */
+  def PermanentRedirect(url: String): SimpleResult = Redirect(url, PERMANENT_REDIRECT)
+
   /** Generates a ‘400 BAD_REQUEST’ result. */
   val BadRequest = new Status(BAD_REQUEST)
 
@@ -1018,8 +1026,16 @@ trait Results {
   /** Generates a ‘424 FAILED_DEPENDENCY’ result. */
   val FailedDependency = new Status(FAILED_DEPENDENCY)
 
-  /** Generates a ‘429 TOO_MANY_REQUEST’ result. */
-  val TooManyRequest = new Status(TOO_MANY_REQUEST)
+  /**
+   * Generates a ‘429 TOO_MANY_REQUESTS’ result.
+   *
+   * @param retryAfter optionally add ‘Retry-After’ header with number of seconds
+   */
+  def TooManyRequests(retryAfter: Option[Int]) = {
+    val response = new Status(TOO_MANY_REQUESTS)
+    retryAfter.map(x => response.withHeaders(RETRY_AFTER -> x.toString)).getOrElse(response)
+  }
+  val TooManyRequest = TooManyRequests _ // backwards-compatible for poor spelling
 
   /** Generates a ‘500 INTERNAL_SERVER_ERROR’ result. */
   val InternalServerError = new Status(INTERNAL_SERVER_ERROR)

--- a/framework/src/play/src/test/scala/play/api/controllers/DefaultSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/controllers/DefaultSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package controllers
+
+import play.api.mvc.{Action, AnyContent}
+import play.api.ControllerWithFakeApplicationSpecification
+import play.api.http.Status._
+
+class DefaultSpec extends ControllerWithFakeApplicationSpecification {
+
+  def is = s2"""
+  Default controller must provide
+    the status for routes using poorly named shortcuts
+      todo                              $statusToDo
+      redirect                          $statusRedirect
+      error                             $statusError
+
+    the status for routes wanting
+      OK                                $statusOK
+      OK (with empty content)           $statusEmptyOK
+      No Content                        $statusNoContent
+      Reset Content                     $statusResetContent
+      Moved Permanently                 $statusMovedPermanently
+      Found                             $statusFound
+      See Other                         $statusSeeOther
+      Temporary Redirect                $statusTemporaryRedirect
+      Permanent Redirect                $statusPermanentRedirect
+      Not Found                         $statusNotFound
+      Gone                              $statusGone
+      Internal Server Error             $statusInternalServerError
+      Not Implemented                   $statusNotImplemented
+      Too Many Requests                 $statusTooManyRequests
+      Too Many Requests (retryAfter)    $statusRetryAfterTooManyRequests
+      Service Unavailable               $statusServiceUnavailable
+  """
+
+  def statusToDo = statusFrom(Default.todo) === NOT_IMPLEMENTED
+  def statusRedirect = statusFrom(Default.redirect("http://localhost/")) === SEE_OTHER
+  def statusError = statusFrom(Default.error) === INTERNAL_SERVER_ERROR
+
+  def statusOK = statusFrom(Default.ok("hello")) === OK
+  def statusEmptyOK = statusFrom(Default.ok) === OK
+  def statusNoContent = statusFrom(Default.noContent) === NO_CONTENT
+  def statusResetContent = statusFrom(Default.resetContent) === RESET_CONTENT
+  def statusMovedPermanently = statusFrom(Default.movedPermanently("http://localhost/")) === MOVED_PERMANENTLY
+  def statusFound = statusFrom(Default.found("http://localhost/")) === FOUND
+  def statusSeeOther = statusFrom(Default.seeOther("http://localhost/")) === SEE_OTHER
+  def statusTemporaryRedirect = statusFrom(Default.temporaryRedirect("http://localhost/")) === TEMPORARY_REDIRECT
+  def statusPermanentRedirect = statusFrom(Default.permanentRedirect("http://localhost/")) === PERMANENT_REDIRECT
+  def statusNotFound = statusFrom(Default.notFound) === NOT_FOUND
+  def statusGone = statusFrom(Default.gone) === GONE
+  def statusTooManyRequests = statusFrom(Default.tooManyRequests) === TOO_MANY_REQUEST
+  def statusRetryAfterTooManyRequests = statusFrom(Default.tooManyRequests("1")) === TOO_MANY_REQUEST
+  def statusInternalServerError = statusFrom(Default.internalServerError) === INTERNAL_SERVER_ERROR
+  def statusNotImplemented = statusFrom(Default.notImplemented) === NOT_IMPLEMENTED
+  def statusServiceUnavailable = statusFrom(Default.serviceUnavailable) === SERVICE_UNAVAILABLE
+
+  private def statusFrom(f: Action[AnyContent]) = {
+    import scala.concurrent.Await
+    import scala.concurrent.ExecutionContext.Implicits._
+
+    val response = f.apply(defaultTestRequest).map(_.header).run
+    Await.result(response, timeout).status
+  }
+}
+
+
+

--- a/framework/src/play/src/test/scala/play/api/controllers/package.scala
+++ b/framework/src/play/src/test/scala/play/api/controllers/package.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api
+
+import org.specs2.specification.{BeforeExample, AfterExample}
+import org.specs2.Specification
+import scala.concurrent.duration._
+import play.api.mvc.Headers
+import play.api.mvc.RequestHeader
+
+abstract class ControllerWithFakeApplicationSpecification extends Specification with BeforeExample with AfterExample {
+  sequential
+
+  implicit val timeout: Duration = Duration(1, SECONDS)  // can be re-used in call to Await in specs
+
+  case class TestRequestHeader(
+    headers: Headers = new Headers {
+      val data = Seq()
+    },
+    method: String = "GET",
+    uri: String = "/",
+    path: String = "",
+    remoteAddress: String = "127.0.0.1",
+    version: String = "HTTP/1.1",
+    id: Long = 666,
+    tags: Map[String, String] = Map.empty[String, String],
+    queryString: Map[String, Seq[String]] = Map(),
+    secure: Boolean = false
+    ) extends RequestHeader
+
+  val defaultTestRequest = TestRequestHeader()
+
+  val appManager = new FakeApplicationManager(FakeApplication(config = Map("play.akka.actor.retrieveBodyParserTimeout" -> timeout.toString)))
+
+  def before = appManager.push()
+
+  def after = appManager.pop()
+}
+
+class FakeApplicationManager(app: FakeApplication) {
+  /**
+   * No atomics or STM here, because of the read lock.
+   * We need a READ lock because ONLY ONE caller reading counter==0 can start the app. Many callers could otherwise correctly read counter==0 and thus all start the app.
+   * We need a WRITE lock because if a caller is reading counter==1 while another is writing counter=0, the writer is also stopping the app, which the reader thinks will be running.
+   */
+  private var counter = 0
+
+  def push(): Unit = synchronized {
+    if (counter == 0) {
+      Play.start(app)
+    }
+    counter += 1
+  }
+
+  def pop(): Unit = synchronized {
+    counter -= 1
+    if (counter == 0) {
+      Play.stop()
+    }
+  }
+}


### PR DESCRIPTION
- Add HTTP responses likely to be wanted from config/routes that
  also require no logic to return useful responses.
- Add tests!
- Add testing infrastructure for managing Play FakeApplication.
- Relegate poorly named redirect, todo, and error.
- Add 308 status.
- Add retryAfter to 429 status.
- Fix poorly spelled mnemonic for 429 status.
- Fix faulty scaladoc for redirect (wrong status code).
