### PR TITLE
Throwable should not be catched

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Concurrent.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Concurrent.scala
@@ -5,6 +5,7 @@ package play.api.libs.iteratee
 
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.{ Try, Failure, Success }
+import scala.util.control.NonFatal
 import Enumerator.Pushee
 import java.util.concurrent.{ TimeUnit }
 import play.api.libs.iteratee.Execution.Implicits.{ defaultExecutionContext => dec }
@@ -119,7 +120,7 @@ object Concurrent {
             case Right(s) =>
               Some(s)
           }(dec).recover {
-            case e: Throwable =>
+            case NonFatal(e) =>
               p.failure(e)
               None
           }(dec)

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
@@ -6,6 +6,7 @@ package play.api.libs.iteratee
 import play.api.libs.iteratee.Execution.Implicits.{ defaultExecutionContext => dec }
 import play.api.libs.iteratee.internal.{ executeIteratee, executeFuture }
 import scala.language.reflectiveCalls
+import scala.util.control.NonFatal
 import scala.concurrent.{ ExecutionContext, Future }
 
 /**
@@ -763,7 +764,7 @@ object Enumeratee {
             }(dec).unflatten.map({ s =>
               s.it
             })(dec).recover({
-              case e: Throwable =>
+              case NonFatal(e) =>
                 f(e, in)
                 Cont(step(it))
             })(pec)

--- a/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
+++ b/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
@@ -6,6 +6,8 @@ package play.core.j
 import play.api.mvc._
 import play.templates._
 
+import scala.util.control.NonFatal
+
 /** Defines a magic helper for Play templates in a Java context. */
 object PlayMagicForJava {
 
@@ -22,7 +24,7 @@ object PlayMagicForJava {
     try {
       play.mvc.Http.Context.Implicit.lang.asInstanceOf[play.api.i18n.Lang]
     } catch {
-      case _: Throwable => play.api.i18n.Lang.defaultLang
+      case NonFatal(_) => play.api.i18n.Lang.defaultLang
     }
   }
 

--- a/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
@@ -14,6 +14,9 @@ import org.fluentlenium.core._
 import java.util.concurrent.TimeUnit
 import com.google.common.base.Function
 import org.openqa.selenium.support.ui.FluentWait
+
+import scala.util.control.NonFatal
+
 /**
  * A test browser (Using Selenium WebDriver) with the FluentLenium API (https://github.com/Fluentlenium/FluentLenium).
  *
@@ -144,7 +147,7 @@ case class TestServer(port: Int, application: FakeApplication = FakeApplication(
     try {
       server = new play.core.server.NettyServer(new play.core.TestApplication(application), Option(port), sslPort = sslPort, mode = Mode.Test)
     } catch {
-      case t: Throwable =>
+      case NonFatal(t) =>
         t.printStackTrace
         throw new RuntimeException(t)
     }

--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -63,7 +63,6 @@ object Configuration {
       if (currentMode == Mode.Prod) Configuration(dontAllowMissingConfig) else Configuration(loadDev(appPath, devSettings))
     } catch {
       case e: ConfigException => throw configError(e.origin, e.getMessage, Some(e))
-      case e: Throwable => throw e
     }
   }
 

--- a/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
+++ b/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
@@ -137,7 +137,7 @@ trait GlobalSettings {
         }
       }))
     } catch {
-      case e: Throwable => {
+      case NonFatal(e) => {
         Logger.error("Error while rendering default error page", e)
         Future.successful(InternalServerError)
       }

--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -129,7 +129,7 @@ class AssetsBuilder extends Controller {
             try {
               (stream.available, Enumerator.fromStream(stream))
             } catch {
-              case _: Throwable => (-1, Enumerator[Array[Byte]]())
+              case NonFatal(_) => (-1, Enumerator[Array[Byte]]())
             }
           }
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
@@ -8,6 +8,7 @@ import play.api.mvc._
 import java.io.File
 import scala.concurrent.Future
 import play.api.libs.iteratee._
+import scala.util.control.NonFatal
 
 /** Adapter that holds the Java `GlobalSettings` and acts as a Scala `GlobalSettings` for the framework. */
 class JavaGlobalSettingsAdapter(val underlying: play.GlobalSettings) extends GlobalSettings {
@@ -59,7 +60,7 @@ class JavaGlobalSettingsAdapter(val underlying: play.GlobalSettings) extends Glo
     try {
       Filters(super.doFilter(a), underlying.filters.map(_.newInstance: play.api.mvc.EssentialFilter): _*)
     } catch {
-      case e: Throwable => {
+      case NonFatal(e) => {
         import play.api.libs.iteratee.Execution.Implicits.trampoline
         EssentialAction(req => Iteratee.flatten(onError(req, e).map(result => Done(result, Input.Empty))))
       }

--- a/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
+++ b/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
@@ -105,7 +105,7 @@ class ReloadableApplication(sbtLink: SBTLink, sbtDocHandler: SBTDocHandler) exte
       Await.result(scala.concurrent.Future {
 
         val reloaded = sbtLink.reload match {
-          case t: Throwable => Failure(t)
+          case NonFatal(t) => Failure(t)
           case cl: ClassLoader => Success(Some(cl))
           case null => Success(None)
         }

--- a/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
@@ -12,6 +12,8 @@ import Keys._
 import java.lang.{ ProcessBuilder => JProcessBuilder }
 import sbt.complete.Parsers._
 
+import scala.util.control.NonFatal
+
 trait PlayCommands extends PlayAssetsCompiler with PlayEclipse with PlayInternalKeys {
   this: PlayReloader =>
 
@@ -153,7 +155,7 @@ trait PlayCommands extends PlayAssetsCompiler with PlayEclipse with PlayInternal
         try {
           ft.process(models)
         } catch {
-          case _: Throwable =>
+          case NonFatal(_) =>
         }
 
       } finally {

--- a/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
@@ -3,6 +3,7 @@
  */
 package play
 
+import scala.util.control.NonFatal
 import play.api._
 import play.core._
 import sbt.{ Project => SbtProject, _ }
@@ -100,7 +101,7 @@ trait PlayReloader {
           nativeWatcher
 
         } catch {
-          case e: Throwable => {
+          case NonFatal(e) => {
 
             println(play.console.Colors.red(
               """|

--- a/framework/src/sbt-plugin/src/main/scala/PlaySourceGenerators.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySourceGenerators.scala
@@ -23,7 +23,6 @@ trait PlaySourceGenerators {
       case RoutesCompilationError(source, message, line, column) => {
         throw reportCompilationError(state, RoutesCompilationException(source, message, line, column.map(_ - 1)))
       }
-      case e: Throwable => throw e
     }
 
     (scalaRoutes.get ++ javaRoutes.get).map(_.getAbsoluteFile)

--- a/framework/src/sbt-plugin/src/main/scala/play/PlayRunHooks.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/PlayRunHooks.scala
@@ -3,6 +3,7 @@
  */
 package play
 
+import scala.util.control.NonFatal
 import java.net.InetSocketAddress
 
 /**
@@ -50,7 +51,7 @@ object PlayRunHook {
         try {
           f(hook)
         } catch {
-          case e: Throwable =>
+          case NonFatal(e) =>
             // Just save the last failure for now...
             lastFailure = Some(e)
         }
@@ -58,7 +59,7 @@ object PlayRunHook {
       // Throw failure if it occurred....
       if (!suppressFailure) lastFailure foreach (throw _)
     } catch {
-      case e: Throwable if suppressFailure =>
+      case NonFatal(e) if suppressFailure =>
       // Ignoring failure in running hooks... (CCE thrown here)
     }
   }


### PR DESCRIPTION
Please, OutOfMemoryError shouldn't be catched by play. I prefer my sbt
to stop working when I'm out of memory but not freeze forever waiting for
SIGKILL.
