### PR TITLE
Upgrade to scala 2.10.3 to include an important Future memory leak fix

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -19,15 +19,15 @@ object BuildSettings {
     (x => x == "true" || x == "") map
     (_ => true) getOrElse default
 
-  val experimental = Option(System.getProperty("experimental")).filter(_ == "true").map(_ => true).getOrElse(false)
+  val experimental = Option(System.getProperty("experimental")).filter(_ == "true")
 
   val buildOrganization = "com.typesafe.play"
   val buildVersion = propOr("play.version", "2.2-SNAPSHOT")
   val buildWithDoc = boolProp("generate.doc")
   val previousVersion = "2.2.0"
-  val buildScalaVersion = propOr("scala.version", "2.10.2")
+  val buildScalaVersion = propOr("scala.version", "2.10.3")
   // TODO - Try to compute this from SBT... or not.
-  val buildScalaVersionForSbt = propOr("play.sbt.scala.version", "2.10.2")
+  val buildScalaVersionForSbt = propOr("play.sbt.scala.version", "2.10.3")
   val buildScalaBinaryVersionForSbt = CrossVersion.binaryScalaVersion(buildScalaVersionForSbt)
   val buildSbtVersion = propOr("play.sbt.version", "0.13.0")
   val buildSbtMajorVersion = "0.13"


### PR DESCRIPTION
Fix for https://github.com/playframework/playframework/issues/1981

Backported 0c29790 to the 2.2.x branch as suggested by @richdougherty in the issue
