### PR TITLE
Fix the bug that "play dependencies" command doesn't behave correctly wh...

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
@@ -316,13 +316,16 @@ trait PlayCommands extends PlayEclipse with PlayInternalKeys {
   }
 
   val computeDependencies = TaskKey[Seq[Map[Symbol, Any]]]("ivy-dependencies")
-  val computeDependenciesTask = (deliverLocal, ivySbt, streams, organizationName, moduleName, version, scalaBinaryVersion) map { (_, ivySbt, s, org, id, version, scalaVersion) =>
+  val computeDependenciesTask = (deliverLocal, ivySbt, streams, organizationName, moduleName, version, scalaBinaryVersion, crossPaths) map { (_, ivySbt, s, org, id, version, scalaVersion, crossPathsValue) =>
 
     import scala.xml._
 
     ivySbt.withIvy(s.log) { ivy =>
-      val report = XML.loadFile(
-        ivy.getResolutionCacheManager.getConfigurationResolveReportInCache(org + "-" + id + "_" + scalaVersion, "runtime"))
+      val file = crossPathsValue match {
+        case false => ivy.getResolutionCacheManager.getConfigurationResolveReportInCache(org + "-" + id, "runtime")
+        case _ => ivy.getResolutionCacheManager.getConfigurationResolveReportInCache(org + "-" + id + "_" + scalaVersion, "runtime")
+      }
+      val report = XML.loadFile(file)
 
       val deps: Seq[Map[Symbol, Any]] = (report \ "dependencies" \ "module").flatMap { module =>
 


### PR DESCRIPTION
...en crossPaths := false.

When crossPaths is set to false, the names of the generated configuration reports have no version suffix, e.g "foo.xml" instead of "foo_2.10.xml". However, sbt tries to search for files with the scala version appended regardless of setting of crossPaths when computing dependencies. Therefore a FileNotFound error would be thrown.

I fix the issue by taking the value of crossPaths into consideration when looking for the reports to compute dependencies. If the crossPaths is set to false, we look for files without the version suffix, otherwise we look for files with the version suffix in their names.
