### PR TITLE
Migration guide 2.3: Missing Json error keys renaming

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsPath.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsPath.scala
@@ -19,11 +19,11 @@ sealed trait PathNode {
 case class RecursiveSearch(key: String) extends PathNode {
   def apply(json: JsValue): List[JsValue] = json match {
     case obj: JsObject => (json \\ key).toList.filterNot {
-      case JsUndefined(_) => true
+      case JsUndefined() => true
       case _ => false
     }
     case arr: JsArray => (json \\ key).toList.filterNot {
-      case JsUndefined(_) => true
+      case JsUndefined() => true
       case _ => false
     }
     case _ => List()
@@ -66,7 +66,7 @@ case class KeyPathNode(key: String) extends PathNode {
 
   def apply(json: JsValue): List[JsValue] = json match {
     case obj: JsObject => List(json \ key).filterNot {
-      case JsUndefined(_) => true
+      case JsUndefined() => true
       case _ => false
     }
     case _ => List()
@@ -442,7 +442,7 @@ case class JsPath(path: List[PathNode] = List()) {
      * Example :
      * {{{
      * val js = Json.obj("key1" -> "value1", "key2" -> "value2")
-     * js.validate( (__ \ 'key2).json.pick )
+     * js.validate((__ \ 'key2).json.pick)
      * => JsSuccess(JsString("value2"))
      * }}}
      */
@@ -478,7 +478,7 @@ case class JsPath(path: List[PathNode] = List()) {
      * {{{
      * val js = Json.obj("key1" -> "value1", "key2" -> Json.obj( "key21" -> "value2") )
      * js.validate( (__ \ 'key2).json.pickBranch )
-     * => JsSuccess(JsObject(Seq( ("key2", Json.obj("key21" -> "value2")) )))
+     * => JsSuccess(JsObject(Seq(("key2", Json.obj("key21" -> "value2")))))
      * }}}
      */
     def pickBranch: Reads[JsObject] = Reads.jsPickBranch[JsValue](self)

--- a/framework/src/play/src/main/resources/messages.default
+++ b/framework/src/play/src/main/resources/messages.default
@@ -43,6 +43,9 @@ error.expected.jsobject=Object value expected
 error.expected.jsstring=String value expected
 error.expected.jsnumberorjsstring=String or number expected
 error.expected.keypathnode=Node value expected
+error.expected.uuid=UUID value expected
+error.expected.validenumvalue=Valid enumeration value expected
+error.expected.enumstring=String value expected
 
 error.path.empty=Empty path
 error.path.missing=Missing path


### PR DESCRIPTION
Hello,

I've just found that many JSON error keys have been renamed between 2.2 and 2.3. These break changes are not mentioned in the Migration Guide.

There are two commits involved:
- https://github.com/playframework/playframework/commit/5b0f70860d329d26aadd47f77547682589c30052
- https://github.com/playframework/playframework/commit/ebe6e017f661355358fcbda939b660f7bcac4ef4
