### PR TITLE
Documentation: WithBrowser class has a wrong parameter name

### DIFF
--- a/documentation/manual/scalaGuide/main/tests/ScalaFunctionalTest.md
+++ b/documentation/manual/scalaGuide/main/tests/ScalaFunctionalTest.md
@@ -87,7 +87,7 @@ If you want to test your application using a browser, you can use [[Selenium Web
 Like `WithServer`, you can change the port, `FakeApplication`, and you can also select the web browser to use:
 
 ```scala
-"run in a browser" in new WithBrowser(browser = FIREFOX) {
+"run in a browser" in new WithBrowser(webDriver = FIREFOX) {
   ...
 }
 ```


### PR DESCRIPTION
WithBrowser class doesn't have a parameter with name 'browser' but it has a parameter with name 'webDriver'

Ref Link: https://github.com/playframework/playframework/blob/2.1.x/framework/src/play-test/src/main/scala/play/api/test/Specs.scala
