### PR TITLE
Fixing form data binding for lists having more than 256 elements

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/Form.java
+++ b/framework/src/play-java/src/main/java/play/data/Form.java
@@ -325,6 +325,7 @@ public class Form<T> {
         dataBinder.setValidator(validator);
         dataBinder.setConversionService(play.data.format.Formatters.conversion);
         dataBinder.setAutoGrowNestedPaths(true);
+        dataBinder.setAutoGrowCollectionLimit(Integer.MAX_VALUE);
         dataBinder.bind(new MutablePropertyValues(objectData));
         Set<ConstraintViolation<Object>> validationErrors;
         if (groups != null) {


### PR DESCRIPTION
Spring data binding enforces a limit of 256 elements for auto-growing collections (see DEFAULT_AUTO_GROW_COLLECTION_LIMIT in https://github.com/spring-projects/spring-framework/blob/master/spring-context/src/main/java/org/springframework/validation/DataBinder.java).

This imposes a restriction of 256 elements as a maximum for Play form collections binding. This limit can be removed by setting the maximum value to Integer.MAX_VALUE (which is also the default in https://github.com/spring-projects/spring-framework/blob/master/spring-context/src/main/java/org/springframework/validation/BeanPropertyBindingResult.java... it looks like Spring has inconsistent default values for their collection binding).
