### PR TITLE
Anorm BatchSql throws an error when executed since Play 2.3

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/Anorm.scala
+++ b/framework/src/anorm/src/main/scala/anorm/Anorm.scala
@@ -367,6 +367,7 @@ sealed trait Sql {
 }
 
 /** Initial SQL query, without parameter values. */
+// @todo Sealed trait to prevent initialize SqlQuery with unparsed statement
 case class SqlQuery(query: String, argsInitialOrder: List[String] = List.empty, queryTimeout: Option[Int] = None) extends Sql {
 
   def getFilledStatement(connection: Connection, getGeneratedKeys: Boolean = false): PreparedStatement = asSimple.getFilledStatement(connection, getGeneratedKeys)
@@ -374,7 +375,7 @@ case class SqlQuery(query: String, argsInitialOrder: List[String] = List.empty, 
   def withQueryTimeout(seconds: Option[Int]): SqlQuery =
     copy(queryTimeout = seconds)
 
-  private def defaultParser: RowParser[Row] = RowParser(row => Success(row))
+  private def defaultParser: RowParser[Row] = RowParser(Success(_))
 
   private[anorm] def asSimple: SimpleSql[Row] = asSimple(defaultParser)
 
@@ -391,7 +392,8 @@ case class SqlQuery(query: String, argsInitialOrder: List[String] = List.empty, 
   def asSimple[T](parser: RowParser[T] = defaultParser): SimpleSql[T] =
     SimpleSql(this, Map.empty, parser)
 
-  def asBatch[T]: BatchSql = BatchSql(this, Nil)
+  @deprecated(message = """Directly use BatchSql("stmt")""", since = "2.3.1")
+  def asBatch[T]: BatchSql = BatchSql(this.query, Nil)
 }
 
 object Sql { // TODO: Rename to SQL

--- a/framework/src/anorm/src/main/scala/anorm/BatchSql.scala
+++ b/framework/src/anorm/src/main/scala/anorm/BatchSql.scala
@@ -119,9 +119,9 @@ sealed trait BatchSql {
         val st: (String, Seq[(Int, ParameterValue)]) =
           Sql.prepareQuery(sql.query, 0, sql.argsInitialOrder.map(ps), Nil)
 
-        val stmt = if (getGeneratedKeys) con.prepareStatement(sql.query, java.sql.Statement.RETURN_GENERATED_KEYS) else con.prepareStatement(sql.query)
+        val stmt = if (getGeneratedKeys) con.prepareStatement(st._1, java.sql.Statement.RETURN_GENERATED_KEYS) else con.prepareStatement(st._1)
 
-        sql.queryTimeout.foreach(timeout => stmt.setQueryTimeout(timeout))
+        sql.queryTimeout.foreach(stmt.setQueryTimeout(_))
 
         fill(con, addBatchParams(stmt, st._2), getGeneratedKeys, pm.tail)
       }
@@ -156,8 +156,8 @@ sealed trait BatchSql {
 object BatchSql {
   @throws[IllegalArgumentException](BatchSqlErrors.HeterogeneousParameterMaps)
   @throws[IllegalArgumentException](BatchSqlErrors.ParameterNamesNotMatchingPlaceholders)
-  def apply(query: SqlQuery, ps: Seq[Seq[NamedParameter]] = Nil): BatchSql =
-    Checked(query, ps.map(_.map(_.tupled).toMap))
+  def apply(sql: String, ps: Seq[Seq[NamedParameter]] = Nil): BatchSql =
+    Checked(SQL(sql), ps.map(_.map(_.tupled).toMap))
 
   @throws[IllegalArgumentException](BatchSqlErrors.HeterogeneousParameterMaps)
   @throws[IllegalArgumentException](BatchSqlErrors.ParameterNamesNotMatchingPlaceholders)

--- a/framework/src/anorm/src/main/scala/anorm/SqlStatementParser.scala
+++ b/framework/src/anorm/src/main/scala/anorm/SqlStatementParser.scala
@@ -29,9 +29,11 @@ object SqlStatementParser extends JavaTokenParsers {
     (r.flatMap(_._1).mkString, (r.flatMap(_._2)))
   }
 
-  private val instr: Parser[List[(String, Option[String])]] = rep(literal | variable | other)
+  private val instr: Parser[List[(String, Option[String])]] =
+    rep(literal | variable | other)
 
-  private val literal: Parser[(String, Option[String])] = (stringLiteral | simpleQuotes) ^^ { case s => (s, None) }
+  private val literal: Parser[(String, Option[String])] =
+    (stringLiteral | simpleQuotes) ^^ { case s => (s, None) }
 
   private val variable = "{" ~> (ident ~ (("." ~> ident)?)) <~ "}" ^^ {
     case i1 ~ i2 => ("%s": String, Some(i1 + i2.map("." + _).getOrElse("")))
@@ -41,7 +43,8 @@ object SqlStatementParser extends JavaTokenParsers {
     case element => (element, None)
   }
 
-  private val simpleQuotes = ("'" + """([^'\p{Cntrl}\\]|\\[\\/bfnrt]|\\u[a-fA-F0-9]{4})*""" + "'").r
+  private val simpleQuotes =
+    ("'" + """([^'\p{Cntrl}\\]|\\[\\/bfnrt]|\\u[a-fA-F0-9]{4})*""" + "'").r
 
   override def skipWhitespace = false
 }

--- a/framework/src/anorm/src/main/scala/anorm/package.scala
+++ b/framework/src/anorm/src/main/scala/anorm/package.scala
@@ -17,6 +17,10 @@ package object anorm {
   import scala.language.implicitConversions
 
   implicit def sqlToSimple(sql: SqlQuery): SimpleSql[Row] = sql.asSimple
+
+  @deprecated(
+    message = """Directly use BatchSql("stmt", params)""",
+    since = "2.3.1")
   implicit def sqlToBatch(sql: SqlQuery): BatchSql = sql.asBatch
 
   implicit def implicitID[ID](id: Id[ID]): ID = id.id

--- a/framework/src/anorm/src/test/scala/anorm/BatchSqlSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/BatchSqlSpec.scala
@@ -1,12 +1,17 @@
 package anorm
 
-object BatchSqlSpec extends org.specs2.mutable.Specification {
+import acolyte.Acolyte
+import acolyte.Implicits._
+
+object BatchSqlSpec 
+    extends org.specs2.mutable.Specification with H2Database {
+
   "Batch SQL" title
 
   "Creation" should {
     "fail with parameter maps not having same names" in {
       lazy val batch = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a}", List("a")),
+        "SELECT * FROM tbl WHERE a = {a}",
         Seq(Seq[NamedParameter]("a" -> 0),
           Seq[NamedParameter]("a" -> 1, "b" -> 2)))
 
@@ -16,7 +21,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
 
     "fail with names not matching query placeholders" in {
       lazy val batch = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a}, b = {b}", List("a", "b")),
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}",
         Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2, "c" -> 3)))
 
       batch.addBatch("a" -> 0).
@@ -26,7 +31,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
 
     "be successful with parameter maps having same names" in {
       lazy val batch = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a}, b = {b}", List("a", "b")),
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}",
         Seq(Seq[NamedParameter]("a" -> 0, "b" -> -1),
           Seq[NamedParameter]("a" -> 1, "b" -> 2)))
 
@@ -43,7 +48,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
   "Appending list of named parameters" should {
     "fail with unexpected name" in {
       val batch = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a}, b = {b}", List("a", "b")),
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}",
         Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2)))
 
       batch.addBatch("a" -> 0, "c" -> 4).
