### PR TITLE
Bump play to use java_server archetype instead of java_application.

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/Project.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/Project.scala
@@ -13,7 +13,7 @@ object Project extends Plugin with PlayExceptions with play.Keys with PlayReload
     with PlayRun with play.Settings with PlayPositionMapper with PlaySourceGenerators {
 
   private lazy val commonSettings: Seq[Setting[_]] =
-    packageArchetype.java_application ++
+    packageArchetype.java_server ++
       defaultSettings ++
       intellijCommandSettings ++
       Seq(testListeners += testListener) ++


### PR DESCRIPTION
Allows new support for SystemV/Upstart to be enabled for Play.

Review by @huntc
