### PR TITLE
Use a separate compile step in runtests script

### DIFF
--- a/framework/runtests
+++ b/framework/runtests
@@ -34,12 +34,12 @@ else
   echo "[info]"
   # separate compile so that compile and doc do not run simultaneously
   # this will also fail early on compilation errors
-  $BUILD "$@" -Dgenerate.doc=true compile test:compile publish-local
+  $BUILD "$@" -Dgenerate.doc=true Fork-Run-Protocol/compile compile test:compile publish-local
   for v in ${crossbuild//,/ } ; do
     echo "[info]"
     echo "[info] ---- BUILDING PLAY (cross building against Scala $v)"
     echo "[info]"
-    $BUILD "$@" -Dgenerate.doc=true -Dscala.version=$v compile test:compile publish-local
+    $BUILD "$@" -Dgenerate.doc=true -Dscala.version=$v Fork-Run-Protocol/compile compile test:compile publish-local
   done
 fi
 

--- a/framework/runtests
+++ b/framework/runtests
@@ -32,12 +32,14 @@ else
   echo "[info]"
   echo "[info] ---- BUILDING PLAY (with its default version of Scala)"
   echo "[info]"
-  $BUILD "$@" -Dgenerate.doc=true publish-local
+  # separate compile so that compile and doc do not run simultaneously
+  # this will also fail early on compilation errors
+  $BUILD "$@" -Dgenerate.doc=true compile test:compile publish-local
   for v in ${crossbuild//,/ } ; do
     echo "[info]"
     echo "[info] ---- BUILDING PLAY (cross building against Scala $v)"
     echo "[info]"
-    $BUILD "$@" -Dgenerate.doc=true -Dscala.version=$v publish-local
+    $BUILD "$@" -Dgenerate.doc=true -Dscala.version=$v compile test:compile publish-local
   done
 fi
 


### PR DESCRIPTION
We're sometimes getting compile failures in the fork run protocol projects. This seems to be caused by compile and doc running simultaneously, causing some concurrency issues with scala pickling reflection (maybe only with Scala 2.10?).

This change is to check whether always having a separate compile step prevents these issues.