### PR TITLE
Fix statement preparation in batch (No longer use SqlQuery at batch creation)

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/BatchSql.scala
+++ b/framework/src/anorm/src/main/scala/anorm/BatchSql.scala
@@ -119,7 +119,7 @@ sealed trait BatchSql {
         val st: (String, Seq[(Int, ParameterValue)]) =
           Sql.prepareQuery(sql.query, 0, sql.argsInitialOrder.map(ps), Nil)
 
-        val stmt = if (getGeneratedKeys) con.prepareStatement(sql.query, java.sql.Statement.RETURN_GENERATED_KEYS) else con.prepareStatement(sql.query)
+        val stmt = if (getGeneratedKeys) con.prepareStatement(st._1, java.sql.Statement.RETURN_GENERATED_KEYS) else con.prepareStatement(st._1)
 
         sql.queryTimeout.foreach(timeout => stmt.setQueryTimeout(timeout))
 


### PR DESCRIPTION
This is a backport of #3016.

@cchantep Please review.  To maintain binary compatibility, I had to reintroduce the old `apply` method, and the new `apply` method I had to overload instead of having default arguments because Scala doesn't allow multiple overloaded methods with the same name to have default arguments.

I'm not sure what the consequences of reintroducing the old `apply` method are.  Looking at original issue reported, it sounds like it's not always an issue?  So that means there could be Play 2.3.0/2.3.1 users who are successfully using it.  I think my implementation of the method means that it should just continue to work for them, right?  Or not?
