### PR TITLE
Make ExecutionContext vals into objects

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Execution.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Execution.scala
@@ -28,7 +28,7 @@ object Execution {
    * Blocking should be strictly avoided as it could hog the current thread.
    * Also, since we're running on a single thread, blocking code risks deadlock.
    */
-  val trampoline: ExecutionContext = new ExecutionContext {
+  object trampoline extends ExecutionContext {
 
     private val local = new ThreadLocal[Deque[Runnable]]
 
@@ -67,7 +67,7 @@ object Execution {
    * Blocking should be strictly avoided as it could hog the current thread.
    * Also, since we're running on a single thread, blocking code risks deadlock.
    */
-  val overflowingExecutionContext: ExecutionContext = new ExecutionContext {
+  object overflowingExecutionContext extends ExecutionContext {
 
     def execute(runnable: Runnable): Unit = {
       runnable.run()


### PR DESCRIPTION
In the performance work I've been doing, it's useful to be able to identify the ExecutionContext that is being used. This change makes it nicer when debugging async code, as it gives these two ExecutionContexts proper classnames (not just a series of dollar signs and digits).
