### PR TITLE
Catch more errors to detect when JNotify fails to load

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
@@ -258,7 +258,7 @@ trait PlayReloader {
                 }
                 case JavacErrorPosition(pos) => {
                   parsed = parsed._1 -> Some(pos.size)
-                  if (first == (None, None)) {
+                  if (first == ((None, None))) {
                     first = parsed
                   }
                 }


### PR DESCRIPTION
Fixes #2831

I list the the exceptions we want to catch rather than just catching Throwable. That's because Throwable matches  a lot of stuff we don't really want to catch, e.g. OutOfMemoryError.
