### PR TITLE
WSResponse does not show contentType

### DIFF
--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -305,6 +305,10 @@ trait WSResponse {
    */
   def json: JsValue
 
+  /**
+   * The response body as a byte array.
+   */
+  def bodyAsBytes: Array[Byte]
 }
 
 /**

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
@@ -693,6 +693,11 @@ case class NingWSResponse(ahcResponse: AHCResponse) extends WSResponse {
    */
   lazy val json: JsValue = Json.parse(ahcResponse.getResponseBodyAsBytes)
 
+  /**
+   * The response body as a byte array.
+   */
+  def bodyAsBytes: Array[Byte] = ahcResponse.getResponseBodyAsBytes
+
 }
 
 /**

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
@@ -264,6 +264,14 @@ object NingWSSpec extends PlaySpecification with Mockito {
       }
     }
 
+    "get the body as bytes from the AHC response" in {
+      val ahcResponse: AHCResponse = mock[AHCResponse]
+      val bytes = Array[Byte](-87, -72, 96, -63, -32, 46, -117, -40, -128, -7, 61, 109, 80, 45, 44, 30)
+      ahcResponse.getResponseBodyAsBytes returns bytes
+      val response = NingWSResponse(ahcResponse)
+      response.bodyAsBytes must_== bytes
+    }
+
     "get headers from an AHC response in a case insensitive map" in {
       val ahcResponse: AHCResponse = mock[AHCResponse]
       val ahcHeaders = new FluentCaseInsensitiveStringsMap()


### PR DESCRIPTION
Possible encoding bug from 

https://stackoverflow.com/questions/26409801/play-framework-ning-ws-api-encoding-issue-with-html-pages

So, looking at the HTTP header from the site, it is:

```
HTTP/1.1 200 OK
Content-Type: text/html
X-UA-Compatible: IE=edge
P3P: policyref="http://www.walla.co.il/w3c/p3p.xml", CP="NOI DSP COR NID CURa TAIa OUR IND UNI COM NAV"
Content-Encoding: gzip
Vary: Accept-Encoding
Date: Thu, 16 Oct 2014 18:28:21 GMT
Content-Length: 16958
Connection: keep-alive
```

The header is 

```
<html lang="he-IL" xml:lang="he-IL">
    <head>
        <meta charset="UTF-8" />
```

As the text says "[only one of these elements is required to set the character set to UTF-8](http://oli.jp/2009/html5-charset/)".

Looking at the [HTML W3 Validator](http://validator.w3.org/) service and entering the URL, it is detected as UTF-8.  So, my guess is that it's Curl doing some additional charset detection there.

However, even if the source is wrong, there should be a way to call response.contentType, and there isn't.  So filing this bug.

https://groups.google.com/d/topic/asynchttpclient/eY5uevka6Rg/discussion
