### PR TITLE
Added evolutions utility APIs

### DIFF
--- a/documentation/manual/working/javaGuide/main/sql/JavaDatabase.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaDatabase.md
@@ -123,3 +123,8 @@ For example, if you use MySQL5, you need to add a [[dependency| SBTDependencies]
 ```
 libraryDependencies += "mysql" % "mysql-connector-java" % "5.1.18"
 ```
+
+## Testing
+
+For information on testing with databases, including how to setup in-memory databases and, see [[Testing With Databases|JavaTestingWithDatabases]].
+

--- a/documentation/manual/working/javaGuide/main/tests/JavaTestingWithDatabases.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTestingWithDatabases.md
@@ -1,0 +1,79 @@
+# Testing with databases
+
+While it is possible to write [[functional tests|JavaFunctionalTest]] that test database access code by starting up a full application including the database, starting up a full application is not often desirable, due to the complexity of having many more components started and running just to test one small part of your application.
+
+Play provides a number of utilities for helping to test database access code that allow it to be tested with a database but in isolation from the rest of your app.  These utilities can easily be used with either ScalaTest or specs2, and can make your database tests much closer to lightweight and fast running unit tests than heavy weight and slow functional tests.
+
+## Using a database
+
+To connect to a database, at a minimum, you just need database driver name and the url of the database, using the [`Database`](api/java/play/db/Database.html) static factory methods.  For example, to connect to MySQL, you might use the following:
+
+@[database](code/javaguide/tests/JavaTestingWithDatabases.java)
+
+This will create a database connection pool for the MySQL `test` database running on `localhost`, with the name `default`.  The name of the database is only used internally by Play, for example, by other features such as evolutions, to load resources associated with that database.
+
+You may want to specify other configuration for the database, including a custom name, or configuration properties such as usernames, passwords and the various connection pool configuration items that Play supports, by supplying a custom name parameter and/or a custom config parameter:
+
+@[full-config](code/javaguide/tests/JavaTestingWithDatabases.java)
+
+After using a database, since the database is typically backed by a connection pool that holds open connections and may also have running threads, you need to shut it down.  This is done by calling the `shutdown` method:
+
+@[shutdown](code/javaguide/tests/JavaTestingWithDatabases.java)
+
+These methods are particularly useful if you use them in combination with JUnit's `@Before` and `@After` annotations, for example:
+
+@[database-junit](code/javaguide/tests/JavaTestingWithDatabases.java)
+
+> **Tip:** You can use this to externalise your test database configuration, using environment variables or system properties to configure what database to use and how to connect to it.  This allows for maximum flexibility for developers to have their own environments set up the way they please, as well as for CI systems that provide particular environments that may differ to development.
+
+### Using an in-memory database
+
+Some people prefer not to require infrastructure such as databases to be installed in order to run tests.  Play provides simple helpers to create an H2 in-memory database for these purposes:
+
+@[in-memory](code/javaguide/tests/JavaTestingWithDatabases.java)
+
+The in-memory database can be configured by supplying a custom name, custom URL arguments, and custom connection pool configuration.  The following shows supplying the `MODE` argument to tell H2 to emulate `MySQL`, as well as configuring the connection pool to log all statements:
+
+@[in-memory-full-config](code/javaguide/tests/JavaTestingWithDatabases.java)
+
+As with the generic database factory, ensure you always shut the in-memory database connection pool down:
+
+@[in-memory-shutdown](code/javaguide/tests/JavaTestingWithDatabases.java)
+
+## Applying evolutions
+
+When running tests, you will typically want your database schema managed for your database.  If you're already using evolutions, it will often make sense to reuse the same evolutions that you use in development and production in your tests.  You may also want to create custom evolutions just for testing.  Play provides some convenient helpers to apply and manage evolutions without having to run a whole Play application.
+
+To apply evolutions, you can use `applyEvolutions` from the [`Evolutions`](api/java/play/db/evolutions/Evolutions.html) static class:
+
+@[apply-evolutions](code/javaguide/tests/JavaTestingWithDatabases.java)
+
+This will load the evolutions from the classpath in the `evolutions/<databasename>` directory, and apply them.
+
+After a test has run, you may want to reset the database to its original state.  If you have implemented your evolutions down scripts in such a way that they will drop all the database tables, you can do this simply by calling the `cleanupEvolutions` method:
+
+@[cleanup-evolutions](code/javaguide/tests/JavaTestingWithDatabases.java)
+
+### Custom evolutions
+
+In some situations you may want to run some custom evolutions in your tests.  Custom evolutions can be used by using a custom [`EvolutionsReader`](api/java/play/db/evolutions/EvolutionsReader.html).  The easiest way to do this is using the static factory methods on `Evolutions`, for example `forDefault` creates an evolutions reader for a simple list of [`Evolution`](api/java/play/db/evolutions/Evolution.html) scripts for the default database.  For example:
+
+@[apply-evolutions-simple](code/javaguide/tests/JavaTestingWithDatabases.java)
+
+Cleaning up custom evolutions is done in the same way as cleaning up regular evolutions, using the `cleanupEvolutions` method:
+
+@[cleanup-evolutions-simple](code/javaguide/tests/JavaTestingWithDatabases.java)
+
+Note though that you don't need to pass the custom evolutions reader here, this is because the state of the evolutions is stored in the database, including the down scripts which will be used to tear down the database.
+
+Sometimes it will be impractical to put your custom evolution scripts in code.  If this is the case, you can put them in the test resources directory, using the `fromClassLoader` factory method:
+
+@[apply-evolutions-custom-path](code/javaguide/tests/JavaTestingWithDatabases.java)
+
+This will load evolutions, in the same structure and format as is done for development and production, from `testdatabase/evolutions/<databasename>/<n>.sql`.
+
+### Integrating with JUnit
+
+Typically you will have many tests that you want to run with the same evolutions, so it will make sense to extract the evolutions setup code into before and after methods, along with the database setup and tear down code.  Here is what a complete test might look like:
+
+@[database-test](code/javaguide/tests/DatabaseTest.java)

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/DatabaseTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/DatabaseTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package javaguide.tests;
+
+//#database-test
+import play.db.Database;
+import play.db.evolutions.*;
+import java.sql.Connection;
+
+import org.junit.*;
+import static org.junit.Assert.*;
+
+public class DatabaseTest {
+
+    Database database;
+
+    @Before
+    public void setupDatabase() {
+        database = Database.inMemory();
+        Evolutions.applyEvolutions(database, Evolutions.forDefault(new Evolution(
+            1,
+            "create table test (id bigint not null, name varchar(255));",
+            "drop table test;"
+        )));
+    }
+
+    @After
+    public void shutdownDatabase() {
+        Evolutions.cleanupEvolutions(database);
+        database.shutdown();
+    }
+
+    @Test
+    public void testDatabase() throws Exception {
+        Connection connection = database.getConnection();
+        connection.prepareStatement("insert into test values (10, 'testing')").execute();
+
+        assertTrue(
+            connection.prepareStatement("select * from test where id = 10")
+                .executeQuery().next()
+        );
+    }
+}
+//#database-test
+

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/JavaTestingWithDatabases.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/JavaTestingWithDatabases.java
@@ -1,0 +1,166 @@
+package javaguide.tests;
+
+import com.google.common.collect.ImmutableMap;
+
+import play.db.Database;
+
+import play.db.evolutions.*;
+import org.junit.*;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+
+public class JavaTestingWithDatabases {
+
+    public static class NotTested {
+        {
+            //#database
+            Database database = Database.createFrom(
+                    "com.mysql.jdbc.Driver",
+                    "jdbc:mysql://localhost/test"
+            );
+            //#database
+        }
+
+        {
+            //#full-config
+            Database database = Database.createFrom(
+                    "mydatabase",
+                    "com.mysql.jdbc.Driver",
+                    "jdbc:mysql://localhost/test",
+                    ImmutableMap.of(
+                            "user", "test",
+                            "password", "secret"
+                    )
+            );
+            //#full-config
+
+            //#shutdown
+            database.shutdown();
+            //#shutdown
+
+        }
+
+        public static class ExampleUnitTest {
+            //#database-junit
+            Database database;
+
+            @Before
+            public void createDatabase() {
+                database = Database.createFrom(
+                        "com.mysql.jdbc.Driver",
+                        "jdbc:mysql://localhost/test"
+                );
+            }
+
+            @After
+            public void shutdownDatabase() {
+                database.shutdown();
+            }
+            //#database-junit
+        }
+
+    }
+
+    @Test
+    public void inMemory() throws Exception {
+        //#in-memory
+        Database database = Database.inMemory();
+        //#in-memory
+
+        try {
+            assertThat(database.getConnection().getMetaData().getDatabaseProductName(), equalTo("H2"));
+        } finally {
+            database.shutdown();
+        }
+    }
+
+    @Test
+    public void inMemoryFullConfig() throws Exception {
+        //#in-memory-full-config
+        Database database = Database.inMemory(
+                "mydatabase",
+                ImmutableMap.of(
+                        "MODE", "MYSQL"
+                ),
+                ImmutableMap.of(
+                        "logStatements", true
+                )
+        );
+        //#in-memory-full-config
+
+        try {
+            assertThat(database.getConnection().getMetaData().getDatabaseProductName(), equalTo("H2"));
+        } finally {
+            //#in-memory-shutdown
+            database.shutdown();
+            //#in-memory-shutdown
+        }
+    }
+
+    @Test
+    public void evolutions() throws Exception {
+        Database database = Database.inMemory();
+        try {
+            //#apply-evolutions
+            Evolutions.applyEvolutions(database);
+            //#apply-evolutions
+
+            //#cleanup-evolutions
+            Evolutions.cleanupEvolutions(database);
+            //#cleanup-evolutions
+        } finally {
+            database.shutdown();
+        }
+    }
+
+    @Test
+    public void staticEvolutions() throws Exception {
+        Database database = Database.inMemory();
+        try {
+            //#apply-evolutions-simple
+            Evolutions.applyEvolutions(database, Evolutions.forDefault(
+                new Evolution(
+                    1,
+                    "create table test (id bigint not null, name varchar(255));",
+                    "drop table test;"
+                )
+            ));
+            //#apply-evolutions-simple
+
+            Connection connection = database.getConnection();
+            connection.prepareStatement("insert into test values (10, 'testing')").execute();
+
+            //#cleanup-evolutions-simple
+            Evolutions.cleanupEvolutions(database);
+            //#cleanup-evolutions-simple
+
+            try {
+                connection.prepareStatement("select * from test").executeQuery();
+                fail();
+            } catch (SQLException e) {
+                // pass
+            }
+        } finally {
+            database.shutdown();
+        }
+    }
+
+    @Test
+    public void customPathEvolutions() throws Exception {
+        Database database = Database.inMemory();
+        try {
+            //#apply-evolutions-custom-path
+            Evolutions.applyEvolutions(database,
+                Evolutions.fromClassLoader(
+                    getClass().getClassLoader(), "testdatabase/")
+            );
+            //#apply-evolutions-custom-path
+        } finally {
+            database.shutdown();
+        }
+    }
+}

--- a/documentation/manual/working/javaGuide/main/tests/index.toc
+++ b/documentation/manual/working/javaGuide/main/tests/index.toc
@@ -1,2 +1,3 @@
 JavaTest:Writing tests
 JavaFunctionalTest:Writing functional tests
+JavaTestingWithDatabases:Testing with databases

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
@@ -30,7 +30,7 @@ object ScalaErrorHandling extends PlaySpecification with WsTestClient {
       import play.core.Router
       import javax.inject.Provider
       def errorHandler(mode: Mode.Mode) = new default.ErrorHandler(
-        Environment.simple(mode), Configuration.empty, new OptionalSourceMapper(None),
+        Environment.simple(mode = mode), Configuration.empty, new OptionalSourceMapper(None),
         new Provider[Router.Routes] { def get = Router.Null }
       )
       def errorContent(mode: Mode.Mode) =

--- a/documentation/manual/working/scalaGuide/main/sql/ScalaDatabase.md
+++ b/documentation/manual/working/scalaGuide/main/sql/ScalaDatabase.md
@@ -170,3 +170,7 @@ DB.withTransaction { conn =>
   // do whatever you need with the connection
 }
 ```
+
+## Testing
+
+For information on testing with databases, including how to setup in-memory databases and, see [[Testing With Databases|ScalaTestingWithDatabases]].

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithDatabases.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithDatabases.md
@@ -1,0 +1,109 @@
+# Testing with databases
+
+While it is possible to write functional tests using [[ScalaTest|ScalaFunctionalTestingWithScalaTest]] or [[specs2|ScalaFunctionalTestingWithSpecs2]] that test database access code by starting up a full application including the database, starting up a full application is not often desirable, due to the complexity of having many more components started and running just to test one small part of your application.
+
+Play provides a number of utilities for helping to test database access code that allow it to be tested with a database but in isolation from the rest of your app.  These utilities can easily be used with either ScalaTest or specs2, and can make your database tests much closer to lightweight and fast running unit tests than heavy weight and slow functional tests.
+
+## Using a database
+
+To connect to a database, at a minimum, you just need database driver name and the url of the database, using the [`Database`](api/scala/index.html#play.api.db.Database$) companion object.  For example, to connect to MySQL, you might use the following:
+
+@[database](code/database/ScalaTestingWithDatabases.scala)
+
+This will create a database connection pool for the MySQL `test` database running on `localhost`, with the name `default`.  The name of the database is only used internally by Play, for example, by other features such as evolutions, to load resources associated with that database.
+
+You may want to specify other configuration for the database, including a custom name, or configuration properties such as usernames, passwords and the various connection pool configuration items that Play supports, by supplying a custom name parameter and/or a custom config parameter:
+
+@[full-config](code/database/ScalaTestingWithDatabases.scala)
+
+After using a database, since the database is typically backed by a connection pool that holds open connections and may also have running threads, you need to shut it down.  This is done by calling the `shutdown` method:
+
+@[shutdown](code/database/ScalaTestingWithDatabases.scala)
+
+Manually creating the database and shutting it down is useful if you're using a test framework that runs startup/shutdown code around each test or suite.  Otherwise it's recommended that you let Play manage the connection pool for you.
+
+### Allowing Play to manage the database for you
+
+Play also provides a `withDatabase` helper that allows you to supply a block of code to execute with a database connection pool managed by Play.  Play will ensure that it is correctly shutdown after the block of code finishes executing:
+
+@[with-database](code/database/ScalaTestingWithDatabases.scala)
+
+Like the `Database.apply` factory method, `withDatabase` also allows you to pass a custom `name` and `config` map if you please.
+
+Typically, using `withDatabase` directly from every test is an excessive amount of boilerplate code.  It is recommended that you create your own helper to remove this boiler plate that your test uses.  For example:
+
+@[custom-with-database](code/database/ScalaTestingWithDatabases.scala)
+
+Then it can be easily used in each test with minimal boilerplate:
+
+@[custom-with-database-use](code/database/ScalaTestingWithDatabases.scala)
+
+> **Tip:** You can use this to externalise your test database configuration, using environment variables or system properties to configure what database to use and how to connect to it.  This allows for maximum flexibility for developers to have their own environments set up the way they please, as well as for CI systems that provide particular environments that may differ to development.
+
+### Using an in-memory database
+
+Some people prefer not to require infrastructure such as databases to be installed in order to run tests.  Play provides simple helpers to create an H2 in-memory database for these purposes:
+
+@[in-memory](code/database/ScalaTestingWithDatabases.scala)
+
+The in-memory database can be configured, by supplying a custom name, custom URL arguments, and custom connection pool configuration.  The following shows supplying the `MODE` argument to tell H2 to emulate `MySQL`, as well as configuring the connection pool to log all statements:
+
+@[in-memory-full-config](code/database/ScalaTestingWithDatabases.scala)
+
+As with the generic database factory, ensure you always shut the in-memory database connection pool down:
+
+@[in-memory-shutdown](code/database/ScalaTestingWithDatabases.scala)
+
+If you're not using a test frameworks before/after capabilities, you may want Play to manage the in-memory database lifecycle for you, this is straight forward using `withInMemory`:
+
+@[with-in-memory](code/database/ScalaTestingWithDatabases.scala)
+
+Like `withDatabase`, it is recommended that to reduce boilerplate code, you create your own method that wraps the `withInMemory` call:
+
+@[with-in-memory-custom](code/database/ScalaTestingWithDatabases.scala)
+
+## Applying evolutions
+
+When running tests, you will typically want your database schema managed for your database.  If you're already using evolutions, it will often make sense to reuse the same evolutions that you use in development and production in your tests.  You may also want to create custom evolutions just for testing.  Play provides some convenient helpers to apply and manage evolutions without having to run a whole Play application.
+
+To apply evolutions, you can use `applyEvolutions` from the [`Evolutions`](api/scala/index.html#play.api.db.evolutions.Evolutions$) companion object:
+
+@[apply-evolutions](code/database/ScalaTestingWithDatabases.scala)
+
+This will load the evolutions from the classpath in the `evolutions/<databasename>` directory, and apply them.
+
+After a test has run, you may want to reset the database to its original state.  If you have implemented your evolutions down scripts in such a way that they will drop all the database tables, you can do this simply by calling the `cleanupEvolutions` method:
+
+@[cleanup-evolutions](code/database/ScalaTestingWithDatabases.scala)
+
+### Custom evolutions
+
+In some situations you may want to run some custom evolutions in your tests.  Custom evolutions can be used by using a custom [`EvolutionsReader`](api/scala/index.html#play.api.db.evolutions.EvolutionsReader).  The simplest of these is the [`SimpleEvolutionsReader`](api/scala/index.html#play.api.db.evolutions.SimpleEvolutionsReader), which is an evolutions reader that takes a preconfigured map of database names to sequences of [`Evolution`](api/scala/index.html#play.api.db.evolutions.Evolution) scripts, and can be constructed using the convenient methods on the [`SimpleEvolutionsReader`](api/scala/index.html#play.api.db.evolutions.SimpleEvolutionsReader$) companion object.  For example:
+
+@[apply-evolutions-simple](code/database/ScalaTestingWithDatabases.scala)
+
+Cleaning up custom evolutions is done in the same way as cleaning up regular evolutions, using the `cleanupEvolutions` method:
+
+@[cleanup-evolutions-simple](code/database/ScalaTestingWithDatabases.scala)
+
+Note though that you don't need to pass the custom evolutions reader here, this is because the state of the evolutions is stored in the database, including the down scripts which will be used to tear down the database.
+
+Sometimes it will be impractical to put your custom evolution scripts in code.  If this is the case, you can put them in the test resources directory, under a custom path using the [`ClassLoaderEvolutionsReader`](api/scala/index.html#play.api.db.evolutions.ClassLoaderEvolutionsReader).  For example:
+
+@[apply-evolutions-custom-path](code/database/ScalaTestingWithDatabases.scala)
+
+This will load evolutions, in the same structure and format as is done for development and production, from `testdatabase/evolutions/<databasename>/<n>.sql`.
+
+### Allowing Play to manage evolutions
+
+The `applyEvolutions` and `cleanupEvolutions` methods are useful if you're using a test framework to manage running the evolutions before and after a test.  Play also provides a convenient `withEvolutions` method to manage it for you, if this lighter weight approach is desired:
+
+@[with-evolutions](code/database/ScalaTestingWithDatabases.scala)
+
+Naturally, `withEvolutions` can be combined with `withDatabase` or `withInMemory` to reduce boilerplate code, allowing you to define a function that both instantiates the database and runs evolutions for you:
+
+@[with-evolutions-custom](code/database/ScalaTestingWithDatabases.scala)
+
+Having defined the custom database management method for our tests, we can now use them in a straight forward manner:
+
+@[with-evolutions-custom-use](code/database/ScalaTestingWithDatabases.scala)

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingYourApplication.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingYourApplication.md
@@ -5,3 +5,9 @@ Writing tests for your application can be an involved process. Play offers integ
 
 * [[Testing your Application with ScalaTest|ScalaTestingWithScalaTest]]
 * [[Testing your Application with specs2|ScalaTestingWithSpecs2]]
+
+## Advanced testing
+
+Play provides a number of helpers for testing specific parts of an application.
+
+* [[Testing with databases|ScalaTestingWithDatabases]]

--- a/documentation/manual/working/scalaGuide/main/tests/code/database/ScalaTestingWithDatabases.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/database/ScalaTestingWithDatabases.scala
@@ -1,0 +1,258 @@
+package scalaguide.testing.database
+
+import java.sql.SQLException
+
+import org.specs2.mutable.Specification
+
+object ScalaTestingWithDatabases extends Specification {
+
+  // We don't test this code because otherwise it would try to connect to MySQL
+  class NotTested {
+    {
+      //#database
+      import play.api.db.Database
+
+      val database = Database(
+        driver = "com.mysql.jdbc.Driver",
+        url = "jdbc:mysql://localhost/test"
+      )
+      //#database
+    }
+
+    {
+      //#full-config
+      import play.api.db.Database
+
+      val database = Database(
+        driver = "com.mysql.jdbc.Driver",
+        url = "jdbc:mysql://localhost/test",
+        name = "mydatabase",
+        config = Map(
+          "user" -> "test",
+          "password" -> "secret"
+        )
+      )
+      //#full-config
+
+      //#shutdown
+      database.shutdown()
+      //#shutdown
+    }
+
+    {
+      //#with-database
+      import play.api.db.Database
+
+      Database.withDatabase(
+        driver = "com.mysql.jdbc.Driver",
+        url = "jdbc:mysql://localhost/test"
+      ) { database =>
+        val connection = database.getConnection()
+        // ...
+      }
+      //#with-database
+    }
+
+    {
+      //#custom-with-database
+      import play.api.db.Database
+
+      def withMyDatabase[T](block: Database => T) = {
+        Database.withDatabase(
+          driver = "com.mysql.jdbc.Driver",
+          url = "jdbc:mysql://localhost/test",
+          name = "mydatabase",
+          config = Map(
+            "user" -> "test",
+            "password" -> "secret"
+          )
+        )(block)
+      }
+      //#custom-with-database
+
+      //#custom-with-database-use
+      withMyDatabase { database =>
+        val connection = database.getConnection()
+        // ...
+      }
+      //#custom-with-database-use
+    }
+
+  }
+
+  "database helpers" should {
+    "allow connecting to an in memory database" in {
+      //#in-memory
+      import play.api.db.Database
+
+      val database = Database.inMemory()
+      //#in-memory
+
+      try {
+        database.getConnection().getMetaData.getDatabaseProductName must_== "H2"
+      } finally {
+        database.shutdown()
+      }
+    }
+
+    "allow connecting to an in memory database with more options" in {
+      //#in-memory-full-config
+      import play.api.db.Database
+
+      val database = Database.inMemory(
+        name = "mydatabase",
+        urlOptions = Map(
+          "MODE" -> "MYSQL"
+        ),
+        config = Map(
+          "logStatements" -> true
+        )
+      )
+      //#in-memory-full-config
+
+      try {
+        database.getConnection().getMetaData.getDatabaseProductName must_== "H2"
+      } finally {
+        //#in-memory-shutdown
+        database.shutdown()
+        //#in-memory-shutdown
+      }
+    }
+    
+    "manage an in memory database for the user" in {
+      //#with-in-memory
+      import play.api.db.Database
+
+      Database.withInMemory() { database =>
+        val connection = database.getConnection()
+        
+        // ...
+      }
+      //#with-in-memory
+      ok
+    }
+
+    "manage an in memory database for the user with custom config" in {
+      //#with-in-memory-custom
+      import play.api.db.Database
+
+      def withMyDatabase[T](block: Database => T) = {
+        Database.withInMemory(
+          name = "mydatabase",
+          urlOptions = Map(
+            "MODE" -> "MYSQL"
+          ),
+          config = Map(
+            "logStatements" -> true
+          )
+        )(block)
+      }
+      //#with-in-memory-custom
+
+      withMyDatabase(_.getConnection().getMetaData.getDatabaseProductName must_== "H2")
+    }
+
+    "allow running evolutions" in play.api.db.Database.withInMemory() { database =>
+      //#apply-evolutions
+      import play.api.db.evolutions._
+
+      Evolutions.applyEvolutions(database)
+      //#apply-evolutions
+
+      //#cleanup-evolutions
+      Evolutions.cleanupEvolutions(database)
+      //#cleanup-evolutions
+      ok
+    }
+
+    "allow running static evolutions" in play.api.db.Database.withInMemory() { database =>
+      //#apply-evolutions-simple
+      import play.api.db.evolutions._
+
+      Evolutions.applyEvolutions(database, SimpleEvolutionsReader.forDefault(
+        Evolution(
+          1,
+          "create table test (id bigint not null, name varchar(255));",
+          "drop table test;"
+        )
+      ))
+      //#apply-evolutions-simple
+
+      val connection = database.getConnection()
+      connection.prepareStatement("insert into test values (10, 'testing')").execute()
+      
+      //#cleanup-evolutions-simple
+      Evolutions.cleanupEvolutions(database)
+      //#cleanup-evolutions-simple
+      
+      connection.prepareStatement("select * from test").executeQuery() must throwAn[SQLException]
+    }
+    
+    "allow running evolutions from a custom path" in play.api.db.Database.withInMemory() { database =>
+      //#apply-evolutions-custom-path
+      import play.api.db.evolutions._
+
+      Evolutions.applyEvolutions(database, ClassLoaderEvolutionsReader.forPrefix("testdatabase/"))
+      //#apply-evolutions-custom-path
+      ok
+    }
+
+    "allow play to manage evolutions for you" in play.api.db.Database.withInMemory() { database =>
+      //#with-evolutions
+      import play.api.db.evolutions._
+
+      Evolutions.withEvolutions(database) {
+        val connection = database.getConnection()
+
+        // ...
+      }
+      //#with-evolutions
+      ok
+    }
+
+    "allow simple composition of with database and with evolutions" in {
+      //#with-evolutions-custom
+      import play.api.db.Database
+      import play.api.db.evolutions._
+
+      def withMyDatabase[T](block: Database => T) = {
+
+        Database.withInMemory(
+          urlOptions = Map(
+            "MODE" -> "MYSQL"
+          ),
+          config = Map(
+            "logStatements" -> true
+          )
+        ) { database =>
+
+          Evolutions.withEvolutions(database, SimpleEvolutionsReader.forDefault(
+            Evolution(
+              1,
+              "create table test (id bigint not null, name varchar(255));",
+              "drop table test;"
+            )
+          )) {
+
+            block(database)
+
+          }
+        }
+      }
+      //#with-evolutions-custom
+
+      //#with-evolutions-custom-use
+      withMyDatabase { database =>
+        val connection = database.getConnection()
+        connection.prepareStatement("insert into test values (10, 'testing')").execute()
+
+        connection.prepareStatement("select * from test where id = 10")
+          .executeQuery().next() must_== true
+      }
+      //#with-evolutions-custom-use
+    }
+
+  }
+
+
+}

--- a/documentation/manual/working/scalaGuide/main/tests/index.toc
+++ b/documentation/manual/working/scalaGuide/main/tests/index.toc
@@ -3,3 +3,4 @@ ScalaTestingWithScalaTest:Testing with ScalaTest
 ScalaFunctionalTestingWithScalaTest:Writing functional tests with ScalaTest
 ScalaTestingWithSpecs2:Testing with specs2
 ScalaFunctionalTestingWithSpecs2:Writing functional tests with specs2
+ScalaTestingWithDatabases:Testing with databases

--- a/documentation/project/Build.scala
+++ b/documentation/project/Build.scala
@@ -79,7 +79,9 @@ object ApplicationBuild extends Build {
       playProject("Play-Java") % "test",
       playProject("Play-Cache") % "test",
       playProject("Play-Java-WS") % "test",
-      playProject("Filters-Helpers") % "test"
+      playProject("Filters-Helpers") % "test",
+      playProject("Play-JDBC") % "test",
+      playProject("Play-Java-JDBC") % "test"
   )
 
   lazy val playDocs = playProject("Play-Docs")

--- a/framework/src/play-integration-test/src/test/scala/play/it/views/DevErrorPageSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/views/DevErrorPageSpec.scala
@@ -23,7 +23,7 @@ object DevErrorPageSpec extends PlaySpecification {
     }
 
     "show prod error page in prod mode" in {
-      val errorHandler = new DefaultHttpErrorHandler(Environment.simple(Mode.Prod), Configuration.empty)
+      val errorHandler = new DefaultHttpErrorHandler(Environment.simple(mode = Mode.Prod), Configuration.empty)
       val result = errorHandler.onServerError(FakeRequest(), testExceptionSource)
       Helpers.contentAsString(result) must contain("Oops, an error occurred")
     }

--- a/framework/src/play-java-jdbc/src/main/java/play/db/DefaultDatabase.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/DefaultDatabase.java
@@ -96,4 +96,7 @@ public class DefaultDatabase extends Database {
         db.shutdown();
     }
 
+    play.api.db.Database toScala() {
+        return db;
+    }
 }

--- a/framework/src/play-java-jdbc/src/main/java/play/db/evolutions/Evolution.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/evolutions/Evolution.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.db.evolutions;
+
+/**
+ * An evolution.
+ */
+public final class Evolution {
+    private final int revision;
+    private final String sqlUp;
+    private final String sqlDown;
+
+    /**
+     * Create the evolution.
+     *
+     * @param revision The revision of the evolution to create.
+     * @param sqlUp The SQL script for bringing the evolution up.
+     * @param sqlDown The SQL script for tearing the evolution down.
+     */
+    public Evolution(int revision, String sqlUp, String sqlDown) {
+        this.revision = revision;
+        this.sqlUp = sqlUp;
+        this.sqlDown = sqlDown;
+    }
+
+    /**
+     * Get the revision of the evolution.
+     */
+    public int getRevision() {
+        return revision;
+    }
+
+    /**
+     * Get the SQL script for bringing the evolution up.
+     */
+    public String getSqlUp() {
+        return sqlUp;
+    }
+
+    /**
+     * Get the SQL script for tearing the evolution down.
+     */
+    public String getSqlDown() {
+        return sqlDown;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Evolution evolution = (Evolution) o;
+
+        if (revision != evolution.revision) return false;
+        if (sqlDown != null ? !sqlDown.equals(evolution.sqlDown) : evolution.sqlDown != null) return false;
+        if (sqlUp != null ? !sqlUp.equals(evolution.sqlUp) : evolution.sqlUp != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = revision;
+        result = 31 * result + (sqlUp != null ? sqlUp.hashCode() : 0);
+        result = 31 * result + (sqlDown != null ? sqlDown.hashCode() : 0);
+        return result;
+    }
+}

--- a/framework/src/play-java-jdbc/src/main/java/play/db/evolutions/Evolutions.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/evolutions/Evolutions.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.db.evolutions;
+
+import play.api.db.evolutions.DatabaseEvolutions;
+import play.db.Database;
+
+import java.util.*;
+
+/**
+ * Utilities for working with evolutions.
+ */
+public class Evolutions {
+
+    /**
+     * Create an evolutions reader that reads evolution files from this classes own classloader.
+     *
+     * Only useful in simple classloading environments, such as when the classloader structure is flat.
+     */
+    public static play.api.db.evolutions.EvolutionsReader fromClassLoader() {
+        return fromClassLoader(Evolutions.class.getClassLoader());
+    }
+
+    /**
+     * Create an evolutions reader that reads evolution files from a classloader.
+     *
+     * @param classLoader The classloader to read from.
+     */
+    public static play.api.db.evolutions.EvolutionsReader fromClassLoader(ClassLoader classLoader) {
+        return fromClassLoader(classLoader, "");
+    }
+
+    /**
+     * Create an evolutions reader that reads evolution files from a classloader.
+     *
+     * @param classLoader The classloader to read from.
+     * @param prefix A prefix that gets added to the resource file names, for example, this could be used to namespace
+     *               evolutions in different environments to work with different databases.
+     */
+    public static play.api.db.evolutions.EvolutionsReader fromClassLoader(ClassLoader classLoader, String prefix) {
+        return new play.api.db.evolutions.ClassLoaderEvolutionsReader(classLoader, prefix);
+    }
+
+    /**
+     * Create an evolutions reader based on a simple map of database names to evolutions.
+     *
+     * @param evolutions The map of database names to evolutions.
+     */
+    public static play.api.db.evolutions.EvolutionsReader fromMap(Map<String, List<Evolution>> evolutions) {
+        return new SimpleEvolutionsReader(evolutions);
+    }
+
+    /**
+     * Create an evolutions reader for the default database from a list of evolutions.
+     *
+     * @param evolutions The list of evolutions.
+     */
+    public static play.api.db.evolutions.EvolutionsReader forDefault(Evolution... evolutions) {
+        Map<String, List<Evolution>> map = new HashMap<String, List<Evolution>>();
+        map.put("default", Arrays.asList(evolutions));
+        return fromMap(map);
+    }
+
+    /**
+     * Apply evolutions for the given database.
+     *
+     * @param database The database to apply the evolutions to.
+     * @param reader The reader to read the evolutions.
+     * @param autocommit Whether autocommit should be used.
+     */
+    public static void applyEvolutions(Database database, play.api.db.evolutions.EvolutionsReader reader, boolean autocommit) {
+        DatabaseEvolutions evolutions = new DatabaseEvolutions(Database.toScala(database));
+        evolutions.evolve(evolutions.scripts(reader), autocommit);
+    }
+
+    /**
+     * Apply evolutions for the given database.
+     *
+     * @param database The database to apply the evolutions to.
+     * @param reader The reader to read the evolutions.
+     */
+    public static void applyEvolutions(Database database, play.api.db.evolutions.EvolutionsReader reader) {
+        applyEvolutions(database, reader, true);
+    }
+
+    /**
+     * Apply evolutions for the given database.
+     *
+     * @param database The database to apply the evolutions to.
+     */
+    public static void applyEvolutions(Database database) {
+        applyEvolutions(database, fromClassLoader());
+    }
+
+    /**
+     * Cleanup evolutions for the given database.
+     *
+     * This will run the down scripts for all the applied evolutions.
+     *
+     * @param database The database to apply the evolutions to.
+     * @param autocommit Whether autocommit should be used.
+     */
+    public static void cleanupEvolutions(Database database, boolean autocommit) {
+        DatabaseEvolutions evolutions = new DatabaseEvolutions(Database.toScala(database));
+        evolutions.evolve(evolutions.resetScripts(), autocommit);
+    }
+
+    /**
+     * Cleanup evolutions for the given database.
+     *
+     * This will run the down scripts for all the applied evolutions.
+     *
+     * @param database The database to apply the evolutions to.
+     */
+    public static void cleanupEvolutions(Database database) {
+        cleanupEvolutions(database, true);
+    }
+}

--- a/framework/src/play-java-jdbc/src/main/java/play/db/evolutions/EvolutionsReader.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/evolutions/EvolutionsReader.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.db.evolutions;
+
+import play.libs.Scala;
+import scala.collection.Seq;
+
+import java.util.*;
+
+/**
+ * Reads evolutions.
+ */
+public abstract class EvolutionsReader implements play.api.db.evolutions.EvolutionsReader {
+    public final Seq<play.api.db.evolutions.Evolution> evolutions(String db) {
+        Collection<Evolution> evolutions = getEvolutions(db);
+        if (evolutions != null) {
+            List<play.api.db.evolutions.Evolution> scalaEvolutions = new ArrayList<play.api.db.evolutions.Evolution>(evolutions.size());
+            for (Evolution e: evolutions) {
+                scalaEvolutions.add(new play.api.db.evolutions.Evolution(e.getRevision(), e.getSqlUp(), e.getSqlDown()));
+            }
+            return Scala.asScala(scalaEvolutions);
+        } else {
+            return Scala.asScala(Collections.<play.api.db.evolutions.Evolution>emptyList());
+        }
+    }
+
+    /**
+     * Get the evolutions for the given database name.
+     *
+     * @param db The name of the database.
+     * @return The collection of evolutions.
+     */
+    public abstract Collection<Evolution> getEvolutions(String db);
+}

--- a/framework/src/play-java-jdbc/src/main/java/play/db/evolutions/SimpleEvolutionsReader.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/evolutions/SimpleEvolutionsReader.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.db.evolutions;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A simple evolutions reader that uses a map to store evolutions
+ */
+public class SimpleEvolutionsReader extends EvolutionsReader {
+    private final Map<String, List<Evolution>> evolutions;
+
+    public SimpleEvolutionsReader(Map<String, List<Evolution>> evolutions) {
+        this.evolutions = evolutions;
+    }
+
+    @Override
+    public Collection<Evolution> getEvolutions(String db) {
+        return evolutions.get(db);
+    }
+}

--- a/framework/src/play-java-jdbc/src/main/resources/evolutionstest/evolutions/default/1.sql
+++ b/framework/src/play-java-jdbc/src/main/resources/evolutionstest/evolutions/default/1.sql
@@ -1,0 +1,10 @@
+# --- Test database schema
+
+# --- !Ups
+
+create table test (id bigint not null, name varchar(255));
+insert into test values (10, 'testing');
+
+# --- !Downs
+
+drop table if exists test;

--- a/framework/src/play-java-jdbc/src/test/java/play/db/evolutions/EvolutionsTest.java
+++ b/framework/src/play-java-jdbc/src/test/java/play/db/evolutions/EvolutionsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.db.evolutions;
+
+import org.junit.*;
+import play.db.Database;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.*;
+
+public class EvolutionsTest {
+    private Database database;
+    private Connection connection;
+
+    @Test
+    public void testEvolutions() throws Exception {
+        Evolutions.applyEvolutions(database, Evolutions.fromClassLoader(this.getClass().getClassLoader(), "evolutionstest/"));
+
+        // Ensure evolutions were applied
+        ResultSet resultSet = executeStatement("select * from test");
+        assertTrue(resultSet.next());
+
+        Evolutions.cleanupEvolutions(database);
+        try {
+            // Ensure tables don't exist
+            executeStatement("select * from test");
+            fail("SQL statement should have thrown an exception");
+        } catch (SQLException se) {
+           // pass
+        }
+    }
+
+    private ResultSet executeStatement(String statement) throws Exception {
+        return connection.prepareStatement(statement).executeQuery();
+    }
+
+    @Before
+    public void createDatabase() {
+        database = Database.inMemory();
+        connection = database.getConnection();
+    }
+
+    @After
+    public void shutdown() {
+        database.shutdown();
+        database = null;
+    }
+
+}

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -3,16 +3,16 @@
  */
 package play.api.db.evolutions
 
-import java.io.{ File, FileInputStream }
+import java.io.{ InputStream, File, FileInputStream }
 import java.sql.{ Connection, Date, PreparedStatement, ResultSet, SQLException }
 import javax.inject.{ Inject, Singleton }
 
 import scala.io.Codec
 import scala.util.control.NonFatal
 
-import play.api.db.DBApi
+import play.api.db.{ Database, DBApi }
 import play.api.libs.Collections
-import play.api.{ Environment, Logger, Mode, PlayException }
+import play.api.{ Environment, Logger, PlayException }
 import play.utils.PlayIO
 
 /**
@@ -38,13 +38,12 @@ trait EvolutionsApi {
   def scripts(db: String, reader: EvolutionsReader): Seq[Script]
 
   /**
-   * Create evolution scripts.
+   * Get all scripts necessary to reset the database state to its initial state.
    *
    * @param db the database name
-   * @param path application root path
    * @return evolution scripts
    */
-  def scripts(db: String, path: File): Seq[Script]
+  def resetScripts(db: String): Seq[Script]
 
   /**
    * Apply evolution scripts to the database.
@@ -70,21 +69,30 @@ trait EvolutionsApi {
 @Singleton
 class DefaultEvolutionsApi @Inject() (dbApi: DBApi) extends EvolutionsApi {
 
+  private def databaseEvolutions(name: String) = new DatabaseEvolutions(dbApi.database(name))
+
+  def scripts(db: String, evolutions: Seq[Evolution]) = databaseEvolutions(db).scripts(evolutions)
+
+  def scripts(db: String, reader: EvolutionsReader) = databaseEvolutions(db).scripts(reader)
+
+  def resetScripts(db: String) = databaseEvolutions(db).resetScripts()
+
+  def evolve(db: String, scripts: Seq[Script], autocommit: Boolean) = databaseEvolutions(db).evolve(scripts, autocommit)
+
+  def resolve(db: String, revision: Int) = databaseEvolutions(db).resolve(revision)
+}
+
+/**
+ * Evolutions for a particular database.
+ */
+class DatabaseEvolutions(database: Database) {
+
   import DefaultEvolutionsApi._
 
-  private val logger = Logger(classOf[DefaultEvolutionsApi])
-
-  /**
-   * Create evolution scripts.
-   *
-   * @param db the database name
-   * @param evolutions the evolutions for the application
-   * @return evolution scripts
-   */
-  def scripts(db: String, evolutions: Seq[Evolution]): Seq[Script] = {
+  def scripts(evolutions: Seq[Evolution]): Seq[Script] = {
     if (evolutions.nonEmpty) {
       val application = evolutions.reverse
-      val database = databaseEvolutions(db)
+      val database = databaseEvolutions()
 
       val (nonConflictingDowns, dRest) = database.span(e => !application.headOption.exists(e.revision <= _.revision))
       val (nonConflictingUps, uRest) = application.span(e => !database.headOption.exists(_.revision >= e.revision))
@@ -98,37 +106,17 @@ class DefaultEvolutionsApi @Inject() (dbApi: DBApi) extends EvolutionsApi {
     } else Nil
   }
 
-  /**
-   * Create evolution scripts.
-   *
-   * @param db the database name
-   * @param reader evolution file reader
-   * @return evolution scripts
-   */
-  def scripts(db: String, reader: EvolutionsReader): Seq[Script] = {
-    scripts(db, reader.evolutions(db))
-  }
-
-  /**
-   * Create evolution scripts.
-   *
-   * @param db the database name
-   * @param path application root path
-   * @return evolution scripts
-   */
-  def scripts(db: String, path: File): Seq[Script] = {
-    scripts(db, new EvolutionsReader(Environment(path, this.getClass.getClassLoader, Mode.Dev /* not used */ )))
+  def scripts(reader: EvolutionsReader): Seq[Script] = {
+    scripts(reader.evolutions(database.name))
   }
 
   /**
    * Read evolutions from the database.
-   *
-   * @param db the database name
    */
-  def databaseEvolutions(db: String): Seq[Evolution] = {
-    implicit val connection = dbApi.database(db).getConnection(autocommit = true)
+  private def databaseEvolutions(): Seq[Evolution] = {
+    implicit val connection = database.getConnection(autocommit = true)
 
-    checkEvolutionsState(db)
+    checkEvolutionsState()
 
     try {
 
@@ -152,14 +140,7 @@ class DefaultEvolutionsApi @Inject() (dbApi: DBApi) extends EvolutionsApi {
     }
   }
 
-  /**
-   * Apply evolution scripts to the database.
-   *
-   * @param db the database name
-   * @param scripts the evolution scripts to run
-   * @param autocommit determines whether the connection uses autocommit
-   */
-  def evolve(db: String, scripts: Seq[Script], autocommit: Boolean): Unit = {
+  def evolve(scripts: Seq[Script], autocommit: Boolean): Unit = {
     def logBefore(script: Script)(implicit conn: Connection): Unit = {
       script match {
         case UpScript(e) => {
@@ -197,8 +178,8 @@ class DefaultEvolutionsApi @Inject() (dbApi: DBApi) extends EvolutionsApi {
       ps.execute()
     }
 
-    implicit val connection = dbApi.database(db).getConnection(autocommit = autocommit)
-    checkEvolutionsState(db)
+    implicit val connection = database.getConnection(autocommit = autocommit)
+    checkEvolutionsState()
 
     var applying = -1
     var lastScript: Script = null
@@ -231,7 +212,7 @@ class DefaultEvolutionsApi @Inject() (dbApi: DBApi) extends EvolutionsApi {
 
           val humanScript = "# --- Rev:" + lastScript.evolution.revision + "," + (if (lastScript.isInstanceOf[UpScript]) "Ups" else "Downs") + " - " + lastScript.evolution.hash + "\n\n" + (if (lastScript.isInstanceOf[UpScript]) lastScript.evolution.sql_up else lastScript.evolution.sql_down);
 
-          throw InconsistentDatabase(db, humanScript, message, lastScript.evolution.revision)
+          throw InconsistentDatabase(database.name, humanScript, message, lastScript.evolution.revision)
         } else {
           updateLastProblem(message, applying)
         }
@@ -240,19 +221,18 @@ class DefaultEvolutionsApi @Inject() (dbApi: DBApi) extends EvolutionsApi {
       connection.close()
     }
 
-    checkEvolutionsState(db)
+    checkEvolutionsState()
   }
 
   /**
    * Checks the evolutions state in the database.
    *
-   * @param db the database name
    * @throws an error if the database is in an inconsistent state
    */
-  private def checkEvolutionsState(db: String): Unit = {
+  private def checkEvolutionsState(): Unit = {
     def createPlayEvolutionsTable()(implicit conn: Connection): Unit = {
       try {
-        val createScript = dbApi.database(db).url match {
+        val createScript = database.url match {
           case SqlServerJdbcUrl() => CreatePlayEvolutionsSqlServerSql
           case OracleJdbcUrl() => CreatePlayEvolutionsOracleSql
           case _ => CreatePlayEvolutionsSql
@@ -264,7 +244,7 @@ class DefaultEvolutionsApi @Inject() (dbApi: DBApi) extends EvolutionsApi {
       }
     }
 
-    implicit val connection = dbApi.database(db).getConnection(autocommit = true)
+    implicit val connection = database.getConnection(autocommit = true)
 
     try {
       val problem = executeQuery("select id, hash, apply_script, revert_script, state, last_problem from play_evolutions where state like 'applying_%'")
@@ -283,7 +263,7 @@ class DefaultEvolutionsApi @Inject() (dbApi: DBApi) extends EvolutionsApi {
 
         val humanScript = "# --- Rev:" + revision + "," + (if (state == "applying_up") "Ups" else "Downs") + " - " + hash + "\n\n" + script;
 
-        throw InconsistentDatabase(db, humanScript, error, revision)
+        throw InconsistentDatabase(database.name, humanScript, error, revision)
       }
 
     } catch {
@@ -294,14 +274,13 @@ class DefaultEvolutionsApi @Inject() (dbApi: DBApi) extends EvolutionsApi {
     }
   }
 
-  /**
-   * Resolve evolution conflicts.
-   *
-   * @param db the database name
-   * @param revision the revision to mark as resolved
-   */
-  def resolve(db: String, revision: Int): Unit = {
-    implicit val connection = dbApi.database(db).getConnection(autocommit = true)
+  def resetScripts(): Seq[Script] = {
+    val appliedEvolutions = databaseEvolutions()
+    appliedEvolutions.map(DownScript)
+  }
+
+  def resolve(revision: Int): Unit = {
+    implicit val connection = database.getConnection(autocommit = true)
     try {
       execute("update play_evolutions set state = 'applied' where state = 'applying_up' and id = " + revision);
       execute("delete from play_evolutions where state = 'applying_down' and id = " + revision);
@@ -323,9 +302,13 @@ class DefaultEvolutionsApi @Inject() (dbApi: DBApi) extends EvolutionsApi {
   private def prepare(sql: String)(implicit c: Connection): PreparedStatement = {
     c.prepareStatement(sql)
   }
+
 }
 
 private object DefaultEvolutionsApi {
+
+  val logger = Logger(classOf[DefaultEvolutionsApi])
+
   val SqlServerJdbcUrl = "^jdbc:sqlserver:.*".r
   val OracleJdbcUrl = "^jdbc:oracle:.*".r
 
@@ -371,15 +354,27 @@ private object DefaultEvolutionsApi {
 }
 
 /**
- * Read evolution files from the application environment.
+ * Reader for evolutions
  */
-@Singleton
-class EvolutionsReader @Inject() (environment: Environment) {
+trait EvolutionsReader {
   /**
-   * Read the application evolutions.
-   *
-   * @param db the database name
+   * Read the evolutions for the given db
    */
+  def evolutions(db: String): Seq[Evolution]
+}
+
+/**
+ * Evolutions reader that reads evolutions from resources, for example, the file system or the classpath
+ */
+abstract class ResourceEvolutionsReader extends EvolutionsReader {
+
+  /**
+   * Load the evolutions resource for the given database and revision.
+   *
+   * @return An InputStream to consume the resource, if such a resource exists.
+   */
+  def loadResource(db: String, revision: Int): Option[InputStream]
+
   def evolutions(db: String): Seq[Evolution] = {
 
     val upsMarker = """^#.*!Ups.*$""".r
@@ -402,9 +397,7 @@ class EvolutionsReader @Inject() (environment: Environment) {
     }
 
     Collections.unfoldLeft(1) { revision =>
-      environment.getExistingFile(Evolutions.fileName(db, revision)).map(new FileInputStream(_)).orElse {
-        environment.resourceAsStream(Evolutions.resourceName(db, revision))
-      }.map { stream =>
+      loadResource(db, revision).map { stream =>
         (revision + 1, (revision, PlayIO.readStreamAsString(stream)(Codec.UTF8)))
       }
     }.sortBy(_._1).map {
@@ -430,7 +423,76 @@ class EvolutionsReader @Inject() (environment: Environment) {
 }
 
 /**
- * Exception thrown when the database is in inconsistent state.
+ * Read evolution files from the application environment.
+ */
+@Singleton
+class EnvironmentEvolutionsReader @Inject() (environment: Environment) extends ResourceEvolutionsReader {
+
+  def loadResource(db: String, revision: Int) = {
+    environment.getExistingFile(Evolutions.fileName(db, revision)).map(new FileInputStream(_)).orElse {
+      environment.resourceAsStream(Evolutions.resourceName(db, revision))
+    }
+  }
+}
+
+/**
+ * Evolutions reader that reads evolution files from a class loader.
+ *
+ * @param classLoader The classloader to read from, defaults to the classloader for this class.
+ * @param prefix A prefix that gets added to the resource file names, for example, this could be used to namespace
+ *               evolutions in different environments to work with different databases.
+ */
+class ClassLoaderEvolutionsReader(classLoader: ClassLoader = classOf[ClassLoaderEvolutionsReader].getClassLoader,
+    prefix: String = "") extends ResourceEvolutionsReader {
+  def loadResource(db: String, revision: Int) = {
+    Option(classLoader.getResourceAsStream(prefix + Evolutions.resourceName(db, revision)))
+  }
+}
+
+/**
+ * Evolutions reader that reads evolution files from a class loader.
+ */
+object ClassLoaderEvolutionsReader {
+  /**
+   * Create a class loader evolutions reader for the given prefix.
+   */
+  def forPrefix(prefix: String) = new ClassLoaderEvolutionsReader(prefix = prefix)
+}
+
+/**
+ * Evolutions reader that reads evolution files from its own classloader.  Only suitable for simple (flat) classloading
+ * environments.
+ */
+object ThisClassLoaderEvolutionsReader extends ClassLoaderEvolutionsReader(classOf[ClassLoaderEvolutionsReader].getClassLoader)
+
+/**
+ * Simple map based implementation of the evolutions reader.
+ */
+class SimpleEvolutionsReader(evolutionsMap: Map[String, Seq[Evolution]]) extends EvolutionsReader {
+  def evolutions(db: String) = evolutionsMap.get(db).getOrElse(Nil)
+}
+
+/**
+ * Simple map based implementation of the evolutions reader.
+ */
+object SimpleEvolutionsReader {
+  /**
+   * Create a simple evolutions reader from the given data.
+   *
+   * @param data A map of database name to a sequence of evolutions.
+   */
+  def from(data: (String, Seq[Evolution])*) = new SimpleEvolutionsReader(data.toMap)
+
+  /**
+   * Create a simple evolutions reader from the given evolutions for the default database.
+   *
+   * @param evolutions The evolutions.
+   */
+  def forDefault(evolutions: Evolution*) = new SimpleEvolutionsReader(Map("default" -> evolutions))
+}
+
+/**
+ * Exception thrown when the database is in an inconsistent state.
  *
  * @param db the database name
  * @param script the evolution script

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/EvolutionsModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/EvolutionsModule.scala
@@ -17,7 +17,7 @@ class EvolutionsModule extends Module {
   def bindings(environment: Environment, configuration: Configuration) = {
     Seq(
       bind[EvolutionsConfig].toProvider[DefaultEvolutionsConfigParser],
-      bind[EvolutionsReader].toSelf,
+      bind[EvolutionsReader].to[EnvironmentEvolutionsReader],
       bind[EvolutionsApi].to[DefaultEvolutionsApi],
       bind[ApplicationEvolutions].toProvider[ApplicationEvolutionsProvider].eagerly
     )
@@ -35,7 +35,7 @@ trait EvolutionsComponents {
   def webCommands: WebCommands
 
   lazy val evolutionsConfig: EvolutionsConfig = new DefaultEvolutionsConfigParser(configuration).parse
-  lazy val evolutionsReader: EvolutionsReader = new EvolutionsReader(environment)
+  lazy val evolutionsReader: EvolutionsReader = new EnvironmentEvolutionsReader(environment)
   lazy val evolutionsApi: EvolutionsApi = new DefaultEvolutionsApi(dbApi)
   lazy val applicationEvolutions: ApplicationEvolutions = new ApplicationEvolutions(evolutionsConfig, evolutionsReader, evolutionsApi, dynamicEvolutions, dbApi, environment, webCommands)
 }

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/DatabaseSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/DatabaseSpec.scala
@@ -11,7 +11,7 @@ object DatabaseSpec extends Specification {
   "Database" should {
 
     "create database" in new WithDatabase {
-      val db = Database("test", "org.h2.Driver", "jdbc:h2:mem:test")
+      val db = Database(name = "test", driver = "org.h2.Driver", url = "jdbc:h2:mem:test")
       db.name must_== "test"
       db.url must_== "jdbc:h2:mem:test"
     }

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/evolutions/EvolutionsReaderSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/evolutions/EvolutionsReaderSpec.scala
@@ -9,11 +9,11 @@ import play.api.{ Environment, Mode }
 
 object EvolutionsReaderSpec extends Specification {
 
-  "EvolutionsReader" should {
+  "EnvironmentEvolutionsReader" should {
 
     "read evolution files from classpath" in {
       val environment = Environment(new File("."), getClass.getClassLoader, Mode.Test)
-      val reader = new EvolutionsReader(environment)
+      val reader = new EnvironmentEvolutionsReader(environment)
 
       reader.evolutions("test") must_== Seq(
         Evolution(1, "create table test (id bigint not null, name varchar(255));", "drop table if exists test;"),

--- a/framework/src/play/src/main/java/play/libs/Scala.java
+++ b/framework/src/play/src/main/java/play/libs/Scala.java
@@ -50,6 +50,13 @@ public class Scala {
     }
 
     /**
+     * Converts a Java Collection to a Scala Seq.
+     */
+    public static <A> scala.collection.immutable.Seq<A> asScala(Collection<A> javaCollection) {
+        return scala.collection.JavaConverters.collectionAsScalaIterableConverter(javaCollection).asScala().toList();
+    }
+
+    /**
      * Converts a Java Callable to a Scala Function0.
      */
     public static <A> scala.Function0<A> asScala(final Callable<A> callable) {

--- a/framework/src/play/src/main/scala/play/api/Environment.scala
+++ b/framework/src/play/src/main/scala/play/api/Environment.scala
@@ -103,5 +103,5 @@ object Environment {
    * Uses the same classloader that the environment classloader is defined in, and the current working directory as the
    * path.
    */
-  def simple(mode: Mode.Mode = Mode.Test) = Environment(new File("."), Environment.getClass.getClassLoader, mode)
+  def simple(path: File = new File("."), mode: Mode.Mode = Mode.Test) = Environment(path, Environment.getClass.getClassLoader, mode)
 }

--- a/framework/src/play/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
@@ -64,7 +64,7 @@ object HttpErrorHandlerSpec extends Specification {
 
   def handler(handlerClass: String, mode: Mode.Mode) = {
     val config = Configuration.from(Map("play.http.errorHandler" -> handlerClass))
-    val env = Environment.simple(mode)
+    val env = Environment.simple(mode = mode)
     Fakes.injectorFromBindings(HttpErrorHandler.bindingsFromConfiguration(env, config)
       ++ Seq(
         BindingKey(classOf[Router.Routes]).to(Router.Null),

--- a/framework/src/play/src/test/scala/play/api/libs/CryptoSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/CryptoSpec.scala
@@ -52,7 +52,7 @@ object CryptoSpec extends Specification {
       val Secret = "abcdefghijklmnopqrs"
 
       def parseSecret(mode: Mode.Mode, secret: Option[String] = None) = {
-        new CryptoConfigParser(Environment.simple(mode),
+        new CryptoConfigParser(Environment.simple(mode = mode),
           Configuration.from(
             secret.map("application.secret" -> _).toMap +
               ("play.crypto.aes.transformation" -> "AES")


### PR DESCRIPTION
Java and Scala now both provide an Evolutions.withEvolutions runner, that runs the evolutions for a database, as well as runs the reset scripts afterwards to leave the database in a clean state.

Added documentation on how to write tests for database code.