### PR TITLE
Add Macro for generating Writes JSON serializer for all getters in a class

### DIFF
--- a/documentation/manual/working/scalaGuide/main/json/ScalaJsonInception.md
+++ b/documentation/manual/working/scalaGuide/main/json/ScalaJsonInception.md
@@ -23,14 +23,14 @@ implicit val personReads = (
 )(Person)
 ```
 
-So you write 4 lines for this case class.  
-You know what?  
-We have had a few complaints from some people who think it's not cool to write a `Reads[TheirClass]` because usually Java JSON frameworks like Jackson or Gson do it behind the curtain without writing anything.  
+So you write 4 lines for this case class.
+You know what?
+We have had a few complaints from some people who think it's not cool to write a `Reads[TheirClass]` because usually Java JSON frameworks like Jackson or Gson do it behind the curtain without writing anything.
 We argued that Play2.1 JSON serializers/deserializers are:
 
-- completely typesafe, 
+- completely typesafe,
 - fully compiled,
-- nothing was performed using introspection/reflection at runtime.  
+- nothing was performed using introspection/reflection at runtime.
 
 But for some, this didn’t justify the extra lines of code for case classes.
 
@@ -54,7 +54,7 @@ case class Person(name: String, age: Int, lovesChocolate: Boolean)
 implicit val personReads = Json.reads[Person]
 ```
 
-1 line only.  
+1 line only.
 Questions you may ask immediately:
 
 > Does it use runtime bytecode enhancement? -> NO
@@ -87,7 +87,7 @@ implicit val personReads = (
   (__ \ 'age).read[Int] and
   (__ \ 'lovesChocolate).read[Boolean]
 )(Person)
-```	
+```
 
 ## <a name="json-incept">Inception equation</a>
 
@@ -101,7 +101,7 @@ Here is the equation describing the windy _Inception_ concept:
 ####Case Class Inspection
 As you may deduce by yourself, in order to ensure preceding code equivalence, we need :
 
-- to inspect `Person` case class, 
+- to inspect `Person` case class,
 - to extract the 3 fields `name`, `age`, `lovesChocolate` and their types,
 - to resolve typeclasses implicits,
 - to find `Person.apply`.
@@ -109,12 +109,12 @@ As you may deduce by yourself, in order to ensure preceding code equivalence, we
 
 <br/>
 ####INJECTION?
-No I stop you immediately…  
+No I stop you immediately…
 
->**Code injection is not dependency injection…**  
->No Spring behind inception… No IOC, No DI… No No No ;)  
-  
-I used this term on purpose because I know that injection is now linked immediately to IOC and Spring. But I'd like to re-establish this word with its real meaning.  
+>**Code injection is not dependency injection…**
+>No Spring behind inception… No IOC, No DI… No No No ;)
+
+I used this term on purpose because I know that injection is now linked immediately to IOC and Spring. But I'd like to re-establish this word with its real meaning.
 Here code injection just means that **we inject code at compile-time into the compiled scala AST** (Abstract Syntax Tree).
 
 So `Json.reads[Person]` is compiled and replaced in the compile AST by:
@@ -131,9 +131,9 @@ Nothing less, nothing more…
 
 <br/>
 ####COMPILE-TIME
-Yes everything is performed at compile-time.  
-No runtime bytecode enhancement.  
-No runtime introspection.  
+Yes everything is performed at compile-time.
+No runtime bytecode enhancement.
+No runtime introspection.
 
 > As everything is resolved at compile-time, you will have a compile error if you did not import the required implicits for all the types of the fields.
 
@@ -146,11 +146,11 @@ We needed a Scala feature enabling:
 - compile-time class/implicits inspection
 - compile-time code injection
 
