### PR TITLE
[Play-2.2.x] some code causes java.lang.VerifyError at runtime

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -56,7 +56,7 @@ object Dependencies {
     ("org.springframework" % "spring-beans" % "4.0.3.RELEASE" notTransitive ())
       .exclude("org.springframework", "spring-core"),
 
-    "org.javassist" % "javassist" % "3.18.1-GA",
+    "org.javassist" % "javassist" % "3.18.2-GA",
 
     ("org.reflections" % "reflections" % "0.9.8" notTransitive ())
       .exclude("javassist", "javassist"),
@@ -112,7 +112,7 @@ object Dependencies {
 
 
   val link = Seq(
-    "org.javassist" % "javassist" % "3.18.1-GA")
+    "org.javassist" % "javassist" % "3.18.2-GA")
 
   val routersCompilerDependencies =  Seq(
     "commons-io" % "commons-io" % "2.0.1"
@@ -140,7 +140,7 @@ object Dependencies {
     "org.avaje.ebeanorm" % "avaje-ebeanorm-agent" % "3.2.2" exclude ("javax.persistence", "persistence-api"),
 
     h2database,
-    "org.javassist" % "javassist" % "3.18.1-GA",
+    "org.javassist" % "javassist" % "3.18.2-GA",
 
     "net.contentobjects.jnotify" % "jnotify" % "0.94",
 


### PR DESCRIPTION
code like below has no problem with compilation.
but causes java.lang.VerifyError at runtime.

``` java
TestObject object = new TestObject();
object.name = "test";  // get or set string value

try { // in try
    object.id = 100L;  // get or set long value
    String name = object.name;  // get or set string value
} catch (Throwable t) {
    t.printStackTrace();
}
```

I think generated getter/setter are the reason.

here's test code : https://github.com/kjkmadness/play-test
and CI : https://travis-ci.org/kjkmadness/play-test
