### PR TITLE
Re-enable WebSocketSpec test

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
@@ -133,7 +133,8 @@ object WebSocketClient {
     }
 
     override def exceptionCaught(ctx: ChannelHandlerContext, e: ExceptionEvent) {
-      disconnected.tryFailure(e.getCause)
+      val exception = new RuntimeException("Exception caught in web socket handler", e.getCause)
+      disconnected.tryFailure(exception)
       ctx.getChannel.close()
       ctx.sendDownstream(e)
     }
@@ -165,8 +166,9 @@ object WebSocketClient {
     }
 
     override def exceptionCaught(ctx: ChannelHandlerContext, e: ExceptionEvent) {
-      disconnected.tryFailure(e.getCause)
-      in.end(e.getCause)
+      val exception = new RuntimeException("Exception caught in web socket handler", e.getCause)
+      disconnected.tryFailure(exception)
+      in.end(exception)
       ctx.getChannel.close()
     }
 


### PR DESCRIPTION
In commit 115f79c38fa28570baa9c57190668e9d18d9ab59 I disabled a test that was causing intermittent failures. Need to re-enable the test and fix the underlying failure.

See also #2646.

https://playframework2.ci.cloudbees.com/job/play2-PRs/2083/consoleFull

```
[info] WebSocketSpec
[info] 
[info] Plays WebSockets should
[info] + allow consuming messages
[info] + allow sending messages
[info] + close when the consumer is done
[info] + clean up when closed
[info] + allow rejecting a websocket with a result
[info] 
[info]   allow handling a WebSocket with an actor
[info]   + allow consuming messages
[info]   + allow sending messages
[info]   + close when the consumer is done
[info]   + clean up when closed
[info]   + allow rejecting a websocket with a result
[info]   + aggregate text frames
[info]   + aggregate binary frames
[info]   + close the websocket when the buffer limit is exceeded
[info]   ! close the websocket when the wrong type of frame is received
[error]      IOException: : Connection reset by peer  (FileDispatcher.java:-2)
[error] sun.nio.ch.FileDispatcher.read0(Native Method)
[error] sun.nio.ch.SocketDispatcher.read(SocketDispatcher.java:21)
[error] sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:202)
[error] sun.nio.ch.IOUtil.read(IOUtil.java:169)
[error] sun.nio.ch.SocketChannelImpl.read(SocketChannelImpl.java:243)
[error] org.jboss.netty.channel.socket.nio.NioWorker.read(NioWorker.java:64)
[error] org.jboss.netty.channel.socket.nio.AbstractNioWorker.process(AbstractNioWorker.java:108)
[error] org.jboss.netty.channel.socket.nio.AbstractNioSelector.run(AbstractNioSelector.java:318)
[error] org.jboss.netty.channel.socket.nio.AbstractNioWorker.run(AbstractNioWorker.java:89)
[error] org.jboss.netty.channel.socket.nio.NioWorker.run(NioWorker.java:178)
```
