### PR TITLE
fix compilation with OpenJDK 8

### DIFF
--- a/framework/src/build-link/src/main/java/play/core/BuildDocHandler.java
+++ b/framework/src/build-link/src/main/java/play/core/BuildDocHandler.java
@@ -19,8 +19,8 @@ public interface BuildDocHandler {
   /**
    * Given a request, either handle it and return some result, or don't, and return none.
    *
-   * @param request A request of type {@link play.api.mvc.RequestHeader}.
-   * @return A value of type {@link Option<play.api.mvc.SimpleResult>}, Some if the result was
+   * @param request A request of type {@code play.api.mvc.RequestHeader}.
+   * @return A value of type {@code Option<play.api.mvc.SimpleResult>}, Some if the result was
    *        handled, None otherwise.
    */
   public Object maybeHandleDocRequest(Object request);

--- a/framework/src/build-link/src/main/java/play/core/BuildLink.java
+++ b/framework/src/build-link/src/main/java/play/core/BuildLink.java
@@ -58,7 +58,7 @@ public interface BuildLink {
     public Object[] findSource(String className, Integer line);
 
     /**
-     * Get the path of the project.  This is used by methods such as {@link play.api.Application#getFile}.
+     * Get the path of the project.  This is used by methods such as {@code play.api.Application#getFile}.
      *
      * @return The path of the project.
      */


### PR DESCRIPTION
The links cannot be resolved as the BuildLink project does
not have the dependencies to satisfy them.
