### PR TITLE
remove last public from /target/web/public/test/public

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -213,7 +213,6 @@ trait PlaySettings {
     },
 
     // Assets for testing
-    public in TestAssets := (public in TestAssets).value / assetsPrefix.value,
     fullClasspath in Test += Attributed.blank((assets in TestAssets).value.getParentFile),
 
     // Settings


### PR DESCRIPTION
i found problem.in template.

asset path some.js is work on run command.but same path is not work in test
@routes.Assets.at("some.js")

casus web-assets-test:assets task generate to /target/web/public/test/public/

I think last public is invalid. because path /target/web/public/test/ is in classpath.
