### PR TITLE
Give more control to users on the error value of the JsResult filtering methods

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsResult.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsResult.scala
@@ -82,8 +82,12 @@ sealed trait JsResult[+A] { self =>
     case e: JsError => e
   }
 
+  @deprecated(message = "Use `filterNot(JsError)(A => Boolean)` instead.", since = "2.3.4")
   def filterNot(error: ValidationError)(p: A => Boolean): JsResult[A] =
-    this.flatMap { a => if (p(a)) JsError(error) else JsSuccess(a) }
+    filterNot(JsError(error))(p)
+
+  def filterNot(error: JsError)(p: A => Boolean): JsResult[A] =
+    this.flatMap { a => if (p(a)) error else JsSuccess(a) }
 
   def filterNot(p: A => Boolean): JsResult[A] =
     this.flatMap { a => if (p(a)) JsError() else JsSuccess(a) }
@@ -91,8 +95,12 @@ sealed trait JsResult[+A] { self =>
   def filter(p: A => Boolean): JsResult[A] =
     this.flatMap { a => if (p(a)) JsSuccess(a) else JsError() }
 
+  @deprecated(message = "Use `filter(JsError)(A => Boolean)` instead.", since = "2.3.4")
   def filter(otherwise: ValidationError)(p: A => Boolean): JsResult[A] =
-    this.flatMap { a => if (p(a)) JsSuccess(a) else JsError(otherwise) }
+    filter(JsError(otherwise))(p)
+
+  def filter(otherwise: JsError)(p: A => Boolean): JsResult[A] =
+    this.flatMap { a => if (p(a)) JsSuccess(a) else otherwise }
 
   def collect[B](otherwise: ValidationError)(p: PartialFunction[A, B]): JsResult[B] = flatMap {
     case t if p.isDefinedAt(t) => JsSuccess(p(t))

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
@@ -905,5 +905,15 @@ object JsonValidSpec extends Specification {
         res2.map(identity) must equalTo(res2)
       }
     }
+
+    "have filtering methods that allow users to customize the error" in {
+      val res: JsResult[String] = JsSuccess("foo")
+      val error = JsError(__ \ "bar", "There is a problem")
+      res.filter(error)(_ != "foo") must equalTo(error)
+      res.filter(error)(_ == "foo") must equalTo(res)
+      res.filterNot(error)(_ == "foo") must equalTo(error)
+      res.filterNot(error)(_ != "foo") must equalTo(res)
+    }
+
   }
 }


### PR DESCRIPTION
The current `filter` method of `JsResult` allows users to supply a custom `ValidationError` to use in case target value is filtered out. In such a case the resulting `JsResult` value is `JsError(validationError)`. The problem with this implementation is that it does not allow users to associate a `JsPath` to the validation error.

This PR fixes this issue by changing the `filter` method so that it takes a `JsError` as parameter. Users can now write `jsResult.filter(JsError(__ \ "foo", "error message"))(predicate)`, so that the `JsError` can have a custom path.

The same applies to `filterNot`.
