### PR TITLE
Fix misleading tip about Enumeratee example

### DIFF
--- a/documentation/manual/scalaGuide/main/async/ScalaComet.md
+++ b/documentation/manual/scalaGuide/main/async/ScalaComet.md
@@ -11,13 +11,11 @@ Let’s write a first proof-of-concept: an enumerator that generates `<script>` 
 
 If you run this action from a web browser, you will see the three events logged in the browser console.
 
-> **Tip:** Writing `events >>> Enumerator.eof` is just another way of writing `events.andThen(Enumerator.eof)`
-
 We can write this in a better way by using `play.api.libs.iteratee.Enumeratee` that is just an adapter to transform an `Enumerator[A]` into another `Enumerator[B]`. Let’s use it to wrap standard messages into the `<script>` tags:
     
 @[enumeratee](code/ScalaComet.scala)
 
-> **Tip:** Writing `events >>> Enumerator.eof &> toCometMessage` is just another way of writing `events.andThen(Enumerator.eof).through(toCometMessage)`
+> **Tip:** Writing `events &> toCometMessage` is just another way of writing `events.through(toCometMessage)`
 
 ## Using the `play.api.libs.Comet` helper
 

--- a/documentation/manual/scalaGuide/main/async/code/ScalaComet.scala
+++ b/documentation/manual/scalaGuide/main/async/code/ScalaComet.scala
@@ -15,7 +15,6 @@ object ScalaCometSpec extends PlaySpecification with Controller {
   "play comet" should {
 
     "allow manually sending comet messages" in new WithApplication() {
-      // todo note to self: Make sure I get rid of the Enumerator.eof once that bug is fixed
       //#manual
       def comet = Action {
         val events = Enumerator(
@@ -23,7 +22,7 @@ object ScalaCometSpec extends PlaySpecification with Controller {
           """<script>console.log('foo')</script>""",
           """<script>console.log('bar')</script>"""
         )
-        Ok.stream(events >>> Enumerator.eof).as(HTML)
+        Ok.stream(events).as(HTML)
       }
       //#manual
       val msgs = cometMessages(comet(FakeRequest()))
@@ -42,7 +41,7 @@ object ScalaCometSpec extends PlaySpecification with Controller {
 
       def comet = Action {
         val events = Enumerator("kiki", "foo", "bar")
-        Ok.stream((events &> toCometMessage) >>> Enumerator.eof)
+        Ok.stream(events &> toCometMessage)
       }
       //#enumeratee
 
@@ -55,7 +54,7 @@ object ScalaCometSpec extends PlaySpecification with Controller {
       //#helper
       def comet = Action {
         val events = Enumerator("kiki", "foo", "bar")
-        Ok.stream((events &> Comet(callback = "console.log")) >>> Enumerator.eof)
+        Ok.stream(events &> Comet(callback = "console.log"))
       }
       //#helper
 
@@ -68,7 +67,7 @@ object ScalaCometSpec extends PlaySpecification with Controller {
       //#iframe
       def comet = Action {
         val events = Enumerator("kiki", "foo", "bar")
-        Ok.stream((events &> Comet(callback = "parent.cometMessage")) >>> Enumerator.eof)
+        Ok.stream(events &> Comet(callback = "parent.cometMessage"))
       }
       //#iframe
 


### PR DESCRIPTION
"events >>> Enumerator.eof &> toCometMessage" is inconsistent with the
code sample being referred to, and is incorrect since Enumerator.eof
shouldn't be sent through toCometMessage. I suspect that the code sample
originally read this way but was corrected, and the tip was not updated
along with it. Furthermore, "Enumerator.eof" is no longer necessary in
this section due to a fixed bug.

This is a copy of the previously PR's patch-1 branch but with commits squashed.
