### PR TITLE
Make header comparisons faster by comparing lengths

### DIFF
--- a/framework/src/play/src/main/scala/play/utils/CaseInsensitiveOrdered.scala
+++ b/framework/src/play/src/main/scala/play/utils/CaseInsensitiveOrdered.scala
@@ -4,10 +4,16 @@
 package play.core.utils
 
 /**
- * Case Insensitive Ordering
+ * Case Insensitive Ordering. We first compare by length, then
+ * use a case insensitive lexicographic order. This allows us to
+ * use a much faster length comparison before we even start looking
+ * at the content of the strings.
  */
-
 object CaseInsensitiveOrdered extends Ordering[String] {
-  def compare(x: String, y: String): Int = x.compareToIgnoreCase(y)
+  def compare(x: String, y: String): Int = {
+    val xl = x.length
+    val yl = y.length
+    if (xl < yl) -1 else if (xl > yl) 1 else x.compareToIgnoreCase(y)
+  }
 }
 


### PR DESCRIPTION
By comparing lengths in many cases we can avoid the need to look at the contents of the headers. This makes header operations a lot faster.