### PR TITLE
Add an SBT setting which allows using the standard directory layout

### DIFF
--- a/documentation/manual/gettingStarted/Anatomy.md
+++ b/documentation/manual/gettingStarted/Anatomy.md
@@ -1,9 +1,9 @@
 <!--- Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com> -->
 # Anatomy of a Play application
 
-## The standard application layout
+## The Play application layout
 
-The layout of a Play application is standardized to keep things as simple as possible. After a first successful compile, a standard Play application looks like this:
+The layout of a Play application is standardized to keep things as simple as possible. After a first successful compile, a Play application looks like this:
 
 ```
 app                      → Application sources
@@ -25,7 +25,7 @@ project                  → sbt configuration files
  └ build.properties      → Marker for sbt project
  └ plugins.sbt           → sbt plugins including the declaration for Play itself
 lib                      → Unmanaged libraries dependencies
-logs                     → Standard logs folder
+logs                     → Logs folder
  └ application.log       → Default log file
 target                   → Generated stuff
  └ scala-2.10.0            
@@ -41,7 +41,7 @@ test                     → source folder for unit or functional tests
 
 The `app` directory contains all executable artifacts: Java and Scala source code, templates and compiled assets’ sources.
 
-There are three standard packages in the `app` directory, one for each component of the MVC architectural pattern: 
+There are three packages in the `app` directory, one for each component of the MVC architectural pattern: 
 
 - `app/controllers`
 - `app/models`
@@ -57,7 +57,7 @@ There is also an optional directory called `app/assets` for compiled assets such
 
 Resources stored in the `public` directory are static assets that are served directly by the Web server.
 
-This directory is split into three standard sub-directories for images, CSS stylesheets and JavaScript files. You should organize your static assets like this to keep all Play applications consistent.
+This directory is split into three sub-directories for images, CSS stylesheets and JavaScript files. You should organize your static assets like this to keep all Play applications consistent.
 
 > In a newly-created application, the `/public` directory is mapped to the `/assets` URL path, but you can easily change that, or even use several directories for your static assets.
 
@@ -65,7 +65,7 @@ This directory is split into three standard sub-directories for images, CSS styl
 
 The `conf` directory contains the application’s configuration files. There are two main configuration files:
 
-- `application.conf`, the main configuration file for the application, which contains standard configuration parameters
+- `application.conf`, the main configuration file for the application, which contains configuration parameters
 - `routes`, the routes definition file.
 
 If you need to add configuration options that are specific to your application, it’s a good idea to add more options to the `application.conf` file.
@@ -109,4 +109,48 @@ target
 tmp
 dist
 .cache
+```
+
+## Alternative layout (AKA standard layout)
+
+You also have the option of using the standard layout used by SBT and Maven. This layout works much better with Eclipse. In the future, this may become the deault layout used by Play. In order to use this layout, set the option `standardLayout := true` in your build file. This will stop Play from overriding the default SBT layout, which looks like this:
+
+```
+build.sbt                  → Application build script
+src                        → Application sources
+ └ main                    → Compiled asset sources
+    └ java                 → Java sources
+       └ controllers       → Java controllers
+       └ models            → Java business layer
+    └ scala                → Scala sources
+       └ controllers       → Scala controllers
+       └ models            → Scala business layer
+    └ resources            → Configurations files and other non-compiled resources (on classpath)
+       └ application.conf  → Main configuration file
+       └ routes            → Routes definition
+    └ twirl                → Templates
+    └ assets               → Compiled asset sources
+       └ css               → Typically LESS CSS sources
+       └ js                → Typically CoffeeScript sources
+    └ public               → Public assets
+       └ css               → CSS files
+       └ js                → Javascript files
+       └ images            → Image files
+ └ test                    → Unit or functional tests
+    └ java                 → Java source folder for unit or functional tests
+    └ scala                → Scala source folder for unit or functional tests
+    └ resources            → Resource folder for unit or functional tests
+project                    → sbt configuration files
+ └ build.properties        → Marker for sbt project
+ └ plugins.sbt             → sbt plugins including the declaration for Play itself
+lib                        → Unmanaged libraries dependencies
+logs                       → Logs folder
+ └ application.log         → Default log file
+target                     → Generated stuff
+ └ scala-2.10.0            
+    └ cache              
+    └ classes              → Compiled class files
+    └ classes_managed      → Managed class files (templates, ...)
+    └ resource_managed     → Managed resources (less, ...)
+    └ src_managed          → Generated sources (templates, ...)
 ```

