### PR TITLE
Catch yet another exception when loading JNotify.

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
@@ -123,7 +123,8 @@ trait PlayReloader {
         } catch {
           case NonFatal(e) => fallbackWatcher(e)
           // JNotify failure on FreeBSD
-          case e: ExceptionInInitializerError => fallbackWatcher(e)
+          case e: ExceptionInInitializerError => fallbackWatcher(e.getCause)
+          case e: NoClassDefFoundError => fallbackWatcher(e)
           // JNotify failure on Linux
           case e: UnsatisfiedLinkError => fallbackWatcher(e)
         }


### PR DESCRIPTION
Here is the output from sbt console on FreeBSD. It turns out on the second _run_ jvm throws NoClassDefFoundError instead of ExceptionInInitializerError. Related to #2831.

> % sbt
> [play-2.3-highlights] $ ~run
> 
> Cannot load the JNotify native library (null)
> Play will check file changes for each request, so expect degraded reloading performace.
> 
> --- (Running the application from SBT, auto-reloading is enabled) ---
> 
> [info] play - Listening for HTTP on /0:0:0:0:0:0:0:0:9000
> 
> (Server started, use Ctrl+D to stop and go back to the console...)
> 
> [success] Compiled in 194ms
> 
> [success] Total time: 5 s, completed 21.06.2014 18:39:32
> 1. Waiting for source changes... (press enter to interrupt)
> 
> [play-2.3-highlights] $ ~run
> 
> java.lang.NoClassDefFoundError: Could not initialize class net.contentobjects.jnotify.JNotify
