### PR TITLE
Suppress benign stack trace on ctrl-d out of sbt ~[command]. AFAIK this ...

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
@@ -92,7 +92,10 @@ trait PlayReloader {
             def addWatch(directoryToWatch: String): Int = {
               addWatchMethod.invoke(null, directoryToWatch, 15: java.lang.Integer, true: java.lang.Boolean, listener).asInstanceOf[Int]
             }
-            def removeWatch(id: Int): Unit = removeWatchMethod.invoke(null, id.asInstanceOf[AnyRef])
+            def removeWatch(id: Int): Unit = {
+							print(" "); // suppresses benign JNotify stack trace on remove watch out of ctrl-d
+							removeWatchMethod.invoke(null, id.asInstanceOf[AnyRef])
+						}
             def reloaded() { _changed = false }
             def changed() { _changed = true }
             def hasChanged = _changed


### PR DESCRIPTION
...is an issue only on Linux but should not affect other operating systems as it just prints a blank space to the console prior to invoking the removeWatch method.
