### PR TITLE
Update SBTSubProjects.md

### DIFF
--- a/documentation/manual/detailedTopics/build/SBTSubProjects.md
+++ b/documentation/manual/detailedTopics/build/SBTSubProjects.md
@@ -19,7 +19,7 @@ playScalaSettings
 
 lazy val myFirstApplication = project.in(file("."))
     .aggregate(myLibrary)
-    .depends(myLibrary)
+    .dependsOn(myLibrary)
 
 lazy val myLibrary = project
 ```


### PR DESCRIPTION
changed the method name from depends to dependsOn as per the github question http://stackoverflow.com/questions/21730323/play-framework-2-2-1-adding-non-play-java-project-as-sub-project, was facing the same issue and this solved it.
