### PR TITLE
WSClient should have close() in public API

### DIFF
--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -155,7 +155,7 @@ Using for comprehensions is a good way to chain WS calls in a trusted environmen
 
 ### Using in a controller
 
-When making a request from a controller, you can map the response to a `Future[Result]`.  This can be used in combination with Play's `Action.async` action builder, as described in [[Handling Asynchronous Results|ScalaAsync]].
+When making a request from a controller, you can map the response to a `Future[Result]`. This can be used in combination with Play's `Action.async` action builder, as described in [[Handling Asynchronous Results|ScalaAsync]].
 
 @[async-result](code/ScalaWSSpec.scala)
 
@@ -163,11 +163,11 @@ When making a request from a controller, you can map the response to a `Future[R
 
 WSClient is a wrapper around the underlying AsyncHttpClient.  It is useful for defining multiple clients with different profiles, or using a mock.
 
-You can define a WS client directly from code without having it injected by WS, and then use it implicitly with `WS.clientUrl()`.  Note that you should always use `NingAsyncHttpClientConfigBuilder` when configuring your client, for secure TLS configuration:
+You can define a WS client directly from code without having it injected by WS, and then use it implicitly with `WS.clientUrl()`. Note that you should always use `NingAsyncHttpClientConfigBuilder` when configuring your client, for secure TLS configuration:
 
 @[implicit-client](code/ScalaWSSpec.scala)
 
-> NOTE: if you instantiate a NingWSClient object, it does not use the WS module lifecycle, and so will not be automatically closed in `Application.onStop`. Instead, the client must be manually shutdown using `client.close()` when processing has completed.  This will release the underlying ThreadPoolExecutor used by AsyncHttpClient.  Failure to close the client may result in out of memory exceptions (especially if you are reloading an application frequently in development mode).
+> NOTE: if you instantiate a NingWSClient object, it does not use the WS module lifecycle, and so will not be automatically closed in `Application.onStop`. Instead, the client must be manually shutdown using `client.close()` when processing has completed. This will release the underlying ThreadPoolExecutor used by AsyncHttpClient. Failure to close the client may result in out of memory exceptions (especially if you are reloading an application frequently in development mode).
 
 or directly:
 

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSClient.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSClient.java
@@ -3,11 +3,12 @@
  */
 package play.libs.ws;
 
-
-public interface WSClient {
+public interface WSClient extends java.io.Closeable {
 
     public Object getUnderlying();
 
     WSRequestHolder url(String url);
 
+    /** Closes this client, and releases underlying resources. */
+    public void close();
 }

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSClient.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSClient.java
@@ -26,7 +26,7 @@ public class NingWSClient implements WSClient {
         return new NingWSRequestHolder(this, url);
     }
 
-    protected void close() {
+    public void close() {
         this.asyncHttpClient.close();
     }
 }

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -35,6 +35,9 @@ trait WSClient {
    * @return a WSRequestHolder
    */
   def url(url: String): WSRequestHolder
+
+  /** Closes this client, and releases underlying resources. */
+  def close(): Unit
 }
 
 /**
@@ -75,7 +78,7 @@ trait WSRequestHolderMagnet {
  * """.stripMargin))
  * val parser = new DefaultWSConfigParser(configuration, Play.current.classloader)
  * val builder = new NingAsyncHttpClientConfigBuilder(parser.parse())
- * val secureClient : WSClient = new NingWSClient(builder.build())
+ * val secureClient: WSClient = new NingWSClient(builder.build())
  * val response = secureClient.url("https://secure.com").get()
  * }}}
  *

--- a/framework/src/play-ws/src/test/scala/play/api/libs/openid/WsMock.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/openid/WsMock.scala
@@ -28,4 +28,6 @@ class WSMock extends Mockito with WSClient {
   }
 
   def underlying[T]: T = this.asInstanceOf[T]
+
+  def close() = ()
 }


### PR DESCRIPTION
If you look at the Java API:

https://github.com/playframework/playframework/blob/master/framework/src/play-java-ws/src/main/java/play/libs/ws/WSClient.java

and the Scala API:

https://github.com/playframework/playframework/blob/master/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala#L22

then you can see the WSClient doesn't have a defined close() method.  

This means that when users try to create a WSClient instance outside of the plugin lifecycle, they have to do

```
val close(wsClient:WSClient) = wsClient.underlying[AsyncHttpClient].close() 
```

This is inconvenient, and entirely avoidable.