### PR TITLE
Add hasHeader to Http.RequestHeader.

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -314,7 +314,9 @@ public class Http {
         public abstract java.util.Map<String,String[]> headers();
 
         /**
-         * Retrieves a single header. Case-insensitive.
+         * Retrieves a single header.
+         *
+         * @param headerName The name of the header (case-insensitive).
          */
         public String getHeader(String headerName) {
             String[] headers = null;
@@ -331,9 +333,11 @@ public class Http {
         }
 
         /**
-         * Checks if the request has the header. Case-insensitive.
+         * Checks if the request has the header.
+         *
+         * @param headerName The name of the header (case-insensitive).
          */
-        public boolean containsHeader(String headerName){
+        public boolean hasHeader(String headerName){
             return getHeader(headerName) != null;
         }
 


### PR DESCRIPTION
It's not clear that `Http.RequestHeader.getHeader` operates in a case-insensitive way.  This commit clarifies the operation in the method's Javadoc.  Because `getHeader` is case-insensitive the developer is forced to do:

```
getHeader("myHeaderName") != null
```

to determine if the Request contains the header, and he may make the mistake of doing

```
headers().containsKey("myHeaderName")
```

which is case-sensitive.  This commit adds a convenience method `containsHeader` which is case-insensitive.
