### PR TITLE
WSRequest#queryString throws NullPointerException

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
@@ -16,55 +16,52 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import java.io.IOException
 
 object WSSpec extends PlaySpecification {
+  "Web service client" title
 
   val app = HttpBinApplication.app
 
   def withServer[T](block: Port => T) = {
     val port = testServerPort
-    running(TestServer(port, app)) {
-      block(port)
-    }
+    running(TestServer(port, app)) { block(port) }
   }
 
   def withResult[T](result: Result)(block: Port => T) = {
     val port = testServerPort
     running(TestServer(port, FakeApplication(withRoutes = {
       case _ => Action(result)
-    }))) {
-      block(port)
-    }
+    }))) { block(port) }
   }
 
   "WS@java" should {
-    import play.libs.ws.WS
-    import play.libs.ws._
+    import play.libs.ws.{ WS, WSRequest, WSSignatureCalculator }
 
     "make GET Requests" in withServer { port =>
       val req = WS.url(s"http://localhost:$port/get").get
       val rep = req.get(1000) // AWait result
 
-      rep.getStatus must be equalTo(200)
-      rep.asJson.path("origin").textValue must not beNull
+      rep.getStatus aka "status" must_== 200 and (
+        rep.asJson.path("origin").textValue must not beNull)
     }
 
     "use queryString in url" in withServer { port =>
       val rep = WS.url(s"http://localhost:$port/get?foo=bar").get().get(1000)
 
-      rep.getStatus() must be equalTo(200)
-      rep.asJson().path("args").path("foo").textValue() must be equalTo("bar")
+      rep.getStatus aka "status" must_== 200 and (
+        rep.asJson().path("args").path("foo").textValue() must_== "bar")
     }
 
     "use user:password in url" in withServer { port =>
       val rep = WS.url(s"http://user:password@localhost:$port/basic-auth/user/password").get().get(1000)
 
-      rep.getStatus() must be equalTo(200)
-      rep.asJson().path("authenticated").booleanValue() must beTrue
+      rep.getStatus aka "status" must_== 200 and (
+        rep.asJson().path("authenticated").booleanValue() must beTrue)
     }
 
     "reject invalid query string" in withServer { port =>
       import java.net.MalformedURLException
 
-      WS.url("http://localhost/get?=&foo") must throwA[RuntimeException].like{
+      WS.url("http://localhost/get?=&foo").
+        aka("invalid request") must throwA[RuntimeException].like {
         case e: RuntimeException =>
           e.getCause must beAnInstanceOf[MalformedURLException]
       }
@@ -73,81 +70,112 @@ object WSSpec extends PlaySpecification {
     "reject invalid user password string" in withServer { port =>
       import java.net.MalformedURLException
 
-      WS.url("http://@localhost/get") must throwA[RuntimeException].like{
+      WS.url("http://@localhost/get").
+        aka("invalid request") must throwA[RuntimeException].like {
         case e: RuntimeException =>
           e.getCause must beAnInstanceOf[MalformedURLException]
       }
     }
 
-    "accept valid query string" in withServer { port =>
-      var empty = WS.url(s"http://localhost:$port/get?foo").get.get(1000)
-      var bar = WS.url(s"http://localhost:$port/get?foo=bar").get.get(1000)
+    "consider query string in JSON conversion" in withServer { port =>
+      val empty = WS.url(s"http://localhost:$port/get?foo").get.get(1000)
+      val bar = WS.url(s"http://localhost:$port/get?foo=bar").get.get(1000)
 
-      empty.asJson.path("args").path("foo").textValue() must equalTo("")
-      bar.asJson.path("args").path("foo").textValue() must equalTo("bar")
+      empty.asJson.path("args").path("foo").textValue() must_== "" and (
+        bar.asJson.path("args").path("foo").textValue() must_== "bar")
     }
 
+    "not throw an exception while signing requests" in withServer { _ =>
+      object CustomSigner extends WSSignatureCalculator {
+        override def sign(request: WSRequest): Unit = {
+          val url = request.getUrl
+        }
+      }
 
+      WS.url("http://localhost").sign(CustomSigner).
+        aka("signed request") must not(throwA[Exception])
+    }
   }
 
   "WS@scala" should {
-    import play.api.libs.ws.WS
+    import play.api.libs.ws.{ WS, WSSignatureCalculator, WSRequest }
     import play.api.Play.current
 
     "make GET Requests" in withServer { port =>
       val req = WS.url(s"http://localhost:$port/get").get
 
-      val rep = Await.result(req, Duration(1, SECONDS))
-
-      rep.status must be equalTo(200)
+      Await.result(req, Duration(1, SECONDS)).status aka "status" must_== 200
     }
 
     "Get 404 errors" in withServer { port =>
-
       val req = WS.url(s"http://localhost:$port/post").get
 
-      val rep = Await.result(req, Duration(1, SECONDS))
-
-      rep.status must be equalTo(404)
+      Await.result(req, Duration(1, SECONDS)).status aka "status" must_== 404
     }
 
-    "get a streamed response" in withResult(Results.Ok.chunked(Enumerator("a", "b", "c"))) { port =>
+    "get a streamed response" in withResult(
+      Results.Ok.chunked(Enumerator("a", "b", "c"))) { port =>
+
       val res = WS.url(s"http://localhost:$port/get").stream()
       val (_, body) = await(res)
-      new String(await(body |>>> Iteratee.consume[Array[Byte]]()), "utf-8") must_== "abc"
+
+      new String(await(body |>>> Iteratee.consume[Array[Byte]]()), "utf-8").
+        aka("streamed response") must_== "abc"
     }
 
-    def slow[E](ms: Long): Enumeratee[E, E] = Enumeratee.mapM { i => Promise.timeout(i, ms) }
+    def slow[E](ms: Long): Enumeratee[E, E] = 
+      Enumeratee.mapM { i => Promise.timeout(i, ms) }
 
     "get a streamed response when the server is slow" in withResult(
-      Results.Ok.chunked(Enumerator("a", "b", "c") &> slow(50))
-    ) { port =>
+      Results.Ok.chunked(Enumerator("a", "b", "c") &> slow(50))) { port =>
+
       val res = WS.url(s"http://localhost:$port/get").stream()
       val (_, body) = await(res)
-      new String(await(body |>>> Iteratee.consume[Array[Byte]]()), "utf-8") must_== "abc"
+
+      (new String(await(body |>>> Iteratee.consume[Array[Byte]]()), "utf-8")).
+        aka("streamed response") must_== "abc"
     }
 
     "get a streamed response when the consumer is slow" in withResult(
-      Results.Ok.chunked(Enumerator("a", "b", "c") &> slow(10))
-    ) { port =>
+      Results.Ok.chunked(Enumerator("a", "b", "c") &> slow(10))) { port =>
+
       val res = WS.url(s"http://localhost:$port/get").stream()
       val (_, body) = await(res)
-      new String(await(body &> slow(50) |>>> Iteratee.consume[Array[Byte]]()), "utf-8") must_== "abc"
+
+      new String(await(body &> slow(50) |>>> 
+        Iteratee.consume[Array[Byte]]()), "utf-8").
+        aka("streamed response") must_== "abc"
     }
 
-    "propogate errors from the stream" in withResult(
+    "propagate errors from the stream" in withResult(
       Results.Ok.feed(Enumerator.unfold(0) {
         case i if i < 3 => Some((i + 1, "chunk".getBytes("utf-8")))
         case _ => throw new Exception()
-      } &> slow(50)).withHeaders("Content-Length" -> "100000")
-    ) { port =>
+      } &> slow(50)).withHeaders("Content-Length" -> "100000")) { port =>
+
       val res = WS.url(s"http://localhost:$port/get").stream()
       val (_, body) = await(res)
-      await(body |>>> Iteratee.consume[Array[Byte]]()) must throwAn[IOException]
+
+      await(body |>>> Iteratee.consume[Array[Byte]]()).
+        aka("streamed response") must throwAn[IOException]
     }
 
+    "not throw an exception while signing requests" >> {
+      object CustomSigner extends WSSignatureCalculator {
+        override def sign(request: WSRequest): Unit = {
+          val queryString = request.queryString
+        }
+      }
+
+      "without query string" in {
+        WS.url("http://localhost").sign(CustomSigner).get().
+          aka("signed request") must not(throwA[NullPointerException])
+      }
+
+      "with query string" in {
+        WS.url("http://localhost").withQueryString("lorem" -> "ipsum").
+          sign(CustomSigner) aka "signed request" must not(throwA[Exception])
+      }
+    }
   }
 }
-
-
-


### PR DESCRIPTION
Most likely related to https://github.com/playframework/playframework/issues/1159

From https://groups.google.com/d/msg/play-framework/cVRE6qf5my0/ejTPUyYhKgoJ

Hello all,

Consider this snippet:

```
object CustomSigner extends SignatureCalculator {
  override def sign(request: WSRequest): Unit = {
    val queryString = request.queryString
  }
}

WS.url("http://www.example.com/foobar").withQueryString("zxc" -> "qwe", "asd" -> "qaz").sign(CustomSigner).get()
```

Trying to access queryString throws a NullPointerException. Apparently it tries to do this: (from WS.scala, around line 150)

```
/**
 * Return the current query string parameters
 */
def queryString: Map[String, Seq[String]] = {
  mapAsScalaMapConverter(request.asInstanceOf[com.ning.http.client.Request].getParams()).asScala.map(e => e._1 -> e._2.asScala.toSeq).toMap
}
```

request.getParams returns null here. Apparently query parameters are set by calling addQueryParameter, but it adds into queryParams in RequestBuilderBase, not params.

Is this a bug or am I doing something wrong?

Best,

Emre
