### PR TITLE
Improve Java Json documentation

### DIFF
--- a/documentation/manual/javaGuide/main/json/JavaJsonActions.md
+++ b/documentation/manual/javaGuide/main/json/JavaJsonActions.md
@@ -1,59 +1,43 @@
 <!--- Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com> -->
 # Handling and serving JSON
 
+In Java, Play uses the [Jackson](http://jackson.codehaus.org/) JSON library to convert objects to and from JSON. Play's actions work with the `JsonNode` type and the framework provides utility methods for conversion in the `play.libs.Json` API.
+
+## Mapping Java objects to JSON
+
+Jackson allows you to easily convert Java objects to JSON by looking at field names, getters and setters. As an example we'll use the following simple Java object:
+
+@[person-class](code/JavaJsonActions.java)
+
+We can parse the JSON representation of the object and create a new `Person`:
+
+@[to-json](code/JavaJsonActions.java)
+
+Similarly, we can write the `Person` object to a `JsonNode`:
+
+@[from-json](code/JavaJsonActions.java)
+
 ## Handling a JSON request
 
 A JSON request is an HTTP request using a valid JSON payload as request body. Its `Content-Type` header must specify the `text/json` or `application/json` MIME type.
 
 By default an action uses an **any content** body parser, which you can use to retrieve the body as JSON (actually as a Jackson `JsonNode`):
 
-```java
-import com.fasterxml.jackson.databind.JsonNode;
-...
-
-public static Result sayHello() {
-  JsonNode json = request().body().asJson();
-  if(json == null) {
-    return badRequest("Expecting Json data");
-  } else {
-    String name = json.findPath("name").textValue();
-    if(name == null) {
-      return badRequest("Missing parameter [name]");
-    } else {
-      return ok("Hello " + name);
-    }
-  }
-}
-```
+@[json-request-as-anycontent](code/JavaJsonActions.java)
 
 Of course it’s way better (and simpler) to specify our own `BodyParser` to ask Play to parse the content body directly as JSON:
 
-```java
-import com.fasterxml.jackson.databind.JsonNode;
-import play.mvc.BodyParser;
-...
+@[json-request-as-json](code/JavaJsonActions.java)
 
-@BodyParser.Of(BodyParser.Json.class)
-public static Result sayHello() {
-  JsonNode json = request().body().asJson();
-  String name = json.findPath("name").textValue();
-  if(name == null) {
-    return badRequest("Missing parameter [name]");
-  } else {
-    return ok("Hello " + name);
-  }
-}
-```
-
-> **Note:** This way, a 400 HTTP response will be automatically returned for non JSON requests with Content-type set to application/json. 
+> **Note:** This way, a 400 HTTP response will be automatically returned for non JSON requests with Content-type set to application/json.
 
 You can test it with **cURL** from a command line:
 
 ```bash
-curl 
-  --header "Content-type: application/json" 
-  --request POST 
-  --data '{"name": "Guillaume"}' 
+curl
+  --header "Content-type: application/json"
+  --request POST
+  --data '{"name": "Guillaume"}'
   http://localhost:9000/sayHello
 ```
 
@@ -71,18 +55,7 @@ Hello Guillaume
 
 In our previous example we handled a JSON request, but replied with a `text/plain` response. Let’s change that to send back a valid JSON HTTP response:
 
-```java
-import play.libs.Json;
-import com.fasterxml.jackson.databind.JsonNode;
-...
-
-public static Result sayHello() {
-  ObjectNode result = Json.newObject();
-  result.put("exampleField1", "foobar");
-  result.put("exampleField2", "Hello world!");
-  return ok(result);
-}
-```
+@[json-response](code/JavaJsonActions.java)
 
 Now it replies with:
 
@@ -95,14 +68,14 @@ Content-Type: application/json; charset=utf-8
 
 You can also return a Java object and have it automatically serialized to JSON by the Jackson library:
 
-```java
-import play.libs.Json;
-...
+@[json-response-dao](code/JavaJsonActions.java)
 
-public Result getPeople() {
-  List<Person> people = personDao.findAll();
-  return ok(Json.toJson(people));
-}
-```
+## Advanced usage
+
+Because Play uses Jackson, you can use your own `ObjectMapper` to create `JsonNode`s. The [documentation for jackson-databind](https://github.com/FasterXML/jackson-databind/blob/master/README.md) explains how you can further customize JSON conversion process.
+
+If you would like to use Play's `Json` APIs (`toJson`/`fromJson`) with a customized `ObjectMapper`, you can add something like this in your `GlobalSettings#onStart`:
+
+@[custom-object-mapper](code/JavaJsonActions.java)
 
 > **Next:** [[Working with XML | JavaXmlRequests]]

--- a/documentation/manual/javaGuide/main/json/code/JavaJsonActions.java
+++ b/documentation/manual/javaGuide/main/json/code/JavaJsonActions.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package javaguide.json;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Test;
+import play.mvc.Result;
+import play.libs.Json;
+
+import play.mvc.BodyParser;
+
+import javaguide.testhelpers.MockJavaAction;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.*;
+import static play.mvc.Results.ok;
+import static play.test.Helpers.*;
+import static javaguide.testhelpers.MockJavaAction.call;
+
+public class JavaJsonActions {
+
+    //#person-class
+    // Note: can use getters/setters as well; here we just use public fields directly.
+    // if using getters/setters, you can keep keep the fields `protected` or `private`
+    public static class Person {
+        public String firstName;
+        public String lastName;
+        public int age;
+    }
+    //#person-class
+
+    @Test
+    public void fromJson() {
+        //#from-json
+        // parse the JSON as a JsonNode
+        JsonNode json = Json.parse("{\"firstName\":\"Foo\", \"lastName\":\"Bar\", \"age\":13}");
+        // read the JsonNode as a Person
+        Person person = Json.fromJson(json, Person.class);
+        //#from-json
+        assertThat(person.firstName, equalTo("Foo"));
+        assertThat(person.lastName, equalTo("Bar"));
+        assertThat(person.age, equalTo(13));
+    }
+
+    @Test
+    public void toJson() {
+        //#to-json
+        Person person = new Person();
+        person.firstName = "Foo";
+        person.lastName = "Bar";
+        person.age = 30;
+        JsonNode personJson = Json.toJson(person); // {"firstName": "Foo", "lastName": "Bar", "age": 30}
+        //#to-json
+        assertThat(personJson.get("firstName").asText(), equalTo("Foo"));
+        assertThat(personJson.get("lastName").asText(), equalTo("Bar"));
+        assertThat(personJson.get("age").asInt(), equalTo(30));
+    }
+
+    @Test
+    public void customObjectMapper() {
+        //#custom-object-mapper
+        ObjectMapper mapper = new ObjectMapper()
+            // enable features and customize the object mapper here ...
+            .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            // etc.
+        Json.setObjectMapper(mapper);
+        //#custom-object-mapper
+        assertThat(Json.mapper(), equalTo(mapper));
+    }
+
+    @Test
+    public void requestAsAnyContentAction() {
+        assertThat(contentAsString(
+            call(new JsonRequestAsJsonAction(), fakeRequest().withJsonBody(Json.parse("{\"name\":\"Greg\"}")))
+        ), equalTo("Hello Greg"));
+    }
+
+    @Test
+    public void requestAsJsonAction() {
+        assertThat(contentAsString(
+            call(new JsonRequestAsJsonAction(), fakeRequest().withJsonBody(Json.parse("{\"name\":\"Greg\"}")))
+        ), equalTo("Hello Greg"));
+    }
+
+    @Test
+    public void responseAction() {
+        assertThat(contentAsString(
+            call(new JsonResponseAction(), fakeRequest())
+        ), equalTo("{\"exampleField1\":\"foobar\",\"exampleField2\":\"Hello world!\"}"));
+    }
+
+    @Test
+    public void responseDaoAction() {
+        assertThat(contentAsString(
+            call(new JsonResponseDaoAction(), fakeRequest())
+        ), equalTo("[{\"firstName\":\"Foo\",\"lastName\":\"Bar\",\"age\":30}]"));
+    }
+
+    static class JsonRequestAsAnyContentAction extends MockJavaAction {
+        //#json-request-as-anycontent
+        public static Result sayHello() {
+            JsonNode json = request().body().asJson();
+            if(json == null) {
+                return badRequest("Expecting Json data");
+            } else {
+                String name = json.findPath("name").textValue();
+                if(name == null) {
+                    return badRequest("Missing parameter [name]");
+                } else {
+                    return ok("Hello " + name);
+                }
+            }
+        }
+        //#json-request-as-anycontent
+    }
+
+    static class JsonRequestAsJsonAction extends MockJavaAction {
+        //#json-request-as-json
+        @BodyParser.Of(BodyParser.Json.class)
+        public static Result sayHello() {
+            JsonNode json = request().body().asJson();
+            String name = json.findPath("name").textValue();
+            if(name == null) {
+                return badRequest("Missing parameter [name]");
+            } else {
+                return ok("Hello " + name);
+            }
+        }
+        //#json-request-as-json
+    }
+
+    static class JsonResponseAction extends MockJavaAction {
+        //#json-response
+        public static Result sayHello() {
+            ObjectNode result = Json.newObject();
+            result.put("exampleField1", "foobar");
+            result.put("exampleField2", "Hello world!");
+            return ok(result);
+        }
+        //#json-response
+    }
+
+    static class JsonResponseDaoAction extends MockJavaAction {
+        static class PersonDao {
+            public List<Person> findAll() {
+                List<Person> people = new ArrayList<Person>();
+
+                Person person = new Person();
+                person.firstName = "Foo";
+                person.lastName = "Bar";
+                person.age = 30;
+                people.add(person);
+
+                return people;
+            }
+        }
+
+        static PersonDao personDao = new PersonDao();
+
+        //#json-response-dao
+        public static Result getPeople() {
+            List<Person> people = personDao.findAll();
+            return ok(Json.toJson(people));
+        }
+        //#json-response-dao
+    }
+}
+
+


### PR DESCRIPTION
Attempt to address #2938. I would call this a work in progress; suggestions welcome.

I'm thinking we should point to the Jackson docs as much as possible for more advanced stuff. All we need to do is make sure people know how to create `JsonNode`s.

Would be great to have someone who works more on the Java side take a look at this. @benmccann?
