### PR TITLE
Fixed broken Sbt link

### DIFF
--- a/documentation/manual/_Sidebar.md
+++ b/documentation/manual/_Sidebar.md
@@ -27,7 +27,7 @@
 
 - [Scala](http://docs.scala-lang.org/)
 - [Akka](http://akka.io/docs/)
-- [sbt](http://www.scala-sbt.org/learn.html)
+- [sbt](http://www.scala-sbt.org/documentation.html)
 - [Configuration](https://github.com/typesafehub/config)
 - [Logback](http://logback.qos.ch/documentation.html)
 


### PR DESCRIPTION
The SBT link in the sidebar under `Additional documentations` was broken.

I made it point to the [Sbt documentation home](http://www.scala-sbt.org/documentation.html)
