### PR TITLE
Add Rich Operation to ResultExtractors

### DIFF
--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -360,6 +360,33 @@ trait ResultExtractors {
    * Extracts all Headers of this Result value.
    */
   def headers(of: Future[Result])(implicit timeout: Timeout): Map[String, String] = Await.result(of, timeout.duration).header.headers
+
+  implicit class RickResultExtractors(of: Future[Result]) {
+
+    def contentType(implicit timeout: Timeout): Option[String] = self.contentType(of)
+
+    def charset(implicit timeout: Timeout): Option[String] = self.charset(of)
+
+    def contentAsString(implicit timeout: Timeout): String = self.contentAsString(of)
+
+    def contentAsBytes(implicit timeout: Timeout): Array[Byte] = self.contentAsBytes(of)
+
+    def contentAsJson(implicit timeout: Timeout): JsValue = self.contentAsJson(of)
+
+    def status(implicit timeout: Timeout): Int = self.status(of)
+
+    def cookies(implicit timeout: Timeout): Cookies = self.cookies(of)
+
+    def flash(implicit timeout: Timeout): Flash = self.flash(of)
+
+    def session(implicit timeout: Timeout): Session = self.session(of)
+
+    def redirectLocation(implicit timeout: Timeout): Option[String] = self.redirectLocation(of)
+
+    def header(header: String)(implicit timeout: Timeout): Option[String] = self.header(header, of)
+
+    def headers(implicit timeout: Timeout): Map[String, String] = self.headers(of)
+  }
 }
 
 object Helpers extends PlayRunners

--- a/framework/src/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/framework/src/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -37,7 +37,9 @@ class HelpersSpec extends Specification {
   "contentAsString" should {
 
     "extract the content from Result as String" in {
-      contentAsString(Future.successful(Ok("abc"))) must_== "abc"
+      val result = Future.successful(Ok("abc"))
+      contentAsString(result) must_== "abc"
+      result.contentAsString must_== "abc"
     }
 
     "extract the content from Content as String" in {
@@ -53,11 +55,15 @@ class HelpersSpec extends Specification {
   "contentAsBytes" should {
 
     "extract the content from Result as Bytes" in {
-      contentAsBytes(Future.successful(Ok("abc"))) must_== Array(97, 98, 99)
+      val result = Future.successful(Ok("abc"))
+      contentAsBytes(result) must_== Array(97, 98, 99)
+      result.contentAsBytes must_== Array(97, 98, 99)
     }
 
     "extract the content from chunked Result as Bytes" in {
-      contentAsBytes(Future.successful(Ok.chunked(Enumerator("a", "b", "c")))) must_== Array(97, 98, 99)
+      val result = Future.successful(Ok.chunked(Enumerator("a", "b", "c")))
+      contentAsBytes(result) must_== Array(97, 98, 99)
+      result.contentAsBytes must_== Array(97, 98, 99)
     }
 
     "extract the content from Content as Bytes" in {
@@ -74,7 +80,9 @@ class HelpersSpec extends Specification {
 
     "extract the content from Result as Json" in {
       val jsonResult = Ok("""{"play":["java","scala"]}""").as("application/json")
-      (contentAsJson(Future.successful(jsonResult)) \ "play").as[List[String]] must_== List("java", "scala")
+      val result = Future.successful(jsonResult)
+      (contentAsJson(result) \ "play").as[List[String]] must_== List("java", "scala")
+      (result.contentAsJson \ "play").as[List[String]] must_== List("java", "scala")
     }
 
     "extract the content from Content as Json" in {


### PR DESCRIPTION
it give a flexible way to write test with post operation as:

```scala
val result = Future.successful(Ok("abc"))

contentType(result) // or
result.status

charset(result) // or
result.charset

contentAsString(result) // or
result.contentAsString

contentAsBytes(result) // or
result.contentAsBytes

contentAsJson(result) // or
result.contentAsJson

cookies(result) // or
result.cookies

flash(result) // or
result.flash

session(result) // or
esult.session

redirectLocation(result) // or
result.redirectLocation

header("header",result) // or
result.status

headers(result) // or
result.headers
```