### PR TITLE
DBPlugin deregisters all SQL Drivers from DriverManager

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -230,7 +230,7 @@ object PlayBuild extends Build {
 
   lazy val PlayJdbcProject = PlayRuntimeProject("Play-JDBC", "play-jdbc")
     .settings(libraryDependencies ++= jdbcDeps)
-    .dependsOn(PlayProject)
+    .dependsOn(PlayProject).dependsOn(PlayTestProject % "test")
 
   lazy val PlayJavaJdbcProject = PlayRuntimeProject("Play-Java-JDBC", "play-java-jdbc")
     .dependsOn(PlayJdbcProject, PlayJavaProject)

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -23,9 +23,8 @@ object Dependencies {
 
   val jdbcDeps = Seq(
     "com.jolbox" % "bonecp" % "0.8.0.RELEASE",
-
-    h2database,
-
+    h2database, 
+    "org.eu.acolyte" % "jdbc-driver" % "1.0.18" % "test",
     "tyrex" % "tyrex" % "1.0.1") ++ specsBuild.map(_ % "test")
 
   val ebeanDeps = Seq(

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
@@ -170,9 +170,8 @@ object DB {
    * @param name The datasource name.
    * @param block Code block to execute.
    */
-  def withTransaction[A](name: String = "default")(block: Connection => A)(implicit app: Application): A = {
+  def withTransaction[A](name: String = "default")(block: Connection => A)(implicit app: Application): A =
     app.plugin[DBPlugin].map(_.api.withTransaction(name)(block)).getOrElse(error)
-  }
 
   /**
    * Execute a block of code, in the scope of a JDBC transaction.
@@ -181,9 +180,8 @@ object DB {
    *
    * @param block Code block to execute.
    */
-  def withTransaction[A](block: Connection => A)(implicit app: Application): A = {
+  def withTransaction[A](block: Connection => A)(implicit app: Application): A =
     app.plugin[DBPlugin].map(_.api.withTransaction("default")(block)).getOrElse(error)
-  }
 
 }
 
@@ -195,13 +193,13 @@ trait DBPlugin extends Plugin {
 }
 
 /**
- * A DBPlugin implementation that provides a DBApi
+ * BoneCP implementation of DBPlugin that provides a DBApi.
  *
  * @param app the application that is registering the plugin
  */
 class BoneCPPlugin(app: Application) extends DBPlugin {
-
-  lazy val dbConfig = app.configuration.getConfig("db").getOrElse(Configuration.empty)
+  lazy val dbConfig = app.configuration.getConfig("db").
+    getOrElse(Configuration.empty)
 
   private def dbURL(conn: Connection): String = {
     val u = conn.getMetaData.getURL
@@ -210,14 +208,13 @@ class BoneCPPlugin(app: Application) extends DBPlugin {
   }
 
   // should be accessed in onStart first
-  private lazy val dbApi: DBApi = new BoneCPApi(dbConfig, app.classloader)
+  private lazy val dbApi = new BoneCPApi(dbConfig, app.classloader)
 
   /**
    * plugin is disabled if either configuration is missing or the plugin is explicitly disabled
    */
-  private lazy val isDisabled = {
-    app.configuration.getString("dbplugin").filter(_ == "disabled").isDefined || dbConfig.subKeys.isEmpty
-  }
+  private lazy val isDisabled = app.configuration.getString("dbplugin").
+    exists(_ == "disabled") || dbConfig.subKeys.isEmpty
 
   /**
    * Is this plugin enabled.
@@ -238,16 +235,17 @@ class BoneCPPlugin(app: Application) extends DBPlugin {
    */
   override def onStart() {
     // Try to connect to each, this should be the first access to dbApi
-    dbApi.datasources.map { ds =>
+    dbApi.datasources map { ds =>
       try {
         ds._1.getConnection.close()
         app.mode match {
           case Mode.Test =>
-          case mode => Play.logger.info("database [" + ds._2 + "] connected at " + dbURL(ds._1.getConnection))
+          case mode => Play.logger.info(s"database [${ds._2}] connected at ${dbURL(ds._1.getConnection)}")
         }
       } catch {
         case NonFatal(e) => {
-          throw dbConfig.reportError(ds._2 + ".url", "Cannot connect to database [" + ds._2 + "]", Some(e.getCause))
+          throw dbConfig.reportError(s"${ds._2}.url",
+            s"Cannot connect to database [${ds._2}]", Some(e.getCause))
         }
       }
     }
@@ -257,46 +255,49 @@ class BoneCPPlugin(app: Application) extends DBPlugin {
    * Closes all data sources.
    */
   override def onStop() {
-    dbApi.datasources.foreach {
+    dbApi.datasources foreach {
       case (ds, _) => try {
         dbApi.shutdownPool(ds)
       } catch { case NonFatal(_) => }
     }
-    val drivers = DriverManager.getDrivers
-    while (drivers.hasMoreElements) {
-      val driver = drivers.nextElement
-      DriverManager.deregisterDriver(driver)
-    }
+    dbApi.deregisterAll()
   }
-
 }
 
-private[db] class BoneCPApi(configuration: Configuration, classloader: ClassLoader) extends DBApi {
+private[db] class BoneCPApi(
+    configuration: Configuration, classloader: ClassLoader) extends DBApi {
 
-  private def error(db: String, message: String = "") = throw configuration.reportError(db, message)
+  private def error(db: String, message: String = "") =
+    throw configuration.reportError(db, message)
 
-  private val dbNames: Set[String] = configuration.subKeys
-
-  private def register(driver: String, c: Configuration) {
+  /**
+   * @param d Driver class name
+   * @param c DB configuration
+   */
+  private def register(d: String, c: Configuration): Driver = {
     try {
-      DriverManager.registerDriver(new play.utils.ProxyDriver(Class.forName(driver, true, classloader).newInstance.asInstanceOf[Driver]))
+      val driver = new play.utils.ProxyDriver(
+        Class.forName(d, true, classloader).newInstance.asInstanceOf[Driver])
+
+      DriverManager.registerDriver(driver)
+      driver
     } catch {
-      case NonFatal(e) => throw c.reportError("driver", "Driver not found: [" + driver + "]", Some(e))
+      case NonFatal(e) => throw c.reportError("driver",
+        s"Driver not found: [$d]", Some(e))
     }
   }
 
-  private def createDataSource(dbName: String, url: String, driver: String, conf: Configuration): DataSource = {
+  /** De-register all drivers this API has previously registered. */
+  def deregisterAll(): Unit = drivers.foreach(DriverManager.deregisterDriver)
+
+  private def createDataSource(dbName: String, conf: Configuration): (DataSource, Driver) = {
 
     val datasource = new BoneCPDataSource
 
     // Try to load the driver
-    conf.getString("driver").map { driver =>
-      try {
-        DriverManager.registerDriver(new play.utils.ProxyDriver(Class.forName(driver, true, classloader).newInstance.asInstanceOf[Driver]))
-      } catch {
-        case NonFatal(e) => throw conf.reportError("driver", "Driver not found: [" + driver + "]", Some(e))
-      }
-    }
+    val d = configuration.getString(s"$dbName.driver").getOrElse(error(dbName, s"Missing configuration [db.$dbName.driver]"))
+
+    val driver = register(d, conf)
 
     val autocommit = conf.getBoolean("autocommit").getOrElse(true)
     val isolation = conf.getString("isolation").map {
@@ -305,7 +306,8 @@ private[db] class BoneCPApi(configuration: Configuration, classloader: ClassLoad
       case "READ_UNCOMMITTED" => Connection.TRANSACTION_READ_UNCOMMITTED
       case "REPEATABLE_READ" => Connection.TRANSACTION_REPEATABLE_READ
       case "SERIALIZABLE" => Connection.TRANSACTION_SERIALIZABLE
-      case unknown => throw conf.reportError("isolation", "Unknown isolation level [" + unknown + "]")
+      case unknown => throw conf.reportError("isolation",
+        s"Unknown isolation level [$unknown]")
     }
     val catalog = conf.getString("defaultCatalog")
     val readOnly = conf.getBoolean("readOnly").getOrElse(false)
@@ -319,7 +321,7 @@ private[db] class BoneCPApi(configuration: Configuration, classloader: ClassLoad
 
       override def onCheckIn(connection: ConnectionHandle) {
         if (logger.isTraceEnabled) {
-          logger.trace("Check in connection %s [%s leased]".format(connection.toString, datasource.getTotalLeased))
+          logger.trace(s"Check in connection $connection [${datasource.getTotalLeased} leased]")
         }
       }
 
@@ -329,7 +331,7 @@ private[db] class BoneCPApi(configuration: Configuration, classloader: ClassLoad
         connection.setReadOnly(readOnly)
         catalog.map(connection.setCatalog)
         if (logger.isTraceEnabled) {
-          logger.trace("Check out connection %s [%s leased]".format(connection.toString, datasource.getTotalLeased))
+          logger.trace(s"Check out connection $connection [${datasource.getTotalLeased} leased]")
         }
       }
 
@@ -348,25 +350,25 @@ private[db] class BoneCPApi(configuration: Configuration, classloader: ClassLoad
 
     conf.getString("url") match {
       case Some(PostgresFullUrl(username, password, host, dbname)) =>
-        datasource.setJdbcUrl("jdbc:postgresql://%s/%s".format(host, dbname))
+        datasource.setJdbcUrl(s"jdbc:postgresql://$host/$dbname")
         datasource.setUsername(username)
         datasource.setPassword(password)
+
       case Some(url @ MysqlFullUrl(username, password, host, dbname)) =>
-        val defaultProperties = """?useUnicode=yes&characterEncoding=UTF-8&connectionCollation=utf8_general_ci"""
+        val defaultProperties = "?useUnicode=yes&characterEncoding=UTF-8&connectionCollation=utf8_general_ci"
         val addDefaultPropertiesIfNeeded = MysqlCustomProperties.findFirstMatchIn(url).map(_ => "").getOrElse(defaultProperties)
-        datasource.setJdbcUrl("jdbc:mysql://%s/%s".format(host, dbname + addDefaultPropertiesIfNeeded))
+        datasource.setJdbcUrl(s"jdbc:mysql://$host/${dbname + addDefaultPropertiesIfNeeded}")
         datasource.setUsername(username)
         datasource.setPassword(password)
+
       case Some(url @ H2DefaultUrl()) if !url.contains("DB_CLOSE_DELAY") =>
         if (Play.maybeApplication.exists(_.mode == Mode.Dev)) {
-          datasource.setJdbcUrl(url + ";DB_CLOSE_DELAY=-1")
-        } else {
-          datasource.setJdbcUrl(url)
-        }
-      case Some(s: String) =>
-        datasource.setJdbcUrl(s)
-      case _ =>
-        throw conf.globalError("Missing url configuration for database [%s]".format(conf))
+          datasource.setJdbcUrl(s"$url;DB_CLOSE_DELAY=-1")
+        } else datasource.setJdbcUrl(url)
+
+      case Some(s: String) => datasource.setJdbcUrl(s)
+
+      case _ => throw conf.globalError(s"Missing url configuration for database $dbName: $conf")
     }
 
     conf.getString("user").map(datasource.setUsername)
@@ -394,28 +396,32 @@ private[db] class BoneCPApi(configuration: Configuration, classloader: ClassLoad
     conf.getString("connectionTestStatement").map(datasource.setConnectionTestStatement)
 
     // Bind in JNDI
-    conf.getString("jndiName").map { name =>
+    conf.getString("jndiName") map { name =>
       JNDI.initialContext.rebind(name, datasource)
-      Play.logger.info("datasource [" + conf.getString("url").get + "] bound to JNDI as " + name)
+      Play.logger.info(s"""datasource [${conf.getString("url").get}] bound to JNDI as $name""")
     }
 
-    datasource
-
+    datasource -> driver
   }
 
-  val datasources: List[(DataSource, String)] = dbNames.toList.map { dbName =>
-    val url = configuration.getString(dbName + ".url").getOrElse(error(dbName, "Missing configuration [db." + dbName + ".url]"))
-    val driver = configuration.getString(dbName + ".driver").getOrElse(error(dbName, "Missing configuration [db." + dbName + ".driver]"))
-    val extraConfig = configuration.getConfig(dbName).getOrElse(error(dbName, "Missing configuration [db." + dbName + "]"))
-    register(driver, extraConfig)
-    createDataSource(dbName, url, driver, extraConfig) -> dbName
+  @annotation.tailrec
+  private def setupDatasources(dbNames: List[String], datasources: List[(DataSource, String)], dsMap: Map[String, DataSource], drivers: Set[Driver]): (List[(DataSource, String)], Map[String, DataSource], Set[Driver]) = dbNames match {
+    case dbName :: ns =>
+      val extraConfig = configuration.getConfig(dbName).getOrElse(error(dbName, s"Missing configuration [db.$dbName]"))
+      val (ds, driver) = createDataSource(dbName, extraConfig)
+      setupDatasources(ns, datasources :+ (ds -> dbName),
+        dsMap + (dbName -> ds), drivers + driver)
+
+    case _ => (datasources, dsMap, drivers)
   }
 
-  def shutdownPool(ds: DataSource) = {
-    ds match {
-      case ds: BoneCPDataSource => ds.close()
-      case _ => error(" - could not recognize DataSource, therefore unable to shutdown this pool")
-    }
+  private val (dsList, dsMap, drivers): (List[(DataSource, String)], Map[String, DataSource], Set[Driver]) = setupDatasources(configuration.subKeys.toList, Nil, Map.empty, Set.empty)
+
+  val datasources = dsList
+
+  def shutdownPool(ds: DataSource) = ds match {
+    case bcp: BoneCPDataSource => bcp.close()
+    case _ => error(" - could not recognize DataSource, therefore unable to shutdown this pool")
   }
 
   /**
@@ -427,9 +433,8 @@ private[db] class BoneCPApi(configuration: Configuration, classloader: ClassLoad
    * @return a JDBC connection
    * @throws an error if the required data source is not registered
    */
-  def getDataSource(name: String): DataSource = {
-    datasources.find(_._2 == name).map(e => e._1).getOrElse(error(" - could not find datasource for " + name))
-  }
+  def getDataSource(name: String): DataSource =
+    dsMap.get(name).getOrElse(error(s" - could not find datasource for $name"))
 
 }
 

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/BoneCPPluginSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/BoneCPPluginSpec.scala
@@ -1,0 +1,55 @@
+package play.api.db
+
+import scala.util.Try
+import java.sql.{ DriverManager, SQLException }
+import play.api.test.FakeApplication
+import org.specs2.mutable.Specification
+
+object BoneCPPluginSpec extends Specification {
+  "BoneCP DB plugin" title
+
+  "JDBC driver" should {
+    sequential 
+
+    "be registered for H2 before plugin starts" in {
+      DriverManager.getDriver("jdbc:h2:mem:") aka "H2 driver" must not(beNull)
+    }
+
+    "not be registered for Acolyte until plugin is started" in {
+      Try { // Ensure driver is not registered
+        DriverManager.deregisterDriver(DriverManager.getDriver(jdbcUrl))
+      }
+
+      DriverManager.getDriver(jdbcUrl) aka "Acolyte driver" must(
+        throwA[SQLException](message = "No suitable driver"))
+    }
+
+    "be registered for both Acolyte & H2 when plugin is started" in {
+      plugin.onStart()
+
+      (DriverManager.getDriver(jdbcUrl) aka "Acolyte driver" must not(beNull)).
+        and(DriverManager.getDriver("jdbc:h2:mem:").
+          aka("H2 driver") must not(beNull))
+    }
+
+    "be deregistered for Acolyte but still there for H2 after plugin stops" in {
+      plugin.onStop()
+
+      (DriverManager.getDriver("jdbc:h2:mem:") aka "H2 driver" must not(beNull))
+      .and(DriverManager.getDriver(jdbcUrl) aka "Acolyte driver" must {
+        throwA[SQLException](message = "No suitable driver")
+      })
+    }
+  }
+
+  val jdbcUrl = "jdbc:acolyte:test?handler=boneCPPluginSpec"
+  lazy val plugin = {
+    acolyte.Driver.register("boneCPPluginSpec", 
+      acolyte.CompositeHandler.empty()) // Fake driver
+
+    new BoneCPPlugin(
+      FakeApplication(additionalConfiguration = Map(
+        "db.default.driver" -> "acolyte.Driver",
+        "db.default.url" -> jdbcUrl)))
+  }
+}


### PR DESCRIPTION
The framework [deregisters all drivers from java.sql.DriverManager on DBPlugin stop](https://github.com/playframework/playframework/blob/b0b459607c1a64cc302da5d6e1d5d9cd75acea2b/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala#L265-L269). I think it does this, because it creates ProxyDrivers and registers them on start. It is probably supposed to be simply a cleanup.

Unfortunately deregistering **all** drivers is very unfriendly behavior.

We for example have unit tests that use a fake application and some others that set up connections on their own. If you are running both in the same JVM the tests which set up their connections themselves will fail because the others have deregistered all drivers.

The correct behavior would be to just deregister drivers that have been registered by the framework.
