### PR TITLE
Missing imports in doc

### DIFF
--- a/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide2.md
+++ b/documentation/manual/javaGuide/tutorials/zentasks/JavaGuide2.md
@@ -317,6 +317,7 @@ Now we create a test case that loads this data and runs some assertions over it:
 ```
 
 > You may find it more convenient to load the test data in your `@Before` method, so that the test data is available for every test.
+> Don't forget to do "import com.avaje.ebean.*; import play.libs.*;"
 
 ## Save your work
 


### PR DESCRIPTION
I just included two import packages that were necessary for compilation problems that occurred when those two packages were not included. 
> Don't forget to do "import com.avaje.ebean.*; import play.libs.*;"