### PR TITLE
Ensured all java enhanced classes are updated in cache

### DIFF
--- a/framework/src/sbt-link/src/main/java/play/core/enhancers/PropertiesEnhancer.java
+++ b/framework/src/sbt-link/src/main/java/play/core/enhancers/PropertiesEnhancer.java
@@ -54,7 +54,7 @@ public class PropertiesEnhancer {
     @Retention(RUNTIME)
     public static @interface RewrittenAccessor {}
     
-    public static void generateAccessors(String classpath, File classFile) throws Exception {
+    public static boolean generateAccessors(String classpath, File classFile) throws Exception {
         ClassPool classPool = new ClassPool();
         classPool.appendSystemPath();
         classPool.appendPathList(classpath);
@@ -64,7 +64,7 @@ public class PropertiesEnhancer {
             CtClass ctClass = classPool.makeClass(is);
             if(hasAnnotation(ctClass, GeneratedAccessor.class)) {
                 is.close();
-                return;
+                return false;
             }
             for (CtField ctField : ctClass.getDeclaredFields()) {
                 if(isProperty(ctField)) {
@@ -126,6 +126,7 @@ public class PropertiesEnhancer {
             FileOutputStream os = new FileOutputStream(classFile);
             os.write(ctClass.toBytecode());
             os.close();
+            return true;
             
         } catch(Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Since the Scala incremental compiler also does incremental compilation for Java sources, when they are touched by the properties enhancer the cache also has to be updated for them.

Improves on #2274 in that it only updates the cache if Java classes were actually rewritten.
