### PR TITLE
Make it easy to override the logging of server errors

### DIFF
--- a/framework/src/play/src/main/java/play/http/DefaultHttpErrorHandler.java
+++ b/framework/src/play/src/main/java/play/http/DefaultHttpErrorHandler.java
@@ -9,6 +9,7 @@ import play.api.UsefulException;
 import play.api.http.HttpErrorHandlerExceptions;
 import play.core.Router;
 import play.libs.F;
+import play.mvc.Http;
 import play.mvc.Http.*;
 import play.mvc.Result;
 import play.mvc.Results;
@@ -117,10 +118,7 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
         try {
             UsefulException usefulException = throwableToUsefulException(exception);
 
-            Logger.error(String.format("\n\n! @%s - Internal server error, for (%s) [%s] ->\n",
-                            usefulException.id, request.method(), request.uri()),
-                usefulException
-            );
+            logServerError(request, usefulException);
 
             switch (environment.mode()) {
                 case PROD:
@@ -132,6 +130,21 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
             Logger.error("Error while handling error", e);
             return F.Promise.<Result>pure(Results.internalServerError());
         }
+    }
+
+    /**
+     * Responsible for logging server errors.
+     *
+     * This can be overridden to add additional logging information, eg. the id of the authenticated user.
+     *
+     * @param request The request that triggered the server error.
+     * @param usefulException The server error.
+     */
+    protected void logServerError(RequestHeader request, UsefulException usefulException) {
+        Logger.error(String.format("\n\n! @%s - Internal server error, for (%s) [%s] ->\n",
+                        usefulException.id, request.method(), request.uri()),
+                usefulException
+        );
     }
 
     /**

--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -179,13 +179,7 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
       val usefulException = HttpErrorHandlerExceptions.throwableToUsefulException(sourceMapper,
         environment.mode == Mode.Prod, exception)
 
-      Logger.error(
-        """
-          |
-          |! @%s - Internal server error, for (%s) [%s] ->
-          |""".stripMargin.format(usefulException.id, request.method, request.uri),
-        usefulException
-      )
+      logServerError(request, usefulException)
 
       environment.mode match {
         case Mode.Prod => onProdServerError(request, usefulException)
@@ -196,6 +190,23 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
         Logger.error("Error while handling error", e)
         Future.successful(InternalServerError)
     }
+  }
+
+  /**
+   * Responsible for logging server errors.
+   *
+   * This can be overridden to add additional logging information, eg. the id of the authenticated user.
+   *
+   * @param request The request that triggered the server error.
+   * @param usefulException The server error.
+   */
+  protected def logServerError(request: RequestHeader, usefulException: UsefulException) {
+    Logger.error("""
+                    |
+                    |! @%s - Internal server error, for (%s) [%s] ->
+                    | """.stripMargin.format(usefulException.id, request.method, request.uri),
+      usefulException
+    )
   }
 
   /**


### PR DESCRIPTION
This would be useful to us because we'd like to add some additional tagging data that we could process in Sentry:

https://github.com/getsentry/raven-java/tree/master/raven-logback#additional-data-and-information

See also https://github.com/guardian/membership-frontend/pull/31
