### PR TITLE
Json DefaultReads/Writes should provide Reads/Writes for relevant JDK8 java.time.*

### DIFF
--- a/documentation/manual/working/scalaGuide/main/json/ScalaJsonInception.md
+++ b/documentation/manual/working/scalaGuide/main/json/ScalaJsonInception.md
@@ -182,7 +182,7 @@ Great power means greater responsability so it's better to discuss all together 
 
 >Please remark that JSON inception just works for structures having `unapply/apply` functions with corresponding input/output types.
 
-Naturally, you can also _incept_ `Writes[T]`and `Format[T]`.
+Naturally, you can also _incept_ `Writes[T]` and `Format[T]`.
 
 ## <a name="writes">Writes[T]</a>
 

--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -4,12 +4,16 @@
 import sbt._
 import Keys._
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
-import com.typesafe.tools.mima.plugin.MimaKeys.{previousArtifact, binaryIssueFilters, reportBinaryIssues}
+import com.typesafe.tools.mima.plugin.MimaKeys.{
+  previousArtifact, binaryIssueFilters, reportBinaryIssues
+}
 import com.typesafe.tools.mima.core._
+
 import com.typesafe.sbt.SbtScalariform.scalariformSettings
-import scala.util.Properties.isJavaAtLeast
+
 import play.twirl.sbt.SbtTwirl
 import play.twirl.sbt.Import.TwirlKeys
+
 import interplay.Omnidoc
 import interplay.Omnidoc.Import.OmnidocKeys
 
@@ -43,10 +47,7 @@ object BuildSettings {
   val buildWithDoc = boolProp("generate.doc")
 
   // Argument for setting size of permgen space or meta space for all forked processes
-  val maxMetaspace = {
-    val space = if (isJavaAtLeast("1.8")) "Metaspace" else "Perm"
-    s"-XX:Max${space}Size=384m"
-  }
+  val maxMetaspace = s"-XX:MaxMetaspaceSize=384m"
 
   def propOr(name: String, value: String): String =
     (sys.props get name) orElse
@@ -243,11 +244,7 @@ object PlayBuild extends Build {
     testBinaryCompatibility = true)
 
   lazy val PlayNettyUtilsProject = PlaySharedJavaProject("Play-Netty-Utils", "play-netty-utils")
-    .settings(javacOptions in (Compile,doc) ++= {
-      // References to the rest of Netty don't work in the code that
-      // we've excised. Disable Javadoc lint checking in Java 8+.
-      if (isJavaAtLeast("1.8")) Seq("-Xdoclint:none") else Seq()
-    })
+    .settings(javacOptions in (Compile,doc) += "-Xdoclint:none")
 
   lazy val PlayProject = PlayRuntimeProject("Play", "play")
     .enablePlugins(SbtTwirl)
@@ -265,8 +262,7 @@ object PlayBuild extends Build {
       BuildLinkProject,
       IterateesProject % "test->test;compile->compile",
       JsonProject,
-      PlayNettyUtilsProject
-    )
+      PlayNettyUtilsProject)
 
   lazy val PlayServerProject = PlayRuntimeProject("Play-Server", "play-server")
     .settings(libraryDependencies ++= playServerDependencies)
