### PR TITLE
start -Dconfig.file from within activator broken

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayRun.scala
@@ -370,7 +370,7 @@ trait PlayRun extends PlayInternalKeys {
         // problem occurs in this area then at least we know what to look at.
         val args = Seq(stagingBin) ++
           properties.map {
-            case (key, value) => s"""-D$key="$value" """
+            case (key, value) => s"-D$key=$value"
           } ++
           javaProductionOptions ++
           Seq("-Dhttp.port=" + httpPort.getOrElse("disabled"))


### PR DESCRIPTION
Play 2.3.1, activator 1.2.2.

```
> activator
$ start -Dconfig.file=local.conf
Configuration error: Configuration error["local.conf" : java.io.FileNotFoundException: "local.conf"  (No such file or directory)]
```

Note the double quotes and extra space: it is actually trying to open a file called '"local.conf" ' even though I put no quotes anywhere in the command and no space after conf.  Here is the relevant strace output:

```
22991 execve("/etc/java-config-2/current-system-vm/bin/java", ["/etc/java-config-2/current-syste"..., "-Xms1024m", "-Xmx1024m", "-XX:MaxPermSize=256m", "-XX:ReservedCodeCacheSize=128m", "-Duser.dir=/home/dylan/databrary"..., "-Dconfig.file=\"local.conf\" ", "-Dhttp.port=9000", "-cp", "/home/dylan/databrary/target/uni"..., "play.core.server.NettyServer"], [/* 41 vars */]) = 0
23054 stat("/home/dylan/databrary/target/universal/stage/\"local.conf\" ", 0x7f64242af2b0) = -1 ENOENT (No such file or directory)
23054 open("\"local.conf\" ", O_RDONLY) = -1 ENOENT (No such file or directory)
```

Using full paths does not help (it still double-quotes the whole path).
