### PR TITLE
FakeRequest Content-Type Header Overwritten

### DIFF
--- a/framework/src/play-test/src/test/scala/play/api/test/FakesSpec.scala
+++ b/framework/src/play-test/src/test/scala/play/api/test/FakesSpec.scala
@@ -3,11 +3,11 @@
  */
 package play.api.test
 
-import org.specs2.mutable.Specification
 import play.api.mvc._
-import play.api.test.Helpers._
 
-object FakesSpec extends Specification {
+object FakesSpec extends PlaySpecification {
+
+  sequential
 
   "FakeApplication" should {
 
@@ -22,6 +22,49 @@ object FakesSpec extends Specification {
         result must beSome
         contentAsString(result.get) must_== "inline route"
         route(app, FakeRequest("GET", "/foo")) must beNone
+      }
+    }
+  }
+
+  "FakeRequest" should {
+    val app = new FakeApplication(
+      withRoutes = {
+        case (PUT, "/process") => Action { req =>
+          Results.Ok(req.headers.get(CONTENT_TYPE) getOrElse "")
+        }
+      }
+    )
+
+    "Define Content-Type header based on body" in new WithApplication(app) {
+      val xml =
+        <foo>
+          <bar>
+            baz
+          </bar>
+        </foo>
+      val bytes = xml.toString.getBytes("utf-16le")
+      val req = FakeRequest(PUT, "/process")
+        .withRawBody(bytes)
+      route(req) aka "response" must beSome.which { resp =>
+        contentAsString(resp) aka "content" must_== "application/octet-stream"
+      }
+    }
+
+    "Not override explicit Content-Type header" in new WithApplication(app) {
+      val xml =
+        <foo>
+          <bar>
+            baz
+          </bar>
+        </foo>
+      val bytes = xml.toString.getBytes("utf-16le")
+      val req = FakeRequest(PUT, "/process")
+        .withRawBody(bytes)
+        .withHeaders(
+          CONTENT_TYPE -> "text/xml;charset=utf-16le"
+        )
+      route(req) aka "response" must beSome.which { resp =>
+        contentAsString(resp) aka "content" must_== "text/xml;charset=utf-16le"
       }
     }
   }


### PR DESCRIPTION
I have a controller that expects xml content in utf-16le.  I have written a custom body parser to handle this as I could not find an easier way.  At any rate, trying to test this controller I need to send utf-16le encoded xml, with a Content-Type of "text/xml".  I have tried to create the FakeRequest multiple ways, setting the correct "Content-Type" header, but when the request is actually executed the Content-Type is set to "application/octet-stream" thus does not validate against my body parser.

```
val bytes = xml.toString.getBytes("utf-16le")
val req = FakeRequest(PUT, "/process")
    .withRawBody(bytes)
    .withHeaders(
        ("Accept", "text/xml"),
        ("Accept-Charset", "utf-16"),
        ("Content-Type", "text/xml"))
val res = route(req).get
```

I also tried  this:

```
val bytes = xml.toString.getBytes("utf-16le")
val body = AnyContentAsRaw(RawBuffer(bytes.length, bytes))
val headers = FakeHeaders(Seq(("Accept", Seq("text/xml")), ("Accept-Charset", Seq("utf-16")), ("Content-Type", Seq("text/xml"))))
val req = FakeRequest(PUT, "/process", headers, body)
route(req).get
```
