### PR TITLE
Ignore unsolicited WebSocket Pong frames

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -3,6 +3,8 @@
  */
 package play.it.http.websocket
 
+import java.nio.charset.Charset
+
 import play.api.test._
 import play.api.Application
 import scala.concurrent.{ Future, Promise }
@@ -44,6 +46,10 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
       })
     }
     await(innerResult.future)
+  }
+
+  def pongFrame(matcher: Matcher[String]): Matcher[WebSocketFrame] = beLike {
+    case t: PongWebSocketFrame => t.getBinaryData.toString(Charset.forName("utf-8")) must matcher
   }
 
   def textFrame(matcher: Matcher[String]): Matcher[WebSocketFrame] = beLike {
@@ -231,6 +237,41 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
         }
         frames must contain(exactly(
           closeFrame(1003)
+        ))
+      }
+    }.pendingUntilAkkaHttpFixed
+
+    "respond to pings" in {
+      withServer(app => WebSocket.using[String] { req =>
+        (Iteratee.head, Enumerator.empty)
+      }) {
+        val frames = runWebSocket { (in, out) =>
+          Enumerator[WebSocketFrame](
+            new PingWebSocketFrame(binaryBuffer("hello")),
+            new CloseWebSocketFrame(1000, "")
+          ) |>> out
+          in |>>> Iteratee.getChunks[WebSocketFrame]
+        }
+        frames must contain(exactly(
+          pongFrame(be_==("hello")),
+          closeFrame()
+        ))
+      }
+    }.pendingUntilAkkaHttpFixed
+
+    "not respond to pongs" in {
+      withServer(app => WebSocket.using[String] { req =>
+        (Iteratee.head, Enumerator.empty)
+      }) {
+        val frames = runWebSocket { (in, out) =>
+          Enumerator[WebSocketFrame](
+            new PongWebSocketFrame(),
+            new CloseWebSocketFrame(1000, "")
+          ) |>> out
+          in |>>> Iteratee.getChunks[WebSocketFrame]
+        }
+        frames must contain(exactly(
+          closeFrame()
         ))
       }
     }.pendingUntilAkkaHttpFixed

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
@@ -110,6 +110,9 @@ private[server] trait WebSocketHandler {
             case (frame: PingWebSocketFrame, _) =>
               ctx.getChannel.write(new PongWebSocketFrame(frame.getBinaryData))
 
+            // pong!
+            case (frame: PongWebSocketFrame, _) => // ignore
+
             // unacceptable frame
             case (frame: WebSocketFrame, _) =>
               closeWebSocket(ctx, WebSocketUnacceptable, "This WebSocket does not handle frames of that type")


### PR DESCRIPTION
IE11 send pong events every ~20 seconds which the server should ignore.
Previously Play responded with an error which causes IE11 to close the websocket.

https://tools.ietf.org/html/rfc6455#section-5.5.3
>A Pong frame MAY be sent unsolicited.  This serves as a unidirectional
heartbeat.  A response to an unsolicited Pong frame is not expected.

Fixes #2992