### PR TITLE
Html.empty replaced by HtmlFormat.empty

### DIFF
--- a/documentation/manual/releases/Migration23.md
+++ b/documentation/manual/releases/Migration23.md
@@ -450,6 +450,10 @@ For sbt builds that use the full scala syntax, `TwirlKeys` can be imported with:
 import play.twirl.sbt.Import._
 ```
 
+### Html.empty replaced by HtmlFormat.empty
+
+If you were using before `Html.empty` (`play.api.templates.Html.empty`), you must now use `play.twirl.api.HtmlFormat.empty`.
+
 ## Play WS
 
 The WS client is now an optional library. If you are using WS in your project then you will need to add the library dependency. For Java projects you will also need to update to a new package.


### PR DESCRIPTION
See: https://groups.google.com/forum/#!msg/play-framework/bTvJbeR_zvU/mpom08-idCQJ and https://github.com/playframework/twirl/blob/master/api/src/main/scala/play/twirl/api/Formats.scala#L77
