### PR TITLE
Re-added and deprecated PlayInternalKeys.playMonitoredFiles

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayInternalKeys.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayInternalKeys.scala
@@ -26,4 +26,7 @@ trait PlayInternalKeys {
   val playPrefixAndPipeline = TaskKey[(String, Seq[(File, String)])]("play-prefix-and-pipeline")
   val playAssetsClassLoader = TaskKey[ClassLoader => ClassLoader]("play-assets-classloader")
   val playPackageAssetsMappings = TaskKey[Seq[(File, String)]]("play-package-assets-mappings")
+
+  @deprecated(message = "Use PlayKeys.playMonitoredFiles instead", since = "2.3.2")
+  val playMonitoredFiles = PlayImport.PlayKeys.playMonitoredFiles
 }


### PR DESCRIPTION
This ensures binary compatibility with anything (such as the play war plugin) that extends PlayInternalKeys.
