### PR TITLE
Use trampoline to avoid Cont.flatMap stack overflows

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Iteratee.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Iteratee.scala
@@ -541,7 +541,7 @@ trait Iteratee[E, +A] {
       }(dec)
       case Step.Cont(k) => {
         implicit val pec = ec.prepare()
-        Cont((in: Input[E]) => k(in).flatMap(f)(pec))
+        Cont((in: Input[E]) => executeIteratee(k(in))(dec).flatMap(f)(pec))
       }
       case Step.Error(msg, e) => Error(msg, e)
     }


### PR DESCRIPTION
Fixes #3855.

The closure inside Iteratee.flatMap could call itself recursively, leading to a StackOverflowError when Cont is flatMapped thousands of times. An unresolved problem is the fact that this closure can still grow so large that it could exhaust memory. This is hard to avoid because there is no easy way in Scala to optimize recursive function composition.