### PR TITLE
Signature for def withRequestTimeout(timeout: Int)

### DIFF
--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -442,14 +442,11 @@ trait WSRequestHolder {
    */
   def withFollowRedirects(follow: Boolean): WSRequestHolder
 
-  @scala.deprecated("use withRequestTimeout instead", "2.1.0")
-  def withTimeout(timeout: Int) = withRequestTimeout(timeout)
-
   /**
    * Sets the maximum time in milliseconds you expect the request to take.
    * Warning: a stream consumption will be interrupted when this time is reached.
    */
-  def withRequestTimeout(timeout: Int): WSRequestHolder
+  def withRequestTimeout(timeout: Long): WSRequestHolder
 
   /**
    * Sets the virtual host to use in this request

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
@@ -417,7 +417,10 @@ case class NingWSRequestHolder(client: NingWSClient,
 
   def withFollowRedirects(follow: Boolean) = copy(followRedirects = Some(follow))
 
-  def withRequestTimeout(timeout: Int) = copy(requestTimeout = Some(timeout))
+  def withRequestTimeout(timeout: Long) = {
+    require(timeout >= 0 && timeout <= Int.MaxValue, s"Request timeout must be between 0 and ${Int.MaxValue}")
+    copy(requestTimeout = Some(timeout.toInt))
+  }
 
   def withVirtualHost(vh: String) = copy(virtualHost = Some(vh))
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
@@ -128,6 +128,10 @@ object NingWSSpec extends PlaySpecification with Mockito {
       req.getPerRequestConfig.getRequestTimeoutInMs must be equalTo 1000
     }
 
+    "not support invalid timeout" in new WithApplication {
+      WS.url("http://playframework.com/").withRequestTimeout(-1) should throwAn[IllegalArgumentException]
+    }
+
     "support a proxy server" in new WithApplication {
       val proxy = DefaultWSProxyServer(protocol = Some("https"), host = "localhost", port = 8080, principal = Some("principal"), password = Some("password"))
       val req = WS.url("http://playframework.com/").withProxyServer(proxy).asInstanceOf[NingWSRequestHolder].prepare().build


### PR DESCRIPTION
Considering that the function toMillis in scala.concurrent.duration returns a long, it would be nice if
WS.url(...).withRequestTimeout would also accept a long, so that one can easily write
WS.url(...).withRequestTimeout(5 seconds toMillis)
