### PR TITLE
Scripted tests and new cross build

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -136,7 +136,7 @@ object BuildSettings {
       "-Xmx768m",
       maxMetaspace,
       "-Dproject.version=" + version.value,
-      "-Dscala.version=" + scalaVersion.value
+      "-Dscala.version=" + (scalaVersion in PlayBuild.PlayProject).value
     )
   )
 

--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -102,6 +102,7 @@ object BuildSettings {
     Project(name, file("src/" + dir))
       .settings(playCommonSettings: _*)
       .settings(PublishSettings.publishSettings: _*)
+      .settings(crossBuildSettings: _*)
   }
 
   /**
@@ -111,12 +112,14 @@ object BuildSettings {
     Project(name, file("src/" + dir))
       .settings(playRuntimeSettings: _*)
       .settings(PublishSettings.publishSettings: _*)
+      .settings(crossBuildSettings: _*)
       .settings(omnidocSettings: _*)
-      .settings(
-        crossScalaVersions := Seq("2.10.4", "2.11.5"),
-        scalaVersion := "2.11.5"
-      )
   }
+
+  def crossBuildSettings: Seq[Setting[_]] = Seq(
+    crossScalaVersions := Seq("2.10.4", "2.11.5"),
+    scalaVersion := "2.11.5"
+  )
 
   def omnidocSettings: Seq[Setting[_]] = Omnidoc.projectSettings ++ Seq(
     OmnidocKeys.githubRepo := "playframework/playframework",

--- a/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/build.sbt
+++ b/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/build.sbt
@@ -4,4 +4,4 @@ DevModeBuild.settings
 
 fork in run := true
 
-scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.5")


### PR DESCRIPTION
A couple of small fixes with the new cross build.

With the default scala version now 2.11, scripted tests were still running against 2.10, but 2.10 artefacts may not have been published locally. This may have been why 2.10 was always the default. I've updated to use the play project scala version, rather than the sbt plugin scala version.

The development projects also need to be cross built for fork run.

There's also one awkward point about running the fork run plugin scripted tests against scala 2.11 -- it starts up an sbt server which won't see the scala version system property. For now I've just made the default 2.11 for it to work. A more complete fix would write the scala version to a file as needed, or something like that.