### PR TITLE
Replace the usage of the deprecated Akka.future() way of invoking async ...

### DIFF
--- a/documentation/manual/Migration22.md
+++ b/documentation/manual/Migration22.md
@@ -118,9 +118,9 @@ Previously, futures in async actions had to be wrapped in the `async` call.  Now
 
 ```java
 public static Promise<Result> myAsyncAction() {
-    Promise<Integer> promiseOfInt = play.libs.Akka.future(
-    new Callable<Integer>() {
-      public Integer call() {
+  Promise<Integer> promiseOfInt = Promise.promise(
+    new Function0<Integer>() {
+      public Integer apply() {
         return intensiveComputation();
       }
     }
@@ -129,7 +129,7 @@ public static Promise<Result> myAsyncAction() {
     new Function<Integer, Result>() {
       public Result apply(Integer i) {
         return ok("Got result: " + i);
-      } 
+      }
     }
   );
 }


### PR DESCRIPTION
...code.

With reference to this discussion in the group: https://groups.google.com/d/msg/play-framework/uVHF-nRX93U/m4oZ8WNHcGIJ

Replaced the deprecated Akka.future() [1] method with the suggested Promise.promise() [2] method.

[1] https://github.com/playframework/playframework/blob/2.2.x/framework/src/play/src/main/java/play/libs/Akka.java#L41
[2] https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/java/play/libs/F.java#L225
