### PR TITLE
Downgrade commons-io dependency so that it's compatible with sbt-idea

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -116,7 +116,7 @@ object Dependencies {
     "org.javassist" % "javassist" % "3.18.1-GA")
 
   val routersCompilerDependencies =  Seq(
-    "commons-io" % "commons-io" % "2.4"
+    "commons-io" % "commons-io" % "2.0.1"
   ) ++ specsSbt.map(_ % "test")
 
   private def sbtPluginDep(moduleId: ModuleID) = {

--- a/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
@@ -256,7 +256,7 @@ object RoutesCompiler {
 
   case class GeneratedSource(file: File) {
 
-    val lines = if (file.exists) FileUtils.readFileToString(file, implicitly[Codec].charSet).split('\n').toList else Nil
+    val lines = if (file.exists) FileUtils.readFileToString(file, implicitly[Codec].name).split('\n').toList else Nil
     val source = lines.find(_.startsWith("// @SOURCE:")).map(m => new File(m.trim.drop(11)))
 
     def isGenerated: Boolean = source.isDefined
@@ -303,7 +303,6 @@ object RoutesCompiler {
 
       val parser = new RouteFileParser
       val routeFile = file.getAbsoluteFile
-      val charSet = implicitly[Codec].charSet
       val routesContent = FileUtils.readFileToString(routeFile)
 
       (parser.parse(routesContent) match {
@@ -312,7 +311,7 @@ object RoutesCompiler {
           throw RoutesCompilationError(file, message, Some(in.pos.line), Some(in.pos.column))
         }
       }).foreach { item =>
-        FileUtils.writeStringToFile(new File(generatedDir, item._1), item._2, charSet)
+        FileUtils.writeStringToFile(new File(generatedDir, item._1), item._2, implicitly[Codec].name)
       }
 
     }


### PR DESCRIPTION
Fixes #2882.

When sbt-idea is a global plugin it brings in an old version of commons-io. This change downgrades Play's version to match sbt-idea's version so that Play's sbt-plugin and sbt-idea can run in the same classloader as each other.
