### PR TITLE
Update Highlights22.md

### DIFF
--- a/documentation/manual/Highlights22.md
+++ b/documentation/manual/Highlights22.md
@@ -13,7 +13,7 @@ In Java applications, this means actions can now just return `Promise<SimpleResu
 ```scala
 def index = Action.async {
   val foo: Future[Foo] = getFoo()
-  foo.map(f => Ok(foo))
+  foo.map(f => Ok(f))
 }
 ```
 


### PR DESCRIPTION
The 'foo' variable listed in the Ok() method on line 16 was incorrect. Ok() needs to wrap the result of foo, or f.
