### PR TITLE
Fix #3527 for master (2.4)

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/Anorm.scala
+++ b/framework/src/anorm/src/main/scala/anorm/Anorm.scala
@@ -72,7 +72,7 @@ case class Object(value: Any)
 case class MetaDataItem(column: ColumnName, nullable: Boolean, clazz: String)
 case class ColumnName(qualified: String, alias: Option[String])
 
-private[anorm] case class MetaData(ms: List[MetaDataItem]) {
+case class MetaData(ms: List[MetaDataItem]) {
   /** Returns meta data for specified column. */
   def get(columnName: String): Option[MetaDataItem] = {
     val key = columnName.toUpperCase


### PR DESCRIPTION
MetaData can be used by clients via Row.metaData, so it should be able to be referenced in their type signatures.
