### PR TITLE
Correct description of absoluteURL and webSocketURL

### DIFF
--- a/documentation/manual/scalaGuide/advanced/routing/ScalaJavascriptRouting.md
+++ b/documentation/manual/scalaGuide/advanced/routing/ScalaJavascriptRouting.md
@@ -75,4 +75,3 @@ If jQuery isn't your thing, or if you'd like to decorate the jQuery ajax method 
 To define this function, in your action pass the ``ajaxMethod`` method parameter, eg:
 
     Routes.javascriptRouter("jsRoutes", Some("myAjaxFunction") ...
-ws = new WebSocket(ws_addr.webSocketURL())


### PR DESCRIPTION
"absoluteURL" and "webSocketURL" are not properties. They are methods which must be called with "()" at the end in order to get the string representing the URL. That's different from getting the url using the "url" property, which is already a string property.
