### PR TITLE
Deprecates passing None as Anorm parameter

### DIFF
--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -126,3 +126,6 @@ When you call `Crypto.decryptAES` it will decode both the old and new formats. T
 
 If you wish to continue using the older format of encryption decryption, here is the [link] (https://github.com/playframework/playframework/blob/2.3.6/framework/src/play/src/main/scala/play/api/libs/Crypto.scala#L187-L277) that provides all the necessary information.
 
+## Anorm
+
+- Passing `None` for a nullable parameter is deprecated, and typesafe `Option.empty[T]` must be use instead.

--- a/framework/src/anorm/src/main/scala/anorm/ToStatement.scala
+++ b/framework/src/anorm/src/main/scala/anorm/ToStatement.scala
@@ -264,8 +264,9 @@ object ToStatement extends JodaToStatement {
    *   .on('c -> None)
    * }}}
    */
+  @deprecated("Parameter value should be passed using `Option.empty[T]`",
+    since = "2.3.7")
   implicit object noneToStatement extends ToStatement[None.type] {
-    // TODO: Deprecates (use None: Option[T])
     def set(s: PreparedStatement, i: Int, n: None.type) = s.setObject(i, null)
   }
 
@@ -286,8 +287,8 @@ object ToStatement extends JodaToStatement {
    * Sets optional A inferred as Option[A].
    *
    * {{{
-   * SQL("SELECT * FROM Test WHERE category = {c}")
-   *   .on('c -> Option("cat"))
+   * SQL("SELECT * FROM Test WHERE category = {c}").on('c -> Option("cat"))
+   * SQL"SELECT * FROM Test WHERE nullable_int = ${Option.empty[Int]}"
    * }}}
    */
   implicit def optionToStatement[A >: Nothing](implicit c: ToStatement[A], meta: ParameterMetaData[A]) =


### PR DESCRIPTION
- Deprecates parameter conversion for unsafe `None`.
- Update documentation accordingly.
