### PR TITLE
Fix algorithm checker in Play-WS

### DIFF
--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmCheckerSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmCheckerSpec.scala
@@ -45,27 +45,15 @@ object AlgorithmCheckerSpec extends Specification {
       success
     }
 
-    "pass a bad signature algorithm (MD5) that is first, because it's a trust anchor" in {
+    "fail a bad signature algorithm (MD5)" in {
       val disabledSignatureAlgorithms = parseAll(line, "MD5").get.toSet
       val disabledKeyAlgorithms = parseAll(line, "").get.toSet
       val checker = new AlgorithmChecker(disabledSignatureAlgorithms, disabledKeyAlgorithms)
 
-      val rootCert:Certificate = CertificateGenerator.generateRSAWithMD5(2048)
+      val intermediateCert:Certificate = CertificateGenerator.generateRSAWithMD5(2048)
+      //val eeCert:Certificate = CertificateGenerator.generateRSAWithSHA256(2048)
 
-      checker.check(rootCert, emptySet())
-      success
-    }
-
-    "fail a bad signature algorithm (MD5) that is second, because it's a NOT trust anchor" in {
-      val disabledSignatureAlgorithms = parseAll(line, "MD5").get.toSet
-      val disabledKeyAlgorithms = parseAll(line, "").get.toSet
-      val checker = new AlgorithmChecker(disabledSignatureAlgorithms, disabledKeyAlgorithms)
-
-      val rootCert:Certificate = CertificateGenerator.generateRSAWithMD5(2048)
-      val eeCert:Certificate = CertificateGenerator.generateRSAWithMD5(2048)
-
-      checker.check(rootCert, emptySet())
-      checker.check(eeCert, emptySet()).must(throwA[CertPathValidatorException])
+      checker.check(intermediateCert, emptySet()).must(throwA[CertPathValidatorException])
     }
   }
 }


### PR DESCRIPTION
Change the filename to reflect the class name, remove incorrect logic (root cert is never in the PXIX chain)

Was using https://www.ssllabs.com/ssltest/analyze.html?d=doc.to as a guide -- previously it was using an MD5 intermediate certificate and an MD5 root certificate.  

The documentation in http://docs.oracle.com/javase/7/docs/technotes/guides/security/certpath/CertPathProgGuide.html#CertPath says 

"This method returns a List of zero or more java.security.cert.Certificate objects. The returned List and the Certificates contained within it are immutable, in order to protect the contents of the CertPath object. The ordering of the certificates returned depends on the type. By convention, the certificates in a CertPath object of type X.509 are ordered starting with the target certificate and ending with a certificate issued by the trust anchor. That is, the issuer of one certificate is the subject of the following one. The certificate representing the TrustAnchor should not be included in the certification path. Unvalidated X.509 CertPaths may not follow this convention. PKIX CertPathValidators will detect any departure from these conventions that cause the certification path to be invalid and throw a CertPathValidatorException. "

Because the trust anchor is not in the chain, there does not need to be an explicit check for a root certificate in the Algorithm checker.
