### PR TITLE
Backport 4074: Better way of adding managed sources to Eclipse classpath

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala
+++ b/framework/src/sbt-plugin/src/main/scala/PlayEclipse.scala
@@ -70,29 +70,12 @@ trait PlayEclipse {
       }
     }
 
-    lazy val addSourcesManaged = new EclipseTransformerFactory[RewriteRule] {
-      override def createTransformer(ref: ProjectRef, state: State): Validation[RewriteRule] = {
-        setting(crossTarget in ref, state) map { ct =>
-          new RewriteRule {
-            override def transform(node: Node): Seq[Node] = node match {
-              case elem if (elem.label == "classpath" && (ct / "src_managed" / "main").exists) =>
-                val newChild = elem.child ++
-                  <classpathentry path={ "target" + `/` + ct.getName + `/` + "src_managed" + `/` + "main" } kind="src"></classpathentry>
-                Elem(elem.prefix, "classpath", elem.attributes, elem.scope, false, newChild: _*)
-              case other =>
-                other
-            }
-          }
-        }
-      }
-    }
-
     mainLang match {
       case SCALA =>
         EclipsePlugin.eclipseSettings ++ Seq(
           EclipseKeys.projectFlavor := EclipseProjectFlavor.Scala,
           EclipseKeys.preTasks := Seq(compile in Compile),
-          EclipseKeys.classpathTransformerFactories := Seq(addSourcesManaged)
+          EclipseKeys.createSrc := EclipseCreateSrc.All
         )
       case JAVA =>
         generateJavaPrefFile()


### PR DESCRIPTION
Although I'm happy #3874 raised some concerns about the state of eclipse support in play, the issue has been marked as resolved because of the merge of #4074.
But, the fix has been applied to play master branch and not to the 2.3.x branch, as the target of #3874 was.

So, here is a backport of #4074 to the 2.3.x branch.

If this solution is too disruptive for a stable release, please reconsider merging #3874.

