### PR TITLE
Play should only apply filters on requests that fall under application.context

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -106,6 +106,17 @@ object FiltersSpec extends Specification with WsTestClient {
         response.body must_== expectedOkText
       }
 
+      "Filters are not applied when the request is outside the application.context" in new WithServer(
+        FakeApplication(
+          withGlobal = Some(GlobalWithThrowExceptionFilter),
+          withRoutes = routerForTest,
+          additionalConfiguration = Map("application.context" -> "/foo"))
+      ) {
+        val response = Await.result(wsUrl("/ok").post(expectedOkText), Duration.Inf)
+        response.status must_== 200
+        response.body must_== expectedOkText
+      }
+
       "Filters work even if one of them does not call next" in new WithServer(FakeApplication(withGlobal = Some(SkipNextGlobal), withRoutes = routerForTest)) {
         val response = Await.result(wsUrl("/ok").get(), Duration.Inf)
         response.status must_== 200


### PR DESCRIPTION
play should not send a csrf cookie in responses of requests that do not fall under the configured context path (`application.context`). Otherwise play may override an existing csrf cookie as the browser will not send the existing csrf cookie due to the csrf cookie path specification. 

What currently happens after configuring play with `application.context=/play` & `csrf.cookie.name` and using `CSRFFilter` globally:
1. a browser goes to http://example/play and receives a csrf cookie with a path of /play 
2. the browser then makes a request for some resource not under the play context path -- for example, `http://example.com/favicon.ico`
3. as `/favicon.ico` is not under the play context path the browser does not send the csrf cookie in its request
4. play receives the request for `/favicon.ico`  and as the browser does did not send a csrf cookie it responds with a 'new' one which has a path set to `application.conf` (/play).
5. the browser updates its csrf cookie from the response to `/favicon.ico` .

What should happen:
1. a browser goes to http://example/play and receives a csrf cookie with a path of /play 
2. the browser then makes a request for some resource not under the play context path -- for example, `http://example.com/favicon.ico`
3. as `/favicon.ico` is not under the play context path the browser does not send the csrf cookie in its request.
4. play receives the request for `/favicon.ico`  and as the requested path is not under `application.context` play does not send a csrf cookie.
