### PR TITLE
Fix F.RedeemablePromise code samples

### DIFF
--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -445,12 +445,12 @@ public class F {
      *
      * <pre>
      * {@code
-     * RedeemablePromise<Int> someFutureInt = RedeemablePromise.empty();
+     * RedeemablePromise<Integer> someFutureInt = RedeemablePromise.empty();
      *
-     * someFutureInt.map(new Function<Int, Result>{
-     *     public apply(Int i) {
+     * someFutureInt.map(new Function<Integer, Result>() {
+     *     public Result apply(Integer i) {
      *         // This would apply once the redeemable promise succeed
-     *         return new Result("" + i);
+     *         return Results.ok("" + i);
      *     }
      * });
      *


### PR DESCRIPTION
I introduced an error in javadoc in #1999. I couldn't reproduce on my workstation and cloudbees didn't reproduced either. But it did produce on @yanns environment.
The error is the following one:

```
[error] /home/simon/projects/play/Play20/framework/src/play/src/main/java/play/libs/F.java:448: error: bad use of '>'
[error]      * someFutureInt.map(new Function<Int, Result>{
```

It look like was caused by wrong example code. While I have been unable to reproduce, the example code should be fixed. Here is the fix.
