### PR TITLE
Send close control frame on client-initiated disconnects

### DIFF
--- a/framework/src/play/src/main/scala/play/core/server/netty/WebSocketHandler.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/WebSocketHandler.scala
@@ -79,7 +79,11 @@ private[server] trait WebSocketHandler {
             case frame: WebSocketFrame if nettyFrameFormatter.fromFrame.isDefinedAt(frame) => {
               enumerator.frameReceived(ctx, El(nettyFrameFormatter.fromFrame(frame)))
             }
-            case frame: CloseWebSocketFrame => { ctx.getChannel().disconnect(); enumerator.frameReceived(ctx, EOF) }
+            case frame: CloseWebSocketFrame => {
+              ctx.getChannel().write(new CloseWebSocketFrame(frame.getStatusCode, ""))
+              ctx.getChannel().disconnect()
+              enumerator.frameReceived(ctx, EOF)
+            }
             case frame: PingWebSocketFrame => { ctx.getChannel().write(new PongWebSocketFrame(frame.getBinaryData)) }
             case frame: WebSocketFrame => //
             case _ => //


### PR DESCRIPTION
Fixes #2456. On a client initiated disconnect (when the server receives a close control frame), reply with a close control frame, as per the [WebSocket Protocol RFC](http://tools.ietf.org/html/rfc6455#section-5.5.1).

On proper client-initiated disconnect:
![](http://i.imgur.com/nd8SBJR.png)

~~A back-port would be appreciated to 2.2.x.~~
