### PR TITLE
Update Migration23.md

### DIFF
--- a/documentation/manual/Migration23.md
+++ b/documentation/manual/Migration23.md
@@ -477,7 +477,7 @@ import play.libs.ws.*;
 Add library dependency to `build.sbt`:
 
 ```scala
-libraryDependencies += PlayKeys.ws
+libraryDependencies += ws
 ```
 
 In addition, usage of the WS client now requires a Play application in scope. Typically this is achieved by adding:


### PR DESCRIPTION
change the definition of PlayKeys.ws by ws witch compile with Play 2.3.0-RC2
