### PR TITLE
Update JavaBodyParsers.md

### DIFF
--- a/documentation/manual/javaGuide/main/http/JavaBodyParsers.md
+++ b/documentation/manual/javaGuide/main/http/JavaBodyParsers.md
@@ -64,9 +64,9 @@ public static Result save() {
   String textBody = body.asText();
   
   if(textBody != null) {
-    ok("Got: " + text);
+    return ok("Got: " + textBody);
   } else {
-    badRequest("Expecting text/plain request body");
+    return badRequest("Expecting text/plain request body");
   }
 }
 ```


### PR DESCRIPTION
Hi,
public static Result save() {
  RequestBody body = request().body();
  String textBody = body.asText();

  if(textBody != null) {
    ok("Got: " + text);
  } else {
    badRequest("Expecting text/plain request body");
  }
}

in this code, text should be textBody as text is not declared.
second thing no returns are added before ok() and badRequest()
So please merge these changes.
thanks
