### PR TITLE
Added a reverse route context

### DIFF
--- a/framework/src/play/src/main/scala/play/core/router/Router.scala
+++ b/framework/src/play/src/main/scala/play/core/router/Router.scala
@@ -107,6 +107,22 @@ object Router {
 
   }
 
+  /**
+   * The context for a reverse route.
+   *
+   * This is made available implicitly to PathBindables and QueryStringBindables in the reverse router so that they can
+   * query the fixed params that are passed to the action.
+   *
+   * An empty reverse router context is made available implicitly to the router and JavaScript router.
+   *
+   * @param fixedParams The fixed params that this route passes to the action.
+   */
+  case class ReverseRouteContext(fixedParams: Map[String, Any])
+
+  object ReverseRouteContext {
+    implicit val empty = ReverseRouteContext(Map())
+  }
+
   case class JavascriptReverseRoute(name: String, f: String)
 
   case class Param[T](name: String, value: Either[String, T])

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -170,7 +170,7 @@ trait PlaySettings {
 
     ivyLoggingLevel := UpdateLogging.DownloadOnly,
 
-    routesImport := Seq.empty[String],
+    routesImport := Seq("controllers.Assets.Asset"),
 
     playMonitoredFiles <<= playMonitoredFilesTask,
 

--- a/framework/test/integrationtest/app/views/index.scala.html
+++ b/framework/test/integrationtest/app/views/index.scala.html
@@ -1,6 +1,6 @@
 @(name:String)
  
-     @views.html.helper.requireJs(core = routes.Assets.at("javascripts/require.js").url, module = routes.Assets.at("javascripts/main").url)
+     @views.html.helper.requireJs(core = routes.Assets.versioned("javascripts/require.js").url, module = routes.Assets.versioned("javascripts/main").url)
 
       
     Hello @name!

--- a/framework/test/integrationtest/conf/routes
+++ b/framework/test/integrationtest/conf/routes
@@ -115,5 +115,5 @@ GET     /routestest             controllers.Application.routetest(yield)
 GET     /routes2                controllers.Application.route2(queryString)
 
 # Map static resources from the /public folder to the /public path
-GET     /public/*file           controllers.Assets.at(path="/public", file)
+GET     /public/*file           controllers.Assets.versioned(path="/public", file: Asset)
 


### PR DESCRIPTION
This is made available whenever a PathBindable is implicitly required, so that PathBindables can look at the context and get information about the route they are binding.

The context contains all the fixed parameters for the route, this allows an asset path bindable, that wants to put a hash of the asset in the path, to lookup the value of the "path" parameter to find that the assets live at "/public", for example.

As a method of testing/validating this, I created a new Assets.Asset class, a new Assets.versioned route, and I modified the integrationtest project to use it. I didn't actually implement the fingerprinting of the asset URL, that depends on other things, but it's a start.
