### PR TITLE
Allow type projection in routes

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
@@ -175,9 +175,31 @@ object RoutesCompiler {
       case _ ~ parts => PathPattern(parts)
     }
 
-    def parameterType: Parser[String] = ":" ~> ignoreWhiteSpace ~> rep1sep(identifier, ".") ~ opt(brackets) ^^ {
-      case t ~ g => t.mkString(".") + g.getOrElse("")
+    def space(s: String): Parser[String] = (ignoreWhiteSpace ~> s <~ ignoreWhiteSpace)
+
+    def parameterType: Parser[String] = ":" ~> ignoreWhiteSpace ~> simpleType
+
+    def simpleType: Parser[String] = {
+      ((stableId <~ ignoreWhiteSpace) ~ opt(typeArgs)) ^^ {
+        case sid ~ ta => sid.toString + ta.getOrElse("")
+      } |
+        (space("(") ~ types ~ space(")")) ^^ {
+          case _ ~ b ~ _ => "(" + b + ")"
+        }
     }
+
+    def typeArgs: Parser[String] = {
+      (space("[") ~ types ~ space("]") ~ opt(typeArgs)) ^^ {
+        case _ ~ ts ~ _ ~ ta => "[" + ts + "]" + ta.getOrElse("")
+      } |
+        (space("#") ~ identifier ~ opt(typeArgs)) ^^ {
+          case _ ~ id ~ ta => "#" + id + ta.getOrElse("")
+        }
+    }
+
+    def types: Parser[String] = rep1sep(simpleType, space(",")) ^^ (_ mkString ",")
+
+    def stableId: Parser[String] = rep1sep(identifier, space(".")) ^^ (_ mkString ".")
 
     def expression: Parser[String] = (multiString | string | parentheses | brackets | """[^),?=\n]""".r +) ^^ {
       case p => p.mkString

--- a/framework/src/routes-compiler/src/test/resources/complexTypes.routes
+++ b/framework/src/routes-compiler/src/test/resources/complexTypes.routes
@@ -1,0 +1,6 @@
+GET    /foo     controllers.FooController.foo(bar: Option[Option[String]])
+GET    /foo     controllers.FooController.foo(bar: (Int,Int,(Int,Int)))
+GET    /foo     controllers.FooController.foo(bar: A#B)
+GET    /foo     controllers.FooController.foo(bar:  Option [ Option [ String ] ] )
+GET    /foo     controllers.FooController.foo(bar:  ( Int , Int , ( Int , Int ) ) )
+GET    /foo     controllers.FooController.foo(bar:  A # B )

--- a/framework/src/routes-compiler/src/test/scala/play/router/RoutesCompilerSpec.scala
+++ b/framework/src/routes-compiler/src/test/scala/play/router/RoutesCompilerSpec.scala
@@ -168,7 +168,15 @@ object RoutesCompilerSpec extends Specification {
 
     "check if there are no routes using overloaded handler methods" in withTempDir { tmp =>
       val file = new File(this.getClass.getClassLoader.getResource("duplicateHandlers.routes").toURI)
-      RoutesCompiler.compile(file, tmp, Seq.empty) must throwA [RoutesCompilationError]
+      RoutesCompiler.compile(file, tmp, Seq.empty) must throwA[RoutesCompilationError]
+    }
+
+    "check if routes with type projection are compiled" in withTempDir { tmp =>
+      val file = new File(this.getClass.getClassLoader.getResource("complexTypes.routes").toURI)
+      object A {
+        type B = Int
+      }
+      RoutesCompiler.compile(file, tmp, Seq.empty) must throwA[RoutesCompilationError].not
     }
   }
 }


### PR DESCRIPTION
It would be nice to allow type projection (`object A { type Id = Int }; A#Id`) in routes. I don't know if anyone else would be interested in this but I have a cool use case in a project with Play + Slick where all the ids are typed in a way that ensures they can't be mixed up.

I've tried without success the alternative of using a case class with type parameter (`case class Id[T](value: Int)`) to add type safety to the router/reverse router, but the compiler didn't like to have a part of the url of type Id[T]. Is there a way around this?
