### PR TITLE
Mention the possibility to upgrade the play installation on version mismatch

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/Project.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/Project.scala
@@ -25,8 +25,8 @@ object Project extends Plugin with PlayExceptions with play.Keys with PlayReload
     case badVersion if badVersion != play.core.PlayVersion.current => {
       println(
         Colors.red("""
-          |This project uses Play %s!
-          |Update the Play sbt-plugin version to %s (usually in project/plugins.sbt)
+          |This project uses Play %1$s while your Play installation uses %2$s!
+          |Update the Play sbt-plugin version to %2$s (usually in project/plugins.sbt) or install Play %1$s
         """.stripMargin.format(play.core.PlayVersion.current, badVersion))
       )
     }


### PR DESCRIPTION
I just updated my project to play 2.2.1 and started it with my old 2.2.0 installation.
The error message

```
This project uses Play 2.2.1!
Update the Play sbt-plugin version to 2.2.0 (usually in project/plugins.sbt)
```

suggested a thing I wasn't interested in, instead it should have told me to update
my play installation. Both suggestions make sense.

One could even compare versions to give a more educated suggestion (detect upgrade/
downgrade), but because this should also support RCs and clever but still still short
suggestions/messages it's not done in a second and it's probably not worth the effort.
