### PR TITLE
Immutable username on HTTP request

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -461,14 +461,20 @@ public class Http {
 
         /**
          * Defines the user name for this request.
+         * @deprecated As of release 2.4, use {@link #withUsername}.
          */
-        void setUsername(String username);
+        @Deprecated void setUsername(String username);
+
+        /**
+         * Returns a request updated with specified user name
+         * @param username the new user name
+         */
+        Request withUsername(String username);
 
         /**
          * For internal Play-use only
          */
         play.api.mvc.Request<RequestBody> _underlyingRequest();
-
     }
 
     /**
@@ -477,7 +483,7 @@ public class Http {
     public static class RequestImpl extends play.core.j.RequestHeaderImpl implements Request {
 
         private final play.api.mvc.Request<RequestBody> underlying;
-        private String username;
+        private String username; // Keep it non-final until setUsername is removed
 
         public RequestImpl(play.api.mvc.RequestHeader header) {
             super(header);
@@ -489,26 +495,29 @@ public class Http {
             this.underlying = request;
         }
 
-        /**
-         * The request body.
-         */
+        private RequestImpl(play.api.mvc.Request<RequestBody> request,
+                            String username) {
+            
+            super(request);
+            
+            this.underlying = request;
+            this.username = username;
+        }        
+
         public RequestBody body() {
             return underlying != null ? underlying.body() : null;
         }
 
-        /**
-         * The user name for this request, if defined.
-         * This is usually set by annotating your Action with <code>@Authenticated</code>.
-         */
         public String username() {
             return username;
         }
 
-        /**
-         * Defines the user name for this request.
-         */
         public void setUsername(String username) {
             this.username = username;
+        }
+
+        public Request withUsername(String username) {
+            return new RequestImpl(this.underlying, username);
         }
 
         public play.api.mvc.Request<RequestBody> _underlyingRequest() {

--- a/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -114,7 +114,7 @@ class DefaultHttpRequestHandler(router: Router, errorHandler: HttpErrorHandler, 
         case HttpVerbs.HEAD =>
           val headAction = routeRequest(request.copy(method = HttpVerbs.GET)) match {
             case Some(action: EssentialAction) => action
-            case None => notFoundHandler
+            case _ => notFoundHandler
           }
           new HeadAction(headAction)
         case _ =>

--- a/framework/src/play/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/framework/src/play/src/test/java/play/mvc/RequestBuilderTest.java
@@ -46,4 +46,13 @@ public class RequestBuilderTest {
     assertEquals("2", ctx.session().get("b"));
   }
 
+    @Test
+    public void testUsername() {
+        final Request req1 =
+            new RequestBuilder().uri("http://playframework.com/").build();
+        final Request req2 = req1.withUsername("user2");
+
+        assertNull(req1.username());
+        assertEquals("user2", req2.username());
+    }
 }


### PR DESCRIPTION
On `Http.Request`, the function `.setUsername` could be deprecated and a `.withUsername` (returning an updated instance of the request) added.