### PR TITLE
Fix subproject/run (2.3.x)

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayRun.scala
@@ -56,12 +56,13 @@ trait PlayRun extends PlayInternalKeys {
     val args = Def.spaceDelimited().parsed
 
     val state = Keys.state.value
+    val scope = resolvedScoped.value.scope
     val interaction = playInteractionMode.value
 
     val reloadCompile = () => PlayReload.compile(
-      () => Project.runTask(playReload, state).map(_._2).get,
-      () => Project.runTask(reloaderClasspath, state).map(_._2).get,
-      () => Project.runTask(streamsManager, state).map(_._2).get.toEither.right.toOption
+      () => Project.runTask(playReload in scope, state).map(_._2).get,
+      () => Project.runTask(reloaderClasspath in scope, state).map(_._2).get,
+      () => Project.runTask(streamsManager in scope, state).map(_._2).get.toEither.right.toOption
     )
 
     val runSbtTask: String => AnyRef = (task: String) => {


### PR DESCRIPTION
Backport of #3970. Use resolvedScope when calling Project.runTask.