### PR TITLE
Remove mainLang which wasn't accurately named or typesafe

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala
@@ -22,12 +22,6 @@ import sbt.compiler.AggressiveCompile
 
 trait PlayCommands extends PlayEclipse with PlayInternalKeys {
 
-  //- mainly scala, mainly java or none
-
-  val JAVA = "java"
-  val SCALA = "scala"
-  val NONE = "none"
-
   val playReloadTask = Def.task(playCompileEverything.value.reduceLeft(_ ++ _))
 
   def intellijCommandSettings = {

--- a/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala
@@ -9,6 +9,8 @@ import Keys._
 import play.sbtplugin.routes.RoutesKeys
 import play.twirl.sbt.Import.TwirlKeys
 
+import com.typesafe.sbteclipse.core.EclipsePlugin._
+
 trait PlayEclipse {
   this: PlayCommands =>
 
@@ -25,11 +27,10 @@ trait PlayEclipse {
 
   /**
    * provides Settings for the eclipse project
-   * @param mainLang mainly scala or java?
+   * @param scalaIDE whether the Scala IDE is being used
    */
-  def eclipseCommandSettings(mainLang: String): Seq[Setting[_]] = {
+  def eclipseCommandSettings(scalaIDE: EclipseProjectFlavor.Value): Seq[Setting[_]] = {
     import com.typesafe.sbteclipse.core._
-    import com.typesafe.sbteclipse.core.EclipsePlugin._
     import com.typesafe.sbteclipse.core.Validation
     import scala.xml._
     import scala.xml.transform.RewriteRule
@@ -53,38 +54,21 @@ trait PlayEclipse {
       }
     }
 
-    lazy val addScalaLib = new EclipseTransformerFactory[RewriteRule] {
-      override def createTransformer(ref: ProjectRef, state: State): Validation[RewriteRule] = {
-        evaluateTask(dependencyClasspath in Compile, ref, state) map { classpath =>
-          val scalaLib =
-            classpath.find(_.get(moduleID.key).exists(moduleFilter(organization = "org.scala-lang", name = "scala-library"))).map(_.data.getAbsolutePath)
-              .getOrElse(throw new RuntimeException("could not find scala-library.jar"))
-          new RewriteRule {
-            override def transform(node: Node): Seq[Node] = node match {
-              case elem if (elem.label == "classpath") =>
-                val newChild = elem.child ++ <classpathentry path={ scalaLib } kind="lib"></classpathentry>
-                Elem(elem.prefix, "classpath", elem.attributes, elem.scope, false, newChild: _*)
-              case other =>
-                other
-            }
-          }
-        }
-      }
-    }
-
-    mainLang match {
-      case SCALA =>
+    scalaIDE match {
+      case EclipseProjectFlavor.Scala =>
         EclipsePlugin.eclipseSettings ++ Seq(
           EclipseKeys.projectFlavor := EclipseProjectFlavor.Scala,
+          EclipseKeys.withBundledScalaContainers := true,
           EclipseKeys.preTasks := Seq(compile in Compile),
           EclipseKeys.createSrc := EclipseCreateSrc.All
         )
-      case JAVA =>
+      case EclipseProjectFlavor.Java =>
         generateJavaPrefFile()
         EclipsePlugin.eclipseSettings ++ Seq(
           EclipseKeys.projectFlavor := EclipseProjectFlavor.Java,
+          EclipseKeys.withBundledScalaContainers := false,
           EclipseKeys.preTasks := Seq(compile in Compile),
-          EclipseKeys.classpathTransformerFactories := Seq(addClassesManaged, addScalaLib)
+          EclipseKeys.classpathTransformerFactories := Seq(addClassesManaged)
         )
     }
   }

--- a/framework/src/sbt-plugin/src/main/scala/play/Project.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/Project.scala
@@ -6,10 +6,11 @@ package play
 import sbt._
 import sbt.Keys._
 
+import com.typesafe.play.sbt.enhancer.PlayEnhancer
 import com.typesafe.sbt.packager.archetypes.JavaServerAppPackaging
 import com.typesafe.sbt.jse.SbtJsTask
 import com.typesafe.sbt.webdriver.SbtWebDriver
-import com.typesafe.play.sbt.enhancer.PlayEnhancer
+import com.typesafe.sbteclipse.core.EclipsePlugin.EclipseProjectFlavor
 import play.twirl.sbt.SbtTwirl
 import play.sbtplugin.PlayPositionMapper
 import play.sbtplugin.routes.RoutesCompiler
@@ -51,7 +52,7 @@ object PlayJava extends AutoPlugin {
   import Play._
   import Play.autoImport._
   override def projectSettings =
-    eclipseCommandSettings(JAVA) ++
+    eclipseCommandSettings(EclipseProjectFlavor.Java) ++
       defaultJavaSettings ++
       Seq(libraryDependencies += javaCore)
 }
@@ -68,7 +69,7 @@ object PlayScala extends AutoPlugin {
 
   import Play._
   override def projectSettings =
-    eclipseCommandSettings(SCALA) ++
+    eclipseCommandSettings(EclipseProjectFlavor.Scala) ++
       defaultScalaSettings
 }
 


### PR DESCRIPTION
 Fix ugly workaround for sbteclipse not setting EclipseKeys.withBundledScalaContainers correctly by default