### PR TITLE
WS: add support for 3 more Ning config params

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -178,7 +178,7 @@ public class JavaWS {
                     none, // acceptAnyCertificate
                     noneSSLConfig);
 
-            NingWSClientConfig clientConfig = new DefaultNingWSClientConfig(wsClientConfig, none, none, none, none, none, none, none, none, none, none);
+            NingWSClientConfig clientConfig = new DefaultNingWSClientConfig(wsClientConfig, none, none, none, none, none, none, none, none, none, none, none, none, none);
 
             // Build a secure config out of the client config:
             NingAsyncHttpClientConfigBuilder secureBuilder = new NingAsyncHttpClientConfigBuilder(clientConfig);

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -228,4 +228,7 @@ Please refer to the [AsyncHttpClientConfig Documentation](http://asynchttpclient
 * `ws.ning.removeQueryParamsOnRedirect`
 * `ws.ning.requestCompressionLevel`
 * `ws.ning.useRawUrl`
+* `ws.ning.maximumConnectionLifeTime`
+* `ws.ning.idleConnectionInPoolTimeout`
+* `ws.ning.webSocketIdleTimeout`
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingConfig.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingConfig.scala
@@ -45,6 +45,12 @@ trait NingWSClientConfig {
 
   def useRawUrl: Option[Boolean]
 
+  def maximumConnectionLifeTime: Option[Int]
+
+  def idleConnectionInPoolTimeout: Option[Int]
+
+  def webSocketIdleTimeout: Option[Int]
+
 }
 
 /**
@@ -60,7 +66,10 @@ case class DefaultNingWSClientConfig(wsClientConfig: WSClientConfig = DefaultWSC
   maxRequestRetry: Option[Int] = None,
   removeQueryParamsOnRedirect: Option[Boolean] = None,
   requestCompressionLevel: Option[Int] = None,
-  useRawUrl: Option[Boolean] = None) extends NingWSClientConfig
+  useRawUrl: Option[Boolean] = None,
+  maximumConnectionLifeTime: Option[Int] = None,
+  idleConnectionInPoolTimeout: Option[Int] = None,
+  webSocketIdleTimeout: Option[Int] = None) extends NingWSClientConfig
 
 /**
  * This class creates a DefaultWSClientConfig object from the play.api.Configuration.
@@ -83,6 +92,9 @@ class DefaultNingWSClientConfigParser @Inject() (wsClientConfig: WSClientConfig,
     val removeQueryParamsOnRedirect = configuration.getBoolean("ws.ning.removeQueryParamsOnRedirect")
     val requestCompressionLevel = configuration.getInt("ws.ning.requestCompressionLevel")
     val useRawUrl = configuration.getBoolean("ws.ning.useRawUrl")
+    val maximumConnectionLifeTime = configuration.getInt("ws.ning.maximumConnectionLifeTime")
+    val idleConnectionInPoolTimeout = configuration.getInt("ws.ning.idleConnectionInPoolTimeout")
+    val webSocketIdleTimeout = configuration.getInt("ws.ning.webSocketIdleTimeout")
 
     DefaultNingWSClientConfig(
       wsClientConfig,
@@ -95,7 +107,10 @@ class DefaultNingWSClientConfigParser @Inject() (wsClientConfig: WSClientConfig,
       maxRequestRetry,
       removeQueryParamsOnRedirect,
       requestCompressionLevel,
-      useRawUrl
+      useRawUrl,
+      maximumConnectionLifeTime,
+      idleConnectionInPoolTimeout,
+      webSocketIdleTimeout
     )
   }
 }
@@ -191,6 +206,9 @@ class NingAsyncHttpClientConfigBuilder(ningConfig: NingWSClientConfig = DefaultN
     ningConfig.removeQueryParamsOnRedirect.foreach(builder.setRemoveQueryParamsOnRedirect)
     ningConfig.requestCompressionLevel.foreach(builder.setRequestCompressionLevel)
     ningConfig.useRawUrl.foreach(builder.setUseRawUrl)
+    ningConfig.maximumConnectionLifeTime.foreach(builder.setMaxConnectionLifeTimeInMs)
+    ningConfig.idleConnectionInPoolTimeout.foreach(builder.setIdleConnectionInPoolTimeoutInMs)
+    ningConfig.webSocketIdleTimeout.foreach(builder.setWebSocketIdleTimeoutInMs)
   }
 
   /**

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingConfigSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingConfigSpec.scala
@@ -48,6 +48,9 @@ object NingConfigSpec extends Specification with Mockito {
                                |ws.ning.removeQueryParamsOnRedirect = true
                                |ws.ning.requestCompressionLevel = 999
                                |ws.ning.useRawUrl = true
+                               |ws.ning.maximumConnectionLifeTime = 60000
+                               |ws.ning.idleConnectionInPoolTimeout = 30000
+                               |ws.ning.webSocketIdleTimeout = 120000
                              """.stripMargin)
 
       actual.allowPoolingConnection must beSome.which(_ must_== false)
@@ -60,6 +63,9 @@ object NingConfigSpec extends Specification with Mockito {
       actual.removeQueryParamsOnRedirect must beSome.which(_ must_== true)
       actual.requestCompressionLevel must beSome.which(_ must_== 999)
       actual.useRawUrl must beSome.which(_ must_== true)
+      actual.maximumConnectionLifeTime must beSome.which(_ must_== 60000)
+      actual.idleConnectionInPoolTimeout must beSome.which(_ must_== 30000)
+      actual.webSocketIdleTimeout must beSome.which(_ must_== 120000)
     }
 
     "with basic options" should {


### PR DESCRIPTION
Adds support for 3 more configuration params for AsyncHttpClient

```
// How long (ms) to keep a connection in the pool (default: forever)
ws.ning.maximumConnectionLifeTime

// How long (ms) to keep an idle connection in the pool (default: 1 min)
ws.ning.idleConnectionInPoolTimeout

// How long (ms) to keep an idle WebSocket conn open (default: 15 min)
ws.ning.webSocketIdleTimeout
```

Also updated the docs accordingly.