### PR TITLE
Allow modules to be specified explicitly in code instead of play.modules file

### DIFF
--- a/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
@@ -1,0 +1,53 @@
+package play.api.inject.guice
+
+import org.specs2.mutable.Specification
+
+import com.google.inject.AbstractModule
+
+import play.api.ApplicationLoader.Context
+import play.api.Configuration
+import play.api.{ Mode, Environment }
+import play.core.DefaultWebCommands
+import play.api.inject.BuiltinModule
+
+class GuiceApplicationLoaderSpec extends Specification {
+
+  "GuiceApplicationLoader" should {
+    "allow adding additional modules" in {
+      val loader = new GuiceApplicationLoader(new AbstractModule {
+        def configure() = {
+          bind(classOf[Bar]) to classOf[MarsBar]
+        }
+      })
+      val app = loader.load(fakeContext)
+      app.injector.instanceOf[Bar] must beAnInstanceOf[MarsBar]
+    }
+    "allow replacing existing modules" in {
+      val loader = new GuiceApplicationLoader() {
+        override def loadModules(env: Environment, conf: Configuration) =
+          Seq(guicify(env, conf, new BuiltinModule), new ManualTestModule)
+      }
+      val app = loader.load(fakeContext)
+      app.injector.instanceOf[Foo] must beAnInstanceOf[ManualFoo]
+    }
+  }
+
+  def fakeContext = Context(
+    Environment(new java.io.File("."), getClass.getClassLoader, Mode.Test),
+    None,
+    new DefaultWebCommands,
+    Configuration.load(new java.io.File("."), Mode.Test)
+  )
+}
+
+class ManualTestModule extends AbstractModule {
+  def configure(): Unit = {
+    bind(classOf[Foo]) to classOf[ManualFoo]
+  }
+}
+
+trait Bar
+class MarsBar extends Bar
+
+trait Foo
+class ManualFoo extends Foo


### PR DESCRIPTION
I think the extra level of indirection of having the `play.modules` file is not particularly useful, and might end up confusing some users. I would much rather add modules by doing something like this:

``` scala
class MyApplicationLoader extends GuiceApplicationLoader {
  override lazy val additionalModules = Seq(new ModuleA, new ModuleB, ...)
}
```

This is extremely clear, type safe, and makes it obvious to users what is loading the application (the `ApplicationLoader`), so they can easily inspect its documentation and customize it more in the future.

The other problem with loading `play.modules` files is that other third-party libraries could define a file with modules that end up binding the same things as the user's modules. This creates conflicting bindings that are unclear to users, as the mechanism of loading modules is hidden from them.

This is also related to #3370.

I'm happy to work on this but I wanted to make sure everyone agreed with the reasoning first.
