### PR TITLE
Creating valid XML HTTP response example code bug

### DIFF
--- a/documentation/manual/javaGuide/main/xml/JavaXmlRequests.md
+++ b/documentation/manual/javaGuide/main/xml/JavaXmlRequests.md
@@ -69,19 +69,19 @@ Hello Guillaume
 In our previous example, we handled an XML request, but replied with a `text/plain` response. Let’s change it to send back a valid XML HTTP response:
 
 ```
-@BodyParser.Of(Xml.class)
+@BodyParser.Of(BodyParser.Xml.class)
 public static Result sayHello() {
-  Document dom = request().body().asXml();
-  if(dom == null) {
-    return badRequest("Expecting Xml data");
-  } else {
-    String name = XPath.selectText("//name", dom);
-    if(name == null) {
-      return badRequest("<message \"status\"=\"KO\">Missing parameter [name]</message>");
+    Document dom = request().body().asXml();
+    if(dom == null) {
+        return badRequest("Expecting Xml data");
     } else {
-      return ok("<message \"status\"=\"OK\">Hello " + name + "</message>");
+        String name = XPath.selectText("//name", dom);
+        if(name == null) {
+            return badRequest("<message status=\"KO\">Missing parameter [name]</message>").as("application/xml");
+        } else {
+            return ok("<message status=\"OK\">Hello " + name + "</message>").as("application/xml");
+        }
     }
-  }
 }
 ```
 


### PR DESCRIPTION
The example code has 2 bugs:
1: it has extra slashes and double quotes surrounding the status attribute
2: it does not create a valid XML HTTP response, instead it creates a simple text/plain response containing a headless xml string.

I removed the extra quotes and slashes and I put the right content-type to the result.
There could be a better version adding: `<?xml version=\"1.0\" encoding=\"UTF-8\"?>` before every <message> tag.
