### PR TITLE
Extend Anorm support for Traversables

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/ToSql.scala
+++ b/framework/src/anorm/src/main/scala/anorm/ToSql.scala
@@ -15,6 +15,18 @@ trait ToSql[A] {
 /** Provided ToSql implementations. */
 object ToSql {
   import scala.language.implicitConversions
+  import scala.collection.immutable.SortedSet
+
+  /**
+   * Returns fragment for each value, separated by ", ".
+   *
+   * {{{
+   * listToSql(List(1, 3, 5))
+   * // "?, ?, ?"
+   * }}}
+   */
+  implicit def listToSql[A](implicit conv: ToSql[A] = null): ToSql[List[A]] =
+    traversableToSql[A, List[A]]
 
   /**
    * Returns fragment for each value, separated by ", ".
@@ -24,18 +36,49 @@ object ToSql {
    * // "?, ?, ?"
    * }}}
    */
-  implicit def seqToSql[A](implicit conv: ToSql[A] = null) = new ToSql[Seq[A]] {
-    def fragment(values: Seq[A]): (String, Int) = {
-      val c: A => (String, Int) =
-        if (conv == null) _ => ("?" -> 1) else conv.fragment
+  implicit def seqToSql[A](implicit conv: ToSql[A] = null): ToSql[Seq[A]] =
+    traversableToSql[A, Seq[A]]
 
-      values.foldLeft("" -> 0) { (s, v) =>
-        val frag = c(v)
-        val st = if (s._2 > 0) ", " + frag._1 else frag._1
-        (s._1 + st, s._2 + frag._2)
-      }
-    }
-  }
+  /**
+   * Returns fragment for each value, separated by ", ".
+   *
+   * {{{
+   * setToSql(Set(1, 3, 5))
+   * // "?, ?, ?"
+   * }}}
+   */
+  implicit def setToSql[A](implicit conv: ToSql[A] = null): ToSql[Set[A]] =
+    traversableToSql[A, Set[A]]
+
+  /**
+   * Returns fragment for each value, separated by ", ".
+   *
+   * {{{
+   * sortedSetToSql(SortedSet("A", "B", "C"))
+   * // "?, ?, ?"
+   * }}}
+   */
+  implicit def sortedSetToSql[A](implicit conv: ToSql[A] = null): ToSql[SortedSet[A]] = traversableToSql[A, SortedSet[A]]
+
+  /**
+   * Returns fragment for each value, separated by ", ".
+   *
+   * {{{
+   * streamToSql(Stream(1, 3, 5))
+   * // "?, ?, ?"
+   * }}}
+   */
+  implicit def streamToSql[A](implicit conv: ToSql[A] = null): ToSql[Stream[A]] = traversableToSql[A, Stream[A]]
+
+  /**
+   * Returns fragment for each value, separated by ", ".
+   *
+   * {{{
+   * vectorToSql(Vector("A", "B", "C"))
+   * // "?, ?, ?"
+   * }}}
+   */
+  implicit def vectorToSql[A](implicit conv: ToSql[A] = null): ToSql[Vector[A]] = traversableToSql[A, Vector[A]]
 
   /** Returns fragment for each value, with custom formatting. */
   implicit def seqParamToSql[A](implicit conv: ToSql[A] = null) =
@@ -54,4 +97,17 @@ object ToSql {
         }
       }
     }
+
+  @inline private def traversableToSql[A, T <: Traversable[A]](implicit conv: ToSql[A] = null) = new ToSql[T] {
+    def fragment(values: T): (String, Int) = {
+      val c: A => (String, Int) =
+        if (conv == null) _ => ("?" -> 1) else conv.fragment
+
+      values.foldLeft("" -> 0) { (s, v) =>
+        val frag = c(v)
+        val st = if (s._2 > 0) ", " + frag._1 else frag._1
+        (s._1 + st, s._2 + frag._2)
+      }
+    }
+  }
 }


### PR DESCRIPTION
Support more Traversable type as statement parameter: List, Set, SortedSet, Stream and Vector (inspired from types supported by Argonaut).

_(See http://stackoverflow.com/questions/25140720/playframework-2-3-multi-value-anorm-required-anorm-namedparameter)_
