### PR TITLE
Parameter value implicit

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/ParameterValue.scala
+++ b/framework/src/anorm/src/main/scala/anorm/ParameterValue.scala
@@ -29,12 +29,14 @@ sealed trait ParameterValue {
  * Value factory for parameter.
  *
  * {{{
- * val param = ParameterValue("str", setter)
+ * val param = ParameterValue("str", null, setter)
  *
  * SQL("...").onParams(param)
  * }}}
  */
 object ParameterValue {
+  import scala.language.implicitConversions
+
   private[anorm] trait Wrapper[T] { def value: T }
 
   def apply[A](v: A, s: ToSql[A], toStmt: ToStatement[A]) =
@@ -60,4 +62,6 @@ object ParameterValue {
         case _ => false
       }
     }
+
+  implicit def toParameterValue[A](a: A)(implicit s: ToSql[A] = null, p: ToStatement[A]): ParameterValue = apply(a, s, p)
 }

--- a/framework/src/anorm/src/main/scala/anorm/package.scala
+++ b/framework/src/anorm/src/main/scala/anorm/package.scala
@@ -21,8 +21,6 @@ package object anorm {
 
   implicit def implicitID[ID](id: Id[ID] with NotNull): ID = id.id
 
-  implicit def toParameterValue[A](a: A)(implicit s: ToSql[A] = null, p: ToStatement[A]): ParameterValue = ParameterValue(a, s, p)
-
   /**
    * Creates an SQL query with given statement.
    * @param stmt SQL statement


### PR DESCRIPTION
Move implicit for `ParameterValue` its companion object, so that package import/wildcard `import anorm._` will no longer be required.
