### PR TITLE
Add a convenient overloaded constructor so that we can use NingWSClient in a few keystrokes

### DIFF
--- a/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -566,7 +566,6 @@ class DefaultEvolutionsApi @Inject() (config: EvolutionsConfig, environment: Env
   start() // on construction
 }
 
-
 /**
  * Defines Evolutions utilities functions.
  */
@@ -647,11 +646,10 @@ trait EvolutionsConfig {
 }
 
 case class DefaultEvolutionsConfig(
-  autocommit: Boolean,
-  useLocks: Boolean,
-  enabledEvolutions: Set[String],
-  enabledDownEvolutions: Set[String]
-) extends EvolutionsConfig {
+    autocommit: Boolean,
+    useLocks: Boolean,
+    enabledEvolutions: Set[String],
+    enabledDownEvolutions: Set[String]) extends EvolutionsConfig {
   def applyEvolutions(db: String): Boolean = enabledEvolutions(db)
   def applyDownEvolutions(db: String): Boolean = enabledDownEvolutions(db)
 }


### PR DESCRIPTION
This PR saves a few characters when you want to use the HTTP client without the hassle of starting a Play application.

Instead of writing the following:

``` scala
val client = new NingWSClient(new NingAsyncHttpClientConfigBuilder(DefaultWSClientConfig()).build())
```

You can now just write this:

``` scala
val client = NingWSClient()
```
