### PR TITLE
Make Cached work with DI and disk caches

### DIFF
--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -69,6 +69,7 @@ While Play 2.4 won't force you to use the dependency injected versions of compon
 | [`Messages`](api/scala/index.html#play.api.i18n.Messages$) | [`MessagesApi`](api/scala/index.html#play.api.i18n.MessagesApi) | Using one of the `preferred` methods, you can get a [`Messages`](api/scala/index.html#play.api.i18n.Messages) instance. |
 | [`DB`](api/scala/index.html#play.api.db.DB$) | [`DBApi`](api/scala/index.html#play.api.db.DBApi) or better, [`Database`](api/scala/index.html#play.api.db.Database) | You can get a particular database using the `@NamedDatabase` annotation. |
 | [`Cache`](api/scala/index.html#play.api.cache.Cache$) | [`CacheApi`](api/scala/index.html#play.api.cache.CacheApi) or better | You can get a particular cache using the `@NamedCache` annotation. |
+| [`Cached` object](api/scala/index.html#play.api.cache.Cached$) | [`Cached` instance](api/scala/index.html#play.api.cache.Cached) | Use an injected instance instead of the companion object. You can use the `@NamedCache` annotation. |
 | [`Akka`](api/scala/index.html#play.api.libs.concurrent.Akka$) | N/A | No longer needed, just declare a dependency on `ActorSystem` |
 | [`WS`](api/scala/index.html#play.api.libs.ws.WS$) | [`WSClient`](api/scala/index.html#play.api.libs.ws.WSClient) | |
 

--- a/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
+++ b/documentation/manual/working/scalaGuide/main/cache/ScalaCache.md
@@ -60,16 +60,19 @@ Now to access these different caches, when you inject them, use the [NamedCache]
 
 ## Caching HTTP responses
 
-You can easily create smart cached actions using standard Action composition. 
+You can easily create smart cached actions using standard Action composition.
 
 > **Note:** Play HTTP `Result` instances are safe to cache and reuse later.
 
-Play provides a default built-in helper for standard cases:
+The [Cached](api/scala/index.html#play.api.cache.Cached) class helps you build cached actions.
+
+@[cached-action-app](code/ScalaCache.scala)
+
+You can cache the result of an action using a fixed key like `"homePage"`.
 
 @[cached-action](code/ScalaCache.scala)
 
-
-Or even:
+If results vary, you can cache each result using a different key. In this example, each user has a different cached result.
 
 @[composition-cached-action](code/ScalaCache.scala)
 

--- a/framework/src/play-cache/src/main/scala/play/api/cache/Cached.scala
+++ b/framework/src/play-cache/src/main/scala/play/api/cache/Cached.scala
@@ -3,6 +3,7 @@
  */
 package play.api.cache
 
+import javax.inject.Inject
 import play.api._
 import play.api.mvc._
 import play.api.libs.Codecs
@@ -15,45 +16,193 @@ import play.core.Execution.Implicits.internalContext
 import scala.concurrent.duration._
 
 /**
- * Cache an action.
- *
- * Uses both server and client caches:
+ * A helper to add caching to an Action.
+ */
+class Cached @Inject() (cache: CacheApi) {
+
+  /**
+   * Cache an action.
+   *
+   * @param key Compute a key from the request header
+   * @param caching Compute a cache duration from the respone header
+   */
+  def apply(
+    key: RequestHeader => String,
+    caching: PartialFunction[ResponseHeader, Duration]): CachedBuilder = new CachedBuilder(cache, key, caching)
+
+  /**
+   * Cache an action.
+   *
+   * @param key Compute a key from the request header
+   */
+  def apply(key: RequestHeader => String): CachedBuilder = {
+    apply(key, duration = 0)
+  }
+
+  /**
+   * Cache an action.
+   *
+   * @param key Cache key
+   */
+  def apply(key: String): CachedBuilder = {
+    apply(_ => key, duration = 0)
+  }
+
+  /**
+   * Cache an action.
+   *
+   * @param key Cache key
+   * @param duration Cache duration (in seconds)
+   */
+  def apply(key: RequestHeader => String, duration: Int): CachedBuilder = {
+    new CachedBuilder(cache, key, { case (_: ResponseHeader) => Duration(duration, SECONDS) })
+  }
+
+  /**
+   * A cached instance caching nothing
+   * Useful for composition
+   */
+  def empty(key: RequestHeader => String): CachedBuilder = new CachedBuilder(cache, key, PartialFunction.empty)
+
+  /**
+   * Caches everything, forever
+   */
+  def everything(key: RequestHeader => String): CachedBuilder = empty(key).default(0)
+
+  /**
+   * Caches everything for the specified seconds
+   */
+  def everything(key: RequestHeader => String, duration: Int): CachedBuilder = empty(key).default(duration)
+
+  /**
+   * Caches the specified status, for the specified number of seconds
+   */
+  def status(key: RequestHeader => String, status: Int, duration: Int): CachedBuilder = empty(key).includeStatus(status, Duration(duration, SECONDS))
+
+  /**
+   * Caches the specified status forever
+   */
+  def status(key: RequestHeader => String, status: Int): CachedBuilder = empty(key).includeStatus(status)
+}
+
+/**
+ * A helper to add caching to an Action. This helper uses the Application's default cache.
+ * If you want to inject a custom cache, see the `Cached` class.
+ */
+object Cached {
+
+  /**
+   * Cache an action.
+   *
+   * @param key Compute a key from the request header
+   * @param caching Compute a cache duration from the respone header
+   */
+  def apply(
+    key: RequestHeader => String,
+    caching: PartialFunction[ResponseHeader, Duration]): UnboundCachedBuilder = new UnboundCachedBuilder(key, caching)
+
+  /**
+   * Cache an action.
+   *
+   * @param key Compute a key from the request header
+   */
+  def apply(key: RequestHeader => String): UnboundCachedBuilder = {
+    apply(key, duration = 0)
+  }
+
+  /**
+   * Cache an action.
+   *
+   * @param key Cache key
+   */
+  def apply(key: String): UnboundCachedBuilder = {
+    apply(_ => key, duration = 0)
+  }
+
+  /**
+   * Cache an action.
+   *
+   * @param key Cache key
+   * @param duration Cache duration (in seconds)
+   */
+  def apply(key: RequestHeader => String, duration: Int): UnboundCachedBuilder = {
+    new UnboundCachedBuilder(key, { case (_: ResponseHeader) => Duration(duration, SECONDS) })
+  }
+
+  /**
+   * A cached instance caching nothing
+   * Useful for composition
+   */
+  def empty(key: RequestHeader => String): UnboundCachedBuilder = new UnboundCachedBuilder(key, PartialFunction.empty)
+
+  /**
+   * Caches everything, forever
+   */
+  def everything(key: RequestHeader => String): UnboundCachedBuilder = empty(key).default(0)
+
+  /**
+   * Caches everything for the specified seconds
+   */
+  def everything(key: RequestHeader => String, duration: Int): UnboundCachedBuilder = empty(key).default(duration)
+
+  /**
+   * Caches the specified status, for the specified number of seconds
+   */
+  def status(key: RequestHeader => String, status: Int, duration: Int): UnboundCachedBuilder = empty(key).includeStatus(status, Duration(duration, SECONDS))
+
+  /**
+   * Caches the specified status forever
+   */
+  def status(key: RequestHeader => String, status: Int): UnboundCachedBuilder = empty(key).includeStatus(status)
+}
+
+/**
+ * Builds an action with caching behavior. Typically created with one of the methods in the `Cached`
+ * class. Uses both server and client caches:
  *
  *  - Adds an `Expires` header to the response, so clients can cache response content ;
  *  - Adds an `Etag` header to the response, so clients can cache response content and ask the server for freshness ;
  *  - Cache the result on the server, so the underlying action is not computed at each call.
  *
+ * @param cache The cache used for caching results
  * @param key Compute a key from the request header
  * @param caching A callback to get the number of seconds to cache results for
  */
-case class Cached(key: RequestHeader => String, caching: PartialFunction[ResponseHeader, Duration]) {
-  import Cached._
-
-  def apply(action: EssentialAction)(implicit app: Application) = build(action)
+final class CachedBuilder(
+    cache: CacheApi,
+    key: RequestHeader => String,
+    caching: PartialFunction[ResponseHeader, Duration]) {
 
   /**
    * Compose the cache with an action
    */
-  def build(action: EssentialAction)(implicit app: Application) = EssentialAction { request =>
+  def apply(action: EssentialAction): EssentialAction = build(action)
+
+  /**
+   * Compose the cache with an action
+   */
+  def build(action: EssentialAction): EssentialAction = EssentialAction { request =>
     val resultKey = key(request)
     val etagKey = s"$resultKey-etag"
 
     // Has the client a version of the resource as fresh as the last one we served?
     val notModified = for {
       requestEtag <- request.headers.get(IF_NONE_MATCH)
-      etag <- Cache.getAs[String](etagKey)
+      etag <- cache.get[String](etagKey)
       if requestEtag == "*" || etag == requestEtag
     } yield Done[Array[Byte], Result](NotModified)
 
     notModified.orElse {
       // Otherwise try to serve the resource from the cache, if it has not yet expired
-      Cache.getAs[Result](resultKey).map(Done[Array[Byte], Result](_))
+      cache.get[SerializableResult](resultKey).map { sr: SerializableResult =>
+        Done[Array[Byte], Result](sr.result)
+      }
     }.getOrElse {
       // The resource was not in the cache, we have to run the underlying action
       val iterateeResult = action(request)
 
       // Add cache information to the response, so clients can cache its content
-      iterateeResult.map(handleResult(_, etagKey, resultKey, app))
+      iterateeResult.map(handleResult(_, etagKey, resultKey))
     }
   }
 
@@ -61,14 +210,16 @@ case class Cached(key: RequestHeader => String, caching: PartialFunction[Respons
    * Eternity is one year long. Duration zero means eternity.
    */
   private val cachingWithEternity = caching.andThen { duration =>
-    if (duration.zero) {
+    // FIXME: Surely Duration.Inf is a better marker for eternity than 0?
+    val zeroDuration: Boolean = duration.neg().equals(duration)
+    if (zeroDuration) {
       Duration(60 * 60 * 24 * 365, SECONDS)
     } else {
       duration
     }
   }
 
-  private def handleResult(result: Result, etagKey: String, resultKey: String, app: Application): Result = {
+  private def handleResult(result: Result, etagKey: String, resultKey: String): Result = {
     cachingWithEternity.andThen { duration =>
       // Format expiration date according to http standard
       val expirationDate = http.dateFormat.print(System.currentTimeMillis() + duration.toMillis)
@@ -79,9 +230,9 @@ case class Cached(key: RequestHeader => String, caching: PartialFunction[Respons
       val resultWithHeaders = result.withHeaders(ETAG -> etag, EXPIRES -> expirationDate)
 
       // Cache the new ETAG of the resource
-      Cache.set(etagKey, etag, duration)(app)
+      cache.set(etagKey, etag, duration)
       // Cache the new Result of the resource
-      Cache.set(resultKey, resultWithHeaders, duration)(app)
+      cache.set(resultKey, new SerializableResult(resultWithHeaders), duration)
 
       resultWithHeaders
     }.applyOrElse(result.header, (_: ResponseHeader) => result)
@@ -91,7 +242,7 @@ case class Cached(key: RequestHeader => String, caching: PartialFunction[Respons
    * Whether this cache should cache the specified response if the status code match
    * This method will cache the result forever
    */
-  def includeStatus(status: Int): Cached = includeStatus(status, Duration.Zero)
+  def includeStatus(status: Int): CachedBuilder = includeStatus(status, Duration.Zero)
 
   /**
    * Whether this cache should cache the specified response if the status code match
@@ -100,7 +251,7 @@ case class Cached(key: RequestHeader => String, caching: PartialFunction[Respons
    * @param status the status code to check
    * @param duration the number of seconds to cache the result for
    */
-  def includeStatus(status: Int, duration: Int): Cached = includeStatus(status, Duration(duration, SECONDS))
+  def includeStatus(status: Int, duration: Int): CachedBuilder = includeStatus(status, Duration(duration, SECONDS))
 
   /**
    * Whether this cache should cache the specified response if the status code match
@@ -109,98 +260,115 @@ case class Cached(key: RequestHeader => String, caching: PartialFunction[Respons
    * @param status the status code to check
    * @param duration how long should we cache the result for
    */
-  def includeStatus(status: Int, duration: Duration): Cached = this.copy(caching = caching.orElse {
+  def includeStatus(status: Int, duration: Duration): CachedBuilder = compose {
     case e if e.status == status => {
       duration
     }
-  })
+  }
 
   /**
    * The returned cache will store all responses whatever they may contain
    * @param duration how long we should store responses
    */
-  def default(duration: Duration): Cached = compose(PartialFunction((_: ResponseHeader) => duration))
+  def default(duration: Duration): CachedBuilder = compose(PartialFunction((_: ResponseHeader) => duration))
 
   /**
    * The returned cache will store all responses whatever they may contain
    * @param duration the number of seconds we should store responses
    */
-  def default(duration: Int): Cached = default(Duration(duration, SECONDS))
+  def default(duration: Int): CachedBuilder = default(Duration(duration, SECONDS))
 
   /**
    * Compose the cache with new caching function
    * @param alternative a closure getting the reponseheader and returning the duration
    *        we should cache for
    */
-  def compose(alternative: PartialFunction[ResponseHeader, Duration]): Cached = this.copy(caching = caching.orElse(alternative))
+  def compose(alternative: PartialFunction[ResponseHeader, Duration]): CachedBuilder = new CachedBuilder(
+    cache = cache,
+    key = key,
+    caching = caching.orElse(alternative)
+  )
 
 }
 
-object Cached {
+/**
+ * Builds an action with caching behavior. Typically created with one of the methods in the `Cached`
+ * companion object. Uses both server and client caches:
+ *
+ *  - Adds an `Expires` header to the response, so clients can cache response content ;
+ *  - Adds an `Etag` header to the response, so clients can cache response content and ask the server for freshness ;
+ *  - Cache the result on the server, so the underlying action is not computed at each call.
+ *
+ * Unlike `CachedBuilder`, an `UnboundCachedBuilder` isn't bound to a particular
+ * cache when it is created. It binds the default cache of the current application
+ * when it builds an action.
+ *
+ * @param key Compute a key from the request header
+ * @param caching A callback to get the number of seconds to cache results for
+ */
+class UnboundCachedBuilder(key: RequestHeader => String, caching: PartialFunction[ResponseHeader, Duration]) {
+  import Cached._
 
   /**
-   * Convenient implicit class for adding a zero method to Duration
+   * Compose the cache with an action
    */
-  private implicit class DurationEmpty(d: Duration) {
-    /**
-     * This tests if the duration is currently zero
-     * @returns boolean checking whether the duration is zero or not
-     */
-    def zero(): Boolean = d.neg().equals(d)
+  def apply(action: EssentialAction)(implicit app: Application): EssentialAction = build(action)
+
+  /**
+   * Compose the cache with an action
+   */
+  def build(action: EssentialAction)(implicit app: Application): EssentialAction = {
+    new CachedBuilder(Cache.cacheApi, key, caching).build(action)
   }
 
   /**
-   * Cache an action.
+   * Whether this cache should cache the specified response if the status code match
+   * This method will cache the result forever
+   */
+  def includeStatus(status: Int): UnboundCachedBuilder = includeStatus(status, Duration.Zero)
+
+  /**
+   * Whether this cache should cache the specified response if the status code match
+   * This method will cache the result for duration seconds
    *
-   * @param key Compute a key from the request header
+   * @param status the status code to check
+   * @param duration the number of seconds to cache the result for
    */
-  def apply(key: RequestHeader => String): Cached = {
-    apply(key, duration = 0)
-  }
+  def includeStatus(status: Int, duration: Int): UnboundCachedBuilder = includeStatus(status, Duration(duration, SECONDS))
 
   /**
-   * Cache an action.
+   * Whether this cache should cache the specified response if the status code match
+   * This method will cache the result for duration seconds
    *
-   * @param key Cache key
+   * @param status the status code to check
+   * @param duration how long should we cache the result for
    */
-  def apply(key: String): Cached = {
-    apply(_ => key, duration = 0)
+  def includeStatus(status: Int, duration: Duration): UnboundCachedBuilder = compose {
+    case e if e.status == status => {
+      duration
+    }
   }
 
   /**
-   * Cache an action.
-   *
-   * @param key Cache key
-   * @param duration Cache duration (in seconds)
+   * The returned cache will store all responses whatever they may contain
+   * @param duration how long we should store responses
    */
-  def apply(key: RequestHeader => String, duration: Int): Cached = {
-    new Cached(key, { case (_: ResponseHeader) => Duration(duration, SECONDS) })
-  }
+  def default(duration: Duration): UnboundCachedBuilder = compose(PartialFunction((_: ResponseHeader) => duration))
 
   /**
-   * A cached instance caching nothing
-   * Useful for composition
+   * The returned cache will store all responses whatever they may contain
+   * @param duration the number of seconds we should store responses
    */
-  def empty(key: RequestHeader => String): Cached = new Cached(key, PartialFunction.empty)
+  def default(duration: Int): UnboundCachedBuilder = default(Duration(duration, SECONDS))
 
   /**
-   * Caches everything, forever
+   * Compose the cache with new caching function
+   * @param alternative a closure getting the reponseheader and returning the duration
+   *        we should cache for
    */
-  def everything(key: RequestHeader => String): Cached = empty(key).default(0)
+  def compose(alternative: PartialFunction[ResponseHeader, Duration]): UnboundCachedBuilder = new UnboundCachedBuilder(
+    key = key,
+    caching = caching.orElse(alternative)
+  )
 
-  /**
-   * Caches everything for the specified seconds
-   */
-  def everything(key: RequestHeader => String, duration: Int): Cached = empty(key).default(duration)
-
-  /**
-   * Caches the specified status, for the specified number of seconds
-   */
-  def status(key: RequestHeader => String, status: Int, duration: Int): Cached = empty(key).includeStatus(status, Duration(duration, SECONDS))
-
-  /**
-   * Caches the specified status forever
-   */
-  def status(key: RequestHeader => String, status: Int): Cached = empty(key).includeStatus(status)
 }
-

--- a/framework/src/play-cache/src/main/scala/play/api/cache/SerializableResult.scala
+++ b/framework/src/play-cache/src/main/scala/play/api/cache/SerializableResult.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.cache
+
+import java.io._
+import play.api._
+import play.api.mvc._
+import play.api.libs.iteratee.{ Enumerator, Iteratee }
+import scala.annotation.tailrec
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+/**
+ * Wraps a Result to make it Serializable.
+ */
+private[play] final class SerializableResult(constructorResult: Result) extends Externalizable {
+
+  /**
+   * Create an empty object. Must call `readExternal` after calling
+   * this method. This constructor is invoked by the Java
+   * deserialization code.
+   */
+  def this() = this(null)
+
+  /**
+   * Hold the Result. Will either be supplied by the constructor or
+   * set by `readExternal`.
+   */
+  private var cachedResult: Result = constructorResult
+
+  def result: Result = {
+    assert(cachedResult != null, "Result should have been provided in constructor or when deserializing")
+    cachedResult
+  }
+  override def readExternal(in: ObjectInput): Unit = {
+    assert(in.readByte() == SerializableResult.encodingVersion)
+
+    val status = in.readInt()
+
+    val headerMap = {
+      val headerLength = in.readInt()
+      val mapBuilder = Map.newBuilder[String, String]
+      for (_ <- 0 until headerLength) {
+        val name = in.readUTF()
+        val value = in.readUTF()
+        mapBuilder += ((name, value))
+      }
+      mapBuilder.result()
+    }
+
+    val body = {
+      val numberOfChunks: Int = in.readInt()
+      val chunks: Array[Array[Byte]] = new Array[Array[Byte]](numberOfChunks)
+      for (i <- 0 until numberOfChunks) {
+        val chunkLength = in.readInt()
+        val chunk = new Array[Byte](chunkLength)
+        @tailrec
+        def readBytes(offset: Int, length: Int): Unit = {
+          if (length > 0) {
+            val readLength = in.read(chunk, offset, length)
+            readBytes(offset + readLength, length - readLength)
+          }
+        }
+        readBytes(0, chunkLength)
+        chunks(i) = chunk
+      }
+      Enumerator(chunks: _*) >>> Enumerator.eof
+    }
+
+    val connection = {
+      val connectionInt: Int = in.readInt()
+      connectionInt match {
+        case 1 => HttpConnection.KeepAlive
+        case 2 => HttpConnection.Close
+        case unknown => throw new IOException(s"Can't deserialize HttpConnection coded as: $unknown")
+      }
+    }
+
+    cachedResult = Result(
+      header = ResponseHeader(status, headerMap),
+      body = body,
+      connection = connection
+    )
+  }
+  override def writeExternal(out: ObjectOutput): Unit = {
+    out.writeByte(SerializableResult.encodingVersion)
+
+    out.writeInt(cachedResult.header.status)
+
+    {
+      val headerMap = cachedResult.header.headers
+      out.writeInt(headerMap.size)
+      for ((name, value) <- headerMap) {
+        out.writeUTF(name)
+        out.writeUTF(value)
+      }
+    }
+
+    {
+      val bodyChunks: List[Array[Byte]] = Await.result(cachedResult.body |>>> Iteratee.getChunks[Array[Byte]], Duration.Inf)
+      out.writeInt(bodyChunks.length)
+      for ((chunk, i) <- bodyChunks.zipWithIndex) {
+        out.writeInt(chunk.length)
+        out.write(chunk)
+      }
+    }
+
+    {
+      val connectionInt: Int = result.connection match {
+        case HttpConnection.KeepAlive => 1
+        case HttpConnection.Close => 2
+        case unknown => throw new IOException(s"Can't serialize HttpConnection value: $unknown")
+      }
+      out.writeInt(connectionInt)
+    }
+  }
+}
+
+private[play] object SerializableResult {
+  val encodingVersion = 1.toByte
+}

--- a/framework/src/play-cache/src/test/scala/play/api/cache/SerializableResultSpec.scala
+++ b/framework/src/play-cache/src/test/scala/play/api/cache/SerializableResultSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.cache
+
+import play.api.test._
+import play.api.mvc.{ Action, HttpConnection, Result, Results }
+import play.api.http
+import play.api.libs.iteratee.{ Enumerator, Iteratee }
+
+import scala.concurrent.duration._
+
+class SerializableResultSpec extends PlaySpecification {
+
+  sequential
+
+  "SerializableResult" should {
+
+    def serializeAndDeserialize(result: Result): Result = {
+      val inWrapper = new SerializableResult(result)
+      import java.io._
+      val baos = new ByteArrayOutputStream()
+      val oos = new ObjectOutputStream(baos)
+      oos.writeObject(inWrapper)
+      oos.flush()
+      oos.close()
+      baos.close()
+      val bytes = baos.toByteArray
+      val bais = new ByteArrayInputStream(bytes)
+      val ois = new ObjectInputStream(bais)
+      val outWrapper = ois.readObject().asInstanceOf[SerializableResult]
+      ois.close()
+      bais.close()
+      outWrapper.result
+    }
+
+    // To be fancy could use a Matcher
+    def compareResults(r1: Result, r2: Result) = {
+      def bodyChunks(r: Result): Vector[Vector[Byte]] = {
+        await(r.body |>>> Iteratee.getChunks[Array[Byte]]).map(_.to[Vector]).to[Vector]
+      }
+      r1.header.status must_== r2.header.status
+      r1.header.headers must_== r2.header.headers
+      bodyChunks(r1) must_== bodyChunks(r2)
+      r1.connection must_== r2.connection
+    }
+
+    def checkSerialization(r: Result) = {
+      val r2 = serializeAndDeserialize(r)
+      compareResults(r, r2)
+    }
+
+    "serialize and deserialize statūs" in {
+      checkSerialization(Results.Ok("x").withHeaders(CONTENT_TYPE -> "text/banana"))
+      checkSerialization(Results.NotFound)
+    }
+    "serialize and deserialize simple Results" in {
+      checkSerialization(Results.Ok("hello!"))
+      checkSerialization(Results.Ok.chunked(Enumerator("hel", "lo!")))
+      checkSerialization(Results.Ok("hello!").withHeaders(CONTENT_TYPE -> "text/banana"))
+      checkSerialization(Results.Ok("hello!").withHeaders(CONTENT_TYPE -> "text/banana", "X-Foo" -> "bar"))
+    }
+    "serialize and deserialize chunked Results" in {
+      checkSerialization(Results.Ok.chunked(Enumerator("hel", "lo!")))
+      checkSerialization(Results.Ok.chunked(Enumerator("hel", "lo", "!")))
+    }
+    "serialize and deserialize connection types" in {
+      checkSerialization(Results.Ok("hello!").copy(connection = HttpConnection.KeepAlive))
+      checkSerialization(Results.Ok("hello!").copy(connection = HttpConnection.Close))
+    }
+    "serialize and deserialize large results" in {
+      val n = 200
+      val chunks = Enumerator.unfold(0) {
+        case i if i < n => {
+          val b = (i & 0xff).toByte
+          val chunk = Array.fill(i)(b)
+          Some((i + 1, chunk))
+        }
+        case _ => None
+      }
+      val headers = (0 until 200).foldLeft(Seq.empty[(String, String)]) {
+        case (s, i) => s :+ ("X-$i" -> i.toString)
+      }
+      checkSerialization(Results.Ok.stream(chunks).withHeaders(headers: _*))
+    }
+  }
+}


### PR DESCRIPTION
- Update Cached to use DI. Introduce the CachedApi as an alternative to Cached.
- Make Results serializable by wrapping them before storing them in Cached's cache.

This PR still needs some work. I'd like to get it into 2.4.
- [x] Get review of DI stuff by @jroper.
- [x] Java version of CachedApi?
- [x] Scaladoc/javadoc
- [x] Improve unit tests to use DI properly
- [x] Remove `//"""` that I accidentally committed!
