### PR TITLE
Refactor SqlQuery case class: backport #3027

### DIFF
--- a/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
+++ b/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
@@ -75,13 +75,25 @@ To execute an update, you can use `executeUpdate()`, which returns the number of
 val result: Int = SQL("delete from City where id = 99").executeUpdate()
 ```
 
-If you are inserting data that has an auto-generated `Long` primary key, you can call `executeInsert()`. If you have more than one generated key, or it is not a Long, `executeInsert` can be passed a `ResultSetParser` to return the correct key.
+If you are inserting data that has an auto-generated `Long` primary key, you can call `executeInsert()`.
 
 ```scala
 val id: Option[Long] = 
   SQL("insert into City(name, country) values ({name}, {country})")
   .on('name -> "Cambridge", 'country -> "New Zealand").executeInsert()
 ```
+
+When key generated on insertion is not a single `Long`, `executeInsert` can be passed a `ResultSetParser` to return the correct key.
+
+```scala
+import anorm.SqlParser.str
+
+val id: List[String] = 
+  SQL("insert into City(name, country) values ({name}, {country})")
+  .on('name -> "Cambridge", 'country -> "New Zealand")
+  .executeInsert(str.+) // insertion returns a list of at least one string keys
+```
+
 Since Scala supports multi-line strings, feel free to use them for complex SQL statements:
 
 ```scala
