### PR TITLE
Trim snapshot branch name for omnidoc

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -32,10 +32,10 @@ object BuildSettings {
 
   val snapshotBranch = {
     try {
-      val branch = "git rev-parse --abbrev-ref HEAD".!!
+      val branch = "git rev-parse --abbrev-ref HEAD".!!.trim
       if (branch == "HEAD") {
         // not on a branch, get the hash
-        "git rev-parse HEAD".!!
+        "git rev-parse HEAD".!!.trim
       } else branch
     } catch {
       case NonFatal(_) => "unknown"


### PR DESCRIPTION
The branch names had a trailing newline, which was invalid in the source jar manifests.