### PR TITLE
Typo in code comment

### DIFF
--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
@@ -92,7 +92,7 @@ class GuiceApplicationLoader(val additionalModules: GuiceModule*) extends Applic
 object GuiceApplicationLoader {
 
   /**
-   * Convert the given bindings Play bindings to a Guice module
+   * Convert the given Play bindings to a Guice module
    */
   private[play] def guiced(bindings: Seq[PlayBinding[_]]): AbstractModule = {
     new AbstractModule {


### PR DESCRIPTION
I don't think "bindings" was meant to be used twice

"Convert the given bindings Play bindings to a Guice module"

https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala#L95

