### PR TITLE
Fix case sensitivity in Java headers map

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaRequestsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaRequestsSpec.scala
@@ -1,8 +1,6 @@
 package play.it.http
 
-import org.specs2.mutable._
 import org.specs2.mock.Mockito
-import org.mockito._
 
 import play.api.test._
 import play.api.mvc._
@@ -17,6 +15,18 @@ import play.mvc.Http.{ RequestBody, Context }
 class JavaRequestsSpec extends PlaySpecification with Mockito {
 
   "JavaHelpers" should {
+
+    "create a request with case insensitive headers" in {
+      val requestHeader: RequestHeader = FakeRequest().withHeaders("Content-type" -> "application/json")
+      val javaRequest: Http.Request = JavaHelpers.createJavaRequest(requestHeader)
+
+      val ct = javaRequest.getHeader("Content-Type")
+      val headers = javaRequest.headers()
+      ct must_== "application/json"
+      headers.get("content-type") must_== Array(ct)
+      headers.get("Content-Type") must_== Array(ct)
+      javaRequest.getHeader("content-type") must_== ct
+    }
 
     "create a request with a helper that can do cookies" in {
       import scala.collection.JavaConversions._

--- a/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
@@ -199,7 +199,7 @@ class DummyRequest(data: Map[String, Array[String]]) extends play.mvc.Http.Reque
   def accept = List("text/html").asJava
   def acceptedTypes = List(new play.api.http.MediaRange("text", "html", Nil, None, Nil)).asJava
   def accepts(mediaType: String) = false
-  def headers() = new java.util.HashMap[String, Array[String]]()
+  def headers() = new java.util.TreeMap[String, Array[String]](play.core.utils.CaseInsensitiveOrdered)
   val remoteAddress = "127.0.0.1"
   def secure() = false
   def body() = new Http.RequestBody {

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -294,7 +294,7 @@ public class Http {
          * The HTTP version.
          */
         public abstract String version();
-        
+
         /**
          * The client IP address.
          *
@@ -362,7 +362,7 @@ public class Http {
         /**
          * Retrieves all headers.
          *
-         * @return headers
+         * @return a map of of header name to headers with case-insensitive keys
          */
         public abstract Map<String,String[]> headers();
 
@@ -372,19 +372,8 @@ public class Http {
          * @param headerName The name of the header (case-insensitive).
          */
         public String getHeader(String headerName) {
-            String[] headers = null;
-            for (String h: headers().keySet()) {
-                if (headerName.toLowerCase().equals(h.toLowerCase())) {
-                    headers = headers().get(h);
-                    break;
-                }
-            }
-
-            if (headers == null || headers.length == 0) {
-                return null;
-            }
-
-            return headers[0];
+            String[] headers = headers().get(headerName);
+            return headers == null ? null : headers[0];
         }
 
         /**

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -55,7 +55,7 @@ trait JavaHelpers {
 
   /**
    * creates a java request (with an empty body) from a scala RequestHeader
-   * @param request incoming requestHeader
+   * @param req incoming requestHeader
    */
   def createJavaRequest(req: RequestHeader): JRequest = {
     new JRequest {
@@ -76,7 +76,7 @@ trait JavaHelpers {
 
       def body = null
 
-      def headers = req.headers.toMap.map(e => e._1 -> e._2.toArray).asJava
+      def headers = createHeaderMap(req.headers)
 
       def acceptLanguages = req.acceptLanguages.map(new play.i18n.Lang(_)).asJava
 
@@ -151,7 +151,7 @@ trait JavaHelpers {
 
       def body = req.body
 
-      def headers = req.headers.toMap.map(e => e._1 -> e._2.toArray).asJava
+      def headers = createHeaderMap(req.headers)
 
       def acceptLanguages = req.acceptLanguages.map(new play.i18n.Lang(_)).asJava
 
@@ -250,6 +250,12 @@ trait JavaHelpers {
   def toPartialFunction[A, B](f: F.Function[A, B]): PartialFunction[A, B] = new PartialFunction[A, B] {
     def apply(a: A) = f.apply(a)
     def isDefinedAt(x: A) = true
+  }
+
+  private def createHeaderMap(headers: Headers): java.util.Map[String, Array[String]] = {
+    val map = new java.util.TreeMap[String, Array[String]](play.core.utils.CaseInsensitiveOrdered)
+    map.putAll(headers.toMap.mapValues(_.toArray).asJava)
+    map
   }
 
 }

--- a/framework/src/play/src/test/java/play/mvc/CallTest.java
+++ b/framework/src/play/src/test/java/play/mvc/CallTest.java
@@ -2,6 +2,7 @@ package play.mvc;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.List;
 import java.util.Map;
 
@@ -15,7 +16,7 @@ public final class CallTest {
 
     @Test
     public void testHttpAbsoluteURL1() throws Throwable {
-        final TestRequest req = 
+        final TestRequest req =
             new TestRequest("GET", "playframework.com", "/playframework",
                             false, "127.0.0.1", "/v", "/u");
 
@@ -27,33 +28,33 @@ public final class CallTest {
 
     @Test
     public void testHttpAbsoluteURL2() throws Throwable {
-        final TestRequest req = 
+        final TestRequest req =
             new TestRequest("GET", "playframework.com", "/playframework",
                             true, "127.0.0.1", "/v", "/u");
 
         final TestCall call = new TestCall("/url", "GET");
 
         assertEquals("Absolute URL should have HTTP scheme",
-                     call.absoluteURL(req, false), 
+                     call.absoluteURL(req, false),
                      "http://playframework.com/url");
     }
 
     @Test
     public void testHttpAbsoluteURL3() throws Throwable {
-        final TestRequest req = 
+        final TestRequest req =
             new TestRequest("GET", "playframework.com", "/playframework",
                             true, "127.0.0.1", "/v", "/u");
 
         final TestCall call = new TestCall("/url", "GET");
 
         assertEquals("Absolute URL should have HTTP scheme",
-                     call.absoluteURL(false, "typesafe.com"), 
+                     call.absoluteURL(false, "typesafe.com"),
                      "http://typesafe.com/url");
     }
 
     @Test
     public void testHttpsAbsoluteURL1() throws Throwable {
-        final TestRequest req = 
+        final TestRequest req =
             new TestRequest("GET", "playframework.com", "/playframework",
                             true, "127.0.0.1", "/v", "/u");
 
@@ -65,33 +66,33 @@ public final class CallTest {
 
     @Test
     public void testHttpsAbsoluteURL2() throws Throwable {
-        final TestRequest req = 
+        final TestRequest req =
             new TestRequest("GET", "playframework.com", "/playframework",
                             false, "127.0.0.1", "/v", "/u");
 
         final TestCall call = new TestCall("/url", "GET");
 
         assertEquals("Absolute URL should have HTTPS scheme",
-                     call.absoluteURL(req, true), 
+                     call.absoluteURL(req, true),
                      "https://playframework.com/url");
     }
 
     @Test
     public void testHttpsAbsoluteURL3() throws Throwable {
-        final TestRequest req = 
+        final TestRequest req =
             new TestRequest("GET", "playframework.com", "/playframework",
                             false, "127.0.0.1", "/v", "/u");
 
         final TestCall call = new TestCall("/url", "GET");
 
         assertEquals("Absolute URL should have HTTPS scheme",
-                     call.absoluteURL(true, "typesafe.com"), 
+                     call.absoluteURL(true, "typesafe.com"),
                      "https://typesafe.com/url");
     }
 
     @Test
     public void testWebSocketURL1() throws Throwable {
-        final TestRequest req = 
+        final TestRequest req =
             new TestRequest("GET", "playframework.com", "/playframework",
                             false, "127.0.0.1", "/v", "/u");
 
@@ -103,33 +104,33 @@ public final class CallTest {
 
     @Test
     public void testWebSocketURL2() throws Throwable {
-        final TestRequest req = 
+        final TestRequest req =
             new TestRequest("GET", "playframework.com", "/playframework",
                             true, "127.0.0.1", "/v", "/u");
 
         final TestCall call = new TestCall("/url", "GET");
 
         assertEquals("WebSocket URL should have HTTP scheme",
-                     call.webSocketURL(req, false), 
+                     call.webSocketURL(req, false),
                      "ws://playframework.com/url");
     }
 
     @Test
     public void testWebSocketURL3() throws Throwable {
-        final TestRequest req = 
+        final TestRequest req =
             new TestRequest("GET", "playframework.com", "/playframework",
                             true, "127.0.0.1", "/v", "/u");
 
         final TestCall call = new TestCall("/url", "GET");
 
         assertEquals("WebSocket URL should have HTTP scheme",
-                     call.webSocketURL(false, "typesafe.com"), 
+                     call.webSocketURL(false, "typesafe.com"),
                      "ws://typesafe.com/url");
     }
 
     @Test
     public void testSecureWebSocketURL1() throws Throwable {
-        final TestRequest req = 
+        final TestRequest req =
             new TestRequest("GET", "playframework.com", "/playframework",
                             true, "127.0.0.1", "/v", "/u");
 
@@ -141,27 +142,27 @@ public final class CallTest {
 
     @Test
     public void testSecureWebSocketURL2() throws Throwable {
-        final TestRequest req = 
+        final TestRequest req =
             new TestRequest("GET", "playframework.com", "/playframework",
                             false, "127.0.0.1", "/v", "/u");
 
         final TestCall call = new TestCall("/url", "GET");
 
         assertEquals("WebSocket URL should have HTTPS scheme",
-                     call.webSocketURL(req, true), 
+                     call.webSocketURL(req, true),
                      "wss://playframework.com/url");
     }
 
     @Test
     public void testSecureWebSocketURL3() throws Throwable {
-        final TestRequest req = 
+        final TestRequest req =
             new TestRequest("GET", "playframework.com", "/playframework",
                             false, "127.0.0.1", "/v", "/u");
 
         final TestCall call = new TestCall("/url", "GET");
 
         assertEquals("WebSocket URL should have HTTPS scheme",
-                     call.webSocketURL(true, "typesafe.com"), 
+                     call.webSocketURL(true, "typesafe.com"),
                      "wss://typesafe.com/url");
     }
 
@@ -181,10 +182,10 @@ final class TestCookies extends ArrayList<Http.Cookie> implements Http.Cookies {
 }
 
 final class TestRequest extends Http.Request {
-    private final HashMap<String,String[]> hs = 
-        new HashMap<String,String[]>();
+    private final TreeMap<String,String[]> hs =
+        new TreeMap<String,String[]>(play.core.utils.CaseInsensitiveOrdered$.MODULE$);
 
-    private final HashMap<String,String[]> qs = 
+    private final HashMap<String,String[]> qs =
         new HashMap<String,String[]>();
 
     private final TestCookies cs = new TestCookies();
@@ -197,7 +198,7 @@ final class TestRequest extends Http.Request {
     private final String v; // Version
     private final String u; // URI
 
-    public TestRequest(String m, String h, String p, 
+    public TestRequest(String m, String h, String p,
                        boolean s, String ra, String v, String u) {
 
         this.m = m;
@@ -244,7 +245,7 @@ final class TestCall extends Call {
         this.u = u;
         this.m = m;
     }
-    
+
     public String url() { return this.u; }
     public String method() { return this.m; }
 }


### PR DESCRIPTION
Actually ends up being less code if we can assume that the map is case insensitive in our `getHeader` implementation.