### PR TITLE
Anorm leaks resources if all results are not read

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -209,6 +209,7 @@ object Dependencies {
     mockitoAll % "test"
 
   val anormDependencies = specsBuild.map(_ % "test") ++ Seq(
+    "com.jsuereth" %% "scala-arm" % "1.4",
     h2database % "test",
     "org.eu.acolyte" %% "jdbc-scala" % acolyteVersion % "test",
     "com.chuusai" % "shapeless" % "2.0.0" % "test" cross CrossVersion.binaryMapped {

--- a/framework/src/anorm/src/main/scala/anorm/SqlParser.scala
+++ b/framework/src/anorm/src/main/scala/anorm/SqlParser.scala
@@ -3,13 +3,9 @@
  */
 package anorm
 
-import SqlParser.ResultSet
-
 object SqlParser {
   import MayErr._
   import java.util.Date
-
-  type ResultSet = Stream[Row]
 
   private val NoColumnsInReturnedResult = SqlMappingError("No column in result")
 
@@ -513,16 +509,16 @@ sealed trait ScalarRowParser[+A] extends RowParser[A] {
   }
 }
 
-trait ResultSetParser[+A] extends (ResultSet => SqlResult[A]) { parent =>
+trait ResultSetParser[+A] extends (Stream[Row] => SqlResult[A]) { parent =>
   def map[B](f: A => B): ResultSetParser[B] =
-    ResultSetParser(rs => parent(rs).map(f))
+    ResultSetParser(parent(_).map(f))
 
 }
 
 private[anorm] object ResultSetParser {
-  def apply[A](f: ResultSet => SqlResult[A]): ResultSetParser[A] =
+  def apply[A](f: Stream[Row] => SqlResult[A]): ResultSetParser[A] =
     new ResultSetParser[A] { rows =>
-      def apply(rows: ResultSet): SqlResult[A] = f(rows)
+      def apply(rows: Stream[Row]): SqlResult[A] = f(rows)
     }
 
   def list[A](p: RowParser[A]): ResultSetParser[List[A]] = {

--- a/framework/src/anorm/src/main/scala/anorm/SqlQueryResult.scala
+++ b/framework/src/anorm/src/main/scala/anorm/SqlQueryResult.scala
@@ -1,6 +1,8 @@
 package anorm
 
-import java.sql.Connection
+import java.sql.{ Connection, SQLWarning }
+
+import resource.ManagedResource
 
 /**
  * A result from execution of an SQL query, row data and context
@@ -9,9 +11,13 @@ import java.sql.Connection
  * @constructor create a result with a result set
  * @param resultSet Result set from executed query
  */
-final case class SqlQueryResult(resultSet: java.sql.ResultSet) {
+final case class SqlQueryResult(
+    /** Underlying result set */
+    resultSet: ManagedResource[java.sql.ResultSet]) {
+
   /** Query statement already executed */
-  val statement: java.sql.Statement = resultSet.getStatement
+  val statement: ManagedResource[java.sql.Statement] =
+    resultSet.map(_.getStatement)
 
   /**
    * Returns statement warning if there is some for this result.
@@ -29,18 +35,16 @@ final case class SqlQueryResult(resultSet: java.sql.ResultSet) {
    * }
    * }}}
    */
-  def statementWarning: Option[java.sql.SQLWarning] =
-    Option(statement.getWarnings)
+  def statementWarning: Option[SQLWarning] =
+    statement.acquireFor(_.getWarnings).fold[Option[SQLWarning]](
+      _.headOption.map(new SQLWarning(_)), Option(_))
 
   /** Returns stream of row from query result. */
   def apply()(implicit connection: Connection): Stream[Row] =
     Sql.resultSetToStream(resultSet)
 
   def as[T](parser: ResultSetParser[T])(implicit connection: Connection): T =
-    parser(Sql.resultSetToStream(resultSet)) match {
-      case Success(a) => a
-      case Error(e) => sys.error(e.toString)
-    }
+    Sql.as(parser, resultSet)
 
   def list[A](rowParser: RowParser[A])(implicit connection: Connection): Seq[A] = as(rowParser.*)
 
@@ -49,10 +53,8 @@ final case class SqlQueryResult(resultSet: java.sql.ResultSet) {
 
   def singleOpt[A](rowParser: RowParser[A])(implicit connection: Connection): Option[A] = as(ResultSetParser.singleOpt(rowParser))
 
+  @deprecated(message = "Use [[as]]", since = "2.3.2")
   def parse[T](parser: ResultSetParser[T])(implicit connection: Connection): T =
-    parser(Sql.resultSetToStream(resultSet)) match {
-      case Success(a) => a
-      case Error(e) => sys.error(e.toString)
-    }
+    as(parser)
 
 }

--- a/framework/src/anorm/src/test/scala/anorm/AnormSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/AnormSpec.scala
@@ -321,18 +321,6 @@ object AnormSpec extends Specification with H2Database with AnormTest {
       }
   }
 
-  "SQL warning" should {
-    "be handle from executed query" in withQueryResult(
-      QueryResult.Nil.withWarning("Warning for test-proc-2")) { implicit c =>
-
-        SQL("EXEC stored_proc({param})")
-          .on("param" -> "test-proc-2").executeQuery()
-          .statementWarning aka "statement warning" must beSome.which { warn =>
-            warn.getMessage aka "message" must_== "Warning for test-proc-2"
-          }
-      }
-  }
-
   "Insertion" should {
     lazy implicit val con = connection(handleStatement withUpdateHandler {
       case UpdateExecution("INSERT ?", ExecutedParameter(1) :: Nil) => 1


### PR DESCRIPTION
Anorm closes the `java.sql.Statement` only once all records have been traversed in the `java.sql.ResultSet`.

https://github.com/playframework/playframework/blob/master/framework/src/anorm/src/main/scala/anorm/Anorm.scala#L366

This introduces the possibility of a resource leak. Examples:
1. The caller intentionally does not read all records.
   
   ```
   SQL("SELECT id FROM country")().head
   ```
   
   Admittedly, this is a dumb example. A more realistic example might involve `takeWhile`, or something similar.
2. An exception occurs before all records can be read. 
   
   ```
   val a = SQL("SELECT id FROM country")()
   val b = SQL("SELECT id, country_id FROM province")()
   ```
   
   If there is an exception is thrown while querying for `b`, the `Statement` created by `a` will never be closed.

These examples are not exhaustive.

The severity of this depends on the JDBC. For example, Oracle will keep resources for a open `ResultSet/Statement`, even after the `Connection` has been closed.
