### PR TITLE
Anorm unsafe None

### DIFF
--- a/framework/src/anorm/src/main/scala/anorm/ParameterMetaData.scala
+++ b/framework/src/anorm/src/main/scala/anorm/ParameterMetaData.scala
@@ -11,7 +11,7 @@ import java.lang.{
   Short => JShort
 }
 
-import java.util.{ UUID => JUUID }
+import java.util.{ Date, UUID => JUUID }
 
 import java.math.{ BigDecimal => JBigDec, BigInteger }
 
@@ -24,6 +24,12 @@ trait ParameterMetaData[T] { // TODO: Move in separate file
    * @see [[java.sql.Types]]
    */
   def sqlType: String
+
+  /**
+   * JDBC type
+   * @see [[java.sql.Types]]
+   */
+  def jdbcType: Int
 }
 
 /**
@@ -35,91 +41,118 @@ object ParameterMetaData {
   /** Boolean parameter meta data */
   implicit object BooleanParameterMetaData extends ParameterMetaData[Boolean] {
     val sqlType = "BOOLEAN"
+    val jdbcType = Types.BOOLEAN
   }
   implicit object JBooleanParameterMetaData extends ParameterMetaData[JBool] {
-    val sqlType = "BOOLEAN"
+    val sqlType = BooleanParameterMetaData.sqlType
+    val jdbcType = BooleanParameterMetaData.jdbcType
   }
 
   /** Double parameter meta data */
   implicit object DoubleParameterMetaData extends ParameterMetaData[Double] {
     val sqlType = "DOUBLE PRECISION"
+    val jdbcType = Types.DOUBLE
   }
   implicit object JDoubleParameterMetaData extends ParameterMetaData[JDouble] {
     val sqlType = DoubleParameterMetaData.sqlType
+    val jdbcType = DoubleParameterMetaData.jdbcType
   }
 
   /** Float parameter meta data */
   implicit object FloatParameterMetaData extends ParameterMetaData[Float] {
     val sqlType = "FLOAT"
+    val jdbcType = Types.FLOAT
   }
   implicit object JFloatParameterMetaData extends ParameterMetaData[JFloat] {
     val sqlType = FloatParameterMetaData.sqlType
+    val jdbcType = FloatParameterMetaData.jdbcType
   }
 
   /** Integer parameter meta data */
   implicit object IntParameterMetaData extends ParameterMetaData[Int] {
     val sqlType = "INTEGER"
+    val jdbcType = Types.INTEGER
   }
   implicit object ByteParameterMetaData extends ParameterMetaData[Byte] {
     val sqlType = IntParameterMetaData.sqlType
+    val jdbcType = Types.TINYINT
   }
   implicit object JByteParameterMetaData extends ParameterMetaData[JByte] {
     val sqlType = IntParameterMetaData.sqlType
+    val jdbcType = ByteParameterMetaData.jdbcType
   }
   implicit object IntegerParameterMetaData extends ParameterMetaData[Integer] {
     val sqlType = IntParameterMetaData.sqlType
+    val jdbcType = IntParameterMetaData.jdbcType
   }
   implicit object ShortParameterMetaData extends ParameterMetaData[Short] {
     val sqlType = IntParameterMetaData.sqlType
+    val jdbcType = Types.SMALLINT
   }
   implicit object JShortParameterMetaData extends ParameterMetaData[JShort] {
     val sqlType = IntParameterMetaData.sqlType
+    val jdbcType = ShortParameterMetaData.jdbcType
   }
 
   /** Numeric (big integer) parameter meta data */
   implicit object BigIntParameterMetaData extends ParameterMetaData[BigInt] {
     val sqlType = "NUMERIC"
+    val jdbcType = Types.BIGINT
   }
   implicit object BigIntegerParameterMetaData
       extends ParameterMetaData[BigInteger] {
     val sqlType = BigIntParameterMetaData.sqlType
+    val jdbcType = BigIntParameterMetaData.jdbcType
   }
   implicit object LongParameterMetaData extends ParameterMetaData[Long] {
     val sqlType = BigIntParameterMetaData.sqlType
+    val jdbcType = BigIntParameterMetaData.jdbcType
   }
   implicit object JLongParameterMetaData extends ParameterMetaData[JLong] {
     val sqlType = BigIntParameterMetaData.sqlType
+    val jdbcType = BigIntParameterMetaData.jdbcType
   }
 
   /** Decimal (big decimal) parameter meta data */
   implicit object BigDecimalParameterMetaData
       extends ParameterMetaData[BigDecimal] {
     val sqlType = "DECIMAL"
+    val jdbcType = Types.DECIMAL
   }
   implicit object JBigDecParameterMetaData extends ParameterMetaData[JBigDec] {
     val sqlType = BigDecimalParameterMetaData.sqlType
+    val jdbcType = BigDecimalParameterMetaData.jdbcType
   }
 
   /** Timestamp parameter meta data */
   implicit object TimestampParameterMetaData
       extends ParameterMetaData[Timestamp] {
     val sqlType = "TIMESTAMP"
+    val jdbcType = Types.TIMESTAMP
+  }
+  implicit object DateParameterMetaData extends ParameterMetaData[Date] {
+    val sqlType = TimestampParameterMetaData.sqlType
+    val jdbcType = TimestampParameterMetaData.jdbcType
   }
 
   /** String/VARCHAR parameter meta data */
   implicit object StringParameterMetaData extends ParameterMetaData[String] {
     val sqlType = "VARCHAR"
+    val jdbcType = Types.VARCHAR
   }
   implicit object UUIDParameterMetaData extends ParameterMetaData[JUUID] {
     val sqlType = StringParameterMetaData.sqlType
+    val jdbcType = StringParameterMetaData.jdbcType
   }
 
   /** Character parameter meta data */
   implicit object CharParameterMetaData extends ParameterMetaData[Char] {
     val sqlType = "CHAR"
+    val jdbcType = Types.CHAR
   }
   implicit object CharacterParameterMetaData
       extends ParameterMetaData[Character] {
     val sqlType = CharParameterMetaData.sqlType
+    val jdbcType = CharParameterMetaData.jdbcType
   }
 }

