### PR TITLE
Entries in play.api.data.Field.indexes are not unique

### DIFF
--- a/framework/src/play/src/main/scala/views/helper/Helpers.scala
+++ b/framework/src/play/src/main/scala/views/helper/Helpers.scala
@@ -88,7 +88,7 @@ package views.html.helper {
         case complete if complete.distinct.size >= min => field.indexes.distinct
         case partial =>
           // We don't have enough elements, append indexes starting from the largest
-          val start = field.indexes.distinct.max + 1
+          val start = field.indexes.max + 1
           val needed = min - field.indexes.distinct.size
           field.indexes.distinct ++ (start until (start + needed))
       }


### PR DESCRIPTION
Entries in 'indexes' of play.api.data.Field are not unique. This code will fix problems that have been caused by this.
To see an example of where this bug causes problems one needs only to look at the sample code provided on /samples/java/form. Where if field validation error is given to the user, the resulting page add several extra fields to the tables which weren't there before form validation.
Pictures:
![1](https://cloud.githubusercontent.com/assets/2955422/2689513/e5c54f0c-c30a-11e3-9337-f719fd160d82.jpg)
Result of pressing insert button:
![2](https://cloud.githubusercontent.com/assets/2955422/2689514/e63919f0-c30a-11e3-8891-b73b6c5199a4.jpg)
