### PR TITLE
2.2.x-specific fix for exception when ws.timeout defined in application.conf

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/ws/WsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ws/WsSpec.scala
@@ -1,0 +1,34 @@
+package play.it.ws
+
+import com.ning.http.client.AsyncHttpClient
+
+import play.api.test._
+import play.api.libs.ws._
+
+object WsSpec extends PlaySpecification {
+
+  "support timeout configuration" in {
+
+    "no timeout specified" in withApplication() {
+      WS.newClient() must beAnInstanceOf[AsyncHttpClient]
+    }
+
+    "simple timeout specified" in withApplication("ws.timeout" -> 60000) {
+      WS.newClient() must beAnInstanceOf[AsyncHttpClient]
+    }
+
+    "detailed timeout specified" in withApplication(
+      "ws.timeout.connection" -> 60000,
+      "ws.timeout.idle" -> 60000,
+      "ws.timeout.request" -> 60000)
+    {
+      WS.newClient() must beAnInstanceOf[AsyncHttpClient]
+    }
+
+  }
+
+  def withApplication[T](config: (String, Any)*)(block: => T): T = running(
+    FakeApplication(additionalConfiguration = Map(config:_ *))
+  )(block)
+
+}


### PR DESCRIPTION
As described in #1739, an exception will be thrown if trying to use the WS client when ws.timeout is defined in application.conf.  This is because the fix contributed in #638 attempts to support the legacy directive at the same time as the new directives it adds.

This issue was fixed in 2.3 by removing support for the ws.timeout directive, but this is a breaking change that can't be backported to 2.2.x.  As was suggested in the #1739 discussion, I've built a 2.2.x-specific fix which allows both the legacy ws.timeout directive and the new ws.timeout.\* directives to be used.

Typesafe CLA has been signed.
