### PR TITLE
fix issue #2480: a custom SSL context can be used for HTTPS

### DIFF
--- a/documentation/manual/detailedTopics/production/ConfiguringHttps.md
+++ b/documentation/manual/detailedTopics/production/ConfiguringHttps.md
@@ -7,6 +7,8 @@ Play can be configured to serve HTTPS.  To enable this, simply tell Play which p
 
 ## SSL Certificates
 
+### SSL Certificates from a keystore
+
 By default, Play will generate itself a self-signed certificate, however typically this will not be suitable for serving a website.  Play uses Java key stores to configure SSL certificates and keys.
 
 Signing authorities often provide instructions on how to create a Java keystore (typically with reference to Tomcat configuration).  The official Oracle documentation on how to generate keystores using the JDK keytool utility can be found [here](http://docs.oracle.com/javase/7/docs/technotes/tools/solaris/keytool.html).
@@ -17,6 +19,27 @@ Having created your keystore, the following system properties can be used to con
 * **https.keyStoreType** - The key store type, defaults to `JKS`
 * **https.keyStorePassword** - The password, defaults to a blank password
 * **https.keyStoreAlgorithm** - The key store algorithm, defaults to the platforms default algorithm
+
+### SSL Certificates from a custom SSL Context
+
+Another alternative to configure the SSL certificates is to provide a custom [SSLContext](http://docs.oracle.com/javase/7/docs/api/javax/net/ssl/SSLContext.html).
+
+#### in Java, an implementation must be provided for [`play.server.SSLContextProvider`](api/java/play/server/SSLContextProvider.html)
+
+@[javaexample](code/java/CustomSSLContextProvider.java)
+
+#### in Scala, an implementation must be provided for [`play.server.api.SSLContextProvider`](api/scala/index.html#play.server.api.SSLContextProvider)
+
+@[scalaexample](code/scala/CustomSSLContextProvider.scala)
+
+Having created an implementation for `play.server.SSLContextProvider` or `play.server.api.SSLContextProvider`, the following system property configures Play to use it:
+
+* **play.http.sslcontextprovider** - The path to the class implementing `play.server.SSLContextProvider` or `play.server.api.SSLContextProvider`:
+
+Example:
+
+    ./start -Dhttps.port=9443 -Dplay.http.sslcontextprovider=mypackage.CustomSSLContextProvider
+
 
 ## Turning HTTP off
 

--- a/documentation/manual/detailedTopics/production/code/java/CustomSSLContextProvider.java
+++ b/documentation/manual/detailedTopics/production/code/java/CustomSSLContextProvider.java
@@ -1,0 +1,22 @@
+package java;
+
+// #javaexample
+import play.server.ApplicationProvider;
+import play.server.SSLContextProvider;
+
+import javax.net.ssl.SSLContext;
+import java.security.NoSuchAlgorithmException;
+
+public class CustomSSLContextProvider implements SSLContextProvider {
+
+    @Override
+    public SSLContext createSSLContext(ApplicationProvider applicationProvider) {
+        try {
+            // change it to your custom implementation
+            return SSLContext.getDefault();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+// #javaexample

--- a/documentation/manual/detailedTopics/production/code/scala/CustomSSLContextProvider.scala
+++ b/documentation/manual/detailedTopics/production/code/scala/CustomSSLContextProvider.scala
@@ -1,0 +1,16 @@
+package scala
+
+// #scalaexample
+import javax.net.ssl.SSLContext
+import play.core.ApplicationProvider
+import play.server.api.SSLContextProvider
+
+class CustomSSLContextProvider extends SSLContextProvider {
+
+  override def createSSLContext(appProvider: ApplicationProvider): SSLContext = {
+    // change it to your custom implementation
+    SSLContext.getDefault
+  }
+
+}
+// #scalaexample

--- a/framework/src/play/src/main/java/play/server/ApplicationProvider.java
+++ b/framework/src/play/src/main/java/play/server/ApplicationProvider.java
@@ -1,0 +1,27 @@
+package play.server;
+
+import play.Application;
+
+import java.io.File;
+
+/**
+ * Provides information about a Play Application running inside a Play server.
+ */
+public class ApplicationProvider {
+
+    private final Application application;
+    private final File path;
+
+    public ApplicationProvider(Application application, File path) {
+        this.application = application;
+        this.path = path;
+    }
+
+    public Application getApplication() {
+        return application;
+    }
+
+    public File getPath() {
+        return path;
+    }
+}

--- a/framework/src/play/src/main/java/play/server/SSLContextProvider.java
+++ b/framework/src/play/src/main/java/play/server/SSLContextProvider.java
@@ -1,0 +1,16 @@
+package play.server;
+
+import javax.net.ssl.SSLContext;
+
+/**
+ * To listen on HTTPS port, play needs a SSL context.
+ * If you want specify your own SSL context, define a class implementing this interface.
+ * The path to this class should be configured with the system property <pre>play.http.sslcontextprovider</pre>
+ */
+public interface SSLContextProvider {
+
+    /**
+     * @return the SSL context to be used for HTTPS connection.
+     */
+    SSLContext createSSLContext(ApplicationProvider applicationProvider);
+}

--- a/framework/src/play/src/main/scala/play/core/server/DefaultSSLContextProvider.scala
+++ b/framework/src/play/src/main/scala/play/core/server/DefaultSSLContextProvider.scala
@@ -1,0 +1,70 @@
+package play.core.server
+
+import play.server.api.SSLContextProvider
+import play.core.ApplicationProvider
+import javax.net.ssl.{ TrustManager, KeyManagerFactory, SSLContext }
+import java.security.KeyStore
+import java.io.{ FileInputStream, File }
+import play.api.Play
+import play.core.server.netty.FakeKeyStore
+import scala.util.control.NonFatal
+import scala.util.{ Try, Failure, Success }
+
+class DefaultSSLContextProvider extends SSLContextProvider {
+  override def createSSLContext(applicationProvider: ApplicationProvider): SSLContext = {
+    val keyManagerFactory: Try[KeyManagerFactory] = Option(System.getProperty("https.keyStore")) match {
+      case Some(path) => {
+        // Load the configured key store
+        val keyStore = KeyStore.getInstance(System.getProperty("https.keyStoreType", "JKS"))
+        val password = System.getProperty("https.keyStorePassword", "").toCharArray
+        val algorithm = System.getProperty("https.keyStoreAlgorithm", KeyManagerFactory.getDefaultAlgorithm)
+        val file = new File(path)
+        if (file.isFile) {
+          try {
+            for (in <- resource.managed(new FileInputStream(file))) {
+              keyStore.load(in, password)
+            }
+            Play.logger.debug("Using HTTPS keystore at " + file.getAbsolutePath)
+            val kmf = KeyManagerFactory.getInstance(algorithm)
+            kmf.init(keyStore, password)
+            Success(kmf)
+          } catch {
+            case NonFatal(e) => {
+              Failure(new Exception("Error loading HTTPS keystore from " + file.getAbsolutePath, e))
+            }
+          }
+        } else {
+          Failure(new Exception("Unable to find HTTPS keystore at \"" + file.getAbsolutePath + "\""))
+        }
+      }
+      case None => {
+        // Load a generated key store
+        Play.logger.warn("Using generated key with self signed certificate for HTTPS. This should not be used in production.")
+        FakeKeyStore.keyManagerFactory(applicationProvider.path)
+      }
+    }
+
+    keyManagerFactory.map { kmf =>
+      // Load the configured trust manager
+      val tm = Option(System.getProperty("https.trustStore")).map {
+        case "noCA" => {
+          Play.logger.warn("HTTPS configured with no client " +
+            "side CA verification. Requires http://webid.info/ for client certificate verification.")
+          Array[TrustManager](noCATrustManager)
+        }
+        case _ => {
+          Play.logger.debug("Using default trust store for client side CA verification")
+          null
+        }
+      }.getOrElse {
+        Play.logger.debug("Using default trust store for client side CA verification")
+        null
+      }
+
+      // Configure the SSL context
+      val sslContext = SSLContext.getInstance("TLS")
+      sslContext.init(kmf.getKeyManagers, tm, null)
+      sslContext
+    }.get
+  }
+}

--- a/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play/src/main/scala/play/core/server/NettyServer.scala
@@ -10,7 +10,6 @@ import org.jboss.netty.handler.codec.http._
 import org.jboss.netty.channel.group._
 import org.jboss.netty.handler.ssl._
 
-import java.security._
 import java.net.InetSocketAddress
 import javax.net.ssl._
 import java.util.concurrent._
@@ -20,7 +19,6 @@ import play.api._
 import play.core.server.netty._
 
 import java.security.cert.X509Certificate
-import java.io.{ File, FileInputStream }
 import scala.util.control.NonFatal
 import com.typesafe.netty.http.pipelining.HttpPipeliningHandler
 
@@ -69,58 +67,13 @@ class NettyServer(appProvider: ApplicationProvider, port: Option[Int], sslPort: 
     }
 
     lazy val sslContext: Option[SSLContext] = //the sslContext should be reused on each connection
-      Option(System.getProperty("https.keyStore")) map { path =>
-        // Load the configured key store
-        val keyStore = KeyStore.getInstance(System.getProperty("https.keyStoreType", "JKS"))
-        val password = System.getProperty("https.keyStorePassword", "").toCharArray
-        val algorithm = System.getProperty("https.keyStoreAlgorithm", KeyManagerFactory.getDefaultAlgorithm)
-        val file = new File(path)
-        if (file.isFile) {
-          try {
-            for (in <- resource.managed(new FileInputStream(file))) {
-              keyStore.load(in, password)
-            }
-            Play.logger.debug("Using HTTPS keystore at " + file.getAbsolutePath)
-            val kmf = KeyManagerFactory.getInstance(algorithm)
-            kmf.init(keyStore, password)
-            Some(kmf)
-          } catch {
-            case NonFatal(e) => {
-              Play.logger.error("Error loading HTTPS keystore from " + file.getAbsolutePath, e)
-              None
-            }
-          }
-        } else {
-          Play.logger.error("Unable to find HTTPS keystore at \"" + file.getAbsolutePath + "\"")
+      try {
+        Some(ServerSSLContext.loadSSLContext(applicationProvider))
+      } catch {
+        case NonFatal(e) => {
+          Play.logger.error(s"cannot load SSL context", e)
           None
         }
-      } orElse {
-
-        // Load a generated key store
-        Play.logger.warn("Using generated key with self signed certificate for HTTPS. This should not be used in production.")
-        Some(FakeKeyStore.keyManagerFactory(applicationProvider.path))
-
-      } flatMap { a => a } map { kmf =>
-        // Load the configured trust manager
-        val tm = Option(System.getProperty("https.trustStore")).map {
-          case "noCA" => {
-            Play.logger.warn("HTTPS configured with no client " +
-              "side CA verification. Requires http://webid.info/ for client certifiate verification.")
-            Array[TrustManager](noCATrustManager)
-          }
-          case _ => {
-            Play.logger.debug("Using default trust store for client side CA verification")
-            null
-          }
-        }.getOrElse {
-          Play.logger.debug("Using default trust store for client side CA verification")
-          null
-        }
-
-        // Configure the SSL context
-        val sslContext = SSLContext.getInstance("TLS")
-        sslContext.init(kmf.getKeyManagers, tm, null)
-        sslContext
       }
   }
 

--- a/framework/src/play/src/main/scala/play/core/server/ServerSSLContext.scala
+++ b/framework/src/play/src/main/scala/play/core/server/ServerSSLContext.scala
@@ -1,0 +1,34 @@
+package play.core.server
+
+import java.io.{ FileInputStream, File }
+import java.security.KeyStore
+import javax.net.ssl.{ TrustManager, KeyManagerFactory, SSLContext }
+import play.api.{ Play, PlayException }
+import play.core.ApplicationProvider
+import play.core.server.netty.FakeKeyStore
+import play.server.api.SSLContextProvider
+import scala.util.control.NonFatal
+import scala.util.{ Success, Failure, Try }
+
+object ServerSSLContext {
+
+  def loadSSLContext(applicationProvider: ApplicationProvider): SSLContext = {
+    val providerClass = Option(System.getProperty("play.http.sslcontextprovider")).getOrElse(classOf[DefaultSSLContextProvider].getName)
+    val classLoader = applicationProvider.get.map(_.classloader).getOrElse(this.getClass.getClassLoader)
+    try {
+
+      val providerInstance = classLoader.loadClass(providerClass).getConstructor().newInstance().asInstanceOf[SSLContextProvider]
+      providerInstance.createSSLContext(applicationProvider)
+
+    } catch {
+      case e: ClassCastException => {
+        // try the Java interface
+        val providerInstance = classLoader.loadClass(providerClass).getConstructor().newInstance().asInstanceOf[play.server.SSLContextProvider]
+        val javaApplication = applicationProvider.get.map(a => new play.Application(a)).getOrElse(null)
+        val javaAppProvider = new play.server.ApplicationProvider(javaApplication, applicationProvider.path)
+        providerInstance.createSSLContext(javaAppProvider)
+      }
+    }
+  }
+
+}

--- a/framework/src/play/src/main/scala/play/core/server/netty/FakeKeyStore.scala
+++ b/framework/src/play/src/main/scala/play/core/server/netty/FakeKeyStore.scala
@@ -13,6 +13,7 @@ import java.io.{ File, FileInputStream, FileOutputStream }
 import javax.net.ssl.KeyManagerFactory
 import scala.util.control.NonFatal
 import scala.util.Properties.isJavaAtLeast
+import scala.util.{ Failure, Success, Try }
 
 /**
  * A fake key store
@@ -21,7 +22,7 @@ object FakeKeyStore {
   val GeneratedKeyStore = "conf/generated.keystore"
   val DnName = "CN=localhost, OU=Unit Testing, O=Mavericks, L=Moon Base 1, ST=Cyberspace, C=CY"
 
-  def keyManagerFactory(appPath: File): Option[KeyManagerFactory] = {
+  def keyManagerFactory(appPath: File): Try[KeyManagerFactory] = {
     try {
       val keyStore = KeyStore.getInstance("JKS")
       val keyStoreFile = new File(appPath, GeneratedKeyStore)
@@ -48,11 +49,10 @@ object FakeKeyStore {
       // Load the key and certificate into a key manager factory
       val kmf = KeyManagerFactory.getInstance("SunX509")
       kmf.init(keyStore, "".toCharArray)
-      Some(kmf)
+      Success(kmf)
     } catch {
       case NonFatal(e) => {
-        Play.logger.error("Error loading fake key store", e)
-        None
+        Failure(new Exception("Error loading fake key store", e))
       }
     }
   }

--- a/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
+++ b/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
@@ -32,7 +32,7 @@ trait DevSettings {
 }
 
 /**
- * generic layout for initialized Applications
+ * Provides information about a Play Application running inside a Play server.
  */
 trait ApplicationProvider {
   def path: File

--- a/framework/src/play/src/main/scala/play/server/api/SSLContextProvider.scala
+++ b/framework/src/play/src/main/scala/play/server/api/SSLContextProvider.scala
@@ -1,0 +1,18 @@
+package play.server.api
+
+import javax.net.ssl.SSLContext
+import play.core.ApplicationProvider
+
+/**
+ * To listen on HTTPS port, play needs a SSL context.
+ * If you want specify your own SSL context, define a class implementing this interface.
+ * The path to this class should be configured with the system property <pre>play.http.sslcontextprovider</pre>
+ */
+trait SSLContextProvider {
+
+  /**
+   * @return the SSL context to be used for HTTPS connection.
+   */
+  def createSSLContext(appProvider: ApplicationProvider): SSLContext
+
+}

--- a/framework/src/play/src/test/scala/play/core/server/ServerSSLContextSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/server/ServerSSLContextSpec.scala
@@ -1,0 +1,79 @@
+package play.core.server
+
+
+import java.io.File
+import javax.net.ssl.SSLContext
+import org.specs2.mock.Mockito
+import org.specs2.mutable.{ After, Specification }
+import org.specs2.specification.Scope
+import play.core.ApplicationProvider
+import play.server
+import play.server.api.SSLContextProvider
+import scala.util.Failure
+
+class WrongSSLContextProvider {}
+
+class RightSSLContextProvider extends SSLContextProvider with Mockito {
+  override def createSSLContext(appPro: ApplicationProvider): SSLContext = mock[SSLContext]
+}
+
+class JavaSSLContextProvider extends play.server.SSLContextProvider with Mockito {
+  override def createSSLContext(applicationProvider: server.ApplicationProvider): SSLContext = mock[SSLContext]
+}
+
+object ServerSSLContextSpec extends Specification with Mockito {
+
+  sequential
+
+  import ServerSSLContext.loadSSLContext
+
+  trait ApplicationContext extends Mockito with Scope {
+    val applicationProvider = mock[ApplicationProvider]
+    applicationProvider.get returns Failure(new Exception("no app"))
+  }
+
+  trait TempConfDir extends After {
+    val tempDir = File.createTempFile("ServerSSLContext", ".tmp")
+    tempDir.delete()
+    val confDir = new File(tempDir, "conf")
+    confDir.mkdirs()
+
+    def after = {
+      confDir.listFiles().foreach(f => f.delete())
+      tempDir.listFiles().foreach(f => f.delete())
+      tempDir.delete()
+    }
+  }
+
+
+  val javaAppProvider = mock[play.core.ApplicationProvider]
+
+  "ServerSSLContext" should {
+
+    "default create a SSL context suitable for development" in new ApplicationContext with TempConfDir {
+      applicationProvider.path returns tempDir
+      System.clearProperty("play.http.sslcontextprovider")
+      loadSSLContext(applicationProvider) should beAnInstanceOf[SSLContext]
+    }
+
+    "fail to load a non existing SSLContextProvider" in new ApplicationContext {
+      System.setProperty("play.http.sslcontextprovider", "bla bla")
+      loadSSLContext(applicationProvider) should throwA[ClassNotFoundException]
+    }
+
+    "fail to load an existing SSLContextProvider with the wrong type" in new ApplicationContext {
+      System.setProperty("play.http.sslcontextprovider", classOf[WrongSSLContextProvider].getName)
+      loadSSLContext(applicationProvider) should throwA[ClassCastException]
+    }
+
+    "load a custom SSLContext from a SSLContextProvider" in new ApplicationContext {
+      System.setProperty("play.http.sslcontextprovider", classOf[RightSSLContextProvider].getName)
+      loadSSLContext(applicationProvider) should beAnInstanceOf[SSLContext]
+    }
+
+    "load a custom SSLContext from a java SSLContextProvider" in new ApplicationContext {
+      System.setProperty("play.http.sslcontextprovider", classOf[JavaSSLContextProvider].getName)
+      loadSSLContext(applicationProvider) should beAnInstanceOf[SSLContext]
+    }
+  }
+}


### PR DESCRIPTION
Fix issue https://github.com/playframework/playframework/issues/2480

The custom SSL context can be configured by the new parameter "play.http.sslcontextprovider", like this:
-Dhttps.port=9443 -Dplay.http.sslcontextprovider=myappr.MySSLContextProvider

Introduce package play.server.api for API for server concerns.
