### PR TITLE
Fix onHandlerNotFound not receiving requests modified by upstream filter...

### DIFF
--- a/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
+++ b/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
@@ -77,7 +77,7 @@ trait GlobalSettings {
    * Default is: route, tag request, then apply filters
    */
   def onRequestReceived(request: RequestHeader): (RequestHeader, Handler) = {
-    val notFoundHandler = Action.async(BodyParsers.parse.empty)(_ => this.onHandlerNotFound(request))
+    val notFoundHandler = Action.async(BodyParsers.parse.empty)(this.onHandlerNotFound)
     val (routedRequest, handler) = onRouteRequest(request) map {
       case handler: RequestTaggingHandler => (handler.tagRequest(request), handler)
       case otherHandler => (request, otherHandler)


### PR DESCRIPTION
The onRequestReceived implementation was always passing the original RequestHeader to onHandlerNotFound, and ignoring the value passed in. If any filters had been applied that modified the request and passed it along the chain (e.g. making a copy and injecting additional headers/cookies) those changes weren't visible to the 404 handler.
