### PR TITLE
Add a RequestBuilder to make it easier to construct a request in Java tests

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaRequestsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaRequestsSpec.scala
@@ -7,7 +7,7 @@ import play.api.mvc._
 
 import play.core.j.JavaHelpers
 import play.mvc.Http
-import play.mvc.Http.{ RequestBody, Context }
+import play.mvc.Http.{ Context, RequestBody, RequestImpl }
 
 /**
  *
@@ -18,7 +18,7 @@ class JavaRequestsSpec extends PlaySpecification with Mockito {
 
     "create a request with case insensitive headers" in {
       val requestHeader: RequestHeader = FakeRequest().withHeaders("Content-type" -> "application/json")
-      val javaRequest: Http.Request = JavaHelpers.createJavaRequest(requestHeader)
+      val javaRequest: Http.Request = new RequestImpl(requestHeader)
 
       val ct = javaRequest.getHeader("Content-Type")
       val headers = javaRequest.headers()
@@ -33,7 +33,7 @@ class JavaRequestsSpec extends PlaySpecification with Mockito {
 
       val cookie1 = Cookie("name1", "value1")
       val requestHeader: RequestHeader = FakeRequest().withCookies(cookie1)
-      val javaRequest: Http.Request = JavaHelpers.createJavaRequest(requestHeader)
+      val javaRequest: Http.Request = new RequestImpl(requestHeader)
 
       val iterator: Iterator[Http.Cookie] = javaRequest.cookies().iterator()
       val cookieList = iterator.toList

--- a/framework/src/play-java/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/DynamicFormSpec.scala
@@ -21,38 +21,38 @@ object DynamicFormSpec extends Specification {
   "a dynamic form" should {
 
     "bind values from a request" in {
-      val form = new DynamicForm().bindFromRequest(new DummyRequest(Map("foo" -> Array("bar"))))
+      val form = new DynamicForm().bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       form.get("foo") must_== "bar"
     }
 
     "allow access to raw data values from request" in {
-      val form = new DynamicForm().bindFromRequest(new DummyRequest(Map("foo" -> Array("bar"))))
+      val form = new DynamicForm().bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       form.data().get("foo") must_== "bar"
     }
 
     "display submitted values in template helpers" in {
-      val form = new DynamicForm().bindFromRequest(new DummyRequest(Map("foo" -> Array("bar"))))
+      val form = new DynamicForm().bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       val html = inputText(form("foo")).body
       html must contain("value=\"bar\"")
       html must contain("name=\"foo\"")
     }
 
     "render correctly when no value is submitted in template helpers" in {
-      val form = new DynamicForm().bindFromRequest(new DummyRequest(Map()))
+      val form = new DynamicForm().bindFromRequest(FormSpec.dummyRequest(Map()))
       val html = inputText(form("foo")).body
       html must contain("value=\"\"")
       html must contain("name=\"foo\"")
     }
 
     "display errors in template helpers" in {
-      val form = new DynamicForm().bindFromRequest(new DummyRequest(Map("foo" -> Array("bar"))))
+      val form = new DynamicForm().bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       form.reject("foo", "There was an error")
       val html = inputText(form("foo")).body
       html must contain("There was an error")
     }
 
     "display errors when a field is not present" in {
-      val form = new DynamicForm().bindFromRequest(new DummyRequest(Map()))
+      val form = new DynamicForm().bindFromRequest(FormSpec.dummyRequest(Map()))
       form.reject("foo", "Foo is required")
       val html = inputText(form("foo")).body
       html must contain("Foo is required")

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -20,6 +20,7 @@ import play.api.libs.iteratee._
 import play.api.libs.iteratee.Input._
 import play.core.server.Server
 import play.core.server.common.{ ForwardedHeaderHandler, ServerRequestUtils, ServerResultUtils }
+import play.core.system.RequestIdProvider
 import play.core.websocket._
 import scala.collection.JavaConverters._
 import scala.util.control.Exception
@@ -32,8 +33,6 @@ import org.jboss.netty.handler.codec.http.websocketx.CloseWebSocketFrame
 private[play] class PlayDefaultUpstreamHandler(server: Server, allChannels: DefaultChannelGroup) extends SimpleChannelUpstreamHandler with WebSocketHandler with RequestBodyHandler {
 
   import PlayDefaultUpstreamHandler._
-
-  private val requestIDs = new java.util.concurrent.atomic.AtomicLong(0)
 
   private lazy val forwardedHeaderHandler = new ForwardedHeaderHandler(
     ForwardedHeaderHandler.ForwardedHeaderHandlerConfig(server.applicationProvider.get.toOption.map(_.configuration)))
@@ -104,7 +103,7 @@ private[play] class PlayDefaultUpstreamHandler(server: Server, allChannels: Defa
         def createRequestHeader(parameters: Map[String, Seq[String]] = Map.empty[String, Seq[String]]) = {
           //mapping netty request to Play's
           val untaggedRequestHeader = new RequestHeader {
-            val id = requestIDs.incrementAndGet
+            val id = RequestIdProvider.requestIDs.incrementAndGet
             val tags = Map.empty[String, String]
             def uri = nettyHttpRequest.getUri
             def path = new URI(nettyUri.getPath).getRawPath //wrapping into URI to handle absoluteURI

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -211,6 +211,19 @@ package play.api.mvc {
     }
   }
 
+  private[play] class RequestHeaderImpl(
+      val id: Long,
+      val tags: Map[String, String],
+      val uri: String,
+      val path: String,
+      val method: String,
+      val version: String,
+      val queryString: Map[String, Seq[String]],
+      val headers: Headers,
+      val remoteAddress: String,
+      val secure: Boolean) extends RequestHeader {
+  }
+
   /**
    * The complete HTTP request.
    *
@@ -382,6 +395,10 @@ package play.api.mvc {
 
     override def toString = data.toString
 
+  }
+
+  class HeadersImpl(_data: Seq[(String, Seq[String])]) extends Headers {
+    protected val data: Seq[(String, Seq[String])] = _data
   }
 
   /**

--- a/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
@@ -27,7 +27,7 @@ class JavaGlobalSettingsAdapter(val underlying: play.GlobalSettings) extends Glo
   }
 
   override def onRouteRequest(request: RequestHeader): Option[Handler] = {
-    val r = JavaHelpers.createJavaRequest(request)
+    val r = new play.mvc.Http.RequestImpl(request)
     Option(underlying.onRouteRequest(r)).map(Some(_)).getOrElse(super.onRouteRequest(request))
   }
 

--- a/framework/src/play/src/main/scala/play/core/system/RequestIdProvider.scala
+++ b/framework/src/play/src/main/scala/play/core/system/RequestIdProvider.scala
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.core.system
+
+import java.util.concurrent.atomic.AtomicLong;
+
+private[play] object RequestIdProvider {
+  val requestIDs: AtomicLong = new AtomicLong(0)
+}

--- a/framework/src/play/src/test/java/play/mvc/CallTest.java
+++ b/framework/src/play/src/test/java/play/mvc/CallTest.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Map;
 
 import play.api.http.MediaRange;
+import play.mvc.Http.Request;
+import play.mvc.Http.RequestBuilder;
 
 import org.junit.Test;
 
@@ -16,9 +18,8 @@ public final class CallTest {
 
     @Test
     public void testHttpAbsoluteURL1() throws Throwable {
-        final TestRequest req =
-            new TestRequest("GET", "playframework.com", "/playframework",
-                            false, "127.0.0.1", "/v", "/u");
+        final Request req = new RequestBuilder()
+            .url("http://playframework.com/playframework").build();
 
         final TestCall call = new TestCall("/url", "GET");
 
@@ -29,9 +30,8 @@ public final class CallTest {
 
     @Test
     public void testHttpAbsoluteURL2() throws Throwable {
-        final TestRequest req =
-            new TestRequest("GET", "playframework.com", "/playframework",
-                            true, "127.0.0.1", "/v", "/u");
+        final Request req = new RequestBuilder()
+            .url("https://playframework.com/playframework").build();
 
         final TestCall call = new TestCall("/url", "GET");
 
@@ -51,9 +51,8 @@ public final class CallTest {
 
     @Test
     public void testHttpsAbsoluteURL1() throws Throwable {
-        final TestRequest req =
-            new TestRequest("GET", "playframework.com", "/playframework",
-                            true, "127.0.0.1", "/v", "/u");
+        final Request req = new RequestBuilder()
+            .url("https://playframework.com/playframework").build();
 
         final TestCall call = new TestCall("/url", "GET");
 
@@ -64,9 +63,8 @@ public final class CallTest {
 
     @Test
     public void testHttpsAbsoluteURL2() throws Throwable {
-        final TestRequest req =
-            new TestRequest("GET", "playframework.com", "/playframework",
-                            false, "127.0.0.1", "/v", "/u");
+        final Request req = new RequestBuilder()
+            .url("http://playframework.com/playframework").build();
 
         final TestCall call = new TestCall("/url", "GET");
 
@@ -86,9 +84,8 @@ public final class CallTest {
 
     @Test
     public void testWebSocketURL1() throws Throwable {
-        final TestRequest req =
-            new TestRequest("GET", "playframework.com", "/playframework",
-                            false, "127.0.0.1", "/v", "/u");
+        final Request req = new RequestBuilder()
+            .url("http://playframework.com/playframework").build();
 
         final TestCall call = new TestCall("/url", "GET");
 
@@ -99,9 +96,8 @@ public final class CallTest {
 
     @Test
     public void testWebSocketURL2() throws Throwable {
-        final TestRequest req =
-            new TestRequest("GET", "playframework.com", "/playframework",
-                            true, "127.0.0.1", "/v", "/u");
+        final Request req = new RequestBuilder()
+            .url("https://playframework.com/playframework").build();
 
         final TestCall call = new TestCall("/url", "GET");
 
@@ -121,9 +117,8 @@ public final class CallTest {
 
     @Test
     public void testSecureWebSocketURL1() throws Throwable {
-        final TestRequest req =
-            new TestRequest("GET", "playframework.com", "/playframework",
-                            true, "127.0.0.1", "/v", "/u");
+        final Request req = new RequestBuilder()
+            .url("https://playframework.com/playframework").build();
 
         final TestCall call = new TestCall("/url", "GET");
 
@@ -134,9 +129,8 @@ public final class CallTest {
 
     @Test
     public void testSecureWebSocketURL2() throws Throwable {
-        final TestRequest req =
-            new TestRequest("GET", "playframework.com", "/playframework",
-                            false, "127.0.0.1", "/v", "/u");
+        final Request req = new RequestBuilder()
+            .url("http://playframework.com/playframework").build();
 
         final TestCall call = new TestCall("/url", "GET");
 
@@ -154,75 +148,6 @@ public final class CallTest {
                      call.webSocketURL(true, "typesafe.com"));
     }
 
-}
-
-// Can't use FakeRequest from Play-Test
-final class TestCookies extends ArrayList<Http.Cookie> implements Http.Cookies {
-    public Http.Cookie get(String name) {
-        if (name == null) return null;
-
-        for (final Http.Cookie c : this) {
-            if (c != null && name.equals(c.name())) return c;
-        }
-
-        return null; // Not found
-    }
-}
-
-final class TestRequest extends Http.Request {
-    private final TreeMap<String,String[]> hs =
-        new TreeMap<String,String[]>(play.core.utils.CaseInsensitiveOrdered$.MODULE$);
-
-    private final HashMap<String,String[]> qs =
-        new HashMap<String,String[]>();
-
-    private final TestCookies cs = new TestCookies();
-
-    private final String m; // Method
-    private final String h; // Host
-    private final String p; // Path
-    private final boolean s; // Secure
-    private final String ra; // Remote address
-    private final String v; // Version
-    private final String u; // URI
-
-    public TestRequest(String m, String h, String p,
-                       boolean s, String ra, String v, String u) {
-
-        this.m = m;
-        this.h = h;
-        this.p = p;
-        this.s = s;
-        this.ra = ra;
-        this.v = v;
-        this.u = u;
-    }
-
-    // ---
-
-    public String method() { return this.m; }
-    public String host() { return this.h; }
-    public String path() { return this.p; }
-    public boolean secure() { return this.s; }
-    public String remoteAddress() { return this.ra; }
-    public String version() { return this.v; }
-    public String uri() { return this.u; }
-
-    public Map<String,String[]> headers() { return hs; }
-
-    public Http.RequestBody body() { return null; /* TODO */ }
-
-    public Http.Cookies cookies() { return this.cs; }
-
-    public Map<String,String[]> queryString() { return this.qs; }
-
-    public boolean accepts(String mimeType) { return true; }
-
-    public List<MediaRange> acceptedTypes() { return null; /* TODO */ }
-
-    public List<String> accept() { return null; /* TODO */ }
-
-    public List<play.i18n.Lang> acceptLanguages() { return null; /* TODO */ }
 }
 
 final class TestCall extends Call {


### PR DESCRIPTION
This adds a RequestBuilder to make Requests and Contexts easier to create in tests

There are some places in the Play tests where the RequestBuilder could save some code. E.g. it'd probably save 100 lines of code in CallTest since TestRequest and TestCookies could both be deleted. However, I didn't use if there since it would create a circular dependency to have the main Play project use the Play test project.