### PR TITLE
[doc] Fix example so it is clear the secure defaults should always be used.

### DIFF
--- a/documentation/manual/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/scalaGuide/main/ws/ScalaWS.md
@@ -165,7 +165,7 @@ The default client can be called from the WS singleton:
 
 @[get-client](code/ScalaWSSpec.scala)
 
-You can define a WS client directly from code without going through WS, and use implicitly with `WS.clientUrl()`
+You can define a WS client directly from code without going through WS, and use implicitly with `WS.clientUrl()`.  Note that you should always use `NingAsyncHttpClientConfigBuilder` when configuring your client, for secure TLS configuration:
 
 @[implicit-client](code/ScalaWSSpec.scala)
 

--- a/documentation/manual/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -6,6 +6,7 @@ package scalaguide.ws.scalaws
 //#imports
 import play.api.Play.current
 import play.api.libs.ws._
+import play.api.libs.ws.ning.NingAsyncHttpClientConfigBuilder
 import scala.concurrent.Future
 //#imports
 
@@ -425,20 +426,25 @@ class ScalaWSSpec extends PlaySpecification with Results {
 
 
       //#implicit-client
-      val builder = new (com.ning.http.client.AsyncHttpClientConfig.Builder)()
-      implicit val sslClient = new play.api.libs.ws.ning.NingWSClient(builder.build())
+      val clientConfig = new DefaultWSClientConfig()
+      val secureDefaults:com.ning.http.client.AsyncHttpClientConfig = new NingAsyncHttpClientConfigBuilder(clientConfig).build()
+      // You can directly use the builder for specific options once you have secure TLS defaults...
+      val builder = new com.ning.http.client.AsyncHttpClientConfig.Builder(secureDefaults)
+      builder.setCompressionEnabled(true)
+      val secureDefaultsWithSpecificOptions:com.ning.http.client.AsyncHttpClientConfig = builder.build()
+      implicit val implicitClient = new play.api.libs.ws.ning.NingWSClient(secureDefaultsWithSpecificOptions)
       val response = WS.clientUrl(url).get()
       //#implicit-client
       await(response).status must_== OK
 
       {
         //#direct-client
-        val response = sslClient.url(url).get()
+        val response = client.url(url).get()
         //#direct-client
         await(response).status must_== OK
       }
 
-      sslClient.close()
+      implicitClient.close()
       ok
     }
 


### PR DESCRIPTION
From https://groups.google.com/d/topic/play-framework/NCCcbA-gkUY/discussion, it's clear that using 

```
val builder = new (com.ning.http.client.AsyncHttpClientConfig.Builder)()
implicit val sslClient = new play.api.libs.ws.ning.NingWSClient(builder.build())
```

is a bad practice, as AsyncHttpClient 1.8.x doesn't do any hostname verification out of the box.

Added a note to ScalaWS and added this revised example:

```
      //#implicit-client
      val clientConfig = new DefaultWSClientConfig()
      val secureDefaults:com.ning.http.client.AsyncHttpClientConfig = new NingAsyncHttpClientConfigBuilder(clientConfig).build()
      // You can directly use the builder for specific options once you have secure TLS defaults...
      val builder = new com.ning.http.client.AsyncHttpClientConfig.Builder(secureDefaults)
      builder.setCompressionEnabled(true)
      val secureDefaultsWithSpecificOptions:com.ning.http.client.AsyncHttpClientConfig = builder.build()
      implicit val implicitClient = new play.api.libs.ws.ning.NingWSClient(secureDefaultsWithSpecificOptions)
      val response = WS.clientUrl(url).get()
      //#implicit-client
```

Fixed example in 2.3.x, needs to be forward ported to master.
