### PR TITLE
Initial implementation of a Forking-dev-mode runner

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -4,7 +4,7 @@
 import sbt._
 
 object Dependencies {
-
+  val sbtRcVersion = "1.0-578454dc9da3c43ecd8e842e6d33c0718a5718ba"
   // Some common dependencies here so they don't need to be declared over and over
   val specsVersion = "2.3.12"
   val specsBuild = Seq(
@@ -75,11 +75,19 @@ object Dependencies {
     "org.easytesting" % "fest-assert" % "1.4" % "test",
     mockitoAll % "test")
 
-  val runtime = Seq(
+  val minimumRuntime = Seq(
     "io.netty" % "netty" % "3.9.3.Final",
 
     "com.typesafe.netty" % "netty-http-pipelining" % "1.1.2",
 
+    "joda-time" % "joda-time" % "2.3",
+    "org.joda" % "joda-convert" % "1.6",
+
+    "com.typesafe.akka" %% "akka-actor" % "2.3.4") ++
+    specsBuild.map(_ % "test") ++
+    javaTestDeps
+
+  val runtime = minimumRuntime ++ Seq(
     "org.slf4j" % "slf4j-api" % "1.7.6",
     "org.slf4j" % "jul-to-slf4j" % "1.7.6",
     "org.slf4j" % "jcl-over-slf4j" % "1.7.6",
@@ -87,14 +95,10 @@ object Dependencies {
     "ch.qos.logback" % "logback-core" % "1.1.1",
     "ch.qos.logback" % "logback-classic" % "1.1.1",
 
-    "com.typesafe.akka" %% "akka-actor" % "2.3.4",
     "com.typesafe.akka" %% "akka-slf4j" % "2.3.4",
 
     "org.scala-stm" %% "scala-stm" % "0.7",
     "commons-codec" % "commons-codec" % "1.9",
-
-    "joda-time" % "joda-time" % "2.3",
-    "org.joda" % "joda-convert" % "1.6",
 
     "org.apache.commons" % "commons-lang3" % "3.1",
 
@@ -127,11 +131,38 @@ object Dependencies {
     )
   }
 
- val runSupportDependencies = Seq(
-    "org.scala-sbt" % "io" % BuildSettings.buildSbtVersion
+  def sbtActorClient(scalaVersion:String):ModuleID =
+    CrossVersion.binaryScalaVersion(scalaVersion) match {
+      case "2.10" => "com.typesafe.sbtrc" % "actor-client-2-10" % sbtRcVersion
+      case "2.11" => "com.typesafe.sbtrc" % "actor-client-2-11" % sbtRcVersion
+    }
+
+  def sbtClient(scalaVersion:String):ModuleID =
+    CrossVersion.binaryScalaVersion(scalaVersion) match {
+      case "2.10" => "com.typesafe.sbtrc" % "client-2-10" % sbtRcVersion
+      case "2.11" => "com.typesafe.sbtrc" % "client-2-11" % sbtRcVersion
+    }
+
+  def sbtIO(scalaVersion:String):ModuleID =
+    CrossVersion.binaryScalaVersion(scalaVersion) match {
+      case "2.10" => "org.scala-sbt" % "io" % BuildSettings.buildSbtVersion
+      case "2.11" => "org.scala-sbt" % "io_2.11" % BuildSettings.buildSbtVersion
+    }
+
+  def runSupportDependencies(scalaVersion:String):Seq[ModuleID] = Seq(
+    sbtIO(scalaVersion),
+    sbtClient(scalaVersion)
   ) ++ specsBuild.map(_ % Test)
 
   val typesafeConfig = "com.typesafe" % "config" % "1.2.1"
+
+  def sbtClientDependencies(scalaVersion:String) = Seq(
+    typesafeConfig % "provided",
+    sbtActorClient(scalaVersion)
+  )
+
+  val sbtServer = "com.typesafe.sbtrc" % "server-0-13" % sbtRcVersion
+  val sbtRcDeps = Seq(sbtServer)
 
   val sbtDependencies = Seq(
     "org.scala-lang" % "scala-reflect" % BuildSettings.buildScalaVersionForSbt % "provided",
@@ -160,7 +191,7 @@ object Dependencies {
 
     sbtPluginDep("com.typesafe.sbt" % "sbt-js-engine" % "1.0.1"),
     sbtPluginDep("com.typesafe.sbt" % "sbt-webdriver" % "1.0.0")
-  ) ++ specsSbt.map(_ % "test")
+  ) ++ sbtRcDeps ++ specsSbt.map(_ % "test")
 
   val playDocsDependencies = Seq(
     "com.typesafe.play" %% "play-doc" % "1.1.0",

--- a/framework/project/build.properties
+++ b/framework/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
 #
-sbt.version=0.13.5
+sbt.version=0.13.6

--- a/framework/src/build-link/src/main/java/play/core/BuildLink.java
+++ b/framework/src/build-link/src/main/java/play/core/BuildLink.java
@@ -92,4 +92,9 @@ public interface BuildLink {
      * @return The result of running the task.
      */
     public Object runTask(String task);
+
+    /**
+     * Indicates if the server is running in forked mode.
+     */
+    public boolean isForked();
 }

--- a/framework/src/fork-runner/src/main/resources/reference.conf
+++ b/framework/src/fork-runner/src/main/resources/reference.conf
@@ -1,0 +1,12 @@
+#
+# Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+#
+
+# Reference configuration for Play dev mode
+
+play-dev {
+  akka {
+    loglevel = ERROR
+    stdout-loglevel = ERROR
+  }
+}

--- a/framework/src/fork-runner/src/main/scala/play/sbtclient/DelegatingClassLoader.scala
+++ b/framework/src/fork-runner/src/main/scala/play/sbtclient/DelegatingClassLoader.scala
@@ -1,0 +1,83 @@
+package play.forkrunner
+
+import java.io.IOException
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+import java.net.URL
+import java.util.Enumeration
+import java.util.Vector
+import play.core.classloader.ApplicationClassLoaderProvider
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
+object DelegatingClassLoader {
+  val buildSharedClasses =
+    List[String](
+      classOf[play.core.BuildLink].getName(),
+      classOf[play.core.BuildDocHandler].getName(),
+      classOf[play.core.server.ServerWithStop].getName(),
+      classOf[play.api.UsefulException].getName(),
+      classOf[play.api.PlayException].getName(),
+      classOf[play.api.PlayException.InterestingLines].getName(),
+      classOf[play.api.PlayException.RichDescription].getName(),
+      classOf[play.api.PlayException.ExceptionSource].getName(),
+      classOf[play.api.PlayException.ExceptionAttachment].getName(),
+      classOf[play.runsupport.ForkRunnerException].getName(),
+      classOf[play.runsupport.PlayExceptionNoSource].getName(),
+      classOf[play.runsupport.PlayExceptionWithSource].getName(),
+      classOf[xsbti.Severity].getName())
+
+  def isSharedClass(name: String): Boolean =
+    buildSharedClasses.contains(name) || name.startsWith("com.typesafe.config") || name.startsWith("java.") || name.startsWith("scala.")
+
+  private def combineResources(resources1: Enumeration[URL], resources2: Enumeration[URL]): Enumeration[URL] = {
+    (resources1.toSet ++ resources2.toSet).toIterator
+  }
+
+}
+
+class DelegatingClassLoader(commonLoader: ClassLoader, buildLoader: ClassLoader, applicationClassLoaderProvider: ApplicationClassLoaderProvider) extends ClassLoader(commonLoader) {
+  import DelegatingClassLoader._
+
+  override def loadClass(name: String, resolve: Boolean): Class[_] = {
+    if (isSharedClass(name)) buildLoader.loadClass(name)
+    else super.loadClass(name, resolve)
+  }
+
+  override def getResource(name: String): URL = {
+    // -- Delegate resource loading. We have to hack here because the default implementation is already recursive.
+    val findResource: Method = try { classOf[ClassLoader].getDeclaredMethod("findResource", classOf[String]) }
+    catch { case e: NoSuchMethodException => throw new IllegalStateException(e) }
+    findResource.setAccessible(true)
+    try {
+      (for {
+        appClassLoader <- Option(applicationClassLoaderProvider.get())
+        resource <- Option(findResource.invoke(appClassLoader, name).asInstanceOf[URL])
+      } yield resource) getOrElse super.getResource(name)
+    } catch {
+      case e: IllegalAccessException => throw new IllegalStateException(e)
+      case e: InvocationTargetException => throw new IllegalStateException(e)
+    }
+  }
+
+  override def getResources(name: String): Enumeration[URL] = {
+    val findResources: Method = try { classOf[ClassLoader].getDeclaredMethod("findResources", classOf[String]) }
+    catch { case e: NoSuchMethodException => throw new IllegalStateException(e) }
+    findResources.setAccessible(true)
+    val resources1: Enumeration[URL] = try {
+      (for {
+        appClassLoader <- Option(applicationClassLoaderProvider.get())
+        resources <- Option(findResources.invoke(appClassLoader, name).asInstanceOf[Enumeration[URL]])
+      } yield resources) getOrElse (new Vector[URL]().elements)
+    } catch {
+      case e: IllegalAccessException => throw new IllegalStateException(e)
+      case e: InvocationTargetException => throw new IllegalStateException(e)
+    }
+    val resources2: Enumeration[URL] = super.getResources(name)
+    combineResources(resources1, resources2)
+  }
+
+  override def toString(): String = {
+    return "DelegatingClassLoader, using parent: " + getParent()
+  }
+}

--- a/framework/src/fork-runner/src/main/scala/play/sbtclient/ForkRunner.scala
+++ b/framework/src/fork-runner/src/main/scala/play/sbtclient/ForkRunner.scala
@@ -1,0 +1,485 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.forkrunner
+
+import play.runsupport.{ PlayExceptions, Serializers }
+import java.io.{ File, Closeable }
+import java.net.{ URI, URLClassLoader }
+import java.util.jar.JarFile
+import sbt.client.{ SbtClient, SbtConnector, TaskKey }
+import sbt.protocol.{ ScopedKey, TaskSuccess, TaskFailure }
+import scala.concurrent.ExecutionContext.Implicits.global
+import play.runsupport.protocol.{ PlayForkSupportResult, SourceMapTarget }
+import play.runsupport.{ PlayExceptionNoSource, PlayExceptionWithSource }
+import play.core.{ BuildLink, BuildDocHandler }
+import play.core.classloader.ApplicationClassLoaderProvider
+import scala.concurrent.{ Promise, Future }
+import play.runsupport.{ PlayWatchService, LoggerProxy, AssetsClassLoader }
+import sbt.{ IO, PathFinder, WatchState, SourceModificationWatch }
+import scala.annotation.tailrec
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.CountDownLatch
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.{ Try, Success, Failure }
+import akka.actor._
+import com.typesafe.config.{ ConfigFactory, Config }
+import akka.event.LoggingAdapter
+import sbt.client.actors.{ SbtClientProxy, SbtConnectionProxy }
+
+object ForkRunner {
+  import scala.language.implicitConversions
+  import Serializers._
+
+  type URL = java.net.URL
+  type Classpath = Seq[File]
+  type ClassLoaderCreator = (String, Array[URL], ClassLoader) => ClassLoader
+  trait PlayBuildLink extends BuildLink {
+    def close()
+    def getClassLoader: Option[ClassLoader]
+  }
+
+  case class Reload(expected: Promise[Either[Throwable, PlayForkSupportResult]])
+
+  import PlayExceptions._
+
+  def urls(cp: Classpath): Array[URL] = cp.map(_.toURI.toURL).toArray
+
+  // dependencyClassLoader: ClassLoaderCreator,
+  def uRLClassLoaderCreator(name: String, urls: Array[URL], parent: ClassLoader): ClassLoader = new java.net.URLClassLoader(urls, parent) {
+    override def toString = name + "{" + getURLs.map(_.toString).mkString(", ") + "}"
+  }
+
+  def assetsClassLoader(parent: ClassLoader, allAssets: Seq[(String, File)]): ClassLoader = new AssetsClassLoader(parent, allAssets)
+
+  // reloaderClassLoader: ClassLoaderCreator
+  def delegatedResourcesClassLoaderCreator(name: String, urls: Array[URL], parent: ClassLoader): ClassLoader = {
+    new java.net.URLClassLoader(urls, parent) {
+      require(parent ne null)
+      override def getResources(name: String): java.util.Enumeration[java.net.URL] = {
+        getParent.getResources(name)
+      }
+      override def toString = name + "{" + getURLs.map(_.toString).mkString(", ") + "}"
+    }
+  }
+
+  private implicit def convertToOption[T](o: xsbti.Maybe[T]): Option[T] =
+    if (o.isDefined()) Some(o.get())
+    else None
+
+  // commonClassLoader: ClassLoader
+  def playCommonClassloaderTask(classpath: Classpath) = {
+    lazy val commonJars: PartialFunction[java.io.File, java.net.URL] = {
+      case jar if jar.getName.startsWith("h2-") || jar.getName == "h2.jar" => jar.toURI.toURL
+    }
+
+    new java.net.URLClassLoader(classpath.collect(commonJars).toArray, null /* important here, don't depend of the sbt classLoader! */ ) {
+      override def toString = "Common ClassLoader: " + getURLs.map(_.toString).mkString(",")
+    }
+  }
+
+  def newReloader(runReload: () => Either[Throwable, PlayForkSupportResult],
+    createClassLoader: ClassLoaderCreator,
+    baseLoader: ClassLoader,
+    monitoredFiles: Seq[String],
+    _projectPath: File,
+    devSettings: Seq[(String, String)],
+    playWatchService: PlayWatchService): PlayBuildLink = {
+    new PlayBuildLink {
+      val projectPath: File = _projectPath
+      // The current classloader for the application
+      @volatile private var currentApplicationClassLoader: Option[ClassLoader] = None
+      // Flag to force a reload on the next request.
+      // This is set if a compile error occurs, and also by the forceReload method on BuildLink, which is called for
+      // example when evolutions have been applied.
+      @volatile private var forceReloadNextTime = false
+      // Whether any source files have changed since the last request.
+      @volatile private var changed = false
+      // The last succesful source map
+      @volatile private var sourceMap = Option.empty[Map[String, SourceMapTarget]]
+      // A watch state for the classpath. Used to determine whether anything on the classpath has changed as a result
+      // of compilation, and therefore a new classloader is needed and the app needs to be reloaded.
+      @volatile private var watchState: WatchState = WatchState.empty
+
+      // Create the watcher, updates the changed boolean when a file has changed.
+      private val watcher = playWatchService.watch(monitoredFiles.map(new File(_)), () => {
+        changed = true
+      })
+      private val classLoaderVersion = new java.util.concurrent.atomic.AtomicInteger(0)
+
+      /**
+       * Contrary to its name, this doesn't necessarily reload the app.  It is invoked on every request, and will only
+       * trigger a reload of the app if something has changed.
+       *
+       * Since this communicates across classloaders, it must return only simple objects.
+       *
+       *
+       * @return Either
+       * - Throwable - If something went wrong (eg, a compile error).
+       * - ClassLoader - If the classloader has changed, and the application should be reloaded.
+       * - null - If nothing changed.
+       */
+      def reload: AnyRef = {
+        if (changed || forceReloadNextTime || sourceMap.isEmpty || currentApplicationClassLoader.isEmpty) {
+
+          val shouldReload = forceReloadNextTime
+
+          changed = false
+          forceReloadNextTime = false
+
+          // Run the reload task, which will trigger everything to compile
+          runReload()
+            .left.map(taskFailureHandler)
+            .right.map { compilationResult =>
+
+              sourceMap = Some(compilationResult.sourceMap)
+
+              // We only want to reload if the classpath has changed.  Assets don't live on the classpath, so
+              // they won't trigger a reload.
+              // Use the SBT watch service, passing true as the termination to force it to break after one check
+              val (_, newState) = SourceModificationWatch.watch(PathFinder.strict(compilationResult.reloaderClasspath).***, 0, watchState)(true)
+              // SBT has a quiet wait period, if that's set to true, sources were modified
+              val triggered = newState.awaitingQuietPeriod
+              watchState = newState
+
+              if (triggered || shouldReload || currentApplicationClassLoader.isEmpty) {
+
+                // Create a new classloader
+                val version = classLoaderVersion.incrementAndGet
+                val name = "ReloadableClassLoader(v" + version + ")"
+                val urls = ForkRunner.urls(compilationResult.reloaderClasspath)
+                val loader = createClassLoader(name, urls, baseLoader)
+                currentApplicationClassLoader = Some(loader)
+                loader
+              } else {
+                null // null means nothing changed
+              }
+            }.fold(identity, identity)
+        } else {
+          null // null means nothing changed
+        }
+      }
+
+      lazy val settings = {
+        import scala.collection.JavaConverters._
+        devSettings.toMap.asJava
+      }
+
+      def forceReload() {
+        forceReloadNextTime = true
+      }
+
+      def findSource(className: String, line: java.lang.Integer): Array[java.lang.Object] = {
+        val topType = className.split('$').head
+        sourceMap.flatMap {
+          _.get(topType).map { st =>
+            Array[java.lang.Object](st.originalSource.getOrElse(st.sourceFile), line)
+          }
+        }.orNull
+      }
+
+      private def taskFailureHandler(in: Throwable): Exception = {
+        // We force reload next time because compilation failed this time
+        forceReloadNextTime = true
+        in match {
+          case e: PlayExceptionNoSource => e
+          case e: PlayExceptionWithSource => e
+          case e: Exception => UnexpectedException(unexpected = Some(e))
+        }
+      }
+
+      // TODO - Cannot implement in the forked running mode
+      def runTask(task: String): AnyRef = {
+        null
+      }
+
+      def close() = {
+        currentApplicationClassLoader = None
+        sourceMap = None
+        watcher.stop()
+      }
+
+      def isForked(): Boolean = true
+
+      def getClassLoader = currentApplicationClassLoader
+    }
+
+  }
+
+  case class Config(connector: SbtConnector,
+      latch: CountDownLatch,
+      command: String,
+      projectDir: File,
+      buildUri: URI,
+      project: String,
+      serverBuilder: PlayForkSupportResult => (() => Either[Throwable, PlayForkSupportResult]) => PlayDevServer) {
+
+    def notifyServerStartCommand(urlString: String): String = s"$project/playNotifyServerStart $urlString"
+  }
+
+  object Int {
+    def unapply(s: String): Option[Int] = try {
+      Some(s.toInt)
+    } catch {
+      case _: java.lang.NumberFormatException => None
+    }
+  }
+
+  def wrapLogger(logger: LoggingAdapter): LoggerProxy = new LoggerProxy {
+    def verbose(message: => String): Unit = logger.debug(message)
+    def debug(message: => String): Unit = logger.debug(message)
+    def info(message: => String): Unit = logger.info(message)
+    def warn(message: => String): Unit = logger.warning(message)
+    def error(message: => String): Unit = logger.error(message)
+    def trace(t: => Throwable): Unit = logger.error(t, "trace")
+    def success(message: => String): Unit = logger.info(message)
+  }
+
+  object AkkaConfig {
+    def config(projectRoot: File) = {
+      val fallback = ConfigFactory.load()
+      ConfigFactory.parseFileAnySyntax(new File(projectRoot, "conf/application.conf")).withFallback(fallback).getConfig("play-dev")
+    }
+  }
+
+  def main(args: Array[String]): Unit = {
+    val baseDirectoryString = args(0)
+    val buildUriString = args(1)
+    val targetDirectory = args(2)
+    val project = args(3)
+    val httpPort: Option[Int] = Int.unapply(args(4))
+    val httpsPort: Option[Int] = Int.unapply(args(5))
+    val pollDelayMillis: Int = args(6).toInt
+    val akkaConfig = AkkaConfig.config(new File(baseDirectoryString))
+    val buildUri = new URI(buildUriString)
+
+    val system = ActorSystem("play-dev-mode-runner", akkaConfig)
+    val log = system.log
+    log.debug(s"Forked Play dev-mode runner started")
+    log.debug(s"baseDirectoryString: $baseDirectoryString")
+    log.debug(s"buildUriString: $buildUriString")
+    log.debug(s"targetDirectory: $targetDirectory")
+    log.debug(s"project: $project")
+    log.debug(s"httpPort: $httpPort")
+    log.debug(s"httpsPort: $httpsPort")
+    log.debug(s"pollDelayMillis: $pollDelayMillis")
+    log.debug(s"akkaConfig: $akkaConfig")
+
+    val latch = new CountDownLatch(1)
+    val projectDir = new File(baseDirectoryString)
+    val conn = SbtConnector("play-fork", "play-fork", projectDir)
+    val serverBuilder = runServer(httpPort, httpsPort, new File(buildUri), new File(targetDirectory), pollDelayMillis, wrapLogger(log))_
+    val config = Config(conn, latch, s"$project/play-default-fork-run-support", projectDir, buildUri, project, serverBuilder)
+    val runner = system.actorOf(Props(new ForkRunner(config)))
+    log.debug("Awaiting ForkRunner shutdown")
+    latch.await()
+    log.debug("Exiting, awaiting actor system shutdown")
+    system.shutdown()
+    log.debug("Exited.")
+  }
+
+  private[forkrunner] trait PlayDevServer extends Closeable {
+    val buildLink: BuildLink
+    def urlString: String
+  }
+
+  def runServer(httpPort: Option[Int],
+    httpsPort: Option[Int],
+    projectPath: File,
+    targetDirectory: File,
+    pollDelayMillis: Int,
+    logger: LoggerProxy)(in: PlayForkSupportResult)(runReload: () => Either[Throwable, PlayForkSupportResult]): PlayDevServer = {
+    try {
+      val buildLoader = this.getClass.getClassLoader
+      val commonClassLoader = playCommonClassloaderTask(in.dependencyClasspath)
+
+      lazy val delegatingLoader: ClassLoader = new DelegatingClassLoader(commonClassLoader, buildLoader, new ApplicationClassLoaderProvider {
+        def get: ClassLoader = { reloader.getClassLoader.orNull }
+      })
+
+      lazy val applicationLoader = uRLClassLoaderCreator("PlayDependencyClassLoader", urls(in.dependencyClasspath), delegatingLoader)
+      lazy val assetsLoader = assetsClassLoader(applicationLoader, in.allAssets)
+
+      lazy val reloader: PlayBuildLink = newReloader(runReload,
+        delegatedResourcesClassLoaderCreator _,
+        assetsLoader,
+        in.monitoredFiles,
+        projectPath,
+        in.devSettings,
+        PlayWatchService.default(targetDirectory, pollDelayMillis, logger))
+
+      val docsLoader = new URLClassLoader(urls(in.docsClasspath), applicationLoader)
+      val docsJarFile = {
+        val f = in.docsClasspath.filter(_.getName.startsWith("play-docs")).head
+        new JarFile(f)
+      }
+      val buildDocHandler = {
+        val docHandlerFactoryClass = docsLoader.loadClass("play.docs.BuildDocHandlerFactory")
+        val factoryMethod = docHandlerFactoryClass.getMethod("fromJar", classOf[JarFile], classOf[String])
+        factoryMethod.invoke(null, docsJarFile, "play/docs/content").asInstanceOf[BuildDocHandler]
+      }
+
+      val server = {
+        val mainClass = applicationLoader.loadClass("play.core.server.NettyServer")
+        if (httpPort.isDefined) {
+          val mainDev = mainClass.getMethod("mainDevHttpMode", classOf[BuildLink], classOf[BuildDocHandler], classOf[Int])
+          mainDev.invoke(null, reloader, buildDocHandler, httpPort.get: java.lang.Integer).asInstanceOf[play.core.server.ServerWithStop]
+        } else {
+          val mainDev = mainClass.getMethod("mainDevOnlyHttpsMode", classOf[BuildLink], classOf[BuildDocHandler], classOf[Int])
+          mainDev.invoke(null, reloader, buildDocHandler, httpsPort.get: java.lang.Integer).asInstanceOf[play.core.server.ServerWithStop]
+        }
+      }
+
+      new PlayDevServer {
+        val buildLink = reloader
+
+        val urlString: String = httpPort match {
+          case Some(port) => s"http://localhost:$port"
+          case None => s"https://localhost:${httpsPort.get}"
+        }
+
+        def close() = {
+          server.stop()
+          docsJarFile.close()
+          reloader.close()
+          sys.exit(0)
+        }
+      }
+    } catch {
+      case e: Throwable =>
+        throw e
+        sys.exit(-1)
+    }
+  }
+}
+
+final class ForkRunner(config: ForkRunner.Config) extends Actor with ActorLogging {
+  import ForkRunner._, Serializers._, PlayExceptions._
+
+  val connectorProxy = context.actorOf(SbtConnectionProxy.props(config.connector))
+
+  private def runReload(self: ActorRef)(): Either[Throwable, PlayForkSupportResult] = {
+    val expected = Promise[Either[Throwable, PlayForkSupportResult]]()
+    log.debug(s"Requesting reload")
+    self.tell(Reload(expected), self)
+    val f = expected.future
+    Await.ready(f, 3.minutes)
+    f.value.get match {
+      case Success(v) => v
+      case Failure(t) => Left(t)
+    }
+  }
+
+  private def reloading(client: ActorRef, command: ScopedKey, server: PlayDevServer, expected: Promise[Either[Throwable, PlayForkSupportResult]]): Receive = {
+    log.debug(s"Doing reload")
+    client ! SbtClientProxy.RequestExecution.ByScopedKey(command, None, self)
+
+    {
+      case _: SbtClientProxy.ExecutionId => // ignore?
+      case SbtClientProxy.WatchEvent(`command`, result) =>
+        result.resultWithCustomThrowables[PlayForkSupportResult](Serializers.throwableDeserializers) match {
+          case Success(x) =>
+            expected.success(Right(x))
+          case Failure(x: PlayExceptionNoSource) =>
+            log.error(s"PlayExceptionNoSource: ${x.getClass.getName} - $x")
+            expected.success(Left(x))
+          case Failure(x: PlayExceptionWithSource) =>
+            log.error(s"PlayExceptionWithSource: ${x.getClass.getName} - $x")
+            expected.success(Left(x))
+          case Failure(x) =>
+            log.error(s"Unknown failure: ${x.getClass.getName} - $x")
+            expected.success(Left(x))
+        }
+        context.become(waitingForReload(client, command, server))
+    }
+  }
+
+  private def waitingForReload(client: ActorRef, command: ScopedKey, server: PlayDevServer): Receive = {
+    case _: SbtClientProxy.ExecutionId => // ignore?
+    case Reload(expected) =>
+      log.debug(s"Got reload")
+      context.become(reloading(client, command, server, expected))
+  }
+
+  private def waitingForInitialBuild(client: ActorRef, command: ScopedKey, server: Option[PlayDevServer], taskId: Option[Long]): Receive = (server, taskId) match {
+    case (Some(s), Some(tid)) =>
+      client ! SbtClientProxy.RequestExecution.ByCommandOrTask(config.notifyServerStartCommand(s.urlString), None, self)
+      waitingForReload(client, command, s)
+    case (_, _) =>
+
+      {
+        case SbtClientProxy.ExecutionId(Success(tid), _) =>
+          context.become(waitingForInitialBuild(client, command, server, Some(tid)))
+        case SbtClientProxy.ExecutionId(Failure(error), _) =>
+          log.error(s"Got failure on initial build -- could not get task ID.  Cannot continue[terminating]: ${error}")
+          exit()
+        case SbtClientProxy.WatchEvent(command, TaskSuccess(result)) =>
+          log.debug(s"Got successful result from initial build: $result")
+          result.value[PlayForkSupportResult] match {
+            case Some(r) =>
+              log.debug("Starting server")
+              val server = config.serverBuilder(r)(runReload(self)_)
+              context.become(waitingForInitialBuild(client, command, Some(server), taskId))
+            case None =>
+              log.error(s"could not decode result into PlayForkSupportResult[terminating]: $result")
+              exit()
+          }
+        case SbtClientProxy.WatchEvent(command, TaskFailure(result)) =>
+          log.error(s"Got failure on initial build.  Cannot continue[terminating]: ${result.stringValue}")
+          exit()
+      }
+  }
+
+  private def initialBuild(client: ActorRef, command: ScopedKey): Receive = {
+    client ! SbtClientProxy.WatchTask(TaskKey[PlayForkSupportResult](command), self)
+
+    {
+      case SbtClientProxy.WatchingTask(_) =>
+        log.debug(s"Doing initial build")
+        client ! SbtClientProxy.RequestExecution.ByScopedKey(command, None, self)
+        context.become(waitingForInitialBuild(client, command, None, None))
+    }
+  }
+
+  private def lookupKey(client: ActorRef): Receive = {
+    client ! SbtClientProxy.LookupScopedKey(config.command, self)
+
+    {
+      case SbtClientProxy.LookupScopedKeyResponse(command, Success(keys)) =>
+        log.debug(s"Retrirved key.  Doing initial build")
+        context.become(initialBuild(client, keys.head))
+      case SbtClientProxy.LookupScopedKeyResponse(command, Failure(error)) =>
+        log.error(s"Could not look up command[terminating]: $command - received: $error")
+        exit()
+    }
+  }
+
+  private def exiting: Receive = {
+    connectorProxy ! SbtConnectionProxy.Close(self)
+
+    {
+      case SbtConnectionProxy.Closed =>
+        context stop self
+        config.latch.countDown()
+    }
+  }
+
+  private def exit(): Unit = context.become(exiting)
+
+  private def waitForClient: Receive = {
+    case SbtConnectionProxy.NewClientResponse.Connected(client) =>
+      log.debug(s"Got client. Looking up key for ${config.command}")
+      context.become(lookupKey(client))
+    case SbtConnectionProxy.NewClientResponse.Error(true, error) =>
+      log.warning(s"recoverable error getting client: $error")
+    case SbtConnectionProxy.NewClientResponse.Error(false, error) =>
+      log.error(s"could not get client[terminating]: $error")
+      exit()
+  }
+
+  def receive: Receive = {
+    connectorProxy ! SbtConnectionProxy.NewClient(self)
+    waitForClient
+  }
+}

--- a/framework/src/play-ws/src/test/scala/play/api/libs/openid/package.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/openid/package.scala
@@ -3,7 +3,7 @@
  */
 package play.api.libs
 
-import io.Source
+import scala.io.Source
 import org.jboss.netty.handler.codec.http.QueryStringDecoder
 import java.net.{MalformedURLException, URL}
 import util.control.Exception._

--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -38,7 +38,9 @@ object Configuration {
           .map(f => new File(f)).getOrElse(new File(appPath, "conf/application.conf"))
       }
       val config = Option(System.getProperty("config.resource"))
-        .map(ConfigFactory.parseResources(_)).getOrElse(ConfigFactory.parseFileAnySyntax(file))
+        .map { r =>
+          ConfigFactory.parseResources(r)
+        } getOrElse { ConfigFactory.parseFileAnySyntax(file) }
 
       ConfigFactory.parseMap(devSettings.asJava).withFallback(ConfigFactory.load(config))
     } catch {

--- a/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
+++ b/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
@@ -102,8 +102,10 @@ class ReloadableApplication(buildLink: BuildLink, buildDocHandler: BuildDocHandl
 
   lazy val path = buildLink.projectPath
 
-  println(play.utils.Colors.magenta("--- (Running the application, auto-reloading is enabled) ---"))
-  println()
+  if (!buildLink.isForked) {
+    println(play.utils.Colors.magenta("--- (Running the application from SBT, auto-reloading is enabled) ---"))
+    println()
+  }
 
   var lastState: Try[Application] = Failure(new PlayException("Not initialized", "?"))
 

--- a/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
@@ -70,16 +70,18 @@ object RoutesCompiler {
     override val whiteSpace = """[ \t]+""".r
 
     override def phrase[T](p: Parser[T]) = new Parser[T] {
-      lastNoSuccess = null
+      var prevNoSuccess: NoSuccess = null
       def apply(in: Input) = p(in) match {
         case s @ Success(out, in1) =>
           if (in1.atEnd)
             s
-          else if (lastNoSuccess == null || lastNoSuccess.next.pos < in1.pos)
+          else if (prevNoSuccess == null || prevNoSuccess.next.pos < in1.pos)
             Failure("end of input expected", in1)
           else
-            lastNoSuccess
-        case _ => lastNoSuccess
+            prevNoSuccess
+        case x: NoSuccess =>
+          prevNoSuccess = x
+          x
       }
     }
 

--- a/framework/src/run-support/src/main/scala/play/runsupport/AssetsClassLoader.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/AssetsClassLoader.scala
@@ -23,6 +23,7 @@ class AssetsClassLoader(parent: ClassLoader, assets: Seq[(String, File)]) extend
   }
 
   def exists(name: String, prefix: String, dir: File) = {
-    name.startsWith(prefix) && (dir / name.substring(prefix.length)).isFile
+    val r = name.startsWith(prefix) && (dir / name.substring(prefix.length)).isFile
+    r
   }
 }

--- a/framework/src/run-support/src/main/scala/play/runsupport/ForkRunnerException.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/ForkRunnerException.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.runsupport
+
+import sbt.protocol.Problem
+import sbt.IO
+import play.api._
+
+sealed trait ForkRunnerException { this: PlayException =>
+  def genericTitle: String
+  def message: String
+  def wrapped: Throwable
+  def category: String
+  def severity: xsbti.Severity
+}
+
+case class PlayExceptionNoSource(genericTitle: String,
+  message: String,
+  category: String,
+  severity: xsbti.Severity,
+  wrapped: Throwable) extends PlayException(genericTitle, message, wrapped) with ForkRunnerException
+
+case class PlayExceptionWithSource(genericTitle: String,
+    message: String,
+    category: String,
+    severity: xsbti.Severity,
+    wrapped: Throwable,
+    row: Int,
+    column: Int,
+    sourceFile: java.io.File) extends PlayException.ExceptionSource(genericTitle, message, wrapped) with ForkRunnerException {
+  def line = row
+  def position = column
+  def input = IO.read(sourceFile)
+  def sourceName = sourceFile.getAbsolutePath
+}
+

--- a/framework/src/run-support/src/main/scala/play/runsupport/PlayExceptions.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/PlayExceptions.scala
@@ -1,12 +1,20 @@
 /*
  * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
  */
-package play
+package play.runsupport
 
 import sbt._
 import play.api._
+import java.io.File
+
+private object PlayExceptionsHelper {
+  implicit def convertToOption[T](o: xsbti.Maybe[T]): Option[T] =
+    if (o.isDefined()) Some(o.get())
+    else None
+}
 
 trait PlayExceptions {
+  import PlayExceptionsHelper._
 
   def filterAnnoyingErrorMessages(message: String): String = {
     val overloaded = """(?s)overloaded method value (.*) with alternatives:(.*)cannot be applied to(.*)""".r

--- a/framework/src/run-support/src/main/scala/play/runsupport/Protocol.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/Protocol.scala
@@ -1,0 +1,15 @@
+package play.runsupport
+
+object protocol {
+  final case class SourceMapTarget(sourceFile: java.io.File, originalSource: Option[java.io.File])
+
+  final case class PlayForkSupportResult(sourceMap: Map[String, SourceMapTarget],
+    dependencyClasspath: Seq[java.io.File],
+    reloaderClasspath: Seq[java.io.File],
+    allAssets: Seq[(String, java.io.File)],
+    monitoredFiles: Seq[String],
+    devSettings: Seq[(String, String)],
+    docsClasspath: Seq[java.io.File])
+}
+
+final case class PlayServerStarted(url: String)

--- a/framework/src/run-support/src/main/scala/play/runsupport/Serializers.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/Serializers.scala
@@ -1,0 +1,83 @@
+package play.runsupport
+
+import play.api.libs.json._
+import play.api.libs.json.Reads._
+import play.api.libs.functional.syntax._
+import play.api.data.validation.ValidationError
+import play.runsupport.protocol._
+import PlayExceptions._
+import sbt.GenericSerializers._
+import sbt.protocol._
+import play.api.PlayException
+
+object Serializers {
+
+  implicit def tuple2Reads[A, B](implicit aReads: Reads[A], bReads: Reads[B]): Reads[(A, B)] = Reads[(A, B)] { i =>
+    i.validate[JsArray].flatMap { arr =>
+      val s = aReads.reads(arr(0))
+      val f = bReads.reads(arr(1))
+      (s, f) match {
+        case (JsSuccess(a, _), JsSuccess(b, _)) => JsSuccess((a, b))
+        case (a @ JsError(_), JsSuccess(_, _)) => a
+        case (JsSuccess(_, _), b @ JsError(_)) => b
+        case (a @ JsError(_), b @ JsError(_)) => a ++ b
+      }
+    }
+  }
+
+  implicit def tuple2Writes[A, B](implicit aWrites: Writes[A], bWrites: Writes[B]): Writes[(A, B)] =
+    Writes[(A, B)] { case (s, f) => JsArray(Seq(aWrites.writes(s), bWrites.writes(f))) }
+
+  sealed trait LocalRegisteredFormat {
+    type T
+    def manifest: Manifest[T]
+    def format: Format[T]
+  }
+  object LocalRegisteredFormat {
+    def fromFormat[U](f: Format[U])(implicit mf: Manifest[U]): LocalRegisteredFormat =
+      new LocalRegisteredFormat {
+        type T = U
+        val manifest = mf
+        val format = f
+      }
+  }
+
+  private implicit val throwableReads = sbt.GenericSerializers.throwableReads
+  private implicit val throwableWrites = sbt.GenericSerializers.throwableWrites
+
+  implicit val sourceMapTargetWrites: Writes[SourceMapTarget] = Json.writes[SourceMapTarget]
+  implicit val sourceMapTargetReads: Reads[SourceMapTarget] = Json.reads[SourceMapTarget]
+  implicit val sourceMapTargetFormat: Format[SourceMapTarget] = Format[SourceMapTarget](sourceMapTargetReads, sourceMapTargetWrites)
+
+  implicit val sourceMapWrites: Writes[Map[String, SourceMapTarget]] = Writes.mapWrites[SourceMapTarget]
+  implicit val sourceMapReads: Reads[Map[String, SourceMapTarget]] = Reads.mapReads[SourceMapTarget]
+  implicit val sourceMapformat: Format[Map[String, SourceMapTarget]] = Format[Map[String, SourceMapTarget]](sourceMapReads, sourceMapWrites)
+
+  implicit val playForkSupportResultWrites: Writes[PlayForkSupportResult] = Json.writes[PlayForkSupportResult]
+  implicit val playForkSupportResultReads: Reads[PlayForkSupportResult] = Json.reads[PlayForkSupportResult]
+  implicit val playForkSupportResultFormat: Format[PlayForkSupportResult] = Format[PlayForkSupportResult](playForkSupportResultReads, playForkSupportResultWrites)
+
+  implicit val playExceptionNoSourceReads: Reads[PlayExceptionNoSource] = Json.reads[PlayExceptionNoSource]
+  implicit val playExceptionNoSourceWrites: Writes[PlayExceptionNoSource] = Json.writes[PlayExceptionNoSource]
+  implicit val playExceptionNoSourceFormat: Format[PlayExceptionNoSource] = Format[PlayExceptionNoSource](playExceptionNoSourceReads, playExceptionNoSourceWrites)
+
+  implicit val playExceptionWithSourceReads: Reads[PlayExceptionWithSource] = Json.reads[PlayExceptionWithSource]
+  implicit val playExceptionWithSourceWrites: Writes[PlayExceptionWithSource] = Json.writes[PlayExceptionWithSource]
+  implicit val playExceptionWithSourceFormat: Format[PlayExceptionWithSource] = Format[PlayExceptionWithSource](playExceptionWithSourceReads, playExceptionWithSourceWrites)
+
+  implicit val playServerStartedReads: Reads[PlayServerStarted] = Json.reads[PlayServerStarted]
+  implicit val playServerStartedWrites: Writes[PlayServerStarted] = Json.writes[PlayServerStarted]
+  implicit val playServerStartedFormat: Format[PlayServerStarted] = Format[PlayServerStarted](playServerStartedReads, playServerStartedWrites)
+
+  val throwableDeserializers = ThrowableDeserializers.empty
+    .add[PlayExceptionWithSource]
+    .add[PlayExceptionNoSource]
+
+  val formats: Seq[LocalRegisteredFormat] = List(LocalRegisteredFormat.fromFormat(playForkSupportResultFormat),
+    LocalRegisteredFormat.fromFormat(sourceMapTargetFormat),
+    LocalRegisteredFormat.fromFormat(sourceMapformat),
+    LocalRegisteredFormat.fromFormat(playExceptionWithSourceFormat),
+    LocalRegisteredFormat.fromFormat(playExceptionNoSourceFormat),
+    LocalRegisteredFormat.fromFormat(playServerStartedFormat))
+}
+

--- a/framework/src/sbt-plugin/src/main/scala/PlayAssetsCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayAssetsCompiler.scala
@@ -7,7 +7,7 @@ import sbt._
 import Keys._
 import play.PlayImport._
 import PlayKeys._
-import PlayExceptions._
+import play.runsupport.PlayExceptions._
 
 // ----- Assets
 trait PlayAssetsCompiler {
@@ -70,7 +70,7 @@ trait PlayAssetsCompiler {
           }
         }
 
-        //write object graph to cache file 
+        //write object graph to cache file
         Sync.writeInfo(cacheFile,
           Relation.empty[File, File] ++ generated,
           currentInfos)(FileInfo.lastModified.format)

--- a/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
@@ -74,7 +74,6 @@ trait PlayCommands extends PlayAssetsCompiler with PlayEclipse with PlayInternal
   // ----- Post compile (need to be refactored and fully configurable)
 
   def PostCompile(scope: Configuration) = (sourceDirectory in scope, dependencyClasspath in scope, compile in scope, javaSource in scope, managedSourceDirectories in scope, classDirectory in scope, cacheDirectory in scope, compileInputs in compile in scope) map { (src, deps, analysis, javaSrc, srcManaged, classes, cacheDir, inputs) =>
-
     val classpath = (deps.map(_.data.getAbsolutePath).toArray :+ classes.getAbsolutePath).mkString(java.io.File.pathSeparator)
 
     val timestampFile = cacheDir / "play_instrumentation"

--- a/framework/src/sbt-plugin/src/main/scala/PlayInternalKeys.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayInternalKeys.scala
@@ -5,10 +5,13 @@ package play
 
 import sbt._
 import sbt.Keys._
+import play.runsupport.protocol.PlayForkSupportResult
 
 trait PlayInternalKeys {
   type ClassLoaderCreator = (String, Array[URL], ClassLoader) => ClassLoader
 
+  val playNotifyServerStart = inputKey[Unit]("Sends an event when the forked dev-server has started")
+  val playBackgroundRunTaskBuilder = TaskKey[Seq[String] => BackgroundJobHandle]("play-background-run-task-builder")
   val playDependencyClasspath = TaskKey[Classpath]("play-dependency-classpath")
   val playReloaderClasspath = TaskKey[Classpath]("play-reloader-classpath")
   val playCommonClassloader = TaskKey[ClassLoader]("play-common-classloader")
@@ -26,6 +29,8 @@ trait PlayInternalKeys {
   val playPrefixAndPipeline = TaskKey[(String, Seq[(File, String)])]("play-prefix-and-pipeline")
   val playAssetsClassLoader = TaskKey[ClassLoader => ClassLoader]("play-assets-classloader")
   val playPackageAssetsMappings = TaskKey[Seq[(File, String)]]("play-package-assets-mappings")
+
+  val playDefaultForkRunSupport = TaskKey[PlayForkSupportResult]("play-default-fork-run-support")
 
   @deprecated(message = "Use PlayKeys.playMonitoredFiles instead", since = "2.3.2")
   val playMonitoredFiles = PlayImport.PlayKeys.playMonitoredFiles

--- a/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayReloader.scala
@@ -4,7 +4,6 @@
 package play
 
 import play.runsupport.PlayWatchService
-import play.sbtplugin.run._
 
 import play.api._
 import play.core._
@@ -12,7 +11,7 @@ import sbt._
 import sbt.Keys._
 import play.PlayImport._
 import PlayKeys._
-import PlayExceptions._
+import play.runsupport.PlayExceptions._
 
 trait PlayReloader {
   this: PlayCommands with PlayPositionMapper =>
@@ -230,6 +229,7 @@ trait PlayReloader {
         Incomplete.allExceptions(incomplete).headOption.map {
           case e: PlayException => e
           case e: xsbti.CompileFailed =>
+            print(s"HRM: ERROR!!!! --> $e")
             getProblems(incomplete)
               .find(_.severity == xsbti.Severity.Error)
               .map(CompilationException)
@@ -253,6 +253,8 @@ trait PlayReloader {
         currentAnalysis = None
         watcher.stop()
       }
+
+      def isForked(): Boolean = false
 
       def getClassLoader = currentApplicationClassLoader
     }

--- a/framework/src/sbt-plugin/src/main/scala/PlaySourceGenerators.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySourceGenerators.scala
@@ -4,7 +4,7 @@
 package play
 
 import sbt._
-import PlayExceptions.{ TemplateCompilationException, RoutesCompilationException }
+import play.runsupport.PlayExceptions.{ TemplateCompilationException, RoutesCompilationException }
 import play.api.PlayException
 
 trait PlaySourceGenerators {

--- a/framework/src/sbt-plugin/src/main/scala/coffeescript/CoffeescriptCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/coffeescript/CoffeescriptCompiler.scala
@@ -5,7 +5,7 @@ package play.core.coffeescript
 
 import sbt._
 import java.io._
-import play.PlayExceptions.AssetCompilationException
+import play.runsupport.PlayExceptions.AssetCompilationException
 
 object CoffeescriptCompiler {
 

--- a/framework/src/sbt-plugin/src/main/scala/jscompile/JavascriptCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/jscompile/JavascriptCompiler.scala
@@ -3,7 +3,7 @@
  */
 package play.core.jscompile
 
-import play.PlayExceptions.AssetCompilationException
+import play.runsupport.PlayExceptions.AssetCompilationException
 import java.io._
 import play.api._
 import scala.collection.JavaConverters._

--- a/framework/src/sbt-plugin/src/main/scala/less/LessCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/less/LessCompiler.scala
@@ -3,7 +3,7 @@
  */
 package play.core.less
 
-import play.PlayExceptions.AssetCompilationException
+import play.runsupport.PlayExceptions.AssetCompilationException
 import java.io._
 
 object LessCompiler {
@@ -31,7 +31,7 @@ object LessCompiler {
                 var timers = [],
                     window = {
                         document: {
-                            getElementById: function(id) { 
+                            getElementById: function(id) {
                                 return [];
                             },
                             getElementsByTagName: function(tagName) {
@@ -39,8 +39,8 @@ object LessCompiler {
                             }
                         },
                         location: {
-                            protocol: 'file:', 
-                            hostname: 'localhost', 
+                            protocol: 'file:',
+                            hostname: 'localhost',
                             port: '80'
                         },
                         setInterval: function(fn, time) {

--- a/framework/src/sbt-plugin/src/main/scala/play/Project.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/Project.scala
@@ -10,6 +10,7 @@ import com.typesafe.sbt.SbtNativePackager.packageArchetype
 import com.typesafe.sbt.jse.SbtJsTask
 import com.typesafe.sbt.webdriver.SbtWebDriver
 import play.twirl.sbt.SbtTwirl
+import play.runsupport.PlayExceptions
 
 /**
  * Base plugin for Play projects. Declares common settings for both Java and Scala based Play projects.
@@ -24,7 +25,7 @@ object Play
   with PlayPositionMapper
   with PlaySourceGenerators {
 
-  override def requires = SbtTwirl && SbtJsTask && SbtWebDriver
+  override def requires = SbtTwirl && SbtJsTask && SbtWebDriver && SbtUIPlugin && SbtBackgroundRunPlugin
 
   val autoImport = play.PlayImport
 

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/project/plugins.sbt
@@ -1,13 +1,13 @@
 // Comment to get more information during initialization
 logLevel := Level.Warn
 
-// The Typesafe repository 
+// The Typesafe repository
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Needed while we're on a snapshot of SBT idea plugin
 resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.0")

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/project/plugins.sbt
@@ -1,13 +1,13 @@
 // Comment to get more information during initialization
 logLevel := Level.Warn
 
-// The Typesafe repository 
+// The Typesafe repository
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Needed while we're on a snapshot of SBT idea plugin
 resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.0")

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/plugins.sbt
@@ -1,11 +1,11 @@
 // Comment to get more information during initialization
 logLevel := Level.Warn
 
-// The Typesafe repository 
+// The Typesafe repository
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Needed while we're on a snapshot of SBT idea plugin
 resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/scala-compilation-times/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/scala-compilation-times/project/plugins.sbt
@@ -1,11 +1,11 @@
 // Comment to get more information during initialization
 logLevel := Level.Warn
 
-// The Typesafe repository 
+// The Typesafe repository
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Needed while we're on a snapshot of SBT idea plugin
 resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/project/plugins.sbt
@@ -1,11 +1,11 @@
 // Comment to get more information during initialization
 logLevel := Level.Warn
 
-// The Typesafe repository 
+// The Typesafe repository
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Needed while we're on a snapshot of SBT idea plugin
 resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))

--- a/framework/src/sbt-plugin/src/test/scala/CoffeeCompilerSpec.scala
+++ b/framework/src/sbt-plugin/src/test/scala/CoffeeCompilerSpec.scala
@@ -5,7 +5,7 @@ package play.core.coffeescript
 
 import java.io._
 import org.specs2.mutable._
-import play.PlayExceptions.AssetCompilationException
+import play.runsupport.PlayExceptions.AssetCompilationException
 
 object AssetsSpec extends Specification {
 

--- a/framework/src/sbt-plugin/src/test/scala/less/LessCompilerSpec.scala
+++ b/framework/src/sbt-plugin/src/test/scala/less/LessCompilerSpec.scala
@@ -5,7 +5,7 @@ package play.core.less
 
 import org.specs2.mutable.Specification
 import java.io.File
-import play.PlayExceptions.AssetCompilationException
+import play.runsupport.PlayExceptions.AssetCompilationException
 
 object LessCompilerSpec extends Specification {
 

--- a/framework/src/sbt-plugin/src/test/scala/play/PlayRunHookSpec.scala
+++ b/framework/src/sbt-plugin/src/test/scala/play/PlayRunHookSpec.scala
@@ -5,7 +5,7 @@ package play
 
 import java.io._
 import org.specs2.mutable._
-import play.PlayExceptions.AssetCompilationException
+import play.runsupport.PlayExceptions.AssetCompilationException
 import scala.collection.mutable.HashMap
 
 object PlayRunHookSpec extends Specification {


### PR DESCRIPTION
Uses sbt-remote-control to connect to a running sbt-server.

How it works:

If

`(fork in run) := true`

Then the run task will fork off the running play app executing the entry
point: `play.sbtclient.ForkRunner.main` passing it:
- base directory for the project
- build uri for the project
- target directory where output artifacts are generated
- project name
- http port
- https port
- poll delay milliseconds for the file watcher

The forked process will then connect back to the sbt-server via the
sbt-client interface. There is a custom task `playDefaultForkRunSupport`
that combines the execution of several tasks and emits them to a remote
client.  This task generates sufficient information to create an
instance of Play's `BuildLink` interface and pass it to the Netty dev
main entry point.  At this point things should more-or-less work the
same as in regular Play dev mode.  Reloading works and errors and
compilation errors are correctly displayed in the web browser.

Known Limitations:
- If the project cannot be built the first time then the BuildLink
  interface cannot be created and the forked process will exit
  immediately.  I think this can be addressed by having a different task
  that feeds non-project classpath info to the forked child and sets the
  reload status to true therefore capturing the error on first load.
- Java compilations failures are not handled.  This is a known issue and
  fixing this has been pushed upstream to the SBT team.
- Routes compilation failures are also not handled.  Investigating
  approaches for fixing this.
- Although much of what is needed is already in place in the
  `ForkRunner` it is unclear how project reloading should be handled.
  Not sure what sbt(-server)'s policy will be in this regard: kill
  background tasks and restart or keep them running if forked.  If the
  policy will be to kill forked processes then nothing need be done.
  Otherwise the ForkRunner can subscribe to build event changes and
  "reboot" as necessary (which may not be needed as the `SbtClientProxy`
  layer automatically resubscribes to watched tasks when a new client is
  available)

Possible TO DOs:
- Since the forked process is "all Play" and not running within sbt it
  may be possible to achieve some simplification in the code base.  In
  particular, the base application classpath: Netty, Play libs, external
  dependencies can be made available on the boot classpath for the
  forked process eliminating the need to do dynamic class loading.
