### PR TITLE
Let exception thrown by delegate call propagate

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Security.java
+++ b/framework/src/play/src/main/java/play/mvc/Security.java
@@ -31,25 +31,24 @@ public class Security {
      */
     public static class AuthenticatedAction extends Action<Authenticated> {
         
-        public F.Promise<Result> call(Context ctx) {
+        public F.Promise<Result> call(Context ctx) throws Throwable {
+            Authenticator authenticator;
             try {
-                Authenticator authenticator = configuration.value().newInstance();
-                String username = authenticator.getUsername(ctx);
-                if(username == null) {
-                    Result unauthorized = authenticator.onUnauthorized(ctx);
-                    return F.Promise.pure(unauthorized);
-                } else {
-                    try {
-                        ctx.request().setUsername(username);
-                        return delegate.call(ctx);
-                    } finally {
-                        ctx.request().setUsername(null);
-                    }
+                authenticator = configuration.value().newInstance();
+            } catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+            String username = authenticator.getUsername(ctx);
+            if (username == null) {
+                Result unauthorized = authenticator.onUnauthorized(ctx);
+                return F.Promise.pure(unauthorized);
+            } else {
+                try {
+                    ctx.request().setUsername(username);
+                    return delegate.call(ctx);
+                } finally {
+                    ctx.request().setUsername(null);
                 }
-            } catch(RuntimeException e) {
-                throw e;
-            } catch(Throwable t) {
-                throw new RuntimeException(t);
             }
         }
 


### PR DESCRIPTION
If there are several action compositions and this one is not executed first (for example if declared at class level), then an expected exception thrown by the controller method (delegate.call) will create a RuntimeException even if it is an expected exception controlled in another action composition. An exception thrown by authenticator can be caught here though.
