### PR TITLE
Routes parsing breaks when combining a scala keyword with a default value

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
@@ -947,7 +947,8 @@ object RoutesCompiler {
                             queryParams.map { p =>
                               ("""implicitly[QueryStringBindable[""" + p.typeName + """]].unbind("""" + p.name + """", """ + safeKeyword(localNames.get(p.name).getOrElse(p.name)) + """)""") -> p
                             }.map {
-                              case (u, Parameter(name, typeName, None, Some(default))) => """if(""" + localNames.get(name).getOrElse(name) + """ == """ + default + """) None else Some(""" + u + """)"""
+                              case (u, Parameter(name, typeName, None, Some(default))) =>
+                                """if(""" + safeKeyword(localNames.getOrElse(name, name)) + """ == """ + default + """) None else Some(""" + u + """)"""
                               case (u, Parameter(name, typeName, None, None)) => "Some(" + u + ")"
                             }.mkString(", "))
 

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/controllers/Application.scala
@@ -40,6 +40,9 @@ object Application extends Controller {
   def routetest(parameter: String) = Action {
     Ok(parameter)
   }
+  def routedefault(parameter: String) = Action {
+    Ok(parameter)
+  }
   def hello = Action {
     Ok("Hello world!")
   }

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/conf/routes
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/conf/routes
@@ -64,4 +64,7 @@ GET         /routes                 controllers.Application.route(while)
 GET         /routestest             controllers.Application.routetest(with)
 GET         /routestest             controllers.Application.routetest(yield)
 
+# Test for default values for scala keywords
+GET         /routesdefault          controllers.Application.routedefault(type ?= "x")
+
 GET         /public/*file           controllers.Assets.versioned(path="/public", file: Asset)


### PR DESCRIPTION
Found on play v2.2.1. Both features work fine by themselves, but break when combined. Note the parameter "type".

Using a scala keyword with a fixed value (or no value) gets escaped correctly and works:

``` scala
  GET       /designer     controllers.Designer.index(type = "x") 
```

Using a default value with "type" renamed to "tpe" (non-keyword) works (of course): 

``` scala
  GET       /designer     controllers.Designer.index(tpe ?= "x")
```

But in combination:

``` scala
  GET       /designer     controllers.Designer.index(type ?= "x")
```

produces

``` sbt
[error] /Users/alvarocarrasco/workspace/devstack/conf/routes:26: illegal start of simple expression
[error] GET       /designer    controllers.Designer.index(type ?= "x")
[error] /Users/alvarocarrasco/workspace/devstack/conf/routes:26: ')' expected but '}' found.
[error] GET       /designer    controllers.Designer.index(type ?= "x")
[error] two errors found
```

Tried looking at the source, but couldn't spot the cause.
