### PR TITLE
Fix issue 1658

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/Form.java
+++ b/framework/src/play-java/src/main/java/play/data/Form.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
  */
 package play.data;
 
@@ -561,8 +561,13 @@ public class Form<T> {
 
     /**
      * Gets the concrete value if the submission was a success.
+     *
+     * @throws IllegalStateException if there are errors binding the form, including the errors as JSON in the message
      */
     public T get() {
+        if (!errors.isEmpty()) {
+            throw new IllegalStateException("Error(s) binding form: " + errorsAsJson());
+        }
         return value.get();
     }
 

--- a/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
  */
 package play.data
 
@@ -35,6 +35,14 @@ object FormSpec extends Specification {
       val myForm = Form.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(true)
       myForm.errors.get("dueDate").get(0).messages().asScala must contain("error.invalid.java.util.Date")
+    }
+    "have an error due to missing required value" in {
+      val req = new DummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter")))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
+
+      val myForm = Form.form(classOf[play.data.models.Task]).bindFromRequest()
+      myForm hasErrors () must beEqualTo(true)
+      myForm.errors.get("dueDate").get(0).messages().asScala must contain("error.required")
     }
     "have an error due to bad value in Id field" in {
       val req = new DummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter"), "dueDate" -> Array("12/12/2009")))


### PR DESCRIPTION
Fix issue 1658

When a form is bound with missing fields, it throws an unhelpful IllegalStateException with the message "No value".  Now it will instead report the errors in the exception.