@@ -435,12 +431,12 @@ object PlayBuild extends Build {
 
   import RepositoryBuilder._
   lazy val RepositoryProject = Project(
-      "Play-Repository", file("repository"))
+    "Play-Repository", file("repository"))
     .settings(PublishSettings.dontPublishSettings: _*)
     .settings(localRepoCreationSettings:_*)
     .settings(mimaDefaultSettings: _*)
     .settings(
-      localRepoProjectsPublished <<= (publishedProjects map (publishLocal in _)).dependOn,
+    localRepoProjectsPublished <<= (publishedProjects map (publishLocal in _)).dependOn,
       addProjectsToRepository(publishedProjects),
       localRepoArtifacts ++= Seq(
         "org.scala-lang" % "scala-compiler" % buildScalaVersion % "master",
@@ -450,13 +446,13 @@ object PlayBuild extends Build {
         "org.scala-sbt" % "sbt" % buildSbtVersion,
         "org.fusesource.jansi" % "jansi" % "1.11" % "master"
       )
-    )
+  )
 
   lazy val PlayDocsSbtPlugin = PlaySbtPluginProject("Play-Docs-SBT-Plugin", "play-docs-sbt-plugin")
     .enablePlugins(SbtTwirl)
     .settings(
       libraryDependencies ++= playDocsSbtPluginDependencies
-    ).dependsOn(SbtPluginProject)
+  ).dependsOn(SbtPluginProject)
 
   lazy val publishedProjects = Seq[ProjectReference](
     PlayProject,

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/ReadsSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/ReadsSpec.scala
@@ -1,0 +1,339 @@
+package play.api.libs.json
+
+import java.math.BigDecimal
+import java.time.{
+  Clock,
+  Instant,
+  LocalDate,
+  LocalDateTime,
+  ZoneId,
+  ZonedDateTime
+}
+import java.time.format.DateTimeFormatter
+import play.api.data.validation.ValidationError
+
+object ReadsSpec extends org.specs2.mutable.Specification {
+  "JSON Reads" title
+
+  "Local date/time" should {
+    val DefaultReads = implicitly[Reads[LocalDateTime]]
+    import DefaultReads.reads
+
+    val CustomReads1 = Reads.localDateTimeReads("dd/MM/yyyy, HH:mm:ss")
+
+    @inline def dateTime(input: String) =
+      LocalDateTime.parse(input, DateTimeFormatter.ISO_DATE_TIME)
+
+    lazy val correctedReads = Reads.localDateTimeReads(
+      DateTimeFormatter.ISO_DATE_TIME, _.drop(1))
+
+    val CustomReads2 = Reads.localDateTimeReads(
+      DateTimeFormatter.ofPattern("dd/MM/yyyy, HH:mm:ss"), _.drop(2))
+
+    "be successfully read from number" in {
+      reads(JsNumber(BigDecimal valueOf 123L)).
+        aka("read date") must_== JsSuccess(LocalDateTime.ofInstant(
+          Instant.ofEpochMilli(123L), ZoneId.systemDefault))
+    }
+
+    "not be read from invalid string" in {
+      reads(JsString("invalid")) aka "read date" must beLike {
+        case JsError((_, ValidationError(
+          "error.expected.date.isoformat", _) :: Nil) :: Nil) => ok
+      }
+    }
+
+    "be successfully read with default implicit" >> {
+      "from '2011-12-03T10:15:30'" in {
+        reads(JsString("2011-12-03T10:15:30")).
+          aka("read date") must_== JsSuccess(dateTime("2011-12-03T10:15:30"))
+      }
+
+      "from '2011-12-03T10:15:30+01:00' (with TZ offset)" in {
+        reads(JsString("2011-12-03T10:15:30+01:00")) aka "read date" must_== (
+          JsSuccess(dateTime("2011-12-03T10:15:30+01:00")))
+      }
+
+      "from '2011-12-03T10:15:30+01:00[Europe/Paris]' (with time zone)" in {
+        reads(JsString("2011-12-03T10:15:30+01:00[Europe/Paris]")).
+          aka("read date") must_== (
+            JsSuccess(dateTime("2011-12-03T10:15:30+01:00[Europe/Paris]")))
+      }
+    }
+
+    "be successfully read with custom pattern from '03/12/2011, 10:15:30'" in {
+      CustomReads1.reads(JsString("03/12/2011, 10:15:30")).
+        aka("read date") must_== JsSuccess(dateTime("2011-12-03T10:15:30"))
+    }
+
+    "not be read from invalid corrected string" >> {
+      "with default implicit" in {
+        correctedReads.reads(JsString("2011-12-03T10:15:30")) must beLike {
+          case JsError((_, ValidationError(
+            "error.expected.date.isoformat", _) :: Nil) :: Nil) => ok
+        }
+      }
+
+      "with custom formatter" in {
+        CustomReads2.reads(JsString("03/12/2011, 10:15:30")) must beLike {
+          case JsError((_, ValidationError(
+            "error.expected.date.isoformat", _) :: Nil) :: Nil) => ok
+        }
+      }
+    }
+
+    "be successfully read from corrected string" >> {
+      lazy val time = dateTime("2011-12-03T10:15:30")
+
+      "with default implicit" in {
+        correctedReads.reads(JsString("_2011-12-03T10:15:30")).
+          aka("read date") must_== JsSuccess(time)
+      }
+
+      "with custom formatter" in {
+        CustomReads2.reads(JsString("# 03/12/2011, 10:15:30")).
+          aka("read date") must_== JsSuccess(time)
+      }
+    }
+  }
+
+  "Zoned date/time" should {
+    val DefaultReads = implicitly[Reads[ZonedDateTime]]
+    import DefaultReads.reads
+
+    val CustomReads1 = Reads.zonedDateTimeReads("dd/MM/yyyy, HH:mm:ss")
+
+    @inline def dateTime(input: String) = try {
+      ZonedDateTime.parse(input, DateTimeFormatter.ISO_DATE_TIME)
+    } catch {
+      case _: Throwable => LocalDateTime.parse(
+        input, DateTimeFormatter.ISO_DATE_TIME).atZone(ZoneId.systemDefault)
+    }
+
+    lazy val correctedReads = Reads.zonedDateTimeReads(
+      DateTimeFormatter.ISO_DATE_TIME, _.drop(1))
+
+    val CustomReads2 = Reads.zonedDateTimeReads(
+      DateTimeFormatter.ofPattern("dd/MM/yyyy, HH:mm:ss"), _.drop(2))
+
+    "be successfully read from number" in {
+      reads(JsNumber(BigDecimal valueOf 123L)).
+        aka("read date") must_== JsSuccess(ZonedDateTime.ofInstant(
+          Instant.ofEpochMilli(123L), ZoneId.systemDefault))
+    }
+
+    "not be read from invalid string" in {
+      reads(JsString("invalid")) aka "read date" must beLike {
+        case JsError((_, ValidationError(
+          "error.expected.date.isoformat", _) :: Nil) :: Nil) => ok
+      }
+    }
+
+    "be successfully read with default implicit" >> {
+      "from '2011-12-03T10:15:30'" in {
+        reads(JsString("2011-12-03T10:15:30")).
+          aka("read date") must_== JsSuccess(dateTime("2011-12-03T10:15:30"))
+      }
+
+      "from '2011-12-03T10:15:30+01:00' (with TZ offset)" in {
+        reads(JsString("2011-12-03T10:15:30+01:00")) aka "read date" must_== (
+          JsSuccess(dateTime("2011-12-03T10:15:30+01:00")))
+      }
+
+      "from '2011-12-03T10:15:30+01:00[Europe/Paris]' (with time zone)" in {
+        reads(JsString("2011-12-03T10:15:30+01:00[Europe/Paris]")).
+          aka("read date") must_== (
+            JsSuccess(dateTime("2011-12-03T10:15:30+01:00[Europe/Paris]")))
+      }
+    }
+
+    "be successfully read with custom pattern from '03/12/2011, 10:15:30'" in {
+      CustomReads1.reads(JsString("03/12/2011, 10:15:30")).
+        aka("read date") must_== JsSuccess(dateTime("2011-12-03T10:15:30"))
+    }
+
+    "not be read from invalid corrected string" >> {
+      "with default implicit" in {
+        correctedReads.reads(JsString("2011-12-03T10:15:30")) must beLike {
+          case JsError((_, ValidationError(
+            "error.expected.date.isoformat", _) :: Nil) :: Nil) => ok
+        }
+      }
+
+      "with custom formatter" in {
+        CustomReads2.reads(JsString("03/12/2011, 10:15:30")) must beLike {
+          case JsError((_, ValidationError(
+            "error.expected.date.isoformat", _) :: Nil) :: Nil) => ok
+        }
+      }
+    }
+
+    "be successfully read from corrected string" >> {
+      lazy val time = dateTime("2011-12-03T10:15:30")
+
+      "with default implicit" in {
+        correctedReads.reads(JsString("_2011-12-03T10:15:30")).
+          aka("read date") must_== JsSuccess(time)
+      }
+
+      "with custom formatter" in {
+        CustomReads2.reads(JsString("# 03/12/2011, 10:15:30")).
+          aka("read date") must_== JsSuccess(time)
+      }
+    }
+  }
+
+  "Local date" should {
+    val DefaultReads = implicitly[Reads[LocalDate]]
+    import DefaultReads.reads
+
+    val CustomReads1 = Reads.localDateReads("dd/MM/yyyy")
+
+    @inline def date(input: String) =
+      LocalDate.parse(input, DateTimeFormatter.ISO_DATE)
+
+    lazy val correctedReads = Reads.localDateReads(
+      DateTimeFormatter.ISO_DATE, _.drop(1))
+
+    val CustomReads2 = Reads.localDateReads(
+      DateTimeFormatter.ofPattern("dd/MM/yyyy"), _.drop(2))
+
+    "be successfully read from number" in {
+      val d = LocalDate.now(Clock.fixed(
+        Instant.ofEpochMilli(123L), ZoneId.systemDefault))
+
+      reads(JsNumber(BigDecimal valueOf 123L)).
+        aka("read date") must_== JsSuccess(d)
+    }
+
+    "not be read from invalid string" in {
+      reads(JsString("invalid")) aka "read date" must beLike {
+        case JsError((_, ValidationError(
+          "error.expected.date.isoformat", _) :: Nil) :: Nil) => ok
+      }
+    }
+
+    "be successfully read with default implicit from '2011-12-03'" in {
+      reads(JsString("2011-12-03")).
+        aka("read date") must_== JsSuccess(date("2011-12-03"))
+    }
+
+    "be successfully read with custom pattern from '03/12/2011'" in {
+      CustomReads1.reads(JsString("03/12/2011")).
+        aka("read date") must_== JsSuccess(date("2011-12-03"))
+    }
+
+    "not be read from invalid corrected string" >> {
+      "with default implicit" in {
+        correctedReads.reads(JsString("2011-12-03")) must beLike {
+          case JsError((_, ValidationError(
+            "error.expected.date.isoformat", _) :: Nil) :: Nil) => ok
+        }
+      }
+
+      "with custom formatter" in {
+        CustomReads2.reads(JsString("03/12/2011")) must beLike {
+          case JsError((_, ValidationError(
+            "error.expected.date.isoformat", _) :: Nil) :: Nil) => ok
+        }
+      }
+    }
+
+    "be successfully read from corrected string" >> {
+      lazy val d = date("2011-12-03")
+
+      "with default implicit" in {
+        correctedReads.reads(JsString("_2011-12-03")).
+          aka("read date") must_== JsSuccess(d)
+      }
+
+      "with custom formatter" in {
+        CustomReads2.reads(JsString("# 03/12/2011")).
+          aka("read date") must_== JsSuccess(d)
+      }
+    }
+  }
+
+  "Instant" should {
+    val DefaultReads = implicitly[Reads[Instant]]
+    import DefaultReads.reads
+
+    val CustomReads1 = Reads.instantReads("dd/MM/yyyy, HH:mm:ss")
+
+    @inline def instant(input: String): Instant = {
+      val time = LocalDateTime.parse(input, DateTimeFormatter.ISO_DATE_TIME)
+      Instant.parse(s"${time}Z")
+    }
+
+    lazy val correctedReads = Reads.instantReads(
+      DateTimeFormatter.ISO_DATE_TIME, _.drop(1))
+
+    val CustomReads2 = Reads.instantReads(
+      DateTimeFormatter.ofPattern("dd/MM/yyyy, HH:mm:ss"), _.drop(2))
+
+    "be successfully read from number" in {
+      reads(JsNumber(BigDecimal valueOf 123L)).
+        aka("read date") must_== JsSuccess(Instant ofEpochMilli 123L)
+    }
+
+    "not be read from invalid string" in {
+      reads(JsString("invalid")) aka "read date" must beLike {
+        case JsError((_, ValidationError(
+          "error.expected.date.isoformat", _) :: Nil) :: Nil) => ok
+      }
+    }
+
+    "be successfully read with default implicit" >> {
+      "from '2011-12-03T10:15:30'" in {
+        reads(JsString("2011-12-03T10:15:30")).
+          aka("read date") must_== JsSuccess(instant("2011-12-03T10:15:30"))
+      }
+
+      "from '2011-12-03T10:15:30+01:00' (with TZ offset)" in {
+        reads(JsString("2011-12-03T10:15:30+01:00")) aka "read date" must_== (
+          JsSuccess(instant("2011-12-03T10:15:30+01:00")))
+      }
+
+      "from '2011-12-03T10:15:30+01:00[Europe/Paris]' (with time zone)" in {
+        reads(JsString("2011-12-03T10:15:30+01:00[Europe/Paris]")).
+          aka("read date") must_== (
+            JsSuccess(instant("2011-12-03T10:15:30+01:00[Europe/Paris]")))
+      }
+    }
+
+    "be successfully read with custom pattern from '03/12/2011, 10:15:30'" in {
+      CustomReads1.reads(JsString("03/12/2011, 10:15:30")).
+        aka("read date") must_== JsSuccess(instant("2011-12-03T10:15:30"))
+    }
+
+    "not be read from invalid corrected string" >> {
+      "with default implicit" in {
+        correctedReads.reads(JsString("2011-12-03T10:15:30")) must beLike {
+          case JsError((_, ValidationError(
+            "error.expected.date.isoformat", _) :: Nil) :: Nil) => ok
+        }
+      }
+
+      "with custom formatter" in {
+        CustomReads2.reads(JsString("03/12/2011, 10:15:30")) must beLike {
+          case JsError((_, ValidationError(
+            "error.expected.date.isoformat", _) :: Nil) :: Nil) => ok
+        }
+      }
+    }
+
+    "be successfully read from corrected string" >> {
+      lazy val time = instant("2011-12-03T10:15:30")
+
+      "with default implicit" in {
+        correctedReads.reads(JsString("_2011-12-03T10:15:30")).
+          aka("read date") must_== JsSuccess(time)
+      }
+
+      "with custom formatter" in {
+        CustomReads2.reads(JsString("# 03/12/2011, 10:15:30")).
+          aka("read date") must_== JsSuccess(time)
+      }
+    }
+  }
+}

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/WritesSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/WritesSpec.scala
@@ -1,0 +1,130 @@
+package play.api.libs.json
+
+import java.time.{
+  Instant,
+  LocalDateTime,
+  LocalDate,
+  ZonedDateTime,
+  ZoneId
+}
+import java.time.format.DateTimeFormatter
+
+object WritesSpec extends org.specs2.mutable.Specification {
+  "JSON Writes" title
+
+  val testZone = ZoneId.of("UTC")
+
+  "Local date/time" should {
+    val DefaultWrites = implicitly[Writes[LocalDateTime]]
+    import DefaultWrites.writes
+
+    @inline def dateTime(input: String) =
+      LocalDateTime.parse(input, DateTimeFormatter.ISO_DATE_TIME)
+
+    val CustomWrites1 = Writes.
+      temporalWrites[LocalDateTime, String]("dd/MM/yyyy, HH:mm:ss")
+
+    "be written as number" in {
+      Writes.LocalDateTimeNumberWrites.writes(LocalDateTime.ofInstant(
+        Instant.ofEpochMilli(1234567890L), testZone)).
+        aka("written date") must_== JsNumber(BigDecimal valueOf 1234567000L)
+    }
+
+    "be written with default implicit as '2011-12-03T10:15:30'" in {
+      writes(dateTime("2011-12-03T10:15:30")) aka "written date" must_== (
+        JsString("2011-12-03T10:15:30"))
+    }
+
+    "be written with custom pattern as '03/12/2011, 10:15:30'" in {
+      CustomWrites1.writes(dateTime("2011-12-03T10:15:30")).
+        aka("written date") must_== JsString("03/12/2011, 10:15:30")
+    }
+  }
+
+  "Zoned date/time" should {
+    val DefaultWrites = implicitly[Writes[ZonedDateTime]]
+    import DefaultWrites.writes
+
+    @inline def dateTime(input: String) = try {
+      ZonedDateTime.parse(input, DateTimeFormatter.ISO_DATE_TIME)
+    } catch {
+      case _: Throwable => LocalDateTime.parse(
+        input, DateTimeFormatter.ISO_DATE_TIME).atZone(testZone)
+    }
+
+    val CustomWrites1 = Writes.
+      temporalWrites[ZonedDateTime, String]("dd/MM/yyyy, HH:mm:ss")
+
+    "be written as number" in {
+      Writes.ZonedDateTimeNumberWrites.writes(ZonedDateTime.ofInstant(
+        Instant.ofEpochMilli(1234567890L), testZone)).
+        aka("written date") must_== JsNumber(BigDecimal valueOf 1234567890L)
+    }
+
+    "be written with default implicit as '2011-12-03T10:15:30'" in {
+      writes(dateTime("2011-12-03T10:15:30")) aka "written date" must_== (
+        JsString("2011-12-03T10:15:30"))
+    }
+
+    "be written with custom pattern as '03/12/2011, 10:15:30'" in {
+      CustomWrites1.writes(dateTime("2011-12-03T10:15:30")).
+        aka("written date") must_== JsString("03/12/2011, 10:15:30")
+    }
+  }
+
+  "Local date" should {
+    val DefaultWrites = implicitly[Writes[LocalDate]]
+    import DefaultWrites.writes
+
+    @inline def date(input: String) =
+      LocalDate.parse(input, DateTimeFormatter.ISO_DATE)
+
+    val CustomWrites1 = Writes.temporalWrites[LocalDate, String]("dd/MM/yyyy")
+
+    "be written as number" in {
+      Writes.LocalDateNumberWrites.writes(
+        LocalDate ofEpochDay 1234567890L) aka "written date" must_== JsNumber(
+          BigDecimal valueOf 106666665696000000L)
+    }
+
+    "be written with default implicit as '2011-12-03T10:15:30'" in {
+      writes(date("2011-12-03")) aka "written date" must_== JsString(
+        "2011-12-03")
+    }
+
+    "be written with custom pattern as '03/12/2011'" in {
+      CustomWrites1.writes(date("2011-12-03")).
+        aka("written date") must_== JsString("03/12/2011")
+    }
+  }
+
+  "Instant" should {
+    val DefaultWrites = implicitly[Writes[Instant]]
+    import DefaultWrites.writes
+
+    lazy val instant = Instant.parse("2011-12-03T10:15:30Z")
+
+    @inline def format(pattern: String, temporal: Instant) =
+      DateTimeFormatter.ofPattern(pattern).
+        format(LocalDateTime.ofInstant(temporal, ZoneId.systemDefault))
+
+    val customPattern1 = "dd/MM/yyyy, HH:mm:ss"
+    val CustomWrites1 = Writes.temporalWrites[Instant, String](customPattern1)
+
+    "be written as number" in {
+      Writes.InstantNumberWrites.writes(Instant ofEpochMilli 1234567890L).
+        aka("written date") must_== JsNumber(BigDecimal valueOf 1234567890L)
+    }
+
+    "be written with default implicit as '2011-12-03T10:15:30'" in {
+
+      writes(instant) aka "written date" must_== JsString(
+        format("yyyy-MM-dd'T'HH:mm:ss", instant))
+    }
+
+    "be written with custom pattern as '03/12/2011, 10:15:30'" in {
+      CustomWrites1.writes(instant).
+        aka("written date") must_== JsString(format(customPattern1, instant))
+    }
+  }
+}


### PR DESCRIPTION
I would suggest to implement them for:

java.time.LocalDateTime
java.time.LocalDate

Anything else which is relevant by default?

Have them implemented locally and would be willing to provide a pull request.