### PR TITLE
Add builders for creating applications with Guice

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/extending/code/javaguide/advanced/extending/JavaPlugins.java
+++ b/documentation/manual/working/javaGuide/advanced/extending/code/javaguide/advanced/extending/JavaPlugins.java
@@ -2,6 +2,7 @@ package javaguide.advanced.extending;
 
 import akka.actor.ActorRef;
 import org.junit.Test;
+import play.Application;
 import play.Play;
 import play.libs.F;
 import play.test.*;
@@ -19,7 +20,7 @@ public class JavaPlugins {
     @Test
     public void pluginsShouldBeAccessible() {
         final AtomicReference<MyComponent> myComponentRef = new AtomicReference<MyComponent>();
-        FakeApplication app = fakeApplication(new HashMap<String, Object>(), Arrays.asList(MyPlugin.class.getName()));
+        Application app = fakeApplication(new HashMap<String, Object>(), Arrays.asList(MyPlugin.class.getName()));
         running(app, new Runnable() {
             public void run() {
                 //#access-plugin
@@ -34,7 +35,7 @@ public class JavaPlugins {
 
     @Test
     public void actorExampleShouldWork() {
-        FakeApplication app = fakeApplication(new HashMap<String, Object>(), Arrays.asList(Actors.class.getName()));
+        Application app = fakeApplication(new HashMap<String, Object>(), Arrays.asList(Actors.class.getName()));
         running(app, new Runnable() {
             public void run() {
                 ActorRef actor = Actors.getMyActor();

--- a/documentation/manual/working/javaGuide/main/cache/code/javaguide/cache/JavaCache.java
+++ b/documentation/manual/working/javaGuide/main/cache/code/javaguide/cache/JavaCache.java
@@ -5,10 +5,10 @@ package javaguide.cache;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
+import play.Application;
 import play.cache.CacheApi;
 import play.cache.Cached;
 import play.mvc.*;
-import play.test.FakeApplication;
 import play.test.WithApplication;
 
 import javaguide.testhelpers.MockJavaAction;
@@ -24,7 +24,7 @@ import static play.test.Helpers.*;
 public class JavaCache extends WithApplication {
 
     @Override
-    protected FakeApplication provideFakeApplication() {
+    protected Application provideApplication() {
         return fakeApplication(ImmutableMap.of("play.modules.cache.bindCaches", Arrays.asList("session-cache")));
     }
 
@@ -33,14 +33,14 @@ public class JavaCache extends WithApplication {
     @Test
     public void inject() {
         // Check that we can instantiate it
-        app.getWrappedApplication().injector().instanceOf(javaguide.cache.inject.Application.class);
+        app.injector().instanceOf(javaguide.cache.inject.Application.class);
         // Check that we can instantiate the qualified one
-        app.getWrappedApplication().injector().instanceOf(javaguide.cache.qualified.Application.class);
+        app.injector().instanceOf(javaguide.cache.qualified.Application.class);
     }
 
     @Test
     public void simple() {
-        CacheApi cache = app.getWrappedApplication().injector().instanceOf(CacheApi.class);
+        CacheApi cache = app.injector().instanceOf(CacheApi.class);
 
         News frontPageNews = new News();
         //#simple-set
@@ -78,7 +78,7 @@ public class JavaCache extends WithApplication {
 
     @Test
     public void http() {
-        CacheApi cache = app.getWrappedApplication().injector().instanceOf(CacheApi.class);
+        CacheApi cache = app.injector().instanceOf(CacheApi.class);
 
         assertThat(contentAsString(MockJavaActionHelper.call(new Controller1(), fakeRequest())), equalTo("Hello world"));
         assertThat(cache.get("homePage"), notNullValue());

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaCsrf.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaCsrf.java
@@ -10,13 +10,13 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
+import play.Application;
 import play.filters.csrf.AddCSRFToken;
 import play.filters.csrf.CSRFFilter;
 import play.filters.csrf.RequireCSRFCheck;
 import play.libs.Crypto;
 import play.mvc.Result;
 import play.test.WithApplication;
-import play.test.FakeApplication;
 
 import static play.test.Helpers.*;
 
@@ -29,12 +29,12 @@ import java.util.regex.Pattern;
 
 public class JavaCsrf extends WithApplication {
     @Override
-    public FakeApplication provideFakeApplication() {
+    public Application provideApplication() {
         return fakeApplication(ImmutableMap.of("application.secret", "foobar"));
     }
 
     public Crypto crypto() {
-      return app.getWrappedApplication().injector().instanceOf(Crypto.class);
+      return app.injector().instanceOf(Crypto.class);
     }
 
     @Test

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
@@ -5,9 +5,9 @@ package javaguide.http;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.*;
+import play.Application;
 import play.libs.Json;
 import play.test.WithApplication;
-import play.test.FakeApplication;
 import javaguide.testhelpers.MockJavaAction;
 
 //#imports
@@ -23,7 +23,7 @@ import static play.test.Helpers.*;
 public class JavaSessionFlash extends WithApplication {
 
     @Override
-    public FakeApplication provideFakeApplication() {
+    public Application provideApplication() {
         return fakeApplication(ImmutableMap.of("application.secret", "pass"));
     }
 

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/JavaI18N.java
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/JavaI18N.java
@@ -7,8 +7,8 @@ import org.junit.Test;
 import org.junit.Before;
 import static org.junit.Assert.*;
 
+import play.Application;
 import play.test.WithApplication;
-import play.test.FakeApplication;
 import static play.test.Helpers.*;
 
 import com.google.common.collect.ImmutableMap;
@@ -19,7 +19,7 @@ import play.i18n.Messages;
 public class JavaI18N extends WithApplication {
 
     @Override
-    public FakeApplication provideFakeApplication() {
+    public Application provideApplication() {
         return fakeApplication(ImmutableMap.of("messages.path", "javaguide/i18n"));
     }
 

--- a/documentation/manual/working/javaGuide/main/tests/JavaFunctionalTest.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaFunctionalTest.md
@@ -18,6 +18,8 @@ To provide an environment for tests, Play provides a [`FakeApplication`](api/jav
 
 @[test-fakeapp](code/javaguide/tests/FakeApplicationTest.java)
 
+If you're using Guice for [[dependency injection|JavaDependencyInjection]] then an `Application` for testing can be [[built directly|JavaTestingWithGuice]], instead of using FakeApplication.
+
 ## Testing with a fake application
 
 To run tests with an `Application`, you can do the following:

--- a/documentation/manual/working/javaGuide/main/tests/JavaFunctionalTest.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaFunctionalTest.md
@@ -20,11 +20,11 @@ To provide an environment for tests, Play provides a [`FakeApplication`](api/jav
 
 ## Testing with a fake application
 
-To run tests within a `FakeAppliction`, you can do the following:
+To run tests with an `Application`, you can do the following:
 
 @[test-running-fakeapp](code/javaguide/tests/FakeApplicationTest.java)
 
-You can also extend `WithApplication`, this will automatically ensure that a fake application is started and stopped for you:
+You can also extend `WithApplication`, this will automatically ensure that an application is started and stopped for you:
 
 @[test-withapp](code/javaguide/tests/FunctionalTest.java)
 

--- a/documentation/manual/working/javaGuide/main/tests/JavaTestingWithGuice.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTestingWithGuice.md
@@ -1,0 +1,97 @@
+<!--- Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com> -->
+# Testing with Guice
+
+If you're using Guice for [[dependency injection|JavaDependencyInjection]] then you can directly configure how components and applications are created for tests. This includes adding extra bindings or overriding existing bindings.
+
+## GuiceApplicationBuilder
+
+[GuiceApplicationBuilder](api/java/play/inject/guice/GuiceApplicationBuilder.html) provides a builder API for configuring the dependency injection and creation of an [Application](api/java/play/Application.html).
+
+### Imports
+
+The main imports you'll need for building applications with Guice are:
+
+@[builder-imports](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+
+### Environment
+
+The [Environment](api/java/play/Environment.html), or parts of the environment such as the root path, mode, or class loader for an application, can be specified. The configured environment will be used for loading the application configuration, it will be used when loading modules and passed when deriving bindings from Play modules, and it will be injectable into other components.
+
+@[set-environment](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+@[set-environment-values](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+
+### Configuration
+
+Additional configuration can be added. This configuration will always be in addition to the configuration loaded automatically for the application. When existing keys are used the new configuration will be preferred.
+
+@[add-configuration](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+
+The automatic loading of configuration from the application environment can also be overridden. This will completely replace the application configuration. For example:
+
+@[override-configuration](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+
+### Bindings and Modules
+
+The bindings used for dependency injection are completely configurable. The builder methods support [[Play Modules and Bindings|JavaDependencyInjection]] and also Guice Modules.
+
+#### Additional bindings
+
+Additional bindings, via Play modules, Play bindings, or Guice modules, can be added:
+
+@[bind-imports](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+@[add-bindings](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+
+#### Override bindings
+
+Bindings can be overridden using Play bindings, or modules that provide  bindings. For example:
+
+@[override-bindings](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+
+#### Disable modules
+
+Any loaded modules can be disabled by class name:
+
+@[disable-modules](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+
+#### Loaded modules
+
+Modules are automatically loaded from the classpath based on the `play.modules.enabled` configuration. This default loading of modules can be overridden. For example:
+
+@[guiceable-imports](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+@[load-modules](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+
+
+## GuiceInjectorBuilder
+
+[GuiceInjectorBuilder](api/java/play/inject/guice/GuiceInjectorBuilder.html) provides a builder API for configuring Guice dependency injection more generally. This builder does not load configuration or modules automatically from the environment like `GuiceApplicationBuilder`, but provides a completely clean state for adding configuration and bindings. The common interface for both builders can be found in [GuiceBuilder](api/java/play/inject/guice/GuiceBuilder.html). A Play [Injector](api/java/play/inject/Injector.html) is created. Here's an example of instantiating a component using the injector builder:
+
+@[injector-imports](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+@[bind-imports](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+@[injector-builder](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+
+
+## Overriding bindings in a functional test
+
+Here is a full example of replacing a component with a mock component for testing. Let's start with a component, that has a default implementation and a mock implementation for testing:
+
+@[component](code/tests/guice/Component.java)
+
+@[default-component](code/tests/guice/DefaultComponent.java)
+
+@[mock-component](code/tests/guice/MockComponent.java)
+
+This component is loaded automatically using a module:
+
+@[component-module](code/tests/guice/ComponentModule.java)
+
+And the component is used in a controller:
+
+@[controller](code/tests/guice/controllers/Application.java)
+
+To build an `Application` to use in [[functional tests|JavaFunctionalTest]] we can simply override the binding for the component:
+
+@[builder-imports](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+@[bind-imports](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+@[override-bindings](code/tests/guice/JavaGuiceApplicationBuilderTest.java)
+
+This application can be used with test helpers such as `running` and `WithApplication`.

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide.tests.guice.routes
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide.tests.guice.routes
@@ -1,0 +1,1 @@
+GET /    controllers.Application.index()

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/FakeApplicationTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/FakeApplicationTest.java
@@ -11,7 +11,7 @@ import play.test.FakeApplication;
 import play.test.Helpers;
 
 public class FakeApplicationTest {
-  
+
     static class Computer {
         String name = "Macintosh";
         String introduced = "1984-01-24";
@@ -35,20 +35,20 @@ public class FakeApplicationTest {
         });
     }
     //#test-running-fakeapp
-    
+
     private void fakeApps() {
-      
+
       //#test-fakeapp
-      FakeApplication fakeApp = Helpers.fakeApplication();
-      
-      FakeApplication fakeAppWithGlobal = fakeApplication(new GlobalSettings() {
+      Application fakeApp = Helpers.fakeApplication();
+
+      Application fakeAppWithGlobal = fakeApplication(new GlobalSettings() {
         @Override
         public void onStart(Application app) {
           System.out.println("Starting FakeApplication");
         }
       });
-      
-      FakeApplication fakeAppWithMemoryDb = fakeApplication(inMemoryDatabase("test"));
+
+      Application fakeAppWithMemoryDb = fakeApplication(inMemoryDatabase("test"));
       //#test-fakeapp
     }
 

--- a/documentation/manual/working/javaGuide/main/tests/code/tests/guice/Component.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/tests/guice/Component.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package javaguide.tests.guice;
+
+// #component
+public interface Component {
+    String hello();
+}
+// #component

--- a/documentation/manual/working/javaGuide/main/tests/code/tests/guice/ComponentModule.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/tests/guice/ComponentModule.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package javaguide.tests.guice;
+
+// #component-module
+import com.google.inject.AbstractModule;
+
+public class ComponentModule extends AbstractModule {
+    protected void configure() {
+        bind(Component.class).to(DefaultComponent.class);
+    }
+}
+// #component-module

--- a/documentation/manual/working/javaGuide/main/tests/code/tests/guice/DefaultComponent.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/tests/guice/DefaultComponent.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package javaguide.tests.guice;
+
+// #default-component
+public class DefaultComponent implements Component {
+    public String hello() {
+        return "default";
+    }
+}
+// #default-component

--- a/documentation/manual/working/javaGuide/main/tests/code/tests/guice/JavaGuiceApplicationBuilderTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/tests/guice/JavaGuiceApplicationBuilderTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package javaguide.tests.guice;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.junit.Test;
+import play.api.inject.Binding;
+import play.Configuration;
+import play.Environment;
+import play.Mode;
+import play.mvc.Result;
+import scala.collection.Seq;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static play.test.Helpers.*;
+
+// #builder-imports
+import play.Application;
+import play.inject.guice.GuiceApplicationBuilder;
+// #builder-imports
+
+// #bind-imports
+import static play.inject.Bindings.bind;
+// #bind-imports
+
+// #guiceable-imports
+import play.inject.guice.Guiceable;
+// #guiceable-imports
+
+// #injector-imports
+import play.inject.Injector;
+import play.inject.guice.GuiceInjectorBuilder;
+// #injector-imports
+
+public class JavaGuiceApplicationBuilderTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void setEnvironment() {
+        ClassLoader classLoader = new URLClassLoader(new URL[0]);
+        // #set-environment
+        Application application = new GuiceApplicationBuilder()
+            .bindings(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule()) // ###skip
+            .in(new Environment(new File("path/to/app"), classLoader, Mode.TEST))
+            .build();
+        // #set-environment
+
+        assertThat(application.path(), equalTo(new File("path/to/app")));
+        assert(application.isTest());
+        assertThat(application.classloader(), sameInstance(classLoader));
+    }
+
+    @Test
+    public void setEnvironmentValues() {
+        ClassLoader classLoader = new URLClassLoader(new URL[0]);
+        // #set-environment-values
+        Application application = new GuiceApplicationBuilder()
+            .bindings(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule()) // ###skip
+            .in(new File("path/to/app"))
+            .in(Mode.TEST)
+            .in(classLoader)
+            .build();
+        // #set-environment-values
+
+        assertThat(application.path(), equalTo(new File("path/to/app")));
+        assert(application.isTest());
+        assertThat(application.classloader(), sameInstance(classLoader));
+    }
+
+    @Test
+    public void addConfiguration() {
+        // #add-configuration
+        Configuration extraConfig = new Configuration(ImmutableMap.of("a", 1));
+        Map<String, Object> configMap = ImmutableMap.of("b", 2, "c", "three");
+
+        Application application = new GuiceApplicationBuilder()
+            .configure(extraConfig)
+            .configure(configMap)
+            .configure("key", "value")
+            .build();
+        // #add-configuration
+
+        assertThat(application.configuration().getInt("a"), equalTo(1));
+        assertThat(application.configuration().getInt("b"), equalTo(2));
+        assertThat(application.configuration().getString("c"), equalTo("three"));
+        assertThat(application.configuration().getString("key"), equalTo("value"));
+    }
+
+    @Test
+    public void overrideConfiguration() {
+        // #override-configuration
+        Application application = new GuiceApplicationBuilder()
+            .loadConfig(env -> Configuration.load(env))
+            .build();
+        // #override-configuration
+    }
+
+    @Test
+    public void addBindings() {
+        // #add-bindings
+        Application application = new GuiceApplicationBuilder()
+            .bindings(new ComponentModule())
+            .bindings(bind(Component.class).to(DefaultComponent.class))
+            .build();
+        // #add-bindings
+
+        assertThat(application.injector().instanceOf(Component.class), instanceOf(DefaultComponent.class));
+    }
+
+    @Test
+    public void overrideBindings() {
+        // #override-bindings
+        Application application = new GuiceApplicationBuilder()
+            .configure("application.router", Routes.class.getName()) // ###skip
+            .bindings(new ComponentModule()) // ###skip
+            .overrides(bind(Component.class).to(MockComponent.class))
+            .build();
+        // #override-bindings
+
+        running(application, () -> {
+            Result result = route(fakeRequest(GET, "/"));
+            assertThat(contentAsString(result), equalTo("mock"));
+        });
+    }
+
+    @Test
+    public void loadModules() {
+        // #load-modules
+        Application application = new GuiceApplicationBuilder()
+            .load(
+                Guiceable.modules(
+                    new play.api.inject.BuiltinModule(),
+                    new play.inject.BuiltInModule()
+                ),
+                Guiceable.bindings(
+                    bind(Component.class).to(DefaultComponent.class)
+                )
+            ).build();
+        // #load-modules
+
+        assertThat(application.injector().instanceOf(Component.class), instanceOf(DefaultComponent.class));
+    }
+
+    @Test
+    public void disableModules() {
+        // #disable-modules
+        Application application = new GuiceApplicationBuilder()
+            .bindings(new ComponentModule()) // ###skip
+            .disable(ComponentModule.class)
+            .build();
+        // #disable-modules
+
+        exception.expect(com.google.inject.ConfigurationException.class);
+        application.injector().instanceOf(Component.class);
+    }
+
+    @Test
+    public void injectorBuilder() {
+        // #injector-builder
+        Injector injector = new GuiceInjectorBuilder()
+            .configure("key", "value")
+            .bindings(new ComponentModule())
+            .overrides(bind(Component.class).to(MockComponent.class))
+            .build();
+
+        Component component = injector.instanceOf(Component.class);
+        // #injector-builder
+
+        assertThat(component, instanceOf(MockComponent.class));
+    }
+
+}

--- a/documentation/manual/working/javaGuide/main/tests/code/tests/guice/MockComponent.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/tests/guice/MockComponent.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package javaguide.tests.guice;
+
+// #mock-component
+public class MockComponent implements Component {
+    public String hello() {
+        return "mock";
+    }
+}
+// #mock-component

--- a/documentation/manual/working/javaGuide/main/tests/code/tests/guice/controllers/Application.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/tests/guice/controllers/Application.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package javaguide.tests.guice.controllers;
+
+import javaguide.tests.guice.Component;
+
+// #controller
+import play.mvc.*;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class Application extends Controller {
+
+    private final Component component;
+
+    @Inject
+    public Application(Component component) {
+        this.component = component;
+    }
+
+    public Result index() {
+        return ok(component.hello());
+    }
+
+}
+// #controller

--- a/documentation/manual/working/javaGuide/main/tests/index.toc
+++ b/documentation/manual/working/javaGuide/main/tests/index.toc
@@ -1,3 +1,4 @@
 JavaTest:Writing tests
 JavaFunctionalTest:Writing functional tests
+JavaTestingWithGuice:Testing with Guice
 JavaTestingWithDatabases:Testing with databases

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
@@ -20,7 +20,7 @@ To provide an environment for tests, Play provides a [`FakeApplication`](api/sca
 
 ## WithApplication
 
-To pass in an application to an example, use [`WithApplication`](api/scala/index.html#play.api.test.WithApplication).  An explicit [`FakeApplication`](api/scala/index.html#play.api.test.FakeApplication) can be passed in, but a default [`FakeApplication`](api/scala/index.html#play.api.test.FakeApplication) is provided for convenience.
+To pass in an application to an example, use [`WithApplication`](api/scala/index.html#play.api.test.WithApplication).  An explicit [`Application`](api/scala/index.html#play.api.Application) can be passed in, but a default [`FakeApplication`](api/scala/index.html#play.api.test.FakeApplication) is provided for convenience.
 
 Because [`WithApplication`](api/scala/index.html#play.api.test.WithApplication) is a built in [`Around`](http://etorreborre.github.io/specs2/guide/org.specs2.guide.Structure.html#Around) block, you can override it to provide your own data population:
 
@@ -40,7 +40,7 @@ A [`FakeApplication`](api/scala/index.html#play.api.test.FakeApplication) can al
 
 ## WithBrowser
 
-If you want to test your application using a browser, you can use [Selenium WebDriver](http://code.google.com/p/selenium/?redir=1). Play will start the WebDriver for you, and wrap it in the convenient API provided by [FluentLenium](https://github.com/FluentLenium/FluentLenium) using [`WithBrowser`](api/scala/index.html#play.api.test.WithBrowser).  Like [`WithServer`](api/scala/index.html#play.api.test.WithServer), you can change the port, [`FakeApplication`](api/scala/index.html#play.api.test.FakeApplication), and you can also select the web browser to use:
+If you want to test your application using a browser, you can use [Selenium WebDriver](http://code.google.com/p/selenium/?redir=1). Play will start the WebDriver for you, and wrap it in the convenient API provided by [FluentLenium](https://github.com/FluentLenium/FluentLenium) using [`WithBrowser`](api/scala/index.html#play.api.test.WithBrowser).  Like [`WithServer`](api/scala/index.html#play.api.test.WithServer), you can change the port, [`Application`](api/scala/index.html#play.api.Application), and you can also select the web browser to use:
 
 @[scalafunctionaltest-testwithbrowser](code/specs2/ScalaFunctionalTestSpec.scala)
 

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithGuice.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithGuice.md
@@ -1,0 +1,87 @@
+<!--- Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com> -->
+# Testing with Guice
+
+If you're using Guice for [[dependency injection|ScalaDependencyInjection]] then you can directly configure how components and applications are created for tests. This includes adding extra bindings or overriding existing bindings.
+
+## GuiceApplicationBuilder
+
+[GuiceApplicationBuilder](api/scala/index.html#play.api.inject.guice.GuiceApplicationBuilder) provides a builder API for configuring the dependency injection and creation of an [Application](api/scala/index.html#play.api.Application).
+
+### Environment
+
+The [Environment](api/scala/index.html#play.api.Environment), or parts of the environment such as the root path, mode, or class loader for an application, can be specified. The configured environment will be used for loading the application configuration, it will be used when loading modules and passed when deriving bindings from Play modules, and it will be injectable into other components.
+
+@[builder-imports](code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala)
+@[set-environment](code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala)
+@[set-environment-values](code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala)
+
+### Configuration
+
+Additional configuration can be added. This configuration will always be in addition to the configuration loaded automatically for the application. When existing keys are used the new configuration will be preferred.
+
+@[add-configuration](code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala)
+
+The automatic loading of configuration from the application environment can also be overridden. This will completely replace the application configuration. For example:
+
+@[override-configuration](code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala)
+
+### Bindings and Modules
+
+The bindings used for dependency injection are completely configurable. The builder methods support [[Play Modules and Bindings|ScalaDependencyInjection]] and also Guice Modules.
+
+#### Additional bindings
+
+Additional bindings, via Play modules, Play bindings, or Guice modules, can be added:
+
+@[bind-imports](code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala)
+@[add-bindings](code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala)
+
+#### Override bindings
+
+Bindings can be overridden using Play bindings, or modules that provide  bindings. For example:
+
+@[override-bindings](code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala)
+
+#### Disable modules
+
+Any loaded modules can be disabled by class name:
+
+@[disable-modules](code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala)
+
+#### Loaded modules
+
+Modules are automatically loaded from the classpath based on the `play.modules.enabled` configuration. This default loading of modules can be overridden. For example:
+
+@[load-modules](code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala)
+
+
+## GuiceInjectorBuilder
+
+[GuiceInjectorBuilder](api/scala/index.html#play.api.inject.guice.GuiceInjectorBuilder) provides a builder API for configuring Guice dependency injection more generally. This builder does not load configuration or modules automatically from the environment like `GuiceApplicationBuilder`, but provides a completely clean state for adding configuration and bindings. The common interface for both builders can be found in [GuiceBuilder](api/scala/index.html#play.api.inject.guice.GuiceBuilder). A Play [Injector](api/scala/index.html#play.api.inject.Injector) is created. Here's an example of instantiating a component using the injector builder:
+
+@[injector-imports](code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala)
+@[bind-imports](code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala)
+@[injector-builder](code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala)
+
+
+## Overriding bindings in a functional test
+
+Here is a full example of replacing a component with a mock component for testing. Let's start with a component, that has a default implementation and a mock implementation for testing:
+
+@[component](code/tests/guice/Component.scala)
+
+This component is loaded automatically using a module:
+
+@[component-module](code/tests/guice/Component.scala)
+
+And the component is used in a controller:
+
+@[controller](code/tests/guice/controllers/Application.scala)
+
+To build an `Application` to use in functional tests we can simply override the binding for the component:
+
+@[builder-imports](code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala)
+@[bind-imports](code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala)
+@[override-bindings](code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala)
+
+The created application can be used with the functional testing helpers for [[Specs2|ScalaFunctionalTestingWithSpecs2]] and [[ScalaTest|ScalaFunctionalTestingWithScalaTest]].

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingYourApplication.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingYourApplication.md
@@ -10,4 +10,5 @@ Writing tests for your application can be an involved process. Play offers integ
 
 Play provides a number of helpers for testing specific parts of an application.
 
+* [[Testing using Guice dependency injection|ScalaTestingWithGuice]]
 * [[Testing with databases|ScalaTestingWithDatabases]]

--- a/documentation/manual/working/scalaGuide/main/tests/code/scalaguide.tests.guice.routes
+++ b/documentation/manual/working/scalaGuide/main/tests/code/scalaguide.tests.guice.routes
@@ -1,0 +1,1 @@
+GET /    controllers.Application.index()

--- a/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/Component.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/Component.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package scalaguide.tests.guice
+
+// #component
+trait Component {
+  def hello: String
+}
+
+class DefaultComponent extends Component {
+  def hello = "default"
+}
+
+class MockComponent extends Component {
+  def hello = "mock"
+}
+// #component
+
+// #component-module
+import play.api.{ Environment, Configuration }
+import play.api.inject.Module
+
+class ComponentModule extends Module {
+  def bindings(env: Environment, conf: Configuration) = Seq(
+    bind[Component].to[DefaultComponent]
+  )
+}
+// #component-module

--- a/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package scalaguide.tests.guice
+
+import java.io.File
+import java.net.URLClassLoader
+import play.api.{ Configuration, Environment, Mode }
+import play.api.test._
+import play.api.test.Helpers._
+
+// #builder-imports
+import play.api.inject.guice.GuiceApplicationBuilder
+// #builder-imports
+
+// #bind-imports
+import play.api.inject.bind
+// #bind-imports
+
+// #injector-imports
+import play.api.inject.guice.GuiceInjectorBuilder
+// #injector-imports
+
+class ScalaGuiceApplicationBuilderSpec extends PlaySpecification {
+
+  "Scala GuiceApplicationBuilder" should {
+
+    "set environment" in {
+      val classLoader = new URLClassLoader(Array.empty)
+      // #set-environment
+      val application = new GuiceApplicationBuilder()
+        .bindings(new play.api.inject.BuiltinModule) // ###skip
+        .in(Environment(new File("path/to/app"), classLoader, Mode.Test))
+        .build
+      // #set-environment
+
+      application.path must_== new File("path/to/app")
+      application.mode must_== Mode.Test
+      application.classloader must be(classLoader)
+    }
+
+    "set environment values" in {
+      val classLoader = new URLClassLoader(Array.empty)
+      // #set-environment-values
+      val application = new GuiceApplicationBuilder()
+        .bindings(new play.api.inject.BuiltinModule) // ###skip
+        .in(new File("path/to/app"))
+        .in(Mode.Test)
+        .in(classLoader)
+        .build
+      // #set-environment-values
+
+      application.path must_== new File("path/to/app")
+      application.mode must_== Mode.Test
+      application.classloader must be(classLoader)
+    }
+
+    "add configuration" in {
+      // #add-configuration
+      val application = new GuiceApplicationBuilder()
+        .configure(Configuration("a" -> 1))
+        .configure(Map("b" -> 2, "c" -> "three"))
+        .configure("d" -> 4, "e" -> "five")
+        .build
+      // #add-configuration
+
+      application.configuration.getInt("a") must beSome(1)
+      application.configuration.getInt("b") must beSome(2)
+      application.configuration.getString("c") must beSome("three")
+      application.configuration.getInt("d") must beSome(4)
+      application.configuration.getString("e") must beSome("five")
+    }
+
+    "override configuration" in {
+      // #override-configuration
+      val application = new GuiceApplicationBuilder()
+        .loadConfig(env => Configuration.load(env))
+        .build
+      // #override-configuration
+
+      application.configuration.keys must not be empty
+    }
+
+    "add bindings" in {
+      // #add-bindings
+      val application = new GuiceApplicationBuilder()
+        .bindings(new ComponentModule)
+        .bindings(bind[Component].to[DefaultComponent])
+        .build
+      // #add-bindings
+
+      application.injector.instanceOf[Component] must beAnInstanceOf[DefaultComponent]
+    }
+
+    "override bindings" in {
+      // #override-bindings
+      val application = new GuiceApplicationBuilder()
+        .configure("application.router" -> classOf[Routes].getName) // ###skip
+        .bindings(new ComponentModule) // ###skip
+        .overrides(bind[Component].to[MockComponent])
+        .build
+      // #override-bindings
+
+      running(application) {
+        val Some(result) = route(FakeRequest(GET, "/"))
+        contentAsString(result) must_== "mock"
+      }
+    }
+
+    "load modules" in {
+      // #load-modules
+      val application = new GuiceApplicationBuilder()
+        .load(
+          new play.api.inject.BuiltinModule,
+          bind[Component].to[DefaultComponent]
+        ).build
+      // #load-modules
+
+      application.injector.instanceOf[Component] must beAnInstanceOf[DefaultComponent]
+    }
+
+    "disable modules" in {
+      // #disable-modules
+      val application = new GuiceApplicationBuilder()
+        .bindings(new ComponentModule) // ###skip
+        .disable[ComponentModule]
+        .build
+      // #disable-modules
+
+      application.injector.instanceOf[Component] must throwA[com.google.inject.ConfigurationException]
+    }
+
+    "injector builder" in {
+      // #injector-builder
+      val injector = new GuiceInjectorBuilder()
+        .configure("key" -> "value")
+        .bindings(new ComponentModule)
+        .overrides(bind[Component].to[MockComponent])
+        .build
+
+      val component = injector.instanceOf[Component]
+      // #injector-builder
+
+      component must beAnInstanceOf[MockComponent]
+    }
+
+  }
+
+}

--- a/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/controllers/Application.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/controllers/Application.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package scalaguide.tests.guice
+package controllers
+
+// #controller
+import play.api.mvc._
+import javax.inject.Inject
+
+class Application @Inject() (component: Component) extends Controller {
+  def index() = Action {
+    Ok(component.hello)
+  }
+}
+// #controller

--- a/documentation/manual/working/scalaGuide/main/tests/index.toc
+++ b/documentation/manual/working/scalaGuide/main/tests/index.toc
@@ -3,4 +3,5 @@ ScalaTestingWithScalaTest:Testing with ScalaTest
 ScalaFunctionalTestingWithScalaTest:Writing functional tests with ScalaTest
 ScalaTestingWithSpecs2:Testing with specs2
 ScalaFunctionalTestingWithSpecs2:Writing functional tests with specs2
+ScalaTestingWithGuice:Testing with Guice
 ScalaTestingWithDatabases:Testing with databases

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -50,7 +50,11 @@ object Dependencies {
   )
   val javassist = link
 
+  val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.3.0"
+
   val javaDeps = Seq(
+    scalaJava8Compat,
+
     "org.yaml" % "snakeyaml" % "1.13",
     // 5.1.0 upgrade notes: need to add JEE dependencies, eg EL
     "org.hibernate" % "hibernate-validator" % "5.0.3.Final",

--- a/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
@@ -54,7 +54,7 @@ trait ServerIntegrationSpecification extends PendingUntilFixed {
    * Override the standard WithServer class.
    */
   abstract class WithServer(
-    app: play.api.test.FakeApplication = play.api.test.FakeApplication(),
+    app: play.api.Application = play.api.test.FakeApplication(),
     port: Int = play.api.test.Helpers.testServerPort) extends play.api.test.WithServer(app, port, serverProvider = integrationServerProvider)
 
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.it.i18n
 
-import play.api.test.{ PlaySpecification, WithApplication, FakeApplication }
+import play.api.test.{ PlaySpecification, WithApplication }
 import play.api.mvc.Controller
 import play.api.i18n._
 import play.api.Mode

--- a/framework/src/play-java-jpa/src/test/java/play/db/jpa/JPATest.java
+++ b/framework/src/play-java-jpa/src/test/java/play/db/jpa/JPATest.java
@@ -6,7 +6,7 @@ package play.db.jpa;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.junit.Test;
-import play.test.FakeApplication;
+import play.Application;
 import play.test.WithApplication;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -16,7 +16,7 @@ import static play.test.Helpers.*;
 public class JPATest extends WithApplication {
 
     @Override
-    protected FakeApplication provideFakeApplication() {
+    protected Application provideApplication() {
         return fakeApplication(ImmutableMap.of(
             "db.default.driver", "org.h2.Driver",
             "db.default.url", "jdbc:h2:mem:play-test-jpa",

--- a/framework/src/play-java/src/main/java/play/inject/BuiltInModule.java
+++ b/framework/src/play-java/src/main/java/play/inject/BuiltInModule.java
@@ -14,7 +14,7 @@ public class BuiltInModule extends play.api.inject.Module {
     public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
         return seq(
           bind(ApplicationLifecycle.class).to(DelegateApplicationLifecycle.class),
-          bind(play.Configuration.class).toInstance(new play.Configuration(configuration)),
+          bind(play.Configuration.class).toProvider(ConfigurationProvider.class),
           bind(Crypto.class).toSelf()
         );
     }

--- a/framework/src/play-java/src/main/java/play/inject/ConfigurationProvider.java
+++ b/framework/src/play-java/src/main/java/play/inject/ConfigurationProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.inject;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import play.Configuration;
+
+@Singleton
+public class ConfigurationProvider implements Provider<Configuration> {
+
+    private final play.api.Configuration delegate;
+
+    @Inject
+    public ConfigurationProvider(play.api.Configuration delegate) {
+        this.delegate = delegate;
+    }
+
+    public Configuration get() {
+        return new Configuration(delegate);
+    }
+
+}

--- a/framework/src/play-java/src/main/java/play/inject/guice/GuiceApplicationBuilder.java
+++ b/framework/src/play-java/src/main/java/play/inject/guice/GuiceApplicationBuilder.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.inject.guice;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.List;
+import play.api.inject.guice.GuiceableModule;
+import play.Application;
+import play.Configuration;
+import play.core.j.JavaGlobalSettingsAdapter;
+import play.Environment;
+import play.GlobalSettings;
+import play.libs.Scala;
+
+import static scala.compat.java8.JFunction.func;
+
+public final class GuiceApplicationBuilder extends GuiceBuilder<GuiceApplicationBuilder, play.api.inject.guice.GuiceApplicationBuilder> {
+
+    public GuiceApplicationBuilder() {
+        this(new play.api.inject.guice.GuiceApplicationBuilder());
+    }
+
+    private GuiceApplicationBuilder(play.api.inject.guice.GuiceApplicationBuilder builder) {
+        super(builder);
+    }
+
+    /**
+     * Set the initial configuration loader.
+     * Overrides the default or any previously configured values.
+     */
+    public GuiceApplicationBuilder loadConfig(Function<Environment, Configuration> load) {
+        return newBuilder(delegate.loadConfig(func((play.api.Environment env) -> load.apply(new Environment(env)).getWrappedConfiguration())));
+    }
+
+    /**
+     * Set the initial configuration.
+     * Overrides the default or any previously configured values.
+     */
+    public GuiceApplicationBuilder loadConfig(Configuration conf) {
+        return loadConfig(env -> conf);
+    }
+
+    /**
+     * Set the global settings object.
+     * Overrides the default or any previously configured values.
+     */
+    public GuiceApplicationBuilder global(GlobalSettings global) {
+        return newBuilder(delegate.global(new JavaGlobalSettingsAdapter(global)));
+    }
+
+    /**
+     * Set the module loader.
+     * Overrides the default or any previously configured values.
+     */
+    public GuiceApplicationBuilder load(BiFunction<Environment, Configuration, List<GuiceableModule>> loader) {
+        return newBuilder(delegate.load(func((play.api.Environment env, play.api.Configuration conf) ->
+            Scala.toSeq(loader.apply(new Environment(env), new Configuration(conf)))
+        )));
+    }
+
+    /**
+     * Override the module loader with the given guiceable modules.
+     */
+    public GuiceApplicationBuilder load(GuiceableModule... modules) {
+        return newBuilder(delegate.load(Scala.varargs(modules)));
+    }
+
+    /**
+     * Override the module loader with the given Guice modules.
+     */
+    public GuiceApplicationBuilder load(com.google.inject.Module... modules) {
+        return load(Guiceable.modules(modules));
+    }
+
+    /**
+     * Override the module loader with the given Play modules.
+     */
+    public GuiceApplicationBuilder load(play.api.inject.Module... modules) {
+        return load(Guiceable.modules(modules));
+    }
+
+    /**
+     * Override the module loader with the given Play bindings.
+     */
+    public GuiceApplicationBuilder load(play.api.inject.Binding<?>... bindings) {
+        return load(Guiceable.bindings(bindings));
+    }
+
+    /**
+     * Create a new Play Application using this configured builder.
+     */
+    public Application build() {
+        return injector().instanceOf(Application.class);
+    }
+
+    /**
+     * Implementation of Self creation for GuiceBuilder.
+     */
+    protected GuiceApplicationBuilder newBuilder(play.api.inject.guice.GuiceApplicationBuilder builder) {
+        return new GuiceApplicationBuilder(builder);
+    }
+
+}

--- a/framework/src/play-java/src/main/java/play/inject/guice/GuiceBuilder.java
+++ b/framework/src/play-java/src/main/java/play/inject/guice/GuiceBuilder.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.inject.guice;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.util.Map;
+import play.api.inject.guice.GuiceableModule;
+import play.Configuration;
+import play.Environment;
+import play.inject.DelegateInjector;
+import play.inject.Injector;
+import play.libs.Scala;
+import play.Mode;
+
+/**
+ * A builder for creating Guice-backed Play Injectors.
+ */
+public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.GuiceBuilder<Delegate>> {
+
+    protected Delegate delegate;
+
+    protected GuiceBuilder(Delegate delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * Set the environment.
+     */
+    public final Self in(Environment env) {
+        return newBuilder(delegate.in(env.underlying()));
+    }
+
+    /**
+     * Set the environment path.
+     */
+    public final Self in(File path) {
+        return newBuilder(delegate.in(path));
+    }
+
+    /**
+     * Set the environment mode.
+     */
+    public final Self in(Mode mode) {
+        return newBuilder(delegate.in(play.api.Mode.apply(mode.ordinal())));
+    }
+
+    /**
+     * Set the environment class loader.
+     */
+    public final Self in(ClassLoader classLoader) {
+        return newBuilder(delegate.in(classLoader));
+    }
+
+    /**
+     * Add additional configuration.
+     */
+    public final Self configure(Configuration conf) {
+        return newBuilder(delegate.configure(conf.getWrappedConfiguration()));
+    }
+
+    /**
+     * Add additional configuration.
+     */
+    public final Self configure(Map<String, Object> conf) {
+        return configure(new Configuration(conf));
+    }
+
+    /**
+     * Add additional configuration.
+     */
+    public final Self configure(String key, Object value) {
+        return configure(ImmutableMap.of(key, value));
+    }
+
+    /**
+     * Add bindings from guiceable modules.
+     */
+    public final Self bindings(GuiceableModule... modules) {
+        return newBuilder(delegate.bindings(Scala.varargs(modules)));
+    }
+
+    /**
+     * Add bindings from Guice modules.
+     */
+    public final Self bindings(com.google.inject.Module... modules) {
+        return bindings(Guiceable.modules(modules));
+    }
+
+    /**
+     * Add bindings from Play modules.
+     */
+    public final Self bindings(play.api.inject.Module... modules) {
+        return bindings(Guiceable.modules(modules));
+    }
+
+    /**
+     * Add Play bindings.
+     */
+    public final Self bindings(play.api.inject.Binding<?>... bindings) {
+        return bindings(Guiceable.bindings(bindings));
+    }
+
+    /**
+     * Override bindings using guiceable modules.
+     */
+    public final Self overrides(GuiceableModule... modules) {
+        return newBuilder(delegate.overrides(Scala.varargs(modules)));
+    }
+
+    /**
+     * Override bindings using Guice modules.
+     */
+    public final Self overrides(com.google.inject.Module... modules) {
+        return overrides(Guiceable.modules(modules));
+    }
+
+    /**
+     * Override bindings using Play modules.
+     */
+    public final Self overrides(play.api.inject.Module... modules) {
+        return overrides(Guiceable.modules(modules));
+    }
+
+    /**
+     * Override bindings using Play bindings.
+     */
+    public final Self overrides(play.api.inject.Binding<?>... bindings) {
+        return overrides(Guiceable.bindings(bindings));
+    }
+
+    /**
+     * Disable modules by class.
+     */
+    public final Self disable(Class<?>... moduleClasses) {
+        return newBuilder(delegate.disable(Scala.toSeq(moduleClasses)));
+    }
+
+    /**
+     * Create a Play Injector backed by Guice using this configured builder.
+     */
+    public Injector injector() {
+        return delegate.injector().instanceOf(Injector.class);
+    }
+
+    protected abstract Self newBuilder(Delegate delegate);
+}

--- a/framework/src/play-java/src/main/java/play/inject/guice/GuiceInjectorBuilder.java
+++ b/framework/src/play-java/src/main/java/play/inject/guice/GuiceInjectorBuilder.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.inject.guice;
+
+import play.inject.Injector;
+
+/**
+ * Default empty builder for creating Guice-backed Injectors.
+ */
+public final class GuiceInjectorBuilder extends GuiceBuilder<GuiceInjectorBuilder, play.api.inject.guice.GuiceInjectorBuilder> {
+
+    public GuiceInjectorBuilder() {
+        this(new play.api.inject.guice.GuiceInjectorBuilder());
+    }
+
+    private GuiceInjectorBuilder(play.api.inject.guice.GuiceInjectorBuilder builder) {
+        super(builder);
+    }
+
+    protected GuiceInjectorBuilder newBuilder(play.api.inject.guice.GuiceInjectorBuilder builder) {
+        return new GuiceInjectorBuilder(builder);
+    }
+
+    /**
+     * Create a Play Injector backed by Guice using this configured builder.
+     */
+    public Injector build() {
+        return injector();
+    }
+
+}

--- a/framework/src/play-java/src/main/java/play/inject/guice/Guiceable.java
+++ b/framework/src/play-java/src/main/java/play/inject/guice/Guiceable.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.inject.guice;
+
+import play.api.inject.guice.GuiceableModule;
+import play.api.inject.guice.GuiceableModule$;
+import play.libs.Scala;
+
+
+public class Guiceable {
+
+    public static GuiceableModule modules(com.google.inject.Module... modules) {
+        return GuiceableModule$.MODULE$.fromGuiceModules(Scala.toSeq(modules));
+    }
+
+    public static GuiceableModule modules(play.api.inject.Module... modules) {
+        return GuiceableModule$.MODULE$.fromPlayModules(Scala.toSeq(modules));
+    }
+
+    public static GuiceableModule bindings(play.api.inject.Binding... bindings) {
+        return GuiceableModule$.MODULE$.fromPlayBindings(Scala.toSeq(bindings));
+    }
+
+    public static GuiceableModule module(Object module) {
+        return GuiceableModule$.MODULE$.guiceable(module);
+    }
+
+}

--- a/framework/src/play-java/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
+++ b/framework/src/play-java/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.inject.guice;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.junit.Test;
+import play.api.inject.guice.GuiceApplicationBuilderSpec;
+import play.Application;
+import play.Configuration;
+import play.GlobalSettings;
+import play.inject.Injector;
+import play.libs.Scala;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static play.inject.Bindings.bind;
+
+public class GuiceApplicationBuilderTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void addBindings() {
+        Application app = new GuiceApplicationBuilder()
+            .bindings(new AModule())
+            .bindings(bind(B.class).to(B1.class))
+            .build();
+
+        assertThat(app.injector().instanceOf(A.class), instanceOf(A1.class));
+        assertThat(app.injector().instanceOf(B.class), instanceOf(B1.class));
+    }
+
+    @Test
+    public void overrideBindings() {
+        Application app = new GuiceApplicationBuilder()
+            .bindings(new AModule())
+            .overrides(
+                // override the scala api configuration, which should underlie the java api configuration
+                bind(play.api.Configuration.class).to(new GuiceApplicationBuilderSpec.ExtendConfiguration(Scala.varargs(Scala.Tuple("a", 1)))),
+                // also override the java api configuration
+                bind(Configuration.class).to(new ExtendConfiguration(new Configuration(ImmutableMap.of("b", 2)))),
+                bind(A.class).to(A2.class))
+            .build();
+
+        assertThat(app.configuration().getInt("a"), is(1));
+        assertThat(app.configuration().getInt("b"), is(2));
+        assertThat(app.injector().instanceOf(A.class), instanceOf(A2.class));
+    }
+
+    @Test
+    public void disableModules() {
+        Application app = new GuiceApplicationBuilder()
+            .bindings(new AModule())
+            .disable(AModule.class)
+            .build();
+
+        exception.expect(com.google.inject.ConfigurationException.class);
+        app.injector().instanceOf(A.class);
+    }
+
+    @Test
+    public void disableLoadedModules() {
+        Application app = new GuiceApplicationBuilder()
+            .disable(play.api.libs.concurrent.AkkaModule.class)
+            .build();
+
+        exception.expect(com.google.inject.ConfigurationException.class);
+        app.injector().instanceOf(akka.actor.ActorSystem.class);
+    }
+
+    @Test
+    public void setInitialConfigurationLoader() {
+        Configuration extra = new Configuration(ImmutableMap.of("a", 1));
+        Application app = new GuiceApplicationBuilder()
+            .loadConfig(env -> extra.withFallback(Configuration.load(env)))
+            .build();
+
+        assertThat(app.configuration().getInt("a"), is(1));
+    }
+
+    @Test
+    public void setInitialConfiguration() {
+        Application app = new GuiceApplicationBuilder()
+            .loadConfig(Configuration.empty())
+            .bindings(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule())
+            .build();
+
+        assertThat(app.configuration().keys().size(), is(0));
+    }
+
+    @Test
+    public void setGlobal() {
+        GlobalSettings global = new GlobalSettings() {
+            @Override
+            public Configuration onLoadConfig(Configuration config, File path, ClassLoader classloader) {
+                Configuration extra = new Configuration(ImmutableMap.of("a", 1));
+                return extra.withFallback(config);
+            }
+        };
+
+        Application app = new GuiceApplicationBuilder()
+            .global(global)
+            .build();
+
+        assertThat(app.configuration().getInt("a"), is(1));
+    }
+
+    @Test
+    public void setModuleLoader() {
+        Application app = new GuiceApplicationBuilder()
+            .load((env, conf) -> ImmutableList.of(
+                Guiceable.modules(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule()),
+                Guiceable.bindings(bind(A.class).to(A1.class))))
+            .build();
+
+        assertThat(app.injector().instanceOf(A.class), instanceOf(A1.class));
+    }
+
+    @Test
+    public void setLoadedModulesDirectly() {
+        Application app = new GuiceApplicationBuilder()
+            .load(
+                Guiceable.modules(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule()),
+                Guiceable.bindings(bind(A.class).to(A1.class)))
+            .build();
+
+        assertThat(app.injector().instanceOf(A.class), instanceOf(A1.class));
+    }
+
+    public static interface A {}
+    public static class A1 implements A {}
+    public static class A2 implements A {}
+
+    public static class AModule extends com.google.inject.AbstractModule {
+        public void configure() {
+            bind(A.class).to(A1.class);
+        }
+    }
+
+    public static interface B {}
+    public static class B1 implements B {}
+
+    public static class ExtendConfiguration implements Provider<Configuration> {
+
+      @Inject Injector injector = null;
+
+      Configuration extra;
+
+      public ExtendConfiguration(Configuration extra) {
+        this.extra = extra;
+      }
+
+      public Configuration get() {
+        Configuration current = injector.instanceOf(play.inject.ConfigurationProvider.class).get();
+        return extra.withFallback(current);
+      }
+    }
+
+}

--- a/framework/src/play-java/src/test/java/play/inject/guice/GuiceInjectorBuilderTest.java
+++ b/framework/src/play-java/src/test/java/play/inject/guice/GuiceInjectorBuilderTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.inject.guice;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.junit.Test;
+import play.api.inject.Binding;
+import play.Configuration;
+import play.Environment;
+import play.inject.Injector;
+import play.Mode;
+import scala.collection.Seq;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static play.inject.Bindings.bind;
+
+public class GuiceInjectorBuilderTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void setEnvironment() {
+        ClassLoader classLoader = new URLClassLoader(new URL[0]);
+        Environment env = new GuiceInjectorBuilder()
+            .in(new Environment(new File("test"), classLoader, Mode.DEV))
+            .bindings(new EnvironmentModule())
+            .injector()
+            .instanceOf(Environment.class);
+
+        assertThat(env.rootPath(), equalTo(new File("test")));
+        assertThat(env.mode(), equalTo(Mode.DEV));
+        assertThat(env.classLoader(), sameInstance(classLoader));
+    }
+
+    @Test
+    public void setEnvironmentValues() {
+        ClassLoader classLoader = new URLClassLoader(new URL[0]);
+        Environment env = new GuiceInjectorBuilder()
+            .in(new File("test"))
+            .in(Mode.DEV)
+            .in(classLoader)
+            .bindings(new EnvironmentModule())
+            .injector()
+            .instanceOf(Environment.class);
+
+        assertThat(env.rootPath(), equalTo(new File("test")));
+        assertThat(env.mode(), equalTo(Mode.DEV));
+        assertThat(env.classLoader(), sameInstance(classLoader));
+    }
+
+    @Test
+    public void setConfiguration() {
+        Configuration conf = new GuiceInjectorBuilder()
+            .configure(new Configuration(ImmutableMap.of("a", 1)))
+            .configure(ImmutableMap.of("b", 2))
+            .configure("c", 3)
+            .configure("d.1", 4)
+            .configure("d.2", 5)
+            .bindings(new ConfigurationModule())
+            .injector()
+            .instanceOf(Configuration.class);
+
+        assertThat(conf.subKeys().size(), is(4));
+        assertThat(conf.subKeys(), hasItems("a", "b", "c", "d"));
+
+        assertThat(conf.getInt("a"), is(1));
+        assertThat(conf.getInt("b"), is(2));
+        assertThat(conf.getInt("c"), is(3));
+        assertThat(conf.getInt("d.1"), is(4));
+        assertThat(conf.getInt("d.2"), is(5));
+    }
+
+    @Test
+    public void supportVariousBindings() {
+        Injector injector = new GuiceInjectorBuilder()
+            .bindings(new EnvironmentModule(), new ConfigurationModule())
+            .bindings(new AModule(), new BModule())
+            .bindings(bind(C.class).to(C1.class), bind(D.class).toInstance(new D1()))
+            .injector();
+
+        assertThat(injector.instanceOf(Environment.class), instanceOf(Environment.class));
+        assertThat(injector.instanceOf(Configuration.class), instanceOf(Configuration.class));
+        assertThat(injector.instanceOf(A.class), instanceOf(A1.class));
+        assertThat(injector.instanceOf(B.class), instanceOf(B1.class));
+        assertThat(injector.instanceOf(C.class), instanceOf(C1.class));
+        assertThat(injector.instanceOf(D.class), instanceOf(D1.class));
+    }
+
+    @Test
+    public void overrideBindings() {
+        Injector injector = new GuiceInjectorBuilder()
+            .bindings(new AModule())
+            .bindings(bind(B.class).to(B1.class))
+            .overrides(new A2Module())
+            .overrides(bind(B.class).to(B2.class))
+            .injector();
+
+        assertThat(injector.instanceOf(A.class), instanceOf(A2.class));
+        assertThat(injector.instanceOf(B.class), instanceOf(B2.class));
+    }
+
+    @Test
+    public void disableModules() {
+        Injector injector = new GuiceInjectorBuilder()
+            .bindings(new AModule(), new BModule())
+            .bindings(bind(C.class).to(C1.class))
+            .disable(AModule.class, CModule.class) // C won't be disabled
+            .injector();
+
+        assertThat(injector.instanceOf(B.class), instanceOf(B1.class));
+        assertThat(injector.instanceOf(C.class), instanceOf(C1.class));
+
+        exception.expect(com.google.inject.ConfigurationException.class);
+        injector.instanceOf(A.class);
+    }
+
+    public static class EnvironmentModule extends play.api.inject.Module {
+        @Override
+        public Seq<Binding<?>> bindings(play.api.Environment env, play.api.Configuration conf) {
+            return seq(bind(Environment.class).toInstance(new Environment(env)));
+        }
+    }
+
+    public static class ConfigurationModule extends play.api.inject.Module {
+        @Override
+        public Seq<Binding<?>> bindings(play.api.Environment env, play.api.Configuration conf) {
+            return seq(bind(Configuration.class).toInstance(new Configuration(conf)));
+        }
+    }
+
+    public static interface A {}
+    public static class A1 implements A {}
+    public static class A2 implements A {}
+
+    public static class AModule extends com.google.inject.AbstractModule {
+        public void configure() {
+            bind(A.class).to(A1.class);
+        }
+    }
+
+    public static class A2Module extends com.google.inject.AbstractModule {
+        public void configure() {
+            bind(A.class).to(A2.class);
+        }
+    }
+
+    public static interface B {}
+    public static class B1 implements B {}
+    public static class B2 implements B {}
+
+    public static class BModule extends com.google.inject.AbstractModule {
+        public void configure() {
+            bind(B.class).to(B1.class);
+        }
+    }
+
+    public static interface C {}
+    public static class C1 implements C {}
+
+    public static class CModule extends com.google.inject.AbstractModule {
+        public void configure() {
+            bind(C.class).to(C1.class);
+        }
+    }
+
+    public static interface D {}
+    public static class D1 implements D {}
+
+    public static class DModule extends com.google.inject.AbstractModule {
+        public void configure() {
+            bind(D.class).to(D1.class);
+        }
+    }
+
+}

--- a/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala
+++ b/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala
@@ -33,7 +33,7 @@ abstract class WithApplicationLoader(applicationLoader: ApplicationLoader = new 
  *
  * @param app The fake application
  */
-abstract class WithApplication(val app: FakeApplication = FakeApplication()) extends Around with Scope {
+abstract class WithApplication(val app: Application = FakeApplication()) extends Around with Scope {
   implicit def implicitApp = app
   override def around[T: AsResult](t: => T): Result = {
     Helpers.running(app)(AsResult.effectively(t))
@@ -49,7 +49,7 @@ abstract class WithApplication(val app: FakeApplication = FakeApplication()) ext
  * server to use. Defaults to providing a Netty server.
  */
 abstract class WithServer(
-    val app: FakeApplication = FakeApplication(),
+    val app: Application = FakeApplication(),
     val port: Int = Helpers.testServerPort,
     val serverProvider: ServerProvider = NettyServer.defaultServerProvider) extends Around with Scope {
   implicit def implicitApp = app

--- a/framework/src/play-specs2/src/test/scala/play/api/test/SpecsSpec.scala
+++ b/framework/src/play-specs2/src/test/scala/play/api/test/SpecsSpec.scala
@@ -5,7 +5,7 @@ package play.api.test
 
 import com.google.inject.AbstractModule
 import org.specs2.mutable._
-import play.api.inject.guice.GuiceApplicationLoader
+import play.api.inject.guice.{ GuiceApplicationBuilder, GuiceApplicationLoader }
 import play.api.{ Play, Application }
 
 object SpecsSpec extends Specification {
@@ -29,7 +29,8 @@ object SpecsSpec extends Specification {
     val myModule = new AbstractModule {
       def configure() = bind(classOf[Int]).toInstance(42)
     }
-    class WithMyApplicationLoader extends WithApplicationLoader(new GuiceApplicationLoader(myModule))
+    val builder = new GuiceApplicationBuilder().bindings(myModule)
+    class WithMyApplicationLoader extends WithApplicationLoader(new GuiceApplicationLoader(builder))
     "allow adding modules" in new WithMyApplicationLoader {
       app.injector.instanceOf(classOf[Int]) must equalTo(42)
     }

--- a/framework/src/play-test/src/main/java/play/test/FakeApplication.java
+++ b/framework/src/play-test/src/main/java/play/test/FakeApplication.java
@@ -3,58 +3,92 @@
  */
 package play.test;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import play.api.mvc.Handler;
+import play.Configuration;
 import play.inject.Injector;
-import play.libs.*;
-import scala.PartialFunction$;
-import scala.Tuple2;
+import play.libs.Scala;
 
 /**
- * A Fake application.
+ * A fake application for testing.
  */
-public class FakeApplication {
+public class FakeApplication implements play.Application {
 
-    final play.api.test.FakeApplication wrappedApplication;
+    private final play.api.test.FakeApplication application;
+    private final Configuration configuration;
+    private final Injector injector;
 
     /**
-     * A Fake application.
+     * Create a fake application.
      *
-     * @param path The application path
-     * @param classloader The application classloader
-     * @param additionalConfiguration Additional configuration
-     * @param additionalPlugins Additional plugins
-     * @param withoutPlugins Plugins to disable
+     * @param path application environment root path
+     * @param classloader application environment class loader
+     * @param additionalConfiguration additional configuration for the application
+     * @param additionalPlugins additional plugins to load
+     * @param withoutPlugins plugins to disable
+     * @param global global settings to use in place of default global
      */
     @SuppressWarnings("unchecked")
-    public FakeApplication(File path, ClassLoader classloader, Map<String, ? extends Object> additionalConfiguration,
-            List<String> additionalPlugins, List<String> withoutPlugins, play.GlobalSettings global) {
-        play.api.GlobalSettings g = null;
-        if(global != null)
-          g = new play.core.j.JavaGlobalSettingsAdapter(global);
-        wrappedApplication = new play.api.test.FakeApplication(
-                path,
-                classloader,
-                Scala.toSeq(additionalPlugins),
-                Scala.toSeq(withoutPlugins),
-                Scala.asScala((Map<String, Object>)additionalConfiguration),
-                scala.Option.apply(g),
-                PartialFunction$.MODULE$.<Tuple2<String, String>, Handler>empty()
-                );
+    public FakeApplication(
+        File path,
+        ClassLoader classloader,
+        Map<String, ? extends Object> additionalConfiguration,
+        List<String> additionalPlugins,
+        List<String> withoutPlugins,
+        play.GlobalSettings global) {
+
+        play.api.GlobalSettings scalaGlobal = (global != null) ? new play.core.j.JavaGlobalSettingsAdapter(global) : null;
+
+        this.application = new play.api.test.FakeApplication(
+            path,
+            classloader,
+            Scala.toSeq(additionalPlugins),
+            Scala.toSeq(withoutPlugins),
+            Scala.asScala((Map<String, Object>) additionalConfiguration),
+            scala.Option.apply(scalaGlobal),
+            scala.PartialFunction$.MODULE$.<scala.Tuple2<String, String>, Handler>empty()
+        );
+        this.configuration = application.injector().instanceOf(Configuration.class);
+        this.injector = application.injector().instanceOf(Injector.class);
     }
 
+    /**
+     * Create a fake application.
+     *
+     * @param path application environment root path
+     * @param classloader application environment class loader
+     * @param additionalConfiguration additional configuration for the application
+     * @param additionalPlugins additional plugins to load
+     * @param global global settings to use in place of default global
+     */
     public FakeApplication(File path, ClassLoader classloader, Map<String, ? extends Object> additionalConfiguration,
                            List<String> additionalPlugins, play.GlobalSettings global) {
         this(path, classloader, additionalConfiguration, additionalPlugins, Collections.<String>emptyList(), global);
     }
 
+    /**
+     * Get the underlying Scala application.
+     */
     public play.api.test.FakeApplication getWrappedApplication() {
-        return wrappedApplication;
+        return application;
     }
 
-    public Injector injector() {
-        return getWrappedApplication().injector().instanceOf(Injector.class);
+    /**
+     * Get the application configuration.
+     */
+    public Configuration configuration() {
+        return configuration;
     }
+
+    /**
+     * Get the injector for this application.
+     */
+    public Injector injector() {
+        return injector;
+    }
+
 }

--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -406,7 +406,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Starts a new application.
      */
-    public static void start(FakeApplication fakeApplication) {
+    public static void start(Application fakeApplication) {
 
         play.api.Play.start(fakeApplication.getWrappedApplication());
     }
@@ -414,14 +414,14 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Stops an application.
      */
-    public static void stop(FakeApplication fakeApplication) {
+    public static void stop(Application fakeApplication) {
         play.api.Play.stop(fakeApplication.getWrappedApplication());
     }
 
     /**
      * Executes a block of code in a running application.
      */
-    public static void running(FakeApplication fakeApplication, final Runnable block) {
+    public static void running(Application fakeApplication, final Runnable block) {
         synchronized (PlayRunners$.MODULE$.mutex()) {
             try {
                 start(fakeApplication);
@@ -443,7 +443,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Creates a new Test server listening on port defined by configuration setting "testserver.port" (defaults to 19001) and using the given FakeApplication.
      */
-    public static TestServer testServer(FakeApplication app) {
+    public static TestServer testServer(Application app) {
         return testServer(play.api.test.Helpers.testServerPort(), app);
     }
 
@@ -457,7 +457,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Creates a new Test server.
      */
-    public static TestServer testServer(int port, FakeApplication app) {
+    public static TestServer testServer(int port, Application app) {
         return new TestServer(port, app);
     }
 

--- a/framework/src/play-test/src/main/java/play/test/TestServer.java
+++ b/framework/src/play-test/src/main/java/play/test/TestServer.java
@@ -3,6 +3,7 @@
  */
 package play.test;
 
+import play.Application;
 import play.core.server.NettyServer;
 import scala.Option;
 
@@ -15,19 +16,19 @@ public class TestServer extends play.api.test.TestServer {
      * A test Netty web server.
      *
      * @param port HTTP port to bind on.
-     * @param application The FakeApplication to load in this server.
+     * @param application The Application to load in this server.
      */
-    public TestServer(int port, FakeApplication application) {
+    public TestServer(int port, Application application) {
         super(port, application.getWrappedApplication(), Option.<Object>apply(null), NettyServer.defaultServerProvider());
     }
 
     /**
      * A test Netty web server with HTTPS support
      * @param port HTTP port to bind on
-     * @param application The FakeApplication to load in this server
+     * @param application The Application to load in this server
      * @param sslPort HTTPS port to bind on
      */
-    public TestServer(int port, FakeApplication application, int sslPort) {
+    public TestServer(int port, Application application, int sslPort) {
         super(port, application.getWrappedApplication(), Option.<Object>apply(sslPort), NettyServer.defaultServerProvider());
     }
 

--- a/framework/src/play-test/src/main/java/play/test/WithApplication.java
+++ b/framework/src/play-test/src/main/java/play/test/WithApplication.java
@@ -5,17 +5,31 @@ package play.test;
 
 import org.junit.After;
 import org.junit.Before;
+import play.Application;
 
 /**
  * Provides an application for JUnit tests. Make your test class extend this class and an application will be started before each test is invoked.
- * You can setup the fake application to use by overriding the provideFakeApplication method.
+ * You can setup the application to use by overriding the provideApplication method.
  * Within a test, the running application is available through the app field.
  */
 public class WithApplication {
 
-    protected FakeApplication app;
+    protected Application app;
 
     /**
+     * Override this method to setup the application to use.
+     *
+     * By default this will call the old {@link #provideFakeApplication() provideFakeApplication} method.
+     *
+     * @return The application to use
+     */
+    protected Application provideApplication() {
+        return provideFakeApplication();
+    }
+
+    /**
+     * Old method - use the new {@link #provideApplication() provideApplication} method instead.
+     *
      * Override this method to setup the fake application to use.
      *
      * @return The fake application to use
@@ -26,7 +40,7 @@ public class WithApplication {
 
     @Before
     public void startPlay() {
-        app = provideFakeApplication();
+        app = provideApplication();
         Helpers.start(app);
     }
 

--- a/framework/src/play-test/src/main/java/play/test/WithServer.java
+++ b/framework/src/play-test/src/main/java/play/test/WithServer.java
@@ -5,19 +5,33 @@ package play.test;
 
 import org.junit.After;
 import org.junit.Before;
+import play.Application;
 
 /**
  * Provides a server to JUnit tests. Make your test class extend this class and an HTTP server will be started before each test is invoked.
- * You can setup the fake application and port to use by overriding the provideFakeApplication and providePort methods.
+ * You can setup the application and port to use by overriding the provideApplication and providePort methods.
  * Within a test, the running application and the TCP port are available through the app and port fields, respectively.
  */
 public class WithServer {
 
-    protected FakeApplication app;
+    protected Application app;
     protected int port;
     protected TestServer testServer;
 
     /**
+     * Override this method to setup the application to use.
+     *
+     * By default this will call the old {@link #provideFakeApplication() provideFakeApplication} method.
+     *
+     * @return The application used by the server
+     */
+    protected Application provideApplication() {
+        return provideFakeApplication();
+    }
+
+    /**
+     * Old method - use the new {@link #provideApplication() provideApplication} method instead.
+     *
      * Override this method to setup the fake application to use.
      *
      * @return The fake application used by the server
@@ -40,7 +54,7 @@ public class WithServer {
         if (testServer != null) {
             testServer.stop();
         }
-        app = provideFakeApplication();
+        app = provideApplication();
         port = providePort();
         testServer = Helpers.testServer(port, app);
         testServer.start();

--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -211,9 +211,7 @@ case class FakeApplication(
     withRoutes: PartialFunction[(String, String), Handler] = PartialFunction.empty) extends Application {
 
   private val environment = Environment(path, classloader, Mode.Test)
-  private val initialConfiguration = Threads.withContextClassLoader(environment.classLoader) {
-    Configuration.load(environment.rootPath, environment.mode)
-  }
+  private val initialConfiguration = Configuration.load(environment)
   override val global = withGlobal.getOrElse(GlobalSettings(initialConfiguration, environment))
   private val config =
     global.onLoadConfig(initialConfiguration, path, classloader, environment.mode) ++

--- a/framework/src/play-test/src/main/scala/play/api/test/TestServer.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/TestServer.scala
@@ -11,7 +11,7 @@ import scala.util.control.NonFatal
  * A test web server.
  *
  * @param port HTTP port to bind on.
- * @param application The FakeApplication to load in this server.
+ * @param application The Application to load in this server.
  * @param sslPort HTTPS port to bind on.
  * @param serverProvider *Experimental API; subject to change* The type of
  * server to use. Defaults to providing a Netty server.

--- a/framework/src/play/src/main/java/play/Application.java
+++ b/framework/src/play/src/main/java/play/Application.java
@@ -20,8 +20,9 @@ import javax.inject.Singleton;
  */
 @Singleton
 public class Application {
-    
+
     private final play.api.Application application;
+    private final Configuration configuration;
     private final Injector injector;
 
     public play.api.Application getWrappedApplication() {
@@ -32,11 +33,12 @@ public class Application {
      * Creates an application from a Scala Application value.
      */
     @Inject
-    public Application(play.api.Application application, Injector injector) {
+    public Application(play.api.Application application, Configuration configuration, Injector injector) {
         this.application = application;
+        this.configuration = configuration;
         this.injector = injector;
     }
-    
+
     /**
      * Retrieves the application path.
      * <p>
@@ -45,16 +47,16 @@ public class Application {
     public File path() {
         return application.path();
     }
-    
+
     /**
-     * Retrieves the application configuration/
+     * Retrieves the application configuration.
      * <p>
      * @return the application path
      */
     public Configuration configuration() {
-        return new Configuration(application.configuration());
+        return configuration;
     }
-    
+
     /**
      * Retrieves the application classloader.
      * <p>
@@ -63,7 +65,7 @@ public class Application {
     public ClassLoader classloader() {
         return application.classloader();
     }
-    
+
     /**
      * Retrieves a file relative to the application root path.
      *
@@ -73,7 +75,7 @@ public class Application {
     public File getFile(String relativePath) {
         return application.getFile(relativePath);
     }
-    
+
     /**
      * Retrieves a resource from the classpath.
      *
@@ -83,7 +85,7 @@ public class Application {
     public URL resource(String relativePath) {
         return Scala.orNull(application.resource(relativePath));
     }
-    
+
     /**
      * Retrieves a resource stream from the classpath.
      *
@@ -93,28 +95,28 @@ public class Application {
     public InputStream resourceAsStream(String relativePath) {
         return Scala.orNull(application.resourceAsStream(relativePath));
     }
-    
+
     /**
      * Retrieve the plugin instance for the class.
      */
     public <T> T plugin(Class<T> pluginClass) {
         return Scala.orNull(application.plugin(pluginClass));
     }
-    
+
     /**
      * Returns `true` if the application is `DEV` mode.
      */
     public boolean isDev() {
         return play.api.Play.isDev(application);
     }
-    
+
     /**
      * Returns `true` if the application is `PROD` mode.
      */
     public boolean isProd() {
         return play.api.Play.isProd(application);
     }
-    
+
     /**
      * Returns `true` if the application is `TEST` mode.
      */

--- a/framework/src/play/src/main/java/play/Application.java
+++ b/framework/src/play/src/main/java/play/Application.java
@@ -3,132 +3,118 @@
  */
 package play;
 
-import java.io.*;
-import java.util.*;
-import java.net.*;
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
 
 import play.inject.Injector;
 import play.libs.Scala;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
 /**
  * A Play application.
- * <p>
+ *
  * Application creation is handled by the framework engine.
  */
-@Singleton
-public class Application {
-
-    private final play.api.Application application;
-    private final Configuration configuration;
-    private final Injector injector;
-
-    public play.api.Application getWrappedApplication() {
-      return application;
-    }
+public interface Application {
 
     /**
-     * Creates an application from a Scala Application value.
+     * Get the underlying Scala application.
      */
-    @Inject
-    public Application(play.api.Application application, Configuration configuration, Injector injector) {
-        this.application = application;
-        this.configuration = configuration;
-        this.injector = injector;
-    }
+    play.api.Application getWrappedApplication();
 
     /**
-     * Retrieves the application path.
-     * <p>
-     * @return the application path
+     * Get the application configuration.
      */
-    public File path() {
-        return application.path();
-    }
-
-    /**
-     * Retrieves the application configuration.
-     * <p>
-     * @return the application path
-     */
-    public Configuration configuration() {
-        return configuration;
-    }
-
-    /**
-     * Retrieves the application classloader.
-     * <p>
-     * @return the application classloader
-     */
-    public ClassLoader classloader() {
-        return application.classloader();
-    }
-
-    /**
-     * Retrieves a file relative to the application root path.
-     *
-     * @param relativePath relative path of the file to fetch
-     * @return a file instance - it is not guaranteed that the file exists
-     */
-    public File getFile(String relativePath) {
-        return application.getFile(relativePath);
-    }
-
-    /**
-     * Retrieves a resource from the classpath.
-     *
-     * @param relativePath relative path of the resource to fetch
-     * @return URL to the resource (may be null)
-     */
-    public URL resource(String relativePath) {
-        return Scala.orNull(application.resource(relativePath));
-    }
-
-    /**
-     * Retrieves a resource stream from the classpath.
-     *
-     * @param relativePath relative path of the resource to fetch
-     * @return InputStream to the resource (may be null)
-     */
-    public InputStream resourceAsStream(String relativePath) {
-        return Scala.orNull(application.resourceAsStream(relativePath));
-    }
-
-    /**
-     * Retrieve the plugin instance for the class.
-     */
-    public <T> T plugin(Class<T> pluginClass) {
-        return Scala.orNull(application.plugin(pluginClass));
-    }
-
-    /**
-     * Returns `true` if the application is `DEV` mode.
-     */
-    public boolean isDev() {
-        return play.api.Play.isDev(application);
-    }
-
-    /**
-     * Returns `true` if the application is `PROD` mode.
-     */
-    public boolean isProd() {
-        return play.api.Play.isProd(application);
-    }
-
-    /**
-     * Returns `true` if the application is `TEST` mode.
-     */
-    public boolean isTest() {
-        return play.api.Play.isTest(application);
-    }
+    Configuration configuration();
 
     /**
      * Get the injector for this application.
      */
-    public Injector injector() {
-        return injector;
+    Injector injector();
+
+    /**
+     * Get the application path.
+     *
+     * @return the application path
+     */
+    default File path() {
+        return getWrappedApplication().path();
+    }
+
+    /**
+     * Get the application classloader.
+     *
+     * @return the application classloader
+     */
+    default ClassLoader classloader() {
+        return getWrappedApplication().classloader();
+    }
+
+    /**
+     * Get a file relative to the application root path.
+     *
+     * @param relativePath relative path of the file to fetch
+     * @return a file instance - it is not guaranteed that the file exists
+     */
+    default File getFile(String relativePath) {
+        return getWrappedApplication().getFile(relativePath);
+    }
+
+    /**
+     * Get a resource from the classpath.
+     *
+     * @param relativePath relative path of the resource to fetch
+     * @return URL to the resource (may be null)
+     */
+    default URL resource(String relativePath) {
+        return Scala.orNull(getWrappedApplication().resource(relativePath));
+    }
+
+    /**
+     * Get a resource stream from the classpath.
+     *
+     * @param relativePath relative path of the resource to fetch
+     * @return InputStream to the resource (may be null)
+     */
+    default InputStream resourceAsStream(String relativePath) {
+        return Scala.orNull(getWrappedApplication().resourceAsStream(relativePath));
+    }
+
+    /**
+     * Get the {@link play.Plugin} instance for the given class.
+     *
+     * @param pluginClass the Class of the plugin
+     * @return an instance of the plugin (if found, otherwise null)
+     */
+    default <T> T plugin(Class<T> pluginClass) {
+        return Scala.orNull(getWrappedApplication().plugin(pluginClass));
+    }
+
+    /**
+     * Check whether the application is in {@link Mode#DEV} mode.
+     *
+     * @return true if the application is in DEV mode
+     */
+    default boolean isDev() {
+        return play.api.Play.isDev(getWrappedApplication());
+    }
+
+    /**
+     * Check whether the application is in {@link Mode#PROD} mode.
+     *
+     * @return true if the application is in PROD mode
+     */
+    default boolean isProd() {
+        return play.api.Play.isProd(getWrappedApplication());
+    }
+
+    /**
+     * Check whether the application is in {@link Mode#TEST} mode.
+     *
+     * @return true if the application is in TEST mode
+     */
+    default boolean isTest() {
+        return play.api.Play.isTest(getWrappedApplication());
     }
 
 }

--- a/framework/src/play/src/main/java/play/Configuration.java
+++ b/framework/src/play/src/main/java/play/Configuration.java
@@ -6,6 +6,7 @@ package play;
 import java.util.*;
 
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigObject;
 import com.typesafe.config.ConfigValue;
 import scala.collection.JavaConverters;
@@ -20,7 +21,7 @@ import javax.inject.Singleton;
  */
 @Singleton
 public class Configuration {
-    
+
     /**
      * The root configuration.
      * <p>
@@ -31,9 +32,23 @@ public class Configuration {
             play.api.Play.unsafeApplication().configuration()
         );
     }
-    
+
+    /**
+     * Load a new configuration from an environment.
+     */
+    public static Configuration load(Environment env) {
+        return new Configuration(play.api.Configuration.load(env.underlying()));
+    }
+
+    /**
+     * A new empty configuration.
+     */
+    public static Configuration empty() {
+        return new Configuration(ConfigFactory.empty());
+    }
+
     // --
-    
+
     private final play.api.Configuration conf;
 
     /**
@@ -41,6 +56,13 @@ public class Configuration {
      */
     public Configuration(Config conf) {
         this(new play.api.Configuration(conf));
+    }
+
+    /**
+     * Creates a new configuration from a map.
+     */
+    public Configuration(Map<String, Object> conf) {
+        this(ConfigFactory.parseMap(conf));
     }
 
     /**
@@ -66,7 +88,7 @@ public class Configuration {
         }
         return null;
     }
-    
+
     /**
      * Retrieves a configuration value as a <code>String</code>.
      *
@@ -87,7 +109,7 @@ public class Configuration {
     public String getString(String key, String defaultString) {
         return Scala.orElse(conf.getString(key, scala.Option.<scala.collection.immutable.Set<java.lang.String>>empty()), defaultString);
     }
-    
+
     /**
      * Retrieves a configuration value as a <code>Milliseconds</code>.
      *
@@ -108,7 +130,7 @@ public class Configuration {
     public Long getMilliseconds(String key, Long defaultMilliseconds) {
         return (Long)Scala.orElse(conf.getMilliseconds(key), defaultMilliseconds);
     }
-        
+
     /**
      * Retrieves a configuration value as a <code>Nanoseconds</code>.
      *
@@ -129,7 +151,7 @@ public class Configuration {
     public Long getNanoseconds(String key, Long defaultNanoseconds) {
         return (Long)Scala.orElse(conf.getNanoseconds(key), defaultNanoseconds);
     }
-    
+
     /**
      * Retrieves a configuration value as a <code>Bytes</code>.
      *
@@ -150,7 +172,7 @@ public class Configuration {
     public Long getBytes(String key, Long defaultBytes) {
         return (Long)Scala.orElse(conf.getBytes(key), defaultBytes);
     }
-    
+
     /**
      * Retrieves a configuration value as an <code>Double</code>.
      *
@@ -192,7 +214,7 @@ public class Configuration {
     public Integer getInt(String key, Integer defaultInteger) {
         return (Integer)Scala.orElse(conf.getInt(key), defaultInteger);
     }
-    
+
     /**
      * Retrieves a configuration value as an <code>Long</code>.
      *
@@ -213,7 +235,7 @@ public class Configuration {
     public Long getLong(String key, Long defaultLong) {
         return (Long)Scala.orElse(conf.getLong(key), defaultLong);
     }
-    
+
     /**
      * Retrieves a configuration value as an <code>Number</code>.
      *
@@ -244,7 +266,7 @@ public class Configuration {
     public Boolean getBoolean(String key) {
         return (Boolean)Scala.orNull(conf.getBoolean(key));
     }
-        
+
     /**
      * Retrieves a configuration value as a <code>Boolean</code>.
      *
@@ -255,7 +277,7 @@ public class Configuration {
     public Boolean getBoolean(String key, Boolean defaultBoolean) {
         return (Boolean)Scala.orElse(conf.getBoolean(key), defaultBoolean);
     }
-    
+
     /**
      * Retrieves the set of keys available in this configuration.
      *
@@ -264,7 +286,7 @@ public class Configuration {
     public Set<String> keys() {
         return JavaConverters.setAsJavaSetConverter(conf.keys()).asJava();
     }
-    
+
     /**
      * Retrieves the set of direct sub-keys available in this configuration.
      *
@@ -302,7 +324,7 @@ public class Configuration {
     public Set<Map.Entry<String, ConfigValue>> entrySet() {
         return conf.underlying().entrySet();
     }
-    
+
     /**
      * Creates a configuration error for a specific configuration key.
      *
@@ -314,55 +336,55 @@ public class Configuration {
     public RuntimeException reportError(String key, String message, Throwable e) {
         return conf.reportError(key, message, scala.Option.apply(e));
     }
-    
+
     /**
      * Retrieves a configuration value as a {@code List<Boolean>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @return a configuration value or <code>null</code>
-     */    
+     */
     public List<Boolean> getBooleanList(String key) {
         return (List<Boolean>)Scala.orNull(conf.getBooleanList(key));
     }
-  
+
     /**
      * Retrieves a configuration value as a {@code List<Boolean>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @param defaultList default value if configuration key doesn't exist
      * @return a configuration value or the defaultList
-     */    
+     */
     public List<Boolean> getBooleanList(String key, List<Boolean> defaultList) {
         return (List<Boolean>)Scala.orElse(conf.getBooleanList(key), defaultList);
     }
-    
+
     /**
      * Retrieves a configuration value as a {@code List<Long>} representing bytes.
      *
      * @param key configuration key (relative to configuration root key)
      * @return a configuration value or <code>null</code>
-     */        
+     */
     public List<Long> getBytesList(String key) {
         return (List<Long>)Scala.orNull(conf.getBytesList(key));
     }
-    
+
     /**
      * Retrieves a configuration value as a {@code List<Long>} representing bytes.
      *
      * @param key configuration key (relative to configuration root key)
      * @param defaultList default value if configuration key doesn't exist
      * @return a configuration value or the defaultList
-     */        
+     */
     public List<Long> getBytesList(String key, List<Long> defaultList) {
         return (List<Long>)Scala.orElse(conf.getBytesList(key), defaultList);
-    }    
+    }
 
     /**
      * Retrieves a configuration value as a {@code List<Configuration>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @return a configuration value or <code>null</code>
-     */        
+     */
     public List<Configuration> getConfigList(String key) {
         if (conf.getConfigList(key).isDefined()) {
           List<Configuration> out = new ArrayList<Configuration>();
@@ -372,86 +394,86 @@ public class Configuration {
           return out;
         }
 
-        return null;      
+        return null;
     }
-    
+
     /**
      * Retrieves a configuration value as a {@code List<Configuration>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @param defaultList default value if configuration key doesn't exist
      * @return a configuration value or the defaultList
-     */        
+     */
     public List<Configuration> getConfigList(String key, List<Configuration> defaultList) {
         List<Configuration> out = getConfigList(key);
         if (out == null) {
           out = defaultList;
         }
         return out;
-    }    
+    }
 
     /**
      * Retrieves a configuration value as a {@code List<Double>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @return a configuration value or <code>null</code>
-     */        
+     */
     public List<Double> getDoubleList(String key) {
         return (List<Double>)Scala.orNull(conf.getDoubleList(key));
     }
-    
+
     /**
      * Retrieves a configuration value as a {@code List<Double>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @param defaultList default value if configuration key doesn't exist
      * @return a configuration value or the defaultList
-     */        
+     */
     public List<Double> getDoubleList(String key, List<Double> defaultList) {
         return (List<Double>)Scala.orElse(conf.getDoubleList(key), defaultList);
-    }    
-    
+    }
+
     /**
      * Retrieves a configuration value as a {@code List<Integer>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @return a configuration value or <code>null</code>
-     */        
+     */
     public List<Integer> getIntList(String key) {
         return (List<Integer>)Scala.orNull(conf.getIntList(key));
     }
-    
+
     /**
      * Retrieves a configuration value as a {@code List<Integer>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @param defaultList default value if configuration key doesn't exist
      * @return a configuration value or the defaultList
-     */        
+     */
     public List<Integer> getIntList(String key, List<Integer> defaultList) {
         return (List<Integer>)Scala.orElse(conf.getIntList(key), defaultList);
-    }    
-    
+    }
+
     /**
      * Retrieves a configuration value as a {@code List<Object>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @return a configuration value or <code>null</code>
-     */        
+     */
     public List<Object> getList(String key) {
         if (conf.getList(key).isDefined()) {
           return conf.getList(key).get().unwrapped();
         }
         return null;
     }
-    
+
     /**
      * Retrieves a configuration value as a {@code List<Object>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @param defaultList default value if configuration key doesn't exist
      * @return a configuration value or the defaultList
-     */        
+     */
     public List<Object> getList(String key, List<Object> defaultList) {
         List<Object> out = getList(key);
         if (out == null) {
@@ -459,97 +481,97 @@ public class Configuration {
         }
         return out;
     }
-    
+
     /**
      * Retrieves a configuration value as a {@code List<Long>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @return a configuration value or <code>null</code>
-     */        
+     */
     public List<Long> getLongList(String key) {
         return (List<Long>)Scala.orNull(conf.getLongList(key));
     }
-    
+
     /**
      * Retrieves a configuration value as a {@code List<Long>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @param defaultList default value if configuration key doesn't exist
      * @return a configuration value or the defaultList
-     */        
+     */
     public List<Long> getLongList(String key, List<Long> defaultList) {
         return (List<Long>)Scala.orElse(conf.getLongList(key), defaultList);
-    }            
-    
+    }
+
     /**
      * Retrieves a configuration value as a {@code List<Long>} representing Milliseconds.
      *
      * @param key configuration key (relative to configuration root key)
      * @return a configuration value or <code>null</code>
-     */        
+     */
     public List<Long> getMillisecondsList(String key) {
         return (List<Long>)Scala.orNull(conf.getMillisecondsList(key));
     }
-    
+
     /**
      * Retrieves a configuration value as a {@code List<Long>} representing Milliseconds.
      *
      * @param key configuration key (relative to configuration root key)
      * @param defaultList default value if configuration key doesn't exist
      * @return a configuration value or the defaultList
-     */        
+     */
     public List<Long> getMillisecondsList(String key, List<Long> defaultList) {
         return (List<Long>)Scala.orElse(conf.getMillisecondsList(key), defaultList);
-    }            
-    
+    }
+
     /**
      * Retrieves a configuration value as a {@code List<Long>} representing Nanoseconds.
      *
      * @param key configuration key (relative to configuration root key)
      * @return a configuration value or <code>null</code>
-     */        
+     */
     public List<Long> getNanosecondsList(String key) {
         return (List<Long>)Scala.orNull(conf.getNanosecondsList(key));
     }
-    
+
     /**
      * Retrieves a configuration value as a {@code List<Long>} representing Nanoseconds.
      *
      * @param key configuration key (relative to configuration root key)
      * @param defaultList default value if configuration key doesn't exist
      * @return a configuration value or the defaultList
-     */        
+     */
     public List<Long> getNanosecondsList(String key, List<Long> defaultList) {
         return (List<Long>)Scala.orElse(conf.getNanosecondsList(key), defaultList);
-    }            
-    
+    }
+
     /**
      * Retrieves a configuration value as a {@code List<Number>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @return a configuration value or <code>null</code>
-     */        
+     */
     public List<Number> getNumberList(String key) {
         return (List<Number>)Scala.orNull(conf.getNumberList(key));
     }
-    
+
     /**
      * Retrieves a configuration value as a {@code List<Number>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @param defaultList default value if configuration key doesn't exist
      * @return a configuration value or the defaultList
-     */        
+     */
     public List<Number> getNumberList(String key, List<Number> defaultList) {
         return (List<Number>)Scala.orElse(conf.getNumberList(key), defaultList);
-    }            
+    }
 
     /**
      * Retrieves a configuration value as a {@code List<Map<String, Object>>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @return a configuration value or <code>null</code>
-     */        
+     */
     public List<Map<String, Object>> getObjectList(String key) {
         if (conf.getObjectList(key).isDefined()) {
           List<Map<String, Object>> out = new ArrayList<Map<String, Object>>();
@@ -560,69 +582,76 @@ public class Configuration {
         }
         return null;
     }
-    
+
     /**
      * Retrieves a configuration value as a {@code List<Map<String, Object>>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @param defaultList default value if configuration key doesn't exist
      * @return a configuration value or the defaultList
-     */        
+     */
     public List<Map<String, Object>> getObjectList(String key, List<Map<String, Object>> defaultList) {
         List<Map<String, Object>> out = getObjectList(key);
         if (out == null) {
           out = defaultList;
         }
         return out;
-    }    
-    
+    }
+
     /**
      * Retrieves a configuration value as a {@code List<String>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @return a configuration value or <code>null</code>
-     */        
+     */
     public List<String> getStringList(String key) {
         return (List<String>)Scala.orNull(conf.getStringList(key));
     }
-    
+
     /**
      * Retrieves a configuration value as a {@code List<Number>}.
      *
      * @param key configuration key (relative to configuration root key)
      * @param defaultList default value if configuration key doesn't exist
      * @return a configuration value or the defaultList
-     */        
+     */
     public List<String> getStringList(String key, List<String> defaultList) {
         return (List<String>)Scala.orElse(conf.getStringList(key), defaultList);
-    } 
-    
+    }
+
     /**
      * Retrieves a configuration value as a <code>Object</code>.
      *
      * @param key configuration key (relative to configuration root key)
      * @return a configuration value or <code>null</code>
-     */        
+     */
     public Object getObject(String key) {
         if (conf.getObject(key).isDefined()) {
           return conf.getObject(key).get().unwrapped();
         }
         return null;
     }
-    
+
     /**
      * Retrieves a configuration value as a <code>Object</code>.
      *
      * @param key configuration key (relative to configuration root key)
      * @param defaultObject default value if configuration key doesn't exist
      * @return a configuration value or the defaultList
-     */        
+     */
     public Object getObject(String key, Object defaultObject) {
         Object out = getObject(key);
         if (out == null) {
           out = defaultObject;
         }
         return out;
+    }
+
+    /**
+     * Extend this configuration with fallback configuration.
+     */
+    public Configuration withFallback(Configuration fallback) {
+        return new Configuration(underlying().withFallback(fallback.underlying()));
     }
 
     public play.api.Configuration getWrappedConfiguration() {

--- a/framework/src/play/src/main/java/play/DefaultApplication.java
+++ b/framework/src/play/src/main/java/play/DefaultApplication.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import play.inject.Injector;
+
+/**
+ * Default implementation of a Play Application.
+ *
+ * Application creation is handled by the framework engine.
+ */
+@Singleton
+public class DefaultApplication implements Application {
+
+    private final play.api.Application application;
+    private final Configuration configuration;
+    private final Injector injector;
+
+    /**
+     * Create an application that wraps a Scala application.
+     */
+    @Inject
+    public DefaultApplication(play.api.Application application, Configuration configuration, Injector injector) {
+        this.application = application;
+        this.configuration = configuration;
+        this.injector = injector;
+    }
+
+    /**
+     * Create an application that wraps a Scala application.
+     */
+    public DefaultApplication(play.api.Application application, Injector injector) {
+        this(application, new Configuration(application.configuration()), injector);
+    }
+
+    /**
+     * Get the underlying Scala application.
+     */
+    public play.api.Application getWrappedApplication() {
+      return application;
+    }
+
+    /**
+     * Get the application configuration.
+     */
+    public Configuration configuration() {
+        return configuration;
+    }
+
+    /**
+     * Get the injector for this application.
+     */
+    public Injector injector() {
+        return injector;
+    }
+
+}

--- a/framework/src/play/src/main/java/play/Environment.java
+++ b/framework/src/play/src/main/java/play/Environment.java
@@ -25,6 +25,22 @@ public class Environment {
         this.env = environment;
     }
 
+    public Environment(File rootPath, ClassLoader classLoader, Mode mode) {
+        this(new play.api.Environment(rootPath, classLoader, play.api.Mode.apply(mode.ordinal())));
+    }
+
+    public Environment(File rootPath, Mode mode) {
+        this(rootPath, Environment.class.getClassLoader(), mode);
+    }
+
+    public Environment(File rootPath) {
+        this(rootPath, Environment.class.getClassLoader(), Mode.TEST);
+    }
+
+    public Environment(Mode mode) {
+        this(new File("."), Environment.class.getClassLoader(), mode);
+    }
+
     /**
      * The root path that the application is deployed at.
      */

--- a/framework/src/play/src/main/java/play/inject/Bindings.java
+++ b/framework/src/play/src/main/java/play/inject/Bindings.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.inject;
+
+import play.api.inject.BindingKey;
+
+public class Bindings {
+
+    /**
+     * Create a binding key for the given class.
+     */
+    public static final <T> BindingKey<T> bind(Class<T> clazz) {
+        return new BindingKey(clazz);
+    }
+
+}

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -6,7 +6,7 @@ package play.api
 import play.api.inject.Injector
 import play.api.inject.guice.GuiceApplicationLoader
 import play.core.{ SourceMapper, WebCommands, DefaultWebCommands }
-import play.utils.{ Threads, Reflect }
+import play.utils.Reflect
 
 /**
  * Loads an application.  This is responsible for instantiating an application given a context.
@@ -30,6 +30,7 @@ trait ApplicationLoader {
    */
   def load(context: ApplicationLoader.Context): Application
 
+  // TODO: remove when FakeApplication no longer needs this
   /**
    * Create an injector for runtime DI.
    *
@@ -80,12 +81,10 @@ object ApplicationLoader {
     initialSettings: Map[String, String] = Map.empty[String, String],
     sourceMapper: Option[SourceMapper] = None,
     webCommands: WebCommands = new DefaultWebCommands) = {
-    val configuration = Threads.withContextClassLoader(environment.classLoader) {
-      Configuration.load(environment.rootPath, environment.mode, initialSettings)
-    }
-
+    val configuration = Configuration.load(environment, initialSettings)
     Context(environment, sourceMapper, webCommands, configuration)
   }
+
 }
 
 /**

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -30,16 +30,6 @@ trait ApplicationLoader {
    */
   def load(context: ApplicationLoader.Context): Application
 
-  // TODO: remove when FakeApplication no longer needs this
-  /**
-   * Create an injector for runtime DI.
-   *
-   * This can be used by runtime DI providers to provide an injector during testing. The injector should contain all
-   * the components specified by the modules, and should also bind itself.
-   *
-   * If this method is not implemented, FakeApplication will use a NewInstanceInjector instead.
-   */
-  def createInjector(environment: Environment, configuration: Configuration, modules: Seq[Any]): Option[Injector] = None
 }
 
 object ApplicationLoader {

--- a/framework/src/play/src/main/scala/play/api/inject/Binding.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Binding.scala
@@ -52,6 +52,10 @@ final case class Binding[T](key: BindingKey[T], target: Option[BindingTarget[T]]
   }
 }
 
+object BindingKey {
+  def apply[T](clazz: Class[T]): BindingKey[T] = new BindingKey(clazz)
+}
+
 /**
  * A binding key.
  *
@@ -60,7 +64,9 @@ final case class Binding[T](key: BindingKey[T], target: Option[BindingTarget[T]]
  * @param clazz The class to bind.
  * @param qualifier An optional qualifier.
  */
-final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnotation] = None) {
+final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnotation]) {
+
+  def this(clazz: Class[T]) = this(clazz, None)
 
   /**
    * Qualify this binding key with the given instance of an annotation.

--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -28,6 +28,7 @@ class BuiltinModule extends Module {
       bind[ApplicationLifecycle].to(bind[DefaultApplicationLifecycle]),
 
       bind[Application].to[DefaultApplication],
+      bind[play.Application].to[play.DefaultApplication],
 
       bind[Router.Routes].toProvider[RoutesProvider],
       bind[Plugins].toProvider[PluginsProvider],

--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -28,8 +28,6 @@ class BuiltinModule extends Module {
       bind[ApplicationLifecycle].to(bind[DefaultApplicationLifecycle]),
 
       bind[Application].to[DefaultApplication],
-      bind[play.inject.Injector].to[play.inject.DelegateInjector],
-      // bind Plugins - eager
 
       bind[Router.Routes].toProvider[RoutesProvider],
       bind[Plugins].toProvider[PluginsProvider],

--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -18,7 +18,8 @@ class BuiltinModule extends Module {
 
     Seq(
       bind[Environment] to env,
-      bind[Configuration] to configuration,
+      bind[ConfigurationProvider].to(new ConfigurationProvider(configuration)),
+      bind[Configuration].toProvider[ConfigurationProvider],
       bind[HttpConfiguration].toProvider[HttpConfiguration.HttpConfigurationProvider],
 
       // Application lifecycle, bound both to the interface, and its implementation, so that Application can access it
@@ -42,6 +43,10 @@ class BuiltinModule extends Module {
       )
   }
 }
+
+// This allows us to access the original configuration via this
+// provider while overriding the binding for Configuration itself.
+class ConfigurationProvider(val get: Configuration) extends Provider[Configuration]
 
 @Singleton
 class RoutesProvider @Inject() (injector: Injector, environment: Environment, configuration: Configuration, httpConfig: HttpConfiguration) extends Provider[Router.Routes] {

--- a/framework/src/play/src/main/scala/play/api/inject/Module.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Module.scala
@@ -58,12 +58,12 @@ abstract class Module {
   /**
    * Create a binding key for the given class.
    */
-  final def bind[T](clazz: Class[T]): BindingKey[T] = BindingKey(clazz)
+  final def bind[T](clazz: Class[T]): BindingKey[T] = play.api.inject.bind(clazz)
 
   /**
    * Create a binding key for the given class.
    */
-  final def bind[T: ClassTag]: BindingKey[T] = BindingKey(implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]])
+  final def bind[T: ClassTag]: BindingKey[T] = play.api.inject.bind[T]
 
   /**
    * Create a seq.
@@ -88,10 +88,9 @@ object Modules {
    *         allowing ApplicationLoader implementations to reuse the same mechanism to load modules specific to them.
    */
   def locate(environment: Environment, configuration: Configuration): Seq[Any] = {
-    import scala.collection.JavaConverters._
 
-    val includes = configuration.underlying.getStringList("play.modules.enabled").asScala
-    val excludes = configuration.underlying.getStringList("play.modules.disabled").asScala
+    val includes = configuration.getStringSeq("play.modules.enabled").getOrElse(Seq.empty)
+    val excludes = configuration.getStringSeq("play.modules.disabled").getOrElse(Seq.empty)
 
     val moduleClassNames = includes.toSet -- excludes
 

--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.inject.guice
+
+import play.api.{ Application, Configuration, Environment, GlobalSettings, Logger, OptionalSourceMapper }
+import play.api.inject.{ bind, Injector => PlayInjector }
+import play.core.{ DefaultWebCommands, WebCommands }
+
+/**
+ * A builder for creating Applications using Guice.
+ */
+final class GuiceApplicationBuilder(
+  environment: Environment = Environment.simple(),
+  configuration: Configuration = Configuration.empty,
+  modules: Seq[GuiceableModule] = Seq.empty,
+  overrides: Seq[GuiceableModule] = Seq.empty,
+  disabled: Seq[Class[_]] = Seq.empty,
+  loadConfiguration: Environment => Configuration = Configuration.load,
+  global: Option[GlobalSettings] = None,
+  loadModules: (Environment, Configuration) => Seq[GuiceableModule] = GuiceableModule.loadModules) extends GuiceBuilder[GuiceApplicationBuilder](
+  environment, configuration, modules, overrides, disabled
+) {
+
+  /**
+   * Set the initial configuration loader.
+   * Overrides the default or any previously configured values.
+   */
+  def loadConfig(loader: Environment => Configuration): GuiceApplicationBuilder =
+    copy(loadConfiguration = loader)
+
+  /**
+   * Set the initial configuration.
+   * Overrides the default or any previously configured values.
+   */
+  def loadConfig(conf: Configuration): GuiceApplicationBuilder =
+    loadConfig(env => conf)
+
+  /**
+   * Set the global settings object.
+   * Overrides the default or any previously configured values.
+   */
+  def global(globalSettings: GlobalSettings): GuiceApplicationBuilder =
+    copy(global = Option(globalSettings))
+
+  /**
+   * Set the module loader.
+   * Overrides the default or any previously configured values.
+   */
+  def load(loader: (Environment, Configuration) => Seq[GuiceableModule]): GuiceApplicationBuilder =
+    copy(loadModules = loader)
+
+  /**
+   * Override the module loader with the given modules.
+   */
+  def load(modules: GuiceableModule*): GuiceApplicationBuilder =
+    load((env, conf) => modules)
+
+  /**
+   * Create a new Play Injector for an Application using this configured builder.
+   */
+  override def injector(): PlayInjector = {
+    val initialConfiguration = loadConfiguration(environment)
+    val globalSettings = global.getOrElse(GlobalSettings(initialConfiguration, environment))
+    val loadedConfiguration = globalSettings.onLoadConfig(initialConfiguration, environment.rootPath, environment.classLoader, environment.mode)
+    val appConfiguration = loadedConfiguration ++ configuration
+
+    // TODO: Logger should be application specific, and available via dependency injection.
+    //       Creating multiple applications will stomp on the global logger configuration.
+    Logger.configure(environment, appConfiguration)
+
+    val loadedModules = loadModules(environment, appConfiguration)
+
+    copy(configuration = appConfiguration)
+      .bindings(loadedModules: _*)
+      .bindings(
+        bind[GlobalSettings] to globalSettings,
+        bind[OptionalSourceMapper] to new OptionalSourceMapper(None),
+        bind[WebCommands] to new DefaultWebCommands
+      ).createInjector
+  }
+
+  /**
+   * Create a new Play Application using this configured builder.
+   */
+  def build(): Application = injector.instanceOf[Application]
+
+  /**
+   * Internal copy method with defaults.
+   */
+  private def copy(
+    environment: Environment = environment,
+    configuration: Configuration = configuration,
+    modules: Seq[GuiceableModule] = modules,
+    overrides: Seq[GuiceableModule] = overrides,
+    disabled: Seq[Class[_]] = disabled,
+    loadConfiguration: Environment => Configuration = loadConfiguration,
+    global: Option[GlobalSettings] = global,
+    loadModules: (Environment, Configuration) => Seq[GuiceableModule] = loadModules): GuiceApplicationBuilder =
+    new GuiceApplicationBuilder(environment, configuration, modules, overrides, disabled, loadConfiguration, global, loadModules)
+
+  /**
+   * Implementation of Self creation for GuiceBuilder.
+   */
+  protected def newBuilder(
+    environment: Environment,
+    configuration: Configuration,
+    modules: Seq[GuiceableModule],
+    overrides: Seq[GuiceableModule],
+    disabled: Seq[Class[_]]): GuiceApplicationBuilder =
+    copy(environment, configuration, modules, overrides, disabled)
+}

--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
@@ -22,6 +22,9 @@ final class GuiceApplicationBuilder(
   environment, configuration, modules, overrides, disabled
 ) {
 
+  // extra constructor for creating from Java
+  def this() = this(environment = Environment.simple())
+
   /**
    * Set the initial configuration loader.
    * Overrides the default or any previously configured values.

--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
@@ -25,10 +25,4 @@ class GuiceApplicationLoader(builder: GuiceApplicationBuilder) extends Applicati
       ).build
   }
 
-  // TODO: remove when FakeApplication no longer needs this
-  override def createInjector(env: Environment, conf: Configuration, modules: Seq[Any]): Option[PlayInjector] = {
-    val guiceableModules = modules map GuiceableModule.guiceable
-    Option(new GuiceInjectorBuilder(env, conf, guiceableModules).injector)
-  }
-
 }

--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
@@ -1,146 +1,34 @@
 /*
  * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
  */
-package play.api.inject
-package guice
+package play.api.inject.guice
 
-import com.google.inject.{ Module => GuiceModule, _ }
-import com.google.inject.util.Providers
-import play.api._
-import play.api.inject.{ Module => PlayModule, Binding => PlayBinding, Injector => PlayInjector }
+import play.api.{ Application, ApplicationLoader, Configuration, Environment, OptionalSourceMapper }
+import play.api.inject.{ bind, Injector => PlayInjector }
 import play.core.WebCommands
 
-import scala.reflect.ClassTag
-
-class GuiceLoadException(message: String) extends RuntimeException(message)
-
 /**
- * An ApplicationLoader that uses guice to bootstrap the application.
+ * An ApplicationLoader that uses Guice to bootstrap the application.
  */
-class GuiceApplicationLoader(val additionalModules: GuiceModule*) extends ApplicationLoader {
-  def this() = this(Seq.empty: _*)
+class GuiceApplicationLoader(builder: GuiceApplicationBuilder) extends ApplicationLoader {
 
-  /**
-   * Load the modules from the environment and configuration.
-   *
-   * By default this uses `Modules.locate` to find modules in `play.modules` files, and adds `additionalModules`.
-   *
-   * Override this method if you want to disable the autoloading functionality and manually install all Guice
-   * modules, including those provided by Play and third-party libraries.
-   *
-   * @return a `Seq[com.google.inject.Module]`, containing Guice modules to be loaded
-   */
-  protected def loadModules(env: Environment, conf: Configuration): Seq[GuiceModule] =
-    Modules.locate(env, conf).map(guicify(env, conf, _)) ++ additionalModules
-
-  import GuiceApplicationLoader._
+  // empty constructor needed for instantiating via reflection
+  def this() = this(new GuiceApplicationBuilder)
 
   def load(context: ApplicationLoader.Context): Application = {
-
-    val env = context.environment
-
-    // Load global
-    val global = GlobalSettings(context.initialConfiguration, env)
-
-    // Create the final configuration
-    // todo - abstract this logic out into something pluggable, with the default delegating to global
-    val configuration = global.onLoadConfig(context.initialConfiguration, env.rootPath, env.classLoader, env.mode)
-
-    Logger.configure(env, configuration)
-
-    val guiceModules = guiced(Seq(
-      BindingKey(classOf[GlobalSettings]) to global,
-      BindingKey(classOf[OptionalSourceMapper]) to new OptionalSourceMapper(context.sourceMapper),
-      BindingKey(classOf[WebCommands]) to context.webCommands
-    )) +: loadModules(env, configuration)
-
-    try {
-      val injector = createGuiceInjector(guiceModules)
-      injector.getInstance(classOf[Application])
-    } catch {
-      case e: CreationException => e.getCause match {
-        case p: PlayException => throw p
-        case _ => throw e
-      }
-    }
+    builder
+      .in(context.environment)
+      .loadConfig(context.initialConfiguration)
+      .overrides(
+        bind[OptionalSourceMapper] to new OptionalSourceMapper(context.sourceMapper),
+        bind[WebCommands] to context.webCommands
+      ).build
   }
 
-  override def createInjector(env: Environment, conf: Configuration, modules: Seq[Any]) = {
-    Some(createGuiceInjector(modules.map(guicify(env, conf, _))).getInstance(classOf[PlayInjector]))
+  // TODO: remove when FakeApplication no longer needs this
+  override def createInjector(env: Environment, conf: Configuration, modules: Seq[Any]): Option[PlayInjector] = {
+    val guiceableModules = modules map GuiceableModule.guiceable
+    Option(new GuiceInjectorBuilder(env, conf, guiceableModules).injector)
   }
 
-  private def createGuiceInjector(modules: Seq[GuiceModule]) = {
-    val guiceModules = modules :+ guiced(Seq(BindingKey(classOf[PlayInjector]).to[GuiceInjector]))
-    import scala.collection.JavaConverters._
-    Guice.createInjector(guiceModules.asJavaCollection)
-  }
-
-  /**
-   * Attempt to convert a module of unknown type to a Guice module
-   */
-  protected def guicify(env: Environment, conf: Configuration, module: Any): GuiceModule = module match {
-    case playModule: PlayModule => guiced(playModule.bindings(env, conf))
-    case guiceModule: GuiceModule => guiceModule
-    case unknown => throw new PlayException(
-      "Unknown module type",
-      s"Module [$unknown] is not a Play module or a Guice module"
-    )
-  }
-
-}
-
-object GuiceApplicationLoader {
-
-  /**
-   * Convert the given Play bindings to a Guice module
-   */
-  private[play] def guiced(bindings: Seq[PlayBinding[_]]): AbstractModule = {
-    new AbstractModule {
-      def configure(): Unit = {
-        for (b <- bindings) {
-          val binding = b.asInstanceOf[PlayBinding[Any]]
-          val builder = binder().withSource(binding).bind(GuiceKey.toGuice(binding.key))
-          binding.target.foreach {
-            case ProviderTarget(provider) => builder.toProvider(Providers.guicify(provider))
-            case ProviderConstructionTarget(provider) => builder.toProvider(provider)
-            case ConstructionTarget(implementation) => builder.to(implementation)
-            case BindingKeyTarget(key) => builder.to(GuiceKey.toGuice(key))
-          }
-          (binding.scope, binding.eager) match {
-            case (Some(scope), false) => builder.in(scope)
-            case (None, true) => builder.asEagerSingleton()
-            case (Some(scope), true) => throw new GuiceLoadException("A binding must either declare a scope or be eager: " + binding)
-            case _ => // do nothing
-          }
-        }
-      }
-    }
-  }
-}
-
-object GuiceKey {
-  def toGuice[T](key: BindingKey[T]): Key[T] = {
-    key.qualifier match {
-      case Some(QualifierInstance(instance)) => Key.get(key.clazz, instance)
-      case Some(QualifierClass(clazz)) => Key.get(key.clazz, clazz)
-      case None => Key.get(key.clazz)
-    }
-  }
-}
-
-private[play] class GuiceInjector @Inject() (injector: Injector) extends PlayInjector {
-  /**
-   * Get an instance of the given class from the injector.
-   */
-  def instanceOf[T](implicit ct: ClassTag[T]) = instanceOf(ct.runtimeClass.asInstanceOf[Class[T]])
-
-  /**
-   * Get an instance of the given class from the injector.
-   */
-  def instanceOf[T](clazz: Class[T]) = injector.getInstance(clazz)
-
-  /**
-   * Get an instance bound to the given binding key.
-   */
-  def instanceOf[T](key: BindingKey[T]) = injector.getInstance(GuiceKey.toGuice(key))
 }

--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
@@ -1,0 +1,312 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.inject
+package guice
+
+import com.google.inject.util.{ Modules => GuiceModules, Providers => GuiceProviders }
+import com.google.inject.{ CreationException, Guice, Module => GuiceModule }
+import java.io.File
+import javax.inject.Inject
+import play.api.inject.{ Binding => PlayBinding, BindingKey, Injector => PlayInjector, Module => PlayModule }
+import play.api.{ Configuration, Environment, Mode, PlayException }
+import scala.reflect.ClassTag
+
+class GuiceLoadException(message: String) extends RuntimeException(message)
+
+/**
+ * A builder for creating Guice-backed Play Injectors.
+ */
+abstract class GuiceBuilder[Self] protected (
+    environment: Environment,
+    configuration: Configuration,
+    modules: Seq[GuiceableModule],
+    overrides: Seq[GuiceableModule],
+    disabled: Seq[Class[_]]) {
+
+  /**
+   * Set the environment.
+   */
+  final def in(env: Environment): Self =
+    copyBuilder(environment = env)
+
+  /**
+   * Set the environment path.
+   */
+  final def in(path: File): Self =
+    copyBuilder(environment = environment.copy(rootPath = path))
+
+  /**
+   * Set the environment mode.
+   */
+  final def in(mode: Mode.Mode): Self =
+    copyBuilder(environment = environment.copy(mode = mode))
+
+  /**
+   * Set the environment class loader.
+   */
+  final def in(classLoader: ClassLoader): Self =
+    copyBuilder(environment = environment.copy(classLoader = classLoader))
+
+  /**
+   * Add additional configuration.
+   */
+  final def configure(conf: Configuration): Self =
+    copyBuilder(configuration = configuration ++ conf)
+
+  /**
+   * Add additional configuration.
+   */
+  final def configure(conf: Map[String, Any]): Self =
+    configure(Configuration.from(conf))
+
+  /**
+   * Add additional configuration.
+   */
+  final def configure(conf: (String, Any)*): Self =
+    configure(conf.toMap)
+
+  /**
+   * Add Guice modules, Play modules, or Play bindings.
+   *
+   * @see [[GuiceableModuleConversions]] for the automatically available implicit
+   *      conversions to [[GuiceableModule]] from modules and bindings.
+   */
+  final def bindings(bindModules: GuiceableModule*): Self =
+    copyBuilder(modules = modules ++ bindModules)
+
+  /**
+   * Override bindings using Guice modules, Play modules, or Play bindings.
+   *
+   * @see [[GuiceableModuleConversions]] for the automatically available implicit
+   *      conversions to [[GuiceableModule]] from modules and bindings.
+   */
+  final def overrides(overrideModules: GuiceableModule*): Self =
+    copyBuilder(overrides = overrides ++ overrideModules)
+
+  /**
+   * Disable modules by class.
+   */
+  final def disable(moduleClasses: Class[_]*): Self =
+    copyBuilder(disabled = disabled ++ moduleClasses)
+
+  /**
+   * Disable module by class.
+   */
+  final def disable[T](implicit tag: ClassTag[T]): Self = disable(tag.runtimeClass)
+
+  /**
+   * Create a Play Injector backed by Guice using this configured builder.
+   */
+  def injector(): PlayInjector = createInjector
+
+  /**
+   * Internal creation of the injector.
+   * Separate method in case builders need to add extra configuration to injector before building.
+   */
+  protected final def createInjector(): PlayInjector = {
+    import scala.collection.JavaConverters._
+    try {
+      val injectorModule = GuiceableModule.guice(Seq(bind[PlayInjector].to[GuiceInjector]))
+      val enabledModules = modules.map(_.disable(disabled))
+      val bindingModules = GuiceableModule.guiced(environment, configuration)(enabledModules) :+ injectorModule
+      val overrideModules = GuiceableModule.guiced(environment, configuration)(overrides)
+      val guiceInjector = Guice.createInjector(GuiceModules.`override`(bindingModules.asJava).`with`(overrideModules.asJava))
+      guiceInjector.getInstance(classOf[PlayInjector])
+    } catch {
+      case e: CreationException => e.getCause match {
+        case p: PlayException => throw p
+        case _ => throw e
+      }
+    }
+  }
+
+  /**
+   * Internal copy method with defaults.
+   */
+  private def copyBuilder(
+    environment: Environment = environment,
+    configuration: Configuration = configuration,
+    modules: Seq[GuiceableModule] = modules,
+    overrides: Seq[GuiceableModule] = overrides,
+    disabled: Seq[Class[_]] = disabled): Self =
+    newBuilder(environment, configuration, modules, overrides, disabled)
+
+  /**
+   * Create a new Self for this immutable builder.
+   * Provided by builder implementations.
+   */
+  protected def newBuilder(
+    environment: Environment,
+    configuration: Configuration,
+    modules: Seq[GuiceableModule],
+    overrides: Seq[GuiceableModule],
+    disabled: Seq[Class[_]]): Self
+
+}
+
+/**
+ * Default empty builder for creating Guice-backed Injectors.
+ */
+final class GuiceInjectorBuilder(
+  environment: Environment = Environment.simple(),
+  configuration: Configuration = Configuration.empty,
+  modules: Seq[GuiceableModule] = Seq.empty,
+  overrides: Seq[GuiceableModule] = Seq.empty,
+  disabled: Seq[Class[_]] = Seq.empty) extends GuiceBuilder[GuiceInjectorBuilder](
+  environment, configuration, modules, overrides, disabled
+) {
+
+  /**
+   * Create a Play Injector backed by Guice using this configured builder.
+   */
+  def build(): PlayInjector = injector()
+
+  protected def newBuilder(
+    environment: Environment,
+    configuration: Configuration,
+    modules: Seq[GuiceableModule],
+    overrides: Seq[GuiceableModule],
+    disabled: Seq[Class[_]]): GuiceInjectorBuilder =
+    new GuiceInjectorBuilder(environment, configuration, modules, overrides, disabled)
+}
+
+/**
+ * Magnet pattern for creating Guice modules from Play modules or bindings.
+ */
+trait GuiceableModule {
+  def guiced(env: Environment, conf: Configuration): Seq[GuiceModule]
+  def disable(classes: Seq[Class[_]]): GuiceableModule
+}
+
+/**
+ * Loading and converting Guice modules.
+ */
+object GuiceableModule extends GuiceableModuleConversions {
+
+  def loadModules(environment: Environment, configuration: Configuration): Seq[GuiceableModule] = {
+    Modules.locate(environment, configuration) map guiceable
+  }
+
+  /**
+   * Attempt to convert a module of unknown type to a GuiceableModule.
+   */
+  def guiceable(module: Any): GuiceableModule = module match {
+    case playModule: PlayModule => fromPlayModule(playModule)
+    case guiceModule: GuiceModule => fromGuiceModule(guiceModule)
+    case unknown => throw new PlayException(
+      "Unknown module type",
+      s"Module [$unknown] is not a Play module or a Guice module"
+    )
+  }
+
+  /**
+   * Apply GuiceableModules to create Guice modules.
+   */
+  def guiced(env: Environment, conf: Configuration)(builders: Seq[GuiceableModule]): Seq[GuiceModule] =
+    builders flatMap { module => module.guiced(env, conf) }
+
+}
+
+/**
+ * Implicit conversions to GuiceableModules.
+ */
+trait GuiceableModuleConversions {
+
+  import scala.language.implicitConversions
+
+  implicit def fromGuiceModule(guiceModule: GuiceModule): GuiceableModule = fromGuiceModules(Seq(guiceModule))
+
+  implicit def fromGuiceModules(guiceModules: Seq[GuiceModule]): GuiceableModule = new GuiceableModule {
+    def guiced(env: Environment, conf: Configuration): Seq[GuiceModule] = guiceModules
+    def disable(classes: Seq[Class[_]]): GuiceableModule = fromGuiceModules(filterOut(classes, guiceModules))
+    override def toString = s"GuiceableModule(${guiceModules.mkString(", ")})"
+  }
+
+  implicit def fromPlayModule(playModule: PlayModule): GuiceableModule = fromPlayModules(Seq(playModule))
+
+  implicit def fromPlayModules(playModules: Seq[PlayModule]): GuiceableModule = new GuiceableModule {
+    def guiced(env: Environment, conf: Configuration): Seq[GuiceModule] = playModules.map(guice(env, conf))
+    def disable(classes: Seq[Class[_]]): GuiceableModule = fromPlayModules(filterOut(classes, playModules))
+    override def toString = s"GuiceableModule(${playModules.mkString(", ")})"
+  }
+
+  implicit def fromPlayBinding(binding: PlayBinding[_]): GuiceableModule = fromPlayBindings(Seq(binding))
+
+  implicit def fromPlayBindings(bindings: Seq[PlayBinding[_]]): GuiceableModule = new GuiceableModule {
+    def guiced(env: Environment, conf: Configuration): Seq[GuiceModule] = Seq(guice(bindings))
+    def disable(classes: Seq[Class[_]]): GuiceableModule = this // no filtering
+    override def toString = s"GuiceableModule(${bindings.mkString(", ")})"
+  }
+
+  private def filterOut[A](classes: Seq[Class[_]], instances: Seq[A]): Seq[A] =
+    instances.filterNot(o => classes.exists(_.isAssignableFrom(o.getClass)))
+
+  /**
+   * Convert the given Play module to a Guice module.
+   */
+  def guice(env: Environment, conf: Configuration)(module: PlayModule): GuiceModule =
+    guice(module.bindings(env, conf))
+
+  /**
+   * Convert the given Play bindings to a Guice module.
+   */
+  def guice(bindings: Seq[PlayBinding[_]]): GuiceModule = {
+    new com.google.inject.AbstractModule {
+      def configure(): Unit = {
+        for (b <- bindings) {
+          val binding = b.asInstanceOf[PlayBinding[Any]]
+          val builder = binder().withSource(binding).bind(GuiceKey(binding.key))
+          binding.target.foreach {
+            case ProviderTarget(provider) => builder.toProvider(GuiceProviders.guicify(provider))
+            case ProviderConstructionTarget(provider) => builder.toProvider(provider)
+            case ConstructionTarget(implementation) => builder.to(implementation)
+            case BindingKeyTarget(key) => builder.to(GuiceKey(key))
+          }
+          (binding.scope, binding.eager) match {
+            case (Some(scope), false) => builder.in(scope)
+            case (None, true) => builder.asEagerSingleton()
+            case (Some(scope), true) => throw new GuiceLoadException("A binding must either declare a scope or be eager: " + binding)
+            case _ => // do nothing
+          }
+        }
+      }
+    }
+  }
+
+}
+
+/**
+ * Conversion from Play BindingKey to Guice Key.
+ */
+object GuiceKey {
+  import com.google.inject.Key
+
+  def apply[T](key: BindingKey[T]): Key[T] = {
+    key.qualifier match {
+      case Some(QualifierInstance(instance)) => Key.get(key.clazz, instance)
+      case Some(QualifierClass(clazz)) => Key.get(key.clazz, clazz)
+      case None => Key.get(key.clazz)
+    }
+  }
+}
+
+/**
+ * Play Injector backed by a Guice Injector.
+ */
+class GuiceInjector @Inject() (injector: com.google.inject.Injector) extends PlayInjector {
+  /**
+   * Get an instance of the given class from the injector.
+   */
+  def instanceOf[T](implicit ct: ClassTag[T]) = instanceOf(ct.runtimeClass.asInstanceOf[Class[T]])
+
+  /**
+   * Get an instance of the given class from the injector.
+   */
+  def instanceOf[T](clazz: Class[T]) = injector.getInstance(clazz)
+
+  /**
+   * Get an instance bound to the given binding key.
+   */
+  def instanceOf[T](key: BindingKey[T]) = injector.getInstance(GuiceKey(key))
+}

--- a/framework/src/play/src/main/scala/play/api/inject/package.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/package.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api
+
+import scala.reflect.ClassTag
+
+package object inject {
+
+  /**
+   * Create a binding key for the given class.
+   */
+  def bind[T](clazz: Class[T]): BindingKey[T] = BindingKey(clazz)
+
+  /**
+   * Create a binding key for the given class.
+   */
+  def bind[T: ClassTag]: BindingKey[T] = BindingKey(implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]])
+
+}

--- a/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.inject
+package guice
+
+import akka.actor.ActorSystem
+import com.google.inject.AbstractModule
+import javax.inject.{ Inject, Provider }
+import org.specs2.mutable.Specification
+import play.api.{ Configuration, Environment, GlobalSettings }
+
+object GuiceApplicationBuilderSpec extends Specification {
+
+  "GuiceApplicationBuilder" should {
+
+    "add bindings" in {
+      val app = new GuiceApplicationBuilder()
+        .bindings(
+          new AModule,
+          bind[B].to[B1])
+        .build
+
+      app.injector.instanceOf[A] must beAnInstanceOf[A1]
+      app.injector.instanceOf[B] must beAnInstanceOf[B1]
+    }
+
+    "override bindings" in {
+      val app = new GuiceApplicationBuilder()
+        .bindings(new AModule)
+        .overrides(
+          bind[Configuration] to new ExtendConfiguration("a" -> 1),
+          bind[A].to[A2])
+        .build
+
+      app.configuration.getInt("a") must beSome(1)
+      app.injector.instanceOf[A] must beAnInstanceOf[A2]
+    }
+
+    "disable modules" in {
+      val app = new GuiceApplicationBuilder()
+        .bindings(new AModule)
+        .disable[play.api.libs.concurrent.AkkaModule]
+        .disable(classOf[AModule])
+        .build
+
+      app.injector.instanceOf[ActorSystem] must throwA[com.google.inject.ConfigurationException]
+      app.injector.instanceOf[A] must throwA[com.google.inject.ConfigurationException]
+    }
+
+    "set initial configuration loader" in {
+      val extraConfig = Configuration("a" -> 1)
+      val app = new GuiceApplicationBuilder()
+        .loadConfig(env => Configuration.load(env) ++ extraConfig)
+        .build
+
+      app.configuration.getInt("a") must beSome(1)
+    }
+
+    "set initial configuration" in {
+      val app = new GuiceApplicationBuilder()
+        .loadConfig(Configuration.empty)
+        .bindings(new BuiltinModule)
+        .build
+
+      app.configuration.keys must beEmpty
+    }
+
+    "set global settings" in {
+      val global = new GlobalSettings {
+        override def configuration = Configuration("a" -> 1)
+      }
+
+      val app = new GuiceApplicationBuilder()
+        .global(global)
+        .build
+
+      app.configuration.getInt("a") must beSome(1)
+    }
+
+    "set module loader" in {
+      val app = new GuiceApplicationBuilder()
+        .load((env, conf) => Seq(new BuiltinModule, bind[A].to[A1]))
+        .build
+
+      app.injector.instanceOf[A] must beAnInstanceOf[A1]
+    }
+
+    "set loaded modules directly" in {
+      val app = new GuiceApplicationBuilder()
+        .load(new BuiltinModule, bind[A].to[A1])
+        .build
+
+      app.injector.instanceOf[A] must beAnInstanceOf[A1]
+    }
+
+  }
+
+  trait A
+  class A1 extends A
+  class A2 extends A
+
+  class AModule extends Module {
+    def bindings(env: Environment, conf: Configuration) = Seq(
+      bind[A].to[A1]
+    )
+  }
+
+  trait B
+  class B1 extends B
+
+  class ExtendConfiguration(conf: (String, Any)*) extends Provider[Configuration] {
+    @Inject
+    var injector: Injector = _
+    lazy val get = {
+      val current = injector.instanceOf[ConfigurationProvider].get
+      current ++ Configuration.from(conf.toMap)
+    }
+  }
+
+}

--- a/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
@@ -4,40 +4,35 @@ import org.specs2.mutable.Specification
 
 import com.google.inject.AbstractModule
 
-import play.api.ApplicationLoader.Context
-import play.api.Configuration
-import play.api.{ Mode, Environment }
-import play.core.DefaultWebCommands
+import play.api.{ ApplicationLoader, Configuration, Environment }
 import play.api.inject.BuiltinModule
 
 class GuiceApplicationLoaderSpec extends Specification {
 
   "GuiceApplicationLoader" should {
+
     "allow adding additional modules" in {
-      val loader = new GuiceApplicationLoader(new AbstractModule {
+      val module = new AbstractModule {
         def configure() = {
           bind(classOf[Bar]) to classOf[MarsBar]
         }
-      })
+      }
+      val builder = new GuiceApplicationBuilder().bindings(module)
+      val loader = new GuiceApplicationLoader(builder)
       val app = loader.load(fakeContext)
       app.injector.instanceOf[Bar] must beAnInstanceOf[MarsBar]
     }
-    "allow replacing existing modules" in {
-      val loader = new GuiceApplicationLoader() {
-        override def loadModules(env: Environment, conf: Configuration) =
-          Seq(guicify(env, conf, new BuiltinModule), new ManualTestModule)
-      }
+
+    "allow replacing automatically loaded modules" in {
+      val builder = new GuiceApplicationBuilder().load(new BuiltinModule, new ManualTestModule)
+      val loader = new GuiceApplicationLoader(builder)
       val app = loader.load(fakeContext)
       app.injector.instanceOf[Foo] must beAnInstanceOf[ManualFoo]
     }
+
   }
 
-  def fakeContext = Context(
-    Environment(new java.io.File("."), getClass.getClassLoader, Mode.Test),
-    None,
-    new DefaultWebCommands,
-    Configuration.load(new java.io.File("."), Mode.Test)
-  )
+  def fakeContext = ApplicationLoader.createContext(Environment.simple())
 }
 
 class ManualTestModule extends AbstractModule {

--- a/framework/src/play/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.inject
+package guice
+
+import com.google.inject.AbstractModule
+import java.io.File
+import java.net.URLClassLoader
+import org.specs2.mutable.Specification
+import play.api.{ Configuration, Environment, Mode }
+
+object GuiceInjectorBuilderSpec extends Specification {
+
+  "GuiceInjectorBuilder" should {
+
+    "set environment" in {
+      val env = new GuiceInjectorBuilder()
+        .in(Environment.simple(mode = Mode.Dev))
+        .bindings(new EnvironmentModule)
+        .injector.instanceOf[Environment]
+
+      env.mode must_== Mode.Dev
+    }
+
+    "set environment values" in {
+      val classLoader = new URLClassLoader(Array.empty)
+      val env = new GuiceInjectorBuilder()
+        .in(new File("test"))
+        .in(Mode.Dev)
+        .in(classLoader)
+        .bindings(new EnvironmentModule)
+        .injector.instanceOf[Environment]
+
+      env.rootPath must_== new File("test")
+      env.mode must_== Mode.Dev
+      env.classLoader must be(classLoader)
+    }
+
+    "set configuration" in {
+      val conf = new GuiceInjectorBuilder()
+        .configure(Configuration("a" -> 1))
+        .configure(Map("b" -> 2))
+        .configure("c" -> 3)
+        .configure("d.1" -> 4, "d.2" -> 5)
+        .bindings(new ConfigurationModule)
+        .injector.instanceOf[Configuration]
+
+      conf.subKeys must contain(exactly("a", "b", "c", "d"))
+      conf.getInt("a") must beSome(1)
+      conf.getInt("b") must beSome(2)
+      conf.getInt("c") must beSome(3)
+      conf.getInt("d.1") must beSome(4)
+      conf.getInt("d.2") must beSome(5)
+    }
+
+    "support various bindings" in {
+      val injector = new GuiceInjectorBuilder()
+        .bindings(
+          new EnvironmentModule,
+          Seq(new ConfigurationModule),
+          new AModule,
+          Seq(new BModule))
+        .bindings(
+          bind[C].to[C1],
+          Seq(bind[D].to[D1]))
+        .injector
+
+      injector.instanceOf[Environment] must beAnInstanceOf[Environment]
+      injector.instanceOf[Configuration] must beAnInstanceOf[Configuration]
+      injector.instanceOf[A] must beAnInstanceOf[A1]
+      injector.instanceOf[B] must beAnInstanceOf[B1]
+      injector.instanceOf[C] must beAnInstanceOf[C1]
+      injector.instanceOf[D] must beAnInstanceOf[D1]
+    }
+
+    "override bindings" in {
+      val injector = new GuiceInjectorBuilder()
+        .in(Mode.Dev)
+        .configure("a" -> 1)
+        .bindings(
+          new EnvironmentModule,
+          new ConfigurationModule)
+        .overrides(
+          bind[Environment] to Environment.simple(),
+          new SetConfigurationModule(Configuration("b" -> 2)))
+        .injector
+
+      val env = injector.instanceOf[Environment]
+      val conf = injector.instanceOf[Configuration]
+      env.mode must_== Mode.Test
+      conf.getInt("a") must beNone
+      conf.getInt("b") must beSome(2)
+    }
+
+    "disable modules" in {
+      val injector = new GuiceInjectorBuilder()
+        .bindings(
+          new EnvironmentModule,
+          new ConfigurationModule,
+          new AModule,
+          new BModule,
+          bind[C].to[C1],
+          bind[D] to new D1)
+        .disable[EnvironmentModule]
+        .disable(classOf[AModule], classOf[CModule]) // C won't be disabled
+        .injector
+
+      injector.instanceOf[Environment] must throwA[com.google.inject.ConfigurationException]
+      injector.instanceOf[A] must throwA[com.google.inject.ConfigurationException]
+
+      injector.instanceOf[Configuration] must beAnInstanceOf[Configuration]
+      injector.instanceOf[B] must beAnInstanceOf[B1]
+      injector.instanceOf[C] must beAnInstanceOf[C1]
+      injector.instanceOf[D] must beAnInstanceOf[D1]
+    }
+
+  }
+
+  class EnvironmentModule extends Module {
+    def bindings(env: Environment, conf: Configuration) = Seq(
+      bind[Environment] to env
+    )
+  }
+
+  class ConfigurationModule extends Module {
+    def bindings(env: Environment, conf: Configuration) = Seq(
+      bind[Configuration] to conf
+    )
+  }
+
+  class SetConfigurationModule(conf: Configuration) extends AbstractModule {
+    def configure = bind(classOf[Configuration]) toInstance conf
+  }
+
+  trait A
+  class A1 extends A
+
+  class AModule extends AbstractModule {
+    def configure = bind(classOf[A]) to classOf[A1]
+  }
+
+  trait B
+  class B1 extends B
+
+  class BModule extends AbstractModule {
+    def configure = bind(classOf[B]) to classOf[B1]
+  }
+
+  trait C
+  class C1 extends C
+
+  class CModule extends AbstractModule {
+    def configure = bind(classOf[C]) to classOf[C1]
+  }
+
+  trait D
+  class D1 extends D
+
+}

--- a/framework/src/play/src/test/scala/play/core/test/Fakes.scala
+++ b/framework/src/play/src/test/scala/play/core/test/Fakes.scala
@@ -3,8 +3,7 @@
  */
 package play.core.test
 
-import com.google.inject.Guice
-import play.api.inject.guice.{ GuiceInjector, GuiceApplicationLoader }
+import play.api.inject.guice.GuiceInjectorBuilder
 import play.api.inject.{ BindingKey, Binding, Injector }
 import play.api.libs.Files.TemporaryFile
 import play.api.libs.json.JsValue
@@ -25,9 +24,7 @@ object Fakes {
    * @return The injector
    */
   def injectorFromBindings(bindings: Seq[Binding[_]]): Injector = {
-    Guice.createInjector(
-      GuiceApplicationLoader.guiced(bindings :+ BindingKey(classOf[Injector]).to[GuiceInjector])
-    ).getInstance(classOf[Injector])
+    new GuiceInjectorBuilder().bindings(bindings).injector
   }
 
 }

--- a/framework/src/play/src/test/scala/play/utils/ReflectSpec.scala
+++ b/framework/src/play/src/test/scala/play/utils/ReflectSpec.scala
@@ -5,11 +5,10 @@ package play.utils
 
 import javax.inject.Inject
 
-import com.google.inject.Guice
 import org.specs2.mutable.Specification
-import play.api.{ PlayException, Configuration, Environment }
 import play.api.inject.Binding
-import play.api.inject.guice.GuiceApplicationLoader
+import play.api.inject.guice.GuiceInjectorBuilder
+import play.api.{ PlayException, Configuration, Environment }
 
 import scala.reflect.ClassTag
 
@@ -90,7 +89,7 @@ object ReflectSpec extends Specification {
   class NotADuck
 
   def doQuack(bindings: Seq[Binding[_]]): String = {
-    Guice.createInjector(GuiceApplicationLoader.guiced(bindings)).getInstance(classOf[Duck]).quack
+    new GuiceInjectorBuilder().bindings(bindings).injector.instanceOf[Duck].quack
   }
 
 }


### PR DESCRIPTION
Builder APIs for creating Guice-backed injectors and applications. These allow overriding bindings.
Switch to using the Application interfaces in test helpers, so that both FakeApplication and directly built Applications can be used.