### PR TITLE
Fix duplicate Content-Type request header in WS

### DIFF
--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -465,8 +465,12 @@ trait WSRequestHolder {
    */
   def withBody[T](body: T)(implicit wrt: Writeable[T], ct: ContentTypeOf[T]): WSRequestHolder = {
     val wsBody = InMemoryBody(wrt.transform(body))
-    ct.mimeType.fold(withBody(wsBody)) { contentType =>
-      withBody(wsBody).withHeaders("Content-Type" -> contentType)
+    if (headers.contains("Content-Type")) {
+      withBody(wsBody)
+    } else {
+      ct.mimeType.fold(withBody(wsBody)) { contentType =>
+        withBody(wsBody).withHeaders("Content-Type" -> contentType)
+      }
     }
   }
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
@@ -99,6 +99,14 @@ object NingWSSpec extends PlaySpecification with Mockito {
       req.getHeaders.get("key").size must equalTo(2)
     }
 
+    "not make Content-Type header if there is Content-Type in headers already" in new WithApplication {
+      val req = WS.url("http://playframework.com/")
+        .withHeaders("Content-Type" -> "text/plain").withBody(<aaa>value1</aaa>).asInstanceOf[NingWSRequestHolder]
+        .prepare().build
+      req.getHeaders.get("Content-Type").contains("text/plain") must beTrue
+      req.getHeaders.get("Content-Type").size must equalTo(1)
+    }
+
     "support a virtual host" in new WithApplication {
       val req = WS.url("http://playframework.com/")
         .withVirtualHost("192.168.1.1").asInstanceOf[NingWSRequestHolder]


### PR DESCRIPTION
Hi, 
WSClient adds Content-Type header even if user specify Content-Type already by using withHeaders. 
This behavior is different from Play2.2.x. See [here](https://github.com/playframework/playframework/blob/2.2.x/framework/src/play/src/main/scala/play/api/libs/ws/WS.scala#L558). 
