### PR TITLE
handle multipart fields with colon inside #3404

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -639,7 +639,7 @@ trait BodyParsers {
               val headerString = new String(headerBytes, "utf-8").trim
               val headers = headerString.lines.map { header =>
                 val key :: value = header.trim.split(":").toList
-                (key.trim.toLowerCase, value.mkString.trim)
+                (key.trim.toLowerCase, value.mkString(":").trim)
               }.toMap
 
               val left = rest.drop(CRLFCRLF.length)


### PR DESCRIPTION
if a form is submitted as multipart/form-data and a field in this form has a colon in its name
e.g. "message_id:signature", the original parameter name would be lost and translated to "message_idsignature"

New pull request of 
https://github.com/playframework/playframework/pull/3404
because I don't know how to modify an existing pull request. 
