### PR TITLE
Expose Ning AsyncHttpClientConfig Settings

### DIFF
--- a/documentation/manual/detailedTopics/configuration/ws/code/HowsMySSLSpec.scala
+++ b/documentation/manual/detailedTopics/configuration/ws/code/HowsMySSLSpec.scala
@@ -18,7 +18,7 @@ class HowsMySSLSpec extends PlaySpecification {
   def createClient(rawConfig: play.api.Configuration): WSClient = {
     val classLoader = Thread.currentThread().getContextClassLoader
     val parser = new DefaultWSConfigParser(rawConfig, new Environment(new File("."), classLoader, Mode.Test))
-    val clientConfig = parser.parse()
+    val clientConfig = new DefaultNingWSClientConfig(parser.parse())
     // Debug flags only take effect in JSSE when DebugConfiguration().configure is called.
     //import play.api.libs.ws.ssl.debug.DebugConfiguration
     //clientConfig.ssl.map {

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -26,6 +26,8 @@ import javax.inject.Inject;
 import com.ning.http.client.*;
 import play.api.libs.ws.WSClientConfig;
 import play.api.libs.ws.DefaultWSClientConfig;
+import play.api.libs.ws.ning.NingWSClientConfig;
+import play.api.libs.ws.ning.DefaultNingWSClientConfig;
 import play.api.libs.ws.ssl.SSLConfig;
 import play.api.libs.ws.ning.NingAsyncHttpClientConfigBuilder;
 // #ws-custom-client-imports
@@ -196,7 +198,7 @@ public class JavaWS {
             scala.Option<Object> none = scala.None$.empty();
             scala.Option<String> noneString = scala.None$.empty();
             scala.Option<SSLConfig> noneSSLConfig = scala.None$.empty();
-            WSClientConfig clientConfig = new DefaultWSClientConfig(
+            WSClientConfig wsClientConfig = new DefaultWSClientConfig(
                     none, // connectionTimeout
                     none, // idleTimeout
                     none, // requestTimeout
@@ -206,6 +208,8 @@ public class JavaWS {
                     none, // compressionEnabled
                     none, // acceptAnyCertificate
                     noneSSLConfig);
+
+            NingWSClientConfig clientConfig = new DefaultNingWSClientConfig(wsClientConfig, none, none, none, none, none, none, none, none, none, none);
 
             // Build a secure config out of the client config:
             NingAsyncHttpClientConfigBuilder secureBuilder = new NingAsyncHttpClientConfigBuilder(clientConfig);

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -212,3 +212,20 @@ There are 3 different timeouts in WS. Reaching a timeout causes the WS request t
 * `ws.timeout.request`: The total time you accept a request to take (it will be interrupted even if the remote host is still sending data) *(default is **none**, to allow stream consuming)*.
 
 The request timeout can be overridden for a specific connection with `withRequestTimeout()` (see "Making a Request" section).
+
+### Configuring AsyncClientConfig
+
+The following advanced settings can be configured on the underlying AsyncHttpClientConfig.
+Please refer to the [AsyncHttpClientConfig Documentation](http://asynchttpclient.github.io/async-http-client/apidocs/com/ning/http/client/AsyncHttpClientConfig.Builder.html) for more information.
+
+* `ws.ning.allowPoolingConnection`
+* `ws.ning.allowSslConnectionPool`
+* `ws.ning.ioThreadMultiplier`
+* `ws.ning.maximumConnectionsPerHost`
+* `ws.ning.maximumConnectionsTotal`
+* `ws.ning.maximumNumberOfRedirects`
+* `ws.ning.maxRequestRetry`
+* `ws.ning.removeQueryParamsOnRedirect`
+* `ws.ning.requestCompressionLevel`
+* `ws.ning.useRawUrl`
+

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -430,11 +430,10 @@ class ScalaWSSpec extends PlaySpecification with Results {
     "allow working with clients directly" in withSimpleServer { ws =>
 
       //#implicit-client
-      import play.api.libs.ws.ning.NingAsyncHttpClientConfigBuilder
-      import play.api.libs.ws.ning.NingWSClient
+      import play.api.libs.ws.ning._
       import com.ning.http.client.AsyncHttpClientConfig
 
-      val clientConfig = new DefaultWSClientConfig()
+      val clientConfig = new DefaultNingWSClientConfig()
       val secureDefaults: AsyncHttpClientConfig = new NingAsyncHttpClientConfigBuilder(clientConfig).build()
       // You can directly use the builder for specific options once you have secure TLS defaults...
       val builder = new AsyncHttpClientConfig.Builder(secureDefaults)
@@ -496,7 +495,8 @@ class ScalaWSSpec extends PlaySpecification with Results {
       val environment = Environment(new File("."), this.getClass.getClassLoader, Mode.Prod)
 
       val parser = new DefaultWSConfigParser(configuration, environment)
-      val builder = new NingAsyncHttpClientConfigBuilder(parser.parse())
+      val config = new DefaultNingWSClientConfig(wsClientConfig = parser.parse())
+      val builder = new NingAsyncHttpClientConfigBuilder(config)
       //#programmatic-config
 
       ok

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSAPI.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSAPI.java
@@ -9,6 +9,7 @@ import play.Environment;
 import play.api.libs.ws.DefaultWSConfigParser;
 import play.api.libs.ws.WSClientConfig;
 import play.api.libs.ws.ning.NingAsyncHttpClientConfigBuilder;
+import play.api.libs.ws.ning.NingWSClientConfig;
 import play.inject.ApplicationLifecycle;
 import play.libs.F;
 import play.libs.ws.WSAPI;
@@ -31,7 +32,7 @@ public class NingWSAPI implements WSAPI {
     private final NingWSClient client;
 
     @Inject
-    public NingWSAPI(WSClientConfig clientConfig, ApplicationLifecycle lifecycle) {
+    public NingWSAPI(NingWSClientConfig clientConfig, ApplicationLifecycle lifecycle) {
         client = new NingWSClient(
                 new NingAsyncHttpClientConfigBuilder(clientConfig).build()
         );


### PR DESCRIPTION
- Add an Option[Configuration] to WSClientConfig trait to be used for client specific settings
- DefaultWSConfigParser#parse takes Option[String] for specific client config under ws namespace.
- NingAsyncHttpClientConfigBuilder looks for settings in "ning" ws config.
  
  ws.ning.allowPoolingConnection = Boolean
  ws.ning.allowSslConnectionPool = Boolean
  ws.ning.ioThreadMultiplier = Int
  ws.ning.maximumConnectionsPerHost = Int
  ws.ning.maximumConnectionsTotal = Int
  ws.ning.maximumNumberOfRedirects = Int
  ws.ning.maxRequestRetry = Int
  ws.ning.removeQueryParamsOnRedirect = Boolean
  ws.ning.requestCompressionLevel = Int
  ws.ning.useRawUrl = Boolean

Fixes #3353
