### PR TITLE
Anorm result cursor

### DIFF
--- a/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
+++ b/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
@@ -232,19 +232,22 @@ val books: Either[List[Throwable], List[String]] =
 It's possible to use a custom streaming:
 
 ```scala
-import anorm.Row
+import anorm.{ Cursor, Row }
 
 @annotation.tailrec
-def go(it: Iterator[Row], l: List[String]): List[String] = 
-  if (!it.hasNext) l // no more result
-  else if (l.size == 100) l // custom limit, partial processing
-  else {
-    val row = it.next()
-    go(it, l :+ row[String]("name"))
+def go(c: Option[Cursor], l: List[String]): List[String] = c match {
+  case Some(cursor) => {
+    if (l.size == 100) l // custom limit, partial processing
+    else {
+      val row = it.next()
+      go(it, l :+ row[String]("name"))
+    }
   }
+  case _ => l
+}
 
 val books: Either[List[Throwable], List[String]] = 
-  SQL("Select name from Books").withIterator(go(_, List.empty[String]))
+  SQL("Select name from Books").withResult(go(_, List.empty[String]))
 ```
 
 ### Multi-value support

--- a/framework/src/anorm/src/main/scala/anorm/Cursor.scala
+++ b/framework/src/anorm/src/main/scala/anorm/Cursor.scala
@@ -1,0 +1,65 @@
+package anorm
+
+import java.sql.ResultSet
+
+/** Result cursor */
+sealed trait Cursor {
+  /** Current row */
+  def row: Row
+
+  /** Cursor to next row */
+  def next: Option[Cursor]
+}
+
+/** Cursor companion */
+object Cursor {
+  import scala.language.reflectiveCalls
+  import java.sql.ResultSetMetaData
+
+  /**
+   * Returns cursor for next row in given result set.
+   *
+   * @param rs Result set, must be before first row
+   * @return None if there is no result in the set
+   */
+  private[anorm] def apply(rs: ResultSet): Option[Cursor] =
+    if (!rs.next) None else Some(new Cursor {
+      val meta = metaData(rs)
+      val columns: List[Int] = List.range(1, meta.columnCount + 1)
+      val row = ResultRow(meta, columns.map(rs.getObject(_)))
+
+      def next = apply(rs, meta, columns)
+    })
+
+  /** Creates cursor after the first one, as meta data is already known. */
+  private def apply(rs: ResultSet, meta: MetaData, columns: List[Int]): Option[Cursor] = if (!rs.next) None else Some(new Cursor {
+    val row = ResultRow(meta, columns.map(rs.getObject(_)))
+    def next = apply(rs)
+  })
+
+  /** Returns metadata for given result set. */
+  private def metaData(rs: ResultSet): MetaData = {
+    val meta = rs.getMetaData()
+    val nbColumns = meta.getColumnCount()
+    MetaData(List.range(1, nbColumns + 1).map(i =>
+      MetaDataItem(column = ColumnName({
+
+        // HACK FOR POSTGRES - Fix in https://github.com/pgjdbc/pgjdbc/pull/107
+        if (meta.getClass.getName.startsWith("org.postgresql.")) {
+          meta.asInstanceOf[{ def getBaseTableName(i: Int): String }].getBaseTableName(i)
+        } else {
+          meta.getTableName(i)
+        }
+
+      } + "." + meta.getColumnName(i), alias = Option(meta.getColumnLabel(i))),
+        nullable = meta.isNullable(i) == ResultSetMetaData.columnNullable,
+        clazz = meta.getColumnClassName(i))))
+  }
+
+  /** Result row to be parsed. */
+  private case class ResultRow(
+      metaData: MetaData, data: List[Any]) extends Row {
+
+    override lazy val toString = "Row(" + metaData.ms.zip(data).map(t => s"'${t._1.column}': ${t._2} as ${t._1.clazz}").mkString(", ") + ")"
+  }
+}

--- a/framework/src/anorm/src/main/scala/anorm/Row.scala
+++ b/framework/src/anorm/src/main/scala/anorm/Row.scala
@@ -55,6 +55,8 @@ trait Row {
       case Error(err) => Left(err)
     }).get
 
+  // TODO: Apply with positional getter
+
   // Data per column name
   private lazy val columnsDictionary: Map[String, Any] = {
     @annotation.tailrec

--- a/framework/src/anorm/src/main/scala/anorm/SqlParser.scala
+++ b/framework/src/anorm/src/main/scala/anorm/SqlParser.scala
@@ -622,7 +622,7 @@ sealed trait ScalarRowParser[+A] extends RowParser[A] {
   }
 }
 
-// TODO: Refactor with Iterator
+// TODO: Refactor with Cursor
 sealed trait ResultSetParser[+A] extends (Stream[Row] => SqlResult[A]) {
   parent =>
   def map[B](f: A => B): ResultSetParser[B] =

--- a/framework/src/anorm/src/test/scala/anorm/CursorSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/CursorSpec.scala
@@ -1,0 +1,38 @@
+package anorm
+
+import acolyte.jdbc.RowLists.rowList1
+import acolyte.jdbc.Implicits._
+
+object CursorSpec extends org.specs2.mutable.Specification {
+  "Cursor" title
+
+  "Cursor" should {
+    "not be returned when there is no result" in {
+      Cursor(stringList.resultSet) aka "cursor" must beNone
+    }
+
+    "be returned for one row" in {
+      Cursor(stringList :+ "A" resultSet) aka "cursor" must beSome.
+        which { cur =>
+          cur.row[String]("str") aka "row" must_== "A" and (
+            cur.next aka "after first" must beNone)
+        }
+    }
+
+    "be return for three rows" in {
+      Cursor(stringList :+ "red" :+ "green" :+ "blue" resultSet).
+        aka("cursor") must beSome.which { first =>
+          first.row[String]("str") aka "row #1" must_== "red" and (
+            first.next aka "after first" must beSome.which { snd =>
+              snd.row[String]("str") aka "row #2" must_== "green" and (
+                snd.next aka "after second" must beSome.which { third =>
+                  third.row[String]("str") aka "row #1" must_== "blue" and (
+                    third.next aka "after third" must beNone)
+                })
+            })
+        }
+    }
+  }
+
+  def stringList = rowList1(classOf[String] -> "str")
+}


### PR DESCRIPTION
Replaces previous result `Iterator` (and even before `Stream`) by a `Cursor` trait that allows to work inside a managed context (see `withResult[T](f: Cursor[Row] => T): T`) and iterate `ResultSet` in an immutable way.
