### PR TITLE
Router requiring running application. Template tests broken

### DIFF
--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -209,7 +209,10 @@ object Assets extends AssetsBuilder {
   // Sames goes for the minified paths cache.
   val minifiedPathsCache = TrieMap[String, String]()
 
-  lazy val checkForMinified = Play.configuration.getBoolean("assets.checkForMinified").getOrElse(true)
+  lazy val checkForMinified = (for {
+    app <- Play.maybeApplication
+    cfm <- app.configuration.getBoolean("assets.checkForMinified")
+  } yield cfm).getOrElse(true)
 
   private[controllers] def minifiedPath(path: String): String = {
     minifiedPathsCache.getOrElse(path, {


### PR DESCRIPTION
The tests for a handful of pull requests are failing with the same error

https://github.com/playframework/playframework/pull/3110
https://github.com/playframework/playframework/pull/3095

```
[error] Test ApplicationTest.renderTemplate failed: java.lang.RuntimeException: There is no started application, took 0.952 sec
[error]     at scala.sys.package$.error(package.scala:27)
[error]     at play.api.Play$$anonfun$current$1.apply(Play.scala:71)
[error]     at play.api.Play$$anonfun$current$1.apply(Play.scala:71)
[error]     at scala.Option.getOrElse(Option.scala:120)
[error]     at play.api.Play$.current(Play.scala:71)
[error]     at controllers.Assets$.checkForMinified$lzycompute(Assets.scala:212)
[error]     at controllers.Assets$.checkForMinified(Assets.scala:212)
[error]     at controllers.Assets$$anonfun$minifiedPath$1.apply(Assets.scala:222)
[error]     at controllers.Assets$$anonfun$minifiedPath$1.apply(Assets.scala:215)
[error]     at scala.collection.MapLike$class.getOrElse(MapLike.scala:128)
[error]     at scala.collection.concurrent.TrieMap.getOrElse(TrieMap.scala:633)
[error]     at controllers.Assets$.minifiedPath(Assets.scala:215)
[error]     at controllers.Assets$Asset$$anon$1$$anonfun$unbind$1.apply(Assets.scala:280)
[error]     at controllers.Assets$Asset$$anon$1$$anonfun$unbind$1.apply(Assets.scala:279)
[error]     at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:53)
[error]     at scala.concurrent.package$.blocking(package.scala:54)
[error]     at controllers.Assets$Asset$$anon$1.unbind(Assets.scala:279)
[error]     at controllers.Assets$Asset$$anon$1.unbind(Assets.scala:273)
[error]     at controllers.ReverseAssets.versioned(routes_reverseRouting.scala:29)
[error]     at views.html.main$.apply(main.template.scala:36)
[error]     at views.html.index$.apply(index.template.scala:31)
[error]     at views.html.index$.render(index.template.scala:39)
[error]     at views.html.index.render(index.template.scala)
[error]     at ApplicationTest.renderTemplate(ApplicationTest.java:39)
```
