### PR TITLE
Fix for Java Message Arguments handling

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
@@ -24,6 +24,32 @@ object MessagesSpec extends PlaySpecification with Controller {
       msg must ===("Required!")
     }
   }
+  
+  "Messages@Java" should{
+    import play.i18n._
+    import java.util
+    val app = FakeApplication()
+    val enUS: Lang = new play.i18n.Lang(play.api.i18n.Lang("en-US"))
+    "allow translation without parameters" in new WithApplication(app) {
+      val msg = Messages.get(enUS, "constraint.email")
+      
+      msg must ===("Email")
+    }
+    "allow translation with any non-list parameter" in new WithApplication(app) {
+      val msg = Messages.get(enUS, "constraint.min", "Croissant")
+
+      msg must ===("Minimum value: Croissant")
+    }
+    "allow translation with any list parameter" in new WithApplication(app) {
+      val msg = {
+        val list: util.ArrayList[String] = new util.ArrayList[String]()
+        list.add("Croissant")
+        Messages.get(enUS, "constraint.min", list)
+      }
+
+      msg must ===("Minimum value: Croissant")
+    }
+  }
 }
 
 

--- a/framework/src/play/src/main/java/play/i18n/Messages.java
+++ b/framework/src/play/src/main/java/play/i18n/Messages.java
@@ -3,6 +3,7 @@
  */
 package play.i18n;
 
+import org.apache.commons.lang3.ArrayUtils;
 import scala.collection.mutable.Buffer;
 
 import java.util.Arrays;
@@ -27,6 +28,36 @@ public class Messages {
     }
 
     /**
+     * Converts the varargs to a scala buffer, 
+     * takes care of wrapping varargs into a intermediate list if necessary
+     * 
+     * @param args the message arguments 
+     * @return scala type for message processing
+     */
+    private static Buffer<Object> convertArgsToScalaBuffer(final Object... args) {
+        return scala.collection.JavaConverters.asScalaBufferConverter(wrapArgsToListIfNeeded(args)).asScala();
+    }
+
+    /**
+     * Wraps arguments passed into a list if necessary. 
+     *
+     * Returns the first value as is if it is the only argument and a subtype of `java.util.List` 
+     * Otherwise, it calls Arrays.asList on args
+     * @param args arguments as a List
+     */
+    static <T> List<T> wrapArgsToListIfNeeded(final T... args) {
+        List<T> out = null;
+        if (ArrayUtils.isNotEmpty(args)
+            && args.length == 1
+            && args[0] instanceof List){
+            out = (List<T>) args[0];
+        }else{
+            out = Arrays.asList(args);
+        }
+        return out;
+    }
+
+    /**
     * Translates a message.
     *
     * Uses `java.text.MessageFormat` internally to format the message.
@@ -37,7 +68,7 @@ public class Messages {
     * @return the formatted message or a default rendering if the key wasn't defined
     */
     public static String get(Lang lang, String key, Object... args) {
-        Buffer<Object> scalaArgs = scala.collection.JavaConverters.asScalaBufferConverter(Arrays.asList(args)).asScala();
+        Buffer<Object> scalaArgs = convertArgsToScalaBuffer(args);
         return play.api.i18n.Messages.apply(key, scalaArgs, lang);
     }
 
