### PR TITLE
Optimize router HandlerInvoker construction and lookup

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ServerBenchmark.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ServerBenchmark.scala
@@ -116,7 +116,11 @@ class ServerBenchmark extends NettyRunners {
       if (Routes.prefix.endsWith("/")) "" else "/"
     }
 
-    private[this] lazy val hello_world = Route("GET", PathPattern(List(StaticPart(Routes.prefix))))
+    private[this] lazy val hello_world_route = Route("GET", PathPattern(List(StaticPart(Routes.prefix))))
+    private[this] lazy val hello_world_invoker = createInvoker(
+      HelloWorldApp.helloWorld,
+      HandlerDef(this.getClass.getClassLoader, "", "hello_world", "index", Nil, "GET", """ Home page""", Routes.prefix + """""")
+    )
 
     def documentation = List(( """GET""", prefix, """hello_world""")).foldLeft(List.empty[(String, String, String)]) {
       (s, e) => e.asInstanceOf[Any] match {
@@ -126,9 +130,9 @@ class ServerBenchmark extends NettyRunners {
     }
 
     def routes: PartialFunction[RequestHeader, Handler] = {
-      case hello_world(params) => {
+      case hello_world_route(params) => {
         call {
-          invokeHandler(HelloWorldApp.helloWorld, HandlerDef(this, "", "hello_world", "index", Nil, "GET", """ Home page""", Routes.prefix + """"""))
+          hello_world_invoker.call(HelloWorldApp.helloWorld)
         }
       }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -209,15 +209,17 @@ object WebSocketSpec extends PlaySpecification with WsTestClient {
 
     "allow handling a WebSocket in java" in {
 
-      import play.core.Router.HandlerInvoker
-      import play.core.Router.HandlerInvoker._
+      import play.core.Router.HandlerInvokerFactory
+      import play.core.Router.HandlerInvokerFactory._
       import play.mvc.{ WebSocket => JWebSocket, Results => JResults }
       import play.libs.F
 
-      implicit def toHandler[J <: AnyRef](javaHandler: J)(implicit invoker: HandlerInvoker[J]): Handler = {
-        invoker.call(javaHandler,
-          new HandlerDef(javaHandler, "package", "controller", "method", Nil, "GET", "", "/stream")
+      implicit def toHandler[J <: AnyRef](javaHandler: J)(implicit factory: HandlerInvokerFactory[J]): Handler = {
+        val invoker = factory.createInvoker(
+          javaHandler,
+          new HandlerDef(javaHandler.getClass.getClassLoader, "package", "controller", "method", Nil, "GET", "", "/stream")
         )
+        invoker.call(javaHandler)
       }
 
       "allow consuming messages" in allowConsumingMessages { _ => consumed =>

--- a/framework/src/play/src/main/resources/play.plugins
+++ b/framework/src/play/src/main/resources/play.plugins
@@ -1,4 +1,3 @@
 100:play.api.i18n.DefaultMessagesPlugin
-100:play.core.RouterCacheLifecycle
 1000:play.api.libs.concurrent.AkkaPlugin
 10000:play.api.GlobalPlugin

--- a/framework/src/play/src/main/scala/play/core/j/JavaWebSocket.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaWebSocket.scala
@@ -83,18 +83,18 @@ object JavaWebSocket extends JavaHelpers {
 
   // -- Bytes
 
-  def ofBytes(retrieveWebSocket: => JWebSocket[Array[Byte]]): Handler =
+  def ofBytes(retrieveWebSocket: => JWebSocket[Array[Byte]]): WebSocket[Array[Byte], Array[Byte]] =
     webSocketWrapper[Array[Byte]](Future.successful(retrieveWebSocket))
 
-  def promiseOfBytes(retrieveWebSocket: => JPromise[JWebSocket[Array[Byte]]]): Handler =
+  def promiseOfBytes(retrieveWebSocket: => JPromise[JWebSocket[Array[Byte]]]): WebSocket[Array[Byte], Array[Byte]] =
     webSocketWrapper[Array[Byte]](retrieveWebSocket.wrapped())
 
   // -- String
 
-  def ofString(retrieveWebSocket: => JWebSocket[String]): Handler =
+  def ofString(retrieveWebSocket: => JWebSocket[String]): WebSocket[String, String] =
     webSocketWrapper[String](Future.successful(retrieveWebSocket))
 
-  def promiseOfString(retrieveWebSocket: => JPromise[JWebSocket[String]]): Handler =
+  def promiseOfString(retrieveWebSocket: => JPromise[JWebSocket[String]]): WebSocket[String, String] =
     webSocketWrapper[String](retrieveWebSocket.wrapped())
 
   // -- Json (JsonNode)
@@ -103,10 +103,9 @@ object JavaWebSocket extends JavaHelpers {
     play.libs.Json.stringify, play.libs.Json.parse
   )
 
-  def ofJson(retrieveWebSocket: => JWebSocket[JsonNode]): Handler =
+  def ofJson(retrieveWebSocket: => JWebSocket[JsonNode]): WebSocket[JsonNode, JsonNode] =
     webSocketWrapper[JsonNode](Future.successful(retrieveWebSocket))
 
-  def promiseOfJson(retrieveWebSocket: => JPromise[JWebSocket[JsonNode]]): Handler =
+  def promiseOfJson(retrieveWebSocket: => JPromise[JWebSocket[JsonNode]]): WebSocket[JsonNode, JsonNode] =
     webSocketWrapper[JsonNode](retrieveWebSocket.wrapped())
-
 }

--- a/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
@@ -436,6 +436,7 @@ object RoutesCompiler {
         |
         |import play.core._
         |import play.core.Router._
+        |import play.core.Router.HandlerInvokerFactory._
         |import play.core.j._
         |
         |import play.api.mvc._
@@ -472,7 +473,7 @@ object RoutesCompiler {
       namespace.map("package " + _).getOrElse(""),
       additionalImports.map(prefixImport).map("import " + _).mkString("\n"),
       rules.collect { case Include(p, r) => "(\"" + p + "\"," + r + ")" }.mkString(","),
-      routeDefinitions(rules),
+      routeDefinitions(namespace.getOrElse(""), rules),
       routing(namespace.getOrElse(""), rules)
     )
 
@@ -484,6 +485,7 @@ object RoutesCompiler {
         |import %sRoutes.{prefix => _prefix, defaultPrefix => _defaultPrefix}
         |import play.core._
         |import play.core.Router._
+        |import play.core.Router.HandlerInvokerFactory._
         |import play.core.j._
         |
         |import play.api.mvc._
@@ -777,7 +779,7 @@ object RoutesCompiler {
                     """
                           |%s
                           |def %s(%s): play.api.mvc.HandlerRef[_] = new play.api.mvc.HandlerRef(
-                          |   %s, HandlerDef(this, "%s", "%s", "%s", %s, "%s", %s, _prefix + %s)
+                          |   %s, HandlerDef(this.getClass.getClassLoader, "%s", "%s", "%s", %s, "%s", %s, _prefix + %s)
                           |)
                       """.stripMargin.format(
                       markLines(route),
@@ -976,21 +978,39 @@ object RoutesCompiler {
 
   }
 
+  private def baseIdent(r: Route, i: Int): String = r.call.packageName.replace(".", "_") + "_" + r.call.controller.replace(".", "_") + "_" + r.call.method + i
+  private def routeIdent(r: Route, i: Int): String = baseIdent(r, i) + "_route"
+  private def invokerIdent(r: Route, i: Int): String = baseIdent(r, i) + "_invoker"
+  private def controllerMethodCall(r: Route, paramFormat: Parameter => String): String = {
+    val methodPart = if (r.call.instantiate) {
+      "play.api.Play.maybeApplication.map(_.global).getOrElse(play.api.DefaultGlobal).getControllerInstance(classOf[" + r.call.packageName + "." + r.call.controller + "])." + r.call.method
+    } else {
+      r.call.packageName + "." + r.call.controller + "." + r.call.method
+    }
+    val paramPart = r.call.parameters.map { params =>
+      params.map(paramFormat).mkString(", ")
+    }.map("(" + _ + ")").getOrElse("")
+    methodPart + paramPart
+  }
+
   /**
    * Generate the routes definitions
    */
-  def routeDefinitions(rules: List[Rule]): String = {
+  def routeDefinitions(routerPackage: String, rules: List[Rule]): String = {
     rules.zipWithIndex.map {
       case (r @ Route(_, _, _, _), i) =>
-        """
-          |%s
-          |private[this] lazy val %s%s = Route("%s", %s)
-        """.stripMargin.format(
-          markLines(r),
-          r.call.packageName.replace(".", "_") + "_" + r.call.controller.replace(".", "_") + "_" + r.call.method,
-          i,
-          r.verb.value,
-          "PathPattern(List(StaticPart(Routes.prefix)" + { if (r.path.parts.isEmpty) "" else """,StaticPart(Routes.defaultPrefix),""" } + r.path.parts.map(_.toString).mkString(",") + "))")
+        val pattern = "PathPattern(List(StaticPart(Routes.prefix)" + { if (r.path.parts.isEmpty) "" else """,StaticPart(Routes.defaultPrefix),""" } + r.path.parts.map(_.toString).mkString(",") + "))"
+        val fakeCall = controllerMethodCall(r, p => s"fakeValue[${p.typeName}]")
+        val handlerDef = """HandlerDef(this.getClass.getClassLoader, """" + routerPackage + """", """" + r.call.packageName + "." + r.call.controller + """", """" + r.call.method + """", """ + r.call.parameters.filterNot(_.isEmpty).map { params =>
+          params.map("classOf[" + _.typeName + "]").mkString(", ")
+        }.map("Seq(" + _ + ")").getOrElse("Nil") + ""","""" + r.verb + """", """ + "\"\"\"" + r.comments.map(_.comment).mkString("\n") + "\"\"\", Routes.prefix + \"\"\"" + r.path + "\"\"\")"
+        s"""
+           |${markLines(r)}
+           |private[this] lazy val ${routeIdent(r, i)} = Route("${r.verb.value}", ${pattern})
+           |private[this] lazy val ${invokerIdent(r, i)} = createInvoker(
+           |${fakeCall},
+           |${handlerDef})
+        """.stripMargin
       case (r @ Include(_, _), i) =>
         """
           |%s
@@ -1037,52 +1057,27 @@ object RoutesCompiler {
           i
         )
       case (r @ Route(_, _, _, _), i) =>
-        """
-            |%s
-            |case %s%s(params) => {
-            |   call%s { %s
-            |        invokeHandler(%s%s, %s)
+        val binding = r.call.parameters.filterNot(_.isEmpty).map { params =>
+          params.map { p =>
+            p.fixed.map { v =>
+              """Param[""" + p.typeName + """]("""" + p.name + """", Right(""" + v + """))"""
+            }.getOrElse {
+              """params.""" + (if (r.path.has(p.name)) "fromPath" else "fromQuery") + """[""" + p.typeName + """]("""" + p.name + """", """ + p.default.map("Some(" + _ + ")").getOrElse("None") + """)"""
+            }
+          }.mkString(", ")
+        }.map("(" + _ + ")").getOrElse("")
+        val localNames = r.call.parameters.filterNot(_.isEmpty).map { params =>
+          params.map(x => safeKeyword(x.name)).mkString(", ")
+        }.map("(" + _ + ") =>").getOrElse("")
+        val call = controllerMethodCall(r, x => safeKeyword(x.name))
+        s"""
+            |${markLines(r)}
+            |case ${routeIdent(r, i)}(params) => {
+            |   call${binding} { ${localNames}
+            |        ${invokerIdent(r, i)}.call(${call})
             |   }
             |}
-        """.stripMargin.format(
-          markLines(r),
-
-          // alias
-          r.call.packageName.replace(".", "_") + "_" + r.call.controller.replace(".", "_") + "_" + r.call.method,
-          i,
-
-          // binding
-          r.call.parameters.filterNot(_.isEmpty).map { params =>
-            params.map { p =>
-              p.fixed.map { v =>
-                """Param[""" + p.typeName + """]("""" + p.name + """", Right(""" + v + """))"""
-              }.getOrElse {
-                """params.""" + (if (r.path.has(p.name)) "fromPath" else "fromQuery") + """[""" + p.typeName + """]("""" + p.name + """", """ + p.default.map("Some(" + _ + ")").getOrElse("None") + """)"""
-              }
-            }.mkString(", ")
-          }.map("(" + _ + ")").getOrElse(""),
-
-          // local names
-          r.call.parameters.filterNot(_.isEmpty).map { params =>
-            params.map(x => safeKeyword(x.name)).mkString(", ")
-          }.map("(" + _ + ") =>").getOrElse(""),
-
-          // call
-          if (r.call.instantiate) {
-            "play.api.Play.maybeApplication.map(_.global).getOrElse(play.api.DefaultGlobal).getControllerInstance(classOf[" + r.call.packageName + "." + r.call.controller + "])." + r.call.method
-          } else {
-            r.call.packageName + "." + r.call.controller + "." + r.call.method
-          },
-
-          // call parameters
-          r.call.parameters.map { params =>
-            params.map(x => safeKeyword(x.name)).mkString(", ")
-          }.map("(" + _ + ")").getOrElse(""),
-
-          // definition
-          """HandlerDef(this, """" + routerPackage + """", """" + r.call.packageName + "." + r.call.controller + """", """" + r.call.method + """", """ + r.call.parameters.filterNot(_.isEmpty).map { params =>
-            params.map("classOf[" + _.typeName + "]").mkString(", ")
-          }.map("Seq(" + _ + ")").getOrElse("Nil") + ""","""" + r.verb + """", """ + "\"\"\"" + r.comments.map(_.comment).mkString("\n") + "\"\"\", Routes.prefix + \"\"\"" + r.path + "\"\"\")")
+        """.stripMargin
     }.mkString("\n")).filterNot(_.isEmpty).getOrElse {
 
       """Map.empty""" // Empty partial function


### PR DESCRIPTION
Before this change routers created a HandlerInvoker for every request. With this change, each route's HandlerInvoker is created once and cached in its own lazy val.

We can use the cached HandlerInvoker to cache route information such as Java reflection info and request tags. That lets us remove the ConcurrentHashMap that was previously used to cache Java reflection info.

These changes improves both Scala and Java performance, but Java performance improves the most.

To implement the change, we change all the implicits that we previously used for creating HandlerInvokers into implicits for creating HandlerInvokerFactories. HandlerInvokerFactories are used to create the HandlerInvokerFactory for each route.

We need to use a hack to implicitly resolve the correct HandlerInvokerFactory.

Before, HandlerInvokers were implicitly resolved while a request was being handled. That meant that the correct implicit HandlerInvoker could be found by calling the controller method with the request parameters.

Now, we can't call the controller method, since we want to create a HandlerInvokerFactories even when we're not handling a request, so we can't call the controller method with the request parameters.

What we do instead is _pretend_ to call the controller method in a call-by-name thunk, but never actually call that thunk.

It's a bit hacky, but it works. Maybe in the future we could use macros to directly get the return type of the controller method.
