### PR TITLE
WsSSL exists in docs twice

### DIFF
--- a/documentation/manual/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/scalaGuide/main/ws/ScalaWS.md
@@ -215,8 +215,4 @@ There are 3 different timeouts in WS. Reaching a timeout causes the WS request t
 
 The request timeout can be overridden for a specific connection with `withRequestTimeout()` (see "Making a Request" section).
 
-## Configuring WS with SSL
-
-To configure WS for use with HTTP over SSL/TLS (HTTPS), please see [[Configuring WS SSL|WsSSL]].
-
 > **Next:** [[OpenID Support in Play|ScalaOpenID]]


### PR DESCRIPTION
Doesn't need to be in there the second time.
