### PR TITLE
Removed colon from Content-Security-Policy directive

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
@@ -19,7 +19,7 @@ import play.api.Configuration
  * <li>{{play.filters.headers.xssProtection}} - sets xssProtection.  Some("1; mode=block") by default.
  * <li>{{play.filters.headers.contentTypeOptions}} - sets contentTypeOptions. Some("nosniff") by default.
  * <li>{{play.filters.headers.permittedCrossDomainPolicies}} - sets permittedCrossDomainPolicies. Some("master-only") by default.
- * <li>{{play.filters.headers.contentSecurityPolicy}} - sets contentSecurityPolicy. Some("default-src: 'self'") by default.
+ * <li>{{play.filters.headers.contentSecurityPolicy}} - sets contentSecurityPolicy. Some("default-src 'self'") by default.
  * </ul>
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options">X-Frame-Options</a>
@@ -40,7 +40,7 @@ object SecurityHeadersFilter {
   val DEFAULT_XSS_PROTECTION = "1; mode=block"
   val DEFAULT_CONTENT_TYPE_OPTIONS = "nosniff"
   val DEFAULT_PERMITTED_CROSS_DOMAIN_POLICIES = "master-only"
-  val DEFAULT_CONTENT_SECURITY_POLICY = "default-src: 'self'"
+  val DEFAULT_CONTENT_SECURITY_POLICY = "default-src 'self'"
 
   /**
    * Convenience method for creating a SecurityHeadersFilter that reads settings from application.conf.  Generally speaking,

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
@@ -48,8 +48,8 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
       header(X_XSS_PROTECTION_HEADER, result) must beSome("1; mode=block")
       header(X_CONTENT_TYPE_OPTIONS_HEADER, result) must beSome("nosniff")
       header(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, result) must beSome("master-only")
-      header(X_CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src: 'self'")
-      header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src: 'self'")
+      header(X_CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src 'self'")
+      header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src 'self'")
     }
 
     "work with singleton apply method using configuration" in {
@@ -69,8 +69,8 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
       header(X_XSS_PROTECTION_HEADER, result) must beSome("1; mode=block")
       header(X_CONTENT_TYPE_OPTIONS_HEADER, result) must beSome("nosniff")
       header(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, result) must beSome("master-only")
-      header(X_CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src: 'self'")
-      header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src: 'self'")
+      header(X_CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src 'self'")
+      header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src 'self'")
     }
 
     "work with new zero argument constructor for Java option" in new WithApplication() {
@@ -87,8 +87,8 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
       header(X_XSS_PROTECTION_HEADER, result) must beSome("1; mode=block")
       header(X_CONTENT_TYPE_OPTIONS_HEADER, result) must beSome("nosniff")
       header(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, result) must beSome("master-only")
-      header(X_CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src: 'self'")
-      header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src: 'self'")
+      header(X_CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src 'self'")
+      header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src 'self'")
     }
 
     "frame options" should {


### PR DESCRIPTION
Content-Security-Policy directives **do not work with colons**.
I testet it in Chrome and Firefox and both reported errors.
Without the colons it worked as expected.

For correct usage have a look at the examples here:
http://content-security-policy.com/ (at the bottom of the page)
http://www.html5rocks.com/en/tutorials/security/content-security-policy/
