### PR TITLE
Redirect from reverse router should allow you to set status as well

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -738,7 +738,8 @@ trait Results {
    * Generates a redirect simple result.
    *
    * @param call Call defining the URL to redirect to, which typically comes from the reverse router
+   * @param status HTTP status
    */
-  def Redirect(call: Call): Result = Redirect(call.url)
+  def Redirect(call: Call, status: Int = SEE_OTHER): Result = Redirect(call.url, Map.empty, status)
 
 }


### PR DESCRIPTION
Seems strange that you can't set the Redirect status from a Redirect on a reverse router.
