### PR TITLE
Fix excessive reloading when fallback watcher is used instead of JNotify.

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
@@ -325,8 +325,11 @@ trait PlayReloader {
               .left.map(taskFailureHandler)
               .right.map {
                 compilationResult =>
-                  updateAnalysis(compilationResult)
-                  newClassLoader.fold(identity, identity)
+                  if (updateAnalysis(compilationResult) != None) {
+                    newClassLoader.fold(identity, identity)
+                  } else {
+                    null
+                  }
               }.fold(identity, identity)
           } else {
             null


### PR DESCRIPTION
Restores pre- a0262e4468 behavior. I have basically the same issue as an author of [this](https://groups.google.com/forum/#!topic/play-framework/__CjPbUUjTA) thread. Could also be related to #3020.
