### PR TITLE
Please, review first app (todolist) documentation when deploy to heroku

### DIFF
--- a/documentation/manual/detailedTopics/assets/Assets.md
+++ b/documentation/manual/detailedTopics/assets/Assets.md
@@ -62,10 +62,9 @@ GET  /assets/*file               controllers.Assets.at(path="/public", file)
 GET  /liabilities/*file          controllers.Assets.at(path="/foo", file)
 ```
 
-you should add this to the project settings in `project/Build.scala`:
+you should add this to the project settings in `build.sbt`:
 
 ```
-// Add your own project settings here
 playAssetsDirectories <+= baseDirectory / "foo"
 ```
 

--- a/documentation/manual/detailedTopics/assets/AssetsCoffeeScript.md
+++ b/documentation/manual/detailedTopics/assets/AssetsCoffeeScript.md
@@ -36,7 +36,7 @@ Two JavaScript files will be compiled: `public/javascripts/main.js` and `public/
 
 ## Options
 
-CoffeeScript compilation can be configured in your project’s `Build.scala` file (in the settings part of the `PlayProject`). The only option currently supported is *bare* mode.
+CoffeeScript compilation can be configured in your project’s `build.sbt` file.  The only option currently supported is *bare* mode.
 
 ```
 coffeescriptOptions := Seq("bare")

--- a/documentation/manual/detailedTopics/assets/AssetsGoogleClosureCompiler.md
+++ b/documentation/manual/detailedTopics/assets/AssetsGoogleClosureCompiler.md
@@ -17,15 +17,13 @@ A minified file is also generated, where `.js` is replaced by `.min.js`. In our 
 
 ## Entry Points
 
-By default, any JavaScript file not prepended by an underscore will be compiled. This behavior can be changed in `project/Build.scala` by overriding the `javascriptEntryPoints` key. This key holds a `PathFinder`.
+By default, any JavaScript file not prepended by an underscore will be compiled. This behavior can be changed in `build.sbt` by overriding the `javascriptEntryPoints` key. This key holds a `PathFinder`.
 
 For example, to compile only `.js` file from the `app/assets/javascripts/main` directory:
 
 ```
-val main = play.Project(appName, appVersion, appDependencies).settings(
-   javascriptEntryPoints <<= baseDirectory(base =>
-      base / "app" / "assets" / "javascripts" / "main" ** "*.js"
-   )
+javascriptEntryPoints <<= baseDirectory(base =>
+    base / "app" / "assets" / "javascripts" / "main" ** "*.js"
 )
 ```
 
@@ -39,7 +37,7 @@ javascriptEntryPoints <<= (sourceDirectory in Compile)(base =>
 
 ## Options
 
-ClosureCompiler compilation can be configured in your project’s `build.sbt` file (in the root of the `PlayProject`). There are several currently supported options:
+ClosureCompiler compilation can be configured in your project’s `build.sbt` file. There are several currently supported options:
 
 - *advancedOptimizations* Achieves extra compressions by being more aggressive in the ways that it transforms code and renames symbols. However, this more aggressive approach means that you must take greater care when you use ADVANCED_OPTIMIZATIONS to ensure that the output code works the same way as the input code.
 - *checkCaja* Checks Caja control structures.

--- a/documentation/manual/detailedTopics/assets/AssetsLess.md
+++ b/documentation/manual/detailedTopics/assets/AssetsLess.md
@@ -58,18 +58,12 @@ The resulting CSS file will be compiled as `public/stylesheets/main.css`, and yo
 
 The default behavior of compiling every file that is not prepended by an underscore may not fit every project; for example if you include a library that has not been designed that way.
 
-This can be configured in `project/Build.scala` by overriding the `lessEntryPoints` key. This key holds a `PathFinder`.
+This can be configured in `build.sbt` by overriding the `lessEntryPoints` key. This key holds a `PathFinder`.
 
 For example, to compile `app/assets/stylesheets/main.less` and nothing else:
 
 ```
- import play.Keys._
- 
-...
-
- val main = play.Project(appName, appVersion, appDependencies).settings(
-   lessEntryPoints <<= baseDirectory(_ / "app" / "assets" / "stylesheets" ** "main.less")
- )
+lessEntryPoints <<= baseDirectory(_ / "app" / "assets" / "stylesheets" ** "main.less")
 ```
 
 > **Next:** [[Using Google Closure Compiler | AssetsGoogleClosureCompiler]]

--- a/documentation/manual/detailedTopics/build/SBTDependencies.md
+++ b/documentation/manual/detailedTopics/build/SBTDependencies.md
@@ -33,7 +33,7 @@ Multiple dependencies can be added either by multiple declarations like the abov
 libraryDependencies ++= Seq(
   "org.apache.derby" % "derby" % "10.4.1.3",
   "org.hibernate" % "hibernate-entitymanager" % "3.6.9.Final"
-  )
+)
 ```
 
 Of course, sbt (via Ivy) has to know where to download the module. If your module is in one of the default repositories sbt comes with then this will just work.
@@ -45,17 +45,13 @@ If you use `groupID %% artifactID % revision` instead of `groupID % artifactID %
 You could write this without the `%%`:
 
 ```scala
-val appDependencies = Seq(
-  "org.scala-tools" % "scala-stm_2.9.1" % "0.3"
-)
+libraryDependencies += "org.scala-tools" % "scala-stm_2.9.1" % "0.3"
 ```
 
 Assuming the `scalaVersion` for your build is `2.9.1`, the following is identical:
 
 ```scala
-val appDependencies = Seq(
-  "org.scala-tools" %% "scala-stm" % "0.3"
-)
+libraryDependencies += "org.scala-tools" %% "scala-stm" % "0.3"
 ```
 
 ### Resolvers

--- a/documentation/manual/detailedTopics/build/SBTSubProjects.md
+++ b/documentation/manual/detailedTopics/build/SBTSubProjects.md
@@ -12,34 +12,40 @@ You can make your application depend on a simple library project. Just add anoth
 ```
 import play.Project._
 
-import play.Project._
-
 name := "my-first-application"
 
 version := "1.0"
 
 playScalaSettings
 
+lazy val myFirstApplication = project.in(file("."))
+    .aggregate(myLibrary)
+    .depends(myLibrary)
+
 lazy val myLibrary = project
 ```
 
 The lowercased `project` on the last line is a Scala Macro which will use the name of the val it is being assigned to in order to determine the project's name and folder.
 
+The `myFirstApplication` project declares the base project.  If you don't have any sub projects, this is already implied, however when declaring sub projects, it's usually required to declare it so that you can ensure that it aggregates (that is, runs things like compile/test etc on the sub projects when run in the base project) and depends on (that is, adds the sub projects to the main projects classpath) the sub projects.
+
 The above example defines a sub-project in the application’s `myLibrary` folder. This sub-project is a standard sbt project, using the default layout:
 
 ```
 myProject
+ └ build.sbt
  └ app
  └ conf
  └ public
-myLibrary
- └ src
-    └ main
+ └ myLibrary
+   └ build.sbt
+   └ src
+     └ main
        └ java
        └ scala
-project
- └ Build.scala
 ```
+
+`myLibrary` has its own `build.sbt` file, this is where it can declare its own settings, dependencies etc.
 
 When you have a sub-project enabled in your build, you can focus on this project and compile, test or run it individually. Just use the `projects` command in the Play console prompt to display all projects:
 
@@ -62,100 +68,77 @@ When you run your Play application in dev mode, the dependent projects are autom
 
 [[subprojectError.png]]
 
-## Splitting your web application into several parts
+## Sharing common variables and code
 
-As a Play application is just a standard sbt project with a default configuration, it can depend on another Play application. 
+If you want your sub projects and root projects to share some common settings or code, then these can be placed in a Scala file in the `project` directory of the root project.  For example, in `project/Common.scala` you might have:
 
-> The following example uses a `build.scala` file to declare a `play.Project`. This approach was the way Play applications were defined prior to version 2.2. The approach is retained in order to support backward compatibility. We recommend that you convert to the `build.sbt` based approach or, if using a `build.scala`, you use sbt's `Project` type and `project` macro.
-
-Configure your sub-project as a `play.Project`:
-
-```
+```scala
 import sbt._
 import Keys._
-import play.Project._
 
-object ApplicationBuild extends Build {
+object Common {
+  val settings: Seq[Setting[_]] = {
+    organization := "com.example",
+    version := "1.2.3-SNAPSHOT"
+  }
 
-  val appName = "zenexity.com"
-  val appVersion = "1.2"
-
-  val common = play.Project(
-    appName + "-common", appVersion, path = file("common")
-  )
-  
-  val website = play.Project(
-    appName + "-website", appVersion, path = file("website")
-  ).dependsOn(common)
-  
-  val adminArea = play.Project(
-    appName + "-admin", appVersion, path = file("admin")
-  ).dependsOn(common)
-  
-  val main = play.Project(
-    appName, appVersion, path = file("main")
-  ).dependsOn(
-    website, adminArea
-  )
+  val fooDependency = "com.foo" %% "foo" % "2.4"
 }
 ```
 
-Here we define a complete project split in two main parts: the website and the admin area. Moreover these two parts depend themselves on a common module.
+Then in each of your `build.sbt` files, you can reference anything declared in the file:
 
-If you would like the dependent projects to be recompiled and tested when you recompile and test the main project then you will need to add an "aggregate" clause.
+```scala
+name := "my-sub-module"
 
+Common.settings
+
+libraryDependencies += fooDependency
 ```
-val main = play.Project(
-  appName, appVersion, appDependencies
-).dependsOn(
-  website, adminArea
-).aggregate(
-  website, adminArea
-)
-```
+
+## Splitting your web application into several parts
+
+As a Play application is just a standard sbt project with a default configuration, it can depend on another Play application.  You can make any sub module a Play application by including `playScalaSettings` or `playJavaSettings`, depending on whether your project is a Java or Scala project, in its corresponding `build.sbt` file.
 
 > Note: in order to avoid naming collision, make sure your controllers, including the Assets controller in your subprojects are using a different name space than the main project
 
 ## Splitting the route file
 
-As of `play 2.1` it's also possible to split the route file into smaller pieces. This is a very handy feature if you want to create a robust, reusable multi-module play application
+It's also possible to split the route file into smaller pieces. This is a very handy feature if you want to create a robust, reusable multi-module play application
 
-### Consider the following build file
+### Consider the following build configuration
 
-`project/Build.scala`:
+`build.sbt`:
 
 ```scala
-import sbt._
-import Keys._
-import play.Project._
+name := "myproject"
 
-object ApplicationBuild extends Build {
+playScalaSettings
 
-    val appName         = "myproject"
-    val appVersion      = "1.0-SNAPSHOT"
+lazy val admin = project.in(file("modules/admin"))
 
-    val adminDeps = Seq(
-      // Add your project dependencies here,
-       "mysql" % "mysql-connector-java" % "5.1.18",
-      jdbc,
-      anorm
-    )
-
-    val mainDeps = Seq()
-  
-    lazy val admin = play.Project(appName + "-admin", appVersion, adminDeps, path = file("modules/admin"))
-
-
-    lazy  val main = play.Project(appName, appVersion, mainDeps).settings(
-      // Add your own project settings here      
-    ).dependsOn(admin).aggregate(admin)
-
-}
+lazy val main = project.in(file("."))
+    .dependsOn(admin).aggregate(admin)
 ```
 
-### project structure
+`modules/admin/build.sbt`
+
+```scala
+name := "myadmin"
+
+playScalaSettings
+
+libraryDependencies ++= Seq(
+  "mysql" % "mysql-connector-java" % "5.1.18",
+  jdbc,
+  anorm
+)
+```
+
+### Project structure
 
 ```
+build.sbt
 app
   └ controllers
   └ models
@@ -164,14 +147,16 @@ conf
   └ application.conf
   └ routes
 modules
+ └ build.sbt
   └ admin
-    └ conf/admin.routes
-    └ app/controllers
-    └ app/models
-    └ app/views     
+    └ conf
+      └ admin.routes
+    └ app
+      └ controllers
+      └ models
+      └ views     
 project
  └ build.properties
- └ Build.scala
  └ plugins.sbt
 ```
 
@@ -276,4 +261,3 @@ triggers
 ```
 controllers.admin.Application.index
 ```
-

--- a/documentation/manual/detailedTopics/configuration/GzipEncoding.md
+++ b/documentation/manual/detailedTopics/configuration/GzipEncoding.md
@@ -1,12 +1,10 @@
 <!--- Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com> -->
 # Configuring gzip encoding
 
-Play provides a gzip filter that can be used to gzip responses.  It can be added to the applications filters using the `Global` object. To enable the gzip filter, add the Play filters helpers dependency to your project in Build.scala:
+Play provides a gzip filter that can be used to gzip responses.  It can be added to the applications filters using the `Global` object. To enable the gzip filter, add the Play filters helpers dependency to your project in `build.sbt`:
 
 ```scala
-val appDependencies = Seq(
-  filters
-)
+libraryDependencies += filters
 ```
 
 ## Enabling gzip in Scala

--- a/documentation/manual/detailedTopics/production/ProductionHeroku.md
+++ b/documentation/manual/detailedTopics/production/ProductionHeroku.md
@@ -101,10 +101,10 @@ $ heroku open
 
 ## Connecting to a database
 
-Heroku provides a number of relational and NoSQL databases through [Heroku Add-ons](https://addons.heroku.com).  Play applications on Heroku are automatically provisioned a [Heroku Postgres](https://addons.heroku.com/heroku-postgresql) database.  To configure your Play application to use the Heroku Postgres database, first add the PostgreSQL JDBC driver to your application dependencies (`project/Build.scala`):
+Heroku provides a number of relational and NoSQL databases through [Heroku Add-ons](https://addons.heroku.com).  Play applications on Heroku are automatically provisioned a [Heroku Postgres](https://addons.heroku.com/heroku-postgresql) database.  To configure your Play application to use the Heroku Postgres database, first add the PostgreSQL JDBC driver to your application dependencies (`build.sbt`):
 
 ```scala
-"postgresql" % "postgresql" % "9.1-901-1.jdbc4"
+libraryDependencies += "postgresql" % "postgresql" % "9.1-901-1.jdbc4"
 ```
 
 Then create a new file in your project's root directory named `Procfile` (with a capital "P") that contains the following (substituting the `myapp` with your project's name):

--- a/documentation/manual/javaGuide/main/forms/JavaCsrf.md
+++ b/documentation/manual/javaGuide/main/forms/JavaCsrf.md
@@ -30,12 +30,10 @@ To allow simple protection for non browser requests, such as requests made throu
 
 ## Applying a global CSRF filter
 
-Play provides a global CSRF filter that can be applied to all requests.  This is the simplest way to add CSRF protection to an application.  To enable the global filter, add the Play filters helpers dependency to your project in `Build.scala`:
+Play provides a global CSRF filter that can be applied to all requests.  This is the simplest way to add CSRF protection to an application.  To enable the global filter, add the Play filters helpers dependency to your project in `build.sbt`:
 
 ```scala
-val appDependencies = Seq(
-  filters
-)
+libraryDependencies += filters
 ```
 
 Now add the filter to your `Global` object:

--- a/documentation/manual/javaGuide/main/sql/JavaDatabase.md
+++ b/documentation/manual/javaGuide/main/sql/JavaDatabase.md
@@ -8,9 +8,7 @@ Play provides a plugin for managing JDBC connection pools. You can configure as 
 To enable the database plugin add javaJdbc in your build dependencies :
 
 ```scala
-val appDependencies = Seq(
-  javaJdbc
-)
+libraryDependencies += javaJdbc
 ```
 
 Then you must configure a connection pool in the `conf/application.conf` file. By convention the default JDBC data source must be called `default`:
@@ -73,12 +71,7 @@ Other than for the h2 in-memory database, useful mostly in development mode, Pla
 For example, if you use MySQL5, you need to add a [[dependency| SBTDependencies]] for the connector:
 
 ```
-val appDependencies = Seq(
-     // Add your project dependencies here,
-     ...
-     "mysql" % "mysql-connector-java" % "5.1.18"
-     ...
-)
+libraryDependencies += "mysql" % "mysql-connector-java" % "5.1.18"
 ```
 
 > **Next:** [[Using Ebean to access your database | JavaEbean]]

--- a/documentation/manual/javaGuide/main/sql/JavaEbean.md
+++ b/documentation/manual/javaGuide/main/sql/JavaEbean.md
@@ -7,9 +7,7 @@ Play comes with the [Ebean](http://www.avaje.org/) ORM. To enable it, add javaEb
 dependencies : 
 
 ```scala
-val appDependencies = Seq(
-  javaEbean
-)
+libraryDependencies += javaEbean
 ```
 
 then add the following line to `conf/application.conf`:

--- a/documentation/manual/javaGuide/main/sql/JavaJPA.md
+++ b/documentation/manual/javaGuide/main/sql/JavaJPA.md
@@ -8,7 +8,7 @@ First you need to tell play that your project need javaJpa plugin which provide 
 There is no built-in JPA implementation in Play; you can choose any available implementation. For example, to use Hibernate, just add the dependency to your project:
 
 ```
-val appDependencies = Seq(
+libraryDependencies ++= Seq(
   javaJpa,
   "org.hibernate" % "hibernate-entitymanager" % "3.6.9.Final" // replace by your jpa implementation
 )

--- a/documentation/manual/javaGuide/main/tests/JavaTest.md
+++ b/documentation/manual/javaGuide/main/tests/JavaTest.md
@@ -30,12 +30,16 @@ public class SimpleTest {
 }
 ```
 
-> **Note:** A new process is forked each time `test` or `test-only` is run.  The new process uses default JVM settings.  Custom settings can be added to `play.Project.settings` in `Build.scala`.  For example:  
+> **Note:** A new process is forked each time `test` or `test-only` is run.  The new process uses default JVM settings.  Custom settings can be added to `build.sbt`.  For example:  
 > ```
-> javaOptions in (Test) += "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9998",
-> javaOptions in (Test) += "-Xms512M",
-> javaOptions in (Test) += "-Xmx1536M",
-> javaOptions in (Test) += "-Xss1M",
+> javaOptions in (Test) += "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9998"
+>
+> javaOptions in (Test) += "-Xms512M"
+>
+> javaOptions in (Test) += "-Xmx1536M"
+>
+> javaOptions in (Test) += "-Xss1M"
+>
 > javaOptions in (Test) += "-XX:MaxPermSize=384M"
 > ```
 
@@ -62,7 +66,7 @@ You can also pass (or override) additional application configuration, or mock an
 fakeApplication(inMemoryDatabase())
 ```
 
-> **Note:** Applications using Ebean ORM may be written to rely on Play's automatic getter/setter generation.  Play also rewrites field accesses to use the generated getters/setters.  Ebean relies on calls to the setters to do dirty checking.  In order to use these patterns in JUnit tests, you will need to enable Play's field access rewriting in test by adding the following to `play.Project.settings` in `Build.scala`:
+> **Note:** Applications using Ebean ORM may be written to rely on Play's automatic getter/setter generation.  Play also rewrites field accesses to use the generated getters/setters.  Ebean relies on calls to the setters to do dirty checking.  In order to use these patterns in JUnit tests, you will need to enable Play's field access rewriting in test by adding the following to `build.sbt`:
 > ```
 > compile in Test <<= PostCompile(Test)
 > ```  

--- a/documentation/manual/javaGuide/tutorials/todolist/JavaTodoList.md
+++ b/documentation/manual/javaGuide/tutorials/todolist/JavaTodoList.md
@@ -365,12 +365,10 @@ web: target/universal/stage/bin/{your project name} -Dhttp.port=${PORT} -DapplyE
 
 Using system properties we override the application configuration when running on Heroku. But since heroku provides a PostgreSQL database we’ll have to add the required driver to our application dependencies. 
 
-Specify it into the `project/Build.scala` file:
+Specify it in the `build.sbt` file:
 
 ```
-val appDependencies = Seq(
-  "postgresql" % "postgresql" % "8.4-702.jdbc4"
-)
+libraryDependencies += "postgresql" % "postgresql" % "8.4-702.jdbc4"
 ```
 
 > **Note:** Read more about [[Dependencies management|SBTDependencies]].

--- a/documentation/manual/scalaGuide/main/forms/ScalaCsrf.md
+++ b/documentation/manual/scalaGuide/main/forms/ScalaCsrf.md
@@ -30,14 +30,10 @@ To allow simple protection for non browser requests, such as requests made throu
 
 ## Applying a global CSRF filter
 
-Play provides a global CSRF filter that can be applied to all requests.  This is the simplest way to add CSRF protection to an application.  To enable the global filter, add the Play filters helpers dependency to your project in `Build.scala`:
+Play provides a global CSRF filter that can be applied to all requests.  This is the simplest way to add CSRF protection to an application.  To enable the global filter, add the Play filters helpers dependency to your project in `build.sbt`:
 
 ```scala
-import play.Keys._
-
-val appDependencies = Seq(
-  filters
-)
+libraryDependencies += filters
 ```
 
 Now add the filter to your `Global` object:

--- a/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
+++ b/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
@@ -46,7 +46,7 @@ Writing SQL queries yourself can be tedious for a simple ‘Hello World’ appli
 You will need to add Anorm and jdbc plugin to your dependencies : 
 
 ```scala
-val appDependencies = Seq(
+libraryDependencies ++= Seq(
   jdbc,
   anorm
 )

--- a/documentation/manual/scalaGuide/main/sql/ScalaDatabase.md
+++ b/documentation/manual/scalaGuide/main/sql/ScalaDatabase.md
@@ -9,9 +9,7 @@ Play provides a plug-in for managing JDBC connection pools. You can configure as
 To enable the database plug-in, add jdbc in your build dependencies :
 
 ```scala
-val appDependencies = Seq(
-  jdbc
-)
+libraryDependencies += jdbc
 ```
 
 Then you must configure a connection pool in the `conf/application.conf` file. By convention, the default JDBC data source must be called `default` and the corresponding configuration properties are `db.default.driver` and `db.default.url`.
@@ -91,9 +89,7 @@ Play is bundled only with an [H2](http://www.h2database.com) database driver. Co
 For example, if you use MySQL5, you need to add a [[dependency | SBTDependencies]] for the connector:
 
 ```scala
-val appDependencies = Seq(
-  "mysql" % "mysql-connector-java" % "5.1.27"
-)
+libraryDependencies += "mysql" % "mysql-connector-java" % "5.1.27"
 ```
 
 Or if the driver can't be found from repositories you can drop the driver into your project's [[unmanaged dependencies|Anatomy]] `lib` directory.


### PR DESCRIPTION
Hi guys

I want to propose some changes in documentation after try the first app tutorial (http://www.playframework.com/documentation/2.2.x/JavaTodoList)

The problems appeared to my when I tried to deploy in heroku
- It's not clear how Build.scala looks. Based in documentation it seams that it exists, but following the tutorial, we have not created this file before, more over, investigationg on Play documentation talks about wrong (or old) instructions, For me this code is running

import sbt._
import Keys._
import play.Project._

object ApplicationBuild extends Build {

  val appName         = "todolist"
  val appVersion      = "1.0-SNAPSHOT"

  val appDependencies = Seq(
    // Add your project dependencies here,
    javaCore,
    javaJdbc,
    javaEbean,
    "postgresql" % "postgresql" % "9.1-901.jdbc4"
  )

  val main = play.Project(appName, appVersion, appDependencies).settings(
    // Add your own project settings here
  )

}

(For example, your documentation talks about playProject object, but it fails to compile

Another thing is postgres configuration. After googling a little I saw that I had to delete db password and user in application.conf because if not heroku starting project.

It's a quick highlight. I wish this help
