### PR TITLE
Upgrade to jboss-logging 3.2.0

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -41,6 +41,8 @@ object Dependencies {
     "org.yaml" % "snakeyaml" % "1.13",
     // 5.1.0 upgrade notes: need to add JEE dependencies, eg EL
     "org.hibernate" % "hibernate-validator" % "5.0.3.Final",
+    // This is depended on by hibernate validator, we upgrade to 3.2.0 to avoid LGPL license of 3.1.x
+    "org.jboss.logging" % "jboss-logging" % "3.2.0.Final",
 
     ("org.springframework" % "spring-context" % "4.0.3.RELEASE" notTransitive ())
       .exclude("org.springframework", "spring-aop")


### PR DESCRIPTION
This is to avoid the LGPL license for jboss-logging 3.1.x which is brought in by hibernate-validator.  I did a manual audit of the changes from 3.1.1 to 3.2.0, the only binary incompatible change was the addition of methods to an interface, but it's not likely that anything we use or that our users use would be implementing this interface.

Forward port to master will be required.
