### PR TITLE
Typo: line 9: parsers-->parser, 36: retun-->return

### DIFF
--- a/documentation/manual/javaGuide/main/http/JavaBodyParsers.md
+++ b/documentation/manual/javaGuide/main/http/JavaBodyParsers.md
@@ -6,7 +6,7 @@ An HTTP request (at least for those using the POST and PUT operations) contains 
 
 > **Note:** You can't write `BodyParser` implementation directly using Java. Because a Play `BodyParser` must handle the body content incrementaly using an `Iteratee[Array[Byte], A]` it must be implemented in Scala.
 >
-> However Play provides default `BodyParser`s that should fit most use cases (parsing Json, Xml, Text, uploading files). And you can reuse these default parsers to create your own directly in Java; for example you can provide an RDF parsers based on the Text one.
+> However Play provides default `BodyParser`s that should fit most use cases (parsing Json, Xml, Text, uploading files). And you can reuse these default parsers to create your own directly in Java; for example you can provide an RDF parser based on the Text one.
 
 ## The `BodyParser` Java API
 
@@ -33,7 +33,7 @@ public static Result index() {
 
 As we just said all body parsers in the Java API will give you a `play.mvc.Http.RequestBody` value. From this body object you can retrieve the request body content in the most appropriate Java type.
 
-> **Note:** The `RequestBody` methods like `asText()` or `asJson()` will return null if the parser used to compute this request body doesn't support this content type. For example in an action method annotated with `@BodyParser.Of(BodyParser.Json.class)`, calling `asXml()` on the generated body will retun null.
+> **Note:** The `RequestBody` methods like `asText()` or `asJson()` will return null if the parser used to compute this request body doesn't support this content type. For example in an action method annotated with `@BodyParser.Of(BodyParser.Json.class)`, calling `asXml()` on the generated body will return null.
 
 Some parsers can provide a more specific type than `Http.RequestBody` (ie. a subclass of `Http.RequestBody`). You can automatically cast the request body into another type using the `as(...)` helper method:
 


### PR DESCRIPTION
Typo corrections in 2.2.x/documentation/manual/javaGuide/main/http/JavaBodyParsers.md
