### PR TITLE
Append the value of the Vary header instead of overwriting it in the Gzip filter.

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -185,7 +185,17 @@ class GzipFilter(gzip: Enumeratee[Array[Byte], Array[Byte]] = Gzip.gzip(GzipFilt
   private def isNotAlreadyCompressed(header: ResponseHeader) = header.headers.get(Names.CONTENT_ENCODING).isEmpty
 
   private def setupHeader(header: Map[String, String]): Map[String, String] = {
-    header.filterNot(_._1 == Names.CONTENT_LENGTH) + (Names.CONTENT_ENCODING -> "gzip") + (Names.VARY -> Names.ACCEPT_ENCODING)
+    header.filterNot(_._1 == Names.CONTENT_LENGTH) + (Names.CONTENT_ENCODING -> "gzip") + addToVaryHeader(header, Names.VARY, Names.ACCEPT_ENCODING)
+  }
+
+  /**
+   * There may be an existing Vary value, which we must add to (comma separated)
+   */
+  private def addToVaryHeader(existingHeaders: Map[String, String], headerName: String, headerValue: String): (String, String) = {
+    existingHeaders.get(headerName) match {
+      case None => (headerName, headerValue)
+      case Some(existing) => (headerName, s"$existing,$headerValue")
+    }
   }
 }
 

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -127,6 +127,12 @@ object GzipFilterSpec extends PlaySpecification with DataTables {
       checkGzipped(result)
       header(LOCATION, result) must beSome("/foo")
     }
+
+    "preserve original Vary header values" in withApplication(Ok("hello").withHeaders(VARY -> "original")) {
+      val result = makeGzipRequest
+      checkGzipped(result)
+      header(VARY, result) must beSome.which(header => header contains "original,")
+    }
   }
 
   def withApplication[T](result: SimpleResult, buffer: Int = 1024)(block: => T): T = {


### PR DESCRIPTION
After enabling the GzipFilter we noticed it would overwrite the value of the existing 'Vary' header. We vary the response on multiple request headers, so this breaks our varnish caching.

This patch just appends "Accept Encoding" to the existing vary header value (separated by a comma).
