### PR TITLE
Add fake application loader

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Plugins.scala
+++ b/framework/src/play/src/main/scala/play/api/Plugins.scala
@@ -54,9 +54,9 @@ private[play] object Plugin {
   type Deprecated = Plugin
 }
 
-class Plugins(plugins: => IndexedSeq[Plugin.Deprecated]) extends IndexedSeqLike[Plugin.Deprecated, IndexedSeq[Plugin.Deprecated]] with IndexedSeq[Plugin.Deprecated] {
+class Plugins(plugins: => Seq[Plugin.Deprecated]) extends IndexedSeqLike[Plugin.Deprecated, IndexedSeq[Plugin.Deprecated]] with IndexedSeq[Plugin.Deprecated] {
   // Fix circular dependency
-  private lazy val thePlugins = plugins
+  private lazy val thePlugins = plugins.toIndexedSeq
   def length = thePlugins.length
   def apply(idx: Int) = thePlugins(idx)
 }

--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
@@ -17,7 +17,9 @@ class GuiceLoadException(message: String) extends RuntimeException(message)
 /**
  * An ApplicationLoader that uses guice to bootstrap the application.
  */
-class GuiceApplicationLoader(val additionalModules: GuiceModule*) extends ApplicationLoader {
+class GuiceApplicationLoader(_additionalModules: GuiceModule*) extends ApplicationLoader {
+  val additionalModules: Seq[GuiceModule] = _additionalModules
+
   def this() = this(Seq.empty: _*)
 
   /**


### PR DESCRIPTION
Add a `FakeApplicationLoader` that wraps an `ApplicationLoader` and allows overriding various properties of the application. This complements Julien's changes in #3370.

Also implements a `FakeGuiceLoader` that can be used to load Guice apps.