### PR TITLE
Fix timeout configuration for 2.2.x

### DIFF
--- a/framework/src/play/src/test/scala/play/api/libs/ws/WSSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/ws/WSSpec.scala
@@ -8,6 +8,7 @@ import com.ning.http.client.{
   Cookie => AHCCookie
 }
 import java.util
+import play.api.Configuration
 
 object WSSpec extends Specification with Mockito {
 
@@ -19,6 +20,23 @@ object WSSpec extends Specification with Mockito {
        req.getQueryParams.get("foo").contains("foo1") must beTrue
        req.getQueryParams.get("foo").contains("foo2") must beTrue
        req.getQueryParams.get("foo").size must equalTo (2)
+    }
+
+    "obey a basic timeout config" in {
+      val config = Some(Configuration.from(Map("ws.timeout" -> 2000)))
+      WS.clientConfig(config).getConnectionTimeoutInMs must equalTo (2000)
+      WS.clientConfig(config).getIdleConnectionTimeoutInMs must equalTo (2000)
+    }
+
+    "obey a detailed timeout.config" in {
+      val config = Some(Configuration.from(Map(
+        "ws.timeout.connection" -> 500,
+        "ws.timeout.idle" -> 5000,
+        "ws.timeout.request" -> 2000
+      )))
+      WS.clientConfig(config).getConnectionTimeoutInMs must equalTo (500)
+      WS.clientConfig(config).getIdleConnectionTimeoutInMs must equalTo (5000)
+      WS.clientConfig(config).getRequestTimeoutInMs must equalTo (2000)
     }
   }
 
@@ -64,5 +82,4 @@ object WSSpec extends Specification with Mockito {
       }
     }
   }
-
 }


### PR DESCRIPTION
See #1739 for the fix on master

Note, this will silently swallow some misconfiguration errors.  Let me know if you think that's a notable issue. 

I tried to keep changes to a minimum to avoid divergence from master, but introducing the clientConfig method made testing the changes much simpler.

I have previously signed the CLA.
