### PR TITLE
2.3.x - Minor fixes for ScalaTest use and added an example for POST with body request

### DIFF
--- a/documentation/manual/scalaGuide/main/tests/ScalaTestingWithScalaTest.md
+++ b/documentation/manual/scalaGuide/main/tests/ScalaTestingWithScalaTest.md
@@ -19,12 +19,12 @@ Testing in Play is based on SBT, and a full description is available in the [tes
 
 ## Using ScalaTest + Play
 
-To use _ScalaTest + Play_, you'll need to add it to your build, by changing `projects/Build.scala` like this:
+To use _ScalaTest + Play_, you'll need to add it to your build, by changing `build.sbt` like this:
 
 ```scala
-val appDependencies = Seq(
-  // Add your project dependencies here,
-  "org.scalatestplus" %% "play" % "1.1.0" % "test"
+libraryDependencies ++= Seq(
+  "org.scalatest" %% "scalatest" % "2.2.1" % "test",
+  "org.scalatestplus" %% "play" % "1.2.0" % "test",
 )
 ```
 
@@ -38,15 +38,22 @@ You can alternatively [define your own base classes](http://scalatest.org/user_g
 
 You can run your tests with Play itself, or in IntelliJ IDEA (using the [Scala plugin](http://blog.jetbrains.com/scala/)) or in Eclipse (using the [Scala IDE](http://scala-ide.org/) and the [ScalaTest Eclipse plugin](http://scalatest.org/user_guide/using_scalatest_with_eclipse)).  Please see the [[IDE page|IDE]] for more details.
 
+Note that in IntelliJ, when creating a new Run Configuration for your unit tests,
+if you select "All in package," choosing "In whole project" for the "Search for tests"
+option, may cause `MethodNotFoundError` exceptions: if that's the case, use "Across module
+dependencies" instead.
+
 ### Matchers
 
 `PlaySpec` mixes in ScalaTest's [`MustMatchers`](http://doc.scalatest.org/2.1.5/index.html#org.scalatest.MustMatchers), so you can write assertions using ScalaTest's matchers DSL:
 
 ```scala
+import play.api.test.Helpers._
+
 "Hello world" must endWith ("world")
 ```
 
-For more information, see the documentation for [`MustMatchers`](http://doc.scalatest.org/2.1.5/index.html#org.scalatest.MustMatchers).
+For more information, see the documentation for [`MustMatchers`](http://doc.scalatest.org/2.2.1/index.html#org.scalatest.MustMatchers).
 
 ### Mockito
 
@@ -113,6 +120,12 @@ Controllers are defined as objects in Play, and so can be trickier to unit test.
 and then test the trait:
 
 @[scalatest-examplecontrollerspec](code-scalatestplus-play/ExampleControllerSpec.scala)
+
+When testing POST requests with, for example, JSON bodies, you won't be able to
+use the pattern shown above (`apply(fakeRequest)`); instead you should use
+`call()` on the `testController`:
+
+@[scalatest-examplepost](code-scalatestplus-play/ExamplePostSpec.scala)
 
 ## Unit Testing EssentialAction
 

--- a/documentation/manual/scalaGuide/main/tests/code-scalatestplus-play/ExamplePostSpec.scala
+++ b/documentation/manual/scalaGuide/main/tests/code-scalatestplus-play/ExamplePostSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package scalaguide.tests.scalatest
+
+// #scalatest-examplecontrollerspec
+import scala.concurrent.Future
+
+import org.scalatest._
+import org.scalatestplus.play._
+
+import play.api.mvc._
+import play.api.test._
+import play.api.test.Helpers._
+
+class ExampleControllerSpec extends PlaySpec with Results {
+
+  //#scalatest-examplepost
+  trait WithControllerAndRequest {
+    val testController = new Controller with ApiController
+
+    def fakeRequest(method: String = "GET", route: String = "/") = FakeRequest(method, route)
+      .withHeaders(
+        ("Date", "2014-10-05T22:00:00"),
+        ("Authorization", "username=bob;hash=foobar==")
+    )
+  }
+
+  "REST API" should {
+    "create a new user" in new WithControllerAndRequest {
+      val request = fakeRequest("POST", "/user").withJsonBody(Json.parse(
+        s"""{"first_name": "Alice",
+          |  "last_name": "Doe",
+          |  "credentials": {
+          |    "username": "alice",
+          |    "password": "secret"
+          |  }
+          |}""".stripMargin))
+      val apiResult = call(testController.createUser, request)
+      status(apiResult) mustEqual CREATED
+      val jsonResult = contentAsJson(apiResult)
+      ObjectId.isValid((jsonResult \ "id").as[String]) mustBe true
+
+      // now get the real thing from the DB and check it was created with the correct values:
+      val newbie = Dao().findByUsername("alice").get
+      newbie.id.get.toString mustEqual (jsonResult \ "id").as[String]
+      newbie.firstName mustEqual "Alice"
+    }
+  }
+  //#scalatest-examplepost
+}


### PR DESCRIPTION
I've created a new pull request, branched off the `2.3.x` branch, so you can actually see what the diff is.
