### PR TITLE
SqlQueryResult with statement warning

### DIFF
--- a/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
+++ b/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
@@ -7,7 +7,7 @@ Play includes a simple data access layer called Anorm that uses plain SQL to int
 
 > In the following documentation, we will use the [MySQL world sample database](http://dev.mysql.com/doc/index-other.html). 
 > 
-> If you want to enable it for your application, follow the MySQL website instructions, and configure it as  explained [[on the Scala database page | ScalaDatabase]].
+> If you want to enable it for your application, follow the MySQL website instructions, and configure it as explained [[on the Scala database page | ScalaDatabase]].
 
 ## Overview
 
@@ -150,6 +150,29 @@ val countries = SQL("Select name,population from Country")().collect {
 ```
 
 Note that since `collect(…)` ignores the cases where the partial function isn’t defined, it allows your code to safely ignore rows that you don’t expect.
+
+## Retrieving data along with execution context
+
+Moreover data, query execution involves context information like SQL warnings that may be raised (and may be fatal or not), especially when working with stored SQL procedure.
+
+Way to get context information along with query data is to use `executeQuery()`:
+
+```scala
+import anorm.SqlQueryResult
+
+val res: SqlQueryResult = SQL("EXEC stored_proc {code}").
+  on('code -> code).executeQuery()
+
+// Check execution context (there warnings) before going on
+val str: Option[String] =
+  res.statementWarning match {
+    case Some(warning) =>
+      warning.printStackTrace()
+      None
+
+    case _ => res.as(scalar[String].singleOpt) // go on row parsing
+  }
+```
 
 ## Special data types
 

--- a/framework/src/anorm/src/test/scala/anorm/AnormSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/AnormSpec.scala
@@ -2,7 +2,7 @@ package anorm
 
 import org.specs2.mutable.Specification
 
-object AnormSpec extends Specification with H2Database {
+object AnormSpec extends Specification with H2Database with AnormTest {
 
   "anorm" should {
     "allow inserting and retrieving data" in withConnection { implicit c =>
@@ -17,6 +17,34 @@ object AnormSpec extends Specification with H2Database {
           row[String]("foo") -> row[Int]("bar")
         ).list() must_== List(("Hello", 20))
     }
-  }
 
+    "returns query result for SELECT" in withConnection { implicit c =>
+      createTestTable()
+      SQL("insert into test(id, foo, bar) values ({id}, {foo}, {bar})")
+        .on('id -> 11L, 'foo -> "World", 'bar -> 21)
+        .execute()
+
+      SQL("select * from test where id = {id}")
+        .on('id -> 11L).as(testTableParser.singleOpt)
+        .aka("result data") must beSome(TestTable(11L, "World", 21))
+
+    }
+
+    "returns result data for stored procedure" in withConnection { implicit c =>
+      createAlias("stored_proc", 
+        """String proc(String param) {return "Result for " + param;}""")
+
+      SQL("CALL stored_proc({param})")
+        .on('param -> "test-proc-1").executeQuery()
+        .as(SqlParser.scalar[String].single) must_== "Result for test-proc-1"
+    }
+  }
+}
+
+sealed trait AnormTest { db: H2Database =>
+  import SqlParser._
+
+  val testTableParser = long("id") ~ str("foo") ~ int("bar") map {
+    case id ~ foo ~ bar => TestTable(id, foo, bar)
+  }
 }

--- a/framework/src/anorm/src/test/scala/anorm/H2Database.scala
+++ b/framework/src/anorm/src/test/scala/anorm/H2Database.scala
@@ -27,4 +27,8 @@ trait H2Database {
   def createTable(name: String, columns: String*)(implicit conn: Connection): Unit = {
     conn.createStatement().execute("create table " + name + " ( " + columns.mkString(", ") + ");")
   }
+
+  def createAlias(name: String, code: String)(implicit conn: Connection): Unit = {
+    conn.createStatement().execute("CREATE ALIAS %s AS $$%s$$;".format(name, code))
+  }
 }


### PR DESCRIPTION
When using Anorm with result from old school stored proc, current way to check warning (that proc may raise) can be improved.

Currently something like:

``` scala
val rs: java.sql.ResultSet = SQL("EXEC some_stored_proc")

rs.getStatement.getWarnings match {
  case null ⇒ // No warning, can go one
    Sql.resultSetToStream(rs).headOption/* get back to Anorm types */
  case warn ⇒ 
    warn.printStackTrace()
    None
}
```

`java.sql.ResultSet` rs instance need to be used as `Sql.resultSet()` prepare and execute statement each time:

``` scala
val sql = SQL("EXEC stored_proc")

sql.resultSet.getStatement.getWarnings match { // 1st query execution to get 1st resultset instance
  case null ⇒ sql.as(...) // 2nd query execution
  // ...
}
```

Letting appart efficiency of executing it twice, in this way warning from `getWarnings` may not be the one accurate from statement of data mapped with `sql.as(...)` (as each are related to different execution).

I think adding a case class like `SqlQueryResult` in this PR would help to execute once, be able to work with execution context (there getting warning from executed statement), and go on with Anorm mapping/parsing features against resultSet in the same execution:

``` scala
val res = SQL("EXEC stored_proc").executeQuery() // executeQuery added to trait Sql

res.statementWarning match {
  case null ⇒ res.as(...) // go on with any parsing-mapping functions similar to those in trait Sql
  case warn ⇒ warn.printStackTrace(); ...
}
```
