### PR TITLE
Refactored the way Play access config

### DIFF
--- a/documentation/manual/detailedTopics/build/SBTSubProjects.md
+++ b/documentation/manual/detailedTopics/build/SBTSubProjects.md
@@ -153,7 +153,7 @@ project
   └ plugins.sbt
 ```
 
-> **Note:** Configuration and route file names must be unique in the whole project structure. Particularly, there must be only one `application.conf` file and only one `routes` file. To define additional routes or configuration in sub-projects, use sub-project-specific names. For instance, the route file in `admin` is called `admin.routes`. To use a specific set of settings in development mode for a sub project, it would be even better to put these settings into the build file, e.g. `Keys.devSettings += ("application.router", "admin.Routes")`.
+> **Note:** Configuration and route file names must be unique in the whole project structure. Particularly, there must be only one `application.conf` file and only one `routes` file. To define additional routes or configuration in sub-projects, use sub-project-specific names. For instance, the route file in `admin` is called `admin.routes`. To use a specific set of settings in development mode for a sub project, it would be even better to put these settings into the build file, e.g. `Keys.devSettings += ("play.http.router", "admin.Routes")`.
 
 `conf/routes`:
 

--- a/documentation/manual/detailedTopics/configuration/ApplicationSecret.md
+++ b/documentation/manual/detailedTopics/configuration/ApplicationSecret.md
@@ -5,7 +5,7 @@ Play uses a secret key for a number of things, including:
 * Signing session cookies and CSRF tokens
 * Built in encryption utilities
 
-It is configured in `application.conf`, with the property name `application.secret`, and defaults to `changeme`.  As the default suggests, it should be changed for production.
+It is configured in `application.conf`, with the property name `play.crypto.secret`, and defaults to `changeme`.  As the default suggests, it should be changed for production.
 
 > When started in prod mode, if Play finds that the secret is not set, or if it is set to `changeme`, Play will throw an error.
 
@@ -16,7 +16,7 @@ Anyone that can get access to the secret will be able to generate any session th
 One way of configuring the application secret on a production server is to pass it as a system property to your start script.  For example:
 
 ```bash
-/path/to/yourapp/bin/yourapp -Dapplication.secret="QCY?tAnfk?aZ?iwrNwnxIlR6CTf:G3gf:90Latabg@5241AB`R5W:1uDFN];Ik@n"
+/path/to/yourapp/bin/yourapp -Dplay.crypto.secret="QCY?tAnfk?aZ?iwrNwnxIlR6CTf:G3gf:90Latabg@5241AB`R5W:1uDFN];Ik@n"
 ```
 
 This approach is very simple, and we will use this approach in the Play documentation on running your app in production mode as a reminder that the application secret needs to be set.  In some environments however, placing secrets in command line arguments is not considered good practice.  There are two ways to address this.
@@ -25,8 +25,8 @@ This approach is very simple, and we will use this approach in the Play document
 
 The first is to place the application secret in an environment variable.  In this case, we recommend you place the following configuration in your `application.conf` file:
 
-    application.secret="changeme"
-    application.secret=${?APPLICATION_SECRET}
+    play.crypto.secret="changeme"
+    play.crypto.secret=${?APPLICATION_SECRET}
 
 The second line in that configuration sets the secret to come from an environment variable called `APPLICATION_SECRET` if such an environment variable is set, otherwise, it leaves the secret unchanged from the previous line.
 
@@ -40,7 +40,7 @@ For example:
 
     include "application"
 
-    application.secret="QCY?tAnfk?aZ?iwrNwnxIlR6CTf:G3gf:90Latabg@5241AB`R5W:1uDFN];Ik@n"
+    play.crypto.secret="QCY?tAnfk?aZ?iwrNwnxIlR6CTf:G3gf:90Latabg@5241AB`R5W:1uDFN];Ik@n"
 
 Then you can start Play with:
 
@@ -68,6 +68,6 @@ To update the secret in `application.conf`, run `play-update-secret` in the Play
 [my-first-app] $ play-update-secret
 [info] Generated new secret: B4FvQWnTp718vr6AHyvdGlrHBGNcvuM4y3jUeRCgXxIwBZIbt
 [info] Updating application secret in /Users/jroper/tmp/my-first-app/conf/application.conf
-[info] Replacing old application secret: application.secret="changeme"
+[info] Replacing old application secret: play.crypto.secret="changeme"
 [success] Total time: 0 s, completed 28/03/2014 2:36:54 PM
 ```

--- a/documentation/manual/detailedTopics/production/Production.md
+++ b/documentation/manual/detailedTopics/production/Production.md
@@ -14,7 +14,7 @@ Before you run your application in production mode, you need to generate an appl
 The easiest way to start an application in production mode is to use the `start` command from the Play console. This requires a Play installation on the server.
 
 ```bash
-[my-first-app] $ start -Dapplication.secret=abcdefghijk
+[my-first-app] $ start -Dplay.crypto.secret=abcdefghijk
 ```
 
 
@@ -31,7 +31,7 @@ If you type `Ctrl+C`, you will kill both JVMs: the Play console and the forked P
 You can also use `activator start` at your OS command prompt to start the server without first starting the Play console:
 
 ```bash
-$ activator start -Dapplication.secret="abcdefghijk"
+$ activator start -Dplay.crypto.secret="abcdefghijk"
 ```
 
 ## Using the stage task
@@ -50,7 +50,7 @@ This cleans and compiles your application, retrieves the required dependencies a
 For example to start an application of the project `my-first-app` from the project folder you can:
 
 ```bash
-$ target/universal/stage/bin/my-first-app -Dapplication.secret=abcdefghijk
+$ target/universal/stage/bin/my-first-app -Dplay.crypto.secret=abcdefghijk
 ```
 
 You can also specify a different configuration file for a production environment, from the command line:

--- a/documentation/manual/detailedTopics/production/ProductionConfiguration.md
+++ b/documentation/manual/detailedTopics/production/ProductionConfiguration.md
@@ -55,7 +55,7 @@ $ /path/to/bin/<project-name> -Dconfig.url=http://conf.mycompany.com/conf/prod.c
 Sometimes you don't want to specify another complete configuration file, but just override a bunch of specific keys. You can do that by specifying then as Java System properties:
 
 ```
