### PR TITLE
Allow to disable JDBC resource

### DIFF
--- a/documentation/manual/scalaGuide/main/sql/ScalaDatabase.md
+++ b/documentation/manual/scalaGuide/main/sql/ScalaDatabase.md
@@ -76,10 +76,16 @@ logger.com.jolbox=DEBUG // for EBean
 # Orders database
 db.orders.driver=org.h2.Driver
 db.orders.url="jdbc:h2:mem:orders"
+db.orders.enabled=true # default is true
 
 # Customers database
 db.customers.driver=org.h2.Driver
 db.customers.url="jdbc:h2:mem:customers"
+
+# Test database for Test environment, disabled by default
+db.customers.driver=org.h2.Driver
+db.customers.url="jdbc:h2:mem:test"
+db.customers.enabled=false
 ```
 
 ## Configuring the JDBC Driver


### PR DESCRIPTION
There are situations, when we want to configure multiple JDBC resources in our `application.conf`. However, sometimes we don't want to have them active all the time. For example, we might want to configure a datasources for a development, test and production environments at once in our `application.conf` and just switch among them by an environmental property. In such a case, all (or at least some) resources should be disabled, otherwise the play would try to connect to these sources, evolve them atd. although they are meant to be active in a different environment. That would result in errors during application start because the application would not be able to connect to all resources. In consequence, it wouldn't start.

By this pull request, I add a configuration property to disable them. For backward compatibility, they are active by default.

**Example:**

```properties
db {
  dev {
    driver = com.mysql.jdbc.Driver
    url = "jdbc:mysql://localhost:3306/dev_db?characterEncoding=utf8"
    user = "dev"
    password = "dev"
    enabled = true
  }

  production {
    driver = com.mysql.jdbc.Driver
    url = "jdbc:mysql://localhost:3306/production_db?characterEncoding=utf8"
    user = "production"
    password = "production"
    enabled = false
  }
}
```

As you can see, by default, only the `dev` db resource is active. The Play then connects to it on start and in case of DB evolution it evolves it. But for production environment, I can pass in two environment variables: `db.dev.enabled=false` and `db.production.enabled=true` and then ensure that application tries to look up proper resource and everything is fine. No errors and I have all my configuration in one place, in this case it is `application.conf`. Otherwise I would have to override the `url`, `user`, `password` and possibly `driver` properties to change the datasource. In a such case, my configuration would not be stored in one place.