### PR TITLE
Use newer scalariform to fix errors for "requires"

### DIFF
--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -16,3 +16,9 @@ libraryDependencies ++= Seq(
   "org.scala-sbt" % "scripted-plugin" % sbtVersion.value,
   "org.webjars" % "webjars-locator" % "0.12"
 )
+
+// override scalariform version to get some fixes
+
+resolvers += Resolver.typesafeRepo("maven-releases")
+
+libraryDependencies += "org.scalariform" %% "scalariform" % "0.1.5-20140822-69e2e30"

--- a/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
+++ b/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
@@ -6,7 +6,7 @@ package com.typesafe.play.docs.sbtplugin
 import java.util.concurrent.Callable
 import java.util.jar.JarFile
 
-import com.typesafe.play.docs.sbtplugin.PlayDocsValidation.{CodeSamplesReport, MarkdownRefReport}
+import com.typesafe.play.docs.sbtplugin.PlayDocsValidation.{ CodeSamplesReport, MarkdownRefReport }
 import play.core.BuildDocHandler
 import play.core.server.ServerWithStop
 import play.sbtplugin.Colors
@@ -55,7 +55,7 @@ object PlayDocsPlugin extends AutoPlugin {
     docsJarScalaBinaryVersion <<= scalaBinaryVersion,
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play-docs" % play.core.PlayVersion.current,
-      "com.typesafe.play" % s"play-docs_${docsJarScalaBinaryVersion.value}" % docsVersion.value % "docs" notTransitive()
+      "com.typesafe.play" % s"play-docs_${docsJarScalaBinaryVersion.value}" % docsVersion.value % "docs" notTransitive ()
     ),
 
     generateMarkdownCodeSamplesReport <<= PlayDocsValidation.generateMarkdownCodeSamplesTask,
@@ -83,7 +83,7 @@ object PlayDocsPlugin extends AutoPlugin {
 
     // Get classloader
     val sbtLoader = this.getClass.getClassLoader
-    val classloader = new java.net.URLClassLoader(classpath.map(_.data.toURI.toURL).toArray, null /* important here, don't depend of the sbt classLoader! */) {
+    val classloader = new java.net.URLClassLoader(classpath.map(_.data.toURI.toURL).toArray, null /* important here, don't depend of the sbt classLoader! */ ) {
       override def loadClass(name: String): Class[_] = {
         if (play.core.classloader.DelegatingClassLoader.isSharedClass(name)) {
           sbtLoader.loadClass(name)
@@ -136,8 +136,10 @@ object PlayDocsPlugin extends AutoPlugin {
     def waitEOF() {
       consoleReader.readCharacter() match {
         case 4 => // STOP
-        case 11 => consoleReader.clearScreen(); waitEOF()
-        case 10 => println(); waitEOF()
+        case 11 =>
+          consoleReader.clearScreen(); waitEOF()
+        case 10 =>
+          println(); waitEOF()
         case _ => waitEOF()
       }
 

--- a/framework/src/sbt-plugin/src/main/scala/play/Project.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/Project.scala
@@ -18,13 +18,13 @@ import play.sbtplugin.routes.RoutesCompiler
  * Base plugin for Play projects. Declares common settings for both Java and Scala based Play projects.
  */
 object Play
-  extends AutoPlugin
-  with PlayExceptions
-  with PlayReloader
-  with PlayCommands
-  with PlayRun
-  with play.PlaySettings
-  with PlayPositionMapper {
+    extends AutoPlugin
+    with PlayExceptions
+    with PlayReloader
+    with PlayCommands
+    with PlayRun
+    with play.PlaySettings
+    with PlayPositionMapper {
 
   override def requires = SbtTwirl && SbtJsTask && SbtWebDriver && RoutesCompiler
 
@@ -55,8 +55,8 @@ object PlayJava extends AutoPlugin {
   import Play.autoImport._
   override def projectSettings =
     eclipseCommandSettings(JAVA) ++
-    defaultJavaSettings ++
-    Seq(libraryDependencies += javaCore)
+      defaultJavaSettings ++
+      Seq(libraryDependencies += javaCore)
 }
 
 /**
@@ -72,5 +72,5 @@ object PlayScala extends AutoPlugin {
   import Play._
   override def projectSettings =
     eclipseCommandSettings(SCALA) ++
-    defaultScalaSettings
+      defaultScalaSettings
 }

--- a/framework/src/sbt-plugin/src/main/scala/play/sbtplugin/routes/RoutesCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbtplugin/routes/RoutesCompiler.scala
@@ -29,13 +29,13 @@ object RoutesCompiler extends AutoPlugin {
   override def trigger = noTrigger
 
   override def requires = JvmPlugin
-  
+
   val autoImport = RoutesKeys
-  
+
   override def projectSettings =
     defaultSettings ++
-    inConfig(Compile)(routesSettings) ++
-    inConfig(Test)(routesSettings)
+      inConfig(Compile)(routesSettings) ++
+      inConfig(Test)(routesSettings)
 
   def routesSettings = Seq(
     routesFiles := Nil,
@@ -63,7 +63,7 @@ object RoutesCompiler extends AutoPlugin {
   }
 
   def compileRoutes(files: Seq[File], generatedDir: File, additionalImports: Seq[String], reverseRouter: Boolean,
-                    reverseRefRouter: Boolean, namespaceRouter: Boolean, cacheDirectory: File, log: Logger): Seq[File] = {
+    reverseRefRouter: Boolean, namespaceRouter: Boolean, cacheDirectory: File, log: Logger): Seq[File] = {
     val ops = files.map(f => RoutesCompilerOp(f, additionalImports, reverseRouter, reverseRefRouter, namespaceRouter))
     val (products, errors) = syncIncremental(cacheDirectory, ops) { opsToRun: Seq[RoutesCompilerOp] =>
 
@@ -96,10 +96,10 @@ object RoutesCompiler extends AutoPlugin {
     // log the source file and line number with the error message
     log.error(Option(error.sourceName).getOrElse("") + Option(error.line).map(":" + _).getOrElse("") + ": " + error.getMessage)
     Option(error.interestingLines(0)).map(_.focus).flatMap(_.headOption) map { line =>
-    // log the line
+      // log the line
       log.error(line)
       Option(error.position).map { pos =>
-      // print a carat under the offending character
+        // print a carat under the offending character
         val spaces = (line: Seq[Char]).take(pos).map {
           case '\t' => '\t'
           case x => ' '
@@ -112,4 +112,4 @@ object RoutesCompiler extends AutoPlugin {
 }
 
 private case class RoutesCompilerOp(file: File, additionalImports: Seq[String], reverseRouter: Boolean,
-                                    reverseRefRouter: Boolean, namespaceReverseRouter: Boolean)
+  reverseRefRouter: Boolean, namespaceReverseRouter: Boolean)


### PR DESCRIPTION
Scalariform previously considered "requires" to be a keyword.
Use a timestamped release of scalariform with the fix.
Also now formats the sbt plugin sources.
