### PR TITLE
Assets controller sends constant etag if path has a space in the name

### DIFF
--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -153,7 +153,7 @@ private[controllers] class AssetInfo(
     }
 
     url.getProtocol match {
-      case "file" => Some(df.print(new File(url.getPath).lastModified))
+      case "file" => Some(df.print(new File(url.toURI).lastModified))
       case "jar" => getLastModified[JarURLConnection](c => c.getJarEntry.getTime)
       case "bundle" => getLastModified[URLConnection](c => c.getLastModified)
       case _ => None

--- a/framework/src/play/src/test/resources/file withspace.css
+++ b/framework/src/play/src/test/resources/file withspace.css
@@ -1,0 +1,3 @@
+h1 {
+    color: blue;
+}

--- a/framework/src/play/src/test/scala/play/api/controllers/AssetsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/controllers/AssetsSpec.scala
@@ -99,5 +99,12 @@ object AssetsSpec extends Specification {
       Assets.resourceNameAt("/a/b", "../../c/d") must beNone
     }
 
+    "use the unescaped path when finding the last modified date of an asset" in {
+      val url = AssetsSpec.getClass.getClassLoader.getResource("file withspace.css")
+      val assetInfo = new AssetInfo("file withspace.css", url, None, None)
+      val lastModified = AssetInfo.df.parseDateTime(assetInfo.lastModified.get)
+      // If it uses the escaped path, the file won't be found, and so last modified will be 0
+      lastModified.toDate.getTime must_!= 0
+    }
   }
 }


### PR DESCRIPTION
On OSX 10.9 (and probably everywhere else).

If the application is running under a path with a space in the name, then the code that gets the last modified date for an asset fails to find the file, and returns 0 (epoch).  In dev mode, since the etag is a digest of last modified, this means the asset etag is always constant, which means even after changing an asset, Play will always return 304 not modified.

The effect is that changes to assets are never reflected in the browser.
