### PR TITLE
Add reason phrase to ResponseHeader

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
@@ -18,7 +18,7 @@ object ScalaResultsSpec extends PlaySpecification {
     val decodedSession = Session.decode(encodedSession)
 
     decodedSession must_== Map("user" -> "kiki", "langs" -> "fr:en:de")
-    val Result(ResponseHeader(_, headers), _, _) =
+    val Result(ResponseHeader(_, headers, _), _, _) =
       Ok("hello").as("text/html")
         .withSession("user" -> "kiki", "langs" -> "fr:en:de")
         .withCookies(Cookie("session", "items"), Cookie("preferences", "blue"))

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyResultStreamer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyResultStreamer.scala
@@ -125,7 +125,12 @@ object NettyResultStreamer {
   }
 
   def createNettyResponse(header: ResponseHeader, connectionHeader: ServerResultUtils.ConnectionHeader, httpVersion: HttpVersion) = {
-    val nettyResponse = new DefaultHttpResponse(httpVersion, HttpResponseStatus.valueOf(header.status))
+    val responseStatus = header.reasonPhrase.fold {
+      HttpResponseStatus.valueOf(header.status)
+    } {
+      phrase => new HttpResponseStatus(header.status, phrase)
+    }
+    val nettyResponse = new DefaultHttpResponse(httpVersion, responseStatus)
 
     import scala.collection.JavaConverters._
 

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -341,11 +341,11 @@ trait ResultExtractors {
    * Extracts the Location header of this Result value if this Result is a Redirect.
    */
   def redirectLocation(of: Future[Result])(implicit timeout: Timeout): Option[String] = Await.result(of, timeout.duration).header match {
-    case ResponseHeader(FOUND, headers) => headers.get(LOCATION)
-    case ResponseHeader(SEE_OTHER, headers) => headers.get(LOCATION)
-    case ResponseHeader(TEMPORARY_REDIRECT, headers) => headers.get(LOCATION)
-    case ResponseHeader(MOVED_PERMANENTLY, headers) => headers.get(LOCATION)
-    case ResponseHeader(_, _) => None
+    case ResponseHeader(FOUND, headers, _) => headers.get(LOCATION)
+    case ResponseHeader(SEE_OTHER, headers, _) => headers.get(LOCATION)
+    case ResponseHeader(TEMPORARY_REDIRECT, headers, _) => headers.get(LOCATION)
+    case ResponseHeader(MOVED_PERMANENTLY, headers, _) => headers.get(LOCATION)
+    case ResponseHeader(_, _, _) => None
   }
 
   /**

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -17,27 +17,29 @@ import scala.collection.immutable.TreeMap
 /**
  * A simple HTTP response header, used for standard responses.
  *
- * @param status the response status, e.g. ‘200 OK’
+ * @param status the response status, e.g. 200
  * @param _headers the HTTP headers
+ * @param reasonPhrase the human-readable description of status, e.g. "Ok";
+ *   if None, the default phrase for the status will be used
  */
-final class ResponseHeader(val status: Int, _headers: Map[String, String] = Map.empty) {
+final class ResponseHeader(val status: Int, _headers: Map[String, String] = Map.empty, val reasonPhrase: Option[String] = None) {
   val headers: Map[String, String] = TreeMap[String, String]()(CaseInsensitiveOrdered) ++ _headers
 
-  def copy(status: Int = status, headers: Map[String, String] = headers): ResponseHeader =
-    new ResponseHeader(status, headers)
+  def copy(status: Int = status, headers: Map[String, String] = headers, reasonPhrase: Option[String] = reasonPhrase): ResponseHeader =
+    new ResponseHeader(status, headers, reasonPhrase)
 
   override def toString = s"$status, $headers"
   override def hashCode = (status, headers).hashCode
   override def equals(o: Any) = o match {
-    case ResponseHeader(s, h) => (s, h).equals((status, headers))
+    case ResponseHeader(s, h, r) => (s, h, r).equals((status, headers, reasonPhrase))
     case _ => false
   }
 }
 object ResponseHeader {
-  def apply(status: Int, headers: Map[String, String] = Map.empty): ResponseHeader =
+  def apply(status: Int, headers: Map[String, String] = Map.empty, reasonPhrase: Option[String] = None): ResponseHeader =
     new ResponseHeader(status, headers)
-  def unapply(rh: ResponseHeader): Option[(Int, Map[String, String])] =
-    if (rh eq null) None else Some((rh.status, rh.headers))
+  def unapply(rh: ResponseHeader): Option[(Int, Map[String, String], Option[String])] =
+    if (rh eq null) None else Some((rh.status, rh.headers, rh.reasonPhrase))
 }
 
 /**

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -23,17 +23,17 @@ object ResultsSpec extends Specification {
   "Result" should {
 
     "have status" in {
-      val Result(ResponseHeader(status, _), _, _) = Ok("hello")
+      val Result(ResponseHeader(status, _, _), _, _) = Ok("hello")
       status must be_==(200)
     }
 
     "support Content-Type overriding" in {
-      val Result(ResponseHeader(_, headers), _, _) = Ok("hello").as("text/html")
+      val Result(ResponseHeader(_, headers, _), _, _) = Ok("hello").as("text/html")
       headers must havePair("Content-Type" -> "text/html")
     }
 
     "support headers manipulation" in {
-      val Result(ResponseHeader(_, headers), _, _) =
+      val Result(ResponseHeader(_, headers, _), _, _) =
         Ok("hello").as("text/html").withHeaders("Set-Cookie" -> "yes", "X-YOP" -> "1", "X-Yop" -> "2")
 
       headers.size must be_==(3)
@@ -59,7 +59,7 @@ object ResultsSpec extends Specification {
       newDecodedCookies("preferences").value must be_==("blue")
       newDecodedCookies("lang").value must be_==("fr")
 
-      val Result(ResponseHeader(_, headers), _, _) =
+      val Result(ResponseHeader(_, headers, _), _, _) =
         Ok("hello").as("text/html")
           .withCookies(Cookie("session", "items"), Cookie("preferences", "blue"))
           .withCookies(Cookie("lang", "fr"), Cookie("session", "items2"))


### PR DESCRIPTION
http://stackoverflow.com/questions/26372528/manipulate-the-response-status-text-in-play-2-2-scala

http://stackoverflow.com/questions/29440983/custom-text-for-http-api-status-code

This is useful when using custom status codes.

---

It would make sense for the parameter order for `ResponseHeader` to be `status`, `reasonPhrase`, `_headers`, since that is the order in which they appear in the response.
But having the order be `status`, `_headers`, `reasonPhrase` is more backwards compatible.