--- a/framework/src/anorm/src/test/scala/anorm/Joda.scala
+++ b/framework/src/anorm/src/test/scala/anorm/Joda.scala
@@ -39,6 +39,8 @@ trait JodaColumnSpec { specs: Specification =>
 }
 
 trait JodaParameterSpec { specs: ParameterSpec.type =>
+  import JodaParameterMetaData._
+
   lazy val dateTime1 = new DateTime(Date1.getTime)
   lazy val instant1 = new Instant(Date1.getTime)
 
@@ -52,6 +54,11 @@ trait JodaParameterSpec { specs: ParameterSpec.type =>
         on("p" -> null.asInstanceOf[DateTime]).execute() must beFalse
     }
 
+    "be undefined joda-time datetime" in withConnection() { implicit c =>
+      SQL("set-null-date {p}").
+        on("p" -> (None: Option[DateTime])).execute() must beFalse
+    }
+
     "be joda-time instant" in withConnection() { implicit c =>
       SQL("set-date {p}").on("p" -> instant1).execute() must beFalse
     }
@@ -59,6 +66,11 @@ trait JodaParameterSpec { specs: ParameterSpec.type =>
     "be null joda-time instant" in withConnection() { implicit c =>
       SQL("set-null-date {p}").
         on("p" -> null.asInstanceOf[Instant]).execute() must beFalse
+    }
+
+    "be undefined joda-time instant" in withConnection() { implicit c =>
+      SQL("set-null-date {p}").
+        on("p" -> (None: Option[Instant])).execute() must beFalse
     }
   }
 }

--- a/framework/src/anorm/src/test/scala/anorm/ParameterSpec.scala
+++ b/framework/src/anorm/src/test/scala/anorm/ParameterSpec.scala
@@ -222,6 +222,11 @@ object ParameterSpec
         execute() must beFalse
     }
 
