### PR TITLE
[error] javadoc: error - Illegal package name: "2.3-SNAPSHOT"

### DIFF
--- a/framework/project/Docs.scala
+++ b/framework/project/Docs.scala
@@ -72,7 +72,6 @@ object Docs {
 
     val javadoc = Doc.javadoc(label, javaCache, compilers.javac)
     javadoc(javaSources, classpath, apiTarget / "java", javadocOptions, 10, streams.log)
-    "javadoc " + javadocOptions.mkString(" ") ! streams.log
 
     apiTarget
   }


### PR DESCRIPTION
I get this when running ./build and then "publish-local" to build the framework on Ubuntu 12.04

```
[info] Generating /usr/local/users/bmccann/playframework/framework/src/play-docs/target/apidocs/java/constant-values.html...
[info] Generating /usr/local/users/bmccann/playframework/framework/src/play-docs/target/apidocs/java/serialized-form.html...
[info] Building index for all the packages and classes...
[info] Generating /usr/local/users/bmccann/playframework/framework/src/play-docs/target/apidocs/java/overview-tree.html...
[info] Generating /usr/local/users/bmccann/playframework/framework/src/play-docs/target/apidocs/java/index-all.html...
[info] Generating /usr/local/users/bmccann/playframework/framework/src/play-docs/target/apidocs/java/deprecated-list.html...
[info] Building index for all classes...
[info] Generating /usr/local/users/bmccann/playframework/framework/src/play-docs/target/apidocs/java/allclasses-frame.html...
[info] Generating /usr/local/users/bmccann/playframework/framework/src/play-docs/target/apidocs/java/allclasses-noframe.html...
[info] Generating /usr/local/users/bmccann/playframework/framework/src/play-docs/target/apidocs/java/index.html...
[info] Generating /usr/local/users/bmccann/playframework/framework/src/play-docs/target/apidocs/java/overview-summary.html...
[info] Generating /usr/local/users/bmccann/playframework/framework/src/play-docs/target/apidocs/java/help-doc.html...
[info] 17 warnings
[info] Play 2.3-SNAPSHOT Java API documentation successful.
[error] javadoc: error - Illegal package name: "2.3-SNAPSHOT"
[info] 1 error
[info] Packaging /usr/local/users/bmccann/playframework/framework/src/play-docs/target/scala-2.10/play-docs_2.10-2.3-SNAPSHOT.jar ...
[info] Done packaging.
[info]  published play-docs_2.10 to /usr/local/users/bmccann/playframework/repository/local/com.typesafe.play/play-docs_2.10/2.3-SNAPSHOT/poms/play-docs_2.10.pom
[info]  published play-docs_2.10 to /usr/local/users/bmccann/playframework/repository/local/com.typesafe.play/play-docs_2.10/2.3-SNAPSHOT/jars/play-docs_2.10.jar
[info]  published play-docs_2.10 to /usr/local/users/bmccann/playframework/repository/local/com.typesafe.play/play-docs_2.10/2.3-SNAPSHOT/srcs/play-docs_2.10-sources.jar
[info]  published play-docs_2.10 to /usr/local/users/bmccann/playframework/repository/local/com.typesafe.play/play-docs_2.10/2.3-SNAPSHOT/srcs/play-docs_2.10-tests-sources.jar
[info]  published ivy to /usr/local/users/bmccann/playframework/repository/local/com.typesafe.play/play-docs_2.10/2.3-SNAPSHOT/ivys/ivy.xml
[success] Total time: 141 s, completed Nov 14, 2013 1:18:40 PM
> 
```
