### PR TITLE
Increase test await timeout from 5 seconds to 20 seconds

### DIFF
--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -136,7 +136,7 @@ trait DefaultAwaitTimeout {
   /**
    * The default await timeout.  Override this to change it.
    */
-  implicit def defaultAwaitTimeout: Timeout = 5.seconds
+  implicit def defaultAwaitTimeout: Timeout = 20.seconds
 
   /**
    * How long we should wait for something that we expect *not* to happen, e.g.


### PR DESCRIPTION
Master is currently failing due to timeouts in certain tests on our
CI box. Increasing the test timeout will hopefully allow CI builds
to work again.

At some point in the future, it would be better to make this
timeout configurable using something like system properties.
At the moment I just need a quick fix.
