### PR TITLE
Fix Json.writes[X] so that it works with non-local names too. Issue #2903.

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -170,14 +170,14 @@ object JsMacroImpl {
     }
 
     // builds the final M[A] using apply method
-    //val applyMethod = Ident( companionSymbol.name )
+    //val applyMethod = Ident( companionSymbol )
     val applyMethod =
       Function(
         params.foldLeft(List[ValDef]())((l, e) =>
           l :+ ValDef(Modifiers(PARAM), newTermName(e.name.encoded), TypeTree(), EmptyTree)
         ),
         Apply(
-          Select(Ident(companionSymbol.name), newTermName("apply")),
+          Select(Ident(companionSymbol), newTermName("apply")),
           params.foldLeft(List[Tree]())((l, e) =>
             l :+ Ident(newTermName(e.name.encoded))
           )
@@ -187,7 +187,7 @@ object JsMacroImpl {
     val unapplyMethod = Apply(
       unliftIdent,
       List(
-        Select(Ident(companionSymbol.name), unapply.name)
+        Select(Ident(companionSymbol), unapply.name)
       )
     )
 

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -48,6 +48,14 @@ object Person {
   implicit val personWrites = Json.writes[Person]
 }
 
+package foreign {
+  case class Foreigner(name: String)
+}
+object ForeignTest {
+  implicit val foreignerReads = Json.reads[foreign.Foreigner]
+  implicit val foreignerWrites = Json.writes[foreign.Foreigner]
+}
+
 import play.api.libs.json._
 
 case class Person2(names: List[String])


### PR DESCRIPTION
The added code in `JsonExtensionSpec.scala` fails to compile without the change in `JsMacroImpl.scala`. The error is:

```
JsonExtensionSpec.scala:55: not found: value Foreigner
  implicit val foreignerReads = Json.reads[foreign.Foreigner]
```
