### PR TITLE
Java: Add test helper routeAsync to return Promise<Result> (fixup)

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -57,7 +57,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
 
     private static Promise<Result> wrapScalaResult(scala.concurrent.Future<play.api.mvc.Result> result) {
         if (result == null) {
-            return null;
+            return Promise.pure(null);
         } else {
             return Promise.wrap(result).map(
                 new Function<play.api.mvc.Result, Result>() {


### PR DESCRIPTION
Minor fixup to @markusjura's PR #2715. I'm submitting a new PR instead of waiting for a fix on the original PR because this change needs to be merged quickly.

Commits not squashed so as to give proper attribution.
