### PR TITLE
Making netty backlog configurable and using netty current thread namer

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/NettyServerThreadNamingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/NettyServerThreadNamingSpec.scala
@@ -1,0 +1,25 @@
+package play.it.http
+
+import org.specs2.mutable.Specification
+
+import play.api.test.{DefaultAwaitTimeout, Helpers, FakeApplication, TestServer}
+import play.api.mvc.Action
+import play.api.mvc.Results.Ok
+import play.api.libs.ws.WS
+
+class NettyServerThreadNamingSpec extends Specification with DefaultAwaitTimeout {
+
+  "NettyServer" should {
+    "make sure the netty uses the thread names specified by Play" in {
+      implicit val app  = FakeApplication(withRoutes = {
+        case _ =>
+          val threadName = Thread.currentThread.getName
+          Action(Ok(threadName))
+      })
+      Helpers.running(TestServer(9191, app)) {
+        val response = Helpers.await(WS.url("http://localhost:9191").get())
+        response.body must beMatching("play-netty-worker-\\d$")
+      }
+    }
+  }
+}

--- a/framework/src/play/src/test/scala/play/core/server/NettyServerSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/server/NettyServerSpec.scala
@@ -5,13 +5,14 @@ package play.core.server
 
 import scala.util.{ Try, Failure }
 
-import org.specs2.mutable.Specification
+import org.specs2.mutable.{Around, Specification}
 import play.core.ApplicationProvider
 import java.io.File
 import scala.util.Random
 import play.api.Application
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import org.specs2.execute.{Result, AsResult}
 
 
 object NettyServerSpec extends Specification {
@@ -21,7 +22,6 @@ object NettyServerSpec extends Specification {
     def get: Try[Application] = Failure(new RuntimeException)
   }
 
-
   "NettyServer" should {
     "fail when no https.port and http.port is missing" in {
       new NettyServer(
@@ -29,6 +29,22 @@ object NettyServerSpec extends Specification {
         None,
         None
       ) must throwAn[IllegalArgumentException]
+    }
+
+    "use the backlog system property" in {
+      System.setProperty("play.netty.backlog", "10")
+      val server = new NettyServer(
+        new Fake,
+        Some(9191),
+        None
+      )
+      try {
+        val Some((bootstrap, _)) = server.HTTP
+        bootstrap.getOptions.get("backlog") must_== 10
+      } finally {
+        server.stop()
+        System.clearProperty("play.netty.backlog")
+      }
     }
   }
 


### PR DESCRIPTION
This fixes couple of issues identified in #2354
- The backlog is configurable using play.netty.backlog settings
- Using Netty NioXXXPool so we can control current thread pool names. If you only use Executors.newCachedThreadPool(...) then netty doesn't use the name passed in the NamedThreadFactory
