### PR TITLE
Make body type argument of WrappedRequest covariant to match Request

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -268,7 +268,7 @@ package play.api.mvc {
   /**
    * Wrap an existing request. Useful to extend a request.
    */
-  class WrappedRequest[A](request: Request[A]) extends Request[A] {
+  class WrappedRequest[+A](request: Request[A]) extends Request[A] {
     def id = request.id
     def tags = request.tags
     def body = request.body


### PR DESCRIPTION
The body type argument of Request in intentially covariant so that one can specify AnyContent in many places that more specific types are known.  There is no reason that WrappedRequest should not match.
