### PR TITLE
Make the trampoline Execution object visible so it can be used in custom BodyParsers

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Execution.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Execution.scala
@@ -10,7 +10,7 @@ import scala.concurrent.ExecutionContext
 /**
  * Contains the default ExecutionContext used by Iteratees.
  */
-private[play] object Execution {
+object Execution {
 
   def defaultExecutionContext: ExecutionContext = Implicits.defaultExecutionContext
 


### PR DESCRIPTION
This is the fix for #2293: the trampoline Execution object is now public so that it can be used outside of Play code, such as in custom BodyParsers.
