### PR TITLE
Refer correct compression setting

### DIFF
--- a/documentation/manual/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/scalaGuide/main/ws/ScalaWS.md
@@ -199,7 +199,7 @@ Use the following properties in `application.conf` to configure the WS client:
 * `ws.followRedirects`: Configures the client to follow 301 and 302 redirects *(default is **true**)*.
 * `ws.useProxyProperties`: To use the system http proxy settings(http.proxyHost, http.proxyPort) *(default is **true**)*. 
 * `ws.useragent`: To configure the User-Agent header field.
-* `ws.compressionEnable`: Set it to true to use gzip/deflater encoding *(default is **false**)*.
+* `ws.compressionEnabled`: Set it to true to use gzip/deflater encoding *(default is **false**)*.
 
 ### Configuring WS with SSL
 


### PR DESCRIPTION
play.api.libs.ws.ning.NingAsyncHttpClientConfigBuilder uses compressionEnabled not ws.compressionEnable:

  /**
- Configures the global settings.
  */
  def configureWS(config: WSClientConfig) {
    import play.api.libs.ws.Defaults._
    builder.setConnectionTimeoutInMs(config.connectionTimeout.getOrElse(connectionTimeout).toInt)
      .setIdleConnectionTimeoutInMs(config.idleTimeout.getOrElse(idleTimeout).toInt)
      .setRequestTimeoutInMs(config.requestTimeout.getOrElse(requestTimeout).toInt)
      .setFollowRedirects(config.followRedirects.getOrElse(followRedirects))
      .setUseProxyProperties(config.useProxyProperties.getOrElse(useProxyProperties))
      .setCompressionEnabled(config.compressionEnabled.getOrElse(compressionEnabled))
  
    config.userAgent.map {
      useragent =>
        builder.setUserAgent(useragent)
    }
  }
