### PR TITLE
Play 2.3-M1 and sbt subprojects assets not found

### DIFF
--- a/documentation/manual/detailedTopics/assets/Assets.md
+++ b/documentation/manual/detailedTopics/assets/Assets.md
@@ -20,7 +20,9 @@ If you follow this structure it will be simpler to get started, but nothing stop
 
 ## How are public assets packaged?
 
-During the build process, the contents of the `public` folder are processed and added to the application classpath. When you package your application, these files are packaged into the application JAR file (under the `public/` path).
+During the build process, the contents of the `public` folder are processed and added to the application classpath.
+
+When you package your application, all assets for the application, including all sub projects, are aggregated into a single jar, in `target/my-first-app-1.0.0-assets.jar`.  This jar is included in the distribution so that your Play application can serve them.  This jar can also be used to deploy the assets to a CDN or reverse proxy.
 
 ## The Assets controller
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
@@ -185,10 +185,5 @@ object AssetsSpec extends PlaySpecification with WsTestClient {
       result.body must beEmpty
     }
 
-    "return 404 when asset is a directory" in withServer {
-      val result = await(wsUrl("/subdir").get())
-      result.status must_== NOT_FOUND
-    }
-
   }
 }

--- a/framework/src/sbt-plugin/src/main/scala/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayImport.scala
@@ -157,5 +157,7 @@ object PlayImport {
     val generateSecret = TaskKey[String]("play-generate-secret", "Generate a new application secret", KeyRanks.BTask)
     val updateSecret = TaskKey[File]("play-update-secret", "Update the application conf to generate an application secret", KeyRanks.BTask)
 
+    val assetsPrefix = SettingKey[String]("assets-prefix")
+    val playPackageAssets = TaskKey[File]("play-package-assets")
   }
 }

--- a/framework/src/sbt-plugin/src/main/scala/PlayInternalKeys.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayInternalKeys.scala
@@ -18,4 +18,10 @@ trait PlayInternalKeys {
   val buildRequire = TaskKey[Seq[(File, File)]]("play-build-require-assets")
   val playCompileEverything = TaskKey[Seq[sbt.inc.Analysis]]("play-compile-everything")
   val playAssetsWithCompilation = TaskKey[sbt.inc.Analysis]("play-assets-with-compilation")
+
+  val playAllAssets = TaskKey[Seq[(String, File)]]("play-all-assets")
+  val playPrefixAndAssets = TaskKey[(String, File)]("play-prefix-and-assets")
+  val playPrefixAndPipeline = TaskKey[(String, Seq[(File, String)])]("play-prefix-and-pipeline")
+  val playAssetsClassLoader = TaskKey[ClassLoader => ClassLoader]("play-assets-classloader")
+  val playPackageAssetsMappings = TaskKey[Seq[(File, String)]]("play-package-assets-mappings")
 }

