### PR TITLE
Add chunked encoding trailer support to Akka HTTP backend

### DIFF
--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumerateesSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumerateesSpec.scala
@@ -179,6 +179,12 @@ object EnumerateesSpec extends Specification
       }
     }
 
+    "pass input through while the predicate is met" in {
+      mustExecute(3) { breakEC =>
+        mustTransformTo(1, 2, 3, 2, 1)(1, 2)(Enumeratee.takeWhile[Int](_ <= 2)(breakEC))
+      }
+    }
+
   }
 
   "Enumeratee.breakE" should {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -183,7 +183,7 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
         val (chunks, trailers) = response.body.right.get
         chunks must containAllOf(Seq("aa", "bb", "cc")).inOrder
         trailers.get("Chunks") must beSome("3")
-      }.pendingUntilAkkaHttpFixed
+      }
 
     "fall back to simple streaming when more than one chunk is sent and protocol is HTTP 1.0" in withServer(
       Result(ResponseHeader(200, Map()), Enumerator("abc", "def", "ghi") &> Enumeratee.map[String](_.getBytes)(ec))


### PR DESCRIPTION
Added Results.dechunkWithTrailers method to support this.