### PR TITLE
JsUndefined should not be a JsValue

### DIFF
--- a/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonCombinatorsSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonCombinatorsSpec.scala
@@ -11,7 +11,7 @@ import org.specs2.runner.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ScalaJsonCombinatorsSpec extends Specification {
-  
+
   val sampleJson = {
     //#sample-json
       import play.api.libs.json._
@@ -37,7 +37,7 @@ class ScalaJsonCombinatorsSpec extends Specification {
       //#sample-json
       json
   }
-  
+
   object SampleModel {
     //#sample-model
     case class Location(lat: Double, long: Double)
@@ -47,160 +47,160 @@ class ScalaJsonCombinatorsSpec extends Specification {
   }
 
   "Scala JSON" should {
-    
+
     "allow using JsPath" in {
-      
+
       //#jspath-define
       import play.api.libs.json._
-      
+
       //###replace: val json = { ... }
       val json: JsValue = sampleJson
-      
+
       // Simple path
       val latPath = JsPath \ "location" \ "lat"
-      
+
       // Recursive path
       val namesPath = JsPath \\ "name"
-      
+
       // Indexed path
       val firstResidentPath = (JsPath \ "residents")(0)
       //#jspath-define
-      
+
       //#jspath-define-alias
       val longPath = __ \ "location" \ "long"
       //#jspath-define-alias
-      
+
       //#jspath-traverse
       val lat: List[JsValue] = latPath(json)
       // List(JsNumber(51.235685))
       //#jspath-traverse
-      
+
       //val name = (JsPath \ "name").read[String] and (JsPath \ "location").read[Int]
       latPath.toString === "/location/lat"
       namesPath.toString === "//name"
       firstResidentPath.toString === "/residents(0)"
     }
-    
+
     "allow creating simple Reads" in {
-      
+
       //#reads-imports
       import play.api.libs.json._ // JSON library
       import play.api.libs.json.Reads._ // Custom validation helpers
       import play.api.libs.functional.syntax._ // Combinator syntax
       //#reads-imports
-      
+
       //###replace: val json = { ... }
       val json: JsValue = sampleJson
-      
+
       //#reads-simple
       val nameReads: Reads[String] = (JsPath \ "name").read[String]
       //#reads-simple
-      
+
       json.validate(nameReads) must beLike {case x: JsSuccess[String] =>  x.get === "Watership Down"}
     }
-    
+
     "allow creating complex Reads" in {
       import SampleModel._
-      
+
       import play.api.libs.json._
       import play.api.libs.functional.syntax._
-      
+
       //###replace: val json = { ... }
       val json: JsValue = sampleJson
-      
+
       //#reads-complex-builder
-      val locationReadsBuilder = 
-        (JsPath \ "lat").read[Double] and 
+      val locationReadsBuilder =
+        (JsPath \ "lat").read[Double] and
         (JsPath \ "long").read[Double]
       //#reads-complex-builder
-      
+
       //#reads-complex-buildertoreads
       implicit val locationReads = locationReadsBuilder.apply(Location.apply _)
       //#reads-complex-buildertoreads
-      
+
       val locationResult = (json \ "location").validate[Location]
       locationResult must beLike {case x: JsSuccess[Location] =>  x.get.lat === 51.235685}
     }
-    
+
     "allow creating complex Reads in a single statement" in {
       import SampleModel._
-      
+
       import play.api.libs.json._
       import play.api.libs.functional.syntax._
-      
+
       //###replace: val json = { ... }
       val json: JsValue = sampleJson
-      
+
       //#reads-complex-statement
       implicit val locationReads: Reads[Location] = (
         (JsPath \ "lat").read[Double] and
         (JsPath \ "long").read[Double]
       )(Location.apply _)
       //#reads-complex-statement
-      
+
       val locationResult = (json \ "location").validate[Location]
       locationResult must beLike {case x: JsSuccess[Location] =>  x.get.lat === 51.235685}
     }
-    
+
     "allow validation with Reads" in {
       import SampleModel._
-      
+
       import play.api.libs.json._
       import play.api.libs.json.Reads._
       import play.api.libs.functional.syntax._
-      
+
       //#reads-validation-simple
       //###replace: val json = { ... }
       val json: JsValue = sampleJson
-      
+
       val nameReads: Reads[String] = (JsPath \ "name").read[String]
-      
+
       val nameResult: JsResult[String] = json.validate[String](nameReads)
-      
+
       nameResult match {
         case s: JsSuccess[String] => println("Name: " + s.get)
-        case e: JsError => println("Errors: " + JsError.toFlatJson(e).toString()) 
+        case e: JsError => println("Errors: " + JsError.toFlatJson(e).toString())
       }
       //#reads-validation-simple
       nameResult must beLike {case x: JsSuccess[String] =>  x.get === "Watership Down"}
-      
+
       //#reads-validation-custom
-      val improvedNameReads = 
+      val improvedNameReads =
         (JsPath \ "name").read[String](minLength[String](2))
       //#reads-validation-custom
       json.validate[String](improvedNameReads) must beLike {case x: JsSuccess[String] =>  x.get === "Watership Down"}
-      
+
     }
-    
+
     "allow creating Reads for model" in {
       import SampleModel._
-      
+
       //#reads-model
       import play.api.libs.json._
       import play.api.libs.json.Reads._
       import play.api.libs.functional.syntax._
-      
+
       implicit val locationReads: Reads[Location] = (
         (JsPath \ "lat").read[Double](min(-90.0) keepAnd max(90.0)) and
         (JsPath \ "long").read[Double](min(-180.0) keepAnd max(180.0))
       )(Location.apply _)
-      
+
       implicit val residentReads: Reads[Resident] = (
         (JsPath \ "name").read[String](minLength[String](2)) and
         (JsPath \ "age").read[Int](min(0) keepAnd max(150)) and
         (JsPath \ "role").readNullable[String]
       )(Resident.apply _)
-      
+
       implicit val placeReads: Reads[Place] = (
         (JsPath \ "name").read[String](minLength[String](2)) and
         (JsPath \ "location").read[Location] and
         (JsPath \ "residents").read[Seq[Resident]]
       )(Place.apply _)
-      
-      
+
+
       //###replace: val json = { ... }
       val json: JsValue = sampleJson
-      
+
       json.validate[Place] match {
         case s: JsSuccess[Place] => {
           val place: Place = s.get
@@ -211,35 +211,35 @@ class ScalaJsonCombinatorsSpec extends Specification {
         }
       }
       //#reads-model
-      
+
       json.validate[Place] must beLike {case x: JsSuccess[Place] =>  x.get.name === "Watership Down"}
     }
-    
+
     "allow creating Writes for model" in {
       import SampleModel._
-      
+
       //#writes-model
       import play.api.libs.json._
       import play.api.libs.functional.syntax._
-      
+
       implicit val locationWrites: Writes[Location] = (
         (JsPath \ "lat").write[Double] and
         (JsPath \ "long").write[Double]
       )(unlift(Location.unapply))
-      
+
       implicit val residentWrites: Writes[Resident] = (
         (JsPath \ "name").write[String] and
         (JsPath \ "age").write[Int] and
         (JsPath \ "role").writeNullable[String]
       )(unlift(Resident.unapply))
-      
+
       implicit val placeWrites: Writes[Place] = (
         (JsPath \ "name").write[String] and
         (JsPath \ "location").write[Location] and
         (JsPath \ "residents").write[Seq[Resident]]
       )(unlift(Place.unapply))
-      
-      
+
+
       val place = Place(
         "Watership Down",
         Location(51.235685, -1.309197),
@@ -248,36 +248,36 @@ class ScalaJsonCombinatorsSpec extends Specification {
           Resident("Bigwig", 6, Some("Owsla"))
         )
       )
-      
+
       val json = Json.toJson(place)
       //#writes-model
-      
+
       val some = (JsPath \ "lat").write[Double] and (JsPath \ "long").write[Double]
       val placeSome = Place.unapply(place)
-      
-      json \ "name" === JsString("Watership Down")
+
+      (json \ "name").get === JsString("Watership Down")
     }
-    
+
     "allow creating Reads/Writes for recursive types"  in {
-      
+
       import play.api.libs.json._
       import play.api.libs.json.Reads._
       import play.api.libs.functional.syntax._
-      
+
       //#reads-writes-recursive
       case class User(name: String, friends: Seq[User])
-      
+
       implicit lazy val userReads: Reads[User] = (
         (__ \ "name").read[String] and
         (__ \ "friends").lazyRead(Reads.seq[User](userReads))
       )(User)
-      
+
       implicit lazy val userWrites: Writes[User] = (
         (__ \ "name").write[String] and
         (__ \ "friends").lazyWrite(Writes.seq[User](userWrites))
       )(unlift(User.unapply))
       //#reads-writes-recursive
-      
+
       // Use Reads for JSON -> model
       val json: JsValue = Json.parse("""
       {
@@ -293,34 +293,34 @@ class ScalaJsonCombinatorsSpec extends Specification {
       """)
       val userResult = json.validate[User]
       userResult must beLike {case x: JsSuccess[User] =>  x.get.name === "Fiver"}
-      
+
       // Use Writes for model -> JSON
       val jsonFromUser = Json.toJson(userResult.get)
       (jsonFromUser \ "name").as[String] === "Fiver"
     }
-    
+
     "allow creating Format from components" in {
       import SampleModel._
-      
+
       import play.api.libs.json._
       import play.api.libs.json.Reads._
       import play.api.libs.functional.syntax._
-      
+
       //#format-components
       val locationReads: Reads[Location] = (
         (JsPath \ "lat").read[Double](min(-90.0) keepAnd max(90.0)) and
         (JsPath \ "long").read[Double](min(-180.0) keepAnd max(180.0))
       )(Location.apply _)
-      
+
       val locationWrites: Writes[Location] = (
         (JsPath \ "lat").write[Double] and
         (JsPath \ "long").write[Double]
       )(unlift(Location.unapply))
-      
+
       implicit val locationFormat: Format[Location] =
         Format(locationReads, locationWrites)
       //#format-components
-      
+
       // Use Reads for JSON -> model
       val json: JsValue = Json.parse("""
       {
@@ -329,27 +329,27 @@ class ScalaJsonCombinatorsSpec extends Specification {
       }
       """)
       val location = json.validate[Location].get
-      location ===  Location(51.235685,-1.309197) 
-      
+      location ===  Location(51.235685,-1.309197)
+
       // Use Writes for model -> JSON
       val jsonFromLocation = Json.toJson(location)
       (jsonFromLocation \ "lat").as[Double] === 51.235685
     }
-    
+
     "allow creating Format from combinators" in {
       import SampleModel._
-      
+
       import play.api.libs.json._
       import play.api.libs.json.Reads._
       import play.api.libs.functional.syntax._
-      
+
       //#format-combinators
       implicit val locationFormat: Format[Location] = (
         (JsPath \ "lat").format[Double](min(-90.0) keepAnd max(90.0)) and
         (JsPath \ "long").format[Double](min(-180.0) keepAnd max(180.0))
       )(Location.apply, unlift(Location.unapply))
       //#format-combinators
-      
+
       // Use Reads for JSON -> model
       val json: JsValue = Json.parse("""
       {
@@ -358,13 +358,13 @@ class ScalaJsonCombinatorsSpec extends Specification {
       }
       """)
       val location = json.validate[Location].get
-      location ===  Location(51.235685,-1.309197) 
-      
+      location ===  Location(51.235685,-1.309197)
+
       // Use Writes for model -> JSON
       val jsonFromLocation = Json.toJson(location)
       (jsonFromLocation \ "lat").as[Double] === 51.235685
     }
-    
+
   }
 
 }

--- a/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonSpec.scala
@@ -11,7 +11,7 @@ import org.specs2.runner.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ScalaJsonSpec extends Specification {
-  
+
   val sampleJson = {
     //#convert-from-string
       import play.api.libs.json._
@@ -37,7 +37,7 @@ class ScalaJsonSpec extends Specification {
       //#convert-from-string
       json
   }
-  
+
   object SampleModel {
     //#sample-model
     case class Location(lat: Double, long: Double)
@@ -50,14 +50,14 @@ class ScalaJsonSpec extends Specification {
     "parse json" in {
       import play.api.libs.json._
       val json = sampleJson
-      (json \ "name") must_== JsString("Watership Down")
-      (json \ "location" \ "lat") must_== JsNumber(51.235685)      
+      (json \ "name").get must_== JsString("Watership Down")
+      (json \ "location" \ "lat").get must_== JsNumber(51.235685)
     }
-    
+
     "allow constructing json using case classes" in {
       //#convert-from-classes
       import play.api.libs.json._
-      
+
       val json: JsValue = JsObject(Seq(
         "name" -> JsString("Watership Down"),
         "location" -> JsObject(Seq("lat" -> JsNumber(51.235685), "long" -> JsNumber(-1.309197))),
@@ -73,15 +73,15 @@ class ScalaJsonSpec extends Specification {
             "role" -> JsString("Owsla")
           ))
         ))
-      ))      
+      ))
       //#convert-from-classes
-      json \ "name" must_== JsString("Watership Down")
+      (json \ "name").get must_== JsString("Watership Down")
     }
 
     "allow constructing json using factory methods" in {
       //#convert-from-factory
       import play.api.libs.json.{JsNull,Json,JsString,JsValue}
-      
+
       val json: JsValue = Json.obj(
         "name" -> "Watership Down",
         "location" -> Json.obj("lat" -> 51.235685, "long" -> -1.309197),
@@ -99,45 +99,45 @@ class ScalaJsonSpec extends Specification {
         )
       )
       //#convert-from-factory
-      json \ "name" must_== JsString("Watership Down")
+      (json \ "name").get must_== JsString("Watership Down")
     }
-    
+
     "allow converting simple types" in {
       //#convert-from-simple
       import play.api.libs.json._
-      
+
       // basic types
       val jsonString = Json.toJson("Fiver")
       val jsonNumber = Json.toJson(4)
       val jsonBoolean = Json.toJson(false)
-      
+
       // collections of basic types
       val jsonArrayOfInts = Json.toJson(Seq(1, 2, 3, 4))
       val jsonArrayOfStrings = Json.toJson(List("Fiver", "Bigwig"))
-      
+
       //#convert-from-simple
-      
+
       jsonString === JsString("Fiver")
       jsonNumber === JsNumber(4)
       jsonBoolean === JsBoolean(false)
       jsonArrayOfInts === Json.arr(1, 2, 3, 4)
       jsonArrayOfStrings === Json.arr("Fiver", "Bigwig")
     }
-    
+
     "allow converting of models" in {
-      
+
       import SampleModel._
-      
+
       //#convert-from-model
       import play.api.libs.json._
-      
+
       implicit val locationWrites = new Writes[Location] {
         def writes(location: Location) = Json.obj(
           "lat" -> location.lat,
           "long" -> location.long
         )
       }
-      
+
       implicit val residentWrites = new Writes[Resident] {
         def writes(resident: Resident) = Json.obj(
           "name" -> resident.name,
@@ -145,14 +145,14 @@ class ScalaJsonSpec extends Specification {
           "role" -> resident.role
         )
       }
-      
+
       implicit val placeWrites = new Writes[Place] {
         def writes(place: Place) = Json.obj(
           "name" -> place.name,
           "location" -> place.location,
           "residents" -> place.residents)
       }
-      
+
       val place = Place(
         "Watership Down",
         Location(51.235685, -1.309197),
@@ -161,39 +161,39 @@ class ScalaJsonSpec extends Specification {
           Resident("Bigwig", 6, Some("Owsla"))
         )
       )
-      
+
       val json = Json.toJson(place)
       //#convert-from-model
-      
-      json \ "name" === JsString("Watership Down")
+
+      (json \ "name").get === JsString("Watership Down")
     }
-    
+
     "allow converting models preferred" in {
-      
+
       import SampleModel._
-      
+
       //#convert-from-model-prefwrites
       import play.api.libs.json._
       import play.api.libs.functional.syntax._
-      
+
       implicit val locationWrites: Writes[Location] = (
         (JsPath \ "lat").write[Double] and
         (JsPath \ "long").write[Double]
       )(unlift(Location.unapply))
-      
+
       implicit val residentWrites: Writes[Resident] = (
         (JsPath \ "name").write[String] and
         (JsPath \ "age").write[Int] and
         (JsPath \ "role").writeNullable[String]
       )(unlift(Resident.unapply))
-      
+
       implicit val placeWrites: Writes[Place] = (
         (JsPath \ "name").write[String] and
         (JsPath \ "location").write[Location] and
         (JsPath \ "residents").write[Seq[Resident]]
       )(unlift(Place.unapply))
       //#convert-from-model-prefwrites
-      
+
       val place = Place(
         "Watership Down",
         Location(51.235685, -1.309197),
@@ -202,48 +202,48 @@ class ScalaJsonSpec extends Specification {
           Resident("Bigwig", 6, Some("Owsla"))
         )
       )
-      
+
       val json = Json.toJson(place)
       //#convert-from-model
-      
-      json \ "name" === JsString("Watership Down")
+
+      (json \ "name").get === JsString("Watership Down")
     }
-    
-    
+
+
     "allow traversing JsValue tree" in {
-      
+
       import play.api.libs.json._
       val json = sampleJson
-      
+
       //#traverse-simple-path
-      val lat = json \ "location" \ "lat"
+      val lat = (json \ "location" \ "lat").get
       // returns JsNumber(51.235685)
       //#traverse-simple-path
 
       lat === JsNumber(51.235685)
-      
+
       //#traverse-recursive-path
-      val names = json \\ "name" 
+      val names = json \\ "name"
       // returns Seq(JsString("Watership Down"), JsString("Fiver"), JsString("Bigwig"))
       //#traverse-recursive-path
       names === Seq(JsString("Watership Down"), JsString("Fiver"), JsString("Bigwig"))
-      
+
       //#traverse-array-index
       val bigwig = (json \ "residents")(1)
       // returns {"name":"Bigwig","age":6,"role":"Owsla"}
       //#traverse-array-index
-      bigwig \ "name" === JsString("Bigwig")
+      (bigwig \ "name").get === JsString("Bigwig")
     }
-    
+
     "allow converting JsValue to String" in {
-      
+
       import play.api.libs.json._
       val json = sampleJson
-      
+
       //#convert-to-string
       val minifiedString: String = Json.stringify(json)
       //#convert-to-string
-      
+
       //#convert-to-string-pretty
       val readableString: String = Json.prettyPrint(json)
       //#convert-to-string-pretty
@@ -251,16 +251,16 @@ class ScalaJsonSpec extends Specification {
       minifiedString must contain("Fiver")
       readableString must contain("Bigwig")
     }
-    
+
     "allow converting JsValue using as" in {
-      
+
       import play.api.libs.json._
       val json = sampleJson
-      
+
       //#convert-to-type-as
       val name = (json \ "name").as[String]
       // "Watership Down"
-      
+
       val names = (json \\ "name").map(_.as[String])
       // Seq("Watership Down", "Fiver", "Bigwig")
       //#convert-to-type-as
@@ -268,16 +268,16 @@ class ScalaJsonSpec extends Specification {
       name === "Watership Down"
       names === Seq("Watership Down", "Fiver", "Bigwig")
     }
-    
+
     "allow converting JsValue using asOpt" in {
-      
+
       import play.api.libs.json._
       val json = sampleJson
-      
+
       //#convert-to-type-as-opt
       val nameOption = (json \ "name").asOpt[String]
       // Some("Watership Down")
-      
+
       val bogusOption = (json \ "bogus").asOpt[String]
       // None
       //#convert-to-type-as-opt
@@ -285,31 +285,31 @@ class ScalaJsonSpec extends Specification {
       nameOption === Some("Watership Down")
       bogusOption must beNone
     }
-    
+
     "allow converting JsValue using validate" in {
       import SampleModel._
-      
+
       import play.api.libs.json._
       import play.api.libs.json.Reads._
-      
+
       //#convert-to-type-validate
       //###replace: val json = { ... }
       val json: JsValue = sampleJson
-      
+
       val nameResult: JsResult[String] = (json \ "name").validate[String]
-      
+
       // Pattern matching
       nameResult match {
         case s: JsSuccess[String] => println("Name: " + s.get)
-        case e: JsError => println("Errors: " + JsError.toFlatJson(e).toString()) 
+        case e: JsError => println("Errors: " + JsError.toFlatJson(e).toString())
       }
-      
+
       // Fallback value
       val nameOrFallback = nameResult.getOrElse("Undefined")
-      
+
       // map
       val nameUpperResult: JsResult[String] = nameResult.map(_.toUpperCase())
-      
+
       // fold
       val nameOption: Option[String] = nameResult.fold(
         invalid = {
@@ -318,54 +318,54 @@ class ScalaJsonSpec extends Specification {
           })
           None
         },
-        valid = { 
+        valid = {
           name => Some(name)
         }
       )
       //#convert-to-type-validate
       nameResult must beLike {case x: JsSuccess[String] =>  x.get === "Watership Down"}
     }
-    
+
     "allow converting JsValue to model" in {
-      
+
       import SampleModel._
-      
+
       //#convert-to-model
       import play.api.libs.json._
       import play.api.libs.functional.syntax._
-      
+
       implicit val locationReads: Reads[Location] = (
         (JsPath \ "lat").read[Double] and
         (JsPath \ "long").read[Double]
       )(Location.apply _)
-      
+
       implicit val residentReads: Reads[Resident] = (
         (JsPath \ "name").read[String] and
         (JsPath \ "age").read[Int] and
         (JsPath \ "role").readNullable[String]
       )(Resident.apply _)
-      
+
       implicit val placeReads: Reads[Place] = (
         (JsPath \ "name").read[String] and
         (JsPath \ "location").read[Location] and
         (JsPath \ "residents").read[Seq[Resident]]
       )(Place.apply _)
-      
-      
+
+
       //###replace: val json = { ... }
       val json = sampleJson
-      
+
       val placeResult: JsResult[Place] = json.validate[Place]
       // JsSuccess(Place(...),)
-      
+
       val residentResult: JsResult[Resident] = (json \ "residents")(1).validate[Resident]
       // JsSuccess(Resident(Bigwig,6,Some(Owsla)),)
       //#convert-to-model
-      
+
       placeResult must beLike {case x: JsSuccess[Place] =>  x.get.name === "Watership Down"}
       residentResult must beLike {case x: JsSuccess[Resident] =>  x.get.name === "Bigwig"}
     }
-    
+
   }
 
 }

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsConstraints.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsConstraints.scala
@@ -204,7 +204,7 @@ trait ConstraintWrites {
     Writes[JsValue] { js => wrs.writes(fixed) }
 
   def pruned[A](implicit w: Writes[A]): Writes[A] = new Writes[A] {
-    def writes(a: A): JsValue = JsUndefined("pruned")
+    def writes(a: A): JsValue = JsNull
   }
 
   def list[A](implicit writes: Writes[A]): Writes[List[A]] = Writes.traversableWrites[A]

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsLookup.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsLookup.scala
@@ -1,0 +1,97 @@
+package play.api.libs.json
+
+import play.api.data.validation.ValidationError
+
+/**
+ * A value representing the value at a particular JSON path, either an actual JSON node or undefined.
+ */
+case class JsLookup(result: JsLookupResult) extends AnyVal {
+
+  /**
+   * Access a value of this array.
+   *
+   * @param index Element index.
+   */
+  def apply(index: Int): JsLookupResult = result match {
+    case JsDefined(arr: JsArray) =>
+      arr.value.lift(index).map(JsDefined.apply).getOrElse(JsUndefined("Array index out of bounds in " + arr))
+    case JsDefined(o) =>
+      JsUndefined(o + " is not an array")
+    case undef => undef
+  }
+
+  /**
+   * Return the property corresponding to the fieldName, supposing we have a JsObject.
+   *
+   * @param fieldName the name of the property to look up
+   * @return the resulting JsValue wrapped in a JsLookup. If the current node is not a JsObject or doesn't have the
+   *         property, a JsUndefined will be returned.
+   */
+  def \(fieldName: String): JsLookupResult = result match {
+    case JsDefined(obj: JsObject) =>
+      obj.value.get(fieldName).map(JsDefined.apply)
+        .getOrElse(JsUndefined("'" + fieldName + "' is undefined on object: " + obj))
+    case JsDefined(o) =>
+      JsUndefined(o + " is not an object")
+    case undef => undef
+  }
+
+  /**
+   * Look up fieldName in the current object and all descendants.
+   *
+   * @return the list of matching nodes
+   */
+  def \\(fieldName: String): Seq[JsValue] = result match {
+    case JsDefined(obj: JsObject) =>
+      obj.value.foldLeft(Seq[JsValue]())((o, pair) => pair match {
+        case (key, value) if key == fieldName => o ++ (value +: (value \\ fieldName))
+        case (_, value) => o ++ (value \\ fieldName)
+      })
+    case JsDefined(arr: JsArray) =>
+      arr.value.flatMap(_ \\ fieldName)
+    case _ => Seq.empty
+  }
+}
+
+sealed trait JsLookupResult extends Any with JsReadable {
+  /**
+   * Tries to convert the node into a JsValue
+   */
+  def toOption: Option[JsValue] = this match {
+    case JsDefined(v) => Some(v)
+    case _ => None
+  }
+  def toEither: Either[ValidationError, JsValue] = this match {
+    case JsDefined(v) => Right(v)
+    case undef: JsUndefined => Left(undef.validationError)
+  }
+  def get: JsValue = toOption.get
+  def getOrElse(v: JsValue): JsValue = toOption.getOrElse(v)
+
+  def validate[A](implicit rds: Reads[A]) = this match {
+    case JsDefined(v) => v.validate[A]
+    case undef: JsUndefined => JsError(undef.validationError)
+  }
+}
+object JsLookupResult {
+  import scala.language.implicitConversions
+  implicit def jsLookupResultToJsLookup(value: JsLookupResult): JsLookup = JsLookup(value)
+}
+/**
+ * Wrapper for JsValue to represent an existing Json value.
+ */
+case class JsDefined(value: JsValue) extends AnyVal with JsLookupResult
+
+/**
+ * Represent a missing Json value.
+ */
+final class JsUndefined(err: => String) extends JsLookupResult {
+  def error = err
+  def validationError = ValidationError(error)
+  override def toString = "JsUndefined(" + err + ")"
+}
+
+object JsUndefined {
+  def apply(err: => String) = new JsUndefined(err)
+  def unapply(o: Object): Boolean = o.isInstanceOf[JsUndefined]
+}

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsPath.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsPath.scala
@@ -18,15 +18,9 @@ sealed trait PathNode {
 
 case class RecursiveSearch(key: String) extends PathNode {
   def apply(json: JsValue): List[JsValue] = json match {
-    case obj: JsObject => (json \\ key).toList.filterNot {
-      case JsUndefined() => true
-      case _ => false
-    }
-    case arr: JsArray => (json \\ key).toList.filterNot {
-      case JsUndefined() => true
-      case _ => false
-    }
-    case _ => List()
+    case obj: JsObject => (json \\ key).toList
+    case arr: JsArray => (json \\ key).toList
+    case _ => Nil
   }
   override def toString = "//" + key
   def toJsonString = "*" + key
@@ -65,10 +59,7 @@ case class RecursiveSearch(key: String) extends PathNode {
 case class KeyPathNode(key: String) extends PathNode {
 
   def apply(json: JsValue): List[JsValue] = json match {
-    case obj: JsObject => List(json \ key).filterNot {
-      case JsUndefined() => true
-      case _ => false
-    }
+    case obj: JsObject => List(json \ key).flatMap(_.toOption)
     case _ => List()
   }
 
@@ -105,7 +96,7 @@ case class KeyPathNode(key: String) extends PathNode {
 
 case class IdxPathNode(idx: Int) extends PathNode {
   def apply(json: JsValue): List[JsValue] = json match {
-    case arr: JsArray => List(arr(idx))
+    case arr: JsArray => List(arr(idx)).flatMap(_.toOption)
     case _ => List()
   }
 
@@ -181,9 +172,9 @@ case class JsPath(path: List[PathNode] = List()) {
     case _ :: _ => JsError(Seq(this -> Seq(ValidationError("error.path.result.multiple"))))
   }
 
-  def asSingleJson(json: JsValue): JsValue = this(json) match {
+  def asSingleJson(json: JsValue): JsLookupResult = this(json) match {
     case Nil => JsUndefined("error.path.missing")
-    case List(js) => js
+    case List(js) => JsDefined(js)
     case _ :: _ => JsUndefined("error.path.result.multiple")
   }
 

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsReadable.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsReadable.scala
@@ -1,0 +1,32 @@
+package play.api.libs.json
+
+/**
+ * A trait representing a Json node which can be read as an arbitrary type A using a Reads[A]
+ */
+trait JsReadable extends Any {
+  /**
+   * Tries to convert the node into a T. An implicit Reads[T] must be defined.
+   * Any error is mapped to None
+   *
+   * @return Some[T] if it succeeds, None if it fails.
+   */
+  def asOpt[T](implicit fjs: Reads[T]): Option[T] = validate(fjs).asOpt
+
+  /**
+   * Tries to convert the node into a T, throwing an exception if it can't. An implicit Reads[T] must be defined.
+   */
+  def as[T](implicit fjs: Reads[T]): T = validate(fjs).fold(
+    valid = identity,
+    invalid = e => throw new JsResultException(e)
+  )
+
+  /**
+   * Transforms this node into a JsResult using provided Json transformer Reads[JsValue]
+   */
+  def transform[A <: JsValue](rds: Reads[A]): JsResult[A] = validate(rds)
+
+  /**
+   * Tries to convert the node into a JsResult[T] (Success or Error). An implicit Reads[T] must be defined.
+   */
+  def validate[T](implicit rds: Reads[T]): JsResult[T]
+}

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/package.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/package.scala
@@ -35,10 +35,8 @@ package play.api.libs
  * }}}
  */
 package object json {
-
   /**
    * Alias for `JsPath` companion object
    */
   val __ = JsPath
-
 }

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -374,11 +374,6 @@ object JsonSpec extends org.specs2.mutable.Specification {
       val stream = new java.io.ByteArrayInputStream(js.toString.getBytes("UTF-8"))
       Json.parse(stream) must beEqualTo(js)
     }
-
-    "throw an exception when stringifying JsUndefined" in {
-      stringify(JsUndefined("test")) must throwA[JsonMappingException]
-      stringify(Json.obj("foo" -> JsUndefined("bar"))) must throwA[JsonMappingException]
-    }
   }
 
   "JSON Writes" should {


### PR DESCRIPTION
After the discussion on #3888 it occurred to me that it should be possible to separate `JsValue` from the type used for traversing paths (which requires `JsUndefined`). I created the `JsLookup` specifically for representing the value at a particular JSON path. Many of the other cases where `JsUndefined` might otherwise be used already return `JsResult` and use `JsError` for when a path does not exist.

There are probably other ways of handling the type for doing traversal (implicit conversions from JsValue?) but I wanted to put this out there first as one possible solution.