### PR TITLE
Generalize ActionBuilder by parameterizing over Request type

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -355,9 +355,63 @@ object BodyParser {
 }
 
 /**
+ * A builder for generic Actions that generalizes over the type of requests.
+ * An ActionFunction[R,P] may be chained onto an existing ActionBuilder[R] to produce a new ActionBuilder[P] using andThen.
+ * The critical (abstract) function is invokeBlock.
+ * Most users will want to use ActionBuilder instead.
+ *
+ * @tparam R the type of the request on which this is invoked (input)
+ * @tparam P the parameter type which blocks executed by this builder take (output)
+ */
+trait ActionFunction[-R[_], +P[_]] {
+  self =>
+
+  /**
+   * Invoke the block.  This is the main method that an ActionBuilder has to implement, at this stage it can wrap it in
+   * any other actions, modify the request object or potentially use a different class to represent the request.
+   *
+   * @param request The request
+   * @param block The block of code to invoke
+   * @return A future of the result
+   */
+  def invokeBlock[A](request: R[A], block: P[A] => Future[Result]): Future[Result]
+
+  /**
+   * Get the execution context to run the request in.  Override this if you want a custom execution context
+   *
+   * @return The execution context
+   */
+  protected def executionContext: ExecutionContext = play.api.libs.concurrent.Execution.defaultContext
+
+  /**
+   * Compose this ActionFunction with another, with this one applied first.
+   *
+   * @param other ActionFunction with which to compose
+   * @return The new ActionFunction
+   */
+  def andThen[Q[_]](other: ActionFunction[P, Q]): ActionFunction[R, Q] = new ActionFunction[R, Q] {
+    def invokeBlock[A](request: R[A], block: Q[A] => Future[Result]) =
+      self.invokeBlock[A](request, other.invokeBlock[A](_, block))
+  }
+
+  /**
+   * Compose another ActionFunction with this one, with this one applied last.
+   *
+   * @param other ActionFunction with which to compose
+   * @return The new ActionFunction
+   */
+  def compose[Q[_]](other: ActionFunction[Q, R]): ActionFunction[Q, P] =
+    other.andThen(this)
+
+  def compose(other: ActionBuilder[R]): ActionBuilder[P] =
+    other.andThen(this)
+
+}
+
+/**
  * Provides helpers for creating `Action` values.
  */
