### PR TITLE
Making the actor system configurable

### DIFF
--- a/documentation/manual/scalaGuide/main/akka/ScalaAkka.md
+++ b/documentation/manual/scalaGuide/main/akka/ScalaAkka.md
@@ -33,6 +33,14 @@ akka.actor.debug.receive = on
 
 For Akka logging configuration, see [[configuring logging|SettingsLogger]].
 
+By default the name of the `ActorSystem` is _application. You can change this via an entry in the `conf/application.conf`:
+
+```
+play.plugins.akka.actor-system = "custom-name"
+```
+
+> **Note:** This feature is useful if you want to put your play application ActorSystem in an akka cluster.
+
 ## Scheduling asynchronous tasks
 
 You can schedule sending messages to actors and executing tasks (functions or `Runnable`). You will get a `Cancellable` back that you can call `cancel` on to cancel the execution of the scheduled operation.

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -7,6 +7,8 @@
 #default timeout for promises
 promise.akka.actor.typed.timeout=5s
 
+play.plugins.akka.actor-system = "application"
+
 play {
 
     akka {

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -41,11 +41,13 @@ class AkkaPlugin(app: Application) extends Plugin {
   private val lazySystem = new ClosableLazy[ActorSystem] {
 
     protected def create() = {
-      val system = ActorSystem("application", app.configuration.underlying, app.classloader)
-      Play.logger.info("Starting application default Akka system.")
+      val config = app.configuration.underlying
+      val name = app.configuration.getString("play.plugins.akka.actor-system").getOrElse("application")
+      val system = ActorSystem(name, app.configuration.underlying, app.classloader)
+      Play.logger.info(s"Starting application default Akka system: $name")
 
       val close: CloseFunction = { () =>
-        Play.logger.info("Shutdown application default Akka system.")
+        Play.logger.info(s"Shutdown application default Akka system: $name")
         system.shutdown()
 
         app.configuration.getMilliseconds("play.akka.shutdown-timeout") match {


### PR DESCRIPTION
The goal is to make the default _ActorSystem_ name configurable.
This is a nice feature if you put your play application inside an akka
cluster.
