### PR TITLE
Move classloaders from build-link to the new run-support library

### DIFF
--- a/framework/src/build-link/src/main/java/play/core/Build.java
+++ b/framework/src/build-link/src/main/java/play/core/Build.java
@@ -1,0 +1,24 @@
+package play.core;
+
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Build {
+
+  public static final List<String> sharedClasses;
+  static {
+    List<String> list = new ArrayList<String>();
+    list.add(play.core.BuildLink.class.getName());
+    list.add(play.core.BuildDocHandler.class.getName());
+    list.add(play.core.server.ServerWithStop.class.getName());
+    list.add(play.api.UsefulException.class.getName());
+    list.add(play.api.PlayException.class.getName());
+    list.add(play.api.PlayException.InterestingLines.class.getName());
+    list.add(play.api.PlayException.RichDescription.class.getName());
+    list.add(play.api.PlayException.ExceptionSource.class.getName());
+    list.add(play.api.PlayException.ExceptionAttachment.class.getName());
+    sharedClasses = Collections.unmodifiableList(list);
+  }
+
+}

--- a/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
+++ b/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
@@ -149,7 +149,7 @@ object PlayDocsPlugin extends AutoPlugin {
     val sbtLoader = this.getClass.getClassLoader
     val classloader = new java.net.URLClassLoader(classpath.map(_.data.toURI.toURL).toArray, null /* important here, don't depend of the sbt classLoader! */ ) {
       override def loadClass(name: String): Class[_] = {
-        if (play.core.classloader.DelegatingClassLoader.isSharedClass(name)) {
+        if (play.core.Build.sharedClasses.contains(name)) {
           sbtLoader.loadClass(name)
         } else {
           super.loadClass(name)

--- a/framework/src/run-support/src/main/java/play/runsupport/classloader/ApplicationClassLoaderProvider.java
+++ b/framework/src/run-support/src/main/java/play/runsupport/classloader/ApplicationClassLoaderProvider.java
@@ -1,4 +1,4 @@
-package play.core.classloader;
+package play.runsupport.classloader;
 
 public interface ApplicationClassLoaderProvider {
   ClassLoader get();

--- a/framework/src/run-support/src/main/java/play/runsupport/classloader/DelegatingClassLoader.java
+++ b/framework/src/run-support/src/main/java/play/runsupport/classloader/DelegatingClassLoader.java
@@ -1,4 +1,4 @@
-package play.core.classloader;
+package play.runsupport.classloader;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -14,37 +14,20 @@ import java.util.Vector;
 
 public class DelegatingClassLoader extends ClassLoader {
 
-  private static final List<String> buildSharedClasses;
-  static {
-    List<String> list = new ArrayList<String>();
-    list.add(play.core.BuildLink.class.getName());
-    list.add(play.core.BuildDocHandler.class.getName());
-    list.add(play.core.server.ServerWithStop.class.getName());
-    list.add(play.api.UsefulException.class.getName());
-    list.add(play.api.PlayException.class.getName());
-    list.add(play.api.PlayException.InterestingLines.class.getName());
-    list.add(play.api.PlayException.RichDescription.class.getName());
-    list.add(play.api.PlayException.ExceptionSource.class.getName());
-    list.add(play.api.PlayException.ExceptionAttachment.class.getName());
-    buildSharedClasses = Collections.unmodifiableList(list);
-  }
-
+  private List<String> sharedClasses;
   private ClassLoader buildLoader;
   private ApplicationClassLoaderProvider applicationClassLoaderProvider;
 
-  public DelegatingClassLoader(ClassLoader commonLoader, ClassLoader buildLoader, ApplicationClassLoaderProvider applicationClassLoaderProvider) {
+  public DelegatingClassLoader(ClassLoader commonLoader, List<String> sharedClasses, ClassLoader buildLoader, ApplicationClassLoaderProvider applicationClassLoaderProvider) {
     super(commonLoader);
+    this.sharedClasses = sharedClasses;
     this.buildLoader = buildLoader;
     this.applicationClassLoaderProvider = applicationClassLoaderProvider;
   }
 
-  public static boolean isSharedClass(String name) {
-    return buildSharedClasses.contains(name);
-  }
-
   @Override
   public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-    if (isSharedClass(name)) {
+    if (sharedClasses.contains(name)) {
       return buildLoader.loadClass(name);
     } else {
       return super.loadClass(name, resolve);

--- a/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -7,8 +7,8 @@ import java.io.{ Closeable, File }
 import java.net.{ URL, URLClassLoader }
 import java.util.jar.JarFile
 import play.api.PlayException
-import play.core.classloader.{ ApplicationClassLoaderProvider, DelegatingClassLoader }
-import play.core.{ BuildLink, BuildDocHandler }
+import play.core.{ Build, BuildLink, BuildDocHandler }
+import play.runsupport.classloader.{ ApplicationClassLoaderProvider, DelegatingClassLoader }
 import sbt.{ PathFinder, WatchState, SourceModificationWatch }
 
 object Reloader {
@@ -164,7 +164,7 @@ object Reloader {
      * buildLoader. Also accesses the reloader resources to make these available
      * to the applicationLoader, creating a full circle for resource loading.
      */
-    lazy val delegatingLoader: ClassLoader = new DelegatingClassLoader(commonClassLoader, buildLoader, new ApplicationClassLoaderProvider {
+    lazy val delegatingLoader: ClassLoader = new DelegatingClassLoader(commonClassLoader, Build.sharedClasses, buildLoader, new ApplicationClassLoaderProvider {
       def get: ClassLoader = { reloader.getClassLoader.orNull }
     })
 

--- a/framework/src/sbt-plugin/src/main/scala/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayRun.scala
@@ -10,9 +10,6 @@ import sbt._
 import Keys._
 import play.PlayImport._
 import PlayKeys._
-import play.sbtplugin.Colors
-import play.core.{ BuildLink, BuildDocHandler }
-import play.core.classloader._
 import annotation.tailrec
 import scala.collection.JavaConverters._
 import java.net.URLClassLoader
@@ -20,7 +17,10 @@ import java.util.jar.JarFile
 import com.typesafe.sbt.SbtNativePackager._
 import com.typesafe.sbt.packager.Keys._
 import com.typesafe.sbt.web.SbtWeb.autoImport._
+import play.core.{ Build, BuildLink, BuildDocHandler }
+import play.sbtplugin.Colors
 import play.runsupport.{ AssetsClassLoader, PlayWatchService, Reloader }
+import play.runsupport.classloader._
 import play.sbtplugin.run._
 
 /**


### PR DESCRIPTION
@corruptmemory @jroper I refactored out a couple of classloader classes a little while back from Play's run code into build-link. The run-support library didn't exist yet, but seems like it could be a better place for them to go. In fact another one of the classloaders is already there - the AssetsClassLoader. What do you think?