### PR TITLE
Docs: ScalaStream page shows example using deprecated ChunkedResult

### DIFF
--- a/documentation/manual/scalaGuide/main/async/ScalaStream.md
+++ b/documentation/manual/scalaGuide/main/async/ScalaStream.md
@@ -132,26 +132,10 @@ val data = getDataStream
 val dataContent: Enumerator[Array[Byte]] = Enumerator.fromStream(data)
 ```
 
-We can now stream these data using a `ChunkedResult`:
+We can now stream these data using a `Ok.chunked`:
 
 ```scala
 def index = Action {
-
-  val data = getDataStream
-  val dataContent: Enumerator[Array[Byte]] = Enumerator.fromStream(data)
-  
-  ChunkedResult(
-    header = ResponseHeader(200),
-    chunks = dataContent
-  )
-}
-```
-
-As always, there are helpers available to do this:
-
-```scala
-def index = Action {
-
   val data = getDataStream
   val dataContent: Enumerator[Array[Byte]] = Enumerator.fromStream(data)
   


### PR DESCRIPTION
http://www.playframework.com/documentation/2.3.x/ScalaStream

This page shows an example using `ChunkedResult`, which is deprecated. The migration guide for 2.2 recommends replacing these with `Ok.chunked` or manually sets proper headers and use enumeratees: http://www.playframework.com/documentation/2.3.x/Migration22.
