### PR TITLE
Adding support for better AES Transformations that use an IV

### DIFF
--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -113,3 +113,16 @@ If you use the Java API, the [`F.Promise`](api/java/play/libs/F.Promise.html) cl
 | Old API | New API | Comments |
 | ------- | --------| -------- |
 | [`TimeoutException`](http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/TimeoutException.html) | [`F.PromiseTimeoutException`](api/java/play/libs/F.PromiseTimeoutException.html) | |
+
+### Crypto APIs
+
+Play's Crypto API improves security by supporting encryption methods that use initialization vectors and by changing the default encryption transformation to `AES/CTR/NoPadding`. To add this support, the Play 2.4 encryption format has changed slightly. This means that cookies and other data encrypted in Play 2.4 will not be readable by older versions of Play. However, Play 2.4 can read cookies and other data encrypted in both the old and new format.
+
+The crypto transformation is configured in `play.crypto.aes.transformation` and the default value has changed from `AES` to `AES/CTR/NoPadding`, which is more secure.
+
+When you call `Crypto.encryptAES` in Play 2.4 it will use the configured transformation (default `AES/CTR/NoPadding`) to encrypt the data and then encode the result in the new format that supports initialization vectors.
+
+When you call `Crypto.decryptAES` it will decode both the old and new formats. The old format is always decoded using the AES transformation. The new format is decoded using the configured transformation (default `AES/CTR/NoPadding`).
+
+If you wish to continue using the older format of encryption decryption, here is the [link] (https://github.com/playframework/playframework/blob/2.3.6/framework/src/play/src/main/scala/play/api/libs/Crypto.scala#L187-L277) that provides all the necessary information.
+

--- a/framework/src/play-java/src/main/java/play/libs/Crypto.java
+++ b/framework/src/play-java/src/main/java/play/libs/Crypto.java
@@ -121,7 +121,7 @@ public class Crypto {
      * <code>application.crypto.provider</code> in <code>application.conf</code>.
      * <br>
      * The transformation algorithm used is the provider specific implementation of the <code>AES</code> name.  On
-     * Oracles JDK, this is <code>AES/ECB/PKCS5Padding</code>.  This algorithm is suitable for small amounts of data,
+     * Oracles JDK, this is <code>AES/CTR/NoPadding</code>.  This algorithm is suitable for small amounts of data,
      * typically less than 32 bytes, hence is useful for encrypting credit card numbers, passwords etc.  For larger
      * blocks of data, this algorithm may expose patterns and be vulnerable to repeat attacks.
      * <br>
@@ -145,7 +145,7 @@ public class Crypto {
      * <code>application.crypto.provider</code> in <code>application.conf</code>.
      * <br>
      * The transformation algorithm used is the provider specific implementation of the <code>AES</code> name.  On
-     * Oracles JDK, this is <code>AES/ECB/PKCS5Padding</code>.  This algorithm is suitable for small amounts of data,
+     * Oracles JDK, this is <code>AES/CTR/NoPadding</code>.  This algorithm is suitable for small amounts of data,
      * typically less than 32bytes, hence is useful for encrypting credit card numbers, passwords etc.  For larger
      * blocks of data, this algorithm may expose patterns and be vulnerable to repeat attacks.
      * <br>
@@ -167,7 +167,7 @@ public class Crypto {
      * The provider used is by default this uses the platform default JSSE provider.  This can be overridden by defining
      * <code>application.crypto.provider</code> in <code>application.conf</code>.
      * <br>
-     * The transformation used is by default <code>AES/ECB/PKCS5Padding</code>.  It can be configured by defining
+     * The transformation used is by default <code>AES/CTR/NoPadding</code>.  It can be configured by defining
      * <code>application.crypto.aes.transformation</code> in <code>application.conf</code>.  Although any cipher
      * transformation algorithm can be selected here, the secret key spec used is always AES, so only AES transformation
      * algorithms will work.
@@ -187,7 +187,7 @@ public class Crypto {
      * The provider used is by default this uses the platform default JSSE provider.  This can be overridden by defining
      * <code>application.crypto.provider</code> in <code>application.conf</code>.
      * <br>
-     * The transformation used is by default <code>AES/ECB/PKCS5Padding</code>.  It can be configured by defining
+     * The transformation used is by default <code>AES/CTR/NoPadding</code>.  It can be configured by defining
      * <code>application.crypto.aes.transformation</code> in <code>application.conf</code>.  Although any cipher
      * transformation algorithm can be selected here, the secret key spec used is always AES, so only AES transformation
      * algorithms will work.

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -102,7 +102,7 @@ play {
 
   crypto {
     aes {
-      transformation = "AES"
+      transformation = "AES/CTR/NoPadding"
     }
   }
 }

--- a/framework/src/play/src/test/scala/play/api/libs/CryptoSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/CryptoSpec.scala
@@ -3,6 +3,9 @@
  */
 package play.api.libs
 
+import javax.crypto.Cipher
+import javax.crypto.spec.SecretKeySpec
+
 import org.specs2.mutable._
 import play.api._
 
@@ -12,7 +15,35 @@ object CryptoSpec extends Specification {
     "be able to encrypt/decrypt text using AES algorithm" in {
       val text = "Play Framework 2.0"
       val key = "0123456789abcdef"
-      Crypto.decryptAES(Crypto.encryptAES(text, key), key) must be equalTo text
+      val cryptoConfig = CryptoConfig(key, None, "AES")
+      val crypto = new Crypto(cryptoConfig)
+      crypto.decryptAES(crypto.encryptAES(text, key), key) must be equalTo text
+    }
+  }
+
+  "Crypto api" should {
+    "be able to encrypt/decrypt text using other AES transformations" in {
+      val text = "Play Framework 2.0"
+      val key = "0123456789abcdef"
+      val cryptoConfig = CryptoConfig(key, None, "AES/CTR/NoPadding")
+      val crypto = new Crypto(cryptoConfig)
+      crypto.decryptAES(crypto.encryptAES(text, key), key) must be equalTo text
+    }
+  }
+
+  "Crypto api" should {
+    "be able to decrypt text generated using the old transformation methods" in {
+      val text = "Play Framework 2.0"
+      val key = "0123456789abcdef"
+      // old way to encrypt things
+      val cipher = Cipher.getInstance("AES")
+      val skeySpec = new SecretKeySpec(key.substring(0, 16).getBytes("utf-8"), "AES")
+      cipher.init(Cipher.ENCRYPT_MODE, skeySpec)
+      val encrypted = Codecs.toHexString(cipher.doFinal(text.getBytes("utf-8")))
+      val cryptoConfig = CryptoConfig(key, None, "AES/CTR/NoPadding")
+      val crypto = new Crypto(cryptoConfig)
+      // should be decryptable
+      crypto.decryptAES(encrypted) must be equalTo text
     }
   }
 


### PR DESCRIPTION
The old  Crypto APIs did not support AES transformations, which require the use of the IV in the `Crypto.decryptAES(..)`
Hence if you used a transformation like `AES/CBC/PKCS5Padding` `Crypto.decryptAES(...)` would fail.

This should address issue #3594 
