### PR TITLE
[doc] Update docs to make WsTestClient usage clearer

### DIFF
--- a/documentation/manual/scalaGuide/main/tests/ScalaFunctionalTest.md
+++ b/documentation/manual/scalaGuide/main/tests/ScalaFunctionalTest.md
@@ -76,4 +76,16 @@ If you are using an SQL database, you can replace the database connection with a
 
 @[scalafunctionaltest-testmodel](code/ScalaFunctionalTestSpec.scala)
 
+## Testing WS calls
+
+If you are calling a web service, you can use [`WSTestClient`](api/scala/index.html#play.api.test.WsTestClient).  There are two calls available, `wsCall` and `wsUrl` that will take a Call or a string, respectively.  Note that they expect to be called in the context of `WithApplication`.
+
+```
+wsCall(controllers.routes.Application.index()).get()
+```
+
+```
+wsUrl("http://localhost:9000").get()
+```
+
 > **Next:** [[Advanced topics|Iteratees]]

--- a/framework/src/play-ws/src/main/scala/play/api/test/WSTestClient.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/test/WSTestClient.scala
@@ -9,17 +9,21 @@ trait WsTestClient {
   type Port = Int
 
   /**
-   * Constructs a WS request for the given reverse route.
+   * Constructs a WS request holder for the given reverse route.  Optionally takes a WSClient.  Note that the WS client used
+   * by default requires a running Play application (use WithApplication for tests).
    *
    * For example:
    * {{{
+   * "work" in new WithApplication() { implicit app =>
    *   wsCall(controllers.routes.Application.index()).get()
+   * }
    * }}}
    */
   def wsCall(call: Call)(implicit port: Port, client: WSClient = WS.client(play.api.Play.current)): WSRequestHolder = wsUrl(call.url)
 
   /**
-   * Constructs a WS request holder for the given relative URL.
+   * Constructs a WS request holder for the given relative URL.  Optionally takes a port and WSClient.  Note that the WS client used
+   * by default requires a running Play application (use WithApplication for tests).
    */
   def wsUrl(url: String)(implicit port: Port, client: WSClient = WS.client(play.api.Play.current)) = {
     WS.clientUrl("http://localhost:" + port + url)


### PR DESCRIPTION
Received an complaint through email that there is insufficient warning that wsCall running with the defaults expects to be in an application.
