### PR TITLE
Fix performance problem with toLocale by switching to lazy val

### DIFF
--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -32,9 +32,7 @@ case class Lang(language: String, country: String = "") {
   /**
    * Convert to a Java Locale value.
    */
-  def toLocale: java.util.Locale = {
-    Option(country).filterNot(_.isEmpty).map(c => new java.util.Locale(language, c)).getOrElse(new java.util.Locale(language))
-  }
+  lazy val toLocale = Option(country).filterNot(_.isEmpty).map(c => new java.util.Locale(language, c)).getOrElse(new java.util.Locale(language))
 
   /**
    * Whether this lang satisfies the given lang.


### PR DESCRIPTION
A simple fix to avoid creating a separate Locale object every time.