### PR TITLE
Clarify documentation on Action asynchronicity

### DIFF
--- a/documentation/manual/javaGuide/main/async/JavaAsync.md
+++ b/documentation/manual/javaGuide/main/async/JavaAsync.md
@@ -1,15 +1,21 @@
-<!--- Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com> -->
+<!--- Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com> -->
 # Handling asynchronous results
 
-## Why asynchronous results?
+## Make controllers asynchronous
 
-Until now, we have been able to compute the result to send to the web client directly. This is not always the case: the result may depend on an expensive computation or on a long web service call.
+Internally, Play Framework is asynchronous from the bottom up. Play always handles requests in an asynchronous, non-blocking way.
 
-Because of the way Play works, action code must be as fast as possible (i.e. non blocking). So what should we return from our action if we are not yet able to compute the result? We should return the *promise* of a result!
+The default configuration is tuned for asynchronous controllers. In other words, the application code should avoid blocking in controllers, i.e., having the controller code wait for an operation. Common examples of such blocking operations are JDBC calls, streaming API, HTTP requests and long computations.
+
+Although it's possible to increase the number of threads in the default execution context to allow more concurrent requests to be processed by blocking controllers, following the recommended approach of keeping the controllers asynchronous makes it easier to scale and to keep the system responsive under load.
+
+## Creating non-blocking actions
+
+Because of the way Play works, action code must be as fast as possible, i.e., non-blocking. So what should we return from our action if we are not yet able to compute the result? We should return the *promise* of a result!
 
 A `Promise<Result>` will eventually be redeemed with a value of type `Result`. By using a `Promise<Result>` instead of a normal `Result`, we are able to return from our action quickly without blocking anything. Play will then serve the result as soon as the promise is redeemed.
 
-The web client will be blocked while waiting for the response but nothing will be blocked on the server, and server resources can be used to serve other clients.
+The web client will be blocked while waiting for the response, but nothing will be blocked on the server, and server resources can be used to serve other clients.
 
 ## How to create a `Promise<Result>`
 
@@ -25,12 +31,24 @@ A simple way to execute a block of code asynchronously and to get a `Promise` is
 
 @[promise-async](code/javaguide/async/JavaAsync.java)
 
-> **Note:** Here, the intensive computation will just be run on another thread. It is also possible to run it remotely on a cluster of backend servers using Akka remote.
+> **Note:** It's important to understand which thread code runs on with promises. Here, the intensive computation will just be run on another thread.
+>
+> You can't magically turn synchronous IO into asynchronous by wrapping it in a `Promise`. If you can't change the application's architecture to avoid blocking operations, at some point that operation will have to be executed, and that thread is going to block. So in addition to enclosing the operation in a `Promise`, it's necessary to configure it to run in a separate execution context that has been configured with enough threads to deal with the expected concurrency. See [[Understanding Play thread pools|ThreadPools]] for more information.
+>
+> It can also be helpful to use Actors for blocking operations. Actors provide a clean model for handling timeouts and failures, setting up blocking execution contexts, and managing any state that may be associated with the service. Also Actors provide patterns like `ScatterGatherFirstCompletedRouter` to address simultaneous cache and database requests and allow remote execution on a cluster of backend servers. But an Actor may be overkill depending on what you need.
 
 ## Async results
 
 We have been returning `Result` up until now. To send an asynchronous result our action needs to return a `Promise<Result>`:
 
 @[async](code/javaguide/async/controllers/Application.java)
+
+## Actions are asynchronous by default
+
+Play [[actions|JavaActions]] are asynchronous by default. For instance, in the controller code below, the returned `Result` is internally enclosed in a promise:
+
+@[simple-action](../http/code/javaguide/http/JavaActions.java)
+
+> **Note:** Whether the action code returns a `Result` or a `Promise<Result>`, both kinds of returned object are handled internally in the same way. There is a single kind of `Action`, which is asynchronous, and not two kinds (a synchronous one and an asynchronous one). Returning a `Promise` is a technique for writing non-blocking code.
 
 > **Next:** [[Streaming HTTP responses | JavaStream]]

--- a/documentation/manual/scalaGuide/main/async/ScalaAsync.md
+++ b/documentation/manual/scalaGuide/main/async/ScalaAsync.md
@@ -1,13 +1,19 @@
-<!--- Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com> -->
+<!--- Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com> -->
 # Handling asynchronous results
 
-## Why asynchronous results?
+## Make controllers asynchronous
 
-Until now, we were able to generate the result to send to the web client directly. However, this is not always the case: the result might depend on an expensive computation or on a long web service call.
+Internally, Play Framework is asynchronous from the bottom up. Play always handles requests in an asynchronous, non-blocking way.
 
-Because of the way Play works, the action code must be as fast as possible (ie. non blocking). So what should we return as result if we are not yet able to generate it? The response is a future result! 
+The default configuration is tuned for asynchronous controllers. In other words, the application code should avoid blocking in controllers, i.e., having the controller code wait for an operation. Common examples of such blocking operations are JDBC calls, streaming API, HTTP requests and long computations.
 
