### PR TITLE
Make the timeout value for java testing configurable #2299

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -35,20 +35,26 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
 
     // --
     @SuppressWarnings(value = "unchecked")
-    private static Result invokeHandler(play.api.mvc.Handler handler, FakeRequest fakeRequest) {
+    private static Result invokeHandler(play.api.mvc.Handler handler, FakeRequest fakeRequest, long timeout) {
         if(handler instanceof play.core.j.JavaAction) {
             play.api.mvc.Action action = (play.api.mvc.Action)handler;
-            return wrapScalaResult(action.apply(fakeRequest.getWrappedRequest()));
+            return wrapScalaResult(action.apply(fakeRequest.getWrappedRequest()), timeout);
         } else {
             throw new RuntimeException("This is not a JavaAction and can't be invoked this way.");
         }
     }
 
-    private static SimpleResult wrapScalaResult(scala.concurrent.Future<play.api.mvc.SimpleResult> result) {
+    /** Default Timeout (milliseconds) for fake requests issued by these Helpers.
+     * This value is determined from System property <b>test.timeout</b>.
+     * The default value is <b>30000</b> (30 seconds).
+     */
+    public static final long DEFAULT_TIMEOUT = Long.getLong("test.timeout", 30000L);
+
+    private static SimpleResult wrapScalaResult(scala.concurrent.Future<play.api.mvc.SimpleResult> result, long timeout) {
         if (result == null) {
             return null;
         } else {
-            final play.api.mvc.SimpleResult simpleResult = new Promise<play.api.mvc.SimpleResult>(result).get(10000);
+            final play.api.mvc.SimpleResult simpleResult = new Promise<play.api.mvc.SimpleResult>(result).get(timeout);
             return new SimpleResult() {
                 public play.api.mvc.SimpleResult getWrappedSimpleResult() {
                     return simpleResult;
@@ -57,11 +63,11 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
         }
     }
 
-    private static SimpleResult unwrapJavaResult(Result result) {
+    private static SimpleResult unwrapJavaResult(Result result, long timeout) {
         if (result instanceof SimpleResult) {
             return (SimpleResult) result;
         } else {
-            return wrapScalaResult(result.getWrappedResult());
+            return wrapScalaResult(result.getWrappedResult(), timeout);
         }
     }
 
@@ -71,15 +77,21 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * Call an action method while decorating it with the right @With interceptors.
      */
     public static Result callAction(HandlerRef actionReference) {
-        return callAction(actionReference, fakeRequest());
+        return callAction(actionReference, DEFAULT_TIMEOUT);
+    }
+    public static Result callAction(HandlerRef actionReference, long timeout) {
+        return callAction(actionReference, fakeRequest(), timeout);
     }
 
     /**
      * Call an action method while decorating it with the right @With interceptors.
      */
     public static Result callAction(HandlerRef actionReference, FakeRequest fakeRequest) {
+        return callAction(actionReference, fakeRequest, DEFAULT_TIMEOUT);
+    }
+    public static Result callAction(HandlerRef actionReference, FakeRequest fakeRequest, long timeout) {
         play.api.mvc.HandlerRef handlerRef = (play.api.mvc.HandlerRef)actionReference;
-        return invokeHandler(handlerRef.handler(), fakeRequest);
+        return invokeHandler(handlerRef.handler(), fakeRequest, timeout);
     }
 
     /**
@@ -185,56 +197,80 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * Extracts the Status code of this Result value.
      */
     public static int status(Result result) {
-        return unwrapJavaResult(result).getWrappedSimpleResult().header().status();
+        return status(result, DEFAULT_TIMEOUT);
+    }
+    public static int status(Result result, long timeout) {
+        return unwrapJavaResult(result, timeout).getWrappedSimpleResult().header().status();
     }
 
     /**
      * Extracts the Location header of this Result value if this Result is a Redirect.
      */
     public static String redirectLocation(Result result) {
-        return header(LOCATION, result);
+        return redirectLocation(result, DEFAULT_TIMEOUT);
+    }
+    public static String redirectLocation(Result result, long timeout) {
+        return header(LOCATION, result, timeout);
     }
 
     /**
      * Extracts the Flash values of this Result value.
      */
     public static play.mvc.Http.Flash flash(Result result) {
-        return play.core.j.JavaResultExtractor.getFlash(unwrapJavaResult(result));
+        return flash(result, DEFAULT_TIMEOUT);
+    }
+    public static play.mvc.Http.Flash flash(Result result, long timeout) {
+        return play.core.j.JavaResultExtractor.getFlash(unwrapJavaResult(result, timeout));
     }
 
     /**
      * Extracts the Session of this Result value.
      */
     public static play.mvc.Http.Session session(Result result) {
-        return play.core.j.JavaResultExtractor.getSession(unwrapJavaResult(result));
+        return session(result, DEFAULT_TIMEOUT);
+    }
+    public static play.mvc.Http.Session session(Result result, long timeout) {
+        return play.core.j.JavaResultExtractor.getSession(unwrapJavaResult(result, timeout));
     }
 
     /**
      * Extracts a Cookie value from this Result value
      */
     public static play.mvc.Http.Cookie cookie(String name, Result result) {
-        return play.core.j.JavaResultExtractor.getCookies(unwrapJavaResult(result)).get(name);
+        return cookie(name, result, DEFAULT_TIMEOUT);
+    }
+    public static play.mvc.Http.Cookie cookie(String name, Result result, long timeout) {
+        return play.core.j.JavaResultExtractor.getCookies(unwrapJavaResult(result, timeout)).get(name);
     }
 
     /**
      * Extracts the Cookies (an iterator) from this result value.
      */
     public static play.mvc.Http.Cookies cookies(Result result) {
-       return play.core.j.JavaResultExtractor.getCookies(unwrapJavaResult(result));
+       return cookies(result, DEFAULT_TIMEOUT);
+    }
+    public static play.mvc.Http.Cookies cookies(Result result, long timeout) {
+       return play.core.j.JavaResultExtractor.getCookies(unwrapJavaResult(result, timeout));
     }
 
     /**
      * Extracts an Header value of this Result value.
      */
     public static String header(String header, Result result) {
-        return play.core.j.JavaResultExtractor.getHeaders(unwrapJavaResult(result)).get(header);
+        return header(header, result, DEFAULT_TIMEOUT);
+    }
+    public static String header(String header, Result result, long timeout) {
+        return play.core.j.JavaResultExtractor.getHeaders(unwrapJavaResult(result, timeout)).get(header);
     }
 
     /**
      * Extracts all Headers of this Result value.
      */
     public static Map<String,String> headers(Result result) {
-        return play.core.j.JavaResultExtractor.getHeaders(unwrapJavaResult(result));
+        return headers(result, DEFAULT_TIMEOUT);
+    }
+    public static Map<String,String> headers(Result result, long timeout) {
+        return play.core.j.JavaResultExtractor.getHeaders(unwrapJavaResult(result, timeout));
     }
 
     /**
@@ -248,7 +284,10 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * Extracts the Content-Type of this Result value.
      */
     public static String contentType(Result result) {
-        String h = header(CONTENT_TYPE, result);
+        return contentType(result, DEFAULT_TIMEOUT);
+    }
+    public static String contentType(Result result, long timeout) {
+        String h = header(CONTENT_TYPE, result, timeout);
         if(h == null) return null;
         if(h.contains(";")) {
             return h.substring(0, h.indexOf(";")).trim();
@@ -261,7 +300,10 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * Extracts the Charset of this Result value.
      */
     public static String charset(Result result) {
-        String h = header(CONTENT_TYPE, result);
+        return charset(result, DEFAULT_TIMEOUT);
+    }
+    public static String charset(Result result, long timeout) {
+        String h = header(CONTENT_TYPE, result, timeout);
         if(h == null) return null;
         if(h.contains("; charset=")) {
             return h.substring(h.indexOf("; charset=") + 10, h.length()).trim();
@@ -274,7 +316,10 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * Extracts the content as bytes.
      */
     public static byte[] contentAsBytes(Result result) {
-        return play.core.j.JavaResultExtractor.getBody(unwrapJavaResult(result));
+        return contentAsBytes(result, DEFAULT_TIMEOUT);
+    }
+    public static byte[] contentAsBytes(Result result, long timeout) {
+        return play.core.j.JavaResultExtractor.getBody(unwrapJavaResult(result, timeout));
     }
 
     /**
@@ -295,12 +340,15 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * Extracts the content as String.
      */
     public static String contentAsString(Result result) {
+        return contentAsString(result, DEFAULT_TIMEOUT);
+    }
+    public static String contentAsString(Result result, long timeout) {
         try {
-            String charset = charset(result);
+            String charset = charset(result, timeout);
             if(charset == null) {
                 charset = "utf-8";
             }
-            return new String(contentAsBytes(result), charset);
+            return new String(contentAsBytes(result, timeout), charset);
         } catch(RuntimeException e) {
             throw e;
         } catch(Throwable t) {
@@ -313,10 +361,13 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * @deprecated
      * @see #route instead
      */
-    @SuppressWarnings(value = "unchecked")
     public static Result routeAndCall(FakeRequest fakeRequest) {
+        return routeAndCall(fakeRequest, DEFAULT_TIMEOUT);
+    }
+    @SuppressWarnings(value = "unchecked")
+    public static Result routeAndCall(FakeRequest fakeRequest, long timeout) {
         try {
-            return routeAndCall((Class<? extends play.core.Router.Routes>)FakeRequest.class.getClassLoader().loadClass("Routes"), fakeRequest);
+            return routeAndCall((Class<? extends play.core.Router.Routes>)FakeRequest.class.getClassLoader().loadClass("Routes"), fakeRequest, timeout);
         } catch(RuntimeException e) {
             throw e;
         } catch(Throwable t) {
@@ -330,10 +381,13 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * @see #route instead
      */
     public static Result routeAndCall(Class<? extends play.core.Router.Routes> router, FakeRequest fakeRequest) {
+        return routeAndCall(router, fakeRequest, DEFAULT_TIMEOUT);
+    }
+    public static Result routeAndCall(Class<? extends play.core.Router.Routes> router, FakeRequest fakeRequest, long timeout) {
         try {
             play.core.Router.Routes routes = (play.core.Router.Routes)router.getClassLoader().loadClass(router.getName() + "$").getDeclaredField("MODULE$").get(null);
             if(routes.routes().isDefinedAt(fakeRequest.getWrappedRequest())) {
-                return invokeHandler(routes.routes().apply(fakeRequest.getWrappedRequest()), fakeRequest);
+                return invokeHandler(routes.routes().apply(fakeRequest.getWrappedRequest()), fakeRequest, timeout);
             } else {
                 return null;
             }
@@ -345,20 +399,32 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     }
 
     public static Result route(FakeRequest fakeRequest) {
-      return route(play.Play.application(), fakeRequest);
+      return route(fakeRequest, DEFAULT_TIMEOUT);
+    }
+    public static Result route(FakeRequest fakeRequest, long timeout) {
+      return route(play.Play.application(), fakeRequest, timeout);
     }
 
     public static Result route(Application app, FakeRequest fakeRequest) {
+      return route(app, fakeRequest, DEFAULT_TIMEOUT);
+    }
+    public static Result route(Application app, FakeRequest fakeRequest, long timeout) {
       final scala.Option<scala.concurrent.Future<play.api.mvc.SimpleResult>> opt = play.api.test.Helpers.jRoute(app.getWrappedApplication(), fakeRequest.fake);
-      return wrapScalaResult(Scala.orNull(opt));
+      return wrapScalaResult(Scala.orNull(opt), timeout);
     }
 
     public static Result route(Application app, FakeRequest fakeRequest, byte[] body) {
-      return wrapScalaResult(Scala.orNull(play.api.test.Helpers.jRoute(app.getWrappedApplication(), fakeRequest.getWrappedRequest(), body)));
+      return route(app, fakeRequest, body, DEFAULT_TIMEOUT);
+    }
+    public static Result route(Application app, FakeRequest fakeRequest, byte[] body, long timeout) {
+      return wrapScalaResult(Scala.orNull(play.api.test.Helpers.jRoute(app.getWrappedApplication(), fakeRequest.getWrappedRequest(), body)), timeout);
     }
 
     public static Result route(FakeRequest fakeRequest, byte[] body) {
-      return route(play.Play.application(), fakeRequest, body);
+      return route(fakeRequest, body, DEFAULT_TIMEOUT);
+    }
+    public static Result route(FakeRequest fakeRequest, byte[] body, long timeout) {
+      return route(play.Play.application(), fakeRequest, body, timeout);
     }
 
     /**


### PR DESCRIPTION
This would seem to be the simplest way to allow setting of the timeout for Helpers-initiated fake requests.

(BTW the other static variables in this class seem to be constants and should probably be marked final.)
