### PR TITLE
small typo and readability improvement

### DIFF
--- a/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
+++ b/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
@@ -186,7 +186,7 @@ Since Scala 2.10 supports custom String Interpolation there is also a 1-step alt
 val name = "Cambridge"
 val country = "New Zealand"
 
-SQL"insert into City(name, country) values ($name, $country)")
+SQL"insert into City(name, country) values ($name, $country)"
 ```
 
 It also supports multi-line string and inline expresions:
@@ -214,7 +214,7 @@ In the following example we will count the number of country rows.
 
 ```scala
 val countryCount: Long = 
-  SQL"Select count(*) as c from Country".fold(0l) { (c, _) => c + 1 }
+  SQL"Select count(*) as c from Country".fold(0L) { (c, _) => c + 1 }
 ```
 
 It's also possible to partially treat the row stream.


### PR DESCRIPTION
Integer Literals
... It is recommended that you use the upper case letter L because the lower case letter l is hard to distinguish from the digit 1.
http://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html

Review by @cchantep
