### PR TITLE
Small typo correction

### DIFF
--- a/documentation/manual/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/scalaGuide/main/async/ScalaWebSockets.md
@@ -43,7 +43,7 @@ A `WebSocket` has access to the request headers (from the HTTP request that init
 When constructing a `WebSocket` this way, we must return both `in` and `out` channels.
 
 - The `in` channel is an `Iteratee[A,Unit]` (where `A` is the message type - here we are using `String`) that will be notified for each message, and will receive `EOF` when the socket is closed on the client side.
-- The `out` channel is en `Enumerator[A]` that will generate the messages to be sent to the Web client. It can close the connection on the server side by sending `EOF`.
+- The `out` channel is an `Enumerator[A]` that will generate the messages to be sent to the Web client. It can close the connection on the server side by sending `EOF`.
 
 It this example we are creating a simple iteratee that prints each message to console. To send messages, we create a simple dummy enumerator that will send a single **Hello!** message.
 


### PR DESCRIPTION
Replaced 'en' with 'an'
