### PR TITLE
Unify `SimpleSql.on(args: (Any,ParameterValue)*)` to `SimpleSql.on(args:...

### DIFF
--- a/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
+++ b/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
@@ -106,6 +106,15 @@ SQL(
 ).on("countryCode" -> "FRA")
 ```
 
+Passing anything different from string or symbol as parameter name is now deprecated. For backward compatibility, you can activate `anorm.features.parameterWithUntypedName`.
+
+```scala
+import anorm.features.parameterWithUntypedName // activate
+
+val untyped: Any = "name" // deprecated
+SQL("SELECT * FROM Country WHERE {p}").on(untyped -> "val")
+```
+
 ## Retrieving data using the Stream API
 
 The first way to access the results of a select query is to use the Stream API.

--- a/framework/src/anorm/src/main/scala/anorm/package.scala
+++ b/framework/src/anorm/src/main/scala/anorm/package.scala
@@ -24,6 +24,34 @@ package object anorm {
 
   implicit def toParameterValue[A](a: A)(implicit p: ToStatement[A]): ParameterValue = ParameterValue(a, p)
 
-  def SQL(stmt: String) = Sql.sql(stmt)
+  /**
+   * Creates an SQL query with given statement.
+   * @param stmt SQL statement
+   *
+   * {{{
+   * val query = SQL("SELECT * FROM Country")
+   * }}}
+   */
+  def SQL(stmt: String): SqlQuery = Sql.sql(stmt)
 
+  /** Activable features */
+  object features {
+
+    /**
+     * Conversion for parameter with untyped named.
+     *
+     * {{{
+     * // For backward compatibility
+     * import anorm.features.parameterWithUntypedName
+     *
+     * val untyped: Any = "name"
+     * SQL("SELECT * FROM Country WHERE {p}").on(untyped -> "val")
+     * }}}
+     */
+    @deprecated(
+      message = "Use typed name for parameter, either string or symbol",
+      since = "2.3.0")
+    implicit def parameterWithUntypedName[V](t: (Any, V))(implicit c: V => ParameterValue): NamedParameter = NamedParameter(t._1.toString, c(t._2))
+
+  }
 }

--- a/samples/scala/zentasks/app/models/Project.scala
+++ b/samples/scala/zentasks/app/models/Project.scala
@@ -33,7 +33,7 @@ object Project {
   def findById(id: Long): Option[Project] = {
     DB.withConnection { implicit connection =>
       SQL("select * from project where id = {id}").on(
-        'id -> id
+        "id" -> id
       ).as(Project.simple.singleOpt)
     }
   }
@@ -50,7 +50,7 @@ object Project {
           where project_member.user_email = {email}
         """
       ).on(
-        'email -> user
+        "email" -> user
       ).as(Project.simple *)
     }
   }
@@ -61,7 +61,7 @@ object Project {
   def rename(id: Long, newName: String) {
     DB.withConnection { implicit connection =>
       SQL("update project set name = {name} where id = {id}").on(
-        'id -> id, 'name -> newName
+        "id" -> id, "name" -> newName
       ).executeUpdate()
     }
   }
@@ -72,7 +72,7 @@ object Project {
   def delete(id: Long) {
     DB.withConnection { implicit connection => 
       SQL("delete from project where id = {id}").on(
-        'id -> id
+        "id" -> id
       ).executeUpdate()
     }
   }
@@ -83,7 +83,7 @@ object Project {
   def deleteInFolder(folder: String) {
     DB.withConnection { implicit connection => 
       SQL("delete from project where folder = {folder}").on(
-        'folder -> folder
+        "folder" -> folder
       ).executeUpdate()
     }
   }
@@ -94,7 +94,7 @@ object Project {
   def renameFolder(folder: String, newName: String) {
     DB.withConnection { implicit connection =>
       SQL("update project set folder = {newName} where folder = {name}").on(
-        'name -> folder, 'newName -> newName
+        "name" -> folder, "newName" -> newName
       ).executeUpdate()
     }
   }
@@ -111,7 +111,7 @@ object Project {
           where project_member.project_id = {project}
         """
       ).on(
-        'project -> project
+        "project" -> project
       ).as(User.simple *)
     }
   }
