### PR TITLE
Parse non-standard If-Modified-Since date format

### DIFF
--- a/framework/src/play/src/test/scala/play/api/controllers/AssetsInfoSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/controllers/AssetsInfoSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package controllers
+
+import org.specs2.mutable.Specification
+import java.util.Date
+import org.joda.time.format.ISODateTimeFormat
+import org.joda.time.DateTimeZone
+
+object AssetInfoSpec extends Specification {
+
+  "AssetInfo.parseModifiedDate" should {
+
+    def parseAndReformat(s: String): Option[String] = {
+      val parsed: Option[Date] = AssetInfo.parseModifiedDate(s)
+      parsed.map { date =>
+        val format = ISODateTimeFormat.dateTime.withZone(DateTimeZone.UTC)
+        format.print(date.getTime)
+      }
+    }
+
+    "parse date from RFC2616" in {
+      parseAndReformat("Sat, 29 Oct 1994 19:43:31 GMT") must beSome("1994-10-29T19:43:31.000Z")
+    }
+
+    "parse non-standard date without GMT" in {
+      parseAndReformat("Sat, 18 Oct 2014 20:41:26") must beSome("2014-10-18T20:41:26.000Z")
+    }
+
+    "parse date with extra length attribute (IE 9-11)" in {
+      parseAndReformat("Sat, 18 Oct 2014 20:41:26; length=1323") must beSome("2014-10-18T20:41:26.000Z")
+    }
+
+    "parse non-standard date with timezone (Chrome 39/Windows 8.1)" in {
+      parseAndReformat("Wed Jan 07 2015 22:54:20 GMT-0800 (Pacific Standard Time)") must beSome("2015-01-08T06:54:20.000Z")
+    }
+
+    "not parse empty date header" in {
+      parseAndReformat("") must beNone
+    }
+
+  }
+
+}

--- a/framework/src/play/src/test/scala/play/api/controllers/AssetsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/controllers/AssetsSpec.scala
@@ -102,7 +102,7 @@ object AssetsSpec extends Specification {
     "use the unescaped path when finding the last modified date of an asset" in {
       val url = AssetsSpec.getClass.getClassLoader.getResource("file withspace.css")
       val assetInfo = new AssetInfo("file withspace.css", url, None, None)
-      val lastModified = AssetInfo.df.parseDateTime(assetInfo.lastModified.get)
+      val lastModified = AssetInfo.dateFormat.parseDateTime(assetInfo.lastModified.get)
       // If it uses the escaped path, the file won't be found, and so last modified will be 0
       lastModified.toDate.getTime must_!= 0
     }


### PR DESCRIPTION
Use a regex to recognize the date format and discard any extra trailing information. Then use one of two date formats to do the parsing. See #3569.

This handles the non-standard IE trailing attributes and the non-standard Chrome header reported with Windows 8.1.

Cc @gmethvin, @Cody-SDLGov.