### PR TITLE
Fix error message for global initialization

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -39,7 +39,8 @@ trait WithDefaultGlobal {
   } catch {
     case e: ClassNotFoundException if !initialConfiguration.getString("application.global").isDefined => DefaultGlobal
     case e if initialConfiguration.getString("application.global").isDefined => {
-      throw initialConfiguration.reportError("application.global", "Cannot initialize the custom Global object (%s) (perhaps it's a wrong reference?)", Some(e))
+      throw initialConfiguration.reportError("application.global",
+        s"Cannot initialize the custom Global object ($globalClass) (perhaps it's a wrong reference?)", Some(e))
     }
   }
 


### PR DESCRIPTION
Assuming that %s should refer to `globalClass`. Changed to string interpolation.
