### PR TITLE
play-ws add compression option

### DIFF
--- a/documentation/manual/javaGuide/main/ws/code/javaguide/ws/application.conf
+++ b/documentation/manual/javaGuide/main/ws/code/javaguide/ws/application.conf
@@ -7,4 +7,6 @@ ws.timeout.connection=120000
 ws.useProxyProperties=true
 # A user agent string to set on each request (default none)
 ws.useragent="My Play Application"
+# Enable compiression default false
+ws.compressionEnabled=true
 # #application

--- a/documentation/manual/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/scalaGuide/main/ws/ScalaWS.md
@@ -208,16 +208,17 @@ This is important in a couple of cases.  WS has a couple of limitations that req
 * `WS` does not support multi part form upload directly.  You can use the underlying client with [RequestBuilder.addBodyPart](http://asynchttpclient.github.io/async-http-client/apidocs/com/ning/http/client/RequestBuilder.html).
 * `WS` does not support client certificates (aka mutual TLS / MTLS / client authentication).  You should set the `SSLContext` directly in an instance of [AsyncHttpClientConfig](http://asynchttpclient.github.io/async-http-client/apidocs/com/ning/http/client/AsyncHttpClientConfig.html) and set up the appropriate KeyStore and TrustStore.
 
-## Configuring WS 
+## Configuring WS
 
 Use the following properties to configure the WS client
 
 * `ws.followRedirects` configures the client to follow 301 and 302 redirects
-* `ws.useProxyProperties`to use the system http proxy settings(http.proxyHost, http.proxyPort) 
+* `ws.useProxyProperties`to use the system http proxy settings(http.proxyHost, http.proxyPort)
 * `ws.useragent` to configure the User-Agent header field
 * `ws.acceptAnyCertificate` set it to false to use the default SSLContext
+* `ws.compressionEnable` set it to true to use gzip/deflater encoding
 
- 
+
 ### Timeouts
 
 There are 3 different timeouts in WS. Reaching a timeout causes the WS request to interrupt.

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSAPI.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSAPI.java
@@ -35,7 +35,8 @@ public class NingWSAPI implements WSAPI {
                 .setIdleConnectionTimeoutInMs(playConfig.getMilliseconds("ws.timeout.idle", 120000L).intValue())
                 .setRequestTimeoutInMs(playConfig.getMilliseconds("ws.timeout.request", 120000L).intValue())
                 .setFollowRedirects(playConfig.getBoolean("ws.followRedirects", true).booleanValue())
-                .setUseProxyProperties(playConfig.getBoolean("ws.useProxyProperties", true));
+                .setUseProxyProperties(playConfig.getBoolean("ws.useProxyProperties", true))
+                .setCompressionEnabled(playConfig.getBoolean("ws.compressionEnabled", false));
 
         String userAgent = playConfig.getString("ws.useragent");
         if (userAgent != null) {

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
@@ -641,6 +641,7 @@ class NingWSAPI(app: Application) extends WSAPI {
       .setRequestTimeoutInMs(playConfig.getMilliseconds("ws.timeout.request").getOrElse(120000L).toInt)
       .setFollowRedirects(playConfig.getBoolean("ws.followRedirects").getOrElse(true))
       .setUseProxyProperties(playConfig.getBoolean("ws.useProxyProperties").getOrElse(true))
+      .setCompressionEnabled(playConfig.getBoolean("ws.compressionEnabled").getOrElse(false))
 
     playConfig.getString("ws.useragent").map {
       useragent =>


### PR DESCRIPTION
Add support for `AHC setCompressionEnabled`  option to support gizp/deflater encoded response
