### PR TITLE
Document X-Forwarded-Proto header for nginx

### DIFF
--- a/documentation/manual/detailedTopics/production/HTTPServer.md
+++ b/documentation/manual/detailedTopics/production/HTTPServer.md
@@ -61,7 +61,7 @@ http {
 
   proxy_buffering    off;
   proxy_set_header   X-Real-IP $remote_addr;
-  proxy_set_header   X-Scheme $scheme;
+  proxy_set_header   X-Forwarded-Proto $scheme;
   proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header   Host $http_host;
   proxy_http_version 1.1;


### PR DESCRIPTION
Modified the example nginx reverse proxy config to add an X-Forwarded-Proto header instead of X-Scheme.