### PR TITLE
Update columnToList to support java.util.Collection

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/Column.scala
+++ b/framework/src/anorm/src/main/scala/anorm/Column.scala
@@ -369,7 +369,7 @@ object Column extends JodaColumn {
       } catch {
         case _: Throwable => Left(TypeDoesNotMatch(s"Cannot convert $value: ${value.asInstanceOf[AnyRef].getClass} to list for column $qualified"))
       }
-      
+
       case arr: java.util.Collection[_] => try {
         transf(arr.toArray, Nil)
       } catch {


### PR DESCRIPTION
Update anorm.Column.columnToList to support java.util.Collection.
neo4j's JDBC library returns a java.util.ArrayList when performing queries with Array columns.
