### PR TITLE
Cannot modify PLAY_SESSION when calling with no cookie and CSRF token is added to session 

### DIFF
--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -33,15 +33,20 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
             ctx.args.put(requestTag, newToken);
 
             // Create a new Scala RequestHeader with the token
-            RequestHeader newRequest = request.copy(request.id(),
+            final RequestHeader newRequest = request.copy(request.id(),
                     request.tags().$plus(new Tuple2<String, String>(requestTag, newToken)),
                     request.uri(), request.path(), request.method(), request.version(), request.queryString(),
                     request.headers(), request.remoteAddress(), request.secure());
 
             // Create a new context that will have the new RequestHeader.  This ensures that the CSRF.getToken call
             // used in templates will find the token.
-            Http.Context newCtx = new Http.Context(ctx.id(), newRequest, ctx.request(), ctx.session(), ctx.flash(),
-                    ctx.args);
+            Http.Context newCtx = new Http.WrappedContext(ctx) {
+                @Override
+                public RequestHeader _requestHeader() {
+                    return newRequest;
+                }
+            };
+
             Http.Context.current.set(newCtx);
 
             // Also add it to the response

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -9,6 +9,7 @@ import java.util.*;
 import org.w3c.dom.*;
 import com.fasterxml.jackson.databind.JsonNode;
 
+import play.api.mvc.RequestHeader;
 import play.i18n.Lang;
 import play.Play;
 import play.i18n.Langs;
@@ -211,6 +212,71 @@ public class Http {
             return "Context attached to (" + request() + ")";
         }
 
+    }
+
+    /**
+     * A wrapped context.
+     *
+     * Use this to modify the context in some way.
+     */
+    public static abstract class WrappedContext extends Context {
+        private final Context wrapped;
+
+        public WrappedContext(Context wrapped) {
+            super(wrapped.id(), wrapped._requestHeader(), wrapped.request(), wrapped.session(), wrapped.flash(), wrapped.args);
+            this.args = wrapped.args;
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public Long id() {
+            return wrapped.id();
+        }
+
+        @Override
+        public Request request() {
+            return wrapped.request();
+        }
+
+        @Override
+        public Response response() {
+            return wrapped.response();
+        }
+
+        @Override
+        public Session session() {
+            return wrapped.session();
+        }
+
+        @Override
+        public Flash flash() {
+            return wrapped.flash();
+        }
+
+        @Override
+        public play.api.mvc.RequestHeader _requestHeader() {
+            return wrapped._requestHeader();
+        }
+
+        @Override
+        public Lang lang() {
+            return wrapped.lang();
+        }
+
+        @Override
+        public boolean changeLang(String code) {
+            return wrapped.changeLang(code);
+        }
+
+        @Override
+        public boolean changeLang(Lang lang) {
+            return wrapped.changeLang(lang);
+        }
+
+        @Override
+        public void clearLang() {
+            wrapped.clearLang();
+        }
     }
 
     public abstract static class RequestHeader {


### PR DESCRIPTION
Using Play for Java version 2.2.3

I've created a small sample app here: https://github.com/Ronnie76er/play-csrf-issue.  

What I'm trying to do is add another variable to the play session.  It works fine when a cookie with a CSRF token is already established.  However, if you call the endpoint with no cookie, you cannot modify the session any further.  

I believe what is happening is that Http.Context.current() doesn't get you the current context that's going to be returned with the call, therefore your modifications to the session are useless.
