### PR TITLE
Problem with arabic Internationalization

### DIFF
--- a/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -16,6 +16,7 @@ import java.sql.{ Statement, Date, Connection, SQLException }
 import scala.util.control.Exception._
 import scala.util.control.NonFatal
 import play.utils.PlayIO
+import scala.io.Codec
 
 /**
  * An SQL evolution - database changes associated with a software version.
@@ -425,7 +426,7 @@ object Evolutions {
       Option(new File(path, evolutionsFilename(db, revision))).filter(_.exists).map(new FileInputStream(_)).orElse {
         Option(applicationClassloader.getResourceAsStream(evolutionsResourceName(db, revision)))
       }.map { stream =>
-        (revision + 1, (revision, PlayIO.readStreamAsString(stream)))
+        (revision + 1, (revision, PlayIO.readStreamAsString(stream)(Codec.UTF8)))
       }
     }.sortBy(_._1).map {
       case (revision, script) => {

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -13,6 +13,7 @@ import scala.util.parsing.combinator._
 import scala.util.control.NonFatal
 import java.net.URL
 import play.api.i18n.Messages.UrlMessageSource
+import scala.io.Codec
 
 /**
  * A Lang supported by the application.
@@ -210,7 +211,7 @@ object Messages {
   }
 
   case class UrlMessageSource(url: URL) extends MessageSource {
-    def read = PlayIO.readUrlAsString(url)
+    def read = PlayIO.readUrlAsString(url)(Codec.UTF8)
   }
 
   private def noMatch(key: String, args: Seq[Any]) = key
@@ -367,7 +368,7 @@ class DefaultMessagesPlugin(app: Application) extends MessagesPlugin {
    * defaultmessagesplugin=disabled
    * }}}
    */
-  override def enabled = pluginEnabled.filter(_ == "disabled").isEmpty
+  override def enabled = pluginEnabled.forall(_ != "disabled")
 
   /**
    * The underlying internationalisation API.

--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -112,7 +112,7 @@ object Files {
    * @return the file contents
    */
   @deprecated("Use Java 7 Files API instead", "2.3")
-  def readFile(path: File): String = PlayIO.readFileAsString(path)
+  def readFile(path: File): String = PlayIO.readFileAsString(path)(Codec.UTF8)
 
   /**
    * Write a file’s contents as a `String`.
@@ -125,7 +125,7 @@ object Files {
     path.getParentFile.mkdirs()
     val out = new FileOutputStream(path)
     try {
-      val writer = new OutputStreamWriter(out, implicitly[Codec].name)
+      val writer = new OutputStreamWriter(out, Codec.UTF8.name)
       try {
         writer.write(content)
       } finally PlayIO.closeQuietly(writer)


### PR DESCRIPTION
After upgrading to playframework 2.3.0-RC1 I received the error with Arabic translation:
Project with error: https://github.com/ajozwik/play-scala-preview

Stack trace:

```
play.api.i18n.Messages$MessagesParser$$anon$1: Configuration error[End of line expected]
    at play.api.i18n.Messages$MessagesParser.parse(Messages.scala:275) ~[play_2.11-2.3.0-RC1.jar:2.3.0-RC1]
    at play.api.i18n.Messages$.messages(Messages.scala:197) ~[play_2.11-2.3.0-RC1.jar:2.3.0-RC1]
    at play.api.i18n.DefaultMessagesPlugin$$anonfun$loadMessages$2.apply(Messages.scala:351) ~[play_2.11-2.3.0-RC1.jar:2.3.0-RC1]
    at play.api.i18n.DefaultMessagesPlugin$$anonfun$loadMessages$2.apply(Messages.scala:350) ~[play_2.11-2.3.0-RC1.jar:2.3.0-RC1]
    at scala.collection.immutable.List.map(List.scala:274) ~[scala-library-2.11.0.jar:na]
```

messages.ar:

```
duration.durationInSecondsFormat={0} ثانية
event.descriptionColumn=وصف
event.duration=المدة
event.chargedAmount=القيمة المحتسبة
event.to=إلى
event.allEvents=جميع الأنشطة
```
