### PR TITLE
Add support for CREATED to ResultExtractors.redirectLocation

### DIFF
--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -377,6 +377,7 @@ trait ResultExtractors {
     case ResponseHeader(SEE_OTHER, headers) => headers.get(LOCATION)
     case ResponseHeader(TEMPORARY_REDIRECT, headers) => headers.get(LOCATION)
     case ResponseHeader(MOVED_PERMANENTLY, headers) => headers.get(LOCATION)
+    case ResponseHeader(CREATED, headers) => headers.get(LOCATION)
     case ResponseHeader(_, _) => None
   }
 


### PR DESCRIPTION
This makes it easier to test RESTful APIs that return a URL in  the 
`Location` header when returning `201 - Created`.
