### PR TITLE
Use SBT's built-in JUnitXmlReportPlugin

### DIFF
--- a/documentation/project/Build.scala
+++ b/documentation/project/Build.scala
@@ -117,8 +117,7 @@ object ApplicationBuild extends Build {
     },
 
     testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "sequential", "true", "junitxml", "console"),
-    testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-v", "--ignore-runners=org.specs2.runner.JUnitRunner"),
-    testListeners <<= (target, streams).map((t, s) => Seq(new eu.henkelmann.sbt.JUnitXmlTestsListener(t.getAbsolutePath, s.log)))
+    testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-v", "--ignore-runners=org.specs2.runner.JUnitRunner")
 
   ).settings(externalPlayModuleSettings:_*)
 

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -103,8 +103,6 @@ trait PlaySettings {
       tf => tf.filter(_ != TestFrameworks.Specs2).:+(TestFrameworks.Specs2)
     },
 
-    testListeners <<= (target, streams).map((t, s) => Seq(new eu.henkelmann.sbt.JUnitXmlTestsListener(t.getAbsolutePath, s.log))),
-
     testResultReporter <<= testResultReporterTask,
 
     testResultReporterReset <<= testResultReporterResetTask,


### PR DESCRIPTION
Backporting https://github.com/playframework/playframework/pull/3152 to 2.3.x

This fixes two issues:
- Test times in junit XML reports are reported properly instead of just time="0.0"
- Test report file names include the package name so that if you have two classes with the same name in different packages they don't collide

I was more conservative with this one and didn't actually delete JUnitXmlTestListener.scala as I did on master so that folks can still use it instead of SBT's built-in one if they want. For everyone else they'll get some bug fixes
