### PR TITLE
Don't generate the router in root package

### DIFF
--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -57,6 +57,8 @@ By default Play will automatically handle the wiring of this router for you usin
 
 The injected routes generator also supports the `@` operator on routes, but it has a slightly different meaning (since everything is injected), if you prefix a controller with `@`, instead of that controller being directly injected, a JSR 330 `Provider` for that controller will be injected.  This can be used, for example, to eliminate circular dependency issues, or if you want a new action instantiated per request.
 
+In addition, Play now, by default, generates the router in the `router` package, instead of at the root package.  This is to aid with dependency injection, so if needed it can be manually created or bound, since classes in the root package can't usually be referenced.
+
 ### Dependency Injected Components
 
 While Play 2.4 won't force you to use the dependency injected versions of components, we do encourage you to start switching to them.  The following tables show old static APIs that use global state and new injected APIs that you should be switching to:

--- a/documentation/manual/working/scalaGuide/advanced/dependencyinjection/code/CompileTimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/advanced/dependencyinjection/code/CompileTimeDependencyInjection.scala
@@ -85,11 +85,15 @@ package routers {
 
 import scalaguide.advanced.dependencyinjection.controllers
 import scalaguide.advanced.dependencyinjection.bar
-import scalaguide.advanced.dependencyinjection.Routes
+
+object router {
+  type Routes = scalaguide.advanced.dependencyinjection.Routes
+}
 
 //#routers
 import play.api._
 import play.api.ApplicationLoader.Context
+import router.Routes
 
 class MyApplicationLoader extends ApplicationLoader {
   def load(context: Context) = {

--- a/framework/src/play/src/main/scala/play/api/routing/Router.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/Router.scala
@@ -53,7 +53,7 @@ object Router {
     val className = PlayConfig(configuration).getOptionalDeprecated[String]("play.http.router", "application.router")
 
     try {
-      Some(Reflect.getClass[Router](className.getOrElse("Routes"), env.classLoader))
+      Some(Reflect.getClass[Router](className.getOrElse("router.Routes"), env.classLoader))
     } catch {
       case e: ClassNotFoundException =>
         // Only throw an exception if a router was explicitly configured, but not found.

--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesCompiler.scala
@@ -72,6 +72,7 @@ object RoutesCompiler {
     namespaceReverseRouter: Boolean = false): Either[Seq[RoutesCompilationError], Seq[File]] = {
 
     val namespace = Option(file.getName).filter(_.endsWith(".routes")).map(_.dropRight(".routes".size))
+      .orElse(Some("router"))
 
     val routeFile = file.getAbsoluteFile
 


### PR DESCRIPTION
It should be generated in `router.Router` or something like that.  Otherwise compile time injection is hard, because you can't refer to the root package.