### PR TITLE
RequestBody.isMaxSizeExceeded returns incorrect result for request body encoded in multipart/form-data

### DIFF
--- a/documentation/manual/Home.md
+++ b/documentation/manual/Home.md
@@ -5,6 +5,7 @@
 >
 > Play is based on a lightweight, stateless, web-friendly architecture and features predictable and minimal resource consumption (CPU, memory, threads) for highly-scalable applications thanks to its reactive model, based on Iteratee IO.
 
+- What's new in Play 2.4? / [[Play 2.4 Migration Guide|Migration24]]
 - [[What's new in Play 2.3?|Highlights23]] / [[Play 2.3 Migration Guide|Migration23]]
 - [[What's new in Play 2.2?|Highlights22]] / [[Play 2.2 Migration Guide|Migration22]]
 - [[What's new in Play 2.1?|Highlights21]] / [[Play 2.1 Migration Guide|Migration21]]

--- a/documentation/manual/Migration24.md
+++ b/documentation/manual/Migration24.md
@@ -1,0 +1,16 @@
+<!--- Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com> -->
+# Play 2.4 Migration Guide
+
+This guide is for migrating to Play 2.4 from Play 2.3. To migrate to Play 2.3, first follow the [[Play 2.3 Migration Guide|Migration23]].
+
+## Maximum body length
+
+For both Scala and Java, there have been some small but important changes to the way the configured maximum body lengths are handled and applied.
+
+A new property, `parsers.disk.maxLength`, specifies the maximum length of any body that is parsed by a parser that may buffer to disk.  This includes the raw body parser and the `multipart/form-data` parser.  By default this is 10MB.
+
+In the case of the `multipart/form-data` parser, the aggregate length of all of the text data parts is limited by the configured `parsers.text.maxLength` value, which defaults to 100KB.
+
+In all cases, when one of the max length parsing properties is exceeded, a 413 response is returned.  This includes Java actions who have explicitly overridden the `maxLength` property on the `BodyParser.Of` annotation - previously it was up to the Java action to check the `RequestBody.isMaxSizeExceeded` flag if a custom max length was configured, this flag has now been deprecated.
+
+Additionally, Java actions may now declare a `BodyParser.Of.maxLength` value that is greater than the configured max length.

--- a/documentation/manual/javaGuide/main/http/JavaBodyParsers.md
+++ b/documentation/manual/javaGuide/main/http/JavaBodyParsers.md
@@ -46,13 +46,13 @@ For example:
 
 ## Max content length
 
-Text based body parsers (such as **text**, **json**, **xml** or **formUrlEncoded**) use a max content length because they have to load all the content into memory. 
-
-There is a default maximum content length of 100KB.  It can be overridden by specifying the `parsers.text.maxLength` property in `application.conf`:
+Text based body parsers (such as **text**, **json**, **xml** or **formUrlEncoded**) use a max content length because they have to load all the content into memory.  By default, the maximum content length that they will parse is 100KB.  It can be overridden by specifying the `parsers.text.maxLength` property in `application.conf`:
 
     parsers.text.maxLength=128K
 
-You can also specify a maximum content length via the `@BodyParser.Of` annotation:
+For parsers that buffer content on disk, such as the raw parser or `multipart/form-data`, the maximum content length is specified using the `parsers.disk.maxLength` property, it defaults to 10MB.  The `multipart/form-data` parser also enforces the text max length property for the aggregate of the data fields.
+
+You can also override the default maximum content length for a given action via the `@BodyParser.Of` annotation:
 
 @[max-length](code/javaguide/http/JavaBodyParsers.java)
 

--- a/documentation/manual/javaGuide/main/http/code/javaguide/http/JavaBodyParsers.java
+++ b/documentation/manual/javaGuide/main/http/code/javaguide/http/JavaBodyParsers.java
@@ -77,15 +77,11 @@ public class JavaBodyParsers extends WithApplication {
                     // Accept only 10KB of data.
                     @BodyParser.Of(value = BodyParser.Text.class, maxLength = 10 * 1024)
                     public Result index() {
-                        if(request().body().isMaxSizeExceeded()) {
-                            return badRequest("Too much data!");
-                        } else {
-                            return ok("Got body: " + request().body().asText());
-                        }
+                        return ok("Got body: " + request().body().asText());
                     }
                     //#max-length
                 }, fakeRequest(), body.toString())),
-                equalTo(400));
+                equalTo(413));
     }
 
 }

--- a/documentation/manual/scalaGuide/main/http/ScalaBodyParsers.md
+++ b/documentation/manual/scalaGuide/main/http/ScalaBodyParsers.md
@@ -88,17 +88,15 @@ In the previous example, all request bodies are stored in the same file. This is
 
 ## Max content length
 
-Text based body parsers (such as **text**, **json**, **xml** or **formUrlEncoded**) use a maximum content length because they have to load all of the content into memory. 
+Text based body parsers (such as **text**, **json**, **xml** or **formUrlEncoded**) use a max content length because they have to load all the content into memory.  By default, the maximum content length that they will parse is 100KB.  It can be overridden by specifying the `parsers.text.maxLength` property in `application.conf`:
 
