### PR TITLE
Enabled disableConnectionTracking option for Bonecp

### DIFF
--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
@@ -318,7 +318,7 @@ private[db] class BoneCPApi(configuration: Configuration, classloader: ClassLoad
 
       override def onCheckIn(connection: ConnectionHandle) {
         if (logger.isTraceEnabled) {
-          logger.trace("Check in connection [%s leased]".format(datasource.getTotalLeased))
+          logger.trace("Check in connection %s [%s leased]".format(connection.toString, datasource.getTotalLeased))
         }
       }
 
@@ -328,7 +328,7 @@ private[db] class BoneCPApi(configuration: Configuration, classloader: ClassLoad
         connection.setReadOnly(readOnly)
         catalog.map(connection.setCatalog)
         if (logger.isTraceEnabled) {
-          logger.trace("Check out connection [%s leased]".format(datasource.getTotalLeased))
+          logger.trace("Check out connection %s [%s leased]".format(connection.toString, datasource.getTotalLeased))
         }
       }
 
@@ -379,6 +379,7 @@ private[db] class BoneCPApi(configuration: Configuration, classloader: ClassLoad
     datasource.setDisableJMX(conf.getBoolean("disableJMX").getOrElse(true))
     datasource.setStatisticsEnabled(conf.getBoolean("statisticsEnabled").getOrElse(false))
     datasource.setIdleConnectionTestPeriod(conf.getMilliseconds("idleConnectionTestPeriod").getOrElse(1000 * 60), java.util.concurrent.TimeUnit.MILLISECONDS)
+    datasource.setDisableConnectionTracking(conf.getBoolean("disableConnectionTracking").getOrElse(true))
 
     conf.getString("initSQL").map(datasource.setInitSQL)
     conf.getBoolean("logStatements").map(datasource.setLogStatementsEnabled)

--- a/samples/scala/computer-database/conf/application.conf
+++ b/samples/scala/computer-database/conf/application.conf
@@ -13,7 +13,7 @@ application.secret="E27D^[_<Lpt0vjad]de;3;tx3gpRmG4ByofnahOIo9gbsMWut1w3xg[>9W"
 # You can declare as many datasources as you want.
 # By convention, the default datasource is named `default`
 db.default.driver=org.h2.Driver
-db.default.url="jdbc:h2:mem:play;TRACE_LEVEL_SYSTEM_OUT=3"
+db.default.url="jdbc:h2:mem:play"
 
 # Assets configuration
 # ~~~~~
@@ -32,6 +32,5 @@ logger.play=INFO
 # Logger provided to your application:
 logger.application=DEBUG
 
-logger.com.jolbox.bonecp=TRACE
 
 


### PR DESCRIPTION
The main motivation for this change is that Bonecp connection tracking appears to closing a connection that has been checked back in. See https://playframework2.ci.cloudbees.com/job/play2-master/1420/consoleFull and search for “disableConnectionTracking” and you’ll see that jdbc[4]’s connection is closed. Tracing back from there the connection for jdbc[4] does not appear to have been checked out (also verified by looking at the source code that should call the check in). It appears to me that the connection should remain open given that it is part of the pool.

Interestingly this problem is intermittent on master, doesn’t occur on the PR validation branch and I cannot reproduce it locally. Perhaps a race condition within BoneCP?

The secondary motivation for this change is that connections do not require management by BoneCP in a situation where they are being managed by a framework such as Play. The BoneCP management will add overhead so not requiring it by default may improve performance.

```
db.default.disableConnectionTracking=false
```

is the config to re-enable it.
