### PR TITLE
Misc WS SSL Fixes

### DIFF
--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/CompositeX509TrustManager.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/CompositeX509TrustManager.scala
@@ -26,7 +26,9 @@ class CompositeX509TrustManager(trustManagers: Seq[X509TrustManager]) extends X5
   //def checkClientTrusted(chain: Array[X509Certificate], authType: String, hostname: String, algorithm: String): Unit = ???
   //def checkServerTrusted(chain: Array[X509Certificate], authType: String, hostname: String, algorithm: String): Unit = ???
 
-  protected val logger = org.slf4j.LoggerFactory.getLogger(getClass)
+  private val logger = org.slf4j.LoggerFactory.getLogger(getClass)
+
+  logger.debug(s"CompositeX509TrustManager start: trustManagers = $trustManagers")
 
   def checkClientTrusted(chain: Array[X509Certificate], authType: String) {
     logger.debug("checkClientTrusted: chain = {}", debugChain(chain))

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/DefaultHostnameVerifier.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/DefaultHostnameVerifier.scala
@@ -56,7 +56,8 @@ class DefaultHostnameVerifier extends HostnameVerifier {
           } catch {
             case e: CertificateException =>
               // Certificate does not match hostname
-              logger.debug("verify: Certificate does not match hostname", e)
+              val subjectAltNames = cert.getSubjectAlternativeNames
+              logger.debug(s"verify: Certificate does not match hostname! subjectAltNames = $subjectAltNames, hostName = $hostname", e)
               false
           }
 


### PR DESCRIPTION
X509ExtendedKeyManager would use chooseEngineClientAlias and chooseEngineServerAlias, but the abstract class simply returned null: 

http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/7u40-b43/javax/net/ssl/X509ExtendedKeyManager.java#67

whereas what the default class returned from KeyManagerFactory does is call `chooseAlias`:

http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/7u40-b43/sun/security/ssl/X509KeyManagerImpl.java#120

So now the composite key manager delegates these methods appropriately.

Also fixed a bug where not including a password with the key store should throw an exception, but doesn't.
