### PR TITLE
Removed references to ToDoList tutorials

### DIFF
--- a/framework/src/play/src/main/scala/views/play20/welcome.scala.html
+++ b/framework/src/play/src/main/scala/views/play20/welcome.scala.html
@@ -86,7 +86,14 @@ GET     /               controllers.Application.index</code></pre>
             <h2>Is this your first time?</h2>
 
             <p>
-                You can now continue with the <a href="/@@documentation/ScalaTodoList">first tutorial</a>, which will guide you through the basics of creating a Play application.
+                If you're not already using it, checkout out <a href="https://typesafe.com/activator">Activator</a>.
+                If you start the Activator UI, by running:
+            </p>
+
+<pre><code>$ activator ui</code></pre>
+
+            <p>
+                You can get access to great templates and tutorials that demonstrate how to write Play applications.
             </p>
 
             <h2>Need to set up an IDE?</h2>
@@ -151,7 +158,6 @@ db.pass=secret</code></pre>
             <ul>
                 <li><a href="/@@documentation/PlayConsole">Using the Play console</a></li>
                 <li><a href="/@@documentation/IDE">Setting up your preferred IDE</a></li>
-                <li><a href="/@@documentation/ScalaTodoList">Your first application</a></li>
             </ul>
         </aside>
 
@@ -220,7 +226,14 @@ GET     /               controllers.Application.index()</code></pre>
             <h2>Is this your first time?</h2>
 
             <p>
-                You can now continue with the <a href="/@@documentation/JavaTodoList">first tutorial</a>, which will guide you through the basics of creating a Play application.
+                If you're not already using it, checkout out <a href="https://typesafe.com/activator">Activator</a>.
+                If you start the Activator UI, by running:
+            </p>
+
+            <pre><code>$ activator ui</code></pre>
+
+            <p>
+                You can get access to great templates and tutorials that demonstrate how to write Play applications.
             </p>
 
             <h2>Need to set up an IDE?</h2>
@@ -285,7 +298,6 @@ db.pass=secret</code></pre>
             <ul>
                 <li><a href="/@@documentation/PlayConsole">Using the Play console</a></li>
                 <li><a href="/@@documentation/IDE">Setting up your preferred IDE</a></li>
-                <li><a href="/@@documentation/JavaTodoList">Your first application</a></li>
             </ul>
         </aside>
 


### PR DESCRIPTION
Instead, the welcome page now points users to Activator.
