### PR TITLE
Fix typo in documentation

### DIFF
--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
@@ -135,7 +135,7 @@ and then test the trait:
 
 ## Unit Testing EssentialAction
 
-Testing [`Action`](api/scala/index.html#play.api.mvc.Action) or [`Filter`](api/scala/index.html#play.api.mvc.Filter) can require to test an an [`EssentialAction`](api/scala/index.html#play.api.mvc.EssentialAction) ([[more information about what an EssentialAction is|HttpApi]])
+Testing [`Action`](api/scala/index.html#play.api.mvc.Action) or [`Filter`](api/scala/index.html#play.api.mvc.Filter) can require to test an [`EssentialAction`](api/scala/index.html#play.api.mvc.EssentialAction) ([[more information about what an EssentialAction is|HttpApi]])
 
 For this, the test [`Helpers.call`](api/scala/index.html#play.api.test.Helpers@call) can be used like that:
 


### PR DESCRIPTION
Test documentation contained a duplicated "an" as: 

can require to test an an [`EssentialAction`]

Fixed it.
