### PR TITLE
Where to put libraryDependencies += javaEbean ?

### DIFF
--- a/documentation/manual/javaGuide/main/sql/JavaEbean.md
+++ b/documentation/manual/javaGuide/main/sql/JavaEbean.md
@@ -4,7 +4,7 @@
 ## Configuring Ebean
 
 Play comes with the [Ebean](http://www.avaje.org/) ORM. To enable it, add javaEbean to your
-dependencies : 
+SBT dependencies (e.g. in `build.sbt` or `project/Build.scala`): 
 
 ```scala
 libraryDependencies += javaEbean


### PR DESCRIPTION
Quote from the documentation at this page http://www.playframework.com/documentation/2.2.x/JavaEbean :

To enable it, add javaEbean to your dependencies :

libraryDependencies += javaEbean

I don't know in which file to add this line. This is frustrating since there my application is not compiling anymore.
Thanks to precise where to add it.
