### PR TITLE
Fix for ticket Wrong RequestHeader is being passed into ErrorHandler's nClientError method

### DIFF
--- a/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
+++ b/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
@@ -105,7 +105,7 @@ trait GlobalSettings {
    */
   def onRequestReceived(request: RequestHeader): (RequestHeader, Handler) = {
     def notFoundHandler = Action.async(BodyParsers.parse.empty)(req =>
-      configuredErrorHandler.onClientError(request, NOT_FOUND)
+      configuredErrorHandler.onClientError(req, NOT_FOUND)
     )
 
     val (routedRequest, handler) = onRouteRequest(request) map {


### PR DESCRIPTION
Fix issue #4098 by porting code from #2231