### PR TITLE
Fix changeLang javadocs: en_US is not valid.

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Controller.java
+++ b/framework/src/play/src/main/java/play/mvc/Controller.java
@@ -35,7 +35,7 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 
     /**
      * Change durably the lang for the current user
-     * @param code New lang code to use (e.g. "fr", "en_US", etc.)
+     * @param code New lang code to use (e.g. "fr", "en-US", etc.)
      * @return true if the requested lang was supported by the application, otherwise false.
      */
     public static boolean changeLang(String code) {

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -125,7 +125,7 @@ public class Http {
 
         /**
          * Change durably the lang for the current user.
-         * @param code New lang code to use (e.g. "fr", "en_US", etc.)
+         * @param code New lang code to use (e.g. "fr", "en-US", etc.)
          * @return true if the requested lang was supported by the application, otherwise false.
          */
         public boolean changeLang(String code) {


### PR DESCRIPTION
Language codes with underscore are not valid (e.g. en_US), dashes should be used instead (e.g. en-US).
