### PR TITLE
Fixed SSE event name regression

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
@@ -56,7 +56,7 @@ object EventSource {
      */
     lazy val formatted = {
       val sb = new StringBuilder
-      name.foreach(sb.append("name: ").append(_).append('\n'))
+      name.foreach(sb.append("event: ").append(_).append('\n'))
       id.foreach(sb.append("id: ").append(_).append('\n'))
       for (line <- data.split("(\r?\n)|\r")) {
         sb.append("data: ").append(line).append('\n')

--- a/framework/src/play/src/test/scala/play/api/libs/EventSourceSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/EventSourceSpec.scala
@@ -17,7 +17,7 @@ object EventSourceSpec extends Specification {
     }
 
     "format an event with a name" in {
-      Event("foo", None, Some("message")).formatted must equalTo ("name: message\ndata: foo\n\n")
+      Event("foo", None, Some("message")).formatted must equalTo ("event: message\ndata: foo\n\n")
     }
 
     "split data by lines" in {


### PR DESCRIPTION
The SSE event name should be prefixed with the event: tag, not name:, according to http://www.w3.org/TR/2009/WD-eventsource-20091029/.

This is a regression just on master, the code is fine on 2.2.x and earlier.
