### PR TITLE
Extend the HandlerRef interface such that we no longer need to cast it to another type when using it

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -98,8 +98,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     }
 
     public static Result callAction(HandlerRef actionReference, FakeRequest fakeRequest, long timeout) {
-        play.api.mvc.HandlerRef handlerRef = (play.api.mvc.HandlerRef)actionReference;
-        return invokeHandler(handlerRef.handler(), fakeRequest, timeout);
+        return invokeHandler(actionReference.handler(), fakeRequest, timeout);
     }
 
     /**

--- a/framework/src/play/src/main/java/play/mvc/HandlerRef.java
+++ b/framework/src/play/src/main/java/play/mvc/HandlerRef.java
@@ -7,5 +7,7 @@ package play.mvc;
  * Reference to an Handler.
  */
 public interface HandlerRef {
+
+  play.api.mvc.Handler handler();
     
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -32,7 +32,7 @@ trait RequestTaggingHandler extends Handler {
  */
 class HandlerRef[T](call: => T, handlerDef: play.core.Router.HandlerDef)(implicit hif: play.core.Router.HandlerInvokerFactory[T]) extends play.mvc.HandlerRef {
 
-  lazy val invoker: HandlerInvoker[T] = hif.createInvoker(call, handlerDef)
+  private lazy val invoker: HandlerInvoker[T] = hif.createInvoker(call, handlerDef)
 
   /**
    * Retrieve a real handler behind this ref.
@@ -44,7 +44,7 @@ class HandlerRef[T](call: => T, handlerDef: play.core.Router.HandlerDef)(implici
   /**
    * String representation of this Handler.
    */
-  lazy val sym = {
+  private lazy val sym = {
     handlerDef.controller + "." + handlerDef.method + "(" + handlerDef.parameterTypes.map(_.getName).mkString(", ") + ")"
   }
 


### PR DESCRIPTION
This PR is an alternative to https://github.com/playframework/playframework/pull/3929