### PR TITLE
Remove need for DefaultHttpErrorHandler to get context from static methods backed by ThreadLocal

### DIFF
--- a/framework/src/play/src/main/java/play/http/DefaultHttpErrorHandler.java
+++ b/framework/src/play/src/main/java/play/http/DefaultHttpErrorHandler.java
@@ -56,7 +56,7 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
             return onNotFound(request, message);
         } else if (statusCode >= 400 && statusCode < 500) {
             return F.Promise.<Result>pure(Results.status(statusCode, views.html.defaultpages.badRequest.render(
-                Context.current()._requestHeader(), message
+                request.method(), request.uri(), message
             )));
         } else {
             throw new IllegalArgumentException("onClientError invoked with non client error status code " + statusCode + ": " + message);
@@ -71,7 +71,7 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
      */
     protected F.Promise<Result> onBadRequest(RequestHeader request, String message) {
         return F.Promise.<Result>pure(Results.badRequest(views.html.defaultpages.badRequest.render(
-                Context.current()._requestHeader(), message
+                request.method(), request.uri(), message
         )));
     }
 
@@ -94,10 +94,10 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
     protected F.Promise<Result> onNotFound(RequestHeader request, String message){
         if (environment.isProd()) {
             return F.Promise.<Result>pure(Results.notFound(views.html.defaultpages.notFound.render(
-                    Context.current()._requestHeader())));
+                    request.method(), request.uri())));
         } else {
             return F.Promise.<Result>pure(Results.notFound(views.html.defaultpages.devNotFound.render(
-                    Context.current()._requestHeader(), Some.apply(routes.get())
+                    request.method(), request.uri(), Some.apply(routes.get())
             )));
         }
     }

--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -77,7 +77,7 @@ private[play] class GlobalSettingsHttpErrorHandler @Inject() (global: Provider[G
       case FORBIDDEN => Future.successful(Forbidden(views.html.defaultpages.unauthorized()))
       case NOT_FOUND => global.get.onHandlerNotFound(request)
       case clientError if statusCode >= 400 && statusCode < 500 =>
-        Future.successful(Results.Status(clientError)(views.html.defaultpages.badRequest(request, message)))
+        Future.successful(Results.Status(clientError)(views.html.defaultpages.badRequest(request.method, request.uri, message)))
       case nonClientError =>
         throw new IllegalArgumentException(s"onClientError invoked with non client error status code $statusCode: $message")
     }
@@ -128,7 +128,7 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
     case FORBIDDEN => onForbidden(request, message)
     case NOT_FOUND => onNotFound(request, message)
     case clientError if statusCode >= 400 && statusCode < 500 =>
-      Future.successful(Results.Status(clientError)(views.html.defaultpages.badRequest(request, message)))
+      Future.successful(Results.Status(clientError)(views.html.defaultpages.badRequest(request.method, request.uri, message)))
     case nonClientError =>
       throw new IllegalArgumentException(s"onClientError invoked with non client error status code $statusCode: $message")
   }
@@ -140,7 +140,7 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
    * @param message The error message.
    */
   protected def onBadRequest(request: RequestHeader, message: String): Future[Result] =
-    Future.successful(BadRequest(views.html.defaultpages.badRequest(request, message)))
+    Future.successful(BadRequest(views.html.defaultpages.badRequest(request.method, request.uri, message)))
 
   /**
    * Invoked when a client makes a request that was forbidden.
@@ -159,8 +159,8 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
    */
   protected def onNotFound(request: RequestHeader, message: String): Future[Result] = {
     Future.successful(NotFound(environment.mode match {
-      case Mode.Prod => views.html.defaultpages.notFound(request)
-      case _ => views.html.defaultpages.devNotFound(request, routes)
+      case Mode.Prod => views.html.defaultpages.notFound(request.method, request.uri)
+      case _ => views.html.defaultpages.devNotFound(request.method, request.uri, routes)
     }))
   }
 

--- a/framework/src/play/src/main/scala/views/defaultpages/badRequest.scala.html
+++ b/framework/src/play/src/main/scala/views/defaultpages/badRequest.scala.html
@@ -1,7 +1,7 @@
 @**
  * Default page for 400 Bad Request responses.
  *@
-@(request:play.api.mvc.RequestHeader, error:String)
+@(method: String, uri: String, error:String)
 
 <!DOCTYPE html>
 <html lang="en">
@@ -40,7 +40,7 @@
         <h1>Bad request</h1>
 
         <p id="detail">
-            For request '@request' [@error]
+            For request '@method @uri' [@error]
         </p>
 
     </body>

--- a/framework/src/play/src/main/scala/views/defaultpages/devNotFound.scala.html
+++ b/framework/src/play/src/main/scala/views/defaultpages/devNotFound.scala.html
@@ -2,7 +2,7 @@
  * Default page for 404 Not Found responses, in development mode.
  * This page display the routes file content.
  *@
-@(request:play.api.mvc.RequestHeader, router:Option[play.core.Router.Routes])
+@(method: String, uri: String, router:Option[play.core.Router.Routes])
 
 <!DOCTYPE html>
 <html lang="en">
@@ -104,7 +104,7 @@
         <h1>Action not found</h1>
 
         <p id="detail">
-            For request '@request'
+            For request '@method @uri'
         </p>
 
         @router match {

--- a/framework/src/play/src/main/scala/views/defaultpages/notFound.scala.html
+++ b/framework/src/play/src/main/scala/views/defaultpages/notFound.scala.html
@@ -1,7 +1,7 @@
 @**
  * Default page for 404 Not Found responses, in production mode.
  *@
-@(request: play.api.mvc.RequestHeader)
+@(method: String, uri: String)
 
 <!DOCTYPE html>
 <html lang="en">
@@ -40,7 +40,7 @@
         <h1>Action not found</h1>
 
         <p id="detail">
-            For request '@request'
+            For request '@method @uri'
         </p>
 
     </body>


### PR DESCRIPTION
This will also help us get rid of _requestHeader(), so that the Java Request object does not need to contain the Scala RequestHeader
