### PR TITLE
Upgrade jackson to version 2.5.1

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
     "com.fasterxml.jackson.core" % "jackson-databind",
     "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8",
     "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310"
-  ).map(_ % "2.4.4")
+  ).map(_ % "2.5.1")
 
   val guava = "com.google.guava" % "guava" % "18.0"
   val findBugs = "com.google.code.findbugs" % "jsr305" % "2.0.3" // Needed by guava

--- a/framework/src/play-java/src/main/java/play/libs/EventSource.java
+++ b/framework/src/play-java/src/main/java/play/libs/EventSource.java
@@ -4,7 +4,6 @@
 package play.libs;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.commons.lang3.StringEscapeUtils;
 import play.mvc.Results.*;
 
 /**

--- a/framework/src/play-java/src/main/java/play/libs/Jsonp.java
+++ b/framework/src/play-java/src/main/java/play/libs/Jsonp.java
@@ -4,8 +4,6 @@
 package play.libs;
 
 import com.fasterxml.jackson.databind.JsonNode;
-
-import play.libs.Json;
 import play.twirl.api.Content;
 
 /**

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
@@ -174,7 +174,7 @@ case class JsObject(fields: Seq[(String, JsValue)]) extends JsValue {
    * @param fieldName the name of the property to lookup
    * @return the resulting JsValue. If the current node is not a JsObject or doesn't have the property, a JsUndefined will be returned.
    */
-  override def \(fieldName: String): JsValue = value.get(fieldName).getOrElse(super.\(fieldName))
+  override def \(fieldName: String): JsValue = value.getOrElse(fieldName, super.\(fieldName))
 
   /**
    * Lookup for fieldName in the current object and all descendants.
@@ -472,7 +472,8 @@ private[play] object JacksonJson {
     val gen = stringJsonGenerator(sw).setPrettyPrinter(
       new com.fasterxml.jackson.core.util.DefaultPrettyPrinter()
     )
-    mapper.writerWithDefaultPrettyPrinter().writeValue(gen, jsValue)
+    val writer: ObjectWriter = mapper.writerWithDefaultPrettyPrinter()
+    writer.writeValue(gen, jsValue)
     sw.flush()
     sw.getBuffer.toString
   }

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
@@ -8,7 +8,6 @@ import java.time.{
   LocalDate,
   LocalDateTime,
   ZoneId,
-  ZoneOffset,
   ZonedDateTime
 }
 import java.time.temporal.Temporal
@@ -19,7 +18,6 @@ import scala.collection._
 import scala.reflect.ClassTag
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.{ ArrayNode, ObjectNode }
 
 import Json._
 

--- a/framework/src/play-json/src/test/scala/play/libs/JavaJsonSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/libs/JavaJsonSpec.scala
@@ -1,7 +1,7 @@
 package play.libs
 
-import java.time.Instant;
-import java.util.Optional;
+import java.time.Instant
+import java.util.Optional
 
 import com.fasterxml.jackson.databind.ObjectMapper
 
@@ -31,7 +31,7 @@ class JavaJsonSpec extends Specification {
       .put("optLong", 55555l)
       .put("a", 2.5)
       .put("copyright", "\u00a9") // copyright symbol
-      .put("baz", mapper.createArrayNode().add(1).add(2).add(3))
+      .set("baz", mapper.createArrayNode().add(1).add(2).add(3))
 
     Json.setObjectMapper(mapper)
   }


### PR DESCRIPTION
Jackson [release notes](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.5) states that:

> It is a "minor" release following 2.4, meaning that it adds new functionality but be backwards compatible with earlier 2.x releases.

I just inspect the code to see if there are uses of deprecated APIs and had to do a small change to fix a compile problem.