### PR TITLE
Ensure close connection header gets set

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -54,12 +54,37 @@ object ScalaResultsHandlingSpec extends PlaySpecification {
       response.body must_== "abc"
     }
 
-    "close the connection for feed results" in makeRequest(
+    "close the connection for feed results" in withServer(
       Results.Ok.feed(Enumerator("a", "b", "c"))
-    ) { response =>
-      response.header(TRANSFER_ENCODING) must beNone
-      response.header(CONTENT_LENGTH) must beNone
-      response.body must_== "abc"
+    ) { port =>
+      val response = BasicHttpClient.makeRequests(port, checkClosed = true)(
+        BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+      )(0)
+      response.status must_== 200
+      response.headers.get(TRANSFER_ENCODING) must beNone
+      response.headers.get(CONTENT_LENGTH) must beNone
+      response.headers.get(CONNECTION) must beSome("close")
+      response.body must beLeft("abc")
+    }
+
+    "close the HTTP 1.1 connection when requested" in withServer(
+      Results.Ok.copy(connection = HttpConnection.Close)
+    ) { port =>
+      val response = BasicHttpClient.makeRequests(port, checkClosed = true)(
+        BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+      )(0)
+      response.status must_== 200
+      response.headers.get(CONNECTION) must beSome("close")
+    }
+
+    "close the HTTP 1.0 connection when requested" in withServer(
+      Results.Ok.copy(connection = HttpConnection.Close)
+    ) { port =>
+      val response = BasicHttpClient.makeRequests(port, checkClosed = true)(
+        BasicRequest("GET", "/", "HTTP/1.0", Map("Connection" -> "keep-alive"), "")
+      )(0)
+      response.status must_== 200
+      response.headers.get(CONNECTION) must beNone
     }
 
     "close the connection when the connection close header is present" in withServer(
@@ -86,6 +111,7 @@ object ScalaResultsHandlingSpec extends PlaySpecification {
         BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
       )
       responses(0).status must_== 200
+      responses(0).headers.get(CONNECTION) must beSome("keep-alive")
       responses(1).status must_== 200
     }
 


### PR DESCRIPTION
Fixes #1958

Also fixed a bug where `Connection: Keep-Alive` header was being set for
HTTP 1.0 clients when the connection was being closed.

Addendum: resolves a merge conflict given that 2.2.x does not handle headers with no values (a change made for master).
