### PR TITLE
Re-factor of the asset controller including caching

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
@@ -185,5 +185,10 @@ object AssetsSpec extends PlaySpecification with WsTestClient {
       result.body must beEmpty
     }
 
+    "return 404 when asset is a directory" in withServer {
+      val result = await(wsUrl("/subdir").get())
+      result.status must_== NOT_FOUND
+    }
+
   }
 }


### PR DESCRIPTION
I've overhauled the implementation of the assets controller with the aspiration of making it easier to comprehend. Along the way I've improved its performance given some internal caching of asset information.

My main motivation for doing this is in anticipation of further working around digest handling. Digest handling will involve reading the contents of a file and so I wanted to ensure that etag handling (in particular) could be done without impacting negatively on performance.

Once we're more aggressive about caching, then there are some more performance gains to be had. Everything will be able to be set to a 1 year age by default (the max permitted by RFC).
## Performance tests
### Method

The angular-seed-play project was used with the plugins.sbt updated to reflect either Play's snapshot or 2.3-M1 for after/before tests.

A curl is initially performed in order to get compilation out of the way when running tests for dev mode.

`curl http://localhost:9000/lib/requirejs/require.js`

Three sets of tests are performed:
- pre-changes (play 2.3-M1 prod mode via start)
- changes-no-cache (play snapshot dev mode via run)
- changes-cache (play snapshot prod mode via start)

Each set receives 10 invocations of siege with the best throughput time noted.
### Results
#### Best Transaction Rates

```
pre-changes:      5263.16 trans/sec
changes-no-cache: 4566.21 trans/sec
changes-cache:  **7246.38 trans/sec**
```
### Data
#### pre-changes

``` bash
Christophers-MacBook-Pro:angular-seed-play huntc$ siege -c100 -r100 http://localhost:9000/lib/requirejs/require.js
** SIEGE 2.72
** Preparing 100 concurrent users for battle.
The server is now under siege..      done.

Transactions:              10000 hits
Availability:             100.00 %
Elapsed time:               1.90 secs
Data transferred:         160.67 MB
Response time:              0.02 secs
Transaction rate:        5263.16 trans/sec
Throughput:            84.56 MB/sec
Concurrency:               82.44
Successful transactions:       10000
Failed transactions:               0
Longest transaction:            0.09
Shortest transaction:           0.00

```
#### changes-no-cache

``` bash
Christophers-MacBook-Pro:angular-seed-play huntc$ siege -c100 -r100 http://localhost:9000/lib/requirejs/require.js
** SIEGE 2.72
** Preparing 100 concurrent users for battle.
The server is now under siege..      done.

Transactions:              10000 hits
Availability:             100.00 %
Elapsed time:               2.19 secs
Data transferred:         788.86 MB
Response time:              0.02 secs
Transaction rate:        4566.21 trans/sec
Throughput:           360.21 MB/sec
Concurrency:               89.09
Successful transactions:       10000
Failed transactions:               0
Longest transaction:            0.07
Shortest transaction:           0.00
```
#### changes-cache

``` bash

Christophers-MacBook-Pro:angular-seed-play huntc$ siege -c100 -r100 http://localhost:9000/lib/requirejs/require.js
** SIEGE 2.72
** Preparing 100 concurrent users for battle.
The server is now under siege..      done.

Transactions:              10000 hits
Availability:             100.00 %
Elapsed time:               1.38 secs
Data transferred:         160.67 MB
Response time:              0.01 secs
Transaction rate:        7246.38 trans/sec
Throughput:           116.42 MB/sec
Concurrency:               82.73
Successful transactions:       10000
Failed transactions:               0
Longest transaction:            0.08
Shortest transaction:           0.00
```
