### PR TITLE
Add some differences between Play 2.2 and sbt-less related to source maps

### DIFF
--- a/documentation/manual/Migration23.md
+++ b/documentation/manual/Migration23.md
@@ -261,6 +261,8 @@ includeFilter in (Assets, LessKeys.less) := "*.less"
 excludeFilter in (Assets, LessKeys.less) := "_*.less"
 ```
 
+Unlike Play 2.2, the sbt-less plugin allows any user to download the original LESS source file and generated source maps. It allows easier debugging in modern web browsers. This feature is enabled even in production mode.
+
 The plugin's options are:
 
 Option              | Description


### PR DESCRIPTION
Related discussion thread: https://groups.google.com/d/topic/play-framework/IO9BrHK4PN0/discussion

backport to 2.3.x

Typesafe CLA signed.
