### PR TITLE
Added formatLineBreaks helper function

### DIFF
--- a/framework/src/play/src/main/scala/views/html/helper/package.scala
+++ b/framework/src/play/src/main/scala/views/html/helper/package.scala
@@ -3,6 +3,8 @@
  */
 package views.html
 
+import play.twirl.api.{ HtmlFormat, Html }
+
 /**
  * Contains template helpers, for example for generating HTML forms.
  */
@@ -28,4 +30,10 @@ package object helper {
   def urlEncode(string: String)(implicit codec: play.api.mvc.Codec): String =
     java.net.URLEncoder.encode(string, codec.charset)
 
+  /**
+   * @return The text with line-break html tags instead of carriage returns
+   */
+  def formatLineBreaks(text: String): Html = {
+    Html(text.lines.map(HtmlFormat.escape).mkString("<br/>"))
+  }
 }

--- a/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -161,5 +161,11 @@ object HelpersSpec extends Specification {
 
       body must contain("""label for="bar_0">bar.0""")
     }
+
+    "format line breaks" in {
+      import play.twirl.api.HtmlFormat
+      formatLineBreaks("foo").toString mustEqual ("foo")
+      formatLineBreaks("foo\nbar").toString mustEqual "foo<br/>bar"
+    }
   }
 }


### PR DESCRIPTION
Replaces carriage returns by HTML line break tags. Typical usage: displaying content from a textarea input.
