### PR TITLE
Support OpenJDK 6 in WS SSL

### DIFF
--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/debug/FixInternalDebugLogging.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/debug/FixInternalDebugLogging.scala
@@ -21,14 +21,14 @@ object FixInternalDebugLogging {
 
     val logger = org.slf4j.LoggerFactory.getLogger("play.api.libs.ws.ssl.debug.FixInternalDebugLogging.MonkeyPatchInternalSslDebugAction")
 
-    val initialResource = foldVersion(
-      run16 = "/javax/net/ssl/SSLContext.class", // in 1.6 the JSSE classes are in rt.jar
-      runHigher = "/sun/security/ssl/Debug.class" // in 1.7 the JSSE classes are in jsse.jar
+    val initialResource = foldRuntime(
+      older = "/javax/net/ssl/SSLContext.class", // in 1.6 the JSSE classes are in rt.jar
+      newer = "/sun/security/ssl/Debug.class" // in 1.7 the JSSE classes are in jsse.jar
     )
 
-    val debugClassName = foldVersion(
-      run16 = "com.sun.net.ssl.internal.ssl.Debug",
-      runHigher = "sun.security.ssl.Debug"
+    val debugClassName = foldRuntime(
+      older = "com.sun.net.ssl.internal.ssl.Debug",
+      newer = "sun.security.ssl.Debug"
     )
 
     /**

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/package.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/package.scala
@@ -6,6 +6,7 @@
 package play.api.libs.ws
 
 import java.security.cert.{ PKIXCertPathValidatorResult, CertPathValidatorResult, Certificate, X509Certificate }
+import scala.util.Properties.{ isJavaAtLeast, javaVmName }
 
 package object ssl {
 
@@ -39,4 +40,12 @@ package object ssl {
         runHigher
     }
   }
+
+  def isOpenJdk: Boolean = javaVmName contains "OpenJDK"
+
+  // NOTE: Some SSL classes in OpenJDK 6 are in the same locations as JDK 7
+  def foldRuntime[T](older: => T, newer: => T): T = {
+    if (isJavaAtLeast("1.7") || isOpenJdk) newer else older
+  }
+
 }


### PR DESCRIPTION
For the debug logging in WS SSL, there's a switch on the Java version for where to find classes and resources. But some of the SSL classes in OpenJDK 6 are actually in the same locations as JDK 7.

For example, Debug.java is not at:

http://hg.openjdk.java.net/jdk6/jdk6/jdk/file/6fdf62509b68/src/share/classes/com/sun/net/ssl/internal/ssl

but at:

http://hg.openjdk.java.net/jdk6/jdk6/jdk/file/6fdf62509b68/src/share/classes/sun/security/ssl/

Currently fixed by creating a new version of `foldVersion` which also takes into account OpenJDK 6.

\cc @wsargent 
