### PR TITLE
Resolve #3289: PlayScala generates "target/target/src_managed/main" in eclipse classpath

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala
@@ -77,7 +77,7 @@ trait PlayEclipse {
             override def transform(node: Node): Seq[Node] = node match {
               case elem if (elem.label == "classpath" && (ct / "src_managed" / "main").exists) =>
                 val newChild = elem.child ++
-                  <classpathentry path={ "target" + `/` + ct.getName + `/` + "src_managed" + `/` + "main" } kind="src"></classpathentry>
+                  <classpathentry path={ ct.getName + `/` + "src_managed" + `/` + "main" } kind="src"></classpathentry>
                 Elem(elem.prefix, "classpath", elem.attributes, elem.scope, false, newChild: _*)
               case other =>
                 other


### PR DESCRIPTION
Ran activator test after change.

Verified the classpath issue was fixed. The last entry in .classpath is now this:

``` XML
<classpathentry path="target/src_managed/main" kind="src"></classpathentry>
```
