### PR TITLE
Add SBT cookbook in the documentation

### DIFF
--- a/documentation/manual/detailedTopics/build/SBTCookbook.md
+++ b/documentation/manual/detailedTopics/build/SBTCookbook.md
@@ -1,0 +1,149 @@
+<!--- Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com> -->
+# SBT Cookbook
+
+## Hook actions around `play run`
+
+You can apply actions around the `play run` command by extending `PlayRunHook`.
+This trait define the following methods:
+
+ * `beforeStarted(): Unit`
+ * `afterStarted(addr: InetSocketAddress): Unit`
+ * `afterStopped(): Unit`
+ 
+`beforeStarted` method is called before the play application is started, but after all "before run" tasks have been completed.
+
+`afterStarted` method is called after the play application has been started.
+
+`afterStopped` method is called after the play process has been stopped.
+
+> **Note:** The following example illustrate how you can start and stop a command with play run hook.
+> In a near future [sbt-web](https://github.com/sbt/sbt-web) will provide a better way to integrate Grunt with an SBT build. 
+
+Now let's say you want to build a Web application with `grunt` before the application is started.
+First, you need to create a Scala object in the `project/` directory to extend `PlayRunHook`.
+Let's name it `Grunt.scala`:
+
+```scala
+import play.PlayRunHook
+import sbt._
+
+object Grunt {
+  def apply(base: File): PlayRunHook = {
+
+    object GruntProcess extends PlayRunHook {
+
+      override def beforeStarted(): Unit = {
+        Process("grunt dist", base).run
+      }
+    }
+
+    GruntProcess
+  }
+}
+```
+
+Then in the `build.sbt` file you need to register this hook:
+
+```scala
+import Grunt._
+
+playRunHooks <+= baseDirectory.map(base => Grunt(base))
+```
+
+This will execute the `grunt dist` command in `baseDirectory` before the application is started.
+
+Now we want to execute `grunt watch` command to observe changes and rebuild the Web application when that happen:
+
+```scala
+import play.PlayRunHook
+import sbt._
+
+import java.net.InetSocketAddress
+
+object Grunt {
+  def apply(base: File): PlayRunHook = {
+
+    object GruntProcess extends PlayRunHook {
+
+    var process: Option[Process] = None
+
+      override def beforeStarted(): Unit = {
+        Process("grunt dist", base).run
+      }
+
+      override def afterStarted(addr: InetSocketAddress): Unit = {
+        process = Some(Process("grunt watch", base).run)
+      }
+
+      override def afterStopped(): Unit = {
+        process.map(p => p.destroy())
+        process = None
+      }
+    }
+
+    GruntProcess
+  }
+}
+```
+
+Once the application has been started we execute `grunt watch` and when the application has been stopped we destroy the grunt process. There's nothing to change in `build.sbt`
+
+## Add compiler options
+
+For example, you may want to add the feature flag to have details on feature warnings:
+
+```
+[info] Compiling 1 Scala source to ~/target/scala-2.10/classes...
+[warn] there were 1 feature warnings; re-run with -feature for details
+```
+
+Simple add `-feature` to the `scalacOptions` attribute:
+
+```scala
+scalacOptions += "-feature"
+```
+
+## Add directory to the `playAssetsDirectories`
+
+For example you can add the `pictures` folder to the play assets directories:
+
+```scala
+playAssetsDirectories <+= baseDirectory { _ / "pictures/" }
+```
+
+This will allow you to use routes.Assets.at` with this folder.
+
+## Disable documentation
+
+To speed up compilation you can disable documentation generation:
+
+```scala
+sources in (Compile, doc) := Seq.empty
+
+publishArtifact in (Compile, packageDoc) := false
+```
+
+The first line will disable documentation generation and the second one will avoid to publish the documentation artifact.
+
+## Configure ivy logging level
+
+By defaut `ivyLoggingLevel` is set on `UpdateLogging.DownloadOnly`. You can change this value with:
+
+ * `UpdateLogging.Quiet` only displays errors
+ * `UpdateLogging.FULL` logs the most
+
+For example if you want to only display errors:
+
+```scala
+ivyLoggingLevel := UpdateLogging.Quiet
+```
+
+## Fork and parallel execution in test
+
+By defaut parallel execution is disable and fork is enable. You can change this behavior by setting `parallelExecution in Test` and/or `fork in Test`:
+
+```scala
+parallelExecution in Test := true
+
+fork in Test := false
+```

--- a/documentation/manual/detailedTopics/build/SBTSubProjects.md
+++ b/documentation/manual/detailedTopics/build/SBTSubProjects.md
@@ -263,3 +263,5 @@ triggers
 ```
 controllers.admin.Application.index
 ```
+
+> **Next:** [[Cookbook | SBTCookbook]]

--- a/documentation/manual/detailedTopics/build/_Sidebar.md
+++ b/documentation/manual/detailedTopics/build/_Sidebar.md
@@ -6,6 +6,7 @@
 - [[Manage application dependencies | SBTDependencies]]
 - [[Working with sub-projects | SBTSubProjects]]
 - [[Improving Compilation Times | CompilationSpeed]]
+- [[Cookbook | SBTCookbook]]
 
 ### Getting started
 


### PR DESCRIPTION
First draft, feedback welcome :smile: 

On SBT settings documentation I found:

``` scala
confDirectory := "myConfFolder" 
```

I think the documentation is outdated and must be:

``` scala
confDirectory := new File("myConfFolder")
```

And maybe we can move that part to the cookbook ?

Play SBT settings to cover ?
- [ ] `devSettings`
- [ ] `templatesImport`
- [x] `playAssetsDirectories`
- [ ] `playInteractionMode`
- [ ] `routesImport`
- [x] `ivyLoggingLevel`
- [ ] `testOptions in Test`
- [x] `fork in Test`

RequireJS SBT settings are documented here : http://www.playframework.com/documentation/2.2.x/RequireJS-support

Sources, resources and conf directory ?

``` scala
    sourceDirectory in Compile <<= baseDirectory / "app",
    sourceDirectory in Test <<= baseDirectory / "test",

    confDirectory <<= baseDirectory / "conf",

    resourceDirectory in Compile <<= baseDirectory / "conf",

    scalaSource in Compile <<= baseDirectory / "app",
    scalaSource in Test <<= baseDirectory / "test",

    javaSource in Compile <<= baseDirectory / "app",
    javaSource in Test <<= baseDirectory / "test",
```

Ref #2408
