### PR TITLE
Evolutions plugin tries to lock datasource before checking if evolutions are even supposed to be run against the datasource

### DIFF
--- a/documentation/manual/detailedTopics/evolutions/Evolutions.md
+++ b/documentation/manual/detailedTopics/evolutions/Evolutions.md
@@ -51,6 +51,18 @@ When evolutions are activated, Play will check your database schema state before
 
 If you agree with the SQL script, you can apply it directly by clicking on the ‘Apply evolutions’ button.
 
+## Evolutions configuration
+
+Evolutions can be configured both globally and per datasource.  For global configuration, keys should be prefixed with `play.modules.evolutions`.  For per datasource configuration, keys should be prefixed with `play.modules.evolutions.db.<datasourcename>`, for example `play.modules.evolutions.db.default`.  The following configuration options are supported:
+
+* `enabled` - Whether evolutions are enabled.  If configured globally to be false, it disables the evolutions module altogether.  Defaults to true.
+* `autocommit` - Whether autocommit should be used.  If false, evolutions will be applied in a single transaction.  Defaults to true.
+* `useLocks` - Whether a locks table should be used.  This must be used if you have many Play nodes that may potentially run evolutions, but you want to ensure that only one does.  It will create a table called `play_evolutions_lock`, and use a `SELECT FOR UPDATE NOWAIT` to lock it.  This will only work for Postgres and Oracle, it will not work for other databases.  Defaults to false.
+* `autoApply` - Whether evolutions should be automatically applied.  In dev mode, this will cause both ups and downs evolutions to be automatically applied.  In prod mode, it will cause only ups evolutions to be automatically applied.  Defaults to false.
+* `autoApplyDowns` - Whether down evolutions should be automatically applied.  In prod mode, this will cause down evolutions to be automatically applied.  Has no effect in dev mode.  Defaults to false.
+
+For example, to enable `autoApply` for all evolutions, you might set `play.modules.evolutions.autoApply=true` in `application.conf` or in a system property.  To disable autocommit for a datasource named `default`, you set `play.modules.evolutions.db.default.autocommit=false`.
+
 ## Synchronizing concurrent changes
 
 Now let’s imagine that we have two developers working on this project. Developer A will work on a feature that requires a new database table. So he will create the following `2.sql` evolution script:
@@ -203,23 +215,5 @@ By default, each statement of each evolution script will be executed immediately
 
 ### Evolution storage and limitations
 
-Evolutions are stored in your database in a table called PLAY_EVOLUTIONS.  A Text column stores the actual evolution script.  Your database probably has a 64kb size limit on a text column.  To work around the 64kb limitation you could: manually alter the play_evolutions table structure changing the column type or (prefered) create multiple evolutions scripts less than 64kb in size.
+Evolutions are stored in your database in a table called `play_evolutions`.  A Text column stores the actual evolution script.  Your database probably has a 64kb size limit on a text column.  To work around the 64kb limitation you could: manually alter the play_evolutions table structure changing the column type or (preferred) create multiple evolutions scripts less than 64kb in size.
 
-## Running Evolutions in Production
-
-The appropriate up and down scripts are run in dev mode when you click 'Apply Evolutions' in the play console. To use evolutions in PROD mode there are two things to consider.
-
-If you want to apply UP evolutions automatically, you should set the system property `-DapplyEvolutions.<database>=true` or set `applyEvolutions.<database>=true` in application.conf.
-If the evolution script calculated by Play only contains UP evolutions and this property is set, then Play will apply them and start the server.
-
-If you want to run UP and DOWN evolutions automatically,  you should set the system property `-DapplyDownEvolutions.<database>=true`. It is not recommended to have this setting in your application.conf.
-If the evolution script calculated by Play only contains DOWN evolutions and this property is NOT set, Play will NOT apply them and will NOT start the server.
-
-### Evolutions and multiple hosts using Postgres or Oracle
-
-If your application is running on several hosts, you must set the config property evolutions.use.locks=true. If this property is set, database locks are used to ensure that only
-one host applies any Evolutions. Play will create a table called PLAY_EVOLUTIONS_LOCKS which will be used with SELECT FOR UPDATE NOWAIT to perform locking.
-
-### Evolutions and multiple hosts NOT using Postgres or Oracle
-
-If your application is running on several hosts, evolutions should be switched off. Multiple hosts may try to apply the evolutions scripts concurrently, with a risk of one of them failing and leaving the database in an inconsistent state.

