### PR TITLE
Add headers methods to WS API

### DIFF
--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSResponse.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSResponse.java
@@ -9,13 +9,16 @@ import org.w3c.dom.Document;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 
 /**
  *
  */
 public interface WSResponse {
 
-    public Object getUnderlying();
+    Map<String, List<String>> getAllHeaders();
+
+    Object getUnderlying();
 
     int getStatus();
 

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSResponse.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSResponse.java
@@ -18,6 +18,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A WS response.
@@ -49,6 +50,14 @@ public class NingWSResponse implements WSResponse {
     @Override
     public String getStatusText() {
         return ahcResponse.getStatusText();
+    }
+
+    /**
+     * Get all the HTTP headers of the response as a case-insensitive map
+     */
+    @Override
+    public Map<String, List<String>> getAllHeaders() {
+        return ahcResponse.getHeaders();
     }
 
     /**

--- a/framework/src/play-java-ws/src/test/scala/play/libs/ws/ning/NingWSSpec.scala
+++ b/framework/src/play-java-ws/src/test/scala/play/libs/ws/ning/NingWSSpec.scala
@@ -1,8 +1,11 @@
 package play.libs.ws.ning
 
-import org.specs2.mutable._
+import scala.collection.JavaConverters._
+
 import org.specs2.mock.Mockito
-import org.mockito._
+import org.specs2.mutable._
+
+import com.ning.http.client.{FluentCaseInsensitiveStringsMap, Response}
 
 object NingWSSpec extends Specification with Mockito {
 
@@ -12,6 +15,37 @@ object NingWSSpec extends Specification with Mockito {
       val client = mock[NingWSClient]
       val request : NingWSRequest = new NingWSRequest(client, "GET")
       request.getMethod must be_==("GET")
+    }
+
+    "should get headers map which retrieves headers case insensitively" in {
+      val client = mock[NingWSClient]
+      val request = new NingWSRequest(client, "GET")
+        .addHeader("Foo", "a")
+        .addHeader("foo", "b")
+        .addHeader("FOO", "b")
+        .addHeader("Bar", "baz")
+
+      val headers = request.getAllHeaders
+      headers.get("foo").asScala must_== Seq("a", "b", "b")
+      headers.get("BAR").asScala must_== Seq("baz")
+    }
+
+  }
+
+  "NingWSResponse" should {
+
+    "should get headers map which retrieves headers case insensitively" in {
+      val srcResponse = mock[Response]
+      val srcHeaders = new FluentCaseInsensitiveStringsMap()
+        .add("Foo", "a")
+        .add("foo", "b")
+        .add("FOO", "b")
+        .add("Bar", "baz")
+      srcResponse.getHeaders returns srcHeaders
+      val response = new NingWSResponse(srcResponse)
+      val headers = response.getAllHeaders
+      headers.get("foo").asScala must_== Seq("a", "b", "b")
+      headers.get("BAR").asScala must_== Seq("baz")
     }
 
   }

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -136,6 +136,11 @@ trait WSRequest {
 trait WSResponse {
 
   /**
+   * Return the current headers of the request being constructed
+   */
+  def allHeaders: Map[String, Seq[String]]
+
+  /**
    * Get the underlying response object.
    */
   def underlying[T]: T

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
@@ -181,6 +181,22 @@ object NingWSSpec extends PlaySpecification with Mockito {
           cookie.secure must beFalse
       }
     }
+
+    "get headers from an AHC response in a case insensitive map" in {
+      val ahcResponse: AHCResponse = mock[AHCResponse]
+      val ahcHeaders = new FluentCaseInsensitiveStringsMap()
+      ahcHeaders.add("Foo", "bar")
+      ahcHeaders.add("Foo", "baz")
+      ahcHeaders.add("Bar", "baz")
+      ahcResponse.getHeaders returns ahcHeaders
+      val response = NingWSResponse(ahcResponse)
+      val headers = response.allHeaders
+      headers must beEqualTo(Map("Foo" -> Seq("bar", "baz"), "Bar" -> Seq("baz")))
+      headers.contains("foo") must beTrue
+      headers.contains("Foo") must beTrue
+      headers.contains("BAR") must beTrue
+      headers.contains("Bar") must beTrue
+    }
   }
 
 }


### PR DESCRIPTION
This pull request attempts to fix the some of the API inconsistencies mentioned in #2240, and also supersedes #1913.

My goal was to keep the `WSResponse` API as consistent with `WSRequest` as possible. I think the use of the case insensitive map makes sense, as it's simple to implement and creates an easy to use API.