-$ /path/to/bin/<project-name> -Dapplication.secret=abcdefghijk -Ddb.default.password=toto
+$ /path/to/bin/<project-name> -Dplay.crypto.secret=abcdefghijk -Ddb.default.password=toto
 ```
 
 ### Using environment variables

--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -86,6 +86,23 @@ While Play 2.4 won't force you to use the dependency injected versions of compon
 | [`WS`](api/java/play/libs/ws/WS.html) | [`WSClient`](api/java/play/libs/ws/WSClient.html) | |
 | [`FakeRequest`](api/java/play/test/FakeRequest.html) | [`RequestBuilder`](api/java/play/mvc/Http.RequestBuilder.html) | |
 
+## Configuration changes
+
+Play 2.4 now uses `reference.conf` to document and specify defaults for all properties.  You can easily find these by going [here](https://github.com/playframework/playframework/find/master) and searching for files called `reference.conf`.
+
+Additionally, Play has now better namespaced a large number of its configuration properties.  The old configuration paths will generally still work, but a deprecation warning will be output at runtime if you use them.  Here is a summary of the changed keys:
+
+| Old key                   | New key                            |
+| ------------------------- | ---------------------------------- |
+| `application.secret`      | `play.crypto.secret`               |
+| `application.context`     | `play.http.context`                |
+| `session.*`               | `play.http.session.*`              |
+| `flash.*`                 | `play.http.flash.*`                |
+| `application.router`      | `play.http.router`                 |
+| `application.langs`       | `play.i18n.langs`                  |
+| `application.lang.cookie` | `play.i18n.langCookieName`         |
+| `parsers.text.maxLength`  | `play.http.parser.maxMemoryBuffer` |
+
 ## Reverse ref routing
 
 The reverse ref router used in Java tests has been removed. Any call to `Helpers.call` that was passed a ref router can be replaced by a call to `Helpers.route` which takes either a standard reverse router reference or a `RequestBuilder`.
@@ -120,9 +137,9 @@ def foo = Action(play.api.mvc.BodyParsers.parse.anyContent) { request =>
 
 For both Scala and Java, there have been some small but important changes to the way the configured maximum body lengths are handled and applied.
 
-A new property, `parsers.disk.maxLength`, specifies the maximum length of any body that is parsed by a parser that may buffer to disk.  This includes the raw body parser and the `multipart/form-data` parser.  By default this is 10MB.
+A new property, `play.http.parser.maxDiskBuffer`, specifies the maximum length of any body that is parsed by a parser that may buffer to disk.  This includes the raw body parser and the `multipart/form-data` parser.  By default this is 10MB.
 
-In the case of the `multipart/form-data` parser, the aggregate length of all of the text data parts is limited by the configured `parsers.text.maxLength` value, which defaults to 100KB.
+In the case of the `multipart/form-data` parser, the aggregate length of all of the text data parts is limited by the configured `play.http.parser.maxMemoryBuffer` value, which defaults to 100KB.
 
 In all cases, when one of the max length parsing properties is exceeded, a 413 response is returned.  This includes Java actions who have explicitly overridden the `maxLength` property on the `BodyParser.Of` annotation - previously it was up to the Java action to check the `RequestBody.isMaxSizeExceeded` flag if a custom max length was configured, this flag has now been deprecated.
 

--- a/documentation/manual/working/javaGuide/advanced/embedding/JavaEmbeddingPlay.md
+++ b/documentation/manual/working/javaGuide/advanced/embedding/JavaEmbeddingPlay.md
@@ -23,4 +23,4 @@ To stop the server once you've started it, simply call the `stop` method:
 
 @[stop](code/javaguide/advanced/embedding/JavaEmbeddingPlay.java)
 
-> **Note:** Play requires an application secret to be configured in order to start.  This can be configured by providing an `application.conf` file in your application, or using the `application.secret` system property.
+> **Note:** Play requires an application secret to be configured in order to start.  This can be configured by providing an `application.conf` file in your application, or using the `play.crypto.secret` system property.

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaCsrf.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaCsrf.java
@@ -28,10 +28,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class JavaCsrf extends WithApplication {
-    @Override
-    public Application provideApplication() {
-        return fakeApplication(ImmutableMap.of("application.secret", "foobar"));
-    }
 
     public Crypto crypto() {
       return app.injector().instanceOf(Crypto.class);

--- a/documentation/manual/working/javaGuide/main/http/JavaBodyParsers.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaBodyParsers.md
@@ -46,11 +46,11 @@ For example:
 
 ## Max content length
 
-Text based body parsers (such as **text**, **json**, **xml** or **formUrlEncoded**) use a max content length because they have to load all the content into memory.  By default, the maximum content length that they will parse is 100KB.  It can be overridden by specifying the `parsers.text.maxLength` property in `application.conf`:
+Text based body parsers (such as **text**, **json**, **xml** or **formUrlEncoded**) use a max content length because they have to load all the content into memory.  By default, the maximum content length that they will parse is 100KB.  It can be overridden by specifying the `play.http.parser.maxMemoryBuffer` property in `application.conf`:
 
-    parsers.text.maxLength=128K
+    play.http.parser.maxMemoryBuffer=128K
 
-For parsers that buffer content on disk, such as the raw parser or `multipart/form-data`, the maximum content length is specified using the `parsers.disk.maxLength` property, it defaults to 10MB.  The `multipart/form-data` parser also enforces the text max length property for the aggregate of the data fields.
+For parsers that buffer content on disk, such as the raw parser or `multipart/form-data`, the maximum content length is specified using the `play.http.parser.maxDiskBuffer` property, it defaults to 10MB.  The `multipart/form-data` parser also enforces the text max length property for the aggregate of the data fields.
 
 You can also override the default maximum content length for a given action via the `@BodyParser.Of` annotation:
 

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaRouting.scala
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaRouting.scala
@@ -59,7 +59,7 @@ object JavaRouting extends Specification {
   }
 
   def contentOf(rh: RequestHeader, router: Class[_ <: Router] = classOf[Routes]) = {
-    val app = FakeApplication(additionalConfiguration = Map("application.router" -> router.getName))
+    val app = FakeApplication(additionalConfiguration = Map("play.http.router" -> router.getName))
     running(app) {
       contentAsString(app.requestHandler.handlerForRequest(rh)._2 match {
         case e: EssentialAction => e(rh).run

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
@@ -22,11 +22,6 @@ import static play.test.Helpers.*;
 
 public class JavaSessionFlash extends WithApplication {
 
-    @Override
-    public Application provideApplication() {
-        return fakeApplication(ImmutableMap.of("application.secret", "pass"));
-    }
-
     @Test
     public void readSession() {
         assertThat(contentAsString(call(new MockJavaAction() {

--- a/documentation/manual/working/javaGuide/main/i18n/JavaI18N.md
+++ b/documentation/manual/working/javaGuide/main/i18n/JavaI18N.md
@@ -8,7 +8,7 @@ To specify your application’s languages, you need a valid language code, speci
 To start, you need to specify the languages that your application supports in its `conf/application.conf` file:
 
 ```
