### PR TITLE
Update IDE.md

### DIFF
--- a/documentation/manual/gettingStarted/IDE.md
+++ b/documentation/manual/gettingStarted/IDE.md
@@ -13,13 +13,13 @@ Play provides a command to simplify Eclipse configuration. To transform a Play a
 without the source jars:
 
 ```
-[My first application] $ eclipse
+[My first application] $ activator eclipse
 ```
 
 if you want to grab the available source jars (this will take longer and it's possible a few sources might be missing):
 
 ```
-[My first application] $ eclipse with-source=true
+[My first application] $ activator eclipse with-source=true
 ```
 
 > Note if you are using sub-projects with aggregate, you would need to set `skipParents` appropriately:


### PR DESCRIPTION
Just writing eclipse command on prompt fails or if eclipse.exe is in you path then open eclipse. 
passing eclipse as parameter to activator works (tested on windows 7 64 bit with activator 1.2.2)
