### PR TITLE
Adds set forms mapping

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/Forms.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Forms.scala
@@ -403,6 +403,18 @@ object Forms {
   def seq[A](mapping: Mapping[A]): Mapping[Seq[A]] = RepeatedMapping(mapping).transform(_.toSeq, _.toList)
 
   /**
+   * Defines a repeated mapping with the Set semantic.
+   * {{{
+   * Form(
+   *   "name" -> set(text)
+   * )
+   * }}}
+   *
+   * @param mapping The mapping to make repeated.
+   */
+  def set[A](mapping: Mapping[A]): Mapping[Set[A]] = RepeatedMapping(mapping).transform(_.toSet, _.toList)
+
+  /**
    * Constructs a simple mapping for a date field.
    *
    * For example:

--- a/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
@@ -122,6 +122,17 @@ object FormSpec extends Specification {
     ScalaForms.repeatedForm.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[]" -> Seq("kiki@gmail.com", "kiki@zen.com")) ).get must equalTo(("Kiki", Seq("kiki@gmail.com", "kiki@zen.com")))
   }
 
+  "support repeated values with set" in {
+    ScalaForms.repeatedFormWithSet.bindFromRequest( Map("name" -> Seq("Kiki")) ).get must equalTo(("Kiki", Set()))
+    ScalaForms.repeatedFormWithSet.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[0]" -> Seq("kiki@gmail.com")) ).get must equalTo(("Kiki", Set("kiki@gmail.com")))
+    ScalaForms.repeatedFormWithSet.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[0]" -> Seq("kiki@gmail.com"), "emails[1]" -> Set("kiki@zen.com")) ).get must equalTo(("Kiki", Set("kiki@gmail.com", "kiki@zen.com")))
+    ScalaForms.repeatedFormWithSet.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[0]" -> Seq(), "emails[1]" -> Seq("kiki@zen.com")) ).hasErrors must equalTo(true)
+    ScalaForms.repeatedFormWithSet.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[]" -> Seq("kiki@gmail.com")) ).get must equalTo(("Kiki", Set("kiki@gmail.com")))
+    ScalaForms.repeatedFormWithSet.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[]" -> Seq("kiki@gmail.com", "kiki@zen.com")) ).get must equalTo(("Kiki", Set("kiki@gmail.com", "kiki@zen.com")))
+    ScalaForms.repeatedFormWithSet.bindFromRequest( Map("name" -> Seq("Kiki"), "emails[]" -> Seq("kiki@gmail.com", "kiki@gmail.com")) ).get must equalTo(("Kiki", Set("kiki@gmail.com")))
+
+  }
+
 
   "render a form with max 18 fields" in {
     ScalaForms.helloForm.bind(Map("name" -> "foo", "repeat" -> "1")).get.toString must equalTo("(foo,1,None,None,None,None,None,None,None,None,None,None,None,None,None,None,None,None)")
@@ -206,6 +217,13 @@ object ScalaForms {
     tuple(
       "name" -> nonEmptyText,
       "emails" -> list(nonEmptyText)
+    )
+  )
+
+  val repeatedFormWithSet = Form(
+    tuple(
+      "name" -> nonEmptyText,
+      "emails" -> set(nonEmptyText)
     )
   )
 


### PR DESCRIPTION
Although the HTTP request can contain repetitive parameter with duplicates, is very common to have a request parameter with a Set semantic instead like the list of permissions, roles and so on. 
