### PR TITLE
[2.1] Logging levels configuration in application.conf is ignored in production mode (dist)

### DIFF
--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -11,7 +11,6 @@ import play.api.mvc._
 
 import scala.concurrent.duration._
 import scala.util.{ Try, Success, Failure }
-import scala.util.control.NonFatal
 import scala.concurrent.Future
 
 trait WebSocketable {
@@ -23,18 +22,6 @@ trait WebSocketable {
  * provides generic server behaviour for Play applications
  */
 trait Server {
-
-  // First delete the default log file for a fresh start (only in Dev Mode)
-  try {
-    if (mode == Mode.Dev) new java.io.File(applicationProvider.path, "logs/application.log").delete()
-  } catch {
-    case NonFatal(_) =>
-  }
-
-  // Configure the logger for the first time
-  Logger.configure(
-    Map("application.home" -> applicationProvider.path.getAbsolutePath),
-    mode = mode)
 
   val bodyParserTimeout = {
     //put in proper config

--- a/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
+++ b/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
@@ -85,6 +85,21 @@ class ReloadableApplication(buildLink: BuildLink, buildDocHandler: BuildDocHandl
     }
   }
 
+  // First delete the default log file for a fresh start (only in Dev Mode)
+  try {
+    new java.io.File(path, "logs/application.log").delete()
+  } catch {
+    case NonFatal(_) =>
+  }
+
+  // Configure the logger for the first time.
+  // This is usually done by Application itself when it's instantiated, which for other types of ApplicationProviders,
+  // is usually instantiated along with or before the provider.  But in dev mode, no application exists initially, so
+  // configure it here.
+  Logger.configure(
+    Map("application.home" -> path.getAbsolutePath),
+    mode = Mode.Dev)
+
   lazy val path = buildLink.projectPath
 
   println(play.utils.Colors.magenta("--- (Running the application from SBT, auto-reloading is enabled) ---"))


### PR DESCRIPTION
The following login configuration in application.conf works in DEV mode but not in a DIST. release:

``` bash
logger.root=DEBUG
logger.play=DEBUG
logger.application=DEBUG
```

These loggin levers are loaded into logback in the Application.scala class

``` scala
   Logger.configure(
      Map("application.home" -> path.getAbsolutePath),
      configuration.getConfig("logger").map { loggerConfig =>
        loggerConfig.keys.map {
          case "resource" | "file" | "url" => "" -> null
          case key @ "root" => "ROOT" -> loggerConfig.getString(key, Some(validValues)).map(setLevel).get
          case key => key -> loggerConfig.getString(key, Some(validValues)).map(setLevel).get
        }.toMap
      }.getOrElse(Map.empty),
      mode)
```

However this configuration gets replaced by this other code in the Server trait when running in DIST. mode:

``` scala
  // Configure the logger for the first time
  Logger.configure(
    Map("application.home" -> applicationProvider.path.getAbsolutePath),
    mode = mode)
```

The logger is reset and all config is lost.

As I understand it, the Server trait constructor should be loaded before Application.scala, but it seems it is the other way around.
