### PR TITLE
ToSql and sequence support

### DIFF
--- a/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
+++ b/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
@@ -218,6 +218,32 @@ val parser = for {
 val parsed: (String, Int) = SELECT("SELECT * FROM Test").as(parser.single)
 ```
 
+## Using multi-value parameter
+
+Anorm parameter can be multi-value, like a sequence of string.
+In such case, values will be prepared to be passed to JDBC.
+
+```scala
+// With default formatting (", " as separator)
+SQL("SELECT * FROM Test WHERE cat IN ({categories})").
+  on('categories -> Seq("a", "b", "c")
+// -> SELECT * FROM Test WHERE cat IN ('a', 'b', 'c')
+
+// With custom formatting
+import anorm.SeqParameter
+SQL("SELECT * FROM Test t WHERE {categories}").
+  on('categories -> SeqParameter(
+    values = Seq("a", "b", "c"), separator = " OR ", 
+    pre = "EXISTS (SELECT NULL FROM j WHERE t.id=j.id AND name=",
+    post = ")"))
+/* ->
+SELECT * FROM Test t WHERE 
+EXISTS (SELECT NULL FROM j WHERE t.id=j.id AND name='a') 
+OR EXISTS (SELECT NULL FROM j WHERE t.id=j.id AND name='b') 
+OR EXISTS (SELECT NULL FROM j WHERE t.id=j.id AND name='c')
+*/
+```
+
 ## Retrieving data along with execution context
 
 Moreover data, query execution involves context information like SQL warnings that may be raised (and may be fatal or not), especially when working with stored SQL procedure.

--- a/framework/src/anorm/src/main/scala/anorm/SqlQueryResult.scala
+++ b/framework/src/anorm/src/main/scala/anorm/SqlQueryResult.scala
@@ -1,0 +1,46 @@
+package anorm
+
+import java.sql.Connection
+
+/**
+ * A result from execution of an SQL query, row data and context
+ * (e.g. statement warnings).
+ *
+ * @constructor create a result with a result set
+ * @param resultSet Result set from executed query
+ */
+final case class SqlQueryResult(resultSet: java.sql.ResultSet) {
+  /** Query statement already executed */
+  val statement: java.sql.Statement = resultSet.getStatement
+
+  /**
+   * Returns statement warning if there is some for this result.
+   *
+   * {{{
+   * val res = SQL("EXEC stored_proc {p}").on("p" -> paramVal).executeQuery()
+   * res.statementWarning match {
+   *   case Some(warning) =>
+   *     warning.printStackTrace()
+   *     None
+   *
+   *   case None =>
+   *     // go on with row parsing ...
+   *     res.as(scalar[String].singleOpt)
+   * }
+   * }}}
+   */
+  def statementWarning: Option[java.sql.SQLWarning] =
+    Option(statement.getWarnings)
+
+  def apply()(implicit connection: Connection) = Sql.resultSetToStream(resultSet)
+
+  def as[T](parser: ResultSetParser[T])(implicit connection: Connection): T = Sql.as[T](parser, resultSet)
+
+  def list[A](rowParser: RowParser[A])(implicit connection: Connection): Seq[A] = as(rowParser.*)
+
+  def single[A](rowParser: RowParser[A])(implicit connection: Connection): A = as(ResultSetParser.single(rowParser))
+
+  def singleOpt[A](rowParser: RowParser[A])(implicit connection: Connection): Option[A] = as(ResultSetParser.singleOpt(rowParser))
+
+  def parse[T](parser: ResultSetParser[T])(implicit connection: Connection): T = Sql.parse[T](parser, resultSet)
+}

--- a/framework/src/anorm/src/main/scala/anorm/SqlStatementParser.scala
+++ b/framework/src/anorm/src/main/scala/anorm/SqlStatementParser.scala
@@ -34,7 +34,7 @@ object SqlStatementParser extends JavaTokenParsers {
   private val literal: Parser[(String, Option[String])] = (stringLiteral | simpleQuotes) ^^ { case s => (s, None) }
 
   private val variable = "{" ~> (ident ~ (("." ~> ident)?)) <~ "}" ^^ {
-    case i1 ~ i2 => ("?": String, Some(i1 + i2.map("." + _).getOrElse("")))
+    case i1 ~ i2 => ("%s": String, Some(i1 + i2.map("." + _).getOrElse("")))
   }
 
   private val other: Parser[(String, Option[String])] = """.""".r ^^ {

--- a/framework/src/anorm/src/main/scala/anorm/ToStatement.scala
+++ b/framework/src/anorm/src/main/scala/anorm/ToStatement.scala
@@ -117,4 +117,18 @@ object ToStatement {
       def set(s: PreparedStatement, index: Int, id: Id[A]): Unit =
         c.set(s, index, id.get)
     }
+
+  implicit def seqToStatement[A](implicit c: ToStatement[A]) =
+    new ToStatement[Seq[A]] {
+      def set(s: PreparedStatement, offset: Int, ps: Seq[A]) {
+        ps.foldLeft(offset) { (i, p) => c.set(s, i, p); i + 1 }
+      }
+    }
+
+  implicit def seqParamToStatement[A](implicit c: ToStatement[Seq[A]]) =
+    new ToStatement[SeqParameter[A]] {
+      def set(s: PreparedStatement, offset: Int, ps: SeqParameter[A]): Unit =
+        c.set(s, offset, ps.values)
+
+    }
 }

--- a/framework/src/anorm/src/main/scala/anorm/package.scala
+++ b/framework/src/anorm/src/main/scala/anorm/package.scala
@@ -21,7 +21,7 @@ package object anorm {
 
   implicit def implicitID[ID](id: Id[ID] with NotNull): ID = id.id
 
-  implicit def toParameterValue[A](a: A)(implicit p: ToStatement[A]): ParameterValue = ParameterValue(a, p)
+  implicit def toParameterValue[A](a: A)(implicit s: ToSql[A] = null, p: ToStatement[A]): ParameterValue = ParameterValue(a, s, p)
 
   /**
    * Creates an SQL query with given statement.

--- a/framework/src/anorm/src/test/scala/anorm/RowSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/RowSpec.scala
@@ -1,13 +1,11 @@
 package anorm
 
-import org.specs2.mutable.Specification
-
 import acolyte.Acolyte.{ connection, handleQuery }
 import acolyte.{ QueryResult, RowLists }
 import RowLists.{ rowList2, rowList1, stringList }
 import acolyte.Implicits._
 
-object RowSpec extends Specification {
+object RowSpec extends org.specs2.mutable.Specification {
   "Row" title
 
   "List of column values" should {

--- a/framework/src/anorm/src/test/scala/anorm/StatementParserSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/StatementParserSpec.scala
@@ -13,7 +13,7 @@ object StatementParserSpec extends org.specs2.mutable.Specification {
         SELECT * FROM schema.table 
         WHERE (name = {name} AND category = {cat}) OR id = ?
       """) aka "updated statement and parameters" mustEqual (
-        "SELECT * FROM schema.table          WHERE (name = ? AND category = ?) OR id = ?" -> List("name", "cat"))
+        "SELECT * FROM schema.table          WHERE (name = %s AND category = %s) OR id = ?" -> List("name", "cat"))
     }
 
     "detect missing query parameter" in withQueryResult(stringList :+ "test") {
@@ -26,6 +26,42 @@ object StatementParserSpec extends org.specs2.mutable.Specification {
       implicit con =>
         SQL("EXEC proc {lang}, {c}").asBatch.addBatch("lang" -> "en").
           execute() aka "execute" must throwA[java.util.NoSuchElementException]
+    }
+  }
+
+  "Value" should {
+    def frag[A](v: A)(implicit c: ToSql[A] = null): (String, Int) =
+      Option(c).fold("?" -> 1)(_.fragment(v))
+
+    "give single-value '?' SQL fragment" in {
+      frag("str").aka("SQL fragment") mustEqual ("?" -> 1)
+    }
+
+    "give multi-value '?, ?, ?' SQL fragment" in {
+      frag(Seq("A", "B", "C")) aka "SQL fragment" mustEqual ("?, ?, ?" -> 3)
+    }
+
+    "give multi-value 'x=? OR x=? OR x=?' SQL fragment" in {
+      frag(SeqParameter(Seq("A", "B", "C"), " OR ", "x=")).
+        aka("SQL fragment") mustEqual ("x=? OR x=? OR x=?" -> 3)
+    }
+  }
+
+  "Rewriting" should {
+    "return some prepared query with updated statement" in {
+      Sql.rewrite("SELECT * FROM t WHERE c IN (%s) AND id = %s", "?, ?") must {
+        beSome.which { rewrited =>
+          (rewrited aka "first rewrite" mustEqual (
+            "SELECT * FROM t WHERE c IN (?, ?) AND id = %s")).
+            and(Sql.rewrite(rewrited, "?") aka "second rewrite" must beSome(
+              "SELECT * FROM t WHERE c IN (?, ?) AND id = ?"))
+        }
+      }
+    }
+
+    "return no prepared query" in {
+      Sql.rewrite("SELECT * FROM Test WHERE id = ?", "x").
+        aka("rewrited") must beNone
     }
   }
 }


### PR DESCRIPTION
Add intermediate SQL preparation level with new `ToSql[A]` trait. It allows to rewrite query with Anorm placeholder (e.g. `{param}`), in case parameter need more than `?` in statement passed to `java.sql.PreparedStatement`.
- For basic/single value parameter, Anorm placeholder is replaced by `?`.
- For parameter `Seq[A]`, Anorm placeholder is replaced by `?, ?, ...` (`?` for each sequence item separated by `,`).
- For custom sequence formatting, wrapper case class `SeqParameter[A]` can be used to specify text before/after each item, along with the sequence.

``` scala
SQL("SELECT * FROM Test WHERE cat IN ({categories})").on('categories -> Seq("a", "b", "c")
// -> SELECT * FROM Test WHERE cat IN ('a', 'b', 'c')

import anorm.SeqParameter
SQL("SELECT * FROM Test t WHERE {categories}").
  on('categories -> SeqParameter(Seq("a", "b", "c"), " OR ", 
    "EXISTS (SELECT NULL FROM j WHERE t.id=j.id AND name=",
    ")"))
/* ->
SELECT * FROM Test t WHERE EXISTS (SELECT NULL FROM j WHERE t.id=j.id AND name='a') OR EXISTS (SELECT NULL FROM j WHERE t.id=j.id AND name='b') OR EXISTS (SELECT NULL FROM j WHERE t.id=j.id AND name='c')
*/
```
