### PR TITLE
Add `sequential` to AkkaHttpServerSpec

### DIFF
--- a/framework/src/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHttpServerSpec.scala
+++ b/framework/src/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHttpServerSpec.scala
@@ -14,6 +14,8 @@ import akka.util.Timeout
 
 object AkkaHttpServerSpec extends PlaySpecification with WsTestClient {
 
+  sequential
+
   def requestFromServer[T](path: String)(exec: WSRequestHolder => Future[WSResponse])(routes: PartialFunction[(String, String), Handler])(check: WSResponse => T): T = {
     running(TestServer(testServerPort, FakeApplication(withRoutes = routes), serverProvider = AkkaHttpServer.defaultServerProvider)) {
       val plainRequest = wsUrl(path)(testServerPort)


### PR DESCRIPTION
This may improve the stability of the test in CI.
