### PR TITLE
Allow enchanced ebean models to be configured in build

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayImport.scala
@@ -118,6 +118,8 @@ object PlayImport {
 
     val ebeanEnabled = SettingKey[Boolean]("play-ebean-enabled")
 
+    val ebeanModels = SettingKey[String]("play-ebean-models")
+
     val playPlugin = SettingKey[Boolean]("play-plugin")
 
     val devSettings = SettingKey[Seq[(String, String)]]("play-dev-settings")

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -131,6 +131,8 @@ trait PlaySettings {
 
     mainClass in (Compile, run) := Some("play.core.server.NettyServer"),
 
+    ebeanModels := configuredEbeanModels.value,
+
     compile in Compile <<= PostCompile(scope = Compile),
 
     compile in Test <<= PostCompile(Test),


### PR DESCRIPTION
See #2317

Adds an `ebeanModels` setting that can be configured per project. Defaults to reading from the configuration as before. Also updates the default `application.conf` location to be relative to the project base directory.
