### PR TITLE
Replace reference to "retailos" with "myapp"

### DIFF
--- a/documentation/manual/detailedTopics/production/ProductionHeroku.md
+++ b/documentation/manual/detailedTopics/production/ProductionHeroku.md
@@ -110,7 +110,7 @@ libraryDependencies += "postgresql" % "postgresql" % "9.1-901-1.jdbc4"
 Then create a new file in your project's root directory named `Procfile` (with a capital "P") that contains the following (substituting the `myapp` with your project's name):
 
 ```txt
-web: target/universal/stage/bin/retailos -Dhttp.port=${PORT} -DapplyEvolutions.default=true -Ddb.default.driver=org.postgresql.Driver -Ddb.default.url=${DATABASE_URL}
+web: target/universal/stage/bin/myapp -Dhttp.port=${PORT} -DapplyEvolutions.default=true -Ddb.default.driver=org.postgresql.Driver -Ddb.default.url=${DATABASE_URL}
 ```
 
 This instructs Heroku that for the process named `web` it will run Play and override the `applyEvolutions.default`, `db.default.driver`, and `db.default.url` configuration parameters.  Note that the `Procfile` command can be maximum 255 characters long.  Alternatively, use the `-Dconfig.resource=` or `-Dconfig.file=` mentioned in [[production configuration|ProductionConfiguration]] page.


### PR DESCRIPTION
Not quite sure why "retailos" was in there but it doesn't match up with the rest of the documentation.
