### PR TITLE
Case-insensitive handling of response headers

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -12,7 +12,7 @@ import play.mvc.Results.Chunks
 
 object JavaResultsHandlingSpec extends PlaySpecification with WsTestClient {
 
-  "java body handling" should {
+  "Java results handling" should {
     def makeRequest[T](controller: MockController)(block: WSResponse => T) = {
       implicit val port = testServerPort
       running(TestServer(port, FakeApplication(
@@ -23,6 +23,17 @@ object JavaResultsHandlingSpec extends PlaySpecification with WsTestClient {
         val response = await(wsUrl("/").get())
         block(response)
       }
+    }
+
+    "treat headers case insensitively" in makeRequest(new MockController {
+      def action = {
+        response.setHeader("content-type", "text/plain")
+        response.setHeader("Content-type", "text/html")
+        Results.ok("Hello world")
+      }
+    }) { response =>
+      response.header(CONTENT_TYPE) must beSome("text/html")
+      response.body must_== "Hello world"
     }
 
     "buffer results with no content length" in makeRequest(new MockController {

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -550,7 +550,11 @@ public class Http {
      */
     public static class Response implements HeaderNames {
 
-        private final Map<String,String> headers = new HashMap<String,String>();
+        private final Map<String, String> headers = new TreeMap<String, String>(new Comparator<String>() {
+            @Override public int compare(String s1, String s2) {
+                return s1.compareToIgnoreCase(s2);
+            }
+        });
         private final List<Cookie> cookies = new ArrayList<Cookie>();
 
         /**

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -30,14 +30,15 @@ object ResultsSpec extends Specification {
       headers must havePair("Content-Type" -> "text/html")
     }
 
-    "support headers manipulaton" in {
+    "support headers manipulation" in {
       val Result(ResponseHeader(_, headers), _, _) =
-        Ok("hello").as("text/html").withHeaders("Set-Cookie" -> "yes", "X-YOP" -> "1", "X-YOP" -> "2")
+        Ok("hello").as("text/html").withHeaders("Set-Cookie" -> "yes", "X-YOP" -> "1", "X-Yop" -> "2")
 
       headers.size must be_==(3)
       headers must havePair("Content-Type" -> "text/html")
       headers must havePair("Set-Cookie" -> "yes")
-      headers must havePair("X-YOP" -> "2")
+      headers must not havePair("X-YOP" -> "1")
+      headers must havePair("X-Yop" -> "2")
     }
 
     "support cookies helper" in {


### PR DESCRIPTION
This makes the map that stores the HTTP response headers case-insensitive, making the behavior consistent with the way request headers are handled, and the WS API.
