### PR TITLE
Add withFragment(...) to Call

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Call.java
+++ b/framework/src/play/src/main/java/play/mvc/Call.java
@@ -23,6 +23,11 @@ public abstract class Call {
     public abstract String method();
 
     /**
+     * The fragment of the URL.
+     */
+    public abstract String fragment();
+
+    /**
      * Append a unique identifier to the URL.
      */
     public Call unique() {
@@ -32,7 +37,25 @@ public abstract class Call {
         } else {
             url = url + "&" + rand.nextLong();
         }
-        return new play.api.mvc.Call(method(), url);
+        return new play.api.mvc.Call(method(), url, fragment());
+    }
+
+    /**
+     * Returns a new Call with the given fragment.
+     */
+    public Call withFragment(String fragment) {
+        return new play.api.mvc.Call(method(), url(), fragment);
+    }
+
+    /**
+     * Returns the fragment (including the leading "#") if this call has one.
+     */
+    protected String appendFragment() {
+        if (this.fragment() != null && !this.fragment().trim().isEmpty()) {
+            return "#" + this.fragment();
+        } else {
+            return "";
+        }
     }
 
     /**
@@ -53,7 +76,7 @@ public abstract class Call {
      * Transform this call to an absolute URL.
      */
     public String absoluteURL(boolean secure, String host) {
-        return "http" + (secure ? "s" : "") + "://" + host + this.url();
+        return "http" + (secure ? "s" : "") + "://" + host + this.url() + this.appendFragment();
     }
 
     /**

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -321,7 +321,7 @@ package play.api.mvc {
    * @param method the request HTTP method
    * @param url the request URL
    */
-  case class Call(method: String, url: String) extends play.mvc.Call {
+  case class Call(method: String, url: String, fragment: String = null) extends play.mvc.Call {
 
     /**
      * Transform this call to an absolute URL.
@@ -341,7 +341,7 @@ package play.api.mvc {
      * Transform this call to an absolute URL.
      */
     def absoluteURL(secure: Boolean)(implicit request: RequestHeader): String =
-      "http" + (if (secure) "s" else "") + "://" + request.host + this.url
+      "http" + (if (secure) "s" else "") + "://" + request.host + this.url + this.appendFragment
 
     /**
      * Transform this call to an WebSocket URL.
@@ -362,7 +362,7 @@ package play.api.mvc {
      */
     def webSocketURL(secure: Boolean)(implicit request: RequestHeader): String = "ws" + (if (secure) "s" else "") + "://" + request.host + this.url
 
-    override def toString = url
+    override def toString = this.url + this.appendFragment
 
   }
 

--- a/framework/src/play/src/test/java/play/mvc/CallTest.java
+++ b/framework/src/play/src/test/java/play/mvc/CallTest.java
@@ -153,12 +153,15 @@ public final class CallTest {
 final class TestCall extends Call {
     private final String u;
     private final String m;
+    private final String f;
 
     TestCall(String u, String m) {
         this.u = u;
         this.m = m;
+        this.f = null;
     }
 
     public String url() { return this.u; }
     public String method() { return this.m; }
+    public String fragment() { return this.f; }
 }


### PR DESCRIPTION
Fixes #4034 

The implementation allows you to write e.g.
```scala
routes.Application.index.withFragment("some-id").absoluteURL(request)
```