### PR TITLE
Upgrade to SBT native packager 0.7.4

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -148,13 +148,7 @@ object Dependencies {
 
     sbtPluginDep("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.4.0"),
     sbtPluginDep("com.github.mpeltonen" % "sbt-idea" % "1.5.1"),
-    sbtPluginDep("com.typesafe.sbt" % "sbt-native-packager" % "0.7.3"),
-    // TODO: remove this workaround for sbt-native-packager pulling in old version of slf4j via jdeb
-    // https://github.com/sbt/sbt-native-packager/issues/291
-    "org.slf4j" % "slf4j-api"       % "1.7.7" force(),
-    "org.slf4j" % "slf4j-nop"       % "1.7.7" force(),
-    "org.slf4j" % "slf4j-jdk14"     % "1.7.7" force(),
-    "org.slf4j" % "jcl-over-slf4j"  % "1.7.7" force(),
+    sbtPluginDep("com.typesafe.sbt" % "sbt-native-packager" % "0.7.4"),
 
     sbtPluginDep("com.typesafe.sbt" % "sbt-js-engine" % "1.0.1"),
     sbtPluginDep("com.typesafe.sbt" % "sbt-webdriver" % "1.0.0")

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -8,19 +8,10 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.6")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.7.3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.7.4")
 
 libraryDependencies <+= sbtVersion { sv =>
   "org.scala-sbt" % "scripted-plugin" % sv
 }
 
 libraryDependencies += "org.webjars" % "webjars-locator" % "0.12"
-
-// TODO: remove this workaround for sbt-native-packager pulling in old version of slf4j via jdeb
-// https://github.com/sbt/sbt-native-packager/issues/291
-libraryDependencies ++= Seq(
-  "org.slf4j" % "slf4j-api"       % "1.7.7" force(),
-  "org.slf4j" % "slf4j-nop"       % "1.7.7" force(),
-  "org.slf4j" % "slf4j-jdk14"     % "1.7.7" force(),
-  "org.slf4j" % "jcl-over-slf4j"  % "1.7.7" force()
-)


### PR DESCRIPTION
Upgrade to SBT native packager 0.7.4 so that we can remove workaround for old version of slf4j being pulled in. The workaround was itself causing problems by putting multiple versions of slf4j on the classpath.

Fixes https://github.com/playframework/playframework/issues/3206
