### PR TITLE
Handle request headers of different cases

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -94,9 +94,7 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
         Seq((CONTENT_TYPE, contentType.value))
     }
     val normalHeaders: Seq[(String, String)] = request.headers.map((rh: HttpHeader) => (rh.name, rh.value))
-    new Headers {
-      val data: Seq[(String, Seq[String])] = (entityHeaders ++ normalHeaders).groupBy(_._1).mapValues(_.map(_._2)).to[Seq]
-    }
+    new Headers(entityHeaders ++ normalHeaders)
   }
 
   /**

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -319,8 +319,8 @@ private[play] class PlayDefaultUpstreamHandler(server: Server, allChannels: Defa
   }
 
   def getHeaders(nettyRequest: HttpRequest): Headers = {
-    val pairs = nettyRequest.headers().entries().asScala.groupBy(_.getKey).mapValues(_.map(_.getValue))
-    new Headers { val data = pairs.toSeq }
+    val pairs = nettyRequest.headers().entries().asScala.map(h => h.getKey -> h.getValue)
+    new Headers(pairs)
   }
 
   def sendDownstream(subSequence: Int, last: Boolean, message: Object)(implicit ctx: ChannelHandlerContext, oue: OrderedUpstreamMessageEvent) = {

--- a/framework/src/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -101,10 +101,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
         case _ => None
       }
 
-      new Headers {
-        override protected val data: Seq[(String, Seq[String])] = s.split("\n")
-          .flatMap { split(_, ":\\s*") }.groupBy(_._1).mapValues(_.map(_._2).toSeq).toSeq
-      }
+      new Headers(s.split("\n").flatMap(split(_, ":\\s*")))
     }
   }
 }

--- a/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -23,9 +23,7 @@ object ServerResultUtilsSpec extends Specification with IterateeSpecification {
     def queryString = Map()
     def remoteAddress = ""
     def secure = false
-    val headers = new Headers {
-      val data = cookie.map { case (name, value) => ("Cookie", Seq(s"$name=$value")) }.toSeq
-    }
+    val headers = new Headers(cookie.map { case (name, value) => "Cookie" -> s"$name=$value" }.toSeq)
   }
 
   "ServerResultUtils.cleanFlashCookie" should {

--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -22,7 +22,7 @@ import play.api.libs.Files.TemporaryFile
  *
  * @param data Headers data.
  */
-case class FakeHeaders(override val data: Seq[(String, Seq[String])] = Seq.empty) extends Headers
+case class FakeHeaders(data: Seq[(String, String)] = Seq.empty) extends Headers(data)
 
 /**
  * Fake HTTP request implementation.
@@ -34,7 +34,7 @@ case class FakeHeaders(override val data: Seq[(String, Seq[String])] = Seq.empty
  * @param body The request body.
  * @param remoteAddress The client IP.
  */
