### PR TITLE
Use a stable DateTimeFormatter for writing Joda datetimes

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
@@ -215,7 +215,8 @@ trait DefaultWrites {
    * @param pattern the pattern used by SimpleDateFormat
    */
   def jodaDateWrites(pattern: String): Writes[org.joda.time.DateTime] = new Writes[org.joda.time.DateTime] {
-    def writes(d: org.joda.time.DateTime): JsValue = JsString(d.toString(pattern))
+    val df = org.joda.time.format.DateTimeFormat.forPattern(pattern)
+    def writes(d: org.joda.time.DateTime): JsValue = JsString(d.toString(df))
   }
 
   /**
@@ -230,7 +231,8 @@ trait DefaultWrites {
    * @param pattern the pattern used by org.joda.time.format.DateTimeFormat
    */
   def jodaLocalDateWrites(pattern: String): Writes[org.joda.time.LocalDate] = new Writes[org.joda.time.LocalDate] {
-    def writes(d: org.joda.time.LocalDate): JsValue = JsString(d.toString(pattern))
+    val df = org.joda.time.format.DateTimeFormat.forPattern(pattern)
+    def writes(d: org.joda.time.LocalDate): JsValue = JsString(d.toString(df))
   }
 
   /**


### PR DESCRIPTION
No need to create one on every call, as DateTimeFormatters are [thread safe](http://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html).
