### PR TITLE
Turn off Javadoc errors for Netty Utils

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -256,6 +256,11 @@ object PlayBuild extends Build {
     testBinaryCompatibility = true)
 
   lazy val PlayNettyUtilsProject = PlaySharedJavaProject("Play-Netty-Utils", "play-netty-utils")
+    .settings(javacOptions in (Compile,doc) ++= {
+      // References to the rest of Netty don't work in the code that
+      // we've excised. Disable Javadoc lint checking in Java 8+.
+      if (isJavaAtLeast("1.8")) Seq("-Xdoclint:none") else Seq()
+    })
 
   lazy val PlayProject = PlayRuntimeProject("Play", "play")
     .enablePlugins(SbtTwirl)


### PR DESCRIPTION
We don't Javadoc to tell us about errors in Netty Utils since this project has just been copied from Netty. The errors I saw were about missing references back to other code in Netty.

This error shows up when building using Java 8 and Scala 2.11. Under Java 7 the javadoc tool is more forgiving. Javadoc doesn't seem to run at all when building with Scala 2.10.
