### PR TITLE
anorm 2.4 execute() is ambiguous

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/package.scala
+++ b/framework/src/anorm/src/main/scala/anorm/package.scala
@@ -16,12 +16,9 @@
 package object anorm {
   import scala.language.implicitConversions
 
+  // TODO: Review implicit usage there 
+  // (add explicit functions on SqlQuery?)
   implicit def sqlToSimple(sql: SqlQuery): SimpleSql[Row] = sql.asSimple
-
-  @deprecated(
-    message = """Directly use BatchSql("stmt", params)""",
-    since = "2.3.1")
-  implicit def sqlToBatch(sql: SqlQuery): BatchSql = sql.asBatch
 
   implicit def implicitID[ID](id: Id[ID]): ID = id.id
 

--- a/framework/src/anorm/src/test/scala/anorm/AnormSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/AnormSpec.scala
@@ -453,6 +453,17 @@ object AnormSpec extends Specification with H2Database with AnormTest {
         aka("insertion") must beSome("generated")
     }
   }
+
+  "Query" should {
+    "be executed as simple SQL" in withQueryResult(
+      RowLists.booleanList :+ true) { implicit con =>
+        val sql = SQL("SELECT 1")
+
+        implicitly[Sql](sql).
+          aka("converted") must beAnInstanceOf[SimpleSql[_]] and (
+            SQL("SELECT 1").execute() aka "executed" must beTrue)
+      }
+  }
 }
 
 sealed trait AnormTest { db: H2Database =>


### PR DESCRIPTION
Hello,
The execute method is gotten via an implicit conversion to SimpleSql or BatchSql, but both are in scope by default. This means that SQL(query).execute() fails during compilation with an ambiguous conversion error. Probably "implicit def sqlToBatch" should be removed from package anorm since it is deprecated anyway, or documentation needs to be updated since it references execute() directly on an SqlQuery. See section "Executing SQL queries" https://www.playframework.com/documentation/2.4.x/ScalaAnorm.

Jeff
