### PR TITLE
java.io.FileNotFoundException: at play.utils.Resources$.isJarResourceDirectory(Resources.scala:26)

### DIFF
--- a/framework/src/play/src/main/scala/play/utils/Resources.scala
+++ b/framework/src/play/src/main/scala/play/utils/Resources.scala
@@ -3,7 +3,7 @@
  */
 package play.utils
 
-import java.net.URL
+import java.net.{ URI, URL }
 import java.io.File
 import java.util.zip.ZipFile
 
@@ -13,17 +13,18 @@ import java.util.zip.ZipFile
 object Resources {
 
   def isDirectory(url: URL) = url.getProtocol match {
-    case "file" => new File(url.getFile).isDirectory
+    case "file" => new File(url.toURI).isDirectory
     case "jar" => isJarResourceDirectory(url)
     case _ => throw new IllegalArgumentException(s"Cannot check isDirectory for a URL with protocol='${url.getProtocol}'")
   }
 
   private def isJarResourceDirectory(url: URL): Boolean = {
-    val startIndex = if (url.getFile.startsWith("file:")) 5 else 0
+    val path = url.getPath
     val bangIndex = url.getFile.indexOf("!")
-    val jarFilePath = url.getFile.substring(startIndex, bangIndex)
-    val resourcePath = url.getFile.substring(bangIndex + 2)
-    val zip = new ZipFile(jarFilePath)
+
+    val jarFile: File = new File(URI.create(path.substring(0, bangIndex)))
+    val resourcePath = URI.create(path.substring(bangIndex + 1)).getPath.drop(1)
+    val zip = new ZipFile(jarFile)
 
     try {
       val entry = zip.getEntry(resourcePath)


### PR DESCRIPTION
using play 2.3.0-RC1
on windows if a directory contains space
sbt  stage && cd target/universal/stage/lib && java -cp \* play.core.server.NettyServer

```
Oops, cannot start the server.
java.io.FileNotFoundException: D:\Documents%20and%20Settings\OlegYch\My%20Documents\Projects\target\univer\stage\lib\cms.cms-2.2.0-SNAPSHOT.jar (The system cannot find the path specified)
        at java.util.zip.ZipFile.open(Native Method)
        at java.util.zip.ZipFile.<init>(ZipFile.java:215)
        at java.util.zip.ZipFile.<init>(ZipFile.java:145)
        at java.util.zip.ZipFile.<init>(ZipFile.java:116)
        at play.utils.Resources$.isJarResourceDirectory(Resources.scala:26)
        at play.utils.Resources$.isDirectory(Resources.scala:17)
        at play.api.i18n.DefaultMessagesPlugin$$anonfun$loadMessages$1.apply(Messages.scala:350)
        at play.api.i18n.DefaultMessagesPlugin$$anonfun$loadMessages$1.apply(Messages.scala:350)
        at scala.collection.TraversableLike$$anonfun$filterNot$1.apply(TraversableLike.scala:274)
        at scala.collection.TraversableLike$$anonfun$filterNot$1.apply(TraversableLike.scala:274)
        at scala.collection.TraversableLike$$anonfun$filter$1.apply(TraversableLike.scala:264)
        at scala.collection.immutable.List.foreach(List.scala:318)
        at scala.collection.TraversableLike$class.filter(TraversableLike.scala:263)
        at scala.collection.AbstractTraversable.filter(Traversable.scala:105)
        at scala.collection.TraversableLike$class.filterNot(TraversableLike.scala:274)
        at scala.collection.AbstractTraversable.filterNot(Traversable.scala:105)
        at play.api.i18n.DefaultMessagesPlugin.loadMessages(Messages.scala:350)
        at play.api.i18n.DefaultMessagesPlugin.messages(Messages.scala:359)
        at play.api.i18n.DefaultMessagesPlugin.api$lzycompute(Messages.scala:375)
        at play.api.i18n.DefaultMessagesPlugin.api(Messages.scala:375)
        at play.api.i18n.DefaultMessagesPlugin.onStart(Messages.scala:380)
        at play.api.Play$$anonfun$start$1$$anonfun$apply$mcV$sp$1.apply(Play.scala:91)
        at play.api.Play$$anonfun$start$1$$anonfun$apply$mcV$sp$1.apply(Play.scala:91)
        at scala.collection.immutable.List.foreach(List.scala:318)
        at play.api.Play$$anonfun$start$1.apply$mcV$sp(Play.scala:91)
        at play.api.Play$$anonfun$start$1.apply(Play.scala:91)
        at play.api.Play$$anonfun$start$1.apply(Play.scala:91)
        at play.utils.Threads$.withContextClassLoader(Threads.scala:21)
        at play.api.Play$.start(Play.scala:90)
        at play.core.StaticApplication.<init>(ApplicationProvider.scala:55)
        at play.core.server.NettyServer$.createServer(NettyServer.scala:207)
        at play.core.server.NettyServer$$anonfun$main$3.apply(NettyServer.scala:243)
        at play.core.server.NettyServer$$anonfun$main$3.apply(NettyServer.scala:238)
        at scala.Option.map(Option.scala:145)
        at play.core.server.NettyServer$.main(NettyServer.scala:238)
        at play.core.server.NettyServer.main(NettyServer.scala)
```
