### PR TITLE
Stop Akka HTTP processing the request body twice

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/Expect100ContinueSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/Expect100ContinueSpec.scala
@@ -34,7 +34,7 @@ trait Expect100ContinueSpec extends PlaySpecification with ServerIntegrationSpec
       responses.length must_== 2
       responses(0).status must_== 100
       responses(1).status must_== 200
-    }.pendingUntilAkkaHttpFixed
+    }
 
     "not read body when expecting 100 continue but action iteratee is done" in withServer(
       EssentialAction(_ => Done(Results.Ok))
@@ -74,6 +74,6 @@ trait Expect100ContinueSpec extends PlaySpecification with ServerIntegrationSpec
         responses(0).status must_== 100
         responses(1).status must_== 200
         responses(2).status must_== 200
-      }.pendingUntilAkkaHttpFixed
+      }
   }
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
@@ -41,7 +41,7 @@ trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSp
       responses.length must_== 2
       responses(0).status must_== 200
       responses(1).status must_== 200
-    }.pendingUntilAkkaHttpFixed
+    }
 
     "gracefully handle early body parser termination" in withServer(EssentialAction { rh =>
       Traversable.takeUpTo[Array[Byte]](20 * 1024) &>> Iteratee.ignore[Array[Byte]].map(_ => Results.Ok)
@@ -56,6 +56,6 @@ trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSp
       responses.length must_== 2
       responses(0).status must_== 200
       responses(1).status must_== 200
-    }.pendingUntilAkkaHttpFixed
+    }
   }
 }


### PR DESCRIPTION
A bit of a silly mistake!