### PR TITLE
First 2 bytes of http headers getting dropped on some http client

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -631,9 +631,9 @@ trait BodyParsers {
             val maxHeaderBuffer = Traversable.takeUpTo[Array[Byte]](4 * 1024) transform Iteratee.consume[Array[Byte]]()
 
             val collectHeaders = maxHeaderBuffer.map { buffer =>
-              val (headerBytes, rest) = Option(buffer.drop(2)).map(b => b.splitAt(b.indexOfSlice(CRLFCRLF))).get
+              val (headerBytes, rest) = Option(buffer).map(b => b.splitAt(b.indexOfSlice(CRLFCRLF))).get
 
-              val headerString = new String(headerBytes, "utf-8")
+              val headerString = new String(headerBytes, "utf-8").trim
               val headers = headerString.lines.map { header =>
                 val key :: value = header.trim.split(":").toList
                 (key.trim.toLowerCase, value.mkString.trim)


### PR DESCRIPTION
On some http client such as MS.net http client the headers does not start with CRLF. So the first 2 bytes of the headers get dropped always, which mangles the first header key.

Unsure how to create a unit test for it.  However tested to work and does not break Chrome 31, Firefox 25 and IE 11.  Removing the drop(2) fixes the issue with MS.net httpclient
