### PR TITLE
Move the default template imports to the build-link project

### DIFF
--- a/framework/src/build-link/src/main/java/play/TemplateImports.java
+++ b/framework/src/build-link/src/main/java/play/TemplateImports.java
@@ -1,0 +1,43 @@
+package play;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class TemplateImports {
+
+  public static List<String> defaultJavaTemplateImports;
+  public static List<String> defaultScalaTemplateImports;
+
+  private static List<String> defaultTemplateImports = Collections.unmodifiableList(
+    Arrays.asList(
+      "models._",
+      "controllers._",
+      "play.api.i18n._",
+      "views.%format%._",
+      "play.api.templates.PlayMagic._"
+    ));
+
+  static {
+    List<String> javaImports = new ArrayList();
+    javaImports.addAll(defaultTemplateImports);
+    javaImports.add("java.lang._");
+    javaImports.add("java.util._");
+    javaImports.add("scala.collection.JavaConversions._");
+    javaImports.add("scala.collection.JavaConverters._");
+    javaImports.add("play.core.j.PlayMagicForJava._");
+    javaImports.add("play.mvc._");
+    javaImports.add("play.data._");
+    javaImports.add("play.api.data.Field");
+    javaImports.add("play.mvc.Http.Context.Implicit._");
+    defaultJavaTemplateImports = Collections.unmodifiableList(javaImports);
+
+    List<String> scalaImports = new ArrayList();
+    scalaImports.addAll(defaultTemplateImports);
+    scalaImports.add("play.api.mvc._");
+    scalaImports.add("play.api.data._");
+    defaultScalaTemplateImports = Collections.unmodifiableList(scalaImports);
+  }
+
+}

--- a/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
+++ b/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
@@ -10,12 +10,14 @@ import com.typesafe.play.docs.sbtplugin.PlayDocsValidation.{ CodeSamplesReport, 
 import play.core.BuildDocHandler
 import play.core.server.ServerWithStop
 import play.PlayImport._
+import play.TemplateImports
 import play.routes.compiler.InjectedRoutesGenerator
 import play.sbtplugin.Colors
 import play.sbtplugin.routes.RoutesCompiler
 import sbt._
 import sbt.Keys._
 import sbt.plugins.JvmPlugin
+import scala.collection.JavaConverters._
 
 object Imports {
   object PlayDocsKeys {
@@ -100,11 +102,11 @@ object PlayDocsPlugin extends AutoPlugin {
 
     // Need to ensure that templates in the Java docs get Java imports, and in the Scala docs get Scala imports
     sourceGenerators in Test <+= (javaManualSourceDirectories, javaTwirlSourceManaged, streams) map { (from, to, s) =>
-      compileTemplates(from, to, defaultTemplateImports ++ defaultJavaTemplateImports, s.log)
+      compileTemplates(from, to, TemplateImports.defaultJavaTemplateImports.asScala, s.log)
     },
 
     sourceGenerators in Test <+= (scalaManualSourceDirectories, scalaTwirlSourceManaged, streams) map { (from, to, s) =>
-      compileTemplates(from, to, defaultTemplateImports ++ defaultScalaTemplateImports, s.log)
+      compileTemplates(from, to, TemplateImports.defaultScalaTemplateImports.asScala, s.log)
     },
 
     sourceGenerators in Test <+= (javaManualSourceDirectories, javaRoutesSourceManaged, streams) map { (from, to, s) =>

--- a/framework/src/sbt-plugin/src/main/scala/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayImport.scala
@@ -39,40 +39,6 @@ object PlayImport {
 
   val javaWs = "com.typesafe.play" %% "play-java-ws" % play.core.PlayVersion.current
 
-  val defaultJavaTemplateImports = Seq(
-    "models._",
-    "controllers._",
-
-    "java.lang._",
-    "java.util._",
-
-    "scala.collection.JavaConversions._",
-    "scala.collection.JavaConverters._",
-
-    "play.api.i18n._",
-    "play.core.j.PlayMagicForJava._",
-
-    "play.mvc._",
-    "play.data._",
-    "play.api.data.Field",
-
-    "play.mvc.Http.Context.Implicit._",
-
-    "views.%format%._")
-
-  val defaultScalaTemplateImports = Seq(
-    "models._",
-    "controllers._",
-
-    "play.api.i18n._",
-
-    "play.api.mvc._",
-    "play.api.data._",
-
-    "views.%format%._")
-
-  val defaultTemplateImports = Seq("play.api.templates.PlayMagic._")
-
   /**
    * Add this to your build.sbt, eg:
    *

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -15,6 +15,7 @@ import com.typesafe.sbt.packager.Keys._
 import play.sbtplugin.{ PlayPositionMapper, ApplicationSecretGenerator }
 import com.typesafe.sbt.web.SbtWeb.autoImport._
 import WebKeys._
+import scala.collection.JavaConverters._
 import scala.language.postfixOps
 import play.twirl.sbt.Import.TwirlKeys
 import play.sbtplugin.routes.RoutesKeys._
@@ -24,7 +25,7 @@ trait PlaySettings {
 
   lazy val defaultJavaSettings = Seq[Setting[_]](
 
-    TwirlKeys.templateImports ++= defaultJavaTemplateImports,
+    TwirlKeys.templateImports ++= TemplateImports.defaultJavaTemplateImports.asScala,
 
     routesImport ++= Seq(
       "play.libs.F"
@@ -35,7 +36,7 @@ trait PlaySettings {
   )
 
   lazy val defaultScalaSettings = Seq[Setting[_]](
-    TwirlKeys.templateImports ++= defaultScalaTemplateImports
+    TwirlKeys.templateImports ++= TemplateImports.defaultScalaTemplateImports.asScala
   )
 
   /** Ask SBT to manage the classpath for the given configuration. */
@@ -219,10 +220,6 @@ trait PlaySettings {
     // Settings
 
     devSettings := Nil,
-
-    // Templates
-
-    TwirlKeys.templateImports ++= defaultTemplateImports,
 
     // Native packaging
 


### PR DESCRIPTION
Other implementers of build link besides just SBT will want to use the same list of default template imports
