### PR TITLE
Add java.util.UUID JavaScript literal binder

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -254,6 +254,13 @@ object JavascriptLiteral {
   implicit def literalAsset: JavascriptLiteral[Asset] = new JavascriptLiteral[Asset] {
     def to(value: Asset) = "\"" + value.name + "\""
   }
+
+  /**
+   * Convert a java.util.UUID to Javascript String (or Javascript null if given UUID value is null)
+   */
+  implicit def literalUUID: JavascriptLiteral[UUID] = new JavascriptLiteral[UUID] {
+    def to(value: UUID) = Option(value).map("\"" + _.toString + "\"").getOrElse("null")
+  }
 }
 
 /**


### PR DESCRIPTION
Without the proposed binder, Play doesn't compile the project with the message:

```
No JavaScript literal binder found for type java.util.UUID. Try to implement an implicit JavascriptLiteral for this type.
```

when using one of the following routes:

```
GET /test1    controllers.Application.test(id: java.util.UUID = null)
# or 
GET /test2    controllers.Application.test(id: java.util.UUID = java.util.UUID.fromString("00000000-0000-0000-0000-000000000000"))
```

With the attached Fix these routes work fine now.

Please backport to 2.3.x like you did with #3044 (be aware to rename `JavascriptLiteral` to `JavascriptLitteral` for the 2.3.x branch).
