### PR TITLE
Fixed typo in documentation on Assets.

### DIFF
--- a/documentation/manual/detailedTopics/assets/Assets.md
+++ b/documentation/manual/detailedTopics/assets/Assets.md
@@ -124,7 +124,7 @@ Usually, using Etag is enough to have proper caching. However if you want to spe
 
 ## Managed assets
 
-By default play compiles all managed assets that are kept in the ```app/assets``` folder. The compilation process will clean and recompile all managed assets regardless of the change. This is the safest strategy since tracking dependencies can be very tricky with front end technologies. 
+By default Play compiles all managed assets that are kept in the ```app/assets``` folder. The compilation process will clean and recompile all managed assets regardless of the change. This is the safest strategy since tracking dependencies can be very tricky with front end technologies. 
 
 You will learn more about managed assets on the next few pages.
 


### PR DESCRIPTION
In section "Managed assets", Play was written with a lowercased "p".
