### PR TITLE
Intellij friendly error message

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/views/DevErrorPageSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/views/DevErrorPageSpec.scala
@@ -1,0 +1,43 @@
+package play.it.views
+
+import play.api.test.PlaySpecification
+
+import play.api.test._
+import play.api.DefaultGlobal
+import java.lang.String
+import scala.Predef.String
+
+object DevErrorPageSpec extends PlaySpecification{
+
+
+  "devError.scala.html" should {
+
+    val testExceptionSource = new play.api.PlayException.ExceptionSource("test","making sure the link shows up") {
+      def line = 100.asInstanceOf[Integer]
+      def position = 20.asInstanceOf[Integer]
+      def input = "test"
+      def sourceName = "someSourceFile"
+    }
+
+    "link the error line if play.editor is configured" in {
+        try {
+          System.setProperty("play.editor", "someEditorLinkWith %s:%s")
+          val result = DefaultGlobal.onError(FakeRequest(), testExceptionSource)
+          Helpers.contentAsString(result) must contain("""href="someEditorLinkWith someSourceFile:100" """)
+        } finally {
+          System.clearProperty("play.editor")
+        }
+    }
+
+    "show prod error page in prod mode" in {
+      val fakeApplication = new FakeApplication() {
+        override val mode = play.api.Mode.Prod
+      }
+      running(fakeApplication) {
+        val result = DefaultGlobal.onError(FakeRequest(), testExceptionSource)
+        Helpers.contentAsString(result) must contain("Oops, an error occured")
+      }
+    }
+  }
+
+}

--- a/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
+++ b/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
@@ -126,11 +126,13 @@ trait GlobalSettings {
    * @return The result to send to the client
    */
   def onError(request: RequestHeader, ex: Throwable): Future[SimpleResult] = {
+    def devError = views.html.defaultpages.devError(Option(System.getProperty("play.editor"))) _
+    def prodError = views.html.defaultpages.error.f
     try {
       Future.successful(InternalServerError(Play.maybeApplication.map {
-        case app if app.mode != Mode.Prod => views.html.defaultpages.devError.f
-        case app => views.html.defaultpages.error.f
-      }.getOrElse(views.html.defaultpages.devError.f) {
+        case app if app.mode == Mode.Prod => prodError
+        case app => devError
+      }.getOrElse(devError) {
         ex match {
           case e: UsefulException => e
           case NonFatal(e) => UnexpectedException(unexpected = Some(e))

--- a/framework/src/play/src/main/scala/views/defaultpages/devError.scala.html
+++ b/framework/src/play/src/main/scala/views/defaultpages/devError.scala.html
@@ -2,7 +2,7 @@
  * Default page for 500 Internal Server Error responses, in development mode.
  * This page display the error in the source code context.
  *@
-@(error: play.api.UsefulException)
+@(playEditor: Option[String])(error: play.api.UsefulException)
 
 <!DOCTYPE html>
 <html>
@@ -25,7 +25,10 @@
 		        border-bottom: 1px solid #690000;
 		        font-size: 28px;
 		    }
-		    p#detail {
+            a {
+                color: #D36D6D;
+            }
+            p#detail {
 		        margin: 0;
 		        padding: 15px 45px;
 		        background: #F5A0A0;
@@ -133,12 +136,17 @@
 						In @Option(source.line).fold {
                           @name (line number not found)
                         }{line =>
-                          @name:@line
+                          @playEditor.fold {
+                            @name:@line
+                          } { link =>
+                            <iframe name="_onlyForFiringEditorLink" style="display:none;"></iframe>
+                            <a href="@{link.format(name, line)}" target="_onlyForFiringEditorLink">@name:@line</a>
+                          }
                         }
 					</h2>
 
                     <div id="source-code">
-    					@Option(source.interestingLines(4)).map { 
+    					@Option(source.interestingLines(4)).map {
 
     						case interesting => {
 


### PR DESCRIPTION
I don't know whether anybody cares about this but I like the fact that you can copy filename with line and IntelliJ takes you right to that line. I can do that with the compilation error messages in the console but from the error message we show in the browser. This pull request kinda fix that so that error message have xxx.scala:<some line number> for me to copy and paste.
