### PR TITLE
The path returned by JsPath.prune should be the original path

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsPath.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsPath.scala
@@ -249,7 +249,10 @@ case class JsPath(path: List[PathNode] = List()) {
     }
 
     js match {
-      case o: JsObject => step(o, this)
+      case o: JsObject => step(o, this) match {
+        case s: JsSuccess[JsObject] => s.copy(path = this)
+        case e => e
+      }
       case _ =>
         JsError(this, ValidationError("error.expected.jsobject"))
     }

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsPathSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsPathSpec.scala
@@ -220,7 +220,7 @@ object JsPathSpec extends Specification {
         "level2" -> 5
       )
 
-      (__ \ 'level2).prune(obj).get must beEqualTo(res)
+      (__ \ 'level2).prune(obj) must beEqualTo(JsSuccess(res, __ \ 'level2))
       (__ \ 'level1 \ 'key1).prune(obj).get must beEqualTo(res2)
       (__ \ 'level1 \ 'key2 \ 'key21).prune(obj).get must beEqualTo(res3)
       (__ \\ 'key21).prune(obj) must beEqualTo(JsError(__ \\ "key21", ValidationError("error.expected.keypathnode")))


### PR DESCRIPTION
Contrary to JsPath.pick, the prune operation does not return a sub-tree of the JSON tree, but a tree where a sub-tree has been removed.

Currently, JsPath.prune returns the pruned path, which leads to paradoxes like the following:

``` scala
scala> val jsonTransformer = (__ \ "a").json.prune andThen (__ \ "b").json.prune
jsonTransformer: play.api.libs.json.Reads[play.api.libs.json.JsObject] = play.api.libs.json.Reads$$anon$8@47517c4a

scala> Json.parse("{\"a\": 12, \"b\": 23, \"c\": 34}").transform(jsonTransformer)
res4: play.api.libs.json.JsResult[play.api.libs.json.JsObject] = JsSuccess({"c":34},/a/b)
```

where the returned path `/a/b` does not even exist in the original document.
