### PR TITLE
Function similar to servlet getParameterMap on request

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/HttpSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/HttpSpec.scala
@@ -1,7 +1,16 @@
-package play.api.mvc
+package play.it.mvc
+
+import play.api.libs.Files.TemporaryFile
 
 import play.api.http.HeaderNames
-import play.api.test.FakeRequest
+import play.api.test.{ FakeHeaders, FakeRequest }
+
+import play.api.mvc.{ 
+  AnyContentAsFormUrlEncoded, 
+  AnyContentAsMultipartFormData, 
+  MultipartFormData,
+  Call 
+}
 
 object HttpSpec extends org.specs2.mutable.Specification {
   "HTTP" title
@@ -60,6 +69,88 @@ object HttpSpec extends org.specs2.mutable.Specification {
       FakeRequest().withHeaders(
         HeaderNames.CONTENT_TYPE -> "text/xml; charset=utf-8").
         charset aka "request charset" must beSome("utf-8")
+    }
+  }
+
+  "Parameters" >> {
+    "without form data" should {
+      "be only from query string" in {
+        FakeRequest("GET", "http://localhost/?a=b&a=c&d=e").
+          parameters aka "parameters" must_== Map(
+            "a" -> Seq("b", "c"), "d" -> Seq("e"))
+      }
+    }
+
+    "with url encoded body" should {
+      "be only from query string with empty body" in {
+        val urlencoded = AnyContentAsFormUrlEncoded(Map.empty)
+
+        FakeRequest("GET", "http://localhost/?a=b&a=c&d=e", FakeHeaders.empty,
+          body = urlencoded).parameters aka "parameters" must_== Map(
+          "a" -> Seq("b", "c"), "d" -> Seq("e"))
+      }
+
+      "be from query string and from body" in {
+        val urlencoded = AnyContentAsFormUrlEncoded(
+          Map("d" -> Seq("f", "g"), "h" -> Nil))
+
+        FakeRequest("GET", "http://localhost/?a=b&a=c&d=e", FakeHeaders.empty,
+          body = urlencoded).parameters aka "parameters" must_== Map(
+          "a" -> Seq("b", "c"), "d" -> Seq("e", "f", "g"), "h" -> Nil)
+      }
+
+      "be only from body" in {
+        val urlencoded = AnyContentAsFormUrlEncoded(
+          Map("d" -> Seq("f", "g"), "h" -> Nil))
+
+        FakeRequest("GET", "http://localhost/", FakeHeaders.empty,
+          body = urlencoded).parameters aka "parameters" must_== Map(
+          "d" -> Seq("f", "g"), "h" -> Nil)
+      }
+    }
+
+    "with multipart body" should {
+      "be only from query string with empty body" in {
+        val bodyParams = Map.empty[String,Seq[String]]
+        val multipart = AnyContentAsMultipartFormData(
+          MultipartFormData[TemporaryFile](bodyParams, Nil, Nil, Nil))
+
+        multipart.asMultipartFormData.map(_.asFormUrlEncoded).
+          aka("multipart parameters") must_== Some(bodyParams) and (
+            FakeRequest("GET", "http://localhost/?a=b&a=c&d=e", 
+              FakeHeaders.empty, body = multipart).parameters.
+              aka("parameters") must_== Map(
+                "a" -> Seq("b", "c"), "d" -> Seq("e")))
+
+      }
+
+      "be from query string and from body" in {
+        val bodyParams = Map("a" -> Seq("foo"), "f" -> Seq("g", "h"))
+        val multipart = AnyContentAsMultipartFormData(
+          MultipartFormData[TemporaryFile](bodyParams, Nil, Nil, Nil))
+
+        multipart.asMultipartFormData.map(_.asFormUrlEncoded).
+          aka("multipart parameters") must_== Some(bodyParams) and (
+            FakeRequest("GET", "http://localhost/?a=b&a=c&d=e", 
+              FakeHeaders.empty, body = multipart).parameters.
+              aka("parameters") must_== Map("a" -> Seq("b", "c", "foo"), 
+                "d" -> Seq("e"), "f" -> Seq("g", "h")))
+
+      }
+
+      "be only from body" in {
+        val bodyParams = Map("a" -> Seq("foo"), "f" -> Seq("g", "h"))
+        val multipart = AnyContentAsMultipartFormData(
+          MultipartFormData[TemporaryFile](bodyParams, Nil, Nil, Nil))
+
+        multipart.asMultipartFormData.map(_.asFormUrlEncoded).
+          aka("multipart parameters") must_== Some(bodyParams) and (
+            FakeRequest("GET", "http://localhost/", 
+              FakeHeaders.empty, body = multipart).parameters.
+              aka("parameters") must_== Map(
+                "a" -> Seq("foo"), "f" -> Seq("g", "h")))
+
+      }
     }
   }
 }

--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -16,7 +16,13 @@ import play.api.libs.Files.TemporaryFile
  *
  * @param data Headers data.
  */
