### PR TITLE
Can't resolve PlayKeys.ws

### DIFF
--- a/documentation/manual/Migration23.md
+++ b/documentation/manual/Migration23.md
@@ -463,7 +463,7 @@ The WS client is now an optional library. If you are using WS in your project th
 Add library dependency to `build.sbt`:
 
 ```scala
-libraryDependencies += PlayKeys.javaWs
+libraryDependencies += javaWs
 ```
 
 Update to the new library package in source files:
@@ -477,7 +477,7 @@ import play.libs.ws.*;
 Add library dependency to `build.sbt`:
 
 ```scala
-libraryDependencies += PlayKeys.ws
+libraryDependencies += ws
 ```
 
 In addition, usage of the WS client now requires a Play application in scope. Typically this is achieved by adding:


### PR DESCRIPTION
There's an error in the migration doc for including Play WS. Following the advice to enable the WS plugin by adding "libraryDependencies += PlayKeys.ws" to my build.sbt I get the following error

```
/...../build.sbt:22: error: value ws is not a member of object play.Play.autoImport.PlayKeys
PlayKeys.ws,
       ^
[error] Type error in expression
```

Looking at the source for PlayImport.scala, it seems apparent why. The ws value is not under the scope of the PlayKeys object, but rather a level higher, and indeed simply changing my build.sbt to "libraryDependencies += ws" solved the problem. 