@@ -53,8 +58,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
 
     "fail with missing names" in {
       val batch = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a} AND b = {b} AND c = {c}",
-          List("a", "b", "c")),
+        "SELECT * FROM tbl WHERE a = {a} AND b = {b} AND c = {c}",
         Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2, "c" -> 3)))
 
       batch.addBatch("a" -> 0).
@@ -65,7 +69,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
     "with first parameter map" >> {
       "fail if parameter names not matching query placeholders" in {
         val batch = BatchSql(
-          SqlQuery("SELECT * FROM tbl WHERE a = {a}, b = {b}", List("a", "b")))
+          "SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
         batch.addBatch("a" -> 0).
           aka("append") must throwA[IllegalArgumentException](
@@ -75,7 +79,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
 
       "be successful" in {
         val b1 = BatchSql(
-          SqlQuery("SELECT * FROM tbl WHERE a = {a}, b = {b}", List("a", "b")))
+          "SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
         lazy val b2 = b1.addBatch("a" -> 0, "b" -> 1)
 
@@ -89,7 +93,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
 
     "be successful" in {
       val b1 = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a}, b = {b}", List("a", "b")),
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}",
         Seq(Seq[NamedParameter]("a" -> 0, "b" -> 1)))
 
       lazy val b2 = b1.addBatch("a" -> 2, "b" -> 3)
@@ -106,7 +110,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
   "Appending list of list of named parameters" should {
     "fail with unexpected name" in {
       val batch = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a}, b = {b}", List("a", "b")),
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}",
         Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2)))
 
       batch.addBatchList(Seq(Seq("a" -> 0, "c" -> 4))).
