### PR TITLE
Updated documentation of select helper

### DIFF
--- a/framework/src/play/src/main/scala/views/helper/select.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/select.scala.html
@@ -3,7 +3,7 @@
  *
  * Example:
  * {{{
- * @select(field = myForm("isDone"), options = options(List("Yes","No")))
+ * @select(field = myForm("isDone"), options = options(List("true" -> "Yes", "false" -> "No")))
  * }}}
  *
  * @param field The form field.


### PR DESCRIPTION
Updated documentation of select helper to reflect the correct type of the options parameter.

Previously, it incorrectly exemplified using a List[String] where it should be a List[(String,String)].
