### PR TITLE
Fix typo in ScalaWS.md

### DIFF
--- a/documentation/manual/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/scalaGuide/main/ws/ScalaWS.md
@@ -212,7 +212,7 @@ Use the following properties to configure the WS client
  
 ### Timeouts
 
-There ore 3 different timeouts in WS. Reaching a timeout causes the WS request to interrupt.
+There are 3 different timeouts in WS. Reaching a timeout causes the WS request to interrupt.
 
 * **Connection Timeout**: The maximum time to wait when connecting to the remote host *(default is **120 seconds**)*.
 * **Connection Idle Timeout**: The maximum time the request can stay idle (connexion is established but waiting for more data) *(default is **120 seconds**)*.


### PR DESCRIPTION
s/ore/are/
