### PR TITLE
HttpExecutionContext should call delegate's prepare (2.3.x backport)

### DIFF
--- a/framework/src/play/src/main/scala/play/core/j/HttpExecutionContext.scala
+++ b/framework/src/play/src/main/scala/play/core/j/HttpExecutionContext.scala
@@ -29,7 +29,7 @@ object HttpExecutionContext {
  * in the current thread. Actual execution is performed by a delegate ExecutionContext.
  */
 class HttpExecutionContext(contextClassLoader: ClassLoader, httpContext: Http.Context, delegate: ExecutionContext) extends ExecutionContextExecutor {
-  def execute(runnable: Runnable) = delegate.execute(new Runnable {
+  override def execute(runnable: Runnable) = delegate.execute(new Runnable {
     def run() {
       val thread = Thread.currentThread()
       val oldContextClassLoader = thread.getContextClassLoader()
@@ -44,5 +44,15 @@ class HttpExecutionContext(contextClassLoader: ClassLoader, httpContext: Http.Co
       }
     }
   })
-  def reportFailure(t: Throwable) = delegate.reportFailure(t)
+
+  override def reportFailure(t: Throwable) = delegate.reportFailure(t)
+
+  override def prepare(): ExecutionContext = {
+    val delegatePrepared = delegate.prepare()
+    if (delegatePrepared eq delegate) {
+      this
+    } else {
+      new HttpExecutionContext(contextClassLoader, httpContext, delegatePrepared)
+    }
+  }
 }

--- a/framework/src/play/src/test/scala/play/core/j/HttpExecutionContextSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/j/HttpExecutionContextSpec.scala
@@ -18,15 +18,14 @@ object HttpExecutionContextSpec extends Specification
 
     "propagate the context ClassLoader and Http.Context" in {
       mustExecute(2) { ec =>
-        val pec = ec.prepare()
         val classLoader = new ClassLoader() {}
         val httpContext = new Http.Context(1, null, null, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava)
-        val hec = new HttpExecutionContext(classLoader, httpContext, pec)
+        val hec = new HttpExecutionContext(classLoader, httpContext, ec).prepare
 
         val hecFromThread = new LinkedBlockingQueue[ExecutionContext]()
         hec.execute(new Runnable {
           def run() = {
-            hecFromThread.offer(HttpExecutionContext.fromThread(pec))
+            hecFromThread.offer(HttpExecutionContext.fromThread(ec).prepare)
           }
         })
 
@@ -42,7 +41,6 @@ object HttpExecutionContextSpec extends Specification
         actualHttpContext.poll(5, SECONDS) must equalTo(httpContext)
       }
     }
-
   }
 
 }


### PR DESCRIPTION
Backport of #3342 for 2.3.x.
