### PR TITLE
Java templates slow loading language from config

### DIFF
--- a/framework/src/play/src/main/java/play/i18n/Messages.java
+++ b/framework/src/play/src/main/java/play/i18n/Messages.java
@@ -10,7 +10,6 @@ import scala.collection.mutable.Buffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import play.api.i18n.Lang;
 
 /**
  * A messages and a language.
@@ -33,7 +32,7 @@ public class Messages {
             lang = play.mvc.Http.Context.current().lang();
         } else {
             Locale defaultLocale = Locale.getDefault();
-            lang = new Lang(defaultLocale.getLanguage(), defaultLocale.getCountry());
+            lang = new Lang(new play.api.i18n.Lang(defaultLocale.getLanguage(), defaultLocale.getCountry()));
         }
         return lang;
     }

--- a/framework/src/play/src/main/java/play/i18n/MessagesApi.java
+++ b/framework/src/play/src/main/java/play/i18n/MessagesApi.java
@@ -110,7 +110,7 @@ public class MessagesApi {
     public Messages preferred(Collection<Lang> candidates) {
         Seq<Lang> cs = JavaConversions.collectionAsScalaIterable(candidates).toSeq();
         play.api.i18n.Messages msgs = messages.preferred((Seq) cs);
-        return new Messages(msgs.lang(), this);
+        return new Messages(new Lang(msgs.lang()), this);
     }
 
 

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import play.i18n.Lang;
 import play.Play;
+import play.i18n.Langs;
+import play.i18n.MessagesApi;
 
 /**
  * Defines HTTP standard objects.
@@ -114,12 +116,8 @@ public class Http {
             if (lang != null) {
                 return lang;
             } else {
-                Cookie cookieLang = request.cookie(Play.langCookieName());
-                if (cookieLang != null) {
-                    Lang lang = Lang.forCode(cookieLang.value());
-                    if (lang != null) return lang;
-                }
-                return Lang.preferred(request().acceptLanguages());
+                return Play.application().injector().instanceOf(MessagesApi.class)
+                        .preferred(request()).lang();
             }
         }
 


### PR DESCRIPTION
Java templates are slower than Scala templates. A lot of the slowness (10-20%) seems to be because Java templates load language settings from the app config, whereas Scala templates use the JVM default language. (See #816 for a discussion of which is the correct approach.)

Below we can see that a lot of Java's slowness is caused by accessing the app config multiple times on each render. Config access seems to be really slow. A fix would be to cache the language after it is loaded from the config.

```
+-------------------------------------------------------------------------------+-----------------+
|                                     Name                                      |    Time (ms)    |
+-------------------------------------------------------------------------------+-----------------+
|  +---play.api.Configuration.getString(String, Option)                         |  39,867  100 %  |
|    |                                                                          |                 |
|    +---play.api.Play$.langCookieName(Application)                             |  25,392   64 %  |
|    | |                                                                        |                 |
|    | +---play.api.Play.langCookieName(Application)                            |                 |
|    |   |                                                                      |                 |
|    |   +---play.Play.langCookieName()                                         |                 |
|    |     |                                                                    |                 |
|    |     +---play.mvc.Http$Context.lang()                                     |                 |
|    |       |                                                                  |                 |
|    |       +---play.mvc.Http$Context$Implicit.lang()                          |                 |
|    |         |                                                                |                 |
|    |         +---play.core.j.PlayMagicForJava$.implicitJavaLang()             |                 |
|    |           |                                                              |                 |
|    |           +---views.html.index$$anonfun$apply$1.apply()                  |                 |
|    |             |                                                            |                 |
|    |             +---views.html.index$$anonfun$apply$1.apply()                |                 |
|    |               |                                                          |                 |
|    |               +---views.html.helper.form$.apply(Call, Seq, Function0)    |                 |
|    |                 |                                                        |                 |
|    |                 +---views.html.index$.apply(Form)                        |                 |
|    |                   |                                                      |                 |
|    |                   +---views.html.index$.render(Form)                     |                 |
|    |                     |                                                    |                 |
|    |                     +---views.html.index.render(Form)                    |                 |
|    |                                                                          |                 |
|    +---play.api.i18n.Lang$.availables(Application)                            |  14,475   36 %  |
|      |                                                                        |                 |
|      +---play.api.i18n.Lang$.preferred(Seq, Application)                      |                 |
|        |                                                                      |                 |
|        +---play.api.i18n.Lang.preferred(Seq, Application)                     |                 |
|          |                                                                    |                 |
|          +---play.i18n.Lang.preferred(List)                                   |                 |
|            |                                                                  |                 |
|            +---play.mvc.Http$Context.lang()                                   |                 |
|              |                                                                |                 |
|              +---play.mvc.Http$Context$Implicit.lang()                        |                 |
|                |                                                              |                 |
|                +---play.core.j.PlayMagicForJava$.implicitJavaLang()           |                 |
|                  |                                                            |                 |
|                  +---views.html.index$$anonfun$apply$1.apply()                |                 |
|                    |                                                          |                 |
|                    +---views.html.index$$anonfun$apply$1.apply()              |                 |
|                      |                                                        |                 |
|                      +---views.html.helper.form$.apply(Call, Seq, Function0)  |                 |
|                        |                                                      |                 |
|                        +---views.html.index$.apply(Form)                      |                 |
|                          |                                                    |                 |
|                          +---views.html.index$.render(Form)                   |                 |
+-------------------------------------------------------------------------------+-----------------+
```
