### PR TITLE
Corrected a simple misspelling in the API documentation

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -605,7 +605,7 @@ trait ActionTransformer[-R[_], +P[_]] extends ActionRefiner[R, P] {
  */
 trait ActionFilter[R[_]] extends ActionRefiner[R, R] {
   /**
-   * Determine whether to process a request.  This is the main method than an ActionFilter has to implement.
+   * Determine whether to process a request.  This is the main method that an ActionFilter has to implement.
    * It can decide to immediately intercept the request and return a Result (Some), or continue processing (None).
    *
    * @param request the input request


### PR DESCRIPTION
Fixed "than" in:

  This is the main method <strong>than</strong> an ActionFilter has to implement.

to "that":

  This is the main method <strong>that</strong> an ActionFilter has to implement.