### PR TITLE
Missing a lot of mappers for Short and Byte

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
@@ -165,6 +165,16 @@ trait DefaultReads {
   }
 
   /**
+   * Deserializer for Byte types.
+   */
+  implicit object ByteReads extends Reads[Byte] {
+    def reads(json: JsValue) = json match {
+      case JsNumber(n) => JsSuccess(n.toByte)
+      case _ => JsError(Seq(JsPath() -> Seq(ValidationError("error.expected.jsnumber"))))
+    }
+  }
+
+  /**
    * Deserializer for Long types.
    */
   implicit object LongReads extends Reads[Long] {

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
@@ -109,6 +109,13 @@ trait DefaultWrites {
   }
 
   /**
+   * Serializer for Byte types.
+   */
+  implicit object ByteWrites extends Writes[Byte] {
+    def writes(o: Byte) = JsNumber(o)
+  }
+
+  /**
    * Serializer for Long types.
    */
   implicit object LongWrites extends Writes[Long] {

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -142,8 +142,24 @@ object JsonSpec extends Specification {
       val t = 1330950829160L
       val m = Map("timestamp" -> t)
       val jsonM = toJson(m)
-      (jsonM \ "timestamp").as[Long] must equalTo(t)
-      (jsonM.toString must equalTo("{\"timestamp\":1330950829160}"))
+      (jsonM \ "timestamp").as[Long] must_== t
+      jsonM.toString must_== "{\"timestamp\":1330950829160}"
+    }
+
+    "Serialize short integers correctly" in {
+      val s: Short = 1234
+      val m = Map("s" -> s)
+      val jsonM = toJson(m)
+      (jsonM \ "s").as[Short] must_== s
+      jsonM.toString must_== "{\"s\":1234}"
+    }
+
+    "Serialize bytes correctly" in {
+      val b: Byte = 123
+      val m = Map("b" -> b)
+      val jsonM = toJson(m)
+      (jsonM \ "b").as[Byte] must_== b
+      jsonM.toString must_== "{\"b\":123}"
     }
 
     "Serialize and deserialize BigDecimals" in {

--- a/framework/src/play/src/main/scala/play/api/data/Forms.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Forms.scala
@@ -220,7 +220,6 @@ object Forms {
 
   // --
 
-  import Form._
   import Formats._
 
   /**
@@ -285,7 +284,7 @@ object Forms {
    * Form("size" -> number)
    * }}}
    */
-  val number: Mapping[Int] = of[Int]
+  val number: Mapping[Int] = number()
 
   /**
    * Constructs a simple mapping for a numeric field (using a Long type behind).
@@ -295,7 +294,27 @@ object Forms {
    * Form("size" -> longNumber)
    * }}}
    */
-  val longNumber: Mapping[Long] = of[Long]
+  val longNumber: Mapping[Long] = longNumber()
+
+  /**
+   * Constructs a simple mapping for a numeric field (using a Short type behind).
+   *
+   * For example:
+   * {{{
+   * Form("size" -> shortNumber)
+   * }}}
+   */
+  val shortNumber: Mapping[Short] = shortNumber()
+
+  /**
+   * Constructs a simple mapping for a numeric field (using a Byte type behind).
+   *
+   * For example:
+   * {{{
+   * Form("size" -> byteNumber)
+   * }}}
+   */
+  val byteNumber: Mapping[Byte] = byteNumber()
 
   /**
    * Constructs a simple mapping for a numeric field.
@@ -309,12 +328,8 @@ object Forms {
    * @param max maximum value
    * @param strict should it be a strict comparison
    */
-  def number(min: Int = Int.MinValue, max: Int = Int.MaxValue, strict: Boolean = false): Mapping[Int] = (min, max) match {
-    case (Int.MinValue, Int.MaxValue) => number
-    case (min, Int.MaxValue) => number verifying Constraints.min(min, strict)
-    case (Int.MinValue, max) => number verifying Constraints.max(max, strict)
-    case (min, max) => number verifying (Constraints.min(min, strict), Constraints.max(max, strict))
-  }
+  def number(min: Int = Int.MinValue, max: Int = Int.MaxValue, strict: Boolean = false): Mapping[Int] =
+    numberMapping[Int](Int.MinValue, Int.MaxValue, min, max, strict)
 
   /**
    * Constructs a simple mapping for a numeric field (using a Long type behind).
@@ -328,11 +343,51 @@ object Forms {
    * @param max maximum value
    * @param strict should it be a strict comparison
    */
-  def longNumber(min: Long = Long.MinValue, max: Long = Long.MaxValue, strict: Boolean = false): Mapping[Long] = (min, max) match {
-    case (Long.MinValue, Long.MaxValue) => longNumber
-    case (min, Long.MaxValue) => longNumber verifying Constraints.min(min, strict)
-    case (Long.MinValue, max) => longNumber verifying Constraints.max(max, strict)
-    case (min, max) => longNumber verifying (Constraints.min(min, strict), Constraints.max(max, strict))
+  def longNumber(min: Long = Long.MinValue, max: Long = Long.MaxValue, strict: Boolean = false): Mapping[Long] =
+    numberMapping[Long](Long.MinValue, Long.MaxValue, min, max, strict)
+
+  /**
+   * Constructs a simple mapping for a numeric field (using a Short type behind).
+   *
+   * For example:
+   * {{{
+   * Form("size" -> shortNumber(min=0, max=100))
+   * }}}
+   *
+   * @param min minimum value
+   * @param max maximum value
+   * @param strict should it be a strict comparison
+   */
+  def shortNumber(min: Short = Short.MinValue, max: Short = Short.MaxValue, strict: Boolean = false): Mapping[Short] =
+    numberMapping[Short](Short.MinValue, Short.MaxValue, min, max, strict)
+
+  /**
+   * Constructs a simple mapping for a numeric field (using a Short type behind).
+   *
+   * For example:
+   * {{{
+   * Form("size" -> byteNumber(min=0, max=100))
+   * }}}
+   *
+   * @param min minimum value
+   * @param max maximum value
+   * @param strict should it be a strict comparison
+   */
+  def byteNumber(min: Byte = Byte.MinValue, max: Byte = Byte.MaxValue, strict: Boolean = false): Mapping[Byte] =
+    numberMapping[Byte](Byte.MinValue, Byte.MaxValue, min, max, strict)
+
+  @inline private def numberMapping[N: Numeric: Formatter](
+    typeMin: N, typeMax: N, min: N, max: N, strict: Boolean): Mapping[N] = {
+    val number = of[N]
+    if (min == typeMin && max == typeMax) {
+      number
+    } else if (min == typeMin) {
+      number verifying Constraints.max(max, strict)
+    } else if (max == typeMax) {
+      number verifying Constraints.min(min, strict)
+    } else {
+      number verifying (Constraints.min(min, strict), Constraints.max(max, strict))
+    }
   }
 
   /**

--- a/framework/src/play/src/main/scala/play/api/data/format/Format.scala
+++ b/framework/src/play/src/main/scala/play/api/data/format/Format.scala
@@ -75,57 +75,44 @@ object Formats {
     }
   }
 
+  private def numberFormatter[T](convert: String => T, real: Boolean = false): Formatter[T] = {
+    val (formatString, errorString) = if (real) ("format.real", "error.real") else ("format.numeric", "error.number")
+    new Formatter[T] {
+      override val format = Some(formatString -> Nil)
+      def bind(key: String, data: Map[String, String]) =
+        parsing(convert, errorString, Nil)(key, data)
+      def unbind(key: String, value: T) = Map(key -> value.toString)
+    }
+  }
+
   /**
    * Default formatter for the `Long` type.
    */
-  implicit def longFormat: Formatter[Long] = new Formatter[Long] {
-
-    override val format = Some(("format.numeric", Nil))
-
-    def bind(key: String, data: Map[String, String]) =
-      parsing(_.toLong, "error.number", Nil)(key, data)
-
-    def unbind(key: String, value: Long) = Map(key -> value.toString)
-  }
+  implicit def longFormat: Formatter[Long] = numberFormatter(_.toLong)
 
   /**
    * Default formatter for the `Int` type.
    */
-  implicit def intFormat: Formatter[Int] = new Formatter[Int] {
+  implicit def intFormat: Formatter[Int] = numberFormatter(_.toInt)
 
-    override val format = Some(("format.numeric", Nil))
+  /**
+   * Default formatter for the `Short` type.
+   */
+  implicit def shortFormat: Formatter[Short] = numberFormatter(_.toShort)
 
-    def bind(key: String, data: Map[String, String]) =
-      parsing(_.toInt, "error.number", Nil)(key, data)
-
-    def unbind(key: String, value: Int) = Map(key -> value.toString)
-  }
-
+  /**
+   * Default formatter for the `Byte` type.
+   */
+  implicit def byteFormat: Formatter[Byte] = numberFormatter(_.toByte)
   /**
    * Default formatter for the `Float` type.
    */
-  implicit def floatFormat: Formatter[Float] = new Formatter[Float] {
-
-    override val format = Some(("format.real", Nil))
-
-    def bind(key: String, data: Map[String, String]) =
-      parsing(_.toFloat, "error.real", Nil)(key, data)
-
-    def unbind(key: String, value: Float) = Map(key -> value.toString)
-  }
+  implicit def floatFormat: Formatter[Float] = numberFormatter(_.toFloat, real = true)
 
   /**
    * Default formatter for the `Double` type.
    */
-  implicit def doubleFormat: Formatter[Double] = new Formatter[Double] {
-
-    override val format = Some(("format.real", Nil))
-
-    def bind(key: String, data: Map[String, String]) =
-      parsing(_.toDouble, "error.real", Nil)(key, data)
-
-    def unbind(key: String, value: Double) = Map(key -> value.toString)
-  }
+  implicit def doubleFormat: Formatter[Double] = numberFormatter(_.toDouble, real = true)
 
   /**
    * Default formatter for the `BigDecimal` type.

--- a/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
@@ -141,6 +141,38 @@ object FormSpec extends Specification {
       f4.errors must beEmpty
     }
 
+    "apply constraints on shortNumber fields" in {
+      val f1 = ScalaForms.shortNumberForm.fillAndValidate(0)
+      f1.errors must haveSize(1)
+      f1.errors.find(_.message == "error.min") must beSome
+
+      val f2 = ScalaForms.shortNumberForm.fillAndValidate(9000)
+      f2.errors must haveSize(1)
+      f2.errors.find(_.message == "error.max") must beSome
+
+      val f3 = ScalaForms.shortNumberForm.fillAndValidate(10)
+      f3.errors must beEmpty
+
+      val f4 = ScalaForms.shortNumberForm.fillAndValidate(42)
+      f4.errors must beEmpty
+    }
+
+    "apply constraints on byteNumber fields" in {
+      val f1 = ScalaForms.byteNumberForm.fillAndValidate(0)
+      f1.errors must haveSize(1)
+      f1.errors.find(_.message == "error.min") must beSome
+
+      val f2 = ScalaForms.byteNumberForm.fillAndValidate(9000)
+      f2.errors must haveSize(1)
+      f2.errors.find(_.message == "error.max") must beSome
+
+      val f3 = ScalaForms.byteNumberForm.fillAndValidate(10)
+      f3.errors must beEmpty
+
+      val f4 = ScalaForms.byteNumberForm.fillAndValidate(42)
+      f4.errors must beEmpty
+    }
+
     "not even attempt to validate on fill" in {
       val failingValidatorForm = Form(
         "foo" -> Forms.text.verifying("isEmpty", s =>
@@ -313,4 +345,8 @@ object ScalaForms {
   )
 
   val longNumberForm = Form("longNumber" -> longNumber(10, 42))
+
+  val shortNumberForm = Form("shortNumber" -> shortNumber(10, 42))
+
+  val byteNumberForm = Form("byteNumber" -> shortNumber(10, 42))
 }


### PR DESCRIPTION
There are few things missing in play framework:
1. `Reads[Byte]` and `Writes[Byte]`.
2. Form mappings for Short and Byte, currently we have only `number` and `longNumber`. It would be nice to also have `shortNumber` and `byteNumber` (so min and max parameters could be used in form helper for HTML5 `<input type="number">`)
3. `Formatter[Short]` and `Formatter[Byte]`.
4. (bonus) All of the above for `Enumeration`s
