### PR TITLE
Adding onError to PlayRunHook, which is called whenever play run has an exception.

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/PlayRunHooks.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/PlayRunHooks.scala
@@ -4,6 +4,7 @@
 package play
 
 import scala.util.control.NonFatal
+import scala.collection.mutable.LinkedHashMap
 import java.net.InetSocketAddress
 
 /**
@@ -22,7 +23,19 @@ trait PlayRunHook {
    * Called after the play process has been stopped.
    */
   def afterStopped(): Unit = ()
+
+  /**
+   * Called if there was any exception thrown during play run.
+   * Useful to implement to clean up any open resources for this hook.
+   */
+  def onError(): Unit = ()
 }
+
+case class RunHookCompositeThrowable(val throwables: Set[Throwable]) extends Exception(
+  "Multiple exceptions thrown during PlayRunHook run: " +
+    throwables.map(t => t + "\n" + t.getStackTrace.take(10).++("...").mkString("\n")).mkString("\n\n")
+)
+
 object PlayRunHook {
 
   def makeRunHookFromOnStarted(f: (java.net.InetSocketAddress) => Unit): PlayRunHook = {
@@ -44,20 +57,26 @@ object PlayRunHook {
   implicit class RunHooksRunner(val hooks: Seq[PlayRunHook]) extends AnyVal {
     /** Runs all the hooks in the sequence of hooks.  reports last failure if any have failure. */
     def run(f: PlayRunHook => Unit, suppressFailure: Boolean = false): Unit = try {
-      // TODO - Should we ignore failure?  Probably not... but just sending first fail may be bad too.
-      // TODO - Should probably have a cleanup method on hooks in case of failure...
-      var lastFailure: Option[Throwable] = None
+
+      val failures: LinkedHashMap[PlayRunHook, Throwable] = LinkedHashMap.empty
+
       hooks foreach { hook =>
         try {
           f(hook)
         } catch {
           case NonFatal(e) =>
-            // Just save the last failure for now...
-            lastFailure = Some(e)
+            failures += hook -> e
         }
       }
+
       // Throw failure if it occurred....
-      if (!suppressFailure) lastFailure foreach (throw _)
+      if (!suppressFailure && failures.nonEmpty) {
+        if (failures.size == 1) {
+          throw failures.values.head
+        } else {
+          throw RunHookCompositeThrowable(failures.values.toSet)
+        }
+      }
     } catch {
       case NonFatal(e) if suppressFailure =>
       // Ignoring failure in running hooks... (CCE thrown here)

--- a/framework/src/sbt-plugin/src/test/scala/play/PlayRunHookSpec.scala
+++ b/framework/src/sbt-plugin/src/test/scala/play/PlayRunHookSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play
+
+import java.io._
+import org.specs2.mutable._
+import play.PlayExceptions.AssetCompilationException
+import scala.collection.mutable.HashMap
+
+object PlayRunHookSpec extends Specification {
+
+  "PlayRunHook runner" should {
+
+    "provide implicit `run` which passes every hook to a provided function" in {
+      val hooks = Seq.fill(3)(new PlayRunHook {})
+      val executedHooks: HashMap[PlayRunHook, Boolean] = HashMap.empty
+
+      hooks.run(hook => executedHooks += ((hook, true)))
+
+      executedHooks.size must be equalTo(3)
+    }
+
+    "re-throw an exception on single hook failure" in {
+      val executedHooks: HashMap[PlayRunHook, Boolean] = HashMap.empty
+      class HookMockException extends Throwable
+
+      val hooks = Seq.fill(3)(new PlayRunHook {
+        executedHooks += ((this, true))
+      }) :+ new PlayRunHook {
+        override def beforeStarted(): Unit = throw new HookMockException()
+      }
+
+      hooks.run(_.beforeStarted()) must throwA[HookMockException]
+
+      executedHooks.size must be equalTo(3)
+    }
+
+    "combine several thrown exceptions into a RunHookCompositeThrowable" in {
+      val executedHooks: HashMap[PlayRunHook, Boolean] = HashMap.empty
+      class HookFirstMockException extends Throwable
+      class HookSecondMockException extends Throwable
+
+      def createDummyHooks = new PlayRunHook {
+        executedHooks += ((this, true))
+      }
+
+      val dummyHooks = Seq.fill(3)(createDummyHooks)
+
+      val firstFailure = new PlayRunHook {
+        override def beforeStarted(): Unit = throw new HookFirstMockException()
+      }
+
+      val lastFailure = new PlayRunHook {
+        override def beforeStarted(): Unit = throw new HookSecondMockException()
+      }
+
+      val hooks = firstFailure +: dummyHooks :+ lastFailure
+
+      hooks.run(_.beforeStarted()) must throwAn[RunHookCompositeThrowable].like {
+        case e: Throwable =>
+          e.getMessage must contain("HookFirstMockException")
+          e.getMessage must contain("HookSecondMockException")
+          e.getMessage must not contain("HookThirdMockException")
+      }
+
+      executedHooks.size must be equalTo(3)
+    }
+  }
+
+}


### PR DESCRIPTION
Adding onError to PlayRunHook, which is called on all `PlayRunHook`s whenever play run has an exception, so that resources can be cleaned up.

([Diff best viewed with ?w=1](https://github.com/playframework/playframework/pull/2437/files?w=1))
- `PlayRun` now calls the hook’s `onError` on any failure between the calling of `beforeStarted` to the end of the run task.
- Previously, Play swallowed all but the last exception when calling `run`. Now, when multiple exceptions are thrown, they’re combined into a `RunHookCompositeThrowable` (modeled directly after `scala.collection.parallel.CompositeThrowable`), which will make the logs more clear.
- Added test coverage to `PlayRunHook`.

It’s useful to let `PlayRunHook`s be notified when there was an exception during Play’s life cycle. For example, if we had resources open or were a running process (like a Grunt watch task) in a `PlayRunHook`, it needs to be cleaned up.

The TypeSafe CLA should be signed.
