### PR TITLE
Resources should be on the Eclipse classpath

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala
@@ -92,6 +92,7 @@ trait PlayEclipse {
         EclipsePlugin.eclipseSettings ++ Seq(
           EclipseKeys.projectFlavor := EclipseProjectFlavor.Scala,
           EclipseKeys.preTasks := Seq(compile in Compile),
+          EclipseKeys.createSrc := EclipseCreateSrc.Default + EclipseCreateSrc.Resource,
           EclipseKeys.classpathTransformerFactories := Seq(addSourcesManaged)
         )
       case JAVA =>
@@ -99,6 +100,7 @@ trait PlayEclipse {
         EclipsePlugin.eclipseSettings ++ Seq(
           EclipseKeys.projectFlavor := EclipseProjectFlavor.Java,
           EclipseKeys.preTasks := Seq(compile in Compile),
+          EclipseKeys.createSrc := EclipseCreateSrc.Default + EclipseCreateSrc.Resource,
           EclipseKeys.classpathTransformerFactories := Seq(addClassesManaged, addScalaLib)
         )
     }


### PR DESCRIPTION
Fix for https://github.com/playframework/playframework/issues/1319

This makes running in Eclipse much closer to running in SBT where resources are on the classpath

@jsuereth do you have any idea why this isn't the SBT Eclipse default? I think the current default doesn't make nearly as much sense as this setting
