### PR TITLE
Added min-height to article of document

### DIFF
--- a/documentation/style/main.css
+++ b/documentation/style/main.css
@@ -10,7 +10,8 @@ blockquote,q{quotes:"" "";}
 ol,ul{list-style:none;}
 hr{display:none;visibility:hidden;}
 :focus{outline:0;}
-article{}article h1,article h2,article h3,article h4,article h5,article h6{color:#333;font-weight:bold;line-height:1.25;margin-top:1.3em;}
+article{min-height: 1860px;}
+article h1,article h2,article h3,article h4,article h5,article h6{color:#333;font-weight:bold;line-height:1.25;margin-top:1.3em;}
 article h1 a,article h2 a,article h3 a,article h4 a,article h5 a,article h6 a{font-weight:inherit;color:#333;}article h1 a:hover,article h2 a:hover,article h3 a:hover,article h4 a:hover,article h5 a:hover,article h6 a:hover{color:#333;}
 article h1{font-size:36px;margin:0 0 18px;border-bottom:4px solid #eee;}
 article h2{font-size:25px;margin-bottom:9px;border-bottom:2px solid #eee;}


### PR DESCRIPTION
Current document is broken layout when article is short, as follows:
- http://www.playframework.com/documentation/2.2.x/SBTSettings
- http://www.playframework.com/documentation/2.3-SNAPSHOT/ThirdPartyTools
- http://www.playframework.com/documentation/2.3-SNAPSHOT/Issues

css styles don't consider the sidebar height, and so I fixed it.

But I have a problem.
It is that original css styles looks harmless on local server, because local layout is different from official web layout.
So I can't check absolutely...

I've upload screenshots to make sure.
## before
- official web

![web](http://gyazo.com/033a4bc9957825d06ec9896eda8a126d.png)
- local

![local](http://gyazo.com/0d1b04e7e5baa22f1e8570b7ac711ae1.png)
## after
- official web

![web1](http://gyazo.com/65d1a08bd9210a0952734d546c1be922.png)

![web2](http://gyazo.com/b7cc9830c548393ce640d38d611575ca.png)
- local

![loca](http://gyazo.com/2da3247dbca3c808eae26d0de9bcb84d.png)
