### PR TITLE
Need import play.api.Play.current

### DIFF
--- a/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
+++ b/documentation/manual/scalaGuide/main/sql/ScalaAnorm.md
@@ -61,6 +61,7 @@ First, import `anorm._`, and then simply use the `SQL` object to create queries.
 ```scala
 import anorm._ 
 import play.api.db.DB
+import play.api.Play.current
 
 DB.withConnection { implicit c =>
   val result: Boolean = SQL("Select 1").execute()    


### PR DESCRIPTION
Need import play.api.Play.current. or playframework will failed:

```
[error] /scala-code/wingo/app/controllers/Admin.scala:15: You do not have an implicit Application in scope. If you want to bring the current running Application into context, just add import play.api.Play.current
[error]     DB.withConnection { implicit c =>

```