### PR TITLE
Fix NullPointerException, add missing JavaScript literal binders and correctly convert null in binders

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -207,10 +207,30 @@ trait JavascriptLiteral[A] {
 object JavascriptLiteral {
 
   /**
-   * Convert a Scala String to Javascript String
+   * Convert a (primitive) value to it's Javascript equivalent
+   */
+  private def toJsValue(value: Any): String = {
+    value match {
+      case null => "null"
+      case _ => value.toString
+    }
+  }
+
+  /**
+   * Convert a value to a Javascript String
+   */
+  private def toJsString(value: Any): String = {
+    value match {
+      case null => "null"
+      case _ => "\"" + value.toString + "\""
+    }
+  }
+
+  /**
+   * Convert a Scala String to Javascript String (or Javascript null if given String value is null)
    */
   implicit def literalString: JavascriptLiteral[String] = new JavascriptLiteral[String] {
-    def to(value: String) = "\"" + value + "\""
+    def to(value: String) = toJsString(value)
   }
 
   /**
@@ -221,10 +241,10 @@ object JavascriptLiteral {
   }
 
   /**
-   * Convert a Java Integer to Javascript number
+   * Convert a Java Integer to Javascript number (or Javascript null if given Integer value is null)
    */
   implicit def literalJavaInteger: JavascriptLiteral[java.lang.Integer] = new JavascriptLiteral[java.lang.Integer] {
-    def to(value: java.lang.Integer) = value.toString
+    def to(value: java.lang.Integer) = toJsValue(value)
   }
 
   /**
@@ -235,10 +255,24 @@ object JavascriptLiteral {
   }
 
   /**
+   * Convert a Java Long to Javascript number (or Javascript null if given Long value is null)
+   */
+  implicit def literalJavaLong: JavascriptLiteral[java.lang.Long] = new JavascriptLiteral[java.lang.Long] {
+    def to(value: java.lang.Long) = toJsValue(value)
+  }
+
+  /**
    * Convert a Scala Boolean to Javascript boolean
    */
   implicit def literalBoolean: JavascriptLiteral[Boolean] = new JavascriptLiteral[Boolean] {
     def to(value: Boolean) = value.toString
+  }
+
+  /**
+   * Convert a Java Boolean to Javascript boolean (or Javascript null if given Boolean value is null)
+   */
+  implicit def literalJavaBoolean: JavascriptLiteral[java.lang.Boolean] = new JavascriptLiteral[java.lang.Boolean] {
+    def to(value: java.lang.Boolean) = toJsValue(value)
   }
 
   /**
@@ -249,17 +283,30 @@ object JavascriptLiteral {
   }
 
   /**
+   * Convert a Java Option to Javascript literal (use null for None)
+   */
+  implicit def literalJavaOption[T](implicit jsl: JavascriptLiteral[T]): JavascriptLiteral[play.libs.F.Option[T]] = new JavascriptLiteral[play.libs.F.Option[T]] {
+    def to(value: play.libs.F.Option[T]) = {
+      if (value.isDefined) {
+        jsl.to(value.get)
+      } else {
+        "null"
+      }
+    }
+  }
+
+  /**
    * Convert a Play Asset to Javascript String
    */
   implicit def literalAsset: JavascriptLiteral[Asset] = new JavascriptLiteral[Asset] {
-    def to(value: Asset) = "\"" + value.name + "\""
+    def to(value: Asset) = toJsString(value.name)
   }
 
   /**
    * Convert a java.util.UUID to Javascript String (or Javascript null if given UUID value is null)
    */
   implicit def literalUUID: JavascriptLiteral[UUID] = new JavascriptLiteral[UUID] {
-    def to(value: UUID) = Option(value).map("\"" + _.toString + "\"").getOrElse("null")
+    def to(value: UUID) = toJsString(value)
   }
 }
 
@@ -366,7 +413,7 @@ object QueryStringBindable {
     bindableBoolean.transform(b => b, b => b)
 
   /**
-   * Path binder for java.util.UUID.
+   * QueryString binder for java.util.UUID.
    */
   implicit object bindableUUID extends Parsing[UUID](
     UUID.fromString(_), _.toString, (key: String, e: Exception) => "Cannot parse parameter %s as UUID: %s".format(key, e.getMessage)


### PR DESCRIPTION
First of all: I created a _very_ simple [project](https://github.com/mkurz/playRoutesTest) to demonstrate the bugs I stumpled into using Play 2.3.5. (After running `activator new routesTest play-java` I only added some basic routes in `conf/routes` and added the accompanying actions in `app/controllers/Application.java` with [this commit](https://github.com/mkurz/playRoutesTest/commit/c923721ed3cdca7f9c6f187e5e6e0cff7b37a298?diff=unified)).

Now Step-by-Step:

**1) There are some JavaScript literal binders missing**
Have a look at the [routes file](https://github.com/mkurz/playRoutesTest/blob/master/conf/routes). When you want to compile this routes file you get following errors:

```
No JavaScript literal binder found for type play.libs.F.Option[Integer]. Try to implement an implicit JavascriptLiteral for this type.
```

and

```
No JavaScript literal binder found for type Long. Try to implement an implicit JavascriptLiteral for this type.
```

and

```
No JavaScript literal binder found for type Boolean. Try to implement an implicit JavascriptLiteral for this type.
```

(You would also get an error for the missing _UUID JavaScript literal binder_ - I already submitted the PR #3508 for this missing UUID JavaScript literal binder yesterday)

So with this PR I added the missing JavaScript literal binders for `play.libs.F.Option`, `java.lang.Long` and `java.lang.Boolean`.

**2) NullPointerExceptions occur when assigning `null` as a default to _Java_ Types in a route**
After implementing the missing binders (including #3508), the project will now fail with a `NullPointerException` in the already existing `java.lang.Integer` JavaScript literal binder when assigning `null` as a default in a route ([see line 13](https://github.com/mkurz/playRoutesTest/blob/master/conf/routes#L13)). If you [have a look at my fix](https://github.com/playframework/playframework/pull/3514/files#diff-7400ac02cbec8f8d98c8173091e15e55L227), you will see that's because `.toString` is called without checking if the default value is null before. (FYI: To actually get this `NullPointerException` you actually have to call the JavaScript route like in [line 53 of the Application.java](https://github.com/mkurz/playRoutesTest/blob/master/app/controllers/Application.java#L53). If you don't call it you won't experience the NullPointerException).

**3) When assigning null as a default to a String in a route, it gets converted to a JavaScript "null" String instead of a Javascript null value**
[See line 9 in the routes file](https://github.com/mkurz/playRoutesTest/blob/master/conf/routes#L9). Without this PR following JavaScript is generated for JavaScript reverse routing (in case you run my test project you could just have a look at `/assets/routes.js`):

```
if (id == "null") {
return _wA({method:"GET", url:"/" + "stringNull"})
}
```

With my PR it correctly becomes:

```
if (id == null) {
return _wA({method:"GET", url:"/" + "stringNull"})
}
```

Please also backport this PR and #3508 to 2.3.x (be aware to rename JavascriptLiteral to JavascriptLitteral for the 2.3.x branch).
Thanks!
