### PR TITLE
Upgrade to Guava 16.0.1 to fix JDK and Guava TypeVariable compatibility

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val specsSbt = specsBuild
   val scalaIoFile = "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.2"
 
-  val guava = "com.google.guava" % "guava" % "15.0"
+  val guava = "com.google.guava" % "guava" % "16.0.1"
   val findBugs = "com.google.code.findbugs" % "jsr305" % "2.0.2" // Needed by guava
   val mockitoAll = "org.mockito" % "mockito-all" % "1.9.5"
 


### PR DESCRIPTION
Ran into a bug in Guava causing us quite a bit of difficulty. Would love to see Play upgrade to the fixed version of Guava to avoid this.
https://code.google.com/p/guava-libraries/issues/detail?id=1635
