### PR TITLE
Don't drop the exception message from the error message if we get an error parsing

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -735,7 +735,7 @@ trait BodyParsers {
               }.left.map {
                 case NonFatal(e) =>
                   Play.logger.debug(errorMessage, e)
-                  createBadResult(errorMessage)(request)
+                  createBadResult(errorMessage + ": " + e.getMessage)(request)
                 case t => throw t
               }
             }


### PR DESCRIPTION
Partial fix for https://github.com/playframework/playframework/issues/3629

I'd still like more info returned, but this seemed like the quickest way to at least somewhat improve the situation
