### PR TITLE
Upgrade to sbteclipse 3.0.0 which has several bug fixes for issues reported by Play users

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -174,7 +174,7 @@ object Dependencies {
     sbtPluginDep("com.typesafe.sbt" % "sbt-twirl" % BuildInfo.sbtTwirlVersion),
     sbtPluginDep("com.typesafe.sbt" % "sbt-play-enhancer" % "1.0.1"),
 
-    sbtPluginDep("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.5.0"),
+    sbtPluginDep("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "3.0.0"),
     sbtPluginDep("com.github.mpeltonen" % "sbt-idea" % "1.6.0"),
     sbtPluginDep("com.typesafe.sbt" % "sbt-native-packager" % BuildInfo.sbtNativePackagerVersion),
 

--- a/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala
@@ -101,7 +101,6 @@ trait PlayEclipse {
         EclipsePlugin.eclipseSettings ++ Seq(
           EclipseKeys.projectFlavor := EclipseProjectFlavor.Scala,
           EclipseKeys.preTasks := Seq(compile in Compile),
-          EclipseKeys.createSrc := EclipseCreateSrc.Default + EclipseCreateSrc.Resource,
           EclipseKeys.classpathTransformerFactories := Seq(addSourcesManaged, addRoutesSources, addTwirlSources)
         )
       case JAVA =>
@@ -109,7 +108,6 @@ trait PlayEclipse {
         EclipsePlugin.eclipseSettings ++ Seq(
           EclipseKeys.projectFlavor := EclipseProjectFlavor.Java,
           EclipseKeys.preTasks := Seq(compile in Compile),
-          EclipseKeys.createSrc := EclipseCreateSrc.Default + EclipseCreateSrc.Resource,
           EclipseKeys.classpathTransformerFactories := Seq(addClassesManaged, addScalaLib)
         )
     }


### PR DESCRIPTION
This fixes several issues:

* conf/ and test/resources/ are now on the Eclipse classpath
* test/resources/ no longer breaks Eclipse project when added to Eclipse classpath
* Eclipse output and SBT output no longer collide by default causing strange build errors