### PR TITLE
Updates specs2 to version 3.1

### DIFF
--- a/documentation/manual/detailedTopics/configuration/code/ThreadPools.scala
+++ b/documentation/manual/detailedTopics/configuration/code/ThreadPools.scala
@@ -11,12 +11,11 @@ import com.typesafe.config.ConfigFactory
 import akka.actor.ActorSystem
 import play.api.libs.concurrent.Akka
 import scala.concurrent.{Future, ExecutionContext}
+import scala.concurrent.ExecutionContext.Implicits.global
 import java.io.File
 import org.specs2.execute.AsResult
 
 object ThreadPoolsSpec extends PlaySpecification {
-
-  override val concurrentExecutionContext = scala.concurrent.ExecutionContext.global
 
   "Play's thread pools" should {
 

--- a/documentation/manual/working/scalaGuide/main/akka/code/ScalaAkka.scala
+++ b/documentation/manual/working/scalaGuide/main/akka/code/ScalaAkka.scala
@@ -7,6 +7,7 @@ import akka.actor.ActorSystem
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import play.api.test._
 import java.io.File

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaComet.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaComet.scala
@@ -7,6 +7,7 @@ import play.api.mvc._
 import play.api.libs.iteratee.{Enumeratee, Iteratee, Enumerator}
 import play.api.test._
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 import play.api.libs.Comet
 
 object ScalaCometSpec extends PlaySpecification with Controller {

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
@@ -5,6 +5,7 @@ import play.api.test._
 //#dependency
 import javax.inject.Inject
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import play.api._
 import play.api.mvc._

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -13,6 +13,7 @@ import org.specs2.runner.JUnitRunner
 //#dependency
 import javax.inject.Inject
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import play.api.mvc._
 import play.api.libs.ws._
@@ -34,8 +35,6 @@ case class Person(name: String, age: Int)
 @RunWith(classOf[JUnitRunner])
 class ScalaWSSpec extends PlaySpecification with Results {
 
-  override val concurrentExecutionContext = scala.concurrent.ExecutionContext.global
-  
   val url = s"http://localhost:$testServerPort/"
 
   // #scalaws-context

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -6,7 +6,7 @@ import buildinfo.BuildInfo
 
 object Dependencies {
 
-  val specsVersion = "2.4.9"
+  val specsVersion = "3.1"
   val specsBuild = Seq(
     "specs2-core",
     "specs2-junit",
@@ -90,7 +90,7 @@ object Dependencies {
   ) ++ javassist ++ specsBuild.map(_ % Test)
 
   val junitInterface = "com.novocode" % "junit-interface" % "0.11"
-  val junit = "junit" % "junit" % "4.11"
+  val junit = "junit" % "junit" % "4.12"
 
   val javaTestDeps = Seq(
     junit,
@@ -256,7 +256,7 @@ object Dependencies {
 
   val scalacheckDependencies = Seq(
     "org.specs2"     %% "specs2-scalacheck" % specsVersion % Test,
-    "org.scalacheck" %% "scalacheck"        % "1.11.3"     % Test
+    "org.scalacheck" %% "scalacheck"        % "1.12.2"     % Test
   )
 
   val playServerDependencies = Seq(

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/CharEncodingSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/CharEncodingSpec.scala
@@ -4,6 +4,8 @@ import org.specs2.mutable._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 object CharEncodingSpec extends Specification {
 
   "CharEncodingSpec.decode()" should {

--- a/framework/src/play-cache/src/test/scala/play/api/cache/SerializableResultSpec.scala
+++ b/framework/src/play-cache/src/test/scala/play/api/cache/SerializableResultSpec.scala
@@ -4,11 +4,10 @@
 package play.api.cache
 
 import play.api.test._
-import play.api.mvc.{ Action, HttpConnection, Result, Results }
-import play.api.http
+import play.api.mvc.{ HttpConnection, Result, Results }
 import play.api.libs.iteratee.{ Enumerator, Iteratee }
 
-import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class SerializableResultSpec extends PlaySpecification {
 

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.filters.gzip
 
-import java.io.{ File, ByteArrayOutputStream }
+import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPOutputStream
 
 import org.apache.commons.io.IOUtils
@@ -14,7 +14,7 @@ import play.api.libs.iteratee.{ Iteratee, Enumeratee, Enumerator }
 import concurrent.duration._
 import org.specs2.mutable.Specification
 
-import scala.io.Source
+import scala.concurrent.ExecutionContext.Implicits.global
 
 object GzipSpec extends Specification with NoTimeConversions {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -20,6 +20,8 @@ import play.core.routing.HandlerDef
 import java.util.concurrent.atomic.AtomicReference
 import org.jboss.netty.buffer.ChannelBuffers
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 object NettyWebSocketSpec extends WebSocketSpec with NettyIntegrationSpecification
 object AkkaHttpWebSocketSpec extends WebSocketSpec with AkkaHttpIntegrationSpecification
 

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/DriverRegistrationSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/DriverRegistrationSpec.scala
@@ -10,8 +10,9 @@ import scala.util.Try
 
 object DriverRegistrationSpec extends Specification {
 
+  sequential
+
   "JDBC driver" should {
-    sequential
 
     "be registered for H2 before databases start" in {
       DriverManager.getDriver("jdbc:h2:mem:") aka "H2 driver" must not(beNull)

--- a/framework/src/play-server/src/test/scala/play/core/server/ssl/ServerSSLEngineSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/ssl/ServerSSLEngineSpec.scala
@@ -7,6 +7,7 @@ package play.core.server.ssl
 
 import java.util.Properties
 
+import org.specs2.matcher.MustThrownExpectations
 import org.specs2.mutable.{ After, Specification }
 import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
@@ -37,7 +38,7 @@ class ServerSSLEngineSpec extends Specification with Mockito {
 
   sequential
 
-  trait ApplicationContext extends Mockito with Scope {
+  trait ApplicationContext extends Mockito with Scope with MustThrownExpectations {
   }
 
   trait TempConfDir extends After {
@@ -72,23 +73,23 @@ class ServerSSLEngineSpec extends Specification with Mockito {
   "ServerSSLContext" should {
 
     "default create a SSL engine suitable for development" in new ApplicationContext with TempConfDir {
-      createEngine(None, Some(tempDir)) should beAnInstanceOf[SSLEngine]
+      createEngine(None, Some(tempDir)) must beAnInstanceOf[SSLEngine]
     }
 
     "fail to load a non existing SSLEngineProvider" in new ApplicationContext {
-      createEngine(Some("bla bla")) should throwA[ClassNotFoundException]
+      createEngine(Some("bla bla")) must throwA[ClassNotFoundException]
     }
 
     "fail to load an existing SSLEngineProvider with the wrong type" in new ApplicationContext {
-      createEngine(Some(classOf[WrongSSLEngineProvider].getName)) should throwA[ClassCastException]
+      createEngine(Some(classOf[WrongSSLEngineProvider].getName)) must throwA[ClassCastException]
     }
 
     "load a custom SSLContext from a SSLEngineProvider" in new ApplicationContext {
-      createEngine(Some(classOf[RightSSLEngineProvider].getName)) should beAnInstanceOf[SSLEngine]
+      createEngine(Some(classOf[RightSSLEngineProvider].getName)) must beAnInstanceOf[SSLEngine]
     }
 
     "load a custom SSLContext from a java SSLEngineProvider" in new ApplicationContext {
-      createEngine(Some(classOf[JavaSSLEngineProvider].getName)) should beAnInstanceOf[SSLEngine]
+      createEngine(Some(classOf[JavaSSLEngineProvider].getName)) must beAnInstanceOf[SSLEngine]
     }
   }
 

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/EnumeratorPublisherSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/EnumeratorPublisherSpec.scala
@@ -9,6 +9,8 @@ import play.api.libs.iteratee.{ Concurrent, Enumerator, Input }
 import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class EnumeratorPublisherSpec extends Specification {
 
   case object OnSubscribe

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/FuturePublisherSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/FuturePublisherSpec.scala
@@ -7,6 +7,8 @@ import org.reactivestreams._
 import org.specs2.mutable.Specification
 import scala.concurrent.{ Future, Promise }
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class FuturePublisherSpec extends Specification {
 
   case object OnSubscribe

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/IterateeSubscriberSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/IterateeSubscriberSpec.scala
@@ -3,11 +3,11 @@
  */
 package play.api.libs.streams.impl
 
-import org.reactivestreams._
 import org.specs2.mutable.Specification
 import play.api.libs.iteratee._
 import scala.concurrent.duration.{ FiniteDuration => ScalaFiniteDuration, SECONDS }
-import scala.concurrent.{ Await, Future, Promise }
+import scala.concurrent.{ Await, Promise }
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{ Failure, Success, Try }
 
 class IterateeSubscriberSpec extends Specification {

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/PromiseSubscriberSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/PromiseSubscriberSpec.scala
@@ -3,11 +3,12 @@
  */
 package play.api.libs.streams.impl
 
-import org.reactivestreams._
 import org.specs2.mutable.Specification
 import scala.concurrent.duration.{ FiniteDuration => ScalaFiniteDuration, SECONDS }
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.Promise
 import scala.util.{ Failure, Success, Try }
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class PromiseSubscriberSpec extends Specification {
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/SystemPropertiesSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/SystemPropertiesSpec.scala
@@ -5,13 +5,16 @@
  */
 package play.api.libs.ws.ssl
 
-import org.specs2.mutable._
+import org.specs2.mutable.Specification
+import org.specs2.specification.After
 import play.api.libs.ws.DefaultWSClientConfig
 import java.security.Security
 
-object SystemPropertiesSpec extends Specification {
+object SystemPropertiesSpec extends Specification with After {
 
   sequential
+
+  def after = sp.clearProperties()
 
   val sp = new SystemConfiguration()
 
@@ -26,8 +29,6 @@ object SystemPropertiesSpec extends Specification {
       Security.getProperty("ocsp.enable") must beNull
       System.getProperty("com.sun.security.enableCRLDP") must beNull
       System.getProperty("com.sun.net.ssl.checkRevocation") must beNull
-    }.after {
-      sp.clearProperties()
     }
 
     "disableCheckRevocation is set explicitly" in {
@@ -39,8 +40,6 @@ object SystemPropertiesSpec extends Specification {
       Security.getProperty("ocsp.enable") must be("true")
       System.getProperty("com.sun.security.enableCRLDP") must be("true")
       System.getProperty("com.sun.net.ssl.checkRevocation") must be("true")
-    }.after {
-      sp.clearProperties()
     }
 
     // @see http://www.oracle.com/technetwork/java/javase/documentation/tlsreadme2-176330.html
@@ -50,8 +49,6 @@ object SystemPropertiesSpec extends Specification {
       sp.configure(config)
 
       System.getProperty("sun.security.ssl.allowLegacyHelloMessages") must beNull
-    }.after {
-      sp.clearProperties()
     }
 
     // @see http://www.oracle.com/technetwork/java/javase/documentation/tlsreadme2-176330.html
@@ -61,8 +58,6 @@ object SystemPropertiesSpec extends Specification {
       sp.configure(config)
 
       System.getProperty("sun.security.ssl.allowLegacyHelloMessages") must be("true")
-    }.after {
-      sp.clearProperties()
     }
 
     // @see http://www.oracle.com/technetwork/java/javase/documentation/tlsreadme2-176330.html
@@ -72,8 +67,6 @@ object SystemPropertiesSpec extends Specification {
       sp.configure(config)
 
       System.getProperty("sun.security.ssl.allowUnsafeRenegotiation") must beNull
-    }.after {
-      sp.clearProperties()
     }
 
     // @see http://www.oracle.com/technetwork/java/javase/documentation/tlsreadme2-176330.html
@@ -83,8 +76,6 @@ object SystemPropertiesSpec extends Specification {
       sp.configure(config)
 
       System.getProperty("sun.security.ssl.allowUnsafeRenegotiation") must be("true")
-    }.after {
-      sp.clearProperties()
     }
 
   }

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/debug/DebugConfigurationSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/debug/DebugConfigurationSpec.scala
@@ -5,10 +5,16 @@
  */
 package play.api.libs.ws.ssl.debug
 
-import org.specs2.mutable._
+import org.specs2.mutable.Specification
+import org.specs2.specification.After
 import play.api.libs.ws.ssl.SSLDebugConfig
 
-object DebugConfigurationSpec extends Specification {
+object DebugConfigurationSpec extends Specification with After {
+
+  def after = {
+    System.clearProperty("java.security.debug")
+    System.clearProperty("javax.net.debug")
+  }
 
   sequential // global settings, must be sequential
 
@@ -37,8 +43,6 @@ object DebugConfigurationSpec extends Specification {
       config.configure(debugConfig)
 
       System.getProperty("java.security.debug") must contain("certpath")
-    }.after {
-      System.clearProperty("java.security.debug")
     }
 
     "turn off java.security.debug code" in {
@@ -49,8 +53,6 @@ object DebugConfigurationSpec extends Specification {
       config.configure(debugConfig)
 
       System.getProperty("java.security.debug") must not contain ("certpath")
-    }.after {
-      System.clearProperty("java.security.debug")
     }
 
     "turn on javax.ssl.debug code" in {
@@ -66,8 +68,6 @@ object DebugConfigurationSpec extends Specification {
       config.configure(debugConfig)
 
       System.getProperty("javax.net.debug") must contain("ssl")
-    }.after {
-      System.clearProperty("javax.net.debug")
     }
 
     "turn off javax.ssl.debug code" in {
@@ -78,8 +78,6 @@ object DebugConfigurationSpec extends Specification {
       config.configure(debugConfig)
 
       System.getProperty("javax.net.debug") must not contain ("ssl")
-    }.after {
-      System.clearProperty("javax.net.debug")
     }
   }
 

--- a/framework/src/play/src/test/scala/play/core/ClosableLazySpec.scala
+++ b/framework/src/play/src/test/scala/play/core/ClosableLazySpec.scala
@@ -8,6 +8,8 @@ import org.specs2.mutable.Specification
 import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 object ClosableLazySpec extends Specification {
 
   "ClosableLazy" should {


### PR DESCRIPTION
Since Playframework has a policy of avoid upgrades in minor versions, I want to help with dependency updates before the release of 2.4.0.

This PR updates specs2 without removing the use of any API deprecated in version 3.x of specs2. That way I can keep this PR simple and small and deprecated APIs can be gradually removed in the future.