@@ -116,8 +120,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
 
     "fail with missing names" in {
       val batch = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a} AND b = {b} AND c = {c}",
-          List("a", "b", "c")),
+        "SELECT * FROM tbl WHERE a = {a} AND b = {b} AND c = {c}",
         Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2, "c" -> 3)))
 
       batch.addBatchList(Seq(Seq("a" -> 0))).
@@ -127,8 +130,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
 
     "with first parameter map" >> {
       "be successful" in {
-        val b1 = BatchSql(
-          SqlQuery("SELECT * FROM tbl WHERE a = {a}, b = {b}", List("a", "b")))
+        val b1 = BatchSql("SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
         lazy val b2 = b1.addBatchList(Seq(Seq("a" -> 0, "b" -> 1)))
 
@@ -141,7 +143,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
 
       "fail with parameter maps not having same names" in {
         val b1 = BatchSql(
-          SqlQuery("SELECT * FROM tbl WHERE a = {a}", List("a")))
+          "SELECT * FROM tbl WHERE a = {a}")
 
         lazy val b2 = b1.addBatchList(Seq(
           Seq("a" -> 0), Seq("a" -> 1, "b" -> 2)))
@@ -152,8 +154,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
 
       "fail with names not matching query placeholders" in {
         val b1 = BatchSql(
-          SqlQuery("SELECT * FROM tbl WHERE a = {a} AND b = {b} AND c = {c}",
-            List("a", "b", "c")))
+          "SELECT * FROM tbl WHERE a = {a} AND b = {b} AND c = {c}")
 
         lazy val b2 = b1.addBatchList(Seq(Seq("a" -> 0)))
 
@@ -163,7 +164,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
 
       "be successful with parameter maps having same names" in {
         val b1 = BatchSql(
-          SqlQuery("SELECT * FROM tbl WHERE a = {a}, b = {b}", List("a", "b")))
+          "SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
         lazy val b2 = b1.addBatchList(Seq(
           Seq[NamedParameter]("a" -> 0, "b" -> -1),
@@ -181,7 +182,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
 
     "be successful" in {
       val b1 = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a}, b = {b}", List("a", "b")),
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}",
         Seq(Seq("a" -> 0, "b" -> 1)))
 
       lazy val b2 = b1.addBatchList(Seq(Seq("a" -> 2, "b" -> 3)))
@@ -196,20 +197,9 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
   }
 
   "Appending list of parameter values" should {
-    "fail with missing names" in {
-      lazy val batch = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a} AND b = {b} AND c = {c}",
-          List("d", "b", "c")),
-        Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2, "c" -> 3)))
-
-      batch.addBatchParams(0).
-        aka("append") must throwA[IllegalArgumentException](
-          message = "Expected parameter names don't correspond to placeholders in query: a, b, c not matching d, b, c")
-    }
-
     "be successful with first parameter map" in {
       val b1 = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a}, b = {b}", List("a", "b")))
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
       lazy val b2 = b1.addBatchParams(0, 1)
       lazy val expectedMaps =
