### PR TITLE
Specifying Timer threads to be run as daemon threads.

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Concurrent.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Concurrent.scala
@@ -17,7 +17,7 @@ import play.api.libs.iteratee.Execution.Implicits.{ defaultExecutionContext => d
  */
 object Concurrent {
 
-  private val timer = new java.util.Timer()
+  private val timer = new java.util.Timer(true)
 
   private def timeoutFuture[A](v: A, delay: Long, unit: TimeUnit): Future[A] = {
 

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/IterateeSpecification.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/IterateeSpecification.scala
@@ -66,7 +66,7 @@ trait IterateeSpecification extends NoConcurrentExecutionContext {
     Iteratee.flatten(timeout(it, delay))
   }
 
-  val timer = new java.util.Timer
+  val timer = new java.util.Timer(true)
   def timeout[A](a: => A, d: Duration)(implicit e: ExecutionContext): Future[A] = {
     val p = Promise[A]()
     timer.schedule(new java.util.TimerTask {

--- a/framework/src/play/src/main/scala/play/core/j/FPromiseHelper.scala
+++ b/framework/src/play/src/main/scala/play/core/j/FPromiseHelper.scala
@@ -22,7 +22,7 @@ import play.core.Execution.internalContext
  */
 private[play] object FPromiseHelper {
 
-  private val timer = new Timer()
+  private val timer = new Timer(true)
 
   def pure[A](a: A): F.Promise[A] = F.Promise.wrap(Future.successful(a))
 


### PR DESCRIPTION
The Timer objects in these classes were not cancelled, thus by default, JVM would not exit and waiting those active non-daemon threads forever.

Implication of this change: JVM will not wait for all scheduled tasks.
