### PR TITLE
Add urlWithQueryString method to WSRequestHolder

### DIFF
--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -3,6 +3,8 @@
  */
 package play.api.libs.ws
 
+import java.net.URI
+
 import scala.concurrent.{ Future, ExecutionContext }
 
 import java.io.File
@@ -342,9 +344,23 @@ case object EmptyBody extends WSBody
 trait WSRequestHolder {
 
   /**
-   * The URL for this request
+   * The base URL for this request
    */
   val url: String
+
+  /**
+   * The URI for this request
+   */
+  lazy val uri: URI = {
+    val enc = (p: String) => java.net.URLEncoder.encode(p, "utf-8")
+    new java.net.URI(if (queryString.isEmpty) url else {
+      val qs = (for {
+        (n, vs) <- queryString
+        v <- vs
+      } yield s"${enc(n)}=${enc(v)}").mkString("&")
+      s"$url?$qs"
+    })
+  }
 
   /**
    * The method for this request

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/WSRequestHolderSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/WSRequestHolderSpec.scala
@@ -1,0 +1,32 @@
+package play.api.libs.ws
+
+import org.specs2.mutable.Specification
+import play.api.test.WithApplication
+
+class WSRequestHolderSpec extends Specification {
+
+  "WSRequestHolder" should {
+
+    "give the full URL with the query string" in new WithApplication() {
+
+      val ws = app.injector.instanceOf[WSClient]
+
+      ws.url("http://foo.com").uri.toString must equalTo("http://foo.com")
+
+      ws.url("http://foo.com").withQueryString("bar" -> "baz").uri.toString must equalTo("http://foo.com?bar=baz")
+
+      ws.url("http://foo.com").withQueryString("bar" -> "baz", "bar" -> "bah").uri.toString must equalTo("http://foo.com?bar=bah&bar=baz")
+
+    }
+
+    "correctly URL-encode the query string part" in new WithApplication() {
+
+      val ws = app.injector.instanceOf[WSClient]
+
+      ws.url("http://foo.com").withQueryString("&" -> "=").uri.toString must equalTo("http://foo.com?%26=%3D")
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
I frequently need to compute an URL without effectively performing an HTTP request (e.g. to compute the authorize URL of an OAuth server).

Unfortunately, the `url` method of `WSRequestHolder` does not include the query string.

This PR adds a `urlWithQueryString` method returing the complete URL.

May be related with #3247.
