### PR TITLE
[2.2.2-java] duplicated list entries view for Lists. @repeat helper is wrong

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/Form.java
+++ b/framework/src/play-java/src/main/java/play/data/Form.java
@@ -8,6 +8,7 @@ import javax.validation.metadata.*;
 
 import java.util.*;
 import java.lang.annotation.*;
+import java.util.regex.Pattern;
 
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
@@ -785,7 +786,6 @@ public class Form<T> {
          */
         @SuppressWarnings("rawtypes")
         public List<Integer> indexes() {
-            List<Integer> result = new ArrayList<Integer>();
             if(form.value().isDefined()) {
                 BeanWrapper beanWrapper = new BeanWrapperImpl(form.value().get());
                 beanWrapper.setAutoGrowNestedPaths(true);
@@ -793,6 +793,8 @@ public class Form<T> {
                 if(form.name() != null && name.startsWith(form.name() + ".")) {
                     objectKey = name.substring(form.name().length() + 1);
                 }
+
+                List<Integer> result = new ArrayList<Integer>();
                 if(beanWrapper.isReadableProperty(objectKey)) {
                     Object value = beanWrapper.getPropertyValue(objectKey);
                     if(value instanceof Collection) {
@@ -801,16 +803,24 @@ public class Form<T> {
                         }
                     }
                 }
+
+                return result;
+
             } else {
-                java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("^" + java.util.regex.Pattern.quote(name) + "\\[(\\d+)\\].*$");
+                Set<Integer> result = new HashSet<Integer>();
+                Pattern pattern = Pattern.compile("^" + Pattern.quote(name) + "\\[(\\d+)\\].*$");
+
                 for(String key: form.data().keySet()) {
                     java.util.regex.Matcher matcher = pattern.matcher(key);
                     if(matcher.matches()) {
                         result.add(Integer.parseInt(matcher.group(1)));
                     }
                 }
+
+                List<Integer> sortedResult = new ArrayList<Integer>(result);
+                Collections.sort(sortedResult);
+                return sortedResult;
             }
-            return result;
         }
 
         /**

--- a/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -8,6 +8,7 @@ import play.api.data.Forms._
 import play.api.data._
 import play.api.i18n.Lang
 import play.api.templates.Html
+import scala.beans.BeanProperty
 
 object HelpersSpec extends Specification {
   import FieldConstructor.defaultField
@@ -108,21 +109,46 @@ object HelpersSpec extends Specification {
     def renderFoo(form: Form[_], min: Int = 1) = repeat.apply(form("foo"), min) { f =>
       Html(f.name + ":" + f.value.getOrElse(""))
     }.map(_.toString)
-    
+
+    val complexForm = Form(single("foo" ->
+      Forms.seq(tuple(
+        "a" -> Forms.text,
+        "b" -> Forms.text
+      ))
+    ))
+    def renderComplex(form: Form[_], min: Int = 1) = repeat.apply(form("foo"), min) { f =>
+      val a = f("a")
+      val b = f("b")
+      Html(s"${a.name}=${a.value.getOrElse("")},${b.name}=${b.value.getOrElse("")}")
+    }.map(_.toString)
+
     "render a sequence of fields" in {
-      renderFoo(form.fill(Seq("a", "b", "c"))) must exactly("foo[0]:a", "foo[1]:b", "foo[2]:c")
+      renderFoo(form.fill(Seq("a", "b", "c"))) must exactly("foo[0]:a", "foo[1]:b", "foo[2]:c").inOrder
     }
 
     "render a sequence of fields in an unfilled form" in {
-      renderFoo(form, 4) must exactly("foo[0]:", "foo[1]:", "foo[2]:", "foo[3]:")
+      renderFoo(form, 4) must exactly("foo[0]:", "foo[1]:", "foo[2]:", "foo[3]:").inOrder
     }
 
     "fill the fields out if less than the min" in {
-      renderFoo(form.fill(Seq("a", "b")), 4) must exactly("foo[0]:a", "foo[1]:b", "foo[2]:", "foo[3]:")
+      renderFoo(form.fill(Seq("a", "b")), 4) must exactly("foo[0]:a", "foo[1]:b", "foo[2]:", "foo[3]:").inOrder
     }
 
     "fill the fields out if less than the min but the maximum is high" in {
-      renderFoo(form.bind(Map("foo[0]" -> "a", "foo[123]" -> "b")), 4) must exactly("foo[0]:a", "foo[123]:b", "foo[124]:", "foo[125]:")
+      renderFoo(form.bind(Map("foo[0]" -> "a", "foo[123]" -> "b")), 4) must exactly("foo[0]:a", "foo[123]:b", "foo[124]:", "foo[125]:").inOrder
+    }
+
+    "render the right number of fields if there's multiple sub fields at a given index when filled" in {
+      renderComplex(
+        complexForm.fill(Seq("somea" -> "someb"))
+      ) must exactly("foo[0].a=somea,foo[0].b=someb")
+    }
+
+    "render fill the right number of fields out if there's multiple sub fields at a given index when bound" in {
+      renderComplex(
+        // Don't bind, we don't want it to use the successfully bound value
+        form.copy(data = Map("foo[0].a" -> "somea", "foo[0].b" -> "someb"))
+      ) must exactly("foo[0].a=somea,foo[0].b=someb")
     }
 
     "work with i18n" in {


### PR DESCRIPTION
With play 2.2.2 and the project samples/java/forms, in the route http://localhost:9000/contacts if you try to click in INSERT without filling any field, the view is refreshed and it shows the corresponding "Required field" error with more PROFILES than the ones created.

The same sample run using play-2.2.1 do not have this problem. 

I don't know if the issue is in the controller side with parsing List of objects, or in the view side, with the Form object.
