### PR TITLE
toSimpleMap supports returning a value by case insensitive

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -340,9 +340,7 @@ package play.api.mvc {
     /**
      * Retrieve all header values associated with the given key.
      */
-    def getAll(key: String): Seq[String] = {
-      data.find({ case (k, v) => k.equalsIgnoreCase(key) }).map(_._2).getOrElse(Nil)
-    }
+    def getAll(key: String): Seq[String] = toMap.get(key).getOrElse(Nil)
 
     /**
      * Retrieve all header keys
@@ -370,10 +368,7 @@ package play.api.mvc {
     /**
      * Transform the Headers to a Map by ignoring multiple values.
      */
-    def toSimpleMap: Map[String, String] = {
-      val simpleSeq = data.map({ case (k, v) => (k, v.headOption.getOrElse("")) })
-      Map.empty ++ simpleSeq
-    }
+    lazy val toSimpleMap: Map[String, String] = toMap.mapValues(_.headOption.getOrElse(""))
 
     override def toString = data.toString
 

--- a/framework/src/play/src/test/scala/play/api/mvc/HttpSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/HttpSpec.scala
@@ -37,6 +37,16 @@ class HttpSpec extends Specification {
 
       headers.toSimpleMap must be_==(Map("a" -> "a1", "b" -> "b1"))
     }
+
+    "return the value from a map by case insensitive" in {
+      headers.toMap.get("A") must be_==(Some(Seq("a1", "a2")))
+      headers.toMap.get("b") must be_==(Some(Seq("b1", "b2")))
+    }
+
+    "return the value from a simple map by case insensitive" in {
+      headers.toSimpleMap.get("A") must be_==(Some("a1"))
+      headers.toSimpleMap.get("b") must be_==(Some("b1"))
+    }
   }
 
   "RequestHeader" should {


### PR DESCRIPTION
`Headers#toMap` supports returning values by case insensitive.
However, `Headers#toSimpleMap` doesn't support it.

This PR resolves the problem.

Related issue: #2398
