### PR TITLE
Remove mentions of the iteratee thread pool that was removed in Play 2.2

### DIFF
--- a/documentation/manual/detailedTopics/configuration/ThreadPools.md
+++ b/documentation/manual/detailedTopics/configuration/ThreadPools.md
@@ -31,9 +31,8 @@ In contrast, the following types of IO do not block:
 Play uses a number of different thread pools for different purposes:
 
 * **Netty boss/worker thread pools** - These are used internally by Netty for handling Netty IO.  An applications code should never be executed by a thread in these thread pools.
-* **Iteratee thread pool** - This is used by the iteratees library.  Its size can be configured by setting `iteratee-threadpool-size` in `application.conf`.  It defaults to the number of processors available.
 * **Play Internal Thread Pool** - This is used internally by Play.  No application code should ever be executed by a thread in this thread pool, and no blocking should ever be done in this thread pool.  Its size can be configured by setting `internal-threadpool-size` in `application.conf`, and it defaults to the number of available processors.
-* **Play default thread pool** - This is the default thread pool in which all application code in Play Framework is executed, excluding some iteratees code.  It is an Akka dispatcher, and can be configured by configuring Akka, described below.  By default, it has one thread per processor.
+* **Play default thread pool** - This is the default thread pool in which all application code in Play Framework is executed.  It is an Akka dispatcher, and can be configured by configuring Akka, described below.  By default, it has one thread per processor.
 * **Akka thread pool** - This is used by the Play Akka plugin, and can be configured the same way that you would configure Akka.
 
 

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
@@ -545,12 +545,13 @@ object Enumerator {
   /**
    * Create an enumerator from the given input stream.
    *
-   * This enumerator will block on reading the input stream, in the default iteratee thread pool.  Care must therefore
-   * be taken to ensure that this isn't a slow stream.  If using this with slow input streams, consider setting the
-   * value of iteratee-threadpool-size to a value appropriate for handling the blocking.
+   * This enumerator will block on reading the input stream, in the supplied ExecutionContext.  Care must therefore
+   * be taken to ensure that this isn't a slow stream.  If using this with slow input streams, make sure the
+   * ExecutionContext is appropriately configured to handle the blocking.
    *
    * @param input The input stream
    * @param chunkSize The size of chunks to read from the stream.
+   * @param ec The ExecutionContext to execute blocking code.
    */
   def fromStream(input: java.io.InputStream, chunkSize: Int = 1024 * 8)(implicit ec: ExecutionContext): Enumerator[Array[Byte]] = {
     implicit val pec = ec.prepare()


### PR DESCRIPTION
This can also be backported to 2.2.
