### PR TITLE
Fix json-Reads flatMap

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
@@ -42,7 +42,11 @@ trait Reads[A] {
     Reads[B] { json => self.reads(json).map(f) }
 
   def flatMap[B](f: A => Reads[B]): Reads[B] = Reads[B] { json =>
-    self.reads(json).flatMap(t => f(t).reads(json))
+    // Do not flatMap result to avoid repath
+    self.reads(json) match {
+      case JsSuccess(a, _) => f(a).reads(json)
+      case error: JsError => error
+    }
   }
 
   def filter(f: A => Boolean): Reads[A] =


### PR DESCRIPTION
* Reads.flatMap must not repath the result of the 2nd JsResult

See also [this](https://groups.google.com/d/msg/play-framework/3mVwMtPTOv8/aOTvpnimIwcJ) discussion.