### PR TITLE
Update IDE.md

### DIFF
--- a/documentation/manual/gettingStarted/IDE.md
+++ b/documentation/manual/gettingStarted/IDE.md
@@ -47,7 +47,7 @@ You then need to import the application into your Workspace with the **File/Impo
 
 To debug, start your application with `activator -jvm-debug 9999 run` and in Eclipse right-click on the project and select **Debug As**, **Debug Configurations**. In the **Debug Configurations** dialog, right-click on **Remote Java Application** and select **New**. Change **Port** to 9999 and click **Apply**. From now on you can click on **Debug** to connect to the running application. Stopping the debugging session will not stop the server.
 
-> **Tip**: You can run your application using `~run` to enable direct compilation on file change. This way scala template files are auto discovered when you create a new template in `view` and auto compiled when the file changes. If you use normal `run` then you have to hit `Refresh` on your browser each time.
+> **Tip**: You can run your application using `activator "~ run"` to enable direct compilation on file change. This way scala template files are auto discovered when you create a new template in `view` and auto compiled when the file changes. If you use normal `run` then you have to hit `Refresh` on your browser each time.
 
 If you make any important changes to your application, such as changing the classpath, use `eclipse` again to regenerate the configuration files.
 


### PR DESCRIPTION
updated instructions for the new activator command. there has to be a space between ~ and run now, which also means the parameter must be quoted (otherwise shell expansion will mess up the command)
