### PR TITLE
Assets handling in stage/dist

### DIFF
--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -171,7 +171,9 @@ class AssetsBuilder extends Controller {
    */
   private[controllers] def resourceNameAt(path: String, file: String): Option[String] = {
     val decodedFile = UriEncoding.decodePath(file, "utf-8")
-    val resourceName = Option(path + "/" + decodedFile).map(name => if (name.startsWith("/")) name else ("/" + name)).get
+    val slashRemover = (input: String) => """//+""".r.replaceAllIn(input, "/")
+    val fullpath = slashRemover(path + "/" + decodedFile)
+    val resourceName = if (fullpath.startsWith("/")) fullpath else ("/" + fullpath)
     if (new File(resourceName).isDirectory || !new File(resourceName).getCanonicalPath.startsWith(new File(path).getCanonicalPath)) {
       None
     } else {

--- a/framework/src/play/src/test/scala/play/api/controllers/AssetsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/controllers/AssetsSpec.scala
@@ -19,10 +19,10 @@ object AssetsSpec extends Specification {
       Assets.resourceNameAt("a", "/b/") must beNone
       Assets.resourceNameAt("/a", "") must beSome("/a/")
       Assets.resourceNameAt("/a", "b") must beSome("/a/b")
-      Assets.resourceNameAt("/a", "/") must beSome("/a//")
-      Assets.resourceNameAt("/a", "/b") must beSome("/a//b")
-      Assets.resourceNameAt("/a", "/b/c") must beSome("/a//b/c")
-      Assets.resourceNameAt("/a", "/b/") must beSome("/a//b/")
+      Assets.resourceNameAt("/a", "/") must beSome("/a/")
+      Assets.resourceNameAt("/a", "/b") must beSome("/a/b")
+      Assets.resourceNameAt("/a", "/b/c") must beSome("/a/b/c")
+      Assets.resourceNameAt("/a", "/b/") must beSome("/a/b/")
     }
 
     "not look up assets with Windows file separators" in {
@@ -34,10 +34,10 @@ object AssetsSpec extends Specification {
       Assets.resourceNameAt("a\\z", "/b/") must beNone
       Assets.resourceNameAt("/a\\z", "") must beSome("/a\\z/")
       Assets.resourceNameAt("/a\\z", "b") must beSome("/a\\z/b")
-      Assets.resourceNameAt("/a\\z", "/") must beSome("/a\\z//")
-      Assets.resourceNameAt("/a\\z", "/b") must beSome("/a\\z//b")
-      Assets.resourceNameAt("/a\\z", "/b/c") must beSome("/a\\z//b/c")
-      Assets.resourceNameAt("/a\\z", "/b/") must beSome("/a\\z//b/")
+      Assets.resourceNameAt("/a\\z", "/") must beSome("/a\\z/")
+      Assets.resourceNameAt("/a\\z", "/b") must beSome("/a\\z/b")
+      Assets.resourceNameAt("/a\\z", "/b/c") must beSome("/a\\z/b/c")
+      Assets.resourceNameAt("/a\\z", "/b/") must beSome("/a\\z/b/")
       Assets.resourceNameAt("\\a\\z", "") must beNone
       Assets.resourceNameAt("\\a\\z", "b") must beNone
       Assets.resourceNameAt("\\a\\z", "/") must beNone
@@ -65,9 +65,9 @@ object AssetsSpec extends Specification {
     }
 
    "look up assets with percent-encoded file separators" in {
-      Assets.resourceNameAt("/x", "%2f") must beSome("/x//")
+      Assets.resourceNameAt("/x", "%2f") must beSome("/x/")
       Assets.resourceNameAt("/x", "a%2fb") must beSome("/x/a/b")
-      Assets.resourceNameAt("/x", "a/%2fb") must beSome("/x/a//b")
+      Assets.resourceNameAt("/x", "a/%2fb") must beSome("/x/a/b")
     }
 
     "fail when looking up assets with invalid chars in the URL" in {
@@ -77,8 +77,8 @@ object AssetsSpec extends Specification {
     }
 
     "look up assets even if the file path is a valid URI" in {
-      Assets.resourceNameAt("/a", "http://localhost/x") must beSome("/a/http://localhost/x")
-      Assets.resourceNameAt("/a", "//localhost/x") must beSome("/a///localhost/x")
+      Assets.resourceNameAt("/a", "http://localhost/x") must beSome("/a/http:/localhost/x")
+      Assets.resourceNameAt("/a", "//localhost/x") must beSome("/a/localhost/x")
       Assets.resourceNameAt("/a", "../") must beNone
     }
 

--- a/framework/test/integrationtest/test/ApplicationSpec.scala
+++ b/framework/test/integrationtest/test/ApplicationSpec.scala
@@ -87,6 +87,13 @@ class ApplicationSpec extends PlaySpecification with WsTestClient {
       val Some(result) = route(FakeRequest(GET, "/public//"))
       status(result) must equalTo (NOT_FOUND)
     }
+
+    "serve assets" in new WithApplication() {
+      val Some(result1) = route(FakeRequest(GET, "/public/empty.txt"))
+      status(result1) must equalTo (OK)
+      val Some(result2) = route(FakeRequest(GET, "/public//empty.txt"))
+      status(result2) must equalTo (OK)
+    }
    
     "remove cache elements" in new WithApplication() {
       import play.api.cache.Cache


### PR DESCRIPTION
File path resolution in jar tends to differ from the way unix
filesystems handle them.
When looking for foo//bar, unix filesystems does no difference to
foo/bar. Jar files makes a difference between both which causes trouble
between play run and play stage environments.

I tried to implement a test to make the difference clearer, but i've been unable to make sbt package test .class files along with the regular ones. I tried `test:stage` but it made no difference. If anyone has ideas for this one ...
