### PR TITLE
Anorm support for parsing UUIDs from JDBC Strings

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/Column.scala
+++ b/framework/src/anorm/src/main/scala/anorm/Column.scala
@@ -7,6 +7,8 @@ import java.io.{ ByteArrayInputStream, InputStream }
 import java.math.{ BigDecimal => JBigDec, BigInteger }
 import java.util.{ Date, UUID }
 
+import scala.util.{ Failure, Success => TrySuccess, Try }
+
 import resource.managed
 
 /** Column mapping */
@@ -242,6 +244,10 @@ object Column extends JodaColumn {
     val MetaDataItem(qualified, nullable, clazz) = meta
     value match {
       case d: UUID => Right(d)
+      case s: String => Try { UUID.fromString(s) } match {
+        case TrySuccess(v) => Right(v)
+        case Failure(ex) => Left(TypeDoesNotMatch(s"Cannot convert $value: ${value.asInstanceOf[AnyRef].getClass} to UUID for column $qualified"))
+      }
       case _ => Left(TypeDoesNotMatch(s"Cannot convert $value: ${value.asInstanceOf[AnyRef].getClass} to UUID for column $qualified"))
     }
   }

--- a/framework/src/anorm/src/test/scala/anorm/ColumnSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/ColumnSpec.scala
@@ -4,6 +4,9 @@ import java.io.{ ByteArrayInputStream, InputStream }
 import java.sql.{ Array => SqlArray }
 import javax.sql.rowset.serial.{ SerialBlob, SerialClob }
 import java.math.BigInteger
+import java.util.UUID
+
+import scala.util.Random
 
 import acolyte.jdbc.{ QueryResult, ImmutableArray }
 import acolyte.jdbc.RowLists.{
@@ -517,6 +520,33 @@ object ColumnSpec
       SQL("SELECT time").as(scalar[java.util.Date].single).
         aka("parsed date") must_== new java.util.Date(time)
 
+    }
+  }
+
+  "Column mapped as UUID" should {
+    val uuid = UUID.randomUUID
+    val uuidStr = uuid.toString
+
+    "be pased from a UUID" in withQueryResult(rowList1(classOf[UUID]) :+ uuid) { implicit con =>
+      SQL("SELECT uuid").as(scalar[UUID].single).
+        aka("parsed uuid") must_== uuid
+    }
+
+    "be parsed from a valid string" in withQueryResult(stringList :+ uuidStr) { implicit con =>
+      SQL("SELECT uuid").as(scalar[UUID].single).
+        aka("parsed uuid") must_== uuid
+    }
+
+    "not be parsed from an invalid string" in withQueryResult(stringList :+ Random.nextString(36)) { implicit con =>
+      SQL("SELECT uuid").as(scalar[UUID].single).
+        aka("parsed uuid") must throwA[Exception](message =
+          "TypeDoesNotMatch\\(Cannot convert.* to UUID")
+    }
+
+    "not be mapped from an unknown type" in withQueryResult(booleanList :+ false) { implicit con =>
+      SQL("SELECT uuid").as(scalar[UUID].single).
+        aka("parsed uuid") must throwA[Exception](message =
+          "TypeDoesNotMatch\\(Cannot convert.*Boolean to UUID")
     }
   }
 


### PR DESCRIPTION
Anorm currently supports retrieving UUID objects via JDBC, but not all databases support UUID types. Some store UUIDs as varchar, so anorm should support parsing the Strings into UUIDs.
