### PR TITLE
Controller#request2lang is coupled with the i18n API that relies on runtime DI

### DIFF
--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -316,3 +316,36 @@ libraryDependencies += specs2 % Test
 ## HTTP server configuration
 
 Advanced Netty configuration options, that is, options prefixed with `http.netty.option`, must now use the prefix `play.server.netty.option` instead.
+
+## I18n
+
+### Scala
+
+You now need to have an implicit [`Messages`](api/scala/index.html#play.api.i18n.Messages) value instead of just `Lang` in order to use the i18n API. The `Messages` type aggregates a `Lang` and a [`MessagesApi`](api/scala/index.html#play.api.i18n.MessagesApi).
+
+This means that you should change your templates to take an implicit `Messages` parameter instead of `Lang`:
+
+```scala
+@(form: Form[Login])(implicit messages: Messages)
+...
+```
+
+From you controllers you can get such an implicit `Messages` value by mixing the [`play.api.i18n.I18nSupport`](api/scala/index.html#play.api.i18n.I18nSupport) trait in your controller that gives you an implicit `Messages` value as long as there is a `RequestHeader` value in the implicit scope. The `I18nSupport` trait has an abstract member `def messagesApi: MessagesApi` so your code will typically look like the following:
+
+```scala
+class MyController(val messagesApi: MessagesApi) extends I18nSupport {
+  // ...
+}
+```
+
+A simpler migration path is also supported if you want your controller to be still an `object` instead of a `class` or don’t want to use the `I18nSupport` trait. Just add the following import:
+
+```scala
+import play.api.i18n.Messages.Implicits._
+```
+
+This import brings you an implicit `Messages` value as long as there are a `Lang` and an `Application` in the implicit scope (thankfully controllers already provide the `Lang` and you can get the currently running application by importing `play.api.Play.current`).
+
+### Java
+
+The API should be backward compatible with your code using Play 2.3 so there is no migration step. Nevertheless, note that you have to start your Play application before using the Java i18n API. That should always be the case when you run your project, however your test code may not always start your application. Please refer to the corresponding [[documentation page|JavaTest]] to know how to start your application before running your tests.

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaFormHelpers.scala
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaFormHelpers.scala
@@ -3,12 +3,12 @@
  */
 package javaguide.forms
 
-import org.specs2.mutable.Specification
+import play.api.test.{WithApplication, PlaySpecification}
 import play.data.Form
 import javaguide.forms.html.{UserForm, User}
 import java.util
 
-object JavaFormHelpers extends Specification {
+object JavaFormHelpers extends PlaySpecification {
 
   "java form helpers" should {
     {
@@ -17,30 +17,30 @@ object JavaFormHelpers extends Specification {
       u.name = "foo"
       u.emails = util.Arrays.asList("a@a", "b@b")
       val userForm = Form.form(classOf[UserForm]).fill(u)
-      val body = html.helpers(form, userForm).body
       def segment(name: String) = {
+        val body = html.helpers(form, userForm).body
         body.lines.dropWhile(_ != "<span class=\"" + name + "\">").drop(1).takeWhile(_ != "</span>").mkString("\n")
       }
 
-      "allow rendering a form" in {
+      "allow rendering a form" in new WithApplication() {
         val form = segment("form")
         form must contain("<form")
         form must contain("""action="/form"""")
       }
 
-      "allow rendering a form with an id" in {
+      "allow rendering a form with an id" in new WithApplication() {
         val form = segment("form-with-id")
         form must contain("<form")
         form must contain("""id="myForm"""")
       }
 
-      "allow passing extra parameters to an input" in {
+      "allow passing extra parameters to an input" in new WithApplication() {
         val input = segment("extra-params")
         input must contain("""id="email"""")
         input must contain("""size="30"""")
       }
 
-      "allow repeated form fields" in {
+      "allow repeated form fields" in new WithApplication() {
         val input = segment("repeat")
         input must contain("emails.0")
         input must contain("emails.1")
@@ -48,7 +48,7 @@ object JavaFormHelpers extends Specification {
     }
 
     {
-      "allow rendering input fields" in {
+      "allow rendering input fields" in new WithApplication() {
         val form = Form.form(classOf[User])
         val body = html.fullform(form).body
         body must contain("""type="text"""")
@@ -57,7 +57,7 @@ object JavaFormHelpers extends Specification {
         body must contain("""name="password"""")
       }
 
-      "allow custom field constructors" in {
+      "allow custom field constructors" in new WithApplication() {
         val form = Form.form(classOf[User])
         val body = html.withFieldConstructor(form).body
         body must contain("foobar")

--- a/documentation/manual/working/javaGuide/main/i18n/JavaI18N.md
+++ b/documentation/manual/working/javaGuide/main/i18n/JavaI18N.md
@@ -29,7 +29,7 @@ You can also specify the language explicitly:
 String title = Messages.get(new Lang(Lang.forCode("fr")), "home.title")
 ```
 
-> **Note:** If you have a `Request` in the scope, it will provide a default `Lang` value corresponding to the preferred language extracted from the `Accept-Language` header and matching one of the application’s supported languages. You should also add a `Lang` implicit parameter to your template like this: `@()(implicit lang: Lang)`.
+> **Note:** If you have a `Request` in the scope, it will use the preferred language extracted from the `Accept-Language` header and matching one of the application’s supported languages.
 
 ## Use in templates
 ```

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaFieldConstructor.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaFieldConstructor.scala
@@ -4,8 +4,13 @@
 package scalaguide.forms.scalafieldconstructor {
 
 import org.specs2.mutable.Specification
+import play.api.{Environment, Configuration}
+import play.api.i18n.{DefaultLangs, DefaultMessagesApi, Messages}
 
 object ScalaFieldConstructorSpec extends Specification {
+
+  val conf = Configuration.empty
+  implicit val messages: Messages = new DefaultMessagesApi(Environment.simple(), conf, new DefaultLangs(conf)).preferred(Seq.empty)
 
   "field constructors" should {
 

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -3,6 +3,9 @@
  */
 package scalaguide.forms.scalaforms {
 
+import play.api.{Environment, Configuration}
+import play.api.i18n.{DefaultLangs, DefaultMessagesApi, Messages}
+
 import scalaguide.forms.scalaforms.controllers.routes
 
 import play.api.mvc._
@@ -23,6 +26,9 @@ import play.api.data.validation.Constraints._
 
 @RunWith(classOf[JUnitRunner])
 class ScalaFormsSpec extends Specification with Controller {
+
+  val conf = Configuration.empty
+  implicit val messages: Messages = new DefaultMessagesApi(Environment.simple(), conf, new DefaultLangs(conf)).preferred(Seq.empty)
 
   "A scala forms" should {
 
@@ -155,6 +161,8 @@ package controllers {
 
 import views.html._
 import views.html.contact._
+import play.api.i18n.Messages.Implicits._
+import play.api.Play.current
 
 class Application extends Controller {
 

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalafieldconstructor/myFieldConstructorTemplate.scala.html
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalafieldconstructor/myFieldConstructorTemplate.scala.html
@@ -2,11 +2,11 @@
 @(elements: helper.FieldElements)
 
 <div class="@if(elements.hasErrors) {error}">
-    <label for="@elements.id">@elements.label(elements.lang)</label>
+    <label for="@elements.id">@elements.label</label>
     <div class="input">
         @elements.input
-        <span class="errors">@elements.errors(elements.lang).mkString(", ")</span>
-        <span class="help">@elements.infos(elements.lang).mkString(", ")</span>
+        <span class="errors">@elements.errors.mkString(", ")</span>
+        <span class="help">@elements.infos.mkString(", ")</span>
     </div>
 </div>
 @* #form-myfield *@

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalafieldconstructor/userDeclare.scala.html
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalafieldconstructor/userDeclare.scala.html
@@ -1,4 +1,4 @@
-@(myForm: Form[User])
+@(myForm: Form[User])(implicit messages: Messages)
 
 @* #declare-implicit *@
 @implicitField = @{ helper.FieldConstructor(myFieldConstructorTemplate.f) }

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalafieldconstructor/userImport.scala.html
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalafieldconstructor/userImport.scala.html
@@ -1,4 +1,4 @@
-@(myForm: Form[User])
+@(myForm: Form[User])(implicit messages: Messages)
 
 @* #import-myhelper *@
 @import MyHelpers._

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/nested.scala.html
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/nested.scala.html
@@ -1,4 +1,4 @@
-@(userFormNested: Form[UserAddressData])
+@(userFormNested: Form[UserAddressData])(implicit messages: Messages)
 
 @import scalaguide.forms.scalaforms.controllers._
 @import scalaguide.forms.scalaforms.controllers.routes

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/repeat.scala.html
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/repeat.scala.html
@@ -1,4 +1,4 @@
-@(myForm: Form[UserListData])
+@(myForm: Form[UserListData])(implicit messages: Messages)
 
 @import scalaguide.forms.scalaforms.controllers.routes
 

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/user.scala.html
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/user.scala.html
@@ -1,5 +1,5 @@
 @* #form-define *@
-@(userForm: Form[UserData])
+@(userForm: Form[UserData])(implicit messages: Messages)
 @* #form-define *@
 
 @import scalaguide.forms.scalaforms._

--- a/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
+++ b/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
@@ -23,13 +23,17 @@ You can then retrieve messages using the `play.api.i18n.Messages` object:
 val title = Messages("home.title")
 ```
 
-All internationalization API calls take an implicit `play.api.i18n.Lang` argument retrieved from the current scope. You can also specify it explicitly:
+All internationalization API calls take an implicit `play.api.i18n.Messages` argument retrieved from the current scope. This implicit value contains both the language to use and (essentially) the internationalized messages.
 
-```scala
-val title = Messages("home.title")(Lang("fr"))
-```
+The simplest way to get such an implicit value is to use the `I18nSupport` trait. For instance you can use it as follows in your controllers:
 
-> **Note:** If you have an implicit `Request` in the scope, it will provide an implicit `Lang` value corresponding to the preferred language extracted from the `Accept-Language` header and matching one of the application supported languages. You should add a `Lang` implicit parameter to your template like this: `@()(implicit lang: Lang)`.
+@[i18n-support](code/ScalaI18N.scala)
+
+The `I18nSupport` trait gives you an implicit `Messages` value as long as there is a `Lang` or a `RequestHeader` in the implicit scope.
+
+> **Note:** If you have a `RequestHeader` in the implicit scope, it will use the preferred language extracted from the `Accept-Language` header and matching one of the `MessagesApi` supported languages. You should add a `Messages` implicit parameter to your template like this: `@()(implicit messages: Messages)`.
+
+> **Note:** Also, Play “knows” out of the box how to inject a `MessagesApi` value (that uses the `DefaultMessagesApi` implementation), so you can just annotate your controller with the `@javax.inject.Inject` annotation and let Play automatically wire the components for you.
 
 ## Messages format
 

--- a/documentation/manual/working/scalaGuide/main/i18n/code/ScalaI18N.scala
+++ b/documentation/manual/working/scalaGuide/main/i18n/code/ScalaI18N.scala
@@ -8,33 +8,36 @@ import play.api.test._
 
 import play.api._
 import play.api.mvc._
-import play.api.i18n._
-
-import scala.collection.JavaConverters._
+import play.api.i18n.{DefaultLangs, DefaultMessagesApi, Messages, MessagesApi}
 
 @RunWith(classOf[JUnitRunner])
 class ScalaI18nSpec extends PlaySpecification with Controller {
-  lazy val app = FakeApplication(additionalConfiguration = Map(
-    "messages.path" -> "scalaguide/i18n"
-  ))
 
-  "A Scala translation" should {
-    "escape single quotes" in {
-      running(app) {
+//#i18n-support
+  import play.api.i18n.I18nSupport
+  class MyController(val messagesApi: MessagesApi) extends Controller with I18nSupport {
+    // ...
+//#i18n-support
+
+    "A Scala translation" should {
+      "escape single quotes" in {
 //#apostrophe-messages
         Messages("info.error") == "You aren't logged in!"
 //#apostrophe-messages
       }
-    }
 
-    "escape parameter substitution" in {
-      running(app) {
+      "escape parameter substitution" in {
 //#parameter-escaping
         Messages("example.formatting") == "When using MessageFormat, '{0}' is replaced with the first parameter."
 //#parameter-escaping
       }
     }
   }
+
+  val conf = Configuration.from(Map("messages.path" -> "scalaguide/i18n"))
+  val messagesApi = new DefaultMessagesApi(Environment.simple(), conf, new DefaultLangs(conf))
+
+  new MyController(messagesApi)
 
 }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/FormBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/FormBodyParserSpec.scala
@@ -36,6 +36,7 @@ class FormBodyParserSpec extends PlaySpecification {
     }
 
     "allow users to override the error reporting behaviour" in new WithApplication() {
+      import play.api.i18n.Messages.Implicits.applicationMessages
       parse(Json.obj("age" -> "Alice"), BodyParsers.parse.form(userForm, onErrors = (form: Form[User]) => Results.BadRequest(form.errorsAsJson))) must beLeft.which { result =>
         result.header.status must equalTo(BAD_REQUEST)
         val json = contentAsJson(Future.successful(result))

--- a/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
@@ -12,14 +12,17 @@ object MessagesSpec extends PlaySpecification with Controller {
 
   sequential
 
+  implicit val lang = Lang("en-US")
+  import play.api.i18n.Messages.Implicits.applicationMessages
+
   "Messages" should {
     "provide default messages" in new WithApplication() {
-      val msg = Messages("constraint.email")(Lang("en-US"))
+      val msg = Messages("constraint.email")
 
       msg must ===("Email")
     }
     "permit default override" in new WithApplication() {
-      val msg = Messages("constraint.required")(Lang("en-US"))
+      val msg = Messages("constraint.required")
 
       msg must ===("Required!")
     }

--- a/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
+++ b/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
@@ -3,8 +3,6 @@
  */
 package play.core.j
 
-import play.api.mvc._
-
 import scala.util.control.NonFatal
 
 /** Defines a magic helper for Play templates in a Java context. */
@@ -59,5 +57,13 @@ object PlayMagicForJava {
   implicit def requestHeader: play.api.mvc.RequestHeader = {
     play.mvc.Http.Context.Implicit.ctx._requestHeader
   }
+
+  implicit def implicitJavaMessages: play.api.i18n.Messages =
+    try {
+      val jmessages = play.mvc.Http.Context.current().messages()
+      play.api.i18n.Messages(jmessages.lang(), jmessages.messagesApi().scalaApi())
+    } catch {
+      case NonFatal(_) => play.api.i18n.Messages(play.api.i18n.Lang.defaultLang, play.api.i18n.Messages.messagesApiCache(play.api.Play.current))
+    }
 
 }

--- a/framework/src/play-java/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/DynamicFormSpec.scala
@@ -4,8 +4,10 @@
 package play.data
 
 import org.specs2.mutable.Specification
+import play.api.{ Configuration, Environment }
+import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
 import views.html.helper.inputText
-import play.core.j.PlayMagicForJava._
+import play.core.j.PlayMagicForJava.javaFieldtoScalaField
 import views.html.helper.FieldConstructor.defaultField
 import scala.collection.JavaConversions._
 
@@ -13,6 +15,9 @@ import scala.collection.JavaConversions._
  * Specs for Java dynamic forms
  */
 object DynamicFormSpec extends Specification {
+  val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.empty, new DefaultLangs(Configuration.empty))
+  implicit val messages = messagesApi.preferred(Seq.empty)
+
   "a dynamic form" should {
 
     "bind values from a request" in {

--- a/framework/src/play/src/main/java/play/Play.java
+++ b/framework/src/play/src/main/java/play/Play.java
@@ -46,6 +46,6 @@ public class Play {
     }
 
     public static String langCookieName() {
-        return play.api.Play.langCookieName(play.api.Play.current());
+        return play.api.i18n.Messages.Implicits$.MODULE$.applicationMessagesApi(play.api.Play.current()).langCookieName();
     }
 }

--- a/framework/src/play/src/main/java/play/i18n/Messages.java
+++ b/framework/src/play/src/main/java/play/i18n/Messages.java
@@ -23,9 +23,6 @@ import java.util.Locale;
 public class Messages {
 
     // All these methods below will be removed once we get rid of the global state
-
-    private static final Messages$ scalaMessages = Messages$.MODULE$;
-
     private static Lang getLang(){
         Lang lang = null;
         if(play.mvc.Http.Context.current.get() != null) {
@@ -35,6 +32,10 @@ public class Messages {
             lang = new Lang(new play.api.i18n.Lang(defaultLocale.getLanguage(), defaultLocale.getCountry()));
         }
         return lang;
+    }
+
+    private static MessagesApi getMessagesApi() {
+        return play.Play.application().injector().instanceOf(MessagesApi.class);
     }
 
     /**
@@ -78,8 +79,7 @@ public class Messages {
     * @return the formatted message or a default rendering if the key wasn't defined
     */
     public static String get(Lang lang, String key, Object... args) {
-        Buffer<Object> scalaArgs = convertArgsToScalaBuffer(args);
-        return scalaMessages.apply(key, scalaArgs, lang);
+        return getMessagesApi().get(lang, key, args);
     }
 
     /**
@@ -93,9 +93,7 @@ public class Messages {
     * @return the formatted message or a default rendering if the key wasn't defined
     */
     public static String get(Lang lang, List<String> keys, Object... args) {
-        Buffer<String> keyArgs = scala.collection.JavaConverters.asScalaBufferConverter(keys).asScala();
-        Buffer<Object> scalaArgs = convertArgsToScalaBuffer(args);
-        return scalaMessages.apply(keyArgs.toSeq(), scalaArgs, lang);
+        return getMessagesApi().get(lang, keys, args);
     }
 
     /**
@@ -108,8 +106,7 @@ public class Messages {
     * @return the formatted message or a default rendering if the key wasn't defined
     */
     public static String get(String key, Object... args) {
-        Buffer<Object> scalaArgs = convertArgsToScalaBuffer(args);
-        return scalaMessages.apply(key, scalaArgs, getLang());
+        return getMessagesApi().get(getLang(), key, args);
     }
 
     /**
@@ -122,9 +119,7 @@ public class Messages {
     * @return the formatted message or a default rendering if the key wasn't defined
     */
     public static String get(List<String> keys, Object... args) {
-        Buffer<String> keyArgs = scala.collection.JavaConverters.asScalaBufferConverter(keys).asScala();
-        Buffer<Object> scalaArgs = convertArgsToScalaBuffer(args);
-        return scalaMessages.apply(keyArgs.toSeq(), scalaArgs, getLang());
+        return getMessagesApi().get(getLang(), keys, args);
     }
 
     /**
@@ -134,7 +129,7 @@ public class Messages {
     * @return a Boolean
     */
     public static Boolean isDefined(Lang lang, String key) {
-        return scalaMessages.isDefinedAt(key, lang);
+        return getMessagesApi().isDefinedAt(lang, key);
     }
 
     /**
@@ -143,7 +138,7 @@ public class Messages {
     * @return a Boolean
     */
     public static Boolean isDefined(String key) {
-        return scalaMessages.isDefinedAt(key, getLang());
+        return getMessagesApi().isDefinedAt(getLang(), key);
     }
 
     // All these methods are the new API
@@ -160,6 +155,13 @@ public class Messages {
      */
     public Lang lang() {
         return lang;
+    }
+
+    /**
+     * @return The underlying API
+     */
+    public MessagesApi messagesApi() {
+        return messages;
     }
 
     /**

--- a/framework/src/play/src/main/java/play/i18n/MessagesApi.java
+++ b/framework/src/play/src/main/java/play/i18n/MessagesApi.java
@@ -24,6 +24,10 @@ public class MessagesApi {
 
     private final play.api.i18n.MessagesApi messages;
 
+    public play.api.i18n.MessagesApi scalaApi() {
+        return messages;
+    }
+
     @Inject
     public MessagesApi(play.api.i18n.MessagesApi messages) {
         this.messages = messages;

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -13,6 +13,7 @@ import play.api.mvc.RequestHeader;
 import play.i18n.Lang;
 import play.Play;
 import play.i18n.Langs;
+import play.i18n.Messages;
 import play.i18n.MessagesApi;
 
 /**
@@ -117,9 +118,15 @@ public class Http {
             if (lang != null) {
                 return lang;
             } else {
-                return Play.application().injector().instanceOf(MessagesApi.class)
-                        .preferred(request()).lang();
+                return messages().lang();
             }
+        }
+
+        /**
+         * @return the messages for the current lang.
+         */
+        public Messages messages() {
+            return Play.application().injector().instanceOf(MessagesApi.class).preferred(request());
         }
 
         /**
@@ -197,6 +204,13 @@ public class Http {
              */
             public static Lang lang() {
                 return Context.current().lang();
+            }
+
+            /**
+             * @return the messages for the current lang.
+             */
+            public static Messages messages() {
+                return Context.current().messages();
             }
 
             /**

--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -3,6 +3,7 @@
  */
 package play.api
 
+import play.api.i18n.MessagesApi
 import play.utils.Threads
 
 import java.io._
@@ -220,12 +221,6 @@ object Play {
   /**
    * Returns the name of the cookie that can be used to permanently set the user's language.
    */
-  def langCookieName(implicit app: Application): String = {
-    app.configuration.getString("play.modules.i18n.langCookieName").orElse {
-      app.configuration.getString("application.lang.cookie").map { name =>
-        Logger.warn("application.lang.cookie is deprecated, use play.modules.i18n.langCookieName instead")
-        name
-      }
-    }.getOrElse("PLAY_LANG")
-  }
+  def langCookieName(implicit messagesApi: MessagesApi): String =
+    messagesApi.langCookieName
 }

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -223,7 +223,7 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
   /**
    * Returns the form errors serialized as Json.
    */
-  def errorsAsJson(implicit lang: play.api.i18n.Lang): play.api.libs.json.JsValue = {
+  def errorsAsJson(implicit lang: play.api.i18n.Messages): play.api.libs.json.JsValue = {
 
     import play.api.libs.json._
 

--- a/framework/src/play/src/main/scala/play/api/i18n/I18nSupport.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/I18nSupport.scala
@@ -1,0 +1,72 @@
+package play.api.i18n
+
+import play.api.mvc.{ RequestHeader, Result }
+
+/**
+ * Brings a convenient implicit conversion from [[RequestHeader]] to [[Messages]].
+ *
+ * Example:
+ * {{{
+ *   import play.api.i18n.Messages
+ *   class MyController(val messagesApi: MessagesApi) extends ControllerLike with I18nSupport {
+ *     val action = Action { implicit request =>
+ *       Ok(Messages("some.key")) // Uses the client’s preferred language
+ *     }
+ *   }
+ * }}}
+ */
+trait I18nSupport extends I18NSupportLowPriorityImplicits {
+
+  /** The [[MessagesApi]] to use. */
+  def messagesApi: MessagesApi
+
+  /**
+   * @return The preferred [[Messages]] according to the given [[RequestHeader]]
+   */
+  implicit def request2Messages(implicit request: RequestHeader): Messages = messagesApi.preferred(request)
+
+  /**
+   * Adds convenient methods to handle the client-side language
+   */
+  implicit class ResultWithLang(result: Result) {
+
+    /**
+     * Sets the user's language permanently for future requests by storing it in a cookie.
+     *
+     * For example:
+     * {{{
+     * implicit val lang = Lang("fr-FR")
+     * Ok(Messages("hello.world")).withLang(lang)
+     * }}}
+     *
+     * @param lang the language to store for the user
+     * @return the new result
+     */
+    def withLang(lang: Lang): Result =
+      messagesApi.setLang(result, lang)
+
+    /**
+     * Clears the user's language by discarding the language cookie set by withLang
+     *
+     * For example:
+     * {{{
+     * Ok(Messages("hello.world")).clearingLang
+     * }}}
+     *
+     * @return the new result
+     */
+    def clearingLang: Result =
+      messagesApi.clearLang(result)
+
+  }
+
+}
+
+trait I18NSupportLowPriorityImplicits { this: I18nSupport =>
+
+  /**
+   * @return A [[Messages]] value that uses the [[Lang]] found in the implicit scope
+   */
+  implicit def lang2Messages(implicit lang: Lang): Messages = Messages(lang, messagesApi)
+
+}

--- a/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
@@ -3,9 +3,8 @@
  */
 package play.api.mvc
 
-import play.api.http._
-import play.api.i18n.{ Messages, Lang }
-import play.api.Play
+import play.api.http.{ ContentTypes, HeaderNames, HttpProtocol, Status }
+import play.api.i18n.Lang
 
 /**
  * Defines utility methods to generate `Action` and `Results` types.
@@ -46,7 +45,7 @@ trait Controller extends Results with BodyParsers with HttpProtocol with Status 
    * }
    * }}}
    */
-  implicit def request2session(implicit request: RequestHeader) = request.session
+  implicit def request2session(implicit request: RequestHeader): Session = request.session
 
   /**
    * Retrieve the flash scope implicitly from the request.
@@ -59,10 +58,10 @@ trait Controller extends Results with BodyParsers with HttpProtocol with Status 
    * }
    * }}}
    */
-  implicit def request2flash(implicit request: RequestHeader) = request.flash
+  implicit def request2flash(implicit request: RequestHeader): Flash = request.flash
 
-  implicit def request2lang(implicit request: RequestHeader) = {
-    Messages.messagesApi.map(_.preferred(request).lang)
+  implicit def request2lang(implicit request: RequestHeader): Lang = {
+    play.api.Play.maybeApplication.map(app => play.api.i18n.Messages.messagesApiCache(app).preferred(request).lang)
       .getOrElse(request.acceptLanguages.headOption.getOrElse(play.api.i18n.Lang.defaultLang))
   }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/RequestExtractors.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/RequestExtractors.scala
@@ -58,7 +58,7 @@ trait AcceptExtractors {
  * }
  * }}}
  */
-case class Accepting(val mimeType: String) {
+case class Accepting(mimeType: String) {
   def unapply(request: RequestHeader): Boolean = request.accepts(mimeType)
   def unapply(mediaRange: play.api.http.MediaRange): Boolean = mediaRange.accepts(mimeType)
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -3,12 +3,11 @@
  */
 package play.api.mvc
 
+import play.api.i18n.{ MessagesApi, Lang }
 import play.api.libs.iteratee._
 import play.api.http._
 import play.api.http.HeaderNames._
 import play.api.http.HttpProtocol._
-import play.api.{ Application, Play }
-import play.api.i18n.{ Messages, Lang }
 
 import play.core.Execution.Implicits._
 import play.api.libs.concurrent.Execution.defaultContext
@@ -251,34 +250,6 @@ case class Result(header: ResponseHeader, body: Enumerator[Array[Byte]],
   def removingFromSession(keys: String*)(implicit request: RequestHeader): Result =
     withSession(new Session(session.data -- keys))
 
-  /**
-   * Sets the user's language permanently for future requests by storing it in a cookie.
-   *
-   * For example:
-   * {{{
-   * implicit val lang = Lang("fr-FR")
-   * Ok(Messages("hello.world")).withLang(lang)
-   * }}}
-   *
-   * @param lang the language to store for the user
-   * @return the new result
-   */
-  def withLang(lang: Lang)(implicit app: Application): Result =
-    Messages.messagesApiCache(app).setLang(this, lang)
-
-  /**
-   * Clears the user's language by discarding the language cookie set by withLang
-   *
-   * For example:
-   * {{{
-   * Ok(Messages("hello.world")).clearingLang
-   * }}}
-   *
-   * @return the new result
-   */
-  def clearingLang(implicit app: Application): Result =
-    discardingCookies(DiscardingCookie(Play.langCookieName))
-
   override def toString = {
     "Result(" + header + ")"
   }
@@ -331,8 +302,49 @@ object Codec {
 
 }
 
+trait LegacyI18nSupport {
+
+  /**
+   * Adds convenient methods to handle the client-side language.
+   *
+   * This class exists only for backward compatibility.
+   */
+  implicit class ResultWithLang(result: Result)(implicit messagesApi: MessagesApi) {
+
+    /**
+     * Sets the user's language permanently for future requests by storing it in a cookie.
+     *
+     * For example:
+     * {{{
+     * implicit val lang = Lang("fr-FR")
+     * Ok(Messages("hello.world")).withLang(lang)
+     * }}}
+     *
+     * @param lang the language to store for the user
+     * @return the new result
+     */
+    def withLang(lang: Lang): Result =
+      messagesApi.setLang(result, lang)
+
+    /**
+     * Clears the user's language by discarding the language cookie set by withLang
+     *
+     * For example:
+     * {{{
+     * Ok(Messages("hello.world")).clearingLang
+     * }}}
+     *
+     * @return the new result
+     */
+    def clearingLang: Result =
+      messagesApi.clearLang(result)
+
+  }
+
+}
+
 /** Helper utilities to generate results. */
-object Results extends Results {
+object Results extends Results with LegacyI18nSupport {
 
   /** Empty result, i.e. nothing to send. */
   case class EmptyContent()

--- a/framework/src/play/src/main/scala/views/helper/Helpers.scala
+++ b/framework/src/play/src/main/scala/views/helper/Helpers.scala
@@ -9,30 +9,30 @@ import scala.collection.JavaConverters._
  */
 package views.html.helper {
 
-  case class FieldElements(id: String, field: play.api.data.Field, input: Html, args: Map[Symbol, Any], lang: play.api.i18n.Lang) {
+  case class FieldElements(id: String, field: play.api.data.Field, input: Html, args: Map[Symbol, Any], messages: play.api.i18n.Messages) {
 
-    def infos(implicit lang: play.api.i18n.Lang): Seq[String] = {
+    def infos: Seq[String] = {
       args.get('_help).map(m => Seq(m.toString)).getOrElse {
         (if (args.get('_showConstraints) match {
           case Some(false) => false
           case _ => true
         }) {
-          field.constraints.map(c => play.api.i18n.Messages(c._1, c._2: _*)) ++
-            field.format.map(f => play.api.i18n.Messages(f._1, f._2: _*))
+          field.constraints.map(c => messages(c._1, c._2: _*)) ++
+            field.format.map(f => messages(f._1, f._2: _*))
         } else Nil)
       }
     }
 
-    def errors(implicit lang: play.api.i18n.Lang): Seq[String] = {
+    def errors: Seq[String] = {
       (args.get('_error) match {
-        case Some(Some(play.api.data.FormError(_, message, args))) => Some(Seq(play.api.i18n.Messages(message, args: _*)))
+        case Some(Some(play.api.data.FormError(_, message, args))) => Some(Seq(messages(message, args: _*)))
         case _ => None
       }).getOrElse {
         (if (args.get('_showErrors) match {
           case Some(false) => false
           case _ => true
         }) {
-          field.errors.map(e => play.api.i18n.Messages(e.message, e.args: _*))
+          field.errors.map(e => messages(e.message, e.args: _*))
         } else Nil)
       }
     }
@@ -41,14 +41,14 @@ package views.html.helper {
       !errors.isEmpty
     }
 
-    def label(implicit lang: play.api.i18n.Lang): Any = {
-      args.get('_label).getOrElse(play.api.i18n.Messages(field.label))
+    def label: Any = {
+      args.get('_label).getOrElse(messages(field.label))
     }
 
     def hasName: Boolean = args.get('_name).isDefined
 
-    def name(implicit lang: play.api.i18n.Lang): Any = {
-      args.get('_name).getOrElse(play.api.i18n.Messages(field.label))
+    def name: Any = {
+      args.get('_name).getOrElse(messages(field.label))
     }
 
   }

--- a/framework/src/play/src/main/scala/views/helper/checkbox.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/checkbox.scala.html
@@ -10,7 +10,7 @@
  * @param args Set of extra HTML attributes ('''id''' and '''label''' are 2 special arguments).
  * @param handler The field constructor.
  *@
-@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, lang: play.api.i18n.Lang)
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 
 @boxValue = @{ args.toMap.get('value).getOrElse("true") }
 

--- a/framework/src/play/src/main/scala/views/helper/defaultFieldConstructor.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/defaultFieldConstructor.scala.html
@@ -17,15 +17,15 @@
 
 <dl class="@elements.args.get('_class) @if(elements.hasErrors) {error}" id="@elements.args.get('_id).getOrElse(elements.id + "_field")">
     @if(elements.hasName) {
-    <dt>@elements.name(elements.lang)</dt>
+    <dt>@elements.name</dt>
     } else {
-    <dt><label for="@elements.id">@elements.label(elements.lang)</label></dt>
+    <dt><label for="@elements.id">@elements.label</label></dt>
     }
     <dd>@elements.input</dd>
-    @elements.errors(elements.lang).map { error =>
+    @elements.errors.map { error =>
         <dd class="error">@error</dd>
     }
-    @elements.infos(elements.lang).map { info =>
+    @elements.infos.map { info =>
         <dd class="info">@info</dd>
     }
 </dl>

--- a/framework/src/play/src/main/scala/views/helper/input.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/input.scala.html
@@ -1,7 +1,7 @@
 @**
  * Prepare a generic HTML input.
  *@
-@(field: play.api.data.Field, args: (Symbol, Any)* )(inputDef: (String, String, Option[String], Map[Symbol,Any]) => Html)(implicit handler: FieldConstructor, lang: play.api.i18n.Lang)
+@(field: play.api.data.Field, args: (Symbol, Any)* )(inputDef: (String, String, Option[String], Map[Symbol,Any]) => Html)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 
 @id = @{ args.toMap.get('id).map(_.toString).getOrElse(field.id) }
 
@@ -11,6 +11,6 @@
         field,
         inputDef(id, field.name, field.value, args.filter(arg => !arg._1.name.startsWith("_") && arg._1 != 'id).toMap),
         args.toMap,
-        lang
+        messages
     )
 )

--- a/framework/src/play/src/main/scala/views/helper/inputCheckboxGroup.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputCheckboxGroup.scala.html
@@ -16,7 +16,7 @@
 * @param args Set of extra HTML attributes.
 * @param handler The field constructor.
 *@
-@(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, lang: play.api.i18n.Lang)
+@(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 
 @input(field, args.map{ x => if(x._1 == '_label) '_name -> x._2 else x }:_*) { (id, name, value, htmlArgs) =>
   <span class="buttonset" id="@id">

--- a/framework/src/play/src/main/scala/views/helper/inputDate.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputDate.scala.html
@@ -10,7 +10,7 @@
  * @param args Set of extra attributes.
  * @param handler The field constructor.
  *@
-@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, lang: play.api.i18n.Lang)
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     <input type="date" id="@id" name="@name" value="@value" @toHtmlArgs(htmlArgs)/>

--- a/framework/src/play/src/main/scala/views/helper/inputFile.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputFile.scala.html
@@ -10,7 +10,7 @@
  * @param args Set of extra attributes.
  * @param handler The field constructor.
  *@
-@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, lang: play.api.i18n.Lang)
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     <input type="file" id="@id" name="@name" @toHtmlArgs(htmlArgs)/>

--- a/framework/src/play/src/main/scala/views/helper/inputPassword.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputPassword.scala.html
@@ -10,7 +10,7 @@
  * @param args Set of extra attributes.
  * @param handler The field constructor.
  *@
-@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, lang: play.api.i18n.Lang)
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     <input type="password" id="@id" name="@name" @toHtmlArgs(htmlArgs)/>

--- a/framework/src/play/src/main/scala/views/helper/inputRadioGroup.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputRadioGroup.scala.html
@@ -15,7 +15,7 @@
  * @param args Set of extra HTML attributes.
  * @param handler The field constructor.
  *@
-@(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, lang: play.api.i18n.Lang)
+@(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 
 @input(field, args.map{ x => if(x._1 == '_label) '_name -> x._2 else x }:_*) { (id, name, value, htmlArgs) =>
   <span class="buttonset" id="@id">

--- a/framework/src/play/src/main/scala/views/helper/inputText.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputText.scala.html
@@ -10,7 +10,7 @@
  * @param args Set of extra attributes.
  * @param handler The field constructor.
  *@
-@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, lang: play.api.i18n.Lang)
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 
 @inputType = @{ args.toMap.get('type).map(_.toString).getOrElse("text") }
 

--- a/framework/src/play/src/main/scala/views/helper/select.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/select.scala.html
@@ -11,7 +11,7 @@
  * @param args Set of extra attributes ('''_default''' is a special argument).
  * @param handler The field constructor.
  *@
-@(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, lang: play.api.i18n.Lang)
+@(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     @defining( if( htmlArgs.contains('multiple) ) "%s[]".format(name) else name ) { selectName =>

--- a/framework/src/play/src/main/scala/views/helper/textarea.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/textarea.scala.html
@@ -10,7 +10,7 @@
  * @param args Set of extra attributes.
  * @param handler The field constructor.
  *@
-@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, lang: play.api.i18n.Lang)
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     <textarea id="@id" name="@name" @toHtmlArgs(htmlArgs)>@value</textarea>

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -9,8 +9,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext.Implicits._
-import play.api.i18n.Lang
-import play.api.{ FakeApplication, Play }
+import play.api.i18n.{ DefaultLangs, DefaultMessagesApi, Lang }
+import play.api.{ Configuration, Environment, FakeApplication, Play }
 import play.api.http.HeaderNames._
 import play.api.http.Status._
 
@@ -112,7 +112,7 @@ object ResultsSpec extends Specification {
     }
 
     "support clearing a language cookie using clearingLang" in {
-      implicit val app = new FakeApplication()
+      implicit val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.empty, new DefaultLangs(Configuration.empty))
       val cookie = Cookies.decode(Ok.clearingLang.header.headers("Set-Cookie")).head
       cookie.name must_== Play.langCookieName
       cookie.value must_== ""

--- a/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -4,14 +4,17 @@
 package views.html.helper
 
 import org.specs2.mutable.Specification
+import play.api.{ Configuration, Environment }
 import play.api.data.Forms._
 import play.api.data._
-import play.api.i18n.Lang
+import play.api.i18n.{ DefaultLangs, DefaultMessagesApi, Lang }
 import play.twirl.api.Html
 import scala.beans.BeanProperty
 
 object HelpersSpec extends Specification {
   import FieldConstructor.defaultField
+  val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.empty, new DefaultLangs(Configuration.empty))
+  implicit val messages = messagesApi.preferred(Seq.empty)
 
   "@inputText" should {
 


### PR DESCRIPTION
See [here](https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/api/mvc/Controller.scala#L65). It means that you get a runtime exception if you try to get an implicit `Lang` from within an action and if your code does not use a runtime DI mechanism.