### PR TITLE
Don't touch SecureRandom!

### DIFF
--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/Config.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/Config.scala
@@ -260,14 +260,6 @@ class DefaultSSLConfigParser(c: Configuration) {
         parseTrustManager(trustStoreConfig)
     }
 
-    val secureRandom = new SecureRandom()
-    // SecureRandom needs to be seeded, and calling nextInt immediately after being
-    // called ensures a seed.  We do it here rather than waiting for JSSE because
-    // seeding can chew through entropy and occasionally block the thread until
-    // it's finished, if on something too dumb to use /dev/urandom.
-    // Better to do it using parsing rather than in the middle of an HTTPS call.
-    secureRandom.nextInt()
-
     DefaultSSLConfig(
       default = default,
       protocol = protocol,
@@ -280,7 +272,7 @@ class DefaultSSLConfigParser(c: Configuration) {
       disabledSignatureAlgorithms = disabledSignatureAlgorithms,
       disabledKeyAlgorithms = disabledKeyAlgorithms,
       trustManagerConfig = trustManagers,
-      secureRandom = Some(secureRandom),
+      secureRandom = None,
       debug = debug,
       loose = looseOptions)
   }

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/DefaultSSLConfigParserSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/DefaultSSLConfigParserSpec.scala
@@ -43,7 +43,7 @@ object DefaultSSLConfigParserSpec extends Specification {
       actual.enabledProtocols must beSome.which(_ must containTheSameElementsAs(Seq("TLSv1.2", "TLSv1.1", "TLS")))
       actual.disabledSignatureAlgorithms must beSome.which(_ must beEqualTo("md2, md4, md5"))
       actual.disabledKeyAlgorithms must beSome.which(_ must beEqualTo("RSA keySize < 1024"))
-      actual.secureRandom must beSome
+      actual.secureRandom must beNone
     }
 
     "parse ws.ssl.loose section" in {


### PR DESCRIPTION
Take out the code that tries to seed SecureRandom.  JDK 1.8 will use a non-blocking source of data, and there's a fair amount of complexity which can result in SecureRandom not being seeded correctly.  Because of the risk of insecure initialiation and the overall code complexity, it's safer to take this out entirely and let JSSE deal with it.

Original motivation: http://docs.oracle.com/cd/E13209_01/wlcp/wlss30/configwlss/jvmrand.html

Configurable Secure Random-Number Generation in JDK 1.8: http://openjdk.java.net/jeps/123
Using SecureRandom: http://moi.vonos.net/java/securerandom/
Mailing list comment on SecureRandom internals: http://mail.openjdk.java.net/pipermail/security-dev/2013-April/007151.html
Bug resulting from someone being clever and setting the seed: http://lists.owasp.org/pipermail/esapi-user/2014-April/001151.html
A huge bug report discussion from JRuby: https://github.com/jruby/jruby/issues/1405
Issues when using java SecureRandom: http://www.cigital.com/justice-league-blog/2014/01/06/issues-when-using-java-securerandom/

Ideally, if we must handle a PRG directly, call SecureRandom.getInstanceStrong() and call sr.nextBytes() to seed, or pull from /dev/urandom directly, but the best thing to do now is to not touch it.
