### PR TITLE
Adds set repeated mapping

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/Forms.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Forms.scala
@@ -401,6 +401,18 @@ object Forms {
    * @param mapping The mapping to make repeated.
    */
   def seq[A](mapping: Mapping[A]): Mapping[Seq[A]] = RepeatedMapping(mapping).transform(_.toSeq, _.toList)
+  
+  /**
+   * Defines a repeated mapping.
+   * {{{
+   * Form(
+   *   "name" -> set(text)
+   * )
+   * }}}
+   *
+   * @param mapping The mapping to make repeated.
+   */
+  def set[A](mapping: Mapping[A]): Mapping[Set[A]] = RepeatedMapping(mapping).transform(_.toSet, _.toList)
 
   /**
    * Constructs a simple mapping for a date field.


### PR DESCRIPTION
In the Forms there are list and seq to define a repeated mapping, but not set. Altought HTTP request doesn't permit to have a set, it can contains repetitions and the order is preserved, it is very common to have a data object having a member with Set semantic instead.