@@ -221,7 +211,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
 
     "fail with missing argument" in {
       val b1 = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a}, b = {b}", List("a", "b"))).
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}").
         addBatchParams(0, 1)
 
       lazy val b2 = b1.addBatchParams(2)
@@ -232,7 +222,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
 
     "be successful" in {
       val b1 = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a}, b = {b}", List("a", "b")))
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
       lazy val b2 = b1.addBatchParams(0, 1).addBatchParams(2, 3)
       lazy val expectedMaps = Seq(
@@ -245,20 +235,8 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
   }
 
   "Appending list of list of parameter values" should {
-    "fail with missing names" in {
-      lazy val batch = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a} AND b = {b} AND c = {c}",
-          List("d", "b", "c")),
-        Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2, "c" -> 3)))
-
-      batch.addBatchParamsList(Seq(Seq(4, 5, 6))).
-        aka("append") must throwA[IllegalArgumentException](
-          message = "Expected parameter names don't correspond to placeholders in query: a, b, c not matching d, b, c")
-    }
-
     "be successful with first parameter map" in {
-      val b1 = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a}, b = {b}", List("a", "b")))
+      val b1 = BatchSql("SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
       lazy val b2 = b1.addBatchParamsList(Seq(Seq(0, 1), Seq(2, 3)))
       lazy val expectedMaps = Seq(
@@ -271,8 +249,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
 
     "fail with missing argument" in {
       val b1 = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a}, b = {b}", List("a", "b"))).
-        addBatchParams(0, 1)
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}").addBatchParams(0, 1)
 
       lazy val b2 = b1.addBatchParamsList(Seq(Seq(2)))
 
@@ -281,8 +258,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
     }
 
     "be successful" in {
-      val b1 = BatchSql(
-        SqlQuery("SELECT * FROM tbl WHERE a = {a}, b = {b}", List("a", "b")))
+      val b1 = BatchSql("SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
       lazy val b2 = b1.addBatchParamsList(Seq(Seq(0, 1))).
         addBatchParamsList(Seq(Seq(2, 3), Seq(4, 5)))
@@ -294,6 +270,21 @@ object BatchSqlSpec extends org.specs2.mutable.Specification {
 
       (b2 aka "append" must not(throwA[Throwable])).
         and(b2.params aka "parameters" must_== expectedMaps)
+    }
+  }
+
+  "Batch inserting" should {
+    "be success on test1 table" in withConnection { implicit con =>
+      createTest1Table()
+
+      lazy val batch = BatchSql(
+        "INSERT INTO test1(id, foo, bar) VALUES({i}, {f}, {b})", Seq(
+          Seq[NamedParameter]('i -> 1, 'f -> "foo #1", 'b -> 2),
+          Seq[NamedParameter]('i -> 2, 'f -> "foo_2", 'b -> 4)))
+
+      (batch.sql.query aka "parsed query" mustEqual(
+        "INSERT INTO test1(id, foo, bar) VALUES(%s, %s, %s)")).
+        and(batch.execute() aka "batch result" mustEqual Array(1, 1))
     }
   }
 }


### PR DESCRIPTION
After I updated to Play 2.3 my batch queries fail to execute with the following exception:

```
PSQLException: The column index is out of range: 1, number of columns: 0.
```

I prepared a simplified sample code to reproduce the error:

```
val paramList = Seq(Seq[NamedParameter]("minAge" -> 43, "maxHeight" -> 180), Seq[NamedParameter]("minAge" -> 37, "maxHeight" -> 195))
val query = BatchSql(SqlQuery("SELECT firstname, lastname FROM person WHERE age > {minAge} AND height < {maxHeight}", List("minAge", "maxHeight")), paramList)
query.execute()
```

In my opinion the issue is that the query parameters are not parsed and still in the form `{}` instead of `?` when the batch parameters are applied to the prepared statement. At least this is the difference I saw compared to a normal query. 

See method `fill` in https://github.com/playframework/playframework/blob/30d6d8c12908603f044d0071af6c2b1a80cab222/framework/src/anorm/src/main/scala/anorm/BatchSql.scala#L116-135
