### PR TITLE
Anorm support for Array parameter

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/ToStatement.scala
+++ b/framework/src/anorm/src/main/scala/anorm/ToStatement.scala
@@ -405,6 +405,18 @@ object ToStatement extends JodaToStatement {
   }
 
   /**
+   * Sets [[java.sql.Array]] as parameter
+   * the [[java.sql.Array]] can be created using [[java.sql.Connection.createArrayOf]]
+   *
+   * {{{
+   * SQL("update table set arr = {arr} ").on('arr -> connection.createArrayOf("varchar", arr.asInstanceOf[Array[AnyRef]]))
+   * }}}
+   */
+  implicit object sqlArrayToStatement extends ToStatement[java.sql.Array] {
+    def set(s: PreparedStatement, i: Int, n: java.sql.Array) = s.setArray(i, n)
+  }
+
+  /**
    * Sets Id parameter on statement.
    *
    * {{{


### PR DESCRIPTION
Currently, array column type can't be set via "on()"

``` scala
val arr = connection.createArrayOf("varchar", Array[Object]("as", "b"))
SQL("update table set arr = {arr}").on(`arr -> arr)
```

this causes, you can't update or insert into array columns.
Array columns need to be set via "java.sql.PreparedStatement.setArray()".

This pull request adds the conversion, changes attached.
