### PR TITLE
Avoid the extra implicit conversion for `Option[T] => Seq[T]`

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -199,7 +199,7 @@ package play.api.mvc {
      */
     private[play] def acceptHeader(headers: Headers, headerName: String): Seq[(Double, String)] = {
       for {
-        header <- headers.get(headerName).toSeq
+        header <- headers.get(headerName).toList
         value0 <- header.split(',')
         value = value0.trim
       } yield {


### PR DESCRIPTION
`Option` offers a `toList`. Calling `toSeq` requires an implicit
to be applied (specifically, `Option.option2Iterable`).

(I know this is sort of a ridiculous PR. In fact, feel free to reject it if you feel so :-))