### PR TITLE
Upgrade to ebean 3.3.3

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
     "tyrex" % "tyrex" % "1.0.1") ++ specsBuild.map(_ % "test")
 
   val ebeanDeps = Seq(
-    "org.avaje.ebeanorm" % "avaje-ebeanorm" % "3.2.5" exclude ("javax.persistence", "persistence-api"),
+    "org.avaje.ebeanorm" % "avaje-ebeanorm" % "3.3.4" exclude ("javax.persistence", "persistence-api"),
     "org.avaje.ebeanorm" % "avaje-ebeanorm-agent" % "3.2.2" exclude ("javax.persistence", "persistence-api")
   )
 
@@ -138,7 +138,7 @@ object Dependencies {
 
     guava,
 
-    "org.avaje.ebeanorm" % "avaje-ebeanorm-agent" % "3.2.1" exclude ("javax.persistence", "persistence-api"),
+    "org.avaje.ebeanorm" % "avaje-ebeanorm-agent" % "3.2.2" exclude ("javax.persistence", "persistence-api"),
 
     h2database,
     "org.javassist" % "javassist" % "3.18.1-GA",

--- a/framework/src/play-java-ebean/src/main/java/play/db/ebean/Model.java
+++ b/framework/src/play-java-ebean/src/main/java/play/db/ebean/Model.java
@@ -462,10 +462,6 @@ public class Model {
             return query().getRawSql();
         }
 
-        public UseIndex getUseIndex() {
-            return query().getUseIndex();
-        }
-
         /**
          * Returns the query's <code>having</code> clause.
          */
@@ -680,10 +676,6 @@ public class Model {
         public Query<T> setUseQueryCache(boolean useQueryCache) {
             return query().setUseQueryCache(useQueryCache);
         }
-        
-        public Query<T> setUseIndex(UseIndex useIndex) {
-            return query().setUseIndex(useIndex);
-        }
 
         /**
          * Adds expressions to the <code>where</code> clause with the ability to chain on the <code>ExpressionList</code>.
@@ -704,14 +696,6 @@ public class Model {
          */
         public Query<T> where(String addToWhereClause) {
             return query().where(addToWhereClause);
-        }
-
-        /**
-         * Return the total hits matched for a lucene text search query.
-         */
-        @Override
-        public int getTotalHits() {
-            return query().getTotalHits();
         }
 
         /**


### PR DESCRIPTION
The upgrade from ebean 3.2.x to 3.3.x is binary incompatible, so we should do it before the 2.3.x release.

Backport to 2.3.x required.
