### PR TITLE
Doc addition for repeated HTTP form parameters and []

### DIFF
--- a/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
@@ -247,9 +247,9 @@ A form mapping can define repeated values using [`Forms.list`](api/scala/index.h
 
 @[userForm-repeated](code/ScalaForms.scala)
 
-When you are using repeated data like this, the form values sent by the browser must be named `emails[0]`, `emails[1]`, `emails[2]`, etc.
+When you are using repeated data like this, there are two alternatives for sending the form values in the HTTP request.  First, you can suffix the parameter with an empty bracket pair, as in "emails[]".  This parameter can then be repeated in the standard way, as in `http://foo.com/request?emails[]=a@b.com&emails[]=c@d.com`.  Alternatively, the client can explicitly name the parameters uniquely with array subscripts, as in `emails[0]`, `emails[1]`, `emails[2]`, and so on.  This approach also allows you to maintain the order of a sequence of inputs.  
 
-Now you have to generate as many inputs for the `emails` field as the form contains, using the [`repeat`](api/scala/index.html#views.html.helper.repeat$) helper:
+If you are using Play to generate your form HTML, you can generate as many inputs for the `emails` field as the form contains, using the [`repeat`](api/scala/index.html#views.html.helper.repeat$) helper:
 
 @[form-field-repeat](code/scalaguide/forms/scalaforms/views/repeat.scala.html)
 


### PR DESCRIPTION
Add note about appending brackets to param name to allow mapping of repeated HTTP form parameters using seq/list.  See https://groups.google.com/forum/#!topic/play-framework/oiUqGQ8IMCo
