### PR TITLE
Fix Promise.sequence

### DIFF
--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -112,7 +112,7 @@ public class F {
          * @param promises The promises to combine
          * @return A single promise whose methods act on the list of redeemed promises
          */
-        public static <A> Promise<List<A>> sequence(Promise<? extends A>... promises){
+        public static <A> Promise<List<A>> sequence(Promise<A>... promises){
             return FPromiseHelper.<A>sequence(java.util.Arrays.asList(promises), HttpExecution.defaultContext());
         }
 
@@ -123,7 +123,7 @@ public class F {
          * @param promises The promises to combine
          * @return A single promise whose methods act on the list of redeemed promises
          */
-        public static <A> Promise<List<A>> sequence(ExecutionContext ec, Promise<? extends A>... promises){
+        public static <A> Promise<List<A>> sequence(ExecutionContext ec, Promise<A>... promises){
             return FPromiseHelper.<A>sequence(java.util.Arrays.asList(promises), ec);
         }
 
@@ -183,7 +183,7 @@ public class F {
          * @param promises The promises to combine
          * @return A single promise whose methods act on the list of redeemed promises
          */
-        public static <A> Promise<List<A>> sequence(Iterable<Promise<? extends A>> promises){
+        public static <A> Promise<List<A>> sequence(Iterable<Promise<A>> promises){
             return FPromiseHelper.<A>sequence(promises, HttpExecution.defaultContext());
         }
 
@@ -194,7 +194,7 @@ public class F {
          * @param ec Used to execute the sequencing operations.
          * @return A single promise whose methods act on the list of redeemed promises
          */
-        public static <A> Promise<List<A>> sequence(Iterable<Promise<? extends A>> promises, ExecutionContext ec){
+        public static <A> Promise<List<A>> sequence(Iterable<Promise<A>> promises, ExecutionContext ec){
             return FPromiseHelper.<A>sequence(promises, ec);
         }
 

--- a/framework/src/play/src/main/scala/play/core/j/FPromiseHelper.scala
+++ b/framework/src/play/src/main/scala/play/core/j/FPromiseHelper.scala
@@ -71,8 +71,8 @@ private[play] object FPromiseHelper {
     F.Promise.wrap(future)
   }
 
-  def sequence[A](promises: JIterable[F.Promise[_ <: A]], ec: ExecutionContext): F.Promise[JList[A]] = {
-    val futures = JavaConverters.iterableAsScalaIterableConverter(promises).asScala.toBuffer.map((_: F.Promise[_ <: A]).wrapped)
+  def sequence[A](promises: JIterable[F.Promise[A]], ec: ExecutionContext): F.Promise[JList[A]] = {
+    val futures = JavaConverters.iterableAsScalaIterableConverter(promises).asScala.toBuffer.map((_: F.Promise[A]).wrapped)
     implicit val pec = ec.prepare() // Easiest to provide implicitly so don't need to provide other implicit arg to sequence method
     F.Promise.wrap(Future.sequence(futures).map(az => JavaConverters.bufferAsJavaListConverter(az).asJava))
   }

--- a/framework/src/play/src/test/java/play/PromiseTest.java
+++ b/framework/src/play/src/test/java/play/PromiseTest.java
@@ -3,6 +3,9 @@
  */
 package play;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -115,6 +118,17 @@ public class PromiseTest {
         assertThat(d.get(t)).isEqualTo(false);
 
         assertThat(b.get(t)).isEqualTo(1);
+    }
+
+    @Test
+    public void testCombinePromiseSequence() {
+        F.Promise<Integer> a = F.Promise.pure(1);
+        F.Promise<Integer> b = F.Promise.pure(2);
+        F.Promise<Integer> c = F.Promise.pure(3);
+
+        F.Promise<List<Integer>> combined = F.Promise.sequence(Arrays.asList(a, b, c));
+
+        assertThat(combined.get(t)).isEqualTo(Arrays.asList(1, 2, 3));
     }
 }
 

--- a/framework/src/play/src/test/scala/play/libs/FSpec.scala
+++ b/framework/src/play/src/test/scala/play/libs/FSpec.scala
@@ -172,17 +172,10 @@ object FSpec extends Specification
       }
     }
 
-    "combine a sequence of promises from a iterable" in {
+    "combine a sequence of promises from an iterable" in {
       mustExecute(8) { ec =>
         import F.Promise.pure
-        F.Promise.sequence[Int](Arrays.asList(pure(1), pure(2), pure(3)): java.lang.Iterable[F.Promise[_ <: Int]], ec).get(5, SECONDS) must equalTo(Arrays.asList(1, 2, 3))
-      }
-    }
-
-    "combine a sequence of promises from a iterable" in {
-      mustExecute(8) { ec =>
-        import F.Promise.pure
-        F.Promise.sequence[Int](Arrays.asList(pure(1), pure(2), pure(3)): java.lang.Iterable[F.Promise[_ <: Int]], ec).get(5, SECONDS) must equalTo(Arrays.asList(1, 2, 3))
+        F.Promise.sequence[Int](Arrays.asList(pure(1), pure(2), pure(3)), ec).get(5, SECONDS) must equalTo(Arrays.asList(1, 2, 3))
       }
     }
 


### PR DESCRIPTION
Remove use of upper-bounded wildcard types in Promise.sequence, as it's currently not usable from Java.

See #1595.
