### PR TITLE
Set Content-Length header for fixed-length Results

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -370,10 +370,10 @@ trait Results {
      * @param content The content to send.
      */
     def apply[C](content: C)(implicit writeable: Writeable[C]): Result = {
-      Result(
-        ResponseHeader(status, writeable.contentType.map(ct => Map(CONTENT_TYPE -> ct)).getOrElse(Map.empty)),
-        Enumerator(writeable.transform(content))
-      )
+      val body: Array[Byte] = writeable.transform(content)
+      val contentTypeHeader: Option[(String, String)] = writeable.contentType.map(CONTENT_TYPE -> _)
+      val headers: Map[String, String] = Map(CONTENT_LENGTH -> body.length.toString) ++ contentTypeHeader
+      Result(ResponseHeader(status, headers), Enumerator(body))
     }
 
     /**

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -27,6 +27,11 @@ object ResultsSpec extends Specification {
       status must be_==(200)
     }
 
+    "have Content-Length header for Writeable content" in {
+      val Result(ResponseHeader(_, headers), _, _) = Ok("hello")
+      headers must havePair("Content-Length" -> "5")
+    }
+
     "support Content-Type overriding" in {
       val Result(ResponseHeader(_, headers), _, _) = Ok("hello").as("text/html")
       headers must havePair("Content-Type" -> "text/html")
@@ -36,7 +41,8 @@ object ResultsSpec extends Specification {
       val Result(ResponseHeader(_, headers), _, _) =
         Ok("hello").as("text/html").withHeaders("Set-Cookie" -> "yes", "X-YOP" -> "1", "X-Yop" -> "2")
 
-      headers.size must be_==(3)
+      headers.size must be_==(4)
+      headers must havePair("Content-Length" -> "5")
       headers must havePair("Content-Type" -> "text/html")
       headers must havePair("Set-Cookie" -> "yes")
       headers must not havePair ("X-YOP" -> "1")


### PR DESCRIPTION
When we have Writeable content we know the length of the result body, so we can easily set the Content-Length header. The header would usually be set anyway after the ServerResultUtils reads the Enumerator and determines that the content has a know length. Setting the header early saves the effort of reading the enumerator and allows the result to be sent earlier.