### PR TITLE
Mimetypes.scala should map rtf to application/rtf instead of text/richtext

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
@@ -412,8 +412,8 @@ object MimeTypes {
         rp=image/vndrn-realpix
         rpm=audio/x-pn-realaudio-plugin
         rt=text/vndrn-realtext
-        rtf=text/richtext
-        rtx=text/richtext
+        rtf=application/rtf
+        rtx=application/rtx
         rv=video/vndrn-realvideo
         s=text/x-asm
         s3m=audio/s3m


### PR DESCRIPTION
The Mimetypes.scala mapping of rtf to text/richtext is probably not the best mapping by extension. While extension is probably not the best indicator, my suspicion would be a much larger number of files with .rtf mean the application/rtf type.

http://en.wikipedia.org/wiki/Rich_Text_Format

