### PR TITLE
Add option to disable CSRF Header Bypass

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -154,7 +154,7 @@ object CSRFAction {
   }
 
   private[csrf] def checkCsrfBypass(request: RequestHeader) = {
-    if (!CSRFConf.AllowBypass){
+    if (!CSRFConf.AllowBypass) {
 
       filterLogger.trace("[CSRF] Bypassing disabled")
       false

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -154,7 +154,12 @@ object CSRFAction {
   }
 
   private[csrf] def checkCsrfBypass(request: RequestHeader) = {
-    if (request.headers.get(CSRFConf.HeaderName).exists(_ == CSRFConf.HeaderNoCheck)) {
+    if (!CSRFConf.AllowBypass){
+
+      filterLogger.trace("[CSRF] Bypassing disabled")
+      false
+
+    } else if (request.headers.get(CSRFConf.HeaderName).exists(_ == CSRFConf.HeaderNoCheck)) {
 
       // Since injecting arbitrary header values is not possible with a CSRF attack, the presence of this header
       // indicates that this is not a CSRF attack

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -18,6 +18,7 @@ private[csrf] object CSRFConf {
   def SecureCookie: Boolean = c.getBoolean("csrf.cookie.secure").getOrElse(Session.secure)
   def PostBodyBuffer: Long = c.getBytes("csrf.body.bufferSize").getOrElse(102400L)
   def SignTokens: Boolean = c.getBoolean("csrf.sign.tokens").getOrElse(true)
+  def AllowBypass: Boolean = c.getBoolean("csrf.allowBypass").getOrElse(true)
 
   val UnsafeMethods = Set("POST")
   val UnsafeContentTypes = Set("application/x-www-form-urlencoded", "text/plain", "multipart/form-data")


### PR DESCRIPTION
Play Framework won't check if the CSRF Token is valid if :
_ header X-Requested-With is defined
_ header Csrf-Token has value "nocheck"

These protection are considered valid because it's theorically impossible to inject custom Header without Javascript (which restrict to same domain). However These protections have been proven insecure under a combination of browser plugins and redirects which can allow an attacker to provide custom HTTP headers on a request to any website. It was a vulnerability in a Flash plugin, now fixed (~late 2013 I think), but others browser extensions (or even browser themselves) maybe vulnerable.

Due to this issue, Ruby on Rails dropped the csrf header validation on 2.0, Django after 1.2.5.

Disabling csrf header bypass would not be backward compatible and could break some application relying on X-Requested-With header (I think Csrf-Token header is only used for debugging purpose).

What I suggest is adding an option "csrf.AllowBypass" defaulted to true, keeping the current behavior of CSRF Validation. If set to false, header bypass would be disabled, only a valid csrf token could validate the response. This would allow a slighty higher security level.