### PR TITLE
Json macros - Use constructor parameters instead of introspecting apply and unapply methods 

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -26,270 +26,195 @@ object JsMacroImpl {
     val unliftIdent = Select(functionalSyntaxPkg, newTermName("unlift"))
     val lazyHelperSelect = Select(utilPkg, newTypeName("LazyHelper"))
 
-    companionType.declaration(stringToTermName("unapply")) match {
-      case NoSymbol => c.abort(c.enclosingPosition, "No unapply function found")
-      case s =>
-        val unapply = s.asMethod
-        val unapplyReturnTypes = unapply.returnType match {
-          case TypeRef(_, _, Nil) =>
-            c.abort(c.enclosingPosition, s"Apply of ${companionSymbol} has no parameters. Are you using an empty case class?")
-          case TypeRef(_, _, args) =>
-            args.head match {
-              case t @ TypeRef(_, _, Nil) => Some(List(t))
-              case t @ TypeRef(_, _, args) =>
-                if (t <:< typeOf[Option[_]]) Some(List(t))
-                else if (t <:< typeOf[Seq[_]]) Some(List(t))
-                else if (t <:< typeOf[Set[_]]) Some(List(t))
-                else if (t <:< typeOf[Map[_, _]]) Some(List(t))
-                else if (t <:< typeOf[Product]) Some(args)
-              case _ => None
-            }
-          case _ => None
-        }
+    val params = weakTypeOf[A].declarations.collectFirst {
+      case m: MethodSymbol if m.isPrimaryConstructor ⇒ m
+    }.get.paramss.head //verify there is a single parameter group
 
-        //println("Unapply return type:" + unapply.returnType)
+    val inferedImplicits = params.map(_.typeSignature).map { implType =>
 
-        companionType.declaration(stringToTermName("apply")) match {
-          case NoSymbol => c.abort(c.enclosingPosition, "No apply function found")
-          case s =>
-            // searches apply method corresponding to unapply
-            val applies = s.asMethod.alternatives
-            val apply = applies.collectFirst {
-              case (apply: MethodSymbol) if (apply.paramss.headOption.map(_.map(_.asTerm.typeSignature)) == unapplyReturnTypes) => apply
-            }
-            apply match {
-              case Some(apply) =>
-                //println("apply found:" + apply)    
-                val params = apply.paramss.head //verify there is a single parameter group
+      val (isRecursive, tpe) = implType match {
+        case TypeRef(_, t, args) =>
+          // Option[_] needs special treatment because we need to use XXXOpt
+          if (implType.typeConstructor <:< typeOf[Option[_]].typeConstructor)
+            (args.exists { a => a.typeSymbol == companioned }, args.head)
+          else (args.exists { a => a.typeSymbol == companioned }, implType)
+        case TypeRef(_, t, _) =>
+          (false, implType)
+      }
 
-                val inferedImplicits = params.map(_.typeSignature).map { implType =>
+      // builds reads implicit from expected type
+      val neededImplicitType = appliedType(weakTypeOf[Reads[_]].typeConstructor, tpe :: Nil)
+      // infers implicit
+      val neededImplicit = c.inferImplicitValue(neededImplicitType)
+      (implType, neededImplicit, isRecursive, tpe)
+    }
 
-                  val (isRecursive, tpe) = implType match {
-                    case TypeRef(_, t, args) =>
-                      // Option[_] needs special treatment because we need to use XXXOpt
-                      if (implType.typeConstructor <:< typeOf[Option[_]].typeConstructor)
-                        (args.exists { a => a.typeSymbol == companioned }, args.head)
-                      else (args.exists { a => a.typeSymbol == companioned }, implType)
-                    case TypeRef(_, t, _) =>
-                      (false, implType)
-                  }
+    // if any implicit is missing, abort
+    // else goes on
+    inferedImplicits.collect { case (t, impl, rec, _) if (impl == EmptyTree && !rec) => t } match {
+      case List() =>
+        val namedImplicits = params.map(_.name).zip(inferedImplicits)
+        //println("Found implicits:"+namedImplicits)
 
-                  // builds reads implicit from expected type
-                  val neededImplicitType = appliedType(weakTypeOf[Reads[_]].typeConstructor, tpe :: Nil)
-                  // infers implicit
-                  val neededImplicit = c.inferImplicitValue(neededImplicitType)
-                  (implType, neededImplicit, isRecursive, tpe)
+        val helperMember = Select(This(tpnme.EMPTY), newTermName("lazyStuff"))
+
+        var hasRec = false
+
+        // combines all reads into CanBuildX
+        val canBuild = namedImplicits.map {
+          case (name, (t, impl, rec, tpe)) =>
+            // inception of (__ \ name).read(impl)
+            val jspathTree = Apply(
+              Select(jsPathSelect, newTermName(scala.reflect.NameTransformer.encode("\\"))),
+              List(Literal(Constant(name.decoded))))
+
+            if (!rec) {
+              val readTree =
+                if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor)
+                  Apply(
+                    Select(jspathTree, newTermName("readNullable")),
+                    List(impl))
+                else Apply(
+                  Select(jspathTree, newTermName("read")),
+                  List(impl))
+
+              readTree
+            } else {
+              hasRec = true
+              val readTree =
+                if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor)
+                  Apply(
+                    Select(jspathTree, newTermName("readNullable")),
+                    List(
+                      Apply(
+                        Select(Apply(jsPathSelect, List()), newTermName("lazyRead")),
+                        List(helperMember))))
+
+                else {
+                  Apply(
+                    Select(jspathTree, newTermName("lazyRead")),
+                    if (tpe.typeConstructor <:< typeOf[List[_]].typeConstructor)
+                      List(
+                      Apply(
+                        Select(readsSelect, newTermName("list")),
+                        List(helperMember)))
+                    else if (tpe.typeConstructor <:< typeOf[Set[_]].typeConstructor)
+                      List(
+                      Apply(
+                        Select(readsSelect, newTermName("set")),
+                        List(helperMember)))
+                    else if (tpe.typeConstructor <:< typeOf[Seq[_]].typeConstructor)
+                      List(
+                      Apply(
+                        Select(readsSelect, newTermName("seq")),
+                        List(helperMember)))
+                    else if (tpe.typeConstructor <:< typeOf[Map[_, _]].typeConstructor)
+                      List(
+                      Apply(
+                        Select(readsSelect, newTermName("map")),
+                        List(helperMember)))
+                    else List(helperMember))
                 }
 
-                // if any implicit is missing, abort
-                // else goes on
-                inferedImplicits.collect { case (t, impl, rec, _) if (impl == EmptyTree && !rec) => t } match {
-                  case List() =>
-                    val namedImplicits = params.map(_.name).zip(inferedImplicits)
-                    //println("Found implicits:"+namedImplicits)
+              readTree
+            }
+        }.reduceLeft { (acc, r) =>
+          Apply(
+            Select(acc, newTermName("and")),
+            List(r))
+        }
 
-                    val helperMember = Select(This(tpnme.EMPTY), newTermName("lazyStuff"))
+        // builds the final Reads using apply method
+        val applyMethod =
+          Function(
+            params.foldLeft(List[ValDef]())((l, e) =>
+              l :+ ValDef(Modifiers(PARAM), newTermName(e.name.encoded), TypeTree(), EmptyTree)),
+            Apply(
+              Select(Ident(companionSymbol.name), newTermName("apply")),
+              params.foldLeft(List[Tree]())((l, e) =>
+                l :+ Ident(newTermName(e.name.encoded)))))
 
-                    var hasRec = false
+        val unapplyMethod = Apply(
+          unliftIdent,
+          List(
+            Select(Ident(companionSymbol.name), "unapply")))
 
-                    // combines all reads into CanBuildX
-                    val canBuild = namedImplicits.map {
-                      case (name, (t, impl, rec, tpe)) =>
-                        // inception of (__ \ name).read(impl)
-                        val jspathTree = Apply(
-                          Select(jsPathSelect, newTermName(scala.reflect.NameTransformer.encode("\\"))),
-                          List(Literal(Constant(name.decoded)))
-                        )
+        // if case class has one single field, needs to use inmap instead of canbuild.apply
+        val finalTree = if (params.length > 1) {
+          Apply(
+            Select(canBuild, newTermName("apply")),
+            List(applyMethod))
+        } else {
+          Apply(
+            Select(canBuild, newTermName("map")),
+            List(applyMethod))
+        }
+        //println("finalTree: "+finalTree)
 
-                        if (!rec) {
-                          val readTree =
-                            if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor)
-                              Apply(
-                                Select(jspathTree, newTermName("readNullable")),
-                                List(impl)
-                              )
-                            else Apply(
-                              Select(jspathTree, newTermName("read")),
-                              List(impl)
-                            )
+        if (!hasRec) {
+          val block = Block(
+            Import(functionalSyntaxPkg, List(ImportSelector(nme.WILDCARD, -1, null, -1))),
+            finalTree)
 
-                          readTree
-                        } else {
-                          hasRec = true
-                          val readTree =
-                            if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor)
-                              Apply(
-                                Select(jspathTree, newTermName("readNullable")),
-                                List(
-                                  Apply(
-                                    Select(Apply(jsPathSelect, List()), newTermName("lazyRead")),
-                                    List(helperMember)
-                                  )
-                                )
-                              )
+          //println("block:"+block)
 
-                            else {
-                              Apply(
-                                Select(jspathTree, newTermName("lazyRead")),
-                                if (tpe.typeConstructor <:< typeOf[List[_]].typeConstructor)
-                                  List(
-                                  Apply(
-                                    Select(readsSelect, newTermName("list")),
-                                    List(helperMember)
-                                  )
-                                )
-                                else if (tpe.typeConstructor <:< typeOf[Set[_]].typeConstructor)
-                                  List(
-                                  Apply(
-                                    Select(readsSelect, newTermName("set")),
-                                    List(helperMember)
-                                  )
-                                )
-                                else if (tpe.typeConstructor <:< typeOf[Seq[_]].typeConstructor)
-                                  List(
-                                  Apply(
-                                    Select(readsSelect, newTermName("seq")),
-                                    List(helperMember)
-                                  )
-                                )
-                                else if (tpe.typeConstructor <:< typeOf[Map[_, _]].typeConstructor)
-                                  List(
-                                  Apply(
-                                    Select(readsSelect, newTermName("map")),
-                                    List(helperMember)
-                                  )
-                                )
-                                else List(helperMember)
-                              )
-                            }
-
-                          readTree
-                        }
-                    }.reduceLeft { (acc, r) =>
-                      Apply(
-                        Select(acc, newTermName("and")),
-                        List(r)
-                      )
-                    }
-
-                    // builds the final Reads using apply method
-                    val applyMethod =
-                      Function(
-                        params.foldLeft(List[ValDef]())((l, e) =>
-                          l :+ ValDef(Modifiers(PARAM), newTermName(e.name.encoded), TypeTree(), EmptyTree)
-                        ),
-                        Apply(
-                          Select(Ident(companionSymbol.name), newTermName("apply")),
-                          params.foldLeft(List[Tree]())((l, e) =>
-                            l :+ Ident(newTermName(e.name.encoded))
-                          )
-                        )
-                      )
-
-                    val unapplyMethod = Apply(
-                      unliftIdent,
-                      List(
-                        Select(Ident(companionSymbol.name), unapply.name)
-                      )
-                    )
-
-                    // if case class has one single field, needs to use inmap instead of canbuild.apply
-                    val finalTree = if (params.length > 1) {
-                      Apply(
-                        Select(canBuild, newTermName("apply")),
-                        List(applyMethod)
-                      )
-                    } else {
-                      Apply(
-                        Select(canBuild, newTermName("map")),
-                        List(applyMethod)
-                      )
-                    }
-                    //println("finalTree: "+finalTree)
-
-                    if (!hasRec) {
-                      val block = Block(
-                        Import(functionalSyntaxPkg, List(ImportSelector(nme.WILDCARD, -1, null, -1))),
-                        finalTree
-                      )
-
-                      //println("block:"+block)
-
-                      /*val reif = reify(
+          /*val reif = reify(
                         /*new play.api.libs.json.util.LazyHelper[Format, A] {
                           override lazy val lazyStuff: Format[A] = null
                         }*/
                       )
                       println("RAW:"+showRaw(reif.tree, printKinds = true))*/
 
-                      c.Expr[Reads[A]](block)
-                    } else {
-                      val helper = newTermName("helper")
-                      val helperVal = ValDef(
-                        Modifiers(),
-                        helper,
-                        TypeTree(weakTypeOf[play.api.libs.json.util.LazyHelper[Reads, A]]),
-                        Apply(lazyHelperSelect, List(finalTree))
-                      )
+          c.Expr[Reads[A]](block)
+        } else {
+          val helper = newTermName("helper")
+          val helperVal = ValDef(
+            Modifiers(),
+            helper,
+            TypeTree(weakTypeOf[play.api.libs.json.util.LazyHelper[Reads, A]]),
+            Apply(lazyHelperSelect, List(finalTree)))
 
-                      val block = Select(
-                        Block(
-                          Import(functionalSyntaxPkg, List(ImportSelector(nme.WILDCARD, -1, null, -1))),
-                          ClassDef(
-                            Modifiers(Flag.FINAL),
-                            newTypeName("$anon"),
-                            List(),
-                            Template(
-                              List(
-                                AppliedTypeTree(
-                                  lazyHelperSelect,
-                                  List(
-                                    Ident(weakTypeOf[Reads[A]].typeSymbol),
-                                    Ident(weakTypeOf[A].typeSymbol)
-                                  )
-                                )
-                              ),
-                              emptyValDef,
-                              List(
-                                DefDef(
-                                  Modifiers(),
-                                  nme.CONSTRUCTOR,
-                                  List(),
-                                  List(List()),
-                                  TypeTree(),
-                                  Block(
-                                    Apply(
-                                      Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR),
-                                      List()
-                                    )
-                                  )
-                                ),
-                                ValDef(
-                                  Modifiers(Flag.OVERRIDE | Flag.LAZY),
-                                  newTermName("lazyStuff"),
-                                  AppliedTypeTree(Ident(weakTypeOf[Reads[A]].typeSymbol), List(TypeTree(weakTypeOf[A]))),
-                                  finalTree
-                                )
-                              )
-                            )
-                          ),
-                          Apply(Select(New(Ident(newTypeName("$anon"))), nme.CONSTRUCTOR), List())
-                        ),
-                        newTermName("lazyStuff")
-                      )
+          val block = Select(
+            Block(
+              Import(functionalSyntaxPkg, List(ImportSelector(nme.WILDCARD, -1, null, -1))),
+              ClassDef(
+                Modifiers(Flag.FINAL),
+                newTypeName("$anon"),
+                List(),
+                Template(
+                  List(
+                    AppliedTypeTree(
+                      lazyHelperSelect,
+                      List(
+                        Ident(weakTypeOf[Reads[A]].typeSymbol),
+                        Ident(weakTypeOf[A].typeSymbol)))),
+                  emptyValDef,
+                  List(
+                    DefDef(
+                      Modifiers(),
+                      nme.CONSTRUCTOR,
+                      List(),
+                      List(List()),
+                      TypeTree(),
+                      Block(
+                        Apply(
+                          Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR),
+                          List()))),
+                    ValDef(
+                      Modifiers(Flag.OVERRIDE | Flag.LAZY),
+                      newTermName("lazyStuff"),
+                      AppliedTypeTree(Ident(weakTypeOf[Reads[A]].typeSymbol), List(TypeTree(weakTypeOf[A]))),
+                      finalTree)))),
+              Apply(Select(New(Ident(newTypeName("$anon"))), nme.CONSTRUCTOR), List())),
+            newTermName("lazyStuff"))
 
-                      //println("block:"+block)
+          //println("block:"+block)
 
-                      c.Expr[Reads[A]](block)
-                    }
-                  case l => c.abort(c.enclosingPosition, s"No implicit Reads for ${l.mkString(", ")} available.")
-                }
-
-              case None => c.abort(c.enclosingPosition, "No apply function found matching unapply return types")
-            }
-
+          c.Expr[Reads[A]](block)
         }
