### PR TITLE
Replaced play.modules with config based mechanism

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/dependencyinjection/JavaDependencyInjection.md
+++ b/documentation/manual/working/javaGuide/advanced/dependencyinjection/JavaDependencyInjection.md
@@ -58,9 +58,9 @@ In some more complex situations, you may want to provide more complex bindings, 
 
 @[guice-module](code/javaguide/advanced/di/guice/HelloModule.java)
 
-To register this module with Play, create a file called `conf/play.modules`, and put the fully qualified class name of your module there:
+To register this module with Play, append it's fully qualified class name to the `play.modules.enabled` list in `application.conf`:
 
-    modules.HelloModule
+    play.modules.enabled += "modules.HelloModule"
 
 ### Play libraries
 
@@ -70,11 +70,17 @@ To provide bindings, implement a [Module](api/scala/index.html#play.api.inject.M
 
 @[play-module](code/javaguide/advanced/di/play/HelloModule.java)
 
-This module can be registered with Play by creating resource at the root of the classpath called `play.modules`, containing a list of the fully qualified class names of all the modules:
+This module can be registered with Play automatically by appending it to the `play.modules.enabled` list in `reference.conf`:
 
-    com.example.HelloModule
+    play.modules.enabled += "com.example.HelloModule"
 
 In order to maximise cross framework compatibility, keep in mind the following things:
 
 * Not all DI frameworks support just in time bindings. Make sure all components that your library provides are explicitly bound.
 * Try to keep binding keys simple - different runtime DI frameworks have very different views on what a key is and how it should be unique or not.
+
+## Excluding modules
+
+If there is a module that you don't want to be loaded, you can exclude it by appending it to the `play.modules.disabled` property in `application.conf`:
+
+    play.modules.disabled += "play.api.db.evolutions.EvolutionsModule"

--- a/documentation/manual/working/scalaGuide/advanced/dependencyinjection/ScalaDependencyInjection.md
+++ b/documentation/manual/working/scalaGuide/advanced/dependencyinjection/ScalaDependencyInjection.md
@@ -51,9 +51,9 @@ In some more complex situations, you may want to provide more complex bindings, 
 
 @[guice-module](code/RuntimeDependencyInjection.scala)
 
-To register this module with Play, create a file called `conf/play.modules`, and put the fully qualified class name of your module there:
+To register this module with Play, append it's fully qualified class name to the `play.modules.enabled` list in `application.conf`:
 
-    modules.HelloModule
+    play.modules.enabled += "modules.HelloModule"
 
 ### Play libraries
 
@@ -63,11 +63,17 @@ To provide bindings, implement a [Module](api/scala/index.html#play.api.inject.M
 
 @[play-module](code/RuntimeDependencyInjection.scala)
 
-This module can be registered with Play by creating resource at the root of the classpath called `play.modules`, containing a list of the fully qualified class names of all the modules:
+This module can be registered with Play automatically by appending it to the `play.modules.enabled` list in `reference.conf`:
 
-    com.example.HelloModule
+    play.modules.enabled += "com.example.HelloModule"
 
 In order to maximise cross framework compatibility, keep in mind the following things:
 
 * Not all DI frameworks support just in time bindings. Make sure all components that your library provides are explicitly bound.
 * Try to keep binding keys simple - different runtime DI frameworks have very different views on what a key is and how it should be unique or not.
+
+## Excluding modules
+
+If there is a module that you don't want to be loaded, you can exclude it by appending it to the `play.modules.disabled` property in `application.conf`:
+
+    play.modules.disabled += "play.api.db.evolutions.EvolutionsModule"

--- a/framework/src/play-cache/src/main/resources/play.modules
+++ b/framework/src/play-cache/src/main/resources/play.modules
@@ -1,1 +1,0 @@
-play.api.cache.EhCacheModule

--- a/framework/src/play-cache/src/main/resources/reference.conf
+++ b/framework/src/play-cache/src/main/resources/reference.conf
@@ -1,9 +1,14 @@
 play {
+
   modules {
+    enabled += "play.api.cache.EhCacheModule"
+
     cache {
-      enabled = true
+      # The name of the xml resource that should be used to configure the cache
       configResource = "ehcache.xml"
+      # The caches to bind
       bindCaches = []
+      # The name of the default cache to use in ehcache
       defaultCache = "play"
     }
   }

--- a/framework/src/play-java-ebean/src/main/java/play/db/ebean/EbeanModule.java
+++ b/framework/src/play-java-ebean/src/main/java/play/db/ebean/EbeanModule.java
@@ -18,14 +18,10 @@ public class EbeanModule extends Module {
 
     @Override
     public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
-        if (configuration.underlying().getBoolean("play.modules.ebean.enabled")) {
-            return seq(
-                bind(DynamicEvolutions.class).to(EbeanDynamicEvolutions.class),
-                bind(EbeanConfig.class).toProvider(DefaultEbeanConfig.EbeanConfigParser.class).in(Singleton.class)
-            );
-        } else {
-            return seq();
-        }
+        return seq(
+            bind(DynamicEvolutions.class).to(EbeanDynamicEvolutions.class),
+            bind(EbeanConfig.class).toProvider(DefaultEbeanConfig.EbeanConfigParser.class).in(Singleton.class)
+        );
     }
 
 }

--- a/framework/src/play-java-ebean/src/main/resources/play.modules
+++ b/framework/src/play-java-ebean/src/main/resources/play.modules
@@ -1,1 +1,0 @@
-play.db.ebean.EbeanModule

--- a/framework/src/play-java-ebean/src/main/resources/reference.conf
+++ b/framework/src/play-java-ebean/src/main/resources/reference.conf
@@ -1,7 +1,5 @@
 play {
   modules {
-    ebean {
-      enabled = true
-    }
+    enabled += "play.db.ebean.EbeanModule"
   }
 }

--- a/framework/src/play-java-jdbc/src/main/java/play/db/DBModule.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/DBModule.java
@@ -26,32 +26,28 @@ public class DBModule extends Module {
 
     @Override
     public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
-        if (configuration.underlying().getBoolean("play.modules.db.enabled")) {
-            String dbKey = configuration.underlying().getString("play.modules.db.config");
-            String defaultDb = configuration.underlying().getString("play.modules.db.default");
+        String dbKey = configuration.underlying().getString("play.modules.db.config");
+        String defaultDb = configuration.underlying().getString("play.modules.db.default");
 
-            ImmutableList.Builder<Binding<?>> list = new ImmutableList.Builder<Binding<?>>();
+        ImmutableList.Builder<Binding<?>> list = new ImmutableList.Builder<Binding<?>>();
 
-            list.add(bind(ConnectionPool.class).to(DefaultConnectionPool.class));
-            list.add(bind(DBApi.class).to(DefaultDBApi.class));
+        list.add(bind(ConnectionPool.class).to(DefaultConnectionPool.class));
+        list.add(bind(DBApi.class).to(DefaultDBApi.class));
 
-            try {
-                Set<String> dbs = configuration.underlying().getConfig(dbKey).root().keySet();
-                for (String db : dbs) {
-                    list.add(bind(Database.class).qualifiedWith(named(db)).to(new NamedDatabaseProvider(db)));
-                }
-
-                if (dbs.contains(defaultDb)) {
-                    list.add(bind(Database.class).to(bind(Database.class).qualifiedWith(named(defaultDb))));
-                }
-            } catch (com.typesafe.config.ConfigException.Missing e) {
-                // ignore missing configuration
+        try {
+            Set<String> dbs = configuration.underlying().getConfig(dbKey).root().keySet();
+            for (String db : dbs) {
+                list.add(bind(Database.class).qualifiedWith(named(db)).to(new NamedDatabaseProvider(db)));
             }
 
-            return Scala.toSeq(list.build());
-        } else {
-            return seq();
+            if (dbs.contains(defaultDb)) {
+                list.add(bind(Database.class).to(bind(Database.class).qualifiedWith(named(defaultDb))));
+            }
+        } catch (com.typesafe.config.ConfigException.Missing e) {
+            // ignore missing configuration
         }
+
+        return Scala.toSeq(list.build());
     }
 
     private NamedDatabase named(String name) {

--- a/framework/src/play-java-jdbc/src/main/resources/play.modules
+++ b/framework/src/play-java-jdbc/src/main/resources/play.modules
@@ -1,1 +1,0 @@
-play.db.DBModule

--- a/framework/src/play-java-jdbc/src/main/resources/reference.conf
+++ b/framework/src/play-java-jdbc/src/main/resources/reference.conf
@@ -1,0 +1,1 @@
+play.modules.enabled += "play.db.DBModule"

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAModule.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAModule.java
@@ -17,14 +17,10 @@ public class JPAModule extends Module {
 
     @Override
     public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
-        if (configuration.underlying().getBoolean("play.modules.jpa.enabled")) {
-            return seq(
-                bind(JPAApi.class).toProvider(DefaultJPAApi.JPAApiProvider.class),
-                bind(JPAConfig.class).toProvider(DefaultJPAConfig.JPAConfigProvider.class)
-            );
-        } else {
-            return seq();
-        }
+        return seq(
+            bind(JPAApi.class).toProvider(DefaultJPAApi.JPAApiProvider.class),
+            bind(JPAConfig.class).toProvider(DefaultJPAConfig.JPAConfigProvider.class)
+        );
     }
 
 }

--- a/framework/src/play-java-jpa/src/main/resources/play.modules
+++ b/framework/src/play-java-jpa/src/main/resources/play.modules
@@ -1,1 +1,0 @@
-play.db.jpa.JPAModule

--- a/framework/src/play-java-jpa/src/main/resources/reference.conf
+++ b/framework/src/play-java-jpa/src/main/resources/reference.conf
@@ -1,7 +1,5 @@
 play {
   modules {
-    jpa {
-      enabled = true
-    }
+    enabled += "play.db.jpa.JPAModule"
   }
 }

--- a/framework/src/play-java-ws/src/main/java/play/libs/openid/OpenIdModule.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/openid/OpenIdModule.java
@@ -13,12 +13,8 @@ public class OpenIdModule extends Module {
 
     @Override
     public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
-        if (configuration.underlying().getBoolean("play.modules.openid.enabled")) {
-            return seq(
-                    bind(OpenIdClient.class).to(DefaultOpenIdClient.class)
-            );
-        } else {
-            return seq();
-        }
+        return seq(
+                bind(OpenIdClient.class).to(DefaultOpenIdClient.class)
+        );
     }
 }

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSModule.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSModule.java
@@ -19,14 +19,10 @@ public class NingWSModule extends Module {
 
     @Override
     public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
-        if (configuration.underlying().getBoolean("play.modules.ws.enabled")) {
-            return seq(
-                    bind(WSAPI.class).to(NingWSAPI.class),
-                    bind(WSClient.class).toProvider(WSClientProvider.class)
-            );
-        } else {
-            return seq();
-        }
+        return seq(
+                bind(WSAPI.class).to(NingWSAPI.class),
+                bind(WSClient.class).toProvider(WSClientProvider.class)
+        );
     }
 
     @Singleton

--- a/framework/src/play-java-ws/src/main/resources/play.modules
+++ b/framework/src/play-java-ws/src/main/resources/play.modules
@@ -1,2 +1,0 @@
-play.libs.ws.ning.NingWSModule
-play.libs.openid.OpenIdModule

--- a/framework/src/play-java-ws/src/main/resources/reference.conf
+++ b/framework/src/play-java-ws/src/main/resources/reference.conf
@@ -1,0 +1,6 @@
+play {
+  modules {
+    enabled += "play.libs.ws.ning.NingWSModule"
+    enabled += "play.libs.openid.OpenIdModule"
+  }
+}

--- a/framework/src/play-java/src/main/resources/play.modules
+++ b/framework/src/play-java/src/main/resources/play.modules
@@ -1,2 +1,0 @@
-play.inject.BuiltInModule
-play.core.ObjectMapperModule

--- a/framework/src/play-java/src/main/resources/reference.conf
+++ b/framework/src/play-java/src/main/resources/reference.conf
@@ -1,0 +1,6 @@
+play {
+  modules {
+    enabled += "play.inject.BuiltInModule"
+    enabled += "play.core.ObjectMapperModule"
+  }
+}

--- a/framework/src/play-jdbc/src/main/resources/play.modules
+++ b/framework/src/play-jdbc/src/main/resources/play.modules
@@ -1,3 +1,0 @@
-play.api.db.DBModule
-play.api.db.BoneCPModule
-play.api.db.evolutions.EvolutionsModule

--- a/framework/src/play-jdbc/src/main/resources/reference.conf
+++ b/framework/src/play-jdbc/src/main/resources/reference.conf
@@ -1,13 +1,13 @@
 play {
+
   modules {
+    enabled += "play.api.db.DBModule"
+    enabled += "play.api.db.BoneCPModule"
+    enabled += "play.api.db.evolutions.EvolutionsModule"
+
     db {
-      enabled = true
       config = "db"
       default = "default"
-      bonecp.enabled = true
-    }
-    evolutions {
-      enabled = true
     }
   }
 }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
@@ -18,10 +18,9 @@ import com.jolbox.bonecp.hooks._
  */
 class BoneCPModule extends Module {
   def bindings(environment: Environment, configuration: Configuration) = {
-    if (configuration.underlying.getBoolean("play.modules.db.bonecp.enabled")) Seq(
+    Seq(
       bind[ConnectionPool].to[BoneConnectionPool]
     )
-    else Nil
   }
 }
 

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DBModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DBModule.scala
@@ -17,16 +17,12 @@ import play.db.NamedDatabaseImpl
  */
 class DBModule extends Module {
   def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
-    if (configuration.underlying.getBoolean("play.modules.db.enabled")) {
-      val dbKey = configuration.underlying.getString("play.modules.db.config")
-      val default = configuration.underlying.getString("play.modules.db.default")
-      val dbs = configuration.getConfig(dbKey).getOrElse(Configuration.empty).subKeys
-      Seq(
-        bind[DBApi].toProvider[DBApiProvider]
-      ) ++ namedDatabaseBindings(dbs) ++ defaultDatabaseBinding(default, dbs)
-    } else {
-      Nil
-    }
+    val dbKey = configuration.underlying.getString("play.modules.db.config")
+    val default = configuration.underlying.getString("play.modules.db.default")
+    val dbs = configuration.getConfig(dbKey).getOrElse(Configuration.empty).subKeys
+    Seq(
+      bind[DBApi].toProvider[DBApiProvider]
+    ) ++ namedDatabaseBindings(dbs) ++ defaultDatabaseBinding(default, dbs)
   }
 
   def bindNamed(name: String): BindingKey[Database] = {

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/EvolutionsModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/EvolutionsModule.scala
@@ -15,16 +15,12 @@ import play.core.WebCommands
  */
 class EvolutionsModule extends Module {
   def bindings(environment: Environment, configuration: Configuration) = {
-    if (configuration.underlying.getBoolean("play.modules.evolutions.enabled")) {
-      Seq(
-        bind[EvolutionsConfig].toProvider[DefaultEvolutionsConfigParser],
-        bind[EvolutionsReader].toSelf,
-        bind[EvolutionsApi].to[DefaultEvolutionsApi],
-        bind[ApplicationEvolutions].toProvider[ApplicationEvolutionsProvider].eagerly
-      )
-    } else {
-      Nil
-    }
+    Seq(
+      bind[EvolutionsConfig].toProvider[DefaultEvolutionsConfigParser],
+      bind[EvolutionsReader].toSelf,
+      bind[EvolutionsApi].to[DefaultEvolutionsApi],
+      bind[ApplicationEvolutions].toProvider[ApplicationEvolutionsProvider].eagerly
+    )
   }
 }
 

--- a/framework/src/play-ws/src/main/resources/play.modules
+++ b/framework/src/play-ws/src/main/resources/play.modules
@@ -1,2 +1,0 @@
-play.api.libs.ws.ning.NingWSModule
-play.api.libs.openid.OpenIDModule

--- a/framework/src/play-ws/src/main/resources/reference.conf
+++ b/framework/src/play-ws/src/main/resources/reference.conf
@@ -1,10 +1,6 @@
 play {
   modules {
-    ws {
-      enabled = true
-    }
-    openid {
-      enabled = true
-    }
+    enabled += "play.api.libs.ws.ning.NingWSModule"
+    enabled += "play.api.libs.openid.OpenIDModule"
   }
 }

--- a/framework/src/play-ws/src/main/scala/play/api/libs/openid/OpenIdClient.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/openid/OpenIdClient.scala
@@ -297,14 +297,10 @@ private[openid] object Discovery {
  */
 class OpenIDModule extends Module {
   def bindings(environment: Environment, configuration: Configuration) = {
-    if (configuration.underlying.getBoolean("play.modules.openid.enabled")) {
-      Seq(
-        bind[OpenIdClient].to[WsOpenIdClient],
-        bind[Discovery].to[WsDiscovery]
-      )
-    } else {
-      Nil
-    }
+    Seq(
+      bind[OpenIdClient].to[WsOpenIdClient],
+      bind[Discovery].to[WsDiscovery]
+    )
   }
 }
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
@@ -512,15 +512,11 @@ case class NingWSRequestHolder(client: NingWSClient,
 
 class NingWSModule extends Module {
   def bindings(environment: Environment, configuration: Configuration) = {
-    if (configuration.underlying.getBoolean("play.modules.ws.enabled")) {
-      Seq(
-        bind[WSAPI].to[NingWSAPI],
-        bind[WSClientConfig].toProvider[DefaultWSConfigParser].in[Singleton],
-        bind[WSClient].toProvider[WSClientProvider].in[Singleton]
-      )
-    } else {
-      Nil
-    }
+    Seq(
+      bind[WSAPI].to[NingWSAPI],
+      bind[WSClientConfig].toProvider[DefaultWSConfigParser].in[Singleton],
+      bind[WSClient].toProvider[WSClientProvider].in[Singleton]
+    )
   }
 }
 

--- a/framework/src/play/src/main/resources/play.modules
+++ b/framework/src/play/src/main/resources/play.modules
@@ -1,3 +1,0 @@
-play.api.inject.BuiltinModule
-play.api.i18n.I18nModule
-play.api.libs.concurrent.AkkaModule

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -59,12 +59,16 @@ play {
 
   modules {
 
+    # The enabled modules that should be automatically loaded.
+    enabled += "play.api.inject.BuiltinModule"
+    enabled += "play.api.i18n.I18nModule"
+    enabled += "play.api.libs.concurrent.AkkaModule"
+
+    # A way to disable modules that are automatically enabled
+    disabled = []
+
     # Internationalisation configuration
     i18n {
-
-      # Whether the i18n module is enabled. Setting this to false will allow you to plug in a different i18n
-      # configuration.
-      enabled = true
 
       # A path to prefix message file loading with.  Use this if you want to place your messages resources at some path
       # other than the root application path.

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -543,14 +543,10 @@ class DefaultMessagesApi @Inject() (environment: Environment, configuration: Con
 
 class I18nModule extends Module {
   def bindings(environment: Environment, configuration: Configuration) = {
-    if (configuration.underlying.getBoolean("play.modules.i18n.enabled")) {
-      Seq(
-        bind[Langs].to[DefaultLangs],
-        bind[MessagesApi].to[DefaultMessagesApi]
-      )
-    } else {
-      Nil
-    }
+    Seq(
+      bind[Langs].to[DefaultLangs],
+      bind[MessagesApi].to[DefaultMessagesApi]
+    )
   }
 }
 


### PR DESCRIPTION
Introduced `play.module.includes` and `play.module.excludes` to add/remove modules from Play.

I'm not sure on the naming, `play.module.*` reads nicely - "play module includes", `play.modules.*` is more consistent with the rest of the configuration naming, but is more awkward, "play modules includes".  I think it does make sense to separate them, one is to configure how modules are loaded themselves, the other is a place for modules to put their configuration, but it could introduce confusion, since it would be very easy to miss the fact that there's a difference, and be stuck wondering why `play.modules.includes` doesn't work.
