### PR TITLE
Change 'play' command to bootstrap SBT with Scala 2.10.3

### DIFF
--- a/documentation/manual/Migration22.md
+++ b/documentation/manual/Migration22.md
@@ -32,7 +32,7 @@ override def rootProject = Some(myProject)
 
 ### Update Scala version
 
-If you have set the scalaVersion (e.g. because you have a multi-project build that uses Project in addition to play.Project), you should update it to 2.10.2.
+If you have set the scalaVersion (e.g. because you have a multi-project build that uses Project in addition to play.Project), you should update it to 2.10.3.
 
 ### Play cache module
 

--- a/framework/build
+++ b/framework/build
@@ -7,7 +7,7 @@ fi
 if [ -z "$JAVA_HOME" ]; then
   JAVA="java"
 else
- JAVA="$JAVA_HOME/bin/java"
+  JAVA="$JAVA_HOME/bin/java"
 fi
 
 if [ -z "${JPDA_PORT}" ]; then
@@ -16,4 +16,8 @@ else
   DEBUG_PARAM="-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=${JPDA_PORT}"
 fi
 
-"$JAVA" ${DEBUG_PARAM} -Xms512M -Xmx1536M -Xss1M -XX:ReservedCodeCacheSize=192m -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=512M ${JAVA_OPTS} -Dfile.encoding=UTF-8 -Dplay.version="${PLAY_VERSION}" -Dplay.home=`dirname $0` -Dsbt.boot.properties=`dirname $0`/sbt/sbt.boot.properties ${PLAY_OPTS} -jar `dirname $0`/sbt/sbt-launch.jar "$@"
+if [ -z "${SBT_SCALA_VERSION}" ]; then
+  SBT_SCALA_VERSION="auto"
+fi
+
+"$JAVA" ${DEBUG_PARAM} -Xms512M -Xmx1536M -Xss1M -XX:ReservedCodeCacheSize=192m -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=512M ${JAVA_OPTS} -Dfile.encoding=UTF-8 -Dplay.version="${PLAY_VERSION}" -Dplay.home=`dirname $0` -Dsbt.boot.properties=`dirname $0`/sbt/sbt.boot.properties -Dsbt.scala.version=${SBT_SCALA_VERSION} ${PLAY_OPTS} -jar `dirname $0`/sbt/sbt-launch.jar "$@"

--- a/framework/build.bat
+++ b/framework/build.bat
@@ -3,6 +3,7 @@
 setlocal enabledelayedexpansion
 
 set PLAY_VERSION="2.2-SNAPSHOT"
+if not defined SBT_SCALA_VERSION set SBT_SCALA_VERSION=auto
 
 if defined JPDA_PORT set DEBUG_PARAM="-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=%JPDA_PORT%"
 
@@ -10,7 +11,7 @@ set p=%~dp0
 set p=%p:\=/%
 set fp=file:///!p: =%%20!
 
-java -Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M %DEBUG_PARAM% %JAVA_OPTS% -Dfile.encoding=UTF-8 -Dinput.encoding=Cp1252 -Dplay.version="%PLAY_VERSION%" -Dsbt.ivy.home="%~dp0..\repository" -Dplay.home="%~dp0." -Dsbt.boot.properties="%fp%sbt/sbt.boot.properties" %PLAY_OPTS% -jar "%~dp0sbt\sbt-launch.jar" %*
+java -Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M %DEBUG_PARAM% %JAVA_OPTS% -Dfile.encoding=UTF-8 -Dinput.encoding=Cp1252 -Dplay.version="%PLAY_VERSION%" -Dsbt.ivy.home="%~dp0..\repository" -Dplay.home="%~dp0." -Dsbt.boot.properties="%fp%sbt/sbt.boot.properties" -Dsbt.scala.version="%SBT_SCALA_VERSION%" %PLAY_OPTS% -jar "%~dp0sbt\sbt-launch.jar" %*
 
 :end
 endlocal

--- a/framework/sbt/play.boot.properties
+++ b/framework/sbt/play.boot.properties
@@ -1,5 +1,5 @@
 [scala]
