### PR TITLE
RequestHeader.path() is unsafe

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
@@ -3,13 +3,13 @@
  */
 package play.it.http
 
+import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
+import play.api._
 import play.api.mvc._
 import play.api.test._
-import play.api.test.TestServer
 import play.it._
+import scala.concurrent.Future
 import scala.util.Random
-import scala.io.Source
-import java.io.InputStream
 
 object NettyBadClientHandlingSpec extends BadClientHandlingSpec with NettyIntegrationSpecification
 object AkkaHttpBadClientHandlingSpec extends BadClientHandlingSpec with AkkaHttpIntegrationSpecification
@@ -18,30 +18,52 @@ trait BadClientHandlingSpec extends PlaySpecification with ServerIntegrationSpec
 
   "Play" should {
 
-    def withServer[T](action: EssentialAction)(block: Port => T) = {
+    def withServer[T](errorHandler: HttpErrorHandler = DefaultHttpErrorHandler)(block: Port => T) = {
       val port = testServerPort
-      running(TestServer(port, FakeApplication(
-        withRoutes = {
-          case _ => action
+
+      val app = new BuiltInComponentsFromContext(ApplicationLoader.createContext(Environment.simple())) {
+        def routes = Routes.routes {
+          case _ => Action(Results.Ok)
         }
-      ))) {
+        override lazy val httpErrorHandler = errorHandler
+      }.application
+
+      running(TestServer(port, app)) {
         block(port)
       }
     }
 
-    "gracefully handle long urls and return 414" in withServer(Action(Results.Ok)) { port =>
+    "gracefully handle long urls and return 414" in withServer() { port =>
       val url = new String(Random.alphanumeric.take(5 * 1024).toArray)
 
-      val conn = new java.net.URL("http://localhost:" + port + "/" + url).openConnection()
-      try {
-        Source.fromInputStream(conn.getContent.asInstanceOf[InputStream]).getLines()
-        failure // must not reach this point
-      } catch {
-        case e: Exception =>
-          e.getMessage must contain("Server returned HTTP response code: 414")
-          success
-      }
+      val response = BasicHttpClient.makeRequests(port)(
+        BasicRequest("GET", "/" + url, "HTTP/1.1", Map(), "")
+      )(0)
+
+      response.status must_== 414
     }
+
+    "return a 400 error on invalid URI" in withServer() { port =>
+      val response = BasicHttpClient.makeRequests(port)(
+        BasicRequest("GET", "/[", "HTTP/1.1", Map(), "")
+      )(0)
+
+      response.status must_== 400
+      response.body must beLeft
+    }
+
+    "allow accessing the raw unparsed path from an error handler" in withServer(new HttpErrorHandler() {
+      def onClientError(request: RequestHeader, statusCode: Int, message: String) =
+        Future.successful(Results.BadRequest("Bad path: " + request.path))
+      def onServerError(request: RequestHeader, exception: Throwable) = Future.successful(Results.Ok)
+    }) { port =>
+      val response = BasicHttpClient.makeRequests(port)(
+        BasicRequest("GET", "/[", "HTTP/1.1", Map(), "")
+      )(0)
+
+      response.status must_== 400
+      response.body must beLeft("Bad path: /[")
+    }.skipUntilAkkaHttpFixed
 
   }
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -228,17 +228,6 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
         response.body must beLeft("")
       }
 
-    "return a 400 error on invalid URI" in withServer(
-      Results.Ok
-    ) { port =>
-        val response = BasicHttpClient.makeRequests(port)(
-          BasicRequest("GET", "/[", "HTTP/1.1", Map(), "")
-        )(0)
-
-        response.status must_== 400
-        response.body must beLeft
-      }
-
     "not send empty chunks before the end of the enumerator stream" in makeRequest(
       Results.Ok.chunked(Enumerator("foo", "", "bar"))
     ) { response =>

--- a/framework/src/play/src/main/scala/play/api/Routes.scala
+++ b/framework/src/play/src/main/scala/play/api/Routes.scala
@@ -1,81 +1,110 @@
 /*
  * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
  */
-package play.api {
+package play.api
 
-  import play.twirl.api.JavaScript
+import play.api.http.{ HttpErrorHandler, DefaultHttpErrorHandler }
+import play.api.mvc.Handler
+import play.twirl.api.JavaScript
+
+/**
+ * Helper utilities related to `Router`.
+ */
+object Routes {
+
+  // -- TAGS
+
+  val ROUTE_VERB = "ROUTE_VERB"
+  val ROUTE_PATTERN = "ROUTE_PATTERN"
+  val ROUTE_CONTROLLER = "ROUTE_CONTROLLER"
+  val ROUTE_ACTION_METHOD = "ROUTE_ACTION_METHOD"
+  val ROUTE_COMMENTS = "ROUTE_COMMENTS"
+
+  // --
+
+  import play.core.Router._
+  import play.api.mvc.RequestHeader
 
   /**
-   * Helper utilities related to `Router`.
+   * Helper to create a router from a partial function
    */
-  object Routes {
+  def routes(routes: PartialFunction[RequestHeader, Handler]): SimpleRoutes = new SimpleRoutes(routes, "/")
 
-    // -- TAGS
-
-    val ROUTE_VERB = "ROUTE_VERB"
-    val ROUTE_PATTERN = "ROUTE_PATTERN"
-    val ROUTE_CONTROLLER = "ROUTE_CONTROLLER"
-    val ROUTE_ACTION_METHOD = "ROUTE_ACTION_METHOD"
-    val ROUTE_COMMENTS = "ROUTE_COMMENTS"
-
-    // --
-
-    import play.core.Router._
-    import play.api.mvc.RequestHeader
-
-    /**
-     * Generates a JavaScript router.
-     *
-     * For example:
-     * {{{
-     * Routes.javascriptRouter("MyRouter")(
-     *   controllers.routes.javascript.Application.index,
-     *   controllers.routes.javascript.Application.list,
-     *   controllers.routes.javascript.Application.create
-     * )
-     * }}}
-     *
-     * And then you can use the JavaScript router as:
-     * {{{
-     * var routeToHome = MyRouter.controllers.Application.index()
-     * }}}
-     *
-     * @param name the JavaScript object name
-     * @param routes the routes to include in this JavaScript router
-     * @return the JavaScript code
-     */
-    def javascriptRouter(name: String = "Router", ajaxMethod: Option[String] = Some("jQuery.ajax"))(routes: JavascriptReverseRoute*)(implicit request: RequestHeader): JavaScript = {
-      javascriptRouter(name, ajaxMethod, request.host, routes: _*)
+  /**
+   * A simple router that just wraps a partial function.
+   *
+   * @param suppliedRoutes The partial function that does the routing.
+   * @param prefix The prefix at which the router lives.
+   */
+  class SimpleRoutes(suppliedRoutes: PartialFunction[RequestHeader, Handler],
+      prefix: String) extends play.core.Router.Routes {
+    def routes = {
+      if (prefix == "/") {
+        suppliedRoutes
+      } else {
+        val p = if (prefix.endsWith("/")) prefix else prefix + "/"
+        val prefixed: PartialFunction[RequestHeader, RequestHeader] = {
+          case rh: RequestHeader if rh.path.startsWith(p) => rh.copy(path = rh.path.drop(p.length - 1))
+        }
+        Function.unlift(prefixed.lift.andThen(_.flatMap(suppliedRoutes.lift)))
+      }
     }
+    def documentation = Nil
+    def withPrefix(prefix: String) = new SimpleRoutes(suppliedRoutes, prefix)
+    val errorHandler = DefaultHttpErrorHandler // This isn't used, so the default one is fine
+  }
 
-    val jsReservedWords = Seq("break", "case", "catch", "continue", "debugger",
-      "default", "delete", "do", "else", "finally", "for", "function", "if",
-      "in", "instanceof", "new", "return", "switch", "this", "throw", "try",
-      "typeof", "var", "void", "while", "with")
+  /**
+   * Generates a JavaScript router.
+   *
+   * For example:
+   * {{{
+   * Routes.javascriptRouter("MyRouter")(
+   *   controllers.routes.javascript.Application.index,
+   *   controllers.routes.javascript.Application.list,
+   *   controllers.routes.javascript.Application.create
+   * )
+   * }}}
+   *
+   * And then you can use the JavaScript router as:
+   * {{{
+   * var routeToHome = MyRouter.controllers.Application.index()
+   * }}}
+   *
+   * @param name the JavaScript object name
+   * @param routes the routes to include in this JavaScript router
+   * @return the JavaScript code
+   */
+  def javascriptRouter(name: String = "Router", ajaxMethod: Option[String] = Some("jQuery.ajax"))(routes: JavascriptReverseRoute*)(implicit request: RequestHeader): JavaScript = {
+    javascriptRouter(name, ajaxMethod, request.host, routes: _*)
+  }
 
-    // TODO: This JS needs to be re-written as it isn't easily maintained.
-    def javascriptRouter(name: String, ajaxMethod: Option[String], host: String, routes: JavascriptReverseRoute*): JavaScript = JavaScript {
-      """|var %s = {}; (function(_root){
-             |var _nS = function(c,f,b){var e=c.split(f||"."),g=b||_root,d,a;for(d=0,a=e.length;d<a;d++){g=g[e[d]]=g[e[d]]||{}}return g}
-             |var _qS = function(items){var qs = ''; for(var i=0;i<items.length;i++) {if(items[i]) qs += (qs ? '&' : '') + items[i]}; return qs ? ('?' + qs) : ''}
-             |var _s = function(p,s){return p+((s===true||(s&&s.secure))?'s':'')+'://'}
-             |var _wA = function(r){return {%s method:r.method,type:r.method,url:r.url,absoluteURL: function(s){return _s('http',s)+'%s'+r.url},webSocketURL: function(s){return _s('ws',s)+'%s'+r.url}}}
-             |%s
-             |})(%s)
-          """.stripMargin.format(
-        name,
-        ajaxMethod.map("ajax:function(c){c=c||{};c.url=r.url;c.type=r.method;return " + _ + "(c)},").getOrElse(""),
-        host,
-        host,
-        routes.map { route =>
-          "_nS('%s'); _root.%s = %s".format(
-            route.name.split('.').dropRight(1).mkString("."),
-            route.name.split('.').map(name => if (jsReservedWords.contains(name)) { "['" + name + "']" } else { "." + name }).mkString("").tail,
-            route.f)
-        }.mkString("\n"),
-        name)
-    }
+  val jsReservedWords = Seq("break", "case", "catch", "continue", "debugger",
+    "default", "delete", "do", "else", "finally", "for", "function", "if",
+    "in", "instanceof", "new", "return", "switch", "this", "throw", "try",
+    "typeof", "var", "void", "while", "with")
 
+  // TODO: This JS needs to be re-written as it isn't easily maintained.
+  def javascriptRouter(name: String, ajaxMethod: Option[String], host: String, routes: JavascriptReverseRoute*): JavaScript = JavaScript {
+    """|var %s = {}; (function(_root){
+           |var _nS = function(c,f,b){var e=c.split(f||"."),g=b||_root,d,a;for(d=0,a=e.length;d<a;d++){g=g[e[d]]=g[e[d]]||{}}return g}
+           |var _qS = function(items){var qs = ''; for(var i=0;i<items.length;i++) {if(items[i]) qs += (qs ? '&' : '') + items[i]}; return qs ? ('?' + qs) : ''}
+           |var _s = function(p,s){return p+((s===true||(s&&s.secure))?'s':'')+'://'}
+           |var _wA = function(r){return {%s method:r.method,type:r.method,url:r.url,absoluteURL: function(s){return _s('http',s)+'%s'+r.url},webSocketURL: function(s){return _s('ws',s)+'%s'+r.url}}}
+           |%s
+           |})(%s)
+        """.stripMargin.format(
+      name,
+      ajaxMethod.map("ajax:function(c){c=c||{};c.url=r.url;c.type=r.method;return " + _ + "(c)},").getOrElse(""),
+      host,
+      host,
+      routes.map { route =>
+        "_nS('%s'); _root.%s = %s".format(
+          route.name.split('.').dropRight(1).mkString("."),
+          route.name.split('.').map(name => if (jsReservedWords.contains(name)) { "['" + name + "']" } else { "." + name }).mkString("").tail,
+          route.f)
+      }.mkString("\n"),
+      name)
   }
 
 }


### PR DESCRIPTION
I have Play 2.3.6 Java app. In it I have my own error handler for handling bad requests, method looks like:

    public Promise<play.mvc.Result> onBadRequest(RequestHeader request, String error {
        Logger.debug("400 error: " + error + ", " + request.path() + ", " + request.remoteAddress());
        return Promise.<play.mvc.Result> pure(badRequest(views.html.error404.render()));
    }
When an error occurs, instead of my own error page I am getting standard error page. It turns out problem is in request.path() method which is supposed to return string. But if the URL is incorrect it throws an exception and breaks my error handling code. 

An example of bad request causing it looks like this: https://www.playframework.com/documentation/2.3.x/Home%
(with % at the end of url).
