### PR TITLE
Optimize Flash cookie cleaning

### DIFF
--- a/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -37,7 +37,12 @@ object ServerResultUtilsSpec extends Specification with IterateeSpecification {
       flashCookieResult(None, None) must beNone
     }
     "send flash if new" in {
-      flashCookieResult(None, Some("a" -> "b")) must beSome
+      flashCookieResult(None, Some("a" -> "b")) must beSome { cookies: Seq[Cookie] =>
+        cookies.length must_== 1
+        val cookie = cookies(0)
+        cookie.name must_== "PLAY_FLASH"
+        cookie.value must_== "a=b"
+      }
     }
     "clear flash when received" in {
       flashCookieResult(Some("PLAY_FLASH" -> "\"a=b\"; Path=/"), None) must beSome { cookies: Seq[Cookie] =>


### PR DESCRIPTION
Rearrange the Flash cookie cleaning logic to make it faster. In the common case where there is no Flash cookie or `Set-Cookie` header we can avoid doing any work at all.