-case class FakeHeaders(override val data: Seq[(String, Seq[String])] = Seq.empty) extends Headers
+case class FakeHeaders(
+  override val data: Seq[(String, Seq[String])] = Seq.empty) extends Headers
+
+/** Fake headers companion */
+object FakeHeaders {
+  lazy val empty = FakeHeaders()
+}
 
 /**
  * Fake HTTP request implementation.
@@ -65,7 +71,7 @@ case class FakeRequest[A](method: String, uri: String, headers: FakeHeaders, bod
       val newData = newHeaders.map {
         case (k, v) => (k, Seq(v))
       }
-      (Map() ++ (headers.data ++ newData)).toSeq
+      (Map.empty ++ (headers.data ++ newData)).toSeq
     }))
   }
 
@@ -112,49 +118,42 @@ case class FakeRequest[A](method: String, uri: String, headers: FakeHeaders, bod
   /**
    * Adds a JSON body to the request.
    */
-  def withJsonBody(json: JsValue): FakeRequest[AnyContentAsJson] = {
+  def withJsonBody(json: JsValue): FakeRequest[AnyContentAsJson] =
     _copy(body = AnyContentAsJson(json))
-  }
 
   /**
    * Adds an XML body to the request.
    */
-  def withXmlBody(xml: NodeSeq): FakeRequest[AnyContentAsXml] = {
+  def withXmlBody(xml: NodeSeq): FakeRequest[AnyContentAsXml] =
     _copy(body = AnyContentAsXml(xml))
-  }
 
   /**
    * Adds a text body to the request.
    */
-  def withTextBody(text: String): FakeRequest[AnyContentAsText] = {
+  def withTextBody(text: String): FakeRequest[AnyContentAsText] =
     _copy(body = AnyContentAsText(text))
-  }
 
   /**
    * Adds a raw body to the request
    */
-  def withRawBody(bytes: Array[Byte]): FakeRequest[AnyContentAsRaw] = {
+  def withRawBody(bytes: Array[Byte]): FakeRequest[AnyContentAsRaw] =
     _copy(body = AnyContentAsRaw(RawBuffer(bytes.length, bytes)))
-  }
 
   /**
    * Adds a multipart form data body to the request
    */
-  def withMultipartFormDataBody(form: MultipartFormData[TemporaryFile]) = {
+  def withMultipartFormDataBody(form: MultipartFormData[TemporaryFile]) =
     _copy(body = AnyContentAsMultipartFormData(form))
-  }
 
   /**
    * Adds a body to the request.
    */
-  def withBody[B](body: B): FakeRequest[B] = {
-    _copy(body = body)
-  }
+  def withBody[B](body: B): FakeRequest[B] = _copy(body = body)
 
   /**
    * Returns the current method
    */
-  def getMethod: String = method
+  lazy val getMethod: String = method
 }
 
 /**
@@ -165,9 +164,8 @@ object FakeRequest {
   /**
    * Constructs a new GET / fake request.
    */
-  def apply(): FakeRequest[AnyContentAsEmpty.type] = {
+  def apply(): FakeRequest[AnyContentAsEmpty.type] =
     FakeRequest("GET", "/", FakeHeaders(), AnyContentAsEmpty)
-  }
 
   /**
    * Constructs a new request.
@@ -176,9 +174,9 @@ object FakeRequest {
     FakeRequest(method, path, FakeHeaders(), AnyContentAsEmpty)
   }
 
-  def apply(call: Call): FakeRequest[AnyContentAsEmpty.type] = {
+  def apply(call: Call): FakeRequest[AnyContentAsEmpty.type] =
     apply(call.method, call.url)
-  }
+
 }
 
 /**
@@ -204,13 +202,12 @@ case class FakeApplication(
   override val sources = None
   override val mode = play.api.Mode.Test
 } with Application with WithDefaultConfiguration with WithDefaultGlobal with WithDefaultPlugins {
-  override def pluginClasses = {
-    additionalPlugins ++ super.pluginClasses.diff(withoutPlugins)
-  }
 
-  override def configuration = {
+  override def pluginClasses =
+    additionalPlugins ++ super.pluginClasses.diff(withoutPlugins)
+
+  override def configuration =
     super.configuration ++ play.api.Configuration.from(additionalConfiguration)
-  }
 
   override lazy val global = withGlobal.getOrElse(super.global)
 


### PR DESCRIPTION
When implementing some action proxyfing/forwarding request, it's useful to be able to get request parameters, from query string and body, like `HttpServletRequest.getParameterMap`.

``` scala
      val queryString = req.queryString.foldLeft(
        Map[String, String]()) { (m, e) ⇒
          val (k, v) = e
          v.headOption.fold(m) { s ⇒ m + (k -> s) }
        }

      val post = (req.body match {
        case AnyContentAsFormUrlEncoded(params) ⇒ params
        case mp @ AnyContentAsMultipartFormData(_) ⇒
          mp.asFormUrlEncoded getOrElse Map[String, Seq[String]]()
        case _ ⇒ Map[String, Seq[String]]()
      }).foldLeft(Map[String, String]()) { (m, e) ⇒
        val (k, v) = e
        v.headOption.fold(m) { s ⇒ m + (k -> s) }
      }

      val params: : Map[String, String] = post ++ queryString
```

Also see http://stackoverflow.com/questions/13355442/how-to-get-all-request-parameters-in-play-and-scala
