### PR TITLE
Issue with Play 2.4-M2 (Guice 3.0 is not Java 8 compatible)

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -125,7 +125,7 @@ object Dependencies {
       // This solves issues later where cglib depends on an older version of asm,
       // and other libraries (pegdown) depend on a newer version with a different groupId,
       // and this causes binary issues.
-      "com.google.inject" % "guice" % "3.0" exclude("org.sonatype.sisu.inject", "cglib"),
+      "com.google.inject" % "guice" % "3.0" classifier "no_aop",
 
       guava % Test,
 


### PR DESCRIPTION
I am facing an issue with Play 2.4.0-M2

To me this seems like Java 8 is not fully supported in Guice 3.0, it may be fixed in 4.0, which is now in Beta5

I think it has something to do with this (using lambda and provides method):
https://github.com/google/guice/issues/757

While this is not directly related to Play it maybe a showstopper for Java 8 and Play 2.4.x users assuming Play would ship with Guice 3.0

Some are saying this will be fixed in Guice 4.0.

Hopefully Guice 4.0 comes out before play 2.4, but even then it there a plan to upgrade to Guice 4.0 before releasing Play 2.4?

[info] play.api.Play$ - Application started (Dev)
[error] application - Error while handling error
com.google.inject.internal.util.$ComputationException: java.lang.ArrayIndexOutOfBoundsException: 9578
	at com.google.inject.internal.util.$MapMaker$StrategyImpl.compute(MapMaker.java:553) ~[guice-3.0.jar:na]
	at com.google.inject.internal.util.$MapMaker$StrategyImpl.compute(MapMaker.java:419) ~[guice-3.0.jar:na]
	at com.google.inject.internal.util.$CustomConcurrentHashMap$ComputingImpl.get(CustomConcurrentHashMap.java:2041) ~[guice-3.0.jar:na]
	at com.google.inject.internal.util.$StackTraceElements.forMember(StackTraceElements.java:53) ~[guice-3.0.jar:na]
	at com.google.inject.internal.Errors.formatSource(Errors.java:690) ~[guice-3.0.jar:na]
	at com.google.inject.internal.Errors.formatInjectionPoint(Errors.java:720) ~[guice-3.0.jar:na]
	at com.google.inject.internal.Errors.formatSource(Errors.java:684) ~[guice-3.0.jar:na]
	at com.google.inject.internal.Errors.format(Errors.java:555) ~[guice-3.0.jar:na]
	at com.google.inject.ProvisionException.getMessage(ProvisionException.java:59) ~[guice-3.0.jar:na]
	at play.api.http.HttpErrorHandlerExceptions$$anon$1.<init>(HttpErrorHandler.scala:244) ~[play_2.10-2.4.0-M2.jar:2.4.0-M2]
Caused by: java.lang.ArrayIndexOutOfBoundsException: 9578
	at com.google.inject.internal.asm.$ClassReader.readClass(Unknown Source) ~[guice-3.0.jar:na]
	at com.google.inject.internal.asm.$ClassReader.accept(Unknown Source) ~[guice-3.0.jar:na]
	at com.google.inject.internal.asm.$ClassReader.accept(Unknown Source) ~[guice-3.0.jar:na]
	at com.google.inject.internal.util.$LineNumbers.<init>(LineNumbers.java:62) ~[guice-3.0.jar:na]
	at com.google.inject.internal.util.$StackTraceElements$1.apply(StackTraceElements.java:36) ~[guice-3.0.jar:na]
	at com.google.inject.internal.util.$StackTraceElements$1.apply(StackTraceElements.java:33) ~[guice-3.0.jar:na]
	at com.google.inject.internal.util.$MapMaker$StrategyImpl.compute(MapMaker.java:549) ~[guice-3.0.jar:na]
	at com.google.inject.internal.util.$MapMaker$StrategyImpl.compute(MapMaker.java:419) ~[guice-3.0.jar:na]
	at com.google.inject.internal.util.$CustomConcurrentHashMap$ComputingImpl.get(CustomConcurrentHashMap.java:2041) ~[guice-3.0.jar:na]
	at com.google.inject.internal.util.$StackTraceElements.forMember(StackTraceElements.java:53) ~[guice-3.0.jar:na]