-  version: 2.10.2
+  version: ${sbt.scala.version}
 
 [app]
   org: com.typesafe.play

--- a/framework/sbt/sbt.boot.properties
+++ b/framework/sbt/sbt.boot.properties
@@ -1,5 +1,5 @@
 [scala]
-  version: auto
+  version: ${sbt.scala.version-auto}
 
 [app]
   org: ${sbt.organization-org.scala-sbt}

--- a/play
+++ b/play
@@ -16,7 +16,11 @@ dir=`dirname $PRG`
 if [ -z "$JAVA_HOME" ]; then
   JAVA="java"
 else
- JAVA="$JAVA_HOME/bin/java"
+  JAVA="$JAVA_HOME/bin/java"
+fi
+
+if [ -z "$SBT_SCALA_VERSION" ]; then
+  SBT_SCALA_VERSION="2.10.3"
 fi
 
 if [ -f conf/application.conf -o -f conf/reference.conf ] || [ -d project ]; then
@@ -61,11 +65,11 @@ if [ -f conf/application.conf -o -f conf/reference.conf ] || [ -d project ]; the
   fi
 
   if [ -n "$1" ]; then
-    JPDA_PORT="${JPDA_PORT}" $dir/framework/build "$@"
+    JPDA_PORT="${JPDA_PORT}" SBT_SCALA_VERSION="${SBT_SCALA_VERSION}" $dir/framework/build "$@"
   else
-    JPDA_PORT="${JPDA_PORT}" $dir/framework/build play
+    JPDA_PORT="${JPDA_PORT}" SBT_SCALA_VERSION="${SBT_SCALA_VERSION}" $dir/framework/build play
   fi
   
 else
-  "$JAVA" -Dplay.home=$dir/framework -Dsbt.boot.properties=$dir/framework/sbt/play.boot.properties ${PLAY_OPTS} -jar $dir/framework/sbt/sbt-launch.jar "$@"
+  SBT_SCALA_VERSION="${SBT_SCALA_VERSION}" "$JAVA" -Dplay.home=$dir/framework -Dsbt.boot.properties=$dir/framework/sbt/play.boot.properties -Dsbt.scala.version=${SBT_SCALA_VERSION} ${PLAY_OPTS} -jar $dir/framework/sbt/sbt-launch.jar "$@"
 fi

--- a/play.bat
+++ b/play.bat
@@ -8,13 +8,14 @@ set p=%p:\=/%
 set fp=file:///!p: =%%20!
 set buildScript="%~dp0framework\build.bat"
 set additionalArgs=%*
+if not defined SBT_SCALA_VERSION set SBT_SCALA_VERSION=2.10.3
 
 if exist "conf\application.conf" goto existingApplication
 if exist "conf\reference.conf" goto existingApplication
 if exist "project" goto existingApplication
 
 :noApplication
-java -Dsbt.ivy.home="%~dp0repository" -Dplay.home="%~dp0framework" -Dsbt.boot.properties="%fp%framework/sbt/play.boot.properties" %PLAY_OPTS% -jar "%~dp0framework\sbt\sbt-launch.jar" %*
+java -Dsbt.ivy.home="%~dp0repository" -Dplay.home="%~dp0framework" -Dsbt.boot.properties="%fp%framework/sbt/play.boot.properties" -Dsbt.scala.version="%SBT_SCALA_VERSION%" %PLAY_OPTS% -jar "%~dp0framework\sbt\sbt-launch.jar" %*
 
 goto end
 


### PR DESCRIPTION
If a bootstrap setting isn't supplied then SBT will usually default to
Scala 2.10.2. That messes up our all-in-one ZIP distribution which we
want to ship with Scala 2.10.3 only.

The 'build' script needs to support bootstrapping SBT with versions
other than 2.10.3 (e.g. when building Play itself), therefore its
default Scala version is 'auto'. It will only use a version of 2.10.3
when called from the 'play' script. The 'play' script sets an
environment variable to override 'build's default value.
