### PR TITLE
Upgrade logback to version 1.1.3

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -107,7 +107,7 @@ object Dependencies {
 
   def runtime(scalaVersion: String) =
     Seq("slf4j-api", "jul-to-slf4j", "jcl-over-slf4j").map("org.slf4j" % _ % "1.7.10") ++
-    Seq("logback-core", "logback-classic").map("ch.qos.logback" % _ % "1.1.2") ++
+    Seq("logback-core", "logback-classic").map("ch.qos.logback" % _ % "1.1.3") ++
     Seq("akka-actor", "akka-slf4j").map("com.typesafe.akka" %% _ % "2.3.7") ++
     jacksons ++
     Seq(


### PR DESCRIPTION
Multiple issues related to `AsyncAppender` were fixed/improved. According [release notes](http://logback.qos.ch/news.html):

1. Fixed a bug in AccessEvent which could cause any AsyncAppender based appender to corrupt the request headers, request parameters, or response headers, before logging.
2. Added max runtime parameter to AsyncAppender to allow the appender to flush events, up to a maximum delay, during a stop of the LoggerContext. This can be used to ensure that all queued events are flushed.

Since Play now uses the `AsyncAppender` (see #3862), I think this is relevant.