### PR TITLE
session.maxAge used to be in seconds - now its in millis

### DIFF
--- a/documentation/manual/Migration23.md
+++ b/documentation/manual/Migration23.md
@@ -372,3 +372,7 @@ There are a few reasons for this, one is that we have found that Bootstrap chang
 Another reason is that the current Bootstrap requirements for CSS classes can't be implemented with Play's field constructor alone, a custom input template is also required.
 
 Our view going forward is that if this is a feature that is valuable to the community, a third party module can be created which provides a separate set of Bootstrap form helper templates, specific to given Bootstrap versions, allowing a much better user experience than can currently be provided.
+
+## Session timeouts
+
+The session timeout configuration item, `session.maxAge`, used to be an integer, defined to be in seconds.  Now it's a duration, so can be specified with values like `1h` or `30m`.  Unfortunately, the default unit if specified with no time unit is milliseconds, which means a config value of `3600` was previously treated as one hour, but is now treated as 3.6 seconds.  You will need to update your configuration to add a time unit.

--- a/framework/src/play-integration-test/src/test/scala/play/it/LogTester.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/LogTester.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.it
+
+import org.slf4j.LoggerFactory
+import ch.qos.logback.core.AppenderBase
+import ch.qos.logback.classic.spi.ILoggingEvent
+import scala.collection.mutable.ListBuffer
+import ch.qos.logback.classic.{Logger, LoggerContext, Level}
+import play.api.Play
+
+/**
+ * Test utility for testing Play logs
+ */
+object LogTester {
+
+  def withLogBuffer[T](block: LogBuffer => T) = {
+    val ctx = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+    val root = ctx.getLogger("ROOT")
+    val rootLevel = root.getLevel
+    val playLogger = Play.logger.logger.asInstanceOf[Logger]
+    val playLevel = playLogger.getLevel
+    val appender = new LogBuffer()
+    appender.start()
+    try {
+      root.addAppender(appender)
+      root.setLevel(Level.ALL)
+      playLogger.addAppender(appender)
+      playLogger.setLevel(Level.ALL)
+      block(appender)
+    } finally {
+      root.detachAppender(appender)
+      root.setLevel(rootLevel)
+      playLogger.detachAppender(appender)
+      playLogger.setLevel(playLevel)
+
+    }
+  }
+
+}
+
+class LogBuffer extends AppenderBase[ILoggingEvent] {
+  private val buffer = ListBuffer.empty[ILoggingEvent]
+
+  def append(eventObject: ILoggingEvent) = buffer.synchronized {
+    buffer.append(eventObject)
+  }
+
+  def find(level: Option[Level] = None,
+           logger: Option[String] = None,
+           messageContains: Option[String] = None
+            ): List[ILoggingEvent] = buffer.synchronized {
+    val byLevel = level.fold(buffer) { l => buffer.filter(_.getLevel == l) }
+    val byLogger = logger.fold(byLevel) { l => byLevel.filter(_.getLoggerName == l)}
+    val byMessageContains = logger.fold(byLogger) { m => byLogger.filter(_.getMessage.contains(m))}
+    byMessageContains.toList
+  }
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/system/MigrationHelperSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/system/MigrationHelperSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.it.system
+
+import play.api.test._
+import play.it.{LogBuffer, LogTester}
+import ch.qos.logback.classic.Level
+import org.specs2.execute.Result
+import play.api.Play
+
+class MigrationHelperSpec extends PlaySpecification {
+
+  sequential
+
+  def logMessage(logs: LogBuffer) = {
+    logs.find(level = Some(Level.WARN), logger = Some("play"), messageContains = Some("session.maxAge")).headOption
+  }
+
+  def assertWasLogged(logs: LogBuffer): Result = {
+    if (logMessage(logs).isDefined) {
+      ok
+    } else {
+      ko("Could not find log message in \n" + logs.find().mkString("\n"))
+    }
+  }
+
+  def assertWasNotLogged(logs: LogBuffer): Result = {
+    logMessage(logs) match {
+      case Some(msg) => ko("Expected no log message but found " + msg)
+      case None => ok
+    }
+  }
+
+  def runTest[T](config: (String, String)*)(block: LogBuffer => T) = {
+    val app = FakeApplication(additionalConfiguration = Map(config:_*))
+    try {
+      LogTester.withLogBuffer { logs =>
+        Play.start(app)
+        block(logs)
+      }
+    } finally {
+      Play.stop()
+    }
+
+  }
+
+  "MigrationHelper" should {
+    "warn when session timeout is too low raw value" in runTest("session.maxAge" -> "3600") { logs =>
+      assertWasLogged(logs)
+    }
+    "not warn when session timeout is not set" in runTest() { logs =>
+      assertWasNotLogged(logs)
+    }
+    "not warn when session timeout has units" in runTest("session.maxAge" -> "3600s") { logs =>
+      assertWasNotLogged(logs)
+    }
+    "not warn when session timeout is significantly large" in runTest("session.maxAge" -> "36000000") { logs =>
+      assertWasNotLogged(logs)
+    }
+    "not warn when migration helper is disabled" in runTest("session.maxAge" -> "3600", "play.migrationhelper" -> "disabled") { logs =>
+      assertWasNotLogged(logs)
+    }
+  }
+
+}

--- a/framework/src/play/src/main/resources/play.plugins
+++ b/framework/src/play/src/main/resources/play.plugins
@@ -1,3 +1,4 @@
+1:play.core.system.MigrationHelper
 100:play.api.i18n.DefaultMessagesPlugin
 1000:play.api.libs.concurrent.AkkaPlugin
 10000:play.api.GlobalPlugin

--- a/framework/src/play/src/main/scala/play/core/system/MigrationHelper.scala
+++ b/framework/src/play/src/main/scala/play/core/system/MigrationHelper.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.core.system
+
+import play.api.{ Play, Plugin, Application }
+
+/**
+ * The migration helper is designed to assist in migration, where some things, such as configuration, have changed in
+ * ways that break silently.
+ */
+class MigrationHelper(app: Application) extends Plugin {
+
+  override def onStart() = {
+    checkSessionMaxAge
+  }
+
+  def checkSessionMaxAge = {
+    app.configuration.getString("session.maxAge").map { maxAge =>
+      if (maxAge.matches("\\d+")) {
+        // It doesn't have a time unit, check that it's a sane number (greater than 10 minutes)
+        if (maxAge.toLong < 600000l) {
+          Play.logger.warn(
+            s"""
+              |In Play 2.3, session.maxAge was changed from being an integer for the number of seconds to being a
+              |duration. This means you can now specify time units, for example 1h, or 30m etc. If however, no time
+              |unit is specified, it defaults to milliseconds, making this a breaking change. The configured value
+              |in this application ($maxAge) does not have a time unit, and is suspiciously low for a session
+              |timeout, you may need to update your configuration. To prevent this warning message from showing in
+              |future, either add a time unit to the session.maxAge configuration item (eg, ms), or disable the
+              |migration helper plugin using play.migrationhelper=disabled.
+            """.stripMargin)
+        }
+      }
+    }
+  }
+
+  override def enabled = app.configuration.getString("play.migrationhelper").forall(_ != "disabled")
+}


### PR DESCRIPTION
You can see from the commit below that for some reason session.maxAge was changed to milliseconds. This is undocumented change that will create unexpected issues

https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/api/mvc/Http.scala#L580
