### PR TITLE
Ensure routes compiler outputs code that doesn't emit warnings

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -139,7 +139,7 @@ object BuildSettings {
       "-Xmx768m",
       maxMetaspace,
       "-Dproject.version=" + version.value,
-      "-Dscala.version=" + (scalaVersion in PlayBuild.PlayProject).value
+      "-Dscala.version=" + sys.props.get("scripted.scala.version").getOrElse((scalaVersion in PlayBuild.PlayProject).value)
     )
   )
 

--- a/framework/runtests
+++ b/framework/runtests
@@ -34,6 +34,11 @@ echo "[info]"
 
 $BUILD "$@" scripted
 
+if [ -n "$CROSSBUILD" ]
+then
+    $BUILD "$@" "set scalaVersion in PlayBuild.PlayProject := \"2.11.5\"" scripted
+fi
+
 rm -rf ./logs
 
 cd $CURRENT

--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
@@ -285,8 +285,8 @@ package object templates {
       (route, localNames, constraints)
     }.foldLeft((Seq.empty[(Route, Map[String, String], String)], false)) {
       case ((routes, true), dead) => (routes, true)
-      case ((routes, false), (route, localNames, None)) => (routes :+ (route, localNames, "true"), true)
-      case ((routes, false), (route, localNames, Some(constraints))) => (routes :+ (route, localNames, constraints), false)
+      case ((routes, false), (route, localNames, None)) => (routes :+ ((route, localNames, "true")), true)
+      case ((routes, false), (route, localNames, Some(constraints))) => (routes :+ ((route, localNames, constraints)), false)
     }._1
   }
 

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/utils/JavaScriptRouterGenerator.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/utils/JavaScriptRouterGenerator.scala
@@ -6,7 +6,7 @@ object JavaScriptRouterGenerator extends App {
 
   import controllers.routes.javascript._
 
-  val jsFile = play.api.Routes.javascriptRouter("jsRoutes", None, "localhost",
+  val jsFile = play.api.routing.JavaScriptReverseRouter("jsRoutes", None, "localhost",
     Application.index,
     Application.post,
     Application.withParam,

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/build.sbt
@@ -41,3 +41,22 @@ compile in Compile := {
     case Value(v) => v
   }
 }
+
+scalacOptions ++= {
+  Seq(
+    "-deprecation",
+    "-encoding", "UTF-8",
+    "-feature",
+    "-language:existentials",
+    "-language:higherKinds",
+    "-language:implicitConversions",
+    "-unchecked",
+    "-Xfatal-warnings",
+    "-Xlint",
+    "-Yno-adapted-args",
+    "-Ywarn-dead-code",
+    "-Ywarn-numeric-widen",
+    "-Ywarn-value-discard",
+    "-Xfuture"
+  )
+}

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/tests/RouterSpec.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/tests/RouterSpec.scala
@@ -113,14 +113,14 @@ object RouterSpec extends PlaySpecification {
 
   "allow reverse routing of routes includes" in new WithApplication() {
     // Force the router to bootstrap the prefix
-    app.routes
+    app.injector.instanceOf[play.api.routing.Router]
     controllers.module.routes.ModuleController.index().url must_== "/module/index"
   }
 
   "document the router" in new WithApplication() {
     // The purpose of this test is to alert anyone that changes the format of the router documentation that
     // it is being used by Swagger. So if you do change it, please let Tony Tam know at tony at wordnik dot com.
-    val someRoute = app.routes.documentation.find(r => r._1 == "GET" && r._2.startsWith("/with/"))
+    val someRoute = app.injector.instanceOf[play.api.routing.Router].documentation.find(r => r._1 == "GET" && r._2.startsWith("/with/"))
     someRoute must beSome[(String, String, String)]
     val route = someRoute.get
     route._2 must_== "/with/$param<[^/]+>"

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/utils/JavaScriptRouterGenerator.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/utils/JavaScriptRouterGenerator.scala
@@ -6,7 +6,7 @@ object JavaScriptRouterGenerator extends App {
 
   import controllers.routes.javascript._
 
-  val jsFile = play.api.Routes.javascriptRouter("jsRoutes", None, "localhost",
+  val jsFile = play.api.routing.JavaScriptReverseRouter("jsRoutes", None, "localhost",
     Application.index,
     Application.post,
     Application.withParam,

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/build.sbt
@@ -39,3 +39,22 @@ compile in Compile := {
     case Value(v) => v
   }
 }
+
+scalacOptions ++= {
+  Seq(
+    "-deprecation",
+    "-encoding", "UTF-8",
+    "-feature",
+    "-language:existentials",
+    "-language:higherKinds",
+    "-language:implicitConversions",
+    "-unchecked",
+    "-Xfatal-warnings",
+    "-Xlint",
+    "-Yno-adapted-args",
+    "-Ywarn-dead-code",
+    "-Ywarn-numeric-widen",
+    "-Ywarn-value-discard",
+    "-Xfuture"
+  )
+}

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/tests/RouterSpec.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/tests/RouterSpec.scala
@@ -101,14 +101,14 @@ object RouterSpec extends PlaySpecification {
 
   "allow reverse routing of routes includes" in new WithApplication() {
     // Force the router to bootstrap the prefix
-    app.routes
+    app.injector.instanceOf[play.api.routing.Router]
     controllers.module.routes.ModuleController.index().url must_== "/module/index"
   }
 
   "document the router" in new WithApplication() {
     // The purpose of this test is to alert anyone that changes the format of the router documentation that
     // it is being used by Swagger. So if you do change it, please let Tony Tam know at tony at wordnik dot com.
-    val someRoute = app.routes.documentation.find(r => r._1 == "GET" && r._2.startsWith("/with/"))
+    val someRoute = app.injector.instanceOf[play.api.routing.Router].documentation.find(r => r._1 == "GET" && r._2.startsWith("/with/"))
     someRoute must beSome[(String, String, String)]
     val route = someRoute.get
     route._2 must_== "/with/$param<[^/]+>"


### PR DESCRIPTION
If a user turns on all warnings in the Scala compiler, including `-Xfatal-warnings`, then the output of the routes compiler may not compile (I think it might be fine on master, but definitely not on 2.3.x).  We should add these flags to our routes compilation scripted tests.  Here's a sample set of flags:

```scala
scalacOptions ++= Seq(
  "-deprecation", 
  "-encoding", "UTF-8",
  "-feature", 
  "-language:existentials",
  "-language:higherKinds",
  "-language:implicitConversions",
  "-unchecked",
  "-Xfatal-warnings", 
  "-Xlint",
  "-Yno-adapted-args", 
  "-Ywarn-dead-code", // N.B. doesn't work well with the ??? hole
  "-Ywarn-numeric-widen", 
  "-Ywarn-value-discard",
  "-Xfuture",
  "-Ywarn-unused-import" // 2.11 only
)
```