### PR TITLE
Fix eclipse classpath generation and cross paths

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala
@@ -6,6 +6,8 @@ package play
 import sbt._
 import sbt.Keys._
 import Keys._
+import play.sbtplugin.routes.RoutesKeys
+import play.twirl.sbt.Import.TwirlKeys
 
 trait PlayEclipse {
   this: PlayCommands =>
@@ -70,15 +72,21 @@ trait PlayEclipse {
       }
     }
 
-    lazy val addSourcesManaged = new EclipseTransformerFactory[RewriteRule] {
+    lazy val addSourcesManaged = addSourceDirectory(sourceManaged in Compile)
+
+    lazy val addRoutesSources = addSourceDirectory(target in (Compile, RoutesKeys.routes))
+
+    lazy val addTwirlSources = addSourceDirectory(target in (Compile, TwirlKeys.compileTemplates))
+
+    def addSourceDirectory(key: SettingKey[File]) = new EclipseTransformerFactory[RewriteRule] {
       override def createTransformer(ref: ProjectRef, state: State): Validation[RewriteRule] = {
         import scalaz.syntax.apply._
-        (setting(baseDirectory in ref, state) |@| setting(sourceManaged in (ref, Compile), state)) { (base, srcManaged) =>
+        (setting(baseDirectory in ref, state) |@| setting(key in ref, state)) { (base, src) =>
           new RewriteRule {
             override def transform(node: Node): Seq[Node] = node match {
-              case elem if (elem.label == "classpath" && srcManaged.exists) =>
-                val srcManagedPath = IO.relativize(base, srcManaged).getOrElse(srcManaged.getAbsolutePath)
-                val newChild = elem.child ++ <classpathentry path={ srcManagedPath } kind="src"></classpathentry>
+              case elem if (elem.label == "classpath" && src.exists) =>
+                val srcPath = IO.relativize(base, src).getOrElse(src.getAbsolutePath)
+                val newChild = elem.child ++ <classpathentry path={ srcPath } kind="src"></classpathentry>
                 Elem(elem.prefix, "classpath", elem.attributes, elem.scope, false, newChild: _*)
               case other =>
                 other
@@ -94,7 +102,7 @@ trait PlayEclipse {
           EclipseKeys.projectFlavor := EclipseProjectFlavor.Scala,
           EclipseKeys.preTasks := Seq(compile in Compile),
           EclipseKeys.createSrc := EclipseCreateSrc.Default + EclipseCreateSrc.Resource,
-          EclipseKeys.classpathTransformerFactories := Seq(addSourcesManaged)
+          EclipseKeys.classpathTransformerFactories := Seq(addSourcesManaged, addRoutesSources, addTwirlSources)
         )
       case JAVA =>
         generateJavaPrefFile()


### PR DESCRIPTION
Fix the way crossTarget was used for adding source managed directory for eclipse. Now gets the source managed directory relative to the base directory.

I'm also assuming that source managed is added for the routes and twirl sources? These are now in different directories, so I've added those too.

Fixes #3289
Replaces #3297
