### PR TITLE
Convert integration tests to run against both Akka HTTP and Netty

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -380,6 +380,7 @@ object PlayBuild extends Build {
     .dependsOn(PlayProject % "test->test", PlayWsProject, PlayWsJavaProject, PlaySpecs2Project)
     .dependsOn(PlayFiltersHelpersProject)
     .dependsOn(PlayJavaProject)
+    .dependsOn(PlayAkkaHttpServerProject)
 
   lazy val PlayCacheProject = PlayRuntimeProject("Play-Cache", "play-cache")
     .settings(

--- a/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
@@ -1,0 +1,65 @@
+package play.it
+
+import org.specs2.execute._
+import play.api.{ Application, FakeApplication }
+import play.core.server.NettyServer
+import play.core.server.ServerProvider
+import play.core.server.akkahttp.AkkaHttpServer
+import AsResult._
+
+/**
+ * Helper for creating tests that test integration with different server
+ * backends. Common integration tests should implement this trait, then
+ * two specific tests should be created, one extending NettyIntegrationSpecification
+ * and another extending AkkaHttpIntegrationSpecification.
+ *
+ * When a test extends this trait it will automatically get overridden versions of
+ * TestServer and WithServer that delegate to the correct server backend.
+ */
+trait ServerIntegrationSpecification extends PendingUntilFixed {
+  parent =>
+  def integrationServerProvider: ServerProvider
+
+  implicit class UntilAkkaHttpFixed[T: AsResult](t: => T) {
+    /**
+     * Don't complain if a test fails, but given an error if it passes so we know to
+     * remove the pending tag.
+     */
+    def pendingUntilAkkaHttpFixed: Result = parent match {
+      case _: NettyIntegrationSpecification => ResultExecution.execute(AsResult(t))
+      case _: AkkaHttpIntegrationSpecification => new PendingUntilFixed(t).pendingUntilFixed
+    }
+    /**
+     * We may want to skip some tests if they're slow due to timeouts. This tag
+     * won't remind us if the tests start passing.
+     */
+    def skipUntilAkkaHttpFixed: Result = parent match {
+      case _: NettyIntegrationSpecification => ResultExecution.execute(AsResult(t))
+      case _: AkkaHttpIntegrationSpecification => Skipped()
+    }
+  }
+
+  /**
+   * Override the standard TestServer factory method.
+   */
+  def TestServer(
+    port: Int,
+    application: Application = play.api.FakeApplication(),
+    sslPort: Option[Int] = None): play.api.test.TestServer = {
+    play.api.test.TestServer(port, application, sslPort, integrationServerProvider)
+  }
+
+  /**
+   * Override the standard WithServer class.
+   */
+  abstract class WithServer(
+    app: play.api.test.FakeApplication = play.api.test.FakeApplication(),
+    port: Int = play.api.test.Helpers.testServerPort) extends play.api.test.WithServer(app, port, serverProvider = integrationServerProvider)
+
+}
+trait NettyIntegrationSpecification extends ServerIntegrationSpecification {
+  override def integrationServerProvider: ServerProvider = NettyServer.defaultServerProvider
+}
+trait AkkaHttpIntegrationSpecification extends ServerIntegrationSpecification {
+  override def integrationServerProvider: ServerProvider = AkkaHttpServer.defaultServerProvider
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecificationSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecificationSpec.scala
@@ -1,0 +1,66 @@
+package play.it
+
+import play.api.http.HeaderNames._
+import play.api.libs.iteratee._
+import play.api.libs.ws._
+import play.api.mvc._
+import play.api.mvc.BodyParsers.parse
+import play.api.mvc.Results._
+import play.api.test._
+import play.core.server.ServerProvider
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import akka.util.Timeout
+
+object NettyServerIntegrationSpecificationSpec extends ServerIntegrationSpecificationSpec with NettyIntegrationSpecification {
+  override def isAkkaHttpServer = false
+  override def expectedServerTag = None
+}
+object AkkaHttpServerIntegrationSpecificationSpec extends ServerIntegrationSpecificationSpec with AkkaHttpIntegrationSpecification {
+  override def isAkkaHttpServer = true
+  override def expectedServerTag = Some("akka-http")
+}
+
+/**
+ * Tests that the ServerIntegrationSpecification, a helper for testing with different
+ * server backends, works properly.
+ */
+trait ServerIntegrationSpecificationSpec extends PlaySpecification
+    with WsTestClient with ServerIntegrationSpecification {
+
+  def isAkkaHttpServer: Boolean
+
+  def expectedServerTag: Option[String]
+
+  "ServerIntegrationSpecification" should {
+
+    val httpServerTagRoutes: PartialFunction[(String, String), Handler] = {
+      case ("GET", "/httpServerTag") => Action { implicit request =>
+        val httpServer = request.tags.get("HTTP_SERVER")
+        Ok(httpServer.toString)
+      }
+    }
+
+    "run the right HTTP server when using TestServer constructor" in {
+      running(TestServer(testServerPort, FakeApplication(withRoutes = httpServerTagRoutes))) {
+        val plainRequest = wsUrl("/httpServerTag")(testServerPort)
+        val responseFuture = plainRequest.get()
+        val response = await(responseFuture)
+        response.status must_== 200
+        response.body must_== expectedServerTag.toString
+      }
+    }
+
+    "run the right server when using WithServer trait" in new WithServer(
+      app = FakeApplication(withRoutes = httpServerTagRoutes)) {
+      val response = await(wsUrl("/httpServerTag").get())
+      response.status must equalTo(OK)
+      response.body must_== expectedServerTag.toString
+    }
+
+    "support pending Akka HTTP tests" in {
+      isAkkaHttpServer must beFalse
+    }.pendingUntilAkkaHttpFixed
+
+  }
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
@@ -6,11 +6,15 @@ package play.it.http
 import play.api.mvc._
 import play.api.test._
 import play.api.test.TestServer
+import play.it._
 import scala.util.Random
 import scala.io.Source
 import java.io.InputStream
 
-object BadClientHandlingSpec extends PlaySpecification {
+object NettyBadClientHandlingSpec extends BadClientHandlingSpec with NettyIntegrationSpecification
+object AkkaHttpBadClientHandlingSpec extends BadClientHandlingSpec with AkkaHttpIntegrationSpecification
+
+trait BadClientHandlingSpec extends PlaySpecification with ServerIntegrationSpecification {
 
   "Play" should {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/Expect100ContinueSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/Expect100ContinueSpec.scala
@@ -3,12 +3,16 @@
  */
 package play.it.http
 
+import play.it._
 import play.api.mvc._
 import play.api.test._
 import play.api.test.TestServer
 import play.api.libs.iteratee._
 
-object Expect100ContinueSpec extends PlaySpecification {
+object NettyExpect100ContinueSpec extends Expect100ContinueSpec with NettyIntegrationSpecification
+object AkkaHttpExpect100ContinueSpec extends Expect100ContinueSpec with AkkaHttpIntegrationSpecification
+
+trait Expect100ContinueSpec extends PlaySpecification with ServerIntegrationSpecification {
 
   "Play" should {
 
@@ -30,7 +34,7 @@ object Expect100ContinueSpec extends PlaySpecification {
       responses.length must_== 2
       responses(0).status must_== 100
       responses(1).status must_== 200
-    }
+    }.pendingUntilAkkaHttpFixed
 
     "not read body when expecting 100 continue but action iteratee is done" in withServer(
       EssentialAction(_ => Done(Results.Ok))
@@ -70,6 +74,6 @@ object Expect100ContinueSpec extends PlaySpecification {
         responses(0).status must_== 100
         responses(1).status must_== 200
         responses(2).status must_== 200
-      }
+      }.pendingUntilAkkaHttpFixed
   }
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
@@ -6,8 +6,12 @@ import play.api.mvc.{ Flash, Action }
 import play.api.mvc.Results._
 import play.api.libs.ws.{ WSCookie, WSResponse, WS }
 import play.api.Logger
+import play.it._
 
-object FlashCookieSpec extends PlaySpecification {
+object NettyFlashCookieSpec extends FlashCookieSpec with NettyIntegrationSpecification
+object AkkaHttpFlashCookieSpec extends FlashCookieSpec with AkkaHttpIntegrationSpecification
+
+trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecification {
 
   sequential
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FormFieldOrderSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FormFieldOrderSpec.scala
@@ -7,8 +7,12 @@ import play.api.mvc._
 import play.api.test._
 import play.api.libs.ws._
 import play.api.test.FakeApplication
+import play.it._
 
-object FormFieldOrderSpec extends PlaySpecification {
+object NettyFormFieldOrderSpec extends FormFieldOrderSpec with NettyIntegrationSpecification
+object AkkaHttpFormFieldOrderSpec extends FormFieldOrderSpec with AkkaHttpIntegrationSpecification
+
+trait FormFieldOrderSpec extends PlaySpecification with ServerIntegrationSpecification {
 
   "Play' form URL Decoding " should {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/HttpPipeliningSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/HttpPipeliningSpec.scala
@@ -8,12 +8,16 @@ import play.api.test._
 import play.api.test.TestServer
 import play.api.libs.concurrent.Promise
 import play.api.libs.iteratee._
+import play.it._
 import java.util.concurrent.TimeUnit
 import scala.concurrent.Future
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-object HttpPipeliningSpec extends PlaySpecification {
+object NettyHttpPipeliningSpec extends HttpPipeliningSpec with NettyIntegrationSpecification
+object AkkaHttpHttpPipeliningSpec extends HttpPipeliningSpec with AkkaHttpIntegrationSpecification
+
+trait HttpPipeliningSpec extends PlaySpecification with ServerIntegrationSpecification {
 
   "Play's http pipelining support" should {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
@@ -7,10 +7,14 @@ import play.api.mvc._
 import play.api.test._
 import play.api.test.TestServer
 import play.api.libs.iteratee._
+import play.it._
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.util.Random
 
-object RequestBodyHandlingSpec extends PlaySpecification {
+object NettyRequestBodyHandlingSpec extends RequestBodyHandlingSpec with NettyIntegrationSpecification
+object AkkaHttpRequestBodyHandlingSpec extends RequestBodyHandlingSpec with AkkaHttpIntegrationSpecification
+
+trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSpecification {
 
   "Play request body handling" should {
 
@@ -37,7 +41,7 @@ object RequestBodyHandlingSpec extends PlaySpecification {
       responses.length must_== 2
       responses(0).status must_== 200
       responses(1).status must_== 200
-    }
+    }.pendingUntilAkkaHttpFixed
 
     "gracefully handle early body parser termination" in withServer(EssentialAction { rh =>
       Traversable.takeUpTo[Array[Byte]](20 * 1024) &>> Iteratee.ignore[Array[Byte]].map(_ => Results.Ok)
@@ -52,6 +56,6 @@ object RequestBodyHandlingSpec extends PlaySpecification {
       responses.length must_== 2
       responses(0).status must_== 200
       responses(1).status must_== 200
-    }
+    }.pendingUntilAkkaHttpFixed
   }
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/SecureFlagSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/SecureFlagSpec.scala
@@ -6,16 +6,20 @@ package play.it.http
 import play.api.mvc._
 import play.api.test._
 import play.api.test.TestServer
+import play.it._
 import java.io.{ File, InputStream }
 import javax.net.ssl.{ SSLContext, HttpsURLConnection, X509TrustManager }
 import java.security.cert.X509Certificate
 import scala.io.Source
 import java.net.URL
 
+object NettySecureFlagSpec extends SecureFlagSpec with NettyIntegrationSpecification
+object AkkaHttpSecureFlagSpec extends SecureFlagSpec with AkkaHttpIntegrationSpecification
+
 /**
  * Specs for the "secure" flag on requests
  */
-object SecureFlagSpec extends PlaySpecification {
+trait SecureFlagSpec extends PlaySpecification with ServerIntegrationSpecification {
 
   sequential
 
@@ -45,19 +49,19 @@ object SecureFlagSpec extends PlaySpecification {
     "show that requests are secure in the absence of X_FORWARDED_PROTO" in withServer(secureFlagAction, Some(sslPort)) { _ =>
       val conn = createConn(sslPort)
       Source.fromInputStream(conn.getContent.asInstanceOf[InputStream]).getLines().next must_== "true"
-    }
+    }.pendingUntilAkkaHttpFixed
     "show that requests are secure in the absence of X_FORWARDED_PROTO" in withServer(secureFlagAction, Some(sslPort)) { _ =>
       val conn = createConn(sslPort)
       Source.fromInputStream(conn.getContent.asInstanceOf[InputStream]).getLines().next must_== "true"
-    }
+    }.pendingUntilAkkaHttpFixed
     "show that requests are secure if X_FORWARDED_PROTO is https" in withServer(secureFlagAction, Some(sslPort)) { _ =>
       val conn = createConn(sslPort, Some("https"))
       Source.fromInputStream(conn.getContent.asInstanceOf[InputStream]).getLines().next must_== "true"
-    }
+    }.pendingUntilAkkaHttpFixed
     "not show that requests are secure if X_FORWARDED_PROTO is http" in withServer(secureFlagAction, Some(sslPort)) { _ =>
       val conn = createConn(sslPort, Some("http"))
       Source.fromInputStream(conn.getContent.asInstanceOf[InputStream]).getLines().next must_== "false"
-    }
+    }.pendingUntilAkkaHttpFixed
   }
 
   "Play http server" should {
@@ -74,7 +78,7 @@ object SecureFlagSpec extends PlaySpecification {
       )
       responses.length must_== 1
       responses(0).body must_== Left("true")
-    }
+    }.pendingUntilAkkaHttpFixed
     "not show that requests are secure if X_FORWARDED_PROTO is http" in withServer(secureFlagAction) { port =>
       val responses = BasicHttpClient.makeRequests(port)(
         BasicRequest("GET", "/", "HTTP/1.1", Map((X_FORWARDED_PROTO, "http")), "foo")

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
@@ -11,10 +11,16 @@ import java.util.zip.GZIPInputStream
 import java.io.ByteArrayInputStream
 import play.api.{ Configuration, Mode }
 import play.api.mvc.{ PathBindable, Handler }
+import play.it._
 import play.utils.{ UriEncoding, Threads }
 import play.core.Router.ReverseRouteContext
 
-object AssetsSpec extends PlaySpecification with WsTestClient {
+object NettyAssetsSpec extends AssetsSpec with NettyIntegrationSpecification
+object AkkaHttpAssetsSpec extends AssetsSpec with AkkaHttpIntegrationSpecification
+
+trait AssetsSpec extends PlaySpecification
+    with WsTestClient with ServerIntegrationSpecification {
+
   "Assets controller" should {
 
     val defaultCacheControl = Some("public, max-age=3600")
@@ -182,7 +188,7 @@ object AssetsSpec extends PlaySpecification with WsTestClient {
 
       result.status must_== OK
       result.body must beEmpty
-    }
+    }.pendingUntilAkkaHttpFixed
 
     "return 404 for files that don't exist" in withServer {
       val result = await(wsUrl("/nosuchfile.txt").get())

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
@@ -7,7 +7,7 @@ import play.it.tools.HttpBinApplication
 
 import play.api.test._
 import play.api.mvc._
-
+import play.it._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import play.api.libs.iteratee._
@@ -15,7 +15,11 @@ import play.api.libs.concurrent.Promise
 import scala.concurrent.ExecutionContext.Implicits.global
 import java.io.IOException
 
-object WSSpec extends PlaySpecification {
+object NettyWSSpec extends WSSpec with NettyIntegrationSpecification
+object AkkaHttpWSSpec extends WSSpec with AkkaHttpIntegrationSpecification
+
+trait WSSpec extends PlaySpecification with ServerIntegrationSpecification {
+
   "Web service client" title
 
   sequential
@@ -160,7 +164,7 @@ object WSSpec extends PlaySpecification {
 
         await(body |>>> Iteratee.consume[Array[Byte]]()).
           aka("streamed response") must throwAn[IOException]
-      }
+      }.skipUntilAkkaHttpFixed
 
     "not throw an exception while signing requests" >> {
       object CustomSigner extends WSSignatureCalculator {

--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -6,11 +6,16 @@ package play.it.mvc
 import org.specs2.mutable.Specification
 import play.api.mvc._
 import play.api.test._
+import play.it._
 import scala.concurrent.duration.Duration
 import scala.concurrent._
 import play.api.libs.concurrent.Execution.{ defaultContext => ec }
 
-object FiltersSpec extends Specification with WsTestClient {
+object NettyFiltersSpec extends FiltersSpec with NettyIntegrationSpecification
+object AkkaHttpFiltersSpec extends FiltersSpec with AkkaHttpIntegrationSpecification
+
+trait FiltersSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
+
   "filters" should {
     "handle errors" in {
 


### PR DESCRIPTION
Not all tests are currently working with Akka HTTP. Failing tests are marked with `pendingUntilAkkaHttpFixed` or `skipUntilAkkaHttpFixed` so that they don't cause test failures.

After this change, the integration tests show:

```
[info] Passed: Total 325, Failed 0, Errors 0, Passed 324, Skipped 1, Pending 41
```
