### PR TITLE
Anorm advanced aggregation

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/SqlQueryResult.scala
+++ b/framework/src/anorm/src/main/scala/anorm/SqlQueryResult.scala
@@ -40,17 +40,43 @@ final case class SqlQueryResult(
       _.headOption.map(new SQLWarning(_)), Option(_))
 
   /** Returns stream of row from query result. */
+  @deprecated("Use [[fold]] or [[foldWhile]] instead, which manages resources and memory", "2.4")
   def apply()(implicit connection: Connection): Stream[Row] =
     Sql.resultSetToStream(resultSet)
+
+  /**
+   * Aggregates over the whole row stream using the specified operator.
+   *
+   * @param z the start value
+   * @param op Aggregate operator
+   * @return Either list of failures at left, or aggregated value
+   * @see #foldWhile
+   */
+  def fold[T](z: T)(op: (T, Row) => T)(implicit connection: Connection): Either[List[Throwable], T] =
+    Sql.fold(resultSet)(z) { (t, r) => op(t, r) -> true } acquireFor identity
+
+  /**
+   * Aggregates over part of or the while row stream,
+   * using the specified operator.
+   *
+   * @param z the start value
+   * @param op Aggregate operator. Returns aggregated value along with true if aggregation must process next value, or false to stop with current value.
+   * @return Either list of failures at left, or aggregated value
+   */
+  def foldWhile[T](z: T)(op: (T, Row) => (T, Boolean))(implicit connection: Connection): Either[List[Throwable], T] =
+    Sql.fold(resultSet)(z) { (t, r) => op(t, r) } acquireFor identity
 
   def as[T](parser: ResultSetParser[T])(implicit connection: Connection): T =
     Sql.as(parser, resultSet)
 
+  // TODO: Scaladoc as `as` equivalent
   def list[A](rowParser: RowParser[A])(implicit connection: Connection): Seq[A] = as(rowParser.*)
 
+  // TODO: Scaladoc as `as` equivalent
   def single[A](rowParser: RowParser[A])(implicit connection: Connection): A =
     as(ResultSetParser.single(rowParser))
 
+  // TODO: Scaladoc as `as` equivalent
   def singleOpt[A](rowParser: RowParser[A])(implicit connection: Connection): Option[A] = as(ResultSetParser.singleOpt(rowParser))
 
   @deprecated(message = "Use [[as]]", since = "2.3.2")

--- a/framework/src/anorm/src/test/scala/anorm/AnormSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/AnormSpec.scala
@@ -321,6 +321,76 @@ object AnormSpec extends Specification with H2Database with AnormTest {
       }
   }
 
+  "Aggregation over all rows" should {
+    "be empty when there is no result" in withQueryResult(QueryResult.Nil) {
+      implicit c => 
+      SQL"EXEC test".fold[Option[Int]](None)({ (_, _) => Some(0) }).
+        aka("aggregated value") must beRight(None)
+
+    }
+
+    "be parsed from mapped result" in withQueryResult(
+      rowList2(classOf[String] -> "foo", classOf[Int] -> "bar").
+        append("row1", 100) :+ ("row2", 200)) { implicit c =>
+
+        SQL"SELECT * FROM test".fold(List[(String,Int)]())(
+          { (l, row) => l :+ (row[String]("foo") -> row[Int]("bar")) }).
+          aka("tuple stream") must_== Right(List("row1" -> 100, "row2" -> 200))
+
+      }
+
+    "handle failure" in withQueryResult(
+      rowList1(classOf[String] -> "foo") :+ "A" :+ "B") { implicit c =>
+      var i = 0
+        SQL"SELECT str".fold(Set[String]()) { (l, row) => 
+      if (i == 0) { i = i+1; l + row[String]("foo") } else sys.error("Failure")
+
+      } aka "aggregate on failure" must beLike {
+        case Left(err :: Nil) => err.getMessage aka "failure" must_== "Failure"
+      } and (i aka "row count" must_== 1)
+    }
+  }
+
+  "Aggregation over variable number of rows" should {
+    "be empty when there is no result" in withQueryResult(QueryResult.Nil) {
+      implicit c => 
+      SQL"EXEC test".foldWhile[Option[Int]](None)(
+        { (_, _) => Some(0) -> true }).
+        aka("aggregated value") must beRight(None)
+
+    }
+
+    "be parsed from mapped result" in withQueryResult(
+      rowList2(classOf[String] -> "foo", classOf[Int] -> "bar").
+        append("row1", 100) :+ ("row2", 200)) { implicit c =>
+
+        SQL"SELECT * FROM test".foldWhile(List[(String,Int)]())({ (l, row) => 
+          (l :+ (row[String]("foo") -> row[Int]("bar"))) -> true 
+        }) aka "tuple stream" must_== Right(List("row1" -> 100, "row2" -> 200))
+      }
+
+    "handle failure" in withQueryResult(
+      rowList1(classOf[String] -> "foo") :+ "A" :+ "B") { implicit c =>
+      var i = 0
+        SQL"SELECT str".foldWhile(Set[String]()) { (l, row) => 
+      if (i == 0) { i = i+1; (l + row[String]("foo")) -> true } 
+      else sys.error("Failure")
+
+      } aka "aggregate on failure" must beLike {
+        case Left(err :: Nil) => err.getMessage aka "failure" must_== "Failure"
+      } and (i aka "row count" must_== 1)
+    }
+
+    "stop after first row" in withQueryResult(
+      rowList1(classOf[String] -> "foo") :+ "A" :+ "B") { implicit c =>
+      var i = 0
+        SQL"SELECT str".foldWhile(Set[String]()) { (l, row) => 
+      if (i == 0) { i = i+1; (l + row[String]("foo")) -> true } else (l, false)
+
+      } aka "partial aggregate" must_== Right(Set("A"))
+    }
+  }
+
   "Insertion" should {
     lazy implicit val con = connection(handleStatement withUpdateHandler {
       case UpdateExecution("INSERT ?", ExecutedParameter(1) :: Nil) => 1


### PR DESCRIPTION
Fixed streaming support for Anorm is indeed loading too many data in memory, to keep same API about it.

This PR deprecates formed API and suggest replacement which allows to process all or some rows one by one (not waiting to have all in memory) inside a managed context (resources are closed by scala-arm). I think it also covers #3114 .

Minor improvements about managed stream.
