### PR TITLE
Added support for query parameters in sird

### DIFF
--- a/documentation/manual/working/scalaGuide/advanced/routing/ScalaSirdRouter.md
+++ b/documentation/manual/working/scalaGuide/advanced/routing/ScalaSirdRouter.md
@@ -23,11 +23,31 @@ Regular expressions are also supported, by postfixing the parameter with a regul
 
 @[regexp](code/ScalaSirdRouter.scala)
 
+Query parameters can also be extracted, using the `?` operator to do further extractions on the request, and using the `q` extractor:
+
+@[required](code/ScalaSirdRouter.scala)
+
+While `q` extracts a required query parameter as a `String`, `q_?` or `q_o` if using Scala 2.10 extracts an optional query parameter as `Option[String]`:
+
+@[optional](code/ScalaSirdRouter.scala)
+
+Likewise, `q_*` or `q_s` can be used to extract a sequence of multi valued query parameters:
+
+@[many](code/ScalaSirdRouter.scala)
+
+Multiple query parameters can be extracted using the `&` operator:
+
+@[multiple](code/ScalaSirdRouter.scala)
+
 Since sird is just a regular extractor object (built by string interpolation), it can be combined with any other extractor object, including extracting its sub parameters even further.  Sird provides some useful extractors for some of the most common types out of the box, namely `int`, `long`, `float`, `double` and `bool`:
 
 @[int](code/ScalaSirdRouter.scala)
 
 In the above, `id` is of type `Int`.  If the `int` extractor failed to match, then of course, the whole pattern will fail to match.
+
+Similarly, the same extractors can be used with query string parameters, including multi value and optional query parameters.  In the case of optional or multi value query parameters, the match will fail if any of the values present can't be bound to the type, but no parameters present doesn't cause the match to fail:
+
+@[query-int](code/ScalaSirdRouter.scala)
 
 To further the point that these are just regular extractor objects, you can see here that you can use all other features of a `case` statement, including `@` syntax and if statements:
 

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/ScalaSirdRouter.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/ScalaSirdRouter.scala
@@ -54,6 +54,64 @@ object ScalaSirdRouter extends Specification {
       router.routes.lift(FakeRequest("GET", "/items/foo")) must beNone
     }
 
