### PR TITLE
updated example of using ``play`` with ``grunt``

### DIFF
--- a/documentation/manual/detailedTopics/build/SBTCookbook.md
+++ b/documentation/manual/detailedTopics/build/SBTCookbook.md
@@ -46,8 +46,8 @@ Then in the `build.sbt` file you need to register this hook:
 
 ```scala
 import Grunt._
+import play.PlayImport.PlayKeys.playRunHooks
 
-val playRunHooks = TaskKey[Seq[play.PlayRunHook]]("play-run-hooks")
 playRunHooks <+= baseDirectory.map(base => Grunt(base))
 ```
 


### PR DESCRIPTION
without this line I am getting:

```
/path/to/myProject/build.sbt:10: error: not found: value playRunHooks
playRunHooks <+= baseDirectory.map(base => Gulp(base))
^
[error] Type error in expression
```
