### PR TITLE
Http1.0 Compliance

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -710,7 +710,7 @@ trait Results {
    *
    * @param status the HTTP response status, e.g ‘200 OK’
    */
-  class Status(status: Int) extends SimpleResult(header = ResponseHeader(status), body = Enumerator.empty,
+  class Status(status: Int) extends SimpleResult(header = ResponseHeader(status, headers = Map("Content-Length" -> "0")), body = Enumerator.empty,
     connection = HttpConnection.KeepAlive) {
 
     /**


### PR DESCRIPTION
This PR fix some of mismatch between rfc1945  (section 7.2 in particular) and play implementation.

Among changes:
- Play should not reply with a body if status is 1xx, 204 or 304
- All other status should have either Content-Length or Connection: Close
- If no reply body is provided, Content-Length should be 0

This PR also makes the chunked reply with http1.0 remove chunking and fallback to regular streaming of the body (see #2127)
