### PR TITLE
[2.4.0-M2] Problem when parsing json number (Scientific notation)

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
@@ -10,6 +10,7 @@ import scala.collection.mutable.ListBuffer
 
 import com.fasterxml.jackson.core.{ JsonTokenId, JsonGenerator, JsonParser }
 import com.fasterxml.jackson.databind._
+import com.fasterxml.jackson.databind.util.TokenBuffer
 import com.fasterxml.jackson.databind.`type`.TypeFactory
 import com.fasterxml.jackson.databind.deser.Deserializers
 import com.fasterxml.jackson.databind.ser.Serializers
@@ -244,15 +245,10 @@ case class JsObject(fields: Seq[(String, JsValue)]) extends JsValue {
     deepMerge(this, other)
   }
 
-  override def equals(other: Any): Boolean =
-    other match {
-
-      case that: JsObject =>
-        (that canEqual this) &&
-          fieldSet == that.fieldSet
-
-      case _ => false
-    }
+  override def equals(other: Any): Boolean = other match {
+    case that: JsObject => (that canEqual this) && fieldSet == that.fieldSet
+    case _ => false
+  }
 
   def canEqual(other: Any): Boolean = other.isInstanceOf[JsObject]
 
@@ -262,11 +258,21 @@ case class JsObject(fields: Seq[(String, JsValue)]) extends JsValue {
 
 // -- Serializers.
 
-private[json] class JsValueSerializer extends JsonSerializer[JsValue] {
+private[json] object JsValueSerializer extends JsonSerializer[JsValue] {
+  import java.math.{ BigDecimal => JBigDec, BigInteger }
+  import com.fasterxml.jackson.databind.node.{ BigIntegerNode, DecimalNode }
 
   override def serialize(value: JsValue, json: JsonGenerator, provider: SerializerProvider) {
     value match {
-      case JsNumber(v) => json.writeNumber(v.bigDecimal)
+      case JsNumber(v) => {
+        // Workaround #3784: Same behaviour as if JsonGenerator were
+        // configured with WRITE_BIGDECIMAL_AS_PLAIN, but forced as this
+        // configuration is ignored when called from ObjectMapper.valueToTree
+        val raw = v.bigDecimal.stripTrailingZeros.toPlainString
+
+        if (raw contains ".") json.writeTree(new DecimalNode(new JBigDec(raw)))
+        else json.writeTree(new BigIntegerNode(new BigInteger(raw)))
+      }
       case JsString(v) => json.writeString(v)
       case JsBoolean(v) => json.writeBoolean(v)
       case JsArray(elements) => {
@@ -407,7 +413,7 @@ private[json] class PlayDeserializers(classLoader: ClassLoader) extends Deserial
 private[json] class PlaySerializers extends Serializers.Base {
   override def findSerializer(config: SerializationConfig, javaType: JavaType, beanDesc: BeanDescription) = {
     val ser: Object = if (classOf[JsValue].isAssignableFrom(beanDesc.getBeanClass)) {
-      new JsValueSerializer
+      JsValueSerializer
     } else {
       null
     }
@@ -416,7 +422,6 @@ private[json] class PlaySerializers extends Serializers.Base {
 }
 
 private[play] object JacksonJson {
-
   import com.fasterxml.jackson.core.Version
   import com.fasterxml.jackson.databind.module.SimpleModule
   import com.fasterxml.jackson.databind.Module.SetupContext
@@ -434,34 +439,38 @@ private[play] object JacksonJson {
     }
   }
 
-  private[this] lazy val jsonFactory = new com.fasterxml.jackson.core.JsonFactory(mapper)
+  private[this] lazy val jsonFactory =
+    new com.fasterxml.jackson.core.JsonFactory(mapper)
 
-  private[this] def stringJsonGenerator(out: java.io.StringWriter) = jsonFactory.createGenerator(out)
+  private[this] def stringJsonGenerator(out: java.io.StringWriter) =
+    jsonFactory.createGenerator(out)
 
-  private[this] def jsonParser(c: String): JsonParser = jsonFactory.createParser(c)
+  private[this] def jsonParser(c: String): JsonParser =
+    jsonFactory.createParser(c)
 
-  private[this] def jsonParser(data: Array[Byte]): JsonParser = jsonFactory.createParser(data)
+  private[this] def jsonParser(data: Array[Byte]): JsonParser =
+    jsonFactory.createParser(data)
 
-  private[this] def jsonParser(stream: InputStream): JsonParser = jsonFactory.createParser(stream)
+  private[this] def jsonParser(stream: InputStream): JsonParser =
+    jsonFactory.createParser(stream)
 
-  def parseJsValue(data: Array[Byte]): JsValue = {
+  def parseJsValue(data: Array[Byte]): JsValue =
     mapper.readValue(jsonParser(data), classOf[JsValue])
-  }
 
-  def parseJsValue(input: String): JsValue = {
+  def parseJsValue(input: String): JsValue =
     mapper.readValue(jsonParser(input), classOf[JsValue])
-  }
 
-  def parseJsValue(stream: InputStream): JsValue = {
+  def parseJsValue(stream: InputStream): JsValue =
     mapper.readValue(jsonParser(stream), classOf[JsValue])
-  }
 
   def generateFromJsValue(jsValue: JsValue, escapeNonASCII: Boolean = false): String = {
     val sw = new java.io.StringWriter
     val gen = stringJsonGenerator(sw)
+
     if (escapeNonASCII) {
       gen.enable(JsonGenerator.Feature.ESCAPE_NON_ASCII)
     }
+
     mapper.writeValue(gen, jsValue)
     sw.flush()
     sw.getBuffer.toString
@@ -477,12 +486,10 @@ private[play] object JacksonJson {
     sw.getBuffer.toString
   }
 
-  def jsValueToJsonNode(jsValue: JsValue): JsonNode = {
+  def jsValueToJsonNode(jsValue: JsValue): JsonNode =
     mapper.valueToTree(jsValue)
-  }
 
-  def jsonNodeToJsValue(jsonNode: JsonNode): JsValue = {
+  def jsonNodeToJsValue(jsonNode: JsonNode): JsValue =
     mapper.treeToValue(jsonNode, classOf[JsValue])
-  }
 
 }

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -179,24 +179,25 @@ object JsonSpec extends Specification {
     "Not lose precision when parsing big integers" in {
       // By big integers, we just mean integers that overflow long, since Jackson has different code paths for them
       // from decimals
-      val i = BigDecimal("123456789012345678901234567890")
-      val json = toJson(i)
+      val json = toJson(BigDecimal("123456789012345678901234567890"))
       parse(stringify(json)) must equalTo(json)
     }
 
     "Serialize and deserialize Lists" in {
       val xs: List[Int] = (1 to 5).toList
       val json = arr(1, 2, 3, 4, 5)
-      toJson(xs) must equalTo(json)
-      fromJson[List[Int]](json) must equalTo(JsSuccess(xs))
+
+      toJson(xs) must_== json and (
+        fromJson[List[Int]](json) must_== JsSuccess(xs))
     }
 
     "Serialize and deserialize Jackson ObjectNodes" in {
       val on = JacksonJson.mapper.createObjectNode()
         .put("foo", 1).put("bar", "two")
       val json = Json.obj("foo" -> 1, "bar" -> "two")
-      toJson(on) must equalTo(json)
-      fromJson[JsonNode](json).map(_.toString) must_== JsSuccess(on.toString)
+
+      toJson(on) must_== json and (
+        fromJson[JsonNode](json).map(_.toString) must_== JsSuccess(on.toString))
     }
 
     "Serialize and deserialize Jackson ArrayNodes" in {
@@ -207,8 +208,18 @@ object JsonSpec extends Specification {
         fromJson[JsonNode](json).map(_.toString) must_== JsSuccess(an.toString))
     }
 
+    "Deserialize integer JsNumber as Jackson number node" in {
+      val jsNum = JsNumber(new java.math.BigDecimal("50"))
+      fromJson[JsonNode](jsNum).map(_.toString) must_== JsSuccess("50")
+    }
+
+    "Deserialize float JsNumber as Jackson number node" in {
+      val jsNum = JsNumber(new java.math.BigDecimal("12.345"))
+      fromJson[JsonNode](jsNum).map(_.toString) must_== JsSuccess("12.345")
+    }
+
     "Map[String,String] should be turned into JsValue" in {
-      toJson(Map("k" -> "v")).toString must equalTo("{\"k\":\"v\"}")
+      toJson(Map("k" -> "v")).toString must_== """{"k":"v"}"""
     }
 
     "Can parse recursive object" in {
@@ -345,7 +356,6 @@ object JsonSpec extends Specification {
       )(unlift(TestCase.unapply))
 
       Json.toJson(TestCase("my-id", "foo", "bar")) must beEqualTo(js)
-
     }
   }
 }

--- a/framework/src/play/src/main/java/play/mvc/Controller.java
+++ b/framework/src/play/src/main/java/play/mvc/Controller.java
@@ -4,8 +4,14 @@
 package play.mvc;
 
 import play.i18n.Lang;
-import play.mvc.Http.*;
 
+import play.mvc.Http.HeaderNames;
+import play.mvc.Http.Response;
+import play.mvc.Http.Context;
+import play.mvc.Http.Request;
+import play.mvc.Http.Session;
+import play.mvc.Http.Status;
+import play.mvc.Http.Flash;
 
 /**
  * Superclass for a Java-based controller.

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -228,20 +228,16 @@ case class RawBuffer(memoryThreshold: Int, initialData: Array[Byte] = Array.empt
    */
   def asBytes(maxLength: Long = memoryThreshold): Option[Array[Byte]] = {
     if (size <= maxLength) {
-
       if (inMemory != null) {
-
         val buffer = new Array[Byte](inMemorySize)
         inMemory.reverse.foldLeft(0) { (position, chunk) =>
           System.arraycopy(chunk, 0, buffer, position, Math.min(chunk.length, buffer.length - position))
           chunk.length + position
         }
         Some(buffer)
-
       } else {
         Some(PlayIO.readFile(backedByTemporaryFile.file))
       }
-
     } else {
       None
     }
@@ -296,6 +292,15 @@ trait BodyParsers {
       app.configuration.getBytes("parsers.text.maxLength").map(_.toInt)
     }.getOrElse(1024 * 100)
 
+    /**
+     * Default max length allowed for text based body.
+     *
+     * You can configure it in application.conf:
+     *
+     * {{{
+     * parsers.disk.maxLength = 512k
+     * }}}
+     */
     def DefaultMaxDiskLength: Long = Play.maybeApplication.flatMap { app =>
       app.configuration.getBytes("parsers.disk.maxLength")
     }.getOrElse(10 * 1024 * 1024)
@@ -563,7 +568,8 @@ trait BodyParsers {
     /**
      * Parse the body as form url encoded without checking the Content-Type.
      */
-    def tolerantFormUrlEncoded: BodyParser[Map[String, Seq[String]]] = tolerantFormUrlEncoded(DefaultMaxTextLength)
+    def tolerantFormUrlEncoded: BodyParser[Map[String, Seq[String]]] =
+      tolerantFormUrlEncoded(DefaultMaxTextLength)
 
     /**
      * Parse the body as form url encoded if the Content-Type is application/x-www-form-urlencoded.
@@ -579,7 +585,8 @@ trait BodyParsers {
     /**
      * Parse the body as form url encoded if the Content-Type is application/x-www-form-urlencoded.
      */
-    def urlFormEncoded: BodyParser[Map[String, Seq[String]]] = urlFormEncoded(DefaultMaxTextLength)
+    def urlFormEncoded: BodyParser[Map[String, Seq[String]]] =
+      urlFormEncoded(DefaultMaxTextLength)
 
     // -- Magic any content
 
@@ -655,10 +662,8 @@ trait BodyParsers {
      *
      * @param filePartHandler Handles file parts.
      */
-    def multipartFormData[A](filePartHandler: Multipart.PartHandler[FilePart[A]],
-      maxLength: Long = DefaultMaxDiskLength): BodyParser[MultipartFormData[A]] = {
+    def multipartFormData[A](filePartHandler: Multipart.PartHandler[FilePart[A]], maxLength: Long = DefaultMaxDiskLength): BodyParser[MultipartFormData[A]] = {
       BodyParser("multipartFormData") { request =>
-
         import play.api.libs.iteratee.Execution.Implicits.trampoline
 
         val parser = Traversable.takeUpTo[Array[Byte]](maxLength).transform(
@@ -750,7 +755,6 @@ trait BodyParsers {
         }
       }
   }
-
 }
 
 /**

--- a/framework/src/play/src/main/scala/play/core/j/JavaParsers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaParsers.scala
@@ -47,41 +47,29 @@ object JavaParsers extends BodyParsers {
       }.orNull
     }
 
-    override def asText = {
-      text.orNull
-    }
+    override def asText = text.orNull
 
-    override lazy val asJson = {
-      json.map(Json.fromJson[JsonNode](_).get).orNull
-    }
+    override lazy val asJson = json.map(Json.fromJson[JsonNode](_).get).orNull
 
-    override lazy val asXml = {
-      xml.map { xml =>
-        play.libs.XML.fromString(xml.toString)
-      }.orNull
-    }
+    override lazy val asXml = xml.map { xml =>
+      play.libs.XML.fromString(xml.toString)
+    }.orNull
 
-    override lazy val asMultipartFormData = {
-      multipart.map { multipart =>
+    override lazy val asMultipartFormData = multipart.map { multipart =>
+      new play.mvc.Http.MultipartFormData {
 
-        new play.mvc.Http.MultipartFormData {
-
-          lazy val asFormUrlEncoded = {
-            multipart.asFormUrlEncoded.mapValues(_.toArray).asJava
-          }
-
-          lazy val getFiles = {
-            multipart.files.map { file =>
-              new play.mvc.Http.MultipartFormData.FilePart(
-                file.key, file.filename, file.contentType.orNull, file.ref.file)
-            }.asJava
-          }
-
+        lazy val asFormUrlEncoded = {
+          multipart.asFormUrlEncoded.mapValues(_.toArray).asJava
         }
 
-      }.orNull
-    }
-
+        lazy val getFiles = {
+          multipart.files.map { file =>
+            new play.mvc.Http.MultipartFormData.FilePart(
+              file.key, file.filename, file.contentType.orNull, file.ref.file)
+          }.asJava
+        }
+      }
+    }.orNull
   }
 
   def default_(maxLength: Long): BodyParser[RequestBody] = anyContent(parse.default(Some(maxLength).filter(_ >= 0)))

--- a/framework/src/play/src/test/scala/play/core/j/JavaParsersSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/j/JavaParsersSpec.scala
@@ -1,0 +1,29 @@
+package play.core.j
+
+import java.math.{ BigDecimal, BigInteger }
+
+import com.fasterxml.jackson.databind.node.BigIntegerNode
+
+import play.api.libs.json.{ JsNumber, JsObject }
+
+import JavaParsers._
+
+object JavaParsersSpecs extends org.specs2.mutable.Specification {
+  "Java parsers" title
+
+  "JSON body" should {
+    "be successfully parsed from integer value" in {
+      val jsonNode =
+        DefaultRequestBody(json = Some(JsNumber(new BigDecimal("50")))).asJson
+
+      jsonNode.intValue must_== 50 and (jsonNode.asText must_== "50")
+    }
+
+    "be successfully parsed from float value" in {
+      val bd = new BigDecimal("12.34")
+      val jsonNode = DefaultRequestBody(json = Some(JsNumber(bd))).asJson
+
+      jsonNode.decimalValue must_== bd and (jsonNode.asText must_== "12.34")
+    }
+  }
+}


### PR DESCRIPTION
I have discovered an issue with Play 2.4.x and parsing JSON body requests. Sending JSON:
```
{"probability":50}
```
to java controller:
```
	@BodyParser.Of(BodyParser.Json.class)
	public static Result create() {
		JsonNode json = request().body().asJson();
		Logger.info("json: " + json);
```
ends with:
```
[info] application - json: {"probability":5E+1}
```
2.3.x works great with that code, 2.4 not.