### PR TITLE
Specify the request body only once in Helpers

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -418,22 +418,27 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
 
     @SuppressWarnings("unchecked")
     public static Result route(Application app, RequestBuilder requestBuilder, long timeout) {
-      final scala.Option<scala.concurrent.Future<play.api.mvc.Result>> opt = play.api.test.Helpers.jRoute(app.getWrappedApplication(), requestBuilder.build()._underlyingRequest());
+      final scala.Option<scala.concurrent.Future<play.api.mvc.Result>> opt = play.api.test.Helpers.jRoute(
+          app.getWrappedApplication(), requestBuilder.build()._underlyingRequest(), requestBuilder.bodyAsAnyContent());
       return wrapScalaResult(Scala.orNull(opt), timeout);
     }
 
+    @Deprecated
     public static Result route(Application app, RequestBuilder requestBuilder, byte[] body) {
       return route(app, requestBuilder, body, DEFAULT_TIMEOUT);
     }
 
+    @Deprecated
     public static Result route(Application app, RequestBuilder requestBuilder, byte[] body, long timeout) {
       return wrapScalaResult(Scala.orNull(play.api.test.Helpers.jRoute(app.getWrappedApplication(), requestBuilder.build()._underlyingRequest(), body)), timeout);
     }
 
+    @Deprecated
     public static Result route(RequestBuilder requestBuilder, byte[] body) {
       return route(requestBuilder, body, DEFAULT_TIMEOUT);
     }
 
+    @Deprecated
     public static Result route(RequestBuilder requestBuilder, byte[] body, long timeout) {
       return route(play.Play.application(), requestBuilder, body, timeout);
     }

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -186,7 +186,7 @@ trait EssentialActionCaller {
    *
    * The body is serialised using the implicit writable, so that the action body parser can deserialise it.
    */
-  def call[T](action: EssentialAction, req: FakeRequest[T])(implicit w: Writeable[T]): Future[Result] =
+  def call[T](action: EssentialAction, req: Request[T])(implicit w: Writeable[T]): Future[Result] =
     call(action, req, req.body)
 
   /**
@@ -210,11 +210,8 @@ trait RouteInvokers extends EssentialActionCaller {
   self: Writeables =>
 
   // Java compatibility
-  def jRoute(app: Application, rh: RequestHeader): Option[Future[Result]] = route(app, rh, AnyContentAsEmpty)
-  def jRoute(app: Application, rh: RequestHeader, body: Array[Byte]): Option[Future[Result]] = route(app, rh, body)(Writeable.wBytes)
-  def jRoute(rh: RequestHeader, body: Array[Byte]): Option[Future[Result]] = jRoute(Play.current, rh, body)
-  def jRoute[T](app: Application, r: FakeRequest[T]): Option[Future[Result]] = {
-    (r.body: @unchecked) match {
+  def jRoute[T](app: Application, r: RequestHeader, body: T): Option[Future[Result]] = {
+    (body: @unchecked) match {
       case body: AnyContentAsFormUrlEncoded => route(app, r, body)
       case body: AnyContentAsJson => route(app, r, body)
       case body: AnyContentAsXml => route(app, r, body)


### PR DESCRIPTION
RequestBuilder allows specifying a request body already, so it is confusing to have helpers that make you specify a request body a second time

This is also a big improvement because it allows these helper methods to be used with all types of bodies instead of just `byte[]`