### PR TITLE
Add support for binding to UUIDs from form data

### DIFF
--- a/framework/src/play/src/main/resources/messages.default
+++ b/framework/src/play/src/main/resources/messages.default
@@ -16,6 +16,7 @@ constraint.email=Email
 format.date=Date (''{0}'')
 format.numeric=Numeric
 format.real=Real
+format.uuid=UUID
 
 # --- Errors
 error.invalid=Invalid value
@@ -33,6 +34,7 @@ error.maxLength=Maximum length is {0}
 error.email=Valid email required
 error.pattern=Must satisfy {0}
 error.date=Valid date required
+error.uuid=Valid UUID required
 
 error.expected.date=Date value expected
 error.expected.date.isoformat=Iso date value expected

--- a/framework/src/play/src/main/scala/play/api/data/Forms.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Forms.scala
@@ -423,6 +423,16 @@ object Forms {
   val date: Mapping[java.util.Date] = of[java.util.Date]
 
   /**
+   * Constructs a simple mapping for a UUID field.
+   *
+   * For example:
+   * {{{
+   * Form("id" -> uuid)
+   * }}}
+   */
+  val uuid: Mapping[java.util.UUID] = of[java.util.UUID]
+
+  /**
    * Define a fixed value in a mapping.
    * This mapping will not participate to the binding.
    *

--- a/framework/src/play/src/main/scala/play/api/data/format/Format.scala
+++ b/framework/src/play/src/main/scala/play/api/data/format/Format.scala
@@ -3,6 +3,8 @@
  */
 package play.api.data.format
 
+import java.util.UUID
+
 import play.api.data._
 
 import annotation.implicitNotFound
@@ -266,9 +268,19 @@ object Formats {
 
   /**
    * Default formatter for `org.joda.time.LocalDate` type with pattern `yyyy-MM-dd`.
-   *
-   * @param pattern a date pattern as specified in `org.joda.time.format.DateTimeFormat`.
    */
   implicit val jodaLocalDateFormat: Formatter[org.joda.time.LocalDate] = jodaLocalDateFormat("yyyy-MM-dd")
+
+  /**
+   * Default formatter for the `java.util.UUID` type.
+   */
+  implicit def uuidFormat: Formatter[UUID] = new Formatter[UUID] {
+
+    override val format = Some(("format.uuid", Nil))
+
+    override def bind(key: String, data: Map[String, String]) = parsing(UUID.fromString, "error.uuid", Nil)(key, data)
+
+    override def unbind(key: String, value: UUID) = Map(key -> value.toString)
+  }
 
 }

--- a/framework/src/play/src/test/scala/play/api/data/format/FormatSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/format/FormatSpec.scala
@@ -4,7 +4,7 @@
 package play.api.data.format
 
 import org.specs2.mutable.Specification
-import java.util.{ Date, TimeZone }
+import java.util.{ UUID, Date, TimeZone }
 
 import play.api.data._
 import play.api.data.Forms._
@@ -56,4 +56,24 @@ object FormatSpec extends Specification {
     }
   }
 
+  "A UUID mapping" should {
+
+    "return a proper UUID when given one" in {
+
+      val testUUID = UUID.randomUUID()
+
+      Form("value" -> uuid).bind(Map("value" -> testUUID.toString)).fold(
+        formWithErrors => { "The mapping should not fail." must equalTo("Error") },
+        { uuid => uuid must equalTo(testUUID) }
+      )
+    }
+
+    "give an error when an invalid UUID is passed in" in {
+
+      Form("value" -> uuid).bind(Map("value" -> "Joe")).fold(
+        formWithErrors => { formWithErrors.errors.head.message must equalTo("error.uuid") },
+        { uuid => uuid must equalTo(UUID.randomUUID()) }
+      )
+    }
+  }
 }


### PR DESCRIPTION
Previously, you could bind to UUIDs from JSON but not form data. Now you can do both!
