### PR TITLE
Make EventSource’s Enumeratee return Events instead of Strings

### DIFF
--- a/framework/src/play/src/test/scala/play/api/libs/EventSourceSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/EventSourceSpec.scala
@@ -1,6 +1,9 @@
 package play.api.libs
 
 import org.specs2.mutable.Specification
+import play.api.http.{ ContentTypes, HeaderNames }
+import play.api.libs.iteratee.Enumerator
+import play.api.mvc.Results
 
 object EventSourceSpec extends Specification {
 
@@ -32,6 +35,13 @@ object EventSourceSpec extends Specification {
       Event("a\r\nb").formatted must equalTo("data: a\ndata: b\n\n")
     }
 
+  }
+
+  "EventSource.Event" should {
+    "be writeable as a response body" in {
+      val result = Results.Ok.chunked(Enumerator("foo", "bar", "baz") &> EventSource())
+      result.header.headers.get(HeaderNames.CONTENT_TYPE) must beSome(ContentTypes.EVENT_STREAM)
+    }
   }
 
 }


### PR DESCRIPTION
We currently have to explicitly set the `Content-Type` of server-sent events responses. See e.g. [here](https://github.com/typesafehub/play-mongo-knockout/blob/master/app/controllers/MainController.scala#L30), [here](https://github.com/matthiasn/sse-chat/blob/master/app/controllers/ChatApplication.scala#L42) or [here](http://stackoverflow.com/questions/21766755/server-sent-events-with-angularjs-and-play-framework-keeps-restarting-after-su).

This PR automatically sets the right content type.
