### PR TITLE
Improve parsing of Jackson JsonNodes

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
@@ -3,10 +3,14 @@
  */
 package play.api.libs.json
 
-import Json._
-import scala.collection._
 import scala.annotation.implicitNotFound
+import scala.collection._
 import scala.reflect.ClassTag
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.{ ArrayNode, ObjectNode }
+
+import Json._
 
 /**
  * Json serializer: write an implicit to define a serializer for any type
@@ -70,8 +74,6 @@ object Writes extends PathWrites with ConstraintWrites with DefaultWrites {
 
   val constraints: ConstraintWrites = this
   val path: PathWrites = this
-
-  import play.api.libs.functional._
 
   /*implicit val contravariantfunctorWrites:ContravariantFunctor[Writes] = new ContravariantFunctor[Writes] {
 
@@ -149,6 +151,13 @@ trait DefaultWrites {
   }
 
   /**
+   * Serializer for Jackson JsonNode
+   */
+  implicit object JsonNodeWrites extends Writes[JsonNode] {
+    def writes(o: JsonNode): JsValue = JacksonJson.jsonNodeToJsValue(o)
+  }
+
+  /**
    * Serializer for Array[T] types.
    */
   implicit def arrayWrites[T: ClassTag](implicit fmt: Writes[T]): Writes[Array[T]] = new Writes[Array[T]] {
@@ -180,7 +189,6 @@ trait DefaultWrites {
    * Serializer for Option.
    */
   implicit def OptionWrites[T](implicit fmt: Writes[T]): Writes[Option[T]] = new Writes[Option[T]] {
-    import scala.util.control.Exception._
     def writes(o: Option[T]) = o match {
       case Some(value) => fmt.writes(value)
       case None => JsNull

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -4,15 +4,11 @@
 package play.api.libs.json
 
 import org.specs2.mutable._
-import play.api.libs.json._
-import play.api.libs.json.Json._
+
+import com.fasterxml.jackson.databind.JsonNode
+
 import play.api.libs.functional.syntax._
-
-import scala.util.control.Exception._
-import java.text.ParseException
-
-import play.api.data.validation.ValidationError 
-
+import play.api.libs.json.Json._
 
 object JsonSpec extends Specification {
   case class User(id: Long, name: String, friends: List[User])
@@ -41,7 +37,7 @@ object JsonSpec extends Specification {
     (__ \ 'body).format[String] and
     (__ \ 'created_at).formatNullable[Option[Date]](
       Format(
-        Reads.optionWithNull(Reads.dateReads(dateFormat)), 
+        Reads.optionWithNull(Reads.dateReads(dateFormat)),
         Writes.optionWithNull(Writes.dateWrites(dateFormat))
       )
     ).inmap( optopt => optopt.flatten, (opt: Option[Date]) => Some(opt) )
@@ -50,8 +46,8 @@ object JsonSpec extends Specification {
   "JSON" should {
     "equals JsObject independently of field order" in {
       Json.obj(
-        "field1" -> 123, 
-        "field2" -> "beta", 
+        "field1" -> 123,
+        "field2" -> "beta",
         "field3" -> Json.obj(
           "field31" -> true,
           "field32" -> 123.45,
@@ -59,7 +55,7 @@ object JsonSpec extends Specification {
         )
       ) must beEqualTo(
         Json.obj(
-          "field2" -> "beta", 
+          "field2" -> "beta",
           "field3" -> Json.obj(
             "field31" -> true,
             "field33" -> Json.arr("blabla", 456L, JsNull),
@@ -70,8 +66,8 @@ object JsonSpec extends Specification {
       )
 
       Json.obj(
-        "field1" -> 123, 
-        "field2" -> "beta", 
+        "field1" -> 123,
+        "field2" -> "beta",
         "field3" -> Json.obj(
           "field31" -> true,
           "field32" -> 123.45,
@@ -79,7 +75,7 @@ object JsonSpec extends Specification {
         )
       ) must not equalTo(
         Json.obj(
-          "field2" -> "beta", 
+          "field2" -> "beta",
           "field3" -> Json.obj(
             "field31" -> true,
             "field33" -> Json.arr("blabla", 456L),
@@ -90,8 +86,8 @@ object JsonSpec extends Specification {
       )
 
       Json.obj(
-        "field1" -> 123, 
-        "field2" -> "beta", 
+        "field1" -> 123,
+        "field2" -> "beta",
         "field3" -> Json.obj(
           "field31" -> true,
           "field32" -> 123.45,
@@ -179,6 +175,22 @@ object JsonSpec extends Specification {
       fromJson[List[Int]](json) must equalTo (JsSuccess(xs))
     }
 
+    "Serialize and deserialize Jackson ObjectNodes" in {
+      val on = JacksonJson.mapper.createObjectNode()
+        .put("foo", 1).put("bar", "two")
+      val json = Json.obj("foo" -> 1, "bar" -> "two")
+      toJson(on) must equalTo (json)
+      fromJson[JsonNode](json).map(_.toString) must_== JsSuccess(on.toString)
+    }
+
+    "Serialize and deserialize Jackson ArrayNodes" in {
+      val an = JacksonJson.mapper.createArrayNode()
+        .add("one").add(2)
+      val json = Json.arr("one", 2)
+      toJson(an) must equalTo (json)
+      fromJson[JsonNode](json).map(_.toString) must_== JsSuccess(an.toString)
+    }
+
     "Map[String,String] should be turned into JsValue" in {
       val f = toJson(Map("k"->"v"))
       f.toString must equalTo("{\"k\":\"v\"}")
@@ -257,7 +269,6 @@ object JsonSpec extends Specification {
 
   "JSON Writes" should {
     "write list/seq/set/map" in {
-      import util._
       import Writes._
 
       Json.toJson(List(1, 2, 3)) must beEqualTo(Json.arr(1, 2, 3))
@@ -272,11 +283,11 @@ object JsonSpec extends Specification {
         (__ \ 'key4).write(constraints.map[String])
       ).tupled
 
-      Json.toJson( List(1, 2, 3), 
-        Set("alpha", "beta", "gamma"), 
-        Seq("alpha", "beta", "gamma"), 
+      Json.toJson( List(1, 2, 3),
+        Set("alpha", "beta", "gamma"),
+        Seq("alpha", "beta", "gamma"),
         Map("key1" -> "value1", "key2" -> "value2")
-      ) must beEqualTo( 
+      ) must beEqualTo(
         Json.obj(
           "key1" -> Json.arr(1, 2, 3),
           "key2" -> Json.arr("alpha", "beta", "gamma"),
@@ -305,7 +316,7 @@ object JsonSpec extends Specification {
 
       Json.toJson(TestCase("my-id", "foo", "bar")) must beEqualTo(js)
 
-    }    
+    }
   }
 
 

--- a/framework/src/play-test/src/main/java/play/test/FakeRequest.java
+++ b/framework/src/play-test/src/main/java/play/test/FakeRequest.java
@@ -30,14 +30,14 @@ public class FakeRequest {
      * Constructs a new GET / fake request.
      */
     public FakeRequest() {
-        this.fake = play.api.test.FakeRequest.apply(); 
+        this.fake = play.api.test.FakeRequest.apply();
     }
 
     /**
      * Constructs a new request.
      */
     public FakeRequest(String method, String path) {
-        this.fake = play.api.test.FakeRequest.apply(method, path); 
+        this.fake = play.api.test.FakeRequest.apply(method, path);
     }
 
     /**
@@ -126,7 +126,7 @@ public class FakeRequest {
     /**
      * Add addtional session to this request.
      */
-    @SuppressWarnings(value = "unchecked")  
+    @SuppressWarnings(value = "unchecked")
     public FakeRequest withSession(String name, String value) {
         fake = fake.withSession(Scala.varargs(Scala.Tuple(name, value)));
         return this;

--- a/framework/src/play/src/main/scala/play/core/j/JavaParsers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaParsers.scala
@@ -3,20 +3,23 @@
  */
 package play.core.j
 
-import play.api.mvc._
-import play.api.libs.Files.TemporaryFile
-import play.api.libs.json._
-import play.api.libs.iteratee.Execution.trampoline
-
-import scala.xml._
 import scala.collection.JavaConverters._
+import scala.xml._
+
+import com.fasterxml.jackson.databind.JsonNode
+
+import play.api.libs.Files.TemporaryFile
+import play.api.libs.iteratee.Execution.trampoline
+import play.api.libs.json.Reads.JsonNodeReads
+import play.api.libs.json._
+import play.api.mvc._
 
 /**
  * provides Java centric BodyParsers
  */
 object JavaParsers extends BodyParsers {
 
-  import play.mvc.Http.{ RequestBody }
+  import play.mvc.Http.RequestBody
 
   case class DefaultRequestBody(
       urlFormEncoded: Option[Map[String, Seq[String]]] = None,
@@ -48,9 +51,7 @@ object JavaParsers extends BodyParsers {
     }
 
     override lazy val asJson = {
-      json.map { json =>
-        play.libs.Json.parse(json.toString)
-      }.orNull
+      json.map(Json.fromJson[JsonNode](_).get).orNull
     }
 
     override lazy val asXml = {


### PR DESCRIPTION
Handles #2902, and also changes the Java BodyParser to parse from the tree instead of re-parsing the JSON as a string.
