### PR TITLE
Correct the BatchSql example in the documentation.  

### DIFF
--- a/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
+++ b/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
@@ -265,9 +265,9 @@ When you need to execute SQL statement several times with different arguments, b
 import anorm.BatchSql
 
 val batch = BatchSql(
-  "INSERT INTO books(title, author) VALUES({title}, {author}", 
+  SQL("INSERT INTO books(title, author) VALUES({title}, {author}"), 
   Seq(Seq[NamedParameter](
-    "title" -> "Play 2 for Scala", "author" -> Peter Hilton"),
+    "title" -> "Play 2 for Scala", "author" -> "Peter Hilton"),
     Seq[NamedParameter]("title" -> "Learning Play! Framework 2",
       "author" -> "Andy Petrella")))
 


### PR DESCRIPTION
It was missing SQL(".........") around the query argument and there was a missing double quote just prior to "Peter Hilton".