### PR TITLE
Add Play Asset JavaScript literal binder

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -190,9 +190,9 @@ trait PathBindable[A] {
  * Transform a value to a Javascript literal.
  */
 @implicitNotFound(
-  "No JavaScript litteral binder found for type ${A}. Try to implement an implicit JavascriptLitteral for this type."
+  "No JavaScript literal binder found for type ${A}. Try to implement an implicit JavascriptLiteral for this type."
 )
-trait JavascriptLitteral[A] {
+trait JavascriptLiteral[A] {
 
   /**
    * Convert a value of A to a JavaScript literal.
@@ -204,54 +204,54 @@ trait JavascriptLitteral[A] {
 /**
  * Default JavaScript literals converters.
  */
-object JavascriptLitteral {
+object JavascriptLiteral {
 
   /**
    * Convert a Scala String to Javascript String
    */
-  implicit def litteralString: JavascriptLitteral[String] = new JavascriptLitteral[String] {
+  implicit def literalString: JavascriptLiteral[String] = new JavascriptLiteral[String] {
     def to(value: String) = "\"" + value + "\""
   }
 
   /**
    * Convert a Scala Int to Javascript number
    */
-  implicit def litteralInt: JavascriptLitteral[Int] = new JavascriptLitteral[Int] {
+  implicit def literalInt: JavascriptLiteral[Int] = new JavascriptLiteral[Int] {
     def to(value: Int) = value.toString
   }
 
   /**
    * Convert a Java Integer to Javascript number
    */
-  implicit def litteralJavaInteger: JavascriptLitteral[java.lang.Integer] = new JavascriptLitteral[java.lang.Integer] {
+  implicit def literalJavaInteger: JavascriptLiteral[java.lang.Integer] = new JavascriptLiteral[java.lang.Integer] {
     def to(value: java.lang.Integer) = value.toString
   }
 
   /**
    * Convert a Scala Long to Javascript Long
    */
-  implicit def litteralLong: JavascriptLitteral[Long] = new JavascriptLitteral[Long] {
+  implicit def literalLong: JavascriptLiteral[Long] = new JavascriptLiteral[Long] {
     def to(value: Long) = value.toString
   }
 
   /**
    * Convert a Scala Boolean to Javascript boolean
    */
-  implicit def litteralBoolean: JavascriptLitteral[Boolean] = new JavascriptLitteral[Boolean] {
+  implicit def literalBoolean: JavascriptLiteral[Boolean] = new JavascriptLiteral[Boolean] {
     def to(value: Boolean) = value.toString
   }
 
   /**
    * Convert a Scala Option to Javascript literal (use null for None)
    */
-  implicit def litteralOption[T](implicit jsl: JavascriptLitteral[T]): JavascriptLitteral[Option[T]] = new JavascriptLitteral[Option[T]] {
+  implicit def literalOption[T](implicit jsl: JavascriptLiteral[T]): JavascriptLiteral[Option[T]] = new JavascriptLiteral[Option[T]] {
     def to(value: Option[T]) = value.map(jsl.to(_)).getOrElse("null")
   }
 
   /**
    * Convert a Play Asset to Javascript String
    */
-  implicit def litteralAsset: JavascriptLitteral[Asset] = new JavascriptLitteral[Asset] {
+  implicit def literalAsset: JavascriptLiteral[Asset] = new JavascriptLiteral[Asset] {
     def to(value: Asset) = "\"" + value.name + "\""
   }
 }

--- a/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
@@ -730,7 +730,7 @@ object RoutesCompiler {
                               Option(route.call.parameters.getOrElse(Nil).filter { p =>
                                 localNames.contains(p.name) && p.fixed.isDefined
                               }.map { p =>
-                                p.name + " == \"\"\" + implicitly[JavascriptLitteral[" + p.typeName + "]].to(" + p.fixed.get + ") + \"\"\""
+                                p.name + " == \"\"\" + implicitly[JavascriptLiteral[" + p.typeName + "]].to(" + p.fixed.get + ") + \"\"\""
                               }).filterNot(_.isEmpty).map(_.mkString(" && ")).getOrElse("true"),
 
                               genCall(route, localNames))


### PR DESCRIPTION
Without the proposed binder, Play doesn't compile the project with the message:

```
No JavaScript litteral binder found for type controllers.Assets.Asset. Try to implement an implicit JavascriptLitteral for this type.
```

when using the following route:

```
GET     /$file<(css|img|js)/.*>     controllers.CustomAssets.at(path="/public", file: Asset)
GET     /robots.txt                 controllers.CustomAssets.at(path="/public", file: Asset ="robots.txt")
GET     /favicon.ico                controllers.CustomAssets.at(path="/public", file: Asset ="img/favicon.ico")
```

It also fixes the spelling (litteral => literal)

See #3031
