### PR TITLE
Allow to use a configured WebDriver when running with test browser

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -433,6 +433,13 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * Executes a block of code in a running server, with a test browser.
      */
     public static synchronized void running(TestServer server, Class<? extends WebDriver> webDriver, final Callback<TestBrowser> block) {
+        running(server, play.api.test.WebDriverFactory.apply(webDriver), block);
+    }
+
+    /**
+     * Executes a block of code in a running server, with a test browser.
+     */
+    public static synchronized void running(TestServer server, WebDriver webDriver, final Callback<TestBrowser> block) {
         TestBrowser browser = null;
         TestServer startedServer = null;
         try {

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -69,11 +69,18 @@ trait PlayRunners {
    * Executes a block of code in a running server, with a test browser.
    */
   def running[T, WEBDRIVER <: WebDriver](testServer: TestServer, webDriver: Class[WEBDRIVER])(block: TestBrowser => T): T = {
+    running(testServer, WebDriverFactory(webDriver))(block)
+  }
+
+  /**
+   * Executes a block of code in a running server, with a test browser.
+   */
+  def running[T](testServer: TestServer, webDriver: WebDriver)(block: TestBrowser => T): T = {
     var browser: TestBrowser = null
     synchronized {
       try {
         testServer.start()
-        browser = TestBrowser.of(webDriver)
+        browser = TestBrowser(webDriver, None)
         block(browser)
       } finally {
         if (browser != null) {

--- a/framework/src/play-test/src/main/scala/play/api/test/Specs.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Specs.scala
@@ -46,14 +46,18 @@ abstract class WithServer(val app: FakeApplication = FakeApplication(),
  * @param port The port to run the server on
  */
 abstract class WithBrowser[WEBDRIVER <: WebDriver](
-    val webDriver: Class[WEBDRIVER] = Helpers.HTMLUNIT,
+    val webDriver: WebDriver,
     val app: FakeApplication = FakeApplication(),
     val port: Int = Helpers.testServerPort) extends Around with Scope {
+
+  def this(webDriver: Class[WEBDRIVER] = Helpers.HTMLUNIT,
+      app: FakeApplication = FakeApplication(),
+      port: Int = Helpers.testServerPort) = this(WebDriverFactory(webDriver), app, port)
 
   implicit def implicitApp = app
   implicit def implicitPort: Port = port
 
-  lazy val browser: TestBrowser = TestBrowser.of(webDriver, Some("http://localhost:" + port))
+  lazy val browser: TestBrowser = TestBrowser(webDriver, Some("http://localhost:" + port))
 
   override def around[T: AsResult](t: => T): Result = {
     try {


### PR DESCRIPTION
Helpers.running so far accepted a WebDriver _class_ to instantiate (and configure)
the appropriate WebDriver instance.

This change allows to provide an already configured WebDriver instance.
This makes it possible to e.g. create an HtmlUnitDriver for a specific
browser version, like this:

```
import org.openqa.selenium.htmlunit._
import com.gargoylesoftware.htmlunit._
val driver = new HtmlUnitDriver(BrowserVersion.FIREFOX_17)
driver.setJavascriptEnabled(true)

running(TestServer(3333), driver) { browser =>
  ..
}
```

Actually for me using the BrowserVersion.FIREFOX_17 fixed an issue
with jquery: integration tests failed with

```
WebDriverException: com.gargoylesoftware.htmlunit.ScriptException: TypeError: Cannot find
function addEventListener in object [object HTMLDocument]. (http://code.jquery.com/jquery-1.10.1.min.js#5)
```

which is an issue that some people experienced before. Using the firefox webdriver lead to problems on our CI system, and using phantomjs needs prerequisites on CI systems as well AFAICS.
Thus using an appropriately configured HtmlUnitDriver was the smalles possible change that worked.

It would be nice to see this in play, I'm especially interested in seeing this in the 2.2.x branch as well.
