### PR TITLE
Use the same ObjectMapper by default in Java and Scala

### DIFF
--- a/framework/src/play-java/src/main/scala/play/core/ObjectMapperPlugin.scala
+++ b/framework/src/play-java/src/main/scala/play/core/ObjectMapperPlugin.scala
@@ -6,6 +6,7 @@ package play.core
 import play.api.Plugin
 import play.api.Application
 import play.libs.Json
+import play.api.libs.json.JacksonJson
 import com.fasterxml.jackson.databind.ObjectMapper
 
 /**
@@ -17,7 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 class ObjectMapperPlugin(app: Application) extends Plugin {
 
   override def onStart() {
-    Json.setObjectMapper(new ObjectMapper())
+    Json.setObjectMapper(JacksonJson.createMapper())
   }
 
   override def onStop() {

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
@@ -3,16 +3,16 @@
  */
 package play.api.libs.json
 
+import scala.annotation.tailrec
+import scala.collection._
+import scala.collection.mutable.ListBuffer
+
 import com.fasterxml.jackson.core.{ JsonGenerator, JsonToken, JsonParser }
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.`type`.TypeFactory
 import com.fasterxml.jackson.databind.deser.Deserializers
 import com.fasterxml.jackson.databind.ser.Serializers
 
-import scala.collection._
-import scala.collection.mutable.ListBuffer
-
-import scala.annotation.tailrec
 import play.api.data.validation.ValidationError
 
 case class JsResultException(errors: Seq[(JsPath, Seq[ValidationError])]) extends RuntimeException("JsResultException(errors:%s)".format(errors))
@@ -450,7 +450,7 @@ private[json] class PlaySerializers extends Serializers.Base {
   }
 }
 
-private[json] object JacksonJson {
+private[play] object JacksonJson {
 
   import com.fasterxml.jackson.core.Version
   import com.fasterxml.jackson.databind.module.SimpleModule
@@ -458,9 +458,11 @@ private[json] object JacksonJson {
 
   private[this] val classLoader = Thread.currentThread().getContextClassLoader
 
-  private[json] val mapper = (new ObjectMapper).registerModule(module)
+  def createMapper(): ObjectMapper = (new ObjectMapper).registerModule(module)
 
-  object module extends SimpleModule("PlayJson", Version.unknownVersion()) {
+  private[json] val mapper = createMapper()
+
+  private[json] object module extends SimpleModule("PlayJson", Version.unknownVersion()) {
     override def setupModule(context: SetupContext) {
       context.addDeserializers(new PlayDeserializers(classLoader))
       context.addSerializers(new PlaySerializers)

--- a/framework/src/play-test/src/main/java/play/test/FakeRequest.java
+++ b/framework/src/play-test/src/main/java/play/test/FakeRequest.java
@@ -71,7 +71,7 @@ public class FakeRequest {
      */
     @SuppressWarnings(value = "unchecked")
     public FakeRequest withJsonBody(JsonNode node) {
-        return withJsonBody(play.api.libs.json.Json.parse(node.toString()));
+        return withJsonBody(play.api.libs.json.JacksonJson$.MODULE$.jsonNodeToJsValue(node));
     }
 
     /**
@@ -98,7 +98,8 @@ public class FakeRequest {
         }
         Map<String, Seq<String>> map = new HashMap<String, Seq<String>>(Scala.asJava(fake.headers().toMap()));
         map.put("Content-Type", Scala.toSeq(new String[] {"application/json"}));
-        AnyContentAsJson content = new AnyContentAsJson(play.api.libs.json.Json.parse(node.toString()));
+        AnyContentAsJson content =
+            new AnyContentAsJson(play.api.libs.json.JacksonJson$.MODULE$.jsonNodeToJsValue(node));
         fake = new play.api.test.FakeRequest(method, fake.uri(), new play.api.test.FakeHeaders(Scala.asScala(map).toSeq()), content, fake.remoteAddress(), fake.version(), fake.id(), fake.tags(), fake.secure());
         return this;
     }


### PR DESCRIPTION
I made a few more changes to use the same ObjectMapper in Java and Scala, so framework users can convert to/from JsValue types in Java.

I also added a change to avoid re-parsing JSON from strings in Java FakeRequest.
