### PR TITLE
Fix exception in Reads.traversableReads when JsArray contains a stream 

### DIFF
--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
@@ -86,6 +86,27 @@ object JsonValidSpec extends Specification {
       )
     }
 
+    "validate JsArray of stream to List" in {
+      JsArray(Stream("alpha", "beta", "delta") map JsString.apply).validate[List[String]] must equalTo(JsSuccess(List("alpha", "beta", "delta")))
+    }
+
+    "invalidate JsArray of stream to List with wrong type conversion" in {
+      JsArray(Stream(JsNumber(1), JsString("beta"), JsString("delta"), JsNumber(4), JsString("five"))).validate[List[Int]] must equalTo(
+        JsError(Seq(
+          JsPath(1) -> Seq(ValidationError("error.expected.jsnumber")),
+          JsPath(2) -> Seq(ValidationError("error.expected.jsnumber")),
+          JsPath(4) -> Seq(ValidationError("error.expected.jsnumber"))
+        ))
+      )
+
+      JsArray(Stream(JsString("alpha"), JsNumber(5), JsBoolean(true))).validate[List[Int]] must equalTo(
+        JsError(Seq(
+          JsPath(0) -> Seq(ValidationError("error.expected.jsnumber")),
+          JsPath(2) -> Seq(ValidationError("error.expected.jsnumber"))
+        ))
+      )
+    }
+
     "validate Dates" in {
       val d = new java.util.Date()
       val df = new java.text.SimpleDateFormat("yyyy-MM-dd")


### PR DESCRIPTION
See the new test case. When the Seq contained in `JsArray` is a lazy
stream, the former implementation of `traversableReads` was throwing an
exception. Because the `ts.zipWithIndex.map` on line 457 is executed
lazily, it does not set the mutable flag `hasErrors` to true. So line
474 `r.foreach(builder += _.right.get)` can be reached even if `r`
contains `Left` values. Hence exception thrown.

This commit removes both mutable flag `hasErrors` and unsafe function
`Either.get`, fixing the bug.

For the sake of consistency, `mapReads` was rewritten too, as it presented the same weaknesses.
