### PR TITLE
[2.3] Make ws.acceptAnyCertificate honor ssl configuration

### DIFF
--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingAsyncHttpClientConfigBuilder.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingAsyncHttpClientConfigBuilder.scala
@@ -30,13 +30,9 @@ class NingAsyncHttpClientConfigBuilder(config: WSClientConfig,
   def build(): AsyncHttpClientConfig = {
     configureWS(config)
 
-    config.acceptAnyCertificate match {
-      case Some(true) =>
-      // lean on the AsyncHttpClient bug
+    val acceptAnyCertificate = config.acceptAnyCertificate.getOrElse(false)
+    configureSSL(acceptAnyCertificate, config.ssl.getOrElse(DefaultSSLConfig()))
 
-      case _ =>
-        configureSSL(config.ssl.getOrElse(DefaultSSLConfig()))
-    }
     builder.build()
   }
 
@@ -107,47 +103,55 @@ class NingAsyncHttpClientConfigBuilder(config: WSClientConfig,
   /**
    * Configures the SSL.  Can use the system SSLContext.getDefault() if "ws.ssl.default" is set.
    */
-  def configureSSL(sslConfig: SSLConfig) {
+  def configureSSL(acceptAnyCertificate: Boolean, sslConfig: SSLConfig) {
 
     // context!
-    val useDefault = sslConfig.default.getOrElse(false)
-    val sslContext = if (useDefault) {
-      logger.info("buildSSLContext: ws.ssl.default is true, using default SSLContext")
-      validateDefaultTrustManager(sslConfig)
-      SSLContext.getDefault
-    } else {
-      // break out the static methods as much as we can...
-      val keyManagerFactory = buildKeyManagerFactory(sslConfig)
-      val trustManagerFactory = buildTrustManagerFactory(sslConfig)
-      new ConfigSSLContextBuilder(sslConfig, keyManagerFactory, trustManagerFactory).build()
-    }
+    val sslContext = configureContext(acceptAnyCertificate, sslConfig)
+
+    // Set up the engine parameters -- this is cloned, and changes are applied to the SSLEngine.
+    val engineParams = sslContext.getDefaultSSLParameters
 
     // protocols!
-    val defaultParams = sslContext.getDefaultSSLParameters
-    val defaultProtocols = defaultParams.getProtocols
+    val defaultProtocols = engineParams.getProtocols
     val protocols = configureProtocols(defaultProtocols, sslConfig)
-    defaultParams.setProtocols(protocols)
+    engineParams.setProtocols(protocols)
 
     // ciphers!
-    val defaultCiphers = defaultParams.getCipherSuites
+    val defaultCiphers = engineParams.getCipherSuites
     val cipherSuites = configureCipherSuites(defaultCiphers, sslConfig)
-    defaultParams.setCipherSuites(cipherSuites)
-
-    val sslEngineFactory = new DefaultSSLEngineFactory(sslConfig, sslContext, enabledProtocols = protocols, enabledCipherSuites = cipherSuites)
+    engineParams.setCipherSuites(cipherSuites)
 
     // Hostname Processing
     val disableHostnameVerification = sslConfig.loose.flatMap(_.disableHostnameVerification).getOrElse(false)
-    if (!disableHostnameVerification) {
+    if (disableHostnameVerification) {
+      logger.warn("buildHostnameVerifier: disabling hostname verification because disableHostnameVerification is set")
+    } else if (acceptAnyCertificate) {
+      logger.warn("buildHostnameVerifier: disabling hostname verification because acceptAnyCertificate is set")
+    } else {
       val hostnameVerifier = buildHostnameVerifier(sslConfig)
       builder.setHostnameVerifier(hostnameVerifier)
-    } else {
-      logger.warn("buildHostnameVerifier: disabling hostname verification")
     }
 
     builder.setSSLContext(sslContext)
 
     // Must set SSL engine factory AFTER the ssl context...
+    val sslEngineFactory = new DefaultSSLEngineFactory(sslContext, engineParams)
     builder.setSSLEngineFactory(sslEngineFactory)
+  }
+
+  def configureContext(acceptAnyCertificate: Boolean, sslConfig: SSLConfig): SSLContext = {
+    val useDefault = sslConfig.default.getOrElse(false)
+
+    if (useDefault) {
+      logger.info("configureContext: ws.ssl.default is true, using default SSLContext")
+      validateDefaultTrustManager(sslConfig)
+      SSLContext.getDefault
+    } else {
+      // break out the static methods as much as we can...
+      val keyManagerFactory = buildKeyManagerFactory(sslConfig)
+      val trustManagerFactory = buildTrustManagerFactory(acceptAnyCertificate, sslConfig)
+      new ConfigSSLContextBuilder(sslConfig, keyManagerFactory, trustManagerFactory, acceptAnyCertificate).build()
+    }
   }
 
   def buildKeyManagerFactory(ssl: SSLConfig): KeyManagerFactoryWrapper = {
@@ -155,9 +159,15 @@ class NingAsyncHttpClientConfigBuilder(config: WSClientConfig,
     new DefaultKeyManagerFactoryWrapper(keyManagerAlgorithm)
   }
 
-  def buildTrustManagerFactory(ssl: SSLConfig): TrustManagerFactoryWrapper = {
-    val trustManagerAlgorithm = ssl.trustManagerConfig.flatMap(_.algorithm).getOrElse(TrustManagerFactory.getDefaultAlgorithm)
-    new DefaultTrustManagerFactoryWrapper(trustManagerAlgorithm)
+  def buildTrustManagerFactory(acceptAnyCertificate: Boolean, ssl: SSLConfig): TrustManagerFactoryWrapper = {
+    if (acceptAnyCertificate) {
+      logger.warn("buildTrustManagerFactory: ws.acceptAnyCertificate is true, using AcceptAnyCertificateTrustManagerFactoryWrapper")
+
+      new AcceptAnyCertificateTrustManagerFactoryWrapper()
+    } else {
+      val trustManagerAlgorithm = ssl.trustManagerConfig.flatMap(_.algorithm).getOrElse(TrustManagerFactory.getDefaultAlgorithm)
+      new DefaultTrustManagerFactoryWrapper(trustManagerAlgorithm)
+    }
   }
 
   def buildHostnameVerifier(sslConfig: SSLConfig): HostnameVerifier = {
@@ -200,7 +210,7 @@ class NingAsyncHttpClientConfigBuilder(config: WSClientConfig,
         algorithmChecker.checkKeyAlgorithms(cert)
       } catch {
         case e: CertPathValidatorException =>
-          logger.warn("You are using ws.ssl.default=true and have a weak certificate in your default trust store!  (You can modify ws.ssl.disabledKeyAlgorithms to remove this message.)", e)
+          logger.warn("You are using ws.ssl.default=true and have a weak certificate in your default trust store: " + e.getMessage)
       }
     }
   }
@@ -208,15 +218,10 @@ class NingAsyncHttpClientConfigBuilder(config: WSClientConfig,
   /**
    * Factory that creates an SSLEngine.
    */
-  class DefaultSSLEngineFactory(config: SSLConfig,
-      sslContext: SSLContext,
-      enabledProtocols: Array[String],
-      enabledCipherSuites: Array[String]) extends SSLEngineFactory {
+  class DefaultSSLEngineFactory(sslContext: SSLContext, sslParameters: SSLParameters) extends SSLEngineFactory {
     def newSSLEngine(): SSLEngine = {
       val sslEngine = sslContext.createSSLEngine()
-      sslEngine.setSSLParameters(sslContext.getDefaultSSLParameters)
-      sslEngine.setEnabledProtocols(enabledProtocols)
-      sslEngine.setEnabledCipherSuites(enabledCipherSuites)
+      sslEngine.setSSLParameters(sslParameters)
       sslEngine.setUseClientMode(true)
       sslEngine
     }

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/AcceptAnyCertificateTrustManager.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/AcceptAnyCertificateTrustManager.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.libs.ws.ssl
+
+import javax.net.ssl.X509TrustManager
+import java.security.cert.X509Certificate
+
+/**
+ * Accepts any certificate.
+ */
+class AcceptAnyCertificateTrustManager extends X509TrustManager {
+
+  private val logger = org.slf4j.LoggerFactory.getLogger(this.getClass)
+
+  def getAcceptedIssuers: Array[X509Certificate] = {
+    new Array[X509Certificate](0)
+  }
+
+  def checkClientTrusted(certs: Array[X509Certificate], authType: String) {
+    logger.warn(s"checkClientTrusted: accepting certs ${certs.toSeq}")
+  }
+
+  def checkServerTrusted(certs: Array[X509Certificate], authType: String) {
+    logger.warn(s"checkServerTrusted: accepting certs ${certs.toSeq}")
+  }
+
+}

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingAsyncHttpClientConfigBuilderSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingAsyncHttpClientConfigBuilderSpec.scala
@@ -14,13 +14,13 @@ import play.api.libs.ws.ssl._
 import play.api.libs.ws.ssl.DefaultSSLConfig
 import play.api.libs.ws.DefaultWSClientConfig
 
-import javax.net.ssl.SSLContext
+import javax.net.ssl.{X509TrustManager, SSLContext}
 import com.ning.http.client.ProxyServerSelector
 import com.ning.http.util.{ProxyUtils, AllowAllHostnameVerifier}
 import play.api.libs.ws.ssl.DefaultHostnameVerifier
 import org.slf4j.LoggerFactory
 
-object NingAsyncHttpClientConfigBuilderSpec extends Specification with Mockito {
+class NingAsyncHttpClientConfigBuilderSpec extends Specification with Mockito {
 
   val defaultConfig = new DefaultWSClientConfig()
 
@@ -103,189 +103,244 @@ object NingAsyncHttpClientConfigBuilderSpec extends Specification with Mockito {
       // The ConfigSSLContextBuilder does most of the work here, but there are a couple of things outside of the
       // SSL context proper...
 
-      "with context" should {
+    "with context" should {
 
-        "use the configured trustmanager and keymanager if context not passed in" in {
-          // Stick a spy into the SSL config so we can verify that things get called on it that would
-          // only be called if it was using the config trust manager...
+      "use the configured trustmanager and keymanager if context not passed in" in {
+        // Stick a spy into the SSL config so we can verify that things get called on it that would
+        // only be called if it was using the config trust manager...
 
-          val sslConfig = spy(DefaultSSLConfig(default = Some(false)))
-          val config = defaultConfig.copy(ssl = Some(sslConfig))
-          val builder = new NingAsyncHttpClientConfigBuilder(config)
+        val sslConfig = spy(DefaultSSLConfig(default = Some(false)))
+        val config = defaultConfig.copy(ssl = Some(sslConfig))
+        val builder = new NingAsyncHttpClientConfigBuilder(config)
 
-          org.mockito.Mockito.doReturn(Some("TLS")).when(sslConfig).protocol
+        org.mockito.Mockito.doReturn(Some("TLS")).when(sslConfig).protocol
 
-          val asyncClientConfig = builder.build()
+        val asyncClientConfig = builder.build()
 
-          // Check that the spy got called...
-          org.mockito.Mockito.verify(sslConfig)
+        // Check that the spy got called...
+        org.mockito.Mockito.verify(sslConfig)
 
-          // ...and return a result so specs2 is happy.
-          asyncClientConfig.getSSLContext must not beNull
-        }
-
-        "use the default with a current certificate" in {
-          val tmc = DefaultTrustManagerConfig()
-          val config = defaultConfig.copy(ssl = Some(DefaultSSLConfig(default = Some(true), trustManagerConfig = Some(tmc))))
-          val builder = new NingAsyncHttpClientConfigBuilder(config)
-
-          val asyncClientConfig = builder.build()
-          val sslContext = asyncClientConfig.getSSLContext
-          sslContext must beEqualTo(SSLContext.getDefault)
-        }
-
-        "log a warning if sslConfig.default is passed in with an weak certificate" in {
-          import ch.qos.logback.classic.spi._
-          import ch.qos.logback.classic._
-
-          // Pass in a configuration which is guaranteed to fail, by banning RSA, DSA and EC certificates
-          val config = defaultConfig.copy(ssl = Some(DefaultSSLConfig(default = Some(true), disabledKeyAlgorithms = Some("RSA, DSA, EC"))))
-          val builder = new NingAsyncHttpClientConfigBuilder(config)
-          // this only works with test:test, has a different type in test:testQuick and test:testOnly!
-          val logger = builder.logger.asInstanceOf[ch.qos.logback.classic.Logger]
-          val appender = new ch.qos.logback.core.read.ListAppender[ILoggingEvent]()
-          val lc = LoggerFactory.getILoggerFactory().asInstanceOf[LoggerContext]
-          appender.setContext(lc)
-          appender.start()
-          logger.addAppender(appender)
-          logger.setLevel(Level.WARN)
-
-          builder.build()
-
-          val warnings = appender.list
-          warnings.size must beGreaterThan(0)
-        }
+        // ...and return a result so specs2 is happy.
+        asyncClientConfig.getSSLContext must not beNull
       }
 
-      "with hostname verifier" should {
-        "use the default hostname verifier" in {
-          val sslConfig = DefaultSSLConfig(hostnameVerifierClassName = None)
-          val config = defaultConfig.copy(ssl = Some(sslConfig))
-          val builder = new NingAsyncHttpClientConfigBuilder(config)
+      "use the default with a current certificate" in {
+        val tmc = DefaultTrustManagerConfig()
+        val config = defaultConfig.copy(ssl = Some(DefaultSSLConfig(default = Some(true), trustManagerConfig = Some(tmc))))
+        val builder = new NingAsyncHttpClientConfigBuilder(config)
 
-          val asyncConfig = builder.build()
-          asyncConfig.getHostnameVerifier must beAnInstanceOf[DefaultHostnameVerifier]
-        }
-
-        "use an explicit hostname verifier" in {
-          val sslConfig = DefaultSSLConfig(hostnameVerifierClassName = Some(classOf[DefaultHostnameVerifier].getName))
-          val config = defaultConfig.copy(ssl = Some(sslConfig))
-          val builder = new NingAsyncHttpClientConfigBuilder(config)
-
-          val asyncConfig = builder.build()
-          asyncConfig.getHostnameVerifier must beAnInstanceOf[DefaultHostnameVerifier]
-        }
-
-        "should disable the hostname verifier if loose.disableHostnameVerification is defined" in {
-          val sslConfig = DefaultSSLConfig(loose = Some(DefaultSSLLooseConfig(disableHostnameVerification = Some(true))))
-          val config = defaultConfig.copy(ssl = Some(sslConfig))
-          val builder = new NingAsyncHttpClientConfigBuilder(config)
-
-          val asyncConfig = builder.build()
-          asyncConfig.getHostnameVerifier must beAnInstanceOf[AllowAllHostnameVerifier]
-        }
+        val asyncClientConfig = builder.build()
+        val sslContext = asyncClientConfig.getSSLContext
+        sslContext must beEqualTo(SSLContext.getDefault)
       }
 
-      "with protocols" should {
+      "log a warning if sslConfig.default is passed in with an weak certificate" in {
+        import ch.qos.logback.classic.spi._
+        import ch.qos.logback.classic._
 
-        "provide recommended protocols if not specified" in {
-          val sslConfig = DefaultSSLConfig()
-          val config = defaultConfig.copy(ssl = Some(sslConfig))
+        // Pass in a configuration which is guaranteed to fail, by banning RSA, DSA and EC certificates
+        val config = defaultConfig.copy(ssl = Some(DefaultSSLConfig(default = Some(true), disabledKeyAlgorithms = Some("RSA, DSA, EC"))))
+        val builder = new NingAsyncHttpClientConfigBuilder(config)
+        // this only works with test:test, has a different type in test:testQuick and test:testOnly!
+        val logger = builder.logger.asInstanceOf[ch.qos.logback.classic.Logger]
+        val appender = new ch.qos.logback.core.read.ListAppender[ILoggingEvent]()
+        val lc = LoggerFactory.getILoggerFactory().asInstanceOf[LoggerContext]
+        appender.setContext(lc)
+        appender.start()
+        logger.addAppender(appender)
+        logger.setLevel(Level.WARN)
+
+        builder.build()
+
+        val warnings = appender.list
+        warnings.size must beGreaterThan(0)
+      }
+    }
+      "with acceptAnyCertificate" should {
+
+        "still use enabledCipherSuites" in {
+          val sslConfig = DefaultSSLConfig(enabledCipherSuites = Some(Seq("SSL_RSA_WITH_RC4_128_MD5")))
+          val config = defaultConfig.copy(acceptAnyCertificate = Some(true), ssl = Some(sslConfig))
           val builder = new NingAsyncHttpClientConfigBuilder(config)
-          val existingProtocols = Array("TLSv1.2", "TLSv1.1", "TLSv1")
 
-          val actual = builder.configureProtocols(existingProtocols, sslConfig)
+          val actual = builder.build()
+          val sslEngine = actual.getSSLEngineFactory.newSSLEngine()
+          val cipherSuites = sslEngine.getEnabledCipherSuites
 
-          actual.toSeq must containTheSameElementsAs(Protocols.recommendedProtocols)
+          cipherSuites must beEqualTo(Array("SSL_RSA_WITH_RC4_128_MD5"))
         }
 
-        "provide explicit protocols if specified" in {
-          val sslConfig = DefaultSSLConfig(enabledProtocols = Some(Seq("derp", "baz", "quux")))
-          val config = defaultConfig.copy(ssl = Some(sslConfig))
+        "still use enabledProtocols" in {
+          val sslConfig = DefaultSSLConfig(enabledProtocols = Some(Seq("TLSv1")))
+          val config = defaultConfig.copy(acceptAnyCertificate = Some(true), ssl = Some(sslConfig))
           val builder = new NingAsyncHttpClientConfigBuilder(config)
-          val existingProtocols = Array("quux", "derp", "baz")
 
-          val actual = builder.configureProtocols(existingProtocols, sslConfig)
+          val actual = builder.build()
+          val sslEngine = actual.getSSLEngineFactory.newSSLEngine()
+          val protocols = sslEngine.getEnabledProtocols
 
-          actual.toSeq must containTheSameElementsAs(Seq("derp", "baz", "quux"))
+          protocols must beEqualTo(Array("TLSv1"))
         }
 
-        "throw exception on deprecated protocols from explicit list" in {
-          val deprecatedProtocol = Protocols.deprecatedProtocols.head
-
-          // the enabled protocol list has a deprecated protocol in it.
-          val enabledProtocols = Array(deprecatedProtocol, "goodOne", "goodTwo")
-          val sslConfig = DefaultSSLConfig(enabledProtocols = Some(enabledProtocols))
-          val config = defaultConfig.copy(ssl = Some(sslConfig))
-
+        "use an allow all hostname verifier" in {
+          val config = defaultConfig.copy(acceptAnyCertificate = Some(true))
           val builder = new NingAsyncHttpClientConfigBuilder(config)
 
-          // The existing protocols is larger than the enabled list, and out of order.
-          val existingProtocols = Array("goodTwo", "badOne", "badTwo", deprecatedProtocol, "goodOne")
-
-          builder.configureProtocols(existingProtocols, sslConfig).must(throwAn[IllegalStateException])
+          val actual = builder.build()
+          val hostnameVerifier = actual.getHostnameVerifier
+          hostnameVerifier must beAnInstanceOf[AllowAllHostnameVerifier]
         }
 
-        "not throw exception on deprecated protocols from list if allowWeakProtocols is enabled" in {
-          val deprecatedProtocol = Protocols.deprecatedProtocols.head
-
-          // the enabled protocol list has a deprecated protocol in it.
-          val enabledProtocols = Array(deprecatedProtocol, "goodOne", "goodTwo")
-          val sslConfig = DefaultSSLConfig(enabledProtocols = Some(enabledProtocols), loose = Some(DefaultSSLLooseConfig(allowWeakProtocols = Some(true))))
-          val config = defaultConfig.copy(ssl = Some(sslConfig))
-
+        "use the loose trust manager" in {
+          val config = defaultConfig.copy(acceptAnyCertificate = Some(true))
           val builder = new NingAsyncHttpClientConfigBuilder(config)
 
-          // The existing protocols is larger than the enabled list, and out of order.
-          val existingProtocols = Array("goodTwo", "badOne", "badTwo", deprecatedProtocol, "goodOne")
+          val actual = builder.build()
 
-          val actual = builder.configureProtocols(existingProtocols, sslConfig)
+          // The trust manager is private to SSLContext, so let's just hack into it for the purposes of testing...
+          val sslContext = actual.getSSLContext
+          val sslContextClass = sslContext.getClass
+          val contextSpiField = sslContextClass.getDeclaredField("contextSpi")
+          contextSpiField.setAccessible(true)
+          val sslContextImpl = contextSpiField.get(sslContext)
 
-          // We should only have the list in order, including the deprecated protocol.
-          actual.toSeq must containTheSameElementsAs(Seq(deprecatedProtocol, "goodOne", "goodTwo"))
+          val trustManagerField = sslContextImpl.getClass.getDeclaredField("trustManager")
+          trustManagerField.setAccessible(true)
+          val trustManager = trustManagerField.get(sslContextImpl).asInstanceOf[X509TrustManager]
+
+          trustManager must beAnInstanceOf[AcceptAnyCertificateTrustManager]
         }
       }
+    }
 
-      "with ciphers" should {
+    "with hostname verifier" should {
+      "use the default hostname verifier" in {
+        val sslConfig = DefaultSSLConfig(hostnameVerifierClassName = None)
+        val config = defaultConfig.copy(ssl = Some(sslConfig))
+        val builder = new NingAsyncHttpClientConfigBuilder(config)
 
-        "provide explicit ciphers if specified" in {
-          val enabledCiphers = Seq("goodone", "goodtwo")
-          val sslConfig = DefaultSSLConfig(enabledCipherSuites = Some(enabledCiphers))
-          val config = defaultConfig.copy(ssl = Some(sslConfig))
-          val builder = new NingAsyncHttpClientConfigBuilder(config)
-          val existingCiphers = Array("goodone", "goodtwo", "goodthree")
-
-          val actual = builder.configureCipherSuites(existingCiphers, sslConfig)
-
-          actual.toSeq must containTheSameElementsAs(Seq("goodone", "goodtwo"))
-        }
-
-        "throw exception on deprecated ciphers from the explicit cipher list" in {
-          val enabledCiphers = Seq(Ciphers.deprecatedCiphers.head, "goodone", "goodtwo")
-
-          val sslConfig = DefaultSSLConfig(enabledCipherSuites = Some(enabledCiphers))
-          val config = defaultConfig.copy(ssl = Some(sslConfig))
-          val builder = new NingAsyncHttpClientConfigBuilder(config)
-          val existingCiphers = enabledCiphers.toArray
-
-          builder.configureCipherSuites(existingCiphers, sslConfig).must(throwAn[IllegalStateException])
-        }
-
-        "not throw exception on deprecated ciphers if allowWeakCiphers is enabled" in {
-          // User specifies list with deprecated ciphers...
-          val enabledCiphers = Seq("badone", "goodone", "goodtwo")
-
-          val sslConfig = DefaultSSLConfig(enabledCipherSuites = Some(enabledCiphers), loose = Some(DefaultSSLLooseConfig(allowWeakCiphers = Some(true))))
-          val config = defaultConfig.copy(ssl = Some(sslConfig))
-          val builder = new NingAsyncHttpClientConfigBuilder(config)
-          val existingCiphers = Array("badone", "goodone", "goodtwo")
-
-          val actual = builder.configureCipherSuites(existingCiphers, sslConfig)
-
-          actual.toSeq must containTheSameElementsAs(Seq("badone", "goodone", "goodtwo"))
-        }
-
+        val asyncConfig = builder.build()
+        asyncConfig.getHostnameVerifier must beAnInstanceOf[DefaultHostnameVerifier]
       }
+
+      "use an explicit hostname verifier" in {
+        val sslConfig = DefaultSSLConfig(hostnameVerifierClassName = Some(classOf[DefaultHostnameVerifier].getName))
+        val config = defaultConfig.copy(ssl = Some(sslConfig))
+        val builder = new NingAsyncHttpClientConfigBuilder(config)
+
+        val asyncConfig = builder.build()
+        asyncConfig.getHostnameVerifier must beAnInstanceOf[DefaultHostnameVerifier]
+      }
+
+      "should disable the hostname verifier if loose.disableHostnameVerification is defined" in {
+        val sslConfig = DefaultSSLConfig(loose = Some(DefaultSSLLooseConfig(disableHostnameVerification = Some(true))))
+        val config = defaultConfig.copy(ssl = Some(sslConfig))
+        val builder = new NingAsyncHttpClientConfigBuilder(config)
+
+        val asyncConfig = builder.build()
+        asyncConfig.getHostnameVerifier must beAnInstanceOf[AllowAllHostnameVerifier]
+      }
+    }
+
+    "with protocols" should {
+
+      "provide recommended protocols if not specified" in {
+        val sslConfig = DefaultSSLConfig()
+        val config = defaultConfig.copy(ssl = Some(sslConfig))
+        val builder = new NingAsyncHttpClientConfigBuilder(config)
+        val existingProtocols = Array("TLSv1.2", "TLSv1.1", "TLSv1")
+
+        val actual = builder.configureProtocols(existingProtocols, sslConfig)
+
+        actual.toSeq must containTheSameElementsAs(Protocols.recommendedProtocols)
+      }
+
+      "provide explicit protocols if specified" in {
+        val sslConfig = DefaultSSLConfig(enabledProtocols = Some(Seq("derp", "baz", "quux")))
+        val config = defaultConfig.copy(ssl = Some(sslConfig))
+        val builder = new NingAsyncHttpClientConfigBuilder(config)
+        val existingProtocols = Array("quux", "derp", "baz")
+
+        val actual = builder.configureProtocols(existingProtocols, sslConfig)
+
+        actual.toSeq must containTheSameElementsAs(Seq("derp", "baz", "quux"))
+      }
+
+      "throw exception on deprecated protocols from explicit list" in {
+        val deprecatedProtocol = Protocols.deprecatedProtocols.head
+
+        // the enabled protocol list has a deprecated protocol in it.
+        val enabledProtocols = Array(deprecatedProtocol, "goodOne", "goodTwo")
+        val sslConfig = DefaultSSLConfig(enabledProtocols = Some(enabledProtocols))
+        val config = defaultConfig.copy(ssl = Some(sslConfig))
+
+        val builder = new NingAsyncHttpClientConfigBuilder(config)
+
+        // The existing protocols is larger than the enabled list, and out of order.
+        val existingProtocols = Array("goodTwo", "badOne", "badTwo", deprecatedProtocol, "goodOne")
+
+        builder.configureProtocols(existingProtocols, sslConfig).must(throwAn[IllegalStateException])
+      }
+
+      "not throw exception on deprecated protocols from list if allowWeakProtocols is enabled" in {
+        val deprecatedProtocol = Protocols.deprecatedProtocols.head
+
+        // the enabled protocol list has a deprecated protocol in it.
+        val enabledProtocols = Array(deprecatedProtocol, "goodOne", "goodTwo")
+        val sslConfig = DefaultSSLConfig(enabledProtocols = Some(enabledProtocols), loose = Some(DefaultSSLLooseConfig(allowWeakProtocols = Some(true))))
+        val config = defaultConfig.copy(ssl = Some(sslConfig))
+
+        val builder = new NingAsyncHttpClientConfigBuilder(config)
+
+        // The existing protocols is larger than the enabled list, and out of order.
+        val existingProtocols = Array("goodTwo", "badOne", "badTwo", deprecatedProtocol, "goodOne")
+
+        val actual = builder.configureProtocols(existingProtocols, sslConfig)
+
+        // We should only have the list in order, including the deprecated protocol.
+        actual.toSeq must containTheSameElementsAs(Seq(deprecatedProtocol, "goodOne", "goodTwo"))
+      }
+    }
+
+    "with ciphers" should {
+
+      "provide explicit ciphers if specified" in {
+        val enabledCiphers = Seq("goodone", "goodtwo")
+        val sslConfig = DefaultSSLConfig(enabledCipherSuites = Some(enabledCiphers))
+        val config = defaultConfig.copy(ssl = Some(sslConfig))
+        val builder = new NingAsyncHttpClientConfigBuilder(config)
+        val existingCiphers = Array("goodone", "goodtwo", "goodthree")
+
+        val actual = builder.configureCipherSuites(existingCiphers, sslConfig)
+
+        actual.toSeq must containTheSameElementsAs(Seq("goodone", "goodtwo"))
+      }
+
+      "throw exception on deprecated ciphers from the explicit cipher list" in {
+        val enabledCiphers = Seq(Ciphers.deprecatedCiphers.head, "goodone", "goodtwo")
+
+        val sslConfig = DefaultSSLConfig(enabledCipherSuites = Some(enabledCiphers))
+        val config = defaultConfig.copy(ssl = Some(sslConfig))
+        val builder = new NingAsyncHttpClientConfigBuilder(config)
+        val existingCiphers = enabledCiphers.toArray
+
+        builder.configureCipherSuites(existingCiphers, sslConfig).must(throwAn[IllegalStateException])
+      }
+
+      "not throw exception on deprecated ciphers if allowWeakCiphers is enabled" in {
+        // User specifies list with deprecated ciphers...
+        val enabledCiphers = Seq("badone", "goodone", "goodtwo")
+
+        val sslConfig = DefaultSSLConfig(enabledCipherSuites = Some(enabledCiphers), loose = Some(DefaultSSLLooseConfig(allowWeakCiphers = Some(true))))
+        val config = defaultConfig.copy(ssl = Some(sslConfig))
+        val builder = new NingAsyncHttpClientConfigBuilder(config)
+        val existingCiphers = Array("badone", "goodone", "goodtwo")
+
+        val actual = builder.configureCipherSuites(existingCiphers, sslConfig)
+
+        actual.toSeq must containTheSameElementsAs(Seq("badone", "goodone", "goodtwo"))
+      }
+
     }
   }
 }


### PR DESCRIPTION
ws.acceptAnyCertificate, when set, would ignore ALL SSL configuration, relying on the underlying asynchttpclient bug that uses an allow all trust manager by default.  This PR unifies the code path so that using acceptAnyCertificate still allows for enabledProtocols or enabledCipherSuite settings to be honored, and adds tests to verify the behavior.
