### PR TITLE
CSRF token disaster when upgrading Play 2.1.5 -> 2.2.2-RC2

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -35,7 +35,8 @@ class CSRFAction(next: EssentialAction,
   import CSRFAction._
 
   // An iteratee that returns a forbidden result saying the CSRF check failed
-  private def checkFailed(req: RequestHeader, msg: String): Iteratee[Array[Byte], Result] = Done(errorHandler.handle(req, msg))
+  private def checkFailed(req: RequestHeader, msg: String): Iteratee[Array[Byte], Result] =
+    Done(clearTokenIfInvalid(req, tokenName, cookieName, secureCookie, errorHandler, msg))
 
   def apply(request: RequestHeader) = {
 
@@ -186,13 +187,9 @@ object CSRFAction {
           result.withCookies(Cookie(name, newToken, path = Session.path, domain = Session.domain,
             secure = secureCookie))
       } getOrElse {
-        // Get the new session, or the incoming session
-        val session = Cookies(result.header.headers.get(SET_COOKIE))
-          .get(Session.COOKIE_NAME).map(_.value).map(Session.decode)
-          .getOrElse(request.session.data)
 
-        val newSession = session + (tokenName -> newToken)
-        result.withSession(Session.deserialize(newSession))
+        val newSession = result.session(request) + (tokenName -> newToken)
+        result.withSession(newSession)
       }
     }
 
@@ -200,6 +197,23 @@ object CSRFAction {
 
   private[csrf] def isCached(result: Result): Boolean =
     result.header.headers.get(CACHE_CONTROL).fold(false)(!_.contains("no-cache"))
+
+  private[csrf] def clearTokenIfInvalid(request: RequestHeader, tokenName: String, cookieName: Option[String],
+    secureCookie: Boolean, errorHandler: ErrorHandler, msg: String): Result = {
+
+    val result = errorHandler.handle(request, msg)
+
+    CSRF.getToken(request).fold(
+      cookieName.flatMap { cookie =>
+        request.cookies.get(cookie).map { token =>
+          result.discardingCookies(DiscardingCookie(cookie, domain = Session.domain, path = Session.path,
+            secure = secureCookie))
+        }
+      }.getOrElse {
+        result.withSession(result.session(request) - tokenName)
+      }
+    )(_ => result)
+  }
 }
 
 /**
@@ -209,8 +223,8 @@ object CSRFAction {
  */
 object CSRFCheck {
 
-  private class CSRFCheckAction[A](tokenName: String, cookieName: Option[String], tokenProvider: TokenProvider,
-      errorHandler: ErrorHandler, wrapped: Action[A]) extends Action[A] {
+  private class CSRFCheckAction[A](tokenName: String, cookieName: Option[String], secureCookie: Boolean,
+      tokenProvider: TokenProvider, errorHandler: ErrorHandler, wrapped: Action[A]) extends Action[A] {
     def parser = wrapped.parser
     def apply(request: Request[A]) = {
 
@@ -237,7 +251,8 @@ object CSRFCheck {
             .collect {
               case queryToken if tokenProvider.compareTokens(queryToken, headerToken) => wrapped(request)
             }
-        }.getOrElse(Future.successful(errorHandler.handle(request, "CSRF token check failed")))
+        }.getOrElse(Future.successful(CSRFAction.clearTokenIfInvalid(request, tokenName, cookieName, secureCookie,
+          errorHandler, "CSRF token check failed")))
       }
     }
   }
@@ -246,7 +261,8 @@ object CSRFCheck {
    * Wrap an action in a CSRF check.
    */
   def apply[A](action: Action[A], errorHandler: ErrorHandler = CSRFConf.defaultErrorHandler): Action[A] =
-    new CSRFCheckAction(CSRFConf.TokenName, CSRFConf.CookieName, CSRFConf.defaultTokenProvider, errorHandler, action)
+    new CSRFCheckAction(CSRFConf.TokenName, CSRFConf.CookieName, CSRFConf.SecureCookie, CSRFConf.defaultTokenProvider,
+      errorHandler, action)
 }
 
 /**

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -124,7 +124,12 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
       "reject requests with unsigned token in session" in {
         csrfCheckRequest(req => addToken(req, "foo")
           .post(Map("foo" -> "bar", TokenName -> generate))
-        )(_.status must_== FORBIDDEN)
+        ) { response =>
+          response.status must_== FORBIDDEN
+          response.cookies.find(_.name.exists(_ == Session.COOKIE_NAME)) must beSome.like {
+            case cookie => cookie.value must beNone
+          }
+        }
       }
       "return a different token on each request" in {
         lazy val token = generate


### PR DESCRIPTION
TL;DR after upgrading to Play 2.2, any user who has visited your website before the upgrade will be unable to POST.

Demo:
1. wipe your browser's cookies for localhost
2. `git clone https://github.com/adamhooper/play-csrf-token-failure.git`
3. `cd play-csrf-token-failure`
4. `git checkout play-2.1.5`
5. `sbt run`
6. Browse to http://localhost:9000. Notice that there is a CSRF token. Click the button; you should see "your CSRF token is valid"
7. Kill sbt; `git checkout play-2.2.2-RC2 && rm -r target project/target`
8. `sbt run`
9. Browse to http://localhost:9000. Notice that there is no CSRF token. Click the button; you will see "Invalid token found in form body"

What happens:
1. On Play 2.1.5, a token is stored in the session.
2. On Play 2.2.2-RC2, the token is read. CSRFAction's `getTokenFromHeader()` detects that a token is present, but it does _not_ detect that the token is not _valid_. In other words, `getTokenFromHeader()` returns `Some`, but `CSRF.getToken()` returns `None`.
3. There is no code path that will actually generate a new CSRF token for the user. That means the user cannot POST until he/she deletes the session cookie.

Workarounds:
- Change `csrf.sign.tokens` to `false`, introducing the BREACH vulnerability signed tokens solve
- Change `application.secret`, effectively destroying all sessions
- Change `csrf.token.name`, which works if you haven't hard-coded "csrfToken" anywhere :)

We chose to change `application.secret`. It's wince-invoking, but what else could we do?

I haven't tested, but I imagine this same bug prevents anybody from editing `csrf.sign.tokens` after anybody has visited the website.