@@ -53,7 +84,7 @@ public class Messages {
     */
     public static String get(Lang lang, List<String> keys, Object... args) {
         Buffer<String> keyArgs = scala.collection.JavaConverters.asScalaBufferConverter(keys).asScala();
-        Buffer<Object> scalaArgs = scala.collection.JavaConverters.asScalaBufferConverter(Arrays.asList(args)).asScala();
+        Buffer<Object> scalaArgs = convertArgsToScalaBuffer(args);
         return play.api.i18n.Messages.apply(keyArgs.toSeq(), scalaArgs, lang);
     }
 
@@ -67,7 +98,7 @@ public class Messages {
     * @return the formatted message or a default rendering if the key wasn't defined
     */
     public static String get(String key, Object... args) {
-        Buffer<Object> scalaArgs = scala.collection.JavaConverters.asScalaBufferConverter(Arrays.asList(args)).asScala();
+        Buffer<Object> scalaArgs = convertArgsToScalaBuffer(args);
         return play.api.i18n.Messages.apply(key, scalaArgs, getLang());
     }
 
@@ -82,7 +113,7 @@ public class Messages {
     */
     public static String get(List<String> keys, Object... args) {
         Buffer<String> keyArgs = scala.collection.JavaConverters.asScalaBufferConverter(keys).asScala();
-        Buffer<Object> scalaArgs = scala.collection.JavaConverters.asScalaBufferConverter(Arrays.asList(args)).asScala();
+        Buffer<Object> scalaArgs = convertArgsToScalaBuffer(args);
         return play.api.i18n.Messages.apply(keyArgs.toSeq(), scalaArgs, getLang());
     }
 

--- a/framework/src/play/src/test/java/play/i18n/MessagesTest.java
+++ b/framework/src/play/src/test/java/play/i18n/MessagesTest.java
@@ -1,0 +1,56 @@
+package play.i18n;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class MessagesTest {
+    
+    @Test
+    public void wrapNoVarArgsToEmptyList(){
+        final List<Object> resultList = Messages.wrapArgsToListIfNeeded();
+        assertThat(resultList).isNotNull();
+        assertThat(resultList.size()).isEqualTo(0);
+    }
+    
+    @Test
+    public void wrapOneStringElementToList(){
+        final List<String> resultList = Messages.wrapArgsToListIfNeeded("Croissant");
+        assertThat(resultList).isNotNull();
+        assertThat(resultList.size()).isEqualTo(1);
+        assertThat(resultList.get(0)).isEqualTo("Croissant");
+    }
+    
+    @Test
+    public void wrapTwoStringElementsToList(){
+        final List<String> resultList = Messages.wrapArgsToListIfNeeded("Croissant", "Baguette");
+        assertThat(resultList).isNotNull();
+        assertThat(resultList.size()).isEqualTo(2);
+        assertThat(resultList.contains("Croissant")).isTrue();
+        assertThat(resultList.contains("Baguette")).isTrue();
+    }
+    
+    @Test
+    public void wrapOneListElementReturnsIt(){
+        final List<String> stringList = Arrays.asList("Croissant", "Baguette");
+        final List<List<String>> resultList = Messages.wrapArgsToListIfNeeded(stringList);
+        assertThat(resultList).isNotNull();
+        assertThat(resultList.size()).isEqualTo(2);
+        assertThat(resultList.contains("Croissant")).isTrue();
+        assertThat(resultList.contains("Baguette")).isTrue();
+    }
+    
+    @Test
+    public void wrapOneListAndOneStringShouldNotFlattenTheList(){
+        final List<String> stringList = Arrays.asList("Croissant", "Baguette");
+        final List<Object> resultList = Messages.wrapArgsToListIfNeeded(stringList, "Pain");
+        assertThat(resultList).isNotNull();
+        assertThat(resultList.size()).isEqualTo(2);
+        assertThat(resultList.contains(stringList)).isTrue();
+        assertThat(resultList.contains("Pain")).isTrue();
+        
+    }
+}


### PR DESCRIPTION
There was a bug in the handling of message arguments when used in Java.

I discovered it when using `@Constraints` annotation on my model objects and returning the validation errors as Json. This simple example illustrate the bug :

```
 //in my model object
 @Constraints.MinLength(2)
 public String myField;

 //in my controller (Json version)
 return badRequest(form.errorsAsJson()); //"Minimum length is [2]"
 //in my controller (form render)
 return badRequest(formView.render(form)); //"Minimum length is 2"
```

 By digging into the code I found out that we were passing directly a List to `Messages.get()`, which in turns rewrap it into another `List` to then call the API. The bug is in fact wider than I first thought and the use case I described must not be the only one where we get this kind of error.

 The patch is simple, it checks if there is only one argument and if it is a `List`, in this case it returns the `List` as is, otherwise the previous behavior is kept (wrapping with `Arrays.asList`).
 Tests were added in MessagesSpec to validate the behavior in Java, and a MessagesTest class was added to check the behavior of the arguments transformation.

 CLA has been signed.
