### PR TITLE
Expose maximumConnectionsPerHost to the WS

### DIFF
--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/Config.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/Config.scala
@@ -27,6 +27,8 @@ trait WSClientConfig {
 
   def userAgent: Option[String]
 
+  def maximumConnectionsPerHost: Option[Int]
+
   def compressionEnabled: Option[Boolean]
 
   def acceptAnyCertificate: Option[Boolean]
@@ -43,6 +45,7 @@ case class DefaultWSClientConfig(connectionTimeout: Option[Long] = None,
   followRedirects: Option[Boolean] = None,
   useProxyProperties: Option[Boolean] = None,
   userAgent: Option[String] = None,
+  maximumConnectionsPerHost: Option[Int] = None,
   compressionEnabled: Option[Boolean] = None,
   acceptAnyCertificate: Option[Boolean] = None,
   ssl: Option[SSLConfig] = None) extends WSClientConfig

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingAsyncHttpClientConfigBuilder.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingAsyncHttpClientConfigBuilder.scala
@@ -83,6 +83,7 @@ class NingAsyncHttpClientConfigBuilder(config: WSClientConfig = DefaultWSClientC
       .setFollowRedirects(config.followRedirects.getOrElse(followRedirects))
       .setUseProxyProperties(config.useProxyProperties.getOrElse(useProxyProperties))
       .setCompressionEnabled(config.compressionEnabled.getOrElse(compressionEnabled))
+      .setMaximumConnectionsPerHost(config.maximumConnectionsPerHost.getOrElse(-1))
 
     config.userAgent foreach builder.setUserAgent
   }


### PR DESCRIPTION
Allow to set a maximum number of connection per host in the WS. "-1" corresponds to no limit in Async Http Client.