### PR TITLE
Fixed the Scala 2.11 scripted tests

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -291,7 +291,8 @@ object PlayBuild extends Build {
     .settings(
       scriptedLaunchOpts ++= Seq(
         maxMetaspace,
-        "-Dproject.version=" + version.value
+        "-Dproject.version=" + version.value,
+        "-Dscala.version=" + buildScalaVersion
       )
     )
     .dependsOn(PlayServerProject, StreamsProject)
@@ -359,7 +360,8 @@ object PlayBuild extends Build {
         "-Xmx768m",
         maxMetaspace,
         "-Dperformance.log=" + new File(baseDirectory.value, "target/sbt-repcomile-performance.properties"),
-        "-Dproject.version=" + version.value
+        "-Dproject.version=" + version.value,
+        "-Dscala.version=" + buildScalaVersion
       ),
       scriptedDependencies := {
         val () = publishLocal.value

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/Build.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/Build.scala
@@ -53,6 +53,7 @@ object ApplicationBuild extends Build {
         bufferLogger +: currentFunction(key)
       }
     },
+    scalaVersion := sys.props.get("scala.version").getOrElse("2.10.4"),
     checkLogContainsTask,
     compileIgnoreErrorsTask
   )

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/incremental-compilation/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/incremental-compilation/build.sbt
@@ -3,9 +3,12 @@
 //
 lazy val root = (project in file(".")).enablePlugins(RoutesCompiler)
 
-scalaVersion := "2.11.1"
+scalaVersion := sys.props.get("scala.version").getOrElse("2.10.4")
 
 routesFiles in Compile := Seq(baseDirectory.value / "a.routes", baseDirectory.value / "b.routes")
+
+// turn off cross paths so that expressions don't need to include the scala version
+crossPaths := false
 
 // because the scripted newer command is broken:
 // https://github.com/sbt/sbt/pull/1419

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/incremental-compilation/test
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/incremental-compilation/test
@@ -2,12 +2,12 @@
 
 > play-routes
 
-$ exists target/scala-2.11/routes/main/a/routes_routing.scala
-$ exists target/scala-2.11/routes/main/a/routes_reverseRouting.scala
-$ exists target/scala-2.11/routes/main/controllers/a/routes.java
-$ exists target/scala-2.11/routes/main/b/routes_routing.scala
-$ exists target/scala-2.11/routes/main/b/routes_reverseRouting.scala
-$ exists target/scala-2.11/routes/main/controllers/b/routes.java
+$ exists target/routes/main/a/routes_routing.scala
+$ exists target/routes/main/a/routes_reverseRouting.scala
+$ exists target/routes/main/controllers/a/routes.java
+$ exists target/routes/main/b/routes_routing.scala
+$ exists target/routes/main/b/routes_reverseRouting.scala
+$ exists target/routes/main/controllers/b/routes.java
 
 # Modify nothing, ensure nothing gets recompiled
 
@@ -16,8 +16,8 @@ $ sleep 1100
 
 > play-routes
 
--> newer target/scala-2.11/routes/main/a/routes_routing.scala target/change1
--> newer target/scala-2.11/routes/main/b/routes_routing.scala target/change1
+-> newer target/routes/main/a/routes_routing.scala target/change1
+-> newer target/routes/main/b/routes_routing.scala target/change1
 
 # Modify a, ensure only a gets recompiled
 
@@ -27,8 +27,8 @@ $ sleep 1100
 
 > play-routes
 
-> newer target/scala-2.11/routes/main/a/routes_routing.scala target/change2
--> newer target/scala-2.11/routes/main/b/routes_routing.scala target/change2
+> newer target/routes/main/a/routes_routing.scala target/change2
+-> newer target/routes/main/b/routes_routing.scala target/change2
 
 # Modify b, change the package it produces routes in, ensure the old routes is deleted and the new is produced
 
@@ -36,13 +36,13 @@ $ copy-file b.routes.1 b.routes
 
 > play-routes
 
-$ exists target/scala-2.11/routes/main/a/routes_routing.scala
-$ exists target/scala-2.11/routes/main/a/routes_reverseRouting.scala
-$ exists target/scala-2.11/routes/main/controllers/a/routes.java
-$ exists target/scala-2.11/routes/main/b/routes_routing.scala
-$ exists target/scala-2.11/routes/main/b/routes_reverseRouting.scala
--$ exists target/scala-2.11/routes/main/controllers/b/routes.java
-$ exists target/scala-2.11/routes/main/controllers/c/routes.java
+$ exists target/routes/main/a/routes_routing.scala
+$ exists target/routes/main/a/routes_reverseRouting.scala
+$ exists target/routes/main/controllers/a/routes.java
+$ exists target/routes/main/b/routes_routing.scala
+$ exists target/routes/main/b/routes_reverseRouting.scala
+-$ exists target/routes/main/controllers/b/routes.java
+$ exists target/routes/main/controllers/c/routes.java
 
 # Modify imports, check that everything gets recompiled
 
@@ -52,5 +52,5 @@ $ sleep 1100
 
 > play-routes
 
-> newer target/scala-2.11/routes/main/a/routes_routing.scala target/change3
-> newer target/scala-2.11/routes/main/b/routes_routing.scala target/change3
+> newer target/routes/main/a/routes_routing.scala target/change3
+> newer target/routes/main/b/routes_routing.scala target/change3

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/build.sbt
@@ -5,7 +5,7 @@ import scala.reflect._
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.11.1"
+scalaVersion := sys.props.get("scala.version").getOrElse("2.10.4")
 
 routesFiles in Compile := Seq(baseDirectory.value / "routes")
 


### PR DESCRIPTION
The scripted test build was always built against Scala 2.11, this meant the build only passed if a 2.10 build happened to run on the same agent before.
