### PR TITLE
Play tries to chunk response when not allowed by request

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Results.java
+++ b/framework/src/play/src/main/java/play/mvc/Results.java
@@ -1317,7 +1317,7 @@ public class Results {
             if(content == null) {
                 throw new NullPointerException("null content");
             }
-            wrappedResult = status.chunked(
+            wrappedResult = status.stream(
                     play.core.j.JavaResults.chunked(content, chunkSize),
                     play.core.j.JavaResults.writeBytes()
                     );

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -418,6 +418,22 @@ trait Results {
         connection = HttpConnection.Close
       )
     }
+
+    /**
+     * Stream the content as the response.
+     *
+     * If a content length is set, this will send the body as is, otherwise it may chunk or may not chunk depending on
+     * whether HTTP/1.1 is used or not.
+     *
+     * @param content Enumerator providing the content to stream.
+     */
+    def stream[C](content: Enumerator[C])(implicit writeable: Writeable[C]): Result = {
+      Result(
+        header = ResponseHeader(status, writeable.contentType.map(ct => Map(CONTENT_TYPE -> ct)).getOrElse(Map.empty)),
+        body = content &> writeable.toEnumeratee,
+        connection = HttpConnection.KeepAlive
+      )
+    }
   }
 
   /**


### PR DESCRIPTION
I'm trying to return an InputStream from a URL and it is failing with the error:

```
The response to this request is chunked and hence requires HTTP 1.1 to be sent, but this is a HTTP 1.0 request.
```

The code I'm using is:

```
try (InputStream is = new URL(url).openStream()) {
  return ok(is);
}
```

It's odd that Play knows it cannot chunk the response and yet tries to anyway.
