### PR TITLE
Add support for nested JPA.withTransaction calls

### DIFF
--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -124,10 +124,13 @@ public class DefaultJPAApi implements JPAApi {
      * @param block Block of code to execute
      */
     public <T> T withTransaction(String name, boolean readOnly, play.libs.F.Function0<T> block) throws Throwable {
+        EntityManager em0 = null;
         EntityManager em = null;
         EntityTransaction tx = null;
 
         try {
+
+            try { em0 = JPA.em(); } catch (RuntimeException e) { }
             em = em(name);
 
             if (em == null) {
@@ -160,8 +163,11 @@ public class DefaultJPAApi implements JPAApi {
             throw t;
         } finally {
             JPA.bindForCurrentThread(null);
-            if (em != null) {
+            if(em != null && em.isOpen()) {
                 em.close();
+            }
+            if (em0 != null && em0.isOpen()) {
+                JPA.bindForCurrentThread(em0);
             }
         }
     }


### PR DESCRIPTION
Hi,

we're facing issues with nested JPA.withTransaction calls which result in well known RuntimeException("No EntityManager bound to this thread...").
Here is simplified use-case:

    @Transactional
    public static Result index() {

        JPA.em().isOpen(); // true

        // 2nd call to JPA.withTransaction binds new EntityManager to current thread (erasing previously bound EntityManager)
        JPA.withTransaction(() -> {
            JPA.em().isOpen(); // true
        });
        // after JPA.withTransaction call there is no EntityManager bound anymore

        JPA.em().isOpen(); // RuntimeException: No EntityManager bound to this thread.

        return ok();
    }

The obvious solution is to keep current EntityManager while new EntityManager is being bound and then rebind it when new EM is no longer used (i.e. at the end of JPA.withTransaction).

Are there any potential or known issues with this solution?

--

insign - simply e-business
http://www.insign.ch
