### PR TITLE
SettingsJDBC suggestion; non-standard port for MySQL and Postgres URLs

### DIFF
--- a/documentation/manual/detailedTopics/configuration/SettingsJDBC.md
+++ b/documentation/manual/detailedTopics/configuration/SettingsJDBC.md
@@ -15,6 +15,17 @@ db.default.url="mysql://user:password@localhost/database"
 db.default.url="postgres://user:password@localhost/database"
 ```
 
+A non-standard port of the database service can be specified:
+
+```
+# To configure MySQL running in Docker
+db.default.url="mysql://user:password@localhost:port/database"
+
+# To configure PostgreSQL running in Docker
+db.default.url="postgres://user:password@localhost:port/database"
+```
+
+
 ## Reference
 
 In addition to the classical `driver`, `url`, `user`, `password` configuration properties, it also supports additional tuning parameters if you need them:


### PR DESCRIPTION
Port added to URL, relevant to databases running in Docker containers
