### PR TITLE
Remove ParameterValue erasure

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/package.scala
+++ b/framework/src/anorm/src/main/scala/anorm/package.scala
@@ -22,8 +22,7 @@ package object anorm {
 
   implicit def implicitID[ID](id: Id[ID] with NotNull): ID = id.id
 
-  implicit def toParameterValue[A](a: A)(implicit p: ToStatement[A]): ParameterValue[A] =
-    ParameterValue(a, p)
+  implicit def toParameterValue[A](a: A)(implicit p: ToStatement[A]): ParameterValue = ParameterValue(a, p)
 
   def SQL(stmt: String) = Sql.sql(stmt)
 


### PR DESCRIPTION
Remove parameter `A` from type `ParameterValue[A]` as it's useless as soon as value is applied/prepared as parameter and is erased when used (always referenced as `ParameterValue[_]`).

Case class is turned as trait without type parameter, and construction is moved to companion object with same arguments, so that instantiation remains the same `ParameterValue(value, setter)`.
