### PR TITLE
Having a "messages/" directory under resources throws exception during startup, fails app

### DIFF
--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -7,6 +7,7 @@ import scala.language.postfixOps
 
 import play.api._
 import play.core._
+import play.utils.Resources
 
 import java.io._
 
@@ -326,7 +327,7 @@ class DefaultMessagesPlugin(app: Application) extends MessagesPlugin {
   }
 
   protected def loadMessages(file: String): Map[String, String] = {
-    app.classloader.getResources(joinPaths(messagesPrefix, file)).asScala.toList.reverse.map { messageFile =>
+    app.classloader.getResources(joinPaths(messagesPrefix, file)).asScala.toList.filterNot(Resources.isDirectory).reverse.map { messageFile =>
       Messages.messages(messageFile.asInput, messageFile.toString).fold(e => throw e, identity)
     }.foldLeft(Map.empty[String, String]) { _ ++ _ }
   }

--- a/framework/src/play/src/main/scala/play/utils/Resources.scala
+++ b/framework/src/play/src/main/scala/play/utils/Resources.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.utils
+
+import java.net.URL
+import java.io.File
+import java.util.zip.ZipFile
+
+/**
+ * Provide resources helpers
+ */
+object Resources {
+
+  def isDirectory(url: URL) = url.getProtocol match {
+    case "file" => new File(url.getFile).isDirectory
+    case "jar" => isJarResourceDirectory(url)
+    case _ => throw new IllegalArgumentException(s"Cannot check isDirectory for a URL with protocol='${url.getProtocol}'")
+  }
+
+  private def isJarResourceDirectory(url: URL): Boolean = {
+    val startIndex = if (url.getFile.startsWith("file:")) 5 else 0
+    val bangIndex = url.getFile.indexOf("!")
+    val jarFilePath = url.getFile.substring(startIndex, bangIndex)
+    val resourcePath = url.getFile.substring(bangIndex + 2)
+    val zip = new ZipFile(jarFilePath)
+
+    try {
+      val entry = zip.getEntry(resourcePath)
+      if (entry.isDirectory) true
+      else {
+        val stream = zip.getInputStream(entry)
+        val isDir = stream == null
+        if (stream != null) stream.close()
+        isDir
+      }
+    } finally {
+      zip.close()
+    }
+  }
+}

--- a/framework/src/play/src/test/scala/play/utils/ResourcesSpec.scala
+++ b/framework/src/play/src/test/scala/play/utils/ResourcesSpec.scala
@@ -1,0 +1,90 @@
+package play.utils
+
+import java.io.{FileInputStream, BufferedInputStream, File, FileOutputStream}
+import java.net.URL
+import java.util.zip.{ZipEntry, ZipOutputStream}
+import org.specs2.mutable.Specification
+
+/**
+ * Tests for Resources object
+ */
+object ResourcesSpec extends Specification {
+  import Resources._
+
+  lazy val tmpDir = createTempDir("resources-", ".tmp")
+  lazy val jar = File.createTempFile("jar-", ".tmp", tmpDir)
+  lazy val fileRes = File.createTempFile("file-", ".tmp", tmpDir)
+  lazy val dirRes = createTempDir("dir-", ".tmp", tmpDir)
+
+  sequential
+  "resources isDirectory" should {
+
+    step {
+      createZip(jar, Seq(fileRes, dirRes))
+    }
+
+    "return true for a directory resource URL with the 'file' protocol" in {
+      val url = new URL("file", "", dirRes.getAbsolutePath)
+      isDirectory(url) must beTrue
+    }
+
+    "return false for a file resource URL with the 'file' protocol" in {
+      val url = new URL("file", "", fileRes.getAbsolutePath)
+      isDirectory(url) must beFalse
+    }
+
+    "return true for a directory resource URL with the 'jar' protocol" in {
+      val url = new URL("jar", "", s"file:${jar.getAbsolutePath}!/${dirRes.getName}")
+      isDirectory(url) must beTrue
+    }
+
+    "return false for a file resource URL with the 'jar' protocol" in {
+      val url = new URL("jar", "", s"file:${jar.getAbsolutePath}!/${fileRes.getName}")
+      isDirectory(url) must beFalse
+    }
+
+    "throw an exception for a URL with a protocol other than 'file'/'jar'" in {
+      val url = new URL("ftp", "", "/some/path")
+      isDirectory(url) must throwAn[IllegalArgumentException]
+    }
+
+    step {
+      tmpDir.listFiles().foreach(f => f.delete())
+      tmpDir.delete()
+    }
+  }
+
+  private def createTempDir(prefix: String, suffix: String, parent: File = null) = {
+    val f = File.createTempFile(prefix, suffix, parent)
+    f.delete()
+    f.mkdir()
+    f
+  }
+
+  private def createZip(zip: File, files: Seq[File]) = {
+    val zipOutputStream = new ZipOutputStream(new FileOutputStream(zip))
+    addFileToZip(zipOutputStream, fileRes)
+    addFileToZip(zipOutputStream, dirRes)
+    zipOutputStream.close()
+  }
+
+  private def addFileToZip(zip: ZipOutputStream, file: File) = {
+    val entryName =
+      if (file.isDirectory) file.getName + "/"
+      else file.getName
+
+    zip.putNextEntry(new ZipEntry(entryName))
+
+    if (!file.isDirectory) {
+      val in = new BufferedInputStream(new FileInputStream(file))
+      var b = in.read()
+      while (b > -1) {
+        zip.write(b)
+        b = in.read()
+      }
+      in.close()
+    }
+
+    zip.closeEntry()
+  }
+}


### PR DESCRIPTION
It seems that having a non-empty `messages/` directory under any of the packaged `resources/` folders (for the play application or _one of the dependency jars_) causes a `Configuration error` and prevents the app from starting.
#### Reproducing
1. Create a new play app
2. Add `conf/messages/foo.ext` (simply adding `messages/` isn't enough, you need to add a file under it)
3. `run`/`start`/`test` the app

(You can also reproduce by creating a new app and adding a dependency jar, which has `src/main/resources/messages/foo.ext`)
#### Stack Trace

```
play> start

(Starting server. Type Ctrl+D to exit logs, the server will remain in background)

Play server process ID is 50664
Oops, cannot start the server.
@6gdk4kp1c: Configuration error in file:/Users/orr/Dev/Projects/play-messages-error/target/scala-2.10/classes/messages:1
    at play.api.i18n.Messages$MessagesParser.parse(Messages.scala:219)
    at play.api.i18n.MessagesPlugin$$anonfun$play$api$i18n$MessagesPlugin$$loadMessages$1.apply(Messages.scala:286)
    at play.api.i18n.MessagesPlugin$$anonfun$play$api$i18n$MessagesPlugin$$loadMessages$1.apply(Messages.scala:285)
    at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
    at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
    at scala.collection.immutable.List.foreach(List.scala:318)
    at scala.collection.TraversableLike$class.map(TraversableLike.scala:244)
    at scala.collection.AbstractTraversable.map(Traversable.scala:105)
    at play.api.i18n.MessagesPlugin.play$api$i18n$MessagesPlugin$$loadMessages(Messages.scala:285)
    at play.api.i18n.MessagesPlugin.messages$lzycompute(Messages.scala:296)
    at play.api.i18n.MessagesPlugin.messages(Messages.scala:292)
    at play.api.i18n.MessagesPlugin.onStart(Messages.scala:309)
    at play.api.Play$$anonfun$start$1$$anonfun$apply$mcV$sp$1.apply(Play.scala:88)
    at play.api.Play$$anonfun$start$1$$anonfun$apply$mcV$sp$1.apply(Play.scala:88)
    at scala.collection.immutable.List.foreach(List.scala:318)
    at play.api.Play$$anonfun$start$1.apply$mcV$sp(Play.scala:88)
    at play.api.Play$$anonfun$start$1.apply(Play.scala:88)
    at play.api.Play$$anonfun$start$1.apply(Play.scala:88)
    at play.utils.Threads$.withContextClassLoader(Threads.scala:18)
    at play.api.Play$.start(Play.scala:87)
    at play.core.StaticApplication.<init>(ApplicationProvider.scala:52)
    at play.core.server.NettyServer$.createServer(NettyServer.scala:243)
    at play.core.server.NettyServer$$anonfun$main$3.apply(NettyServer.scala:279)
    at play.core.server.NettyServer$$anonfun$main$3.apply(NettyServer.scala:274)
    at scala.Option.map(Option.scala:145)
    at play.core.server.NettyServer$.main(NettyServer.scala:274)
    at play.core.server.NettyServer.main(NettyServer.scala)
```
#### Problem Analysis

In `play.api.i18n.DefaultMessagesPlugin` the `messages` method, which gets called by `onStart()` -> `api` -> `messages`, calls `loadMessages("messages")`. `loadMessages` then uses `ClassLoader.getResources("messages")`, which also returns the directory we added to `conf/messages` (or found under any of the `resources/` of our dependency jars). Trying to run `parse` on that `messageFile: URL` results in the exception.

I think the preferred solution would be to only attempt to parse `messages` _files_ and not `messages/` _folders_. I'm not sure what's the best way to implement this though.

Leaving the current behavior makes it impossible to use 3rd party jars that have a `resources/messages/` folder, which is how I encountered this error in the first place (and prevents us from using Play at the moment).

I have no problem implementing a fix myself, if we can agree on the best way to safely ignore directory resources.
