### PR TITLE
OptionReads should validate JSON value if it exists

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
@@ -492,11 +492,6 @@ trait DefaultReads {
     }
   }
 
-  implicit def OptionReads[T](implicit fmt: Reads[T]): Reads[Option[T]] = new Reads[Option[T]] {
-    import scala.util.control.Exception._
-    def reads(json: JsValue) = fmt.reads(json).fold(e => JsSuccess(None), v => JsSuccess(Some(v)))
-  }
-
   /**
    * Deserializer for Map[String,V] types.
    */


### PR DESCRIPTION
Currently OptionReads delegates to format.reads without checking if the value exists and ignores the error returned by the format.

Say I have:
`case class User(name: Option[String])`

Then `{ "name": "Drew" }` is a valid JSON, so is `{ }`, but `{ "name": 12 }` is not. Currently, OptionReads will return JsSuccess(None) when reading `{ "name": 12 }` instead of an error. This PR fixes that.