### PR TITLE
Handle Enumerator errors in EnumeratorPublisher

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
@@ -168,7 +168,7 @@ trait WSSpec extends PlaySpecification with ServerIntegrationSpecification with 
             aka("streamed response") must throwAn[IOException]
 
         }
-      }.skipUntilAkkaHttpFixed
+      }.pendingUntilAkkaHttpFixed // Waiting for Akka HTTP to support closing connections after results with known Content-Length
 
     "not throw an exception while signing requests" >> {
       object CustomSigner extends WSSignatureCalculator {

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/impl/EnumeratorPublisher.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/impl/EnumeratorPublisher.scala
@@ -173,6 +173,21 @@ private[streams] class EnumeratorSubscription[T, U >: T](
   }
 
   /**
+   * Called when the Iteratee returned by the Enumerator application
+   * enters a failure state. This may indicate that an error occurred
+   * during evaluation of the Enumerator.
+   */
+  private def enumeratorApplicationFailed(): Unit = exclusive {
+    case Requested(_, _) =>
+      subr.onComplete()
+      state = Completed
+    case Cancelled =>
+      ()
+    case Completed =>
+      () // not sure if this can happen
+  }
+
+  /**
    * Called when we want to read an input element from the Enumerator. This
    * method attaches an Iteratee to the end of the Iteratee chain. The
    * Iteratee it attaches will call one of the `*Enumerated` methods when
@@ -197,7 +212,9 @@ private[streams] class EnumeratorSubscription[T, U >: T](
     }
     its match {
       case Unattached =>
-        enum(iteratee)
+        enum(iteratee).onFailure {
+          case _ => enumeratorApplicationFailed()
+        }(Execution.trampoline)
       case Attached(link0) =>
         link0.success(iteratee)
     }

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/EnumeratorPublisherSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/EnumeratorPublisherSpec.scala
@@ -158,6 +158,18 @@ class EnumeratorPublisherSpec extends Specification {
       testEnv.next must_== OnComplete
       testEnv.isEmptyAfterDelay() must beTrue
     }
+    "handle errors when enumerating" in {
+      val testEnv = new TestEnv[Int]
+      val lotsOfItems = 0 until 25
+      val enum = Enumerator.flatten(Future.failed(new Exception("x")))
+      val pubr = new EnumeratorPublisher[Nothing](enum)
+      pubr.subscribe(testEnv.subscriber)
+      testEnv.next must_== OnSubscribe
+      testEnv.request(1)
+      testEnv.next must_== RequestMore(1)
+      testEnv.next must_== OnComplete
+      testEnv.isEmptyAfterDelay() must beTrue
+    }
     "enumerate 25 items" in {
       val testEnv = new TestEnv[Int]
       val lotsOfItems = 0 until 25


### PR DESCRIPTION
This partly fixes an Akka HTTP integration test. We now close the stream properly when an error occurs, but unfortunately Akka HTTP strips out the Content-Length on the result so the WS client doesn't realise that the stream closed early. I'm talking to the Akka team now about whether Akka HTTP can support forcing streams to close even if they have a known length or are chunked.