### PR TITLE
Making it possible to disable evolutions for a specific datasource

### DIFF
--- a/documentation/manual/detailedTopics/evolutions/Evolutions.md
+++ b/documentation/manual/detailedTopics/evolutions/Evolutions.md
@@ -43,8 +43,7 @@ As you see you have to delimit the both Ups and Downs section by using comments 
 
 > Play splits your `.sql` files into a series of semicolon-delimited statements before executing them one-by-one against the database. So if you need to use a semicolon *within* a statement, escape it by entering `;;` instead of `;`. For example, `INSERT INTO punctuation(name, character) VALUES ('semicolon', ';;');`.
 
-Evolutions are automatically activated if a database is configured in `application.conf` and evolution scripts are present. You can disable them by setting `evolutionplugin=disabled`. For example when tests set up their own database you can disable evolutions for the test environment.
-
+Evolutions are automatically activated if a database is configured in `application.conf` and evolution scripts are present. You can disable them for all datasources by setting `evolutionplugin=disabled` or for a single datasource by setting `evolutionplugin.default=false` (if the datasource you want to disable them for is `default`). For example when tests set up their own database you can disable evolutions for the test environment.
 When evolutions are activated, Play will check your database schema state before each request in DEV mode, or before starting the application in PROD mode. In DEV mode, if your database schema is not up to date, an error page will suggest that you synchronise your database schema by running the appropriate SQL script.
 
 [[images/evolutions.png]]

--- a/framework/skeletons/java-skel/conf/application.conf
+++ b/framework/skeletons/java-skel/conf/application.conf
@@ -45,6 +45,8 @@ application.langs="en"
 # ~~~~~
 # You can disable evolutions if needed
 # evolutionplugin=disabled
+# You can disable evolutions for a specific datasource if necessary
+# evolutionplugin.default=disabled
 
 # Ebean configuration
 # ~~~~~

--- a/framework/skeletons/scala-skel/conf/application.conf
+++ b/framework/skeletons/scala-skel/conf/application.conf
@@ -42,6 +42,8 @@ application.langs="en"
 # ~~~~~
 # You can disable evolutions if needed
 # evolutionplugin=disabled
+# You can disable evolutions for a specific datasource if necessary
+# evolutionplugin.default=disabled
 
 # Logger
 # ~~~~~

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -461,32 +461,37 @@ class EvolutionsPlugin(app: Application) extends Plugin with HandleWebCommandSup
   override def onStart() {
     dbApi.datasources.foreach {
       case (ds, db) => {
-        withLock(ds) {
-          val script = evolutionScript(dbApi, app.path, app.classloader, db)
-          val hasDown = script.exists(_.isInstanceOf[DownScript])
 
-          lazy val applyEvolutions = app.configuration.getBoolean("applyEvolutions." + db).getOrElse(false)
-          lazy val applyDownEvolutions = app.configuration.getBoolean("applyDownEvolutions." + db).getOrElse(false)
+        val disableEvolutions = app.configuration.getString("evolutionplugin." + db).exists(_ == "disabled")
 
-          if (!script.isEmpty) {
-            app.mode match {
-              case Mode.Test => Evolutions.applyScript(dbApi, db, script)
-              case Mode.Dev if applyEvolutions => Evolutions.applyScript(dbApi, db, script)
-              case Mode.Prod if !hasDown && applyEvolutions => Evolutions.applyScript(dbApi, db, script)
-              case Mode.Prod if hasDown && applyEvolutions && applyDownEvolutions => Evolutions.applyScript(dbApi, db, script)
-              case Mode.Prod if hasDown => {
-                Play.logger.warn("Your production database [" + db + "] needs evolutions, including downs! \n\n" + toHumanReadableScript(script))
-                Play.logger.warn("Run with -DapplyEvolutions." + db + "=true and -DapplyDownEvolutions." + db + "=true if you want to run them automatically, including downs (be careful, especially if your down evolutions drop existing data)")
+        if (!disableEvolutions) {
+          withLock(ds) {
+            val script = evolutionScript(dbApi, app.path, app.classloader, db)
+            val hasDown = script.exists(_.isInstanceOf[DownScript])
 
-                throw InvalidDatabaseRevision(db, toHumanReadableScript(script))
+            lazy val applyEvolutions = app.configuration.getBoolean("applyEvolutions." + db).getOrElse(false)
+            lazy val applyDownEvolutions = app.configuration.getBoolean("applyDownEvolutions." + db).getOrElse(false)
+
+            if (!script.isEmpty) {
+              app.mode match {
+                case Mode.Test => Evolutions.applyScript(dbApi, db, script)
+                case Mode.Dev if applyEvolutions => Evolutions.applyScript(dbApi, db, script)
+                case Mode.Prod if !hasDown && applyEvolutions => Evolutions.applyScript(dbApi, db, script)
+                case Mode.Prod if hasDown && applyEvolutions && applyDownEvolutions => Evolutions.applyScript(dbApi, db, script)
+                case Mode.Prod if hasDown => {
+                  Play.logger.warn("Your production database [" + db + "] needs evolutions, including downs! \n\n" + toHumanReadableScript(script))
+                  Play.logger.warn("Run with -DapplyEvolutions." + db + "=true and -DapplyDownEvolutions." + db + "=true if you want to run them automatically, including downs (be careful, especially if your down evolutions drop existing data)")
+
+                  throw InvalidDatabaseRevision(db, toHumanReadableScript(script))
+                }
+                case Mode.Prod => {
+                  Play.logger.warn("Your production database [" + db + "] needs evolutions! \n\n" + toHumanReadableScript(script))
+                  Play.logger.warn("Run with -DapplyEvolutions." + db + "=true if you want to run them automatically (be careful)")
+
+                  throw InvalidDatabaseRevision(db, toHumanReadableScript(script))
+                }
+                case _ => throw InvalidDatabaseRevision(db, toHumanReadableScript(script))
               }
-              case Mode.Prod => {
-                Play.logger.warn("Your production database [" + db + "] needs evolutions! \n\n" + toHumanReadableScript(script))
-                Play.logger.warn("Run with -DapplyEvolutions." + db + "=true if you want to run them automatically (be careful)")
-
-                throw InvalidDatabaseRevision(db, toHumanReadableScript(script))
-              }
-              case _ => throw InvalidDatabaseRevision(db, toHumanReadableScript(script))
             }
           }
         }


### PR DESCRIPTION
This PR is meant to make it possible to disable evolutions for a specific datasource, which can be useful in some situations (see #2436).

The setting is done via a new `evolutionplugin.dbName` setting in order to be consistent with the existing `evolutionplugin` setting.
