### PR TITLE
Ensure byte code enhancer updates incremental compiler analysis

### DIFF
--- a/framework/src/sbt-link/src/main/java/play/core/enhancers/PropertiesEnhancer.java
+++ b/framework/src/sbt-link/src/main/java/play/core/enhancers/PropertiesEnhancer.java
@@ -138,17 +138,17 @@ public class PropertiesEnhancer {
         }
     }
     
-    public static void rewriteAccess(String classpath, File classFile) throws Exception {
+    public static boolean rewriteAccess(String classpath, File classFile) throws Exception {
         ClassPool classPool = new ClassPool();
         classPool.appendSystemPath();
         classPool.appendPathList(classpath);
-        
+
         FileInputStream is = new FileInputStream(classFile);
         try {
             CtClass ctClass = classPool.makeClass(is);
             if(hasAnnotation(ctClass, RewrittenAccessor.class)) {
                 is.close();
-                return;
+                return false;
             }
             
             for (final CtBehavior ctMethod : ctClass.getDeclaredBehaviors()) {
@@ -206,6 +206,7 @@ public class PropertiesEnhancer {
             }
             throw e;
         }
+        return true;
     }
     
     // --

--- a/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
@@ -13,6 +13,8 @@ import java.lang.{ ProcessBuilder => JProcessBuilder }
 import sbt.complete.Parsers._
 
 import scala.util.control.NonFatal
+import sbt.inc.{ Analysis, Stamp }
+import sbt.compiler.AggressiveCompile
 
 trait PlayCommands extends PlayAssetsCompiler with PlayEclipse with PlayInternalKeys {
   this: PlayReloader =>
@@ -93,7 +95,7 @@ trait PlayCommands extends PlayAssetsCompiler with PlayEclipse with PlayInternal
 
   // ----- Post compile (need to be refactored and fully configurable)
 
-  def PostCompile(scope: Configuration) = (sourceDirectory in scope, dependencyClasspath in scope, compile in scope, javaSource in scope, sourceManaged in scope, classDirectory in scope, cacheDirectory in scope) map { (src, deps, analysis, javaSrc, srcManaged, classes, cacheDir) =>
+  def PostCompile(scope: Configuration) = (sourceDirectory in scope, dependencyClasspath in scope, compile in scope, javaSource in scope, sourceManaged in scope, classDirectory in scope, cacheDirectory in scope, compileInputs in compile in scope) map { (src, deps, analysis, javaSrc, srcManaged, classes, cacheDir, inputs) =>
 
     val classpath = (deps.map(_.data.getAbsolutePath).toArray :+ classes.getAbsolutePath).mkString(java.io.File.pathSeparator)
 
@@ -115,7 +117,7 @@ trait PlayCommands extends PlayAssetsCompiler with PlayEclipse with PlayInternal
 
     javaClasses.foreach(play.core.enhancers.PropertiesEnhancer.generateAccessors(classpath, _))
     javaClasses.foreach(play.core.enhancers.PropertiesEnhancer.rewriteAccess(classpath, _))
-    templateClasses.foreach(play.core.enhancers.PropertiesEnhancer.rewriteAccess(classpath, _))
+    val enhancedTemplateClasses = templateClasses.filter(play.core.enhancers.PropertiesEnhancer.rewriteAccess(classpath, _))
 
     IO.write(timestampFile, System.currentTimeMillis.toString)
 
@@ -163,6 +165,7 @@ trait PlayCommands extends PlayAssetsCompiler with PlayEclipse with PlayInternal
       }
     }
     // Copy managed classes - only needed in Compile scope
+    // This is done to ease integration with Eclipse, but it's doubtful as to how effective it is.
     if (scope.name.toLowerCase == "compile") {
       val managedClassesDirectory = classes.getParentFile / (classes.getName + "_managed")
 
@@ -176,7 +179,32 @@ trait PlayCommands extends PlayAssetsCompiler with PlayEclipse with PlayInternal
       // Remove deleted class files
       (managedClassesDirectory ** "*.class").get.filterNot(managedSet.contains(_)).foreach(_.delete())
     }
-    analysis
+
+    if (!enhancedTemplateClasses.isEmpty) {
+      // Since we may have modified some of the products of the incremental compiler, that is, the compiled template
+      // classes, we need to update their timestamps in the incremental compiler, otherwise the incremental compiler will
+      // see that they've changed since it last compiled them, and recompile them.
+      val updatedAnalysis = analysis.copy(stamps = templateClasses.foldLeft(analysis.stamps) { (stamps, classFile) =>
+        stamps.markProduct(classFile, Stamp.lastModified(classFile))
+      })
+
+      // Need to persist the updated analysis.
+      val agg = new AggressiveCompile(inputs.incSetup.cacheFile)
+      // Load the old one. We do this so that we can get a copy of CompileSetup, which is the cache compiler
+      // configuration used to determine when everything should be invalidated. We could calculate it ourselves, but
+      // that would by a heck of a lot of fragile code due to the vast number of things we would have to depend on.
+      // Reading it out of the existing file is good enough.
+      val existing: Option[(Analysis, CompileSetup)] = agg.store.get()
+      // Since we've just done a compile before this task, this should never return None, so don't worry about what to
+      // do when it returns None.
+      existing.foreach {
+        case (_, compileSetup) => agg.store.set(updatedAnalysis, compileSetup)
+      }
+
+      updatedAnalysis
+    } else {
+      analysis
+    }
   }
 
   // ----- Play prompt


### PR DESCRIPTION
In SBT 0.13.1, a feature was added to the incremental compiler that meant that products (class files) were invalidated if their modification date changed, where previously the only check that was done was whether they existed.

Play's byte code enhancement enhances Scala template classes, and this enhancement was updating the modification date, naturally causing the incremental compiler to invalidate the classes on its next run, and recompiling them unnecessarily.  

This change updates the analysis object after Play has modified any template files, and then writes the updated analysis out to disk.
