### PR TITLE
Added details of how to import the cache into the documentation

### DIFF
--- a/documentation/manual/javaGuide/main/cache/JavaCache.md
+++ b/documentation/manual/javaGuide/main/cache/JavaCache.md
@@ -6,6 +6,16 @@ For any data stored in the cache, a regeneration strategy needs to be put in pla
 
 The default implementation of the cache API uses [EHCache](http://www.ehcache.org/) and it's enabled by default. You can also provide your own implementation via a plugin. 
 
+## Importing the Cache API
+
+Add `cache` into your dependencies list. For example, in `build.sbt`:
+
+```scala
+libraryDependencies ++= Seq(
+  cache,
+  ...
+)
+```
 
 ## Accessing the Cache API
 

--- a/documentation/manual/scalaGuide/main/cache/ScalaCache.md
+++ b/documentation/manual/scalaGuide/main/cache/ScalaCache.md
@@ -2,6 +2,17 @@
 
 The default implementation of the Cache API uses [EHCache](http://ehcache.org/). You can also provide your own implementation via a plug-in.
 
+## Importing the Cache API
+
+Add `cache` into your dependencies list. For example, in `build.sbt`:
+
+```scala
+libraryDependencies ++= Seq(
+  cache,
+  ...
+)
+```
+
 ## Accessing the Cache API
 
 The cache API is provided by the `play.api.cache.Cache` object. It requires a registered cache plug-in.


### PR DESCRIPTION
I'm working on a Play 2 project and needed to use the cache - couldn't find details on how to do it, so I added documentation to the cache page.
