### PR TITLE
quickfix for return type of the SimpleResult methods

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -267,7 +267,7 @@ object HttpConnection extends Enumeration {
  * @param connection the connection semantics to use
  */
 case class SimpleResult(header: ResponseHeader, body: Enumerator[Array[Byte]],
-    connection: HttpConnection.Connection = HttpConnection.KeepAlive) extends PlainResult {
+    connection: HttpConnection.Connection = HttpConnection.KeepAlive) extends PlainResult with WithHeaders[SimpleResult] {
 
   /**
    * Adds headers to this result.


### PR DESCRIPTION
The methods of `PlainResult` that weren’t overriden by `SimpleResult` still returned a `PlainResult`, though this type is deprecated.

This commit changes `SimpleResult` so that all of its methods return a `SimpleResult`.
