### PR TITLE
Method name in wrong case

### DIFF
--- a/documentation/manual/javaGuide/main/sql/JavaDatabase.md
+++ b/documentation/manual/javaGuide/main/sql/JavaDatabase.md
@@ -92,7 +92,7 @@ The `play.db` package provides access to the configured data sources:
 ```java
 import play.db.*;
 
-DataSource ds = DB.getDatasource();
+DataSource ds = DB.getDataSource();
 ```
 
 ## Obtaining a JDBC connection


### PR DESCRIPTION
The static method play.db.DB.getDataSource() was spelled in a wrong case "play.db.DB.getDatasource()"