-application.langs="en,en-US,fr"
+play.i18n.langs = [ "en", "en-US", "fr" ]
 ```
 
 ## Externalizing messages

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ApplicationTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ApplicationTest.java
@@ -25,7 +25,7 @@ public class ApplicationTest extends WithApplication {
   @Override
   protected FakeApplication provideFakeApplication() {
     return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(),
-        ImmutableMap.of("application.router", "javaguide.tests.Routes"), new ArrayList<String>(), null);
+        ImmutableMap.of("play.http.router", "javaguide.tests.Routes"), new ArrayList<String>(), null);
   }
 
   @Test

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/FunctionalTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/FunctionalTest.java
@@ -29,13 +29,13 @@ public class FunctionalTest extends WithApplication {
 
     private TestServer testServer() {
         Map<String, String> config = new HashMap<String, String>();
-        config.put("application.router", "javaguide.tests.Routes");
+        config.put("play.http.router", "javaguide.tests.Routes");
         return Helpers.testServer(fakeApplication(config));
     }
 
     private TestServer testServer(int port) {
         Map<String, String> config = new HashMap<String, String>();
-        config.put("application.router", "javaguide.tests.Routes");
+        config.put("play.http.router", "javaguide.tests.Routes");
         return Helpers.testServer(port, fakeApplication(config));
     }
 

--- a/documentation/manual/working/javaGuide/main/tests/code/tests/guice/JavaGuiceApplicationBuilderTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/tests/guice/JavaGuiceApplicationBuilderTest.java
@@ -51,7 +51,7 @@ public class JavaGuiceApplicationBuilderTest {
         // #set-environment
         Application application = new GuiceApplicationBuilder()
             .load(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule()) // ###skip
-            .loadConfig(Configuration.empty()) // ###skip
+            .loadConfig(Configuration.reference()) // ###skip
             .in(new Environment(new File("path/to/app"), classLoader, Mode.TEST))
             .build();
         // #set-environment
@@ -67,7 +67,7 @@ public class JavaGuiceApplicationBuilderTest {
         // #set-environment-values
         Application application = new GuiceApplicationBuilder()
             .load(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule()) // ###skip
-            .loadConfig(Configuration.empty()) // ###skip
+            .loadConfig(Configuration.reference()) // ###skip
             .in(new File("path/to/app"))
             .in(Mode.TEST)
             .in(classLoader)
@@ -123,7 +123,7 @@ public class JavaGuiceApplicationBuilderTest {
     public void overrideBindings() {
         // #override-bindings
         Application application = new GuiceApplicationBuilder()
-            .configure("application.router", Routes.class.getName()) // ###skip
+            .configure("play.http.router", Routes.class.getName()) // ###skip
             .bindings(new ComponentModule()) // ###skip
             .overrides(bind(Component.class).to(MockComponent.class))
             .build();

--- a/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlay.md
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlay.md
@@ -21,4 +21,4 @@ To stop the server once you've started it, simply call the `stop` method:
 
 @[stop](code/ScalaEmbeddingPlay.scala)
 
-> **Note:** Play requires an application secret to be configured in order to start.  This can be configured by providing an `application.conf` file in your application, or using the `application.secret` system property.
+> **Note:** Play requires an application secret to be configured in order to start.  This can be configured by providing an `application.conf` file in your application, or using the `play.crypto.secret` system property.

--- a/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
+++ b/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
@@ -133,7 +133,7 @@ class ScalaCacheSpec extends PlaySpecification with Controller {
   }
 
   def assertAction[A, T: AsResult](action: EssentialAction, request: => Request[A] = FakeRequest(), expectedResponse: Int = OK)(assertions: Future[Result] => T) = {
-    running(FakeApplication(additionalConfiguration = Map("application.secret" -> "pass"))) {
+    running(FakeApplication()) {
       val result = action(request).run
       status(result) must_== expectedResponse
       assertions(result)

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaCsrf.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaCsrf.scala
@@ -140,9 +140,7 @@ object ScalaCsrf extends PlaySpecification {
     }
   }
 
-  def withApplication[T](block: => T) = running(FakeApplication(
-    additionalConfiguration = Map("application.secret" -> "foobar")
-  )) {
+  def withApplication[T](block: => T) = running(FakeApplication()) {
     block
   }
 

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaFieldConstructor.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaFieldConstructor.scala
@@ -9,7 +9,7 @@ import play.api.i18n.{DefaultLangs, DefaultMessagesApi, Messages}
 
 object ScalaFieldConstructorSpec extends Specification {
 
-  val conf = Configuration.empty
+  val conf = Configuration.reference
   implicit val messages: Messages = new DefaultMessagesApi(Environment.simple(), conf, new DefaultLangs(conf)).preferred(Seq.empty)
 
   "field constructors" should {

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -27,7 +27,7 @@ import play.api.data.validation.Constraints._
 @RunWith(classOf[JUnitRunner])
 class ScalaFormsSpec extends Specification with Controller {
 
-  val conf = Configuration.empty
+  val conf = Configuration.reference
   implicit val messages: Messages = new DefaultMessagesApi(Environment.simple(), conf, new DefaultLangs(conf)).preferred(Seq.empty)
 
   "A scala forms" should {

--- a/documentation/manual/working/scalaGuide/main/http/ScalaBodyParsers.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaBodyParsers.md
@@ -88,11 +88,11 @@ In the previous example, all request bodies are stored in the same file. This is
 
 ## Max content length
 
-Text based body parsers (such as **text**, **json**, **xml** or **formUrlEncoded**) use a max content length because they have to load all the content into memory.  By default, the maximum content length that they will parse is 100KB.  It can be overridden by specifying the `parsers.text.maxLength` property in `application.conf`:
+Text based body parsers (such as **text**, **json**, **xml** or **formUrlEncoded**) use a max content length because they have to load all the content into memory.  By default, the maximum content length that they will parse is 100KB.  It can be overridden by specifying the `play.http.parser.maxMemoryBuffer` property in `application.conf`:
 
-    parsers.text.maxLength=128K
+    play.http.parser.maxMemoryBuffer=128K
 
-For parsers that buffer content on disk, such as the raw parser or `multipart/form-data`, the maximum content length is specified using the `parsers.disk.maxLength` property, it defaults to 10MB.  The `multipart/form-data` parser also enforces the text max length property for the aggregate of the data fields.
+For parsers that buffer content on disk, such as the raw parser or `multipart/form-data`, the maximum content length is specified using the `play.http.parser.maxDiskBuffer` property, it defaults to 10MB.  The `multipart/form-data` parser also enforces the text max length property for the aggregate of the data fields.
 
 You can also override the default maximum length for a given action:
 

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -248,7 +248,7 @@ package scalaguide.http.scalaactionscomposition {
     }
 
     def assertAction[A, T: AsResult](action: EssentialAction, request: => Request[A] = FakeRequest(), expectedResponse: Int = OK)(assertions: Future[Result] => T) = {
-      running(FakeApplication(additionalConfiguration = Map("application.secret" -> "pass"))) {
+      running(FakeApplication()) {
         val result = action(request).run
         status(result) must_== expectedResponse
         assertions(result)

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParser.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParser.scala
@@ -100,7 +100,7 @@ import play.api.mvc._
     }
 
     def assertAction[A: Writeable, T: AsResult](action: EssentialAction, request: => FakeRequest[A], expectedResponse: Int = OK)(assertions: Future[Result] => T) = {
-      running(FakeApplication(additionalConfiguration = Map("application.secret" -> "pass"))) {
+      running(FakeApplication()) {
         val result = call(action, request)
         status(result) must_== expectedResponse
         assertions(result)

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
@@ -113,7 +113,7 @@ package scalaguide.http.scalasessionflash {
     }
 
     def assertAction[A, T: AsResult](action: Action[A], expectedResponse: Int = OK, request: => Request[A] = FakeRequest())(assertions: Future[Result] => T) = {
-      val fakeApp = FakeApplication(additionalConfiguration = Map("application.secret" -> "pass"))
+      val fakeApp = FakeApplication()
       running(fakeApp) {
         val result = action(request)
         status(result) must_== expectedResponse

--- a/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
+++ b/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
@@ -8,7 +8,7 @@ A valid language code is specified by a valid **ISO 639-2 language code**, optio
 To start you need to specify the languages supported by your application in the `conf/application.conf` file:
 
 ```
