### PR TITLE
update typesafe config 1.2.1

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -127,7 +127,7 @@ object Dependencies {
 
   val sbtDependencies = Seq(
     "org.scala-lang" % "scala-reflect" % BuildSettings.buildScalaVersionForSbt % "provided",
-    "com.typesafe" % "config" % "1.2.0",
+    "com.typesafe" % "config" % "1.2.1",
     "org.mozilla" % "rhino" % "1.7R4",
 
     ("com.google.javascript" % "closure-compiler" % "v20130603")
@@ -162,7 +162,7 @@ object Dependencies {
 
   val iterateesDependencies = Seq(
     "org.scala-stm" %% "scala-stm" % "0.7",
-    "com.typesafe" % "config" % "1.2.0") ++
+    "com.typesafe" % "config" % "1.2.1") ++
     specsBuild.map(_ % "test")
 
   val jsonDependencies = Seq(


### PR DESCRIPTION
akka 2.3.3 depends on typesafe config 1.2.1 https://github.com/akka/akka/blob/v2.3.3/project/AkkaBuild.scala#L1146
I think we should use same version
