### PR TITLE
Publish Play to Maven Central

### DIFF
--- a/framework/package
+++ b/framework/package
@@ -102,14 +102,14 @@ then
     "$DIR/build" clean
 fi
 
-"$DIR/build" $PUBLISHCMD
+"$DIR/build" -Dgenerate.doc=true $PUBLISHCMD
 
 for v in $(echo $CROSSBUILD | sed "s/,/ /")
 do
     if [ -n "$v" ]
     then
         echo "Cross building Play against Scala $v"
-        "$DIR/build" -Dscala.version=$v $PUBLISHCMD
+        "$DIR/build" -Dgenerate.doc=true -Dscala.version=$v $PUBLISHCMD
     fi
 done
 

--- a/framework/project/Publish.scala
+++ b/framework/project/Publish.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+import sbt.Keys._
+import sbt._
+
+/**
+ * Any resolvers that we may be interested in
+ */
+object ResolverSettings {
+  val typesafeReleases = "Typesafe Releases Repository" at "https://repo.typesafe.com/typesafe/releases/"
+  val typesafeSnapshots = "Typesafe Snapshots Repository" at "https://repo.typesafe.com/typesafe/snapshots/"
+  val typesafeIvyReleases = Resolver.url("Typesafe Ivy Releases Repository", url("https://repo.typesafe.com/typesafe/ivy-releases"))(Resolver.ivyStylePatterns)
+  val typesafeIvySnapshots = Resolver.url("Typesafe Ivy Snapshots Repository", url("https://repo.typesafe.com/typesafe/ivy-snapshots"))(Resolver.ivyStylePatterns)
+  val publishTypesafeMavenReleases = "Typesafe Maven Releases Repository for publishing" at "https://private-repo.typesafe.com/typesafe/maven-releases/"
+  val publishTypesafeMavenSnapshots = "Typesafe Maven Snapshots Repository for publishing" at "https://private-repo.typesafe.com/typesafe/maven-snapshots/"
+  val publishTypesafeIvyReleases = Resolver.url("Typesafe Ivy Releases Repository for publishing", url("https://private-repo.typesafe.com/typesafe/ivy-releases/"))(Resolver.ivyStylePatterns)
+  val publishTypesafeIvySnapshots = Resolver.url("Typesafe Ivy Snapshots Repository for publishing", url("https://private-repo.typesafe.com/typesafe/ivy-snapshots/"))(Resolver.ivyStylePatterns)
+
+  val publishSonatypeReleases = "Sonatype Maven Repository for publishing" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+  val publishSonatypeSnapshots = "Sonatype Maven Snapshots Repository for publishing" at "https://oss.sonatype.org/content/repositories/snapshots"
+
+  val sonatypeSnapshots = "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
+  val sbtPluginSnapshots = Resolver.url("sbt plugin snapshots", url("http://repo.scala-sbt.org/scalasbt/sbt-plugin-snapshots"))(Resolver.ivyStylePatterns)
+
+  val playResolvers = Seq(typesafeReleases, typesafeIvyReleases)
+}
+
+object PublishSettings {
+
+  private def commonPublishSettings: Seq[Setting[_]] = Seq(
+    publishArtifact in (Compile, packageDoc) := BuildSettings.buildWithDoc,
+    publishArtifact in (Test, packageDoc) := false,
+    publishArtifact in (Compile, packageSrc) := true,
+    publishArtifact in (Test, packageSrc) := false,
+    pomIncludeRepository := { _ => false },
+    pomExtra := pomExtraXml
+
+  )
+
+  /**
+   * We actually must publish when doing a publish-local in order to ensure the scala 2.11 build works, very strange
+   * things happen if you set publishArtifact := false, since it still publishes an ivy file when you do a
+   * publish-local, but that ivy file says there's no artifacts.
+   *
+   * So, to disable publishing for the 2.11 build, we simply publish to a dummy repo instead of to the real thing.
+   */
+  def dontPublishSettings: Seq[Setting[_]] = Seq(
+    publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo")))
+  )
+
+  /**
+   * Default publish settings
+   */
+  def publishSettings: Seq[Setting[_]] = commonPublishSettings ++ Seq(
+    publishTo := {
+      Some(if (isSnapshot(version.value)) {
+        ResolverSettings.publishSonatypeSnapshots
+      } else {
+        ResolverSettings.publishSonatypeReleases
+      })
+    },
+    publishMavenStyle := true
+  )
+
+  /**
+   * Publish settings for sub projects that don't get cross built - they should only be published when Play is being
+   * cross built.
+   */
+  def nonCrossBuildPublishSettings: Seq[Setting[_]] = {
+    if (BuildSettings.thisBuildIsCrossBuild) {
+      dontPublishSettings
+    } else {
+      publishSettings
+    }
+  }
+
+  /**
+   * Publish settings for SBT plugins
+   */
+  def sbtPluginPublishSettings: Seq[Setting[_]] = {
+    if (BuildSettings.thisBuildIsCrossBuild) {
+      dontPublishSettings
+    } else {
+      commonPublishSettings ++ Seq(
+        publishTo := {
+          Some(if (isSnapshot(version.value)) {
+            ResolverSettings.publishTypesafeIvySnapshots
+          } else {
+            ResolverSettings.publishTypesafeIvyReleases
+          })
+        },
+        publishMavenStyle := false
+      )
+    }
+  }
+
+  private def isSnapshot(version: String) = {
+    version.endsWith("SNAPSHOT")
+  }
+
+  private val pomExtraXml =
+    <scm>
+      <url>git@github.com:playframework/playframework.git</url>
+      <connection>scm:git:git@github.com:playframework/playframework.git</connection>
+    </scm> ++ makeDevelopersXml(
+      ("guillaumebort", "Guillaume Bort", "http://guillaume.bort.fr"),
+      ("pk11", "Peter Hausel", "https://twitter.com/pk11"),
+      ("sadache", "Sadek Drobi", "http://sadache.tumblr.com"),
+      ("erwan", "Erwan Loisant", "http://caffeinelab.net/"),
+      ("jroper", "James Roper", "https://jazzy.id.au"),
+      ("huntc", "Christopher Hunt", "http://christopherhunt-software.blogspot.com.au/"),
+      ("richdougherty", "Rich Dougherty", "http://www.richdougherty.com/"),
+      ("pvlugter", "Peter Vlugter", "https://github.com/pvlugter"),
+      ("wsargent", "Will Sargent", "https://github.com/wsargent"),
+      ("julienrf", "Julien Richard-Foy", "http://julien.richard-foy.fr"),
+      ("baloo", "Arthur Gautier", "https://twitter.com/baloose"),
+      ("cchantep", "Cédric Chantepie", "https://twitter.com/cchantep"),
+      ("benmccann", "Ben McCann", "http://www.benmccann.com"),
+      ("mandubian", "Pascal Voitot", "http://www.mandubian.com"),
+      ("nraychaudhuri", "Nilanjan Raychaudhuri", "http://www.manning.com/raychaudhuri/"),
+      ("gmethvin", "Greg Methvin", "http://methvin.net")
+    )
+
+
+  private def makeDevelopersXml(developers: (String, String, String)*) =
+    <developers>
+      {
+      for ((id, name, url) <- developers) yield
+        <developer>
+          <id>{id}</id>
+          <name>{name}</name>
+          <url>{url}</url>
+        </developer>
+      }
+    </developers>
+}

