### PR TITLE
Fix #3484: mysubproject/run doesn't work

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayRun.scala
@@ -57,12 +57,13 @@ trait PlayRun extends PlayInternalKeys {
     val args = Def.spaceDelimited().parsed
 
     val state = Keys.state.value
+    val scope = resolvedScoped.value.scope
     val interaction = playInteractionMode.value
 
     val reloadCompile = () => PlayReload.compile(
-      () => Project.runTask(playReload, state).map(_._2).get,
-      () => Project.runTask(reloaderClasspath, state).map(_._2).get,
-      () => Project.runTask(streamsManager, state).map(_._2).get.toEither.right.toOption
+      () => Project.runTask(playReload in scope, state).map(_._2).get,
+      () => Project.runTask(reloaderClasspath in scope, state).map(_._2).get,
+      () => Project.runTask(streamsManager in scope, state).map(_._2).get.toEither.right.toOption
     )
 
     val runSbtTask: String => AnyRef = (task: String) => {


### PR DESCRIPTION
Fix #3484 by using `resolvedScope` when calling `Project#runTask`.

This can be trivially backported to 2.3.x.

---

There are other places where it seems there may be similar errors, but I am not well acquainted with them.

I was a little surprised at how frequently `Project#runTask` is used.