### PR TITLE
CSRF check supports HEAD method

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -29,7 +29,7 @@ private[csrf] object CSRFConf {
   def defaultCreateIfNotFound(request: RequestHeader) = {
     // If the request isn't accepting HTML, then it won't be rendering a form, so there's no point in generating a
     // CSRF token for it.
-    request.method == "GET" && (request.accepts("text/html") || request.accepts("application/xml+xhtml"))
+    (request.method == "GET" || request.method == "HEAD") && (request.accepts("text/html") || request.accepts("application/xml+xhtml"))
   }
 
   /**

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -32,6 +32,12 @@ object CSRFFilterSpec extends CSRFCommonSpecs {
     "add a token to GET requests that accept HTML" in {
       buildCsrfAddToken()(_.withHeaders(ACCEPT -> "text/html").get())(_.status must_== OK)
     }
+    "not add a token to HEAD requests that don't accept HTML" in {
+      buildCsrfAddToken()(_.withHeaders(ACCEPT -> "application/json").head())(_.status must_== NOT_FOUND)
+    }
+    "add a token to HEAD requests that accept HTML" in {
+      buildCsrfAddToken()(_.withHeaders(ACCEPT -> "text/html").head())(_.status must_== OK)
+    }
 
     // extra conditions for not doing a check
     "not check non form bodies" in {


### PR DESCRIPTION
HEAD method always returns 500 error with CSRF check.
Reporting from user forum. https://groups.google.com/forum/#!topic/play-framework/k6b4X3iqtgg

backport to play 2.3.x.
