### PR TITLE
Improvement of #3873

### DIFF
--- a/documentation/manual/detailedTopics/production/ProductionDist.md
+++ b/documentation/manual/detailedTopics/production/ProductionDist.md
@@ -180,7 +180,7 @@ libraryDependencies ~= { _ map {
 
 // Take the first ServerWithStop because it's packaged into two jars
 assemblyMergeStrategy in assembly := {
-  case "play/core/server/ServerWithStop.class" => MergeStrategy.first
+  case PathList("play", "core", "server", "ServerWithStop.class") => MergeStrategy.first
   case other => (assemblyMergeStrategy in assembly).value(other)
 }
 ```


### PR DESCRIPTION
On windows system, the merge strategy below won't work because of the defference of path separator.

```
assemblyMergeStrategy in assembly := {
  case "play/core/server/ServerWithStop.class" => MergeStrategy.first
  case other => (assemblyMergeStrategy in assembly).value(other)
}
```