+      case l => c.abort(c.enclosingPosition, s"No implicit Reads for ${l.mkString(", ")} available.")
     }
+
   }
 
   def writesImpl[A: c.WeakTypeTag](c: Context): c.Expr[Writes[A]] = {
@@ -310,267 +235,191 @@ object JsMacroImpl {
     val unliftIdent = Select(functionalSyntaxPkg, newTermName("unlift"))
     val lazyHelperSelect = Select(utilPkg, newTypeName("LazyHelper"))
 
-    companionType.declaration(stringToTermName("unapply")) match {
-      case NoSymbol => c.abort(c.enclosingPosition, "No unapply function found")
-      case s =>
-        val unapply = s.asMethod
-        val unapplyReturnTypes = unapply.returnType match {
-          case TypeRef(_, _, Nil) =>
-            c.abort(c.enclosingPosition, s"Unapply of ${companionSymbol} has no parameters. Are you using an empty case class?")
-          case TypeRef(_, _, args) =>
-            args.head match {
-              case t @ TypeRef(_, _, Nil) => Some(List(t))
-              case t @ TypeRef(_, _, args) =>
-                if (t <:< typeOf[Option[_]]) Some(List(t))
-                else if (t <:< typeOf[Seq[_]]) Some(List(t))
-                else if (t <:< typeOf[Set[_]]) Some(List(t))
-                else if (t <:< typeOf[Map[_, _]]) Some(List(t))
-                else if (t <:< typeOf[Product]) Some(args)
-              case _ => None
-            }
-          case _ => None
-        }
+    val params = weakTypeOf[A].declarations.collectFirst {
+      case m: MethodSymbol if m.isPrimaryConstructor ⇒ m
+    }.get.paramss.head //verify there is a single parameter group
 
-        //println("Unapply return type:" + unapplyReturnTypes)
+    val inferedImplicits = params.map(_.typeSignature).map { implType =>
 
-        companionType.declaration(stringToTermName("apply")) match {
-          case NoSymbol => c.abort(c.enclosingPosition, "No apply function found")
-          case s =>
-            // searches apply method corresponding to unapply
-            val applies = s.asMethod.alternatives
-            val apply = applies.collectFirst {
-              case (apply: MethodSymbol) if (apply.paramss.headOption.map(_.map(_.asTerm.typeSignature)) == unapplyReturnTypes) => apply
-            }
-            apply match {
-              case Some(apply) =>
-                //println("apply found:" + apply)    
-                val params = apply.paramss.head //verify there is a single parameter group
+      val (isRecursive, tpe) = implType match {
+        case TypeRef(_, t, args) =>
+          // Option[_] needs special treatment because we need to use XXXOpt
+          if (implType.typeConstructor <:< typeOf[Option[_]].typeConstructor)
+            (args.exists { a => a.typeSymbol == companioned }, args.head)
+          else (args.exists { a => a.typeSymbol == companioned }, implType)
+        case TypeRef(_, t, _) =>
+          (false, implType)
+      }
 
-                val inferedImplicits = params.map(_.typeSignature).map { implType =>
+      // builds reads implicit from expected type
+      val neededImplicitType = appliedType(weakTypeOf[Writes[_]].typeConstructor, tpe :: Nil)
+      // infers implicit
+      val neededImplicit = c.inferImplicitValue(neededImplicitType)
+      (implType, neededImplicit, isRecursive, tpe)
+    }
 
-                  val (isRecursive, tpe) = implType match {
-                    case TypeRef(_, t, args) =>
-                      // Option[_] needs special treatment because we need to use XXXOpt
-                      if (implType.typeConstructor <:< typeOf[Option[_]].typeConstructor)
-                        (args.exists { a => a.typeSymbol == companioned }, args.head)
-                      else (args.exists { a => a.typeSymbol == companioned }, implType)
-                    case TypeRef(_, t, _) =>
-                      (false, implType)
-                  }
+    // if any implicit is missing, abort
+    // else goes on
+    inferedImplicits.collect { case (t, impl, rec, _) if (impl == EmptyTree && !rec) => t } match {
+      case List() =>
+        val namedImplicits = params.map(_.name).zip(inferedImplicits)
+        //println("Found implicits:"+namedImplicits)
 
-                  // builds reads implicit from expected type
-                  val neededImplicitType = appliedType(weakTypeOf[Writes[_]].typeConstructor, tpe :: Nil)
-                  // infers implicit
-                  val neededImplicit = c.inferImplicitValue(neededImplicitType)
-                  (implType, neededImplicit, isRecursive, tpe)
+        val helperMember = Select(This(tpnme.EMPTY), newTermName("lazyStuff"))
+
+        var hasRec = false
+
+        // combines all reads into CanBuildX
+        val canBuild = namedImplicits.map {
+          case (name, (t, impl, rec, tpe)) =>
+            // inception of (__ \ name).read(impl)
+            val jspathTree = Apply(
+              Select(jsPathSelect, newTermName(scala.reflect.NameTransformer.encode("\\"))),
+              List(Literal(Constant(name.decoded))))
+
+            if (!rec) {
+              val writesTree =
+                if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor)
+                  Apply(
+                    Select(jspathTree, newTermName("writeNullable")),
+                    List(impl))
+                else Apply(
+                  Select(jspathTree, newTermName("write")),
+                  List(impl))
+
+              writesTree
+            } else {
+              hasRec = true
+              val writesTree =
+                if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor)
+                  Apply(
+                    Select(jspathTree, newTermName("writeNullable")),
+                    List(
+                      Apply(
+                        Select(Apply(jsPathSelect, List()), newTermName("lazyWrite")),
+                        List(helperMember))))
+
+                else {
+                  Apply(
+                    Select(jspathTree, newTermName("lazyWrite")),
+                    if (tpe.typeConstructor <:< typeOf[List[_]].typeConstructor)
+                      List(
+                      Apply(
+                        Select(writesSelect, newTermName("list")),
+                        List(helperMember)))
+                    else if (tpe.typeConstructor <:< typeOf[Set[_]].typeConstructor)
+                      List(
+                      Apply(
+                        Select(writesSelect, newTermName("set")),
+                        List(helperMember)))
+                    else if (tpe.typeConstructor <:< typeOf[Seq[_]].typeConstructor)
+                      List(
+                      Apply(
+                        Select(writesSelect, newTermName("seq")),
+                        List(helperMember)))
+                    else if (tpe.typeConstructor <:< typeOf[Map[_, _]].typeConstructor)
+                      List(
+                      Apply(
+                        Select(writesSelect, newTermName("map")),
+                        List(helperMember)))
+                    else List(helperMember))
                 }
 
-                // if any implicit is missing, abort
-                // else goes on
-                inferedImplicits.collect { case (t, impl, rec, _) if (impl == EmptyTree && !rec) => t } match {
-                  case List() =>
-                    val namedImplicits = params.map(_.name).zip(inferedImplicits)
-                    //println("Found implicits:"+namedImplicits)
+              writesTree
+            }
+        }.reduceLeft { (acc, r) =>
+          Apply(
+            Select(acc, newTermName("and")),
+            List(r))
+        }
 
-                    val helperMember = Select(This(tpnme.EMPTY), newTermName("lazyStuff"))
+        // builds the final Reads using apply method
+        //val applyMethod = Ident( companionSymbol.name )
+        val applyMethod =
+          Function(
+            params.foldLeft(List[ValDef]())((l, e) =>
+              l :+ ValDef(Modifiers(PARAM), newTermName(e.name.encoded), TypeTree(), EmptyTree)),
+            Apply(
+              Select(Ident(companionSymbol.name), newTermName("apply")),
+              params.foldLeft(List[Tree]())((l, e) =>
+                l :+ Ident(newTermName(e.name.encoded)))))
 
-                    var hasRec = false
+        val unapplyMethod = Apply(
+          unliftIdent,
+          List(
+            Select(Ident(companionSymbol.name), "unapply")))
 
-                    // combines all reads into CanBuildX
-                    val canBuild = namedImplicits.map {
-                      case (name, (t, impl, rec, tpe)) =>
-                        // inception of (__ \ name).read(impl)
-                        val jspathTree = Apply(
-                          Select(jsPathSelect, newTermName(scala.reflect.NameTransformer.encode("\\"))),
-                          List(Literal(Constant(name.decoded)))
-                        )
+        // if case class has one single field, needs to use inmap instead of canbuild.apply
+        val finalTree = if (params.length > 1) {
+          Apply(
+            Select(canBuild, newTermName("apply")),
+            List(unapplyMethod))
+        } else {
+          Apply(
+            Select(canBuild, newTermName("contramap")),
+            List(unapplyMethod))
+        }
+        //println("finalTree: "+finalTree)
 
-                        if (!rec) {
-                          val writesTree =
-                            if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor)
-                              Apply(
-                                Select(jspathTree, newTermName("writeNullable")),
-                                List(impl)
-                              )
-                            else Apply(
-                              Select(jspathTree, newTermName("write")),
-                              List(impl)
-                            )
+        if (!hasRec) {
+          val block = Block(
+            Import(functionalSyntaxPkg, List(ImportSelector(nme.WILDCARD, -1, null, -1))),
+            finalTree)
+          //println("block:"+block)
+          c.Expr[Writes[A]](block)
+        } else {
+          val helper = newTermName("helper")
+          val helperVal = ValDef(
+            Modifiers(),
+            helper,
+            TypeTree(weakTypeOf[play.api.libs.json.util.LazyHelper[Writes, A]]),
+            Apply(lazyHelperSelect, List(finalTree)))
 
-                          writesTree
-                        } else {
-                          hasRec = true
-                          val writesTree =
-                            if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor)
-                              Apply(
-                                Select(jspathTree, newTermName("writeNullable")),
-                                List(
-                                  Apply(
-                                    Select(Apply(jsPathSelect, List()), newTermName("lazyWrite")),
-                                    List(helperMember)
-                                  )
-                                )
-                              )
-
-                            else {
-                              Apply(
-                                Select(jspathTree, newTermName("lazyWrite")),
-                                if (tpe.typeConstructor <:< typeOf[List[_]].typeConstructor)
-                                  List(
-                                  Apply(
-                                    Select(writesSelect, newTermName("list")),
-                                    List(helperMember)
-                                  )
-                                )
-                                else if (tpe.typeConstructor <:< typeOf[Set[_]].typeConstructor)
-                                  List(
-                                  Apply(
-                                    Select(writesSelect, newTermName("set")),
-                                    List(helperMember)
-                                  )
-                                )
-                                else if (tpe.typeConstructor <:< typeOf[Seq[_]].typeConstructor)
-                                  List(
-                                  Apply(
-                                    Select(writesSelect, newTermName("seq")),
-                                    List(helperMember)
-                                  )
-                                )
-                                else if (tpe.typeConstructor <:< typeOf[Map[_, _]].typeConstructor)
-                                  List(
-                                  Apply(
-                                    Select(writesSelect, newTermName("map")),
-                                    List(helperMember)
-                                  )
-                                )
-                                else List(helperMember)
-                              )
-                            }
-
-                          writesTree
-                        }
-                    }.reduceLeft { (acc, r) =>
-                      Apply(
-                        Select(acc, newTermName("and")),
-                        List(r)
-                      )
-                    }
-
-                    // builds the final Reads using apply method
-                    //val applyMethod = Ident( companionSymbol.name )
-                    val applyMethod =
-                      Function(
-                        params.foldLeft(List[ValDef]())((l, e) =>
-                          l :+ ValDef(Modifiers(PARAM), newTermName(e.name.encoded), TypeTree(), EmptyTree)
-                        ),
-                        Apply(
-                          Select(Ident(companionSymbol.name), newTermName("apply")),
-                          params.foldLeft(List[Tree]())((l, e) =>
-                            l :+ Ident(newTermName(e.name.encoded))
-                          )
-                        )
-                      )
-
-                    val unapplyMethod = Apply(
-                      unliftIdent,
+          val block = Select(
+            Block(
+              Import(functionalSyntaxPkg, List(ImportSelector(nme.WILDCARD, -1, null, -1))),
+              ClassDef(
+                Modifiers(Flag.FINAL),
+                newTypeName("$anon"),
+                List(),
+                Template(
+                  List(
+                    AppliedTypeTree(
+                      lazyHelperSelect,
                       List(
-                        Select(Ident(companionSymbol.name), unapply.name)
-                      )
-                    )
+                        Ident(weakTypeOf[Writes[A]].typeSymbol),
+                        Ident(weakTypeOf[A].typeSymbol)))),
+                  emptyValDef,
+                  List(
+                    DefDef(
+                      Modifiers(),
+                      nme.CONSTRUCTOR,
+                      List(),
+                      List(List()),
+                      TypeTree(),
+                      Block(
+                        Apply(
+                          Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR),
+                          List()))),
+                    ValDef(
+                      Modifiers(Flag.OVERRIDE | Flag.LAZY),
+                      newTermName("lazyStuff"),
+                      AppliedTypeTree(Ident(weakTypeOf[Writes[A]].typeSymbol), List(TypeTree(weakTypeOf[A]))),
+                      finalTree)))),
+              Apply(Select(New(Ident(newTypeName("$anon"))), nme.CONSTRUCTOR), List())),
+            newTermName("lazyStuff"))
 
-                    // if case class has one single field, needs to use inmap instead of canbuild.apply
-                    val finalTree = if (params.length > 1) {
-                      Apply(
-                        Select(canBuild, newTermName("apply")),
-                        List(unapplyMethod)
-                      )
-                    } else {
-                      Apply(
-                        Select(canBuild, newTermName("contramap")),
-                        List(unapplyMethod)
-                      )
-                    }
-                    //println("finalTree: "+finalTree)
+          //println("block:"+block)
 
-                    if (!hasRec) {
-                      val block = Block(
-                        Import(functionalSyntaxPkg, List(ImportSelector(nme.WILDCARD, -1, null, -1))),
-                        finalTree
-                      )
-                      //println("block:"+block)
-                      c.Expr[Writes[A]](block)
-                    } else {
-                      val helper = newTermName("helper")
-                      val helperVal = ValDef(
-                        Modifiers(),
-                        helper,
-                        TypeTree(weakTypeOf[play.api.libs.json.util.LazyHelper[Writes, A]]),
-                        Apply(lazyHelperSelect, List(finalTree))
-                      )
-
-                      val block = Select(
-                        Block(
-                          Import(functionalSyntaxPkg, List(ImportSelector(nme.WILDCARD, -1, null, -1))),
-                          ClassDef(
-                            Modifiers(Flag.FINAL),
-                            newTypeName("$anon"),
-                            List(),
-                            Template(
-                              List(
-                                AppliedTypeTree(
-                                  lazyHelperSelect,
-                                  List(
-                                    Ident(weakTypeOf[Writes[A]].typeSymbol),
-                                    Ident(weakTypeOf[A].typeSymbol)
-                                  )
-                                )
-                              ),
-                              emptyValDef,
-                              List(
-                                DefDef(
-                                  Modifiers(),
-                                  nme.CONSTRUCTOR,
-                                  List(),
-                                  List(List()),
-                                  TypeTree(),
-                                  Block(
-                                    Apply(
-                                      Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR),
-                                      List()
-                                    )
-                                  )
-                                ),
-                                ValDef(
-                                  Modifiers(Flag.OVERRIDE | Flag.LAZY),
-                                  newTermName("lazyStuff"),
-                                  AppliedTypeTree(Ident(weakTypeOf[Writes[A]].typeSymbol), List(TypeTree(weakTypeOf[A]))),
-                                  finalTree
-                                )
-                              )
-                            )
-                          ),
-                          Apply(Select(New(Ident(newTypeName("$anon"))), nme.CONSTRUCTOR), List())
-                        ),
-                        newTermName("lazyStuff")
-                      )
-
-                      //println("block:"+block)
-
-                      /*val reif = reify(
+          /*val reif = reify(
                         new play.api.libs.json.util.LazyHelper[Format, A] {
                           override lazy val lazyStuff: Format[A] = null
                         }
                       )
                       //println("RAW:"+showRaw(reif.tree, printKinds = true))*/
-                      c.Expr[Writes[A]](block)
-                    }
-                  case l => c.abort(c.enclosingPosition, s"No implicit Writes for ${l.mkString(", ")} available.")
-                }
-
-              case None => c.abort(c.enclosingPosition, "No apply function found matching unapply parameters")
-            }
-
+          c.Expr[Writes[A]](block)
         }
