### PR TITLE
Create a more useful Bootstrap example

### DIFF
--- a/documentation/manual/detailedTopics/assets/AssetsLess.md
+++ b/documentation/manual/detailedTopics/assets/AssetsLess.md
@@ -71,7 +71,7 @@ sbt-web will automatically extract WebJars into a lib folder relative to your as
 @import "lib/bootstrap/less/bootstrap.less";
 
 h1 {
-  color: @font-size-h1;
+  color: @gray-darker;
 }
 ```
 


### PR DESCRIPTION
Setting the CSS color property with a font-size variable didn't make sense.