### PR TITLE
JavaAction should be an abstract class instead of a trait

### DIFF
--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -42,7 +42,7 @@ class JavaActionAnnotations(val controller: Class[_], val method: java.lang.refl
 /*
  * An action that's handling Java requests
  */
-trait JavaAction extends Action[play.mvc.Http.RequestBody] with JavaHelpers {
+abstract class JavaAction extends Action[play.mvc.Http.RequestBody] with JavaHelpers {
 
   def invocation: JPromise[JResult]
   val annotations: JavaActionAnnotations


### PR DESCRIPTION
This allows it to be extended from in Java code
