### PR TITLE
Added more Http Headers & fixed ETag header

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -962,6 +962,7 @@ public class Http {
         String AUTHORIZATION = "Authorization";
         String CACHE_CONTROL = "Cache-Control";
         String CONNECTION = "Connection";
+        String CONTENT_DISPOSITION = "Content-Disposition";
         String CONTENT_ENCODING = "Content-Encoding";
         String CONTENT_LANGUAGE = "Content-Language";
         String CONTENT_LENGTH = "Content-Length";
@@ -972,7 +973,7 @@ public class Http {
         String CONTENT_TYPE = "Content-Type";
         String COOKIE = "Cookie";
         String DATE = "Date";
-        String ETAG = "Etag";
+        String ETAG = "ETag";
         String EXPECT = "Expect";
         String EXPIRES = "Expires";
         String FROM = "From";
@@ -1012,6 +1013,10 @@ public class Http {
         String ORIGIN = "Origin";
         String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method";
         String ACCESS_CONTROL_REQUEST_HEADERS = "Access-Control-Request-Headers";
+        String X_FORWARDED_FOR = "X-Forwarded-For";
+        String X_FORWARDED_HOST = "X-Forwarded-Host";
+        String X_FORWARDED_PORT = "X-Forwarded-Port";
+        String X_FORWARDED_PROTO = "X-Forwarded-Proto";
     }
 
     /**


### PR DESCRIPTION
With this PR `play.mvc.Http.HeaderNames` is now up-to-date with [play.api.http.HeaderNames](https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/api/http/StandardValues.scala#L215)

Plus: It's `ETag` not `Etag` - see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.19
