### PR TITLE
Unified column resolution by name or alias

### DIFF
--- a/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
+++ b/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
@@ -149,7 +149,7 @@ val code: String = SQL(
 // code == "First"
 ```
 
-When a column is aliased, typically using SQL `AS`, its value can be resolved with `getAliased` parser. Following example parses column with `country_lang` alias.
+When a column is aliased, typically using SQL `AS`, its value can also be resolved. Following example parses column with `country_lang` alias.
 
 ```scala
 import anorm.{ SQL, SqlParser }
@@ -160,7 +160,7 @@ val lang: String = SQL(
     join CountryLanguage l on l.CountryCode = c.Code 
     where c.code = {countryCode}
   """).on("countryCode" -> "FRA").
-    as(SqlParser.getAliased[String]("country_lang").single)
+    as(SqlParser.str("country_lang").single)
 ```
 
 Columns can also be specified by position, rather than name:

--- a/framework/src/anorm/src/main/scala/anorm/SqlParser.scala
+++ b/framework/src/anorm/src/main/scala/anorm/SqlParser.scala
@@ -297,6 +297,7 @@ object SqlParser {
   def date(columnPosition: Int)(implicit c: Column[Date]): RowParser[Date] =
     get[Date](columnPosition)(c)
 
+  @deprecated(message = "Use [[get]] with alias", since = "2.3.3")
   def getAliased[T](aliasName: String)(implicit extractor: Column[T]): RowParser[T] = RowParser { row =>
     (for {
       col <- row.getAliased(aliasName)
@@ -319,7 +320,7 @@ object SqlParser {
   def get[T](name: String)(implicit extractor: Column[T]): RowParser[T] =
     RowParser { row =>
       (for {
-        col <- row.get1(name)
+        col <- row.get(name)
         res <- extractor.tupled(col)
       } yield res).fold(Error(_), Success(_))
     }
@@ -509,6 +510,7 @@ sealed trait ScalarRowParser[+A] extends RowParser[A] {
   }
 }
 
+// TODO: Refactory using fold?
 trait ResultSetParser[+A] extends (Stream[Row] => SqlResult[A]) { parent =>
   def map[B](f: A => B): ResultSetParser[B] =
     ResultSetParser(parent(_).map(f))

--- a/framework/src/anorm/src/test/scala/anorm/SqlResultSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/SqlResultSpec.scala
@@ -348,8 +348,7 @@ object SqlResultSpec extends org.specs2.mutable.Specification with H2Database {
     "not be found without alias parser" in withTestDB(v2) { implicit c =>
       SQL"SELECT foo AS AL, bar FROM test1".as(SqlParser.str("foo").single).
         aka("by name") must_== v2 and (SQL"SELECT foo AS AL, bar FROM test1".
-          as(SqlParser.str("AL").single).aka("by alias") must throwA[Exception](
-            "AL not found, available columns : TEST1.FOO, AL, TEST1.BAR, BAR"))
+          as(SqlParser.str("AL").single).aka("by alias") must_== v2)
 
     }
 


### PR DESCRIPTION
Deprecates the requirement to use `getAliased` for aliased column with some JDBC driver. Unified use with `get` (and convinient functions based on, e.g. `str`).
