### PR TITLE
Don’t use ContentTypeOf in play-ws

### DIFF
--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -7,7 +7,7 @@ import scala.concurrent.{ Future, ExecutionContext }
 
 import java.io.File
 
-import play.api.http.{ Writeable, ContentTypeOf }
+import play.api.http.Writeable
 import play.api.libs.iteratee._
 
 import play.api._
@@ -463,12 +463,12 @@ trait WSRequestHolder {
   /**
    * Sets the body for this request
    */
-  def withBody[T](body: T)(implicit wrt: Writeable[T], ct: ContentTypeOf[T]): WSRequestHolder = {
+  def withBody[T](body: T)(implicit wrt: Writeable[T]): WSRequestHolder = {
     val wsBody = InMemoryBody(wrt.transform(body))
     if (headers.contains("Content-Type")) {
       withBody(wsBody)
     } else {
-      ct.mimeType.fold(withBody(wsBody)) { contentType =>
+      wrt.contentType.fold(withBody(wsBody)) { contentType =>
         withBody(wsBody).withHeaders("Content-Type" -> contentType)
       }
     }
@@ -505,7 +505,7 @@ trait WSRequestHolder {
   /**
    * Perform a PATCH on the request asynchronously.
    */
-  def patch[T](body: T)(implicit wrt: Writeable[T], ct: ContentTypeOf[T]) =
+  def patch[T](body: T)(implicit wrt: Writeable[T]) =
     withMethod("PATCH").withBody(body).execute()
 
   /**
@@ -518,7 +518,7 @@ trait WSRequestHolder {
    * performs a POST with supplied body
    * @param consumer that's handling the response
    */
-  def patchAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Iteratee[Array[Byte], A])(implicit wrt: Writeable[T], ct: ContentTypeOf[T], ec: ExecutionContext): Future[Iteratee[Array[Byte], A]] = {
+  def patchAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Iteratee[Array[Byte], A])(implicit wrt: Writeable[T], ec: ExecutionContext): Future[Iteratee[Array[Byte], A]] = {
     withMethod("PATCH").withBody(body).stream().flatMap {
       case (response, enumerator) =>
         enumerator(consumer(response))
@@ -528,7 +528,7 @@ trait WSRequestHolder {
   /**
    * Perform a POST on the request asynchronously.
    */
-  def post[T](body: T)(implicit wrt: Writeable[T], ct: ContentTypeOf[T]) =
+  def post[T](body: T)(implicit wrt: Writeable[T]) =
     withMethod("POST").withBody(body).execute()
 
   /**
@@ -541,7 +541,7 @@ trait WSRequestHolder {
    * performs a POST with supplied body
    * @param consumer that's handling the response
    */
-  def postAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Iteratee[Array[Byte], A])(implicit wrt: Writeable[T], ct: ContentTypeOf[T], ec: ExecutionContext): Future[Iteratee[Array[Byte], A]] = {
+  def postAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Iteratee[Array[Byte], A])(implicit wrt: Writeable[T], ec: ExecutionContext): Future[Iteratee[Array[Byte], A]] = {
     withMethod("POST").withBody(body).stream().flatMap {
       case (response, enumerator) =>
         enumerator(consumer(response))
@@ -551,7 +551,7 @@ trait WSRequestHolder {
   /**
    * Perform a PUT on the request asynchronously.
    */
-  def put[T](body: T)(implicit wrt: Writeable[T], ct: ContentTypeOf[T]) =
+  def put[T](body: T)(implicit wrt: Writeable[T]) =
     withMethod("PUT").withBody(body).execute()
 
   /**
@@ -564,7 +564,7 @@ trait WSRequestHolder {
    * performs a PUT with supplied body
    * @param consumer that's handling the response
    */
-  def putAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Iteratee[Array[Byte], A])(implicit wrt: Writeable[T], ct: ContentTypeOf[T], ec: ExecutionContext): Future[Iteratee[Array[Byte], A]] = {
+  def putAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Iteratee[Array[Byte], A])(implicit wrt: Writeable[T], ec: ExecutionContext): Future[Iteratee[Array[Byte], A]] = {
     withMethod("PUT").withBody(body).stream().flatMap {
       case (response, enumerator) =>
         enumerator(consumer(response))

--- a/framework/src/play-ws/src/test/scala/play/api/libs/openid/OpenIDSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/openid/OpenIDSpec.scala
@@ -114,7 +114,7 @@ object OpenIDSpec extends Specification with Mockito {
 
       val argument = ArgumentCaptor.forClass(classOf[Params])
       "direct verification using a POST request was used" in {
-        there was one(ws.request).post(argument.capture())(any[Writeable[Params]], any[ContentTypeOf[Params]])
+        there was one(ws.request).post(argument.capture())(any[Writeable[Params]])
 
         val verificationQuery = argument.getValue
 
@@ -152,7 +152,7 @@ object OpenIDSpec extends Specification with Mockito {
           // Use discovery to resolve the endpoint
           one(ws.request).get()
           // Verify the response
-          one(ws.request).post(any[Params])(any[Writeable[Params]], any[ContentTypeOf[Params]])
+          one(ws.request).post(any[Params])(any[Writeable[Params]])
         }
       }
       "use direct verification on the discovered endpoint" in {
@@ -172,7 +172,7 @@ object OpenIDSpec extends Specification with Mockito {
 
       Await.result(openId.verifiedId(setupMockRequest()), dur) must throwA[AUTH_ERROR.type]
 
-      there was one(ws.request).post(any[Params])(any[Writeable[Params]], any[ContentTypeOf[Params]])
+      there was one(ws.request).post(any[Params])(any[Writeable[Params]])
     }
 
     "fail response verification if the response indicates an error" in {
@@ -208,7 +208,7 @@ object OpenIDSpec extends Specification with Mockito {
           // Use discovery to resolve the endpoint
           one(ws.request).get()
           // Verify the response
-          one(ws.request).post(any[Params])(any[Writeable[Params]], any[ContentTypeOf[Params]])
+          one(ws.request).post(any[Params])(any[Writeable[Params]])
         }
       }
     }

--- a/framework/src/play-ws/src/test/scala/play/api/libs/openid/WsMock.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/openid/WsMock.scala
@@ -21,7 +21,7 @@ class WSMock extends Mockito with WSClient {
     response.body returns ""
 
     request.get() returns Future.successful(response)
-    request.post(anyString)(any[Writeable[String]], any[ContentTypeOf[String]]) returns Future.successful(response)
+    request.post(anyString)(any[Writeable[String]]) returns Future.successful(response)
 
     def url(url: String): WSRequestHolder = {
       urls += url


### PR DESCRIPTION
Actually, I think `ContentTypeOf` should be deprecated because it is redundant with `Writeable`. However, removing it is a hard work. In the meanwhile, we should minimize our dependencies to it. This PR does just this for play-ws.

Please tell me if you agree with me that we should remove `ContentTypeOf`. A major issue is that we probably can not do it in a source compatible way. Indeed, the current design of `Writeable[A]` makes it impossible to retrieve the content type directly from the `A`. If it was the case, then we could get rid of `ContentTypeOf` [here](https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/api/http/Writeable.scala#L49-L51).

`ContentTypeOf` probably does no harm, but I keep thinking we should prevent potential harm by keeping the code simple and clean. Currently the way to set the content type of a result is scattered in at least three places in the code (`Writeable`, `ContentTypeOf` and some other place to bridge with the Java API). We should try to have just one place for such a thing.
