### PR TITLE
[WS] Add filter pipeline to WS

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -89,6 +89,12 @@ Here is an example showing how you could stream a large image to a different end
 
 The `largeImage` in the code snippet above is an Akka Streams `Source<ByteString, ?>`.
 
+### Request Filters
+
+You can do additional processing on a WSRequest by adding a request filter.  A request filter is added by extending the [`play.libs.ws.WSRequestFilter`](api/java/play/libs/ws/WSRequestFilter.html) trait, and then adding it to the request with `request.withRequestFilter(filter)`.  
+
+@[ws-request-filter](code/javaguide/ws/JavaWS.java)
+
 ## Processing the Response
 
 Working with the [`WSResponse`](api/java/play/libs/ws/WSResponse.html) is done by applying transformations such as `thenApply` and `thenCompose` to the `CompletionStage`.

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -103,6 +103,25 @@ For example, imagine you have executed a database query that is returning a larg
 
 The `largeImageFromDB` in the code snippet above is an Akka Streams `Source[ByteString, _]`.
 
+### Request Filters
+
+You can do additional processing on a WSRequest by adding a request filter.  A request filter is added by extending the [`play.api.libs.ws.WSRequestFilter`](api/scala/play/api/libs/ws/WSRequestFilter.html) trait, and then adding it to the request with `request.withRequestFilter(filter)`.  
+
+A sample request filter that logs the request in cURL format to SLF4J has been added in [`play.api.libs.ws.ahc.AhcCurlRequestLogger`](api/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.html).
+
+@[curl-logger-filter](code/ScalaWSSpec.scala)
+
+will output:
+
+```
+curl \
+  --verbose \
+  --request PUT \
+ --header 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
+ --data 'key=value' \
+ 'http://localhost:19001/
+```
+
 ## Processing the Response
 
 Working with the [Response](api/scala/play/api/libs/ws/WSResponse.html) is easily done by mapping inside the [Future](http://www.scala-lang.org/api/current/index.html#scala.concurrent.Future).

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -539,5 +539,16 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
       ok
     }
 
