### PR TITLE
Default message for error.date message key missing

### DIFF
--- a/framework/src/play/src/main/resources/messages.default
+++ b/framework/src/play/src/main/resources/messages.default
@@ -32,6 +32,7 @@ error.minLength=Minimum length is {0}
 error.maxLength=Maximum length is {0}
 error.email=Valid email required
 error.pattern=Must satisfy {0}
+error.date=Valid date required
 
 error.expected.date=Date value expected
 error.expected.date.isoformat=Iso date value expected


### PR DESCRIPTION
There was no default error message for the `error.date` message key, which is used a lot in `Format.scala`.
