### PR TITLE
Allow to use a configured WebDriver when running with test browser.

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -424,6 +424,13 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * Executes a block of code in a running server, with a test browser.
      */
     public static synchronized void running(TestServer server, Class<? extends WebDriver> webDriver, final Callback<TestBrowser> block) {
+        running(server, play.api.test.WebDriverFactory.apply(webDriver), block);
+    }
+
+    /**
+     * Executes a block of code in a running server, with a test browser.
+     */
+    public static synchronized void running(TestServer server, WebDriver webDriver, final Callback<TestBrowser> block) {
         TestBrowser browser = null;
         TestServer startedServer = null;
         try {

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -68,11 +68,18 @@ trait PlayRunners {
    * Executes a block of code in a running server, with a test browser.
    */
   def running[T, WEBDRIVER <: WebDriver](testServer: TestServer, webDriver: Class[WEBDRIVER])(block: TestBrowser => T): T = {
+    running(testServer, WebDriverFactory(webDriver))(block)
+  }
+
+  /**
+   * Executes a block of code in a running server, with a test browser.
+   */
+  def running[T](testServer: TestServer, webDriver: WebDriver)(block: TestBrowser => T): T = {
     var browser: TestBrowser = null
     synchronized {
       try {
         testServer.start()
-        browser = TestBrowser.of(webDriver)
+        browser = TestBrowser(webDriver, None)
         block(browser)
       } finally {
         if (browser != null) {

--- a/framework/src/play-test/src/main/scala/play/api/test/Specs.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Specs.scala
@@ -43,14 +43,19 @@ abstract class WithServer(val app: FakeApplication = FakeApplication(),
  * @param port The port to run the server on
  */
 abstract class WithBrowser[WEBDRIVER <: WebDriver](
-    val webDriver: Class[WEBDRIVER] = Helpers.HTMLUNIT,
+    val webDriver: WebDriver = WebDriverFactory(Helpers.HTMLUNIT),
     val app: FakeApplication = FakeApplication(),
     val port: Int = Helpers.testServerPort) extends Around with Scope {
+
+  def this(
+    webDriver: Class[WEBDRIVER],
+    app: FakeApplication,
+    port: Int) = this(WebDriverFactory(webDriver), app, port)
 
   implicit def implicitApp = app
   implicit def implicitPort: Port = port
 
-  lazy val browser: TestBrowser = TestBrowser.of(webDriver, Some("http://localhost:" + port))
+  lazy val browser: TestBrowser = TestBrowser(webDriver, Some("http://localhost:" + port))
 
   override def around[T: AsResult](t: => T): Result = {
     try {


### PR DESCRIPTION
This has been causing me a fair amount of trouble, so I'd love to see the fix included in 2.2.2

Commit from master: https://github.com/playframework/playframework/commit/71de3355e4ff18795789ca27cfffe67b93a525be
