### PR TITLE
Akka HTTP backend fixes

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
@@ -153,7 +153,7 @@ class AkkaHttpServer(config: ServerConfig, appProvider: ApplicationProvider) ext
     val resultFuture: Future[Result] = requestBodyEnumerator |>>> actionIteratee
     val responseFuture: Future[HttpResponse] = resultFuture.flatMap { result =>
       val cleanedResult: Result = ServerResultUtils.cleanFlashCookie(taggedRequestHeader, result)
-      ModelConversion.convertResult(cleanedResult)
+      ModelConversion.convertResult(cleanedResult, request.protocol)
     }
     responseFuture
   }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
@@ -134,6 +134,9 @@ class BasicHttpClient(port: Int) {
     try {
       // Read status line
       val statusLine = reader.readLine()
+      if (statusLine == null) {
+        throw new RuntimeException(s"No response $responseDesc: EOF reached")
+      }
       val (version, status, reasonPhrase) = statusLine.split(" ", 3) match {
         case Array(v, s, r) => (v, s.toInt, r)
         case Array(v, s) => (v, s.toInt, "")


### PR DESCRIPTION
A couple more fixes for the Akka HTTP backend. The code to wait for Akka HTTP to start has been broken since upgrading to the new Akka Streams DSL a couple of weeks ago, but is now fixed. The code for result streaming has been factored out of NettyResultStreamer. I thought I had it working properly before but I'd missed a couple of cases.
