### PR TITLE
Allow a manually set remote address for a fake request [Java]

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/FakeRequest.java
+++ b/framework/src/play-test/src/main/java/play/test/FakeRequest.java
@@ -41,6 +41,17 @@ public class FakeRequest {
     }
 
     /**
+     * Change the remote-address for this request.
+     * @param remoteAddress the remote address, e.g. "127.0.0.1"
+     * @return the Fake Request
+     */
+    @SuppressWarnings(value = "unchecked")
+    public FakeRequest withRemoteAddress(String remoteAddress) {
+        fake = new play.api.test.FakeRequest(fake.method(), fake.uri(), fake.headers(), fake.body(), remoteAddress, fake.version(), fake.id(), fake.tags(), fake.secure());
+        return this;
+    }
+
+    /**
      * Add additional headers to this request.
      */
     @SuppressWarnings(value = "unchecked")


### PR DESCRIPTION
Provides a quick way to change the remote address for a fake request. I needed to simulate different IP-addresses for security-tests.

Note: new PR against master. Old PR now closed: https://github.com/playframework/playframework/pull/3452
