### PR TITLE
Add customizable CSRF error handling

### DIFF
--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/CSRFErrorHandler.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/CSRFErrorHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.filters.csrf;
+
+import play.mvc.Results;
+import play.mvc.Result;
+
+/**
+ * This interface handles the CSRF error.
+ */
+public interface CSRFErrorHandler {
+
+    /**
+     * Handle the CSRF error.
+     *
+     * @param msg message is passed by framework.
+     * @return Client gets this result.
+     */
+    Result handle(String msg);
+
+    public static class DefaultCSRFErrorHandler extends Results implements CSRFErrorHandler {
+
+        @Override
+        public Result handle(String msg) {
+            return (Result) forbidden(msg);
+        }
+
+    }
+}

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheck.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheck.java
@@ -17,4 +17,12 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 public @interface RequireCSRFCheck {
+
+    /**
+     * Call a implementation class for handling the CSRF error.
+     *
+     * @see play.filters.csrf.CSRFErrorHandler
+     */
+    Class<? extends CSRFErrorHandler> error() default CSRFErrorHandler.DefaultCSRFErrorHandler.class;
+
 }

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
@@ -53,14 +53,19 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
                     if (tokenProvider.compareTokens(tokenToCheck, headerToken.get())) {
                         return delegate.call(ctx);
                     } else {
-                        return F.Promise.pure((Result) forbidden("CSRF tokens don't match"));
+                        return F.Promise.pure(handleTokenError("CSRF tokens don't match"));
                     }
                 } else {
-                    return F.Promise.pure((Result) forbidden("CSRF token not found in body or query string"));
+                    return F.Promise.pure(handleTokenError("CSRF token not found in body or query string"));
                 }
             } else {
-                return F.Promise.pure((Result) forbidden("CSRF token not found in session"));
+                return F.Promise.pure(handleTokenError("CSRF token not found in session"));
             }
         }
+    }
+
+    private Result handleTokenError(String msg) throws Exception {
+        CSRFErrorHandler handler = configuration.error().newInstance();
+        return handler.handle(msg);
     }
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
@@ -4,7 +4,7 @@
 package play.filters.csrf
 
 import play.api.mvc._
-import play.filters.csrf.CSRF.TokenProvider
+import play.filters.csrf.CSRF.{ TokenProvider, ErrorHandler }
 
 /**
  * A filter that provides CSRF protection.
@@ -20,12 +20,14 @@ import play.filters.csrf.CSRF.TokenProvider
  * @param createIfNotFound Whether a new CSRF token should be created if it's not found.  Default creates one if it's
  *                         a GET request that accepts HTML.
  * @param tokenProvider A token provider to use.
+ * @param checkFailedResult handling failed token error.
  */
 class CSRFFilter(tokenName: => String = CSRFConf.TokenName,
     cookieName: => Option[String] = CSRFConf.CookieName,
     secureCookie: => Boolean = CSRFConf.SecureCookie,
     createIfNotFound: (RequestHeader) => Boolean = CSRFConf.defaultCreateIfNotFound,
-    tokenProvider: => TokenProvider = CSRFConf.defaultTokenProvider) extends EssentialFilter {
+    tokenProvider: => TokenProvider = CSRFConf.defaultTokenProvider,
+    errorHandler: => ErrorHandler = CSRFConf.defaultErrorHandler) extends EssentialFilter {
 
   /**
    * Default constructor, useful from Java
@@ -33,7 +35,7 @@ class CSRFFilter(tokenName: => String = CSRFConf.TokenName,
   def this() = this(CSRFConf.TokenName)
 
   def apply(next: EssentialAction): EssentialAction = new CSRFAction(next, tokenName, cookieName, secureCookie,
-    createIfNotFound, tokenProvider)
+    createIfNotFound, tokenProvider, errorHandler)
 }
 
 object CSRFFilter {
@@ -41,7 +43,8 @@ object CSRFFilter {
     cookieName: => Option[String] = CSRFConf.CookieName,
     secureCookie: => Boolean = CSRFConf.SecureCookie,
     createIfNotFound: (RequestHeader) => Boolean = CSRFConf.defaultCreateIfNotFound,
-    tokenProvider: => TokenProvider = CSRFConf.defaultTokenProvider) = {
-    new CSRFFilter(tokenName, cookieName, secureCookie, createIfNotFound, tokenProvider)
+    tokenProvider: => TokenProvider = CSRFConf.defaultTokenProvider,
+    errorHandler: => ErrorHandler = CSRFConf.defaultErrorHandler) = {
+    new CSRFFilter(tokenName, cookieName, secureCookie, createIfNotFound, tokenProvider, errorHandler)
   }
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -5,6 +5,7 @@ package play.filters.csrf
 
 import play.api.mvc._
 import play.api._
+import play.api.mvc.Results._
 import play.api.libs.Crypto
 
 private[csrf] object CSRFConf {
@@ -29,6 +30,7 @@ private[csrf] object CSRFConf {
     // CSRF token for it.
     request.method == "GET" && (request.accepts("text/html") || request.accepts("application/xml+xhtml"))
   }
+  def defaultErrorHandler = CSRF.DefaultErrorHandler
   def defaultTokenProvider = {
     if (SignTokens) {
       CSRF.SignedTokenProvider
@@ -100,6 +102,18 @@ object CSRF {
   object UnsignedTokenProvider extends TokenProvider {
     def generateToken = Crypto.generateToken
     def compareTokens(tokenA: String, tokenB: String) = Crypto.constantTimeEquals(tokenA, tokenB)
+  }
+
+  /**
+   * This trait handles the CSRF error.
+   */
+  trait ErrorHandler {
+    /** Handle a result */
+    def handle(msg: String): Result
+  }
+
+  object DefaultErrorHandler extends ErrorHandler {
+    def handle(msg: String) = Forbidden(msg)
   }
 }
 


### PR DESCRIPTION
CSRF error will never occur rarely in normal operation to user.
However, there is a possiblity accident. For example, reloading page again after user posted data.

CSRF module returns only text message to user if the module found CSRF token error.
I think almost users can't understand the message what should I do next.

> Invalid token found in form body

Application would like to redirect to signed in page.
In another case, application may would like to throw Exception for handling on Global object.

My PR is able to customize the error handling on application.

```
private def checkFailedResult(msg: String): SimpleResult = throw new CsrfException(msg)

def post = CSRFFilter(checkFailedResult = checkFailedResult) { Action {

}}
```