-application.langs="en,en-US,fr"
+play.i18n.langs = [ "en", "en-US", "fr" ]
 ```
 
 ## Externalizing messages

--- a/documentation/manual/working/scalaGuide/main/i18n/code/ScalaI18N.scala
+++ b/documentation/manual/working/scalaGuide/main/i18n/code/ScalaI18N.scala
@@ -34,7 +34,7 @@ class ScalaI18nSpec extends PlaySpecification with Controller {
     }
   }
 
-  val conf = Configuration.from(Map("messages.path" -> "scalaguide/i18n"))
+  val conf = Configuration.reference ++ Configuration.from(Map("play.i18n.path" -> "scalaguide/i18n"))
   val messagesApi = new DefaultMessagesApi(Environment.simple(), conf, new DefaultLangs(conf))
 
   new MyController(messagesApi)

--- a/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala
@@ -30,7 +30,7 @@ class ScalaGuiceApplicationBuilderSpec extends PlaySpecification {
       // #set-environment
       val application = new GuiceApplicationBuilder()
         .load(new play.api.inject.BuiltinModule) // ###skip
-        .loadConfig(Configuration.empty) // ###skip
+        .loadConfig(Configuration.reference) // ###skip
         .in(Environment(new File("path/to/app"), classLoader, Mode.Test))
         .build
       // #set-environment
@@ -45,7 +45,7 @@ class ScalaGuiceApplicationBuilderSpec extends PlaySpecification {
       // #set-environment-values
       val application = new GuiceApplicationBuilder()
         .load(new play.api.inject.BuiltinModule) // ###skip
-        .loadConfig(Configuration.empty) // ###skip
+        .loadConfig(Configuration.reference) // ###skip
         .in(new File("path/to/app"))
         .in(Mode.Test)
         .in(classLoader)
@@ -97,7 +97,7 @@ class ScalaGuiceApplicationBuilderSpec extends PlaySpecification {
     "override bindings" in {
       // #override-bindings
       val application = new GuiceApplicationBuilder()
-        .configure("application.router" -> classOf[Routes].getName) // ###skip
+        .configure("play.http.router" -> classOf[Routes].getName) // ###skip
         .bindings(new ComponentModule) // ###skip
         .overrides(bind[Component].to[MockComponent])
         .build

--- a/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
+++ b/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
@@ -67,7 +67,7 @@ package scalaguide.upload.fileupload {
     }
 
     def testAction[A](action: Action[A], request: => Request[A] = FakeRequest(), expectedResponse: Int = OK) = {
-      running(FakeApplication(additionalConfiguration = Map("application.secret" -> "pass"))) {
+      running(FakeApplication()) {
 
         val result = action(request)
 

--- a/documentation/src/test/resources/application.conf
+++ b/documentation/src/test/resources/application.conf
@@ -1,1 +1,1 @@
-application.secret = "i am very secret"
+play.crypto.secret = "i am very secret"

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -234,7 +234,7 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
   implicit def simpleFormContentType: ContentTypeOf[Map[String, String]] = ContentTypeOf[Map[String, String]](Some(ContentTypes.FORM))
 
   def withServer[T](config: Seq[(String, String)])(router: PartialFunction[(String, String), Handler])(block: => T) = running(TestServer(testServerPort, FakeApplication(
-    additionalConfiguration = Map(config: _*) ++ Map("application.secret" -> "foobar"),
+    additionalConfiguration = Map(config: _*) ++ Map("play.crypto.secret" -> "foobar"),
     withRoutes = router
   )))(block)
 }

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -75,7 +75,7 @@ object CSRFFilterSpec extends CSRFCommonSpecs {
     }
 
     val notBufferedFakeApp = FakeApplication(
-      additionalConfiguration = Map("application.secret" -> "foobar", "csrf.body.bufferSize" -> "200"),
+      additionalConfiguration = Map("play.crypto.secret" -> "foobar", "csrf.body.bufferSize" -> "200"),
       withRoutes = {
         case _ => CSRFFilter()(Action(
           _.body.asFormUrlEncoded

--- a/framework/src/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
@@ -60,5 +60,5 @@ object SecuritySpec extends PlaySpecification {
   case class Connection(name: String)
 
   def withApplication[T](block: => T) =
-    running(FakeApplication(additionalConfiguration = Map("application.secret" -> "foobar")))(block)
+    running(FakeApplication(additionalConfiguration = Map("play.crypto.secret" -> "foobar")))(block)
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
@@ -83,7 +83,7 @@ object ScalaResultsSpec extends PlaySpecification {
   }
 
   def withApplication[T](config: (String, Any)*)(block: => T): T = running(
-    FakeApplication(additionalConfiguration = Map(config: _*) + ("application.secret" -> "foo"))
+    FakeApplication(additionalConfiguration = Map(config: _*) + ("play.crypto.secret" -> "foo"))
   )(block)
 
   def withFooPath[T](block: => T) = withApplication("application.context" -> "/foo")(block)

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -70,7 +70,7 @@ object MultipartFormDataParserSpec extends PlaySpecification {
     }
 
     "validate the full length of the body" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("parsers.disk.maxLength" -> "100")
+      additionalConfiguration = Map("play.http.parser.maxDiskBuffer" -> "100")
     )) {
       val parser = parse.multipartFormData.apply(FakeRequest().withHeaders(
         CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
@@ -84,7 +84,7 @@ object MultipartFormDataParserSpec extends PlaySpecification {
     }
 
     "not parse more than the max data length" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("parsers.text.maxLength" -> "30")
+      additionalConfiguration = Map("play.http.parser.maxMemoryBuffer" -> "30")
     )) {
       val parser = parse.multipartFormData.apply(FakeRequest().withHeaders(
         CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"

--- a/framework/src/play-integration-test/src/test/scala/play/it/i18n/LangSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/i18n/LangSpec.scala
@@ -9,7 +9,7 @@ import play.api.test._
 class LangSpec extends PlaySpecification {
   "lang spec" should {
     "allow selecting preferred language" in {
-      implicit val app = FakeApplication(additionalConfiguration = Map("application.langs" -> "en-US,es-ES,de"))
+      implicit val app = FakeApplication(additionalConfiguration = Map("play.i18n.langs" -> Seq("en-US", "es-ES", "de")))
       val esEs = Lang("es", "ES")
       val es = Lang("es")
       val deDe = Lang("de", "DE")

--- a/framework/src/play-java/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
+++ b/framework/src/play-java/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
@@ -87,16 +87,6 @@ public class GuiceApplicationBuilderTest {
     }
 
     @Test
-    public void setInitialConfiguration() {
-        Application app = new GuiceApplicationBuilder()
-            .loadConfig(Configuration.empty())
-            .bindings(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule())
-            .build();
-
-        assertThat(app.configuration().keys().size(), is(0));
-    }
-
-    @Test
     public void setGlobal() {
         GlobalSettings global = new GlobalSettings() {
             @Override

--- a/framework/src/play-java/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/DynamicFormSpec.scala
@@ -3,6 +3,7 @@
  */
 package play.data
 
+import com.typesafe.config.ConfigFactory
 import org.specs2.mutable.Specification
 import play.api.{ Configuration, Environment }
 import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
@@ -15,7 +16,7 @@ import scala.collection.JavaConversions._
  * Specs for Java dynamic forms
  */
 object DynamicFormSpec extends Specification {
-  val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.empty, new DefaultLangs(Configuration.empty))
+  val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
   implicit val messages = messagesApi.preferred(Seq.empty)
 
   "a dynamic form" should {

--- a/framework/src/play/src/main/java/play/Configuration.java
+++ b/framework/src/play/src/main/java/play/Configuration.java
@@ -47,6 +47,13 @@ public class Configuration {
         return new Configuration(ConfigFactory.empty());
     }
 
+    /**
+     * A new reference configuration.
+     */
+    public static Configuration reference() {
+        return new Configuration(ConfigFactory.defaultReference());
+    }
+
     // --
 
     private final play.api.Configuration conf;

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -15,15 +15,52 @@ play {
     context = "/"
 
     # The error handler.
+    # Used by Play's built in DI support to locate and bind a request handler.  Must be the FQCN of a Play router.
+    # If null, will attempt to load a class called Routes in the root package, otherwise if that's not found, an empty
+    # router will be bound.
+    router = null
+
+    # The error handler.
+    # Used by Play's built in DI support to locate and bind a request handler.  Must be one of the following:
+    # - A FQCN that implements play.api.http.HttpRequestHandler (Scala).
+    # - A FQCN that implements play.http.HttpRequestHandler (Java).
+    # - provided, indicates that the application has bound an instance of play.api.http.HttpRequestHandler through some
+    #   other mechanism.
+    # If null, will attempt to load a class called RequestHandler in the root package, otherwise if that's
+    # not found, will default to play.api.http.GlobalSettingsHttpRequestHandler, which delegates to legacy request
+    # handling methods on Global.
+    requestHandler = null
+
+    # The error handler.
     # Used by Play's built in DI support to locate and bind an error handler.  Must be one of the following:
     # - A FQCN that implements play.api.http.HttpErrorHandler (Scala).
     # - A FQCN that implements play.http.HttpErrorHandler (Java).
     # - provided, indicates that the application has bound an instance of play.api.http.HttpErrorHandler through some
     #   other mechanism.
-    # If undefined or empty, will attempt to load a class called ErrorHandler in the root package, otherwise if that's
+    # If null, will attempt to load a class called ErrorHandler in the root package, otherwise if that's
     # not found, will default to play.api.http.GlobalSettingsHttpErrorHandler, which delegates to legacy error handling
     # methods on Global.
-    errorHandler = ""
+    errorHandler = null
+
+    # The filters.
+    # Used by Play's built in DI support to locate and bind a class to provide filters.  Must be one of the following:
+    # - A FQCN that implements play.api.http.HttpFilters (Scala).
+    # - A FQCN that implements play.http.HttpFilters (Java).
+    # - provided, indicates that the application has bound an instance of play.api.http.HttpFilters through some
+    #   other mechanism.
+    # If null, will attempt to load a class called Filters in the root package, otherwise if that's not found, will
+    # default to play.api.http.NoHttpFilters, which provides no filters.
+    filters = null
+
+    # Parsing configuration
+    parser = {
+
+      # The maximum amount of a request body that should be buffered into memory
+      maxMemoryBuffer = 100k
+
+      # The maximum amount of a request body that should be buffered into disk
+      maxDiskBuffer = 10m
+    }
 
     # Session configuration
     session = {
@@ -35,24 +72,27 @@ play {
       secure = false
 
       # The max age to set on the cookie.
-      # If not defined, session cookies are used (that is, the cookie expires when the user closes their browser).
+      # If null, session cookies are used (that is, the cookie expires when the user closes their browser).
       # An important thing to note, this only sets when the browser will discard the cookie. Play will consider any
       # cookie value with a valid signature to be a valid session forever. To implement a server side session timeout,
       # you need to put a timestamp in the session and check it at regular intervals to possibly expire it.
-      # maxAge = 2 hours
+      maxAge = null
 
       # Whether the HTTP only attribute of the cookie should be set to true
       httpOnly = true
 
       # The domain to set on the session cookie
-      # If undefined or empty, does not set a domain on the session cookie.
-      domain = ""
+      # If null, does not set a domain on the session cookie.
+      domain = null
     }
 
     # Flash configuration
     flash = {
       # The cookie name
       cookieName = "PLAY_FLASH"
+
+      # Whether the flash cookie should be secure or not
+      secure = false
     }
 
   }
@@ -67,24 +107,32 @@ play {
     # A way to disable modules that are automatically enabled
     disabled = []
 
-    # Internationalisation configuration
-    i18n {
+  }
 
-      # A path to prefix message file loading with.  Use this if you want to place your messages resources at some path
-      # other than the root application path.
-      path = ""
+  # Internationalisation configuration
+  i18n {
 
-      # The name of the cookie to store the Play language in.  This cookie is set when Langs.setLang is invoked, and
-      # read when the preferred lang is loaded.
-      langCookieName = "PLAY_LANG"
+    # The languages supported by this application
+    langs = []
 
-    }
-    akka {
-      actor-system = "application"
-    }
+    # A path to prefix message file loading with.  Use this if you want to place your messages resources at some path
+    # other than the root application path.
+    path = null
+
+    # The name of the cookie to store the Play language in.  This cookie is set when Langs.setLang is invoked, and
+    # read when the preferred lang is loaded.
+    langCookieName = "PLAY_LANG"
+
   }
 
   akka {
+
+    # The name of the actor system that Play creates
+    actor-system = "application"
+
+    # How long Play should wait for Akka to shutdown before timing it.  If null, waits indefinitely.
+    shutdown-timeout = null
+
     loggers = ["akka.event.slf4j.Slf4jLogger"]
     loglevel = "WARNING"
 
@@ -100,7 +148,17 @@ play {
 
   }
 
+  # Crypto configuration
   crypto {
+
+    # The application secret. Must be set. A value of "changeme" will cause the application to fail to start in
+    # production.
+    secret = "changeme"
+
+    # The JCE provider to use. If null, uses the platform default.
+    provider = null
+
+
     aes {
       transformation = "AES/CTR/NoPadding"
     }

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -3,7 +3,6 @@
  */
 package play.api
 
-import play.api.inject.Injector
 import play.api.inject.guice.GuiceApplicationLoader
 import play.core.{ SourceMapper, WebCommands, DefaultWebCommands }
 import play.utils.Reflect

--- a/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -5,7 +5,8 @@ package play.api.http
 
 import javax.inject.{ Singleton, Inject, Provider }
 
-import play.api.{ Application, Play, Configuration }
+import com.typesafe.config.ConfigMemorySize
+import play.api.{ PlayConfig, Application, Play, Configuration }
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -13,9 +14,14 @@ import scala.concurrent.duration.FiniteDuration
  * HTTP related configuration of a Play application
  *
  * @param context The HTTP context
+ * @param parser The parser configuration
  * @param session The session configuration
+ * @param flash The flash configuration
  */
-case class HttpConfiguration(context: String = "/", session: SessionConfiguration = SessionConfiguration(),
+case class HttpConfiguration(
+  context: String = "/",
+  parser: ParserConfiguration = ParserConfiguration(),
+  session: SessionConfiguration = SessionConfiguration(),
   flash: FlashConfiguration = FlashConfiguration())
 
 /**
@@ -38,6 +44,16 @@ case class SessionConfiguration(cookieName: String = "PLAY_SESSION", secure: Boo
  */
 case class FlashConfiguration(cookieName: String = "PLAY_FLASH", secure: Boolean = false)
 
+/**
+ * Configuration for body parsers.
+ *
+ * @param maxMemoryBuffer The maximum size that a request body that should be buffered in memory.
+ * @param maxDiskBuffer The maximum size that a request body should be buffered on disk.
+ */
+case class ParserConfiguration(
+  maxMemoryBuffer: Int = 102400,
+  maxDiskBuffer: Long = 10485760)
+
 object HttpConfiguration {
 
   @Singleton
@@ -46,8 +62,10 @@ object HttpConfiguration {
   }
 
   def fromConfiguration(configuration: Configuration) = {
+    val config = PlayConfig(configuration
+    )
     val context = {
-      val ctx = configuration.getDeprecatedString("play.http.context", "application.context")
+      val ctx = config.getDeprecated[String]("play.http.context", "application.context")
       if (!ctx.startsWith("/")) {
         throw configuration.globalError("play.http.context must start with a /")
       }
@@ -56,16 +74,21 @@ object HttpConfiguration {
 
     HttpConfiguration(
       context = context,
+      parser = ParserConfiguration(
+        maxMemoryBuffer = config.getDeprecated[ConfigMemorySize]("play.http.parser.maxMemoryBuffer", "parsers.text.maxLength")
+          .toBytes.toInt,
+        maxDiskBuffer = config.get[ConfigMemorySize]("play.http.parser.maxDiskBuffer").toBytes
+      ),
       session = SessionConfiguration(
-        cookieName = configuration.getDeprecatedString("play.http.session.cookieName", "session.cookieName"),
-        secure = configuration.getDeprecatedBoolean("play.http.session.secure", "session.secure"),
-        maxAge = configuration.getDeprecatedDurationOpt("play.http.session.maxAge", "session.maxAge"),
-        httpOnly = configuration.getDeprecatedBoolean("play.http.session.httpOnly", "session.httpOnly"),
-        domain = configuration.getDeprecatedStringOpt("play.http.session.domain", "session.domain")
+        cookieName = config.getDeprecated[String]("play.http.session.cookieName", "session.cookieName"),
+        secure = config.getDeprecated[Boolean]("play.http.session.secure", "session.secure"),
+        maxAge = config.getOptionalDeprecated[FiniteDuration]("play.http.session.maxAge", "session.maxAge"),
+        httpOnly = config.getDeprecated[Boolean]("play.http.session.httpOnly", "session.httpOnly"),
+        domain = config.getOptionalDeprecated[String]("play.http.session.domain", "session.domain")
       ),
       flash = FlashConfiguration(
-        cookieName = configuration.getDeprecatedString("play.http.flash.cookieName", "flash.cookieName"),
-        secure = configuration.getBoolean("play.http.flash.secure").getOrElse(false)
+        cookieName = config.getDeprecated[String]("play.http.flash.cookieName", "flash.cookieName"),
+        secure = config.get[Boolean]("play.http.flash.secure")
       )
     )
   }

--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -49,7 +49,7 @@ object HttpErrorHandler {
    * Get the bindings for the error handler from the configuration
    */
   def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
-    Reflect.bindingsFromConfiguration[HttpErrorHandler, play.http.HttpErrorHandler, JavaHttpErrorHandlerAdapter, GlobalSettingsHttpErrorHandler](environment, configuration, "play.http.errorHandler", "ErrorHandler")
+    Reflect.bindingsFromConfiguration[HttpErrorHandler, play.http.HttpErrorHandler, JavaHttpErrorHandlerAdapter, GlobalSettingsHttpErrorHandler](environment, PlayConfig(configuration), "play.http.errorHandler", "ErrorHandler")
   }
 }
 

--- a/framework/src/play/src/main/scala/play/api/http/HttpFilters.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpFilters.scala
@@ -5,7 +5,7 @@ package play.api.http
 
 import javax.inject.Inject
 
-import play.api.{ Configuration, Environment }
+import play.api.{ PlayConfig, Configuration, Environment }
 import play.api.mvc.EssentialFilter
 import play.utils.Reflect
 
@@ -24,7 +24,7 @@ object HttpFilters {
 
   def bindingsFromConfiguration(environment: Environment, configuration: Configuration) = {
     Reflect.bindingsFromConfiguration[HttpFilters, play.http.HttpFilters, JavaHttpFiltersAdapter, NoHttpFilters](environment,
-      configuration, "play.http.filters", "Filters")
+      PlayConfig(configuration), "play.http.filters", "Filters")
   }
 }
 

--- a/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -7,7 +7,7 @@ import javax.inject.{ Provider, Inject }
 
 import play.api.inject.{ BindingKey, Binding }
 import play.api.libs.iteratee.Done
-import play.api.{ Configuration, Environment, GlobalSettings }
+import play.api.{ PlayConfig, Configuration, Environment, GlobalSettings }
 import play.api.http.Status._
 import play.api.mvc._
 import play.api.routing.Router
@@ -44,7 +44,7 @@ object HttpRequestHandler {
     val javaComponentsBinding = BindingKey(classOf[play.core.j.JavaHandlerComponents]).toSelf
 
     Reflect.configuredClass[HttpRequestHandler, play.http.HttpRequestHandler, GlobalSettingsHttpRequestHandler](environment,
-      configuration, "play.http.requestHandler", "RequestHandler") match {
+      PlayConfig(configuration), "play.http.requestHandler", "RequestHandler") match {
         case None => Nil
         case Some(Left(scalaImpl)) =>
           Seq(

--- a/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
@@ -3,7 +3,6 @@
  */
 package play.api.libs
 
-import java.nio.{ ByteOrder, ByteBuffer }
 import java.security.{ MessageDigest, SecureRandom }
 import javax.crypto._
 import javax.crypto.spec.{ IvParameterSpec, SecretKeySpec }
@@ -203,6 +202,8 @@ class CryptoConfigParser @Inject() (environment: Environment, configuration: Con
 
   lazy val get = {
 
+    val config = PlayConfig(configuration)
+
     /*
      * The Play secret.
      *
@@ -228,7 +229,7 @@ class CryptoConfigParser @Inject() (environment: Environment, configuration: Con
      *
      * To achieve 4, using the location of application.conf to generate the secret should ensure this.
      */
-    val secret = configuration.getString("application.secret") match {
+    val secret = config.getOptionalDeprecated[String]("play.crypto.secret", "application.secret") match {
       case (Some("changeme") | Some(Blank()) | None) if environment.mode == Mode.Prod =>
         logger.error("The application secret has not been set, and we are in prod mode. Your application is not secure.")
         logger.error("To set the application secret, please read http://playframework.com/documentation/latest/ApplicationSecret")
@@ -246,8 +247,8 @@ class CryptoConfigParser @Inject() (environment: Environment, configuration: Con
       case Some(s) => s
     }
 
-    val provider = configuration.getString("play.crypto.provider")
-    val transformation = configuration.underlying.getString("play.crypto.aes.transformation")
+    val provider = config.getOptional[String]("play.crypto.provider")
+    val transformation = config.get[String]("play.crypto.aes.transformation")
 
     CryptoConfig(secret, provider, transformation)
   }

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -3,7 +3,7 @@
  */
 package play.api.libs.concurrent
 
-import java.util.concurrent.{ TimeUnit, TimeoutException }
+import java.util.concurrent.TimeoutException
 import javax.inject.{ Provider, Inject, Singleton }
 import play.api._
 import play.api.inject.{ ApplicationLifecycle, Module }
@@ -60,19 +60,19 @@ class ActorSystemProvider @Inject() (environment: Environment, configuration: Co
   private val logger = Logger(classOf[ActorSystemProvider])
 
   lazy val get: ActorSystem = {
-    val config = configuration.underlying
-    val name = configuration.getString("play.modules.akka.actor-system").getOrElse("application")
-    val system = ActorSystem(name, config, environment.classLoader)
+    val config = PlayConfig(configuration)
+    val name = config.get[String]("play.akka.actor-system")
+    val system = ActorSystem(name, configuration.underlying, environment.classLoader)
     logger.info(s"Starting application default Akka system: $name")
 
     applicationLifecycle.addStopHook { () =>
       logger.info(s"Shutdown application default Akka system: $name")
       system.shutdown()
 
-      configuration.getMilliseconds("play.akka.shutdown-timeout") match {
+      config.getOptional[Duration]("play.akka.shutdown-timeout") match {
         case Some(timeout) =>
           try {
-            system.awaitTermination(Duration(timeout, TimeUnit.MILLISECONDS))
+            system.awaitTermination(timeout)
           } catch {
             case te: TimeoutException =>
               // oh well.  We tried to be nice.

--- a/framework/src/play/src/main/scala/play/api/routing/Router.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/Router.scala
@@ -3,7 +3,7 @@
  */
 package play.api.routing
 
-import play.api.{ Configuration, Environment }
+import play.api.{ PlayConfig, Configuration, Environment }
 import play.api.mvc.{ RequestHeader, Handler }
 import play.utils.Reflect
 
@@ -50,7 +50,7 @@ object Router {
    * @return The router class if configured or if a default one in the root package was detected.
    */
   def load(env: Environment, configuration: Configuration): Option[Class[_ <: Router]] = {
-    val className = configuration.getString("application.router")
+    val className = PlayConfig(configuration).getOptionalDeprecated[String]("play.http.router", "application.router")
 
     try {
       Some(Reflect.getClass[Router](className.getOrElse("Routes"), env.classLoader))

--- a/framework/src/play/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/framework/src/play/src/test/java/play/mvc/RequestBuilderTest.java
@@ -1,5 +1,8 @@
 package play.mvc;
 
+import play.api.Application;
+import play.api.Play;
+import play.api.inject.guice.GuiceApplicationBuilder;
 import play.mvc.Http.Context;
 import play.mvc.Http.Request;
 import play.mvc.Http.RequestBuilder;
@@ -41,9 +44,12 @@ public class RequestBuilderTest {
 
   @Test
   public void testSession() {
+    Application app = new GuiceApplicationBuilder().build();
+    Play.start(app);
     Context ctx = new Context(new RequestBuilder().session("a","1").session("b","1").session("b","2"));
     assertEquals("1", ctx.session().get("a"));
     assertEquals("2", ctx.session().get("b"));
+    Play.stop(app);
   }
 
 }

--- a/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
@@ -22,7 +22,7 @@ object MessagesSpec extends Specification {
     "fr-CH" -> Map(
       "title" -> "Titre suisse"))
   val api = new DefaultMessagesApi(new Environment(new File("."), this.getClass.getClassLoader, Mode.Dev),
-    Configuration.from(Map("play.modules.i18n.langCookieName" -> "PLAY_LANG")), new Langs() {
+    Configuration.reference, new Langs() {
       def availables = Nil
       def preferred(candidates: Seq[Lang]) = Lang.defaultLang
     }

--- a/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
@@ -57,15 +57,6 @@ object GuiceApplicationBuilderSpec extends Specification {
       app.configuration.getInt("a") must beSome(1)
     }
 
-    "set initial configuration" in {
-      val app = new GuiceApplicationBuilder()
-        .loadConfig(Configuration.empty)
-        .bindings(new BuiltinModule)
-        .build
-
-      app.configuration.keys must beEmpty
-    }
-
     "set global settings" in {
       val global = new GlobalSettings {
         override def configuration = Configuration("a" -> 1)

--- a/framework/src/play/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
@@ -46,7 +46,7 @@ object GuiceInjectorBuilderSpec extends Specification {
         .bindings(new ConfigurationModule)
         .injector.instanceOf[Configuration]
 
-      conf.subKeys must contain(exactly("a", "b", "c", "d"))
+      conf.subKeys must contain(allOf("a", "b", "c", "d"))
       conf.getInt("a") must beSome(1)
       conf.getInt("b") must beSome(2)
       conf.getInt("c") must beSome(3)

--- a/framework/src/play/src/test/scala/play/api/libs/CryptoSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/CryptoSpec.scala
@@ -53,8 +53,8 @@ object CryptoSpec extends Specification {
 
       def parseSecret(mode: Mode.Mode, secret: Option[String] = None) = {
         new CryptoConfigParser(Environment.simple(mode = mode),
-          Configuration.from(
-            secret.map("application.secret" -> _).toMap +
+          Configuration.reference ++ Configuration.from(
+            secret.map("play.crypto.secret" -> _).toMap +
               ("play.crypto.aes.transformation" -> "AES")
           )).get.secret
       }

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -112,7 +112,7 @@ object ResultsSpec extends Specification {
     }
 
     "support clearing a language cookie using clearingLang" in {
-      implicit val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.empty, new DefaultLangs(Configuration.empty))
+      implicit val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
       val cookie = Cookies.decode(Ok.clearingLang.header.headers("Set-Cookie")).head
       cookie.name must_== Play.langCookieName
       cookie.value must_== ""

--- a/framework/src/play/src/test/scala/play/utils/ReflectSpec.scala
+++ b/framework/src/play/src/test/scala/play/utils/ReflectSpec.scala
@@ -8,7 +8,7 @@ import javax.inject.Inject
 import org.specs2.mutable.Specification
 import play.api.inject.Binding
 import play.api.inject.guice.GuiceInjectorBuilder
-import play.api.{ PlayException, Configuration, Environment }
+import play.api.{ PlayConfig, PlayException, Configuration, Environment }
 
 import scala.reflect.ClassTag
 
@@ -23,15 +23,15 @@ object ReflectSpec extends Specification {
       }
 
       "return the default implementation when none configured or default class doesn't exist" in {
-        doQuack(bindings("", "NoDuck")) must_== "quack"
+        doQuack(bindings(null, "NoDuck")) must_== "quack"
       }
 
       "return a default Scala implementation" in {
-        doQuack(bindings[CustomDuck]("")) must_== "custom quack"
+        doQuack(bindings[CustomDuck](null)) must_== "custom quack"
       }
 
       "return a default Java implementation" in {
-        doQuack(bindings[CustomJavaDuck]("")) must_== "java quack"
+        doQuack(bindings[CustomJavaDuck](null)) must_== "java quack"
       }
 
       "return a configured Scala implementation" in {
@@ -55,7 +55,7 @@ object ReflectSpec extends Specification {
 
   def bindings(configured: String, defaultClassName: String): Seq[Binding[_]] = {
     Reflect.bindingsFromConfiguration[Duck, JavaDuck, JavaDuckAdapter, DefaultDuck](
-      Environment.simple(), Configuration.from(Map("duck" -> configured)), "duck", defaultClassName)
+      Environment.simple(), PlayConfig(Configuration.from(Map("duck" -> configured))), "duck", defaultClassName)
   }
 
   def bindings[Default: ClassTag](configured: String): Seq[Binding[_]] = {

--- a/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -13,7 +13,7 @@ import scala.beans.BeanProperty
 
 object HelpersSpec extends Specification {
   import FieldConstructor.defaultField
-  val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.empty, new DefaultLangs(Configuration.empty))
+  val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
   implicit val messages = messagesApi.preferred(Seq.empty)
 
   "@inputText" should {

--- a/framework/src/sbt-plugin/src/main/scala/play/sbtplugin/ApplicationSecretGenerator.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbtplugin/ApplicationSecretGenerator.scala
@@ -26,14 +26,14 @@ object ApplicationSecretGenerator {
     secret
   }
 
-  private val ApplicationSecret = """\s*application\.secret\s*[=:].*""".r
+  private val ApplicationSecret = """\s*(?:(?:application\.secret)|(?:play\.crypto\.secret))\s*[=:].*""".r
 
   def updateSecretTask = Def.task[File] {
     val secret: String = play.PlayImport.PlayKeys.generateSecret.value
     val baseDir: File = Keys.baseDirectory.value
     val log = Keys.streams.value.log
 
-    val secretConfig = s"""application.secret="$secret""""
+    val secretConfig = s"""play.crypto.secret="$secret""""
 
     val appConfFile = Option(System.getProperty("config.file")) match {
       case Some(applicationConf) => new File(baseDir, applicationConf)

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/conf/application.conf
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/conf/application.conf
@@ -5,11 +5,11 @@
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-application.secret=";1[WE]JmK;XMCxV=S2P6kYl?A<^YcKYW3aui[SmusaQlkjq97A`M8l_S:iV?OmDh"
+play.crypto.secret=";1[WE]JmK;XMCxV=S2P6kYl?A<^YcKYW3aui[SmusaQlkjq97A`M8l_S:iV?OmDh"
 
 # The application languages
 # ~~~~~
