### PR TITLE
Add support for sbt-web 1.1

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayImport.scala
@@ -159,6 +159,7 @@ object PlayImport {
     val updateSecret = TaskKey[File]("play-update-secret", "Update the application conf to generate an application secret", KeyRanks.BTask)
 
     val assetsPrefix = SettingKey[String]("assets-prefix")
+    val playAggregateAssets = SettingKey[Boolean]("play-aggregate-assets", "Determines whether assets from project dependencies are included.")
     val playPackageAssets = TaskKey[File]("play-package-assets")
 
     val playMonitoredFiles = TaskKey[Seq[String]]("play-monitored-files")

--- a/framework/src/sbt-plugin/src/main/scala/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayRun.scala
@@ -361,10 +361,14 @@ trait PlayRun extends PlayInternalKeys {
   }
 
   val playAllAssetsSetting = playAllAssets := {
-    (playPrefixAndAssets ?).all(ScopeFilter(
-      inDependencies(ThisProject),
-      inConfigurations(Compile)
-    )).value.flatten
+    if (playAggregateAssets.value) {
+      (playPrefixAndAssets ?).all(ScopeFilter(
+        inDependencies(ThisProject),
+        inConfigurations(Compile)
+      )).value.flatten
+    } else {
+      Seq(playPrefixAndAssets.value)
+    }
   }
 
   val playAssetsClassLoaderSetting = playAssetsClassLoader := { parent =>
@@ -376,10 +380,15 @@ trait PlayRun extends PlayInternalKeys {
   }
 
   val playPackageAssetsMappingsSetting = playPackageAssetsMappings := {
-    val allPipelines = (playPrefixAndPipeline ?).all(ScopeFilter(
-      inDependencies(ThisProject),
-      inConfigurations(Compile)
-    )).value.flatten
+    val allPipelines =
+      if (playAggregateAssets.value) {
+        (playPrefixAndPipeline ?).all(ScopeFilter(
+          inDependencies(ThisProject),
+          inConfigurations(Compile)
+        )).value.flatten
+      } else {
+        Seq(playPrefixAndPipeline.value)
+      }
 
     val allMappings = allPipelines.flatMap {
       case (prefix, pipeline) => pipeline.map {

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -159,6 +159,9 @@ trait PlaySettings {
     // all user classes, in this project and any other subprojects that it depends on
     playReloaderClasspath <<= Classpaths.concatDistinct(exportedProducts in Runtime, internalDependencyClasspath in Runtime),
 
+    // filter out asset directories from the classpath (supports sbt-web 1.0 and 1.1)
+    playReloaderClasspath ~= { _.filter(_.get(WebKeys.webModulesLib.key).isEmpty) },
+
     playCommonClassloader <<= playCommonClassloaderTask,
 
     playDependencyClassLoader := createURLClassLoader,
@@ -223,6 +226,9 @@ trait PlaySettings {
       (compile in Compile).value
     },
 
+    // Assets
+    playAggregateAssets := true,
+
     // Assets for run mode
     playPrefixAndAssetsSetting,
     playAllAssetsSetting,
@@ -250,7 +256,12 @@ trait PlaySettings {
     // Assets for testing
     public in TestAssets := (public in TestAssets).value / assetsPrefix.value,
     fullClasspath in Test ++= {
-      val testAssetDirs = ((assets in TestAssets) ?).all(ScopeFilter(inDependencies(ThisProject))).value.flatten
+      val testAssetDirs = {
+        if (playAggregateAssets.value)
+          ((assets in TestAssets) ?).all(ScopeFilter(inDependencies(ThisProject))).value.flatten
+        else
+          Seq((assets in TestAssets).value)
+      }
       testAssetDirs.map(dir => Attributed.blank(dir.getParentFile))
     },
 


### PR DESCRIPTION
Add support for using upcoming sbt-web 1.1 with play 2.3.

Filter out asset directories from the reloader classpath so that dev reloading does not do a full reload on asset changes. In sbt-web 1.1 multi-module builds there are extra class directories on the classpath, with the assets in webjar format, and these are marked with an attribute.

Add a switch for disabling the asset aggregation built into the play plugin.
