### PR TITLE
Added `blocking` to mark the code as blocking

### DIFF
--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
@@ -4,6 +4,8 @@
 package scalaguide.async.scalaasync
 
 import scala.concurrent.Future
+import scala.concurrent.blocking
+
 import play.api.mvc._
 
 import play.api.test._
@@ -75,7 +77,7 @@ object ScalaAsyncSamples extends Controller {
   }
 
   def timeout(t: Long) = {
-    def intensiveComputation() = {
+    def intensiveComputation() = blocking {
       Thread.sleep(t)
       10
     }


### PR DESCRIPTION
As the documentation says:
> Used to designate a piece of code which potentially blocks, allowing the current BlockContext to adjust the runtime's behavior.