@@ -122,8 +122,8 @@ object Project {
   def addMember(project: Long, user: String) {
     DB.withConnection { implicit connection =>
       SQL("insert into project_member values({project}, {user})").on(
-        'project -> project,
-        'user -> user
+        "project" -> project,
+        "user" -> user
       ).executeUpdate()
     }
   }
@@ -134,8 +134,8 @@ object Project {
   def removeMember(project: Long, user: String) {
     DB.withConnection { implicit connection =>
       SQL("delete from project_member where project_id = {project} and user_email = {user}").on(
-        'project -> project,
-        'user -> user
+        "project" -> project,
+        "user" -> user
       ).executeUpdate()
     }
   }
@@ -152,8 +152,8 @@ object Project {
           where project_member.project_id = {project} and user.email = {email}
         """
       ).on(
-        'project -> project,
-        'email -> user
+        "project" -> project,
+        "email" -> user
       ).as(scalar[Boolean].single)
     }
   }
@@ -177,14 +177,14 @@ object Project {
            )
          """
        ).on(
-         'id -> id,
-         'name -> project.name,
-         'folder -> project.folder
+         "id" -> id,
+         "name" -> project.name,
+         "folder" -> project.folder
        ).executeUpdate()
        
        // Add members
        members.foreach { email =>
-         SQL("insert into project_member values ({id}, {email})").on('id -> id, 'email -> email).executeUpdate()
+         SQL("insert into project_member values ({id}, {email})").on("id" -> id, "email" -> email).executeUpdate()
        }
        
        project.copy(id = Id(id))

--- a/samples/scala/zentasks/app/models/Task.scala
+++ b/samples/scala/zentasks/app/models/Task.scala
@@ -41,7 +41,7 @@ object Task {
   def findById(id: Long): Option[Task] = {
     DB.withConnection { implicit connection =>
       SQL("select * from task where id = {id}").on(
-        'id -> id
+        "id" -> id
       ).as(Task.simple.singleOpt)
     }
   }
@@ -59,7 +59,7 @@ object Task {
           where task.done = false and project_member.user_email = {email}
         """
       ).on(
-        'email -> user
+        "email" -> user
       ).as(Task.simple ~ Project.simple map {
         case task~project => task -> project
       } *)
@@ -77,7 +77,7 @@ object Task {
           where task.project = {project}
         """
       ).on(
-        'project -> project
+        "project" -> project
       ).as(Task.simple *)
     }
   }
@@ -88,7 +88,7 @@ object Task {
   def delete(id: Long) {
     DB.withConnection { implicit connection =>
       SQL("delete from task where id = {id}").on(
-        'id -> id
+        "id" -> id
       ).executeUpdate()
     }
   }
@@ -99,7 +99,7 @@ object Task {
   def deleteInFolder(projectId: Long, folder: String) {
     DB.withConnection { implicit connection =>
       SQL("delete from task where project = {project} and folder = {folder}").on(
-        'project -> projectId, 'folder -> folder
+        "project" -> projectId, "folder" -> folder
       ).executeUpdate()
     }
   }
@@ -110,8 +110,8 @@ object Task {
   def markAsDone(taskId: Long, done: Boolean) {
     DB.withConnection { implicit connection =>
       SQL("update task set done = {done} where id = {id}").on(
-        'id -> taskId,
-        'done -> done
+        "id" -> taskId,
+        "done" -> done
       ).executeUpdate()
     }
   }
@@ -122,7 +122,7 @@ object Task {
   def renameFolder(projectId: Long, folder: String, newName: String) {
     DB.withConnection { implicit connection =>
       SQL("update task set folder = {newName} where folder = {name} and project = {project}").on(
-        'project -> projectId, 'name -> folder, 'newName -> newName
+        "project" -> projectId, "name" -> folder, "newName" -> newName
       ).executeUpdate()
     }
   }
@@ -140,8 +140,8 @@ object Task {
           where project_member.user_email = {email} and task.id = {task}
         """
       ).on(
-        'task -> task,
-        'email -> user
+        "task" -> task,
+        "email" -> user
       ).as(scalar[Boolean].single)
     }
   }
@@ -164,13 +164,13 @@ object Task {
           )
         """
       ).on(
-        'id -> id,
-        'folder -> task.folder,
-        'project -> task.project,
-        'title -> task.title,
-        'done -> task.done,
-        'dueDate -> task.dueDate,
-        'assignedTo -> task.assignedTo
+        "id" -> id,
+        "folder" -> task.folder,
+        "project" -> task.project,
+        "title" -> task.title,
+        "done" -> task.done,
+        "dueDate" -> task.dueDate,
+        "assignedTo" -> task.assignedTo
       ).executeUpdate()
       
       task.copy(id = Id(id))

--- a/samples/scala/zentasks/app/models/User.scala
+++ b/samples/scala/zentasks/app/models/User.scala
@@ -33,7 +33,7 @@ object User {
   def findByEmail(email: String): Option[User] = {
     DB.withConnection { implicit connection =>
       SQL("select * from user where email = {email}").on(
-        'email -> email
+        "email" -> email
       ).as(User.simple.singleOpt)
     }
   }
@@ -58,8 +58,8 @@ object User {
          email = {email} and password = {password}
         """
       ).on(
-        'email -> email,
-        'password -> password
+        "email" -> email,
+        "password" -> password
       ).as(User.simple.singleOpt)
     }
   }
@@ -76,9 +76,9 @@ object User {
           )
         """
       ).on(
-        'email -> user.email,
-        'name -> user.name,
-        'password -> user.password
+        "email" -> user.email,
+        "name" -> user.name,
+        "password" -> user.password
       ).executeUpdate()
       
       user


### PR DESCRIPTION
... (String,ParameterValue)*)`.

I think it will avoid converting anything to parameter name, arbitrarily using [Any.toString](https://github.com/playframework/playframework/blob/master/framework/src/anorm/src/main/scala/anorm/Anorm.scala#L392) (typesafe), and would avoid maintaining code that can be unified by String (which covers all cases of parameter name).

For usage of Symbol as parameter name, as direct deprecation can hardly be used there, either existing parameter names are migrated to string (trivial `'name` to "name") or existing code update `.on(...)` to `.on1(...)` to use deprecated version:

``` scala
// No longer supporter: SQL("...").on('name -> "str")
SQL("...").on1('name -> "str") // deprecated version
SQL("...").on("name" -> "str") // unified version
```
