### PR TITLE
[2.4.0-M3] Bug: CSRF cookie not set when using application.context

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -4,163 +4,221 @@
 package play.it.mvc
 
 import org.specs2.mutable.Specification
+import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws.WSClient
+import play.api.routing.Router
+import play.api.{ Environment, ApplicationLoader, BuiltInComponentsFromContext }
 import play.api.mvc._
 import play.api.test._
+import play.core.server.Server
 import play.it._
 import scala.concurrent.duration.Duration
 import scala.concurrent._
 import play.api.libs.concurrent.Execution.{ defaultContext => ec }
 
-object NettyFiltersSpec extends FiltersSpec with NettyIntegrationSpecification
-object AkkaHttpFiltersSpec extends FiltersSpec with AkkaHttpIntegrationSpecification
+object NettyDefaultFiltersSpec extends DefaultFiltersSpec with NettyIntegrationSpecification
+object NettyGlobalFiltersSpec extends GlobalFiltersSpec with NettyIntegrationSpecification
+object AkkaDefaultHttpFiltersSpec extends DefaultFiltersSpec with AkkaHttpIntegrationSpecification
 
-trait FiltersSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
+trait DefaultFiltersSpec extends FiltersSpec {
+  def withServer[T](settings: Map[String, String] = Map.empty, errorHandler: Option[HttpErrorHandler] = None)(filters: EssentialFilter*)(block: WSClient => T) = {
+
+    val app = new BuiltInComponentsFromContext(ApplicationLoader.createContext(
+      environment = Environment.simple(),
+      initialSettings = settings
+    )) {
+      lazy val router = testRouter
+      override lazy val httpFilters: Seq[EssentialFilter] = filters
+      override lazy val httpErrorHandler = errorHandler.getOrElse(
+        new DefaultHttpErrorHandler(environment, configuration, sourceMapper, Some(router))
+      )
+    }.application
+
+    Server.withApplication(app) { implicit port =>
+      WsTestClient.withClient(block)
+    }
+
+  }
+}
+
+trait GlobalFiltersSpec extends FiltersSpec {
+  def withServer[T](settings: Map[String, String] = Map.empty, errorHandler: Option[HttpErrorHandler] = None)(filters: EssentialFilter*)(block: WSClient => T) = {
+
+    import play.api.inject.bind
+
+    val appBuilder = new GuiceApplicationBuilder()
+      .configure(settings)
+      .overrides(bind[Router].toInstance(testRouter))
+      .global(
+        new WithFilters(filters: _*) {
+          override def onHandlerNotFound(request: RequestHeader) = {
+            errorHandler.fold(super.onHandlerNotFound(request))(_.onClientError(request, 404, ""))
+          }
+        }
+      )
+
+    Server.withApplication(appBuilder.build()) { implicit port =>
+      WsTestClient.withClient(block)
+    }
+  }
+}
+
+trait FiltersSpec extends Specification with ServerIntegrationSpecification {
+
+  sequential
 
   "filters" should {
     "handle errors" in {
 
-      object ErrorHandlingFilter extends Filter {
-        def apply(next: RequestHeader => Future[Result])(request: RequestHeader): Future[Result] = {
-          try {
-            next(request).recover {
-              case t: Throwable =>
-                Results.InternalServerError(t.getMessage)
-            }(play.api.libs.concurrent.Execution.Implicits.defaultContext)
-          } catch {
-            case t: Throwable => Future.successful(Results.InternalServerError(t.getMessage))
-          }
-        }
-      }
-
-      object SkipNextFilter extends Filter {
-        val expectedText = "This filter does not call next"
-
-        def apply(next: RequestHeader => Future[Result])(request: RequestHeader): Future[Result] = {
-          Future.successful(Results.Ok(expectedText))
-        }
-      }
-
-      object SkipNextWithErrorFilter extends Filter {
-        val expectedText = "This filter does not call next and throws an exception"
-
-        def apply(next: RequestHeader => Future[Result])(request: RequestHeader): Future[Result] = {
-          Future.failed(new RuntimeException(expectedText))
-        }
-      }
-
-      object ThrowExceptionFilter extends Filter {
-        val expectedText = "This filter calls next and throws an exception afterwords"
-
-        override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
-          next(rh).map { _ =>
-            throw new RuntimeException(expectedText)
-          }(ec)
-        }
-      }
-
-      object ErrorHandlingGlobal extends WithFilters(ErrorHandlingFilter)
-      object SkipNextGlobal extends WithFilters(ErrorHandlingFilter, SkipNextFilter)
-      object SkipNextWithErrorGlobal extends WithFilters(ErrorHandlingFilter, SkipNextWithErrorFilter)
-      object GlobalWithThrowExceptionFilter extends WithFilters(ErrorHandlingFilter, ThrowExceptionFilter)
-
-      val expectedOkText = "Hello World"
-      val expectedErrorText = "Error"
-
-      val routerForTest: PartialFunction[(String, String), Handler] = {
-        case ("GET", "/ok") => Action { request => Results.Ok(expectedOkText) }
-        case ("POST", "/ok") => Action { request => Results.Ok(request.body.asText.getOrElse("")) }
-        case ("GET", "/error") => Action { request => throw new RuntimeException(expectedErrorText) }
-        case ("POST", "/error") => Action { request => throw new RuntimeException(request.body.asText.getOrElse("")) }
-        case ("GET", "/error-async") => Action.async { request => Future { throw new RuntimeException(expectedErrorText) }(ec) }
-        case ("POST", "/error-async") => Action.async { request => Future { throw new RuntimeException(request.body.asText.getOrElse("")) }(ec) }
-      }
-
-      "ErrorHandlingFilter has no effect on a GET that returns a 200 OK" in new WithServer(FakeApplication(withGlobal = Some(ErrorHandlingGlobal), withRoutes = routerForTest)) {
-        val response = Await.result(wsUrl("/ok").get(), Duration.Inf)
+      "ErrorHandlingFilter has no effect on a GET that returns a 200 OK" in withServer()(ErrorHandlingFilter) { ws =>
+        val response = Await.result(ws.url("/ok").get(), Duration.Inf)
         response.status must_== 200
         response.body must_== expectedOkText
       }
 
-      "ErrorHandlingFilter has no effect on a POST that returns a 200 OK" in new WithServer(FakeApplication(withGlobal = Some(ErrorHandlingGlobal), withRoutes = routerForTest)) {
-        val response = Await.result(wsUrl("/ok").post(expectedOkText), Duration.Inf)
+      "ErrorHandlingFilter has no effect on a POST that returns a 200 OK" in withServer()(ErrorHandlingFilter) { ws =>
+        val response = Await.result(ws.url("/ok").post(expectedOkText), Duration.Inf)
         response.status must_== 200
         response.body must_== expectedOkText
       }
 
-      "ErrorHandlingFilter recovers from a GET that throws a synchronous exception" in new WithServer(FakeApplication(withGlobal = Some(ErrorHandlingGlobal), withRoutes = routerForTest)) {
-        val response = Await.result(wsUrl("/error").get(), Duration.Inf)
+      "ErrorHandlingFilter recovers from a GET that throws a synchronous exception" in withServer()(ErrorHandlingFilter) { ws =>
+        val response = Await.result(ws.url("/error").get(), Duration.Inf)
         response.status must_== 500
         response.body must_== expectedErrorText
       }
 
-      "ErrorHandlingFilter recovers from a GET that throws an asynchronous exception" in new WithServer(FakeApplication(withGlobal = Some(ErrorHandlingGlobal), withRoutes = routerForTest)) {
-        val response = Await.result(wsUrl("/error-async").get(), Duration.Inf)
+      "ErrorHandlingFilter recovers from a GET that throws an asynchronous exception" in withServer()(ErrorHandlingFilter) { ws =>
+        val response = Await.result(ws.url("/error-async").get(), Duration.Inf)
         response.status must_== 500
         response.body must_== expectedErrorText
       }
 
-      "ErrorHandlingFilter recovers from a POST that throws a synchronous exception" in new WithServer(FakeApplication(withGlobal = Some(ErrorHandlingGlobal), withRoutes = routerForTest)) {
-        val response = Await.result(wsUrl("/error").post(expectedOkText), Duration.Inf)
+      "ErrorHandlingFilter recovers from a POST that throws a synchronous exception" in withServer()(ErrorHandlingFilter) { ws =>
+        val response = Await.result(ws.url("/error").post(expectedOkText), Duration.Inf)
         response.status must_== 500
         response.body must_== expectedOkText
       }
 
-      "ErrorHandlingFilter recovers from a POST that throws an asynchronous exception" in new WithServer(FakeApplication(withGlobal = Some(ErrorHandlingGlobal), withRoutes = routerForTest)) {
-        val response = Await.result(wsUrl("/error-async").post(expectedOkText), Duration.Inf)
+      "ErrorHandlingFilter recovers from a POST that throws an asynchronous exception" in withServer()(ErrorHandlingFilter) { ws =>
+        val response = Await.result(ws.url("/error-async").post(expectedOkText), Duration.Inf)
         response.status must_== 500
         response.body must_== expectedOkText
       }
+    }
 
-      "Filters are not applied when the request is outside the application.context" in new WithServer(
-        FakeApplication(
-          withGlobal = Some(GlobalWithThrowExceptionFilter),
-          withRoutes = routerForTest,
-          additionalConfiguration = Map("application.context" -> "/foo"))
-      ) {
-        val response = Await.result(wsUrl("/ok").post(expectedOkText), Duration.Inf)
+    "Filters are not applied when the request is outside the application.context" in withServer(
+      Map("play.http.context" -> "/foo"))(ErrorHandlingFilter, ThrowExceptionFilter) { ws =>
+        val response = Await.result(ws.url("/ok").post(expectedOkText), Duration.Inf)
         response.status must_== 200
         response.body must_== expectedOkText
       }
 
-      "Filters work even if one of them does not call next" in new WithServer(FakeApplication(withGlobal = Some(SkipNextGlobal), withRoutes = routerForTest)) {
-        val response = Await.result(wsUrl("/ok").get(), Duration.Inf)
+    "Filters are applied on the root of the application context" in withServer(
+      Map("play.http.context" -> "/foo"))(SkipNextFilter) { ws =>
+        val response = Await.result(ws.url("/foo").post(expectedOkText), Duration.Inf)
         response.status must_== 200
         response.body must_== SkipNextFilter.expectedText
       }
 
-      "ErrorHandlingFilter can recover from an exception throw by another filter in the filter chain, even if that Filter does not call next" in new WithServer(FakeApplication(withGlobal = Some(SkipNextWithErrorGlobal), withRoutes = routerForTest)) {
-        val response = Await.result(wsUrl("/ok").get(), Duration.Inf)
-        response.status must_== 500
-        response.body must_== SkipNextWithErrorFilter.expectedText
+    "Filters work even if one of them does not call next" in withServer()(ErrorHandlingFilter, SkipNextFilter) { ws =>
+      val response = Await.result(ws.url("/ok").get(), Duration.Inf)
+      response.status must_== 200
+      response.body must_== SkipNextFilter.expectedText
+    }
+
+    "ErrorHandlingFilter can recover from an exception throw by another filter in the filter chain, even if that Filter does not call next" in withServer()(ErrorHandlingFilter, SkipNextWithErrorFilter) { ws =>
+      val response = Await.result(ws.url("/ok").get(), Duration.Inf)
+      response.status must_== 500
+      response.body must_== SkipNextWithErrorFilter.expectedText
+    }
+
+    "ErrorHandlingFilter can recover from an exception throw by another filter in the filter chain when that filter calls next and asynchronously throws an exception" in withServer()(ErrorHandlingFilter, ThrowExceptionFilter) { ws =>
+      val response = Await.result(ws.url("/ok").get(), Duration.Inf)
+      response.status must_== 500
+      response.body must_== ThrowExceptionFilter.expectedText
+    }
+
+    val filterAddedHeaderKey = "CUSTOM_HEADER"
+    val filterAddedHeaderVal = "custom header val"
+
+    object CustomHeaderFilter extends Filter {
+      def apply(next: RequestHeader => Future[Result])(request: RequestHeader): Future[Result] = {
+        next(request.copy(headers = addCustomHeader(request.headers)))
       }
-
-      "ErrorHandlingFilter can recover from an exception throw by another filter in the filter chain when that filter calls next and asynchronously throws an exception" in new WithServer(FakeApplication(withGlobal = Some(GlobalWithThrowExceptionFilter), withRoutes = routerForTest)) {
-        val response = Await.result(wsUrl("/ok").get(), Duration.Inf)
-        response.status must_== 500
-        response.body must_== ThrowExceptionFilter.expectedText
+      def addCustomHeader(originalHeaders: Headers): Headers = {
+        FakeHeaders(originalHeaders.headers :+ (filterAddedHeaderKey -> filterAddedHeaderVal))
       }
+    }
 
-      val filterAddedHeaderKey = "CUSTOM_HEADER"
-      val filterAddedHeaderVal = "custom header val"
-
-      object MockGlobal3 extends WithFilters(new Filter {
-        def apply(next: RequestHeader => Future[Result])(request: RequestHeader): Future[Result] = {
-          next(request.copy(headers = addCustomHeader(request.headers)))
-        }
-        def addCustomHeader(originalHeaders: Headers): Headers = {
-          FakeHeaders(originalHeaders.headers :+ (filterAddedHeaderKey -> filterAddedHeaderVal))
-        }
-      }) {
-        override def onHandlerNotFound(request: RequestHeader) = {
-          Future.successful(Results.NotFound(request.headers.get(filterAddedHeaderKey).getOrElse("undefined header")))
-        }
+    object CustomErrorHandler extends HttpErrorHandler {
+      def onClientError(request: RequestHeader, statusCode: Int, message: String) = {
+        Future.successful(Results.NotFound(request.headers.get(filterAddedHeaderKey).getOrElse("undefined header")))
       }
+      def onServerError(request: RequestHeader, exception: Throwable) = Future.successful(Results.InternalServerError)
+    }
 
-      "requests not matching a route should receive a RequestHeader modified by upstream filters" in new WithServer(FakeApplication(withGlobal = Some(MockGlobal3))) {
-        val response = Await.result(wsUrl("/not-a-real-route").get(), Duration.Inf)
-        response.status must_== 404
-        response.body must_== filterAddedHeaderVal
+    "requests not matching a route should receive a RequestHeader modified by upstream filters" in withServer(errorHandler = Some(CustomErrorHandler))(CustomHeaderFilter) { ws =>
+      val response = Await.result(ws.url("/not-a-real-route").get(), Duration.Inf)
+      response.status must_== 404
+      response.body must_== filterAddedHeaderVal
+    }
+  }
+
+  object ErrorHandlingFilter extends Filter {
+    def apply(next: RequestHeader => Future[Result])(request: RequestHeader): Future[Result] = {
+      try {
+        next(request).recover {
+          case t: Throwable =>
+            Results.InternalServerError(t.getMessage)
+        }(play.api.libs.concurrent.Execution.Implicits.defaultContext)
+      } catch {
+        case t: Throwable => Future.successful(Results.InternalServerError(t.getMessage))
       }
     }
   }
+
+  object SkipNextFilter extends Filter {
+    val expectedText = "This filter does not call next"
+
+    def apply(next: RequestHeader => Future[Result])(request: RequestHeader): Future[Result] = {
+      Future.successful(Results.Ok(expectedText))
+    }
+  }
+
+  object SkipNextWithErrorFilter extends Filter {
+    val expectedText = "This filter does not call next and throws an exception"
+
+    def apply(next: RequestHeader => Future[Result])(request: RequestHeader): Future[Result] = {
+      Future.failed(new RuntimeException(expectedText))
+    }
+  }
+
+  object ThrowExceptionFilter extends Filter {
+    val expectedText = "This filter calls next and throws an exception afterwords"
+
+    override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
+      next(rh).map { _ =>
+        throw new RuntimeException(expectedText)
+      }(ec)
+    }
+  }
+
+  val expectedOkText = "Hello World"
+  val expectedErrorText = "Error"
+
+  import play.api.routing.sird._
+  val testRouter = Router.from {
+    case GET(p"/") => Action { request => Results.Ok(expectedOkText) }
+    case GET(p"/ok") => Action { request => Results.Ok(expectedOkText) }
+    case POST(p"/ok") => Action { request => Results.Ok(request.body.asText.getOrElse("")) }
+    case GET(p"/error") => Action { request => throw new RuntimeException(expectedErrorText) }
+    case POST(p"/error") => Action { request => throw new RuntimeException(request.body.asText.getOrElse("")) }
+    case GET(p"/error-async") => Action.async { request => Future { throw new RuntimeException(expectedErrorText) }(ec) }
+    case POST(p"/error-async") => Action.async { request => Future { throw new RuntimeException(request.body.asText.getOrElse("")) }(ec) }
+  }
+
+  def withServer[T](settings: Map[String, String] = Map.empty, errorHandler: Option[HttpErrorHandler] = None)(filters: EssentialFilter*)(block: WSClient => T): T
+
 }

--- a/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
+++ b/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
@@ -137,11 +137,12 @@ trait GlobalSettings {
    */
   def doFilter(next: RequestHeader => Handler): (RequestHeader => Handler) = {
     (request: RequestHeader) =>
-      val context = Play.maybeApplication.fold("/") { app =>
-        httpConfigurationCache(app).context.replaceAll("/$", "") + "/"
+      val context = Play.maybeApplication.fold("") { app =>
+        httpConfigurationCache(app).context.stripSuffix("/")
       }
       next(request) match {
-        case action: EssentialAction if request.path startsWith context => doFilter(action)
+        case action: EssentialAction if context.isEmpty || request.path == context || request.path.startsWith(context + "/") =>
+          doFilter(action)
         case handler => handler
       }
   }


### PR DESCRIPTION
To reproduce:
* Create a plain new `play-java` project.
* Add the [Global CSRF filter](https://github.com/playframework/playframework/blob/master/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/csrf/Global.java) to `Global.java` like shown in the [docs](https://www.playframework.com/documentation/2.4.x/JavaCsrf#Applying-a-global-CSRF-filter)
* Add `filters` to the `libraryDependencies` in `build.sbt`
* In your `application.conf` set
```java
    application.context=/abc
    csrf.cookie.name=csrfcookie
```
* Make sure you use Milestone 3 in your `project/plugins.sbt`
```
    addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0-M3")
```
* Open your browser and **make sure you clean your cookies**
* Run the project and goto http://127.0.0.1:9000/abc.

Result: The `csrfcookie` does **not** get set (which also causes `"Missing CSRF Token"` exceptions when e.g. using `@CSRF.formField` in a view).
When using the exact same project and switching to `2.3.8` it works.
(Make sure you always clean the cookies between browser refreshes.)