@@ -105,6 +117,8 @@ SQL(
   """
 ).on("countryCode" -> "FRA")
 ```
+
+You can also use string interpolation to pass parameters (see details thereafter).
 
 In case several columns are found with same name in query result, for example columns named `code` in both `Country` and `CountryLanguage` tables, there can be ambiguity. By default a mapping like following one will use the last column:
 
@@ -150,6 +164,60 @@ val product: (String, Float) = SQL("SELECT * FROM prod WHERE id = {id}").
 
 `java.util.UUID` can be used as parameter, in which case its string value is passed to statement.
 
+### SQL queries using String Interpolation
+
+Since Scala 2.10 supports custom String Interpolation there is also a 1-step alternative to `SQL(queryString).on(params)` seen before. You can abbreviate the code as: 
+
+```scala
+val name = "Cambridge"
+val country = "New Zealand"
+
+SQL"insert into City(name, country) values ($name, $country)")
+```
+
+It also supports multi-line string and inline expresions:
+
+```scala
+val lang = "French"
+val population = 10000000
+val margin = 500000
+
+val code: String = SQL"""
+  select * from Country c 
+    join CountryLanguage l on l.CountryCode = c.Code 
+    where l.Language = $lang and c.Population >= ${population - margin}
+    order by c.Population desc limit 1"""
+  .as(SqlParser.str("Country.code").single)
+```
+
+This feature tries to make faster, more concise and easier to read the way to retrieve data in Anorm. Please, feel free to use it wherever you see a combination of `SQL().on()` functions (or even an only `SQL()` without parameters).
+
+## Retrieving data using the Stream API
+
+The first way to access the results of a select query is to use the Stream API.
+
+When you call `apply()` on any SQL statement, you will receive a lazy `Stream` of `Row` instances, where each row can be seen as a dictionary:
+
+```scala
+// Create an SQL query
+val selectCountries = SQL("Select * from Country")
+ 
+// Transform the resulting Stream[Row] to a List[(String,String)]
+val countries = selectCountries().map(row => 
+  row[String]("code") -> row[String]("name")
+).toList
+```
+
+In the following example we will count the number of `Country` entries in the database, so the result set will be a single row with a single column:
+
+```scala
+// First retrieve the first row
+val firstRow = SQL("Select count(*) as c from Country").apply().head
+ 
+// Next get the content of the 'c' column as Long
+val countryCount = firstRow[Long]("c")
+```
+
 ### Using multi-value parameter
 
 Anorm parameter can be multi-value, like a sequence of string.
@@ -174,6 +242,23 @@ EXISTS (SELECT NULL FROM j WHERE t.id=j.id AND name='a')
 OR EXISTS (SELECT NULL FROM j WHERE t.id=j.id AND name='b') 
 OR EXISTS (SELECT NULL FROM j WHERE t.id=j.id AND name='c')
 */
+```
+
+### Batch update
+
+When you need to execute SQL statement several times with different arguments, batch query can be used (e.g. to execute a batch of insertions).
+
+```scala
+import anorm.BatchSql
+
+val batch = BatchSql(
+  "INSERT INTO books(title, author) VALUES({title}, {author}", 
+  Seq(Seq[NamedParameter](
+    "title" -> "Play 2 for Scala", "author" -> Peter Hilton"),
+    Seq[NamedParameter]("title" -> "Learning Play! Framework 2",
+      "author" -> "Andy Petrella")))
+
+val res: Array[Int] = batch.execute() // array of update count
 ```
 
 ### Edge cases
@@ -245,60 +330,6 @@ SQL("UPDATE item SET last_modified = {mod} WHERE id = {id}").on(params:_*)
 
 It's not recommanded because moreover hiding implicit resolution issues, as untyped it could lead to runtime conversion error, with values are passed on statement using `setObject`.
 In previous example, `java.util.Date` is accepted as parameter but would with most databases raise error (as it's not valid JDBC type).
-
-### SQL queries using String Interpolation
-
-Since Scala 2.10 supports custom String Interpolation there is also a 1-step alternative to `SQL(queryString).on(params)` seen before. You can abbreviate the code as: 
-
-```scala
-val name = "Cambridge"
-val country = "New Zealand"
-
-SQL"insert into City(name, country) values ($name, $country)")
-```
-
-It also supports multi-line string and inline expresions:
-
-```scala
-val lang = "French"
-val population = 10000000
-val margin = 500000
-
-val code: String = SQL"""
-  select * from Country c 
-    join CountryLanguage l on l.CountryCode = c.Code 
-    where l.Language = $lang and c.Population >= ${population - margin}
-    order by c.Population desc limit 1"""
-  .as(SqlParser.str("Country.code").single)
-```
-
-This feature tries to make faster, more concise and easier to read the way to retrieve data in Anorm. Please, feel free to use it wherever you see a combination of `SQL().on()` functions (or even an only `SQL()` without parameters).
-
-## Retrieving data using the Stream API
-
-The first way to access the results of a select query is to use the Stream API.
-
-When you call `apply()` on any SQL statement, you will receive a lazy `Stream` of `Row` instances, where each row can be seen as a dictionary:
-
-```scala
-// Create an SQL query
-val selectCountries = SQL("Select * from Country")
- 
-// Transform the resulting Stream[Row] to a List[(String,String)]
-val countries = selectCountries().map(row => 
-  row[String]("code") -> row[String]("name")
-).toList
-```
-
-In the following example we will count the number of `Country` entries in the database, so the result set will be a single row with a single column:
-
-```scala
-// First retrieve the first row
-val firstRow = SQL("Select count(*) as c from Country").apply().head
- 
-// Next get the content of the 'c' column as Long
-val countryCount = firstRow[Long]("c")
-```
 
 ## Using Pattern Matching
 

--- a/framework/src/anorm/src/main/scala/anorm/BatchSql.scala
+++ b/framework/src/anorm/src/main/scala/anorm/BatchSql.scala
@@ -31,7 +31,7 @@ sealed trait BatchSql {
       val ks = ps.keySet
 
       if (!BatchSql.matchPlaceholders(sql, ks))
-        throw new IllegalArgumentException(s"""Expected parameter names don't correspond to placeholders in query: ${ks mkString ", "} not matching ${sql.argsInitialOrder mkString ", "}""")
+        throw new IllegalArgumentException(s"""Expected parameter names don't correspond to placeholders in query: ${ks mkString ", "} not matching ${sql.paramsInitialOrder mkString ", "}""")
 
       copy(names = ks, params = Seq(ps))
     } else copy(params = this.params :+ checkedMap(args))