--- a/framework/src/sbt-plugin/src/main/scala/play/sbtplugin/run/AssetsClassLoader.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbtplugin/run/AssetsClassLoader.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.sbtplugin.run
+
+import sbt._
+
+/**
+ * A ClassLoader for serving assets.
+ *
+ * Serves assets from the given directories, at the given prefix.
+ *
+ * @param assets A list of assets directories, paired with the prefix they should be served from.
+ */
+class AssetsClassLoader(parent: ClassLoader, assets: Seq[(String, File)]) extends ClassLoader(parent) {
+  override def findResource(name: String) = {
+    assets.collectFirst {
+      case (prefix, dir) if exists(name, prefix, dir) =>
+        (dir / name.substring(prefix.length)).toURI.toURL
+    }.orNull
+  }
+
+  def exists(name: String, prefix: String, dir: File) = {
+    name.startsWith(prefix) && (dir / name.substring(prefix.length)).isFile
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
@@ -17,12 +17,6 @@ distAndUnzip := {
   targetUnzippedFolder
 }
 
-val unzipProjectJar = TaskKey[Unit]("unzip-project-jar")
-
-unzipProjectJar := {
-  IO.unzip(distAndUnzip.value / "lib" / s"${organization.value}.${normalizedName.value}-${version.value}.jar", target.value / "projectJar")
-}
-
 val checkStartScript = TaskKey[Unit]("check-start-script")
 
 checkStartScript := {

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/test
@@ -4,9 +4,6 @@ $ exists target/dist/README
 $ exists target/dist/SomeFile.txt
 $ exists target/dist/SomeFolder/SomeOtherFile.txt
 
-> unzip-project-jar
-$ exists target/projectJar/public/main.css
-
 > check-start-script
 $ exists target/dist/conf/application.conf
 -$ exists target/dist/conf/routes

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/app/assets/main.less
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/app/assets/main.less
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+h2 {
+  color: red;
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/build.sbt
@@ -1,0 +1,51 @@
+import java.net.URLClassLoader
+
+name := "assets-sample"
+
+version := "1.0-SNAPSHOT"
+
+lazy val root = (project in file(".")).addPlugins(PlayScala)
+  .dependsOn(module)
+  .aggregate(module)
+
+lazy val module = (project in file("module")).addPlugins(PlayScala)
+
+TaskKey[Unit]("unzip-assets-jar") := {
+  IO.unzip(target.value / "universal" / "stage" / "lib" / s"${organization.value}.${normalizedName.value}-${version.value}-assets.jar", target.value / "assetsJar")
+}
+
+InputKey[Unit]("check-on-classpath") := {
+  val args = Def.spaceDelimited("<resource>*").parsed
+  val creator: ClassLoader => ClassLoader = play.Play.playAssetsClassLoader.value
+  val classloader = creator(null)
+  args.foreach { resource =>
+    if (classloader.getResource(resource) == null) {
+      throw new RuntimeException("Could not find " + resource + "\n in assets classloader")
+    } else {
+      streams.value.log.info("Found " + resource + " in classloader")
+    }
+  }
+}
+
+InputKey[Unit]("check-on-test-classpath") := {
+  val args = Def.spaceDelimited("<resource>*").parsed
+  val classpath: Classpath = (fullClasspath in Test).value
+  val classloader = new URLClassLoader(classpath.map(_.data.toURI.toURL).toArray)
+  args.foreach { resource =>
+    if (classloader.getResource(resource) == null) {
+      throw new RuntimeException("Could not find " + resource + "\nin test classpath: " + classpath)
+    } else {
+      streams.value.log.info("Found " + resource + " in classloader")
+    }
+  }
+}
+
+TaskKey[Unit]("check-assets-jar-on-classpath") := {
+  val startScript = IO.read(target.value / "universal" / "stage" / "bin" / normalizedName.value)
+  val assetsJar = s"${organization.value}.${normalizedName.value}-${version.value}-assets.jar"
+  if (startScript.contains(assetsJar)) {
+    println("Found reference to " + assetsJar + " in start script")
+  } else {
+    throw new RuntimeException("Could not find " + assetsJar + " in start script")
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/module/app/assets/module.less
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/module/app/assets/module.less
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+h1 {
+  color: blue;
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/module/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/module/build.sbt
@@ -1,0 +1,3 @@
+name := "assets-module-sample"
+
+version := "1.0-SNAPSHOT"

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/project/build.properties
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/project/build.properties
@@ -1,0 +1,4 @@
+#
+# Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+#
+sbt.version=0.13.5-M2

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/project/plugins.sbt
@@ -1,0 +1,20 @@
+// Comment to get more information during initialization
+logLevel := Level.Warn
+
+// The Typesafe repository 
+resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+
+// Needed while we're on a snapshot of SBT idea plugin
+resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
+
+// Use the Play sbt plugin for Play projects
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3-SNAPSHOT")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.0-M2a")
+
+
+// FIXME: override provided here to fix a problem related to jdk6:
+// https://github.com/apigee/trireme/pull/51
+// Remove this dependency on Trireme once the PR is merged and 0.7.3 is released
+// (will also require an updated js-engine of course.
+libraryDependencies += "io.apigee.trireme" % "trireme-core" % "0.7.3-play23M1"

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/test
@@ -1,0 +1,23 @@
+# Check that sub project assets get compiled on reload
+> play-reload
+$ exists target/web/public/main/main.css
+$ exists module/target/web/public/main/module.css
+
+# Check that they are mounted at the right place in the run classloader
+> check-on-classpath public/main.css
+> check-on-classpath public/module.css
+
+# Check that they are on the test classpath
+> check-on-test-classpath public/main.css
+> check-on-test-classpath public/module.css
+
+# Clean and ensure that it really did clean
+> clean
+-$ exists target/web/public/main/main.css
+-$ exists module/target/web/public/main/module.css
+
+# Check that sub project assets get compiled and included in the distribution when staged
+> stage
+> unzip-assets-jar
+$ exists target/assetsJar/public/main.css
+$ exists target/assetsJar/public/module.css

--- a/framework/test/integrationtest/test/ApplicationSpec.scala
+++ b/framework/test/integrationtest/test/ApplicationSpec.scala
@@ -85,11 +85,6 @@ class ApplicationSpec extends PlaySpecification with WsTestClient {
       play.test.Helpers.charset(javaResult(result)) must equalTo("utf-8")
     }
 
-    "not serve asset directories" in new WithApplication() {
-      val Some(result) = route(FakeRequest(GET, "/public//"))
-      status(result) must equalTo (NOT_FOUND)
-    }
-
     "serve assets" in new WithApplication() {
       val Some(result1) = route(FakeRequest(GET, "/public/empty.txt"))
       status(result1) must equalTo (OK)


### PR DESCRIPTION
Hi,
I'm testing play2.3 and i'm working with sub projects

I have an issue while running projects with subproject. All subprojects assets are unreachable when project is laucned via (activator '~ run')
When i use activator 'start' it all works ok.

I pushed a minimal project here :
https://github.com/digitalLumberjack/play-2.3-subproject-assets-error

try activator run and see the 404 error on the subproject asset
try activator start to see working project

Thank you
