### PR TITLE
Anorm support for joda-time DateTime and Instant

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -218,6 +218,8 @@ object Dependencies {
     "com.jsuereth" %% "scala-arm" % "1.4",
     h2database % Test,
     "org.eu.acolyte" %% "jdbc-scala" % acolyteVersion % Test,
+    "joda-time" % "joda-time" % "2.3",
+    "org.joda" % "joda-convert" % "1.6",
     "com.chuusai" % "shapeless" % "2.0.0" % Test cross CrossVersion.binaryMapped {
       case "2.10" => BuildSettings.buildScalaVersion
       case x => x

--- a/framework/src/anorm/src/main/scala/anorm/Column.scala
+++ b/framework/src/anorm/src/main/scala/anorm/Column.scala
@@ -293,6 +293,42 @@ object Column {
     }
   }
 
+  /**
+   * Parses column as joda DateTime
+   *
+   * {{{
+   * import org.joda.time.DateTime
+   *
+   * val d: Date = SQL("SELECT last_mod FROM tbl").as(scalar[DateTime].single)
+   * }}}
+   */
+  implicit val columnToJodaDateTime: Column[org.joda.time.DateTime] = nonNull { (value, meta) =>
+    val MetaDataItem(qualified, nullable, clazz) = meta
+    value match {
+      case date: Date => Right(new org.joda.time.DateTime(date.getTime))
+      case time: Long => Right(new org.joda.time.DateTime(time))
+      case _ => Left(TypeDoesNotMatch(s"Cannot convert $value: ${value.asInstanceOf[AnyRef].getClass} to DateTime for column $qualified"))
+    }
+  }
+
+  /**
+   * Parses column as joda Instant
+   *
+   * {{{
+   * import org.joda.time.Instant
+   *
+   * val d: Date = SQL("SELECT last_mod FROM tbl").as(scalar[Instant].single)
+   * }}}
+   */
+  implicit val columnToJodaInstant: Column[org.joda.time.Instant] = nonNull { (value, meta) =>
+    val MetaDataItem(qualified, nullable, clazz) = meta
+    value match {
+      case date: Date => Right(new org.joda.time.Instant(date.getTime))
+      case time: Long => Right(new org.joda.time.Instant(time))
+      case _ => Left(TypeDoesNotMatch(s"Cannot convert $value: ${value.asInstanceOf[AnyRef].getClass} to Instant for column $qualified"))
+    }
+  }
+
   implicit def columnToPk[T](implicit c: Column[T]): Column[Pk[T]] =
     nonNull { (value, meta) => c(value, meta).map(Id(_)) }
 

--- a/framework/src/anorm/src/main/scala/anorm/ToStatement.scala
+++ b/framework/src/anorm/src/main/scala/anorm/ToStatement.scala
@@ -377,6 +377,34 @@ object ToStatement {
   }
 
   /**
+   * Sets joda-time DateTime as statement parameter.
+   * For `null` value, `setNull` with `TIMESTAMP` is called on statement.
+   *
+   * {{{
+   * SQL("UPDATE tbl SET modified = {d}").on('d -> new org.joda.time.DateTime())
+   * }}}
+   */
+  implicit object jodaDateTimeToStatement extends ToStatement[org.joda.time.DateTime] {
+    def set(s: PreparedStatement, index: Int, date: org.joda.time.DateTime): Unit =
+      if (date != null) s.setTimestamp(index, new Timestamp(date.getMillis()))
+      else s.setNull(index, Types.TIMESTAMP)
+  }
+
+  /**
+   * Sets joda-time Instant as statement parameter.
+   * For `null` value, `setNull` with `TIMESTAMP` is called on statement.
+   *
+   * {{{
+   * SQL("UPDATE tbl SET modified = {d}").on('d -> new org.joda.time.Instant())
+   * }}}
+   */
+  implicit object jodaInstantToStatement extends ToStatement[org.joda.time.Instant] {
+    def set(s: PreparedStatement, index: Int, instant: org.joda.time.Instant): Unit =
+      if (instant != null) s.setTimestamp(index, new Timestamp(instant.getMillis))
+      else s.setNull(index, Types.TIMESTAMP)
+  }
+
+  /**
    * Sets UUID as statement parameter.
    * For `null` value, `setNull` with `VARCHAR` is called on statement.
    *

--- a/framework/src/anorm/src/test/scala/anorm/ColumnSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/ColumnSpec.scala
@@ -598,6 +598,55 @@ object ColumnSpec extends org.specs2.mutable.Specification {
     }
   }
 
+  "Column mapped as joda-time datetime" should {
+    import org.joda.time.DateTime
+    val time = DateTime.now()
+
+    "be parsed from date" in withQueryResult(
+      dateList :+ new java.sql.Date(time.getMillis)) { implicit con =>
+        SQL("SELECT d").as(scalar[DateTime].single).
+          aka("parsed date") must_== time
+      }
+
+    "be parsed from timestamp" in withQueryResult(
+      timestampList :+ new java.sql.Timestamp(time.getMillis)) { implicit con =>
+        SQL("SELECT ts").as(scalar[DateTime].single).
+          aka("parsed date") must beLike {
+            case d => d aka "time" must_== time
+          }
+      }
+
+    "be parsed from time" in withQueryResult(longList :+ time.getMillis) { implicit con =>
+      SQL("SELECT time").as(scalar[DateTime].single).
+        aka("parsed date") must_== time
+
+    }
+  }
+
+  "Column mapped as joda-time instant" should {
+    import org.joda.time.Instant
+    val time = Instant.now()
+
+    "be parsed from date" in withQueryResult(
+      dateList :+ new java.sql.Date(time.getMillis)) { implicit con =>
+        SQL("SELECT d").as(scalar[Instant].single).
+          aka("parsed date") must_== time
+      }
+
+    "be parsed from timestamp" in withQueryResult(
+      timestampList :+ new java.sql.Timestamp(time.getMillis)) { implicit con =>
+        SQL("SELECT ts").as(scalar[Instant].single).
+          aka("parsed date") must beLike {
+            case d => d aka "time" must_== time
+          }
+      }
+
+    "be parsed from time" in withQueryResult(longList :+ time.getMillis) { implicit con =>
+      SQL("SELECT time").as(scalar[Instant].single).
+        aka("parsed date") must_== time
+    }
+  }
+
   def withQueryResult[A](r: QueryResult)(f: java.sql.Connection => A): A =
     f(connection(handleQuery { _ => r }))
 

--- a/framework/src/anorm/src/test/scala/anorm/ParameterSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/ParameterSpec.scala
@@ -14,6 +14,7 @@ import java.util.Date
 import java.sql.{ SQLFeatureNotSupportedException, Timestamp }
 
 import scala.collection.immutable.SortedSet
+import org.joda.time.{ DateTime, Instant }
 
 import acolyte.jdbc.{
   DefinedParameter => DParam,
@@ -32,6 +33,8 @@ object ParameterSpec extends org.specs2.mutable.Specification {
   val sbi1 = BigInt(jbi1)
   val Date1 = new Date()
   val Timestamp1 = { val ts = new Timestamp(123l); ts.setNanos(123456789); ts }
+  val dateTime1 = DateTime.now()
+  val instant1 = Instant.now()
   val uuid1 = java.util.UUID.randomUUID; val Uuid1str = uuid1.toString
   val SqlStr = ParameterMetaData.Str
   val SqlBool = ParameterMetaData.Bool
@@ -359,6 +362,24 @@ object ParameterSpec extends org.specs2.mutable.Specification {
     "be null timestamp" in withConnection() { implicit c =>
       SQL("set-null-ts {p}").
         on("p" -> null.asInstanceOf[Timestamp]).execute() must beFalse
+    }
+
+    "be joda-time datetime" in withConnection() { implicit c =>
+      SQL("set-date {p}").on("p" -> dateTime1).execute() must beFalse
+    }
+
+    "be null joda-time datetime" in withConnection() { implicit c =>
+      SQL("set-null-date {p}").
+        on("p" -> null.asInstanceOf[DateTime]).execute() must beFalse
+    }
+
+    "be joda-time instant" in withConnection() { implicit c =>
+      SQL("set-date {p}").on("p" -> instant1).execute() must beFalse
+    }
+
+    "be null joda-time instant" in withConnection() { implicit c =>
+      SQL("set-null-date {p}").
+        on("p" -> null.asInstanceOf[Instant]).execute() must beFalse
     }
 
     "be UUID" in withConnection() { implicit c =>


### PR DESCRIPTION
Column and ToStatement instances for DateTime and Instant.
- Associated tests for Column and ToStatement instances.

Note: this adds joda-time and joda-convert to anorm dependencies.

This time, it's based on master.

See issue #3283
See PR 3283
https://github.com/playframework/playframework/pull/3287
