### PR TITLE
Don't include body and Content-Length in 204 and 304 responses.  Fixes #3899

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -159,6 +159,8 @@ private[akkahttp] object ModelConversion {
           contentType = convertedHeaders.contentType,
           data = dataSource(enum)
         ))
+      case ServerResultUtils.StreamWithNoBody =>
+        Right(HttpEntity.Empty)
       case ServerResultUtils.StreamWithKnownLength(enum) =>
         Right(HttpEntity.Default(
           contentType = convertedHeaders.contentType,


### PR DESCRIPTION
As described in http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4,
both 204 and 304 responses must not include a message-body. This requirement
was not enforced in Play, but the built-in instances for both 204 and 304
responses (see `play.api.mvc.Results.NoContent` and
`play.api.mvc.Results.NotModified`) are constructed with an empty body. Hence,
the above mentioned requirement was already respected (though not enforced)
when using these values.

This commit enforces the requirement, returning an empty body for both 204 and
304 responses (whether a message body is provided or not).

Ticket #3899 requested the `Content-Length` header to never be included in a
304 result. The specification for 304 (see
http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5) only states
that no message body should be returned, but it does not say that a
`Content-Length` must not be passed.

Hence, the solution adopted in this commit is to be lenient with the
`Content-Length` for both 204 and 304 responses. Meaning that we won't
automatically inject a `Content-Length` header for such responses, but we also
won't disallow users to provide it.