### PR TITLE
Global object's location  to enable GZIP in Java

### DIFF
--- a/documentation/manual/detailedTopics/configuration/GzipEncoding.md
+++ b/documentation/manual/detailedTopics/configuration/GzipEncoding.md
@@ -21,6 +21,7 @@ For example, the code below only gzips HTML responses:
 
 ## Enabling GZIP in Java
 
-To enable gzip in Java, add it to the list of filters in the `Global` object:
+To enable gzip in Java, add it to the list of filters in the [[Global|JavaGlobal]] object.
+
 
 @[global](code/detailedtopics/configuration/gzipencoding/Global.java)


### PR DESCRIPTION
There should be reference to Global object for easy lookup.
