### PR TITLE
Custom validator always produce the same validation error message

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/validation/Constraints.java
+++ b/framework/src/play-java/src/main/java/play/data/validation/Constraints.java
@@ -453,7 +453,7 @@ public class Constraints {
     @Constraint(validatedBy = ValidateWithValidator.class)
     @play.data.Form.Display(name="constraint.validatewith", attributes={})
     public static @interface ValidateWith {
-        String message() default ValidateWithValidator.message;
+        String message() default ValidateWithValidator.defaultMessage;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
         Class<? extends Validator> value();
@@ -464,7 +464,7 @@ public class Constraints {
      */
     public static class ValidateWithValidator extends Validator<Object> implements ConstraintValidator<ValidateWith, Object> {
 
-        final static public String message = "error.invalid";
+        final static public String defaultMessage = "error.invalid";
         Class<?> clazz = null;
         Validator validator = null;
 
@@ -494,8 +494,16 @@ public class Constraints {
             }
         }
 
+        @SuppressWarnings("unchecked")
         public Tuple<String, Object[]> getErrorMessageKey() {
-            return Tuple(message, new Object[] {});
+            Tuple<String, Object[]> errorMessageKey = null;
+            try {
+                errorMessageKey = validator.getErrorMessageKey();
+            } catch(Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            return (errorMessageKey != null) ? errorMessageKey : Tuple(defaultMessage, new Object[] {});
         }
 
     }

--- a/framework/src/play-java/src/test/java/play/data/BlueValidator.java
+++ b/framework/src/play-java/src/test/java/play/data/BlueValidator.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.data;
+
+
+import play.data.validation.Constraints;
+import play.libs.F;
+
+
+public class BlueValidator extends Constraints.Validator<String> {
+
+    public boolean isValid(String value) {
+        return "blue".equals(value);
+    }
+
+    public F.Tuple<String, Object[]> getErrorMessageKey() {
+        return F.Tuple("notblue", new Object[] {});
+    }
+}

--- a/framework/src/play-java/src/test/java/play/data/MyBlueUser.java
+++ b/framework/src/play-java/src/test/java/play/data/MyBlueUser.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.data;
+
+import play.libs.F.Option;
+import play.data.validation.Constraints.ValidateWith;
+
+public class MyBlueUser {
+    public String name;
+
+    @ValidateWith(BlueValidator.class)
+    private String skinColor;
+    
+    @ValidateWith(value=BlueValidator.class, message="i-am-blue")
+    private String hairColor;
+    
+    public String getSkinColor() {
+        return skinColor;
+    }
+    
+    public void setSkinColor(String value) {
+        skinColor = value;
+    }
+    
+    public String getHairColor() {
+        return hairColor;
+    }
+    
+    public void setHairColor(String value) {
+        hairColor = value;
+    }
+}

--- a/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
@@ -99,12 +99,35 @@ object FormSpec extends Specification {
       userEmail.bind(Map("email" -> "john@ex'ample.com").asJava).errors().asScala must not beEmpty
     }
 
-    "support custom class validators" in {
-      val form = Form.form(classOf[Red])
-      val bound = form.bind(Map("name" -> "blue").asJava)
-      bound.hasErrors must_== true
-      bound.hasGlobalErrors must_== true
-      bound.globalErrors().asScala must not beEmpty
+    "support custom validators" in {
+      "that fails when validator's condition is not met" in {
+        val form = Form.form(classOf[Red])
+        val bound = form.bind(Map("name" -> "blue").asJava)
+        bound.hasErrors must_== true
+        bound.hasGlobalErrors must_== true
+        bound.globalErrors().asScala must not beEmpty
+      }
+
+      "that returns customized message when validator fails" in {
+        val form = Form.form(classOf[MyBlueUser]).bind(
+          Map("name" -> "Shrek", "skinColor" -> "green", "hairColor" -> "blue").asJava)
+        form.hasErrors must beEqualTo(true)
+        form.errors().get("hairColor") must beNull
+        val validationErrors = form.errors().get("skinColor")
+        validationErrors.size() must beEqualTo(1)
+        validationErrors.get(0).message must beEqualTo("notblue")
+      }
+
+      "that returns customized message in annotation when validator fails" in {
+        val form = Form.form(classOf[MyBlueUser]).bind(
+          Map("name" -> "Smurf", "skinColor" -> "blue", "hairColor" -> "white").asJava)
+        form.errors().get("skinColor") must beNull
+        form.hasErrors must beEqualTo(true)
+        val validationErrors = form.errors().get("hairColor")
+        validationErrors.size() must beEqualTo(1)
+        validationErrors.get(0).message must beEqualTo("i-am-blue")
+      }
+
     }
 
     "work with the @repeat helper" in {


### PR DESCRIPTION
When you implement your own Validator class to be used with ValidateWith annotation, the error message can't be customized through getErrorMessageKey() method. 

The problem is the message used in the following code is hardcoded instead of calling same validator's method:

https://github.com/playframework/playframework/blob/master/framework/src/play-java/src/main/java/play/data/validation/Constraints.java#L498
