### PR TITLE
Consider making java play.db.DB a first class citizen

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -232,8 +232,9 @@ object PlayBuild extends Build {
     .settings(libraryDependencies ++= jdbcDeps)
     .dependsOn(PlayProject).dependsOn(PlayTestProject % "test")
 
-  lazy val PlayJavaJdbcProject = PlayRuntimeProject("Play-Java-JDBC", "play-java-jdbc")
+  lazy val PlayJavaJdbcProject = PlayRuntimeProject("Play-Java-JDBC", "play-java-jdbc").settings(libraryDependencies ++= javaJdbcDeps)
     .dependsOn(PlayJdbcProject, PlayJavaProject)
+    .dependsOn(PlayTestProject % "test")
 
   lazy val PlayEbeanProject = PlayRuntimeProject("Play-Java-Ebean", "play-java-ebean")
     .settings(

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -27,6 +27,8 @@ object Dependencies {
     "org.eu.acolyte" % "jdbc-driver" % "1.0.18" % "test",
     "tyrex" % "tyrex" % "1.0.1") ++ specsBuild.map(_ % "test")
 
+  val javaJdbcDeps = Seq("org.eu.acolyte" % "jdbc-driver" % "1.0.18" % "test")
+
   val ebeanDeps = Seq(
     "org.avaje.ebeanorm" % "avaje-ebeanorm" % "3.3.4" exclude ("javax.persistence", "persistence-api"),
     "org.avaje.ebeanorm" % "avaje-ebeanorm-agent" % "3.2.2" exclude ("javax.persistence", "persistence-api")

--- a/framework/src/play-java-jdbc/src/main/java/play/db/DB.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/DB.java
@@ -3,8 +3,12 @@
  */
 package play.db;
 
-import java.sql.*;
-import javax.sql.*;
+import java.sql.Connection;
+import javax.sql.DataSource;
+
+import scala.runtime.AbstractFunction1;
+
+import play.api.Application;
 
 /**
  * Provides a high-level API for getting JDBC connections.
@@ -19,21 +23,26 @@ public class DB {
     }
     
     /**
-     * Returns any default datasource.
+     * Returns specified database.
+     *
+     * @param name Datasource name
      */
-    public static DataSource getDataSource(String database) {
-        return play.api.db.DB.getDataSource(database, play.api.Play.unsafeApplication());
+    public static DataSource getDataSource(String name) {
+        return play.api.db.DB.
+            getDataSource(name, play.api.Play.unsafeApplication());
     }
     
     /**
-     * Returns a connection from the default datasource, with auto-commit enabled.
+     * Returns a connection from the default datasource, 
+     * with auto-commit enabled.
      */
     public static Connection getConnection() {
         return getConnection("default");
     }
     
     /**
-     * Returns a connection from the default datasource, with the specified auto-commit setting.
+     * Returns a connection from the default datasource, 
+     * with the specified auto-commit setting.
      */
     public static Connection getConnection(boolean autocommit) {
         return getConnection("default", autocommit);
@@ -41,16 +50,167 @@ public class DB {
     
     /**
      * Returns a connection from any datasource, with auto-commit enabled.
+     *
+     * @param name Datasource name
      */
-    public static Connection getConnection(String database) {
-        return getConnection(database, true);
+    public static Connection getConnection(String name) {
+        return getConnection(name, true);
     }
     
     /**
-     * Get a connection from any datasource, with the specified auto-commit setting.
+     * Get a connection from any datasource, 
+     * with the specified auto-commit setting.
+     *
+     * @param name Datasource name
+     * @param autocommit Auto-commit setting
      */
-    public static Connection getConnection(String database, boolean autocommit) {
-        return play.api.db.DB.getConnection(database, autocommit, play.api.Play.unsafeApplication());
+    public static Connection getConnection(String name, boolean autocommit) {
+        return play.api.db.DB.
+            getConnection(name, autocommit, 
+                          play.api.Play.unsafeApplication());
     }
     
+    /**
+     * Executes a block of code, providing a JDBC connection. 
+     * The connection and all created statements are automatically released.
+     *
+     * @param name Datasource name
+     * @param block Code block to execute
+     * @param application Play application (<tt>play.api.Play.unsafeApplication()</tt>)
+     */
+    public static <A> A withConnection(String name, 
+                                       ConnectionCallable<A> block,
+                                       Application application) {
+
+        return play.api.db.DB.
+            withConnection(name, connectionFunction(block), application);
+
+    }
+
+    /**
+     * Execute a block of code, providing a JDBC connection. 
+     * The connection and all created statements are automatically released.
+     *
+     * @param block Code block to execute
+     * @param application Play application (<tt>play.api.Play.unsafeApplication()</tt>)
+     */
+    public static <A> A withConnection(ConnectionCallable<A> block, 
+                                       Application application) {
+
+        return play.api.db.DB.
+            withConnection(connectionFunction(block), application);
+    }
+
+    /**
+     * Executes a block of code, providing a JDBC connection. 
+     * The connection and all created statements are automatically released.
+     *
+     * @param name Datasource name
+     * @param block Code block to execute
+     */
+    public static <A> A withConnection(String name, ConnectionCallable<A> block) {
+        return play.api.db.DB.withConnection(name, connectionFunction(block), 
+                                             play.api.Play.unsafeApplication());
+
+    }
+
+    /**
+     * Execute a block of code, providing a JDBC connection. 
+     * The connection and all created statements are automatically released.
+     *
+     * @param block Code block to execute
+     */
+    public static <A> A withConnection(ConnectionCallable<A> block) {
+        return play.api.db.DB.withConnection(connectionFunction(block), 
+                                             play.api.Play.unsafeApplication());
+    }
+
+    /**
+     * Execute a block of code, in the scope of a JDBC transaction.
+     * The connection and all created statements are automatically released.
+     * The transaction is automatically committed, unless an exception occurs.
+     *
+     * @param name Datasource name
+     * @param block Code block to execute
+     * @param application Play application (<tt>play.api.Play.unsafeApplication()</tt>)
+     */
+    public static <A> A withTransaction(String name, 
+                                        ConnectionCallable<A> block,
+                                        Application application) {
+
+        return play.api.db.DB.
+            withTransaction(name, connectionFunction(block), application);
+    }
+
+    /**
+     * Execute a block of code, in the scope of a JDBC transaction.
+     * The connection and all created statements are automatically released.
+     * The transaction is automatically committed, unless an exception occurs.
+     *
+     * @param block Code block to execute
+     * @param application Play application (<tt>play.api.Play.unsafeApplication()</tt>)
+     */
+    public static <A> A withTransaction(ConnectionCallable<A> block, 
+                                        Application application) {
+
+        return play.api.db.DB.
+            withTransaction(connectionFunction(block), application);
+        
+    }
+
+    /**
+     * Execute a block of code, in the scope of a JDBC transaction.
+     * The connection and all created statements are automatically released.
+     * The transaction is automatically committed, unless an exception occurs.
+     *
+     * @param name Datasource name
+     * @param block Code block to execute
+     */
+    public static <A> A withTransaction(String name, 
+                                        ConnectionCallable<A> block) {
+
+        return play.api.db.DB.
+            withTransaction(name, connectionFunction(block), 
+                            play.api.Play.unsafeApplication());
+    }
+
+    /**
+     * Execute a block of code, in the scope of a JDBC transaction.
+     * The connection and all created statements are automatically released.
+     * The transaction is automatically committed, unless an exception occurs.
+     *
+     * @param block Code block to execute
+     */
+    public static <A> A withTransaction(ConnectionCallable<A> block) {
+
+        return play.api.db.DB.
+            withTransaction(connectionFunction(block), 
+                            play.api.Play.unsafeApplication());
+        
+    }
+
+    /** Returns a function wrapper from Java callable. */
+    private static final <A> AbstractFunction1<Connection,A> connectionFunction(final ConnectionCallable<A> block) {
+        return new AbstractFunction1<Connection,A>() {
+            public A apply(Connection con) { return block.call(con); }
+        };
+    }
+}
+
+/**
+ * Similar to java.util.concurrent.Callable with a connection as argument.
+ * Usable from vanilla Java 6+, or as lambda as it's a functionnal interface.
+ *
+ * Vanilla Java:
+ * <code>
+ * new ConnectionCallable<A>() {
+ *   public A call(Connection con) { ... }
+ * }
+ * </code>
+ *
+ * Java Lambda:
+ * <code>(Connection con) -> ...</code>
+ */
+interface ConnectionCallable<A> {
+    public A call(Connection con);
 }

--- a/framework/src/play-java-jdbc/src/test/scala/play/db/DBSpec.scala
+++ b/framework/src/play-java-jdbc/src/test/scala/play/db/DBSpec.scala
@@ -1,0 +1,55 @@
+package play.db;
+
+import play.api.test.FakeApplication
+
+object DBSpec extends org.specs2.mutable.Specification {
+  "Java DB utility" title
+
+  "DB" should {
+    "execute block with default connection" in {
+      val id = s"withConnection-${System.identityHashCode(this)}"
+
+      DB.withConnection(callable(id), fakeApp).
+        aka("connection block result") must_== id
+
+    }
+
+    "execute block with connection from specified datasource" in {
+      val id = s"withConnection-${System.identityHashCode(this)}"
+
+      DB.withConnection("default", callable(id), fakeApp).
+        aka("connection block result") must_== id
+
+    }
+
+    "execute block with transaction for default connection" in {
+      val id = s"withConnection-${System.identityHashCode(this)}"
+
+      DB.withTransaction(callable(id), fakeApp).
+        aka("transaction block result") must_== id
+
+    }
+
+    "execute block with transaction from specified datasource" in {
+      val id = s"withConnection-${System.identityHashCode(this)}"
+
+      DB.withTransaction("default", callable(id), fakeApp).
+        aka("connection block result") must_== id
+
+    }
+  }
+
+  // ---
+
+  def callable(res: String) = new ConnectionCallable[String] {
+    def call(con: java.sql.Connection) = res
+  }
+
+  lazy val fakeApp = {
+    acolyte.Driver.register("test", acolyte.CompositeHandler.empty())
+    FakeApplication(additionalConfiguration = Map(
+      "db.default.driver" -> "acolyte.Driver",
+      "db.default.url" -> "jdbc:acolyte:test?handler=test"))
+
+  }
+}

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
@@ -69,7 +69,7 @@ trait DBApi {
   }
 
   /**
-   * Execute a block of code, providing a JDBC connection. The connection and all created statements are
+   * Executes a block of code, providing a JDBC connection. The connection and all created statements are
    * automatically released.
    *
    * @param name The datasource name.
@@ -85,7 +85,7 @@ trait DBApi {
   }
 
   /**
-   * Execute a block of code, in the scope of a JDBC transaction.
+   * Executes a block of code, in the scope of a JDBC transaction.
    * The connection and all created statements are automatically released.
    * The transaction is automatically committed, unless an exception occurs.
    *


### PR DESCRIPTION
Unlike its scala cousin, play.api.db.DB, in java there are very few methods. Specially, the ones with the pattern "withConnection/Transaction" would be very useful.
