### PR TITLE
Add support for Java 8 code samples in documentation

### DIFF
--- a/documentation/manual/javaGuide/main/async/JavaAsync.md
+++ b/documentation/manual/javaGuide/main/async/JavaAsync.md
@@ -21,15 +21,22 @@ The web client will be blocked while waiting for the response, but nothing will 
 
 To create a `Promise<Result>` we need another promise first: the promise that will give us the actual value we need to compute the result:
 
-@[promise-pi](code/javaguide/async/JavaAsync.java)
+Java
+: @[promise-pi](code/javaguide/async/JavaAsync.java)
+> **Note:** Writing functional composition in Java is verbose. See the Java 8 sample for a more readable version using lambdas.
 
-> **Note:** Writing functional composition in Java is really verbose at the moment, but it should be better when Java supports [lambda notation](http://docs.oracle.com/javase/tutorial/java/javaOO/lambdaexpressions.html).
+Java 8
+: @[promise-pi](java8code/java8guide/async/JavaAsync.java)
 
 Play asynchronous API methods give you a `Promise`. This is the case when you are calling an external web service using the `play.libs.WS` API, or if you are using Akka to schedule asynchronous tasks or to communicate with Actors using `play.libs.Akka`.
 
 A simple way to execute a block of code asynchronously and to get a `Promise` is to use the `promise()` helper:
 
-@[promise-async](code/javaguide/async/JavaAsync.java)
+Java
+: @[promise-async](code/javaguide/async/JavaAsync.java)
+
+Java 8
+: @[promise-async](java8code/java8guide/async/JavaAsync.java)
 
 > **Note:** It's important to understand which thread code runs on with promises. Here, the intensive computation will just be run on another thread.
 >
@@ -41,7 +48,11 @@ A simple way to execute a block of code asynchronously and to get a `Promise` is
 
 We have been returning `Result` up until now. To send an asynchronous result our action needs to return a `Promise<Result>`:
 
-@[async](code/javaguide/async/controllers/Application.java)
+Java
+: @[async](code/javaguide/async/controllers/Application.java)
+
+Java 8
+: @[async](java8code/java8guide/async/controllers/Application.java)
 
 ## Actions are asynchronous by default
 

--- a/documentation/manual/javaGuide/main/async/java8code/java8guide/async/JavaAsync.java
+++ b/documentation/manual/javaGuide/main/async/java8code/java8guide/async/JavaAsync.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package java8guide.async;
+
+import org.junit.Test;
+import play.test.WithApplication;
+import play.libs.F.Promise;
+import play.mvc.Result;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.*;
+import static play.mvc.Results.ok;
+import static play.test.Helpers.*;
+
+public class JavaAsync extends WithApplication {
+
+    @Test
+    public void promisePi() {
+        //#promise-pi
+        Promise<Double> promiseOfPIValue = computePIAsynchronously();
+        Promise<Result> promiseOfResult = promiseOfPIValue.map(pi ->
+            ok("PI value computed: " + pi)
+        );
+        //#promise-pi
+        assertThat(status(promiseOfResult.get(1000)), equalTo(200));
+    }
+
+    @Test
+    public void promiseAsync() {
+        //#promise-async
+        Promise<Integer> promiseOfInt = Promise.promise(() -> intensiveComputation());
+        //#promise-async
+        assertEquals(intensiveComputation(), promiseOfInt.get(1000));
+    }
+
+    private static Promise<Double> computePIAsynchronously() {
+        return Promise.pure(Math.PI);
+    }
+
+    private static Integer intensiveComputation() {
+        return 1 + 1;
+    }
+
+}

--- a/documentation/manual/javaGuide/main/async/java8code/java8guide/async/controllers/Application.java
+++ b/documentation/manual/javaGuide/main/async/java8code/java8guide/async/controllers/Application.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package java8guide.async.controllers;
+
+import play.mvc.Result;
+import play.libs.F.Promise;
+import play.mvc.Controller;
+
+public class Application extends Controller {
+    //#async
+    public static Promise<Result> index() {
+      return Promise.promise(() -> intensiveComputation())
+                    .map((Integer i) -> ok("Got result: " + i));
+    }
+    //#async
+    public static int intensiveComputation() { return 2;}
+}

--- a/documentation/project/Build.scala
+++ b/documentation/project/Build.scala
@@ -10,6 +10,7 @@ import play.Keys._
 import play.core.{ SBTDocHandler, SBTLink, PlayVersion }
 import play.PlaySourceGenerators._
 import DocValidation._
+import scala.util.Properties.isJavaAtLeast
 
 object ApplicationBuild extends Build {
 
@@ -66,6 +67,10 @@ object ApplicationBuild extends Build {
     javaManualSourceDirectories <<= (baseDirectory)(base => (base / "manual" / "javaGuide" ** codeFilter).get),
     scalaManualSourceDirectories <<= (baseDirectory)(base => (base / "manual" / "scalaGuide" ** codeFilter).get),
 
+    javaManualSourceDirectories <++= (baseDirectory) { base =>
+      if (isJavaAtLeast("1.8")) (base / "manual" / "javaGuide" ** "java8code").get else Nil
+    },
+
     unmanagedSourceDirectories in Test <++= javaManualSourceDirectories,
     unmanagedSourceDirectories in Test <++= scalaManualSourceDirectories,
     unmanagedSourceDirectories in Test <++= (baseDirectory)(base => (base / "manual" / "detailedTopics" ** codeFilter).get),
@@ -106,7 +111,7 @@ object ApplicationBuild extends Build {
     validateExternalLinks <<= ValidateExternalLinksTask,
 
     testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "sequential", "true", "junitxml", "console"),
-    testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "--ignore-runners=org.specs2.runner.JUnitRunner"),
+    testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-v", "--ignore-runners=org.specs2.runner.JUnitRunner"),
     testListeners <<= (target, streams).map((t, s) => Seq(new eu.henkelmann.sbt.JUnitXmlTestsListener(t.getAbsolutePath, s.log)))
 
   ).settings(externalPlayModuleSettings:_*)

--- a/documentation/style/main.css
+++ b/documentation/style/main.css
@@ -48,6 +48,13 @@ article p.note{padding:15px 20px;}
 article table{width:100%;}article table td{padding:8px;}
 article table tr{background:#F4F4F7;border-bottom:1px solid #eee;}
 article table tr:nth-of-type(odd){background:#fafafa;}
+article dl dt{font-weight:bold;}
+article dl.tabbed{position:relative;}
+article dl.tabbed dt{float:left;margin:0 5px 0 0;border:1px solid #ddd;padding:0 20px;line-height:2;border-radius: 5px 5px 0 0;}
+article dl.tabbed dt a{display:block;height:30px;color:#333;text-decoration:none;}
+article dl.tabbed dt.current{background: #f7f7f7;}
+article dl.tabbed dd{position:absolute;width:100%;left:0;top:30px;}
+article dl.tabbed dd pre{margin-top:0;border-top-left-radius:0;}
 a{color:#80c846;}a:hover{color:#6dae38;}
 p{margin:1em 0;}
 h1{-webkit-font-smoothing:antialiased;}

--- a/documentation/style/main.js
+++ b/documentation/style/main.js
@@ -1,0 +1,28 @@
+$(function() {
+
+  // Tabbed code samples
+
+  $("dl").has("dd > pre").each(function() {
+    var dl = $(this);
+    dl.addClass("tabbed");
+    dl.find("dt").each(function(i) {
+      var dt = $(this);
+      dt.html("<a href=\"#tab" + i + "\">" + dt.text() + "</a>");
+    });
+    dl.find("dd").hide();
+    var current = dl.find("dt:first").addClass("current");
+    var currentContent = current.next("dd").show();
+    dl.css("height", current.height() + currentContent.height());
+  });
+
+  $("dl.tabbed dt a").click(function(e){
+    e.preventDefault();
+    var current = $(this).parent("dt");
+    var dl = current.parent("dl");
+    dl.find(".current").removeClass("current").next("dd").hide();
+    current.addClass("current");
+    var currentContent = current.next("dd").show();
+    dl.css("height", current.height() + currentContent.height());
+  });
+
+});

--- a/framework/src/play/src/main/scala/views/play20/manual.scala.html
+++ b/framework/src/play/src/main/scala/views/play20/manual.scala.html
@@ -5,6 +5,7 @@
         <title>@title</title>
         <link rel="stylesheet" media="screen" href="/@@documentation/resources/style/main.css"></link>
         <script type="text/javascript" src='/@@documentation/resources/@locate("jquery.min.js")'></script>
+        <script type="text/javascript" src="/@@documentation/resources/style/main.js"></script>
     </head>
     <body>
 


### PR DESCRIPTION
Initial changes to support Java 8 samples in the documentation, with some examples in JavaAsync. More Java 8 samples will be added if this looks okay.

This adds tabbed code samples. To create a tabbed code sample a definition list is used, which is supported in markdown. For example:

```
## Async results

We have been returning `Result` up until now. To send an asynchronous result
our action needs to return a `Promise<Result>`:

Java
: @[async](code/javaguide/async/controllers/Application.java)

Java 8
: @[async](java8code/java8guide/async/controllers/Application.java)
```

This will render as something like:

![java](https://f.cloud.github.com/assets/59895/2496397/f78767f6-b31b-11e3-8141-63d3dee3e7cb.png)

Or the Java 8 tab:

![java8](https://f.cloud.github.com/assets/59895/2496398/fac531c8-b31b-11e3-81a9-7dadb66c0080.png)

Javascript is used to add the tabbed view. If javascript is disabled it renders as:

![no-javascript](https://f.cloud.github.com/assets/59895/2496402/0d01b69a-b31c-11e3-92be-7a8694b503e0.png)
