### PR TITLE
return to using HTML5 regex for email verification. Fixes #4022

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/validation/Validation.scala
+++ b/framework/src/play/src/main/scala/play/api/data/validation/Validation.scala
@@ -73,7 +73,7 @@ trait Constraints {
    * '''name'''[constraint.email]
    * '''error'''[error.email]
    */
-  private val emailRegex = """^(?!\.)("([^"\r\\]|\\["\r\\])*"|([-a-zA-Z0-9!#$%&'*+/=?^_`{|}~]|(?<!\.)\.)*)(?<!\.)@[a-zA-Z0-9][\w\.-]*[a-zA-Z0-9]\.[a-zA-Z][a-zA-Z\.]*[a-zA-Z]$""".r
+  private val emailRegex = """^[a-zA-Z0-9\.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$""".r
   def emailAddress: Constraint[String] = Constraint[String]("constraint.email") { e =>
     if (e == null) Invalid(ValidationError("error.email"))
     else if (e.trim.isEmpty) Invalid(ValidationError("error.email"))

--- a/framework/src/play/src/test/scala/play/api/data/validation/ValidationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/validation/ValidationSpec.scala
@@ -82,9 +82,7 @@ object ValidationSpec extends Specification {
 
   "Email constraint" should {
     val valid = Seq(
-      """"Fred Bloggs"@example.com""",
-      """"Joe\\Blow"@example.com""",
-      """"Abc@def"@example.com""",
+      """simple@example.com""",
       """customer/department=shipping@example.com""",
       """$A12345@example.com""",
       """!def!xyz%abc@example.com""",
@@ -106,10 +104,6 @@ object ValidationSpec extends Specification {
       "\"\"test\blah\"\"@example.com",
       "\"test\rblah\"@example.com",
       "\"\"test\"\"blah\"\"@example.com",
-      ".wooly@example.com",
-      "wo..oly@example.com",
-      "pootietang.@example.com",
-      ".@example.com",
       "Ima Fool@example.com"
     )
     "invalidate invalid addresses" in {


### PR DESCRIPTION
To quote @jroper:
> "At the end of the day, if you want to validate an email address, the
> only real way to do it is to send an email to it with a secret token.
> For this reason, false positives are not a big problem, what is a big
> problem is false negatives, ie issues like this very bug."