### PR TITLE
Optimize string ops for adding / to context

### DIFF
--- a/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
+++ b/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
@@ -138,7 +138,12 @@ trait GlobalSettings {
   def doFilter(next: RequestHeader => Handler): (RequestHeader => Handler) = {
     (request: RequestHeader) =>
       val context = Play.maybeApplication.fold("/") { app =>
-        httpConfigurationCache(app).context.replaceAll("/$", "") + "/"
+        val configuration = httpConfigurationCache(app)
+        if (configuration.context.endsWith("/")) {
+          configuration.context
+        } else {
+          configuration.context + "/"
+        }
       }
       next(request) match {
         case action: EssentialAction if request.path startsWith context => doFilter(action)


### PR DESCRIPTION
For one thing, don't use a regex to detect a string ending in /. For another, don't add a / if it's already present. These operations are already fast in DefaultHttpRequestHandler. They only needed fixing in GlobalSettings.