### PR TITLE
Fix incorrect regex

### DIFF
--- a/documentation/manual/scalaGuide/main/http/ScalaRouting.md
+++ b/documentation/manual/scalaGuide/main/http/ScalaRouting.md
@@ -53,7 +53,7 @@ The default matching strategy for a dynamic part is defined by the regular expre
 
 ### Dynamic parts spanning several /
 
-If you want a dynamic part to capture more than one URI path segment, separated by forward slashes, you can define a dynamic part using the `*id` syntax, which uses the `.*` regular expression:
+If you want a dynamic part to capture more than one URI path segment, separated by forward slashes, you can define a dynamic part using the `*id` syntax, which uses the `.+` regular expression:
 
 @[spanning-path](code/scalaguide.http.routing.routes)
 


### PR DESCRIPTION
The `.*` regex described under "Dynamic parts spanning several /" does not match the actual functionality of the framework. For instance, if I describe the route: `GET /blah/*path` it will not match /blah/
