### PR TITLE
DI for CSRF filter

### DIFF
--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -1,0 +1,3 @@
+play.modules {
+  enabled += "play.filters.csrf.CSRFModule"
+}

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/ScalaCSRFActionSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/ScalaCSRFActionSpec.scala
@@ -42,6 +42,6 @@ object ScalaCSRFActionSpec extends CSRFCommonSpecs {
 
   class CustomErrorHandler extends CSRF.ErrorHandler {
     import play.api.mvc.Results.Unauthorized
-    def handle(req: RequestHeader, msg: String) = Unauthorized(msg)
+    def handle(req: RequestHeader, msg: String) = Future.successful(Unauthorized(msg))
   }
 }


### PR DESCRIPTION
The CSRF filter (and other components) should use DI.  If possible, existing zero arg constructors should still work, but I don't think we need to worry about maintaining backwards compatibility if you want to configure it.

The approach:
- The CSRF filter should have three dependencies, a configuration object, a TokenProvider and an ErrorHandler
- A CSRF module should provide bindings for these dependencies and the filter itself
- The module should however not be installed by default, so by default, users will have to add the module to Play via whatever mechanisms we provide for doing that (configuration or programmatic)
- If a user wants to provide a custom CSRF configuration, then rather than including the module, they can provide their own bindings.