-application.langs="en"
+play.i18n.langs = [ "en" ]
 
 # Global object class
 # ~~~~~

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/scala-compilation-times/conf/application.conf
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/scala-compilation-times/conf/application.conf
@@ -5,11 +5,11 @@
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-application.secret="F7wDxMt3=vRS@/hpthf]DwlE>fhCyl?g6bXfI`phDX]_:`<WxWKZmn`3EnNhEH_x"
+play.crypto.secret="F7wDxMt3=vRS@/hpthf]DwlE>fhCyl?g6bXfI`phDX]_:`<WxWKZmn`3EnNhEH_x"
 
 # The application languages
 # ~~~~~
-application.langs="en"
+play.i18n.langs = [ "en" ]
 
 # Global object class
 # ~~~~~

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/conf/application.conf
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/conf/application.conf
@@ -5,6 +5,6 @@
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-application.secret="changeme"
+play.crypto.secret="changeme"
 
 # foo

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/project/Build.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/project/Build.scala
@@ -9,7 +9,7 @@ object ApplicationBuild extends Build {
   val appName = "secret-sample"
   val appVersion = "1.0-SNAPSHOT"
 
-  val Secret = """(?s).*application.secret="(.*)".*""".r
+  val Secret = """(?s).*play.crypto.secret="(.*)".*""".r
 
   val main = Project(appName, file(".")).enablePlugins(play.PlayScala).settings(
     version := appVersion,

--- a/templates/play-java-intro/conf/application.conf
+++ b/templates/play-java-intro/conf/application.conf
@@ -8,17 +8,11 @@
 # This must be changed for production, but we recommend not changing it in this file.
 #
 # See http://www.playframework.com/documentation/latest/ApplicationSecret for more details.
-application.secret="changeme"
+play.crypto.secret = "changeme"
 
 # The application languages
 # ~~~~~
-application.langs="en"
-
-# Global object class
-# ~~~~~
-# Define the Global object class for this application.
-# Default to Global in the root package.
-# application.global=Global
+play.i18n.langs = [ "en" ]
 
 # Router
 # ~~~~~
@@ -26,10 +20,10 @@ application.langs="en"
 # This router will be looked up first when the application is starting up,
 # so make sure this is the entry point.
 # Furthermore, it's assumed your route file is named properly.
-# So for an application router like `conf/my.application.Router`,
-# you may need to define a router file `my.application.routes`.
-# Default to Routes in the root package (and `conf/routes`)
-# application.router=my.application.Routes
+# So for an application router like `my.application.Router`,
+# you may need to define a router file `conf/my.application.routes`.
+# Default to Routes in the root package (and conf/routes)
+# play.http.router = my.application.Routes
 
 # Database configuration
 # ~~~~~
@@ -50,6 +44,9 @@ jpa.default=defaultPersistenceUnit
 # ~~~~~
 # You can disable evolutions if needed
 # play.modules.evolutions.enabled=false
+
+# You can disable evolutions for a specific datasource if necessary
+# play.modules.evolutions.db.default.enabled=false
 
 # Logger
 # ~~~~~

--- a/templates/play-java/conf/application.conf
+++ b/templates/play-java/conf/application.conf
@@ -8,17 +8,11 @@
 # This must be changed for production, but we recommend not changing it in this file.
 #
 # See http://www.playframework.com/documentation/latest/ApplicationSecret for more details.
-application.secret="changeme"
+play.crypto.secret = "changeme"
 
 # The application languages
 # ~~~~~
-application.langs="en"
-
-# Global object class
-# ~~~~~
-# Define the Global object class for this application.
-# Default to Global in the root package.
-# application.global=Global
+play.i18n.langs = [ "en" ]
 
 # Router
 # ~~~~~
@@ -26,10 +20,10 @@ application.langs="en"
 # This router will be looked up first when the application is starting up,
 # so make sure this is the entry point.
 # Furthermore, it's assumed your route file is named properly.
-# So for an application router like `conf/my.application.Router`,
-# you may need to define a router file `my.application.routes`.
-# Default to Routes in the root package (and `conf/routes`)
-# application.router=my.application.Routes
+# So for an application router like `my.application.Router`,
+# you may need to define a router file `conf/my.application.routes`.
+# Default to Routes in the root package (and conf/routes)
+# play.http.router = my.application.Routes
 
 # Database configuration
 # ~~~~~
@@ -40,9 +34,6 @@ application.langs="en"
 # db.default.url="jdbc:h2:mem:play"
 # db.default.user=sa
 # db.default.password=""
-#
-# You can expose this datasource via JNDI if needed (Useful for JPA)
-# db.default.jndiName=DefaultDS
 
 # Evolutions
 # ~~~~~

--- a/templates/play-scala-intro/conf/application.conf
+++ b/templates/play-scala-intro/conf/application.conf
@@ -8,17 +8,11 @@
 # This must be changed for production, but we recommend not changing it in this file.
 #
 # See http://www.playframework.com/documentation/latest/ApplicationSecret for more details.
-application.secret="changeme"
+play.crypto.secret = "changeme"
 
 # The application languages
 # ~~~~~
-application.langs="en"
-
-# Global object class
-# ~~~~~
-# Define the Global object class for this application.
-# Default to Global in the root package.
-# application.global=Global
+play.i18n.langs = [ "en" ]
 
 # Router
 # ~~~~~
@@ -29,7 +23,7 @@ application.langs="en"
 # So for an application router like `my.application.Router`,
 # you may need to define a router file `conf/my.application.routes`.
 # Default to Routes in the root package (and conf/routes)
-# application.router=my.application.Routes
+# play.http.router = my.application.Routes
 
 # Database configuration
 # ~~~~~
@@ -46,6 +40,9 @@ slick.default="models.*"
 # ~~~~~
 # You can disable evolutions if needed
 # play.modules.evolutions.enabled=false
+
+# You can disable evolutions for a specific datasource if necessary
+# play.modules.evolutions.db.default.enabled=false
 
 # Logger
 # ~~~~~

--- a/templates/play-scala/conf/application.conf
+++ b/templates/play-scala/conf/application.conf
@@ -8,17 +8,11 @@
 # This must be changed for production, but we recommend not changing it in this file.
 #
 # See http://www.playframework.com/documentation/latest/ApplicationSecret for more details.
-application.secret="changeme"
+play.crypto.secret = "changeme"
 
 # The application languages
 # ~~~~~
-application.langs="en"
-
-# Global object class
-# ~~~~~
-# Define the Global object class for this application.
-# Default to Global in the root package.
-# application.global=Global
+play.i18n.langs = [ "en" ]
 
 # Router
 # ~~~~~
@@ -29,7 +23,7 @@ application.langs="en"
 # So for an application router like `my.application.Router`,
 # you may need to define a router file `conf/my.application.routes`.
 # Default to Routes in the root package (and conf/routes)
-# application.router=my.application.Routes
+# play.http.router = my.application.Routes
 
 # Database configuration
 # ~~~~~


### PR DESCRIPTION
* Introduced PlayConfig helper which is more suited to idiomatic use of Typesafe config
* Migrated a number of config options from old paths to new paths
* Removed "modules" from configuration keys
* Moved more settings to reference.conf
* Introduced idiom of using "null" rather than blank or no setting for default values.