### PR TITLE
Allowed Java apps to configure CSRF error handler

### DIFF
--- a/documentation/manual/javaGuide/main/forms/JavaCsrf.md
+++ b/documentation/manual/javaGuide/main/forms/JavaCsrf.md
@@ -94,6 +94,7 @@ The following options can be configured in `application.conf`:
 * `csrf.cookie.secure` - If `csrf.cookie.name` is set, whether the CSRF cookie should have the secure flag set.  Defaults to the same value as `session.secure`.
 * `csrf.body.bufferSize` - In order to read tokens out of the body, Play must first buffer the body and potentially parse it.  This sets the maximum buffer size that will be used to buffer the body.  Defaults to 100k.
 * `csrf.sign.tokens` - Whether Play should use signed CSRF tokens.  Signed CSRF tokens ensure that the token value is randomised per request, thus defeating BREACH style attacks.
+* `csrf.error.handler` - The error handler.  Must implement `play.filters.csrf.CSRFErrorHandler` or `play.filters.csrf.CSRF.ErrorHandler`.
 
 > **Next:** [[Working with JSON| JavaJsonRequests]]
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
@@ -5,6 +5,7 @@ package play.filters.csrf
 
 import play.api.mvc._
 import play.filters.csrf.CSRF.{ TokenProvider, ErrorHandler }
+import play.api.Play
 
 /**
  * A filter that provides CSRF protection.
@@ -20,7 +21,7 @@ import play.filters.csrf.CSRF.{ TokenProvider, ErrorHandler }
  * @param createIfNotFound Whether a new CSRF token should be created if it's not found.  Default creates one if it's
  *                         a GET request that accepts HTML.
  * @param tokenProvider A token provider to use.
- * @param checkFailedResult handling failed token error.
+ * @param errorHandler handling failed token error.
  */
 class CSRFFilter(tokenName: => String = CSRFConf.TokenName,
     cookieName: => Option[String] = CSRFConf.CookieName,
@@ -32,7 +33,10 @@ class CSRFFilter(tokenName: => String = CSRFConf.TokenName,
   /**
    * Default constructor, useful from Java
    */
-  def this() = this(CSRFConf.TokenName)
+  def this() = {
+    this(CSRFConf.TokenName, CSRFConf.CookieName, CSRFConf.SecureCookie, CSRFConf.defaultCreateIfNotFound,
+      CSRFConf.defaultTokenProvider, CSRFConf.defaultJavaErrorHandler)
+  }
 
   def apply(next: EssentialAction): EssentialAction = new CSRFAction(next, tokenName, cookieName, secureCookie,
     createIfNotFound, tokenProvider, errorHandler)
@@ -47,4 +51,5 @@ object CSRFFilter {
     errorHandler: => ErrorHandler = CSRFConf.defaultErrorHandler) = {
     new CSRFFilter(tokenName, cookieName, secureCookie, createIfNotFound, tokenProvider, errorHandler)
   }
+
 }

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
@@ -5,8 +5,8 @@ package play.filters.csrf
 
 import scala.concurrent.Future
 import play.api.libs.ws._
-import play.mvc.{Results, Result, Controller}
-import play.core.j.{JavaActionAnnotations, JavaAction}
+import play.mvc.{ Results, Result, Controller }
+import play.core.j.{ JavaActionAnnotations, JavaAction }
 import play.libs.F
 
 /**

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/ScalaCSRFActionSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/ScalaCSRFActionSpec.scala
@@ -3,9 +3,8 @@
  */
 package play.filters.csrf
 
-import play.api.libs.ws.WS.WSRequestHolder
 import scala.concurrent.Future
-import play.api.libs.ws.{WS, Response}
+import play.api.libs.ws.{ WS, WSResponse, WSRequestHolder }
 import play.api.mvc._
 
 /**
@@ -14,7 +13,7 @@ import play.api.mvc._
 object ScalaCSRFActionSpec extends CSRFCommonSpecs {
 
   def buildCsrfCheckRequest(sendUnauthorizedResult: Boolean, configuration: (String, String)*) = new CsrfTester {
-    def apply[T](makeRequest: (WSRequestHolder) => Future[Response])(handleResponse: (Response) => T) = withServer(configuration) {
+    def apply[T](makeRequest: (WSRequestHolder) => Future[WSResponse])(handleResponse: (WSResponse) => T) = withServer(configuration) {
       case _ => if (sendUnauthorizedResult) {
         CSRFCheck(Action(Results.Ok), new CustomErrorHandler())
       } else {
@@ -27,7 +26,7 @@ object ScalaCSRFActionSpec extends CSRFCommonSpecs {
   }
 
   def buildCsrfAddToken(configuration: (String, String)*) = new CsrfTester {
-    def apply[T](makeRequest: (WSRequestHolder) => Future[Response])(handleResponse: (Response) => T) = withServer(configuration) {
+    def apply[T](makeRequest: (WSRequestHolder) => Future[WSResponse])(handleResponse: (WSResponse) => T) = withServer(configuration) {
       case _ => CSRFAddToken(Action {
         implicit req =>
           CSRF.getToken(req).map {
@@ -43,6 +42,6 @@ object ScalaCSRFActionSpec extends CSRFCommonSpecs {
 
   class CustomErrorHandler extends CSRF.ErrorHandler {
     import play.api.mvc.Results.Unauthorized
-    def handle(msg: String) = Unauthorized(msg)
+    def handle(req: RequestHeader, msg: String) = Unauthorized(msg)
   }
 }


### PR DESCRIPTION
It was possible to configure a CSRF error handler per action, but not if you're using the global CSRFFilter.  This change makes that possible, via supplying a csrf.error.handler configuration parameter with the class name of the filter.
