### PR TITLE
Fix ScalaDependencyInjection.md's Spring description grammar

### DIFF
--- a/documentation/manual/scalaGuide/advanced/dependencyinjection/ScalaDependencyInjection.md
+++ b/documentation/manual/scalaGuide/advanced/dependencyinjection/ScalaDependencyInjection.md
@@ -27,7 +27,7 @@ The pace of development and the myriad of options even within a single DI framew
 
 ### Spring
 
-[Spring](http://www.springsource.org/) is a popular application development for Java that has a dependency injection framework at its core.  There is also an additional project [Spring Scala](https://github.com/SpringSource/spring-scala), which provides additional integration options using Scala and Spring.
+[Spring](http://www.springsource.org/) is a popular application framework for Java that has dependency injection at its core.  There is also an additional project [Spring Scala](https://github.com/SpringSource/spring-scala), which provides additional integration options using Scala and Spring.
 
 There is an [Activator](http://www.typesafe.com/activator) project available for Spring.  You can download it from Activator [directly](http://typesafe.com/activator/template/play-spring-data-jpa), or clone it from [https://github.com/typesafehub/play-spring-data-jpa](https://github.com/typesafehub/play-spring-data-jpa).
 


### PR DESCRIPTION
Simple grammar/conciseness fix in ScalaDependencyInjection.md's description of Spring Framework.
