### PR TITLE
Add back activator stop command

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayRun.scala
@@ -237,4 +237,21 @@ trait PlayRun extends PlayInternalKeys {
 
   }
 
+  val playStopCommand = Command.args("stop", "") { (state: State, args: Seq[String]) =>
+
+    val extracted = Project.extract(state)
+
+    val pidFile = extracted.get(stagingDirectory in Universal) / "RUNNING_PID"
+    if (!pidFile.exists) {
+      println("No PID file found. Are you sure the app is running?")
+    } else {
+      val pid = IO.read(pidFile)
+      s"kill $pid".!
+      // PID file will be deleted by a shutdown hook attached on start in ServerStart.scala
+      println(s"Stopped application with process ID $pid")
+    }
+    println()
+
+    state.copy(remainingCommands = Seq.empty)
+  }
 }

--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -89,7 +89,7 @@ trait PlaySettings {
       (sources ** "*" --- assets ** "*").get
     },
 
-    commands ++= Seq(shCommand, playStartCommand, h2Command, classpathCommand, licenseCommand, computeDependenciesCommand),
+    commands ++= Seq(shCommand, playStartCommand, playStopCommand, h2Command, classpathCommand, licenseCommand, computeDependenciesCommand),
 
     // THE `in Compile` IS IMPORTANT!
     run in Compile <<= playDefaultRunTask,


### PR DESCRIPTION
This was lost in the process of moving from shell script to
activator. This fixes issue #3664.