### PR TITLE
Use an inline cache when accessing Application.injector

### DIFF
--- a/framework/src/play-cache/src/main/scala/play/api/cache/Cache.scala
+++ b/framework/src/play-cache/src/main/scala/play/api/cache/Cache.scala
@@ -59,9 +59,8 @@ trait CacheApi {
  */
 object Cache {
 
-  private def cacheApi(implicit app: Application): CacheApi = {
-    app.injector.instanceOf[CacheApi]
-  }
+  private val cacheApiCache = Application.instanceCache[CacheApi]
+  private def cacheApi(implicit app: Application) = cacheApiCache(app)
 
   private def intToDuration(seconds: Int): Duration = if (seconds == 0) Duration.Inf else seconds.seconds
 

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
@@ -18,7 +18,8 @@ import play.api.Application
  */
 object DB {
 
-  private def db(implicit app: Application): DBApi = app.injector.instanceOf[DBApi]
+  private val dbCache = Application.instanceCache[DBApi]
+  private def db(implicit app: Application): DBApi = dbCache(app)
 
   /**
    * Retrieves a JDBC connection.

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -96,9 +96,8 @@ object WS {
   @deprecated("Please use play.api.libs.ws.WSRequestHolder", "2.3.0")
   type WSRequestHolder = play.api.libs.ws.WSRequestHolder
 
-  protected[play] def wsapi(implicit app: Application): WSAPI = {
-    app.injector.instanceOf[WSAPI]
-  }
+  private val wsapiCache = Application.instanceCache[WSAPI]
+  protected[play] def wsapi(implicit app: Application): WSAPI = wsapiCache(app)
 
   import scala.language.implicitConversions
 

--- a/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -5,7 +5,7 @@ package play.api.http
 
 import javax.inject.{ Singleton, Inject, Provider }
 
-import play.api.{ Play, Configuration }
+import play.api.{ Application, Play, Configuration }
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -69,8 +69,9 @@ object HttpConfiguration {
     )
   }
 
+  private val httpConfigurationCache = Application.instanceCache[HttpConfiguration]
   /**
    * Don't use this - only exists for transition from global state
    */
-  def current = Play.maybeApplication.fold(HttpConfiguration())(_.injector.instanceOf[HttpConfiguration])
+  def current = Play.maybeApplication.fold(HttpConfiguration())(httpConfigurationCache)
 }

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -105,6 +105,8 @@ object Lang {
     }
   }
 
+  private val langsCache = Application.instanceCache[Langs]
+
   /**
    * Retrieve Lang availables from the application configuration.
    *
@@ -113,7 +115,7 @@ object Lang {
    * }}}
    */
   def availables(implicit app: Application): Seq[Lang] = {
-    app.injector.instanceOf[Langs].availables
+    langsCache(app).availables
   }
 
   /**
@@ -121,7 +123,7 @@ object Lang {
    * The first Lang that matches an available Lang wins, otherwise returns the first Lang available in this application.
    */
   def preferred(langs: Seq[Lang])(implicit app: Application): Lang = {
-    app.injector.instanceOf[Langs].preferred(langs)
+    langsCache(app).preferred(langs)
   }
 }
 