+    "use logging" in withSimpleServer { ws =>
+      // #curl-logger-filter
+      ws.url(s"http://localhost:$testServerPort")
+        .withRequestFilter(AhcCurlRequestLogger())
+        .withBody(Map("param1" -> Seq("value1")))
+        .put(Map("key" -> Seq("value")))
+      // #curl-logger-filter
+
+      ok
+    }
+
   }
 }

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
@@ -191,6 +191,14 @@ public interface WSRequest {
      */
     CompletionStage<StreamedResponse> stream();
 
+    /**
+     * Adds a request filter.
+     *
+     * @param filter a tranforming filter.
+     * @return the modified request.
+     */
+    WSRequest withRequestFilter(WSRequestFilter filter);
+
     //-------------------------------------------------------------------------
     // Setters
     //-------------------------------------------------------------------------

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequestExecutor.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequestExecutor.java
@@ -1,0 +1,7 @@
+package play.libs.ws;
+
+import java.util.concurrent.CompletionStage;
+
+public interface WSRequestExecutor {
+    CompletionStage<WSResponse> apply(WSRequest request);
+}

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequestFilter.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequestFilter.java
@@ -1,0 +1,5 @@
+package play.libs.ws;
+
+public interface WSRequestFilter {
+    WSRequestExecutor apply(WSRequestExecutor executor);
+}

--- a/framework/src/play-java-ws/src/test/scala/play/libs/ws/WSSpec.scala
+++ b/framework/src/play-java-ws/src/test/scala/play/libs/ws/WSSpec.scala
@@ -7,23 +7,26 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.{ Result, Action }
 import play.api.mvc.Results._
 import play.api.test._
+import play.libs.ws.ahc.{ AhcWSRequest, AhcWSClient }
+import play.test.WithApplication
 
 object WSSpec extends PlaySpecification {
 
   sequential
 
-  val uploadApp = GuiceApplicationBuilder().routes {
-    case ("POST", "/") =>
-      Action { request =>
-        request.body.asRaw.fold[Result](BadRequest) { raw =>
-          val size = raw.size
-          Ok(s"size=$size")
-        }
-      }
-  }.build()
+  "WS.url().post(InputStream)" should {
 
-  "post(InputStream)" should {
-    "upload the stream" in new WithServer(app = uploadApp, port = 3333) {
+    val uploadApp = FakeApplication(withRoutes = {
+      case ("POST", "/") =>
+        Action { request =>
+          request.body.asRaw.fold[Result](BadRequest) { raw =>
+            val size = raw.size
+            Ok(s"size=$size")
+          }
+        }
+    })
+
+    "uploads the stream" in new WithServer(app = uploadApp, port = 3333) {
       val wsClient = app.injector.instanceOf(classOf[WSClient])
 
       val input = this.getClass.getClassLoader.getResourceAsStream("play/libs/ws/play_full_color.png")
@@ -31,6 +34,36 @@ object WSSpec extends PlaySpecification {
 
       rep.getStatus must ===(200)
       rep.getBody must ===("size=20039")
+    }
+  }
+
+  "withRequestFilter" should {
+
+    class CallbackRequestFilter(callList: scala.collection.mutable.Buffer[Int], value: Int) extends WSRequestFilter {
+      override def apply(executor: WSRequestExecutor): WSRequestExecutor = {
+        callList.append(value)
+        executor
+      }
+    }
+
+    "work with one request filter" in new WithServer() {
+      val client = app.injector.instanceOf(classOf[play.libs.ws.WSClient])
+      val callList = scala.collection.mutable.ArrayBuffer[Int]()
+      val responseFuture = client.url(s"http://example.com:$testServerPort")
+        .withRequestFilter(new CallbackRequestFilter(callList, 1))
+        .get()
+      callList must contain(1)
+    }
+
+    "work with three request filter" in new WithServer() {
+      val client = app.injector.instanceOf(classOf[play.libs.ws.WSClient])
+      val callList = scala.collection.mutable.ArrayBuffer[Int]()
+      val responseFuture = client.url(s"http://localhost:${testServerPort}")
+        .withRequestFilter(new CallbackRequestFilter(callList, 1))
+        .withRequestFilter(new CallbackRequestFilter(callList, 2))
+        .withRequestFilter(new CallbackRequestFilter(callList, 3))
+        .get()
+      callList must containTheSameElementsAs(Seq(1, 2, 3))
     }
   }
 

--- a/framework/src/play-java-ws/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/framework/src/play-java-ws/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -5,6 +5,8 @@ package play.libs.ws.ahc
 
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
+import play.libs.ws.{ WSRequestExecutor, WSRequestFilter }
+import play.test.WithApplication
 
 class AhcWSRequestSpec extends Specification with Mockito {
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -51,6 +51,14 @@ trait WSRequestMagnet {
   def apply(): WSRequest
 }
 
+trait WSRequestExecutor {
+  def execute(request: WSRequest): Future[WSResponse]
+}
+
+trait WSRequestFilter {
+  def apply(next: WSRequestExecutor): WSRequestExecutor
+}
+
 /**
  * Asynchronous API to to query web services, as an http client.
  *
@@ -388,6 +396,11 @@ trait WSRequest {
    * Warning: a stream consumption will be interrupted when this time is reached unless Duration.Inf is set.
    */
   def withRequestTimeout(timeout: Duration): WSRequest
+
+  /**
+   * Adds a filter to the request that can transform the request for subsequent filters.
+   */
+  def withRequestFilter(filter: WSRequestFilter): WSRequest
 
   /**
    * Sets the virtual host to use in this request

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.libs.ws.ahc
+
+import java.nio.charset.StandardCharsets
+
+import org.asynchttpclient.util.HttpUtils
+import org.slf4j.LoggerFactory
+import play.api.libs.ws._
+
+import scala.concurrent.Future
+
+/**
+ * Logs WSRequest and pulls information into Curl format to an SLF4J logger.
+ *
+ * @param logger an SLF4J logger
+ */
+class AhcCurlRequestLogger(logger: org.slf4j.Logger) extends WSRequestFilter with CurlFormat {
+  def apply(executor: WSRequestExecutor): WSRequestExecutor = {
+    new WSRequestExecutor {
+      override def execute(request: WSRequest): Future[WSResponse] = {
+        val ningRequest = request.asInstanceOf[AhcWSRequest]
+        logger.info(toCurl(ningRequest))
+        executor.execute(request)
+      }
+    }
+  }
+}
+
+object AhcCurlRequestLogger {
+
+  private val logger = LoggerFactory.getLogger("play.api.libs.ws.ahc.AhcCurlRequestLogger")
+
+  private val instance = new AhcCurlRequestLogger(logger)
+
+  def apply() = instance
+
+  def apply(logger: org.slf4j.Logger): AhcCurlRequestLogger = {
+    new AhcCurlRequestLogger(logger)
+  }
+}
+
+trait CurlFormat {
+  def toCurl(request: AhcWSRequest): String = {
+    val b = new StringBuilder("curl \\\n")
+
+    // verbose, since it's a fair bet this is for debugging
+    b.append("  --verbose")
+    b.append(" \\\n")
+
+    // method
+    b.append(s"  --request ${request.method}")
+    b.append(" \\\n")
+
+    // headers
+    request.headers.foreach {
+      case (k, values) =>
+        values.foreach { v =>
+          b.append(s"  --header '${quote(k)}: ${quote(v)}'")
+          b.append(" \\\n")
+        }
+    }
+
+    // body (note that this has only been checked for text, not binary)
+    request.getBody.map { body =>
+      val charset = findCharset(request)
+      val bodyString = body.decodeString(charset)
+      // XXX Need to escape any quotes within the body of the string.
+      b.append(s"  --data '${quote(bodyString)}'")
+      b.append(" \\\n")
+    }
+
+    // pull out some underlying values from the request.  This creates a new Request
+    // but should be harmless.
+    val asyncHttpRequest = request.buildRequest()
+    val proxyServer = asyncHttpRequest.getProxyServer
+    if (proxyServer != null) {
+      b.append(s"  --proxy ${proxyServer.getHost}:${proxyServer.getPort}")
+      b.append(" \\\n")
+    }
+
+    // url
+    b.append(s"  '${quote(asyncHttpRequest.getUrl)}'")
+
+    val curlOptions = b.toString()
+    curlOptions
+  }
+
+  protected def findCharset(request: AhcWSRequest): String = {
+    request.contentType.map { ct =>
+      Option(HttpUtils.parseCharset(ct)).getOrElse {
+        StandardCharsets.UTF_8
+      }.name()
+    }.getOrElse(HttpUtils.parseCharset("UTF-8").name())
+  }
+
+  def quote(unsafe: String): String = unsafe.replace("'", "'\\''")
+}

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.libs.ws.ahc
+
+import org.slf4j.Logger
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.mock.Mockito
+import play.api.libs.ws._
+import play.api.test.{ WithServer, WsTestClient, PlaySpecification, WithApplication }
+
+import scala.concurrent.Future
+
+class AhcCurlRequestLoggerSpec extends PlaySpecification
+    with WsTestClient
+    with Mockito
+    with org.specs2.specification.mutable.ExecutionEnvironment {
+
+  def is(implicit ee: ExecutionEnv) = {
+
+    "AhcCurlRequestLogger" should {
+
+      "log a request with custom headers" in new WithServer {
+        val client = wsUrl("/")
+        val logger = mock[Logger]
+
+        val headers = Seq(
+          "accept" -> "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+          "user-agent" -> "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.94 Safari/537.36"
+        )
+
+        val responseFuture = client.withRequestFilter(AhcCurlRequestLogger(logger))
+          .withHeaders(headers: _*)
+          .get()
+        responseFuture must beAnInstanceOf[AhcWSResponse].await
+
+        val curlStatement = s"""curl \\
+                              |  --verbose \\
+                              |  --request GET \\
+                              |  --header 'accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8' \\
+                              |  --header 'user-agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.94 Safari/537.36' \\
+                              |  'http://localhost:$testServerPort/'""".stripMargin
+        there was one(logger).info(curlStatement)
+      }
+
+      "log a request with POST" in new WithServer() {
+        val client = wsUrl("/")
+        val logger = mock[Logger]
+
+        val responseFuture = client.withRequestFilter(AhcCurlRequestLogger(logger))
+          .post(Map("key" -> Seq("value")))
+        responseFuture must beAnInstanceOf[AhcWSResponse].await
+
+        val curlStatement = s"""curl \\
+                              |  --verbose \\
+                              |  --request POST \\
+                              |  --header 'Content-Type: application/x-www-form-urlencoded' \\
+                              |  --data 'key=value' \\
+                              |  'http://localhost:$testServerPort/'""".stripMargin
+        there was one(logger).info(curlStatement)
+      }
+
+      "log a request with POST with an explicit content type" in new WithServer() {
+        val client = wsUrl("/")
+        val logger = mock[Logger]
+        val headers = Seq("Content-Type" -> "text/plain; charset=utf-8")
+
+        val responseFuture = client.withRequestFilter(AhcCurlRequestLogger(logger))
+          .withHeaders(headers: _*)
+          .post("this is plain text")
+        responseFuture must beAnInstanceOf[AhcWSResponse].await
+
+        val curlStatement = s"""curl \\
+                              |  --verbose \\
+                              |  --request POST \\
+                              |  --header 'Content-Type: text/plain; charset=utf-8' \\
+                              |  --data 'this is plain text' \\
+                              |  'http://localhost:$testServerPort/'""".stripMargin
+        there was one(logger).info(curlStatement)
+      }
+
+      "log a query string" in new WithServer() {
+        val client = wsUrl("/")
+        val logger = mock[Logger]
+        val requestLogger = AhcCurlRequestLogger(logger)
+
+        val responseFuture = client.withRequestFilter(AhcCurlRequestLogger(logger))
+          .withQueryString("search" -> "&?$HOME'")
+          .get()
+        responseFuture must beAnInstanceOf[AhcWSResponse].await
+
+        val curlStatement = s"""curl \\
+                              |  --verbose \\
+                              |  --request GET \\
+                              |  'http://localhost:$testServerPort/?search=%26%3F%24HOME%27'""".stripMargin
+        there was one(logger).info(curlStatement)
+      }
+
+      "log a request with POST with a hanging quote" in new WithServer() {
+        val client = wsUrl("/")
+        val logger = mock[Logger]
+        val requestLogger = AhcCurlRequestLogger(logger)
+        val headers = Seq(
+          "Content-Type" -> "text/plain; charset=utf-8"
+        )
+
+        val responseFuture = client.withRequestFilter(AhcCurlRequestLogger(logger))
+          .withHeaders(headers: _*)
+          .post("this is ' text with a hanging quote")
+        responseFuture must beAnInstanceOf[AhcWSResponse].await
+
+        val curlStatement = s"""curl \\
+                              |  --verbose \\
+                              |  --request POST \\
+                              |  --header 'Content-Type: text/plain; charset=utf-8' \\
+                              |  --data 'this is '\\'' text with a hanging quote' \\
+                              |  'http://localhost:$testServerPort/'""".stripMargin
+
+        there was one(logger).info(curlStatement)
+      }
+
+      "log a request with PUT" in new WithServer {
+        val client = wsUrl("/")
+        val logger = mock[Logger]
+
+        val responseFuture = client.withRequestFilter(AhcCurlRequestLogger(logger))
+          .withBody(Map("param1" -> Seq("value1")))
+          .put(Map("key" -> Seq("value")))
+        responseFuture must beAnInstanceOf[AhcWSResponse].await
+
+        val curlStatement = s"""curl \\
+                              |  --verbose \\
+                              |  --request PUT \\
+                              |  --header 'Content-Type: application/x-www-form-urlencoded' \\
+                              |  --data 'key=value' \\
+                              |  'http://localhost:$testServerPort/'""".stripMargin
+
+        there was one(logger).info(curlStatement)
+      }
+      //
+      //      "log a request with a proxy" in new WithServer {
+      //        val client = wsUrl("/")
+      //        val proxy = DefaultWSProxyServer(host = "localhost", port = 8080)
+      //        val logger = mock[Logger]
+      //        val requestLogger = AhcCurlRequestLogger(logger)
+      //
+      //        val responseFuture = client.withRequestFilter(AhcCurlRequestLogger(logger))
+      //          .withProxyServer(proxy)
+      //          .get()
+      //        responseFuture must beAnInstanceOf[AhcWSResponse].await
+      //
+      //        val curlStatement = s"""curl \\
+      //                              |  --verbose \\
+      //                              |  --request GET \\
+      //                              |  --proxy localhost:8080 \\
+      //                              |  'http://localhost:$testServerPort/'""".stripMargin
+      //
+      //        there was one(logger).info(curlStatement)
+      //      }
+    }
+  }
+
+}


### PR DESCRIPTION
This is a first pass at https://github.com/playframework/playframework/issues/2932

The idea is that requests that seem to go wrong can have a request logger attached to them which has access to the WSRequest.  From there, it should be pretty easy to write a Curl logger.

```
val logger = new WSRequestLogger {
    def log(request: WSRequest): Unit = {
      Console.println(s"request = $request")
  }
}
WS.url("http://playframework.com").withRequestLogger(logger).get()
```