### PR TITLE
Add Java 8 lambda-friendly factory method to EventSource

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -232,7 +232,7 @@ object PlayBuild extends Build {
     ).dependsOn(PlayProject)
 
   lazy val PlayJavaProject = PlayRuntimeProject("Play-Java", "play-java")
-    .settings(libraryDependencies := javaDeps)
+    .settings(libraryDependencies := javaDeps ++ javaTestDeps)
     .dependsOn(PlayProject)
 
   lazy val PlayDocsProject = PlayRuntimeProject("Play-Docs", "play-docs")

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -67,6 +67,12 @@ object Dependencies {
     "javax.servlet" % "javax.servlet-api" % "3.0.1") ++
     specsBuild.map(_ % "test")
 
+  val javaTestDeps = Seq(
+    "junit" % "junit" % "4.11" % "test",
+    "com.novocode" % "junit-interface" % "0.10" % "test" exclude("junit", "junit-dep"),
+    "org.easytesting" % "fest-assert" % "1.4" % "test",
+    mockitoAll % "test")
+
   val runtime = Seq(
     "io.netty" % "netty" % "3.7.0.Final",
 
@@ -98,16 +104,14 @@ object Dependencies {
 
     "xerces" % "xercesImpl" % "2.11.0",
 
-    "javax.transaction" % "jta" % "1.1") ++ specsBuild.map(_ % "test") ++ Seq(
+    "javax.transaction" % "jta" % "1.1",
 
-    mockitoAll % "test",
-    "com.novocode" % "junit-interface" % "0.10" % "test" exclude("junit", "junit-dep"),
-    "org.easytesting" % "fest-assert" % "1.4" % "test",
     guava % "test",
 
-    "org.scala-lang" % "scala-reflect" % BuildSettings.buildScalaVersion,
+    "org.scala-lang" % "scala-reflect" % BuildSettings.buildScalaVersion) ++
+    specsBuild.map(_ % "test") ++
+    javaTestDeps
 
-    "junit" % "junit" % "4.11" % "test")
 
   val link = Seq(
     "org.javassist" % "javassist" % "3.18.0-GA")

--- a/framework/src/play-java/src/main/java/play/libs/EventSource.java
+++ b/framework/src/play-java/src/main/java/play/libs/EventSource.java
@@ -100,6 +100,43 @@ public abstract class EventSource extends Chunks<String> {
     }
 
     /**
+     * Creates an EventSource. The abstract {@code onConnected} method is
+     * implemented using the specified {@code F.Callback<EventSource>} and
+     * is invoked with {@code EventSource.this}.
+     *
+     * @param callback the callback used to implement onConnected
+     * @return a new EventSource
+     * @throws NullPointerException if the specified callback is null
+     */
+    public static EventSource whenConnected(F.Callback<EventSource> callback) {
+        return new WhenConnectedEventSource(callback);
+    }
+
+    /**
+     * An extension of EventSource that obtains its onConnected from
+     * the specified {@code F.Callback<EventSource>}.
+     */
+    static final class WhenConnectedEventSource extends EventSource {
+
+        private final F.Callback<EventSource> callback;
+
+        WhenConnectedEventSource(F.Callback<EventSource> callback) {
+            super();
+            if (callback == null) throw new NullPointerException("EventSource onConnected callback cannot be null");
+            this.callback = callback;
+        }
+
+        @Override
+        public void onConnected() {
+            try {
+                callback.invoke(this);
+            } catch (Throwable e) {
+                play.Logger.of("play").error("Exception in EventSource.onConnected", e);
+            }
+        }
+    }
+
+    /**
      * Utility class to build events.
      */
     public static class Event {

--- a/framework/src/play-java/src/test/java/play/libs/EventSourceTest.java
+++ b/framework/src/play-java/src/test/java/play/libs/EventSourceTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.libs;
+
+import java.util.concurrent.CountDownLatch;
+import org.junit.Test;
+import play.libs.F;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertTrue;
+
+public class EventSourceTest {
+
+    @Test
+    public void testWhenConnectedFactory() throws Exception {
+        final CountDownLatch invoked = new CountDownLatch(1);
+        EventSource eventSource = EventSource.whenConnected(new F.Callback<EventSource>() {
+            @Override
+            public void invoke(EventSource es) {
+                invoked.countDown();
+            }
+        });
+        eventSource.onConnected();
+        assertTrue(invoked.await(1, SECONDS));
+    }
+}

--- a/framework/src/play-java/src/test/java8/play/libs/EventSourceJava8Test.java
+++ b/framework/src/play-java/src/test/java8/play/libs/EventSourceJava8Test.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.libs;
+
+import java.util.concurrent.CountDownLatch;
+import org.junit.Test;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertTrue;
+
+public class EventSourceJava8Test {
+
+    @Test
+    public void testWhenConnectedFactory() throws Exception {
+        final CountDownLatch invoked = new CountDownLatch(1);
+        EventSource eventSource = EventSource.whenConnected(es -> invoked.countDown());
+        eventSource.onConnected();
+        assertTrue(invoked.await(1, SECONDS));
+    }
+}


### PR DESCRIPTION
From Java 8 this allows:

``` java
EventSource.whenConnected(es -> clock.tell(es, null));
```

in place of:

``` java
new EventSource() {
    public void onConnected() {
        clock.tell(this, null);
    }
}
```

If this is useful then similar factory methods can be added for Comet and Websocket, and possibly other classes that are usually implemented with anonymous classes but are not functional interfaces.
