### PR TITLE
Improve executeQuery/SqlQueryResult tests (SQL warning specs)

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -160,7 +160,8 @@ object PlayBuild extends Build {
     )
 
   lazy val AnormProject = PlayRuntimeProject("Anorm", "anorm")
-    .settings(libraryDependencies ++= anormDependencies)
+    .settings(libraryDependencies ++= anormDependencies,
+      resolvers += "Applicius Releases Repository" at "https://raw.github.com/applicius/mvn-repo/master/releases/")
 
   lazy val IterateesProject = PlayRuntimeProject("Play-Iteratees", "iteratees")
     .settings(libraryDependencies := iterateesDependencies)

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -210,7 +210,8 @@ object Dependencies {
 
   val anormDependencies = Seq(
     specsBuild % "test",
-    h2database % "test"
+    h2database % "test",
+    "acolyte" %% "acolyte-scala" % "1.0.9" % "test"
   )
 
 }

--- a/framework/src/anorm/src/test/scala/anorm/H2Database.scala
+++ b/framework/src/anorm/src/test/scala/anorm/H2Database.scala
@@ -27,8 +27,4 @@ trait H2Database {
   def createTable(name: String, columns: String*)(implicit conn: Connection): Unit = {
     conn.createStatement().execute("create table " + name + " ( " + columns.mkString(", ") + ");")
   }
-
-  def createAlias(name: String, code: String)(implicit conn: Connection): Unit = {
-    conn.createStatement().execute("CREATE ALIAS %s AS $$%s$$;".format(name, code))
-  }
 }


### PR DESCRIPTION
H2 doesn't support SQL warning.
Use acolyte for simulating/managing in-memory test DB for testing.
