### PR TITLE
Fixing globalErrors miss

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/Form.java
+++ b/framework/src/play-java/src/main/java/play/data/Form.java
@@ -518,6 +518,7 @@ public class Form<T> {
         List<ValidationError> e = errors.get("");
         if(e == null) {
             e = new ArrayList<ValidationError>();
+            errors.put("", e);
         }
         return e;
     }


### PR DESCRIPTION
Currently, whenever we use the globalErrors() method to add a new ValidationError to the `Form` instance, the playframework return a new `ArrayList<ValidationError>`. However, it does not include that new list in the internal error list, making the new ValidationErrors added not attached to the `Form` instance.
