### PR TITLE
Update to higlights and migration guide for 2.3

### DIFF
--- a/documentation/manual/Highlights23.md
+++ b/documentation/manual/Highlights23.md
@@ -1,14 +1,17 @@
 <!--- Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com> -->
 # What's new in Play 2.3
 
+This page highlights the new features of Play 2.3. If you want learn about the changes you need to make to migrate to Play 2.3, check out the [[Play 2.3 Migration Guide|Migration23]].
+
 ## Activator
 
-The first thing you'll notice about Play 2.3 is that the `play` command has become the `activator` command. Play has moved to use [Typesafe Activator](https://typesafe.com/activator) so that we can:
+The first thing you'll notice about Play 2.3 is that the `play` command has become the `activator` command. Play has been updated to use [Activator](https://typesafe.com/activator) so that we can:
 
 * Extend the range of templates we provide for getting started with Play projects. Activator supports a much [richer library](https://typesafe.com/activator/templates) of project templates. Templates can also include tutorials and other resources for getting started. The Play community can [contribute templates](https://typesafe.com/activator/template/contribute) too.
-* Provide a nice web UI for getting started with Play, especially for newcomers who are unfamiliar with command line interfaces. Users can write code and run tests through the web UI. The command line interface is still available though!
+* Provide a nice web UI for getting started with Play, especially for newcomers who are unfamiliar with command line interfaces. Users can write code and run tests through the web UI. For experienced users, the command line interface is available just like before.
 * Make Play's high productivity development approach available to other projects. Activator isn't just for Play. Other projects can use Activator too.
-* In the future Activator is likely to get even more features to aid developer productivity, and these features will automatically benefit Play and other projects that use Activator. [Activator is open source](https://github.com/typesafehub/activator), so the community can contribute to its evolution.
+
+In the future Activator will get even more features, and these features will automatically benefit Play and other projects that use Activator. [Activator is open source](https://github.com/typesafehub/activator), so the community can contribute to its evolution.
 
 ### Activator command
 
@@ -18,9 +21,15 @@ All the features that were available with the `play` command are still available
 * `activator` to run the console. See [[Using the Play console|PlayConsole]].
 * `activator ui` is a new command that launches a web user interface.
 
+> The new `activator` command and the old `play` command are both wrappers around [sbt](http://www.scala-sbt.org/). If you prefer, you can use the `sbt` command directly. However, if you use sbt you will miss out on several Activator features, such as templates (`activator new`) and the web user interface (`activator ui`). Both sbt and Activator support all the usual console commands such as `test` and `run`.
+
 ### Activator distribution
 
-Play is distributed as an Activator distribution that contains all Play's dependencies. You can download this distribution from the [Play download](http://www.playframework.com/download) page. If you prefer, you can also download a minimal (1MB) version of Activator from the [Activator site](https://typesafe.com/activator). The minimal version will only download dependencies when they're needed.
+Play is distributed as an Activator distribution that contains all Play's dependencies. You can download this distribution from the [Play download](http://www.playframework.com/download) page.
+
+If you prefer, you can also download a minimal (1MB) version of Activator from the [Activator site](https://typesafe.com/activator). Look for the "mini" distribution on the download page. The minimal version of Activator will only download dependencies when they're needed.
+
+Since Activator is a wrapper around sbt, you can also download and use [sbt](http://www.scala-sbt.org/) directly, if you prefer.
 
 ## Build improvements
 
@@ -51,7 +60,7 @@ One new capability for Play 2.3 is the support for asset fingerprinting, similar
 
 ### Java 8
 
-Play 2.3 will work just fine with Java 8; there is nothing special to do other than ensuring that your Java environment is configured for Java 8. There is a new Activator sample available for Java 8:
+Play 2.3 has been tested with Java 8. Your project will work just fine with Java 8; there is nothing special to do other than ensuring that your Java environment is configured for Java 8. There is a new Activator sample available for Java 8:
 
 http://typesafe.com/activator/template/reactive-stocks-java8
 
@@ -61,28 +70,60 @@ For a complete overview of going Reactive with Java 8 and Play check out this bl
 
 ### Java performance
 
-We've worked on Java performance. Compared to Play 2.2, throughput of simple Java actions has increased by 40-90%.
+We've worked on Java performance. Compared to Play 2.2, throughput of simple Java actions has increased by 40-90%. Here are the main optimizations:
+
+* Reducing thread switches for Java actions and body parsers.
+* Caching more route information and using per-route caching rather than a shared Map.
+* Reducing body parsing overhead for GET requests.
+* Using a unicast enumerator for returning chunked responses.
+
+Some of these changes also improved Scala performance, but Java had the biggest performance gains and was the main focus of our work.
 
 ## Play WS
 
-The WS client has been factored out into its own library in order to further reduce the size of play.core and promote modularization.
+### Separate library
 
-It is now possible to use WS outside of the context of an application:
+The WS client library has been refactored into its own library which can be used outside of Play. You can now have multiple `WSClient` objects, rather than only using the `WS` singleton.
 
+[[Java|JavaWS]]
+
+```java
+WSClient client = new NingWSClient(config);
+Promise<WSResponse> response = client.url("http://example.com").get();
 ```
-val client:WSClient = new NingWSClient(new Builder().build())
-client.url("http://example.com").get()
+
+[[Scala|ScalaWS]]
+
+```scala
+val client: WSClient = new NingWSClient(config)
+val response = client.url("http://example.com").get()
 ```
 
-The WS client also comes with comprehensive SSL/TLS configuration options and configures JSSE to be secure by default.
+Each WS client can be configured with its own options. This allows different Web Services to have different settings for timeouts, redirects and security options.
+
+The underlying `AsyncHttpClient` object can also now be accessed, which means that multi-part form and streaming body uploads are supported.
+
+### WS Security
+
+WS clients have [[settings|WsSSL]] for comprehensive SSL/TLS configuration. WS client configuration is now more secure by default.
 
 ## Actor WebSockets
 
 A method to use actors for handling websocket interactions has been incorporated for both Java and Scala e.g. using Scala:
 
+[[Java|JavaWebSockets]]
+
+```java
+public static WebSocket<String> socket() {
+    return WebSocket.withActor(MyWebSocketActor::props);
+}
+```
+
+[[Scala|ScalaWebSockets]]
+
 ```scala
-   def webSocket = WebSocket.acceptWithActor[JsValue, JsValue] { req => out =>
-     MyWebSocketActor.props(out)
+def webSocket = WebSocket.acceptWithActor[JsValue, JsValue] { req => out =>
+  MyWebSocketActor.props(out)
 ```
 
 ## Results restructuring completed
@@ -91,7 +132,7 @@ In Play 2.2, a number of new result types were introduced and old results types 
 
 ## Anorm
 
-There are various fixes included in new Anorm (type safety, option parsing, error handling, ...) and new interesting features.
+There are various fixes included in Play 2.3's Anorm (type safety, option parsing, error handling, ...) and new interesting features.
 
 - String interpolation is available to write SQL statements more easily, with less verbosity (passing arguments) and performance improvements (up to x7 faster processing parameters). e.g. `SQL"SELECT * FROM table WHERE id = $id"`
 - Multi-value (sequence/list) can be passed as parameter. e.g. `SQL"""SELECT * FROM Test WHERE cat IN (${Seq("a", "b", "c")})"""`
@@ -99,3 +140,6 @@ There are various fixes included in new Anorm (type safety, option parsing, erro
 - Query results include not only data, but execution context (with SQL warning).
 - More types are supported as parameter and as column: `java.util.UUID`, numeric types (Java/Scala big decimal and integer, more column conversions between numerics), temporal types (`java.sql.Timestamp`), character types.
 
+## Custom SSLEngine for HTTPS
+
+The Play server can now [[use a custom `SSLEngine`|ConfiguringHttps]]. This is also useful in cases where customization is required, such as in the case of client authentication.

--- a/documentation/manual/Migration23.md
+++ b/documentation/manual/Migration23.md
@@ -3,17 +3,53 @@
 
 This guide is for migrating to Play 2.3 from Play 2.2. To migrate to Play 2.2, first follow the [[Play 2.2 Migration Guide|Migration22]].
 
-## Distribution
+## Activator
 
-Play is no longer distributed as a zip file that needs to installed.  Instead, the preferred way to obtain and run Play is using [Typesafe Activator](https://typesafe.com/activator).  Typesafe Activator provides an `activator` command, which, like the Play command, delegates to sbt.  So generally, where you previously run commands like `play run`, now you run `activator run`.
+In Play 2.3 the `play` command has become the `activator` command. Play has been updated to use [Activator](https://typesafe.com/activator).
 
-To download and get started with Activator, follow the instructions [here](https://typesafe.com/platform/getstarted).
+### Activator command
 
-## Build tasks
+All the features that were available with the `play` command are still available with the `activator` command.
 
-### Auto Plugins
+* `activator new` to create a new project. See [[Creating a new application|NewApplication]].
+* `activator` to run the console. See [[Using the Play console|PlayConsole]].
+* `activator ui` is a new command that launches a web user interface.
 
-sbt 0.13.5 is now the version used by Play. This version brings a new feature named "auto plugins".
+> The new `activator` command and the old `play` command are both wrappers around [sbt](http://www.scala-sbt.org/). If you prefer, you can use the `sbt` command directly. However, if you use sbt you will miss out on several Activator features, such as templates (`activator new`) and the web user interface (`activator ui`). Both sbt and Activator support all the usual console commands such as `test` and `run`.
+
+### Activator distribution
+
+Play is distributed as an Activator distribution that contains all Play's dependencies. You can download this distribution from the [Play download](http://www.playframework.com/download) page.
+
+If you prefer, you can also download a minimal (1MB) version of Activator from the [Activator site](https://typesafe.com/activator). Look for the "mini" distribution on the download page. The minimal version of Activator will only download dependencies when they're needed.
+
+Since Activator is a wrapper around sbt, you can also download and use [sbt](http://www.scala-sbt.org/) directly, if you prefer.
+
+## Build changes
+
+### sbt
+
+Play uses sbt 0.13.5. If you're updating an existing project, change your `project/build.properties` file to:
+
+```
+sbt.version=0.13.5-RC1
+```
+
+### Plugin changes
+
+Change the version of the Play plugin in `project/plugins.sbt`:
+
+```scala
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.XXX")
+```
+
+Where `2.3.XXX` is the version of Play you want to use.
+
+You will also need to add some sbt-web plugins, see the *sbt-web* section below.
+
+### Auto Plugins and plugin settings
+
+sbt 0.13.5 brings a new feature named "auto plugins".
 
 Auto plugins permit sbt plugins to be declared in the `project` folder (typically the `plugins.sbt`) as before. What has changed though is that plugins may now declare their requirements of other plugins and what triggers their enablement for a given build. Before auto plugins, plugins added to the build were always available; now plugins are enabled selectively for given modules.
 
@@ -93,6 +129,24 @@ or
 ```scala
 import play.Play.autoImport._
 import PlayKeys._
+```
+
+### Explicit scalaVersion
+
+Play 2.3 supports both Scala 2.11 and Scala 2.10. The Play plugin previously set the `scalaVersion` sbt setting for you. Now you should indicate which version of Scala you wish to use.
+
+Update your `build.sbt` or `Build.scala` to include the Scala version:
+
+For Scala 2.11:
+
+```scala
+scalaVersion := "2.11.0"
+```
+
+For Scala 2.10:
+
+```scala
+scalaVersion := "2.10.4"
 ```
 
 ### sbt-web


### PR DESCRIPTION
- Revised Activator section
- Expanded info on Java performance
- Split WS changes into separate library and security changes
- Mentioned SSLEngine change
- Migration for sbt version
- Mention needed change to Play plugin version
- Mention need for explicit scalaVersion setting
