### PR TITLE
Handle 'bundle' protocol in Resources.isDirectory. Fixes #3212

### DIFF
--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -524,7 +524,7 @@ class DefaultMessagesApi @Inject() (environment: Environment, configuration: Con
     import scala.collection.JavaConverters._
 
     environment.classLoader.getResources(joinPaths(messagesPrefix, file)).asScala.toList
-      .filterNot(Resources.isDirectory).reverse
+      .filterNot(url => Resources.isDirectory(environment.classLoader, url)).reverse
       .map { messageFile =>
         Messages.messages(Messages.UrlMessageSource(messageFile), messageFile.toString).fold(e => throw e, identity)
       }.foldLeft(Map.empty[String, String]) { _ ++ _ }

--- a/framework/src/play/src/main/scala/play/utils/Resources.scala
+++ b/framework/src/play/src/main/scala/play/utils/Resources.scala
@@ -12,10 +12,24 @@ import java.util.zip.ZipFile
  */
 object Resources {
 
-  def isDirectory(url: URL) = url.getProtocol match {
+  def isDirectory(classLoader: ClassLoader, url: URL) = url.getProtocol match {
     case "file" => new File(url.toURI).isDirectory
     case "jar" => isJarResourceDirectory(url)
+    case "bundle" => isBundleResourceDirectory(classLoader, url)
     case _ => throw new IllegalArgumentException(s"Cannot check isDirectory for a URL with protocol='${url.getProtocol}'")
+  }
+
+  private def isBundleResourceDirectory(classLoader: ClassLoader, url: URL): Boolean = {
+    /* ClassLoader within an OSGi container behave differently than the standard classloader.
+     * One difference is how getResource returns when the resource's name end with a slash.
+     * In a standard JVM, getResource doesn't care of ending slashes, and return the URL of
+     * any existing resources. In an OSGi container (tested with Apache Felix), ending slashe
+     * refers to a directory (return null otherwise). */
+
+    val path = url.getPath
+    val pathSlash = if (path.last == '/') path else path + '/'
+
+    classLoader.getResource(path) != null && classLoader.getResource(pathSlash) != null
   }
 
   private def isJarResourceDirectory(url: URL): Boolean = {


### PR DESCRIPTION
Within an OSGi container, URLs' protocol is "bundle://".

In order to detect if a resource is a directory, this fix
rely on the class loader's behavior, which differ between
the standalone JVM and within an OSGi environment.
Most notably, ClassLoader.getResource returns differently
when the resource's name end with a slash.

In a standard JVM, getResource doesn't care of ending slashes,
and return the URL of any existing resources. In an OSGi container
(tested with Apache Felix), ending slashe refers to a directory
(return null otherwise).

In order to test Resources.isDirectory when the protocol is "bundle://",
there are 2 options:
a) run the test within an OSGi container (using Pax Exam),
b) simulate the behavior of an OSGi class loader, which is the
implemented solution.
