### PR TITLE
Upgrade to sbteclipse 3.0.0 which has several bug fixes for issues reported by Play users

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -160,7 +160,7 @@ object Dependencies {
 
     sbtPluginDep("com.typesafe.sbt" % "sbt-twirl" % "1.0.2"),
 
-    sbtPluginDep("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.4.0"),
+    sbtPluginDep("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "3.0.0"),
     sbtPluginDep("com.github.mpeltonen" % "sbt-idea" % "1.5.1"),
     sbtPluginDep("com.typesafe.sbt" % "sbt-native-packager" % "0.7.4"),
 


### PR DESCRIPTION
This fixes several issues:

* conf/ and test/resources/ are now on the Eclipse classpath (https://github.com/playframework/playframework/issues/1319 https://github.com/playframework/playframework/issues/3604)
* test/resources/ no longer breaks Eclipse project when added to Eclipse classpath. This issues stopped us from addressing the above for quite awhile
* Eclipse output and SBT output no longer collide by default causing strange build errors (https://github.com/playframework/playframework/issues/2904)
* Classpath ordering now more closely matches SBT's (https://github.com/typesafehub/sbteclipse/commit/1d7cd88b5c5119b325263a95b877fa369a52dbc4)

Despite the version bump, there's not a ton of changes beyond these. The change that made it go from 2.x to 3.x was a change I made that sends the Eclipse compilation output to the Eclipse default build directory instead of target/. Sending the output to target/ made extremely weird things happen to your SBT build because SBT and Eclipse would both be compiling to that directory at the same time.

Given the number of bug fixes present for issues affecting Play users and the small number of changes that weren't fixing one of these bugs I think this upgrade should be considered for the 2.3.x branch despite the fact that we wouldn't normally upgrade this library for a minor release.