### PR TITLE
Add Enumerator source to import

### DIFF
--- a/documentation/manual/scalaGuide/main/http/code/ScalaActions.scala
+++ b/documentation/manual/scalaGuide/main/http/code/ScalaActions.scala
@@ -83,6 +83,9 @@ object ScalaActionsSpec extends Specification with Controller {
 
     "support returning a simple result" in {
       //#simple-result-action
+      import play.api.mvc.Action
+      import play.api.mvc.Result
+      import play.api.mvc.ResponseHeader
       import play.api.libs.iteratee.Enumerator
 
       def index = Action {


### PR DESCRIPTION
In Play 2.3.1, I have to add `import play.api.libs.iteratee.Enumerator` to run the controller.
