### PR TITLE
Cached invalidate annotation

### DIFF
--- a/framework/src/play-cache/src/main/java/play/cache/CachedInvalidate.java
+++ b/framework/src/play-cache/src/main/java/play/cache/CachedInvalidate.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.cache;
+
+import play.mvc.With;
+
+import java.lang.annotation.*;
+
+/**
+ * Mark an action to remove cache keys values when this action trigger.
+ */
+@With(CachedInvalidateAction.class)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CachedInvalidate {
+    /**
+     * The cache keys to remove
+     */
+    String[] keys();
+
+}

--- a/framework/src/play-cache/src/main/java/play/cache/CachedInvalidateAction.java
+++ b/framework/src/play-cache/src/main/java/play/cache/CachedInvalidateAction.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.cache;
+
+import play.cache.Cache;
+import play.libs.F;
+import play.mvc.*;
+import play.mvc.Http.*;
+
+/**
+ * Invalidate cache after trigger action.
+ */
+public class CachedInvalidateAction extends Action<CachedInvalidate> {
+
+    public F.Promise<Result> call(Context ctx) {
+        try {
+            final String[] keys = configuration.keys();
+            F.Promise<Result> promise = delegate.call(ctx);
+            for(String key: keys){
+                Cache.remove(key);
+            }
+            return promise;
+        } catch(RuntimeException e) {
+            throw e;
+        } catch(Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+}


### PR DESCRIPTION
Add CachedInvalidate annotation and CachedInvalidateAction for Invalidate cache after trigger action.
https://github.com/playframework/playframework/issues/4019
