### PR TITLE
Remove warning on closed scalac case object issue

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
@@ -87,8 +87,7 @@ sealed trait JsValue {
 }
 
 /**
- * Represent a Json null value.
- * with Scala 2.10-M7, this code generates WARNING : https://issues.scala-lang.org/browse/SI-6513
+ * Represents a Json null value.
  */
 case object JsNull extends JsValue
 


### PR DESCRIPTION
This warning was showing up in scaladoc (and the linked issue in question is closed):

http://www.playframework.com/documentation/2.2.x/api/scala/index.html#play.api.libs.json.JsNull$
