### PR TITLE
Add some more test helper routing methods

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -391,6 +391,22 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
         }
     }
 
+    public static Result route(Call call) {
+      return route(fakeRequest(call));
+    }
+
+    public static Result route(Call call, long timeout) {
+      return route(fakeRequest(call), timeout);
+    }
+
+    public static Result route(Application app, Call call) {
+      return route(app, fakeRequest(call));
+    }
+
+    public static Result route(Application app, Call call, long timeout) {
+      return route(app, fakeRequest(call), timeout);
+    }
+
     public static Result route(RequestBuilder requestBuilder) {
       return route(requestBuilder, DEFAULT_TIMEOUT);
     }


### PR DESCRIPTION
Right now you have to do:

    Helpers.route(Helpers.fakeRequest(controllers.routes.Application.index()));

It'd be nicer to be able to do:

    Helpers.route(controllers.routes.Application.index());