### PR TITLE
Fix typo in ScalaHttpFilters.md

### DIFF
--- a/documentation/manual/scalaGuide/advanced/http/ScalaHttpFilters.md
+++ b/documentation/manual/scalaGuide/advanced/http/ScalaHttpFilters.md
@@ -50,7 +50,7 @@ Since filters are applied after routing is done, it is possible to access routin
 
 @[routing-info-access](code/FiltersRouting.scala)
 
-> Routing tags are a feature of the Play router.  If you use a custom router, or return a custom action in `Glodal.onRouteRequest`, these parameters may not be available.
+> Routing tags are a feature of the Play router.  If you use a custom router, or return a custom action in `Global.onRouteRequest`, these parameters may not be available.
 
 ## More powerful filters
 


### PR DESCRIPTION
Global was written as Glodal. Just fixed that.
