### PR TITLE
Parameter type-safety

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -160,7 +160,8 @@ object PlayBuild extends Build {
     )
 
   lazy val AnormProject = PlayRuntimeProject("Anorm", "anorm")
-    .settings(libraryDependencies ++= anormDependencies)
+    .settings(libraryDependencies ++= anormDependencies,
+      resolvers += sonatypeSnapshots)
 
   lazy val IterateesProject = PlayRuntimeProject("Play-Iteratees", "iteratees")
     .settings(libraryDependencies := iterateesDependencies)

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -196,7 +196,8 @@ object Dependencies {
 
   val anormDependencies = specsBuild.map(_ % "test") ++ Seq(
     h2database % "test",
-    "org.eu.acolyte" %% "acolyte-scala" % "1.0.12" % "test"
+    "org.eu.acolyte" %% "acolyte-scala" % "1.0.12" % "test",
+    "com.chuusai" % "shapeless_2.10.2" % "2.0.0-M1" % "test"
   )
 
 }

--- a/framework/src/anorm/src/main/scala/anorm/ToStatement.scala
+++ b/framework/src/anorm/src/main/scala/anorm/ToStatement.scala
@@ -1,60 +1,122 @@
 package anorm
 
+import java.lang.{
+  Boolean => JBool,
+  Byte => JByte,
+  Character,
+  Double => JDouble,
+  Float => JFloat,
+  Long => JLong,
+  Integer,
+  Short => JShort
+}
+
 import java.sql.PreparedStatement
 
 /** Set value as statement parameter. */
