### PR TITLE
Clarify usage of i18n.Messages

### DIFF
--- a/documentation/manual/scalaGuide/main/i18n/ScalaI18N.md
+++ b/documentation/manual/scalaGuide/main/i18n/ScalaI18N.md
@@ -29,7 +29,29 @@ All internationalization API calls take an implicit `play.api.i18n.Lang` argumen
 val title = Messages("home.title")(Lang("fr"))
 ```
 
-> **Note:** If you have an implicit `Request` in the scope, it will provide an implicit `Lang` value corresponding to the preferred language extracted from the `Accept-Language` header and matching one of the application supported languages. You should add a `Lang` implicit parameter to your template like this: `@()(implicit lang: Lang)`.
+In order to use the `Lang` value preferred by a browser's useragent string, you must use an implicit `Request` in your `Action` body, and it will provide an implicit `Lang` value corresponding to the preferred language extracted from the `Accept-Language` header and matching one of the application supported languages. 
+
+```scala
+def index() = Action { implicit request =>
+  Ok(Messages("a.localized.message"))
+}
+```
+
+Without the `Request` implicit parameter in your `Action` scope, the default framework language will be supplied by the controller's method signature. Here is code which will always use the default framework language, even if the `conf/application.conf` file contains a line with `application.langs="fr, en,en-US,"`, and the requesting browser supplies only `fr` as its preferred locale: 
+
+```scala
+def index() = Action {
+  Ok(Messages("a.localized.message")) // Without 'implicit request =>' this will always read from the conf/messages file!
+}
+```
+
+To make the `Lang` implicit parameter available to your templates, you should add it to the template function signature. Here is template code which will use the supplied language when calling the `Messages` object: 
+
+```
+@()(implicit lang: Lang)
+
+@Messages("a.localized.message")
+```
 
 ## Messages format
 


### PR DESCRIPTION
It  makes explicit that without an "implicit request =>" component to an Action's body, the
implicit Lang will always be the default rather than the
user-agent-supplied language preference.