### PR TITLE
Make reverse routes always use the first matching route

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
@@ -612,9 +612,9 @@ object RoutesCompiler {
               """
                   |%s
                   |class Reverse%s {
-                  |    
+                  |
                   |%s
-                  |    
+                  |
                   |}
               """.stripMargin.format(
                 markLines(routes: _*),
@@ -774,9 +774,9 @@ object RoutesCompiler {
               """
                               |%s
                               |class Reverse%s {
-                              |    
+                              |
                               |%s
-                              |    
+                              |
                               |}
                           """.stripMargin.format(
                 markLines(routes: _*),
@@ -851,9 +851,9 @@ object RoutesCompiler {
               """
                               |%s
                               |class Reverse%s {
-                              |    
+                              |
                               |%s
-                              |    
+                              |
                               |}
                           """.stripMargin.format(
                 markLines(routes: _*),
@@ -969,10 +969,7 @@ object RoutesCompiler {
                           // We will generate a list of routes. Then we should remove duplicates from them.
                           // Routes are considered duplicates if parameters and parameters constraints (see
                           // definition below) are identical.
-                          //
-                          // We will generate a seq of route then pass to ListMap (to preserve order) to have
-                          // a distinctBy we control then get the values of this map.
-                          ListMap((route +: routes).map { route =>
+                          (route +: routes).map { route =>
 
                             val localNames = reverseParameters.map {
                               case (lp, i) => route.call.parameters.get(i).name -> lp.name
@@ -1005,7 +1002,7 @@ object RoutesCompiler {
                                          """.stripMargin.format(markers, parameters, parametersConstraints, reverseRouteContext, call)
 
                             (parameters -> parametersConstraints) -> result
-                          }: _*).values
+                          }.groupBy(_._1).map(_._2.head._2)
                             .mkString("\n"))
                       }
 
@@ -1067,7 +1064,7 @@ object RoutesCompiler {
       """|
          |def documentation = List(%s).foldLeft(List.empty[(String,String,String)]) { (s,e) => e.asInstanceOf[Any] match {
          |  case r @ (_,_,_) => s :+ r.asInstanceOf[(String,String,String)]
-         |  case l => s ++ l.asInstanceOf[List[(String,String,String)]] 
+         |  case l => s ++ l.asInstanceOf[List[(String,String,String)]]
          |}}
       """.stripMargin.format(
         rules.map {

--- a/framework/test/integrationtest/conf/routes
+++ b/framework/test/integrationtest/conf/routes
@@ -65,6 +65,7 @@ GET     /async-error            controllers.Application.asyncError()
 GET     /ident/:è27             controllers.πø$7ß.ôü65$t(è27: Int)
 
 GET     /hello                  controllers.Application.hello()
+GET     /hello2                 controllers.Application.hello()
 GET     /setLang                controllers.Application.setLang(lang)
 
 POST    /any-xml                controllers.Application.anyXml

--- a/framework/test/integrationtest/test/ApplicationSpec.scala
+++ b/framework/test/integrationtest/test/ApplicationSpec.scala
@@ -16,7 +16,7 @@ import scala.concurrent.Future
 class ApplicationSpec extends PlaySpecification with WsTestClient {
 
   "an Application" should {
-  
+
     "execute index" in new WithApplication() {
       val action = controllers.Application.index()
       val result = action(FakeRequest())
@@ -41,7 +41,7 @@ class ApplicationSpec extends PlaySpecification with WsTestClient {
        anyData.put("email", "peter.hausel@yay.com")
        userForm.bind(anyData).get.toString must contain ("")
     }
-  
+
     "execute index again" in new WithApplication() {
       val action = controllers.Application.index()
       val result = action(FakeRequest())
@@ -51,7 +51,7 @@ class ApplicationSpec extends PlaySpecification with WsTestClient {
       charset(result) must equalTo(Some("utf-8"))
       contentAsString(result) must contain("Hello world")
     }
-    
+
     "execute json" in new WithApplication() {
       val Some(result) = route(FakeRequest(GET, "/json"))
       status(result) must equalTo(OK)
@@ -91,7 +91,7 @@ class ApplicationSpec extends PlaySpecification with WsTestClient {
       val Some(result2) = route(FakeRequest(GET, "/public//empty.txt"))
       status(result2) must equalTo (OK)
     }
-   
+
     "remove cache elements" in new WithApplication() {
       import play.api.cache.Cache
       Cache.set("foo", "bar")
@@ -305,6 +305,10 @@ class ApplicationSpec extends PlaySpecification with WsTestClient {
       // Force the router to bootstrap the prefix
       app.routes
       controllers.module.routes.ModuleController.index().url must_== "/module/index"
+    }
+
+    "choose the first matching route for a call in reverse routes" in new WithApplication() {
+      controllers.routes.Application.hello().url must_== "/hello"
     }
 
     "document the router" in new WithApplication() {


### PR DESCRIPTION
Fixes #3050. The previous way of removing the extra routes would prioritize the last matching route as opposed to the first one. Now it should work the same as in 2.2, but without the warning.
