### PR TITLE
Form <input> types should be well formed

### DIFF
--- a/framework/src/play/src/main/scala/views/helper/checkbox.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/checkbox.scala.html
@@ -15,6 +15,6 @@
 @boxValue = @{ args.toMap.get('value).getOrElse("true") }
 
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
-    <input type="checkbox" id="@id" name="@name" value="@boxValue" @(if(value == Some(boxValue)) "checked" else "") @toHtmlArgs(htmlArgs.filterKeys(_ != 'value))>
+    <input type="checkbox" id="@id" name="@name" value="@boxValue" @if(value == Some(boxValue)){checked="checked"} @toHtmlArgs(htmlArgs.filterKeys(_ != 'value))/>
     <span>@args.toMap.get('_text)</span>
 }

--- a/framework/src/play/src/main/scala/views/helper/inputCheckboxGroup.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputCheckboxGroup.scala.html
@@ -22,7 +22,7 @@
   <span class="buttonset" id="@id">
     @defining(field.indexes.map( i => field("[%s]".format(i)).value ).flatten.toSet) { values =>
       @options.map { v =>
-        <input type="checkbox" id="@(id)_@v._1" name="@{name + "[]"}" value="@v._1" @(if(values.contains(v._1)) "checked" else "") @toHtmlArgs(htmlArgs)>
+        <input type="checkbox" id="@(id)_@v._1" name="@{name + "[]"}" value="@v._1" @if(values.contains(v._1)){checked="checked"} @toHtmlArgs(htmlArgs)/>
         <label for="@(id)_@v._1">@v._2</label>
       }
     }

--- a/framework/src/play/src/main/scala/views/helper/inputDate.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputDate.scala.html
@@ -13,5 +13,5 @@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, lang: play.api.i18n.Lang)
 
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
-    <input type="date" id="@id" name="@name" value="@value" @toHtmlArgs(htmlArgs)>
+    <input type="date" id="@id" name="@name" value="@value" @toHtmlArgs(htmlArgs)/>
 }

--- a/framework/src/play/src/main/scala/views/helper/inputFile.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputFile.scala.html
@@ -13,5 +13,5 @@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, lang: play.api.i18n.Lang)
 
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
-    <input type="file" id="@id" name="@name" @toHtmlArgs(htmlArgs)>
+    <input type="file" id="@id" name="@name" @toHtmlArgs(htmlArgs)/>
 }

--- a/framework/src/play/src/main/scala/views/helper/inputPassword.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputPassword.scala.html
@@ -13,5 +13,5 @@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, lang: play.api.i18n.Lang)
 
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
-    <input type="password" id="@id" name="@name" @toHtmlArgs(htmlArgs)>
+    <input type="password" id="@id" name="@name" @toHtmlArgs(htmlArgs)/>
 }

--- a/framework/src/play/src/main/scala/views/helper/inputRadioGroup.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputRadioGroup.scala.html
@@ -20,7 +20,7 @@
 @input(field, args.map{ x => if(x._1 == '_label) '_name -> x._2 else x }:_*) { (id, name, value, htmlArgs) =>
   <span class="buttonset" id="@id">
     @options.map { v =>
-      <input type="radio" id="@(id)_@v._1" name="@name" value="@v._1" @(if(value == Some(v._1)) "checked" else "") @toHtmlArgs(htmlArgs)>
+      <input type="radio" id="@(id)_@v._1" name="@name" value="@v._1" @if(value == Some(v._1)){checked="checked"} @toHtmlArgs(htmlArgs)/>
       <label for="@(id)_@v._1">@v._2</label>
     }
   </span>

--- a/framework/src/play/src/main/scala/views/helper/inputText.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputText.scala.html
@@ -15,5 +15,5 @@
 @inputType = @{ args.toMap.get('type).map(_.toString).getOrElse("text") }
 
 @input(field, args.filter(_._1 != 'type):_*) { (id, name, value, htmlArgs) =>
-    <input type="@inputType" id="@id" name="@name" value="@value" @toHtmlArgs(htmlArgs)>
+    <input type="@inputType" id="@id" name="@name" value="@value" @toHtmlArgs(htmlArgs)/>
 }

--- a/framework/src/play/src/main/scala/views/helper/select.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/select.scala.html
@@ -24,7 +24,7 @@
                 <option class="blank" value="">@defaultValue</option>
             }
             @options.map { v =>
-                <option value="@v._1" @if(values.contains(v._1)){selected}>@v._2</option>
+                <option value="@v._1" @if(values.contains(v._1)){selected="selected"}>@v._2</option>
             }
         </select>
     }}

--- a/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -50,8 +50,8 @@ object HelpersSpec extends Specification {
        // Append [] to the name for the form binding
        body must contain( "name=\"hobbies[]\"" )
 
-       body must contain( """<input type="checkbox" id="hobbies_S" name="hobbies[]" value="S" checked >""" )
-       body must contain( """<input type="checkbox" id="hobbies_B" name="hobbies[]" value="B" checked >""" )
+       body must contain( """<input type="checkbox" id="hobbies_S" name="hobbies[]" value="S" checked="checked" />""" )
+       body must contain( """<input type="checkbox" id="hobbies_B" name="hobbies[]" value="B" checked="checked" />""" )
      }
   }
 
@@ -86,7 +86,7 @@ object HelpersSpec extends Specification {
 
       body must contain( "name=\"foo\"" )
 
-      body must contain( """<option value="0" selected>""" )
+      body must contain( """<option value="0" selected="selected">""" )
       body must contain( """<option value="1" >""" )
     }
 
@@ -98,8 +98,8 @@ object HelpersSpec extends Specification {
       body must contain( "name=\"foo[]\"" )
       body must contain( "multiple" )
 
-      body must contain( """<option value="0" selected>""" )
-      body must contain( """<option value="1" selected>""" )
+      body must contain( """<option value="0" selected="selected">""" )
+      body must contain( """<option value="1" selected="selected">""" )
     }
   }
 

