### PR TITLE
Anorm string interpolation

### DIFF
--- a/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
+++ b/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
@@ -157,6 +157,34 @@ val untyped: Any = "name" // deprecated
 SQL("SELECT * FROM Country WHERE {p}").on(untyped -> "val")
 ```
 
+### SQL queries using String Interpolation
+
+Since Scala 2.10 supports custom String Interpolation there is also a 1-step alternative to `SQL(queryString).on(params)` seen before. You can abbreviate the code as: 
+
+```scala
+val name = "Cambridge"
+val country = "New Zealand"
+
+SQL"insert into City(name, country) values ($name, $country)")
+```
+
+It also supports multi-line string and inline expresions:
+
+```scala
+val lang = "French"
+val population = 10000000
+val margin = 500000
+
+val code: String = SQL"""
+  select * from Country c 
+    join CountryLanguage l on l.CountryCode = c.Code 
+    where l.Language = $lang and c.Population >= ${population - margin}
+    order by c.Population desc limit 1"""
+  .as(SqlParser.str("Country.code").single)
+```
+
+This feature tries to make faster, more concise and easier to read the way to retrieve data in Anorm. Please, feel free to use it wherever you see a combination of `SQL().on()` functions (or even an only `SQL()` without parameters).
+
 ## Retrieving data using the Stream API
 
 The first way to access the results of a select query is to use the Stream API.

--- a/framework/src/anorm/src/main/scala/anorm/Anorm.scala
+++ b/framework/src/anorm/src/main/scala/anorm/Anorm.scala
@@ -514,6 +514,26 @@ object Sql { // TODO: Rename to SQL
     SqlQuery(sql, paramsNames)
   }
 
+  /**
+   * Creates a SimpleSql using String Interpolation feature.
+   * It is a 1-step alternative for SQL().on() functions.
+   *
+   * {{{
+   * SQL"""
+   *   update computer
+   *   set name = ${computer.name}, introduced = ${computer.introduced}, discontinued = ${computer.discontinued}, company_id = ${computer.companyId}
+   *   where id = $id
+   * """.executeUpdate()
+   * }}}
+   */
+  def sqlFromStringContext(params: Seq[ParameterValue])(sc: StringContext) = {
+    // Generates the string query with "%s" as the placeholders for each parameter
+    val sql = sc.parts.mkString("%s")
+    // Generates a list of tupled version of NamedParameters with an arbitrary name
+    val tupledNamedParameters = params.zipWithIndex.map { case (p, i) => ('_'.toString + i, p) }
+    SimpleSql(SqlQuery(sql, tupledNamedParameters.map(_._1).toList), tupledNamedParameters.toMap, defaultParser = RowParser(row => Success(row)))
+  }
+
   import java.sql._
   import java.sql.ResultSetMetaData._
 

--- a/framework/src/anorm/src/main/scala/anorm/package.scala
+++ b/framework/src/anorm/src/main/scala/anorm/package.scala
@@ -33,6 +33,18 @@ package object anorm {
    */
   def SQL(stmt: String): SqlQuery = Sql.sql(stmt)
 
+  /**
+   * Creates an SQL query using String Interpolation feature.
+   * It is a 1-step alternative for SQL().on() functions.
+   *
+   * {{{
+   * val query = SQL"SELECT * FROM Country"
+   * }}}
+   */
+  implicit class SqlStringInterpolation(val sc: StringContext) extends AnyVal {
+    def SQL(args: ParameterValue*) = Sql.sqlFromStringContext(args)(sc)
+  }
+
   /** Activable features */
   object features {
 

--- a/framework/src/anorm/src/test/scala/anorm/ParameterSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/ParameterSpec.scala
@@ -108,6 +108,15 @@ object ParameterSpec extends org.specs2.mutable.Specification {
             q.execute() aka "execution" must beFalse
         }
     }
+	
+    "be one string with string interpolation" in withConnection() { implicit c =>
+      SQL"""set-str ${"string"}""".
+        aka("query") must beLike {
+          case q @ SimpleSql( // check accross construction
+            SqlQuery("set-str %s", List("_0"), _), ps, _) if (ps contains "_0") =>
+            q.execute() aka "execution" must beFalse
+        }
+    }
 
     "be boolean true" in withConnection() { implicit c =>
       SQL("set-true {p}").on("p" -> true).execute() must beFalse
@@ -182,6 +191,12 @@ object ParameterSpec extends org.specs2.mutable.Specification {
     "be multiple (string, Scala big decimal)" in withConnection() {
       implicit c =>
         SQL("set-s-sbg {a}, {b}").on("a" -> "string", "b" -> sbg1).
+          execute() aka "execution" must beFalse
+    }
+
+    "be multiple (string, Scala big decimal) with string interpolation" in withConnection() {
+      implicit c =>
+        SQL"""set-s-sbg ${"string"}, $sbg1""".
           execute() aka "execution" must beFalse
     }
 
@@ -282,6 +297,16 @@ object ParameterSpec extends org.specs2.mutable.Specification {
           case q @ SimpleSql(
             SqlQuery("set-seqp %s", "p" :: Nil, _), ps, _) if (
             ps.size == 1 && ps.contains("p")) =>
+            q.execute() aka "execution" must beFalse
+        }
+    }
+	
+    "set formatted value from sequence with string interpolation" in withConnection() { implicit c =>
+      SQL"""set-seqp ${SeqParameter(Seq(1.2f, 23.4f, 5.6f), " OR ", "cat = ")}""".
+        aka("query") must beLike {
+          case q @ SimpleSql(
+            SqlQuery("set-seqp %s", "_0" :: Nil, _), ps, _) if (
+            ps.size == 1 && ps.contains("_0")) =>
             q.execute() aka "execution" must beFalse
         }
     }


### PR DESCRIPTION
This resolves #2273 to add String Interpolation feature to generate SQL queries as:

``` scala
SQL"select * from computer where id = $id".as(Computer.simple.singleOpt)
```

or

``` scala
SQL"""
  update computer
  set name = ${computer.name}, introduced = ${computer.introduced},
  discontinued = ${computer.discontinued},   company_id = ${computer.companyId}
  where id = $id
""".executeUpdate()
```

This also allows to insert sequence values for supporting IN clauses:

``` scala
val list = Seq("Apple Inc.", "Sony", "Samsung Electronics")
val computers = SQL"select * from computer left join company on computer.company_id = company.id where company.name in ($list) order by company.id, computer.name".as(Computer.simple *)
```

I've tested it with the database for _computer-database_ example and depending on the number of parameters within the query it runs approximately **from x1.25 and x7 faster**.

Here I attach some examples to get the execution times respect to their original SQL().on() functions. Each result is the average of 10 sets of executions.

**First example: select with 0 parameters**

``` scala
var i = 0
var t = System.currentTimeMillis
while (i < 10000) {
  SQL"select * from computer limit 50".as(Computer.simple *)
  i += 1
}
val time1 = (System.currentTimeMillis - t)
```

Execution time: 3450.1 ms (using _string interpolation_)
Original time: 4320.9 ms (using original _SQL().on()_ funciton)
=> **x1.25 faster**

**Second example: select with 2 parameters**

``` scala
val companyName = "a%"
val computerName = "a%"
var i = 0
var t = System.currentTimeMillis
while (i < 10000) {
  SQL"""
    select * from computer left join company on computer.company_id = company.id
    where company.name like $companyName and computer.name like $computerName
    limit 50
    """.as(Computer.simple *)
  i += 1
}
val time1 = (System.currentTimeMillis - t)
```

Execution time: 2895.7 ms (using _string interpolation_)
Original time: 6282.1 ms (using original _SQL().on()_ funciton)
=> **x2.17 faster**

**Third example: update with 5 parameters**

``` scala
var i = 0
var t = System.currentTimeMillis
while (i < 10000) {
  SQL"""
    update computer
    set name = ${computer.name}, introduced = ${computer.introduced},
    discontinued = ${computer.discontinued}, company_id = ${computer.companyId}
    where id = $id
    """.executeUpdate()
  i += 1
}
val time1 = (System.currentTimeMillis - t)
```

Execution time: 371.3 ms (using _string interpolation_)
Original time: 2646.3 ms (using original _SQL().on()_ funciton)
=> **x7.13 faster**
