### PR TITLE
Make the helpful tolerantBodyParser utility function public

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -689,7 +689,7 @@ trait BodyParsers {
         .getOrElse(Future.successful(Results.BadRequest))
     }
 
-    private def tolerantBodyParser[A](name: String, maxLength: Long, errorMessage: String)(parser: (RequestHeader, Array[Byte]) => A): BodyParser[A] =
+    def tolerantBodyParser[A](name: String, maxLength: Long, errorMessage: String)(parser: (RequestHeader, Array[Byte]) => A): BodyParser[A] =
       BodyParser(name + ", maxLength=" + maxLength) { request =>
         import play.api.libs.iteratee.Execution.Implicits.trampoline
         import scala.util.control.Exception._


### PR DESCRIPTION
`tolerantBodyParser` is used for 3 different BodyParsers (JSON, XML, Forms) in the PlayFramework, and looks like a generally useful utility function (eg like `when`).

My own desire to use it stems from wanting to write a payload-HMAC-validating BodyParser for a GitHub webhook endpoint:

https://developer.github.com/webhooks/#delivery-headers

I want the JSON body of the content, but also to validate the binary data has the correct HMAC signature. A custom BodyParser seems to be the neatest way to do this, something like this:

```
def tolerantSignedGithubJson(maxLength: Int): BodyParser[JsValue] =
  tolerantBodyParser[JsValue]("json", maxLength, "Invalid Json") { (request, bytes) =>
    assertSecureEquals(request.headers("X-Hub-Signature"), sign(bytes, sharedSecret))
    Json.parse(bytes)
  }
```

...which I can't do if `tolerantBodyParser()` is private. The body of `tolerantBodyParser()` is sufficiently large & dense that copy-&-pasting it seems a shame.
