### PR TITLE
Consider using Async appender to improve Logback performance

### DIFF
--- a/documentation/manual/detailedTopics/configuration/SettingsLogger.md
+++ b/documentation/manual/detailedTopics/configuration/SettingsLogger.md
@@ -4,46 +4,20 @@
 Play uses [Logback](http://logback.qos.ch/) as its logging engine, see the [Logback documentation](http://logback.qos.ch/manual/configuration.html) for details on configuration.
 
 ## Default configuration
+
 Play uses the following default configuration in production:
 
-```xml
-<configuration>
-    
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
-  
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-     <file>${application.home}/logs/application.log</file>
-     <encoder>
-       <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
-     </encoder>
-   </appender>
+@[](/confs/play/logback-play-default.xml)
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
-    </encoder>
-  </appender>
-  
-  <logger name="play" level="INFO" />
-  <logger name="application" level="DEBUG" />
-  
-  <!-- Off these ones as they are annoying, and anyway we manage configuration ourself -->
-  <logger name="com.avaje.ebean.config.PropertyMapLoader" level="OFF" />
-  <logger name="com.avaje.ebeaninternal.server.core.XmlConfigLoader" level="OFF" />
-  <logger name="com.avaje.ebeaninternal.server.lib.BackgroundThread" level="OFF" />
-  <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
+A few things to note about this configuration:
 
-  <root level="WARN">
-    <appender-ref ref="STDOUT" />
-    <appender-ref ref="FILE" />
-  </root>
-  
-</configuration>
-```
-
-This specifies a file appender writing to `logs/application.log`, a console appender, and log levels for the root/play/application loggers.
+* This specifies a file appender that writes to `logs/application.log`.
+* The file logger logs full exception stack traces, while the console logger only logs 10 lines of an exception stack trace.
+* Play uses ANSI color codes by default in level messages.
+* Play puts both the console and the file logger behind the logback [AsyncAppender](http://logback.qos.ch/manual/appenders.html#AsyncAppender).  For details on the performance implications on this, see this [blog post](http://blog.takipi.com/how-to-instantly-improve-your-java-logging-with-7-logback-tweaks/).
 
 ## Configuring log levels in application.conf
+
 You can override log levels in application.conf as follows:
 
 ```properties
@@ -103,7 +77,7 @@ $ start -Dlogger.file=/opt/prod/logger.xml
 
 ### Examples
 
-Here's an example of configuration that would work well in a production environment:
+Here's an example of configuration that uses a rolling file appender, as well as a seperate appender for outputting an access log:
 
 ```xml
 <configuration>
@@ -157,6 +131,7 @@ This demonstrates a few useful features:
 - All loggers are set to a threshold of `INFO` which is a common choice for production logging.  
 
 ## Akka logging configuration
+
 Akka has its own logging system which may or may not use Play's underlying logging engine depending on how it is configured.
 
 By default, Akka will ignore Play's logging configuration and print log messages to STDOUT using its own format. You can configure the log level in `application.conf`:

--- a/framework/project/Docs.scala
+++ b/framework/project/Docs.scala
@@ -21,7 +21,7 @@ object Docs {
   val apiDocsUseCache = SettingKey[Boolean]("api-docs-use-cache", "Whether to cache the doc inputs (can hit cache limit with dbuild)")
   val apiDocs = TaskKey[File]("api-docs", "Generate the API docs")
   val extractWebjars = TaskKey[File]("extract-webjars", "Extract webjar contents")
-  val allReferenceConfs = TaskKey[Seq[(String, File)]]("all-reference-confs", "Gather all reference confs")
+  val allConfs = TaskKey[Seq[(String, File)]]("all-confs", "Gather all configuration files")
 
   lazy val settings = Seq(
     apiDocsInclude := false,
@@ -33,8 +33,8 @@ object Docs {
     apiDocs <<= apiDocsTask,
     ivyConfigurations += Webjars,
     extractWebjars <<= extractWebjarContents,
-    allReferenceConfs in Global <<= (thisProjectRef, buildStructure) flatMap allReferenceConfsTask,
-    mappings in (Compile, packageBin) <++= (baseDirectory, apiDocs, extractWebjars, version, allReferenceConfs) map { (base, apiBase, webjars, playVersion, referenceConfs) =>
+    allConfs in Global <<= (thisProjectRef, buildStructure) flatMap allConfsTask,
+    mappings in (Compile, packageBin) <++= (baseDirectory, apiDocs, extractWebjars, version, allConfs) map { (base, apiBase, webjars, playVersion, confs) =>
       // Include documentation and API docs in main binary JAR
       val docBase = base / "../../../documentation"
       val raw = (docBase \ "manual" ** "*") +++ (docBase \ "style" ** "*")
@@ -46,9 +46,9 @@ object Docs {
       // The play version is added so that resource paths are versioned
       val webjarMappings = webjars.*** pair rebase(webjars, "play/docs/content/webjars/" + playVersion)
 
-      // Gather all the reference.conf files into the project
-      val referenceConfMappings = referenceConfs.map {
-        case (projectName, referenceConf) => referenceConf -> s"play/docs/content/confs/$projectName/reference.conf"
+      // Gather all the conf files into the project
+      val referenceConfMappings = confs.map {
+        case (projectName, conf) => conf -> s"play/docs/content/confs/$projectName/${conf.getName}"
       }
 
       docMappings ++ apiDocMappings ++ webjarMappings ++ referenceConfMappings
@@ -72,9 +72,9 @@ object Docs {
         val playVersion = version.value
         val webjarMappings = webjars.*** pair rebase(webjars, "webjars/" + playVersion)
 
-        // Gather all the reference.conf files into the project
-        val referenceConfs = allReferenceConfs.value.map {
-          case (projectName, referenceConf) => referenceConf -> s"confs/$projectName/reference.conf"
+        // Gather all the conf files into the project
+        val referenceConfs = allConfs.value.map {
+          case (projectName, conf) => conf -> s"confs/$projectName/${conf.getName}"
         }
 
         docMappings ++ webjarMappings ++ referenceConfs
@@ -138,22 +138,22 @@ object Docs {
     apiTarget
   }
 
-  def allReferenceConfsTask(projectRef: ProjectRef, structure: BuildStructure): Task[Seq[(String, File)]] = {
+  def allConfsTask(projectRef: ProjectRef, structure: BuildStructure): Task[Seq[(String, File)]] = {
     val projects = allApiProjects(projectRef.build, structure)
     val unmanagedResourcesTasks = projects map { ref =>
       def taskFromProject[T](task: TaskKey[T]) = task in Compile in ref get structure.data
 
       val projectId = moduleName in ref get structure.data
 
-      val referenceConfs = (unmanagedResources in Compile in ref get structure.data).map(_.map { resources =>
+      val confs = (unmanagedResources in Compile in ref get structure.data).map(_.map { resources =>
         (for {
-          referenceConf <- resources.find(_.name == "reference.conf")
-          id <- projectId
-        } yield id -> referenceConf).toSeq
+          conf <- resources.filter(resource => resource.name == "reference.conf" || resource.name.endsWith(".xml"))
+          id <- projectId.toSeq
+        } yield id -> conf).distinct
       })
 
       // Join them
-      val tasks = referenceConfs.toSeq
+      val tasks = confs.toSeq
       tasks.join.map(_.flatten)
     }
     unmanagedResourcesTasks.join.map(_.flatten)

--- a/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsValidation.scala
+++ b/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsValidation.scala
@@ -389,18 +389,22 @@ object PlayDocsValidation {
       "Could not find source file")
 
     def segmentExists(sample: CodeSampleRef) = {
-      // Find the code segment
-      val sourceCode = {
-        val file = new File(base, sample.source)
-        if (file.exists()) {
-          IO.readLines(new File(base, sample.source))
-        } else {
-          docsJarRepo.loadFile(sample.source)(is => IO.readLines(new BufferedReader(new InputStreamReader(is)))).get
+      if (sample.segment.nonEmpty) {
+        // Find the code segment
+        val sourceCode = {
+          val file = new File(base, sample.source)
+          if (file.exists()) {
+            IO.readLines(new File(base, sample.source))
+          } else {
+            docsJarRepo.loadFile(sample.source)(is => IO.readLines(new BufferedReader(new InputStreamReader(is)))).get
+          }
         }
+        val notLabel = (s: String) => !s.contains("#" + sample.segment)
+        val segment = sourceCode dropWhile (notLabel) drop (1) takeWhile (notLabel)
+        !segment.isEmpty
+      } else {
+        true
       }
-      val notLabel = (s: String) => !s.contains("#" + sample.segment)
-      val segment = sourceCode dropWhile (notLabel) drop (1) takeWhile (notLabel)
-      !segment.isEmpty
     }
 
     assertLinksNotMissing("Missing source segments test", existing.collect {

--- a/framework/src/play/src/main/resources/logback-play-default.xml
+++ b/framework/src/play/src/main/resources/logback-play-default.xml
@@ -5,20 +5,28 @@
 <configuration>
     
   <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
-  
+
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
      <file>${application.home}/logs/application.log</file>
      <encoder>
        <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
      </encoder>
-   </appender>
+  </appender>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
     </encoder>
   </appender>
-  
+
+  <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="FILE" />
+  </appender>
+
+  <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="FILE" />
+  </appender>
+
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
   
@@ -29,8 +37,8 @@
   <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
 
   <root level="WARN">
-    <appender-ref ref="STDOUT" />
-    <appender-ref ref="FILE" />
+    <appender-ref ref="ASYNCFILE" />
+    <appender-ref ref="ASYNCSTDOUT" />
   </root>
   
 </configuration>


### PR DESCRIPTION
Logback's synchronized appender can be a bottleneck in Play performance. We have reports of dramatic performance improvements when using the [AsyncAppender](http://logback.qos.ch/manual/appenders.html#AsyncAppender), e.g. decrease in large transaction time from 120s down to 20s; apparently all threads were blocking on ch.qos.logback.core.spi.LogbackLock. A downside is that some log messages might be lost if the app crashes, because events are no longer synchronously written to disk. By default debug/trace/info messages will also be discarded if the log queue is full; but this can be disabled by setting *discardingThreshold* to 0.

A good writeup on all the trade offs has been written up by Takipi: http://blog.takipi.com/how-to-instantly-improve-your-java-logging-with-7-logback-tweaks/. It's fascinating that their multi-file logger improves performance so much and still guarantees that events won't be lost. Unfortunately spreading events across multiple log files would be very confusing without using special software to combine the events back together again.