### PR TITLE
documentation: add play2-closure to Module listing

### DIFF
--- a/documentation/manual/Modules.md
+++ b/documentation/manual/Modules.md
@@ -73,6 +73,10 @@
 * **Website (docs, sample):** [https://github.com/typesafehub/play-plugins/tree/master/dust](https://github.com/typesafehub/play-plugins/tree/master/dust)
 * **Short description:** provides support for the dust client side template language
 
+## Google Closure Template Plugin
+* **Website (docs, sample):** [https://github.com/gawkermedia/play2-closure](https://github.com/gawkermedia/play2-closure)
+* **Short description:** provides support for Google Closure Templates
+
 ## Elasticsearch
 
 * **Website:** [https://github.com/cleverage/play2-elasticsearch]


### PR DESCRIPTION
I just realized `play2-closure` was missing from the module listing page
