### PR TITLE
Sorted out conf directory

### DIFF
--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -390,3 +390,10 @@ The API should be backward compatible with your code using Play 2.3 so there is 
 ## IntelliJ IDEA
 
 Play no longer includes the sbt idea plugin.  IntelliJ is now able to import sbt projects natively, so we recommend using that instead.  Alternatively, the sbt idea plugin can be manually installed and used, instructions can be found [here](https://github.com/mpeltonen/sbt-idea).
+
+## Distribution
+
+Previously, Play added all the resources to the the `conf` directory in the distribution, but didn't add the `conf` directory to the classpath.  Now Play adds the `conf` directory to the classpath by default.
+
+This can be turned off by setting `PlayKeys.externalizeResources := false`, which will cause no `conf` directory to be created in the distribution, and it will not be on the classpath.  The contents of the applications `conf` directory will still be on the classpath by virtue of the fact that it's included in the applications jar file.
+

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/ApplicationSecretGenerator.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/ApplicationSecretGenerator.scala
@@ -37,7 +37,7 @@ object ApplicationSecretGenerator {
 
     val appConfFile = Option(System.getProperty("config.file")) match {
       case Some(applicationConf) => new File(baseDir, applicationConf)
-      case None => confDirectory.value / "application.conf"
+      case None => (Keys.resourceDirectory in Compile).value / "application.conf"
     }
 
     if (appConfFile.exists()) {

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -94,7 +94,7 @@ object PlayImport {
     /** A hook to configure how play blocks on user input while running. */
     val playInteractionMode = SettingKey[PlayInteractionMode]("play-interaction-mode", "Hook to configure how Play blocks when running")
 
-    val confDirectory = SettingKey[File]("play-conf", "Where the Play conf directory lives")
+    val externalizeResources = SettingKey[Boolean]("playExternalizeResources", "Whether resources should be externalized into the conf directory when Play is packaged as a distribution.")
 
     val playOmnidoc = SettingKey[Boolean]("play-omnidoc", "Determines whether to use the aggregated Play documentation")
     val playDocsName = SettingKey[String]("play-docs-name", "Artifact name of the Play documentation")

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/Global.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/Global.scala
@@ -1,0 +1,24 @@
+import play.api._
+
+object Global extends GlobalSettings {
+
+  override def onStart(app: Application): Unit = {
+    // If the app lasts for more than 10 seconds, shut it down, so that the scripted tests don't leak,
+    // but be sure that we don't call System.exit while shutting down, as this will create a deadlock
+    val thread = new Thread() {
+      override def run() = {
+        try {
+          Thread.sleep(10000)
+          // We won't reach here if the app shuts down normally, because an exception will be thrown
+          println("Forcibly terminating JVM that hasn't been shut down")
+          System.exit(1)
+        } catch {
+          case _: Throwable =>
+        }
+      }
+    }
+    thread.setDaemon(true)
+    thread.start()
+  }
+
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/controllers/Application.scala
@@ -5,6 +5,7 @@ package controllers
 
 import play.api._
 import play.api.mvc._
+import play.api.Play.current
 
 object Application extends Controller {
 
@@ -12,4 +13,7 @@ object Application extends Controller {
     Ok(views.html.index("Your new application is ready."))
   }
 
+  def config = Action {
+    Ok(Play.configuration.underlying.getString("some.config"))
+  }
 }

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
@@ -6,22 +6,52 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.4")
 
-val distAndUnzip = TaskKey[File]("dist-and-unzip")
-
-distAndUnzip := {
-  val unzippedFiles = IO.unzip(dist.value, target.value)
-  val unzippedFilePath = unzippedFiles.head.getCanonicalPath.stripPrefix(target.value.getCanonicalPath)
-  val unzippedFolder = target.value / unzippedFilePath.split('/')(1)
-  val targetUnzippedFolder = target.value / "dist"
-  IO.move(Seq(unzippedFolder -> targetUnzippedFolder))
-  targetUnzippedFolder
-}
-
-val checkStartScript = TaskKey[Unit]("check-start-script")
+val checkStartScript = InputKey[Unit]("check-start-script")
 
 checkStartScript := {
-  val startScript = distAndUnzip.value / "bin/dist-sample"
-  if (!IO.read(startScript).contains( """app_mainclass="play.core.server.NettyServer"""")) {
-    error("Cannot find the declaration of the main class in the script")
+  val args = Def.spaceDelimited().parsed
+  val startScript = target.value / "universal/stage/bin/dist-sample"
+  def startScriptError(contents: String, msg: String) = {
+    println("Error in start script, dumping contents:")
+    println(contents)
+    sys.error(msg)
+  }
+  val contents = IO.read(startScript)
+  if (!contents.contains( """app_mainclass="play.core.server.NettyServer"""")) {
+    startScriptError(contents, "Cannot find the declaration of the main class in the script")
+  }
+  if (args.contains("no-conf")) {
+    if (contents.contains("../conf")) {
+      startScriptError(contents, "Start script is adding conf directory to the classpath when it shouldn't be")
+    }
+  } else {
+    if (!contents.contains("../conf")) {
+      startScriptError(contents, "Start script is not adding conf directory to the classpath when it should be")
+    }
+  }
+}
+
+def retry[B](max: Int = 10, sleep: Long = 500, current: Int = 1)(block: => B): B = {
+  try {
+    block
+  } catch {
+    case scala.util.control.NonFatal(e) =>
+      if (current == max) {
+        throw e
+      } else {
+        Thread.sleep(sleep)
+        retry(max, sleep, current + 1)(block)
+      }
+  }
+}
+
+InputKey[Unit]("check-config") := {
+  val expected = Def.spaceDelimited().parsed.head
+  import java.net.URL
+  val config = retry() {
+    IO.readLinesURL(new URL("http://localhost:9000/config")).mkString("\n")
+  }
+  if (expected != config) {
+    sys.error(s"Expected config $expected but got $config")
   }
 }

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/conf/alternate.conf
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/conf/alternate.conf
@@ -1,3 +1,3 @@
 play.crypto.secret=";1[WE]JmK;XMCxV=S2P6kYl?A<^YcKYW3aui[SmusaQlkjq97A`M8l_S:iV?OmDh"
 play.i18n.langs = [ "en" ]
-some.config="foo"
+some.config="bar"

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/conf/routes
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/conf/routes
@@ -3,7 +3,9 @@
 # ~~~~
 
 # Home page
-GET     /                           controllers.Application.index
+GET        /                    controllers.Application.index
+
+GET        /config              controllers.Application.config
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file               controllers.Assets.at(path="/public", file)
+GET        /assets/*file        controllers.Assets.at(path="/public", file)

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/test
@@ -1,12 +1,27 @@
 # Build the distribution and ensure that the files we expect are indeed there
-> dist-and-unzip
-$ exists target/dist/README
-$ exists target/dist/SomeFile.txt
-$ exists target/dist/SomeFolder/SomeOtherFile.txt
+> stage
+$ exists target/universal/stage/README
+$ exists target/universal/stage/SomeFile.txt
+$ exists target/universal/stage/SomeFolder/SomeOtherFile.txt
 
 > check-start-script
-$ exists target/dist/conf/application.conf
--$ exists target/dist/conf/routes
-$ exists target/dist/lib
-$ exists target/dist/share/doc/api
+$ exists target/universal/stage/conf/application.conf
+$ exists target/universal/stage/lib
+$ exists target/universal/stage/share/doc/api
 
+# Run it to make sure everything works
+> start --no-exit-sbt
+> check-config foo
+> stop --no-exit-sbt
+
+# Change the configuration in the conf directory, make sure it takes effect
+$ copy-file conf/alternate.conf target/universal/stage/conf/application.conf
+> start --no-exit-sbt
+> check-config bar
+> stop --no-exit-sbt
+
+# Turn off externalize resources, rebuild, make sure the conf directory is not created or on the classpath
+> set PlayKeys.externalizeResources := false
+> stage
+-$ exists target/dist/conf/application.conf
+> check-start-script no-conf


### PR DESCRIPTION
* conf directory in dist artifact is now added to the classpath by
 default
* Added externalizeResources SBT setting to turn off including the
 conf directory as an external (as in, not in the applications jar)
 directory and including it in the classpath
* Added --no-exit-sbt flag to Play start and stop commands to help with
 scripted tests
* Updated distribution scripted test, which now tests running Play in
 prod mode, as well as testing if the conf directory is on the
 classpath.

Fixes #3473.

Depends on #4108 being merged first.