### PR TITLE
Remove config commandline override in doc

### DIFF
--- a/documentation/manual/detailedTopics/configuration/Configuration.md
+++ b/documentation/manual/detailedTopics/configuration/Configuration.md
@@ -379,7 +379,3 @@ For powers of two, exactly these strings are supported:
  - `E`, `e`, `Ei`, `EiB`, `exbibyte`, `exbibytes`
  - `Z`, `z`, `Zi`, `ZiB`, `zebibyte`, `zebibytes`
  - `Y`, `y`, `Yi`, `YiB`, `yobibyte`, `yobibytes`
-
-## Conventional override by system properties
-
-For an application's config, Java system properties _override_ settings found in the configuration file. This supports specifying config options on the command line.


### PR DESCRIPTION
In documentation : Remove unexplained suggestion that config can be overridden on the command line. I can't find a working suggestion anywhere which works for 2.2 and certainly `play -Dkey=value test` does not work.
