### PR TITLE
Upgrade specs2 to version 3.3.1

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -6,7 +6,7 @@ import buildinfo.BuildInfo
 
 object Dependencies {
 
-  val specsVersion = "3.1"
+  val specsVersion = "3.3.1"
   val specsBuild = Seq(
     "specs2-core",
     "specs2-junit",

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipSpec.scala
@@ -7,7 +7,7 @@ import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPOutputStream
 
 import org.apache.commons.io.IOUtils
-import org.specs2.time.NoTimeConversions
+import scala.concurrent.duration._
 
 import concurrent.Await
 import play.api.libs.iteratee.{ Iteratee, Enumeratee, Enumerator }
@@ -16,7 +16,7 @@ import org.specs2.mutable.Specification
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-object GzipSpec extends Specification with NoTimeConversions {
+object GzipSpec extends Specification {
 
   "gzip" should {
 

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
@@ -1,7 +1,6 @@
 package play.api.db
 
 import com.zaxxer.hikari.HikariConfig
-import org.specs2.time.NoTimeConversions
 import play.api.{ PlayConfig, Configuration }
 
 import org.specs2.specification.Scope

--- a/framework/src/play-specs2/src/main/scala/play/api/test/PlaySpecification.scala
+++ b/framework/src/play-specs2/src/main/scala/play/api/test/PlaySpecification.scala
@@ -4,7 +4,6 @@
 package play.api.test
 
 import org.specs2.mutable.Specification
-import org.specs2.time.NoTimeConversions
 import play.api.http.{ HttpProtocol, HttpVerbs, Status, HeaderNames }
 
 /**
@@ -14,7 +13,6 @@ import play.api.http.{ HttpProtocol, HttpVerbs, Status, HeaderNames }
  * methods.  It also mixes in the Play test helpers and types for convenience.
  */
 trait PlaySpecification extends Specification
-    with NoTimeConversions
     with PlayRunners
     with HeaderNames
     with Status

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/WSConfigParserSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/WSConfigParserSpec.scala
@@ -5,13 +5,12 @@ package play.api.libs.ws
 
 import org.specs2.mutable._
 import com.typesafe.config.ConfigFactory
-import org.specs2.time.NoTimeConversions
 import play.api.Environment
 import play.api.test.WithApplication
 
 import scala.concurrent.duration._
 
-object WSConfigParserSpec extends Specification with NoTimeConversions {
+object WSConfigParserSpec extends Specification {
 
   "WSConfigParser" should {
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingConfigSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingConfigSpec.scala
@@ -8,7 +8,6 @@ package play.api.libs.ws.ning
 import com.typesafe.config.ConfigFactory
 import org.specs2.mutable._
 import org.specs2.mock._
-import org.specs2.time.NoTimeConversions
 import play.api.Environment
 
 import play.api.libs.ws.WSClientConfig
@@ -28,7 +27,7 @@ class TestHostnameVerifier extends HostnameVerifier {
   override def verify(s: String, sslSession: SSLSession): Boolean = true
 }
 
-object NingConfigSpec extends Specification with Mockito with NoTimeConversions {
+object NingConfigSpec extends Specification with Mockito {
 
   val defaultWsConfig = new WSClientConfig()
   val defaultConfig = new NingWSClientConfig(defaultWsConfig)


### PR DESCRIPTION
Also, replace deprecated NoTimeConvertions with the proper import to scala.concurrent.duration.