### PR TITLE
Firefox 26 does not work with fluentlenium 2.33

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -174,7 +174,7 @@ object Dependencies {
     "com.novocode" % "junit-interface" % "0.10" exclude("junit", "junit-dep"),
     guava,
     findBugs,
-    ("org.fluentlenium" % "fluentlenium-festassert" % "0.9.0")
+    ("org.fluentlenium" % "fluentlenium-festassert" % "0.9.2")
       .exclude("org.jboss.netty", "netty")
   )
 


### PR DESCRIPTION
Firefox comes up, but does not have a connection to the firefox webdriver.

http://stackoverflow.com/a/20498619/5266 indicates that Selenium 2.39.x works

but 2.2.1 is on 2.33.0:

```
[error] Build info: version: '2.33.0', revision: '4ecaf82108b2a6cc6f006aae81961236eba93358', time: '2013-05-22 12:00:17
```

Workaround is to add 

```
"org.fluentlenium" % "fluentlenium-festassert" % "0.9.2" % "test"
```

to SBT dependencies, as 0.9.2 depends on Selenium 2.39.x.  Likewise, fix is to upgrade fluentlenium in Dependencies.scala to 0.9.2.

The 2.2.x branch has fluentlenium at "0.8.0" which will absolutely not work with the latest Firefox. 
