### PR TITLE
Use Akka HTTP's HttpEntity.empty when Content-Length is 0

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -174,11 +174,18 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
           data = dataSource(enum)
         ))
       case ServerResultUtils.StreamWithKnownLength(enum) =>
-        Right(HttpEntity.Default(
-          contentType = convertedHeaders.contentType,
-          contentLength = convertedHeaders.contentLength.get,
-          data = dataSource(enum)
-        ))
+        convertedHeaders.contentLength.get match {
+          case 0 =>
+            Right(HttpEntity.empty(
+              contentType = convertedHeaders.contentType
+            ))
+          case contentLength =>
+            Right(HttpEntity.Default(
+              contentType = convertedHeaders.contentType,
+              contentLength = contentLength,
+              data = dataSource(enum)
+            ))
+        }
       case ServerResultUtils.StreamWithStrictBody(body) =>
         Right(HttpEntity.Strict(
           contentType = convertedHeaders.contentType,

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
@@ -188,7 +188,7 @@ trait AssetsSpec extends PlaySpecification
 
       result.status must_== OK
       result.body must beEmpty
-    }.pendingUntilAkkaHttpFixed
+    }
 
     "return 404 for files that don't exist" in withServer {
       val result = await(wsUrl("/nosuchfile.txt").get())


### PR DESCRIPTION
Akka HTTP doesn't let you construct HTTP entities with a streamed body and a Content-Length of 0. A special constructor needs to be used.