### PR TITLE
web-assets:assets Duplicate mappings on runtime

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -153,7 +153,7 @@ object Dependencies {
     sbtPluginDep("com.github.mpeltonen" % "sbt-idea" % "1.5.1"),
     sbtPluginDep("com.typesafe.sbt" % "sbt-native-packager" % "0.7.1"),
 
-    sbtPluginDep("com.typesafe.sbt" % "sbt-js-engine" % "1.0.0"),
+    sbtPluginDep("com.typesafe.sbt" % "sbt-js-engine" % "1.0.1"),
     sbtPluginDep("com.typesafe.sbt" % "sbt-webdriver" % "1.0.0")
   ) ++ specsSbt.map(_ % "test")
 


### PR DESCRIPTION
Hello,

It seems that the .svn folder in my public folder are not excluded when play try to compile assets.

This is our stack trace:
[error](ngl-sq/web-assets:assets) Duplicate mappings:
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/app-ngl-sq/target/web/public/main/.svn/entries
[error] from
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/app-ngl-sq/app/assets/.svn/entries
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/app-ngl-sq/public/.svn/entries
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/app-ngl-sq/target/web/public/main/.svn/all-wcprops
[error] from
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/app-ngl-sq/app/assets/.svn/all-wcprops
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/app-ngl-sq/public/.svn/all-wcprops
[error](ngl-common/web-assets:assets) Duplicate mappings:
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-common/target/web/public/main/.svn/entries
[error] from
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-common/app/assets/.svn/entries
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-common/public/.svn/entries
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-common/target/web/public/main/.svn/all-wcprops
[error] from
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-common/app/assets/.svn/all-wcprops
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-common/public/.svn/all-wcprops
[error](lib-frameworkweb/web-assets:assets) Duplicate mappings:
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-frameworkweb/target/web/public/main/.svn/all-wcprops
[error] from
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-frameworkweb/app/assets/.svn/all-wcprops
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-frameworkweb/public/.svn/all-wcprops
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-frameworkweb/target/web/public/main/.svn/entries
[error] from
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-frameworkweb/app/assets/.svn/entries
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-frameworkweb/public/.svn/entries
[error](datatable/web-assets:assets) Duplicate mappings:
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/target/web/public/main/.svn/entries
[error] from
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/app/assets/.svn/entries
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/public/.svn/entries
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/target/web/public/main/.svn/all-wcprops
[error] from
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/app/assets/.svn/all-wcprops
[error]  
/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/public/.svn/all-wcprops
[error] application -

! @6ijfh3jdo - Internal server error, for (GET) [/] ->

play.PlayExceptions$UnexpectedException: Unexpected
exception[RuntimeException: Duplicate mappings:

/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/target/web/public/main/.svn/entries
from

/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/app/assets/.svn/entries

/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/public/.svn/entries

/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/target/web/public/main/.svn/all-wcprops
from

/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/app/assets/.svn/all-wcprops

/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/public/.svn/all-wcprops]
     at
play.PlayReloader$$anon$1$$anonfun$play$PlayReloader$$anon$$taskFailureHandler$1.apply(PlayReloader.scala:300)
~[na:na]
     at
play.PlayReloader$$anon$1$$anonfun$play$PlayReloader$$anon$$taskFailureHandler$1.apply(PlayReloader.scala:292)
~[na:na]
     at scala.Option.map(Option.scala:145) ~[scala-library-2.11.1.jar:na]
     at
play.PlayReloader$$anon$1.play$PlayReloader$$anon$$taskFailureHandler(PlayReloader.scala:292)
~[na:na]
     at
play.PlayReloader$$anon$1$$anonfun$reload$2.apply(PlayReloader.scala:325) ~[na:na] Caused by: java.lang.RuntimeException: Duplicate mappings:

/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/target/web/public/main/.svn/entries
from

/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/app/assets/.svn/entries

/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/public/.svn/entries

/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/target/web/public/main/.svn/all-wcprops
from

/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/app/assets/.svn/all-wcprops

/env/export/nfs8/genosphere/workspaces/mhaquell/ngl-test/ngl/lib-ngl-datatable/public/.svn/all-wcprops
     at scala.sys.package$.error(package.scala:27)
~[scala-library-2.11.1.jar:na]
     at sbt.Sync$.noDuplicateTargets(Sync.scala:67) ~[na:na]
     at sbt.Sync$$anonfun$apply$1.apply(Sync.scala:26) ~[na:na]
     at sbt.Sync$$anonfun$apply$1.apply(Sync.scala:23) ~[na:na]
     at com.typesafe.sbt.web.SbtWeb$.syncMappings(SbtWeb.scala:369) ~[na:na]

Can we resolve this problem in the build.scala ? or is it an issue ?

Thanks
