### PR TITLE
Added handling of IBM WebSphere specific wsjar protocol.

### DIFF
--- a/framework/src/play/src/main/scala/play/utils/Resources.scala
+++ b/framework/src/play/src/main/scala/play/utils/Resources.scala
@@ -14,8 +14,7 @@ object Resources {
 
   def isDirectory(url: URL) = url.getProtocol match {
     case "file" => new File(url.toURI).isDirectory
-    case "jar" => isJarResourceDirectory(url)
-    case "wsjar" => isJarResourceDirectory(url)
+    case "jar" | "wsjar" => isJarResourceDirectory(url)
     case _ => throw new IllegalArgumentException(s"Cannot check isDirectory for a URL with protocol='${url.getProtocol}'")
   }
 


### PR DESCRIPTION
The classloader used by IBM WebSphere uses the protocol wsjar instead of jar. Both is the same but WebSphere uses a different protocol name. Shame on IBM!
