### PR TITLE
Attach Done iteratee when EnumeratorPublisher is cancelled

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
@@ -112,7 +112,7 @@ trait HeadActionSpec extends PlaySpecification
         await(wsUrl("/get").head())
         wasCalled.get() must be_==(true).eventually
       }
-    }.pendingUntilAkkaHttpFixed
+    }
 
     "respect deliberately set Content-Length headers" in withServer {
       val result = await(wsUrl("/manualContentSize").head())

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/impl/EnumeratorPublisher.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/impl/EnumeratorPublisher.scala
@@ -114,7 +114,14 @@ private[streams] class EnumeratorSubscription[T, U >: T](
   }
 
   override def cancel(): Unit = exclusive {
-    case Requested(_, _) =>
+    case Requested(_, its) =>
+      val cancelLink: Iteratee[T, Unit] = Done(())
+      its match {
+        case Unattached =>
+          enum(cancelLink)
+        case Attached(link0) =>
+          link0.success(cancelLink)
+      }
       state = Cancelled
     case Cancelled | Completed =>
       ()

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/EnumeratorPublisherSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/EnumeratorPublisherSpec.scala
@@ -5,8 +5,9 @@ package play.api.libs.streams.impl
 
 import org.reactivestreams._
 import org.specs2.mutable.Specification
-import play.api.libs.iteratee.{ Enumerator, Input }
-import scala.concurrent.{ Future, Promise }
+import play.api.libs.iteratee.{ Concurrent, Enumerator, Input }
+import scala.concurrent.{ Await, Future, Promise }
+import scala.concurrent.duration._
 
 class EnumeratorPublisherSpec extends Specification {
 
@@ -79,6 +80,47 @@ class EnumeratorPublisherSpec extends Specification {
       testEnv.next must_== OnNext(3)
       testEnv.next must_== OnComplete
       testEnv.isEmptyAfterDelay() must beTrue
+    }
+    "be done enumerating after EOF" in {
+      val testEnv = new TestEnv[Int]
+      var enumDone = Promise[Boolean]()
+      val enum = (Enumerator(1, 2, 3) >>> Enumerator.eof).onDoneEnumerating {
+        enumDone.success(true)
+      }
+      val pubr = new EnumeratorPublisher(enum)
+      pubr.subscribe(testEnv.subscriber)
+      testEnv.next must_== OnSubscribe
+      testEnv.request(4)
+      testEnv.next must_== RequestMore(4)
+      testEnv.next must_== OnNext(1)
+      testEnv.next must_== OnNext(2)
+      testEnv.next must_== OnNext(3)
+      testEnv.next must_== OnComplete
+      testEnv.isEmptyAfterDelay() must beTrue
+      Await.result(enumDone.future, Duration(5, SECONDS)) must beTrue
+    }
+    "be done enumerating after being cancelled" in {
+      val testEnv = new TestEnv[Int]
+      var enumDone = Promise[Boolean]()
+      val (broadcastEnum, channel) = Concurrent.broadcast[Int]
+      val enum = broadcastEnum.onDoneEnumerating {
+        enumDone.success(true)
+      }
+      val pubr = new EnumeratorPublisher(enum)
+      pubr.subscribe(testEnv.subscriber)
+      testEnv.next must_== OnSubscribe
+      testEnv.request(4)
+      testEnv.next must_== RequestMore(4)
+      testEnv.isEmptyAfterDelay() must beTrue
+      testEnv.cancel()
+      // Element push occurs after cancel, so will not generate an event.
+      // However it is necessary to have an event so that the publisher's
+      // Cont is satisfied. We want to advance the iteratee to pick up the
+      // Done iteratee caused by the cancel.
+      channel.push(0)
+      testEnv.next must_== Cancel
+      testEnv.isEmptyAfterDelay() must beTrue
+      Await.result(enumDone.future, Duration(5, SECONDS)) must beTrue
     }
     "enumerate eof only" in {
       val testEnv = new TestEnv[Int]


### PR DESCRIPTION
This ensures that the underlying enumerator is cleaned up properly.