### PR TITLE
Fix example code on scala json

### DIFF
--- a/documentation/manual/scalaGuide/main/json/ScalaJsonCombinators.md
+++ b/documentation/manual/scalaGuide/main/json/ScalaJsonCombinators.md
@@ -946,8 +946,11 @@ For example:
 scala> case class Person(name: String)
 defined class Person
 
-scala> __.write[String].contramap( (p: Person) => p.name )
-res5: play.api.libs.json.OWrites[Person] = play.api.libs.json.OWrites$$anon$2@61df9fa8
+scala> val pwrite: Writes[Person] = (__ \ "name").write[String].contramap( (p: Person) => p.name )
+pwrite: play.api.libs.json.Writes[Person] = play.api.libs.json.OWrites$$anon$2@7466b0df
+
+scala>  pwrite.writes(Person("aaa"))
+res15: play.api.libs.json.JsValue = {"name":"aaa"}
 ```
 
 ### `(Writes[A] and Writes[B]).tupled: Writes[(A, B)]` 


### PR DESCRIPTION
The example code doesn't work. I guess that the code should be this PR.

```
scala> import play.api.libs.json._
import play.api.libs.json._
scala> import play.api.libs.functional.syntax._
import play.api.libs.functional.syntax._
scala> case class Person(name: String)
defined class Person
scala> implicit val pwrite: Writes[Person] = __.write[String].contramap( (p: Person) => p.name )
pwrite: play.api.libs.json.Writes[Person] = play.api.libs.json.OWrites$$anon$2@17b63c
scala>  pwrite.writes(Person("aaa"))
java.lang.RuntimeException: when empty JsPath, expecting JsObject
    at play.api.libs.json.JsPath$.step$1(JsPath.scala:143)
    at play.api.libs.json.JsPath$.play$api$libs$json$JsPath$$buildSubPath$1(JsPath.scala:156)
    at play.api.libs.json.JsPath$$anonfun$createObj$1.apply(JsPath.scala:161)
    at play.api.libs.json.JsPath$$anonfun$createObj$1.apply(JsPath.scala:159)
    at scala.collection.IndexedSeqOptimized$class.foldl(IndexedSeqOptimized.scala:51)
    at scala.collection.IndexedSeqOptimized$class.foldLeft(IndexedSeqOptimized.scala:60)
    at scala.collection.mutable.WrappedArray.foldLeft(WrappedArray.scala:34)
    at play.api.libs.json.JsPath$.createObj(JsPath.scala:159)
```
