### PR TITLE
sbt plugins should support Java 1.6

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -55,8 +55,7 @@ object BuildSettings {
     resolvers ++= ResolverSettings.playResolvers,
     resolvers += "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases", // specs2 depends on scalaz-stream
 
-    javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-encoding", "UTF-8", "-Xlint:-options", "-J-Xmx512m"),
-    javacOptions in doc := Seq("-source", "1.8"),
+    javacOptions ++= Seq("-encoding", "UTF-8", "-Xlint:-options", "-J-Xmx512m"),
 
     scalacOptions ++= Seq("-encoding", "UTF-8", "-Xlint", "-deprecation", "-unchecked", "-feature"),
 
@@ -81,6 +80,11 @@ object BuildSettings {
     Docs.apiDocsInclude := true
   )
 
+  def javaVersionSettings(version: String): Seq[Setting[_]] = Seq(
+    javacOptions ++= Seq("-source", version, "-target", version),
+    javacOptions in doc := Seq("-source", version)
+  )
+
   /**
    * A project that is shared between the SBT runtime and the Play runtime
    */
@@ -89,6 +93,7 @@ object BuildSettings {
       .settings(playRuntimeSettings: _*)
       .settings(PublishSettings.publishSettings: _*)
       .settings(omnidocSettings: _*)
+      .settings(javaVersionSettings("1.6"): _*)
       .settings(
         autoScalaLibrary := false,
         crossPaths := false
@@ -103,6 +108,7 @@ object BuildSettings {
       .settings(playCommonSettings: _*)
       .settings(PublishSettings.publishSettings: _*)
       .settings(crossBuildSettings: _*)
+      .settings(javaVersionSettings("1.6"): _*)
   }
 
   /**
@@ -114,6 +120,7 @@ object BuildSettings {
       .settings(PublishSettings.publishSettings: _*)
       .settings(crossBuildSettings: _*)
       .settings(omnidocSettings: _*)
+      .settings(javaVersionSettings("1.8"): _*)
   }
 
   def crossBuildSettings: Seq[Setting[_]] = Seq(


### PR DESCRIPTION
If I upgrade an existing Play project to Play 2.4, and it was previously imported in IntelliJ with the SDK set to Java 1.6, then I reimport it into IntelliJ using IntelliJ's built in sbt support, IntelliJ will use Java 1.6 to run sbt to import it, which will fail with an error saying there was a binary compatibility, but that error is truncated in IntelliJ's UI, so you can't see that it's an unsupported major version of 52, so even someone that knows what that means and how to solve it can't immediately solve the problem.

A simple solution would be for us to target the Java projects that the sbt plugin depends on such as build link, play exceptions etc at Java 1.6.  We don't need Java 1.8 for them anyway.