### PR TITLE
Synchronize when configuring the logger globally

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Logger.scala
+++ b/framework/src/play/src/main/scala/play/api/Logger.scala
@@ -257,7 +257,7 @@ object Logger extends LoggerLike {
   /**
    * Reconfigures the underlying logback infrastructure.
    */
-  def configure(properties: Map[String, String], config: Option[URL], levels: Map[String, LogbackLevel]): Unit = {
+  def configure(properties: Map[String, String], config: Option[URL], levels: Map[String, LogbackLevel]): Unit = synchronized {
     // Redirect JUL -> SL4FJ
     {
       import org.slf4j.bridge._


### PR DESCRIPTION
This avoids multiple applications configuring the logger simultaneously, which can cause a lot of extra logging from logback and sometimes concurrent modification exceptions.