### PR TITLE
Untyped/opaque parameter specs and docs

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/ToStatement.scala
+++ b/framework/src/anorm/src/main/scala/anorm/ToStatement.scala
@@ -170,8 +170,13 @@ object ToStatement { // TODO: Scaladoc
   }
 
   implicit object uuidToStatement extends ToStatement[java.util.UUID] {
-    def set(s: PreparedStatement, index: Int, aValue: java.util.UUID): Unit =
-      s.setObject(index, aValue)
+    def set(s: PreparedStatement, index: Int, id: java.util.UUID): Unit =
+      s.setObject(index, id)
+  }
+
+  implicit object objectToStatement extends ToStatement[anorm.Object] {
+    def set(s: PreparedStatement, index: Int, o: anorm.Object): Unit =
+      s.setObject(index, o.value)
   }
 
   implicit def idToStatement[A](implicit c: ToStatement[A]) =
@@ -193,4 +198,5 @@ object ToStatement { // TODO: Scaladoc
         c.set(s, offset, ps.values)
 
     }
+
 }


### PR DESCRIPTION
Backward compatibility feature (see https://github.com/playframework/playframework/pull/2292/files#r9336767 ), specs and docs for untyped parameter.
Add object wrapper for `Any` with its implicit, to explicitly passed value as opaque parameter.
