### PR TITLE
OpenID breaks after a reload

### DIFF
--- a/documentation/manual/javaGuide/main/ws/JavaOpenID.md
+++ b/documentation/manual/javaGuide/main/ws/JavaOpenID.md
@@ -14,7 +14,7 @@ Step 1 may be omitted if all your users are using the same OpenID provider (for 
 
 ## Usage
 
-To use OpenId, first add `javaWs`  to your `build.sbt` file:
+To use OpenID, first add `javaWs`  to your `build.sbt` file:
 
 ```scala
 libraryDependencies ++= Seq(
@@ -22,12 +22,14 @@ libraryDependencies ++= Seq(
 )
 ```
 
+Now any controller or component that wants to use OpenID will have to declare a dependency on the [OpenIdClient](api/java/play/libs/openid/OpenIdClient.html).
+
 ## OpenID in Play
 
 The OpenID API has two important functions:
 
-* `OpenID.redirectURL` calculates the URL where you should redirect the user. It involves fetching the user's OpenID page asynchronously, this is why it returns a `Promise<String>`. If the OpenID is invalid, the returned `Promise` will be a `Thrown`.
-* `OpenID.verifiedId` inspects the current request to establish the user information, including his verified OpenID. It will do a call to the OpenID server asynchronously to check the authenticity of the information, this is why it returns a `Promise<UserInfo>`. If the information is not correct or if the server check is false (for example if the redirect URL has been forged), the returned `Promise` will be a `Thrown`.
+* `OpenIdClient.redirectURL` calculates the URL where you should redirect the user. It involves fetching the user's OpenID page asynchronously, this is why it returns a `Promise<String>`. If the OpenID is invalid, the returned `Promise` will be a `Thrown`.
+* `OpenIdClient.verifiedId` inspects the current request to establish the user information, including his verified OpenID. It will do a call to the OpenID server asynchronously to check the authenticity of the information, returning a promise of [UserInfo](api/java/play/libs/openid/UserInfo.html). If the information is not correct or if the server check is false (for example if the redirect URL has been forged), the returned `Promise` will be a `Thrown`.
 
 If the `Promise` fails, you can define a fallback, which redirects back the user to the login page or return a `BadRequest`.
 

--- a/documentation/manual/javaGuide/main/ws/java8code/java8guide/ws/controllers/OpenIDController.java
+++ b/documentation/manual/javaGuide/main/ws/java8code/java8guide/ws/controllers/OpenIDController.java
@@ -1,16 +1,20 @@
 package java8guide.ws.controllers;
 
-//#ws-openid-controller
 import javaguide.ws.controllers.routes;
+
+//#ws-openid-controller
 import play.data.DynamicForm;
 import play.data.Form;
 import play.libs.F.Promise;
-import play.libs.openid.OpenID;
-import play.libs.openid.OpenID.UserInfo;
+import play.libs.openid.*;
 import play.mvc.Controller;
 import play.mvc.Result;
 
+import javax.inject.Inject;
+
 public class OpenIDController extends Controller {
+
+  @Inject OpenIdClient openIdClient;
 
   public Result login() {
     //###replace:     return ok(views.html.login.render(""));
@@ -24,7 +28,7 @@ public class OpenIDController extends Controller {
     final String openID = requestData.get("openID");
     
     final Promise<String> redirectUrlPromise =
-        OpenID.redirectURL(openID, routes.OpenIDController.openIDCallback().absoluteURL(request()));
+        openIdClient.redirectURL(openID, routes.OpenIDController.openIDCallback().absoluteURL(request()));
 
     final Promise<Result> resultPromise = redirectUrlPromise.map(url -> {
       return redirect(url);
@@ -38,7 +42,7 @@ public class OpenIDController extends Controller {
 
   public Promise<Result> openIDCallback() {
 
-    final Promise<UserInfo> userInfoPromise = OpenID.verifiedId();
+    final Promise<UserInfo> userInfoPromise = openIdClient.verifiedId();
     
     final Promise<Result> resultPromise = userInfoPromise.map(userInfo -> {
       return (Result) ok(userInfo.id + "\n" + userInfo.attributes);

--- a/documentation/manual/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
+++ b/documentation/manual/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
@@ -1,0 +1,83 @@
+package scalaguide.ws.scalaopenid
+
+import play.api.test._
+
+//#dependency
+import javax.inject.Inject
+import scala.concurrent.Future
+
+import play.api._
+import play.api.mvc._
+import play.api.data._
+import play.api.data.Forms._
+import play.api.libs.openid._
+
+class Application @Inject() (openIdClient: OpenIdClient) extends Controller {
+
+}
+//#dependency
+
+
+object ScalaOpenIdSpec extends PlaySpecification {
+
+  "Scala OpenId" should {
+    "be injectable" in new WithApplication() {
+      app.injector.instanceOf[Application] must beAnInstanceOf[Application]
+    }
+  }
+
+  def openIdClient: OpenIdClient = null
+
+  import play.api.mvc.Results._
+
+  //#flow
+  def login = Action {
+    Ok(views.html.login())
+  }
+
+  def loginPost = Action.async { implicit request =>
+    Form(single(
+      "openid" -> nonEmptyText
+    )).bindFromRequest.fold({ error =>
+      Logger.info("bad request " + error.toString)
+      Future.successful(BadRequest(error.toString))
+    }, { openId =>
+      openIdClient.redirectURL(openId, routes.Application.openIdCallback.absoluteURL())
+        .map(url => Redirect(url))
+        .recover { case t: Throwable => Redirect(routes.Application.login)}
+    })
+  }
+
+  def openIdCallback = Action.async { implicit request =>
+    openIdClient.verifiedId(request).map(info => Ok(info.id + "\n" + info.attributes))
+      .recover {
+      case t: Throwable =>
+        // Here you should look at the error, and give feedback to the user
+        Redirect(routes.Application.login)
+    }
+  }
+  //#flow
+
+  def extended(openId: String)(implicit request: RequestHeader) = {
+    //#extended
+    openIdClient.redirectURL(
+      openId,
+      routes.Application.openIdCallback.absoluteURL(),
+      Seq("email" -> "http://schema.openid.net/contact/email")
+    )
+    //#extended
+  }
+}
+
+object routes {
+  object Application {
+    val login = Call("GET", "login")
+    val openIdCallback = Call("GET", "callback")
+  }
+}
+
+package views {
+object html {
+  def login() = "loginpage"
+}
+}

--- a/framework/src/play-java-ws/src/main/java/play/libs/openid/DefaultOpenIdClient.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/openid/DefaultOpenIdClient.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.libs.openid;
+
+import play.core.Invoker;
+import play.libs.F;
+import play.libs.Scala;
+import play.mvc.Http;
+import scala.collection.JavaConversions;
+import scala.runtime.AbstractFunction1;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DefaultOpenIdClient implements OpenIdClient {
+
+    private final play.api.libs.openid.OpenIdClient client;
+
+    @Inject
+    public DefaultOpenIdClient(play.api.libs.openid.OpenIdClient client) {
+        this.client = client;
+    }
+
+    /**
+     * Retrieve the URL where the user should be redirected to start the OpenID authentication process
+     */
+    @Override
+    public F.Promise<String> redirectURL(String openID, String callbackURL) {
+        return redirectURL(openID, callbackURL, null, null, null);
+    }
+
+    /**
+     * Retrieve the URL where the user should be redirected to start the OpenID authentication process
+     */
+    @Override
+    public F.Promise<String> redirectURL(String openID, String callbackURL, Map<String, String> axRequired) {
+        return redirectURL(openID, callbackURL, axRequired, null, null);
+    }
+
+    /**
+     * Retrieve the URL where the user should be redirected to start the OpenID authentication process
+     */
+    @Override
+    public F.Promise<String> redirectURL(String openID,
+                                         String callbackURL,
+                                         Map<String, String> axRequired,
+                                         Map<String, String> axOptional) {
+        return redirectURL(openID, callbackURL, axRequired, axOptional, null);
+    }
+
+    /**
+     * Retrieve the URL where the user should be redirected to start the OpenID authentication process
+     */
+    @Override
+    public F.Promise<String> redirectURL(String openID,
+                                         String callbackURL,
+                                         Map<String, String> axRequired,
+                                         Map<String, String> axOptional,
+                                         String realm) {
+        if (axRequired == null) axRequired = new HashMap<String, String>();
+        if (axOptional == null) axOptional = new HashMap<String, String>();
+        return F.Promise.wrap(client.redirectURL(openID,
+                callbackURL,
+                JavaConversions.mapAsScalaMap(axRequired).toSeq(),
+                JavaConversions.mapAsScalaMap(axOptional).toSeq(),
+                Scala.Option(realm)));
+    }
+
+    /**
+     * Check the identity of the user from the current request, that should be the callback from the OpenID server
+     */
+    @Override
+    public F.Promise<UserInfo> verifiedId(Http.RequestHeader request) {
+        scala.concurrent.Future<UserInfo> scalaPromise = client.verifiedId(request.queryString()).map(
+                new AbstractFunction1<play.api.libs.openid.UserInfo, UserInfo>() {
+                    @Override
+                    public UserInfo apply(play.api.libs.openid.UserInfo scalaUserInfo) {
+                        return new UserInfo(scalaUserInfo.id(), JavaConversions.mapAsJavaMap(scalaUserInfo.attributes()));
+                    }
+                }, Invoker.executionContext());
+        return F.Promise.wrap(scalaPromise);
+    }
+
+    /**
+     * Check the identity of the user from the current request, that should be the callback from the OpenID server
+     */
+    @Override
+    public F.Promise<UserInfo> verifiedId() {
+        return verifiedId(Http.Context.current().request());
+    }
+}

--- a/framework/src/play-java-ws/src/main/java/play/libs/openid/OpenIdClient.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/openid/OpenIdClient.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.libs.openid;
+
+import play.libs.F;
+import play.mvc.Http;
+
+import java.util.Map;
+
+/**
+ * Created by jroper on 29/08/14.
+ */
+public interface OpenIdClient {
+
+    /**
+     * Retrieve the URL where the user should be redirected to start the OpenID authentication process
+     */
+    F.Promise<String> redirectURL(String openID, String callbackURL);
+
+    /**
+     * Retrieve the URL where the user should be redirected to start the OpenID authentication process
+     */
+    F.Promise<String> redirectURL(String openID, String callbackURL, Map<String, String> axRequired);
+
+    /**
+     * Retrieve the URL where the user should be redirected to start the OpenID authentication process
+     */
+    F.Promise<String> redirectURL(String openID,
+                                  String callbackURL,
+                                  Map<String, String> axRequired,
+                                  Map<String, String> axOptional);
+
+    /**
+     * Retrieve the URL where the user should be redirected to start the OpenID authentication process
+     */
+    F.Promise<String> redirectURL(String openID,
+                                  String callbackURL,
+                                  Map<String, String> axRequired,
+                                  Map<String, String> axOptional,
+                                  String realm);
+
+    /**
+     * Check the identity of the user from the current request, that should be the callback from the OpenID server
+     */
+    F.Promise<UserInfo> verifiedId(Http.RequestHeader request);
+
+    /**
+     * Check the identity of the user from the current request, that should be the callback from the OpenID server
+     */
+    F.Promise<UserInfo> verifiedId();
+}

--- a/framework/src/play-java-ws/src/main/java/play/libs/openid/OpenIdModule.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/openid/OpenIdModule.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.libs.openid;
+
+import play.api.Configuration;
+import play.api.Environment;
+import play.api.inject.Binding;
+import play.api.inject.Module;
+import scala.collection.Seq;
+
+public class OpenIdModule extends Module {
+
+    @Override
+    public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
+        if (configuration.underlying().getBoolean("play.modules.openid.enabled")) {
+            return seq(
+                    bind(OpenIdClient.class).to(DefaultOpenIdClient.class)
+            );
+        } else {
+            return seq();
+        }
+    }
+}

--- a/framework/src/play-java-ws/src/main/java/play/libs/openid/UserInfo.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/openid/UserInfo.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.libs.openid;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * The OpenID user info
+ */
+public class UserInfo {
+
+    private final String id;
+    private final Map<String, String> attributes;
+
+    public UserInfo(String id) {
+        this.id = id;
+        this.attributes = Collections.emptyMap();
+    }
+
+    public UserInfo(String id, Map<String, String> attributes) {
+        this.id = id;
+        this.attributes = Collections.unmodifiableMap(attributes);
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public Map<String, String> attributes() {
+        return attributes;
+    }
+}

--- a/framework/src/play-java-ws/src/main/resources/play.modules
+++ b/framework/src/play-java-ws/src/main/resources/play.modules
@@ -1,1 +1,2 @@
 play.libs.ws.ning.NingWSModule
+play.libs.openid.OpenIdModule

--- a/framework/src/play-ws/src/main/resources/play.modules
+++ b/framework/src/play-ws/src/main/resources/play.modules
@@ -1,1 +1,2 @@
 play.api.libs.ws.ning.NingWSModule
+play.api.libs.openid.OpenIDModule

--- a/framework/src/play-ws/src/main/resources/reference.conf
+++ b/framework/src/play-ws/src/main/resources/reference.conf
@@ -3,5 +3,8 @@ play {
     ws {
       enabled = true
     }
+    openid {
+      enabled = true
+    }
   }
 }

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
@@ -10,6 +10,7 @@ import com.ning.http.client.cookie.{ Cookie => AHCCookie }
 import com.ning.http.client.Realm.{ RealmBuilder, AuthScheme }
 import com.ning.http.util.AsyncHttpProviderUtils
 import play.api.inject.{ ApplicationLifecycle, Module }
+import play.api.libs.openid.OpenIdClient
 
 import collection.immutable.TreeMap
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/openid/DiscoveryClientSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/openid/DiscoveryClientSpec.scala
@@ -11,16 +11,15 @@ import play.api.http.Status._
 import scala.concurrent.duration.Duration
 import scala.concurrent.Await
 import java.util.concurrent.TimeUnit
-import org.specs2.control.NoStackTraceFilter
 import play.api.libs.ws._
 
-object DiscoverySpec extends Specification with Mockito {
+object DiscoveryClientSpec extends Specification with Mockito {
 
   val dur = Duration(10, TimeUnit.SECONDS)
 
   private def normalize(s: String) = {
     val ws = new WSMock
-    val discovery = new Discovery(ws)
+    val discovery = new WsDiscovery(ws)
     discovery.normalizeIdentifier(s)
   }
 
@@ -150,7 +149,7 @@ object DiscoverySpec extends Specification with Mockito {
 
         val returnTo = "http://foo.bar.com/openid"
         val openId = "http://abc.example.com/foo"
-        val redirectUrl = Await.result(new OpenIDClient(ws).redirectURL(openId, returnTo), dur)
+        val redirectUrl = Await.result(new WsOpenIdClient(ws, new WsDiscovery(ws)).redirectURL(openId, returnTo), dur)
 
         there was one(ws.request).get()
 
@@ -168,7 +167,7 @@ object DiscoverySpec extends Specification with Mockito {
 
         val returnTo = "http://foo.bar.com/openid"
         val openId = "http://abc.example.com/foo"
-        val redirectUrl = Await.result(new OpenIDClient(ws).redirectURL(openId, returnTo), dur)
+        val redirectUrl = Await.result(new WsOpenIdClient(ws, new WsDiscovery(ws)).redirectURL(openId, returnTo), dur)
 
         there was one(ws.request).get()
 
@@ -187,7 +186,7 @@ object DiscoverySpec extends Specification with Mockito {
 
         val returnTo = "http://foo.bar.com/openid"
         val openId = "http://abc.example.com/foo"
-        val redirectUrl = Await.result(new OpenIDClient(ws).redirectURL(openId, returnTo), dur)
+        val redirectUrl = Await.result(new WsOpenIdClient(ws, new WsDiscovery(ws)).redirectURL(openId, returnTo), dur)
 
         there was one(ws.request).get()
 
@@ -206,7 +205,7 @@ object DiscoverySpec extends Specification with Mockito {
 
         val returnTo = "http://foo.bar.com/openid"
         val openId = "http://abc.example.com/foo"
-        val redirectUrl = Await.result(new OpenIDClient(ws).redirectURL(openId, returnTo), dur)
+        val redirectUrl = Await.result(new WsOpenIdClient(ws, new WsDiscovery(ws)).redirectURL(openId, returnTo), dur)
 
         there was one(ws.request).get()
 
@@ -220,7 +219,7 @@ object DiscoverySpec extends Specification with Mockito {
         ws.response.body returns readFixture("discovery/html/opLocalIdentityPage.html")
 
         val returnTo = "http://foo.bar.com/openid"
-        val redirectUrl = Await.result(new OpenIDClient(ws).redirectURL("http://example.com/", returnTo), dur)
+        val redirectUrl = Await.result(new WsOpenIdClient(ws, new WsDiscovery(ws)).redirectURL("http://example.com/", returnTo), dur)
 
         there was one(ws.request).get()
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/openid/OpenIDSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/openid/OpenIDSpec.scala
@@ -31,14 +31,14 @@ object OpenIDSpec extends Specification with Mockito {
   "OpenID" should {
     "initiate discovery" in {
       val ws = createMockWithValidOpDiscoveryAndVerification
-      val openId = new OpenIDClient(ws)
+      val openId = new WsOpenIdClient(ws, new WsDiscovery(ws))
       openId.redirectURL("http://example.com", "http://foo.bar.com/openid")
       there was one(ws.request).get()
     }
 
     "generate a valid redirectUrl" in {
       val ws = createMockWithValidOpDiscoveryAndVerification
-      val openId = new OpenIDClient(ws)
+      val openId = new WsOpenIdClient(ws, new WsDiscovery(ws))
       val redirectUrl = Await.result(openId.redirectURL("http://example.com", "http://foo.bar.com/returnto"), dur)
 
       val query = parseQueryString(redirectUrl)
@@ -51,7 +51,7 @@ object OpenIDSpec extends Specification with Mockito {
 
     "generate a valid redirectUrl with a proper required extended attributes request" in {
       val ws = createMockWithValidOpDiscoveryAndVerification
-      val openId = new OpenIDClient(ws)
+      val openId = new WsOpenIdClient(ws, new WsDiscovery(ws))
       val redirectUrl = Await.result(openId.redirectURL("http://example.com", "http://foo.bar.com/returnto",
         axRequired = Seq("email" -> "http://schema.openid.net/contact/email")), dur)
 
@@ -67,7 +67,7 @@ object OpenIDSpec extends Specification with Mockito {
 
     "generate a valid redirectUrl with a proper 'if_available' extended attributes request" in {
       val ws = createMockWithValidOpDiscoveryAndVerification
-      val openId = new OpenIDClient(ws)
+      val openId = new WsOpenIdClient(ws, new WsDiscovery(ws))
       val redirectUrl = Await.result(openId.redirectURL("http://example.com", "http://foo.bar.com/returnto",
         axOptional = Seq("email" -> "http://schema.openid.net/contact/email")), dur)
 
@@ -83,7 +83,7 @@ object OpenIDSpec extends Specification with Mockito {
 
     "generate a valid redirectUrl with a proper 'if_available' AND required extended attributes request" in {
       val ws = createMockWithValidOpDiscoveryAndVerification
-      val openId = new OpenIDClient(ws)
+      val openId = new WsOpenIdClient(ws, new WsDiscovery(ws))
       val redirectUrl = Await.result(openId.redirectURL("http://example.com", "http://foo.bar.com/returnto",
         axRequired = Seq("first" -> "http://axschema.org/namePerson/first"),
         axOptional = Seq("email" -> "http://schema.openid.net/contact/email")), dur)
@@ -103,7 +103,7 @@ object OpenIDSpec extends Specification with Mockito {
     "verify the response" in {
       val ws = createMockWithValidOpDiscoveryAndVerification
 
-      val openId = new OpenIDClient(ws)
+      val openId = new WsOpenIdClient(ws, new WsDiscovery(ws))
 
       val responseQueryString = openIdResponse
       val userInfo = Await.result(openId.verifiedId(setupMockRequest(responseQueryString)), dur)
@@ -134,7 +134,7 @@ object OpenIDSpec extends Specification with Mockito {
     // Claimed Identifier in the response to make sure that the OP is authorized to make assertions about the Claimed Identifier.
     "verify the response using discovery on the claimed Identifier" in {
       val ws = createMockWithValidOpDiscoveryAndVerification
-      val openId = new OpenIDClient(ws)
+      val openId = new WsOpenIdClient(ws, new WsDiscovery(ws))
 
       val spoofedEndpoint = "http://evilhackerendpoint.com"
       val responseQueryString = openIdResponse - "openid.op_endpoint" + ("openid.op_endpoint" -> Seq(spoofedEndpoint))
@@ -168,7 +168,7 @@ object OpenIDSpec extends Specification with Mockito {
       ws.response.xml returns scala.xml.XML.loadString(readFixture("discovery/xrds/simple-op.xml"))
       ws.response.body returns "is_valid:false\n"
 
-      val openId = new OpenIDClient(ws)
+      val openId = new WsOpenIdClient(ws, new WsDiscovery(ws))
 
       Await.result(openId.verifiedId(setupMockRequest()), dur) must throwA[AUTH_ERROR.type]
 
@@ -183,7 +183,7 @@ object OpenIDSpec extends Specification with Mockito {
       ws.response.xml returns scala.xml.XML.loadString(readFixture("discovery/xrds/simple-op.xml"))
       ws.response.body returns "is_valid:false\n"
 
-      val openId = new OpenIDClient(ws)
+      val openId = new WsOpenIdClient(ws, new WsDiscovery(ws))
 
       val errorResponse = (openIdResponse - "openid.mode") + ("openid.mode" -> Seq("error"))
 
@@ -193,7 +193,7 @@ object OpenIDSpec extends Specification with Mockito {
     // OpenID 1.1 compatibility - 14.2.1
     "verify an OpenID 1.1 response that is missing the \"openid.op_endpoint\" parameter" in {
       val ws = createMockWithValidOpDiscoveryAndVerification
-      val openId = new OpenIDClient(ws)
+      val openId = new WsOpenIdClient(ws, new WsDiscovery(ws))
 
       val responseQueryString = (openIdResponse - "openid.op_endpoint")
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/openid/package.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/openid/package.scala
@@ -3,7 +3,7 @@
  */
 package play.api.libs
 
-import io.Source
+import scala.io.Source
 import org.jboss.netty.handler.codec.http.QueryStringDecoder
 import java.net.{ MalformedURLException, URL }
 import util.control.Exception._
@@ -20,7 +20,7 @@ package object openid {
     def hostAndPath = new URL(url.getProtocol, url.getHost, url.getPort, url.getPath).toExternalForm
   }
 
-  def readFixture(filePath: String) = this.synchronized {
+  def readFixture(filePath: String): String = this.synchronized {
     Source.fromInputStream(this.getClass.getResourceAsStream(filePath)).mkString
   }
 


### PR DESCRIPTION
The current OpenID implementation (in Play-WS) is a singleton object bound at load-time to the currently running application. While this initially seems to work (and should work without issues in prod mode), it causes constant IOExceptions if the Application is recreated (for example, after a code reload).