+      case l => c.abort(c.enclosingPosition, s"No implicit Writes for ${l.mkString(", ")} available.")
     }
   }
 
@@ -593,284 +442,203 @@ object JsMacroImpl {
     val unliftIdent = Select(functionalSyntaxPkg, newTermName("unlift"))
     val lazyHelperSelect = Select(utilPkg, newTypeName("LazyHelper"))
 
-    companionType.declaration(stringToTermName("unapply")) match {
-      case NoSymbol => c.abort(c.enclosingPosition, "No unapply function found")
-      case s =>
-        val unapply = s.asMethod
-        val unapplyReturnTypes = unapply.returnType match {
-          case TypeRef(_, _, Nil) =>
-            c.abort(c.enclosingPosition, s"Unapply of ${companionSymbol} has no parameters. Are you using an empty case class?")
-          case TypeRef(_, _, args) =>
-            args.head match {
-              case t @ TypeRef(_, _, Nil) => Some(List(t))
-              case t @ TypeRef(_, _, args) =>
-                if (t <:< typeOf[Option[_]]) Some(List(t))
-                else if (t <:< typeOf[Seq[_]]) Some(List(t))
-                else if (t <:< typeOf[Set[_]]) Some(List(t))
-                else if (t <:< typeOf[Map[_, _]]) Some(List(t))
-                else if (t <:< typeOf[Product]) Some(args)
-              case _ => None
-            }
-          case _ => None
-        }
+    val params = weakTypeOf[A].declarations.collectFirst {
+      case m: MethodSymbol if m.isPrimaryConstructor ⇒ m
+    }.get.paramss.head //verify there is a single parameter group
 
-        //println("Unapply return type:" + unapplyReturnTypes)
+    val inferedImplicits = params.map(_.typeSignature).map { implType =>
 
-        companionType.declaration(stringToTermName("apply")) match {
-          case NoSymbol => c.abort(c.enclosingPosition, "No apply function found")
-          case s =>
-            // searches apply method corresponding to unapply
-            val applies = s.asMethod.alternatives
-            val apply = applies.collectFirst {
-              case (apply: MethodSymbol) if (apply.paramss.headOption.map(_.map(_.asTerm.typeSignature)) == unapplyReturnTypes) => apply
-            }
-            apply match {
-              case Some(apply) =>
-                //println("apply found:" + apply)    
-                val params = apply.paramss.head //verify there is a single parameter group
+      val (isRecursive, tpe) = implType match {
+        case TypeRef(_, t, args) =>
+          // Option[_] needs special treatment because we need to use XXXOpt
+          if (implType.typeConstructor <:< typeOf[Option[_]].typeConstructor)
+            (args.exists { a => a.typeSymbol == companioned }, args.head)
+          else (args.exists { a => a.typeSymbol == companioned }, implType)
+        case TypeRef(_, t, _) =>
+          (false, implType)
+      }
 
-                val inferedImplicits = params.map(_.typeSignature).map { implType =>
+      // builds reads implicit from expected type
+      val neededImplicitType = appliedType(weakTypeOf[Format[_]].typeConstructor, tpe :: Nil)
+      // infers implicit
+      val neededImplicit = c.inferImplicitValue(neededImplicitType)
+      (implType, neededImplicit, isRecursive, tpe)
+    }
 
-                  val (isRecursive, tpe) = implType match {
-                    case TypeRef(_, t, args) =>
-                      // Option[_] needs special treatment because we need to use XXXOpt
-                      if (implType.typeConstructor <:< typeOf[Option[_]].typeConstructor)
-                        (args.exists { a => a.typeSymbol == companioned }, args.head)
-                      else (args.exists { a => a.typeSymbol == companioned }, implType)
-                    case TypeRef(_, t, _) =>
-                      (false, implType)
-                  }
+    // if any implicit is missing, abort
+    // else goes on
+    inferedImplicits.collect { case (t, impl, rec, _) if (impl == EmptyTree && !rec) => t } match {
+      case List() =>
+        val namedImplicits = params.map(_.name).zip(inferedImplicits)
+        //println("Found implicits:"+namedImplicits)
 
-                  // builds reads implicit from expected type
-                  val neededImplicitType = appliedType(weakTypeOf[Format[_]].typeConstructor, tpe :: Nil)
-                  // infers implicit
-                  val neededImplicit = c.inferImplicitValue(neededImplicitType)
-                  (implType, neededImplicit, isRecursive, tpe)
+        val helperMember = Select(This(tpnme.EMPTY), newTermName("lazyStuff"))
+
+        var hasRec = false
+
+        // combines all reads into CanBuildX
+        val canBuild = namedImplicits.map {
+          case (name, (t, impl, rec, tpe)) =>
+            // inception of (__ \ name).read(impl)
+            val jspathTree = Apply(
+              Select(jsPathSelect, newTermName(scala.reflect.NameTransformer.encode("\\"))),
+              List(Literal(Constant(name.decoded))))
+
+            if (!rec) {
+              val formatTree =
+                if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor)
+                  Apply(
+                    Select(jspathTree, newTermName("formatNullable")),
+                    List(impl))
+                else Apply(
+                  Select(jspathTree, newTermName("format")),
+                  List(impl))
+
+              formatTree
+            } else {
+              hasRec = true
+              val formatTree =
+                if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor)
+                  Apply(
+                    Select(jspathTree, newTermName("formatNullable")),
+                    List(
+                      Apply(
+                        Select(Apply(jsPathSelect, List()), newTermName("lazyFormat")),
+                        List(helperMember))))
+
+                else {
+                  Apply(
+                    Select(jspathTree, newTermName("lazyFormat")),
+                    if (tpe.typeConstructor <:< typeOf[List[_]].typeConstructor)
+                      List(
+                      Apply(
+                        Select(readsSelect, newTermName("list")),
+                        List(helperMember)),
+                      Apply(
+                        Select(writesSelect, newTermName("list")),
+                        List(helperMember)))
+                    else if (tpe.typeConstructor <:< typeOf[Set[_]].typeConstructor)
+                      List(
+                      Apply(
+                        Select(readsSelect, newTermName("set")),
+                        List(helperMember)),
+                      Apply(
+                        Select(writesSelect, newTermName("set")),
+                        List(helperMember)))
+                    else if (tpe.typeConstructor <:< typeOf[Seq[_]].typeConstructor)
+                      List(
+                      Apply(
+                        Select(readsSelect, newTermName("seq")),
+                        List(helperMember)),
+                      Apply(
+                        Select(writesSelect, newTermName("seq")),
+                        List(helperMember)))
+                    else if (tpe.typeConstructor <:< typeOf[Map[_, _]].typeConstructor)
+                      List(
+                      Apply(
+                        Select(readsSelect, newTermName("map")),
+                        List(helperMember)),
+                      Apply(
+                        Select(writesSelect, newTermName("map")),
+                        List(helperMember)))
+                    else List(helperMember))
                 }
 
-                // if any implicit is missing, abort
-                // else goes on
-                inferedImplicits.collect { case (t, impl, rec, _) if (impl == EmptyTree && !rec) => t } match {
-                  case List() =>
-                    val namedImplicits = params.map(_.name).zip(inferedImplicits)
-                    //println("Found implicits:"+namedImplicits)
+              formatTree
+            }
+        }.reduceLeft { (acc, r) =>
+          Apply(
+            Select(acc, newTermName("and")),
+            List(r))
+        }
 
-                    val helperMember = Select(This(tpnme.EMPTY), newTermName("lazyStuff"))
+        // builds the final Reads using apply method
+        //val applyMethod = Ident( companionSymbol.name )
+        val applyMethod =
+          Function(
+            params.foldLeft(List[ValDef]())((l, e) =>
+              l :+ ValDef(Modifiers(PARAM), newTermName(e.name.encoded), TypeTree(), EmptyTree)),
+            Apply(
+              Select(Ident(companionSymbol.name), newTermName("apply")),
+              params.foldLeft(List[Tree]())((l, e) =>
+                l :+ Ident(newTermName(e.name.encoded)))))
 
-                    var hasRec = false
+        val unapplyMethod = Apply(
+          unliftIdent,
+          List(
+            Select(Ident(companionSymbol.name), "unapply")))
 
-                    // combines all reads into CanBuildX
-                    val canBuild = namedImplicits.map {
-                      case (name, (t, impl, rec, tpe)) =>
-                        // inception of (__ \ name).read(impl)
-                        val jspathTree = Apply(
-                          Select(jsPathSelect, newTermName(scala.reflect.NameTransformer.encode("\\"))),
-                          List(Literal(Constant(name.decoded)))
-                        )
+        // if case class has one single field, needs to use inmap instead of canbuild.apply
+        val finalTree = if (params.length > 1) {
+          Apply(
+            Select(canBuild, newTermName("apply")),
+            List(applyMethod, unapplyMethod))
+        } else {
+          Apply(
+            Select(canBuild, newTermName("inmap")),
+            List(applyMethod, unapplyMethod))
+        }
+        //println("finalTree: "+finalTree)
 
-                        if (!rec) {
-                          val formatTree =
-                            if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor)
-                              Apply(
-                                Select(jspathTree, newTermName("formatNullable")),
-                                List(impl)
-                              )
-                            else Apply(
-                              Select(jspathTree, newTermName("format")),
-                              List(impl)
-                            )
+        if (!hasRec) {
+          val block = Block(
+            Import(functionalSyntaxPkg, List(ImportSelector(nme.WILDCARD, -1, null, -1))),
+            finalTree)
+          //println("block:"+block)
+          c.Expr[Format[A]](block)
+        } else {
+          val helper = newTermName("helper")
+          val helperVal = ValDef(
+            Modifiers(),
+            helper,
+            Ident(weakTypeOf[play.api.libs.json.util.LazyHelper[Format, A]].typeSymbol),
+            Apply(Ident(newTermName("LazyHelper")), List(finalTree)))
 
-                          formatTree
-                        } else {
-                          hasRec = true
-                          val formatTree =
-                            if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor)
-                              Apply(
-                                Select(jspathTree, newTermName("formatNullable")),
-                                List(
-                                  Apply(
-                                    Select(Apply(jsPathSelect, List()), newTermName("lazyFormat")),
-                                    List(helperMember)
-                                  )
-                                )
-                              )
-
-                            else {
-                              Apply(
-                                Select(jspathTree, newTermName("lazyFormat")),
-                                if (tpe.typeConstructor <:< typeOf[List[_]].typeConstructor)
-                                  List(
-                                  Apply(
-                                    Select(readsSelect, newTermName("list")),
-                                    List(helperMember)
-                                  ),
-                                  Apply(
-                                    Select(writesSelect, newTermName("list")),
-                                    List(helperMember)
-                                  )
-                                )
-                                else if (tpe.typeConstructor <:< typeOf[Set[_]].typeConstructor)
-                                  List(
-                                  Apply(
-                                    Select(readsSelect, newTermName("set")),
-                                    List(helperMember)
-                                  ),
-                                  Apply(
-                                    Select(writesSelect, newTermName("set")),
-                                    List(helperMember)
-                                  )
-                                )
-                                else if (tpe.typeConstructor <:< typeOf[Seq[_]].typeConstructor)
-                                  List(
-                                  Apply(
-                                    Select(readsSelect, newTermName("seq")),
-                                    List(helperMember)
-                                  ),
-                                  Apply(
-                                    Select(writesSelect, newTermName("seq")),
-                                    List(helperMember)
-                                  )
-                                )
-                                else if (tpe.typeConstructor <:< typeOf[Map[_, _]].typeConstructor)
-                                  List(
-                                  Apply(
-                                    Select(readsSelect, newTermName("map")),
-                                    List(helperMember)
-                                  ),
-                                  Apply(
-                                    Select(writesSelect, newTermName("map")),
-                                    List(helperMember)
-                                  )
-                                )
-                                else List(helperMember)
-                              )
-                            }
-
-                          formatTree
-                        }
-                    }.reduceLeft { (acc, r) =>
-                      Apply(
-                        Select(acc, newTermName("and")),
-                        List(r)
-                      )
-                    }
-
-                    // builds the final Reads using apply method
-                    //val applyMethod = Ident( companionSymbol.name )
-                    val applyMethod =
-                      Function(
-                        params.foldLeft(List[ValDef]())((l, e) =>
-                          l :+ ValDef(Modifiers(PARAM), newTermName(e.name.encoded), TypeTree(), EmptyTree)
-                        ),
-                        Apply(
-                          Select(Ident(companionSymbol.name), newTermName("apply")),
-                          params.foldLeft(List[Tree]())((l, e) =>
-                            l :+ Ident(newTermName(e.name.encoded))
-                          )
-                        )
-                      )
-
-                    val unapplyMethod = Apply(
-                      unliftIdent,
+          val block = Select(
+            Block(
+              Import(functionalSyntaxPkg, List(ImportSelector(nme.WILDCARD, -1, null, -1))),
+              ClassDef(
+                Modifiers(Flag.FINAL),
+                newTypeName("$anon"),
+                List(),
+                Template(
+                  List(
+                    AppliedTypeTree(
+                      lazyHelperSelect,
                       List(
-                        Select(Ident(companionSymbol.name), unapply.name)
-                      )
-                    )
+                        Ident(weakTypeOf[Format[A]].typeSymbol),
+                        Ident(weakTypeOf[A].typeSymbol)))),
+                  emptyValDef,
+                  List(
+                    DefDef(
+                      Modifiers(),
+                      nme.CONSTRUCTOR,
+                      List(),
+                      List(List()),
+                      TypeTree(),
+                      Block(
+                        Apply(
+                          Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR),
+                          List()))),
+                    ValDef(
+                      Modifiers(Flag.OVERRIDE | Flag.LAZY),
+                      newTermName("lazyStuff"),
+                      AppliedTypeTree(Ident(weakTypeOf[Format[A]].typeSymbol), List(TypeTree(weakTypeOf[A]))),
+                      finalTree)))),
+              Apply(Select(New(Ident(newTypeName("$anon"))), nme.CONSTRUCTOR), List())),
+            newTermName("lazyStuff"))
 
-                    // if case class has one single field, needs to use inmap instead of canbuild.apply
-                    val finalTree = if (params.length > 1) {
-                      Apply(
-                        Select(canBuild, newTermName("apply")),
-                        List(applyMethod, unapplyMethod)
-                      )
-                    } else {
-                      Apply(
-                        Select(canBuild, newTermName("inmap")),
-                        List(applyMethod, unapplyMethod)
-                      )
-                    }
-                    //println("finalTree: "+finalTree)
+          //println("block:"+block)
 
-                    if (!hasRec) {
-                      val block = Block(
-                        Import(functionalSyntaxPkg, List(ImportSelector(nme.WILDCARD, -1, null, -1))),
-                        finalTree
-                      )
-                      //println("block:"+block)
-                      c.Expr[Format[A]](block)
-                    } else {
-                      val helper = newTermName("helper")
-                      val helperVal = ValDef(
-                        Modifiers(),
-                        helper,
-                        Ident(weakTypeOf[play.api.libs.json.util.LazyHelper[Format, A]].typeSymbol),
-                        Apply(Ident(newTermName("LazyHelper")), List(finalTree))
-                      )
-
-                      val block = Select(
-                        Block(
-                          Import(functionalSyntaxPkg, List(ImportSelector(nme.WILDCARD, -1, null, -1))),
-                          ClassDef(
-                            Modifiers(Flag.FINAL),
-                            newTypeName("$anon"),
-                            List(),
-                            Template(
-                              List(
-                                AppliedTypeTree(
-                                  lazyHelperSelect,
-                                  List(
-                                    Ident(weakTypeOf[Format[A]].typeSymbol),
-                                    Ident(weakTypeOf[A].typeSymbol)
-                                  )
-                                )
-                              ),
-                              emptyValDef,
-                              List(
-                                DefDef(
-                                  Modifiers(),
-                                  nme.CONSTRUCTOR,
-                                  List(),
-                                  List(List()),
-                                  TypeTree(),
-                                  Block(
-                                    Apply(
-                                      Select(Super(This(tpnme.EMPTY), tpnme.EMPTY), nme.CONSTRUCTOR),
-                                      List()
-                                    )
-                                  )
-                                ),
-                                ValDef(
-                                  Modifiers(Flag.OVERRIDE | Flag.LAZY),
-                                  newTermName("lazyStuff"),
-                                  AppliedTypeTree(Ident(weakTypeOf[Format[A]].typeSymbol), List(TypeTree(weakTypeOf[A]))),
-                                  finalTree
-                                )
-                              )
-                            )
-                          ),
-                          Apply(Select(New(Ident(newTypeName("$anon"))), nme.CONSTRUCTOR), List())
-                        ),
-                        newTermName("lazyStuff")
-                      )
-
-                      //println("block:"+block)
-
-                      /*val reif = reify(
+          /*val reif = reify(
                         new play.api.libs.json.util.LazyHelper[Format, A] {
                           override lazy val lazyStuff: Format[A] = null
                         }
                       )
                       //println("RAW:"+showRaw(reif.tree, printKinds = true))*/
-                      c.Expr[Format[A]](block)
-                    }
-                  case l => c.abort(c.enclosingPosition, s"No implicit format for ${l.mkString(", ")} available.")
-                }
-
-              case None => c.abort(c.enclosingPosition, "No apply function found matching unapply parameters")
-            }
-
+          c.Expr[Format[A]](block)
         }
