### PR TITLE
Handle missing less imports correctly

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/less/LessCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/less/LessCompiler.scala
@@ -73,7 +73,11 @@ object LessCompiler {
 
                         var imported = LessCompiler.resolve(context[context.length - 1], path);
                         var importedName = String(imported.getAbsolutePath());
-                        var input = String(LessCompiler.readContent(imported));
+                        try {
+                          var input = String(LessCompiler.readContent(imported));
+                        } catch (e) {
+                          return fn({ type: "File", message: "File not found: " + importedName });
+                        }
 
                         // Store it in the contents, for error reporting
                         env.contents[importedName] = input;

--- a/framework/src/sbt-plugin/src/test/resources/importmissing.less
+++ b/framework/src/sbt-plugin/src/test/resources/importmissing.less
@@ -1,0 +1,9 @@
+.foo {
+  color: red;
+}
+
+@import "missing.less";
+
+.bar {
+  color: blue;
+}

--- a/framework/src/sbt-plugin/src/test/scala/less/LessCompilerSpec.scala
+++ b/framework/src/sbt-plugin/src/test/scala/less/LessCompilerSpec.scala
@@ -70,6 +70,17 @@ object LessCompilerSpec extends Specification {
       }
     }
 
+    "correctly handle missing import files" in {
+      LessCompiler.compile(getFile("importmissing.less")) must throwAn[AssetCompilationException].like {
+        case e: AssetCompilationException =>
+          e.atLine must beSome(5)
+          e.column must beSome(0)
+          e.message must contain("File not found: ")
+          e.message must contain("/missing.less")
+          e.source must beSome(getFile("importmissing.less"))
+      }
+    }
+
   }
 
   def getFile(fileName: String):File = {


### PR DESCRIPTION
If a less import file was missing, this should be handled by calling the callback passed to the imported with an error.  The old code just threw an exception, and the result of this was that the code apparently compiled fine, but the output file just contained `org.mozilla.javascript.Undefined@...`
