### PR TITLE
Don't wrap code in a Java Context that doesn't use that Context

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/JavaFormSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/JavaFormSpec.scala
@@ -7,6 +7,7 @@ import play.api.test._
 import play.core.j.JavaHelpers
 import play.data.Form
 import play.data.validation.Constraints.Required
+import play.mvc.Http.Context
 import scala.annotation.meta.field
 import scala.beans.BeanProperty
 import scala.collection.JavaConverters._
@@ -16,12 +17,16 @@ object JavaFormSpec extends PlaySpecification {
   "A Java form" should {
 
     "throw a meaningful exception when get is called on an invalid form" in new WithApplication() {
-      JavaHelpers.withContext(FakeRequest()) { _ =>
+      val javaContext = JavaHelpers.createJavaContext(FakeRequest())
+      try {
+        Context.current.set(javaContext)
         val myForm = Form.form(classOf[FooForm]).bind(Map("id" -> "1234567891").asJava)
         myForm.hasErrors must beEqualTo(true)
         myForm.get must throwAn[IllegalStateException].like {
           case e => e.getMessage must contain("fooName")
         }
+      } finally {
+        Context.current.remove()
       }
     }
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -79,7 +79,7 @@ abstract class JavaAction(components: JavaHandlerComponents) extends Action[play
     }
     val actionFuture: Future[Future[JResult]] = Future { finalAction.call(javaContext).wrapped }(trampolineWithContext)
     val flattenedActionFuture: Future[JResult] = actionFuture.flatMap(identity)(trampoline)
-    val resultFuture: Future[Result] = flattenedActionFuture.map(createResult(javaContext, _))(trampoline)
+    val resultFuture: Future[Result] = flattenedActionFuture.map(createScalaResult(javaContext, _))(trampoline)
     resultFuture
   }
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
@@ -32,17 +32,17 @@ class JavaGlobalSettingsAdapter(val underlying: play.GlobalSettings) extends Glo
   }
 
   override def onError(request: RequestHeader, ex: Throwable): Future[Result] = {
-    JavaHelpers.invokeWithContextOpt(request, req => underlying.onError(req, ex))
+    Option(JavaHelpers.invokeWithoutContext(request, req => underlying.onError(req, ex)))
       .getOrElse(super.onError(request, ex))
   }
 
   override def onHandlerNotFound(request: RequestHeader): Future[Result] = {
-    JavaHelpers.invokeWithContextOpt(request, req => underlying.onHandlerNotFound(req))
+    Option(JavaHelpers.invokeWithoutContext(request, req => underlying.onHandlerNotFound(req)))
       .getOrElse(super.onHandlerNotFound(request))
   }
 
   override def onBadRequest(request: RequestHeader, error: String): Future[Result] = {
-    JavaHelpers.invokeWithContextOpt(request, req => underlying.onBadRequest(req, error))
+    Option(JavaHelpers.invokeWithoutContext(request, req => underlying.onBadRequest(req, error)))
       .getOrElse(super.onBadRequest(request, error))
   }
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaHttpErrorHandlerAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHttpErrorHandlerAdapter.scala
@@ -15,10 +15,10 @@ import play.http.{ HttpErrorHandler => JHttpErrorHandler }
 class JavaHttpErrorHandlerAdapter @Inject() (underlying: JHttpErrorHandler) extends HttpErrorHandler {
 
   def onClientError(request: RequestHeader, statusCode: Int, message: String) = {
-    JavaHelpers.invokeWithContext(request, req => underlying.onClientError(req, statusCode, message))
+    JavaHelpers.invokeWithoutContext(request, req => underlying.onClientError(req, statusCode, message))
   }
 
   def onServerError(request: RequestHeader, exception: Throwable) = {
-    JavaHelpers.invokeWithContext(request, req => underlying.onServerError(req, exception))
+    JavaHelpers.invokeWithoutContext(request, req => underlying.onServerError(req, exception))
   }
 }

--- a/framework/src/play/src/main/scala/play/core/j/JavaWebSocket.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaWebSocket.scala
@@ -38,7 +38,7 @@ object JavaWebSocket extends JavaHelpers {
       val reject = Option(jws.rejectWith())
       reject.map { result =>
 
-        Left(createResult(javaContext, result))
+        Left(createScalaResult(javaContext, result))
 
       } getOrElse {
 


### PR DESCRIPTION
The reason I'm submitting this change is that it makes is much easier to understand how a `Context` is used. In some places a `Context` doesn't have a request body and in some in does. The `Context` in the Java API only has a `Request` and sometimes the body is null. It's not the typesafe `Request` and `RequestHeader` like in Scala. So I wanted to know where I could expect the `Request` to have a body that's been parsed vs null. That was very hard to do when the context was being created in as many places as it was. If this change is merged it will help give me much more confidence in understanding whether some other changes I'm making are safe and won't have problems with the request body possibly being null when I expect it to be there.