### PR TITLE
Lock is a reserved keyword in MySQL 5.5+

### DIFF
--- a/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -521,7 +521,7 @@ class EvolutionsPlugin(app: Application) extends Plugin with HandleWebCommandSup
    */
   def quoteColumnName(c: Connection, s: String): String = {
     val isMySQL = c.getMetaData.getDatabaseProductName contains "MySQL"
-    if (isMySQL) s"`$s`" else s'"$s"'
+    if (isMySQL) s"`$s`" else s"""\"$s\"""
   }
 
   def createLockTableIfNecessary(c: Connection, s: Statement) {


### PR DESCRIPTION
Determine if the database being used is MySQL, if so, use backticks to quote the column name `lock`. For anything other than MySQL, use double-quotes "lock".
