### PR TITLE
Macro for generating JSON Writes that traverse all getters of a class

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -181,7 +181,14 @@ object Dependencies {
     jodaConvert,
     "org.scala-lang" % "scala-reflect" % BuildSettings.buildScalaVersion) ++
   jacksons ++
-  specsBuild.map(_ % Test)
+  specsBuild.map(_ % Test) ++ quasiquotesDependencies
+
+  lazy val quasiquotesDependencies = if (BuildSettings.buildScalaVersion.startsWith("2.10"))
+    Seq(
+      compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full),
+      "org.scalamacros" %% "quasiquotes" % "2.0.1"
+    )
+    else Nil
 
   val scalacheckDependencies = Seq(
     "org.specs2"     %% "specs2-scalacheck" % specsVersion % Test,

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
@@ -233,4 +233,32 @@ object Json {
    */
   def format[A] = macro JsMacroImpl.formatImpl[A]
 
+  /**
+   * Creates a Writes[T] by resolving getters & required implicits at COMPILE-time
+   *
+   * If any missing implicit is discovered, compiler will break with corresponding error.
+   * {{{
+   *   import play.api.libs.json.Json
+   *
+   *   case class UserWithFields(age: Int, name: String) {
+   *    val ageWithName: String = s"$age $name"
+   *    var ageWithNameVar: String = s"$age $name"
+   *    def test(x: Int): Int = x + 999 // This should be ignored
+   *   }
+   *
+   *   implicit val userWithWrites = writesWithGetters[UserWithFields]
+   *   // macro-compiler replaces Json.writes[User] by injecting into compile chain
+   *   // the exact code you would write yourself. This is strictly equivalent to:
+   *   implicit val userWrites = new Writes[UserWithFields] {
+   *     def writes(o: UserWithFields): JsValue = Json.obj(
+   *      "age" -> o.age,
+   *      "name" -> o.name,
+   *      "ageWithName" -> o.ageWithName,
+   *      "ageWithNameVar" -> o.ageWithNameVar
+   *     )
+   *   }
+   * }}}
+   */
+  def writesWithGetters[A] = macro JsMacroImpl.writesWithGettersImpl[A]
+
 }

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -8,6 +8,7 @@ import play.api.libs.json._
 import play.api.libs.json.Json._
 
 case class User(age: Int, name: String)
+
 case class Dog(name: String, master: User)
 
 case class Cat(name: String)
@@ -103,11 +104,11 @@ object JsonExtensionSpec extends Specification {
 
       Json.fromJson[Dog](
         Json.obj(
-          "name" -> "medor", 
+          "name" -> "medor",
           "master" -> Json.obj("name" -> "toto", "age" -> 45)
         )
       ) must beEqualTo(JsSuccess(Dog("medor", User(45, "toto"))))
-      
+
     }
 
     "create a writes[Dog]" in {
@@ -118,7 +119,7 @@ object JsonExtensionSpec extends Specification {
 
       Json.toJson(Dog("medor", User(45, "toto"))) must beEqualTo(
         Json.obj(
-          "name" -> "medor", 
+          "name" -> "medor",
           "master" -> Json.obj("name" -> "toto", "age" -> 45)
         )
       )
@@ -132,14 +133,14 @@ object JsonExtensionSpec extends Specification {
 
       Json.fromJson[Dog](
         Json.obj(
-          "name" -> "medor", 
+          "name" -> "medor",
           "master" -> Json.obj("name" -> "toto", "age" -> 45)
         )
       ) must beEqualTo(JsSuccess(Dog("medor", User(45, "toto"))))
 
       Json.toJson(Dog("medor", User(45, "toto"))) must beEqualTo(
         Json.obj(
-          "name" -> "medor", 
+          "name" -> "medor",
           "master" -> Json.obj("name" -> "toto", "age" -> 45)
         )
       )
@@ -153,7 +154,7 @@ object JsonExtensionSpec extends Specification {
 
       Json.fromJson[RecUser](
         Json.obj(
-          "name" -> "bob", 
+          "name" -> "bob",
           "cat" -> Json.obj("name" -> "minou"),
           "hobbies" -> Json.arr("bobsleig", "manhunting"),
           "friends" -> Json.arr(Json.obj( "name" -> "tom", "hobbies" -> Json.arr(), "friends" -> Json.arr() ))
@@ -161,7 +162,7 @@ object JsonExtensionSpec extends Specification {
       ) must beEqualTo(
         JsSuccess(
           RecUser(
-            "bob", 
+            "bob",
             Some(Cat("minou")),
             List("bobsleig", "manhunting"),
             List(RecUser("tom"))
@@ -179,14 +180,14 @@ object JsonExtensionSpec extends Specification {
 
       Json.toJson(
         RecUser(
-          "bob", 
+          "bob",
           Some(Cat("minou")),
           List("bobsleig", "manhunting"),
           List(RecUser("tom"))
         )
       ) must beEqualTo(
         Json.obj(
-          "name" -> "bob", 
+          "name" -> "bob",
           "cat" -> Json.obj("name" -> "minou"),
           "hobbies" -> Json.arr("bobsleig", "manhunting"),
           "friends" -> Json.arr(Json.obj( "name" -> "tom", "hobbies" -> Json.arr(), "friends" -> Json.arr() ))
@@ -203,7 +204,7 @@ object JsonExtensionSpec extends Specification {
 
       Json.fromJson[RecUser](
         Json.obj(
-          "name" -> "bob", 
+          "name" -> "bob",
           "cat" -> Json.obj("name" -> "minou"),
           "hobbies" -> Json.arr("bobsleig", "manhunting"),
           "friends" -> Json.arr(Json.obj( "name" -> "tom", "hobbies" -> Json.arr(), "friends" -> Json.arr() ))
@@ -211,7 +212,7 @@ object JsonExtensionSpec extends Specification {
       ) must beEqualTo(
         JsSuccess(
           RecUser(
-            "bob", 
+            "bob",
             Some(Cat("minou")),
             List("bobsleig", "manhunting"),
             List(RecUser("tom"))
@@ -221,14 +222,14 @@ object JsonExtensionSpec extends Specification {
 
       Json.toJson(
         RecUser(
-          "bob", 
+          "bob",
           Some(Cat("minou")),
           List("bobsleig", "manhunting"),
           List(RecUser("tom"))
         )
       ) must beEqualTo(
         Json.obj(
-          "name" -> "bob", 
+          "name" -> "bob",
           "cat" -> Json.obj("name" -> "minou"),
           "hobbies" -> Json.arr("bobsleig", "manhunting"),
           "friends" -> Json.arr(Json.obj( "name" -> "tom", "hobbies" -> Json.arr(), "friends" -> Json.arr() ))
@@ -244,13 +245,13 @@ object JsonExtensionSpec extends Specification {
 
       Json.fromJson[User1](
         Json.obj(
-          "name" -> "bob", 
+          "name" -> "bob",
           "friend" -> Json.obj( "name" -> "tom" )
         )
       ) must beEqualTo(
         JsSuccess(
           User1(
-            "bob", 
+            "bob",
             Some(User1("tom"))
           )
         )
@@ -265,12 +266,12 @@ object JsonExtensionSpec extends Specification {
 
       Json.toJson(
         User1(
-          "bob", 
+          "bob",
           Some(User1("tom"))
         )
       ) must beEqualTo(
         Json.obj(
-          "name" -> "bob", 
+          "name" -> "bob",
           "friend" -> Json.obj( "name" -> "tom" )
         )
       )
@@ -284,13 +285,13 @@ object JsonExtensionSpec extends Specification {
 
       Json.fromJson[User1](
         Json.obj(
-          "name" -> "bob", 
+          "name" -> "bob",
           "friend" -> Json.obj( "name" -> "tom" )
         )
       ) must beEqualTo(
         JsSuccess(
           User1(
-            "bob", 
+            "bob",
             Some(User1("tom"))
           )
         )
@@ -298,16 +299,51 @@ object JsonExtensionSpec extends Specification {
 
       Json.toJson(
         User1(
-          "bob", 
+          "bob",
           Some(User1("tom"))
         )
       ) must beEqualTo(
         Json.obj(
-          "name" -> "bob", 
+          "name" -> "bob",
           "friend" -> Json.obj( "name" -> "tom" )
         )
       )
 
+    }
+
+    "create a writes[UserWithFields]" in {
+      import play.api.libs.json.Json
+
+      case class UserWithFields(age: Int, name: String) {
+        val ageWithName: String = s"$age $name"
+        var ageWithNameVar: String = s"$age $name"
+        def test(x: Int): Int = x + 999 // This should be ignored
+      }
+
+      // The following shouldn't crash the compiler
+      implicit val user1Writes = writesWithGetters[User1]
+      implicit val catWrites = writesWithGetters[Cat]
+      implicit val recUserWrites = writesWithGetters[RecUser]
+      implicit val userWithFieldWrites = writesWithGetters[UserWithFields]
+      implicit val userMapFieldWrites = writesWithGetters[UserMap]
+
+      val userWithField = UserWithFields(age = 10, name = "Billy")
+      val userMap = UserMap("toto", Map("tutu" -> UserMap("tutu")))
+
+      ( Json.obj(
+        "age" -> 10,
+        "ageWithNameVar" -> "10 Billy",
+        "ageWithName" -> "10 Billy",
+        "name" -> "Billy")
+       ) must beEqualTo(
+        Json.toJson(userWithField)
+      )
+
+      (
+        Json.obj("name" -> "toto", "friends" -> Json.obj("tutu" -> Json.obj("name" -> "tutu", "friends" -> Json.obj())))
+      ) must beEqualTo(
+        Json.toJson(userMap)
+      )
     }
 
     "manage Map[String, User]" in {
@@ -325,7 +361,7 @@ object JsonExtensionSpec extends Specification {
     "manage Boxed class" in {
       import play.api.libs.functional.syntax._
 
-      implicit def idReads[A](implicit rds: Reads[A]): Reads[Id[A]] = 
+      implicit def idReads[A](implicit rds: Reads[A]): Reads[Id[A]] =
         Reads[Id[A]] { js => rds.reads(js).map( Id[A](_) ) }
 
       //val c2Reads1 = Json.reads[C2]
@@ -350,14 +386,14 @@ object JsonExtensionSpec extends Specification {
 
       success
     }*/
-    "test 21 fields" in {      
+    "test 21 fields" in {
       implicit val XReads = Json.reads[X]
       implicit val XWrites = Json.writes[X]
       implicit val XFormat = Json.format[X]
       success
     }
 
-    "test inception with overriden object" in {      
+    "test inception with overriden object" in {
       implicit val programFormat = Json.reads[Program]
       success
     }
@@ -406,11 +442,11 @@ object JsonExtensionSpec extends Specification {
 
       val js = Json.obj("name" -> Json.arr(
         Json.obj(
-          "name" -> "medor", 
+          "name" -> "medor",
           "master" -> Json.obj("name" -> "toto", "age" -> 45)
         ),
         Json.obj(
-          "name" -> "brutus", 
+          "name" -> "brutus",
           "master" -> Json.obj("name" -> "tata", "age" -> 23)
         )
       ))
@@ -431,6 +467,6 @@ object JsonExtensionSpec extends Specification {
       Json.fromJson[Person2](Json.toJson(Person2(List("bob", "bobby")))).get must beEqualTo(Person2(List("bob", "bobby")))
     }
 
-  }    
+  }
 
 }


### PR DESCRIPTION
I found myself wanting to have a macro that would generate a JSON serialiser that would serialise not just the constructor arguments of a case class, but across all getters (vals, vars) of a class, and so took at stab at implementing it.

I couldn't really re-use the existing macro implementation because it is largely designed to work with case class constructor parameters (JsPath w/ apply, unapply), although the Implicit checker-related logic was very useful.