-There is a default maximum content length (the default is 100KB), but you can also specify it inline:
+    parsers.text.maxLength=128K
+
+For parsers that buffer content on disk, such as the raw parser or `multipart/form-data`, the maximum content length is specified using the `parsers.disk.maxLength` property, it defaults to 10MB.  The `multipart/form-data` parser also enforces the text max length property for the aggregate of the data fields.
+
+You can also override the default maximum length for a given action:
 
 @[body-parser-limit-text](code/ScalaBodyParser.scala)
-
-> **Tip:** The default content size can be defined in `application.conf`:
-> 
-> `parsers.text.maxLength=128K`
-> 
-> Unit sizes are defined in **Size in bytes format** section of the [[Configuration]] page.
 
 You can also wrap any body parser with `maxLength`:
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.it.http.parsing
+
+import play.api.libs.Files.TemporaryFile
+import play.api.libs.iteratee.Enumerator
+import play.api.mvc.{ Result, MultipartFormData, BodyParsers }
+import play.api.test._
+import play.core.parsers.Multipart.FileInfoMatcher
+import play.utils.PlayIO
+
+object MultipartFormDataParserSpec extends PlaySpecification {
+
+  val body =
+    """
+      |--aabbccddee
+      |Content-Disposition: form-data; name="text1"
+      |
+      |the first text field
+      |--aabbccddee
+      |Content-Disposition: form-data; name="text2"
+      |
+      |the second text field
+      |--aabbccddee
+      |Content-Disposition: form-data; name="file1"; filename="file1.txt"
+      |Content-Type: text/plain
+      |
+      |the first file
+      |
+      |--aabbccddee
+      |Content-Disposition: form-data; name="file2"; filename="file2.txt"
+      |Content-Type: text/plain
+      |
+      |the second file
+      |
+      |--aabbccddee--
+      |""".stripMargin.lines.mkString("\r\n")
+
+  val parse = new BodyParsers() {}.parse
+
+  def checkResult(result: Either[Result, MultipartFormData[TemporaryFile]]) = {
+    result must beRight.like {
+      case parts =>
+        parts.dataParts.get("text1") must beSome.like {
+          case field :: Nil => field must_== "the first text field"
+        }
+        parts.dataParts.get("text2") must beSome.like {
+          case field :: Nil => field must_== "the second text field"
+        }
+        parts.files must haveLength(2)
+        parts.file("file1") must beSome.like {
+          case filePart => PlayIO.readFileAsString(filePart.ref.file) must_== "the first file\r\n"
+        }
+        parts.file("file2") must beSome.like {
+          case filePart => PlayIO.readFileAsString(filePart.ref.file) must_== "the second file\r\n"
+        }
+    }
+  }
+
+  "The multipart/form-data parser" should {
+    "parse some content" in new WithApplication() {
+      val parser = parse.multipartFormData.apply(FakeRequest().withHeaders(
+        CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+      ))
+
+      val result = await(Enumerator(body.getBytes("utf-8")).run(parser))
+
+      checkResult(result)
+    }
+
+    "validate the full length of the body" in new WithApplication(FakeApplication(
+      additionalConfiguration = Map("parsers.disk.maxLength" -> "100")
+    )) {
+      val parser = parse.multipartFormData.apply(FakeRequest().withHeaders(
+        CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+      ))
+
+      val result = await(Enumerator(body.getBytes("utf-8")).run(parser))
+
+      result must beLeft.like {
+        case error => error.header.status must_== REQUEST_ENTITY_TOO_LARGE
+      }
+    }
+
+    "not parse more than the max data length" in new WithApplication(FakeApplication(
+      additionalConfiguration = Map("parsers.text.maxLength" -> "30")
+    )) {
+      val parser = parse.multipartFormData.apply(FakeRequest().withHeaders(
+        CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+      ))
+
+      val result = await(Enumerator(body.getBytes("utf-8")).run(parser))
+
+      result must beLeft.like {
+        case error => error.header.status must_== REQUEST_ENTITY_TOO_LARGE
+      }
+    }
+
+    "work if there's no crlf at the start" in new WithApplication() {
+      val parser = parse.multipartFormData.apply(FakeRequest().withHeaders(
+        CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
+      ))
+
+      val result = await(Enumerator(body.trim.getBytes("utf-8")).run(parser))
+
+      checkResult(result)
+    }
+
+    "parse headers with semicolon inside quotes" in {
+      val result = FileInfoMatcher.unapply(Map("content-disposition" -> """form-data; name="document"; filename="semicolon;inside.jpg"""", "content-type" -> "image/jpeg"))
+      result must not beEmpty;
+      result.get must equalTo(("document", "semicolon;inside.jpg", Option("image/jpeg")));
+    }
+
+    "parse headers with escaped quote inside quotes" in {
+      val result = FileInfoMatcher.unapply(Map("content-disposition" -> """form-data; name="document"; filename="quotes\"\".jpg"""", "content-type" -> "image/jpeg"))
+      result must not beEmpty;
+      result.get must equalTo(("document", """quotes"".jpg""", Option("image/jpeg")));
+    }
+  }
+
+}

--- a/framework/src/play-test/src/main/java/play/test/FakeRequest.java
+++ b/framework/src/play-test/src/main/java/play/test/FakeRequest.java
@@ -170,9 +170,8 @@ public class FakeRequest {
                         anyContent.asText(),
                         anyContent.asJson(),
                         anyContent.asXml(),
-                        anyContent.asMultipartFormData(),
-                        false
-                        );
+                        anyContent.asMultipartFormData()
+                );
             }
         });
     }

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -10,7 +10,7 @@ import java.lang.annotation.*;
  */
 public interface BodyParser {
 
-    play.api.mvc.BodyParser<Http.RequestBody> parser(int maxLength);
+    play.api.mvc.BodyParser<Http.RequestBody> parser(long maxLength);
 
     /**
      * Specify the body parser to use for an Action method.
@@ -19,14 +19,14 @@ public interface BodyParser {
     @Retention(RetentionPolicy.RUNTIME)
     public @interface Of {
         Class<? extends BodyParser> value();
-        int maxLength() default -1;
+        long maxLength() default -1;
     }
 
     /**
      * Guess the body content by checking the Content-Type header.
      */
     public static class AnyContent implements BodyParser {
-        public play.api.mvc.BodyParser<Http.RequestBody> parser(int maxLength) {
+        public play.api.mvc.BodyParser<Http.RequestBody> parser(long maxLength) {
             return play.core.j.JavaParsers.anyContent(maxLength);
         }
     }
@@ -35,7 +35,7 @@ public interface BodyParser {
      * Parse the body as Json if the Content-Type is text/json or application/json.
      */
     public static class Json implements BodyParser {
-        public play.api.mvc.BodyParser<Http.RequestBody> parser(int maxLength) {
+        public play.api.mvc.BodyParser<Http.RequestBody> parser(long maxLength) {
             return play.core.j.JavaParsers.json(maxLength);
         }
     }
@@ -44,7 +44,7 @@ public interface BodyParser {
      * Parse the body as Json without checking the Content-Type.
      */
     public static class TolerantJson implements BodyParser {
-        public play.api.mvc.BodyParser<Http.RequestBody> parser(int maxLength) {
+        public play.api.mvc.BodyParser<Http.RequestBody> parser(long maxLength) {
             return play.core.j.JavaParsers.tolerantJson(maxLength);
         }
     }
@@ -53,7 +53,7 @@ public interface BodyParser {
      * Parse the body as Xml if the Content-Type is application/xml.
      */
     public static class Xml implements BodyParser {
-        public play.api.mvc.BodyParser<Http.RequestBody> parser(int maxLength) {
+        public play.api.mvc.BodyParser<Http.RequestBody> parser(long maxLength) {
             return play.core.j.JavaParsers.xml(maxLength);
         }
     }
@@ -62,7 +62,7 @@ public interface BodyParser {
      * Parse the body as Xml without checking the Content-Type.
      */
     public static class TolerantXml implements BodyParser {
-        public play.api.mvc.BodyParser<Http.RequestBody> parser(int maxLength) {
+        public play.api.mvc.BodyParser<Http.RequestBody> parser(long maxLength) {
             return play.core.j.JavaParsers.tolerantXml(maxLength);
         }
     }
@@ -71,7 +71,7 @@ public interface BodyParser {
      * Parse the body as text if the Content-Type is text/plain.
      */
     public static class Text implements BodyParser {
-        public play.api.mvc.BodyParser<Http.RequestBody> parser(int maxLength) {
+        public play.api.mvc.BodyParser<Http.RequestBody> parser(long maxLength) {
             return play.core.j.JavaParsers.text(maxLength);
         }
     }
@@ -80,7 +80,7 @@ public interface BodyParser {
      * Parse the body as text without checking the Content-Type.
      */
     public static class TolerantText implements BodyParser {
-        public play.api.mvc.BodyParser<Http.RequestBody> parser(int maxLength) {
+        public play.api.mvc.BodyParser<Http.RequestBody> parser(long maxLength) {
             return play.core.j.JavaParsers.tolerantText(maxLength);
         }
     }
@@ -89,7 +89,7 @@ public interface BodyParser {
      * Store the body content in a RawBuffer.
      */
     public static class Raw implements BodyParser {
-        public play.api.mvc.BodyParser<Http.RequestBody> parser(int maxLength) {
+        public play.api.mvc.BodyParser<Http.RequestBody> parser(long maxLength) {
             return play.core.j.JavaParsers.raw(maxLength);
         }
     }
@@ -98,7 +98,7 @@ public interface BodyParser {
      * Parse the body as form url encoded if the Content-Type is application/x-www-form-urlencoded.
      */
     public static class FormUrlEncoded implements BodyParser {
-        public play.api.mvc.BodyParser<Http.RequestBody> parser(int maxLength) {
+        public play.api.mvc.BodyParser<Http.RequestBody> parser(long maxLength) {
             return play.core.j.JavaParsers.formUrlEncoded(maxLength);
         }
     }
@@ -107,7 +107,7 @@ public interface BodyParser {
      * Parse the body as form url encoded without checking the Content-Type.
      */
     public static class MultipartFormData implements BodyParser {
-        public play.api.mvc.BodyParser<Http.RequestBody> parser(int maxLength) {
+        public play.api.mvc.BodyParser<Http.RequestBody> parser(long maxLength) {
             return play.core.j.JavaParsers.multipartFormData(maxLength);
         }
     }
@@ -116,7 +116,7 @@ public interface BodyParser {
      * Don't parse the body.
      */
     public static class Empty implements BodyParser {
-        public play.api.mvc.BodyParser<Http.RequestBody> parser(int maxLength) {
+        public play.api.mvc.BodyParser<Http.RequestBody> parser(long maxLength) {
             if (maxLength != -1) throw new IllegalArgumentException("Empty BodyParser's maxLength argument is ignored so it must have a value of -1, was: " + maxLength);
             return play.core.j.JavaParsers.empty();
         }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -480,6 +480,11 @@ public class Http {
      */
     public static class RequestBody {
 
+        /**
+         * @deprecated Since Play 2.4, this method always returns false. When the max size is exceeded, a 413 error is
+         *             returned.
+         */
+        @Deprecated
         public boolean isMaxSizeExceeded() {
             return false;
         }

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -26,7 +26,7 @@ class JavaActionAnnotations(val controller: Class[_], val method: java.lang.refl
       .filterNot(_ == null)
       .headOption.map { bodyParserOf =>
         bodyParserOf.value.newInstance.parser(bodyParserOf.maxLength)
-      }.getOrElse(JavaParsers.anyContent(java.lang.Integer.MAX_VALUE))
+      }.getOrElse(JavaParsers.anyContent(-1))
 
   val controllerAnnotations = play.api.libs.Collections.unfoldLeft[Seq[java.lang.annotation.Annotation], Option[Class[_]]](Option(controller)) { clazz =>
     clazz.map(c => (Option(c.getSuperclass), c.getDeclaredAnnotations.toSeq))

--- a/framework/src/play/src/main/scala/play/core/j/JavaParsers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaParsers.scala
@@ -3,6 +3,8 @@
  */
 package play.core.j
 
+import play.core.parsers.Multipart
+
 import scala.collection.JavaConverters._
 import scala.xml._
 
@@ -27,8 +29,7 @@ object JavaParsers extends BodyParsers {
       text: Option[String] = None,
       json: Option[JsValue] = None,
       xml: Option[NodeSeq] = None,
-      multipart: Option[MultipartFormData[TemporaryFile]] = None,
-      override val isMaxSizeExceeded: Boolean = false) extends RequestBody {
+      multipart: Option[MultipartFormData[TemporaryFile]] = None) extends RequestBody {
 
     override lazy val asFormUrlEncoded = {
       urlFormEncoded.map(_.mapValues(_.toArray).asJava).orNull
@@ -83,96 +84,68 @@ object JavaParsers extends BodyParsers {
 
   }
 
-  def anyContent(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.anyContent).map {
-    _.fold(
-      _ => DefaultRequestBody(isMaxSizeExceeded = true),
-      anyContent =>
-        DefaultRequestBody(
-          anyContent.asFormUrlEncoded,
-          anyContent.asRaw,
-          anyContent.asText,
-          anyContent.asJson,
-          anyContent.asXml,
-          anyContent.asMultipartFormData)
-    )
-  }(trampoline)
+  def anyContent(maxLength: Long): BodyParser[RequestBody] =
+    parse.anyContent(Some(maxLength).filter(_ >= 0)).map { anyContent =>
+      DefaultRequestBody(
+        anyContent.asFormUrlEncoded,
+        anyContent.asRaw,
+        anyContent.asText,
+        anyContent.asJson,
+        anyContent.asXml,
+        anyContent.asMultipartFormData)
+    }(trampoline)
 
-  def json(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.json(Integer.MAX_VALUE)).map {
-    _.fold(
-      _ => DefaultRequestBody(isMaxSizeExceeded = true),
-      json =>
-        DefaultRequestBody(json = Some(json))
-    )
-  }(trampoline)
+  def json(maxLength: Long): BodyParser[RequestBody] =
+    parse.json(orDefault(maxLength)).map { json =>
+      DefaultRequestBody(json = Some(json))
+    }(trampoline)
 
-  def tolerantJson(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.tolerantJson(Integer.MAX_VALUE)).map {
-    _.fold(
-      _ => DefaultRequestBody(isMaxSizeExceeded = true),
-      json =>
-        DefaultRequestBody(json = Some(json))
-    )
-  }(trampoline)
+  def tolerantJson(maxLength: Long): BodyParser[RequestBody] =
+    parse.tolerantJson(orDefault(maxLength)).map { json =>
+      DefaultRequestBody(json = Some(json))
+    }(trampoline)
 
-  def xml(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.xml(Integer.MAX_VALUE)).map {
-    _.fold(
-      _ => DefaultRequestBody(isMaxSizeExceeded = true),
-      xml =>
-        DefaultRequestBody(xml = Some(xml))
-    )
-  }(trampoline)
+  def xml(maxLength: Long): BodyParser[RequestBody] =
+    parse.xml(orDefault(maxLength)).map { xml =>
+      DefaultRequestBody(xml = Some(xml))
+    }(trampoline)
 
-  def tolerantXml(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.tolerantXml(Integer.MAX_VALUE)).map {
-    _.fold(
-      _ => DefaultRequestBody(isMaxSizeExceeded = true),
-      xml =>
-        DefaultRequestBody(xml = Some(xml))
-    )
-  }(trampoline)
+  def tolerantXml(maxLength: Long): BodyParser[RequestBody] =
+    parse.tolerantXml(orDefault(maxLength)).map { xml =>
+      DefaultRequestBody(xml = Some(xml))
+    }(trampoline)
 
-  def text(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.text(Integer.MAX_VALUE)).map {
-    _.fold(
-      _ => DefaultRequestBody(isMaxSizeExceeded = true),
-      text =>
-        DefaultRequestBody(text = Some(text))
-    )
-  }(trampoline)
+  def text(maxLength: Long): BodyParser[RequestBody] =
+    parse.text(orDefault(maxLength)).map { text =>
+      DefaultRequestBody(text = Some(text))
+    }(trampoline)
 
-  def tolerantText(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.tolerantText(Integer.MAX_VALUE)).map {
-    _.fold(
-      _ => DefaultRequestBody(isMaxSizeExceeded = true),
-      text =>
-        DefaultRequestBody(text = Some(text))
-    )
-  }(trampoline)
+  def tolerantText(maxLength: Long): BodyParser[RequestBody] =
+    parse.tolerantText(orDefault(maxLength)).map { text =>
+      DefaultRequestBody(text = Some(text))
+    }(trampoline)
 
-  def formUrlEncoded(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.urlFormEncoded(Integer.MAX_VALUE)).map {
-    _.fold(
-      _ => DefaultRequestBody(isMaxSizeExceeded = true),
-      urlFormEncoded =>
-        DefaultRequestBody(urlFormEncoded = Some(urlFormEncoded))
-    )
-  }(trampoline)
+  def formUrlEncoded(maxLength: Long): BodyParser[RequestBody] =
+    parse.urlFormEncoded(orDefault(maxLength)).map { urlFormEncoded =>
+      DefaultRequestBody(urlFormEncoded = Some(urlFormEncoded))
+    }(trampoline)
 
-  def multipartFormData(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.multipartFormData).map {
-    _.fold(
-      _ => DefaultRequestBody(isMaxSizeExceeded = true),
-      multipart =>
-        DefaultRequestBody(multipart = Some(multipart))
-    )
-  }(trampoline)
+  def multipartFormData(maxLength: Long): BodyParser[RequestBody] = {
+    val maxLengthOrDefault = if (maxLength < 0) BodyParsers.parse.DefaultMaxDiskLength else maxLength
+    parse.multipartFormData(Multipart.handleFilePartAsTemporaryFile, maxLengthOrDefault).map { multipart =>
+      DefaultRequestBody(multipart = Some(multipart))
+    }(trampoline)
+  }
 
-  def raw(maxLength: Int): BodyParser[RequestBody] = parse.maxLength(orDefault(maxLength), parse.raw).map { body =>
-    body
-      .left.map(_ => DefaultRequestBody(isMaxSizeExceeded = true))
-      .right.map { raw =>
-        DefaultRequestBody(raw = Some(raw))
-      }.fold(identity, identity)
-  }(trampoline)
+  def raw(maxLength: Long): BodyParser[RequestBody] =
+    parse.raw(parse.DefaultMaxTextLength, orDefault(maxLength)).map { raw =>
+      DefaultRequestBody(raw = Some(raw))
+    }(trampoline)
 
   def empty(): BodyParser[RequestBody] = parse.empty.map {
     (_: Unit) => new RequestBody()
   }(trampoline)
 
-  private def orDefault(maxLength: Int) = if (maxLength < 0) BodyParsers.parse.DEFAULT_MAX_TEXT_LENGTH else maxLength
+  private def orDefault(maxLength: Long) = if (maxLength < 0) parse.DefaultMaxTextLength else maxLength.toInt
 
 }

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.core.parsers
+
+import java.io.FileOutputStream
+
+import play.api.Play
+import play.api.libs.Files.TemporaryFile
+import play.api.libs.iteratee.Parsing.MatchInfo
+import play.api.libs.iteratee._
+import play.api.mvc._
+import play.api.mvc.MultipartFormData._
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.Future
+
+import play.api.libs.iteratee.Execution.Implicits.trampoline
+
+/**
+ * Utilities for handling multipart bodies
+ */
+object Multipart {
+
+  def multipartParser[A](
+    maxDataLength: Int,
+    filePartHandler: PartHandler[FilePart[A]]): BodyParser[MultipartFormData[A]] = BodyParser("multipartFormData") { request =>
+
+    val maybeBoundary = for {
+      mt <- request.mediaType
+      (_, value) <- mt.parameters.find(_._1.equalsIgnoreCase("boundary"))
+      boundary <- value
+    } yield ("\r\n--" + boundary).getBytes("utf-8")
+
+    maybeBoundary.map { boundary =>
+
+      for {
+        // First, we ignore the first boundary.  Note that if the body contains a preamble, this won't work.  But the
+        // body never contains a preamble.
+        _ <- Traversable.take[Array[Byte]](boundary.size - 2) transform Iteratee.ignore
+        // We use the search enumeratee to turn the stream into a stream of data chunks that are either the boundary,
+        // or not the boundary, and we parse that
+        result <- Parsing.search(boundary) transform parseParts(maxDataLength, filePartHandler)
+      } yield {
+        result.right.map { reversed =>
+          // We built the parts by prepending a list, so we need to reverse them
+          val parts = reversed.reverse
+          val data = parts.collect { case DataPart(key, value) => (key, value) }.groupBy(_._1).mapValues(_.map(_._2))
+          val files = parts.collect { case file: FilePart[A] => file }
+          val bad = parts.collect { case bad: BadPart => bad }
+          val missing = parts.collect { case missing: MissingFilePart => missing }
+          MultipartFormData(data, files, bad, missing)
+        }
+      }
+    }.getOrElse {
+      Iteratee.flatten(createBadResult("Missing boundary header")(request).map(r => Done(Left(r))))
+    }
+  }
+
+  type PartHandler[A] = PartialFunction[Map[String, String], Iteratee[Array[Byte], A]]
+
+  def handleFilePartAsTemporaryFile: PartHandler[FilePart[TemporaryFile]] = {
+    handleFilePart {
+      case FileInfo(partName, filename, contentType) =>
+        val tempFile = TemporaryFile("multipartBody", "asTemporaryFile")
+        import play.core.Execution.Implicits.internalContext
+        Iteratee.fold[Array[Byte], FileOutputStream](new java.io.FileOutputStream(tempFile.file)) { (os, data) =>
+          os.write(data)
+          os
+        }(internalContext).map { os =>
+          os.close()
+          tempFile
+        }(internalContext)
+    }
+  }
+
+  private val CRLF = "\r\n".getBytes
+  private val CRLFCRLF = CRLF ++ CRLF
+
+  private type ParserInput = MatchInfo[Array[Byte]]
+  private type Parser[T] = Iteratee[ParserInput, T]
+
+  /**
+   * Recursively parses the parts
+   */
+  private def parseParts(dataPartLimit: Int,
+    filePartHandler: PartHandler[Part],
+    parts: List[Part] = Nil): Parser[Either[Result, List[Part]]] = {
+    parsePart(dataPartLimit, filePartHandler).flatMap {
+      // None, we've reached the end of the body
+      case None => Done(Right(parts))
+      // The max data part size has been exceeded, return an error
+      case Some(MaxDataPartSizeExceeded(_)) => Done(Left(Results.EntityTooLarge))
+      // A data part, handled specially so we can calculate the data part limit
+      case Some(dp @ DataPart(_, value)) =>
+        for {
+          // Drop the boundary
+          _ <- Iteratee.head
+          result <- parseParts(dataPartLimit - value.length, filePartHandler, dp :: parts)
+        } yield result
+      // All other parts
+      case Some(other: Part) =>
+        for {
+          // Drop the boundary
+          _ <- Iteratee.head
+          result <- parseParts(dataPartLimit, filePartHandler, other :: parts)
+        } yield result
+    }
+  }
+
+  private def parsePart(dataPartLimit: Int,
+    filePartHandler: PartHandler[Part]): Parser[Option[Part]] = {
+
+    // Enumeratee that takes everything up to the boundary
+    val takeUpToBoundary = Enumeratee.takeWhile[ParserInput](!_.isMatch)
+
+    // Buffer the header
+    val maxHeaderBuffer = Traversable.takeUpTo[Array[Byte]](4 * 1024) transform Iteratee.consume[Array[Byte]]()
+
+    // Collect the headers, returns none if we got the last part, otherwise returns the headers, and the part of the
+    // buffer that wasn't part of the headers
+    val collectHeaders: Iteratee[Array[Byte], Option[(Map[String, String], Array[Byte])]] = maxHeaderBuffer.map { buffer =>
+
+      // The headers should be split from the part by a double crlf
+      val (headerBytes, rest) = Option(buffer).map(b => b.splitAt(b.indexOfSlice(CRLFCRLF))).get
+
+      val headerString = new String(headerBytes, "utf-8").trim
+      if (headerString.startsWith("--") || headerString.isEmpty) {
+        // It's the last part
+        None
+      } else {
+        val headers = headerString.lines.map { header =>
+          val key :: value = header.trim.split(":").toList
+          (key.trim.toLowerCase, value.mkString.trim)
+        }.toMap
+
+        val left = rest.drop(CRLFCRLF.length)
+        Some((headers, left))
+      }
+    }
+
+    // Create a part handler that reads all the different types of parts
+    val readPart: PartHandler[Part] = handleDataPart(dataPartLimit)
+      .orElse[Map[String, String], Iteratee[Array[Byte], Part]]({
+        case FileInfoMatcher(partName, fileName, _) if fileName.trim.isEmpty =>
+          Done(MissingFilePart(partName), Input.Empty)
+      })
+      .orElse(filePartHandler)
+      .orElse({
+        case headers => Done(BadPart(headers), Input.Empty)
+      })
+
+    // Put everything together - take up to the boundary, remove the MatchInfo wrapping, collect headers, and then
+    // read the part
+    takeUpToBoundary compose Enumeratee.map[MatchInfo[Array[Byte]]](_.content) transform collectHeaders.flatMap {
+      case Some((headers, left)) => Iteratee.flatten(readPart(headers).feed(Input.El(left))).map(Some.apply)
+      case _ => Done(None)
+    }
+
+  }
+
+  private case class FileInfo(partName: String, fileName: String, contentType: Option[String])
+
+  private[play] object FileInfoMatcher {
+
+    private def split(str: String) = {
+      var buffer = new StringBuffer
+      var escape: Boolean = false
+      var quote: Boolean = false
+      val result = new ListBuffer[String]
+
+      def addPart() = {
+        result += buffer.toString.trim
+        buffer = new StringBuffer
+      }
+
+      str foreach {
+        case '\\' =>
+          buffer.append('\\')
+          escape = true
+        case '"' =>
+          buffer.append('"')
+          if (!escape)
+            quote = !quote
+          escape = false
+        case ';' =>
+          if (!quote) {
+            addPart()
+          } else {
+            buffer.append(';')
+          }
+          escape = false
+        case c =>
+          buffer.append(c)
+          escape = false
+      }
+
+      addPart()
+      result.toList
+    }
+
+    def unapply(headers: Map[String, String]): Option[(String, String, Option[String])] = {
+
+      val keyValue = """^([a-zA-Z_0-9]+)="(.*)"$""".r
+
+      for {
+        value <- headers.get("content-disposition")
+
+        values = split(value).map(_.trim).map {
+          // unescape escaped quotes
+          case keyValue(key, v) => (key.trim, v.trim.replaceAll("""\\"""", "\""))
+          case key => (key.trim, "")
+        }.toMap
+
+        _ <- values.get("form-data")
+
+        partName <- values.get("name")
+
+        fileName <- values.get("filename")
+
+        contentType = headers.get("content-type")
+
+      } yield (partName, fileName, contentType)
+    }
+  }
+
+  private def handleFilePart[A](handler: FileInfo => Iteratee[Array[Byte], A]): PartHandler[FilePart[A]] = {
+    case FileInfoMatcher(partName, fileName, contentType) =>
+      val safeFileName = fileName.split('\\').takeRight(1).mkString
+      handler(FileInfo(partName, safeFileName, contentType)).map(a => FilePart(partName, safeFileName, contentType, a))
+  }
+
+  private object PartInfoMatcher {
+
+    def unapply(headers: Map[String, String]): Option[String] = {
+
+      val keyValue = """^([a-zA-Z_0-9]+)="(.*)"$""".r
+
+      for {
+        value <- headers.get("content-disposition")
+
+        values = value.split(";").map(_.trim).map {
+          case keyValue(key, v) => (key.trim, v.trim)
+          case key => (key.trim, "")
+        }.toMap
+
+        _ <- values.get("form-data")
+
+        partName <- values.get("name")
+
+      } yield partName
+    }
+  }
+
+  private def handleDataPart(maxLength: Int): PartHandler[Part] = {
+    case headers @ PartInfoMatcher(partName) if !FileInfoMatcher.unapply(headers).isDefined =>
+      Traversable.takeUpTo[Array[Byte]](maxLength)
+        .transform(Iteratee.consume[Array[Byte]]().map(bytes => DataPart(partName, new String(bytes, "utf-8"))))
+        .flatMap { data =>
+          Cont({
+            case Input.El(_) => Done(MaxDataPartSizeExceeded(partName), Input.Empty)
+            case in => Done(data, in)
+          })
+        }
+  }
+
+  private def createBadResult(msg: String): RequestHeader => Future[Result] = { request =>
+    Play.maybeApplication.map(_.global.onBadRequest(request, msg))
+      .getOrElse(Future.successful(Results.BadRequest))
+  }
+}

--- a/framework/src/play/src/test/scala/play/api/mvc/ContentTypesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ContentTypesSpec.scala
@@ -4,31 +4,9 @@
 package play.api.mvc
 
 import org.specs2.mutable.Specification
-import scala.concurrent.Await
-import scala.concurrent.Future
-import scala.concurrent.duration._
-import play.api.libs.iteratee.Enumerator
 import play.utils.PlayIO
 
 object ContentTypesSpec extends Specification {
-
-  import play.api.mvc.BodyParsers.parse.Multipart._
-
-  "FileInfoMatcher" should {
-
-    "parse headers with semicolon inside quotes" in {
-      val result = FileInfoMatcher.unapply(Map("content-disposition" -> """form-data; name="document"; filename="semicolon;inside.jpg"""", "content-type" -> "image/jpeg"))
-      result must not beEmpty;
-      result.get must equalTo(("document", "semicolon;inside.jpg", Option("image/jpeg")));
-    }
-
-    "parse headers with escaped quote inside quotes" in {
-      val result = FileInfoMatcher.unapply(Map("content-disposition" -> """form-data; name="document"; filename="quotes\"\".jpg"""", "content-type" -> "image/jpeg"))
-      result must not beEmpty;
-      result.get must equalTo(("document", """quotes"".jpg""", Option("image/jpeg")));
-    }
-
-  }
 
   "RawBuffer" should {
     implicit def stringToBytes(s: String): Array[Byte] = s.getBytes("utf-8")
@@ -95,49 +73,6 @@ object ContentTypesSpec extends Specification {
       buffer.size must_== 11
       val file = buffer.asFile
       PlayIO.readFileAsString(file) must_== "hello world"
-    }
-  }
-
-  "Multipart parser" should {
-
-    "get the file parts" in {
-      testMultiPart("-----------------------------117723558510316372842092349957\r\nContent-Disposition: form-data; name=\"picture\"; filename=\"README\"\r\nContent-Type: application/octet-stream\r\n\r\nThis is your new Play application\r\n=====================================\r\nThis file will be packaged with your application, when using `play dist`.\r\n-----------------------------117723558510316372842092349957--\r\n")
-    }
-
-    "get the file parts with boundary that has no CRLF at start" in {
-      testMultiPart("-----------------------------117723558510316372842092349957Content-Disposition: form-data; name=\"picture\"; filename=\"README\"\r\nContent-Type: application/octet-stream\r\n\r\nThis is your new Play application\r\n=====================================\r\nThis file will be packaged with your application, when using `play dist`.\r\n-----------------------------117723558510316372842092349957--\r\n")
-    }
-
-    def testMultiPart(testMultipartBody: String) = {
-
-      def await[T](f: Future[T]) = Await.result(f, Duration("5 seconds"))
-      case class TestRequestHeader(headers: Headers, method: String = "GET", uri: String = "/", path: String = "", remoteAddress: String = "127.0.0.1", version: String = "HTTP/1.1", id: Long = 1, tags: Map[String, String] = Map.empty[String, String], queryString: Map[String, Seq[String]] = Map(), secure: Boolean = false) extends RequestHeader
-      val multipartFormDataParser = BodyParsers.parse.multipartFormData
-
-      val rh = TestRequestHeader(headers = new Headers {
-        val data = Seq(play.api.http.HeaderNames.CONTENT_TYPE -> Seq("multipart/form-data; boundary=---------------------------117723558510316372842092349957"), play.api.http.HeaderNames.CONTENT_LENGTH -> Seq("382"))
-      })
-
-      val body = Enumerator(testMultipartBody.getBytes)
-      val parsedResult = await(body run multipartFormDataParser(rh))
-
-      parsedResult.isRight must beTrue
-
-      parsedResult match {
-        case Right(multipartFormData) =>
-          multipartFormData.badParts.isEmpty must beTrue
-          multipartFormData.missingFileParts.isEmpty must beTrue
-          multipartFormData.dataParts.isEmpty must beTrue
-
-          multipartFormData.files.size must_== 1
-          val filePart = multipartFormData.files.head
-          filePart.filename must_== "README"
-          filePart.contentType must beSome("application/octet-stream")
-          filePart.key must_== "picture"
-          success
-        case Left(_) =>
-          failure("must not get a Left result")
-      }
     }
   }
 }


### PR DESCRIPTION
RequestBody.isMaxSizeExceeded always returns false for a request body encoded in multipart/form-data, even if the request body has an entity which exceeds `parsers.text.maxLength`. But I can't get the entity because it exceeds the limit.

If you submit this form with a `body` entity which is larger than `parsers.text.maxLength`:

``` html
    <form action="/data" method="POST" enctype="multipart/form-data">
        <textarea name="body"></textarea>
        <input type="submit">
    </form> 
```

`isMaxSizeExceeded()` returns false and the `body` entity is null.

``` java
    public static Result submit() {
        Boolean isExceeded = request().body().isMaxSizeExceeded()); // false
        String body = request().body().asMultipartFormData()
                .asFormUrlEncoded().get("body"); // null
        return ok();
    } 
```

ps. `isMaxSizeExceeded()` works correctly without any problem for `application/x-www-form-urlencoded`.