--- a/framework/src/sbt-plugin/src/main/scala/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayImport.scala
@@ -107,6 +107,8 @@ object PlayImport {
   }
 
   object PlayKeys {
+    val standardLayout = SettingKey[Boolean]("play-standard-layout", "Whether to use the standard SBT layout instead of the original Play layout.")
+
     val playDefaultPort = SettingKey[Int]("play-default-port", "The default port that Play runs on")
 
     /** Our means of hooking the run task with additional behavior. */

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -51,23 +51,44 @@ trait PlaySettings {
       "Typesafe Releases Repository" at "https://repo.typesafe.com/typesafe/releases/"
     ),
 
+    standardLayout := false,
+
     target <<= baseDirectory(_ / "target"),
+    sourceDirectory in Compile := {
+      if (standardLayout.value) (sourceDirectory in Compile).value else baseDirectory.value / "app"
+    },
+    sourceDirectory in Test := {
+      if (standardLayout.value) (sourceDirectory in Test).value else baseDirectory.value / "test"
+    },
 
-    sourceDirectory in Compile <<= baseDirectory(_ / "app"),
-    sourceDirectory in Test <<= baseDirectory(_ / "test"),
+    confDirectory := {
+      if (standardLayout.value) confDirectory.value else baseDirectory.value / "conf"
+    },
 
-    confDirectory <<= baseDirectory(_ / "conf"),
+    resourceDirectory in Compile := {
+      if (standardLayout.value) (resourceDirectory in Compile).value else baseDirectory.value / "conf"
+    },
 
-    resourceDirectory in Compile <<= baseDirectory(_ / "conf"),
+    scalaSource in Compile := {
+      if (standardLayout.value) (scalaSource in Compile).value else baseDirectory.value / "app"
+    },
+    scalaSource in Test := {
+      if (standardLayout.value) (scalaSource in Test).value else baseDirectory.value / "test"
+    },
 
-    scalaSource in Compile <<= baseDirectory(_ / "app"),
-    scalaSource in Test <<= baseDirectory(_ / "test"),
+    javaSource in Compile := {
+      if (standardLayout.value) (javaSource in Compile).value else baseDirectory.value / "app"
+    },
+    javaSource in Test := {
+      if (standardLayout.value) (javaSource in Test).value else baseDirectory.value / "test"
+    },
 
-    javaSource in Compile <<= baseDirectory(_ / "app"),
-    javaSource in Test <<= baseDirectory(_ / "test"),
-
-    sourceDirectories in (Compile, TwirlKeys.compileTemplates) := Seq((sourceDirectory in Compile).value),
-    sourceDirectories in (Test, TwirlKeys.compileTemplates) := Seq((sourceDirectory in Test).value),
+    sourceDirectories in (Compile, TwirlKeys.compileTemplates) := {
+      if (standardLayout.value) (sourceDirectories in (Compile, TwirlKeys.compileTemplates)).value else Seq((sourceDirectory in Compile).value)
+    },
+    sourceDirectories in (Test, TwirlKeys.compileTemplates) := {
+      if (standardLayout.value) (sourceDirectories in (Test, TwirlKeys.compileTemplates)).value else Seq((sourceDirectory in Test).value)
+    },
 
     javacOptions in (Compile, doc) := List("-encoding", "utf8"),
 
@@ -180,11 +201,17 @@ trait PlaySettings {
     playInteractionMode := play.PlayConsoleInteractionMode,
 
     // sbt-web
-    sourceDirectory in Assets := (sourceDirectory in Compile).value / "assets",
-    sourceDirectory in TestAssets := (sourceDirectory in Test).value / "assets",
+    sourceDirectory in Assets := {
+      if (standardLayout.value) (sourceDirectory in Assets).value else (sourceDirectory in Compile).value / "assets"
+    },
+    sourceDirectory in TestAssets := {
+      if (standardLayout.value) (sourceDirectory in TestAssets).value else (sourceDirectory in Test).value / "assets"
+    },
 
     jsFilter in Assets := new PatternFilter("""[^_].*\.js""".r.pattern),
-    resourceDirectory in Assets := baseDirectory.value / "public",
+    resourceDirectory in Assets := {
+      if (standardLayout.value) (resourceDirectory in Assets).value else baseDirectory.value / "public"
+    },
 
     WebKeys.stagingDirectory := WebKeys.stagingDirectory.value / "public",
 


### PR DESCRIPTION
Fix for https://github.com/playframework/playframework/issues/3560. Today you cannot run the functional tests in Eclipse because the test resources are missing from the classpath. They cannot be added to the classpath due to the resources folder being located inside a source folder, which is not allowed in Eclipse.
