### PR TITLE
Don't add the scala lib to the Eclipse classpath of a Play Java proj.  Fix #3818

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala
@@ -55,7 +55,7 @@ trait PlayEclipse {
 
     lazy val addScalaLib = new EclipseTransformerFactory[RewriteRule] {
       override def createTransformer(ref: ProjectRef, state: State): Validation[RewriteRule] = {
-        evaluateTask(dependencyClasspath in Runtime, ref, state) map { classpath =>
+        evaluateTask(dependencyClasspath in Compile, ref, state) map { classpath =>
           val scalaLib =
             classpath.find(_.get(moduleID.key).exists(moduleFilter(organization = "org.scala-lang", name = "scala-library"))).map(_.data.getAbsolutePath)
               .getOrElse(throw new RuntimeException("could not find scala-library.jar"))


### PR DESCRIPTION
As explained in the related ticket https://github.com/playframework/playframework/issues/3818, sbteclipse should already be taking care of
adding the scala lib to the Eclipse classpath entries, and therefore the Play
Eclipse sbt plug-in should not need to duplicate the work.

Review by @jsuereth