@@ -182,7 +184,8 @@ class DefaultLangs @Inject() (configuration: Configuration) extends Langs {
  */
 object Messages {
 
-  private def messagesApi = Play.maybeApplication.map(_.injector.instanceOf[MessagesApi])
+  private[play] val messagesApiCache = Application.instanceCache[MessagesApi]
+  private[play] def messagesApi: Option[MessagesApi] = Play.maybeApplication.map(messagesApiCache)
 
   /**
    * Translates a message.

--- a/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
@@ -35,12 +35,13 @@ object Crypto {
    */
   class CryptoException(val message: String = null, val throwable: Throwable = null) extends RuntimeException(message, throwable)
 
+  private val cryptoCache = Application.instanceCache[Crypto]
   private def crypto = {
     Play.maybeApplication.fold(
       new Crypto(new CryptoConfigParser(
         Environment.simple(), Configuration.from(Map("play.crypto.aes.transformation" -> "AES/CTR/NoPadding"))
       ).get)
-    )(_.injector.instanceOf[Crypto])
+    )(cryptoCache)
   }
 
   /**

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -16,6 +16,8 @@ import scala.concurrent.duration._
  */
 object Akka {
 
+  private val actorSystemCache = Application.instanceCache[ActorSystem]
+
   /**
    * Retrieve the application Akka Actor system.
    *
@@ -24,9 +26,7 @@ object Akka {
    * val newActor = Akka.system.actorOf[Props[MyActor]]
    * }}}
    */
-  def system(implicit app: Application) = {
-    app.injector.instanceOf[ActorSystem]
-  }
+  def system(implicit app: Application): ActorSystem = actorSystemCache(app)
 
 }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
@@ -4,7 +4,7 @@
 package play.api.mvc
 
 import play.api.http._
-import play.api.i18n.{ MessagesApi, Lang }
+import play.api.i18n.{ Messages, Lang }
 import play.api.Play
 
 /**
@@ -62,9 +62,8 @@ trait Controller extends Results with BodyParsers with HttpProtocol with Status 
   implicit def request2flash(implicit request: RequestHeader) = request.flash
 
   implicit def request2lang(implicit request: RequestHeader) = {
-    play.api.Play.maybeApplication.map { implicit app =>
-      app.injector.instanceOf[MessagesApi].preferred(request).lang
-    }.getOrElse(request.acceptLanguages.headOption.getOrElse(play.api.i18n.Lang.defaultLang))
+    Messages.messagesApi.map(_.preferred(request).lang)
+      .getOrElse(request.acceptLanguages.headOption.getOrElse(play.api.i18n.Lang.defaultLang))
   }
 
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -8,7 +8,7 @@ import play.api.http._
 import play.api.http.HeaderNames._
 import play.api.http.HttpProtocol._
 import play.api.{ Application, Play }
-import play.api.i18n.{ MessagesApi, Lang }
+import play.api.i18n.{ Messages, Lang }
 
 import play.core.Execution.Implicits._
 import play.api.libs.concurrent.Execution.defaultContext
@@ -261,7 +261,7 @@ case class Result(header: ResponseHeader, body: Enumerator[Array[Byte]],
    * @return the new result
    */
   def withLang(lang: Lang)(implicit app: Application): Result =
-    app.injector.instanceOf[MessagesApi].setLang(this, lang)
+    Messages.messagesApiCache(app).setLang(this, lang)
 
   /**
    * Clears the user's language by discarding the language cookie set by withLang

--- a/framework/src/play/src/main/scala/play/utils/InlineCache.scala
+++ b/framework/src/play/src/main/scala/play/utils/InlineCache.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.utils
+
+import java.lang.ref.WeakReference
+
+/**
+ * Creates a wrapper for a function that uses an inline cache to
+ * optimize calls to the function. The function's result for a
+ * a *single* input will be cached. If the input changes, the
+ * function will be called again and its new output will be cached.
+ *
+ * Even though this function only caches a single value, it can
+ * be useful for functions where the input only changes occasionally.
+ * Because it only caches a single value, the cached value can
+ * be accessed very quickly.
+ *
+ * This class will improve performance when the function input changes
+ * infrequently and the function is somewhat expensive to call.
+ * Even when the input changes, this class will still function
+ * correctly and return the correct value, although it will be less
+ * efficient than an unwrapped function because it will update
+ * the cache.
+ *
+ * The cached input and output will be wrapped by a WeakReference
+ * so that they can be garbage collected. This may mean that the
+ * cache needs to be repopulated after garbage collection has
+ * been run.
+ *
+ * The function may sometimes be called again for the same input.
+ * In the current implementation this happens in order to avoid
+ * synchronizing the cached value across threads. It may also
+ * happen when the weakly-referenced cache is cleared by the
+ * garbage collector.
+ *
+ * Reference equality is used to compare inputs, for speed and
+ * to be conservative.
+ */
+private[play] final class InlineCache[A <: AnyRef, B](f: A => B) extends (A => B) {
+  /**
+   * For performance, don't synchronize this value. Instead, let
+   * the cache be updated on different threads. If the input value
+   * is stable then the value of this variable will eventually
+   * reach the same value. If the input value is different, then
+   * there's no point sharing the value across threads anyway.
+   */
+  var cache: WeakReference[(A, B)] = null
+
+  override def apply(a: A): B = {
+    // Get the current value of the cache into a local variable.
+    // If it's null then this is our first call to the function
+    // (on this thread) so get a fresh value.
+    val cacheSnapshot = cache
+    if (cacheSnapshot == null) return fresh(a)
+    // Get cached input/output pair out of the WeakReference.
+    // If the pair is null then the reference has been collected
+    // and we need a fresh value.
+    val inputOutput = cacheSnapshot.get
+    if (inputOutput == null) return fresh(a)
+    // If the inputs don't match then we need a fresh value.
+    if (inputOutput._1 ne a) return fresh(a)
+    // We got the cached value, return it.
+    inputOutput._2
+  }
+
+  /** Get a fresh value and update the cache with it. */
+  private def fresh(a: A): B = {
+    val b = f(a)
+    cache = new WeakReference((a, b))
+    b
+  }
+}


### PR DESCRIPTION
Improves application performance by about 3–5% in some benchmarks by eliminating calls to Guice when making requests.

@jroper, you might be interested in this one.
