### PR TITLE
Reduce size of PlayIO API (2.3 backport)

### DIFF
--- a/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -426,11 +426,7 @@ object Evolutions {
       Option(new File(path, evolutionsFilename(db, revision))).filter(_.exists).map(new FileInputStream(_)).orElse {
         Option(applicationClassloader.getResourceAsStream(evolutionsResourceName(db, revision)))
       }.map { stream =>
-        try {
-          (revision + 1, (revision, PlayIO.readStreamAsString(stream)(Codec.UTF8)))
-        } finally {
-          PlayIO.closeQuietly(stream)
-        }
+        (revision + 1, (revision, PlayIO.readStreamAsString(stream)(Codec.UTF8)))
       }
     }.sortBy(_._1).map {
       case (revision, script) => {


### PR DESCRIPTION
Backported from master to 2.3.x. Some changes from original commit because its ordering with "Ensure UTF-8 is used for reading/writing files" was is reversed in 2.3.x compared with master.
- Inline some methods into the Files API
- Always close when reading a stream
- Didn't use scala.io.Source because it doesn't really support reading
  binary data and because it looks slow, which wouldn't be great for some
  use cases, e.g. reading assets or when a user uses Files.readFile.
