### PR TITLE
Anorm positional extractor on Row & implicit refactoring

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/MayErr.scala
+++ b/framework/src/anorm/src/main/scala/anorm/MayErr.scala
@@ -3,6 +3,7 @@
  */
 package anorm
 
+@deprecated("For internal use, will be made private", "2.3.6")
 case class MayErr[+E, +A](toEither: Either[E, A]) {
 
   def flatMap[B, EE >: E](f: A => MayErr[EE, B]): MayErr[EE, B] =
@@ -27,13 +28,17 @@ case class MayErr[+E, +A](toEither: Either[E, A]) {
    */
   def fold[B](f: E => B, s: A => B): B = toEither.fold(f, s)
 
+  /**
+   * Returns successful value, or throws exception.
+   */
   def get = toEither.fold(e =>
     throw new RuntimeException(toEither.toString), a => a)
 
 }
 
-// TODO Remove (make it more explicit)
 object MayErr {
   import scala.language.implicitConversions
+
+  @deprecated("Use [[MayErr]] constructor explicitly.", "2.3.6")
   implicit def eitherToError[E, EE >: E, A, AA >: A](e: Either[E, A]): MayErr[EE, AA] = MayErr[E, A](e)
 }

--- a/framework/src/anorm/src/main/scala/anorm/SqlParser.scala
+++ b/framework/src/anorm/src/main/scala/anorm/SqlParser.scala
@@ -20,11 +20,11 @@ object SqlParser {
   def scalar[T](implicit transformer: Column[T]): RowParser[T] =
     new ScalarRowParser[T] {
       def apply(row: Row): SqlResult[T] = {
-        (for {
-          meta <- row.metaData.ms.headOption.toRight(NoColumnsInReturnedResult)
-          value <- row.data.headOption.toRight(NoColumnsInReturnedResult)
-          result <- transformer(value, meta)
-        } yield result).fold(Error(_), Success(_))
+        MayErr((for {
+          m <- row.metaData.ms.headOption
+          v <- row.data.headOption
+        } yield v -> m) toRight NoColumnsInReturnedResult).
+          flatMap(transformer.tupled).fold(Error(_), Success(_))
       }
     }
 

--- a/framework/src/anorm/src/main/scala/anorm/SqlResult.scala
+++ b/framework/src/anorm/src/main/scala/anorm/SqlResult.scala
@@ -2,6 +2,7 @@ package anorm
 
 /** Parsed SQL result. */
 sealed trait SqlResult[+A] { self =>
+  // TODO: Review along with MayErr (unify?)
 
   def flatMap[B](k: A => SqlResult[B]): SqlResult[B] = self match {
     case Success(a) => k(a)

--- a/framework/src/anorm/src/test/scala/anorm/RowSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/RowSpec.scala
@@ -1,8 +1,7 @@
 package anorm
 
-import acolyte.jdbc.AcolyteDSL.{ connection, handleQuery }
-import acolyte.jdbc.{ QueryResult, RowLists }
-import RowLists.{ rowList2, rowList1, stringList }
+import acolyte.jdbc.AcolyteDSL.withQueryResult
+import acolyte.jdbc.RowLists.{ rowList2, rowList1, stringList }
 import acolyte.jdbc.Implicits._
 
 object RowSpec extends org.specs2.mutable.Specification {
@@ -71,9 +70,17 @@ object RowSpec extends org.specs2.mutable.Specification {
       }
   }
 
-  // ---
+  "Column" should {
+    "be extracted by name" in withQueryResult(
+      rowList1(classOf[String] -> "foo") :+ "byName") { implicit c =>
+        SQL("SELECT *").map(_.apply[String]("foo")).single.
+          aka("column by name") must_== "byName"
+      }
 
-  def withQueryResult[A](r: QueryResult)(f: java.sql.Connection => A): A =
-    f(connection(handleQuery { _ => r }))
-
+    "be extracted by position" in withQueryResult(stringList :+ "byPos") {
+      implicit c =>
+        SQL("SELECT *").map(_.apply[String](1)).single.
+          aka("column by name") must_== "byPos"
+    }
+  }
 }


### PR DESCRIPTION
- Anorm positional getter on Row (e.g. `row[T](1)`)
- Implicit refactoring for `MayErr`: remove `eitherToError`
