### PR TITLE
Removed "X-"Content-Security-Policy header - it's a mess

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
@@ -33,7 +33,6 @@ object SecurityHeadersFilter {
   val X_XSS_PROTECTION_HEADER = "X-XSS-Protection"
   val X_CONTENT_TYPE_OPTIONS_HEADER = "X-Content-Type-Options"
   val X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER = "X-Permitted-Cross-Domain-Policies"
-  val X_CONTENT_SECURITY_POLICY_HEADER = "X-Content-Security-Policy"
   val CONTENT_SECURITY_POLICY_HEADER = "Content-Security-Policy"
 
   val DEFAULT_FRAME_OPTIONS = "DENY"
@@ -169,7 +168,6 @@ class SecurityHeadersFilter(config: SecurityHeadersConfig) extends Filter {
           config.xssProtection.map(X_XSS_PROTECTION_HEADER -> _),
           config.contentTypeOptions.map(X_CONTENT_TYPE_OPTIONS_HEADER -> _),
           config.permittedCrossDomainPolicies.map(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER -> _),
-          config.contentSecurityPolicy.map(X_CONTENT_SECURITY_POLICY_HEADER -> _),
           config.contentSecurityPolicy.map(CONTENT_SECURITY_POLICY_HEADER -> _)
         ).flatten
         r.withHeaders(headers: _*)

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
@@ -48,7 +48,6 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
       header(X_XSS_PROTECTION_HEADER, result) must beSome("1; mode=block")
       header(X_CONTENT_TYPE_OPTIONS_HEADER, result) must beSome("nosniff")
       header(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, result) must beSome("master-only")
-      header(X_CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src 'self'")
       header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src 'self'")
     }
 
@@ -69,7 +68,6 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
       header(X_XSS_PROTECTION_HEADER, result) must beSome("1; mode=block")
       header(X_CONTENT_TYPE_OPTIONS_HEADER, result) must beSome("nosniff")
       header(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, result) must beSome("master-only")
-      header(X_CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src 'self'")
       header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src 'self'")
     }
 
@@ -87,7 +85,6 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
       header(X_XSS_PROTECTION_HEADER, result) must beSome("1; mode=block")
       header(X_CONTENT_TYPE_OPTIONS_HEADER, result) must beSome("nosniff")
       header(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, result) must beSome("master-only")
-      header(X_CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src 'self'")
       header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src 'self'")
     }
 
@@ -171,14 +168,12 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
         """.stripMargin))) {
         val result = route(FakeRequest()).get
 
-        header(X_CONTENT_SECURITY_POLICY_HEADER, result) must beSome("some content security policy")
         header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("some content security policy")
       }
 
       "work with none" in withApplication(Ok("hello"), SecurityHeadersFilter(defaultConfig.copy(contentSecurityPolicy = None))) {
         val result = route(FakeRequest()).get
 
-        header(X_CONTENT_SECURITY_POLICY_HEADER, result) must beNone
         header(CONTENT_SECURITY_POLICY_HEADER, result) must beNone
       }
     }


### PR DESCRIPTION
The `X-Content-Security-Policy` header (with the preceding "`X-`") is a total mess and we shouldn't support this non-standard header in play.

What's wrong with the header?
It **only** [targets IE 10 & 11](http://caniuse.com/#feat=contentsecuritypolicy) and it these browsers do **not** adhere to the standards at all. The only directive for the Content-Security-Policy these browsers support is `sandbox` ([see my pull request for caniuse.com with all it's references](https://github.com/Fyrd/caniuse/pull/512)), all others are ignored. These means the current implementation in play has no effect at all, because we set the header to `default-src 'self'` right now, which, as I said, would get ignored by these browsers and therefore makes no sense at all.

So if on IE 10 & 11 only the `sandbox` directive is supported, why we just don't use this one as the default for the header?
Because it completely differs from the `default-src 'self'` directive behaviour which we apply by default for the standard conform `Content-Security-Policy` header which is supported by all other mature browsers (Firefox, Chrome, Safari). By default `sandbox` does not allow **any** javascript execution at all (doesn't matter if inline or not), does not allow form submits, does not allow xhr requests on the same domain and does not allow popups - whereas the `default-src 'self'` [does allow all this by default](http://content-security-policy.com/) (except inline script execution). So if we want to have kind of the same result for these headers, we would have to apply the header: `X-Content-Security-Policy: sandbox allow-forms allow-same-origin allow-scripts allow-popups`, which then would make the sandbox directive completly obsolete because we would enable all restriction anyway! 
Plus on the other hand, like it is right now, people may expect the same behaviour for all browsers when setting `play.filters.headers.contentSecurityPolicy` in the config (which right now get applied for both headers), which is just not true.

IMHO if someone knows what he is doing and want's to target IE 10 & 11 by using the faulty `X-Content-Security-Policy: sandbox`, it should be done in the users' code, but not by default in play.