+    "be undefined string" in withConnection() { implicit c =>
+      SQL("set-null-str {p}").on("p" -> (None: Option[String])).
+        execute() must beFalse
+    }
+
     "be character 'x'" in withConnection() { implicit c =>
       (SQL("set-char {b}").on('b -> new java.lang.Character('x')).
         aka("query") must beLike {
@@ -234,6 +239,11 @@ object ParameterSpec
 
     "be null character" in withConnection() { implicit c =>
       SQL("set-null-char {p}").on("p" -> null.asInstanceOf[Character]).
+        execute() must beFalse
+    }
+
+    "be undefined character" in withConnection() { implicit c =>
+      SQL("set-null-char {p}").on("p" -> (None: Option[Char])).
         execute() must beFalse
     }
 
@@ -252,6 +262,11 @@ object ParameterSpec
         aka("execution") must beFalse
     }
 
+    "be undefined boolean" in withConnection() { implicit c =>
+      SQL("set-null-bool {p}").on('p -> (None: Option[Boolean])).execute().
+        aka("execution") must beFalse
+    }
+
     "be int" in withConnection() { implicit c =>
       (SQL("set-int {p}").on("p" -> 2).execute() must beFalse).
         and(SQL("set-int {p}").on("p" -> new Integer(2)).execute() must beFalse)
@@ -259,6 +274,11 @@ object ParameterSpec
 
     "be null int" in withConnection() { implicit c =>
       SQL("set-null-int {p}").on("p" -> null.asInstanceOf[Integer]).
+        execute() must beFalse
+    }
+
+    "be undefined int" in withConnection() { implicit c =>
+      SQL("set-null-int {p}").on("p" -> (None: Option[Int])).
         execute() must beFalse
     }
 
@@ -273,6 +293,11 @@ object ParameterSpec
         "p" -> null.asInstanceOf[JShort]).execute() must beFalse
     }
 
+    "be undefined short" in withConnection() { implicit c =>
+      SQL("set-null-short {p}").on(
+        "p" -> (None: Option[Short])).execute() must beFalse
+    }
+
     "be byte" in withConnection() { implicit c =>
       (SQL("set-byte {p}").on("p" -> 4.toByte).execute() must beFalse).
         and(SQL("set-byte {p}").on(
@@ -281,6 +306,11 @@ object ParameterSpec
 
     "be null byte" in withConnection() { implicit c =>
       SQL("set-null-byte {p}").on("p" -> null.asInstanceOf[JByte]).
+        execute() must beFalse
+    }
+
+    "be undefined byte" in withConnection() { implicit c =>
+      SQL("set-null-byte {p}").on("p" -> (None: Option[Byte])).
         execute() must beFalse
     }
 
@@ -295,6 +325,11 @@ object ParameterSpec
         execute() must beFalse
     }
 
+    "be undefined long" in withConnection() { implicit c =>
+      SQL("set-null-long {p}").on("p" -> (None: Option[Long])).
+        execute() must beFalse
+    }
+
     "be float" in withConnection() { implicit c =>
       (SQL("set-float {p}").on("p" -> 1.23f).execute() must beFalse).
         and(SQL("set-float {p}").on(
@@ -303,6 +338,11 @@ object ParameterSpec
 
     "be null float" in withConnection() { implicit c =>
       SQL("set-null-float {p}").on("p" -> null.asInstanceOf[JFloat]).
+        execute() must beFalse
+    }
+
+    "be undefined float" in withConnection() { implicit c =>
+      SQL("set-null-float {p}").on("p" -> (None: Option[Float])).
         execute() must beFalse
     }
 
@@ -315,6 +355,11 @@ object ParameterSpec
     "be null double" in withConnection() { implicit c =>
       SQL("set-null-double {p}").on(
         "p" -> null.asInstanceOf[JDouble]).execute() must beFalse
+    }
+
+    "be undefined double" in withConnection() { implicit c =>
+      SQL("set-null-double {p}").on(
+        "p" -> (None: Option[Double])).execute() must beFalse
     }
 
     "be Java big integer" in withConnection() { implicit c =>
@@ -332,6 +377,11 @@ object ParameterSpec
 
     "be null Scala big integer" in withConnection() { implicit c =>
       SQL("set-null-sbi {p}").on("p" -> null.asInstanceOf[BigInt]).
+        execute() must beFalse
+    }
+
+    "be undefined Scala big integer" in withConnection() { implicit c =>
+      SQL("set-null-sbi {p}").on("p" -> (None: Option[BigInt])).
         execute() must beFalse
     }
 
@@ -353,6 +403,11 @@ object ParameterSpec
         on("p" -> null.asInstanceOf[BigDecimal]).execute() must beFalse
     }
 
+    "be undefined Scala big decimal" in withConnection() { implicit c =>
+      SQL("set-null-sbd {p}").
+        on("p" -> (None: Option[BigDecimal])).execute() must beFalse
+    }
+
     "be date" in withConnection() { implicit c =>
       SQL("set-date {p}").on("p" -> Date1).execute() must beFalse
     }
@@ -360,6 +415,11 @@ object ParameterSpec
     "be null date" in withConnection() { implicit c =>
       SQL("set-null-date {p}").
         on("p" -> null.asInstanceOf[Date]).execute() must beFalse
+    }
+
+    "be undefined date" in withConnection() { implicit c =>
+      SQL("set-null-date {p}").
+        on("p" -> (None: Option[Date])).execute() must beFalse
     }
 
     "be timestamp" in withConnection() { implicit c =>
@@ -371,6 +431,11 @@ object ParameterSpec
         on("p" -> null.asInstanceOf[Timestamp]).execute() must beFalse
     }
 
+    "be undefined timestamp" in withConnection() { implicit c =>
+      SQL("set-null-ts {p}").
+        on("p" -> (None: Option[Timestamp])).execute() must beFalse
+    }
+
     "be UUID" in withConnection() { implicit c =>
       SQL("set-uuid {p}").on("p" -> uuid1).execute() must beFalse
     }
@@ -378,6 +443,11 @@ object ParameterSpec
     "be null UUID" in withConnection() { implicit c =>
       SQL("set-null-uuid {p}").
         on("p" -> null.asInstanceOf[java.util.UUID]).execute() must beFalse
+    }
+
+    "be undefined UUID" in withConnection() { implicit c =>
+      SQL("set-null-uuid {p}").
+        on("p" -> (None: Option[java.util.UUID])).execute() must beFalse
     }
 
     "be Id of string" in withConnection() { implicit c =>


### PR DESCRIPTION
Historically Anorm passes `None` as JDBC parameter using `.setObject(x, null)`. That's unsafe and causing issues (e.g. http://stackoverflow.com/questions/26798371/anorm-play-scala-and-postgresql-dynamic-sql-clause-not-working ).