--- a/documentation/manual/detailedTopics/production/Deploying-CleverCloud.md
+++ b/documentation/manual/detailedTopics/production/Deploying-CleverCloud.md
@@ -51,7 +51,7 @@ The file must contain the following fields:
 
 That field can contain additional configuration like:
 
-`"-Dconfig.resource=clevercloud.conf"`, `"-Dplay.version=2.0.4"` or `"-DapplyEvolutions.default=true"`.
+`"-Dconfig.resource=clevercloud.conf"`, `"-Dplay.version=2.0.4"` or `"-Dplay.modules.evolutions.autoApply=true"`.
 
 ## Connecting to a database
 

--- a/documentation/manual/detailedTopics/production/ProductionHeroku.md
+++ b/documentation/manual/detailedTopics/production/ProductionHeroku.md
@@ -110,10 +110,10 @@ libraryDependencies += "postgresql" % "postgresql" % "9.1-901-1.jdbc4"
 Then create a new file in your project's root directory named `Procfile` (with a capital "P") that contains the following (substituting the `myapp` with your project's name):
 
 ```txt
-web: target/universal/stage/bin/myapp -Dhttp.port=${PORT} -DapplyEvolutions.default=true -Ddb.default.driver=org.postgresql.Driver -Ddb.default.url=${DATABASE_URL}
+web: target/universal/stage/bin/myapp -Dhttp.port=${PORT} -Dplay.modules.evolutions.autoApply=true -Ddb.default.driver=org.postgresql.Driver -Ddb.default.url=${DATABASE_URL}
 ```
 
-This instructs Heroku that for the process named `web` it will run Play and override the `applyEvolutions.default`, `db.default.driver`, and `db.default.url` configuration parameters.  Note that the `Procfile` command can be maximum 255 characters long.  Alternatively, use the `-Dconfig.resource=` or `-Dconfig.file=` mentioned in [[production configuration|ProductionConfiguration]] page.
+This instructs Heroku that for the process named `web` it will run Play and override the `play.modules.evolutions.autoApply`, `db.default.driver`, and `db.default.url` configuration parameters.  Note that the `Procfile` command can be maximum 255 characters long.  Alternatively, use the `-Dconfig.resource=` or `-Dconfig.file=` mentioned in [[production configuration|ProductionConfiguration]] page.
 Note that the creation of a Procfile is not actually required by Heroku, as Heroku will look in your play application's conf directory for an application.conf file in order to determine that it is a play application.
 
 ## Further learning resources

--- a/framework/src/play-jdbc/src/main/resources/reference.conf
+++ b/framework/src/play-jdbc/src/main/resources/reference.conf
@@ -5,7 +5,9 @@ play {
       config = "db"
       default = "default"
       bonecp.enabled = true
-      evolutions.enabled = true
+    }
+    evolutions {
+      enabled = true
     }
   }
 }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/EvolutionsModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/EvolutionsModule.scala
