### PR TITLE
Update to asynchttpclient 1.8.14

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -196,7 +196,7 @@ object Dependencies {
 
   val playWsDeps = Seq(
     guava,
-    "com.ning" % "async-http-client" % "1.8.8",
+    "com.ning" % "async-http-client" % "1.8.14",
     "oauth.signpost" % "signpost-core" % "1.2.1.2",
     "oauth.signpost" % "signpost-commonshttp4" % "1.2.1.2") ++
     specsBuild.map(_ % "test") :+

--- a/framework/src/play-java-ws/src/test/scala/play/libs/ws/ning/NingWSSpec.scala
+++ b/framework/src/play-java-ws/src/test/scala/play/libs/ws/ning/NingWSSpec.scala
@@ -27,13 +27,13 @@ object NingWSSpec extends Specification with Mockito {
 
     "should respond to getMethod" in {
       val client = mock[NingWSClient]
-      val request : NingWSRequest = new NingWSRequest(client, "GET", "", emptyMap, emptyMap)
+      val request : NingWSRequest = new NingWSRequest(client, "GET", "http://example.com", emptyMap, emptyMap)
       request.getMethod must be_==("GET")
     }
 
     "should set virtualHost appropriately" in {
       val client = mock[NingWSClient]
-      val request = new NingWSRequest(client, "GET", "", emptyMap, emptyMap)
+      val request = new NingWSRequest(client, "GET", "http://example.com", emptyMap, emptyMap)
       request.setVirtualHost("foo.com")
       val actual = request.getBuilder().build().getVirtualHost()
       actual must beEqualTo("foo.com")


### PR DESCRIPTION
Fixes the error when hostname validation fails in WS SSL (see https://github.com/playframework/playframework/issues/2767 and https://github.com/AsyncHttpClient/async-http-client/issues/555)
