### PR TITLE
Documentation ScalaWebSockets, should create a single Concurrent.broadcast

### DIFF
--- a/documentation/manual/scalaGuide/main/async/code/ScalaWebSockets.scala
+++ b/documentation/manual/scalaGuide/main/async/code/ScalaWebSockets.scala
@@ -317,11 +317,10 @@ object Samples {
     import play.api.libs.iteratee._
     import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-    def socket =  WebSocket.using[String] { request =>
+    // Concurrent.broadcast returns (Enumerator, Concurrent.Channel)
+    val (out, channel) = Concurrent.broadcast[String]
 
-      // Concurrent.broadcast returns (Enumerator, Concurrent.Channel)
-      val (out, channel) = Concurrent.broadcast[String]
-
+    def socket = WebSocket.using[String] { request =>
       // log the message to stdout and send response back to client
       val in = Iteratee.foreach[String] {
         msg => println(msg)
@@ -329,7 +328,7 @@ object Samples {
           // receive the pushed messages
           channel push("I received your message: " + msg)
       }
-      (in,out)
+      (in, out)
     }
     //#iteratee3
   }


### PR DESCRIPTION
The example of Concurrent.broadcast is confusing as it will create an instance of broadcast(Enumerator and Concurrent.Channel) for every client and thus the broadcast to one client doesn't make sense.
It's better to create it once so the messages are broadcasted to all clients to show it working.
Here is an example of a confused user http://stackoverflow.com/questions/23966883/cannot-broadcast-to-all-clients-in-play2/23967653#23967653
