### PR TITLE
play-scala-intro template: Make sorm compatible with Scala 2.11

### DIFF
--- a/templates/play-scala-intro/build.sbt
+++ b/templates/play-scala-intro/build.sbt
@@ -4,10 +4,12 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.10.4"
+scalaVersion := "%SCALA_VERSION%"
+
+resolvers += "sorm Scala 2.11 fork" at "http://markusjura.github.io/sorm"
 
 libraryDependencies ++= Seq(  
-  "org.sorm-framework" % "sorm" % "0.3.15",
+  "org.sorm-framework" % "sorm" % "0.4.1",
   "com.h2database" % "h2" % "1.4.177"
 )     
 


### PR DESCRIPTION
I created a new version of sorm which is compatible with Scala 2.11. The play-scala-intro project is using this version with the PR.
