### PR TITLE
Support for advanced Netty options

### DIFF
--- a/documentation/manual/detailedTopics/production/ProductionConfiguration.md
+++ b/documentation/manual/detailedTopics/production/ProductionConfiguration.md
@@ -133,4 +133,32 @@ Using this file, you can stop your application using the `kill` command, for exa
 $ kill $(cat /var/run/play.pid)
 ```
 
+## Advanced HTTP server configuration
+
+The Play HTTP server can be tuned in a number of ways via system properties.
+
+> **Note:** You cannot use `application.conf` to configure the HTTP server properties.
+
+The following HTTP protocol options are supported:
+
+`http.netty.maxInitialLineLength`
+: The maximum length for the initial line of an HTTP request, defaults to 4096
+`http.netty.maxHeaderSize`
+: The maximum size for the entire HTTP header, defaults to 8192
+`http.netty.maxChunkSize`
+: The maximum size that Netty will buffer body chunks before splitting them, defaults to 8192
+
+Play also allows configuring the full list of TCP socket options that Netty supports, by prefixing them with `http.netty.option`. Note that socket options that should be applied to sockets of accepted connections should have an additional `child` prefix before the option.  Here are some common ones:
+
+`http.netty.option.child.keepAlive`
+: Set to true/false to turn on/off TCP keep alive
+`http.netty.option.backlog`
+: Configure the maximum size for queued incoming connections
+
+For a full list of supported options, see the following Netty documentation:
+
+* [SocketChannelConfig](http://netty.io/3.9/api/org/jboss/netty/channel/socket/SocketChannelConfig.html)
+* [ServerSocketChannelConfig](http://netty.io/3.9/api/org/jboss/netty/channel/socket/ServerSocketChannelConfig.html)
+* [NioSocketChannelConfig](http://netty.io/3.9/api/org/jboss/netty/channel/socket/nio/NioSocketChannelConfig.html)
+
 > **Next:** [[Setting up a front end HTTP server|HTTPServer]]


### PR DESCRIPTION
Fixes #2747.

To test this, I set a breakpoint on the point where Netty calls Socket.setKeepAlive, and ensured that it was set.
