### PR TITLE
Make the JavaScript reverse router return a JavaScript value

### DIFF
--- a/framework/src/play/src/main/java/play/Routes.java
+++ b/framework/src/play/src/main/java/play/Routes.java
@@ -3,6 +3,7 @@
  */
 package play;
 
+import play.api.templates.JavaScript;
 import play.libs.Scala;
 
 /**
@@ -18,14 +19,14 @@ public class Routes {
     /**
      * Generates a JavaScript router.
      */
-    public static String javascriptRouter(String name, play.core.Router.JavascriptReverseRoute... routes) {
+    public static JavaScript javascriptRouter(String name, play.core.Router.JavascriptReverseRoute... routes) {
         return javascriptRouter(name, "jQuery.ajax", routes);
     }
 
     /**
      * Generates a JavaScript router.
      */
-    public static String javascriptRouter(String name, String ajaxMethod, play.core.Router.JavascriptReverseRoute... routes) {
+    public static JavaScript javascriptRouter(String name, String ajaxMethod, play.core.Router.JavascriptReverseRoute... routes) {
         return play.api.Routes.javascriptRouter(
             name, Scala.Option(ajaxMethod), play.mvc.Http.Context.current().request().host(), Scala.toSeq(routes)
         );

--- a/framework/src/play/src/main/scala/play/api/Routes.scala
+++ b/framework/src/play/src/main/scala/play/api/Routes.scala
@@ -3,6 +3,8 @@
  */
 package play.api {
 
+  import play.api.templates.JavaScript
+
   /**
    * Helper utilities related to `Router`.
    */
@@ -42,7 +44,7 @@ package play.api {
      * @param routes the routes to include in this JavaScript router
      * @return the JavaScript code
      */
-    def javascriptRouter(name: String = "Router", ajaxMethod: Option[String] = Some("jQuery.ajax"))(routes: JavascriptReverseRoute*)(implicit request: RequestHeader): String = {
+    def javascriptRouter(name: String = "Router", ajaxMethod: Option[String] = Some("jQuery.ajax"))(routes: JavascriptReverseRoute*)(implicit request: RequestHeader): JavaScript = {
       javascriptRouter(name, ajaxMethod, request.host, routes: _*)
     }
 
@@ -52,7 +54,7 @@ package play.api {
       "typeof", "var", "void", "while", "with")
 
     // TODO: This JS needs to be re-written as it isn't easily maintained.
-    def javascriptRouter(name: String, ajaxMethod: Option[String], host: String, routes: JavascriptReverseRoute*): String = {
+    def javascriptRouter(name: String, ajaxMethod: Option[String], host: String, routes: JavascriptReverseRoute*): JavaScript = JavaScript {
       """|var %s = {}; (function(_root){
              |var _nS = function(c,f,b){var e=c.split(f||"."),g=b||_root,d,a;for(d=0,a=e.length;d<a;d++){g=g[e[d]]=g[e[d]]||{}}return g}
              |var _qS = function(items){var qs = ''; for(var i=0;i<items.length;i++) {if(items[i]) qs += (qs ? '&' : '') + items[i]}; return qs ? ('?' + qs) : ''}

--- a/framework/src/play/src/main/scala/views/helper/javascriptRouter.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/javascriptRouter.scala.html
@@ -24,5 +24,5 @@
 @(name:String = "Router")(routes:play.core.Router.JavascriptReverseRoute*)(implicit request: play.api.mvc.RequestHeader)
 
 <script type="text/javascript">
-    @Html(play.api.Routes.javascriptRouter(name)(routes:_*))
+    @Html(play.api.Routes.javascriptRouter(name)(routes: _*).body.replace("/", "\\/"))
 </script>

--- a/framework/test/integrationtest/app/controllers/Application.scala
+++ b/framework/test/integrationtest/app/controllers/Application.scala
@@ -115,7 +115,7 @@ object Application extends Controller {
   
   def javascriptRoutes = Action { implicit request =>
     import play.api.Routes
-    Ok(Routes.javascriptRouter("routes")(routes.javascript.Application.javascriptTest)).as("text/javascript")
+    Ok(Routes.javascriptRouter("routes")(routes.javascript.Application.javascriptTest))
   }
 
   def javascriptTest(name: String) = Action {

--- a/samples/java/zentasks/app/controllers/Application.java
+++ b/samples/java/zentasks/app/controllers/Application.java
@@ -64,7 +64,6 @@ public class Application extends Controller {
     // -- Javascript routing
     
     public static Result javascriptRoutes() {
-        response().setContentType("text/javascript");
         return ok(
             Routes.javascriptRouter("jsRoutes",
             

--- a/samples/scala/zentasks/app/controllers/Application.scala
+++ b/samples/scala/zentasks/app/controllers/Application.scala
@@ -59,7 +59,7 @@ object Application extends Controller {
         Tasks.renameFolder, Tasks.deleteFolder, Tasks.index,
         Tasks.add, Tasks.update, Tasks.delete
       )
-    ).as("text/javascript") 
+    )
   }
 
 }


### PR DESCRIPTION
The current implementation of the JavaScript reverse router returns a `String`, forcing users to explicitly set their response content-type to `text/javascript`. This pull request replaces this `String` with a more meaningful `play.api.templates.JavaScript` type.