--- a/framework/project/Tasks.scala
+++ b/framework/project/Tasks.scala
@@ -27,7 +27,7 @@ object Tasks {
   def scalaTemplateSourceMappings = (excludeFilter in unmanagedSources, unmanagedSourceDirectories in Compile, baseDirectory) map {
     (excludes, sdirs, base) =>
       val scalaTemplateSources = sdirs.descendantsExcept("*.scala.html", excludes)
-      ((scalaTemplateSources --- sdirs --- base) pair (relativeTo(sdirs) | relativeTo(base) | flat)) toSeq
+      ((scalaTemplateSources --- sdirs --- base) pair (relativeTo(sdirs) | relativeTo(base) | flat)).toSeq
   }
 
 }

--- a/framework/runtests
+++ b/framework/runtests
@@ -32,12 +32,12 @@ else
   echo "[info]"
   echo "[info] ---- BUILDING PLAY (with its default version of Scala)"
   echo "[info]"
-  $BUILD "$@" publish-local
+  $BUILD "$@" -Dgenerate.doc=true publish-local
   for v in ${crossbuild//,/ } ; do
     echo "[info]"
     echo "[info] ---- BUILDING PLAY (cross building against Scala $v)"
     echo "[info]"
-    $BUILD "$@" -Dscala.version=$v publish-local
+    $BUILD "$@" -Dgenerate.doc=true -Dscala.version=$v publish-local
   done
 fi
 


### PR DESCRIPTION
We should try to publish Play to Maven Central so that it is more accessible to users. It also means we have a backup if the Typesafe repository becomes unavailable for any reason.
