### PR TITLE
Cookie enhancements and fixes

### DIFF
--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -60,7 +60,7 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
             if (config.cookieName().isDefined()) {
                 Option<String> domain = Session.domain();
                 ctx.response().setCookie(config.cookieName().get(), newToken, null, Session.path(),
-                        domain.isDefined() ? domain.get() : null, config.secureCookie(), false);
+                        domain.isDefined() ? domain.get() : null, config.secureCookie(), config.httpOnlyCookie());
             } else {
                 ctx.session().put(config.tokenName(), newToken);
             }

--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -26,6 +26,9 @@ play.filters {
 
       # Whether the cookie should be set to secure
       secure = ${play.http.session.secure}
+
+      # Whether the cookie should have the HTTP only flag set
+      httpOnly = false
     }
 
     # How much of the body should be buffered when looking for the token in the request body

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -188,7 +188,7 @@ object CSRFAction {
         // cookie
         name =>
           result.withCookies(Cookie(name, newToken, path = Session.path, domain = Session.domain,
-            secure = config.secureCookie))
+            secure = config.secureCookie, httpOnly = config.httpOnlyCookie))
       } getOrElse {
 
         val newSession = result.session(request) + (config.tokenName -> newToken)

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -27,6 +27,7 @@ import javax.inject.{ Singleton, Provider, Inject }
  * @param tokenName The name of the token.
  * @param cookieName If defined, the name of the cookie to read the token from/write the token to.
  * @param secureCookie If using a cookie, whether it should be secure.
+ * @param httpOnlyCookie If using a cookie, whether it should have the HTTP only flag.
  * @param postBodyBuffer How much of the POST body should be buffered if checking the body for a token.
  * @param signTokens Whether tokens should be signed.
  * @param checkMethod Returns true if a request for that method should be checked.
@@ -37,6 +38,7 @@ import javax.inject.{ Singleton, Provider, Inject }
 case class CSRFConfig(tokenName: String = "csrfToken",
   cookieName: Option[String] = None,
   secureCookie: Boolean = false,
+  httpOnlyCookie: Boolean = false,
   createIfNotFound: (RequestHeader) => Boolean = CSRFConfig.defaultCreateIfNotFound,
   postBodyBuffer: Long = 102400,
   signTokens: Boolean = true,
@@ -85,6 +87,7 @@ object CSRFConfig {
       tokenName = config.get[String]("token.name"),
       cookieName = config.getOptional[String]("cookie.name"),
       secureCookie = config.get[Boolean]("cookie.secure"),
+      httpOnlyCookie = config.get[Boolean]("cookie.httpOnly"),
       postBodyBuffer = config.get[ConfigMemorySize]("body.bufferSize").toBytes,
       signTokens = config.get[Boolean]("token.sign"),
       checkMethod = checkMethod,

--- a/framework/src/play/src/main/java/play/Play.java
+++ b/framework/src/play/src/main/java/play/Play.java
@@ -48,4 +48,12 @@ public class Play {
     public static String langCookieName() {
         return play.api.i18n.Messages.Implicits$.MODULE$.applicationMessagesApi(play.api.Play.current()).langCookieName();
     }
+
+    public static boolean langCookieSecure() {
+        return play.api.i18n.Messages.Implicits$.MODULE$.applicationMessagesApi(play.api.Play.current()).langCookieSecure();
+    }
+
+    public static boolean langCookieHttpOnly() {
+        return play.api.i18n.Messages.Implicits$.MODULE$.applicationMessagesApi(play.api.Play.current()).langCookieHttpOnly();
+    }
 }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -190,7 +190,9 @@ public class Http {
         public boolean changeLang(Lang lang) {
             if (Lang.availables().contains(lang)) {
                 this.lang = lang;
-                response.setCookie(Play.langCookieName(), lang.code());
+                scala.Option<String> domain = play.api.mvc.Session.domain();
+                response.setCookie(Play.langCookieName(), lang.code(), null, play.api.mvc.Session.path(),
+                    domain.isDefined() ? domain.get() : null, Play.langCookieSecure(), Play.langCookieHttpOnly());
                 return true;
             } else {
                 return false;
@@ -202,7 +204,9 @@ public class Http {
          */
         public void clearLang() {
             this.lang = null;
-            response.discardCookie(Play.langCookieName());
+            scala.Option<String> domain = play.api.mvc.Session.domain();
+            response.discardCookie(Play.langCookieName(), play.api.mvc.Session.path(),
+                domain.isDefined() ? domain.get() : null, Play.langCookieSecure());
         }
 
         /**

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -126,6 +126,12 @@ play {
     # read when the preferred lang is loaded.
     langCookieName = "PLAY_LANG"
 
+    # Whether the language cookie should be secure or not
+    langCookieSecure = false
+
+    # Whether the HTTP only attribute of the cookie should be set to true
+    langCookieHttpOnly = false
+
   }
 
   akka {

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -93,6 +93,9 @@ play {
 
       # Whether the flash cookie should be secure or not
       secure = false
+
+      # Whether the HTTP only attribute of the cookie should be set to true
+      httpOnly = true
     }
 
   }

--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -223,4 +223,16 @@ object Play {
    */
   def langCookieName(implicit messagesApi: MessagesApi): String =
     messagesApi.langCookieName
+
+  /**
+   * Returns whether the language cookie should have the secure flag set.
+   */
+  def langCookieSecure(implicit messagesApi: MessagesApi): Boolean =
+    messagesApi.langCookieSecure
+
+  /**
+   * Returns whether the language cookie should have the HTTP only flag set.
+   */
+  def langCookieHttpOnly(implicit messagesApi: MessagesApi): Boolean =
+    messagesApi.langCookieHttpOnly
 }

--- a/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -41,8 +41,10 @@ case class SessionConfiguration(cookieName: String = "PLAY_SESSION", secure: Boo
  * The flash configuration
  *
  * @param cookieName The name of the cookie used to store the session
+ * @param secure Whether the flash cookie should set the secure flag or not
+ * @param httpOnly Whether the HTTP only attribute of the cookie should be set
  */
-case class FlashConfiguration(cookieName: String = "PLAY_FLASH", secure: Boolean = false)
+case class FlashConfiguration(cookieName: String = "PLAY_FLASH", secure: Boolean = false, httpOnly: Boolean = true)
 
 /**
  * Configuration for body parsers.
@@ -88,7 +90,8 @@ object HttpConfiguration {
       ),
       flash = FlashConfiguration(
         cookieName = config.getDeprecated[String]("play.http.flash.cookieName", "flash.cookieName"),
-        secure = config.get[Boolean]("play.http.flash.secure")
+        secure = config.get[Boolean]("play.http.flash.secure"),
+        httpOnly = config.get[Boolean]("play.http.flash.httpOnly")
       )
     )
   }

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -6,7 +6,7 @@ package play.api.i18n
 import javax.inject.{ Inject, Singleton }
 
 import play.api.inject.Module
-import play.api.mvc.{ DiscardingCookie, Cookie, Result, RequestHeader }
+import play.api.mvc.{ DiscardingCookie, Cookie, Result, RequestHeader, Session }
 import play.mvc.Http
 
 import scala.language.postfixOps
@@ -456,6 +456,10 @@ trait MessagesApi {
 
   def langCookieName: String
 
+  def langCookieSecure: Boolean
+
+  def langCookieHttpOnly: Boolean
+
 }
 
 /**
@@ -483,9 +487,11 @@ class DefaultMessagesApi @Inject() (environment: Environment, configuration: Con
 
   def preferred(request: Http.RequestHeader) = preferred(request._underlyingHeader())
 
-  def setLang(result: Result, lang: Lang) = result.withCookies(Cookie(langCookieName, lang.code))
+  def setLang(result: Result, lang: Lang) = result.withCookies(Cookie(langCookieName, lang.code, path = Session.path, domain = Session.domain,
+    secure = langCookieSecure, httpOnly = langCookieHttpOnly))
 
-  def clearLang(result: Result) = result.discardingCookies(DiscardingCookie(langCookieName))
+  def clearLang(result: Result) = result.discardingCookies(DiscardingCookie(langCookieName, path = Session.path, domain = Session.domain,
+    secure = langCookieSecure))
 
   def apply(key: String, args: Any*)(implicit lang: Lang): String = {
     translate(key, args).getOrElse(noMatch(key, args))
@@ -543,6 +549,12 @@ class DefaultMessagesApi @Inject() (environment: Environment, configuration: Con
 
   lazy val langCookieName =
     config.getDeprecated[String]("play.i18n.langCookieName", "application.lang.cookie")
+
+  lazy val langCookieSecure =
+    config.get[Boolean]("play.i18n.langCookieSecure")
+
+  lazy val langCookieHttpOnly =
+    config.get[Boolean]("play.i18n.langCookieHttpOnly")
 
 }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -723,6 +723,8 @@ package play.api.mvc {
     val COOKIE_NAME = HttpConfiguration.current.flash.cookieName
     override def path = HttpConfiguration.current.context
     override def secure = HttpConfiguration.current.flash.secure
+    override def httpOnly = HttpConfiguration.current.flash.httpOnly
+    override def domain = HttpConfiguration.current.session.domain
 
     val emptyCookie = new Flash
 


### PR DESCRIPTION
Fixes #4068:
* Add setting `play.http.flash.httpOnly` (defaults to `true`)
* Flash cookie uses same `domain` as session cookie now
* Add setting `csrf.cookie.httpOnly` (defaults to `false`)
* Add conf `play.i18n.langCookieSecure` and `play.i18n.langCookieHttpOnly`
* The language cookie uses same `domain` and `path` of as session cookie now