### PR TITLE
Where is PostCompile in 2.3.x [documentation]

### DIFF
--- a/documentation/manual/working/javaGuide/main/tests/JavaTest.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTest.md
@@ -37,7 +37,7 @@ The default way to test a Play application is with [JUnit](http://www.junit.org/
 
 ### Assertions & Matchers
 
-Some developers prefer to write their assertions in a more fluent style than JUnit asserts. Popular libraries for other assertion styles are included for convenience. 
+Some developers prefer to write their assertions in a more fluent style than JUnit asserts. Popular libraries for other assertion styles are included for convenience.
 
 Hamcrest matchers:
 
@@ -80,10 +80,16 @@ In this way, the `UserService.isAdmin` method can be tested by mocking the `User
 > ```scala
 > compile in Test <<= PostCompile(Test)
 > ```
+>
+> You may also need the following import at the top of your `build.sbt`:
+>
+> ```scala
+> import play.Play._
+> ```
 
 ## Unit testing controllers
 
-You can test your controllers using Play's [test helpers](api/java/play/test/Helpers.html) to extract useful properties. 
+You can test your controllers using Play's [test helpers](api/java/play/test/Helpers.html) to extract useful properties.
 
 @[test-controller-test](code/javaguide/tests/ApplicationTest.java)
 


### PR DESCRIPTION
The JavaTest doc ( https://www.playframework.com/documentation/2.3.x/JavaTest ) says that

> Note: Applications using Ebean ORM may be written to rely on Play’s automatic getter/setter generation. Play also rewrites field accesses to use the generated getters/setters. Ebean relies on calls to the setters to do dirty checking. In order to use these patterns in JUnit tests, you will need to enable Play’s field access rewriting in test by adding the following to build.sbt:
> 
>    compile in Test <<= PostCompile(Test)

But adding `compile in Test <<= PostCompile(Test)` in build.sbt results in

```
error: not found: value PostCompile
```

Where is that needle hidden in 2.3.x? And maybe the documentation should be improved to include that information?
