### PR TITLE
ProxyPassReverse should refer to balancer instead of back ends

### DIFF
--- a/documentation/manual/detailedTopics/production/HTTPServer.md
+++ b/documentation/manual/detailedTopics/production/HTTPServer.md
@@ -155,8 +155,7 @@ In Apache, I have the following configuration:
   ProxyPreserveHost On
   ProxyPass /balancer-manager !
   ProxyPass / balancer://mycluster/
-  ProxyPassReverse / http://localhost:9999/
-  ProxyPassReverse / http://localhost:9998/
+  ProxyPassReverse / balancer://mycluster/
 </VirtualHost>
 ```
 


### PR DESCRIPTION
When Apache is used for load balancing, directive `ProxyPassReverse` should refer to the url of a balancer instead of the individual urls of the back end systems.

Currently, it directly refers to the two Play instances:

```
ProxyPassReverse / http://localhost:9999/
ProxyPassReverse / http://localhost:9998/
```

However, I think it should refer to the balancer instead:

```
ProxyPassReverse / balancer://mycluster/
```

See also: [Examples of a balancer configuration](http://httpd.apache.org/docs/current/mod/mod_proxy_balancer.html#example) in the Apache Module mod_proxy_balancer documentation.
