### PR TITLE
Use URI instead of URL to parse Java WS URLs

### DIFF
--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSRequestHolder.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSRequestHolder.java
@@ -17,7 +17,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import java.util.*;
 
 /**
@@ -42,23 +42,18 @@ public class NingWSRequestHolder implements WSRequestHolder {
     private String virtualHost = null;
 
     public NingWSRequestHolder(NingWSClient client, String url) {
-        try {
-            this.client = client;
-            URL reference = new URL(url);
+        this.client = client;
+        URI reference = URI.create(url);
 
-            this.url = url;
+        this.url = url;
 
-            String userInfo = reference.getUserInfo();
-            if (userInfo != null) {
-                this.setAuth(userInfo);
-            }
-            if (reference.getQuery() != null) {
-                this.setQueryString(reference.getQuery());
-            }
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
+        String userInfo = reference.getUserInfo();
+        if (userInfo != null) {
+            this.setAuth(userInfo);
         }
-
+        if (reference.getQuery() != null) {
+            this.setQueryString(reference.getQuery());
+        }
     }
 
     /**


### PR DESCRIPTION
AsyncHttpClient eventually passes the url to URI.create anyway, so this means that NingWSRequestHolder will fail in a manner consistent with AsyncHttpClient.

The specific use case that this has been done to address is allowing WebSocket URLs, which URI.create is fine with, but new URL throws an exception.
