### PR TITLE
Changed play-scala-intro Scala version to 2.10.4

### DIFF
--- a/templates/play-scala-intro/build.sbt
+++ b/templates/play-scala-intro/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "%SCALA_VERSION%"
+scalaVersion := "2.10.4"
 
 libraryDependencies ++= Seq(  
   "org.sorm-framework" % "sorm" % "0.3.15",


### PR DESCRIPTION
The DB framework sorm is only working with Scala 2.10.4. Therefor the Scala version in the build.sbt is explicitly set to 2.10.4.