+      case l => c.abort(c.enclosingPosition, s"No implicit format for ${l.mkString(", ")} available.")
     }
   }
-
 }


### PR DESCRIPTION
This pull request tries to simplify a bit the implementation of JSON inception.Basically, fields of the class are retrieved directly from the constructor instead of finding them by introspecting `apply` and `unapply` methods.

As the proposed change modified the indentation, the diff is difficult to read, so I will detail for clarity the modifications.

To retrieve class fields (`params`), the current implementation does the following:

``` scala
companionType.declaration(stringToTermName("unapply")) match {
      case NoSymbol => c.abort(c.enclosingPosition, "No unapply function found")
      case s =>

        companionType.declaration(stringToTermName("apply")) match {
          case NoSymbol => c.abort(c.enclosingPosition, "No apply function found")
          case s =>
            // searches apply method corresponding to unapply
            val applies = s.asMethod.alternatives
            val apply = applies.collectFirst {
              case (apply: MethodSymbol) if (apply.paramss.headOption.map(_.map(_.asTerm.typeSignature)) == unapplyReturnTypes) => apply
            }
            apply match {
              case Some(apply) =>
                 val params = apply.paramss.head

                  ... CONTINUE TO WORK ...  

              case None => c.abort(c.enclosingPosition, "No apply function found matching unapply return types")
            }

        }
    }
```

The proposed implementation retrieves the fields by:
- Get all `declarations` of the class
- Find the primary constructor in the list
- Get the constructor parameters

``` scala
val params = weakTypeOf[A].declarations.collectFirst {
  case m: MethodSymbol if m.isPrimaryConstructor ⇒ m
}.get.paramss.head
```

The 3 modified methods (`readsImpl`, `writesImpl`, `formatsImpl`) follow the same pattern.
In addition to complexity reduction, it enables case classes without unapply `methods` (case classes [with more than 22 parameters](https://github.com/scala/scala/pull/2305) since 2.11) to be used, even if [play functional library](https://github.com/playframework/playframework/blob/master/framework/src/play-functional/src/main/scala/play/api/libs/functional/Products.scala) needs to be enhanced to support more than 22 parameters to be useful. 
