### PR TITLE
Handle missing play config in Invoker

### DIFF
--- a/framework/src/play/src/main/scala/play/core/system/Invoker.scala
+++ b/framework/src/play/src/main/scala/play/core/system/Invoker.scala
@@ -31,8 +31,12 @@ private[play] object Invoker {
       (system, close)
     }
 
-    private def loadActorConfig(config: Config) = {
-      config.getConfig("play")
+    private def loadActorConfig(config: Config): Config = {
+      try {
+        config.getConfig("play")
+      } catch {
+        case _: ConfigException.Missing => ConfigFactory.empty()
+      }
     }
 
   }


### PR DESCRIPTION
The missing config exception comes up when running documentation translation projects (or modularised doc projects).