+    "allow extracting required query parameters" in {
+      //#required
+      val router = Router.from {
+        case GET(p"/search" ? q"query=$query") => Action {
+          Results.Ok(s"Searching for $query")
+        }
+      }
+      //#required
+
+      router.routes.lift(FakeRequest("GET", "/search?query=foo")) must beSome[Handler]
+      router.routes.lift(FakeRequest("GET", "/search")) must beNone
+    }
+
+    "allow extracting optional query parameters" in {
+      //#optional
+      val router = Router.from {
+        case GET(p"/items" ? q_o"page=$page") => Action {
+          val thisPage = page.getOrElse("1")
+          Results.Ok(s"Showing page $thisPage")
+        }
+      }
+      //#optional
+
+      router.routes.lift(FakeRequest("GET", "/items?page=10")) must beSome[Handler]
+      router.routes.lift(FakeRequest("GET", "/items")) must beSome[Handler]
+    }
+
+    "allow extracting multi value query parameters" in {
+      //#many
+      val router = Router.from {
+        case GET(p"/items" ? q_s"tag=$tags") => Action {
+          val allTags = tags.mkString(", ")
+          Results.Ok(s"Showing items tagged: $allTags")
+        }
+      }
+      //#many
+
+      router.routes.lift(FakeRequest("GET", "/items?tag=a&tag=b")) must beSome[Handler]
+      router.routes.lift(FakeRequest("GET", "/items")) must beSome[Handler]
+    }
+
+    "allow extracting multiple query parameters" in {
+      //#multiple
+      val router = Router.from {
+        case GET(p"/items" ? q_o"page=$page"
+          & q_o"per_page=$perPage") => Action {
+          val thisPage = page.getOrElse("1")
+          val pageLength = perPage.getOrElse("10")
+
+          Results.Ok(s"Showing page $thisPage of length $pageLength")
+        }
+      }
+      //#multiple
+
+      router.routes.lift(FakeRequest("GET", "/items?page=10&per_page=20")) must beSome[Handler]
+      router.routes.lift(FakeRequest("GET", "/items")) must beSome[Handler]
+    }
+
     "allow sub extractor" in {
       //#int
       val router = Router.from {
@@ -67,20 +125,36 @@ object ScalaSirdRouter extends Specification {
       router.routes.lift(FakeRequest("GET", "/items/foo")) must beNone
     }
 
+    "allow sub extractor on a query parameter" in {
+      //#query-int
+      val router = Router.from {
+        case GET(p"/items" ? q_o"page=${int(page)}") => Action {
+          val thePage = page.getOrElse(1)
+          Results.Ok(s"Items page $thePage")
+        }
+      }
+      //#query-int
+
+      router.routes.lift(FakeRequest("GET", "/items?page=21")) must beSome[Handler]
+      router.routes.lift(FakeRequest("GET", "/items?page=foo")) must beNone
+      router.routes.lift(FakeRequest("GET", "/items")) must beSome[Handler]
+    }
+
     "allow complex extractors" in {
       //#complex
       val router = Router.from {
-        case rh @ GET(p"/items/${idString @ int(id)}")
-          if rh.getQueryString("type").isDefined =>
+        case rh @ GET(p"/items/${idString @ int(id)}" ?
+          q"price=${int(price)}")
+          if price > 200 =>
           Action {
-            Results.Ok(s"Item $id")
+            Results.Ok(s"Expensive item $id")
           }
       }
       //#complex
 
-      router.routes.lift(FakeRequest("GET", "/items/21?type=json")) must beSome[Handler]
-      router.routes.lift(FakeRequest("GET", "/items/21")) must beNone
-      router.routes.lift(FakeRequest("GET", "/items/foo?type=json")) must beNone
+      router.routes.lift(FakeRequest("GET", "/items/21?price=400")) must beSome[Handler]
+      router.routes.lift(FakeRequest("GET", "/items/21?price=foo")) must beNone
+      router.routes.lift(FakeRequest("GET", "/items/foo?price=400")) must beNone
     }
 
   }

--- a/framework/src/play/src/main/scala/play/api/routing/sird/PathBindableExtractor.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/sird/PathBindableExtractor.scala
@@ -9,8 +9,38 @@ import play.api.mvc.PathBindable
  * An extractor that extracts from a String using a [[PathBindable]].
  */
 class PathBindableExtractor[T](implicit pb: PathBindable[T]) {
+  self =>
+
+  /**
+   * Extract s to T if it can be bound, otherwise don't match.
+   */
   def unapply(s: String): Option[T] = {
     pb.bind("anon", s).right.toOption
+  }
+
+  /**
+   * Extract Option[T] only if s is None, Some value that can be bound, otherwise don't match.
+   */
+  def unapply(s: Option[String]): Option[Option[T]] = {
+    s match {
+      case None => Some(None)
+      case Some(self(value)) => Some(Some(value))
+      case _ => None
+    }
+  }
+
+  /**
+   * Extract Seq[T] only if ever element of s can be bound, otherwise don't match.
+   */
+  def unapply(s: Seq[String]): Option[Seq[T]] = {
+    val bound = s.collect {
+      case self(value) => value
+    }
+    if (bound.length == s.length) {
+      Some(bound)
+    } else {
+      None
+    }
   }
 }
 

--- a/framework/src/play/src/main/scala/play/api/routing/sird/PathExtractor.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/sird/PathExtractor.scala
@@ -25,15 +25,10 @@ import scala.util.matching.Regex
  * @param partDescriptors Descriptors saying whether each part should be decoded or not.
  */
 class PathExtractor(regex: Regex, partDescriptors: Seq[PathPart.Value]) {
-  def unapplySeq(obj: Any): Option[List[String]] = {
-    obj match {
-      case path: String => extract(path)
-      case request: RequestHeader => extract(request.path)
-      case uri: URI if uri.getRawPath != null => extract(uri.getRawPath)
-      case url: URL if url.getPath != null => extract(url.getPath)
-      case _ => None
-    }
-  }
+  def unapplySeq(path: String): Option[List[String]] = extract(path)
+  def unapplySeq(request: RequestHeader): Option[List[String]] = extract(request.path)
+  def unapplySeq(url: URL): Option[List[String]] = Option(url.getPath).flatMap(extract)
+  def unapplySeq(uri: URI): Option[List[String]] = Option(uri.getRawPath).flatMap(extract)
 
   private def extract(path: String): Option[List[String]] = {
     regex.unapplySeq(path).map { parts =>

--- a/framework/src/play/src/main/scala/play/api/routing/sird/QueryStringExtractors.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/sird/QueryStringExtractors.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.routing.sird
+
+import java.net.{ URI, URL }
+
+import play.api.mvc.RequestHeader
+
+import scala.reflect.macros.Context
+
+class RequiredQueryStringParameter(paramName: String) extends QueryStringParameterExtractor[String] {
+  def unapply(qs: QueryString): Option[String] = qs.get(paramName).flatMap(_.headOption)
+}
+
+class OptionalQueryStringParameter(paramName: String) extends QueryStringParameterExtractor[Option[String]] {
+  def unapply(qs: QueryString): Option[Option[String]] = Some(qs.get(paramName).flatMap(_.headOption))
+}
+
+class SeqQueryStringParameter(paramName: String) extends QueryStringParameterExtractor[Seq[String]] {
+  def unapply(qs: QueryString): Option[Seq[String]] = Some(qs.get(paramName).getOrElse(Nil))
+}
+
+trait QueryStringParameterExtractor[T] {
+  import QueryStringParameterExtractor._
+  def unapply(qs: QueryString): Option[T]
+  def unapply(req: RequestHeader): Option[T] = unapply(req.queryString)
+  def unapply(uri: URI): Option[T] = unapply(parse(uri.getRawQuery))
+  def unapply(uri: URL): Option[T] = unapply(parse(uri.getQuery))
+}
+
+object QueryStringParameterExtractor {
+  private def parse(query: String): QueryString = {
+    Option(query).map(_.split("&").toSeq.map { keyValue =>
+      keyValue.split("=", 2) match {
+        case Array(key, value) => key -> value
+        case Array(key) => key -> ""
+      }
+    }.groupBy(_._1).mapValues(_.map(_._2)).toMap)
+      .getOrElse(Map.empty)
+  }
+
+  def required(name: String) = new RequiredQueryStringParameter(name)
+  def optional(name: String) = new OptionalQueryStringParameter(name)
+  def seq(name: String) = new SeqQueryStringParameter(name)
+}
+
+/**
+ * The macros are used to parse and validate the query string parameters at compile time.
+ *
+ * They generate AST that constructs the extractors directly with the parsed parameter name, instead of having to parse
+ * the string context parameters at runtime.
+ */
+private[sird] object QueryStringParameterMacros {
+  val paramEquals = "([^&=]+)=".r
+
+  def required(c: Context) = {
+    macroImpl(c, "q", "required")
+  }
+
+  def optional(c: Context) = {
+    macroImpl(c, "q_?", "optional")
+  }
+
+  def seq(c: Context) = {
+    macroImpl(c, "q_*", "seq")
+  }
+
+  def macroImpl(c: Context, name: String, extractorName: String) = {
+    import c.universe._
+
+    // Inspect the prefix, this is call that constructs the StringContext, containing the StringContext parts
+    c.prefix.tree match {
+      case Apply(_, List(Apply(_, rawParts))) =>
+        // extract the part literals
+        val parts = rawParts map { case Literal(Constant(const: String)) => const }
+
+        // Extract paramName, and validate
+        val startOfString = c.enclosingPosition.point + name.length + 1
+        val paramName = parts.head match {
+          case paramEquals(param) => param
+          case _ => c.abort(c.enclosingPosition.withPoint(startOfString), "Invalid start of string for query string extractor '" + parts.head + "', extractor string must have format " + name + "\"param=$extracted\"")
+        }
+
+        if (parts.length == 1) {
+          c.abort(c.enclosingPosition.withPoint(startOfString + paramName.length), "Unexpected end of String, expected parameter extractor, eg $extracted")
+        }
+
+        if (parts.length > 2) {
+          c.abort(c.enclosingPosition, "Query string extractor can only extract one parameter, extract multiple parameters using the & extractor, eg: " + name + "\"param1=$param1\" & " + name + "\"param2=$param2\"")
+        }
+
+        if (parts(1).nonEmpty) {
+          c.abort(c.enclosingPosition, s"Unexpected text at end of query string extractor: '${parts(1)}'")
+        }
+
+        // the QueryStringParameterExtractor object
+        val sirdPackage = Select(Select(Select(Ident(newTermName("play")), newTermName("api")),
+          newTermName("routing")), newTermName("sird"))
+        val extractor = Select(sirdPackage, newTermName("QueryStringParameterExtractor"))
+
+        // Return AST that invokes the desired method to create the extractor on QueryStringParameterExtractor, passing
+        // the parameter name to it
+        c.Expr(Apply(
+          Select(extractor, newTermName(extractorName)),
+          List(Literal(Constant(paramName)))
+        ))
+
+      case _ =>
+        c.abort(c.enclosingPosition, "Invalid use of query string extractor")
+    }
+  }
+
+}

--- a/framework/src/play/src/test/scala/play/api/routing/sird/DslSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/routing/sird/DslSpec.scala
@@ -106,5 +106,68 @@ object DslSpec extends Specification {
         case GET(p"/foo/$bar") => bar must_== "bar"
       }
     }
+
+    "support extracting query strings" in {
+      FakeRequest("GET", "/foo/bar?a=1&b=2&c=3&c=4") must beLike {
+        case GET(p"/foo/$bar" ? q"a=$a" & q_o"b=$b" & q_s"c=$cs") =>
+          bar must_== "bar"
+          a must_== "1"
+          b must beSome("2")
+          cs must_== Seq("3", "4")
+      }
+    }
+
+    "extract ints from query strings" in {
+      "match" in {
+        FakeRequest("GET", "/foo?a=1") must beLike {
+          case GET(p"/foo" ? q"a=${ int(a) }") => a must_== 1
+        }
+      }
+      "no match" in {
+        FakeRequest("GET", "/foo?a=a") must beLike {
+          case GET(p"/foo" ? q"a=${ int(a) }") => ko
+          case _ => ok
+        }
+      }
+    }
+
+    "extract optional ints from query strings" in {
+      "match" in {
+        FakeRequest("GET", "/foo?a=1") must beLike {
+          case GET(p"/foo" ? q_o"a=${ int(a) }") => a must beSome(1)
+        }
+      }
+      "no match" in {
+        FakeRequest("GET", "/foo?a=a") must beLike {
+          case GET(p"/foo" ? q_o"a=${ int(a) }") => ko
+          case _ => ok
+        }
+      }
+      "none" in {
+        FakeRequest("GET", "/foo") must beLike {
+          case GET(p"/foo" ? q_o"a=${ int(a) }") => a must beNone
+        }
+      }
+    }
+
+    "extract many ints from query strings" in {
+      "match" in {
+        FakeRequest("GET", "/foo?a=1&a=2") must beLike {
+          case GET(p"/foo" ? q_s"a=${ int(a) }") => a must_== Seq(1, 2)
+        }
+      }
+      "no match" in {
+        FakeRequest("GET", "/foo?a=a&a=2") must beLike {
+          case GET(p"/foo" ? q_s"a=${ int(a) }") => ko
+          case _ => ok
+        }
+      }
+      "none" in {
+        FakeRequest("GET", "/foo") must beLike {
+          case GET(p"/foo" ? q_s"a=${ int(a) }") => a must beEmpty
+        }
+      }
+    }
+
   }
 }


### PR DESCRIPTION
* Added new query parameter extractor macros for extracting query parameters in the sird DSL. Macros are used to parse and validate at compile time.
* Added ? and & extractors for combining multiple extractors together.
* Modified path bindable extractors to allow extracting optional and sequences of query parameters.
* Made path extractor more typesafe, it no longer extracts object, but uses overloaded unapplySeq methods.
* Small refactor of SimpleRouter, it's now a trait so it can be extended if desired.