### PR TITLE
Scope mainClass setting to run task in server plugins

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlaySettings.scala
@@ -186,6 +186,8 @@ trait PlaySettings {
 
     sourceDirectory in Universal <<= baseDirectory(_ / "dist"),
 
+    mainClass in Compile <<= mainClass in (Compile, run),
+
     mappings in Universal ++= {
       val confDirectoryLen = confDirectory.value.getCanonicalPath.length
       val pathFinder = confDirectory.value ** ("*" -- "routes")

--- a/framework/src/sbt-plugin/src/main/scala/play/Project.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/Project.scala
@@ -87,7 +87,7 @@ object PlayNettyServer extends AutoPlugin {
         Seq("com.typesafe.play" %% "play-netty-server" % play.core.PlayVersion.current)
       }
     },
-    mainClass in Compile := Some("play.core.server.NettyServer")
+    mainClass in (Compile, run) := Some("play.core.server.NettyServer")
   )
 }
 
@@ -99,6 +99,6 @@ object PlayAkkaHttpServer extends AutoPlugin {
 
   override def projectSettings = Seq(
     libraryDependencies += "com.typesafe.play" %% "play-akka-http-server-experimental" % play.core.PlayVersion.current,
-    mainClass in Compile := Some("play.core.server.akkahttp.AkkaHttpServer")
+    mainClass in (Compile, run) := Some("play.core.server.akkahttp.AkkaHttpServer")
   )
 }


### PR DESCRIPTION
Otherwise the default main class selection will be used, which relies on discovered main classes from compile. It also means that compile was being triggered before dev mode run, which is different from previous behaviour of only triggering compile on application load.