### PR TITLE
Remove PID file after calling onStop

### DIFF
--- a/framework/src/play-server/src/test/scala/play/core/server/ServerStartSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/ServerStartSpec.scala
@@ -227,16 +227,15 @@ object ServerStartSpec extends Specification {
       val serverStart = new FakeServerStart(new FakeServerProvider)
       val pid = "12345"
       val process = new FakeServerProcess(pid = Some(pid))
-      startResult(serverStart.createPidFile(process, tempDir)) must_== Right(())
       val pidFile = new File(tempDir, "RUNNING_PID")
+      startResult(serverStart.createPidFile(process, tempDir)) must_== Right(Some(pidFile))
       try {
         pidFile.exists must beTrue
         Files.toString(pidFile, Charset.forName("US-ASCII")) must_== pid
       } finally {
         process.shutdown()
       }
-      pidFile.exists must beFalse
-   }
+    }
     "fail to create a pid file if it can't get the process pid" in withTempDir { tempDir =>
       val serverStart = new FakeServerStart(new FakeServerProvider)
       val process = new FakeServerProcess(pid = None)


### PR DESCRIPTION
Fixes #3239. This consolidates the shutdown hooks into a single hook that stops the Play server then deletes the PID file.

I also updated the test to avoid actually testing if the file was deleted, moving that to an assertion in the code. The existing test wouldn't work since the shutdown hooks are run in another thread, so we have to wait until the run hook completes to test if the file is deleted.
