### PR TITLE
Improve documentation for running documentation locally

### DIFF
--- a/documentation/manual/hacking/Documentation.md
+++ b/documentation/manual/hacking/Documentation.md
@@ -104,7 +104,9 @@ Other code may or may not be testable.  It may make sense to test Javascript cod
 
 ## Testing the docs
 
-To ensure that the docs render correctly, run `./build run` from within the documentation directory.  This will start a small Play server that does nothing but serve the documentation.
+To build the docs, you'll first need to build and publish Play locally. You can do this by running `./build publish-local` from within the `framework` directory of the playframework repository.
+
+To ensure that the docs render correctly, run `./build run` from within the `documentation` directory.  This will start a small Play server that does nothing but serve the documentation.
 
 To ensure that the code samples compile, run and tests pass, run `./build test`.
 


### PR DESCRIPTION
Running the playframework documentation locally with `./build run` in the `master` branch throws this error:

```
[error] (*:update) sbt.ResolveException: unresolved dependency: com.typesafe.play#sbt-plugin;2.3-SNAPSHOT: not found
```

Fix would be useful for the community so that they can help improving Play's documentation.
