### PR TITLE
Mention session.maxAge in the documentation

### DIFF
--- a/documentation/manual/scalaGuide/main/http/ScalaSessionFlash.md
+++ b/documentation/manual/scalaGuide/main/http/ScalaSessionFlash.md
@@ -13,7 +13,7 @@ Of course, cookie values are signed with a secret key so the client can’t modi
 
 The Play Session is not intended to be used as a cache. If you need to cache some data related to a specific Session, you can use the Play built-in cache mechanism and store a unique ID in the user Session to keep them related to a specific user.
 
-> There is no technical timeout for the Session. It expires when the user closes the web browser. If you need a functional timeout for a specific application, just store a timestamp into the user Session and use it however your application needs (e.g. for a maximum session duration, maximum inactivity duration, etc.).
+> By default, there is no technical timeout for the Session. It expires when the user closes the web browser. If you need a functional timeout for a specific application, just store a timestamp into the user Session and use it however your application needs (e.g. for a maximum session duration, maximum inactivity duration, etc.). You can also set the maximum age of the session cookie by configuring the key `session.maxAge` (in milliseconds) in application.conf.
 
 ## Storing data in the Session
 


### PR DESCRIPTION
There is a way to set the maximum age of the session cookie but the documentation did not point it out.

Maybe there is a downside to this and/or this parameter will be deleted in an upcoming update?
