### PR TITLE
Revert to 2.10 as default scala version

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -118,7 +118,7 @@ object BuildSettings {
 
   def crossBuildSettings: Seq[Setting[_]] = Seq(
     crossScalaVersions := Seq("2.10.4", "2.11.5"),
-    scalaVersion := "2.11.5"
+    scalaVersion := "2.10.4"
   )
 
   def omnidocSettings: Seq[Setting[_]] = Omnidoc.projectSettings ++ Seq(

--- a/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/build.sbt
+++ b/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/build.sbt
@@ -4,4 +4,4 @@ DevModeBuild.settings
 
 fork in run := true
 
-scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.5")
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")

--- a/templates/build.sbt
+++ b/templates/build.sbt
@@ -3,7 +3,7 @@ import play.core.PlayVersion
 
 templateSettings
 
-scalaVersion := "2.11.5"
+scalaVersion := "2.10.4"
 
 crossScalaVersions := Seq("2.10.4", "2.11.5")
 


### PR DESCRIPTION
The templates build has a project reference on play-ws which doesn't work with a 2.11 default version. The templates build also uses PlayVersion.current, which it gets via the project reference.

Just a quick fix to get other builds working again.