### PR TITLE
Ensure that a keystore intended for a keymanager has private keys

### DIFF
--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/ConfigSSLContextBuilderSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/ConfigSSLContextBuilderSpec.scala
@@ -280,8 +280,7 @@ class ConfigSSLContextBuilderSpec extends Specification with Mockito {
 
       val info = DefaultSSLConfig(keyManagerConfig = Some(keyManagerConfig))
       val builder = new ConfigSSLContextBuilder(info, keyManagerFactory, trustManagerFactory)
-      val privateKeys = builder.validateStoreContainsPrivateKeys(ksc, keyStore)
-      privateKeys.size must be_==(1)
+      builder.validateStoreContainsPrivateKeys(ksc, keyStore) must beTrue
     }
 
     "validate a failure of the keystore without a private key" in {
@@ -312,8 +311,7 @@ class ConfigSSLContextBuilderSpec extends Specification with Mockito {
       val info = DefaultSSLConfig(keyManagerConfig = Some(keyManagerConfig))
       val builder = new ConfigSSLContextBuilder(info, keyManagerFactory, trustManagerFactory)
 
-      val privateKeys = builder.validateStoreContainsPrivateKeys(ksc, keyStore)
-      privateKeys.size must be_==(0)
+      builder.validateStoreContainsPrivateKeys(ksc, keyStore) must beFalse
     }
 
     "validate the keystore with a weak certificate " in {


### PR DESCRIPTION
When using client authentication, the key store must contain private keys.  JSSE does not do a very good job at communicating this, and so this patch iterates through the key manager's keystore and logs warnings if an entry is found without a private key, and logs an error if no private key is found. 

It does not throw exceptions or terminate early, as the TLS handshake will still work fine if even if the keystore is misconfigured if the server does not use client authentication.
