### PR TITLE
Parsing single null value as scalar option

### DIFF
--- a/framework/src/anorm/src/test/scala/anorm/AnormSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/AnormSpec.scala
@@ -33,6 +33,12 @@ object AnormSpec extends Specification with H2Database with AnormTest {
 
     }
 
+    "returns None for missing single value" in withQueryResult(
+      null.asInstanceOf[String]) { implicit c =>
+        SQL("SELECT * FROM test").as(SqlParser.scalar[String].singleOpt).
+          aka("single value") must beNone
+      }
+
     "executes query for stored procedure" >> {
       "returns result data" in withQueryResult("Result for test-proc-1") {
         implicit con =>


### PR DESCRIPTION
For now, if statement like `SELECT singleval FROM table` return 1 row with `NULL` as single value, following parsing will fail with an `UnexpectedNullableFound`:

``` scala
SQL("SELECT singleval FROM table").as(scalar[String].singleOpt) // Error even if value is optional
```

I think that's should be better a `None` there.
