### PR TITLE
docs: Add a note on declaring file: Asset

### DIFF
--- a/documentation/manual/detailedTopics/assets/Assets.md
+++ b/documentation/manual/detailedTopics/assets/Assets.md
@@ -118,8 +118,10 @@ In essence asset fingerprinting permits your static assets to be served with agg
 The above declaration of `pipelineStages` and the requisite `addSbtPlugin` declarations in your `plugins.sbt` for the plugins you require are your start point. You must then declare to Play what assets are to be versioned. The following routes file entry declares that all assets are to be versioned:
 
 ```scala
-GET    /assets/*file    controllers.Assets.versioned(path="/public", file: Asset)
+GET  /assets/*file  controllers.Assets.versioned(path="/public", file: Asset)
 ```
+
+> Make sure you indicate that `file` is an asset by writing `file: Asset`.
 
 You then use the reverse router, for example within a `scala.html` view:
 


### PR DESCRIPTION
Without it, the asset pipeline won't work, for instance it won't trigger fingerprinting paths to be rendered in templates.

I've spent roughly 20 hours over several attempts trying to figure out why both fingerprinting and using minified versioned wasn't working until I finally found a few references about making sure to write "file: Asset" between the mailing list and stackoverflow. I think this should be explicitly pointed out in the docs for future readers.