### PR TITLE
Use DigestUtils in Codecs

### DIFF
--- a/framework/src/play-cache/src/main/scala/play/api/cache/Cached.scala
+++ b/framework/src/play-cache/src/main/scala/play/api/cache/Cached.scala
@@ -3,10 +3,9 @@
  */
 package play.api.cache
 
-import org.apache.commons.codec.digest.DigestUtils
-
 import play.api._
 import play.api.mvc._
+import play.api.libs.Codecs
 import play.api.libs.iteratee.{ Iteratee, Done }
 import play.api.http.HeaderNames.{ IF_NONE_MATCH, ETAG, EXPIRES }
 import play.api.mvc.Results.NotModified
@@ -75,7 +74,7 @@ case class Cached(key: RequestHeader => String, caching: PartialFunction[Respons
       val expirationDate = http.dateFormat.print(System.currentTimeMillis() + duration.toMillis)
       // Generate a fresh ETAG for it
       // Use quoted sha1 hash of expiration date as ETAG
-      val etag = s""""${DigestUtils.sha1Hex(expirationDate)}""""
+      val etag = s""""${Codecs.sha1(expirationDate)}""""
 
       val resultWithHeaders = result.withHeaders(ETAG -> etag, EXPIRES -> expirationDate)
 

--- a/framework/src/play/src/main/scala/play/api/libs/Codecs.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Codecs.scala
@@ -3,6 +3,9 @@
  */
 package play.api.libs
 
+import org.apache.commons.codec.digest.DigestUtils
+import org.apache.commons.codec.binary.Hex
+
 /**
  * Utilities for Codecs operations.
  */
@@ -14,13 +17,7 @@ object Codecs {
    * @param bytes the data to hash
    * @return the SHA-1 digest, encoded as a hex string
    */
-  def sha1(bytes: Array[Byte]): String = {
-    import java.security.MessageDigest
-    val digest = MessageDigest.getInstance("SHA-1")
-    digest.reset()
-    digest.update(bytes)
-    digest.digest().map(0xFF & _).map { "%02x".format(_) }.foldLeft("") { _ + _ }
-  }
+  def sha1(bytes: Array[Byte]): String = DigestUtils.sha1Hex(bytes)
 
   /**
    * Computes the MD5 digest for a byte array.
@@ -28,52 +25,28 @@ object Codecs {
    * @param bytes the data to hash
    * @return the MD5 digest, encoded as a hex string
    */
-  def md5(bytes: Array[Byte]): String = {
-    import java.security.MessageDigest
-    val digest = MessageDigest.getInstance("MD5")
-    digest.reset()
-    digest.update(bytes)
-    digest.digest().map(0xFF & _).map { "%02x".format(_) }.foldLeft("") { _ + _ }
-  }
-
+  def md5(bytes: Array[Byte]): String = DigestUtils.md5Hex(bytes)
   /**
    * Compute the SHA-1 digest for a `String`.
    *
    * @param text the text to hash
    * @return the SHA-1 digest, encoded as a hex string
    */
-  def sha1(text: String): String = sha1(text.getBytes)
-
-  // --
-
-  private val hexChars = Array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f')
+  def sha1(text: String): String = DigestUtils.sha1Hex(text)
 
   /**
    * Converts a byte array into an array of characters that denotes a hexadecimal representation.
    */
-  def toHex(array: Array[Byte]): Array[Char] = {
-    val result = new Array[Char](array.length * 2)
-    for (i <- 0 until array.length) {
-      val b = array(i) & 0xff
-      result(2 * i) = hexChars(b >> 4)
-      result(2 * i + 1) = hexChars(b & 0xf)
-    }
-    result
-  }
+  def toHex(array: Array[Byte]): Array[Char] = Hex.encodeHex(array)
 
   /**
    * Converts a byte array into a `String` that denotes a hexadecimal representation.
    */
-  def toHexString(array: Array[Byte]): String = {
-    new String(toHex(array))
-  }
+  def toHexString(array: Array[Byte]): String = Hex.encodeHexString(array)
 
   /**
    * Transform an hexadecimal String to a byte array.
    */
-  def hexStringToByte(hexString: String): Array[Byte] = {
-    import org.apache.commons.codec.binary.Hex;
-    Hex.decodeHex(hexString.toCharArray());
-  }
+  def hexStringToByte(hexString: String): Array[Byte] = Hex.decodeHex(hexString.toCharArray)
 
 }


### PR DESCRIPTION
Since we have a dependency `DigestUtils` from apache commons codec, we might as well use its implementations instead of creating our own.
