### PR TITLE
Read some server configuration from a file

### DIFF
--- a/framework/src/play-server/src/main/resources/server-reference.conf
+++ b/framework/src/play-server/src/main/resources/server-reference.conf
@@ -1,0 +1,34 @@
+play {
+
+  server {
+
+    # The root directory for the Play server instance. This value can
+    # be set by providing a path as the first argument to the Play server
+    # launcher script. See `ServerConfig.loadConfiguration`.
+    dir = ${?user.dir}
+
+    # The HTTP port of the server. Use a value of "disabled" if the server
+    # shouldn't bind an HTTP port.
+    http.port = 9000
+    http.port = ${?http.port}
+
+    # The HTTPS port of the server. 
+    https.port = ${?https.port}
+
+    # The interface address to bind to.
+    http.address = "0.0.0.0"
+    http.address = ${?http.address}
+
+    # The type of ServerProvider that should be used to create the server.
+    # If not provided, the ServerStart class that instantiates the server
+    # will provide a default value.
+    provider = ${?server.provider}
+
+    # The path to the process id file created by the server when it runs.
+    # If set to "/dev/null" then no pid file will be created.
+    pidfile.path = ${play.server.dir}/RUNNING_PID
+    pidfile.path = ${?pidfile.path}
+  }
+
+
+}

--- a/framework/src/play-server/src/main/scala/play/core/server/ServerConfig.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ServerConfig.scala
@@ -3,20 +3,88 @@
  */
 package play.core.server
 
+import com.typesafe.config.{ Config, ConfigFactory }
 import java.io.File
 import java.util.Properties
-import play.api.Mode
+import play.api.{ Configuration, Mode }
 
 /**
  * Common configuration for servers such as NettyServer.
+ *
+ * @param rootDir The root directory of the server. Used to find default locations of
+ * files, log directories, etc.
+ * @param port The HTTP port to use.
+ * @param sslPort The HTTPS port to use.
+ * @param address The socket address to bind to.
+ * @param mode The run mode: dev, test or prod.
+ * @param configuration: The configuration to use for loading the server. This is not
+ * the same as application configuration. This configuration is usually loaded from a
+ * server.conf file, whereas the application configuration is usually loaded from an
+ * application.conf file.
  */
 case class ServerConfig(
+    rootDir: File,
+    port: Option[Int],
+    sslPort: Option[Int],
+    address: String,
+    mode: Mode.Mode,
+    properties: Properties,
+    configuration: Configuration) {
+  // Some basic validation of config
+  if (!port.isDefined && !sslPort.isDefined) throw new IllegalArgumentException("Must provide either an HTTP port or an HTTPS port")
+}
+
+object ServerConfig {
+
+  def apply(
     rootDir: File,
     port: Option[Int],
     sslPort: Option[Int] = None,
     address: String = "0.0.0.0",
     mode: Mode.Mode = Mode.Prod,
-    properties: Properties) {
-  // Some basic validation of config
-  if (!port.isDefined && !sslPort.isDefined) throw new IllegalArgumentException("Must provide either an HTTP port or an HTTPS port")
+    properties: Properties): ServerConfig = {
+    ServerConfig(
+      rootDir = rootDir,
+      port = port,
+      sslPort = sslPort,
+      address = address,
+      mode = mode,
+      properties = properties,
+      configuration = loadConfiguration(properties, rootDir)
+    )
+  }
+
+  /**
+   * Create a server Configuration object (a wrapper around a Typesafe Config object)
+   * given some Properties. At this moment this just reads from server-reference.conf
+   * and from the given properties.
+   *
+   * @param properties The properties to base the configuration on.
+   */
+  def loadConfiguration(properties: Properties): Configuration = {
+    Configuration(loadDefaultConfig(properties).resolve())
+  }
+
+  /**
+   * Creates a server Configuration with `loadConfiguration(Properties)` but also
+   * sets the given rootDir property as a low-priority configuration option
+   * with the key "play.server.dir".
+   */
+  def loadConfiguration(properties: Properties, rootDir: File): Configuration = {
+    val javaMap = new java.util.HashMap[String, String]()
+    javaMap.put("play.server.dir", rootDir.getAbsolutePath)
+    val rootDirConfig = ConfigFactory.parseMap(javaMap)
+    val config = loadDefaultConfig(properties).withFallback(rootDirConfig).resolve()
+    Configuration(config)
+  }
+
+  private def loadDefaultConfig(properties: Properties): Config = {
+    // TODO: Flesh the logic out here so it is closer to the standard ConfigFactory.load()
+    // logic. E.g. support reading from server.conf resource, support overriding config
+    // file location with properties, etc.
+    val serverReferenceConfig = ConfigFactory.parseResources("server-reference.conf")
+    val systemPropertyConfig = ConfigFactory.parseProperties(properties)
+    systemPropertyConfig.withFallback(serverReferenceConfig)
+  }
+
 }

--- a/framework/src/play-test/src/main/scala/play/api/test/TestServer.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/TestServer.scala
@@ -73,7 +73,7 @@ object TestServer {
     val serverStart: ServerStart = new ServerStart {
       def defaultServerProvider = testServerProvider
     }
-    val configuredServerProvider = serverStart.readServerProviderSetting(process)
+    val configuredServerProvider = serverStart.readServerProviderSetting(process, config.configuration)
     val appProvider = new play.core.TestApplication(application)
     val server = configuredServerProvider.createServer(config, appProvider)
     process.addShutdownHook { server.stop() }


### PR DESCRIPTION
First part of #3429.

Some of the generic server configuration is now read from a server-reference.conf file. Moved lots of error checking, validation, system property reading and default values out of code and into the config file. This change preserves existing behaviour. All existing system properties still work.

This PR moves starts the process of getting #3429 done and can be merged as-is. More work will be needed in separate PRs. For the record, here's what still needs to be done:
- Allow user to create a server.conf file to override settings.
- Allow users to override server.conf location using system properties.
- Documentation for server.conf.
- Update NettyServer and AkkaHttpServer to use configuration. Then remove the Properties object from ServerConfig.