-This is enabled by a new experimental feature introduced in Scala 2.10: [Scala Macros](http://scalamacros.org/)  
+This is enabled by a new experimental feature introduced in Scala 2.10: [Scala Macros](http://scalamacros.org/)
 
 Scala macros is a new feature (still experimental) with a huge potential. You can :
 
-- introspect code at compile-time based on Scala reflection API, 
+- introspect code at compile-time based on Scala reflection API,
 - access all imports, implicits in the current compile context
 - create new code expressions, generate compiling errors and inject them into compile chain.
 
@@ -162,19 +162,19 @@ Please note that:
 - **It doesn't add, hide unexpected code behind the curtain.**
 - **We follow the *no-surprise* principle**
 
-As you may discover, writing a macro is not a trivial process since your macro code executes in the compiler runtime (or universe).  
+As you may discover, writing a macro is not a trivial process since your macro code executes in the compiler runtime (or universe).
 
-    So you write macro code 
-      that is compiled and executed 
-      in a runtime that manipulates your code 
-         to be compiled and executed 
-         in a future runtime…           
+    So you write macro code
+      that is compiled and executed
+      in a runtime that manipulates your code
+         to be compiled and executed
+         in a future runtime…
 **That's also certainly why I called it *Inception* ;)**
 
 So it requires some mental exercises to follow exactly what you do. The API is also quite complex and not fully documented yet. Therefore, you must persevere when you begin using macros.
 
-I'll certainly write other articles about Scala macros because there are lots of things to say.  
-This article is also meant **to begin the reflection about the right way to use Scala Macros**.  
+I'll certainly write other articles about Scala macros because there are lots of things to say.
+This article is also meant **to begin the reflection about the right way to use Scala Macros**.
 Great power means greater responsability so it's better to discuss all together and establish a few good manners…
 
 <br/>
@@ -188,8 +188,13 @@ Naturally, you can also _incept_ `Writes[T]` and `Format[T]`.
 
 ```
 import play.api.libs.json._
- 
+
 implicit val personWrites = Json.writes[Person]
+
+/* If you want a writer that will write `val` fields as well as constructor arguments
+
+ ` implicit val personWritesWithGetters = Json.writesGetters[Person]`
+*/
 ```
 
 ## <a name="format">Format[T]</a>

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -4,10 +4,37 @@
 package play.api.libs.json
 
 import scala.language.higherKinds
-import scala.reflect.macros.Context
+import scala.reflect.macros._
 import language.experimental.macros
 
 object JsMacroImpl {
+
+  // <-- Package references
+  private def libsPkg(c: Context): c.universe.Select = {
+    import c.universe._
+    Select(Select(Ident(newTermName("play")), newTermName("api")), newTermName("libs"))
+  }
+
+  private def jsonPkg(c: Context): c.universe.Select = {
+    import c.universe._
+    Select(libsPkg(c), newTermName("json"))
+  }
+
+  private def functionalSyntaxPkg(c: Context) = {
+    import c.universe._
+    Select(Select(libsPkg(c), newTermName("functional")), newTermName("syntax"))
+  }
+
+  private def utilPkg(c: Context) = {
+    import c.universe._
+    Select(jsonPkg(c), newTermName("util"))
+  }
+
+  private def lazyHelper(c: Context) = {
+    import c.universe._
+    Select(utilPkg(c), newTypeName("LazyHelper"))
+  }
+  // Package references -->
 
   def formatImpl[A: c.WeakTypeTag](c: Context): c.Expr[Format[A]] =
     macroImpl[A, Format](c, "format", "inmap", reads = true, writes = true)
@@ -18,10 +45,59 @@ object JsMacroImpl {
   def writesImpl[A: c.WeakTypeTag](c: Context): c.Expr[Writes[A]] =
     macroImpl[A, Writes](c, "write", "contramap", reads = false, writes = true)
 
-  def macroImpl[A, M[_]](c: Context, methodName: String, mapLikeMethod: String, reads: Boolean, writes: Boolean)(implicit atag: c.WeakTypeTag[A], matag: c.WeakTypeTag[M[A]]): c.Expr[M[A]] = {
+  def writesGettersImpl[A: c.WeakTypeTag](c: Context): c.Expr[Writes[A]] = {
+    import c.universe._
+    import c.universe.Flag._
 
-    val nullableMethodName = s"${methodName}Nullable"
-    val lazyMethodName = s"lazy${methodName.capitalize}"
+    val typeToWrite = c.weakTypeOf[A]
+    val getterMethodSymbols = for {
+      memberSymbol <- typeToWrite.members
+      term = memberSymbol.asTerm
+      if term.isPublic && term.isGetter
+    } yield memberSymbol
+    if (getterMethodSymbols.isEmpty)
+      c.abort(c.enclosingPosition, s"${typeToWrite} has no getters. Are you using the right class?")
+    val getterMethodTerms = getterMethodSymbols.map(_.asTerm)
+
+    val (canBuildFrom, hasRec) = canBuildTree[A, Writes](c)(
+      methodName = "write",
+      reads = false,
+      writes = true,
+      typeToWrite = typeToWrite.typeSymbol,
+      accessorSymbols = getterMethodSymbols.toSeq,
+      hasVarArgs = false,
+      unapplyReturnTypes = None)
+
+    // Manually-built "unapply"
+    val objectTerm = newTermName("o")
+    val objectIdent = Ident(objectTerm)
+    val unapplyExpressions = getterMethodTerms.map { term => Select(objectIdent, term) }
+    val unapplyWrapper = if (unapplyExpressions.size > 1)
+      Select(Ident(newTermName("scala")), newTermName(s"Tuple${getterMethodTerms.size}"))
+    else
+      Ident(newTermName("identity")) // If only 1 term, don't put in a tuple
+    val unapplyBody = Function(
+      List(ValDef(Modifiers(PARAM), objectTerm, TypeTree(typeToWrite), EmptyTree)),
+      Apply(
+        unapplyWrapper,
+        unapplyExpressions.toList
+      )
+    )
+
+    val applier = newTermName(if (getterMethodTerms.size > 1) "apply" else "contramap")
+    val unliftIdent = Select(functionalSyntaxPkg(c), newTermName("unlift"))
+    val finalTree = Apply(
+      Select(canBuildFrom, applier),
+      List(
+        unapplyBody
+      )
+    )
+
+    val block = buildFinalBlock[A, Writes](c)(finalTree, hasRec)
+    c.Expr[Writes[A]](block)
+  }
+
+  def macroImpl[A, M[_]](c: Context, methodName: String, mapLikeMethod: String, reads: Boolean, writes: Boolean)(implicit atag: c.WeakTypeTag[A], matag: c.WeakTypeTag[M[A]]): c.Expr[M[A]] = {
 
     def conditionalList[T](ifReads: T, ifWrites: T): List[T] =
       (if (reads) List(ifReads) else Nil) :::
@@ -34,16 +110,7 @@ object JsMacroImpl {
     val companionSymbol = companioned.companionSymbol
     val companionType = companionSymbol.typeSignature
 
-    val libsPkg = Select(Select(Ident(newTermName("play")), newTermName("api")), newTermName("libs"))
-    val jsonPkg = Select(libsPkg, newTermName("json"))
-    val functionalSyntaxPkg = Select(Select(libsPkg, newTermName("functional")), newTermName("syntax"))
-    val utilPkg = Select(jsonPkg, newTermName("util"))
-
-    val jsPathSelect = Select(jsonPkg, newTermName("JsPath"))
-    val readsSelect = Select(jsonPkg, newTermName("Reads"))
-    val writesSelect = Select(jsonPkg, newTermName("Writes"))
-    val unliftIdent = Select(functionalSyntaxPkg, newTermName("unlift"))
-    val lazyHelperSelect = Select(utilPkg, newTypeName("LazyHelper"))
+    val unliftIdent = Select(functionalSyntaxPkg(c), newTermName("unlift"))
 
     val unapply = companionType.declaration(stringToTermName("unapply"))
     val unapplySeq = companionType.declaration(stringToTermName("unapplySeq"))
@@ -106,12 +173,83 @@ object JsMacroImpl {
 
     //println("apply found:" + apply)
 
+    // builds the final M[A] using apply method
+    //val applyMethod = Ident( companionSymbol )
+    val applyBody = {
+      val body = params.foldLeft(List[Tree]())((l, e) =>
+        l :+ Ident(newTermName(e.name.encoded))
+      )
+      if (hasVarArgs)
+        body.init :+ Typed(body.last, Ident(tpnme.WILDCARD_STAR))
+      else body
+    }
+    val applyMethod =
+      Function(
+        params.foldLeft(List[ValDef]())((l, e) =>
+          l :+ ValDef(Modifiers(PARAM), newTermName(e.name.encoded), TypeTree(), EmptyTree)
+        ),
+        Apply(
+          Select(Ident(companionSymbol), newTermName("apply")),
+          applyBody
+        )
+      )
+
+    val unapplyMethod = Apply(
+      unliftIdent,
+      List(
+        Select(Ident(companionSymbol), effectiveUnapply.name)
+      )
+    )
+
+    val (canBuildFrom, hasRec) = canBuildTree[A, M](c)(
+      methodName = methodName,
+      reads = reads,
+      writes = writes,
+      typeToWrite = companioned,
+      accessorSymbols = params,
+      hasVarArgs = hasVarArgs,
+      unapplyReturnTypes = unapplyReturnTypes)
+
+    // if case class has one single field, needs to use inmap instead of canbuild.apply
+    val method = if (params.length > 1) "apply" else mapLikeMethod
+    val finalTree = Apply(
+      Select(canBuildFrom, newTermName(method)),
+      conditionalList(applyMethod, unapplyMethod)
+    )
+    //println("finalTree: "+finalTree)
+
+    val block = buildFinalBlock[A, M](c)(finalTree, hasRec)
+    c.Expr[M[A]](block)
+  }
+
+  private def canBuildTree[A, M[_]](c: Context)(
+    methodName: String,
+    reads: Boolean,
+    writes: Boolean,
+    typeToWrite: c.universe.Symbol,
+    accessorSymbols: Seq[c.universe.Symbol],
+    hasVarArgs: Boolean,
+    unapplyReturnTypes: Option[List[c.universe.Type]])(implicit atag: c.WeakTypeTag[A], matag: c.WeakTypeTag[M[A]]): (c.universe.Apply, Boolean) = {
+
+    import c.universe._
+
+    def conditionalList[T](ifReads: T, ifWrites: T): List[T] =
+      (if (reads) List(ifReads) else Nil) :::
+        (if (writes) List(ifWrites) else Nil)
+
+    val nullableMethodName = s"${methodName}Nullable"
+    val lazyMethodName = s"lazy${methodName.capitalize}"
+
+    val jsPathSelect = Select(jsonPkg(c), newTermName("JsPath"))
+    val readsSelect = Select(jsonPkg(c), newTermName("Reads"))
+    val writesSelect = Select(jsonPkg(c), newTermName("Writes"))
+
     final case class Implicit(paramName: Name, paramType: Type, neededImplicit: Tree, isRecursive: Boolean, tpe: Type)
 
-    val createImplicit = { (name: Name, implType: c.universe.type#Type) =>
+    val createImplicit = { (name: Name, implType: c.universe.Type) =>
       val (isRecursive, tpe) = implType match {
         case TypeRef(_, t, args) =>
-          val isRec = args.exists(_.typeSymbol == companioned)
+          val isRec = args.exists(_.typeSymbol == typeToWrite)
           // Option[_] needs special treatment because we need to use XXXOpt
           val tp = if (implType.typeConstructor <:< typeOf[Option[_]].typeConstructor) args.head else implType
           (isRec, tp)
@@ -126,7 +264,11 @@ object JsMacroImpl {
       Implicit(name, implType, neededImplicit, isRecursive, tpe)
     }
 
-    val applyParamImplicits = params.map { param => createImplicit(param.name, param.typeSignature) }
+    val applyParamImplicits = accessorSymbols.map { accessor =>
+      // For accesors that are methods (vals in the body), we only care about the return type
+      val implType = if (accessor.isMethod) accessor.asMethod.returnType else accessor.typeSignature
+      createImplicit(accessor.name, implType)
+    }
     val effectiveInferredImplicits = if (hasVarArgs) {
       val varArgsImplicit = createImplicit(applyParamImplicits.last.paramName, unapplyReturnTypes.get.last)
       applyParamImplicits.init :+ varArgsImplicit
@@ -188,52 +330,20 @@ object JsMacroImpl {
         List(r)
       )
     }
+    //println(s"canBuildTree returns: $canBuild, $hasRec")
+    (canBuild, hasRec)
+  }
 
-    // builds the final M[A] using apply method
-    //val applyMethod = Ident( companionSymbol )
-
-    val applyBody = {
-      val body = params.foldLeft(List[Tree]())((l, e) =>
-        l :+ Ident(newTermName(e.name.encoded))
-      )
-      if (hasVarArgs)
-        body.init :+ Typed(body.last, Ident(tpnme.WILDCARD_STAR))
-      else body
-    }
-    val applyMethod =
-      Function(
-        params.foldLeft(List[ValDef]())((l, e) =>
-          l :+ ValDef(Modifiers(PARAM), newTermName(e.name.encoded), TypeTree(), EmptyTree)
-        ),
-        Apply(
-          Select(Ident(companionSymbol), newTermName("apply")),
-          applyBody
-        )
-      )
-
-    val unapplyMethod = Apply(
-      unliftIdent,
-      List(
-        Select(Ident(companionSymbol), effectiveUnapply.name)
-      )
-    )
-
-    // if case class has one single field, needs to use inmap instead of canbuild.apply
-    val method = if (params.length > 1) "apply" else mapLikeMethod
-    val finalTree = Apply(
-      Select(canBuild, newTermName(method)),
-      conditionalList(applyMethod, unapplyMethod)
-    )
-    //println("finalTree: " + finalTree)
-
-    val importFunctionalSyntax = Import(functionalSyntaxPkg, List(ImportSelector(nme.WILDCARD, -1, null, -1)))
+  private def buildFinalBlock[A, M[_]](c: Context)(finalTree: c.universe.Tree, hasRec: Boolean)(implicit atag: c.WeakTypeTag[A], matag: c.WeakTypeTag[M[A]]) = {
+    import c.universe._
+    val lazyHelperSelect = lazyHelper(c)
+    val importFunctionalSyntax = Import(functionalSyntaxPkg(c), List(ImportSelector(nme.WILDCARD, -1, null, -1)))
     if (!hasRec) {
       val block = Block(
         List(importFunctionalSyntax),
         finalTree
       )
-      //println("block:"+block)
-      c.Expr[M[A]](block)
+      block
     } else {
       val helper = newTermName("helper")
       val helperVal = ValDef(
@@ -293,10 +403,8 @@ object JsMacroImpl {
         ),
         newTermName("lazyStuff")
       )
-
-      // println("block:" + block)
-
-      c.Expr[M[A]](block)
+      //println("block:"+block)
+      block
     }
   }
 

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
@@ -242,4 +242,30 @@ object Json {
    */
   def format[A] = macro JsMacroImpl.formatImpl[A]
 
+  /**
+   * Creates a Writes[T] by resolving getters & required implicits at COMPILE-time
+   *
+   * If any missing implicit is discovered, compiler will break with corresponding error.
+   * {{{
+   *   import play.api.libs.json.Json
+   *
+   *   case class UserWithFields(age: Int, name: String) {
+   *    val ageWithName: String = s"$age $name"
+   *    var ageWithNameVar: String = s"$age $name"
+   *    def test(x: Int): Int = x + 999 // This should be ignored
+   *   }
+   *
+   *   implicit val userWithWrites = writesGetters[UserWithFields]
+   *   // macro-compiler replaces Json.writes[User] by injecting into compile chain
+   *   // the exact code you would write yourself. This is strictly equivalent to:
+   *   implicit val userWrites = (
+   *    (__ \ 'age).write[Int] and
+   *    (__ \ 'name).write[String] and
+   *    (__ \ 'ageWithName).write[String] and
+   *    (__ \ 'ageWithNameVar).write[String]
+   *   )(o: UserWithFields => (o.age, o.name, o.ageWithName, o.ageWithNameVar))
+   * }}}
+   */
+  def writesGetters[A] = macro JsMacroImpl.writesGettersImpl[A]
+
 }


### PR DESCRIPTION
As mentioned in #3302 I found myself wanting to have a macro that would generate a JSON serialiser that would serialise not just the constructor arguments of a case class, but across all getters (vals, vars) of a class, and so took at stab at implementing it.

In this PR, I refactored `JsMacroImpl` to pull out the code inside the original `macroImp` method into separate private helper methods to make the logic more reuseable and added a macro implementation method that looks for the getter methods in a given class and invokes those helpers to generate a `Writes` serializer.