### PR TITLE
Remove dependency on servlet API

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -64,9 +64,7 @@ object Dependencies {
       .exclude("javassist", "javassist"),
 
     guava,
-    findBugs,
-
-    "org.apache.tomcat" % "tomcat-servlet-api" % "8.0.5") ++
+    findBugs) ++
     specsBuild.map(_ % "test")
 
   val javaTestDeps = Seq(


### PR DESCRIPTION
The dependency is not used by Play. The included API was compiled with Java 7 so it is not compatible with Java 6, which Play 2.3 needs to support.

Perhaps we actually need to keep this dependency, in which case it might be better just to downgrade to version 7.0.57 which is compatible with Java 6.