### PR TITLE
When PLAY_LANG is set; treat it as first accepted lang.

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -114,12 +114,16 @@ public class Http {
             if (lang != null) {
                 return lang;
             } else {
+                List<Lang> candidateLangs = new ArrayList<Lang>();
                 Cookie cookieLang = request.cookie(Play.langCookieName());
                 if (cookieLang != null) {
                     Lang lang = Lang.forCode(cookieLang.value());
-                    if (lang != null) return lang;
+                    if (lang != null) {
+                        candidateLangs.add(lang);
+                    };
                 }
-                return Lang.preferred(request().acceptLanguages());
+                candidateLangs.addAll(request().acceptLanguages());
+                return Lang.preferred(candidateLangs);
             }
         }
 


### PR DESCRIPTION
Instead of blindly taking the PLAY_LANG value into lang(),
we treat it as the most prioritary language for the user.
This way a user cannot set a language that is undefined for
the application.