### PR TITLE
Support Seq pairs for select list options.

### DIFF
--- a/framework/src/play/src/main/scala/views/helper/Helpers.scala
+++ b/framework/src/play/src/main/scala/views/helper/Helpers.scala
@@ -99,6 +99,7 @@ package views.html.helper {
 
   object options {
 
+    def apply(options: Seq[(String, String)]) = options
     def apply(options: (String, String)*) = options.toSeq
     def apply(options: Map[String, String]) = options.toSeq
     def apply(options: java.util.Map[String, String]) = options.asScala.toSeq


### PR DESCRIPTION
See google group thread for context:
https://groups.google.com/forum/#!topic/play-framework/2U13MZ9fJEg

Since the select method itself accepts a Seq[(String,String)], we should let users pass in a value of this type explicitly. As it stands Maps are useless since there is no defined ordering, so have to resort to ListMap hackery as a workaround.
