### PR TITLE
Commas in etag break browser caching

### DIFF
--- a/framework/src/play-cache/src/main/scala/play/api/cache/Cached.scala
+++ b/framework/src/play-cache/src/main/scala/play/api/cache/Cached.scala
@@ -3,6 +3,8 @@
  */
 package play.api.cache
 
+import org.apache.commons.codec.digest.DigestUtils
+
 import play.api._
 import play.api.mvc._
 import play.api.libs.iteratee.{ Iteratee, Done }
@@ -72,7 +74,8 @@ case class Cached(key: RequestHeader => String, caching: PartialFunction[Respons
       // Format expiration date according to http standard
       val expirationDate = http.dateFormat.print(System.currentTimeMillis() + duration.toMillis)
       // Generate a fresh ETAG for it
-      val etag = expirationDate // Use the expiration date as ETAG
+      // Use quoted sha1 hash of expiration date as ETAG
+      val etag = s""""${DigestUtils.sha1Hex(expirationDate)}""""
 
       val resultWithHeaders = result.withHeaders(ETAG -> etag, EXPIRES -> expirationDate)
 

--- a/framework/src/play-cache/src/test/scala/play/api/cache/CachedSpec.scala
+++ b/framework/src/play-cache/src/test/scala/play/api/cache/CachedSpec.scala
@@ -36,7 +36,7 @@ class CachedSpec extends PlaySpecification {
       status(result1) must_== 200
       invoked.get() must_== 1
       val etag = header(ETAG, result1)
-      etag must beSome
+      etag must beSome(matching("""([wW]/)?"([^"]|\\")*""""))
       val result2 = action(FakeRequest().withHeaders(IF_NONE_MATCH -> etag.get)).run
       status(result2) must_== NOT_MODIFIED
       invoked.get() must_== 1


### PR DESCRIPTION
The Etag value used by the `Cached` class include an unquoted date string containing a comma. This is parsed by the browser as a list of headers, so Chrome sends the first token of the string for If-None-Match. For example, chrome requests "If-None-Match:Sun" for the header: "ETag:Sun, 20 Dec 2015 20:11:43 GMT".