### PR TITLE
Move HeadAction out of play.api.controllers

### DIFF
--- a/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
+++ b/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
@@ -7,8 +7,8 @@ import play.api.mvc._
 import java.io.File
 import scala.util.control.NonFatal
 import scala.concurrent.Future
-import play.api.controllers.HeadAction
 import play.api.http.HttpVerbs
+import play.core.actions.HeadAction
 
 /**
  * Defines an application’s global settings.

--- a/framework/src/play/src/main/scala/play/core/actions/HeadAction.scala
+++ b/framework/src/play/src/main/scala/play/core/actions/HeadAction.scala
@@ -2,7 +2,7 @@
  * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
  */
 
-package play.api.controllers
+package play.core.actions
 
 import play.api.mvc._
 import play.api.libs.iteratee._


### PR DESCRIPTION
The new `HeadAction` is in a new `play.api.controllers` package.  The problem with this, is it cause the following code, that did compile in Play 2.2.x, to not compile:

``` scala
import play.api._
import controllers.foo.Bar
```

`HeadAction` is actually an internal API anyway, so it should be moved to something like `play.core.actions`.
