### PR TITLE
Allow the logging configuration file to be called logback.xml

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Logger.scala
+++ b/framework/src/play/src/main/scala/play/api/Logger.scala
@@ -250,6 +250,7 @@ object Logger extends LoggerLike {
               }.orElse {
                 Option(this.getClass.getClassLoader.getResource("application-logger.xml"))
                   .orElse(Option(this.getClass.getClassLoader.getResource("logger.xml")))
+                  .orElse(Option(this.getClass.getClassLoader.getResource("logback.xml")))
               }
 
           configResource.foreach { url => configurator.doConfigure(url) }


### PR DESCRIPTION
Allow the logging configuration file to be called logback.xml which is one of the standard names. By default logback looks for files named logback.groovy, logback-test.xml, and logback.xml. Using the standard name allows it to be used much more easily with other tools like Eclipse and also makes it obvious that logback is being used so that it is easier to lookup reference materials for logging configuration
