### PR TITLE
Construction of WSClient could be improved

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -32,7 +32,7 @@ import play.api.libs.ws.ning.NingAsyncHttpClientConfigBuilder;
 
 public class JavaWS {
     private static final String feedUrl = "http://localhost:3333/feed";
-    
+
     public static class Controller0 extends MockJavaAction {
 
         private WSClient ws;
@@ -41,63 +41,63 @@ public class JavaWS {
             // #ws-holder
             WSRequestHolder holder = ws.url("http://example.com");
             // #ws-holder
-          
+
             // #ws-complex-holder
             WSRequestHolder complexHolder = holder.setHeader("headerKey", "headerValue")
                                                   .setTimeout(1000)
                                                   .setQueryParameter("paramKey", "paramValue");
             // #ws-complex-holder
-            
+
             // #ws-get
             Promise<WSResponse> responsePromise = complexHolder.get();
             // #ws-get
-            
+
             String url = "http://example.com";
             // #ws-auth
             ws.url(url).setAuth("user", "password", WSAuthScheme.BASIC).get();
             // #ws-auth
-            
+
             // #ws-follow-redirects
             ws.url(url).setFollowRedirects(true).get();
             // #ws-follow-redirects
-            
+
             // #ws-query-parameter
             ws.url(url).setQueryParameter("paramKey", "paramValue");
             // #ws-query-parameter
-            
+
             // #ws-header
             ws.url(url).setHeader("headerKey", "headerValue").get();
             // #ws-header
-            
+
             String jsonString = "{\"key1\":\"value1\"}";
             // #ws-header-content-type
             ws.url(url).setHeader("Content-Type", "application/json").post(jsonString);
             // OR
             ws.url(url).setContentType("application/json").post(jsonString);
             // #ws-header-content-type
-            
+
             // #ws-timeout
             ws.url(url).setTimeout(1000).get();
             // #ws-timeout
-            
+
             // #ws-post-form-data
             ws.url(url).setContentType("application/x-www-form-urlencoded")
                        .post("key1=value1&key2=value2");
             // #ws-post-form-data
-            
+
             // #ws-post-json
             JsonNode json = Json.newObject()
                                 .put("key1", "value1")
                                 .put("key2", "value2");
-            
+
             ws.url(url).post(json);
             // #ws-post-json
         }
-        
+
         public void responseExamples() {
-          
+
           String url = "http://example.com";
-          
+
           // #ws-response-json
           Promise<JsonNode> jsonPromise = ws.url(url).get().map(
               new Function<WSResponse, JsonNode>() {
@@ -108,7 +108,7 @@ public class JavaWS {
               }
           );
           // #ws-response-json
-          
+
           // #ws-response-xml
           Promise<Document> documentPromise = ws.url(url).get().map(
               new Function<WSResponse, Document>() {
@@ -119,42 +119,42 @@ public class JavaWS {
               }
           );
           // #ws-response-xml
-          
+
           // #ws-response-input-stream
           final Promise<File> filePromise = ws.url(url).get().map(
               new Function<WSResponse, File>() {
                   public File apply(WSResponse response) throws Throwable {
-                    
+
                       InputStream inputStream = null;
                       OutputStream outputStream = null;
                       try {
                           inputStream = response.getBodyAsStream();
-                        
+
                           // write the inputStream to a File
                           final File file = new File("/tmp/response.txt");
                           outputStream = new FileOutputStream(file);
-                        
+
                           int read = 0;
                           byte[] buffer = new byte[1024];
-               
+
                           while ((read = inputStream.read(buffer)) != -1) {
                               outputStream.write(buffer, 0, read);
                           }
-                      
-                          return file;  
+
+                          return file;
                       } catch (IOException e) {
                           throw e;
                       } finally {
                           if (inputStream != null) {inputStream.close();}
                           if (outputStream != null) {outputStream.close();}
                       }
-                      
+
                   }
               }
           );
           // #ws-response-input-stream
         }
-        
+
         public void patternExamples() {
             String urlOne = "http://localhost:3333/one";
             // #ws-composition
@@ -174,7 +174,7 @@ public class JavaWS {
                 }
             );
             // #ws-composition
-            
+
             // #ws-recover
             Promise<WSResponse> responsePromise = ws.url("http://example.com").get();
             Promise<WSResponse> recoverPromise = responsePromise.recoverWith(new Function<Throwable, Promise<WSResponse>>() {
@@ -185,7 +185,7 @@ public class JavaWS {
             });
             // #ws-recover
         }
-        
+
         public void clientExamples() {
             // #ws-client
             WSClient client = WS.client();
@@ -207,10 +207,8 @@ public class JavaWS {
                     none, // acceptAnyCertificate
                     noneSSLConfig);
 
-            // Build a secure config out of the client config and the ning builder:
-            AsyncHttpClientConfig.Builder asyncHttpClientBuilder = new AsyncHttpClientConfig.Builder();
-            NingAsyncHttpClientConfigBuilder secureBuilder = new NingAsyncHttpClientConfigBuilder(clientConfig,
-                    asyncHttpClientBuilder);
+            // Build a secure config out of the client config:
+            NingAsyncHttpClientConfigBuilder secureBuilder = new NingAsyncHttpClientConfigBuilder(clientConfig);
             AsyncHttpClientConfig secureDefaults = secureBuilder.build();
 
             // You can directly use the builder for specific options once you have secure TLS defaults...
@@ -219,15 +217,15 @@ public class JavaWS {
                             .setCompressionEnabled(true)
                             .build();
             WSClient customClient = new play.libs.ws.ning.NingWSClient(customConfig);
-            
+
             Promise<WSResponse> responsePromise = customClient.url("http://example.com/feed").get();
             // #ws-custom-client
-            
+
             // #ws-underlying-client
-            com.ning.http.client.AsyncHttpClient underlyingClient = 
+            com.ning.http.client.AsyncHttpClient underlyingClient =
                 (com.ning.http.client.AsyncHttpClient) ws.getUnderlying();
             // #ws-underlying-client
-            
+
         }
     }
 
@@ -274,5 +272,5 @@ public class JavaWS {
         }
         // #composed-call
     }
-    
+
 }

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSAPI.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSAPI.java
@@ -33,7 +33,7 @@ public class NingWSAPI implements WSAPI {
     @Inject
     public NingWSAPI(WSClientConfig clientConfig, ApplicationLifecycle lifecycle) {
         client = new NingWSClient(
-                new NingAsyncHttpClientConfigBuilder(clientConfig, new AsyncHttpClientConfig.Builder()).build()
+                new NingAsyncHttpClientConfigBuilder(clientConfig).build()
         );
         lifecycle.addStopHook(new Callable<F.Promise<Void>>() {
             @Override

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
@@ -35,7 +35,7 @@ import scala.collection.JavaConverters._
  *
  * @param config a client configuration object
  */
-class NingWSClient(config: AsyncHttpClientConfig) extends WSClient {
+case class NingWSClient(config: AsyncHttpClientConfig) extends WSClient {
 
   private val asyncHttpClient = new AsyncHttpClient(config)
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
@@ -289,4 +289,18 @@ object NingWSSpec extends PlaySpecification with Mockito {
     }
   }
 
+  "Ning WS Config" should {
+    "support overriding secure default values" in {
+      val ahcConfig = new NingAsyncHttpClientConfigBuilder().modifyUnderlying { builder =>
+        builder.setCompressionEnabled(true)
+        builder.setFollowRedirects(false)
+      }.build()
+      ahcConfig.isCompressionEnabled must beTrue
+      ahcConfig.isRedirectEnabled must beFalse
+      ahcConfig.getConnectionTimeoutInMs must_== Defaults.connectionTimeout
+      ahcConfig.getRequestTimeoutInMs must_== Defaults.requestTimeout
+      ahcConfig.getIdleConnectionTimeoutInMs must_== Defaults.idleTimeout
+    }
+  }
+
 }


### PR DESCRIPTION
Right now, in order to construct a NingWSClient entirely programmatically, you have to do something like

```
import play.api.libs.ws.ning.NingAsyncHttpClientConfigBuilder
import play.api.libs.ws.ning.NingWSClient
import com.ning.http.client.AsyncHttpClientConfig

val clientConfig = new DefaultWSClientConfig()
val secureDefaults: AsyncHttpClientConfig = new NingAsyncHttpClientConfigBuilder(clientConfig).build()
// You can directly use the builder for specific options once you have secure TLS defaults...
val builder = new AsyncHttpClientConfig.Builder(secureDefaults)
builder.setCompressionEnabled(true)
val secureDefaultsWithSpecificOptions: AsyncHttpClientConfig = builder.build()
val wsClient:WSClient = new NingWSClient(secureDefaultsWithSpecificOptions)
```

This could be much cleaner.
