### PR TITLE
Use versions like 2.4.x in template doc URLs

### DIFF
--- a/templates/build.sbt
+++ b/templates/build.sbt
@@ -33,7 +33,11 @@ val playVersion = propOrElse("play.version", {
 // The Play templates should default to using the latest compatible version of Scala
 val playScalaVersion = propOrElse("scala.version", "2.11.0")
 
-val playDocsUrl = propOrElse("play.docs.url", s"http://www.playframework.com/documentation/${playVersion}")
+val playDocsUrl = propOrElse("play.docs.url", {
+  // Use a version like 2.4.x for the documentation
+  val docVersion = playVersion.replaceAll("""(\d+)\.(\d+)\D(.*)""", "$1.$2.x")
+  s"http://www.playframework.com/documentation/${docVersion}"}
+)
 
 // Use different names for release and milestone templates
 val (templateNameSuffix, templateTitleSuffix) = {


### PR DESCRIPTION
Using the raw Play version wasn't what we wanted.

Needs to be backported to the 2.3.x branch.
