### PR TITLE
Reloading play project leads to JNotify Errors

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/sbtplugin/run/PlayWatchService.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbtplugin/run/PlayWatchService.scala
@@ -3,10 +3,12 @@
  */
 package play.sbtplugin.run
 
+import java.net.URLClassLoader
 import java.util.Locale
 
 import sbt._
 
+import scala.reflect.ClassTag
 import scala.util.{ Properties, Try }
 import scala.util.control.NonFatal
 
@@ -53,8 +55,8 @@ object PlayWatchService {
     }.getOrElse(Other)
   }
 
-  def default(targetDirectory: File, pollDelayMillis: Int, logger: Logger): PlayWatchService = {
-    os match {
+  def default(targetDirectory: File, pollDelayMillis: Int, logger: Logger): PlayWatchService = new PlayWatchService {
+    lazy val delegate = os match {
       // If Windows or Linux and JDK7, use JDK7 watch service
       case (Windows | Linux) if Properties.isJavaAtLeast("1.7") => JDK7PlayWatchService(logger).get
       // If Windows, Linux or OSX, use JNotify but fall back to SBT
@@ -66,6 +68,8 @@ object PlayWatchService {
       }.get
       case _ => new SbtPlayWatchService(pollDelayMillis)
     }
+
+    def watch(filesToWatch: Seq[File], onChange: () => Unit) = delegate.watch(filesToWatch, onChange)
   }
 
   def jnotify(targetDirectory: File): PlayWatchService = optional(JNotifyPlayWatchService(targetDirectory))
@@ -167,42 +171,47 @@ private object JNotifyPlayWatchService {
     watchService match {
       case None =>
         val ws = scala.util.control.Exception.allCatch.withTry {
-          val jnotifyJarFile = this.getClass.getClassLoader.asInstanceOf[java.net.URLClassLoader].getURLs
-            .map(_.getFile)
-            .find(_.contains("/jnotify"))
-            .map(new File(_))
-            .getOrElse(sys.error("Missing JNotify?"))
 
-          val sbtLoader = this.getClass.getClassLoader.getParent.asInstanceOf[java.net.URLClassLoader]
-          val method = classOf[java.net.URLClassLoader].getDeclaredMethod("addURL", classOf[java.net.URL])
-          method.setAccessible(true)
-          method.invoke(sbtLoader, jnotifyJarFile.toURI.toURL)
+          val classloader = GlobalStaticVar.get[ClassLoader]("playWatchServiceJNotifyHack").getOrElse {
+            val jnotifyJarFile = this.getClass.getClassLoader.asInstanceOf[java.net.URLClassLoader].getURLs
+              .map(_.getFile)
+              .find(_.contains("/jnotify"))
+              .map(new File(_))
+              .getOrElse(sys.error("Missing JNotify?"))
 
-          val nativeLibrariesDirectory = new File(targetDirectory, "native_libraries")
+            val nativeLibrariesDirectory = new File(targetDirectory, "native_libraries")
 
-          if (!nativeLibrariesDirectory.exists) {
-            // Unzip native libraries from the jnotify jar to target/native_libraries
-            IO.unzip(jnotifyJarFile, targetDirectory, (name: String) => name.startsWith("native_libraries"))
+            if (!nativeLibrariesDirectory.exists) {
+              // Unzip native libraries from the jnotify jar to target/native_libraries
+              IO.unzip(jnotifyJarFile, targetDirectory, (name: String) => name.startsWith("native_libraries"))
+            }
+
+            val libs = new File(nativeLibrariesDirectory, System.getProperty("sun.arch.data.model") + "bits").getAbsolutePath
+
+            // Hack to set java.library.path
+            System.setProperty("java.library.path", {
+              Option(System.getProperty("java.library.path")).map { existing =>
+                existing + java.io.File.pathSeparator + libs
+              }.getOrElse(libs)
+            })
+            val fieldSysPath = classOf[ClassLoader].getDeclaredField("sys_paths")
+            fieldSysPath.setAccessible(true)
+            fieldSysPath.set(null, null)
+
+            // Create classloader just for jnotify
+            val loader = new URLClassLoader(Array(jnotifyJarFile.toURI.toURL), null)
+
+            GlobalStaticVar.set("playWatchServiceJNotifyHack", loader)
+
+            loader
           }
 
-          val libs = new File(nativeLibrariesDirectory, System.getProperty("sun.arch.data.model") + "bits").getAbsolutePath
-
-          // Hack to set java.library.path
-          System.setProperty("java.library.path", {
-            Option(System.getProperty("java.library.path")).map { existing =>
-              existing + java.io.File.pathSeparator + libs
-            }.getOrElse(libs)
-          })
-          val fieldSysPath = classOf[ClassLoader].getDeclaredField("sys_paths")
-          fieldSysPath.setAccessible(true)
-          fieldSysPath.set(null, null)
-
-          val jnotifyClass = sbtLoader.loadClass("net.contentobjects.jnotify.JNotify")
-          val jnotifyListenerClass = sbtLoader.loadClass("net.contentobjects.jnotify.JNotifyListener")
+          val jnotifyClass = classloader.loadClass("net.contentobjects.jnotify.JNotify")
+          val jnotifyListenerClass = classloader.loadClass("net.contentobjects.jnotify.JNotifyListener")
           val addWatchMethod = jnotifyClass.getMethod("addWatch", classOf[String], classOf[Int], classOf[Boolean], jnotifyListenerClass)
           val removeWatchMethod = jnotifyClass.getMethod("removeWatch", classOf[Int])
 
-          val d = new JNotifyDelegate(sbtLoader, jnotifyListenerClass, addWatchMethod, removeWatchMethod)
+          val d = new JNotifyDelegate(classloader, jnotifyListenerClass, addWatchMethod, removeWatchMethod)
 
           // Try it
           d.ensureLoaded()
@@ -425,5 +434,75 @@ private object JDK7PlayWatchService {
 private class OptionalPlayWatchServiceDelegate(watchService: Try[PlayWatchService]) extends PlayWatchService {
   def watch(filesToWatch: Seq[File], onChange: () => Unit) = {
     watchService.map(ws => ws.watch(filesToWatch, onChange)).get
+  }
+}
+
+/**
+ * Provides a global (cross classloader) static var.
+ *
+ * This does not leak classloaders (unless the value passed to it references a classloader that shouldn't be leaked).
+ * It uses an MBeanServer to store an AtomicReference as an mbean, exposing the get method of the AtomicReference as an
+ * mbean operation, so that the value can be retrieved.
+ */
+private[run] object GlobalStaticVar {
+  import javax.management._
+  import javax.management.modelmbean._
+  import java.lang.management._
+  import java.util.concurrent.atomic.AtomicReference
+
+  private def objectName(name: String) = {
+    new ObjectName(":type=GlobalStaticVar,name=" + name)
+  }
+
+  /**
+   * Set a global static variable with the given name.
+   */
+  def set(name: String, value: AnyRef): Unit = {
+
+    val reference = new AtomicReference[AnyRef](value)
+
+    // Now we construct a MBean that exposes the AtomicReference.get method
+    val getMethod = classOf[AtomicReference[_]].getMethod("get")
+    val getInfo = new ModelMBeanOperationInfo("The value", getMethod)
+    val mmbi = new ModelMBeanInfoSupport("GlobalStaticVar",
+      "A global static variable",
+      null, // no attributes
+      null, // no constructors
+      Array(getInfo), // the operation
+      null); // no notifications
+
+    val mmb = new RequiredModelMBean(mmbi)
+    mmb.setManagedResource(reference, "ObjectReference")
+
+    // Register the Model MBean in the MBean Server
+    ManagementFactory.getPlatformMBeanServer.registerMBean(mmb, objectName(name))
+  }
+
+  /**
+   * Get a global static variable by the given name.
+   */
+  def get[T](name: String)(implicit ct: ClassTag[T]): Option[T] = {
+    try {
+      val value = ManagementFactory.getPlatformMBeanServer.invoke(objectName(name), "get", Array.empty, Array.empty)
+      if (ct.runtimeClass.isInstance(value)) {
+        Some(value.asInstanceOf[T])
+      } else {
+        throw new ClassCastException(s"Global static var $name is not an instance of ${ct.runtimeClass}, but is actually a ${Option(value).fold("null")(_.getClass.getName)}")
+      }
+    } catch {
+      case e: InstanceNotFoundException =>
+        None
+    }
+  }
+
+  /**
+   * Clear a global static variable with the given name.
+   */
+  def remove(name: String): Unit = {
+    try {
+      ManagementFactory.getPlatformMBeanServer.unregisterMBean(objectName(name))
+    } catch {
+      case e: InstanceNotFoundException =>
+    }
   }
 }

--- a/framework/src/sbt-plugin/src/test/scala/play/sbtplugin/run/GlobalStaticVarSpec.scala
+++ b/framework/src/sbt-plugin/src/test/scala/play/sbtplugin/run/GlobalStaticVarSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.sbtplugin.run
+
+import org.specs2.mutable.Specification
+
+class GlobalStaticVarSpec extends Specification {
+
+  "global static var" should {
+    "support setting and getting" in {
+      try {
+        GlobalStaticVar.set("message", "hello world")
+        GlobalStaticVar.get[String]("message") must beSome("hello world")
+      } finally {
+        GlobalStaticVar.remove("message")
+      }
+    }
+    "return none when not set" in {
+      GlobalStaticVar.get[String]("notset") must beNone
+    }
+    "support removing" in {
+      try {
+        GlobalStaticVar.set("msg", "hello world")
+        GlobalStaticVar.get[String]("msg") must beSome("hello world")
+        GlobalStaticVar.remove("msg")
+        GlobalStaticVar.get[String]("msg") must beNone
+      } finally {
+        GlobalStaticVar.remove("msg")
+      }
+    }
+    "support complex types like classloaders" in {
+      try {
+        val classLoader = this.getClass.getClassLoader
+        GlobalStaticVar.set("classLoader", classLoader)
+        GlobalStaticVar.get[ClassLoader]("classLoader") must beSome(classLoader)
+      } finally {
+        GlobalStaticVar.remove("classLoader")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Here's the output:

``` scala
[error] (compile:run) java.lang.UnsatisfiedLinkError: Native Library /home/jsuereth/projects/test/reactive-maps/ReactiveMaps/target/native_libraries/64bits/libjnotify.so already loaded in another classloader
[error] Total time: 0 s, completed Apr 8, 2014 1:57:06 PM
```

Once I've managed to hack my classloader death-point (by modifying the build in just the right way), this is unrecoverable without killing the process.

Steps to reproduce:
1.  `$ sbt`
2. `> run`
3.  `ctl + D`
4. `> reboot`
5. `> run`

Guaranteed every time.  At a minimum, JNotify should be _optional_ if the SO can't load.  At a maximum, Play should use the `~` feature _or_ push JNotify requests upstream into sbt where we can use our native-library hackery so that reloading is ok.
