### PR TITLE
Close a security hole by using https to fetch artifacts

### DIFF
--- a/documentation/manual/detailedTopics/build/Build.md
+++ b/documentation/manual/detailedTopics/build/Build.md
@@ -95,7 +95,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayJava)
 ...and so are resolvers for adding in additional repositories:
 
 ```scala
-resolvers += "Repository name" at "http://url.to/repository" 
+resolvers += "Repository name" at "https://url.to/repository" 
 ```
 
 

--- a/documentation/manual/detailedTopics/build/SBTDependencies.md
+++ b/documentation/manual/detailedTopics/build/SBTDependencies.md
@@ -56,7 +56,7 @@ libraryDependencies += "org.scala-tools" %% "scala-stm" % "0.3"
 
 ### Resolvers
 
-sbt uses the standard Maven2 repository and the Typesafe Releases (<http://repo.typesafe.com/typesafe/releases>) repositories by default. If your dependency isn’t on one of the default repositories, you’ll have to add a resolver to help Ivy find it.
+sbt uses the standard Maven2 repository and the Typesafe Releases (<https://repo.typesafe.com/typesafe/releases>) repositories by default. If your dependency isn’t on one of the default repositories, you’ll have to add a resolver to help Ivy find it.
 
 Use the `resolvers` setting key to add your own resolver.
 

--- a/documentation/manual/detailedTopics/production/ProductionDist.md
+++ b/documentation/manual/detailedTopics/production/ProductionDist.md
@@ -141,11 +141,11 @@ You have to configure the repository you want to publish to, in your `build.sbt`
 
 ```scala
  publishTo := Some(
-   "My resolver" at "http://mycompany.com/repo"
+   "My resolver" at "https://mycompany.com/repo"
  ),
  
  credentials += Credentials(
-   "Repo", "http://mycompany.com/repo", "admin", "admin123"
+   "Repo", "https://mycompany.com/repo", "admin", "admin123"
  )
 ```
 

--- a/documentation/manual/gettingStarted/NewApplication.md
+++ b/documentation/manual/gettingStarted/NewApplication.md
@@ -54,7 +54,7 @@ In `project/plugins.sbt`, add:
 
 ```scala
 // The Typesafe repository
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "%PLAY_VERSION%")
@@ -64,7 +64,7 @@ Be sure to replace `%PLAY_VERSION%` here by the exact version you want to use. I
 
 ```
 // Typesafe snapshots
-resolvers += "Typesafe Snapshots" at "http://repo.typesafe.com/typesafe/snapshots/"
+resolvers += "Typesafe Snapshots" at "https://repo.typesafe.com/typesafe/snapshots/"
 ```
 
 To ensure the proper sbt version is used, make sure you have the following in `project/build.properties`:

--- a/documentation/manual/hacking/Repositories.md
+++ b/documentation/manual/hacking/Repositories.md
@@ -3,7 +3,7 @@
 
 ## Typesafe repository
 
-All Play artifacts are published to the Typesafe repository at <http://repo.typesafe.com/typesafe/releases/>.
+All Play artifacts are published to the Typesafe repository at <https://repo.typesafe.com/typesafe/releases/>.
 
 > **Note:** it's a Maven2 compatible repository.
 
@@ -11,17 +11,17 @@ To enable it in your sbt build, you must add a proper resolver (typically in `pl
 
 ```
 // The Typesafe repository
-resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 ```
 
 ## Accessing snapshots
 
-Snapshots are published daily from our [[Continuous Integration Server|ThirdPartyTools]] to the Typesafe snapshots repository at <http://repo.typesafe.com/typesafe/snapshots/>.
+Snapshots are published daily from our [[Continuous Integration Server|ThirdPartyTools]] to the Typesafe snapshots repository at <https://repo.typesafe.com/typesafe/snapshots/>.
 
 > **Note:** it's an ivy style repository.
 
 ```
 // The Typesafe snapshots repository
-resolvers += Resolver.url("Typesafe Ivy Snapshots Repository", url("http://repo.typesafe.com/typesafe/ivy-snapshots"))(Resolver.ivyStylePatterns)
+resolvers += Resolver.url("Typesafe Ivy Snapshots Repository", url("https://repo.typesafe.com/typesafe/ivy-snapshots"))(Resolver.ivyStylePatterns)
 ```
 

--- a/documentation/project/Build.scala
+++ b/documentation/project/Build.scala
@@ -35,7 +35,7 @@ object ApplicationBuild extends Build {
 
   val externalPlayModules: Map[String, Seq[Setting[_]]] = Map(
     "scalatestplus-play" -> Seq(
-      resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases", // TODO: Delete this eventually, just needed for lag between deploying to sonatype and getting on maven central
+      resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases", // TODO: Delete this eventually, just needed for lag between deploying to sonatype and getting on maven central
       libraryDependencies += "org.scalatestplus" %% "play" % "1.1.0-RC1" % "test" exclude("com.typesafe.play", "play-test_2.10")
     )
   )

--- a/documentation/project/plugins.sbt
+++ b/documentation/project/plugins.sbt
@@ -4,7 +4,7 @@
 logLevel := Level.Warn
 
 // The Typesafe repository
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "play-docs-sbt-plugin" % Option(System.getProperty("play.version")).getOrElse {

--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -156,16 +156,18 @@ object Resolvers {
 
   import BuildSettings._
 
-  val typesafeReleases = "Typesafe Releases Repository" at "http://repo.typesafe.com/typesafe/releases/"
-  val typesafeSnapshots = "Typesafe Snapshots Repository" at "http://repo.typesafe.com/typesafe/snapshots/"
-  val typesafeIvyReleases = Resolver.url("Typesafe Ivy Releases Repository", url("http://repo.typesafe.com/typesafe/ivy-releases"))(Resolver.ivyStylePatterns)
-  val typesafeIvySnapshots = Resolver.url("Typesafe Ivy Snapshots Repository", url("http://repo.typesafe.com/typesafe/ivy-snapshots"))(Resolver.ivyStylePatterns)
+  val typesafeReleases = "Typesafe Releases Repository" at "https://repo.typesafe.com/typesafe/releases/"
+  val typesafeSnapshots = "Typesafe Snapshots Repository" at "https://repo.typesafe.com/typesafe/snapshots/"
+  val typesafeIvyReleases = Resolver.url("Typesafe Ivy Releases Repository", url("https://repo.typesafe.com/typesafe/ivy-releases"))(Resolver.ivyStylePatterns)
+  val typesafeIvySnapshots = Resolver.url("Typesafe Ivy Snapshots Repository", url("https://repo.typesafe.com/typesafe/ivy-snapshots"))(Resolver.ivyStylePatterns)
   val publishTypesafeMavenReleases = "Typesafe Maven Releases Repository for publishing" at "https://private-repo.typesafe.com/typesafe/maven-releases/"
   val publishTypesafeMavenSnapshots = "Typesafe Maven Snapshots Repository for publishing" at "https://private-repo.typesafe.com/typesafe/maven-snapshots/"
   val publishTypesafeIvyReleases = Resolver.url("Typesafe Ivy Releases Repository for publishing", url("https://private-repo.typesafe.com/typesafe/ivy-releases/"))(Resolver.ivyStylePatterns)
   val publishTypesafeIvySnapshots = Resolver.url("Typesafe Ivy Snapshots Repository for publishing", url("https://private-repo.typesafe.com/typesafe/ivy-snapshots/"))(Resolver.ivyStylePatterns)
 
-  val sonatypeSnapshots = "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
+  val sonatypeSnapshots = "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
+  // This is a security issue. This repository should not be loaded via http
+  // See http://blog.ontoillogical.com/blog/2014/07/28/how-to-take-over-any-java-developer/
   val sbtPluginSnapshots = Resolver.url("sbt plugin snapshots", url("http://repo.scala-sbt.org/scalasbt/sbt-plugin-snapshots"))(Resolver.ivyStylePatterns)
 
   val isSnapshotBuild = buildVersion.endsWith("SNAPSHOT")

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -47,7 +47,7 @@ trait PlaySettings {
     playPlugin := false,
 
     resolvers ++= Seq(
-      "Typesafe Releases Repository" at "http://repo.typesafe.com/typesafe/releases/"
+      "Typesafe Releases Repository" at "https://repo.typesafe.com/typesafe/releases/"
     ),
 
     target <<= baseDirectory(_ / "target"),

--- a/templates/play-java-intro/project/plugins.sbt
+++ b/templates/play-java-intro/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "%PLAY_VERSION%")

--- a/templates/play-java/project/plugins.sbt
+++ b/templates/play-java/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "%PLAY_VERSION%")

--- a/templates/play-scala-intro/project/plugins.sbt
+++ b/templates/play-scala-intro/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "%PLAY_VERSION%")

--- a/templates/play-scala/project/plugins.sbt
+++ b/templates/play-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "%PLAY_VERSION%")

--- a/templates/project/plugins.sbt
+++ b/templates/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-s3" % "0.5")
 


### PR DESCRIPTION
Close a security hole by using https to fetch artifacts instead of http. Should never download software over http. See http://blog.ontoillogical.com/blog/2014/07/28/how-to-take-over-any-java-developer/

There are two that I didn't update here
http://repo.scala-sbt.org/scalasbt/sbt-plugin-snapshots is not available via https :-(
https://github.com/playframework/playframework/pull/3286 just added one that I wasn't 100% sure how to test if https would work
