### PR TITLE
Add Enumeratees for character encoding and decoding

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/CharEncoding.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/CharEncoding.scala
@@ -1,0 +1,150 @@
+package play.api.libs.iteratee
+
+import java.io.{ ByteArrayOutputStream, StringWriter }
+import java.nio.{ ByteBuffer, CharBuffer }
+import java.nio.charset._
+import play.api.libs.iteratee.Execution.defaultExecutionContext
+import scala.annotation.tailrec
+
+/**
+ * [[Enumeratee]]s for converting chunks of bytes to chunks of chars, and vice-versa.
+ *
+ * These methods can handle cases where characters straddle a chunk boundary, and redistribute the data.
+ * An erroneous encoding or an incompatible decoding causes a [[Step.Error]].
+ */
+object CharEncoding {
+
+  private trait Coder[From, To] extends Enumeratee[From, To] {
+    private type Inner[A] = Iteratee[To, A]
+
+    protected def empty: From
+
+    protected def code(data: From, last: Boolean): Either[CoderResult, (To, From)]
+
+    protected def concat(a: From, b: From): From
+
+    private def step[A](initial: From = empty)(it: Inner[A]): K[From, Inner[A]] = {
+      case in @ Input.El(chars) =>
+        it.pureFlatFold[From, Inner[A]] {
+          case Step.Cont(k) =>
+            code(concat(initial, chars), false).fold({ result =>
+              Error(s"coding error: $result", in)
+            }, {
+              case (bytes, remaining) =>
+                val newIt = Iteratee.flatten(it.feed(Input.El(bytes)))
+                Cont(step(remaining)(newIt))
+            })
+          case _ => Done(it)
+        }(defaultExecutionContext)
+      case in @ Input.Empty =>
+        val newIt = Iteratee.flatten(it.feed(in))
+        Cont(step(initial)(newIt))
+      case in @ Input.EOF =>
+        code(initial, true).fold({ result =>
+          Error(s"coding error: $result", in)
+        }, {
+          case (string, remaining) =>
+            val newIt = Iteratee.flatten(it.feed(Input.El(string)).flatMap(_.feed(in))(defaultExecutionContext))
+            Done(newIt)
+        })
+    }
+
+    def applyOn[A](inner: Inner[A]) = Cont(step()(inner))
+  }
+
+  def decode(charset: Charset): Enumeratee[Array[Byte], String] = new Coder[Array[Byte], String] {
+    protected val empty = Array[Byte]()
+
+    protected def concat(a: Array[Byte], b: Array[Byte]) = a ++ b
+
+    protected def code(bytes: Array[Byte], last: Boolean) = {
+      val decoder = charset.newDecoder
+
+      val byteBuffer = ByteBuffer.wrap(bytes)
+      // at least 2, for UTF-32
+      val charBuffer = CharBuffer.allocate(2 max math.ceil(bytes.length * decoder.averageCharsPerByte).toInt)
+      val out = new StringWriter
+
+      @tailrec
+      def process(charBuffer: CharBuffer): CoderResult = {
+        val result = decoder.decode(byteBuffer, charBuffer, true)
+        out.write(charBuffer.array, 0, charBuffer.position)
+        if (result.isOverflow) {
+          if (charBuffer.position == 0) {
+            // shouldn't happen for most encodings
+            process(CharBuffer.allocate(2 * charBuffer.capacity))
+          } else {
+            charBuffer.clear()
+            process(charBuffer)
+          }
+        } else {
+          result
+        }
+      }
+      val result = process(charBuffer)
+
+      if (result.isUnmappable || last && result.isMalformed) {
+        Left(result)
+      } else {
+        val remaining = if (result.isError) bytes.drop(byteBuffer.position) else empty
+        Right((out.toString, remaining))
+      }
+    }
+  }
+
+  /**
+   * @throws UnsupportedCharsetException
+   */
+  def decode(charset: String): Enumeratee[Array[Byte], String] = decode(Charset.forName(charset))
+
+  def encode(charset: Charset): Enumeratee[String, Array[Byte]] = new Coder[String, Array[Byte]] {
+    protected def empty = ""
+
+    protected def concat(a: String, b: String) = a + b
+
+    protected def code(chars: String, last: Boolean) = {
+      val encoder = charset.newEncoder
+
+      val charBuffer = CharBuffer.wrap(chars)
+      // at least 6, for UTF-8
+      val byteBuffer = ByteBuffer.allocate(6 max math.ceil(chars.length * encoder.averageBytesPerChar).toInt)
+      val out = new ByteArrayOutputStream
+      @tailrec
+      def process(byteBuffer: ByteBuffer): CoderResult = {
+        val result = encoder.encode(charBuffer, byteBuffer, true)
+        out.write(byteBuffer.array, 0, byteBuffer.position)
+        if (result.isOverflow) {
+          if (byteBuffer.position == 0) {
+            // shouldn't happen for most encodings
+            process(ByteBuffer.allocate(2 * byteBuffer.capacity))
+          } else {
+            byteBuffer.clear()
+            process(byteBuffer)
+          }
+        } else {
+          result
+        }
+      }
+      val result = process(byteBuffer)
+      if (result.isUnmappable || last && result.isMalformed) {
+        Left(result)
+      } else {
+        val remaining = if (result.isError) chars.drop(charBuffer.position) else ""
+        val bytes = out.toByteArray
+        val bytesWithoutBom = if (charset.name.startsWith("UTF-") && bytes.length >= 2 && bytes(0) == 0xfe.toByte && bytes(1) == 0xff.toByte) {
+          bytes.drop(2)
+        } else {
+          bytes
+        }
+        Right((bytesWithoutBom, remaining))
+      }
+    }
+
+  }
+
+  /**
+   * @throws UnsupportedCharsetException
+   */
+  def encode(charset: String): Enumeratee[String, Array[Byte]] = encode(Charset.forName(charset))
+
+}

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/CharEncodingSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/CharEncodingSpec.scala
@@ -1,0 +1,240 @@
+package play.api.libs.iteratee
+
+import org.specs2.mutable._
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+object CharEncodingSpec extends Specification {
+
+  "CharEncodingSpec.decode()" should {
+
+    "decode US-ASCII" in {
+      val input = Seq(
+        Array[Byte](0x48, 0x65, 0x6c),
+        Array[Byte](0x6c, 0x6f, 0x20, 0x57),
+        Array[Byte](0x6f, 0x72, 0x6c, 0x64)
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.decode("US-ASCII") |>>> Iteratee.consume[String]()
+      Await.result(result, Duration.Inf) must be equalTo new String(input.flatten.toArray, "US-ASCII")
+    }
+
+    "decode UTF-8" in {
+      val input = Seq(
+        Array[Byte](0x48, 0x65, 0x6c),
+        Array[Byte](0x6c, 0x6f, 0x20, 0x57),
+        Array[Byte](0x6f, 0x72, 0x6c, 0x64)
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.decode("UTF-8") |>>> Iteratee.consume[String]()
+      Await.result(result, Duration.Inf) must be equalTo new String(input.flatten.toArray, "UTF-8")
+    }
+
+    "decode UTF-8 with split characters" in {
+      val input = Seq(
+        Array[Byte](0xe2.toByte),
+        Array[Byte](0x82.toByte),
+        Array[Byte](0xac.toByte),
+        Array[Byte](0xf0.toByte),
+        Array[Byte](0x9f.toByte),
+        Array[Byte](0x82.toByte),
+        Array[Byte](0xA5.toByte)
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.decode("UTF-8") |>>> Iteratee.consume[String]()
+      Await.result(result, Duration.Inf) must be equalTo "\u20ac\ud83c\udca5"
+    }
+
+    "decode UTF-16" in {
+      val input = Seq(
+        Array[Byte](0x00, 0x48, 0x00, 0x65, 0x00, 0x6c),
+        Array[Byte](0x00, 0x6c, 0x00, 0x6f, 0x00, 0x20, 0x00, 0x57),
+        Array[Byte](0x00, 0x6f, 0x00, 0x72, 0x00, 0x6c, 0x00, 0x64)
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.decode("UTF-16") |>>> Iteratee.consume[String]()
+      Await.result(result, Duration.Inf) must be equalTo "Hello World"
+    }
+
+    "decode UTF-16 with split characters" in {
+      val input = Seq(
+        Array[Byte](0x20),
+        Array[Byte](0xac.toByte),
+        Array[Byte](0xd8.toByte),
+        Array[Byte](0x3c),
+        Array[Byte](0xdc.toByte),
+        Array[Byte](0xa5.toByte)
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.decode("UTF-16") |>>> Iteratee.consume[String]()
+      Await.result(result, Duration.Inf) must be equalTo "\u20ac\ud83c\udca5"
+    }
+
+    "decode UTF-32" in {
+      val input = Seq(
+        Array[Byte](0x00, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x65, 0x00, 0x00, 0x00, 0x6c),
+        Array[Byte](0x00, 0x00, 0x00, 0x6c, 0x00, 0x00, 0x00, 0x6f, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x57),
+        Array[Byte](0x00, 0x00, 0x00, 0x6f, 0x00, 0x00, 0x00, 0x72, 0x00, 0x00, 0x00, 0x6c, 0x00, 0x00, 0x00, 0x64)
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.decode("UTF-32") |>>> Iteratee.consume[String]()
+      Await.result(result, Duration.Inf) must be equalTo "Hello World"
+    }
+
+    "decode UTF-32 with split characters" in {
+      val input = Seq(
+        Array[Byte](0x00),
+        Array[Byte](0x00),
+        Array[Byte](0x20),
+        Array[Byte](0xac.toByte),
+        Array[Byte](0x00),
+        Array[Byte](0x01),
+        Array[Byte](0xf0.toByte),
+        Array[Byte](0xa5.toByte)
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.decode("UTF-32") |>>> Iteratee.consume[String]()
+      Await.result(result, Duration.Inf) must be equalTo "\u20ac\ud83c\udca5"
+    }
+
+    "fail on invalid ASCII" in {
+      val input = Seq(
+        Array[Byte](0x80.toByte)
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.decode("US-ASCII") |>>> Iteratee.skipToEof
+      val status = result.map { _ => "success" }.recover { case e => "failure" }
+      Await.result(status, Duration.Inf) must be equalTo "failure"
+    }
+
+    "fail on invalid UTF-8" in {
+      val input = Seq(
+        Array[Byte](0xe2.toByte, 0xe2.toByte, 0xe2.toByte)
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.decode("UTF-8") |>>> Iteratee.skipToEof
+      val status = result.map { _ => "success" }.recover { case e => "failure" }
+      Await.result(status, Duration.Inf) must be equalTo "failure"
+    }
+
+    "fail on invalid UTF-16" in {
+      val input = Seq(
+        Array[Byte](0xd8.toByte, 0x00),
+        Array[Byte](0xd8.toByte, 0x00)
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.decode("UTF-16") |>>> Iteratee.skipToEof
+      val status = result.map { _ => "success" }.recover { case e => "failure" }
+      Await.result(status, Duration.Inf) must be equalTo "failure"
+    }
+
+    "fail on invalid UTF-32" in {
+      val input = Seq(
+        Array[Byte](0x00)
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.decode("UTF-32") |>>> Iteratee.skipToEof
+      val status = result.map { _ => "success" }.recover { case e => "failure" }
+      Await.result(status, Duration.Inf) must be equalTo "failure"
+    }
+
+  }
+
+  "CharEncodingSpec.encode()" should {
+
+    "encode US-ASCII" in {
+      val input = Seq(
+        "Hel",
+        "lo W",
+        "orld"
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.encode("US-ASCII") |>>> Iteratee.consume[Array[Byte]]()
+      Await.result(result, Duration.Inf) must be equalTo input.mkString.getBytes("US-ASCII")
+    }
+
+    "encode UTF-8" in {
+      val input = Seq(
+        "Hel",
+        "lo W",
+        "orld"
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.encode("UTF-8") |>>> Iteratee.consume[Array[Byte]]()
+      Await.result(result, Duration.Inf) must be equalTo input.mkString.getBytes("UTF-8")
+    }
+
+    "encode UTF-8 with split characters" in {
+      val input = Seq(
+        "\u20ac",
+        "\ud83c",
+        "\udca5"
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.encode("UTF-8") |>>> Iteratee.consume[Array[Byte]]()
+      Await.result(result, Duration.Inf) must be equalTo input.mkString.getBytes("UTF-8")
+    }
+
+    "encode UTF-16" in {
+      val input = Seq(
+        "Hel",
+        "lo W",
+        "orld"
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.encode("UTF-16") |>>> Iteratee.consume[Array[Byte]]()
+      Await.result(result, Duration.Inf) must be equalTo input.mkString.getBytes("UTF-16BE")
+    }
+
+    "encode UTF-16 with split characters" in {
+      val input = Seq(
+        "\u20ac",
+        "\ud83c",
+        "\udca5"
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.encode("UTF-16") |>>> Iteratee.consume[Array[Byte]]()
+      Await.result(result, Duration.Inf) must be equalTo input.mkString.getBytes("UTF-16BE")
+    }
+
+    "encode UTF-32" in {
+      val input = Seq(
+        "Hel",
+        "lo W",
+        "orld"
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.encode("UTF-32") |>>> Iteratee.consume[Array[Byte]]()
+      Await.result(result, Duration.Inf) must be equalTo input.mkString.getBytes("UTF-32")
+    }
+
+    "encode UTF-32 with split characters" in {
+      val input = Seq(
+        "\u20ac",
+        "\ud83c",
+        "\udca5"
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.encode("UTF-32") |>>> Iteratee.consume[Array[Byte]]()
+      Await.result(result, Duration.Inf) must be equalTo input.mkString.getBytes("UTF-32")
+    }
+
+    "fail on unmappable ASCII" in {
+      val input = Seq("\u20ac")
+      val result = Enumerator(input: _*) &> CharEncoding.encode("US-ASCII") |>>> Iteratee.skipToEof
+      val status = result.map { _ => "success" }.recover { case e => "failure" }
+      Await.result(status, Duration.Inf) must be equalTo "failure"
+    }
+
+    "fail on invalid Unicode with UTF-8" in {
+      val input = Seq(
+        "\ud83c"
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.encode("UTF-8") |>>> Iteratee.skipToEof
+      val status = result.map { _ => "success" }.recover { case e => "failure" }
+      Await.result(status, Duration.Inf) must be equalTo "failure"
+    }
+
+    "fail on invalid Unicode with UTF-8" in {
+      val input = Seq(
+        "\ud83c"
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.encode("UTF-16") |>>> Iteratee.skipToEof
+      val status = result.map { _ => "success" }.recover { case e => "failure" }
+      Await.result(status, Duration.Inf) must be equalTo "failure"
+    }
+
+    "fail on invalid Unicode with UTF-32" in {
+      val input = Seq(
+        "\ud83c"
+      )
+      val result = Enumerator(input: _*) &> CharEncoding.encode("UTF-32") |>>> Iteratee.skipToEof
+      val status = result.map { _ => "success" }.recover { case e => "failure" }
+      Await.result(status, Duration.Inf) must be equalTo "failure"
+    }
+
+  }
+
+}


### PR DESCRIPTION
While building a few `Enumeratees` I ran into an obvious issue: **text-based formats deal in *characters*, not *bytes*.**

Translating between the two is not easy, as there are dozens of reasonably common encodings.

I made a couple `Enumeratee`s to encode and decode between `Array[Byte]` and `String` (I could have used `Array[Char]` instead of `String`, but the latter is more common in APIs).

They use Java's [CharsetEncoder](http://docs.oracle.com/javase/6/docs/api/java/nio/charset/CharsetEncoder.html) and [CharsetDecoder](http://docs.oracle.com/javase/6/docs/api/java/nio/charset/CharsetDecoder.html) to incrementally encode and decode, handling cases where characters are split across chunks.

This allows for broad support, and now my text-based `Enumeratee`s can be used on any encoding Java understands.

Given the abundance of text-based formats, I believe this is a utility that most writers of `Enumeratees` in the Play framework will quickly find they need.

---

There is one sticky spot, though it probably sounds worse than it actually is: I assume that if two `Array[Byte]`s can be decoded, the decoding of their concatenation is the concatenation of their decodings. Likewise, if two `String`s can be encoded, the encoding of their concatenation is the concatenation of their encodings.

If the `Enumeratee` (1) uses the mutable `CharsetEncoder` and `CharsetDecoder`, (2) processes input without permanently storing it, and (3) is not mutable itself, then I believe this assumption is a necessary one.

To my knowledge, every major encoding follows this, with one exception: the Unicode [BOM](https://en.wikipedia.org/wiki/Byte_order_mark) (byte-order-mark). Specifically, Unicode can have a 0xfeff marker at the beginning indicating byte-order. It's only a problem when decoding strings. Each time a `CharsetEncoder` starts, it can put a BOM. But you can't just concatenate the `Byte[Array]`s of multiple `CharsetEncoder`s together, as this mark is considered invalid anywhere except the beginning. Use of BOM is discouraged (and unncessary) for UTF-8 and UTF-32 and slightly discouraged for UTF-16. But, for example, OpenJDK prepends a BOM onto UTF-16 decodings. There's an ugly bit of code that removes it, that probably needs one final tweak.

---

The `Enumeratee`s follow important guidelines: they're immutable and check whether the inner `Iteratee` is done or not. They have also be designed with performance in mind, so they operate on chunks of input, not individual `Byte`s or `Char`s.

I'm interested in feedback on my approach and whether it would make sense to include in the Play framework.