### PR TITLE
ignore unknown JSON fields when deserializing to a POJO

### DIFF
--- a/framework/src/play-json/src/main/java/play/libs/Json.java
+++ b/framework/src/play-json/src/main/java/play/libs/Json.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator.Feature;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -19,8 +20,14 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * Helper functions to handle JsonNode values.
  */
 public class Json {
-    private static final ObjectMapper defaultObjectMapper = new ObjectMapper();
+    private static final ObjectMapper defaultObjectMapper = newDefaultMapper();
     private static volatile ObjectMapper objectMapper = null;
+
+    static ObjectMapper newDefaultMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return mapper;
+    }
 
     /**
      * Get the ObjectMapper used to serialize and deserialize objects to and from JSON values.

--- a/framework/src/play-json/src/test/scala/play/libs/JavaJsonSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/libs/JavaJsonSpec.scala
@@ -53,5 +53,10 @@ class JavaJsonSpec extends Specification {
         Json.prettyPrint(testJson) must_== testJsonString
       }
     }
+    "ignore unknown fields when deserializing to a POJO" in new JsonScope(Json.newDefaultMapper()) {
+      val javaPOJO = Json.fromJson(testJson, classOf[JavaPOJO])
+      javaPOJO.getBar must_== "baz"
+      javaPOJO.getFoo must_== "bar"
+    }
   }
 }

--- a/framework/src/play-json/src/test/scala/play/libs/JavaPOJO.java
+++ b/framework/src/play-json/src/test/scala/play/libs/JavaPOJO.java
@@ -1,0 +1,31 @@
+package play.libs;
+
+public class JavaPOJO {
+
+    private String foo;
+    private String bar;
+
+    public JavaPOJO() {
+    }
+
+    public JavaPOJO(String foo, String bar) {
+        this.foo = foo;
+        this.bar = bar;
+    }
+
+    public String getFoo() {
+        return foo;
+    }
+
+    public void setFoo(String foo) {
+        this.foo = foo;
+    }
+
+    public String getBar() {
+        return bar;
+    }
+
+    public void setBar(String bar) {
+        this.bar = bar;
+    }
+}


### PR DESCRIPTION
An external REST API can be extended and stay backwards compatible,
for example just be adding new fields in the JSON result.

The default mapper is configured so that a client using the
java Play JSON API can still consume the external REST API.
