### PR TITLE
fix bindable for list and seq so it doesn't swallow errors

### DIFF
--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/tests/RouterSpec.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/tests/RouterSpec.scala
@@ -48,7 +48,7 @@ object RouterSpec extends PlaySpecification {
     }
     "from a list of numbers and letters" in new WithApplication() {
       val Some(result) = route(FakeRequest(GET, "/take-list?x=1&x=a&x=2"))
-      contentAsString(result) must equalTo("1,2")
+      status(result) must equalTo(BAD_REQUEST)
     }
     "when there is no parameter at all" in new WithApplication() {
       val Some(result) = route(FakeRequest(GET, "/take-list"))

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/tests/RouterSpec.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/tests/RouterSpec.scala
@@ -45,7 +45,7 @@ object RouterSpec extends PlaySpecification {
     }
     "from a list of numbers and letters" in new WithApplication() {
       val Some(result) = route(FakeRequest(GET, "/take-list?x=1&x=a&x=2"))
-      contentAsString(result) must equalTo("1,2")
+      status(result) must equalTo(BAD_REQUEST)
     }
     "when there is no parameter at all" in new WithApplication() {
       val Some(result) = route(FakeRequest(GET, "/take-list"))


### PR DESCRIPTION
Fixes https://github.com/playframework/playframework/issues/4003

Given the following contrived example:

```
   import play.api.mvc.QueryStringBindable
   import play.api.mvc.QueryStringBindable.bindableSeq
    val values = Seq("i", "once", "knew", "a", "man", "from", "nantucket")
    val params = Map("q" -> values)
      implicit val brokenBinder: QueryStringBindable[String] = {
        new QueryStringBindable.Parsing[String](
          { x =>
            if (x == "i" || x == "nantucket") x else sys.error(s"failed: ${x}")
          },
          identity,
          (key, ex) => s"failed to parse ${key}: ${ex.getMessage}"
        ) 
      } 
      val brokenSeqBinder = implicitly[QueryStringBindable[Seq[String]]]
```

`brokenSeqBinder.bind("q", params)`, will output `Some(Right(Seq("i", "nantucket")))`

I would have expected the result to be an error message detailing what went wrong.