### PR TITLE
Placeholder scaffolding for application loader documentation

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/dependencyinjection/JavaDependencyInjection.md
+++ b/documentation/manual/working/javaGuide/advanced/dependencyinjection/JavaDependencyInjection.md
@@ -59,6 +59,14 @@ To register this module with Play, append it's fully qualified class name to the
 
     play.modules.enabled += "modules.HelloModule"
 
+You can also provide your own application loader:
+
+@[guice-app-loader](code/javaguide/advanced/di/guice/CustomApplicationLoader.java)
+
+You then need to specifiy it in `play.application.loader`:
+
+    play.modules.enabled := "modules.CustomApplicationLoader"
+
 ### Play libraries
 
 If you're implementing a library for Play, then you probably want it to be DI framework agnostic, so that your library will work out of the box regardless of which DI framework is being used in an application.  For this reason, Play provides a lightweight binding API for providing bindings in a DI framework agnostic way.

--- a/documentation/manual/working/javaGuide/advanced/dependencyinjection/code/javaguide/advanced/di/guice/CustomApplicationLoader.java
+++ b/documentation/manual/working/javaGuide/advanced/dependencyinjection/code/javaguide/advanced/di/guice/CustomApplicationLoader.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package javaguide.advanced.di.guice;
+
+//#guice-app-loader
+import play.api.Application;
+import play.api.ApplicationLoader;
+import play.api.inject.guice.GuiceApplicationLoader;
+
+public class CustomApplicationLoader extends GuiceApplicationLoader {
+
+  @Override
+  public Application load(ApplicationLoader.Context context) {
+    // TODO: document how to create a Guice Module for the builder which relies on configuration settings
+    return builder(context).build();
+  }
+
+}
+//#guice-app-loader

--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
@@ -16,13 +16,20 @@ class GuiceApplicationLoader(builder: GuiceApplicationBuilder) extends Applicati
   def this() = this(new GuiceApplicationBuilder)
 
   def load(context: ApplicationLoader.Context): Application = {
+    builder(context).build
+  }
+
+  def builder(context: ApplicationLoader.Context): GuiceApplicationBuilder = {
     builder
       .in(context.environment)
       .loadConfig(context.initialConfiguration)
-      .overrides(
-        bind[OptionalSourceMapper] to new OptionalSourceMapper(context.sourceMapper),
-        bind[WebCommands] to context.webCommands
-      ).build
+      .overrides(overrides(context): _*)
+  }
+
+  def overrides(context: ApplicationLoader.Context): Seq[GuiceableModule] = {
+    Seq(
+      bind[OptionalSourceMapper] to new OptionalSourceMapper(context.sourceMapper),
+      bind[WebCommands] to context.webCommands)
   }
 
 }


### PR DESCRIPTION
I tried passing in my own Guice `Module` using the `GuiceApplicationBuilder`, but it's really not easy. We should make it easier to do that and then update these docs with an example showing how. I thought I'd at least send in this since it should provide a placeholder for better docs