### PR TITLE
handle multipart fields with colon inside [2.4.x]

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -19,7 +19,7 @@ object MultipartFormDataParserSpec extends PlaySpecification {
       |
       |the first text field
       |--aabbccddee
-      |Content-Disposition: form-data; name="text2"
+      |Content-Disposition: form-data; name="text2:colon"
       |
       |the second text field
       |--aabbccddee
@@ -45,7 +45,7 @@ object MultipartFormDataParserSpec extends PlaySpecification {
         parts.dataParts.get("text1") must beSome.like {
           case field :: Nil => field must_== "the first text field"
         }
-        parts.dataParts.get("text2") must beSome.like {
+        parts.dataParts.get("text2:colon") must beSome.like {
           case field :: Nil => field must_== "the second text field"
         }
         parts.files must haveLength(2)

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -132,7 +132,7 @@ object Multipart {
       } else {
         val headers = headerString.lines.map { header =>
           val key :: value = header.trim.split(":").toList
-          (key.trim.toLowerCase, value.mkString.trim)
+          (key.trim.toLowerCase, value.mkString(":").trim)
         }.toMap
 
         val left = rest.drop(CRLFCRLF.length)


### PR DESCRIPTION
if a form is submitted as multipart/form-data and a field in this form has a colon in its name
e.g. "message_id:signature", the original parameter name would be lost and translated to "message_idsignature"

adjusted pull request for changes made from 2.3.x -> 2.4.x
Original pull request: https://github.com/playframework/playframework/pull/3404
Pull Request on 2.3.x: https://github.com/playframework/playframework/pull/3546
