### PR TITLE
Documentation: Add missing language arguments for field constructor

### DIFF
--- a/documentation/manual/scalaGuide/main/forms/code/scalaguide/forms/scalafieldconstructor/views/myFieldConstructorTemplate.scala.html
+++ b/documentation/manual/scalaGuide/main/forms/code/scalaguide/forms/scalafieldconstructor/views/myFieldConstructorTemplate.scala.html
@@ -2,11 +2,11 @@
 @(elements: helper.FieldElements)
 
 <div class="@if(elements.hasErrors) {error}">
-    <label for="@elements.id">@elements.label</label>
+    <label for="@elements.id">@elements.label(elements.lang)</label>
     <div class="input">
         @elements.input
-        <span class="errors">@elements.errors.mkString(", ")</span>
-        <span class="help">@elements.infos.mkString(", ")</span>
+        <span class="errors">@elements.errors(elements.lang).mkString(", ")</span>
+        <span class="help">@elements.infos(elements.lang).mkString(", ")</span>
     </div>
 </div>
 @* #form-myfield *@


### PR DESCRIPTION
I have been bitten twice by form validation not being translated. This fix applies what the default field constructor does for proper i18n.
