### PR TITLE
Fix use of deprecated old procedure syntax.

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/router/RoutesCompiler.scala
@@ -451,7 +451,7 @@ object RoutesCompiler {
         |
         |private var _prefix = "/"
         |
-        |def setPrefix(prefix: String) {
+        |def setPrefix(prefix: String): Unit = {
         |  _prefix = prefix
         |  List[(String,Routes)](%s).foreach {
         |    case (p, router) => router.setPrefix(prefix + (if(prefix.endsWith("/")) "" else "/") + p)


### PR DESCRIPTION
Without this fix, you cannot compile Play apps with -Xfatal-warnings because the code generated by routes-compiler uses the deprecated procedure syntax.
