### PR TITLE
Ok.chunked is  *not* ignoring empty blocks

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
@@ -664,6 +664,10 @@ object Enumeratee {
     }
   }
 
+  /**
+   * An enumeratee that passes all input through until EOF is reached, redeeming the final iteratee with EOF as the
+   * left over input.
+   */
   def passAlong[M] = new Enumeratee.CheckDone[M, M] {
 
     def step[A](k: K[M, A]): K[M, Iteratee[M, A]] = {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -221,6 +221,14 @@ object ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient {
       response.body must beLeft
     }
 
+    "not send empty chunks before the end of the enumerator stream" in makeRequest(
+      Results.Ok.chunked(Enumerator("foo", "", "bar"))
+    ) { response =>
+      response.header(TRANSFER_ENCODING) must beSome("chunked")
+      response.header(CONTENT_LENGTH) must beNone
+      response.body must_== "foobar"
+    }
+
   }
 
 }


### PR DESCRIPTION
We recently faced this issue when streaming file contents as Ok.Chunked. The contents of the file is split into multiple Enumerators and all these enumerators are chained together. If any of the enumerator in the chain ends up with an empty contents Ok.chunked terminates the connection.It would be nice if Ok.chunked could only do that when it reaches EOF.

  `def index = Action {    
         Ok.chunked(
           Enumerator("some lines" * 100)
             .andThen(Enumerator(""))
             .andThen(Enumerator("some more lines" * 100))
        )
  }`

Right now I am using Enumeratee.filter to fix this issue but the current behavior did took me and @brikis98 as surprise.
