### PR TITLE
Don't evaluate remoteAddress/secure when copying RequestHeader

### DIFF
--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -3,9 +3,11 @@
  */
 package play.filters.csrf;
 
+import java.util.concurrent.Callable;
 import play.api.mvc.RequestHeader;
 import play.api.mvc.Session;
 import play.libs.F;
+import play.libs.Scala;
 import play.mvc.Action;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -43,7 +45,8 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
             final RequestHeader newRequest = request.copy(request.id(),
                     request.tags().$plus(new Tuple2<String, String>(requestTag, newToken)),
                     request.uri(), request.path(), request.method(), request.version(), request.queryString(),
-                    request.headers(), request.remoteAddress(), request.secure());
+                    request.headers(), Scala.asScala((Callable<String>) () -> request.remoteAddress()),
+                    Scala.asScala((Callable<Object>) () -> request.secure()));
 
             // Create a new context that will have the new RequestHeader.  This ensures that the CSRF.getToken call
             // used in templates will find the token.

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -174,9 +174,9 @@ package play.api.mvc {
       version: String = this.version,
       queryString: Map[String, Seq[String]] = this.queryString,
       headers: Headers = this.headers,
-      remoteAddress: String = this.remoteAddress,
-      secure: Boolean = this.secure): RequestHeader = {
-      val (_id, _tags, _uri, _path, _method, _version, _queryString, _headers, _remoteAddress, _secure) = (id, tags, uri, path, method, version, queryString, headers, remoteAddress, secure)
+      remoteAddress: => String = this.remoteAddress,
+      secure: => Boolean = this.secure): RequestHeader = {
+      val (_id, _tags, _uri, _path, _method, _version, _queryString, _headers, _remoteAddress, _secure) = (id, tags, uri, path, method, version, queryString, headers, () => remoteAddress, () => secure)
       new RequestHeader {
         val id = _id
         val tags = _tags
@@ -186,8 +186,8 @@ package play.api.mvc {
         val version = _version
         val queryString = _queryString
         val headers = _headers
-        val remoteAddress = _remoteAddress
-        val secure = _secure
+        lazy val remoteAddress = _remoteAddress()
+        lazy val secure = _secure()
       }
     }
 
@@ -264,6 +264,7 @@ package play.api.mvc {
 
   }
 
+  /** Used by Java wrapper */
   private[play] class RequestImpl[A](
       val body: A,
       val id: Long,


### PR DESCRIPTION
We make the `remoteAddress` and `secure` fields into a LazyField instead of a standard Scala lazy value. This allows us to copy the field state without evaluating it.

Note: I've made RequestHeader's lazy field state `private[play]`. Should the field state be public so that people can extend `RequestHeader` and `Request`?