### PR TITLE
Impossible to tell what line cause test failure

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/test/JUnitXmlTestListener.scala
+++ b/framework/src/sbt-plugin/src/main/scala/test/JUnitXmlTestListener.scala
@@ -30,6 +30,23 @@ class JUnitXmlTestsListener(val outputDir: String, logger: Logger) extends Tests
   /**The dir in which we put all result files. Is equal to the given dir + "/test-reports"*/
   val targetDir = new File(outputDir + "/test-reports/")
 
+  /**
+   * We search from the bottom of the stack trace to the top, dropping elements until one of them doesn't have
+   * a package that starts with one of these prefixes.
+   */
+  val IgnoredStackTraceClasses = Seq(
+    "sbt.",
+    "com.novocode.junit.",
+    "org.junit.",
+    "java.",
+    "sun.reflect.",
+    "org.mockito."
+  )
+
+  def cleanStackTrace(stackTrace: Seq[StackTraceElement]): Seq[StackTraceElement] = {
+    stackTrace.reverse.dropWhile(e => IgnoredStackTraceClasses.exists(e.getClassName.startsWith)).reverse
+  }
+
   /**all system properties as XML*/
   val properties =
     <properties>
@@ -96,6 +113,13 @@ class JUnitXmlTestsListener(val outputDir: String, logger: Logger) extends Tests
         case TStatus.Skipped => logWith(Colors.yellow("o"))
         case TStatus.Success => logWith(Colors.green("+"))
         case _ => ()
+      }
+
+      event.throwable match {
+        case SbtOptionalThrowable(t) =>
+          logger.error(t.toString)
+          logger.error(cleanStackTrace(t.getStackTrace).map("    at " + _).mkString("\n"))
+        case _ =>
       }
     }
 


### PR DESCRIPTION
This is a bug in junit-interface (https://github.com/sbt/junit-interface/issues/41). However, I'm going to file it here as well because I think it's a serious enough that we should probably be involved in fixing it

Our test set is becoming a nightmare to run. Whenever a test fails the output looks like this:

```
[error] Test com.benmccann.StringUtilTest.myTest failed: null
[info] com.benmccann.StringUtilTest
[info] x myTest
```

It's really hard to figure out where the error is because there's no line number. All we know is that there way a failure somewhere in a given method, but that's most often a frustrating lack of information.