-case class FakeRequest[A](method: String, uri: String, headers: FakeHeaders, body: A, remoteAddress: String = "127.0.0.1", version: String = "HTTP/1.1", id: Long = 666, tags: Map[String, String] = Map.empty[String, String], secure: Boolean = false) extends Request[A] {
+case class FakeRequest[A](method: String, uri: String, headers: Headers, body: A, remoteAddress: String = "127.0.0.1", version: String = "HTTP/1.1", id: Long = 666, tags: Map[String, String] = Map.empty[String, String], secure: Boolean = false) extends Request[A] {
 
   private def _copy[B](
     id: Long = this.id,
@@ -43,7 +43,7 @@ case class FakeRequest[A](method: String, uri: String, headers: FakeHeaders, bod
     path: String = this.path,
     method: String = this.method,
     version: String = this.version,
-    headers: FakeHeaders = this.headers,
+    headers: Headers = this.headers,
     remoteAddress: String = this.remoteAddress,
     secure: Boolean = this.secure,
     body: B = this.body): FakeRequest[B] = {
@@ -67,12 +67,7 @@ case class FakeRequest[A](method: String, uri: String, headers: FakeHeaders, bod
    * Constructs a new request with additional headers. Any existing headers of the same name will be replaced.
    */
   def withHeaders(newHeaders: (String, String)*): FakeRequest[A] = {
-    _copy(headers = FakeHeaders({
-      val newData = newHeaders.map {
-        case (k, v) => (k, Seq(v))
-      }
-      (Map() ++ (headers.data ++ newData)).toSeq
-    }))
+    _copy(headers = headers.replace(newHeaders: _*))
   }
 
   /**

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -198,7 +198,7 @@ trait EssentialActionCaller {
     import play.api.http.HeaderNames._
     val newContentType = rh.headers.get(CONTENT_TYPE).fold(w.contentType)(_ => None)
     val rhWithCt = newContentType.map { ct =>
-      rh.copy(headers = FakeHeaders((rh.headers.toMap + (CONTENT_TYPE -> Seq(ct))).toSeq))
+      rh.copy(headers = rh.headers.replace(CONTENT_TYPE -> ct))
     }.getOrElse(rh)
 
     val requestBody = Enumerator(body) &> w.toEnumeratee

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -27,7 +27,6 @@ import play.api.mvc.AnyContentAsRaw;
 import play.api.mvc.AnyContentAsText;
 import play.api.mvc.AnyContentAsXml;
 import play.api.mvc.Headers;
-import play.api.mvc.HeadersImpl;
 import play.api.mvc.RawBuffer;
 import play.core.system.RequestIdProvider;
 import play.i18n.Lang;
@@ -907,11 +906,13 @@ public class Http {
         }
 
         protected Headers buildHeaders() {
-            List<Tuple2<String, Seq<String>>> list = new ArrayList<>();
+            List<Tuple2<String, String>> list = new ArrayList<>();
             for (Map.Entry<String,String[]> entry : headers().entrySet()) {
-              list.add(new Tuple2(entry.getKey(), JavaConversions.asScalaBuffer(Arrays.asList(entry.getValue()))));
+                for (String value : entry.getValue()) {
+                    list.add(new Tuple2<>(entry.getKey(), value));
+                }
             }
-            return new HeadersImpl(JavaConversions.asScalaBuffer(list));
+            return new Headers(JavaConversions.asScalaBuffer(list));
         }
 
     }

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -3,6 +3,8 @@
  */
 package play.api.mvc {
 
+  import java.util.Locale
+
   import play.api._
   import play.api.http.{ HttpConfiguration, MediaType, MediaRange, HeaderNames }
   import play.api.i18n.Lang
@@ -379,6 +381,11 @@ package play.api.mvc {
      */
     def apply(key: String): String = get(key).getOrElse(scala.sys.error("Header doesn't exist"))
 
+    override def equals(other: Any) = {
+      other.isInstanceOf[Headers] &&
+        toMap == other.asInstanceOf[Headers].toMap
+    }
+
     /**
      * Optionally returns the first header value associated with a key.
      */
@@ -388,6 +395,13 @@ package play.api.mvc {
      * Retrieve all header values associated with the given key.
      */
     def getAll(key: String): Seq[String] = toMap.getOrElse(key, Nil)
+
+    override def hashCode = {
+      toMap.map {
+        case (name, value) =>
+          name.toLowerCase(Locale.ENGLISH) -> value
+      }.hashCode()
+    }
 
     /**
      * Retrieve all header keys

--- a/framework/src/play/src/test/scala/play/api/mvc/HttpSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/HttpSpec.scala
@@ -55,6 +55,22 @@ object HttpSpec extends Specification {
     "replace headers by case insensitive" in {
       headers.replace("a" -> "a3", "A" -> "a4").getAll("a") must_== Seq("a3", "a4")
     }
+
+    "equal other Headers by case insensitive" in {
+      val other = Headers("A" -> "a1", "a" -> "a2", "b" -> "b1", "b" -> "b2", "B" -> "b3")
+      (headers must_== other) and
+        (headers.## must_== other.##)
+    }
+
+    "equal other Headers with same relative order" in {
+      val other = Headers("A" -> "a1", "b" -> "b1", "a" -> "a2", "b" -> "b2", "B" -> "b3")
+      (headers must_== other) and
+        (headers.## must_== other.##)
+    }
+
+    "not equal other Headers with different relative order" in {
+      headers must_!= Headers("a" -> "a2", "A" -> "a1", "b" -> "b1", "b" -> "b2", "B" -> "b3")
+    }
   }
 
   "Cookies" should {

--- a/framework/src/play/src/test/scala/play/api/mvc/HttpSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/HttpSpec.scala
@@ -8,17 +8,17 @@ import org.specs2.mutable._
 object HttpSpec extends Specification {
   "HTTP" title
 
-  val headers = new Headers {
-    val data = Seq(("a", Seq("a1", "a2")), ("b", Seq("b1", "b2")))
-  }
+  val headers = Headers("a" -> "a1", "a" -> "a2", "b" -> "b1", "b" -> "b2", "B" -> "b3")
 
   "Headers" should {
-    "return the header value associated with a" in {
-      headers.get("a") must beSome("a1")
+    "return the header value associated with a by case insensitive" in {
+      headers.get("a") must beSome("a1") and
+        (headers.get("A") must beSome("a1"))
     }
 
-    "return the header values associated with b" in {
-      headers.getAll("b") must be_==(Seq("b1", "b2"))
+    "return the header values associated with b by case insensitive" in {
+      (headers.getAll("b") must_== Seq("b1", "b2", "b3")) and
+        (headers.getAll("B") must_== Seq("b1", "b2", "b3"))
     }
 
     "not return an empty sequence of values associated with an unknown key" in {
@@ -35,12 +35,25 @@ object HttpSpec extends Specification {
 
     "return the value from a map by case insensitive" in {
       (headers.toMap.get("A") must_== Some(Seq("a1", "a2"))) and
-        (headers.toMap.get("b") must_== Some(Seq("b1", "b2")))
+        (headers.toMap.get("b") must_== Some(Seq("b1", "b2", "b3")))
     }
 
     "return the value from a simple map by case insensitive" in {
       (headers.toSimpleMap.get("A") must beSome("a1")) and
         (headers.toSimpleMap.get("b") must beSome("b1"))
+    }
+
+    "add headers" in {
+      headers.add("a" -> "a3", "a" -> "a4").getAll("a") must_== Seq("a1", "a2", "a3", "a4")
+    }
+
+    "remove headers by case insensitive" in {
+      headers.remove("a").getAll("a") must beEmpty and
+        (headers.remove("A").getAll("a") must beEmpty)
+    }
+
+    "replace headers by case insensitive" in {
+      headers.replace("a" -> "a3", "A" -> "a4").getAll("a") must_== Seq("a3", "a4")
     }
   }
 

--- a/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -41,9 +41,9 @@ class RequestHeaderSpec extends Specification {
     }
   }
 
-  def accept(value: String) = DummyRequestHeader(Map("Accept-Language" -> Seq(value))).acceptLanguages
+  def accept(value: String) = DummyRequestHeader(Headers("Accept-Language" -> value)).acceptLanguages
 
-  case class DummyRequestHeader(headersMap: Map[String, Seq[String]] = Map()) extends RequestHeader {
+  case class DummyRequestHeader(headers: Headers = Headers()) extends RequestHeader {
     def id = 1
     def tags = Map()
     def uri = ""
@@ -53,6 +53,5 @@ class RequestHeaderSpec extends Specification {
     def queryString = Map()
     def remoteAddress = ""
     def secure = false
-    lazy val headers = new Headers { val data = headersMap.toSeq }
   }
 }

--- a/framework/src/play/src/test/scala/play/core/test/Fakes.scala
+++ b/framework/src/play/src/test/scala/play/core/test/Fakes.scala
@@ -34,9 +34,9 @@ object Fakes {
  *
  * @param data Headers data.
  */
-case class FakeHeaders(override val data: Seq[(String, Seq[String])] = Seq.empty) extends Headers
+case class FakeHeaders(data: Seq[(String, String)] = Seq.empty) extends Headers(data)
 
-case class FakeRequest[A](method: String, uri: String, headers: FakeHeaders, body: A, remoteAddress: String = "127.0.0.1", version: String = "HTTP/1.1", id: Long = 666, tags: Map[String, String] = Map.empty[String, String], secure: Boolean = false) extends Request[A] {
+case class FakeRequest[A](method: String, uri: String, headers: Headers, body: A, remoteAddress: String = "127.0.0.1", version: String = "HTTP/1.1", id: Long = 666, tags: Map[String, String] = Map.empty[String, String], secure: Boolean = false) extends Request[A] {
 
   private def _copy[B](
     id: Long = this.id,
@@ -45,7 +45,7 @@ case class FakeRequest[A](method: String, uri: String, headers: FakeHeaders, bod
     path: String = this.path,
     method: String = this.method,
     version: String = this.version,
-    headers: FakeHeaders = this.headers,
+    headers: Headers = this.headers,
     remoteAddress: String = this.remoteAddress,
     secure: Boolean = this.secure,
     body: B = this.body): FakeRequest[B] = {
@@ -69,12 +69,7 @@ case class FakeRequest[A](method: String, uri: String, headers: FakeHeaders, bod
    * Constructs a new request with additional headers. Any existing headers of the same name will be replaced.
    */
   def withHeaders(newHeaders: (String, String)*): FakeRequest[A] = {
-    _copy(headers = FakeHeaders({
-      val newData = newHeaders.map {
-        case (k, v) => (k, Seq(v))
-      }
-      (Map() ++ (headers.data ++ newData)).toSeq
-    }))
+    _copy(headers = headers.replace(newHeaders: _*))
   }
 
   /**


### PR DESCRIPTION
Mixing cases in request headers is currently not handled correctly.

```scala
def foo = Action { request =>
  Ok(request.headers.getAll("X-Foo").mkString(","))
}
```

```bash
curl -H 'X-Foo: a' -H 'X-Foo: b' http://localhost:9000
a,b
```
```bash
curl -H 'X-foo: a' -H 'X-foo: b' http://localhost:9000
a,b
```
```bash
curl -H 'X-Foo: a' -H 'X-foo: b' http://localhost:9000
b
```

---

This change will choose one of the headers (the last one) as the canonical form for purposes of `Headers.keys`. Both values will be available with `Headers.getAll`, by any capitalization.

This is handled in `PlayDefaultUpstreamHandler`. It could have also been handled in `Headers`. Currently, however, we are already expecting the caller to deduplicate headers:

> The internal data structure here is a sequence of header to sequence of value pairs. Multiple headers with the same name are not expected in the sequence. Instead the same header with multiple values in the order that they appear in the http header is expected.
