### PR TITLE
Switch to using ivy cache in users home directory

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -260,7 +260,6 @@ object PlayBuild extends Build {
     .settings(
       scriptedLaunchOpts <++= (baseDirectory in ThisBuild) { baseDir =>
         Seq(
-          "-Dsbt.ivy.home=" + new File(baseDir.getParent, "repository"),
           "-Dsbt.boot.directory=" + new File(baseDir, "sbt/boot"),
           "-Dplay.home=" + System.getProperty("play.home"),
           "-XX:MaxPermSize=384M",

--- a/framework/sbt/play.boot.properties
+++ b/framework/sbt/play.boot.properties
@@ -14,6 +14,7 @@
 [repositories]
   local
   maven-local
+  play-local: file://${play.home}/../repository/local/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
   typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
   maven-central
 
@@ -21,5 +22,7 @@
   directory: ${play.home}/sbt/boot
 
 [ivy]
-  ivy-home: ${sbt.ivy.home-${play.home}/../repository}
-
+  ivy-home: ${sbt.ivy.home-${user.home}/.ivy2/}
+  checksums: ${sbt.checksums-sha1,md5}
+  override-build-repos: ${sbt.override.build.repos-false}
+  repository-config: ${sbt.repository.config-${sbt.global.base-${user.home}/.sbt}/repositories}

--- a/framework/sbt/sbt.boot.properties
+++ b/framework/sbt/sbt.boot.properties
@@ -15,16 +15,15 @@
 [repositories]
   local
   maven-local
+  play-local: file://${play.home}/../repository/local/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext]
   typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
-  # temporarily while the IDE plugins are snapshots. URL can be removed once Play itself is upgraded to 0.13.0
-  sonatype-oss-snapshots: http://oss.sonatype.org/content/repositories/snapshots/
   maven-central
 
 [boot]
   directory: ${play.home}/sbt/boot
 
 [ivy]
-  ivy-home: ${sbt.ivy.home-${play.home}/../repository}
+  ivy-home: ${sbt.ivy.home-${user.home}/.ivy2/}
   checksums: ${sbt.checksums-sha1,md5}
   override-build-repos: ${sbt.override.build.repos-false}
   repository-config: ${sbt.repository.config-${sbt.global.base-${user.home}/.sbt}/repositories}


### PR DESCRIPTION
One small step for Play, one giant leap back to using SBT in a vanilla configuration...
- Adds the play local repository to the list of SBT boot repositories, so it gets automatically used like it used to when it was instead the default local repository.
- Makes the ivy home directory the default one, in the users home directory.
- This means ivy cache is shared between vanilla SBT/ivy apps and Play apps.
- Also means local repository (when you run publish-local) is shared.