--- a/samples/java/computer-database-jpa/test/FunctionalTest.java
+++ b/samples/java/computer-database-jpa/test/FunctionalTest.java
@@ -64,9 +64,9 @@ public class FunctionalTest {
                 );
                 
                 assertThat(status(result)).isEqualTo(BAD_REQUEST);
-                assertThat(contentAsString(result)).contains("<option value=\"1\" selected>Apple Inc.</option>");
-                assertThat(contentAsString(result)).contains("<input type=\"text\" id=\"introduced\" name=\"introduced\" value=\"badbadbad\" >");
-                assertThat(contentAsString(result)).contains("<input type=\"text\" id=\"name\" name=\"name\" value=\"FooBar\" >");
+                assertThat(contentAsString(result)).contains("<option value=\"1\" selected=\"selected\">Apple Inc.</option>");
+                assertThat(contentAsString(result)).contains("<input type=\"text\" id=\"introduced\" name=\"introduced\" value=\"badbadbad\" />");
+                assertThat(contentAsString(result)).contains("<input type=\"text\" id=\"name\" name=\"name\" value=\"FooBar\" />");
                 
                 data.put("introduced", "2011-12-24");
                 

--- a/samples/java/computer-database/test/FunctionalTest.java
+++ b/samples/java/computer-database/test/FunctionalTest.java
@@ -64,9 +64,9 @@ public class FunctionalTest {
                 );
                 
                 assertThat(status(result)).isEqualTo(BAD_REQUEST);
-                assertThat(contentAsString(result)).contains("<option value=\"1\" selected>Apple Inc.</option>");
-                assertThat(contentAsString(result)).contains("<input type=\"text\" id=\"introduced\" name=\"introduced\" value=\"badbadbad\" >");
-                assertThat(contentAsString(result)).contains("<input type=\"text\" id=\"name\" name=\"name\" value=\"FooBar\" >");
+                assertThat(contentAsString(result)).contains("<option value=\"1\" selected=\"selected\">Apple Inc.</option>");
+                assertThat(contentAsString(result)).contains("<input type=\"text\" id=\"introduced\" name=\"introduced\" value=\"badbadbad\" />");
+                assertThat(contentAsString(result)).contains("<input type=\"text\" id=\"name\" name=\"name\" value=\"FooBar\" />");
                 
                 data.put("introduced", "2011-12-24");
                 

--- a/samples/scala/computer-database/test/ApplicationSpec.scala
+++ b/samples/scala/computer-database/test/ApplicationSpec.scala
@@ -61,9 +61,9 @@ class ApplicationSpec extends Specification {
         )
         
         status(badDateFormat) must equalTo(BAD_REQUEST)
-        contentAsString(badDateFormat) must contain("""<option value="1" selected>Apple Inc.</option>""")
-        contentAsString(badDateFormat) must contain("""<input type="text" id="introduced" name="introduced" value="badbadbad" >""")
-        contentAsString(badDateFormat) must contain("""<input type="text" id="name" name="name" value="FooBar" >""")
+        contentAsString(badDateFormat) must contain("""<option value="1" selected="selected">Apple Inc.</option>""")
+        contentAsString(badDateFormat) must contain("""<input type="text" id="introduced" name="introduced" value="badbadbad" />""")
+        contentAsString(badDateFormat) must contain("""<input type="text" id="name" name="name" value="FooBar" />""")
         
         val result = controllers.Application.save(
           FakeRequest().withFormUrlEncodedBody("name" -> "FooBar", "introduced" -> "2011-12-24", "company" -> "1")


### PR DESCRIPTION
Play's form helpers for input\* fields generated invalid XML, there should be a trailing slash on any self closing tag.

For Play users that prefer XML over @ template generated Html, it's impossible to convert Form <input ...>s to XML since the tags are not well formed.
