### PR TITLE
#2401: fix error handling in Filters by using a new recover method on Iteratee

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Iteratee.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Iteratee.scala
@@ -548,6 +548,78 @@ trait Iteratee[E, +A] {
     }(dec)
   }
 
+  /**
+   * Creates a new Iteratee that will handle any matching exception the original Iteratee may contain. This lets you
+   * provide a fallback value in case your Iteratee ends up in an error state.
+   *
+   * Example:
+   *
+   * {{{
+   * def it = Iteratee.map(i => 10 / i).recover { case t: Throwable =>
+   *   Logger.error("Must have divided by zero!", t)
+   *   Integer.MAX_VALUE
+   * }
+   *
+   * Enumerator(5).run(it) // => 2
+   * Enumerator(0).run(it) // => returns Integer.MAX_VALUE and logs "Must have divied by zero!"
+   * }}}
+   *
+   * @param pf
+   * @param ec
+   * @tparam B
+   * @return
+   */
+  def recover[B >: A](pf: PartialFunction[Throwable, B])(implicit ec: ExecutionContext): Iteratee[E, B] = {
+    recoverM { case t: Throwable if pf.isDefinedAt(t) => Future.successful(pf(t)) }(ec)
+  }
+
+  /**
+   * A version of `recover` that allows the partial function to return a Future[B] instead of B.
+   *
+   * @param pf
+   * @param ec
+   * @tparam B
+   * @return
+   */
+  def recoverM[B >: A](pf: PartialFunction[Throwable, Future[B]])(implicit ec: ExecutionContext): Iteratee[E, B] = {
+    val pec = ec.prepare()
+    recoverWith { case t: Throwable if pf.isDefinedAt(t) => Iteratee.flatten(pf(t).map(b => Done[E, B](b))(pec)) }(ec)
+  }
+
+  /**
+   * A version of `recover` that allows the partial function to return an Iteratee[E, B] instead of B.
+   *
+   * @param pf
+   * @param ec
+   * @tparam B
+   * @return
+   */
+  def recoverWith[B >: A](pf: PartialFunction[Throwable, Iteratee[E, B]])(implicit ec: ExecutionContext): Iteratee[E, B] = {
+    val pec = ec.prepare()
+
+    def step(it: Iteratee[E, A])(input: Input[E]): Iteratee[E, B] = {
+      val nextIt = it.pureFlatFold[E, B] {
+        case Step.Cont(k) =>
+          val n = k(input)
+          n.pureFlatFold {
+            case Step.Cont(_) => Cont(step(n))
+            case Step.Error(msg, _) => throw new IterateeExeption(msg)
+            case other => other.it
+          }(dec)
+        case Step.Error(msg, _) => throw new IterateeExeption(msg)
+        case other => other.it
+      }(dec)
+
+      Iteratee.flatten(
+        nextIt.unflatten
+          .map(_.it)(dec)
+          .recover(pf)(pec)
+      )
+    }
+
+    Cont(step(this))
+  }
+
   def joinI[AIn](implicit in: A <:< Iteratee[_, AIn]): Iteratee[E, AIn] = {
     this.flatMap { a =>
       val inner = in(a)
@@ -689,3 +761,9 @@ object Error {
    */
   def apply[E](msg: String, e: Input[E]): Iteratee[E, Nothing] = new ErrorIteratee[E](msg, e)
 }
+
+/**
+ * An Exception that represents an Iteratee that ended up in an Error state with the given
+ * error message.
+ */
+class IterateeExeption(msg: String) extends Exception(msg)

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/ConcurrentSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/ConcurrentSpec.scala
@@ -14,17 +14,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 object ConcurrentSpec extends Specification
   with IterateeSpecification with ExecutionSpecification {
 
-  val timer = new java.util.Timer
-  def timeout[A](a: => A, d: Duration)(implicit e: ExecutionContext): Future[A] = {
-    val p = Promise[A]()
-    timer.schedule(new java.util.TimerTask {
-      def run() {
-        p.success(a)
-      }
-    }, d.toMillis)
-    p.future
-  }
-
   "Concurrent.broadcast (0-arg)" should {
     "broadcast the same to already registered iteratees" in {
       mustExecute(38) { foldEC =>

--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.it.mvc
+
+import org.specs2.mutable.Specification
+import play.api.mvc._
+import play.api.Routes
+import play.api.test._
+import play.api.test.Helpers._
+import scala.concurrent.duration.Duration
+import scala.concurrent._
+import play.api.libs.concurrent.Execution.{defaultContext => ec}
+
+object FiltersSpec extends Specification with WsTestClient {
+  "filters" should {
+    "handle errors" in {
+          
+      object ErrorHandlingFilter extends Filter {                        
+        def apply(next: RequestHeader => Future[SimpleResult])(request: RequestHeader): Future[SimpleResult] = {
+          try {
+            next(request).recover { case t: Throwable =>
+              Results.InternalServerError(t.getMessage)
+            }(play.api.libs.concurrent.Execution.Implicits.defaultContext)
+          } catch {
+            case t: Throwable => Future.successful(Results.InternalServerError(t.getMessage))
+          }
+        }        
+      }
+
+      object SkipNextFilter extends Filter {
+        val expectedText = "This filter does not call next"
+        
+        def apply(next: RequestHeader => Future[SimpleResult])(request: RequestHeader): Future[SimpleResult] = {
+          Future.successful(Results.Ok(expectedText))
+        }                
+      }
+
+      object SkipNextWithErrorFilter extends Filter {
+        val expectedText = "This filter does not call next and throws an exception"
+        
+        def apply(next: RequestHeader => Future[SimpleResult])(request: RequestHeader): Future[SimpleResult] = {
+          Future.failed(new RuntimeException(expectedText))
+        }                
+      }
+      
+      object ThrowExceptionFilter extends Filter {
+        val expectedText = "This filter calls next and throws an exception afterwords"
+
+        override def apply(next: (RequestHeader) => Future[SimpleResult])(rh: RequestHeader): Future[SimpleResult] = {
+          next(rh).map { _ =>
+            throw new RuntimeException(expectedText)
+          }(ec)
+        }
+      }    
+      
+      object ErrorHandlingGlobal extends WithFilters(ErrorHandlingFilter)
+      object SkipNextGlobal extends WithFilters(ErrorHandlingFilter, SkipNextFilter)
+      object SkipNextWithErrorGlobal extends WithFilters(ErrorHandlingFilter, SkipNextWithErrorFilter)      
+      object GlobalWithThrowExceptionFilter extends WithFilters(ErrorHandlingFilter, ThrowExceptionFilter)
+      
+      val expectedOkText = "Hello World"
+      val expectedErrorText = "Error"
+
+      val routerForTest: PartialFunction[(String, String), Handler] = {
+        case ("GET", "/ok") => Action { request => Results.Ok(expectedOkText) }
+        case ("POST", "/ok") => Action { request => Results.Ok(request.body.asText.getOrElse("")) }
+        case ("GET", "/error") => Action { request => throw new RuntimeException(expectedErrorText) }
+        case ("POST", "/error") => Action { request => throw new RuntimeException(request.body.asText.getOrElse("")) }
+        case ("GET", "/error-async") => Action.async { request => Future { throw new RuntimeException(expectedErrorText) }(ec) }
+        case ("POST", "/error-async") => Action.async { request => Future { throw new RuntimeException(request.body.asText.getOrElse("")) }(ec) }
+      }
+
+      "ErrorHandlingFilter has no effect on a GET that returns a 200 OK" in new WithServer(FakeApplication(withGlobal = Some(ErrorHandlingGlobal), withRoutes = routerForTest)) {
+        val response = Await.result(wsUrl("/ok").get(), Duration.Inf)
+        response.status must_== 200
+        response.body must_== expectedOkText
+      }
+      
+      "ErrorHandlingFilter has no effect on a POST that returns a 200 OK" in new WithServer(FakeApplication(withGlobal = Some(ErrorHandlingGlobal), withRoutes = routerForTest)) {
+        val response = Await.result(wsUrl("/ok").post(expectedOkText), Duration.Inf)
+        response.status must_== 200
+        response.body must_== expectedOkText
+      }
+      
+      "ErrorHandlingFilter recovers from a GET that throws a synchronous exception" in new WithServer(FakeApplication(withGlobal = Some(ErrorHandlingGlobal), withRoutes = routerForTest)) {
+        val response = Await.result(wsUrl("/error").get(), Duration.Inf)
+        response.status must_== 500
+        response.body must_== expectedErrorText
+      }
+      
+      "ErrorHandlingFilter recovers from a GET that throws an asynchronous exception" in new WithServer(FakeApplication(withGlobal = Some(ErrorHandlingGlobal), withRoutes = routerForTest)) {
+        val response = Await.result(wsUrl("/error-async").get(), Duration.Inf)
+        response.status must_== 500
+        response.body must_== expectedErrorText
+      }
+      
+      "ErrorHandlingFilter recovers from a POST that throws a synchronous exception" in new WithServer(FakeApplication(withGlobal = Some(ErrorHandlingGlobal), withRoutes = routerForTest)) {
+        val response = Await.result(wsUrl("/error").post(expectedOkText), Duration.Inf)
+        response.status must_== 500
+        response.body must_== expectedOkText
+      }
+      
+      "ErrorHandlingFilter recovers from a POST that throws an asynchronous exception" in new WithServer(FakeApplication(withGlobal = Some(ErrorHandlingGlobal), withRoutes = routerForTest)) {
+        val response = Await.result(wsUrl("/error-async").post(expectedOkText), Duration.Inf)
+        response.status must_== 500
+        response.body must_== expectedOkText
+      }
+      
+      "Filters work even if one of them does not call next" in new WithServer(FakeApplication(withGlobal = Some(SkipNextGlobal), withRoutes = routerForTest)) {
+        val response = Await.result(wsUrl("/ok").get(), Duration.Inf)
+        response.status must_== 200
+        response.body must_== SkipNextFilter.expectedText
+      }
+      
+      "ErrorHandlingFilter can recover from an exception throw by another filter in the filter chain, even if that Filter does not call next" in new WithServer(FakeApplication(withGlobal = Some(SkipNextWithErrorGlobal), withRoutes = routerForTest)) {
+        val response = Await.result(wsUrl("/ok").get(), Duration.Inf)
+        response.status must_== 500
+        response.body must_== SkipNextWithErrorFilter.expectedText
+      }
+      
+      "ErrorHandlingFilter can recover from an exception throw by another filter in the filter chain when that filter calls next and asynchronously throws an exception" in new WithServer(FakeApplication(withGlobal = Some(GlobalWithThrowExceptionFilter), withRoutes = routerForTest)) {
+        val response = Await.result(wsUrl("/ok").get(), Duration.Inf)
+        response.status must_== 500
+        response.body must_== ThrowExceptionFilter.expectedText
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a fix for #2401: Filters can now propagate and handle errors correctly. This is done by using new methods `recover`, `recoverM`, and `recoverWith` that I added to the `Iteratee` class. 

I added a number of unit tests for the various `recover` methods and several integration tests that check that error handling now works in Filters. The latter tests were failing before this patch and our now passing.
