### PR TITLE
Added missing dependencies in order to compile the project

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -128,6 +128,8 @@ object Dependencies {
     "org.scala-lang" % "scala-reflect" % BuildSettings.buildScalaVersionForSbt % "provided",
     "com.typesafe" % "config" % "1.2.0",
     "org.mozilla" % "rhino" % "1.7R4",
+    "org.slf4j" % "slf4j-api" % "1.7.6",
+    "commons-io" % "commons-io" % "2.4",
 
     ("com.google.javascript" % "closure-compiler" % "v20130603")
       .exclude("args4j", "args4j")
@@ -196,6 +198,7 @@ object Dependencies {
   val playWsDeps = Seq(
     guava,
     "com.ning" % "async-http-client" % "1.8.8",
+    "commons-logging" % "commons-logging" % "1.1.3",
     "oauth.signpost" % "signpost-core" % "1.2.1.2",
     "oauth.signpost" % "signpost-commonshttp4" % "1.2.1.2") ++
     specsBuild.map(_ % "test") :+


### PR DESCRIPTION
With master, after a fresh git clone, a clean local maven cache, jdk8 installed, ./build and compile gives me:

```
Updating {file:/Users/nicolas/Projects/playframework/framework/}SBT-Plugin...
[info] Resolving org.scala-sbt#sbt-launch;0.13.5-M2 ...
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: org.slf4j#slf4j-api;1.7.5: configuration not found in org.slf4j#slf4j-api;1.7.5: 'compile'. It was required from org.slf4j#slf4j-simple;1.7.5 compile
[warn]  :: commons-io#commons-io;2.4: configuration not found in commons-io#commons-io;2.4: 'compile'. It was required from net.sourceforge.htmlunit#htmlunit;2.13 compile
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[info] Updating {file:/Users/nicolas/Projects/playframework/framework/}Play-WS...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: commons-logging#commons-logging;1.1.3: configuration not found in commons-logging#commons-logging;1.1.3: 'compile'. It was required from org.apache.httpcomponents#httpclient;4.3.1 compile

```

Adding those dependencies solves the dependency issue.