-sealed trait ToStatement[A] {
+trait ToStatement[A] {
   def set(s: PreparedStatement, index: Int, aValue: A): Unit
 }
 
 /**
- * Helper for parameter setters.
+ * Provided conversions to set statement parameter.
  */
-object ToStatement {
-  // TODO: Documentation
-  implicit def anyParameter[T] = new ToStatement[T] {
-    def set(s: PreparedStatement, i: Int, v: T): Unit = v match {
-      case None | NotAssigned => s.setObject(i, null) // untyped null
-      case o => s.setObject(i, o)
-    }
-  }
-
-  implicit val booleanToStatement = new ToStatement[Boolean] {
+object ToStatement { // TODO: Scaladoc
+  implicit object booleanToStatement extends ToStatement[Boolean] {
     def set(s: PreparedStatement, i: Int, b: Boolean): Unit = s.setBoolean(i, b)
   }
 
-  implicit val byteToStatement = new ToStatement[Byte] {
+  implicit object javaBooleanToStatement extends ToStatement[JBool] {
+    def set(s: PreparedStatement, i: Int, b: JBool): Unit = s.setBoolean(i, b)
+  }
+
+  implicit object byteToStatement extends ToStatement[Byte] {
     def set(s: PreparedStatement, i: Int, b: Byte): Unit = s.setByte(i, b)
   }
 
-  implicit val doubleToStatement = new ToStatement[Double] {
+  implicit object javaByteToStatement extends ToStatement[JByte] {
+    def set(s: PreparedStatement, i: Int, b: JByte): Unit = s.setByte(i, b)
+  }
+
+  implicit object doubleToStatement extends ToStatement[Double] {
     def set(s: PreparedStatement, i: Int, d: Double): Unit = s.setDouble(i, d)
   }
 
-  implicit val floatToStatement = new ToStatement[Float] {
+  implicit object javaDoubleToStatement extends ToStatement[JDouble] {
+    def set(s: PreparedStatement, i: Int, d: JDouble): Unit = s.setDouble(i, d)
+  }
+
+  implicit object floatToStatement extends ToStatement[Float] {
     def set(s: PreparedStatement, i: Int, f: Float): Unit = s.setFloat(i, f)
   }
 
-  implicit val longToStatement = new ToStatement[Long] {
+  implicit object javaFloatToStatement extends ToStatement[JFloat] {
+    def set(s: PreparedStatement, i: Int, f: JFloat): Unit = s.setFloat(i, f)
+  }
+
+  implicit object longToStatement extends ToStatement[Long] {
     def set(s: PreparedStatement, i: Int, l: Long): Unit = s.setLong(i, l)
   }
 
-  implicit val intToStatement = new ToStatement[Int] {
+  implicit object javaLongToStatement extends ToStatement[JLong] {
+    def set(s: PreparedStatement, i: Int, l: JLong): Unit = s.setLong(i, l)
+  }
+
+  implicit object intToStatement extends ToStatement[Int] {
     def set(s: PreparedStatement, i: Int, v: Int): Unit = s.setInt(i, v)
   }
 
-  implicit val shortToStatement = new ToStatement[Short] {
+  implicit object integerToStatement extends ToStatement[Integer] {
+    def set(s: PreparedStatement, i: Int, v: Integer): Unit = s.setInt(i, v)
+  }
+
+  implicit object shortToStatement extends ToStatement[Short] {
     def set(s: PreparedStatement, i: Int, v: Short): Unit = s.setShort(i, v)
   }
 
-  implicit val stringToStatement = new ToStatement[String] {
+  implicit object javaShortToStatement extends ToStatement[JShort] {
+    def set(s: PreparedStatement, i: Int, v: JShort): Unit = s.setShort(i, v)
+  }
+
+  implicit object characterToStatement extends ToStatement[Character] {
+    def set(s: PreparedStatement, i: Int, v: Character): Unit =
+      s.setString(i, v.toString)
+
+  }
+
+  implicit object stringToStatement extends ToStatement[String] {
     def set(s: PreparedStatement, index: Int, str: String): Unit =
       s.setString(index, str)
   }
 
-  implicit val charToStatement = new ToStatement[Char] {
+  implicit object charToStatement extends ToStatement[Char] {
     def set(s: PreparedStatement, index: Int, ch: Char): Unit =
       s.setString(index, Character.toString(ch))
+  }
+
+  /**
+   * Sets null for not assigned value
+   *
+   * {{{
+   * SQL("SELECT * FROM Test WHERE category = {c}")
+   *   .on('c -> NotAssigned)
+   * }}}
+   */
+  implicit object notAssignedToStatement extends ToStatement[NotAssigned.type] {
+    def set(s: PreparedStatement, i: Int, n: NotAssigned.type): Unit =
+      s.setObject(i, null)
+  }
+
+  /**
+   * Sets null for None value.
+   *
+   * {{{
+   * SQL("SELECT * FROM Test WHERE category = {c}")
+   *   .on('c -> None)
+   * }}}
+   */
+  implicit object noneToStatement extends ToStatement[None.type] {
+    def set(s: PreparedStatement, i: Int, n: None.type) = s.setObject(i, null)
   }
 
   /**
@@ -86,28 +148,28 @@ object ToStatement {
       // TODO: Better null handling
     }
 
-  implicit val javaBigDecimalToStatement =
-    new ToStatement[java.math.BigDecimal] {
-      def set(s: PreparedStatement, index: Int, v: java.math.BigDecimal): Unit =
-        s.setBigDecimal(index, v)
-    }
+  implicit object javaBigDecimalToStatement
+      extends ToStatement[java.math.BigDecimal] {
+    def set(s: PreparedStatement, index: Int, v: java.math.BigDecimal): Unit =
+      s.setBigDecimal(index, v)
+  }
 
-  implicit val scalaBigDecimalToStatement = new ToStatement[BigDecimal] {
+  implicit object scalaBigDecimalToStatement extends ToStatement[BigDecimal] {
     def set(s: PreparedStatement, index: Int, v: BigDecimal): Unit =
       s.setBigDecimal(index, v.bigDecimal)
   }
 
-  implicit val timestampToStatement = new ToStatement[java.sql.Timestamp] {
+  implicit object timestampToStatement extends ToStatement[java.sql.Timestamp] {
     def set(s: PreparedStatement, index: Int, ts: java.sql.Timestamp): Unit =
       s.setTimestamp(index, ts)
   }
 
-  implicit val dateToStatement = new ToStatement[java.util.Date] {
+  implicit object dateToStatement extends ToStatement[java.util.Date] {
     def set(s: PreparedStatement, index: Int, date: java.util.Date): Unit =
       s.setTimestamp(index, new java.sql.Timestamp(date.getTime()))
   }
 
-  implicit val uuidToStatement = new ToStatement[java.util.UUID] {
+  implicit object uuidToStatement extends ToStatement[java.util.UUID] {
     def set(s: PreparedStatement, index: Int, aValue: java.util.UUID): Unit =
       s.setObject(index, aValue)
   }


### PR DESCRIPTION
Avoid unsafe conversion to `ParameterValue`, refactoring `None` and `NotAssigned` cases as others provided `ToStatement` (+ documentation).

Also fixes https://github.com/playframework/playframework/pull/2166/files#r9113098 .