-trait ActionBuilder[+R[_]] {
+trait ActionBuilder[+R[_]] extends ActionFunction[Request, R] {
   self =>
 
   /**
@@ -472,16 +526,6 @@ trait ActionBuilder[+R[_]] {
   })
 
   /**
-   * Invoke the block.  This is the main method that an ActionBuilder has to implement, at this stage it can wrap it in
-   * any other actions, modify the request object or potentially use a different class to represent the request.
-   *
-   * @param request The request
-   * @param block The block of code to invoke
-   * @return A future of the result
-   */
-  protected def invokeBlock[A](request: Request[A], block: R[A] => Future[Result]): Future[Result]
-
-  /**
    * Compose the parser.  This allows the action builder to potentially intercept requests before they are parsed.
    *
    * @param bodyParser The body parser to compose
@@ -497,12 +541,12 @@ trait ActionBuilder[+R[_]] {
    */
   protected def composeAction[A](action: Action[A]): Action[A] = action
 
-  /**
-   * Get the execution context to run the request in.  Override this if you want a custom execution context
-   *
-   * @return The execution context
-   */
-  protected def executionContext: ExecutionContext = play.api.libs.concurrent.Execution.defaultContext
+  override def andThen[Q[_]](other: ActionFunction[R, Q]): ActionBuilder[Q] = new ActionBuilder[Q] {
+    def invokeBlock[A](request: Request[A], block: Q[A] => Future[Result]) =
+      self.invokeBlock[A](request, other.invokeBlock[A](_, block))
+    override protected def composeParser[A](bodyParser: BodyParser[A]): BodyParser[A] = self.composeParser(bodyParser)
+    override protected def composeAction[A](action: Action[A]): Action[A] = self.composeAction(action)
+  }
 }
 
 /**
@@ -510,4 +554,65 @@ trait ActionBuilder[+R[_]] {
  */
 object Action extends ActionBuilder[Request] {
   def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = block(request)
+}
+
+/* NOTE: the following are all example uses of ActionFunction, each subtly
+ * different but useful in different ways. They may not all be necessary. */
+
+/**
+ * A simple kind of ActionFunction which, given a request (of type R), may
+ * either immediately produce a Result (for example, an error), or call
+ * its Action block with a parameter (of type P).
+ * The critical (abstract) function is refine.
+ */
+trait ActionRefiner[-R[_], +P[_]] extends ActionFunction[R, P] {
+  /**
+   * Determine how to process a request.  This is the main method than an ActionRefiner has to implement.
+   * It can decide to immediately intercept the request and return a Result (Left), or continue processing with a new parameter of type P (Right).
+   *
+   * @param request the input request
+   * @return Either a result or a new parameter to pass to the Action block
+   */
+  protected def refine[A](request: R[A]): Future[Either[Result, P[A]]]
+
+  final def invokeBlock[A](request: R[A], block: P[A] => Future[Result]) =
+    refine(request).flatMap(_.fold(Future.successful _, block))(executionContext)
+}
+
+/**
+ * A simple kind of ActionRefiner which, given a request (of type R),
+ * unconditionally transforms it to a new parameter type (P) to be passed to
+ * its Action block.  The critical (abstract) function is transform.
+ */
+trait ActionTransformer[-R[_], +P[_]] extends ActionRefiner[R, P] {
+  /**
+   * Augment or transform an existing request.  This is the main method than an ActionTransformer has to implement.
+   *
+   * @param request the input request
+   * @return The new parameter to pass to the Action block
+   */
+  protected def transform[A](request: R[A]): Future[P[A]]
+
+  final def refine[A](request: R[A]) =
+    transform(request).map(Right(_))(executionContext)
+}
+
+/**
+ * A simple kind of ActionRefiner which, given a request (of type R), may
+ * either immediately produce a Result (for example, an error), or
+ * continue its Action block with the same request.
+ * The critical (abstract) function is filter.
+ */
+trait ActionFilter[R[_]] extends ActionRefiner[R, R] {
+  /**
+   * Determine whether to process a request.  This is the main method than an ActionFilter has to implement.
+   * It can decide to immediately intercept the request and return a Result (Some), or continue processing (None).
+   *
+   * @param request the input request
+   * @return An optional Result with which to abort the request
+   */
+  protected def filter[A](request: R[A]): Future[Option[Result]]
+
+  final protected def refine[A](request: R[A]) =
+    filter(request).map(_.toLeft(request))(executionContext)
 }


### PR DESCRIPTION
I love the new ActionBuilder in play 2.2, but I want even more.  I want (and in fact am now using) something like this:

``` scala
/** A generic version of ActionBuilder parameterized over the request type. */
trait ActionFunction[-R[_],P[_]] {
  parent =>
  def invokeBlock[A](request : R[A], block : P[A] => Future[SimpleResult]) : Future[SimpleResult]

  /** Compose this ActionFunction with another. */
  def ~>[Q[_]](child : ActionFunction[P,Q]) : ActionFunction[R,Q] = new ActionFunction[R,Q] {
    def invokeBlock[A](request : R[A], block : Q[A] => Future[SimpleResult]) =
      parent.invokeBlock(request, (p : P[A]) => child.invokeBlock(p, block))
  }
}

trait ActionBuilder[R[_]] extends ActionFunction[Request,R] {
  ...
}
```

This allows arbitrary processing of the Request and composition of these processes.  For example, I define another trait that can choose to provide an immediate result or pass on to another ActionFunction:

``` scala
trait ActionRefiner[-R[_],P[_]] extends ActionFunction[R,P] {
  protected def refine[A](request : R[A]) : Future[Either[SimpleResult,P[A]]]
  final def invokeBlock[A](request : R[A], block : P[A] => Future[SimpleResult]) =
    refine(request).flatMap(_.fold(Future.successful _, block))
}
```

I've found this really useful for layering various permission checks or object lookups that can get added to the request.
