### PR TITLE
Fix JSON media type

### DIFF
--- a/documentation/manual/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -67,7 +67,7 @@ class ScalaWSSpec extends PlaySpecification with Results {
 
       //#complex-holder
       val complexHolder: WSRequestHolder =
-        holder.withHeaders("Accept" -> "application.json")
+        holder.withHeaders("Accept" -> "application/json")
           .withRequestTimeout(10000)
           .withQueryString("search" -> "play")
       //#complex-holder


### PR DESCRIPTION
As defined in RFC 4627:
"The MIME media type for JSON text is application/json."
