### PR TITLE
Anorm causes queries with comments to be invalid

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/SqlStatementParser.scala
+++ b/framework/src/anorm/src/main/scala/anorm/SqlStatementParser.scala
@@ -25,7 +25,7 @@ object SqlStatementParser extends JavaTokenParsers {
    * }}}
    */
   def parse(sql: String): (String, List[String]) = {
-    val r = parse(instr, sql.trim().replace("\r", "").replace("\n", " ")).get
+    val r = parse(instr, sql.trim()).get
     (r.flatMap(_._1).mkString, (r.flatMap(_._2)))
   }
 
@@ -39,7 +39,7 @@ object SqlStatementParser extends JavaTokenParsers {
     case i1 ~ i2 => ("%s": String, Some(i1 + i2.map("." + _).getOrElse("")))
   }
 
-  private val other: Parser[(String, Option[String])] = """.""".r ^^ {
+  private val other: Parser[(String, Option[String])] = """(.|[\r\n])""".r ^^ {
     case element => (element, None)
   }
 

--- a/framework/src/anorm/src/test/scala/anorm/StatementParserSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/StatementParserSpec.scala
@@ -8,12 +8,13 @@ object StatementParserSpec extends org.specs2.mutable.Specification {
   "SQL statement parser" title
 
   "Statement" should {
-    "be parsed with 'name' and 'cat' parameters" in {
+    "be parsed with 'name' and 'cat' parameters and support multiple lines" in {
       SqlStatementParser.parse("""
         SELECT * FROM schema.table 
         WHERE (name = {name} AND category = {cat}) OR id = ?
       """) aka "updated statement and parameters" mustEqual (
-        "SELECT * FROM schema.table          WHERE (name = %s AND category = %s) OR id = ?" -> List("name", "cat"))
+        """SELECT * FROM schema.table 
+        WHERE (name = %s AND category = %s) OR id = ?""" -> List("name", "cat"))
     }
 
     "detect missing query parameter" in withQueryResult(stringList :+ "test") {


### PR DESCRIPTION
Anorm's SqlStatementParser.parse function causes bugs, or worse, silent failures. It does this by stripping newlines, which can cause a valid sql statements to be truncated at the first comment.

```
select
    1
--some comment
  , 2
```

The above will silently cause a bug. This is because after parse() transforms the query, it becomes

```
select 1 --some comment , 2
```

which return a result set with one column instead of two.

Comments inside of queries are used heavily in code that creates triggers, functions, and so on. As a temporary fix I'm removing comments from generated code, but that's not the ideal situation.

Jeff
