### PR TITLE
[doc] [2.3.x] Fix JavaWS example to use secure defaults.

### DIFF
--- a/documentation/manual/detailedTopics/configuration/ws/code/HowsMySSLSpec.scala
+++ b/documentation/manual/detailedTopics/configuration/ws/code/HowsMySSLSpec.scala
@@ -1,13 +1,12 @@
 package detailedtopics.configuration.ws {
 
 // #context
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import play.api.libs.json.JsSuccess
 import play.api.libs.ws._
 import play.api.libs.ws.ning._
-import play.api.libs.ws.ssl.debug.DebugConfiguration
 import play.api.test._
 
-import com.typesafe.config.ConfigFactory
 import scala.concurrent.duration._
 
 class HowsMySSLSpec extends PlaySpecification {
@@ -16,9 +15,11 @@ class HowsMySSLSpec extends PlaySpecification {
     val classLoader = Thread.currentThread().getContextClassLoader
     val parser = new DefaultWSConfigParser(rawConfig, classLoader)
     val clientConfig = parser.parse()
-    clientConfig.ssl.map {
-      _.debug.map(new DebugConfiguration().configure)
-    }
+    // Debug flags only take effect in JSSE when DebugConfiguration().configure is called.
+    //import play.api.libs.ws.ssl.debug.DebugConfiguration
+    //clientConfig.ssl.map {
+    //   _.debug.map(new DebugConfiguration().configure)
+    //}
     val builder = new NingAsyncHttpClientConfigBuilder(clientConfig)
     val client = new NingWSClient(builder.build())
     client
@@ -32,14 +33,56 @@ class HowsMySSLSpec extends PlaySpecification {
   "WS" should {
 
     "verify common behavior" in {
-      val rawConfig = play.api.Configuration(ConfigFactory.parseString(
-        """
-          |ws.ssl.debug=["ssl"]
+
+      // GeoTrust SSL CA - G2 intermediate certificate not found in cert chain!
+      // See https://github.com/jmhodges/howsmyssl/issues/38 for details.
+      val geoTrustPem =
+        """-----BEGIN CERTIFICATE-----
+          |MIIEWTCCA0GgAwIBAgIDAjpjMA0GCSqGSIb3DQEBBQUAMEIxCzAJBgNVBAYT
+          |AlVTMRYwFAYDVQQKEw1HZW9UcnVzdCBJbmMuMRswGQYDVQQDExJHZW9UcnVz
+          |dCBHbG9iYWwgQ0EwHhcNMTIwODI3MjA0MDQwWhcNMjIwNTIwMjA0MDQwWjBE
+          |MQswCQYDVQQGEwJVUzEWMBQGA1UEChMNR2VvVHJ1c3QgSW5jLjEdMBsGA1UE
+          |AxMUR2VvVHJ1c3QgU1NMIENBIC0gRzIwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+          |DwAwggEKAoIBAQC5J/lP2Pa3FT+Pzc7WjRxr/X/aVCFOA9jK0HJSFbjJgltY
+          |eYT/JHJv8ml/vJbZmnrDPqnPUCITDoYZ2+hJ74vm1kfy/XNFCK6PrF62+J58
+          |9xD/kkNm7xzU7qFGiBGJSXl6Jc5LavDXHHYaKTzJ5P0ehdzgMWUFRxasCgdL
+          |LnBeawanazpsrwUSxLIRJdY+lynwg2xXHNil78zs/dYS8T/bQLSuDxjTxa9A
+          |kl0HXk7+Yhc3iemLdCai7bgK52wVWzWQct3YTSHUQCNcj+6AMRaraFX0DjtU
+          |6QRN8MxOgV7pb1JpTr6mFm1C9VH/4AtWPJhPc48Obxoj8cnI2d+87FLXAgMB
+          |AAGjggFUMIIBUDAfBgNVHSMEGDAWgBTAephojYn7qwVkDBF9qn1luMrMTjAd
+          |BgNVHQ4EFgQUEUrQcznVW2kIXLo9v2SaqIscVbwwEgYDVR0TAQH/BAgwBgEB
+          |/wIBADAOBgNVHQ8BAf8EBAMCAQYwOgYDVR0fBDMwMTAvoC2gK4YpaHR0cDov
+          |L2NybC5nZW90cnVzdC5jb20vY3Jscy9ndGdsb2JhbC5jcmwwNAYIKwYBBQUH
+          |AQEEKDAmMCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5nZW90cnVzdC5jb20w
+          |TAYDVR0gBEUwQzBBBgpghkgBhvhFAQc2MDMwMQYIKwYBBQUHAgEWJWh0dHA6
+          |Ly93d3cuZ2VvdHJ1c3QuY29tL3Jlc291cmNlcy9jcHMwKgYDVR0RBCMwIaQf
+          |MB0xGzAZBgNVBAMTElZlcmlTaWduTVBLSS0yLTI1NDANBgkqhkiG9w0BAQUF
+          |AAOCAQEAPOU9WhuiNyrjRs82lhg8e/GExVeGd0CdNfAS8HgY+yKk3phLeIHm
+          |TYbjkQ9C47ncoNb/qfixeZeZ0cNsQqWSlOBdDDMYJckrlVPg5akMfUf+f1Ex
+          |RF73Kh41opQy98nuwLbGmqzemSFqI6A4ZO6jxIhzMjtQzr+t03UepvTp+UJr
+          |YLLdRf1dVwjOLVDmEjIWE4rylKKbR6iGf9mY5ffldnRk2JG8hBYo2CVEMH6C
+          |2Kyx5MDkFWzbtiQnAioBEoW6MYhYR3TjuNJkpsMyWS4pS0XxW4lJLoKaxhgV
+          |RNAuZAEVaDj59vlmAwxVG52/AECu8EgnTOCAXi25KhV6vGb4NQ==
+          |-----END CERTIFICATE-----
+        """.stripMargin
+
+      val configString = """
+          |//ws.ssl.debug=["certpath", "ssl", "trustmanager"]
           |ws.ssl.protocol="TLSv1"
           |ws.ssl.enabledProtocols=["TLSv1"]
-        """.stripMargin))
+          |
+          |ws.ssl.trustManager = {
+          |  stores = [
+          |    { type: "PEM", data = ${geotrust.pem} }
+          |  ]
+          |}
+        """.stripMargin
+      val rawConfig = ConfigFactory.parseString(configString)
+      val configWithPem = rawConfig.withValue("geotrust.pem", ConfigValueFactory.fromAnyRef(geoTrustPem))
+      val configWithSystemProperties = ConfigFactory.load(configWithPem)
+      val playConfiguration = play.api.Configuration(configWithSystemProperties)
 
-      val client = createClient(rawConfig)
+      val client = createClient(playConfiguration)
       val response = await(client.url("https://www.howsmyssl.com/a/check").get())(5.seconds)
       response.status must be_==(200)
 

--- a/documentation/manual/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/javaGuide/main/ws/JavaWS.md
@@ -153,7 +153,9 @@ The default client can be called from the WS class:
 
 @[ws-client](code/javaguide/ws/JavaWS.java)
 
-You can define a WS client directly from code and use this for making requests.
+You can define a WS client directly from code and use this for making requests.  Note that you must follow a particular series of steps to use HTTPS correctly if you are defining a client directly:
+
+@[ws-custom-client-imports](code/javaguide/ws/JavaWS.java)
 
 @[ws-custom-client](code/javaguide/ws/JavaWS.java)
 
@@ -176,6 +178,10 @@ Use the following properties in `application.conf` to configure the WS client:
 * `ws.useProxyProperties`: To use the system http proxy settings(http.proxyHost, http.proxyPort) *(default is **true**)*. 
 * `ws.useragent`: To configure the User-Agent header field.
 * `ws.compressionEnable`: Set it to true to use gzip/deflater encoding *(default is **false**)*.
+
+### Configuring WS with SSL
+
+To configure WS for use with HTTP over SSL/TLS (HTTPS), please see [[Configuring WS SSL|WsSSL]].
 
 ### Timeouts
 

--- a/documentation/manual/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -20,149 +20,157 @@ import java.io.*;
 import org.w3c.dom.Document;
 import play.mvc.Result;
 
+// #ws-custom-client-imports
+import com.ning.http.client.*;
+import play.api.libs.ws.WSClientConfig;
+import play.api.libs.ws.DefaultWSClientConfig;
+import play.api.libs.ws.ssl.SSLConfig;
+import play.api.libs.ws.ning.NingAsyncHttpClientConfigBuilder;
+// #ws-custom-client-imports
+
 public class JavaWS {
     private static final String feedUrl = "http://localhost:3333/feed";
-    
+
     public static class Controller0 extends MockJavaAction {
-      
+
         public static void requestExamples() {
             // #ws-holder
             WSRequestHolder holder = WS.url("http://example.com");
             // #ws-holder
-          
+
             // #ws-complex-holder
             WSRequestHolder complexHolder = holder.setHeader("headerKey", "headerValue")
-                                                  .setTimeout(1000)
-                                                  .setQueryParameter("paramKey", "paramValue");
+                    .setTimeout(1000)
+                    .setQueryParameter("paramKey", "paramValue");
             // #ws-complex-holder
-            
+
             // #ws-get
             Promise<WSResponse> responsePromise = complexHolder.get();
             // #ws-get
-            
+
             String url = "http://example.com";
             // #ws-auth
             WS.url(url).setAuth("user", "password", WSAuthScheme.BASIC).get();
             // #ws-auth
-            
+
             // #ws-follow-redirects
             WS.url(url).setFollowRedirects(true).get();
             // #ws-follow-redirects
-            
+
             // #ws-query-parameter
             WS.url(url).setQueryParameter("paramKey", "paramValue");
             // #ws-query-parameter
-            
+
             // #ws-header
             WS.url(url).setHeader("headerKey", "headerValue").get();
             // #ws-header
-            
+
             String jsonString = "{\"key1\":\"value1\"}";
             // #ws-header-content-type
             WS.url(url).setHeader("Content-Type", "application/json").post(jsonString);
             // OR
             WS.url(url).setContentType("application/json").post(jsonString);
             // #ws-header-content-type
-            
+
             // #ws-timeout
             WS.url(url).setTimeout(1000).get();
             // #ws-timeout
-            
+
             // #ws-post-form-data
             WS.url(url).setContentType("application/x-www-form-urlencoded")
-                       .post("key1=value1&key2=value2");
+                    .post("key1=value1&key2=value2");
             // #ws-post-form-data
-            
+
             // #ws-post-json
             JsonNode json = Json.newObject()
-                                .put("key1", "value1")
-                                .put("key2", "value2");
-            
+                    .put("key1", "value1")
+                    .put("key2", "value2");
+
             WS.url(url).post(json);
             // #ws-post-json
         }
-        
+
         public static void responseExamples() {
-          
-          String url = "http://example.com";
-          
-          // #ws-response-json
-          Promise<JsonNode> jsonPromise = WS.url(url).get().map(
-              new Function<WSResponse, JsonNode>() {
-                  public JsonNode apply(WSResponse response) {
-                      JsonNode json = response.asJson();
-                      return json;
-                  }
-              }
-          );
-          // #ws-response-json
-          
-          // #ws-response-xml
-          Promise<Document> documentPromise = WS.url(url).get().map(
-              new Function<WSResponse, Document>() {
-                  public Document apply(WSResponse response) {
-                      Document xml = response.asXml();
-                      return xml;
-                  }
-              }
-          );
-          // #ws-response-xml
-          
-          // #ws-response-input-stream
-          final Promise<File> filePromise = WS.url(url).get().map(
-              new Function<WSResponse, File>() {
-                  public File apply(WSResponse response) throws Throwable {
-                    
-                      InputStream inputStream = null;
-                      OutputStream outputStream = null;
-                      try {
-                          inputStream = response.getBodyAsStream();
-                        
-                          // write the inputStream to a File
-                          final File file = new File("/tmp/response.txt");
-                          outputStream = new FileOutputStream(file);
-                        
-                          int read = 0;
-                          byte[] buffer = new byte[1024];
-               
-                          while ((read = inputStream.read(buffer)) != -1) {
-                              outputStream.write(buffer, 0, read);
-                          }
-                      
-                          return file;  
-                      } catch (IOException e) {
-                          throw e;
-                      } finally {
-                          if (inputStream != null) {inputStream.close();}
-                          if (outputStream != null) {outputStream.close();}
-                      }
-                      
-                  }
-              }
-          );
-          // #ws-response-input-stream
+
+            String url = "http://example.com";
+
+            // #ws-response-json
+            Promise<JsonNode> jsonPromise = WS.url(url).get().map(
+                    new Function<WSResponse, JsonNode>() {
+                        public JsonNode apply(WSResponse response) {
+                            JsonNode json = response.asJson();
+                            return json;
+                        }
+                    }
+            );
+            // #ws-response-json
+
+            // #ws-response-xml
+            Promise<Document> documentPromise = WS.url(url).get().map(
+                    new Function<WSResponse, Document>() {
+                        public Document apply(WSResponse response) {
+                            Document xml = response.asXml();
+                            return xml;
+                        }
+                    }
+            );
+            // #ws-response-xml
+
+            // #ws-response-input-stream
+            final Promise<File> filePromise = WS.url(url).get().map(
+                    new Function<WSResponse, File>() {
+                        public File apply(WSResponse response) throws Throwable {
+
+                            InputStream inputStream = null;
+                            OutputStream outputStream = null;
+                            try {
+                                inputStream = response.getBodyAsStream();
+
+                                // write the inputStream to a File
+                                final File file = new File("/tmp/response.txt");
+                                outputStream = new FileOutputStream(file);
+
+                                int read = 0;
+                                byte[] buffer = new byte[1024];
+
+                                while ((read = inputStream.read(buffer)) != -1) {
+                                    outputStream.write(buffer, 0, read);
+                                }
+
+                                return file;
+                            } catch (IOException e) {
+                                throw e;
+                            } finally {
+                                if (inputStream != null) {inputStream.close();}
+                                if (outputStream != null) {outputStream.close();}
+                            }
+
+                        }
+                    }
+            );
+            // #ws-response-input-stream
         }
-        
+
         public static void patternExamples() {
             String urlOne = "http://localhost:3333/one";
             // #ws-composition
             final Promise<WSResponse> responseThreePromise = WS.url(urlOne).get().flatMap(
-                new Function<WSResponse, Promise<WSResponse>>() {
-                    public Promise<WSResponse> apply(WSResponse responseOne) {
-                        String urlTwo = responseOne.getBody();
-                        return WS.url(urlTwo).get().flatMap(
-                            new Function<WSResponse, Promise<WSResponse>>() {
-                                public Promise<WSResponse> apply(WSResponse responseTwo) {
-                                    String urlThree = responseTwo.getBody();
-                                    return WS.url(urlThree).get();
-                                }
-                            }
-                        );
+                    new Function<WSResponse, Promise<WSResponse>>() {
+                        public Promise<WSResponse> apply(WSResponse responseOne) {
+                            String urlTwo = responseOne.getBody();
+                            return WS.url(urlTwo).get().flatMap(
+                                    new Function<WSResponse, Promise<WSResponse>>() {
+                                        public Promise<WSResponse> apply(WSResponse responseTwo) {
+                                            String urlThree = responseTwo.getBody();
+                                            return WS.url(urlThree).get();
+                                        }
+                                    }
+                            );
+                        }
                     }
-                }
             );
             // #ws-composition
-            
+
             // #ws-recover
             Promise<WSResponse> responsePromise = WS.url("http://example.com").get();
             Promise<WSResponse> recoverPromise = responsePromise.recoverWith(new Function<Throwable, Promise<WSResponse>>() {
@@ -173,28 +181,49 @@ public class JavaWS {
             });
             // #ws-recover
         }
-        
+
         public static void clientExamples() {
             // #ws-client
             WSClient client = WS.client();
             // #ws-client
-            
+
             // #ws-custom-client
-            com.ning.http.client.AsyncHttpClientConfig customConfig =
-                new com.ning.http.client.AsyncHttpClientConfig.Builder()
-                    .setProxyServer(new com.ning.http.client.ProxyServer("127.0.0.1", 38080))
-                    .setCompressionEnabled(true)
-                    .build();
+            // Set up the client config (you can also use a parser here):
+            scala.Option<Object> none = scala.None$.empty();
+            scala.Option<String> noneString = scala.None$.empty();
+            scala.Option<SSLConfig> noneSSLConfig = scala.None$.empty();
+            WSClientConfig clientConfig = new DefaultWSClientConfig(
+                    none, // connectionTimeout
+                    none, // idleTimeout
+                    none, // requestTimeout
+                    none, // followRedirects
+                    none, // useProxyProperties
+                    noneString, // userAgent
+                    none, // compressionEnabled
+                    none, // acceptAnyCertificate
+                    noneSSLConfig);
+
+            // Build a secure config out of the client config and the ning builder:
+            AsyncHttpClientConfig.Builder asyncHttpClientBuilder = new AsyncHttpClientConfig.Builder();
+            NingAsyncHttpClientConfigBuilder secureBuilder = new NingAsyncHttpClientConfigBuilder(clientConfig,
+                    asyncHttpClientBuilder);
+            AsyncHttpClientConfig secureDefaults = secureBuilder.build();
+
+            // You can directly use the builder for specific options once you have secure TLS defaults...
+           AsyncHttpClientConfig customConfig = new AsyncHttpClientConfig.Builder(secureDefaults)
+                            .setProxyServer(new com.ning.http.client.ProxyServer("127.0.0.1", 38080))
+                            .setCompressionEnabled(true)
+                            .build();
             WSClient customClient = new play.libs.ws.ning.NingWSClient(customConfig);
-            
+
             Promise<WSResponse> responsePromise = customClient.url("http://example.com/feed").get();
             // #ws-custom-client
-            
+
             // #ws-underlying-client
-            com.ning.http.client.AsyncHttpClient underlyingClient = 
-                (com.ning.http.client.AsyncHttpClient) WS.client().getUnderlying();
+            com.ning.http.client.AsyncHttpClient underlyingClient =
+                    (com.ning.http.client.AsyncHttpClient) WS.client().getUnderlying();
             // #ws-underlying-client
-            
+
         }
     }
 
@@ -235,5 +264,5 @@ public class JavaWS {
         }
         // #composed-call
     }
-    
+
 }


### PR DESCRIPTION
There needs to be a better API for creating new WSClient on the fly, but for now this is the simplest(!) thing to do to enable hostname validation.  See the corresponding Scala PR https://github.com/playframework/playframework/pull/3393 for more details.

Also fix lack of intermediate certificate in howsmyssl.com causing the integration test to fail (also filed   https://github.com/jmhodges/howsmyssl/issues/38).
Also remove tabs inside of JavaWS.scala.
