### PR TITLE
Set `Connection: close` header when closing HTTP 1.1 connections

### DIFF
--- a/framework/src/play/src/main/scala/play/core/server/netty/NettyResultStreamer.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/NettyResultStreamer.scala
@@ -55,7 +55,7 @@ object NettyResultStreamer {
       }
 
       case CloseConnection() => {
-        result.body |>>> nettyStreamIteratee(createNettyResponse(result.header, closeConnection, httpVersion), startSequence, true)
+        result.body |>>> nettyStreamIteratee(createNettyResponse(result.header, true, httpVersion), startSequence, true)
       }
 
       case EndOfBodyInProtocol() => {
@@ -182,6 +182,8 @@ object NettyResultStreamer {
     // Response header Connection: Keep-Alive is needed for HTTP 1.0
     if (!closeConnection && httpVersion == HttpVersion.HTTP_1_0) {
       nettyResponse.setHeader(CONNECTION, KEEP_ALIVE)
+    } else if (closeConnection && httpVersion == HttpVersion.HTTP_1_1) {
+      nettyResponse.setHeader(CONNECTION, CLOSE)
     }
 
     nettyResponse


### PR DESCRIPTION
There are certain circumstances where we close HTTP 1.1 connections, even when the client hasn't requested it.  The HTTP spec says:

> HTTP/1.1 applications that do not support persistent connections MUST include the "close" connection option in every message.

The reason for this is that the client may try to send a another HTTP request on the same connection after the response is received but before the TCP RST packet has been received.

This affects 2.0.x-master, and should be fixed on all stable branches.
