### PR TITLE
Remove the scalaVersion setting from the Play sbt plugin

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -49,8 +49,6 @@ trait PlaySettings {
 
   lazy val defaultSettings = Defaults.packageTaskSettings(playPackageAssets, playPackageAssetsMappings) ++ Seq[Setting[_]](
 
-    scalaVersion := play.core.PlayVersion.scalaVersion,
-
     playPlugin := false,
 
     resolvers ++= Seq(

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
@@ -6,6 +6,8 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")
+
 val distAndUnzip = TaskKey[File]("dist-and-unzip")
 
 distAndUnzip := {

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/build.sbt
@@ -10,6 +10,8 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 lazy val module = (project in file("module")).enablePlugins(PlayScala)
 
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")
+
 TaskKey[Unit]("unzip-assets-jar") := {
   IO.unzip(target.value / "universal" / "stage" / "lib" / s"${organization.value}.${normalizedName.value}-${version.value}-assets.jar", target.value / "assetsJar")
 }

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/module/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/module/build.sbt
@@ -2,6 +2,8 @@ name := "assets-module-sample"
 
 version := "1.0-SNAPSHOT"
 
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")
+
 includeFilter in (Assets, LessKeys.less) := "*.less"
 
 excludeFilter in (Assets, LessKeys.less) := new PatternFilter("""[_].*\.less""".r.pattern)

--- a/framework/test/integrationtest/build.sbt
+++ b/framework/test/integrationtest/build.sbt
@@ -1,1 +1,3 @@
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")
+
 javaOptions in Test += "-XX:MaxPermSize=128m"

--- a/samples/java/comet-clock/build.sbt
+++ b/samples/java/comet-clock/build.sbt
@@ -3,3 +3,5 @@ name := "comet-clock"
 version := "1.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/samples/java/computer-database-jpa/build.sbt
+++ b/samples/java/computer-database-jpa/build.sbt
@@ -9,3 +9,5 @@ libraryDependencies ++= Seq(
   )
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/samples/java/computer-database/build.sbt
+++ b/samples/java/computer-database/build.sbt
@@ -5,3 +5,5 @@ version := "1.0"
 libraryDependencies ++= Seq(javaJdbc, javaEbean)
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/samples/java/eventsource-clock/build.sbt
+++ b/samples/java/eventsource-clock/build.sbt
@@ -3,3 +3,5 @@ name := "eventSource-clock"
 version := "1.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/samples/java/forms/build.sbt
+++ b/samples/java/forms/build.sbt
@@ -3,3 +3,5 @@ name := "forms"
 version := "1.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/samples/java/helloworld/build.sbt
+++ b/samples/java/helloworld/build.sbt
@@ -3,3 +3,5 @@ name := "helloworld"
 version := "1.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/samples/java/websocket-chat/build.sbt
+++ b/samples/java/websocket-chat/build.sbt
@@ -5,3 +5,5 @@ version := "1.0"
 javacOptions += "-Xlint:deprecation"     
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/samples/java/zentasks/build.sbt
+++ b/samples/java/zentasks/build.sbt
@@ -5,3 +5,5 @@ version := "1.0"
 libraryDependencies ++= Seq(javaJdbc, javaEbean)     
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/samples/scala/comet-clock/build.sbt
+++ b/samples/scala/comet-clock/build.sbt
@@ -3,3 +3,5 @@ name := "comet-clock"
 version := "1.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/samples/scala/comet-live-monitoring/build.sbt
+++ b/samples/scala/comet-live-monitoring/build.sbt
@@ -3,3 +3,5 @@ name := "comet-live-monitoring"
 version := "1.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/samples/scala/computer-database/build.sbt
+++ b/samples/scala/computer-database/build.sbt
@@ -5,3 +5,5 @@ version := "1.0"
 libraryDependencies ++= Seq(jdbc, anorm)
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/samples/scala/eventsource-clock/build.sbt
+++ b/samples/scala/eventsource-clock/build.sbt
@@ -3,3 +3,5 @@ name := "eventSource-clock"
 version := "1.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/samples/scala/forms/build.sbt
+++ b/samples/scala/forms/build.sbt
@@ -3,3 +3,5 @@ name := "forms"
 version := "1.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/samples/scala/helloworld/build.sbt
+++ b/samples/scala/helloworld/build.sbt
@@ -3,3 +3,5 @@ name := "helloworld"
 version := "1.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/samples/scala/websocket-chat/build.sbt
+++ b/samples/scala/websocket-chat/build.sbt
@@ -3,3 +3,5 @@ name := "websocket-chat"
 version := "1.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/samples/scala/zentasks/build.sbt
+++ b/samples/scala/zentasks/build.sbt
@@ -5,3 +5,5 @@ version := "1.0"
 libraryDependencies ++= Seq(jdbc, anorm)
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/templates/build.sbt
+++ b/templates/build.sbt
@@ -31,6 +31,9 @@ val playVersion = propOrElse("play.version", {
   throw new RuntimeException("No play version")
 })
 
+// The Play templates should default to using the latest compatible version of Scala
+val playScalaVersion = propOrElse("scala.version", "2.11.0")
+
 val playDocsUrl = propOrElse("play.docs.url", s"http://www.playframework.com/documentation/${playVersion}")
 
 // Use different names for release and milestone templates
@@ -43,6 +46,7 @@ def propOrElse(prop: String, default: => String): String = sys.props.get(prop).g
 
 templateParameters := Map(
   "PLAY_VERSION" -> playVersion,
+  "SCALA_VERSION" -> playScalaVersion,
   "PLAY_DOCS_URL" -> playDocsUrl,
   "SBT_VERSION" -> playSbtVersion,
   "COFFEESCRIPT_VERSION" -> coffeescriptVersion,

--- a/templates/play-2.3-highlights/build.sbt
+++ b/templates/play-2.3-highlights/build.sbt
@@ -5,6 +5,8 @@ version := "2.3-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
+scalaVersion := "%SCALA_VERSION%"
+
 libraryDependencies ++= Seq(
   "org.webjars" % "bootstrap" % "3.1.1",
   "org.webjars" % "jquery" % "2.1.0-2",

--- a/templates/play-java/build.sbt
+++ b/templates/play-java/build.sbt
@@ -4,9 +4,11 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
+scalaVersion := "%SCALA_VERSION%"
+
 libraryDependencies ++= Seq(
   javaJdbc,
   javaEbean,
   cache,
   javaWs
-)     
+)

--- a/templates/play-scala/build.sbt
+++ b/templates/play-scala/build.sbt
@@ -4,10 +4,11 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
+scalaVersion := "%SCALA_VERSION%"
+
 libraryDependencies ++= Seq(
   jdbc,
   anorm,
   cache,
   ws
-)     
-
+)


### PR DESCRIPTION
Play 2.3 will support multiple versions of Play so it's no longer
appropriate for the sbt plugin to provide a setting with a fixed
Scala version. The setting has been removed. Instead the Play
templates will provide an explicit scalaVersion setting instead.

Change all build file to accept the scala.version system property
to configure the version of Scala that they use. Most build files
default to Scala 2.10.4, but the build file that generates the
Play templates will generate build.sbt files with a default value
of 2.11.0.

With this commit, runtests works with Scala 2.10.4, but fails on
the documentation tests when run with Scala 2.11.0. I haven't
fixed the documentation tests as part of this commit because this
commit is blocking 2.3.
