### PR TITLE
remove excessive trailing newlines from skeletons

### DIFF
--- a/framework/skeletons/java-skel/conf/application.conf
+++ b/framework/skeletons/java-skel/conf/application.conf
@@ -66,4 +66,3 @@ logger.play=INFO
 
 # Logger provided to your application:
 logger.application=DEBUG
-

--- a/framework/skeletons/scala-skel/conf/application.conf
+++ b/framework/skeletons/scala-skel/conf/application.conf
@@ -56,4 +56,3 @@ logger.play=INFO
 
 # Logger provided to your application:
 logger.application=DEBUG
-


### PR DESCRIPTION
New applications are being generated with 2 blank lines in the end of application.conf. This patch normalizes it to just one trailing newline, like the rest of the files.
