### PR TITLE
Allow connections to be closed in Akka HTTP when a Content-Length is set

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
@@ -149,7 +149,7 @@ class AkkaHttpServer(config: ServerConfig, appProvider: ApplicationProvider) ext
     val resultFuture: Future[Result] = requestBodyEnumerator |>>> actionIteratee
     val responseFuture: Future[HttpResponse] = resultFuture.flatMap { result =>
       val cleanedResult: Result = ServerResultUtils.cleanFlashCookie(taggedRequestHeader, result)
-      modelConversion.convertResult(cleanedResult, request.protocol)
+      modelConversion.convertResult(taggedRequestHeader, cleanedResult, request.protocol)
     }
     responseFuture
   }

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -63,7 +63,7 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
       def uri = request.uri.toString
       def path = request.uri.path.toString
       def method = request.method.name
-      def version = request.protocol.toString
+      def version = request.protocol.value
       def queryString = request.uri.query.toMultiMap
       val headers = convertRequestHeaders(request)
       def remoteAddress: String = ServerRequestUtils.findRemoteAddress(
@@ -126,27 +126,31 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
    * Convert a Play `Result` object into an Akka `HttpResponse` object.
    */
   def convertResult(
+    requestHeaders: RequestHeader,
     result: Result,
     protocol: HttpProtocol): Future[HttpResponse] = {
 
     val convertedHeaders: AkkaHttpHeaders = convertResponseHeaders(result.header.headers)
     import play.api.libs.iteratee.Execution.Implicits.trampoline
-    convertResultBody(convertedHeaders, result, protocol).flatMap {
+    convertResultBody(requestHeaders, convertedHeaders, result, protocol).flatMap {
       case Left(alternativeResult) =>
-        convertResult(alternativeResult, protocol)
-      case Right(entity) =>
-        Future.successful(HttpResponse(
-          status = result.header.status,
-          headers = convertedHeaders.misc,
-          entity = entity,
-          protocol = protocol))
+        convertResult(requestHeaders, alternativeResult, protocol)
+      case Right((entity, connection)) =>
+        Future.successful(
+          HttpResponse(
+            status = result.header.status,
+            headers = convertedHeaders.misc ++ connection,
+            entity = entity,
+            protocol = protocol)
+        )
     }
   }
 
   def convertResultBody(
+    requestHeaders: RequestHeader,
     convertedHeaders: AkkaHttpHeaders,
     result: Result,
-    protocol: HttpProtocol): Future[Either[Result, ResponseEntity]] = {
+    protocol: HttpProtocol): Future[Either[Result, (ResponseEntity, Option[Connection])]] = {
 
     import Execution.Implicits.trampoline
 
@@ -155,75 +159,89 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
       AkkaStreamsConversion.enumeratorToSource(dataEnum)
     }
 
-    val isHttp10 = protocol == HttpProtocols.`HTTP/1.0`
-    ServerResultUtils.determineResultStreaming(result, isHttp10).map {
-      case ServerResultUtils.CannotStream(reason, alternativeResult) =>
+    ServerResultUtils.determineResultStreaming(requestHeaders, result).map {
+      case Left(ServerResultUtils.InvalidResult(reason, alternativeResult)) =>
         logger.warn(s"Cannot send result, sending error result instead: $reason")
         Left(alternativeResult)
-      case ServerResultUtils.StreamWithClose(enum) =>
-        Right(HttpEntity.CloseDelimited(
-          contentType = convertedHeaders.contentType,
-          data = dataSource(enum)
-        ))
-      case ServerResultUtils.StreamWithNoBody =>
-        Right(HttpEntity.Empty)
-      case ServerResultUtils.StreamWithKnownLength(enum) =>
-        convertedHeaders.contentLength.get match {
-          case 0 =>
-            Right(HttpEntity.empty(
-              contentType = convertedHeaders.contentType
-            ))
-          case contentLength =>
-            Right(HttpEntity.Default(
+      case Right((streaming, connectionHeader)) =>
+        def valid(entity: ResponseEntity): Right[Nothing, (ResponseEntity, Option[Connection])] = {
+          val akkaConnectionHeader: Option[Connection] = connectionHeader.header.map(h => Connection(h))
+          Right((entity, akkaConnectionHeader))
+        }
+        streaming match {
+          case ServerResultUtils.StreamWithClose(enum) =>
+            assert(connectionHeader.willClose)
+            valid(HttpEntity.CloseDelimited(
               contentType = convertedHeaders.contentType,
-              contentLength = contentLength,
               data = dataSource(enum)
             ))
-        }
-      case ServerResultUtils.StreamWithStrictBody(body) =>
-        Right(HttpEntity.Strict(
-          contentType = convertedHeaders.contentType,
-          data = if (body.isEmpty) ByteString.empty else ByteString(body)
-        ))
-      case ServerResultUtils.UseExistingTransferEncoding(transferEncodedEnum) =>
-        assert(convertedHeaders.transferEncoding.isDefined) // Guaranteed by ServerResultUtils
-        val transferEncoding = convertedHeaders.transferEncoding.get
-        transferEncoding match {
-          case immutable.Seq(TransferEncodings.chunked) =>
-            val chunksEnum = (transferEncodedEnum &> Results.dechunkWithTrailers &> Enumeratee.map {
-              case Left(bytes) => HttpEntity.ChunkStreamPart(bytes)
-              case Right(rawHeaderStrings) =>
-                val rawHeaders = rawHeaderStrings.map {
-                  case (name, value) => RawHeader(name, value)
-                }
-                val convertedHeaders: List[HttpHeader] = HeaderParser.parseHeaders(rawHeaders.to[List]) match {
-                  case (Nil, headers) => headers
-                  case (errors, _) => sys.error(s"Error parsing trailers: $errors")
-                }
-                HttpEntity.LastChunk(trailer = convertedHeaders)
-            }) >>> Enumerator.eof
+          case ServerResultUtils.StreamWithNoBody =>
+            valid(HttpEntity.Empty)
+          case ServerResultUtils.StreamWithKnownLength(enum) =>
+            convertedHeaders.contentLength.get match {
+              case 0 =>
+                valid(HttpEntity.empty(
+                  contentType = convertedHeaders.contentType
+                ))
+              case contentLength =>
+                valid(HttpEntity.Default(
+                  contentType = convertedHeaders.contentType,
+                  contentLength = contentLength,
+                  data = dataSource(enum)
+                ))
+            }
+          case ServerResultUtils.StreamWithStrictBody(body) =>
+            valid(HttpEntity.Strict(
+              contentType = convertedHeaders.contentType,
+              data = if (body.isEmpty) ByteString.empty else ByteString(body)
+            ))
+          case ServerResultUtils.UseExistingTransferEncoding(transferEncodedEnum) =>
+            assert(convertedHeaders.transferEncoding.isDefined) // Guaranteed by ServerResultUtils
+            val transferEncoding = convertedHeaders.transferEncoding.get
+            transferEncoding match {
+              case immutable.Seq(TransferEncodings.chunked) =>
+                valid(HttpEntity.Chunked(
+                  contentType = convertedHeaders.contentType,
+                  chunks = dechunkAndRechunk(transferEncodedEnum)
+                ))
+              case other =>
+                logger.warn(s"Cannot send result, sending error instead: Akka HTTP server only supports 'Transfer-Encoding: chunked', was $other")
+                Left(Results.InternalServerError(""))
+            }
+          case ServerResultUtils.PerformChunkedTransferEncoding(enum) =>
+            val chunksEnum = (
+              enum.map(HttpEntity.ChunkStreamPart(_)) >>>
+              Enumerator.enumInput(Input.El(HttpEntity.LastChunk)) >>>
+              Enumerator.eof
+            )
             val chunksSource = AkkaStreamsConversion.enumeratorToSource(chunksEnum)
-            Right(HttpEntity.Chunked(
+            valid(HttpEntity.Chunked(
               contentType = convertedHeaders.contentType,
               chunks = chunksSource
             ))
-          case other =>
-            logger.warn(s"Cannot send result, sending error instead: Akka HTTP server only supports 'Transfer-Encoding: chunked', was $other")
-            Left(Results.InternalServerError(""))
         }
-      case ServerResultUtils.PerformChunkedTransferEncoding(enum) =>
-        val chunksEnum = (
-          enum.map(HttpEntity.ChunkStreamPart(_)) >>>
-          Enumerator.enumInput(Input.El(HttpEntity.LastChunk)) >>>
-          Enumerator.eof
-        )
-        val chunksSource = AkkaStreamsConversion.enumeratorToSource(chunksEnum)
-
-        Right(HttpEntity.Chunked(
-          contentType = convertedHeaders.contentType,
-          chunks = chunksSource
-        ))
     }
+  }
+
+  /**
+   * Given a chunk encoded stream, decode it and reencode it in Akka's chunk format.
+   */
+  private def dechunkAndRechunk(chunkEncodedEnum: Enumerator[Array[Byte]]): Source[HttpEntity.ChunkStreamPart, Unit] = {
+    import Execution.Implicits.trampoline
+    val rechunkEnee = Results.dechunkWithTrailers ><> Enumeratee.map[Either[Array[Byte], Seq[(String, String)]]][HttpEntity.ChunkStreamPart] {
+      case Left(bytes) => HttpEntity.ChunkStreamPart(bytes)
+      case Right(rawHeaderStrings) =>
+        val rawHeaders = rawHeaderStrings.map {
+          case (name, value) => RawHeader(name, value)
+        }
+        val convertedHeaders: List[HttpHeader] = HeaderParser.parseHeaders(rawHeaders.to[List]) match {
+          case (Nil, headers) => headers
+          case (errors, _) => sys.error(s"Error parsing trailers: $errors")
+        }
+        HttpEntity.LastChunk(trailer = convertedHeaders)
+    }
+    val akkaChunksEnum: Enumerator[HttpEntity.ChunkStreamPart] = (chunkEncodedEnum &> rechunkEnee) >>> Enumerator.eof
+    AkkaStreamsConversion.enumeratorToSource(akkaChunksEnum)
   }
 
   /**

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
@@ -168,7 +168,7 @@ trait WSSpec extends PlaySpecification with ServerIntegrationSpecification with 
             aka("streamed response") must throwAn[IOException]
 
         }
-      }.pendingUntilAkkaHttpFixed // Waiting for Akka HTTP to support closing connections after results with known Content-Length
+      }
 
     "not throw an exception while signing requests" >> {
       object CustomSigner extends WSSignatureCalculator {

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -84,11 +84,10 @@ private[play] class PlayDefaultUpstreamHandler(server: Server, allChannels: Defa
       case nettyHttpRequest: HttpRequest =>
 
         logger.trace("Http request received by netty: " + nettyHttpRequest)
-        val keepAlive = isKeepAlive(nettyHttpRequest)
         val websocketableRequest = websocketable(nettyHttpRequest)
         var nettyVersion = nettyHttpRequest.getProtocolVersion
         val nettyUri = new QueryStringDecoder(nettyHttpRequest.getUri)
-        val rHeaders = getHeaders(nettyHttpRequest)
+        val rHeaders: Headers = getHeaders(nettyHttpRequest)
 
         def rRemoteAddress = ServerRequestUtils.findRemoteAddress(
           forwardedHeaderHandler,
@@ -277,7 +276,7 @@ private[play] class PlayDefaultUpstreamHandler(server: Server, allChannels: Defa
           }.flatMap {
             case (result, sequence) =>
               val cleanedResult = ServerResultUtils.cleanFlashCookie(requestHeader, result)
-              NettyResultStreamer.sendResult(cleanedResult, !keepAlive, nettyVersion, sequence)
+              NettyResultStreamer.sendResult(requestHeader, cleanedResult, nettyVersion, sequence)
           }
 
         }

--- a/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -5,6 +5,7 @@ package play.core.server.common
 
 import play.api._
 import play.api.mvc._
+import play.api.http.HttpProtocol
 import play.api.http.HeaderNames._
 import play.api.libs.iteratee._
 import scala.concurrent.{ Future, Promise }
@@ -14,59 +15,201 @@ object ServerResultUtils {
   /** Save allocation by caching an empty array */
   private val emptyBytes = new Array[Byte](0)
 
+  /**
+   * Used to indicate that a result can't be streamed. Offers an
+   * alternative result that can be sent instead.
+   */
+  final case class InvalidResult(reason: String, alternativeResult: Result)
+
+  /**
+   * Indicates the streaming strategy to use for returning the response.
+   */
   sealed trait ResultStreaming
-  final case class CannotStream(reason: String, alternativeResult: Result) extends ResultStreaming
-  final case class StreamWithClose(enum: Enumerator[Array[Byte]]) extends ResultStreaming
-  final case class StreamWithKnownLength(enum: Enumerator[Array[Byte]]) extends ResultStreaming
-  final case class StreamWithStrictBody(body: Array[Byte]) extends ResultStreaming
+  /**
+   * Used for responses that may not contain a body, e.g. 204 or 304 responses.
+   * The server shouldn't send a body and, since the response cannot have a
+   * body, the Content-Length header shouldn't be sent either.
+   */
   final case object StreamWithNoBody extends ResultStreaming
+  /**
+   * Used for responses that have unknown length and should be delimited by
+   * the connection closing. This is used for all HTTP 1.0 responses with
+   * unknown length, since HTTP 1.0 doesn't support chunked encoding. It can
+   * also be used for some HTTP 1.1 responses, if chunked encoding isn't
+   * desired for some reason, e.g. see the `Results.feed` method.
+   */
+  final case class StreamWithClose(enum: Enumerator[Array[Byte]]) extends ResultStreaming
+  /**
+   * A stream with a known length where the Content-Length header can be
+   * set.
+   */
+  final case class StreamWithKnownLength(enum: Enumerator[Array[Byte]]) extends ResultStreaming
+  /**
+   * A stream with bytes that are already entirely known. The Content-Length
+   * can be sent and an efficient streaming strategy can be used by the server.
+   */
+  final case class StreamWithStrictBody(body: Array[Byte]) extends ResultStreaming
+  /**
+   * A stream where the response has already been encoded by the user, e.g. using
+   * `Results.chunked`. The server may be able to feed this encoded data directly -
+   * or it may need to reverse the encoding before resending it. :(
+   */
   final case class UseExistingTransferEncoding(transferEncodedEnum: Enumerator[Array[Byte]]) extends ResultStreaming
+  /**
+   * A stream where the response should be chunk encoded. This is usually used for
+   * an HTTP 1.1 connection where the response has unknown size.
+   */
   final case class PerformChunkedTransferEncoding(enum: Enumerator[Array[Byte]]) extends ResultStreaming
+
+  /**
+   * The connection header logic to use for the result.
+   */
+  sealed trait ConnectionHeader {
+    def willClose: Boolean
+    def header: Option[String]
+  }
+  /**
+   * A `Connection: keep-alive` header should be sent. Used to
+   * force an HTTP 1.0 connection to remain open.
+   */
+  final case object SendKeepAlive extends ConnectionHeader {
+    override def willClose = false
+    override def header = Some(KEEP_ALIVE)
+  }
+  /**
+   * A `Connection: close` header should be sent. Used to
+   * force an HTTP 1.1 connection to close.
+   */
+  final case object SendClose extends ConnectionHeader {
+    override def willClose = true
+    override def header = Some(CLOSE)
+  }
+  /**
+   * No `Connection` header should be sent. Used on an HTTP 1.0
+   * connection where the default behavior is to close the connection.
+   */
+  final case object DefaultClose extends ConnectionHeader {
+    override def willClose = true
+    override def header = None
+  }
+  /**
+   * No `Connection` header should be sent. Used on an HTTP 1.1
+   * connection where the default behavior is to keep the connection
+   * open.
+   */
+  final case object DefaultKeepAlive extends ConnectionHeader {
+    override def willClose = false
+    override def header = None
+  }
+
+  // Values for the Connection header
+  private val KEEP_ALIVE = "keep-alive"
+  private val CLOSE = "close"
 
   /**
    * Analyze the Result and determine how best to send it. This may involve looking at
    * headers, buffering the enumerator, etc. The returned value will indicate how to
    * stream the result and will provide an Enumerator or Array with the result body
-   * that should be streamed. CannotStream will be returned if the Result cannot be
+   * that should be streamed.
+   *
+   * CannotStream will be returned if the Result cannot be
    * streamed to the given client. This can happen if a result requires Transfer-Encoding
    * but the client uses HTTP 1.0. It can also happen if there is an error in the
    * Result headers.
+   *
+   * The ConnectionHeader returned for a successful result will indicate how the
+   * header should be set in the response header.
    */
-  def determineResultStreaming(result: Result, isHttp10: Boolean): Future[ResultStreaming] = {
-    def mustNotIncludeBody(result: Result): Boolean = result.header.status == 204 || result.header.status == 304
+  def determineResultStreaming(
+    requestHeader: RequestHeader,
+    result: Result): Future[Either[InvalidResult, (ResultStreaming, ConnectionHeader)]] = {
+
+    // The protocol version will affect how we stream the result and
+    // the value of the Connection header that we set
+    val isHttp10 = requestHeader.version == HttpProtocol.HTTP_1_0
+
+    // Work out whether we should close the connection after our response
+    val needsClose: Boolean = {
+      // Has the user has requested that the connection be closed?
+      val forceClose: Boolean = result.connection == HttpConnection.Close
+      // Did the request we receive indicate whether the connection should be closed?
+      def defaultClose: Boolean = {
+        val requestConnectionHeader: Option[String] = requestHeader.headers.get(CONNECTION)
+        def requestConnectionHeaderMatches(value: String): Boolean = requestConnectionHeader.exists(_.equalsIgnoreCase(value))
+        (isHttp10 && !requestConnectionHeaderMatches(KEEP_ALIVE)) || (!isHttp10 && requestConnectionHeaderMatches(CLOSE))
+      }
+      forceClose || defaultClose
+    }
+
+    // Get a Connection header to use that will close the connection or keep it alive,
+    // depending on what we need to do.
+    val connection: ConnectionHeader = {
+      if (needsClose) {
+        if (isHttp10) DefaultClose else SendClose
+      } else {
+        if (isHttp10) SendKeepAlive else DefaultKeepAlive
+      }
+    }
+
+    // Helpers for creating return values for this method
+    def invalid(reason: String, alternativeResult: Result): Future[Left[InvalidResult, Nothing]] = {
+      Future.successful(Left(InvalidResult(reason, alternativeResult)))
+    }
+    def valid(streaming: ResultStreaming, connection: ConnectionHeader): Future[Right[Nothing, (ResultStreaming, ConnectionHeader)]] = {
+      Future.successful(Right((streaming, connection)))
+    }
+
     result match {
+
+      // Check if the header has invalid values
       case _ if result.header.headers.exists(_._2 == null) =>
-        Future.successful(CannotStream(
+        invalid(
           "A header was set to null",
           Results.InternalServerError("")
-        ))
-      case _ if mustNotIncludeBody(result) =>
-        Future.successful(StreamWithNoBody)
-      case _ if (result.connection == HttpConnection.Close) =>
-        Future.successful(StreamWithClose(result.body))
+        )
+
+      // The HTTP spec requires that some responses don't have a body
+      case _ if result.header.status == 204 || result.header.status == 304 =>
+        valid(StreamWithNoBody, connection)
+
+      // Check if the user has already transfer encoded the response
       case _ if (result.header.headers.contains(TRANSFER_ENCODING)) =>
         if (isHttp10) {
-          Future.successful(CannotStream(
+          invalid(
             "Chunked response to HTTP/1.0 request",
             Results.HttpVersionNotSupported("The response to this request is chunked and hence requires HTTP 1.1 to be sent, but this is a HTTP 1.0 request.")
-          ))
+          )
         } else {
-          Future.successful(UseExistingTransferEncoding(result.body))
+          valid(UseExistingTransferEncoding(result.body), connection)
         }
+
+      // Check if the result has a known length
       case _ if (result.header.headers.contains(CONTENT_LENGTH)) =>
-        Future.successful(StreamWithKnownLength(result.body))
+        valid(StreamWithKnownLength(result.body), connection)
+
+      // Check if the connection is required to close (if so we don't need to
+      // worry about chunking the response)
+      case _ if connection.willClose =>
+        valid(StreamWithClose(result.body), connection)
+
+      // Read ahead one element and see if we can send the body
+      // in one element, or if we need to chunk it, or if we need
+      // to stream it and then close the connection
       case _ =>
         import play.api.libs.iteratee.Execution.Implicits.trampoline
         val bodyReadAhead = readAheadOne(result.body >>> Enumerator.eof)
         bodyReadAhead.map {
           case Left(bodyOption) =>
             val body = bodyOption.getOrElse(emptyBytes)
-            StreamWithStrictBody(body)
+            Right((StreamWithStrictBody(body), connection))
           case Right(bodyEnum) =>
+            // Use chunked encoding for HTTP 1.1. For HTTP 1.0
+            // delimit the end of the result by closing the
+            // connection.
             if (isHttp10) {
-              StreamWithClose(bodyEnum) // HTTP 1.0 doesn't support chunked encoding
+              Right((StreamWithClose(bodyEnum), DefaultClose))
             } else {
-              PerformChunkedTransferEncoding(bodyEnum)
+              Right((PerformChunkedTransferEncoding(bodyEnum), connection))
             }
         }
     }


### PR DESCRIPTION
This required a reasonably big refactor of the result streaming code. The streaming logic in ServerResultUtils now gets passed a RequestHeader so it can check the HTTP version and the request Connection header.

This commit fixes the main remaining Akka HTTP integration test.