### PR TITLE
Make junit-interface be a consistent version throughout the build file

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -182,7 +182,7 @@ object Dependencies {
   )
 
   val testDependencies = Seq("junit" % "junit" % "4.11") ++ specsBuild ++ Seq(
-    "com.novocode" % "junit-interface" % "0.10" exclude("junit", "junit-dep"),
+    "com.novocode" % "junit-interface" % "0.11-RC1",
     guava,
     findBugs,
     ("org.fluentlenium" % "fluentlenium-festassert" % "0.9.2")


### PR DESCRIPTION
I upgraded junit-interface to 0.11-RC1 earlier, but I missed that it was referenced twice in the build file and so I only upgraded it one place
