### PR TITLE
Bugfix for reverse routing when using F.Option

### DIFF
--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -760,6 +760,19 @@ public class F {
             throw new UnsupportedOperationException();
         }
 
+        @Override
+        public int hashCode() {
+            return Arrays.deepHashCode(this.toArray());
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null) return false;
+            if (!(obj instanceof Option)) return false;
+            return Arrays.deepEquals(this.toArray(), ((Option)obj).toArray());
+        }
+
     }
 
     /**

--- a/framework/src/play/src/test/java/play/OptionTest.java
+++ b/framework/src/play/src/test/java/play/OptionTest.java
@@ -9,6 +9,8 @@ import play.libs.F;
 import play.libs.F.Option;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 // see http://docs.oracle.com/javase/7/docs/api/java/util/Collection.html#toArray(T[])
 public class OptionTest {
@@ -37,6 +39,34 @@ public class OptionTest {
     public void throwArrayStoreException() {
         F.Option<String> a = Option.Some("a");
         a.toArray(new Integer[]{});
+    }
+
+    @Test
+    public void testEquals() {
+        assertTrue(F.Option.<Integer>Some(12345).equals(F.Option.<Integer>Some(12345)));
+        assertTrue(F.Option.<String>Some("").equals(F.Option.<String>Some("")));
+        assertTrue(F.Option.<String>Some("foo").equals(F.Option.<String>Some("foo")));
+        assertTrue(F.Option.None().equals(F.Option.None()));
+        assertTrue(F.Option.Some(null).equals(F.Option.Some(null)));
+
+        assertFalse(F.Option.<Integer>Some(12345).equals(F.Option.<Integer>Some(98765)));
+        assertFalse(F.Option.<String>Some("").equals(F.Option.<String>Some("foo")));
+        assertFalse(F.Option.<Integer>Some(12345).equals(F.Option.<Integer>None()));
+        assertFalse(F.Option.<Integer>Some(null).equals(F.Option.<Integer>None()));
+    }
+
+    @Test
+    public void testHashCode() {
+        assertThat(F.Option.<Integer>Some(12345).hashCode()).isEqualTo(F.Option.<Integer>Some(12345).hashCode());
+        assertThat(F.Option.<String>Some("").hashCode()).isEqualTo(F.Option.<String>Some("").hashCode());
+        assertThat(F.Option.<String>Some("foo").hashCode()).isEqualTo(F.Option.<String>Some("foo").hashCode());
+        assertThat(F.Option.None().hashCode()).isEqualTo(F.Option.None().hashCode());
+        assertThat(F.Option.Some(null).hashCode()).isEqualTo(F.Option.Some(null).hashCode());
+
+        assertThat(F.Option.<Integer>Some(12345).hashCode()).isNotEqualTo(F.Option.<Integer>Some(98765).hashCode());
+        assertThat(F.Option.<String>Some("").hashCode()).isNotEqualTo(F.Option.<String>Some("foo").hashCode());
+        assertThat(F.Option.<Integer>Some(12345).hashCode()).isNotEqualTo(F.Option.None().hashCode());
+        assertThat(F.Option.Some(null).hashCode()).isNotEqualTo(F.Option.None().hashCode());
     }
 
 }


### PR DESCRIPTION
Using latest 2.4-SNAPSHOT or latest 2.3-SNAPSHOT with following routes:

```
GET     /JOptionNull                controllers.Application.jOptionRoute(id: play.libs.F.Option[Integer] = play.libs.F.Option.None[Integer])
GET     /JOptionValue               controllers.Application.jOptionRoute(id: play.libs.F.Option[Integer] = play.libs.F.Option.Some(12345))
GET     /JOptionValue1              controllers.Application.jOptionRoute(id: play.libs.F.Option[Integer] = play.libs.F.Option.Some(98765))
GET     /JOptionValue2              controllers.Application.jOptionRoute(id: play.libs.F.Option[Integer])
```

In a template having reverse routes for them:

```
@routes.Application.jOptionRoute(play.libs.F.Option.None())
@routes.Application.jOptionRoute(play.libs.F.Option.Some(12345))
@routes.Application.jOptionRoute(play.libs.F.Option.Some(98765))
@routes.Application.jOptionRoute(play.libs.F.Option.Some(11111))
```

Gives me the following routes:

```
/JOptionValue2
/JOptionValue2?id=12345
/JOptionValue2?id=98765
/JOptionValue2?id=11111 
```

Which is wrong! Correct would be:

```
/JOptionNull
/JOptionValue
/JOptionValue1
/JOptionValue2?id=11111
```

Only when using `F.Option` reverse routing is "broken" - it works fine with any other type (`Long`, `java.lang.Long`, `java.util.UUID`, `Int`, `java.lang.Integer` and even with Scala `Option`).

The cause for this bug is that in `target/scala-2.11/src_managed/main/routes_reverseRouting.scala`  Scala code like this gets generated:

```
def jOptionRoute(id:play.libs.F.Option[Integer]): Call = {
...
case (id) if id == play.libs.F.Option.None[Integer] =>
...
case (id) if id == play.libs.F.Option.Some(12345) =>
...
case (id) if id == play.libs.F.Option.Some(98765) =>
...
}
```

But `F.Option` does not have an `equals` (and `hashCode`) method, so all of the above conditions will always be `false`!

```
play.libs.F.Option.Some(12345) == play.libs.F.Option.Some(12345) // (in Scala) returns false - Bug!
play.libs.F.Option.Some(12345).equals(play.libs.F.Option.Some(12345)) // returns false - Bug!
```

This PR simply adds the equals/hashCode methods (including tests) to `F.Option` which as a consequence fixes the above reverse routing bug.