@@ -15,7 +15,7 @@ import play.core.WebCommands
  */
 class EvolutionsModule extends Module {
   def bindings(environment: Environment, configuration: Configuration) = {
-    if (configuration.underlying.getBoolean("play.modules.db.evolutions.enabled")) {
+    if (configuration.underlying.getBoolean("play.modules.evolutions.enabled")) {
       Seq(
         bind[EvolutionsConfig].toProvider[DefaultEvolutionsConfigParser],
         bind[EvolutionsReader].toSelf,

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/evolutions/DefaultEvolutionsConfigParserSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/evolutions/DefaultEvolutionsConfigParserSpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.db.evolutions
+
+import org.specs2.mutable.Specification
+import play.api.Configuration
+
+object DefaultEvolutionsConfigParserSpec extends Specification {
+
+  def parse(config: (String, Any)*): EvolutionsConfig = {
+    new DefaultEvolutionsConfigParser(Configuration.from(config.toMap)).get
+  }
+
+  def test(key: String)(read: EvolutionsDatasourceConfig => Boolean) = {
+    read(parse(key -> true).forDatasource("default")) must_== true
+    read(parse(key -> false).forDatasource("default")) must_== false
+  }
+
+  def testN(key: String)(read: EvolutionsDatasourceConfig => Boolean) = {
+    test("play.modules.evolutions." + key)(read)
+  }
+
+  val default = parse().forDatasource("default")
+
+  "The evolutions config parser" should {
+    "parse the deprecated style of configuration" in {
+      "autocommit" in {
+        test("evolutions.autocommit")(_.autocommit)
+      }
+      "useLocks" in {
+        test("evolutions.use.locks")(_.useLocks)
+      }
+      "autoApply" in {
+        test("applyEvolutions.default")(_.autoApply)
+      }
+      "autoApplyDowns" in {
+        test("applyDownEvolutions.default")(_.autoApplyDowns)
+      }
+    }
+    "parse global configuration" in {
+      "autocommit" in {
+        testN("autocommit")(_.autocommit)
+      }
+      "useLocks" in {
+        testN("useLocks")(_.useLocks)
+      }
+      "autoApply" in {
+        testN("autoApply")(_.autoApply)
+      }
+      "autoApplyDowns" in {
+        testN("autoApplyDowns")(_.autoApplyDowns)
+      }
+    }
+    "parse datasource specific configuration" in {
+      "enabled" in {
+        testN("db.default.enabled")(_.enabled)
+      }
+      "autocommit" in {
+        testN("db.default.autocommit")(_.autocommit)
+      }
+      "useLocks" in {
+        testN("db.default.useLocks")(_.useLocks)
+      }
+      "autoApply" in {
+        testN("db.default.autoApply")(_.autoApply)
+      }
+      "autoApplyDowns" in {
+        testN("db.default.autoApplyDowns")(_.autoApplyDowns)
+      }
+    }
+    "parse defaults" in {
+      "enabled" in {
+        default.enabled must_== true
+      }
+      "autocommit" in {
+        default.autocommit must_== true
+      }
+      "useLocks" in {
+        default.useLocks must_== false
+      }
+      "autoApply" in {
+        default.autoApply must_== false
+      }
+      "autoApplyDowns" in {
+        default.autoApplyDowns must_== false
+      }
+    }
+
+  }
+
+}

--- a/templates/play-java/conf/application.conf
+++ b/templates/play-java/conf/application.conf
@@ -49,6 +49,9 @@ application.langs="en"
 # You can disable evolutions if needed
 # play.modules.evolutions.enabled=false
 
+# You can disable evolutions for a specific datasource if necessary
+# play.modules.evolutions.db.default.enabled=false
+
 # Ebean configuration
 # ~~~~~
 # You can declare as many Ebean servers as you want.

--- a/templates/play-scala/conf/application.conf
+++ b/templates/play-scala/conf/application.conf
@@ -46,6 +46,9 @@ application.langs="en"
 # You can disable evolutions if needed
 # play.modules.evolutions.enabled=false
 
+# You can disable evolutions for a specific datasource if necessary
+# play.modules.evolutions.db.default.enabled=false
+
 # Logger
 # ~~~~~
 # You can also configure logback (http://logback.qos.ch/),


### PR DESCRIPTION
There appears to be a problem with the Evolutions plugin in 2.2.x (and in master) when using multiple datasources, and only one datasource is configured to have evolutions applied. It seems that the plugin tries to create the lock table in the database before checking if that database has the "applyEvolutions" config property set. And if one of the datasources doesn't support evolution syntax (like in our case a MySQL database), this causes an error with the evolution process.

Looking at this code: 
https://github.com/playframework/playframework/blob/2.2.x/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala#L461-L466

``` scala
/**
   * Checks the evolutions state.
   */
  override def onStart() {
    dbApi.datasources.foreach {
      case (ds, db) => {
        withLock(ds) {
          val script = evolutionScript(dbApi, app.path, app.classloader, db)
          val hasDown = script.exists(_.isInstanceOf[DownScript])

          lazy val applyEvolutions = app.configuration.getBoolean("applyEvolutions." + db).getOrElse(false)
          lazy val applyDownEvolutions = app.configuration.getBoolean("applyDownEvolutions." + db).getOrElse(false)
```
