### PR TITLE
play.test.Helpers.testServer does not use the default test port

### DIFF
--- a/documentation/manual/javaGuide/main/tests/code/javaguide/tests/FunctionalTest.java
+++ b/documentation/manual/javaGuide/main/tests/code/javaguide/tests/FunctionalTest.java
@@ -27,6 +27,12 @@ public class FunctionalTest extends WithApplication {
 
     int timeout = 5000;
 
+    private TestServer testServer() {
+        Map<String, String> config = new HashMap<String, String>();
+        config.put("application.router", "javaguide.tests.Routes");
+        return Helpers.testServer(fakeApplication(config));
+    }
+
     private TestServer testServer(int port) {
         Map<String, String> config = new HashMap<String, String>();
         config.put("application.router", "javaguide.tests.Routes");
@@ -49,12 +55,12 @@ public class FunctionalTest extends WithApplication {
     //#with-browser
     @Test
     public void runInBrowser() {
-        running(testServer(3333), HTMLUNIT, new Callback<TestBrowser>() {
+        running(testServer(), HTMLUNIT, new Callback<TestBrowser>() {
             public void invoke(TestBrowser browser) {
-                browser.goTo("http://localhost:3333");
+                browser.goTo("/");
                 assertThat(browser.$("#title").getText()).isEqualTo("Welcome to Play!");
                 browser.$("a").click();
-                assertThat(browser.url()).isEqualTo("http://localhost:3333/login");
+                assertThat(browser.url()).isEqualTo("/login");
             }
         });
     }

--- a/documentation/manual/javaGuide/main/tests/java8code/java8guide/tests/FunctionalTest.java
+++ b/documentation/manual/javaGuide/main/tests/java8code/java8guide/tests/FunctionalTest.java
@@ -18,6 +18,12 @@ public class FunctionalTest extends WithApplication {
 
     int timeout = 5000;
 
+    private TestServer testServer() {
+        Map<String, String> config = new HashMap<String, String>();
+        config.put("application.router", "javaguide.tests.Routes");
+        return Helpers.testServer(fakeApplication(config));
+    }
+
     private TestServer testServer(int port) {
         Map<String, String> config = new HashMap<String, String>();
         config.put("application.router", "javaguide.tests.Routes");
@@ -38,11 +44,11 @@ public class FunctionalTest extends WithApplication {
     //#with-browser
     @Test
     public void runInBrowser() {
-        running(testServer(3333), HTMLUNIT, browser -> {
-            browser.goTo("http://localhost:3333");
-            assertThat(browser.$("#title").getText()).isEqualTo("Hello Guest");
+        running(testServer(), HTMLUNIT, browser -> {
+            browser.goTo("/");
+            assertThat(browser.$("#title").getText()).isEqualTo("Welcome to Play!");
             browser.$("a").click();
-            assertThat(browser.url()).isEqualTo("http://localhost:3333/login");
+            assertThat(browser.url()).isEqualTo("/login");
         });
     }
     //#with-browser

--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -490,6 +490,20 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
 
 
     /**
+     * Creates a new Test server listening on port defined by configuration setting "testserver.port" (defaults to 19001).
+     */
+    public static TestServer testServer() {
+        return testServer(play.api.test.Helpers.testServerPort());
+    }
+
+    /**
+     * Creates a new Test server listening on port defined by configuration setting "testserver.port" (defaults to 19001) and using the given FakeApplication.
+     */
+    public static TestServer testServer(FakeApplication app) {
+        return testServer(play.api.test.Helpers.testServerPort(), app);
+    }
+
+    /**
      * Creates a new Test server.
      */
     public static TestServer testServer(int port) {


### PR DESCRIPTION
The Scala API has a `play.api.test.Helpers.testServerPort` member allowing users to retrieve their test server port from one place (and the value can be overridden by configuration).

The Java API sometimes uses it, but the `play.test.Helpers.testServer` overloads do not use it, forcing users to either always explicitly use their own port number (and not benefiting from the `testServerPort` thing) or to explicitly retrieve the `testServerPort` value using the following expression: `play.api.test.Helpers.testServerPort()`.

We could solve this problem by adding yet another overload of `play.test.Helpers.testServer` that does not take a port number as parameter and retrieves it using `play.api.test.Helpers.testServerPort()`.
