### PR TITLE
Fix L#392 and L#403 by closing string literal

### DIFF
--- a/documentation/manual/scalaGuide/tutorials/todolist/ScalaTodoList.md
+++ b/documentation/manual/scalaGuide/tutorials/todolist/ScalaTodoList.md
@@ -392,7 +392,7 @@ It’s time to complete the implementation:
 def create(label: String) {
   DB.withConnection { implicit c =>
     SQL("insert into task (label) values ({label})").on(
-      'label -> label
+      'label' -> label
     ).executeUpdate()
   }
 }
@@ -400,7 +400,7 @@ def create(label: String) {
 def delete(id: Long) {
   DB.withConnection { implicit c =>
     SQL("delete from task where id = {id}").on(
-      'id -> id
+      'id' -> id
     ).executeUpdate()
   }
 }


### PR DESCRIPTION
This also fixes the broken syntax highlighting (seen below): 

![Syntax highlighting](https://dl-web.dropbox.com/get/Screenshots/Screenshot%202013-12-09%2014.01.44.png?w=AADFHVHE7rBAJgvQgTen5K8M2Bt0fxPLPdtecUXwERP8dw)
