### PR TITLE
Add support for JDK7 watch service

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayImport.scala
@@ -3,6 +3,7 @@
  */
 package play
 
+import play.sbtplugin.run.PlayWatchService
 import sbt._
 import Keys._
 
@@ -128,5 +129,6 @@ object PlayImport {
     val playPackageAssets = TaskKey[File]("play-package-assets")
 
     val playMonitoredFiles = TaskKey[Seq[String]]("play-monitored-files")
+    val playWatchService = SettingKey[PlayWatchService]("play-watch-service", "The watch service Play uses to watch for file changes")
   }
 }

--- a/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
@@ -35,7 +35,7 @@ trait PlayReloader {
     classpathTask: TaskKey[Classpath],
     baseLoader: ClassLoader,
     monitoredFiles: Seq[String],
-    targetDirectory: File): PlayBuildLink = {
+    playWatchService: PlayWatchService): PlayBuildLink = {
 
     val extracted = Project.extract(state)
 
@@ -58,7 +58,9 @@ trait PlayReloader {
       @volatile private var watchState: WatchState = WatchState.empty
 
       // Create the watcher, updates the changed boolean when a file has changed.
-      private val watcher = PlayWatchService(targetDirectory).watch(monitoredFiles.map(new File(_)), () => changed = true)
+      private val watcher = playWatchService.watch(monitoredFiles.map(new File(_)), () => {
+        changed = true
+      })
       private val classLoaderVersion = new java.util.concurrent.atomic.AtomicInteger(0)
 
       /**

--- a/framework/src/sbt-plugin/src/main/scala/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayRun.scala
@@ -20,7 +20,7 @@ import java.util.jar.JarFile
 import com.typesafe.sbt.SbtNativePackager._
 import com.typesafe.sbt.packager.Keys._
 import com.typesafe.sbt.web.SbtWeb.autoImport._
-import play.sbtplugin.run.AssetsClassLoader
+import play.sbtplugin.run.{ PlayWatchService, AssetsClassLoader }
 
 /**
  * Provides mechanisms for running a Play application in SBT
@@ -110,7 +110,7 @@ trait PlayRun extends PlayInternalKeys {
       assetsClassLoader.value,
       playCommonClassloader.value,
       playMonitoredFiles.value,
-      (target in LocalRootProject).value,
+      playWatchService.value,
       (managedClasspath in DocsApplication).value,
       interaction,
       playDefaultPort.value,
@@ -216,7 +216,7 @@ trait PlayRun extends PlayInternalKeys {
     dependencyClasspath: Classpath, dependencyClassLoader: ClassLoaderCreator,
     reloaderClasspathTask: TaskKey[Classpath], reloaderClassLoader: ClassLoaderCreator,
     assetsClassLoader: ClassLoader => ClassLoader, commonClassLoader: ClassLoader,
-    monitoredFiles: Seq[String], targetDirectory: File,
+    monitoredFiles: Seq[String], playWatchService: PlayWatchService,
     docsClasspath: Classpath, interaction: PlayInteractionMode, defaultHttpPort: Int,
     args: Seq[String]): PlayDevServer = {
 
@@ -292,7 +292,7 @@ trait PlayRun extends PlayInternalKeys {
     lazy val assetsLoader = assetsClassLoader(applicationLoader)
 
     lazy val reloader = newReloader(state, playReload, reloaderClassLoader, reloaderClasspathTask, assetsLoader,
-      monitoredFiles, targetDirectory)
+      monitoredFiles, playWatchService)
 
     try {
       // Now we're about to start, let's call the hooks:

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -3,6 +3,7 @@
  */
 package play
 
+import play.sbtplugin.run.PlayWatchService
 import sbt._
 import sbt.Keys._
 import play.PlayImport._
@@ -160,6 +161,8 @@ trait PlaySettings {
     routesFiles in Compile ++= ((confDirectory.value * "routes").get ++ (confDirectory.value * "*.routes").get),
 
     playMonitoredFiles <<= playMonitoredFilesTask,
+
+    playWatchService := PlayWatchService.default(target.value, pollInterval.value, sLog.value),
 
     playDefaultPort := 9000,
 

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/application.conf.2
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/application.conf.2
@@ -1,1 +1,0 @@
-fail = false

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/new.css
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/new.css
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+.original {
+    color: blue;
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/new.css.1
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/new.css.1
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+.first {
+    color: blue;
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/some.css.0
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/some.css.0
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+.original {
+    color: blue;
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/Build.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/Build.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+import play.sbtplugin.run.PlayWatchService
+import sbt._
+
+import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
+import scala.util.Properties
+
+object DevModeBuild {
+
+  def jdk7WatchService = Def.setting {
+    if (Properties.isJavaAtLeast("1.7")) {
+      PlayWatchService.jdk7(Keys.sLog.value)
+    } else {
+      println("Not testing JDK7 watch service because we're not on JDK7")
+      PlayWatchService.sbt(Keys.pollInterval.value)
+    }
+  }
+
+  def jnotifyWatchService = Def.setting {
+    PlayWatchService.jnotify(Keys.target.value)
+  }
+
+  val MaxAttempts = 10
+  val WaitTime = 500l
+
+  @tailrec
+  def verifyResourceContains(path: String, status: Int, assertions: Seq[String], attempts: Int): Unit = {
+    println(s"Attempt $attempts at $path")
+    val messages = ListBuffer.empty[String]
+    try {
+      val url = new java.net.URL("http://localhost:9000" + path)
+      val conn = url.openConnection().asInstanceOf[java.net.HttpURLConnection]
+
+      if (status == conn.getResponseCode) {
+        messages += s"Resource at $path returned $status as expected"
+      } else {
+        throw new RuntimeException(s"Resource at $path returned ${conn.getResponseCode} instead of $status")
+      }
+
+      val is = if (conn.getResponseCode >= 400) {
+        conn.getErrorStream
+      } else {
+        conn.getInputStream
+      }
+
+      // The input stream may be null if there's no body
+      val contents = if (is != null) {
+        val c = IO.readStream(is)
+        is.close()
+        c
+      } else ""
+      conn.disconnect()
+
+      assertions.foreach { assertion =>
+        if (contents.contains(assertion)) {
+          messages += s"Resource at $path contained $assertion"
+        } else {
+          throw new RuntimeException(s"Resource at $path didn't contain '$assertion':\n$contents")
+        }
+      }
+
+      messages.foreach(println)
+    } catch {
+      case e: Exception =>
+        if (attempts < MaxAttempts) {
+          Thread.sleep(WaitTime)
+          verifyResourceContains(path, status, assertions, attempts + 1)
+        } else {
+          messages.foreach(println)
+          println(s"After $attempts attempts:")
+          throw e
+        }
+    }
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
@@ -1,4 +1,108 @@
+# Structure of this test:
+# =======================
+
+# First we test that the different watchers correctly detect events such as changing a file, creating a new file,
+# changing that new file, and deleting a file.
+
+# Then we test the specifics of the reloader - for example, ensuring that it only reloads when the classpath changes,
+# and testing failure conditions.
+
+# Additionally, when making assertions about reloads, we need to wait at least a second after changing the file before
+# we make a request.  The reason for this is that the classpath change detection is based on file modification times,
+# which only have 1 second precision
+
+# Watcher tests
+# -------------
+
+# SBT watcher
+# - - - - - -
+
 # Start dev mode
+> run
+
+# Existing file change detection
+> verify-resource-contains /assets/some.css 200 original
+$ copy-file changes/some.css.1 public/some.css
+> verify-resource-contains /assets/some.css 200 first
+$ delete public/some.css
+> verify-resource-contains /assets/some.css 404
+
+# New file change detection
+> verify-resource-contains /assets/new.css 404
+$ copy-file changes/new.css public/new.css
+> verify-resource-contains /assets/new.css 200 original
+# Need to wait a little while, because incremental compilation timestamps.
+$ sleep 1000
+$ copy-file changes/new.css.1 public/new.css
+> verify-resource-contains /assets/new.css 200 first
+$ delete public/new.css
+> verify-resource-contains /assets/new.css 404
+
+> play-stop
+$ copy-file changes/some.css.0 public/some.css
+
+# JDK7 watcher
+# - - - - - -
+
+> set PlayKeys.playWatchService <<= DevModeBuild.jdk7WatchService
+
+# Start dev mode
+> run
+
+# Existing file change detection
+> verify-resource-contains /assets/some.css 200 original
+$ copy-file changes/some.css.1 public/some.css
+> verify-resource-contains /assets/some.css 200 first
+$ delete public/some.css
+> verify-resource-contains /assets/some.css 404
+
+# New file change detection
+> verify-resource-contains /assets/new.css 404
+$ copy-file changes/new.css public/new.css
+> verify-resource-contains /assets/new.css 200 original
+# Need to wait a little while, because incremental compilation timestamps.
+$ sleep 1000
+$ copy-file changes/new.css.1 public/new.css
+> verify-resource-contains /assets/new.css 200 first
+$ delete public/new.css
+> verify-resource-contains /assets/new.css 404
+
+> play-stop
+$ copy-file changes/some.css.0 public/some.css
+
+# JNotify watch service
+# - - - - - - - - - - -
+
+> set PlayKeys.playWatchService <<= DevModeBuild.jnotifyWatchService
+
+# Start dev mode
+> run
+
+# Existing file change detection
+> verify-resource-contains /assets/some.css 200 original
+$ copy-file changes/some.css.1 public/some.css
+> verify-resource-contains /assets/some.css 200 first
+$ delete public/some.css
+> verify-resource-contains /assets/some.css 404
+
+# New file change detection
+> verify-resource-contains /assets/new.css 404
+$ copy-file changes/new.css public/new.css
+> verify-resource-contains /assets/new.css 200 original
+# Need to wait a little while, because incremental compilation timestamps.
+$ sleep 1000
+$ copy-file changes/new.css.1 public/new.css
+> verify-resource-contains /assets/new.css 200 first
+$ delete public/new.css
+> verify-resource-contains /assets/new.css 404
+
+> play-stop
+$ copy-file changes/some.css.0 public/some.css
+
+# Reloader tests
+# --------------
+
+> reset-reloads
 > run
 
 # Check various action types
@@ -50,10 +154,5 @@ $ sleep 1000
 > verify-resource-contains / 500
 > verify-reloads 4
 
-# Fix the start up failure
-$ copy-file changes/application.conf.2 conf/application.conf
-$ sleep 1000
-> verify-resource-contains / 200
-> verify-reloads 5
-
 > play-stop
+


### PR DESCRIPTION
- Automatically uses JDK7 watch service if available and not OSX (because on OSX it does polling)
- Otherwise attempts to use JNotify if Windows, OSX or Linux
- Falls back to SBT watch service if all others fail
- Can be configured by end user
- Made the dev-mode tests test all 3 watch services (if available)
- Made the dev-mode tests a little more robust and faster by spinning for up to 10 seconds to wait for conditions to be true.
