### PR TITLE
single quotes in html to avoid double double quotes

### DIFF
--- a/framework/skeletons/scala-skel/app/views/main.scala.html
+++ b/framework/skeletons/scala-skel/app/views/main.scala.html
@@ -5,9 +5,9 @@
 <html>
     <head>
         <title>@title</title>
-        <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/main.css")">
-        <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
-        <script src="@routes.Assets.at("javascripts/jquery-1.9.0.min.js")" type="text/javascript"></script>
+        <link rel="stylesheet" media="screen" href='@routes.Assets.at("stylesheets/main.css")'>
+        <link rel="shortcut icon" type="image/png" href='@routes.Assets.at("images/favicon.png")'>
+        <script src='@routes.Assets.at("javascripts/jquery-1.9.0.min.js")' type="text/javascript"></script>
     </head>
     <body>
         @content


### PR DESCRIPTION
This cleans up issues in IDE's and other syntax highlighting locations (e.g. GitHubs inline editor)