-A `Future[Result]` will eventually be redeemed with a value of type `Result`. By giving a `Future[Result]` instead of a normal `Result`, we are able to quickly generate the result without blocking. Then, Play will serve this result as soon as the promise is redeemed. 
+Although it's possible to increase the number of threads in the default execution context to allow more concurrent requests to be processed by blocking controllers, following the recommended approach of keeping the controllers asynchronous makes it easier to scale and to keep the system responsive under load.
+
+## Creating non-blocking actions
+
+Because of the way Play works, action code must be as fast as possible, i.e., non-blocking. So what should we return as result if we are not yet able to generate it? The response is a *future* result!
+
+A `Future[Result]` will eventually be redeemed with a value of type `Result`. By giving a `Future[Result]` instead of a normal `Result`, we are able to quickly generate the result without blocking. Play will then serve the result as soon as the promise is redeemed.
 
 The web client will be blocked while waiting for the response, but nothing will be blocked on the server, and server resources can be used to serve other clients.
 
@@ -23,13 +29,25 @@ Here is a simple way to execute a block of code asynchronously and to get a `Fut
 
 @[intensive-computation](code/ScalaAsync.scala)
 
-It's important to understand which thread code runs on with futures.  In the two code blocks above, there is an import on Plays default execution context.  This is an implicit parameter that gets passed to all methods on the future API that accept callbacks.  The execution context will often be equivalent to a thread pool, though not necessarily.
+> **Note:** It's important to understand which thread code runs on with futures. In the two code blocks above, there is an import on Plays default execution context. This is an implicit parameter that gets passed to all methods on the future API that accept callbacks. The execution context will often be equivalent to a thread pool, though not necessarily.
+>
+> You can't magically turn synchronous IO into asynchronous by wrapping it in a `Future`. If you can't change the application's architecture to avoid blocking operations, at some point that operation will have to be executed, and that thread is going to block. So in addition to enclosing the operation in a `Future`, it's necessary to configure it to run in a separate execution context that has been configured with enough threads to deal with the expected concurrency. See [[Understanding Play thread pools|ThreadPools]] for more information.
+>
+> It can also be helpful to use Actors for blocking operations. Actors provide a clean model for handling timeouts and failures, setting up blocking execution contexts, and managing any state that may be associated with the service. Also Actors provide patterns like `ScatterGatherFirstCompletedRouter` to address simultaneous cache and database requests and allow remote execution on a cluster of backend servers. But an Actor may be overkill depending on what you need.
 
 ## Returning futures
 
-While we were using the `Action.apply` builder methods to build actions until now, to send an asynchronous result, we need to use the `Action.async` builder method:
+While we were using the `Action.apply` builder method to build actions until now, to send an asynchronous result we need to use the `Action.async` builder method:
 
 @[async-result](code/ScalaAsync.scala)
+
+## Actions are asynchronous by default
+
+Play [[actions|ScalaActions]] are asynchronous by default. For instance, in the controller code below, the `{ Ok(...) }` part of the code is not the method body of the controller. It is an anonymous function that is being passed to the `Action` object's `apply` method, which creates an object of type `Action`. Internally, the anonymous function that you wrote will be called and its result will be enclosed in a `Future`.
+
+@[echo-action](../http/code/ScalaActions.scala)
+
+> **Note:** Both `Action.apply` and `Action.async` create `Action` objects that are handled internally in the same way. There is a single kind of `Action`, which is asynchronous, and not two kinds (a synchronous one and an asynchronous one). The `.async` builder is just a facility to simplify creating actions based on APIs that return a `Future`, which makes it easier to write non-blocking code.
 
 ## Handling time-outs
 


### PR DESCRIPTION
When someone is learning about the Play framework, it takes some time to realize that Action { } and Action.async { } are both asynchronous.

In the Main concepts topic, [HTTP programming](http://www.playframework.com/documentation/2.2.x/ScalaActions) talks about Actions, without mentioning asynchronicity. [Asynchronous HTTP programming](http://www.playframework.com/documentation/2.2.x/ScalaAsync) discusses Action.async without mentioning that regular Action is also async. In fact, the text under "Why asynchronous results?" leads newcomers to the impression that in order to an action to be asynchronous you need to explicitly create a Future[Result] and return it with Action.async.

The [async by default forum thread](https://groups.google.com/d/msg/play-framework-dev/30MqnKDp0Fs/25PU-Y0RhGoJ) explains clearly how things actually work, but it's not easily discoverable.

the [Should you always use Action.async? forum thread](https://groups.google.com/forum/#!topic/play-framework/WWQ0HeLDOjg) adds additional information and serves as an example of the common misunderstandings.

I propose that someone knowledgeable of Play's internals add some clarification about this, possibly in the [Handling asynchronous results documentation page](http://www.playframework.com/documentation/2.2.x/ScalaAsync), explaining that Actions are async by default. Some additional information or links to related concepts such as common patters for using thread pools, Actors, etc., as explained in the forum threads above, would also be great.
