### PR TITLE
Fix bug with javascript unbind and transform

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -102,6 +102,7 @@ trait QueryStringBindable[A] {
       self.bind(key, params).map(_.right.map(toB))
     }
     def unbind(key: String, value: B): String = self.unbind(key, toA(value))
+    override def javascriptUnbind: String = self.javascriptUnbind
   }
 }
 


### PR DESCRIPTION
If you had previously defined a custom value for javascriptUnbind then it gets overwritten when doing a transform. This is because the transform function calls `new QueryStringBindable[B]` which sets the javascriptUnbind method to the default `def javascriptUnbind: String = """function(k,v) {return encodeURIComponent(k)+'='+encodeURIComponent(v)}"""`.

This fixes that by passing through the custom value of javascriptUnbind.