### PR TITLE
Expose play.libs.Json.mapper to make custom Json manipulation easier

### DIFF
--- a/framework/src/play-json/src/main/java/play/libs/Json.java
+++ b/framework/src/play-json/src/main/java/play/libs/Json.java
@@ -22,8 +22,14 @@ public class Json {
     private static final ObjectMapper defaultObjectMapper = new ObjectMapper();
     private static volatile ObjectMapper objectMapper = null;
 
-    // Ensures that there always is *a* object mapper
-    private static ObjectMapper mapper() {
+  /**
+   * Get the ObjectMapper used to serialize and deserialize objects to and from JSON values.
+   *
+   * This can be set to a custom implementation using Json.setObjectMapper.
+   *
+   * @return the ObjectMapper currently being used
+   */
+    public static ObjectMapper mapper() {
         if (objectMapper == null) {
             return defaultObjectMapper;
         } else {

--- a/framework/src/play-json/src/test/scala/play/libs/JavaJsonSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/libs/JavaJsonSpec.scala
@@ -30,6 +30,9 @@ class JavaJsonSpec extends Specification {
   }
 
   "Json" should {
+    "use the correct object mapper" in new JsonScope {
+      Json.mapper() must_== mapper
+    }
     "parse" in {
       "from string" in new JsonScope {
         Json.parse(testJsonString) must_== testJson


### PR DESCRIPTION
Based on feedback from #2939. We've already committed to using Jackson in Play-Java, so it makes sense to me to make it as easy as possible to use the tools Jackson has to manipulate things.

We should add some documentation better explaining the convenience methods `Json` has, and refer to the Jackson docs when necessary for more advanced uses.
