### PR TITLE
Remove portion of message that says application is running from SBT

### DIFF
--- a/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
+++ b/framework/src/play/src/main/scala/play/core/system/ApplicationProvider.scala
@@ -101,7 +101,7 @@ class ReloadableApplication(buildLink: BuildLink, buildDocHandler: BuildDocHandl
 
   lazy val path = buildLink.projectPath
 
-  println(play.utils.Colors.magenta("--- (Running the application from SBT, auto-reloading is enabled) ---"))
+  println(play.utils.Colors.magenta("--- (Running the application, auto-reloading is enabled) ---"))
   println()
 
   var lastState: Try[Application] = Failure(new PlayException("Not initialized", "?"))


### PR DESCRIPTION
The application has no idea if that's true. In particular Gradle is now starting to support running Play applications and this message is very confusing when run from Gradle
