### PR TITLE
Avoid splitting headers unless Set-Cookie is present

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -264,7 +264,7 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
    */
   private def convertResponseHeaders(
     playHeaders: Map[String, String]): AkkaHttpHeaders = {
-    val rawHeaders = ServerResultUtils.splitHeadersIntoSeq(playHeaders).map {
+    val rawHeaders = ServerResultUtils.splitSetCookieHeaders(playHeaders).map {
       case (name, value) => RawHeader(name, value)
     }
     val convertedHeaders: List[HttpHeader] = HeaderParser.parseHeaders(rawHeaders.to[List]) match {

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyResultStreamer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyResultStreamer.scala
@@ -130,7 +130,7 @@ object NettyResultStreamer {
     import scala.collection.JavaConverters._
 
     // Set response headers
-    val headers = ServerResultUtils.splitHeadersIntoSeq(header.headers)
+    val headers = ServerResultUtils.splitSetCookieHeaders(header.headers)
     try {
       headers.foreach {
         case (name, value) => nettyResponse.headers().add(name, value)


### PR DESCRIPTION
When the `Set-Cookie` header is present we need to perform an expensive operation to split the headers. This change checks for the presence of the `Set-Cookie` header and only splits the headers if Set-Cookie is present.