### PR TITLE
Upgraded to Netty 3.9.2

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -76,7 +76,7 @@ object Dependencies {
     mockitoAll % "test")
 
   val runtime = Seq(
-    "io.netty" % "netty" % "3.9.1.Final",
+    "io.netty" % "netty" % "3.9.2.Final",
 
     "com.typesafe.netty" % "netty-http-pipelining" % "1.1.2",
 


### PR DESCRIPTION
Netty 3.9.2 contains a DoS vulnerability fix in the SSLHandler.

Backport to 2.3.x necessary.
