### PR TITLE
Allow a manually set remote address for a fake request

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/FakeRequest.java
+++ b/framework/src/play-test/src/main/java/play/test/FakeRequest.java
@@ -46,7 +46,7 @@ public class FakeRequest {
      * @return the Fake Request
      */
     @SuppressWarnings(value = "unchecked")
-    public FakeRequest fromRemoteAddress(String remoteAddress) {
+    public FakeRequest withRemoteAddress(String remoteAddress) {
         fake = new play.api.test.FakeRequest(fake.method(), fake.uri(), fake.headers(), fake.body(), remoteAddress, fake.version(), fake.id(), fake.tags(), fake.secure());
         return this;
     }


### PR DESCRIPTION
Provides a quick way to change the remote address for a fake request. I needed to simulate different IP-addresses for security-tests.
