### PR TITLE
Preserve the order of errors in Form.

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/Form.java
+++ b/framework/src/play-java/src/main/java/play/data/Form.java
@@ -377,7 +377,7 @@ public class Form<T> {
         }
 
         if (result.hasErrors() || result.getGlobalErrorCount() > 0) {
-            Map<String,List<ValidationError>> errors = new HashMap<String,List<ValidationError>>();
+            Map<String,List<ValidationError>> errors = new LinkedHashMap<String,List<ValidationError>>();
             for (FieldError error: result.getFieldErrors()) {
                 String key = error.getObjectName() + "." + error.getField();
                 if (key.startsWith("target.") && rootName == null) {
@@ -426,7 +426,7 @@ public class Form<T> {
                 }
             }
             if (globalError != null) {
-                Map<String,List<ValidationError>> errors = new HashMap<String,List<ValidationError>>();
+                Map<String,List<ValidationError>> errors = new LinkedHashMap<String,List<ValidationError>>();
                 if (globalError instanceof String) {
                     errors.put("", new ArrayList<ValidationError>());
                     errors.get("").add(new ValidationError("", (String)globalError, new ArrayList()));
@@ -443,7 +443,7 @@ public class Form<T> {
                 }
                 return new Form(rootName, backedType, data, errors, None(), groups);
             }
-            return new Form(rootName, backedType, new HashMap<String,String>(data), new HashMap<String,List<ValidationError>>(errors), Some((T)result.getTarget()), groups);
+            return new Form(rootName, backedType, new HashMap<String,String>(data), new LinkedHashMap<String,List<ValidationError>>(errors), Some((T)result.getTarget()), groups);
         }
     }
 


### PR DESCRIPTION
Due to nautre of HashMap, order of errros in Form class was not preserved. Iterating over the errors in scala template would result in different views for different clients.