### PR TITLE
Reduce size of PlayIO API

### DIFF
--- a/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -425,11 +425,7 @@ object Evolutions {
       Option(new File(path, evolutionsFilename(db, revision))).filter(_.exists).map(new FileInputStream(_)).orElse {
         Option(applicationClassloader.getResourceAsStream(evolutionsResourceName(db, revision)))
       }.map { stream =>
-        try {
-          (revision + 1, (revision, PlayIO.readStreamAsString(stream)))
-        } finally {
-          PlayIO.closeQuietly(stream)
-        }
+        (revision + 1, (revision, PlayIO.readStreamAsString(stream)))
       }
     }.sortBy(_._1).map {
       case (revision, script) => {


### PR DESCRIPTION
- Inline some methods into the Files API
- Always close when reading a stream
- Didn't use scala.io.Source because it doesn't really support reading binary data and because it looks slow, which wouldn't be great for some use cases, e.g. reading assets or when a user uses Files.readFile.