@@ -49,7 +49,7 @@ sealed trait BatchSql {
 
   /**
    * Adds a parameter map, created by zipping values with query placeholders
-   * ([[SqlQuery.argsInitialOrder]]). If parameter is used for more than one
+   * ([[SqlQuery.paramsInitialOrder]]). If parameter is used for more than one
    * placeholder, it will result in a parameter map with smaller size than
    * given arguments (as duplicate entry are removed from map).
    */
@@ -58,9 +58,9 @@ sealed trait BatchSql {
   def addBatchParams(args: ParameterValue*): BatchSql = {
     if (params.isEmpty) {
       BatchSql.Checked(sql,
-        Seq(Sql.zipParams(sql.argsInitialOrder, args, Map.empty)))
+        Seq(Sql.zipParams(sql.paramsInitialOrder, args, Map.empty)))
     } else {
-      val m = checkedMap(sql.argsInitialOrder.zip(args).
+      val m = checkedMap(sql.paramsInitialOrder.zip(args).
         foldLeft(Seq[NamedParameter]())((ps, t) =>
           ps :+ implicitly[NamedParameter](t)))
 
@@ -70,7 +70,7 @@ sealed trait BatchSql {
 
   /**
    * Adds a parameter maps, created by zipping values with query placeholders
-   * ([[SqlQuery.argsInitialOrder]]). If parameter is used for more than one
+   * ([[SqlQuery.paramsInitialOrder]]). If parameter is used for more than one
    * placeholder, it will result in parameter maps with smaller size than
    * given arguments (as duplicate entry are removed from map).
    */
@@ -79,10 +79,10 @@ sealed trait BatchSql {
   def addBatchParamsList(args: Traversable[Seq[ParameterValue]]): BatchSql = {
     if (params.isEmpty) {
       BatchSql.Checked(sql,
-        args.map(Sql.zipParams(sql.argsInitialOrder, _, Map.empty)))
+        args.map(Sql.zipParams(sql.paramsInitialOrder, _, Map.empty)))
 
     } else {
-      val ms = args.map(x => checkedMap(sql.argsInitialOrder.zip(x).
+      val ms = args.map(x => checkedMap(sql.paramsInitialOrder.zip(x).
         foldLeft(Seq[NamedParameter]())((ps, t) =>
           ps :+ implicitly[NamedParameter](t))))
 
@@ -116,18 +116,18 @@ sealed trait BatchSql {
   private def fill(con: Connection, statement: PreparedStatement, getGeneratedKeys: Boolean = false, pm: Seq[Map[String, ParameterValue]]): PreparedStatement =
     (statement, pm.headOption) match {
       case (null, Some(ps)) => { // First
-        val st: (String, Seq[(Int, ParameterValue)]) =
-          Sql.prepareQuery(sql.query, 0, sql.argsInitialOrder.map(ps), Nil)
+        val st: (String, Seq[(Int, ParameterValue)]) = Sql.prepareQuery(
+          sql.statement, 0, sql.paramsInitialOrder.map(ps), Nil)
 
         val stmt = if (getGeneratedKeys) con.prepareStatement(st._1, java.sql.Statement.RETURN_GENERATED_KEYS) else con.prepareStatement(st._1)
 
-        sql.queryTimeout.foreach(timeout => stmt.setQueryTimeout(timeout))
+        sql.timeout.foreach(stmt.setQueryTimeout(_))
 
         fill(con, addBatchParams(stmt, st._2), getGeneratedKeys, pm.tail)
       }
       case (stmt, Some(ps)) => {
-        val vs: Seq[(Int, ParameterValue)] =
-          Sql.prepareQuery(sql.query, 0, sql.argsInitialOrder.map(ps), Nil)._2
+        val vs: Seq[(Int, ParameterValue)] = Sql.prepareQuery(
+          sql.statement, 0, sql.paramsInitialOrder.map(ps), Nil)._2
 
         fill(con, addBatchParams(stmt, vs), getGeneratedKeys, pm.tail)
       }
@@ -156,8 +156,8 @@ sealed trait BatchSql {
 object BatchSql {
   @throws[IllegalArgumentException](BatchSqlErrors.HeterogeneousParameterMaps)
   @throws[IllegalArgumentException](BatchSqlErrors.ParameterNamesNotMatchingPlaceholders)
-  def apply(query: SqlQuery, ps: Seq[Seq[NamedParameter]] = Nil): BatchSql =
-    Checked(query, ps.map(_.map(_.tupled).toMap))
+  def apply(sql: String, ps: Seq[Seq[NamedParameter]] = Nil): BatchSql =
+    Checked(SQL(sql), ps.map(_.map(_.tupled).toMap))
 
   @throws[IllegalArgumentException](BatchSqlErrors.HeterogeneousParameterMaps)
   @throws[IllegalArgumentException](BatchSqlErrors.ParameterNamesNotMatchingPlaceholders)
@@ -166,7 +166,7 @@ object BatchSql {
       val ks = m.keySet
 
       if (!matchPlaceholders(query, ks))
-        throw new IllegalArgumentException(s"""Expected parameter names don't correspond to placeholders in query: ${ks mkString ", "} not matching ${query.argsInitialOrder mkString ", "}""")
+        throw new IllegalArgumentException(s"""Expected parameter names don't correspond to placeholders in query: ${ks mkString ", "} not matching ${query.paramsInitialOrder mkString ", "}""")
 
       paramNames(ps.tail, m.keySet) match {
         case Left(err) => throw new IllegalArgumentException(err)
@@ -174,9 +174,11 @@ object BatchSql {
       }
     }
 
-  /** Checks whether parameter `names` matches [[SqlQuery.argsInitialOrder]] */
+  /**
+   * Checks whether parameter `names` matches [[SqlQuery.paramsInitialOrder]].
+   */
   @inline private[anorm] def matchPlaceholders(query: SqlQuery, names: Set[String]): Boolean = {
-    val pl = query.argsInitialOrder.toSet
+    val pl = query.paramsInitialOrder.toSet
     (pl.size == names.size && pl.intersect(names).size == names.size)
   }
 

--- a/framework/src/anorm/src/main/scala/anorm/SqlQuery.scala
+++ b/framework/src/anorm/src/main/scala/anorm/SqlQuery.scala
@@ -1,0 +1,77 @@
+package anorm
+
+import java.sql.{ Connection, PreparedStatement }
+
+/** Initial SQL query, without parameter values. */
+sealed trait SqlQuery {
+  /** SQL statement */
+  def statement: String
+
+  @deprecated(message = "Use [[statement]]", since = "2.3.1")
+  final def query = statement
+
+  /** Names of parameters in initial order */
+  def paramsInitialOrder: List[String]
+
+  @deprecated(message = "Use [[paramsInitialOrder]]", since = "2.3.1")
+  final def argsInitialOrder = paramsInitialOrder
+
+  /** Execution timeout */
+  def timeout: Option[Int]
+
+  @deprecated(message = "Use [[timeout]]", since = "2.3.1")
+  final def queryTimeout = timeout
+
+  def getFilledStatement(connection: Connection, getGeneratedKeys: Boolean = false): PreparedStatement = asSimple.getFilledStatement(connection, getGeneratedKeys)
+
+  /** Returns this query with timeout updated to `seconds` delay. */
+  def withQueryTimeout(seconds: Option[Int]): SqlQuery = copy(timeout = seconds)
+
+  private[anorm] def asSimple: SimpleSql[Row] = asSimple(defaultParser)
+
+  /**
+   * Prepares query as a simple one.
+   * @param parser Row parser
+   *
+   * {{{
+   * import anorm.{ SQL, SqlParser }
+   *
+   * SQL("SELECT 1").asSimple(SqlParser.scalar[Int])
+   * }}}
+   */
+  def asSimple[T](parser: RowParser[T] = defaultParser): SimpleSql[T] =
+    SimpleSql(this, Map.empty, parser)
+
+  @deprecated(message = """Directly use BatchSql("stmt")""", since = "2.3.1")
+  def asBatch[T]: BatchSql = BatchSql(this.query, Nil)
+
+  private def defaultParser: RowParser[Row] = RowParser(Success(_))
+
+  // TODO: Make it private
+  @deprecated(
+    "Use anorm.SQL(…) as SqlQuery should not be directly created", "2.3.1")
+  def copy(statement: String = this.statement, paramsInitialOrder: List[String] = this.paramsInitialOrder, timeout: Option[Int] = this.timeout) = SqlQuery(statement, paramsInitialOrder, timeout)
+}
+
+/* TODO: Make it private[anorm] to prevent SqlQuery from being created with
+ unchecked properties (e.g. unchecked/unparsed statement). */
+object SqlQuery {
+
+  /**
+   * Returns created SQL query.
+   *
+   * @param st SQL statement (see [[SqlQuery.statement]])
+   * @param params Parameter names in initial order (see [[SqlQuery.paramsInitialOrder]])
+   * @param tmout Query execution timeout (see [[SqlQuery.timeout]])
+   */
+  @deprecated(message = "Use anorm.SQL(…)", since = "2.3.1")
+  def apply(st: String, params: List[String] = List.empty, tmout: Option[Int] = None): SqlQuery = new SqlQuery {
+    val statement = st
+    val paramsInitialOrder = params
+    val timeout = tmout
+  }
+
+  /** Extractor for pattern matching */
+  def unapply(query: SqlQuery): Option[(String, List[String], Option[Int])] =
+    Option(query).map(q => (q.statement, q.paramsInitialOrder, q.timeout))
+}

--- a/framework/src/anorm/src/test/scala/anorm/BatchSqlSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/BatchSqlSpec.scala
@@ -3,13 +3,15 @@ package anorm
 import acolyte.Acolyte
 import acolyte.Implicits._
 
-object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
+object BatchSqlSpec 
+    extends org.specs2.mutable.Specification with H2Database {
+
   "Batch SQL" title
 
   "Creation" should {
     "fail with parameter maps not having same names" in {
       lazy val batch = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {a}"),
+        "SELECT * FROM tbl WHERE a = {a}",
         Seq(Seq[NamedParameter]("a" -> 0),
           Seq[NamedParameter]("a" -> 1, "b" -> 2)))
 
@@ -19,7 +21,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
 
     "fail with names not matching query placeholders" in {
       lazy val batch = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {a}, b = {b}"),
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}",
         Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2, "c" -> 3)))
 
       batch.addBatch("a" -> 0).
@@ -29,7 +31,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
 
     "be successful with parameter maps having same names" in {
       lazy val batch = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {a}, b = {b}"),
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}",
         Seq(Seq[NamedParameter]("a" -> 0, "b" -> -1),
           Seq[NamedParameter]("a" -> 1, "b" -> 2)))
 
@@ -46,7 +48,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
   "Appending list of named parameters" should {
     "fail with unexpected name" in {
       val batch = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {a}, b = {b}"),
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}",
         Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2)))
 
       batch.addBatch("a" -> 0, "c" -> 4).
@@ -56,7 +58,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
 
     "fail with missing names" in {
       val batch = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {a} AND b = {b} AND c = {c}"),
+        "SELECT * FROM tbl WHERE a = {a} AND b = {b} AND c = {c}",
         Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2, "c" -> 3)))
 
       batch.addBatch("a" -> 0).
@@ -67,7 +69,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
     "with first parameter map" >> {
       "fail if parameter names not matching query placeholders" in {
         val batch = BatchSql(
-          SQL("SELECT * FROM tbl WHERE a = {a}, b = {b}"))
+          "SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
         batch.addBatch("a" -> 0).
           aka("append") must throwA[IllegalArgumentException](
@@ -77,7 +79,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
 
       "be successful" in {
         val b1 = BatchSql(
-          SQL("SELECT * FROM tbl WHERE a = {a}, b = {b}"))
+          "SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
         lazy val b2 = b1.addBatch("a" -> 0, "b" -> 1)
 
@@ -91,7 +93,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
 
     "be successful" in {
       val b1 = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {a}, b = {b}"),
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}",
         Seq(Seq[NamedParameter]("a" -> 0, "b" -> 1)))
 
       lazy val b2 = b1.addBatch("a" -> 2, "b" -> 3)
@@ -108,7 +110,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
   "Appending list of list of named parameters" should {
     "fail with unexpected name" in {
       val batch = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {a}, b = {b}"),
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}",
         Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2)))
 
       batch.addBatchList(Seq(Seq("a" -> 0, "c" -> 4))).
@@ -118,7 +120,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
 
     "fail with missing names" in {
       val batch = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {a} AND b = {b} AND c = {c}"),
+        "SELECT * FROM tbl WHERE a = {a} AND b = {b} AND c = {c}",
         Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2, "c" -> 3)))
 
       batch.addBatchList(Seq(Seq("a" -> 0))).
@@ -128,8 +130,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
 
     "with first parameter map" >> {
       "be successful" in {
-        val b1 = BatchSql(
-          SQL("SELECT * FROM tbl WHERE a = {a}, b = {b}"))
+        val b1 = BatchSql("SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
         lazy val b2 = b1.addBatchList(Seq(Seq("a" -> 0, "b" -> 1)))
 
@@ -142,7 +143,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
 
       "fail with parameter maps not having same names" in {
         val b1 = BatchSql(
-          SQL("SELECT * FROM tbl WHERE a = {a}"))
+          "SELECT * FROM tbl WHERE a = {a}")
 
         lazy val b2 = b1.addBatchList(Seq(
           Seq("a" -> 0), Seq("a" -> 1, "b" -> 2)))
@@ -153,7 +154,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
 
       "fail with names not matching query placeholders" in {
         val b1 = BatchSql(
-          SQL("SELECT * FROM tbl WHERE a = {a} AND b = {b} AND c = {c}"))
+          "SELECT * FROM tbl WHERE a = {a} AND b = {b} AND c = {c}")
 
         lazy val b2 = b1.addBatchList(Seq(Seq("a" -> 0)))
 
@@ -163,7 +164,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
 
       "be successful with parameter maps having same names" in {
         val b1 = BatchSql(
-          SQL("SELECT * FROM tbl WHERE a = {a}, b = {b}"))
+          "SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
         lazy val b2 = b1.addBatchList(Seq(
           Seq[NamedParameter]("a" -> 0, "b" -> -1),
@@ -181,7 +182,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
 
     "be successful" in {
       val b1 = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {a}, b = {b}"),
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}",
         Seq(Seq("a" -> 0, "b" -> 1)))
 
       lazy val b2 = b1.addBatchList(Seq(Seq("a" -> 2, "b" -> 3)))
@@ -196,19 +197,9 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
   }
 
   "Appending list of parameter values" should {
-    "fail with missing names" in {
-      lazy val batch = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {d} AND b = {b} AND c = {c}"),
-        Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2, "c" -> 3)))
-
-      batch.addBatchParams(0).
-        aka("append") must throwA[IllegalArgumentException](
-          message = "Expected parameter names don't correspond to placeholders in query: a, b, c not matching d, b, c")
-    }
-
     "be successful with first parameter map" in {
       val b1 = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {a}, b = {b}"))
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
       lazy val b2 = b1.addBatchParams(0, 1)
       lazy val expectedMaps =
@@ -220,7 +211,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
 
     "fail with missing argument" in {
       val b1 = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {a}, b = {b}")).
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}").
         addBatchParams(0, 1)
 
       lazy val b2 = b1.addBatchParams(2)
@@ -231,7 +222,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
 
     "be successful" in {
       val b1 = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {a}, b = {b}"))
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
       lazy val b2 = b1.addBatchParams(0, 1).addBatchParams(2, 3)
       lazy val expectedMaps = Seq(
@@ -244,19 +235,8 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
   }
 
   "Appending list of list of parameter values" should {
-    "fail with missing names" in {
-      lazy val batch = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {d} AND b = {b} AND c = {c}"),
-        Seq(Seq[NamedParameter]("a" -> 1, "b" -> 2, "c" -> 3)))
-
-      batch.addBatchParamsList(Seq(Seq(4, 5, 6))).
-        aka("append") must throwA[IllegalArgumentException](
-          message = "Expected parameter names don't correspond to placeholders in query: a, b, c not matching d, b, c")
-    }
-
     "be successful with first parameter map" in {
-      val b1 = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {a}, b = {b}"))
+      val b1 = BatchSql("SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
       lazy val b2 = b1.addBatchParamsList(Seq(Seq(0, 1), Seq(2, 3)))
       lazy val expectedMaps = Seq(
@@ -269,8 +249,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
 
     "fail with missing argument" in {
       val b1 = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {a}, b = {b}")).
-        addBatchParams(0, 1)
+        "SELECT * FROM tbl WHERE a = {a}, b = {b}").addBatchParams(0, 1)
 
       lazy val b2 = b1.addBatchParamsList(Seq(Seq(2)))
 
@@ -279,8 +258,7 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
     }
 
     "be successful" in {
-      val b1 = BatchSql(
-        SQL("SELECT * FROM tbl WHERE a = {a}, b = {b}"))
+      val b1 = BatchSql("SELECT * FROM tbl WHERE a = {a}, b = {b}")
 
       lazy val b2 = b1.addBatchParamsList(Seq(Seq(0, 1))).
         addBatchParamsList(Seq(Seq(2, 3), Seq(4, 5)))
@@ -300,11 +278,13 @@ object BatchSqlSpec extends org.specs2.mutable.Specification with H2Database {
       createTest1Table()
 
       lazy val batch = BatchSql(
-        SQL("INSERT INTO test1(id, foo, bar) VALUES({i}, {f}, {b})"), Seq(
+        "INSERT INTO test1(id, foo, bar) VALUES({i}, {f}, {b})", Seq(
           Seq[NamedParameter]('i -> 1, 'f -> "foo #1", 'b -> 2),
           Seq[NamedParameter]('i -> 2, 'f -> "foo_2", 'b -> 4)))
 
-      batch.execute() aka "batch result" mustEqual Array(1, 1)
+      (batch.sql.statement aka "parsed statement" mustEqual(
+        "INSERT INTO test1(id, foo, bar) VALUES(%s, %s, %s)")).
+        and(batch.execute() aka "batch result" mustEqual Array(1, 1))
     }
   }
 }

--- a/framework/src/anorm/src/test/scala/anorm/ParameterSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/ParameterSpec.scala
@@ -635,13 +635,13 @@ object ParameterSpec extends org.specs2.mutable.Specification {
 
     "be defined string option as Some[String]" in withConnection() {
       implicit c =>
-        SQL("set-some-str ?").copy(argsInitialOrder = List("p")).
+        SQL("set-some-str ?").copy(paramsInitialOrder = List("p")).
           onParams(pv(Some("string"))).execute() aka "execution" must beFalse
     }
 
     "be defined string option as Option[String]" in withConnection() {
       implicit c =>
-        SQL("set-some-str ?").copy(argsInitialOrder = List("p")).
+        SQL("set-some-str ?").copy(paramsInitialOrder = List("p")).
           onParams(pv(Option("string"))).
           execute() aka "execution" must beFalse
     }
@@ -683,7 +683,7 @@ object ParameterSpec extends org.specs2.mutable.Specification {
 
     "be partially set if matching placeholder is missing for second one" in {
       withConnection() { implicit c =>
-        SQL("no-snd-placeholder ?").copy(argsInitialOrder = List("p")).
+        SQL("no-snd-placeholder ?").copy(paramsInitialOrder = List("p")).
           onParams(pv("first"), pv("second")).execute() must beFalse
 
       }


### PR DESCRIPTION
Refactor SqlQuery case class as trait with companion object, so that it will be possible better check its creation. Update BatchSql, which was directly using SqlQuery at creation, replacing it by raw (string) statement, with SqlQuery created internally with checks.

``` scala
import anorm.BatchSql

// Before
BatchSql(SqlQuery("SQL")) // No longer accepted (won't compile)

// Now
BatchSql("SQL")
// Simpler and safer, as SqlQuery is created&validated internally
```
