### PR TITLE
[2.2.1-java] impossible to use promise with withTransaction into @Transactional controllers

### DIFF
--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -90,7 +90,10 @@ public class DefaultJPAApi implements JPAApi {
      * Run a block of asynchronous code in a JPA transaction.
      *
      * @param block Block of code to execute
+     *
+     * @deprecated This may cause deadlocks
      */
+    @Deprecated
     public <T> F.Promise<T> withTransactionAsync(play.libs.F.Function0<F.Promise<T>> block) throws Throwable {
         return withTransactionAsync("default", false, block);
     }
@@ -169,7 +172,10 @@ public class DefaultJPAApi implements JPAApi {
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
      * @param block Block of code to execute.
+     *
+     * @deprecated This may cause deadlocks
      */
+    @Deprecated
     public <T> F.Promise<T> withTransactionAsync(String name, boolean readOnly, play.libs.F.Function0<F.Promise<T>> block) throws Throwable {
         EntityManager em = null;
         EntityTransaction tx = null;

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
@@ -105,7 +105,10 @@ public class JPA {
      * Run a block of asynchronous code in a JPA transaction.
      *
      * @param block Block of code to execute.
+     *
+     * @deprecated This may cause deadlocks
      */
+    @Deprecated
     public static <T> F.Promise<T> withTransactionAsync(play.libs.F.Function0<F.Promise<T>> block) throws Throwable {
         return jpaApi().withTransactionAsync(block);
     }
@@ -136,7 +139,10 @@ public class JPA {
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
      * @param block Block of code to execute.
+     *
+     * @deprecated This may cause deadlocks
      */
+    @Deprecated
     public static <T> F.Promise<T> withTransactionAsync(String name, boolean readOnly, play.libs.F.Function0<F.Promise<T>> block) throws Throwable {
         return jpaApi().withTransactionAsync(name, readOnly, block);
     }

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
@@ -34,7 +34,10 @@ public interface JPAApi {
      * Run a block of asynchronous code in a JPA transaction.
      *
      * @param block Block of code to execute
+     *
+     * @deprecated This may cause deadlocks
      */
+    @Deprecated
     public <T> F.Promise<T> withTransactionAsync(play.libs.F.Function0<F.Promise<T>> block) throws Throwable;
 
     /**
@@ -59,7 +62,10 @@ public interface JPAApi {
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
      * @param block Block of code to execute.
+     *
+     * @deprecated This may cause deadlocks
      */
+    @Deprecated
     public <T> F.Promise<T> withTransactionAsync(String name, boolean readOnly, play.libs.F.Function0<F.Promise<T>> block) throws Throwable;
 
     /**

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/TransactionalAction.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/TransactionalAction.java
@@ -15,7 +15,7 @@ import javax.persistence.*;
 public class TransactionalAction extends Action<Transactional> {
     
     public F.Promise<Result> call(final Context ctx) throws Throwable {
-        return JPA.withTransactionAsync(
+        return JPA.withTransaction(
             configuration.value(),
             configuration.readOnly(),
             new play.libs.F.Function0<F.Promise<Result>>() {


### PR DESCRIPTION
Example: https://github.com/zadonskiyd/play2jpaProblemExample

``` java
F.Promise<String> helloPromise = promise(new F.Function0<String>() {
    @Override
    public String apply() throws Throwable {
        return JPA.withTransaction(new F.Function0<String>() {
            @Override
            public String apply() throws Throwable {
                return "hello";
             }
        });
    }
});
String hello = helloPromise.get(1000);
```

removes em from current thread ?

```
[RuntimeException: No EntityManager bound to this thread. 
Try to annotate your action method with @play.db.jpa.Transactional] 
```

at

```
84        Long total = (Long)JPA.em()
```

In 2.1.0 same code (with Akka.future instead of promise) works fine
