### PR TITLE
returning iterator must be ran

### DIFF
--- a/documentation/manual/scalaGuide/main/tests/code/ExampleControllerSpec.scala
+++ b/documentation/manual/scalaGuide/main/tests/code/ExampleControllerSpec.scala
@@ -24,7 +24,7 @@ object ExampleControllerSpec extends PlaySpecification with Results {
   "Example Page#index" should {
     "should be valid" in {
       val controller = new TestController()
-      val result: Future[SimpleResult] = controller.index().apply(FakeRequest())
+      val result: Future[SimpleResult] = controller.index().apply(FakeRequest()).run
       val bodyText: String = contentAsString(result)
       bodyText must be equalTo "ok"
     }


### PR DESCRIPTION
returning iterator must be ran in order to yield a value with type `Future[SimpleResult]`
