### PR TITLE
Fix multiple redirections in rewrite rule in nginx

### DIFF
--- a/documentation/manual/detailedTopics/production/HTTPServer.md
+++ b/documentation/manual/detailedTopics/production/HTTPServer.md
@@ -60,7 +60,7 @@ http {
   }
 
   server {
-    server_name www.mysite.com mysite.com;
+    server_name mysite.com;
     rewrite ^(.*) https://www.mysite.com$1 permanent;
   }
 


### PR DESCRIPTION
In the nginx config, setting www.mysite.com and site.com as server_name creates a redirection loop in the browser as the rule redirects to www.mysite.com
