### PR TITLE
Fix docstring periods and capitals

### DIFF
--- a/framework/project/Release.scala
+++ b/framework/project/Release.scala
@@ -124,9 +124,9 @@ object Release {
     /**
      * Execute the release stage.
      *
-     * @param state The sbt state.
-     * @param options The release options.
-     * @return Any extra commands that should be run before the next command is run.
+     * @param state The sbt state
+     * @param options The release options
+     * @return any extra commands that should be run before the next command is run
      */
     def execute(state: State, options: ReleaseOptions): Seq[String]
   }

--- a/framework/src/build-link/src/main/java/play/core/BuildDocHandler.java
+++ b/framework/src/build-link/src/main/java/play/core/BuildDocHandler.java
@@ -19,9 +19,9 @@ public interface BuildDocHandler {
   /**
    * Given a request, either handle it and return some result, or don't, and return none.
    *
-   * @param request A request of type {@code play.api.mvc.RequestHeader}.
-   * @return A value of type {@code Option<play.api.mvc.SimpleResult>}, Some if the result was
-   *        handled, None otherwise.
+   * @param request A request of type {@code play.api.mvc.RequestHeader}
+   * @return a value of type {@code Option<play.api.mvc.SimpleResult>}, Some if the result was
+   *        handled, None otherwise
    */
   public Object maybeHandleDocRequest(Object request);
 

--- a/framework/src/build-link/src/main/java/play/core/BuildLink.java
+++ b/framework/src/build-link/src/main/java/play/core/BuildLink.java
@@ -23,7 +23,7 @@ public interface BuildLink {
      * This method is called multiple times on every request, so it is advised that change detection happens
      * asynchronously to this call, and that this call just check a boolean.
      *
-     * @return Either
+     * @return either
      * <ul>
      *     <li>Throwable - If something went wrong (eg, a compile error).  {@link play.api.PlayException} and its sub
      *     types can be used to provide specific details on compile errors or other exceptions.</li>
@@ -43,9 +43,9 @@ public interface BuildLink {
      * If the class is generated (eg a template), then the original source file should be returned, and the line number
      * should be mapped back to the line number in the original source file, if possible.
      *
-     * @param className The name of the class to find the source for.
-     * @param line The line number the exception was thrown at.
-     * @return Either:
+     * @param className The name of the class to find the source for
+     * @param line The line number the exception was thrown at
+     * @return either:
      * <ul>
      *     <li>[File, Integer] - The source file, and the passed in line number, if the source wasn't generated, or if
      *     it was generated, and the line number could be mapped, then the original source file and the mapped line
@@ -60,7 +60,7 @@ public interface BuildLink {
     /**
      * Get the path of the project.  This is used by methods such as {@code play.api.Application#getFile}.
      *
-     * @return The path of the project.
+     * @return the path of the project
      */
     public File projectPath();
 
@@ -75,7 +75,7 @@ public interface BuildLink {
     /**
      * Returns a list of application settings configured in the build system.
      *
-     * @return The settings.
+     * @return the settings
      */
     public Map<String,String> settings();
 
@@ -88,8 +88,8 @@ public interface BuildLink {
      * For the default SBT implementation, it's a standard SBT task, and the result is the return value of that task.
      * Note that if the return value is anything but JDK classes, the only way to access it will be using reflection.
      *
-     * @param task The name of the task to run.
-     * @return The result of running the task.
+     * @param task The name of the task to run
+     * @return the result of running the task
      */
     public Object runTask(String task);
 }

--- a/framework/src/build-link/src/main/java/play/core/server/ServerWithStop.java
+++ b/framework/src/build-link/src/main/java/play/core/server/ServerWithStop.java
@@ -16,7 +16,7 @@ public interface ServerWithStop {
   /**
    * Get the address of the server.
    *
-   * @return The address of the server.
+   * @return the address of the server
    */
   public java.net.InetSocketAddress mainAddress(); 
 

--- a/framework/src/iteratees/src/main/scala/play/api/libs/concurrent/NonBlockingMutex.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/concurrent/NonBlockingMutex.scala
@@ -45,7 +45,7 @@ private[play] final class NonBlockingMutex {
    * run very quickly. If any expensive work needs to be done then it the operation
    * should schedule the work to run asynchronously.
    *
-   * @param body The body of the operation to run.
+   * @param body The body of the operation to run
    */
   def exclusive(body: => Unit): Unit = {
     schedule(() => body)

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Concurrent.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Concurrent.scala
@@ -12,8 +12,8 @@ import play.api.libs.iteratee.Execution.Implicits.{ defaultExecutionContext => d
 /**
  * Utilities for concurrent usage of iteratees, enumerators and enumeratees.
  *
- * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
- * @define paramEcMultiple @param ec The context to execute the supplied functions with. The context is prepared on the calling thread before being used.
+ * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used
+ * @define paramEcMultiple @param ec The context to execute the supplied functions with. The context is prepared on the calling thread before being used
  */
 object Concurrent {
 
@@ -58,7 +58,7 @@ object Concurrent {
      * invocation, that is, subsequent calls to end will change the behaviour of attaching new iteratees to the
      * broadcast enumerator.
      *
-     * @param e The failure.
+     * @param e The failure
      */
     def end(e: Throwable)
 
@@ -282,7 +282,7 @@ object Concurrent {
    * for example if the enumerator is a database result set that holds a transaction open, but the result set is being
    * serialised and fed directly to an HTTP response.
    *
-   * @param maxBuffer The maximum size to buffer.  The size is computed using the given `length` function.
+   * @param maxBuffer The maximum size to buffer.  The size is computed using the given `length` function
    * @param length A function that computes the length of an input item
    * $paramEcSingle
    */
@@ -437,8 +437,8 @@ object Concurrent {
    *
    * @param onStart Called when an enumerator is applied to an iteratee, providing the channel to feed input into that
    *                iteratee.
-   * @param onComplete Called when an iteratee is done.
-   * @param onError Called when an iteratee encounters an error, supplying the error and the input that caused the error.
+   * @param onComplete Called when an iteratee is done
+   * @param onError Called when an iteratee encounters an error, supplying the error and the input that caused the error
    * $paramEcMultiple
    */
   def unicast[E](
@@ -522,9 +522,9 @@ object Concurrent {
    * attached to the broadcasting enumerator.
    *
    * @param e The enumerator to broadcast
-   * @param interestIsDownToZero Function that is invoked when all iteratees are done.  May be invoked multiple times.
+   * @param interestIsDownToZero Function that is invoked when all iteratees are done.  May be invoked multiple times
    * $paramEcSingle
-   * @return A tuple of the broadcasting enumerator, that can be applied to each iteratee that wants to receive the
+   * @return a tuple of the broadcasting enumerator, that can be applied to each iteratee that wants to receive the
    *         input, and the broadcaster.
    */
   def broadcast[E](e: Enumerator[E], interestIsDownToZero: Broadcaster => Unit = _ => ())(implicit ec: ExecutionContext): (Enumerator[E], Broadcaster) = {
@@ -686,7 +686,7 @@ object Concurrent {
     /**
      * Patch in the given enumerator into the iteratee.
      *
-     * @return Whether the enumerator was successfully patched in.  Will return false if the patch panel is closed.
+     * @return whether the enumerator was successfully patched in.  Will return false if the patch panel is closed
      */
     def patchIn(e: Enumerator[E]): Boolean
 
@@ -702,7 +702,7 @@ object Concurrent {
   /**
    * An enumerator that allows patching in enumerators to supply it with input.
    *
-   * @param patcher A function that passes a patch panel whenever the enumerator is applied to an iteratee.
+   * @param patcher A function that passes a patch panel whenever the enumerator is applied to an iteratee
    * $paramEcSingle
    */
   def patchPanel[E](patcher: PatchPanel[E] => Unit)(implicit ec: ExecutionContext): Enumerator[E] = new Enumerator[E] {

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
@@ -78,8 +78,8 @@ trait Enumeratee[From, To] {
 }
 
 /**
- * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
- * @define paramEcMultiple @param ec The context to execute the supplied functions with. The context is prepared on the calling thread before being used.
+ * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used
+ * @define paramEcMultiple @param ec The context to execute the supplied functions with. The context is prepared on the calling thread before being used
  */
 object Enumeratee {
 
@@ -123,9 +123,9 @@ object Enumeratee {
    * Create an Enumeratee that zips two Iteratees together, using the passed in zipper function to combine the results
    * of the two.
    *
-   * @param inner1 The first Iteratee to combine.
-   * @param inner2 The second Iteratee to combine.
-   * @param zipper Used to combine the results of each Iteratee.
+   * @param inner1 The first Iteratee to combine
+   * @param inner2 The second Iteratee to combine
+   * @param zipper Used to combine the results of each Iteratee
    * $paramEcSingle
    */
   def zipWith[E, A, B, C](inner1: Iteratee[E, A], inner2: Iteratee[E, B])(zipper: (A, B) => C)(implicit ec: ExecutionContext): Iteratee[E, C] = {
@@ -185,7 +185,7 @@ object Enumeratee {
    */
   trait MapInput[From] {
     /**
-     * @param f Used to transform each input element.
+     * @param f Used to transform each input element
      * $paramEcSingle
      */
     def apply[To](f: Input[From] => Input[To])(implicit ec: ExecutionContext): Enumeratee[From, To]
@@ -218,7 +218,7 @@ object Enumeratee {
    */
   trait MapConcatInput[From] {
     /**
-     * @param f Used to transform each input element into a sequence of inputs.
+     * @param f Used to transform each input element into a sequence of inputs
      * $paramEcSingle
      */
     def apply[To](f: From => Seq[Input[To]])(implicit ec: ExecutionContext): Enumeratee[From, To]
@@ -236,7 +236,7 @@ object Enumeratee {
    */
   trait MapConcat[From] {
     /**
-     * @param f Used to transform each input element into a sequence of input elements.
+     * @param f Used to transform each input element into a sequence of input elements
      * $paramEcSingle
      */
     def apply[To](f: From => Seq[To])(implicit ec: ExecutionContext): Enumeratee[From, To]
@@ -254,7 +254,7 @@ object Enumeratee {
    */
   trait MapFlatten[From] {
     /**
-     * @param f Used to transform each input element into an Enumerator.
+     * @param f Used to transform each input element into an Enumerator
      * $paramEcSingle
      */
     def apply[To](f: From => Enumerator[To])(implicit ec: ExecutionContext): Enumeratee[From, To]
@@ -286,7 +286,7 @@ object Enumeratee {
    */
   trait MapInputFlatten[From] {
     /**
-     * @param f Used to transform each input into an Enumerator.
+     * @param f Used to transform each input into an Enumerator
      * $paramEcSingle
      */
     def apply[To](f: Input[From] => Enumerator[To])(implicit ec: ExecutionContext): Enumeratee[From, To]
@@ -313,7 +313,7 @@ object Enumeratee {
    */
   trait MapInputM[From] {
     /**
-     * @param f Used to transform each input.
+     * @param f Used to transform each input
      * $paramEcSingle
      */
     def apply[To](f: Input[From] => Future[Input[To]])(implicit ec: ExecutionContext): Enumeratee[From, To]
@@ -342,7 +342,7 @@ object Enumeratee {
    */
   trait MapM[E] {
     /**
-     * @param f Used to transform each input element.
+     * @param f Used to transform each input element
      * $paramEcSingle
      */
     def apply[NE](f: E => Future[NE])(implicit ec: ExecutionContext): Enumeratee[E, NE]
@@ -364,7 +364,7 @@ object Enumeratee {
    */
   trait Map[E] {
     /**
-     * @param f A function to transform input elements.
+     * @param f A function to transform input elements
      * $paramEcSingle
      */
     def apply[NE](f: E => NE)(implicit ec: ExecutionContext): Enumeratee[E, NE]
@@ -489,7 +489,7 @@ object Enumeratee {
   /**
    * Create an Enumeratee that filters the inputs using the given predicate
    *
-   * @param predicate A function to filter the input elements.
+   * @param predicate A function to filter the input elements
    * $paramEcSingle
    */
   def filter[E](predicate: E => Boolean)(implicit ec: ExecutionContext): Enumeratee[E, E] = new CheckDone[E, E] {
@@ -515,7 +515,7 @@ object Enumeratee {
   /**
    * Create an Enumeratee that filters the inputs using the negation of the given predicate
    *
-   * @param predicate A function to filter the input elements.
+   * @param predicate A function to filter the input elements
    * $paramEcSingle
    */
   def filterNot[E](predicate: E => Boolean)(implicit ec: ExecutionContext): Enumeratee[E, E] = filter[E](e => !predicate(e))(ec)
@@ -525,7 +525,7 @@ object Enumeratee {
    */
   trait Collect[From] {
     /**
-     * @param transformer A function to transform and filter the input elements with.
+     * @param transformer A function to transform and filter the input elements with
      * $paramSingleEc
      */
     def apply[To](transformer: PartialFunction[From, To])(implicit ec: ExecutionContext): Enumeratee[From, To]
@@ -584,7 +584,7 @@ object Enumeratee {
   /**
    * Create an Enumeratee that drops input until a predicate is satisfied.
    *
-   * @param f A predicate to test the input with.
+   * @param f A predicate to test the input with
    * $paramEcSingle
    */
   def dropWhile[E](p: E => Boolean)(implicit ec: ExecutionContext): Enumeratee[E, E] = {
@@ -612,7 +612,7 @@ object Enumeratee {
    * Create an Enumeratee that passes input through while a predicate is satisfied. Once the predicate
    * fails, no more input is passed through.
    *
-   * @param f A predicate to test the input with.
+   * @param f A predicate to test the input with
    * $paramEcSingle
    */
   def takeWhile[E](p: E => Boolean)(implicit ec: ExecutionContext): Enumeratee[E, E] = {
@@ -640,7 +640,7 @@ object Enumeratee {
    * Create an Enumeratee that passes input through until a predicate is satisfied. Once the predicate
    * is satisfied, no more input is passed through.
    *
-   * @param f A predicate to test the input with.
+   * @param f A predicate to test the input with
    * $paramEcSingle
    */
   def breakE[E](p: E => Boolean)(implicit ec: ExecutionContext) = new Enumeratee[E, E] {
@@ -700,7 +700,7 @@ object Enumeratee {
   /**
    * Create an Enumeratee that performs an action when its Iteratee is done.
    *
-   * @param action The action to perform.
+   * @param action The action to perform
    * $paramEcSingle
    */
   def onIterateeDone[E](action: () => Unit)(implicit ec: ExecutionContext): Enumeratee[E, E] = new Enumeratee[E, E] {
@@ -713,7 +713,7 @@ object Enumeratee {
   /**
    * Create an Enumeratee that performs an action on EOF.
    *
-   * @param action The action to perform.
+   * @param action The action to perform
    * $paramEcSingle
    */
   def onEOF[E](action: () => Unit)(implicit ec: ExecutionContext): Enumeratee[E, E] = new CheckDone[E, E] {
@@ -746,7 +746,7 @@ object Enumeratee {
    *  } |>>> Iteratee.getChunks // => List(4, 2)
    * }}}
    *
-   * @param f Called when an error occurs with the cause of the error and the input associated with the error.
+   * @param f Called when an error occurs with the cause of the error and the input associated with the error
    * $paramEcSingle
    */
   def recover[E](f: (Throwable, Input[E]) => Unit = (_: Throwable, _: Input[E]) => ())(implicit ec: ExecutionContext): Enumeratee[E, E] = {

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
@@ -12,8 +12,8 @@ import scala.language.reflectiveCalls
 /**
  * A producer which pushes input to an [[play.api.libs.iteratee.Iteratee]].
  *
- * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
- * @define paramEcMultiple @param ec The context to execute the supplied functions with. The context is prepared on the calling thread before being used.
+ * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used
+ * @define paramEcMultiple @param ec The context to execute the supplied functions with. The context is prepared on the calling thread before being used
  */
 trait Enumerator[E] {
   parent =>
@@ -140,7 +140,7 @@ trait Enumerator[E] {
   /**
    * Creates an Enumerator, based on this one, with each input transformed by the given function.
    *
-   * @param f Used to transform the input.
+   * @param f Used to transform the input
    * $paramEcSingle
    */
   def mapInput[U](f: Input[E] => Input[U])(implicit ec: ExecutionContext): Enumerator[U] = parent &> Enumeratee.mapInput[E](f)(ec)
@@ -173,8 +173,8 @@ trait Enumerator[E] {
  * Enumerator is the source that pushes input into a given iteratee.
  * It enumerates some input into the iteratee and eventually returns the new state of that iteratee.
  *
- * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
- * @define paramEcMultiple @param ec The context to execute the supplied functions with. The context is prepared on the calling thread before being used.
+ * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used
+ * @define paramEcMultiple @param ec The context to execute the supplied functions with. The context is prepared on the calling thread before being used
  */
 object Enumerator {
 
@@ -402,7 +402,7 @@ object Enumerator {
   /**
    * Repeat the given input function indefinitely.
    *
-   * @param e The input function.
+   * @param e The input function
    * $paramEcSingle
    */
   def repeat[E](e: => E)(implicit ec: ExecutionContext): Enumerator[E] = checkContinue0(new TreatCont0[E] {
@@ -487,7 +487,7 @@ object Enumerator {
    *
    * @param retriever The input function.  Returns a future eventually redeemed with Some value if there is input to pass, or a
    *          future eventually redeemed with None if the end of the stream has been reached.
-   * @param onComplete Called when the end of the stream is reached.
+   * @param onComplete Called when the end of the stream is reached
    * @param onError Called when an error occurs in the iteratee
    * $paramEcMultiple
    */
@@ -550,8 +550,8 @@ object Enumerator {
    * ExecutionContext is appropriately configured to handle the blocking.
    *
    * @param input The input stream
-   * @param chunkSize The size of chunks to read from the stream.
-   * @param ec The ExecutionContext to execute blocking code.
+   * @param chunkSize The size of chunks to read from the stream
+   * @param ec The ExecutionContext to execute blocking code
    */
   def fromStream(input: java.io.InputStream, chunkSize: Int = 1024 * 8)(implicit ec: ExecutionContext): Enumerator[Array[Byte]] = {
     implicit val pec = ec.prepare()
@@ -575,8 +575,8 @@ object Enumerator {
    *
    * Note that this enumerator will block when it reads from the file.
    *
-   * @param file The file to create the enumerator from.
-   * @param chunkSize The size of chunks to read from the file.
+   * @param file The file to create the enumerator from
+   * @param chunkSize The size of chunks to read from the file
    */
   def fromFile(file: java.io.File, chunkSize: Int = 1024 * 8)(implicit ec: ExecutionContext): Enumerator[Array[Byte]] = {
     fromStream(new java.io.FileInputStream(file), chunkSize)(ec)
@@ -589,7 +589,7 @@ object Enumerator {
    * OutputStream will not push back.  This means it should not be used with large streams since there is a risk of
    * running out of memory.
    *
-   * @param a A callback that provides the output stream when this enumerator is written to an iteratee.
+   * @param a A callback that provides the output stream when this enumerator is written to an iteratee
    * $paramEcSingle
    */
   def outputStream(a: java.io.OutputStream => Unit)(implicit ec: ExecutionContext): Enumerator[Array[Byte]] = {

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Iteratee.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Iteratee.scala
@@ -11,8 +11,8 @@ import play.api.libs.iteratee.internal.{ eagerFuture, executeFuture, executeIter
 /**
  * Various helper methods to construct, compose and traverse Iteratees.
  *
- * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
- * @define paramEcMultiple @param ec The context to execute the supplied functions with. The context is prepared on the calling thread before being used.
+ * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used
+ * @define paramEcMultiple @param ec The context to execute the supplied functions with. The context is prepared on the calling thread before being used
  */
 object Iteratee {
 
@@ -205,7 +205,7 @@ object Iteratee {
      * @param eofValue Value if the input is [[play.api.libs.iteratee.Input.EOF]]
      * @tparam A Type of `eofValue`
      * @tparam B Type of `otherwise`
-     * @return An `Iteratee[E, Either[B, A]]` that consumes one input and produces a `Right(eofValue)` if this input is [[play.api.libs.iteratee.Input.EOF]] otherwise it produces a `Left(otherwise)`
+     * @return an `Iteratee[E, Either[B, A]]` that consumes one input and produces a `Right(eofValue)` if this input is [[play.api.libs.iteratee.Input.EOF]] otherwise it produces a `Left(otherwise)`
      */
     def apply[A, B](otherwise: B)(eofValue: A): Iteratee[E, Either[B, A]]
   }
@@ -229,7 +229,7 @@ object Iteratee {
   def ignore[E]: Iteratee[E, Unit] = fold[E, Unit](())((_, _) => ())(dec)
 
   /**
-   * @return an [[play.api.libs.iteratee.Iteratee]] which executes a provided function for every chunk. Returns Done on EOF.
+   * @return an [[play.api.libs.iteratee.Iteratee]] which executes a provided function for every chunk. Returns Done on EOF
    *
    * Example:
    * {{{
@@ -327,7 +327,7 @@ object Step {
   /**
    * A continuing state of an iteratee.
    *
-   * @param k A function that can receive input for the iteratee to process.
+   * @param k A function that can receive input for the iteratee to process
    */
   case class Cont[E, +A](k: Input[E] => Iteratee[E, A]) extends Step[E, A]
 
@@ -370,8 +370,8 @@ object Step {
  * @tparam E Input type
  * @tparam A Result type of this Iteratee
  *
- * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread.
- * @define paramEcMultiple @param ec The context to execute the supplied functions with. The context is prepared on the calling thread.
+ * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread
+ * @define paramEcMultiple @param ec The context to execute the supplied functions with. The context is prepared on the calling thread
  */
 trait Iteratee[E, +A] {
   self =>

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/RunQueue.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/RunQueue.scala
@@ -153,8 +153,8 @@ private object RunQueue {
   /**
    * A reified operation to be executed.
    *
-   * @param thunk The logic to execute.
-   * @param ec The ExecutionContext to use for execution. Already prepared.
+   * @param thunk The logic to execute
+   * @param ec The ExecutionContext to use for execution. Already prepared
    */
   final case class Op(thunk: () => Future[Unit], ec: ExecutionContext)
 

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/TraversableIteratee.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/TraversableIteratee.scala
@@ -7,7 +7,7 @@ import play.api.libs.iteratee.Execution.Implicits.{ defaultExecutionContext => d
 import scala.concurrent.{ ExecutionContext, Future }
 
 /**
- * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
+ * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used
  */
 object Traversable {
 
@@ -92,7 +92,7 @@ object Traversable {
    * Splits a stream of traversable input elements on a predicate. Yields all input up until
    * the predicate matches within an input element. The input following a match is unprocessed.
    *
-   * @param p The predicate to split input on.
+   * @param p The predicate to split input on
    * $paramEcSingle
    */
   def splitOnceAt[M, E](p: E => Boolean)(implicit traversableLike: M => scala.collection.TraversableLike[E, M], ec: ExecutionContext): Enumeratee[M, M] = new CheckDone[M, M] {

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/TestExecutionContext.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/TestExecutionContext.scala
@@ -17,7 +17,7 @@ object TestExecutionContext {
 /**
  * An `ExecutionContext` that counts its executions.
  *
- * @param delegate The underlying `ExecutionContext` to delegate execution to.
+ * @param delegate The underlying `ExecutionContext` to delegate execution to
  */
 class TestExecutionContext(delegate: ExecutionContext) extends ExecutionContext {
   top =>

--- a/framework/src/play-cache/src/main/java/play/cache/Cache.java
+++ b/framework/src/play-cache/src/main/java/play/cache/Cache.java
@@ -26,9 +26,9 @@ public class Cache {
     /**
      * Retrieve a value from the cache, or set it from a default Callable function.
      *
-     * @param key        Item key.
+     * @param key        Item key
      * @param block      block returning value to set if key does not exist
-     * @param expiration expiration period in seconds.
+     * @param expiration expiration period in seconds
      * @return value
      */
     @SuppressWarnings("unchecked")

--- a/framework/src/play-cache/src/main/java/play/cache/CacheApi.java
+++ b/framework/src/play-cache/src/main/java/play/cache/CacheApi.java
@@ -19,9 +19,9 @@ public interface CacheApi {
     /**
      * Retrieve a value from the cache, or set it from a default Callable function.
      *
-     * @param key Item key.
+     * @param key Item key
      * @param block block returning value to set if key does not exist
-     * @param expiration expiration period in seconds.
+     * @param expiration expiration period in seconds
      * @return value
      */
     public <T> T getOrElse(String key, Callable<T> block, int expiration);
@@ -31,7 +31,7 @@ public interface CacheApi {
      *
      * The value has no expiration.
      *
-     * @param key Item key.
+     * @param key Item key
      * @param block block returning value to set if key does not exist
      * @return value
      */
@@ -40,8 +40,8 @@ public interface CacheApi {
     /**
      * Sets a value with expiration.
      *
-     * @param key Item key.
-     * @param value The value to set.
+     * @param key Item key
+     * @param value The value to set
      * @param expiration expiration in seconds
      */
     public void set(String key, Object value, int expiration);
@@ -49,15 +49,15 @@ public interface CacheApi {
     /**
      * Sets a value without expiration.
      *
-     * @param key Item key.
-     * @param value The value to set.
+     * @param key Item key
+     * @param value The value to set
      */
     public void set(String key, Object value);
 
     /**
      * Removes a value from the cache.
      *
-     * @param key The key to remove the value for.
+     * @param key The key to remove the value for
      */
     public void remove(String key);
 }

--- a/framework/src/play-cache/src/main/scala/play/api/cache/Cache.scala
+++ b/framework/src/play-cache/src/main/scala/play/api/cache/Cache.scala
@@ -23,9 +23,9 @@ trait CacheApi {
   /**
    * Set a value into the cache.
    *
-   * @param key Item key.
-   * @param value Item value.
-   * @param expiration Expiration time.
+   * @param key Item key
+   * @param value Item value
+   * @param expiration Expiration time
    */
   def set(key: String, value: Any, expiration: Duration = Duration.Inf)
 
@@ -37,16 +37,16 @@ trait CacheApi {
   /**
    * Retrieve a value from the cache, or set it from a default function.
    *
-   * @param key Item key.
-   * @param expiration expiration period in seconds.
-   * @param orElse The default function to invoke if the value was not found in cache.
+   * @param key Item key
+   * @param expiration expiration period in seconds
+   * @param orElse The default function to invoke if the value was not found in cache
    */
   def getOrElse[A: ClassTag](key: String, expiration: Duration = Duration.Inf)(orElse: => A): A
 
   /**
    * Retrieve a value from the cache for the given type
    *
-   * @param key Item key.
+   * @param key Item key
    * @return result as Option[T]
    */
   def get[T: ClassTag](key: String): Option[T]
@@ -67,9 +67,9 @@ object Cache {
   /**
    * Set a value into the cache.
    *
-   * @param key Item key.
-   * @param value Item value.
-   * @param expiration Expiration time as a [[scala.concurrent.duration.Duration]].
+   * @param key Item key
+   * @param value Item value
+   * @param expiration Expiration time as a [[scala.concurrent.duration.Duration]]
    */
   def set(key: String, value: Any, expiration: Duration = Duration.Inf)(implicit app: Application): Unit = {
     cacheApi.set(key, value, expiration)
@@ -78,9 +78,9 @@ object Cache {
   /**
    * Set a value into the cache.
    *
-   * @param key Item key.
-   * @param value Item value.
-   * @param expiration Expiration time in seconds (0 second means eternity).
+   * @param key Item key
+   * @param value Item value
+   * @param expiration Expiration time in seconds (0 second means eternity)
    */
   def set(key: String, value: Any, expiration: Int)(implicit app: Application): Unit = {
     set(key, value, intToDuration(expiration))
@@ -89,7 +89,7 @@ object Cache {
   /**
    * Retrieve a value from the cache.
    *
-   * @param key Item key.
+   * @param key Item key
    */
   def get(key: String)(implicit app: Application): Option[Any] = {
     cacheApi.get[Any](key)
@@ -98,9 +98,9 @@ object Cache {
   /**
    * Retrieve a value from the cache, or set it from a default function.
    *
-   * @param key Item key.
-   * @param expiration expiration period as a [[scala.concurrent.duration.Duration]].
-   * @param orElse The default function to invoke if the value was not found in cache.
+   * @param key Item key
+   * @param expiration expiration period as a [[scala.concurrent.duration.Duration]]
+   * @param orElse The default function to invoke if the value was not found in cache
    */
   def getOrElse[A](key: String, expiration: Duration = Duration.Inf)(orElse: => A)(implicit app: Application, ct: ClassTag[A]): A = {
     cacheApi.getOrElse(key, expiration)(orElse)
@@ -109,9 +109,9 @@ object Cache {
   /**
    * Retrieve a value from the cache, or set it from a default function.
    *
-   * @param key Item key.
-   * @param expiration expiration period in seconds.
-   * @param orElse The default function to invoke if the value was not found in cache.
+   * @param key Item key
+   * @param expiration expiration period in seconds
+   * @param orElse The default function to invoke if the value was not found in cache
    */
   def getOrElse[A](key: String, expiration: Int)(orElse: => A)(implicit app: Application, ct: ClassTag[A]): A = {
     getOrElse(key, intToDuration(expiration))(orElse)
@@ -120,7 +120,7 @@ object Cache {
   /**
    * Retrieve a value from the cache for the given type
    *
-   * @param key Item key.
+   * @param key Item key
    * @return result as Option[T]
    */
   def getAs[T](key: String)(implicit app: Application, ct: ClassTag[T]): Option[T] = {

--- a/framework/src/play-docs/src/main/java/play/docs/BuildDocHandlerFactory.java
+++ b/framework/src/play-docs/src/main/java/play/docs/BuildDocHandlerFactory.java
@@ -30,7 +30,7 @@ public class BuildDocHandlerFactory {
      * Create an BuildDocHandler that serves documentation from a given directory by
      * wrapping a FilesystemRepository.
      *
-     * @param directory The directory to serve the documentation from.
+     * @param directory The directory to serve the documentation from
      */
     public static BuildDocHandler fromDirectory(File directory) {
         FileRepository repo = new FilesystemRepository(directory);
@@ -42,8 +42,8 @@ public class BuildDocHandlerFactory {
      * wrapping a FilesystemRepository, and the API docs from a given JAR file by
      * wrapping a JarRepository
      *
-     * @param directory The directory to serve the documentation from.
-     * @param jarFile The JAR file to server the documentation from.
+     * @param directory The directory to serve the documentation from
+     * @param jarFile The JAR file to server the documentation from
      * @param base    The directory within the JAR file to serve the documentation from, or null if the
      *                documentation should be served from the root of the JAR.
      */
@@ -56,11 +56,11 @@ public class BuildDocHandlerFactory {
      * wrapping a FilesystemRepository, and the API docs from a given JAR file by
      * wrapping a JarRepository.
      *
-     * @param directory The directory to serve the documentation from.
-     * @param jarFile The JAR file to server the documentation from.
+     * @param directory The directory to serve the documentation from
+     * @param jarFile The JAR file to server the documentation from
      * @param base    The directory within the JAR file to serve the documentation from, or null if the
      *                documentation should be served from the root of the JAR.
-     * @param fallbackToJar Whether the doc handler should fall back to the jar repo for docs.
+     * @param fallbackToJar Whether the doc handler should fall back to the jar repo for docs
      */
     public static BuildDocHandler fromDirectoryAndJar(File directory, JarFile jarFile, String base, boolean fallbackToJar) {
         FileRepository fileRepo = new FilesystemRepository(directory);
@@ -79,7 +79,7 @@ public class BuildDocHandlerFactory {
      * Create an BuildDocHandler that serves documentation from a given JAR file by
      * wrapping a JarRepository.
      *
-     * @param jarFile The JAR file to server the documentation from.
+     * @param jarFile The JAR file to server the documentation from
      * @param base    The directory within the JAR file to serve the documentation from, or null if the
      *                documentation should be served from the root of the JAR.
      */

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/CSRFErrorHandler.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/CSRFErrorHandler.java
@@ -19,8 +19,8 @@ public interface CSRFErrorHandler {
      * Handle the CSRF error.
      *
      * @param req The request
-     * @param msg message is passed by framework.
-     * @return Client gets this result.
+     * @param msg message is passed by framework
+     * @return client gets this result
      */
     F.Promise<Result> handle(Http.RequestHeader req, String msg);
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
@@ -56,7 +56,7 @@ object CORSActionBuilder {
    * Construct an action builder that uses a subtree of the application configuration.
    *
    * @param  configuration  The configuration to load the config from
-   * @param  configPath  The path to the subtree of the application configuration.
+   * @param  configPath  The path to the subtree of the application configuration
    */
   def apply(configuration: Configuration, configPath: String = "play.filters.cors"): CORSActionBuilder = new CORSActionBuilder {
     override protected def corsConfig = {
@@ -70,7 +70,7 @@ object CORSActionBuilder {
   /**
    * Construct an action builder that uses locally defined configuration.
    *
-   * @param  config  The local configuration to use in place of the global configuration.
+   * @param  config  The local configuration to use in place of the global configuration
    * @see [[CORSConfig]]
    */
   def apply(config: CORSConfig): CORSActionBuilder = new CORSActionBuilder {

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -14,10 +14,10 @@ import scala.concurrent.Future
 /**
  * An action that provides CSRF protection.
  *
- * @param config The CSRF configuration.
- * @param tokenProvider A token provider to use.
- * @param next The composed action that is being protected.
- * @param errorHandler handling failed token error.
+ * @param config The CSRF configuration
+ * @param tokenProvider A token provider to use
+ * @param next The composed action that is being protected
+ * @param errorHandler handling failed token error
  */
 class CSRFAction(next: EssentialAction,
     config: CSRFConfig = CSRFConfig(),

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
@@ -15,8 +15,8 @@ import play.filters.csrf.CSRF._
  * and hence depend on a started application, they must be by name.
  *
  * @param config A csrf configuration object
- * @param tokenProvider A token provider to use.
- * @param errorHandler handling failed token error.
+ * @param tokenProvider A token provider to use
+ * @param errorHandler handling failed token error
  */
 class CSRFFilter(
     config: => CSRFConfig,

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -24,16 +24,16 @@ import javax.inject.{ Singleton, Provider, Inject }
 /**
  * CSRF configuration.
  *
- * @param tokenName The name of the token.
- * @param cookieName If defined, the name of the cookie to read the token from/write the token to.
- * @param secureCookie If using a cookie, whether it should be secure.
- * @param httpOnlyCookie If using a cookie, whether it should have the HTTP only flag.
- * @param postBodyBuffer How much of the POST body should be buffered if checking the body for a token.
- * @param signTokens Whether tokens should be signed.
- * @param checkMethod Returns true if a request for that method should be checked.
- * @param checkContentType Returns true if a request for that content type should be checked.
- * @param headerName The name of the HTTP header to check for tokens from.
- * @param headerBypass Whether CSRF check can be bypassed by the presence of certain headers, such as X-Requested-By.
+ * @param tokenName The name of the token
+ * @param cookieName If defined, the name of the cookie to read the token from/write the token to
+ * @param secureCookie If using a cookie, whether it should be secure
+ * @param httpOnlyCookie If using a cookie, whether it should have the HTTP only flag
+ * @param postBodyBuffer How much of the POST body should be buffered if checking the body for a token
+ * @param signTokens Whether tokens should be signed
+ * @param checkMethod Returns true if a request for that method should be checked
+ * @param checkContentType Returns true if a request for that content type should be checked
+ * @param headerName The name of the HTTP header to check for tokens from
+ * @param headerBypass Whether CSRF check can be bypassed by the presence of certain headers, such as X-Requested-By
  */
 case class CSRFConfig(tokenName: String = "csrfToken",
   cookieName: Option[String] = None,
@@ -145,7 +145,7 @@ object CSRF {
    * Extract token from current Java request
    *
    * @param request The request to extract the token from
-   * @return The token, if found.
+   * @return the token, if found
    */
   def getToken(request: play.mvc.Http.Request): Optional[Token] = {
     Optional.ofNullable(getToken(request._underlyingHeader()).orNull)

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -191,8 +191,8 @@ object GzipFilter {
 /**
  * Configuration for the gzip filter
  *
- * @param gzip The gzip enumeratee to use.
- * @param chunkedThreshold The content length threshold, after which the filter will switch to chunking the result.
+ * @param gzip The gzip enumeratee to use
+ * @param chunkedThreshold The content length threshold, after which the filter will switch to chunking the result
  * @param shouldGzip Whether the given request/result should be gzipped.  This can be used, for example, to implement
  *                   black/white lists for gzipping by content type.
  */

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
@@ -42,7 +42,7 @@ object SecurityHeadersFilter {
    * Convenience method for creating a SecurityHeadersFilter that reads settings from application.conf.  Generally speaking,
    * you'll want to use this or the apply(SecurityHeadersConfig) method.
    *
-   * @return a configured SecurityHeadersFilter.
+   * @return a configured SecurityHeadersFilter
    */
   def apply(config: SecurityHeadersConfig = SecurityHeadersConfig()): SecurityHeadersFilter = {
     new SecurityHeadersFilter(config)
@@ -51,8 +51,8 @@ object SecurityHeadersFilter {
   /**
    * Convenience method for creating a filter using play.api.Configuration.  Good for testing.
    *
-   * @param config a configuration object that may contain string settings.
-   * @return a configured SecurityHeadersFilter.
+   * @param config a configuration object that may contain string settings
+   * @return a configured SecurityHeadersFilter
    */
   def apply(config: Configuration): SecurityHeadersFilter = {
     new SecurityHeadersFilter(SecurityHeadersConfig.fromConfiguration(config))
@@ -65,7 +65,7 @@ object SecurityHeadersFilter {
  * @param frameOptions "X-Frame-Options":
  * @param xssProtection "X-XSS-Protection":
  * @param contentTypeOptions "X-Content-Type-Options"
- * @param permittedCrossDomainPolicies "X-Permitted-Cross-Domain-Policies".
+ * @param permittedCrossDomainPolicies "X-Permitted-Cross-Domain-Policies"
  * @param contentSecurityPolicy "Content-Security-Policy"
  */
 case class SecurityHeadersConfig(frameOptions: Option[String] = Some("DENY"),

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
@@ -19,7 +19,7 @@ object BasicHttpClient {
    * @param checkClosed Whether to check if the channel is closed after receiving the responses
    * @param trickleFeed A timeout to use between sending request body chunks
    * @param requests The requests to make
-   * @return The parsed number of responses.  This may be more than the number of requests, if continue headers are sent.
+   * @return the parsed number of responses.  This may be more than the number of requests, if continue headers are sent
    */
   def makeRequests(port: Int, checkClosed: Boolean = false, trickleFeed: Option[Long] = None)(requests: BasicRequest*): Seq[BasicResponse] = {
     val client = new BasicHttpClient(port)
@@ -76,7 +76,7 @@ class BasicHttpClient(port: Int) {
    * @param waitForResponses Whether we should wait for responses
    * @param trickleFeed Whether bodies should be trickle fed.  Trickle feeding will simulate a more realistic network
    *                    environment.
-   * @return The responses (may be more than one if Expect: 100-continue header is present) if requested to wait for
+   * @return the responses (may be more than one if Expect: 100-continue header is present) if requested to wait for
    *         them
    */
   def sendRequest(request: BasicRequest, requestDesc: String, waitForResponses: Boolean = true,
@@ -128,7 +128,7 @@ class BasicHttpClient(port: Int) {
    * Read a response
    *
    * @param responseDesc Description of the response, for error reporting
-   * @return The response
+   * @return the response
    */
   def readResponse(responseDesc: String) = {
     try {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
@@ -29,7 +29,7 @@ trait WebSocketClient {
   /**
    * Connect to the given URI.
    *
-   * @return A future that will be redeemed when the connection is closed.
+   * @return a future that will be redeemed when the connection is closed
    */
   def connect(url: URI, version: WebSocketVersion = WebSocketVersion.V13)(onConnect: Handler): Future[Unit]
 

--- a/framework/src/play-java-jdbc/src/main/java/play/db/evolutions/Evolution.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/evolutions/Evolution.java
@@ -14,9 +14,9 @@ public final class Evolution {
     /**
      * Create the evolution.
      *
-     * @param revision The revision of the evolution to create.
-     * @param sqlUp The SQL script for bringing the evolution up.
-     * @param sqlDown The SQL script for tearing the evolution down.
+     * @param revision The revision of the evolution to create
+     * @param sqlUp The SQL script for bringing the evolution up
+     * @param sqlDown The SQL script for tearing the evolution down
      */
     public Evolution(int revision, String sqlUp, String sqlDown) {
         this.revision = revision;

--- a/framework/src/play-java-jdbc/src/main/java/play/db/evolutions/Evolutions.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/evolutions/Evolutions.java
@@ -25,7 +25,7 @@ public class Evolutions {
     /**
      * Create an evolutions reader that reads evolution files from a classloader.
      *
-     * @param classLoader The classloader to read from.
+     * @param classLoader The classloader to read from
      */
     public static play.api.db.evolutions.EvolutionsReader fromClassLoader(ClassLoader classLoader) {
         return fromClassLoader(classLoader, "");
@@ -34,7 +34,7 @@ public class Evolutions {
     /**
      * Create an evolutions reader that reads evolution files from a classloader.
      *
-     * @param classLoader The classloader to read from.
+     * @param classLoader The classloader to read from
      * @param prefix A prefix that gets added to the resource file names, for example, this could be used to namespace
      *               evolutions in different environments to work with different databases.
      */
@@ -45,7 +45,7 @@ public class Evolutions {
     /**
      * Create an evolutions reader based on a simple map of database names to evolutions.
      *
-     * @param evolutions The map of database names to evolutions.
+     * @param evolutions The map of database names to evolutions
      */
     public static play.api.db.evolutions.EvolutionsReader fromMap(Map<String, List<Evolution>> evolutions) {
         return new SimpleEvolutionsReader(evolutions);
@@ -54,7 +54,7 @@ public class Evolutions {
     /**
      * Create an evolutions reader for the default database from a list of evolutions.
      *
-     * @param evolutions The list of evolutions.
+     * @param evolutions The list of evolutions
      */
     public static play.api.db.evolutions.EvolutionsReader forDefault(Evolution... evolutions) {
         Map<String, List<Evolution>> map = new HashMap<String, List<Evolution>>();
@@ -65,9 +65,9 @@ public class Evolutions {
     /**
      * Apply evolutions for the given database.
      *
-     * @param database The database to apply the evolutions to.
-     * @param reader The reader to read the evolutions.
-     * @param autocommit Whether autocommit should be used.
+     * @param database The database to apply the evolutions to
+     * @param reader The reader to read the evolutions
+     * @param autocommit Whether autocommit should be used
      */
     public static void applyEvolutions(Database database, play.api.db.evolutions.EvolutionsReader reader, boolean autocommit) {
         DatabaseEvolutions evolutions = new DatabaseEvolutions(Database.toScala(database));
@@ -77,8 +77,8 @@ public class Evolutions {
     /**
      * Apply evolutions for the given database.
      *
-     * @param database The database to apply the evolutions to.
-     * @param reader The reader to read the evolutions.
+     * @param database The database to apply the evolutions to
+     * @param reader The reader to read the evolutions
      */
     public static void applyEvolutions(Database database, play.api.db.evolutions.EvolutionsReader reader) {
         applyEvolutions(database, reader, true);
@@ -87,7 +87,7 @@ public class Evolutions {
     /**
      * Apply evolutions for the given database.
      *
-     * @param database The database to apply the evolutions to.
+     * @param database The database to apply the evolutions to
      */
     public static void applyEvolutions(Database database) {
         applyEvolutions(database, fromClassLoader());
@@ -98,8 +98,8 @@ public class Evolutions {
      *
      * This will run the down scripts for all the applied evolutions.
      *
-     * @param database The database to apply the evolutions to.
-     * @param autocommit Whether autocommit should be used.
+     * @param database The database to apply the evolutions to
+     * @param autocommit Whether autocommit should be used
      */
     public static void cleanupEvolutions(Database database, boolean autocommit) {
         DatabaseEvolutions evolutions = new DatabaseEvolutions(Database.toScala(database));
@@ -111,7 +111,7 @@ public class Evolutions {
      *
      * This will run the down scripts for all the applied evolutions.
      *
-     * @param database The database to apply the evolutions to.
+     * @param database The database to apply the evolutions to
      */
     public static void cleanupEvolutions(Database database) {
         cleanupEvolutions(database, true);

--- a/framework/src/play-java-jdbc/src/main/java/play/db/evolutions/EvolutionsReader.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/evolutions/EvolutionsReader.java
@@ -28,8 +28,8 @@ public abstract class EvolutionsReader implements play.api.db.evolutions.Evoluti
     /**
      * Get the evolutions for the given database name.
      *
-     * @param db The name of the database.
-     * @return The collection of evolutions.
+     * @param db The name of the database
+     * @return the collection of evolutions
      */
     public abstract Collection<Evolution> getEvolutions(String db);
 }

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -171,7 +171,7 @@ public class DefaultJPAApi implements JPAApi {
      *
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
-     * @param block Block of code to execute.
+     * @param block Block of code to execute
      *
      * @deprecated This may cause deadlocks
      */

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
@@ -95,7 +95,7 @@ public class JPA {
     /**
      * Run a block of code in a JPA transaction.
      *
-     * @param block Block of code to execute.
+     * @param block Block of code to execute
      */
     public static <T> T withTransaction(play.libs.F.Function0<T> block) throws Throwable {
         return jpaApi().withTransaction(block);
@@ -104,7 +104,7 @@ public class JPA {
     /**
      * Run a block of asynchronous code in a JPA transaction.
      *
-     * @param block Block of code to execute.
+     * @param block Block of code to execute
      *
      * @deprecated This may cause deadlocks
      */
@@ -116,7 +116,7 @@ public class JPA {
     /**
      * Run a block of code in a JPA transaction.
      *
-     * @param block Block of code to execute.
+     * @param block Block of code to execute
      */
     public static void withTransaction(final play.libs.F.Callback0 block) {
         jpaApi().withTransaction(block);
@@ -127,7 +127,7 @@ public class JPA {
      *
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
-     * @param block Block of code to execute.
+     * @param block Block of code to execute
      */
     public static <T> T withTransaction(String name, boolean readOnly, play.libs.F.Function0<T> block) throws Throwable {
         return jpaApi().withTransaction(name, readOnly, block);
@@ -138,7 +138,7 @@ public class JPA {
      *
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
-     * @param block Block of code to execute.
+     * @param block Block of code to execute
      *
      * @deprecated This may cause deadlocks
      */

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
@@ -61,7 +61,7 @@ public interface JPAApi {
      *
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
-     * @param block Block of code to execute.
+     * @param block Block of code to execute
      *
      * @deprecated This may cause deadlocks
      */

--- a/framework/src/play-java-ws/src/main/java/play/libs/oauth/OAuth.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/oauth/OAuth.java
@@ -49,7 +49,7 @@ public class OAuth {
      * Request the request token and secret.
      *
      * @param callbackURL the URL where the provider should redirect to (usually a URL on the current app)
-     * @return A Right(RequestToken) in case of success, Left(OAuthException) otherwise
+     * @return a Right(RequestToken) in case of success, Left(OAuthException) otherwise
      */
     public RequestToken retrieveRequestToken(String callbackURL) {
         OAuthConsumer consumer = new DefaultOAuthConsumer(info.key.key, info.key.secret);
@@ -66,7 +66,7 @@ public class OAuth {
      *
      * @param token the token/secret pair obtained from a previous call
      * @param verifier a string you got through your user, with redirection
-     * @return A Right(RequestToken) in case of success, Left(OAuthException) otherwise
+     * @return a Right(RequestToken) in case of success, Left(OAuthException) otherwise
      */
     public RequestToken retrieveAccessToken(RequestToken token, String verifier) {
         OAuthConsumer consumer = new DefaultOAuthConsumer(info.key.key, info.key.secret);

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WS.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WS.java
@@ -42,8 +42,8 @@ public class WS {
      * with /), then this client will make the request on localhost using the supplied port.  This is particularly
      * useful in test situations.
      *
-     * @param port The port to use on localhost when relative URLs are requested.
-     * @return A running WS client.
+     * @param port The port to use on localhost when relative URLs are requested
+     * @return a running WS client
      */
     public static WSClient newClient(int port) {
         WSClient client = new NingWSClient(new AsyncHttpClientConfig.Builder()

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
@@ -250,8 +250,8 @@ public interface WSRequest {
     /**
      * Sets the request timeout in milliseconds.
      *
-     * @param timeout the request timeout in milliseconds.
-     * @return the modified WSRequest.
+     * @param timeout the request timeout in milliseconds
+     * @return the modified WSRequest
      */
     WSRequest setRequestTimeout(long timeout);
 
@@ -268,22 +268,22 @@ public interface WSRequest {
     //-------------------------------------------------------------------------
 
     /**
-     * @return the URL of the request.  This has not passed through an internal request builder and so will not be signed.
+     * @return the URL of the request.  This has not passed through an internal request builder and so will not be signed
      */
     String getUrl();
 
     /**
-     * @return the headers (a copy to prevent side-effects). This has not passed through an internal request builder and so will not be signed.
+     * @return the headers (a copy to prevent side-effects). This has not passed through an internal request builder and so will not be signed
      */
     Map<String, Collection<String>> getHeaders();
 
     /**
-     * @return the query parameters (a copy to prevent side-effects). This has not passed through an internal request builder and so will not be signed.
+     * @return the query parameters (a copy to prevent side-effects). This has not passed through an internal request builder and so will not be signed
      */
     Map<String, Collection<String>> getQueryParameters();
 
     /**
-     * @return the auth username, null if not an authenticated request.
+     * @return the auth username, null if not an authenticated request
      */
     String getUsername();
 
@@ -293,12 +293,12 @@ public interface WSRequest {
     String getPassword();
 
     /**
-     * @return the auth scheme, null if not an authenticated request.
+     * @return the auth scheme, null if not an authenticated request
      */
     WSAuthScheme getScheme();
 
     /**
-     * @return the signature calculator (example: OAuth), null if none is set.
+     * @return the signature calculator (example: OAuth), null if none is set
      */
     WSSignatureCalculator getCalculator();
 
@@ -309,7 +309,7 @@ public interface WSRequest {
     long getRequestTimeout();
 
     /**
-     * @return true if the request is configure to follow redirect, false if it is configure not to, null if nothing is configured and the global client preference should be used instead.
+     * @return true if the request is configure to follow redirect, false if it is configure not to, null if nothing is configured and the global client preference should be used instead
      */
     Boolean getFollowRedirects();
 

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSResponse.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSResponse.java
@@ -154,7 +154,7 @@ public class NingWSResponse implements WSResponse {
 
     /**
      * Get the response body as a stream
-     * @return The stream to read the response body from
+     * @return the stream to read the response body from
      */
     @Override
     public InputStream getBodyAsStream() {
@@ -167,7 +167,7 @@ public class NingWSResponse implements WSResponse {
 
     /**
      * Get the response body as a byte array
-     * @return The byte array
+     * @return the byte array
      */
     @Override
     public byte[] asByteArray() {
@@ -182,7 +182,7 @@ public class NingWSResponse implements WSResponse {
      * Return the request {@link java.net.URI}. Note that if the request got redirected, the value of the
      * {@link java.net.URI} will be the last valid redirect url.
      *
-     * @return the request {@link java.net.URI}.
+     * @return the request {@link java.net.URI}
      */
     @Override
     public URI getUri() {

--- a/framework/src/play-java/src/main/java/play/data/Form.java
+++ b/framework/src/play-java/src/main/java/play/data/Form.java
@@ -450,8 +450,8 @@ public class Form<T> {
     /**
      * Convert the error arguments.
      *
-     * @param arguments The arguments to convert.
-     * @return The converted arguments.
+     * @param arguments The arguments to convert
+     * @return the converted arguments
      */
     private List<Object> convertErrorArguments(Object[] arguments) {
         List<Object> converted = new ArrayList<Object>(arguments.length);
@@ -512,7 +512,7 @@ public class Form<T> {
     /**
      * Retrieve all global errors - errors without a key.
      *
-     * @return All global errors.
+     * @return all global errors
      */
     public List<ValidationError> globalErrors() {
         List<ValidationError> e = errors.get("");
@@ -525,7 +525,7 @@ public class Form<T> {
     /**
      * Retrieves the first global error (an error without any key), if it exists.
      *
-     * @return An error or <code>null</code>.
+     * @return an error or <code>null</code>
      */
     public ValidationError globalError() {
         List<ValidationError> errors = globalErrors();
@@ -539,7 +539,7 @@ public class Form<T> {
     /**
      * Returns all errors.
      *
-     * @return All errors associated with this form.
+     * @return all errors associated with this form
      */
     public Map<String,List<ValidationError>> errors() {
         return errors;
@@ -597,7 +597,7 @@ public class Form<T> {
     /**
      * Adds an error to this form.
      *
-     * @param error the <code>ValidationError</code> to add.
+     * @param error the <code>ValidationError</code> to add
      */
     public void reject(ValidationError error) {
         if(!errors.containsKey(error.key())) {
@@ -640,7 +640,7 @@ public class Form<T> {
     /**
      * Add a global error to this form.
      *
-     * @param error the error message.
+     * @param error the error message
      */    
     public void reject(String error) {
         reject("", error, new ArrayList<Object>());
@@ -784,7 +784,7 @@ public class Form<T> {
         /**
          * Returns the field name.
          *
-         * @return The field name.
+         * @return the field name
          */
         public String name() {
             return name;
@@ -793,7 +793,7 @@ public class Form<T> {
         /**
          * Returns the field value, if defined.
          *
-         * @return The field value, if defined.
+         * @return the field value, if defined
          */
         public String value() {
             return value;
@@ -809,7 +809,7 @@ public class Form<T> {
         /**
          * Returns all the errors associated with this field.
          *
-         * @return The errors associated with this field.
+         * @return the errors associated with this field
          */
         public List<ValidationError> errors() {
             return errors;
@@ -818,7 +818,7 @@ public class Form<T> {
         /**
          * Returns all the constraints associated with this field.
          *
-         * @return The constraints associated with this field.
+         * @return the constraints associated with this field
          */
         public List<Tuple<String,List<Object>>> constraints() {
             return constraints;
@@ -827,7 +827,7 @@ public class Form<T> {
         /**
          * Returns the expected format for this field.
          * 
-         * @return The expected format for this field.
+         * @return the expected format for this field
          */
         public Tuple<String,List<Object>> format() {
             return format;

--- a/framework/src/play-java/src/main/java/play/data/format/Formats.java
+++ b/framework/src/play-java/src/main/java/play/data/format/Formats.java
@@ -28,7 +28,7 @@ public class Formats {
         /**
          * Creates a date formatter.
          *
-         * @param pattern date pattern, as specified for {@link SimpleDateFormat}.
+         * @param pattern date pattern, as specified for {@link SimpleDateFormat}
          */
         public DateFormatter(String pattern) {
             this.pattern = pattern;

--- a/framework/src/play-java/src/main/java/play/data/format/Formatters.java
+++ b/framework/src/play-java/src/main/java/play/data/format/Formatters.java
@@ -77,7 +77,7 @@ public class Formatters {
     /**
      * Computes the display string for any value, for a specific type.
      *
-     * @param desc the field descriptor - custom formatters are extracted from this descriptor.
+     * @param desc the field descriptor - custom formatters are extracted from this descriptor
      * @param t the value to print
      * @return the formatted string
      */
@@ -151,7 +151,7 @@ public class Formatters {
         /**
          * Unbind this field (ie. transform a concrete value to plain string)
          *
-         * @param annotation the annotation that trigerred this formatter.
+         * @param annotation the annotation that trigerred this formatter
          * @param value the value to unbind
          * @param locale the current <code>Locale</code>
          * @return printable version of the value

--- a/framework/src/play-java/src/main/java/play/data/validation/Constraints.java
+++ b/framework/src/play-java/src/main/java/play/data/validation/Constraints.java
@@ -36,7 +36,7 @@ public class Constraints {
         /**
          * Returns <code>true</code> if this value is valid for the given constraint.
          *
-         * @param constraintContext The JSR-303 validation context.
+         * @param constraintContext The JSR-303 validation context
          */
         public boolean isValid(T object, ConstraintValidatorContext constraintContext) {
             return isValid(object);

--- a/framework/src/play-java/src/main/java/play/libs/Comet.java
+++ b/framework/src/play-java/src/main/java/play/libs/Comet.java
@@ -22,7 +22,7 @@ public abstract class Comet extends Chunks<String> {
     /**
      * Create a new Comet socket
      *
-     * @param callbackMethod The Javascript callback method to call on each message.
+     * @param callbackMethod The Javascript callback method to call on each message
      */
     public Comet(String callbackMethod) {
         super(play.core.j.JavaResults.writeString("text/html", play.api.mvc.Codec.javaSupported("utf-8")));

--- a/framework/src/play-java/src/main/java/play/libs/Crypto.java
+++ b/framework/src/play-java/src/main/java/play/libs/Crypto.java
@@ -34,9 +34,9 @@ public class Crypto {
      * By default this uses the platform default JSSE provider.  This can be overridden by defining
      * <code>application.crypto.provider</code> in <code>application.conf</code>.
      *
-     * @param message The message to sign.
-     * @param key     The private key to sign with.
-     * @return A hexadecimal encoded signature.
+     * @param message The message to sign
+     * @param key     The private key to sign with
+     * @return a hexadecimal encoded signature
      */
     public String sign(String message, byte[] key) {
         return crypto.sign(message, key);
@@ -48,8 +48,8 @@ public class Crypto {
      * By default this uses the platform default JSSE provider.  This can be overridden by defining
      * <code>application.crypto.provider</code> in <code>application.conf</code>.
      *
-     * @param message The message to sign.
-     * @return A hexadecimal encoded signature.
+     * @param message The message to sign
+     * @return a hexadecimal encoded signature
      */
     public String sign(String message) {
         return crypto.sign(message);
@@ -62,7 +62,7 @@ public class Crypto {
      * request, without actually changing the value.
      *
      * @param token The token to sign
-     * @return The signed token
+     * @return the signed token
      */
     public String signToken(String token) {
         return crypto.signToken(token);
@@ -71,8 +71,8 @@ public class Crypto {
     /**
      * Extract a signed token that was signed by {@link #signToken(String)}.
      *
-     * @param token The signed token to extract.
-     * @return The verified raw token, or null if the token isn't valid.
+     * @param token The signed token to extract
+     * @return the verified raw token, or null if the token isn't valid
      */
     public String extractSignedToken(String token) {
         scala.Option<String> extracted = crypto.extractSignedToken(token);
@@ -129,8 +129,8 @@ public class Crypto {
      * <code>application.conf</code>.  Although any cipher transformation algorithm can be selected here, the secret key
      * spec used is always AES, so only AES transformation algorithms will work.
      *
-     * @param value The String to encrypt.
-     * @return An hexadecimal encrypted string.
+     * @param value The String to encrypt
+     * @return an hexadecimal encrypted string
      */
     public String encryptAES(String value) {
         return crypto.encryptAES(value);
@@ -153,9 +153,9 @@ public class Crypto {
      * <code>application.conf</code>.  Although any cipher transformation algorithm can be selected here, the secret key
      * spec used is always AES, so only AES transformation algorithms will work.
      *
-     * @param value      The String to encrypt.
-     * @param privateKey The key used to encrypt.
-     * @return An hexadecimal encrypted string.
+     * @param value      The String to encrypt
+     * @param privateKey The key used to encrypt
+     * @return an hexadecimal encrypted string
      */
     public String encryptAES(String value, String privateKey) {
         return crypto.encryptAES(value, privateKey);
@@ -172,8 +172,8 @@ public class Crypto {
      * transformation algorithm can be selected here, the secret key spec used is always AES, so only AES transformation
      * algorithms will work.
      *
-     * @param value An hexadecimal encrypted string.
-     * @return The decrypted String.
+     * @param value An hexadecimal encrypted string
+     * @return the decrypted String
      */
     public String decryptAES(String value) {
         return crypto.decryptAES(value);
@@ -192,9 +192,9 @@ public class Crypto {
      * transformation algorithm can be selected here, the secret key spec used is always AES, so only AES transformation
      * algorithms will work.
      *
-     * @param value      An hexadecimal encrypted string.
-     * @param privateKey The key used to encrypt.
-     * @return The decrypted String.
+     * @param value      An hexadecimal encrypted string
+     * @param privateKey The key used to encrypt
+     * @return the decrypted String
      */
     public String decryptAES(String value, String privateKey) {
         return crypto.decryptAES(value, privateKey);

--- a/framework/src/play-java/src/main/java/play/libs/EventSource.java
+++ b/framework/src/play-java/src/main/java/play/libs/EventSource.java
@@ -110,7 +110,7 @@ public abstract class EventSource extends Chunks<String> {
 
         /**
          * @param name Event name
-         * @return A copy of this event, with name {@code name}
+         * @return a copy of this event, with name {@code name}
          */
         public Event withName(String name) {
             return new Event(this.data, this.id, name);
@@ -118,14 +118,14 @@ public abstract class EventSource extends Chunks<String> {
 
         /**
          * @param id Event id
-         * @return A copy of this event, with id {@code id}.
+         * @return a copy of this event, with id {@code id}
          */
         public Event withId(String id) {
             return new Event(this.data, id, this.name);
         }
 
         /**
-         * @return This event formatted according to the EventSource protocol.
+         * @return this event formatted according to the EventSource protocol
          */
         public String formatted() {
             return new play.api.libs.EventSource.Event(data, Scala.Option(id), Scala.Option(name)).formatted();
@@ -133,7 +133,7 @@ public abstract class EventSource extends Chunks<String> {
 
         /**
          * @param data Event content
-         * @return An event with {@code data} as content
+         * @return an event with {@code data} as content
          */
         public static Event event(String data) {
             return new Event(data, null, null);
@@ -141,7 +141,7 @@ public abstract class EventSource extends Chunks<String> {
 
         /**
          * @param json Json value to use
-         * @return An event with a string representation of {@code json} as content
+         * @return an event with a string representation of {@code json} as content
          */
         public static Event event(JsonNode json) {
             return new Event(Json.stringify(json), null, null);

--- a/framework/src/play-java/src/main/java/play/libs/Jsonp.java
+++ b/framework/src/play-java/src/main/java/play/libs/Jsonp.java
@@ -51,7 +51,7 @@ public class Jsonp implements Content {
     /**
      * @param padding Name of the callback
      * @param json Json content
-     * @return A JSONP Content using padding and json.
+     * @return a JSONP Content using padding and json
      */
     public static Jsonp jsonp(String padding, JsonNode json) {
         return new Jsonp(padding, json);

--- a/framework/src/play-java/src/main/java/play/libs/XPath.java
+++ b/framework/src/play-java/src/main/java/play/libs/XPath.java
@@ -89,7 +89,7 @@ public class XPath {
     /**
      * Return the text of a node, or the value of an attribute
      * @param path the XPath to execute
-     * @param node the node, node-set or Context object for evaluation. This value can be null.
+     * @param node the node, node-set or Context object for evaluation. This value can be null
      */
     public static String selectText(String path, Object node, Map<String, String> namespaces) {
         try {
@@ -111,7 +111,7 @@ public class XPath {
     /**
      * Return the text of a node, or the value of an attribute
      * @param path the XPath to execute
-     * @param node the node, node-set or Context object for evaluation. This value can be null.
+     * @param node the node, node-set or Context object for evaluation. This value can be null
      */
     public static String selectText(String path, Object node) {
         return selectText(path, node, null);

--- a/framework/src/play-java/src/main/java/play/libs/Yaml.java
+++ b/framework/src/play-java/src/main/java/play/libs/Yaml.java
@@ -27,7 +27,7 @@ public class Yaml {
     /** 
      * Load the specified InputStream as Yaml.
      *
-     * @param classloader The classloader to use to instantiate Java objects.
+     * @param classloader The classloader to use to instantiate Java objects
      */
     public static Object load(InputStream is, ClassLoader classloader) {
         org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml(new CustomClassLoaderConstructor(classloader));

--- a/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
+++ b/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
@@ -70,8 +70,8 @@ public class RoutingDsl {
     /**
      * Create a GET route for the given path pattern.
      *
-     * @param pathPattern The path pattern.
-     * @return A GET route matcher.
+     * @param pathPattern The path pattern
+     * @return a GET route matcher
      */
     public PathPatternMatcher GET(String pathPattern) {
         return new PathPatternMatcher("GET", pathPattern);
@@ -80,8 +80,8 @@ public class RoutingDsl {
     /**
      * Create a HEAD route for the given path pattern.
      *
-     * @param pathPattern The path pattern.
-     * @return A HEAD route matcher.
+     * @param pathPattern The path pattern
+     * @return a HEAD route matcher
      */
     public PathPatternMatcher HEAD(String pathPattern) {
         return new PathPatternMatcher("HEAD", pathPattern);
@@ -90,8 +90,8 @@ public class RoutingDsl {
     /**
      * Create a POST route for the given path pattern.
      *
-     * @param pathPattern The path pattern.
-     * @return A POST route matcher.
+     * @param pathPattern The path pattern
+     * @return a POST route matcher
      */
     public PathPatternMatcher POST(String pathPattern) {
         return new PathPatternMatcher("POST", pathPattern);
@@ -100,8 +100,8 @@ public class RoutingDsl {
     /**
      * Create a PUT route for the given path pattern.
      *
-     * @param pathPattern The path pattern.
-     * @return A PUT route matcher.
+     * @param pathPattern The path pattern
+     * @return a PUT route matcher
      */
     public PathPatternMatcher PUT(String pathPattern) {
         return new PathPatternMatcher("PUT", pathPattern);
@@ -110,8 +110,8 @@ public class RoutingDsl {
     /**
      * Create a DELETE route for the given path pattern.
      *
-     * @param pathPattern The path pattern.
-     * @return A DELETE route matcher.
+     * @param pathPattern The path pattern
+     * @return a DELETE route matcher
      */
     public PathPatternMatcher DELETE(String pathPattern) {
         return new PathPatternMatcher("DELETE", pathPattern);
@@ -120,8 +120,8 @@ public class RoutingDsl {
     /**
      * Create a PATCH route for the given path pattern.
      *
-     * @param pathPattern The path pattern.
-     * @return A PATCH route matcher.
+     * @param pathPattern The path pattern
+     * @return a PATCH route matcher
      */
     public PathPatternMatcher PATCH(String pathPattern) {
         return new PathPatternMatcher("PATCH", pathPattern);
@@ -130,8 +130,8 @@ public class RoutingDsl {
     /**
      * Create a OPTIONS route for the given path pattern.
      *
-     * @param pathPattern The path pattern.
-     * @return A OPTIONS route matcher.
+     * @param pathPattern The path pattern
+     * @return a OPTIONS route matcher
      */
     public PathPatternMatcher OPTIONS(String pathPattern) {
         return new PathPatternMatcher("OPTIONS", pathPattern);
@@ -141,8 +141,8 @@ public class RoutingDsl {
      * Create a route for the given method and path pattern.
      *
      * @param method      The method;
-     * @param pathPattern The path pattern.
-     * @return A route matcher.
+     * @param pathPattern The path pattern
+     * @return a route matcher
      */
     public PathPatternMatcher match(String method, String pathPattern) {
         return new PathPatternMatcher(method, pathPattern);
@@ -151,7 +151,7 @@ public class RoutingDsl {
     /**
      * Build the router.
      *
-     * @return The built router.
+     * @return the built router
      */
     public play.api.routing.Router build() {
         return RouterBuilderHelper.build(this);
@@ -281,8 +281,8 @@ public class RoutingDsl {
         /**
          * Route with no parameters.
          *
-         * @param action The action to execute.
-         * @return This router builder.
+         * @param action The action to execute
+         * @return this router builder
          */
         public RoutingDsl routeTo(F.Function0<Result> action) {
             return build(0, action, F.Function0.class);
@@ -291,8 +291,8 @@ public class RoutingDsl {
         /**
          * Route with one parameter.
          *
-         * @param action The action to execute.
-         * @return This router builder.
+         * @param action The action to execute
+         * @return this router builder
          */
         public <A1> RoutingDsl routeTo(F.Function<A1, Result> action) {
             return build(1, action, F.Function.class);
@@ -301,8 +301,8 @@ public class RoutingDsl {
         /**
          * Route with two parameters.
          *
-         * @param action The action to execute.
-         * @return This router builder.
+         * @param action The action to execute
+         * @return this router builder
          */
         public <A1, A2> RoutingDsl routeTo(F.Function2<A1, A2, Result> action) {
             return build(2, action, F.Function2.class);
@@ -311,8 +311,8 @@ public class RoutingDsl {
         /**
          * Route with three parameters.
          *
-         * @param action The action to execute.
-         * @return This router builder.
+         * @param action The action to execute
+         * @return this router builder
          */
         public <A1, A2, A3> RoutingDsl routeTo(F.Function3<A1, A2, A3, Result> action) {
             return build(3, action, F.Function3.class);
@@ -321,8 +321,8 @@ public class RoutingDsl {
         /**
          * Route with no parameters.
          *
-         * @param action The action to execute.
-         * @return This router builder.
+         * @param action The action to execute
+         * @return this router builder
          */
         public RoutingDsl routeAsync(F.Function0<F.Promise<Result>> action) {
             return build(0, action, F.Function0.class);
@@ -331,8 +331,8 @@ public class RoutingDsl {
         /**
          * Route with one parameter.
          *
-         * @param action The action to execute.
-         * @return This router builder.
+         * @param action The action to execute
+         * @return this router builder
          */
         public <A1> RoutingDsl routeAsync(F.Function<A1, F.Promise<Result>> action) {
             return build(1, action, F.Function.class);
@@ -341,8 +341,8 @@ public class RoutingDsl {
         /**
          * Route with two parameters.
          *
-         * @param action The action to execute.
-         * @return This router builder.
+         * @param action The action to execute
+         * @return this router builder
          */
         public <A1, A2> RoutingDsl routeAsync(F.Function2<A1, A2, F.Promise<Result>> action) {
             return build(2, action, F.Function2.class);
@@ -351,8 +351,8 @@ public class RoutingDsl {
         /**
          * Route with three parameters.
          *
-         * @param action The action to execute.
-         * @return This router builder.
+         * @param action The action to execute
+         * @return this router builder
          */
         public <A1, A2, A3> RoutingDsl routeAsync(F.Function3<A1, A2, A3, F.Promise<Result>> action) {
             return build(3, action, F.Function3.class);

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
@@ -44,9 +44,9 @@ object DB {
    * Execute a block of code, providing a JDBC connection. The connection is
    * automatically released.
    *
-   * @param name The datasource name.
+   * @param name The datasource name
    * @param autocommit when `true`, sets this connection to auto-commit
-   * @param block Code block to execute.
+   * @param block Code block to execute
    */
   def withConnection[A](name: String = "default", autocommit: Boolean = true)(block: Connection => A)(implicit app: Application): A =
     db.database(name).withConnection(autocommit)(block)
@@ -55,7 +55,7 @@ object DB {
    * Execute a block of code, providing a JDBC connection. The connection and all created statements are
    * automatically released.
    *
-   * @param block Code block to execute.
+   * @param block Code block to execute
    */
   def withConnection[A](block: Connection => A)(implicit app: Application): A =
     db.database("default").withConnection(block)
@@ -65,8 +65,8 @@ object DB {
    * The connection and all created statements are automatically released.
    * The transaction is automatically committed, unless an exception occurs.
    *
-   * @param name The datasource name.
-   * @param block Code block to execute.
+   * @param name The datasource name
+   * @param block Code block to execute
    */
   def withTransaction[A](name: String = "default")(block: Connection => A)(implicit app: Application): A =
     db.database(name).withTransaction(block)
@@ -76,7 +76,7 @@ object DB {
    * The connection and all created statements are automatically released.
    * The transaction is automatically committed, unless an exception occurs.
    *
-   * @param block Code block to execute.
+   * @param block Code block to execute
    */
   def withTransaction[A](block: Connection => A)(implicit app: Application): A =
     db.database("default").withTransaction(block)

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/Database.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/Database.scala
@@ -133,7 +133,7 @@ object Database {
    * @param name the database name
    * @param config a map of extra database configuration
    * @param block The block of code to run
-   * @return The result of the block
+   * @return the result of the block
    */
   def withDatabase[T](driver: String, url: String, name: String = "default",
     config: Map[String, _ <: Any] = Map.empty)(block: Database => T): T = {
@@ -152,7 +152,7 @@ object Database {
    * @param urlOptions a map of extra url options
    * @param config a map of extra database configuration
    * @param block The block of code to run
-   * @return The result of the block
+   * @return the result of the block
    */
   def withInMemory[T](name: String = "default", urlOptions: Map[String, String] = Map.empty,
     config: Map[String, _ <: Any] = Map.empty)(block: Database => T): T = {

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
@@ -308,7 +308,7 @@ class EvolutionsWebCommands @Inject() (evolutions: EvolutionsApi, reader: Evolut
  * Exception thrown when the database is not up to date.
  *
  * @param db the database name
- * @param script the script to be run to resolve the conflict.
+ * @param script the script to be run to resolve the conflict
  */
 case class InvalidDatabaseRevision(db: String, script: String) extends PlayException.RichDescription(
   "Database '" + db + "' needs evolution!",

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -159,9 +159,9 @@ object Evolutions {
   /**
    * Apply evolutions for the given database.
    *
-   * @param database The database to apply the evolutions to.
-   * @param evolutionsReader The reader to read the evolutions.
-   * @param autocommit Whether to use autocommit or not, evolutions will be manually committed if false.
+   * @param database The database to apply the evolutions to
+   * @param evolutionsReader The reader to read the evolutions
+   * @param autocommit Whether to use autocommit or not, evolutions will be manually committed if false
    */
   def applyEvolutions(database: Database, evolutionsReader: EvolutionsReader = ThisClassLoaderEvolutionsReader,
     autocommit: Boolean = true): Unit = {
@@ -176,8 +176,8 @@ object Evolutions {
    * This will leave the database in the original state it was before evolutions were applied, by running the down
    * scripts for all the evolutions that have been previously applied to the database.
    *
-   * @param database The database to clean the evolutions for.
-   * @param autocommit Whether to use atocommit or not, evolutions will be manually committed if false.
+   * @param database The database to clean the evolutions for
+   * @param autocommit Whether to use atocommit or not, evolutions will be manually committed if false
    */
   def cleanupEvolutions(database: Database, autocommit: Boolean = true): Unit = {
     val dbEvolutions = new DatabaseEvolutions(database)
@@ -189,8 +189,8 @@ object Evolutions {
    * Execute the following code block with the evolutions for the database, cleaning up afterwards by running the downs.
    *
    * @param database The database to execute the evolutions on
-   * @param evolutionsReader The evolutions reader to use.  Defaults to reading evolutions from the evolution readers own classloader.
-   * @param autocommit Whether to use autocommit or not, evolutions will be manually committed if false.
+   * @param evolutionsReader The evolutions reader to use.  Defaults to reading evolutions from the evolution readers own classloader
+   * @param autocommit Whether to use autocommit or not, evolutions will be manually committed if false
    * @param block The block to execute
    */
   def withEvolutions[T](database: Database, evolutionsReader: EvolutionsReader = ThisClassLoaderEvolutionsReader,

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -371,7 +371,7 @@ abstract class ResourceEvolutionsReader extends EvolutionsReader {
   /**
    * Load the evolutions resource for the given database and revision.
    *
-   * @return An InputStream to consume the resource, if such a resource exists.
+   * @return an InputStream to consume the resource, if such a resource exists
    */
   def loadResource(db: String, revision: Int): Option[InputStream]
 
@@ -438,7 +438,7 @@ class EnvironmentEvolutionsReader @Inject() (environment: Environment) extends R
 /**
  * Evolutions reader that reads evolution files from a class loader.
  *
- * @param classLoader The classloader to read from, defaults to the classloader for this class.
+ * @param classLoader The classloader to read from, defaults to the classloader for this class
  * @param prefix A prefix that gets added to the resource file names, for example, this could be used to namespace
  *               evolutions in different environments to work with different databases.
  */
@@ -479,14 +479,14 @@ object SimpleEvolutionsReader {
   /**
    * Create a simple evolutions reader from the given data.
    *
-   * @param data A map of database name to a sequence of evolutions.
+   * @param data A map of database name to a sequence of evolutions
    */
   def from(data: (String, Seq[Evolution])*) = new SimpleEvolutionsReader(data.toMap)
 
   /**
    * Create a simple evolutions reader from the given evolutions for the default database.
    *
-   * @param evolutions The evolutions.
+   * @param evolutions The evolutions
    */
   def forDefault(evolutions: Evolution*) = new SimpleEvolutionsReader(Map("default" -> evolutions))
 }

--- a/framework/src/play-json/src/main/java/play/libs/Json.java
+++ b/framework/src/play-json/src/main/java/play/libs/Json.java
@@ -69,7 +69,7 @@ public class Json {
     /**
      * Convert an object to JsonNode.
      *
-     * @param data Value to convert in Json.
+     * @param data Value to convert in Json
      */
     public static JsonNode toJson(final Object data) {
         try {
@@ -82,8 +82,8 @@ public class Json {
     /**
      * Convert a JsonNode to a Java value
      *
-     * @param json Json value to convert.
-     * @param clazz Expected Java value type.
+     * @param json Json value to convert
+     * @param clazz Expected Java value type
      */
     public static <A> A fromJson(JsonNode json, Class<A> clazz) {
         try {

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsLookup.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsLookup.scala
@@ -10,7 +10,7 @@ case class JsLookup(result: JsLookupResult) extends AnyVal {
   /**
    * Access a value of this array.
    *
-   * @param index Element index.
+   * @param index Element index
    */
   def apply(index: Int): JsLookupResult = result match {
     case JsDefined(arr: JsArray) =>

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsReadable.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsReadable.scala
@@ -8,7 +8,7 @@ trait JsReadable extends Any {
    * Tries to convert the node into a T. An implicit Reads[T] must be defined.
    * Any error is mapped to None
    *
-   * @return Some[T] if it succeeds, None if it fails.
+   * @return some[T] if it succeeds, None if it fails
    */
   def asOpt[T](implicit fjs: Reads[T]): Option[T] = validate(fjs).asOpt
 

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
@@ -77,7 +77,7 @@ object Json {
    * }}}
    *
    * @param json the JsValue to convert
-   * @return a String with the json representation with all non-ascii characters escaped.
+   * @return a String with the json representation with all non-ascii characters escaped
    */
   def asciiStringify(json: JsValue): String = JacksonJson.generateFromJsValue(json, true)
 
@@ -112,14 +112,14 @@ object Json {
   /**
    * Provided a Writes implicit for its type is available, convert any object into a JsValue.
    *
-   * @param o Value to convert in Json.
+   * @param o Value to convert in Json
    */
   def toJson[T](o: T)(implicit tjs: Writes[T]): JsValue = tjs.writes(o)
 
   /**
    * Provided a Reads implicit for that type is available, convert a JsValue to any type.
    *
-   * @param json Json value to transform as an instance of T.
+   * @param json Json value to transform as an instance of T
    */
   def fromJson[T](json: JsValue)(implicit fjs: Reads[T]): JsResult[T] = fjs.reads(json)
 

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
@@ -251,7 +251,7 @@ trait DefaultReads {
   /**
    * Reads for the `java.util.Date` type.
    *
-   * @param pattern a date pattern, as specified in `java.text.SimpleDateFormat`.
+   * @param pattern a date pattern, as specified in `java.text.SimpleDateFormat`
    * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks
    */
   def dateReads(pattern: String, corrector: String => String = identity): Reads[java.util.Date] = new Reads[java.util.Date] {
@@ -397,7 +397,7 @@ trait DefaultReads {
    *
    * @tparam T Type of argument to instantiate date/time parser
    * @param parsing Argument to instantiate date/time parser. Actually either a pattern (string) or a formatter (`java.time.format.DateTimeFormatter`)
-   * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed.
+   * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed
    * @param p Typeclass instance based on `parsing`
    * @see [[TemporalFormatter]]
    *
@@ -441,7 +441,7 @@ trait DefaultReads {
    *
    * @tparam T Type of argument to instantiate date/time parser
    * @param parsing Argument to instantiate date/time parser. Actually either a pattern (string) or a formatter (`java.time.format.DateTimeFormatter`)
-   * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed.
+   * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed
    * @param p Typeclass instance based on `parsing`
    * @see [[TemporalFormatter]]
    *
@@ -485,7 +485,7 @@ trait DefaultReads {
    *
    * @tparam T Type of argument to instantiate date parser
    * @param parsing Argument to instantiate date parser. Actually either a pattern (string) or a formatter (`java.time.format.DateTimeFormatter`)
-   * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed.
+   * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed
    * @param p Typeclass instance based on `parsing`
    * @see [[TemporalFormatter]]
    *
@@ -528,7 +528,7 @@ trait DefaultReads {
    *
    * @tparam T Type of argument to instantiate date parser
    * @param parsing Argument to instantiate date parser. Actually either a pattern (string) or a formatter (`java.time.format.DateTimeFormatter`)
-   * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed.
+   * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed
    * @param p Typeclass instance based on `parsing`
    * @see [[TemporalFormatter]]
    *
@@ -596,7 +596,7 @@ trait DefaultReads {
   /**
    * Reads for the `org.joda.time.DateTime` type.
    *
-   * @param pattern a date pattern, as specified in `java.text.SimpleDateFormat`.
+   * @param pattern a date pattern, as specified in `java.text.SimpleDateFormat`
    * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks
    */
   def jodaDateReads(pattern: String, corrector: String => String = identity): Reads[org.joda.time.DateTime] = new Reads[org.joda.time.DateTime] {
@@ -626,7 +626,7 @@ trait DefaultReads {
   /**
    * Reads for the `org.joda.time.LocalDate` type.
    *
-   * @param pattern a date pattern, as specified in `org.joda.time.format.DateTimeFormat`.
+   * @param pattern a date pattern, as specified in `org.joda.time.format.DateTimeFormat`
    * @param corrector string transformation function (See jodaDateReads)
    */
   def jodaLocalDateReads(pattern: String, corrector: String => String = identity): Reads[org.joda.time.LocalDate] = new Reads[org.joda.time.LocalDate] {
@@ -656,7 +656,7 @@ trait DefaultReads {
   /**
    * Reads for the `org.joda.time.LocalTime` type.
    *
-   * @param pattern a date pattern, as specified in `org.joda.time.format.DateTimeFormat`.
+   * @param pattern a date pattern, as specified in `org.joda.time.format.DateTimeFormat`
    * @param corrector string transformation function (See jodaTimeReads)
    */
   def jodaLocalTimeReads(pattern: String, corrector: String => String = identity): Reads[org.joda.time.LocalTime] = new Reads[org.joda.time.LocalTime] {
@@ -687,7 +687,7 @@ trait DefaultReads {
   /**
    * Reads for the `java.sql.Date` type.
    *
-   * @param pattern a date pattern, as specified in `java.text.SimpleDateFormat`.
+   * @param pattern a date pattern, as specified in `java.text.SimpleDateFormat`
    * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks
    */
   def sqlDateReads(pattern: String, corrector: String => String = identity): Reads[java.sql.Date] =
@@ -701,7 +701,7 @@ trait DefaultReads {
   /**
    * Reads for `scala.Enumeration` types using the name.
    *
-   * @param enum a `scala.Enumeration`.
+   * @param enum a `scala.Enumeration`
    */
   def enumNameReads[E <: Enumeration](enum: E): Reads[E#Value] = new Reads[E#Value] {
     def reads(json: JsValue) = json match {

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -212,9 +212,9 @@ object NettyServer extends ServerStart {
   /**
    * Create a Netty server from the given application and server configuration.
    *
-   * @param application The application.
-   * @param config The server configuration.
-   * @return A started Netty server, serving the application.
+   * @param application The application
+   * @param config The server configuration
+   * @return a started Netty server, serving the application
    */
   def fromApplication(application: Application, config: ServerConfig = ServerConfig()): NettyServer = {
     new NettyServer(config, new ApplicationProvider {

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyResultStreamer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyResultStreamer.scala
@@ -32,7 +32,7 @@ object NettyResultStreamer {
   /**
    * Send the result to netty
    *
-   * @return A Future that will be redeemed when the result is completely sent
+   * @return a Future that will be redeemed when the result is completely sent
    */
   def sendResult(requestHeader: RequestHeader, result: Result, httpVersion: HttpVersion, startSequence: Int)(implicit ctx: ChannelHandlerContext, oue: OrderedUpstreamMessageEvent): Future[_] = {
     import play.api.libs.iteratee.Execution.Implicits.trampoline

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/RequestBodyHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/RequestBodyHandler.scala
@@ -21,10 +21,10 @@ private[server] trait RequestBodyHandler {
    * Creates a new upstream handler for the purposes of receiving chunked requests. Requests are buffered as an
    * optimization.
    *
-   * @param bodyHandler the iteratee used to handle the body.
-   * @param replaceHandler a function to handle the registration of a new handler. A handler is passed as a param.
-   * @param handlerFinished a function to handle the de-registration of the handler i.e. when the chunked request is complete.
-   * @return a future of an iteratee that will return the result.
+   * @param bodyHandler the iteratee used to handle the body
+   * @param replaceHandler a function to handle the registration of a new handler. A handler is passed as a param
+   * @param handlerFinished a function to handle the de-registration of the handler i.e. when the chunked request is complete
+   * @return a future of an iteratee that will return the result
    */
   def newRequestBodyUpstreamHandler[A](bodyHandler: Iteratee[Array[Byte], A],
     replaceHandler: ChannelUpstreamHandler => Unit,

--- a/framework/src/play-server/src/main/java/play/server/Server.java
+++ b/framework/src/play-server/src/main/java/play/server/Server.java
@@ -50,8 +50,8 @@ public class Server {
      * <p>
      * The server will be running in TEST mode.
      *
-     * @param router The router for the server to serve.
-     * @return The running server.
+     * @param router The router for the server to serve
+     * @return the running server
      */
     public static Server forRouter(Router router) {
         return forRouter(router, Mode.TEST, 0);
@@ -63,9 +63,9 @@ public class Server {
      * The server will be running on a randomly selected ephemeral port, which can be checked using the httpPort
      * property.
      *
-     * @param router The router for the server to serve.
-     * @param mode   The mode the server will run on.
-     * @return The running server.
+     * @param router The router for the server to serve
+     * @param mode   The mode the server will run on
+     * @return the running server
      */
     public static Server forRouter(Router router, Mode mode) {
         return forRouter(router, mode, 0);
@@ -76,9 +76,9 @@ public class Server {
      * <p>
      * The server will be running in TEST mode.
      *
-     * @param router The router for the server to serve.
-     * @param port   The port the server will run on.
-     * @return The running server.
+     * @param router The router for the server to serve
+     * @param port   The port the server will run on
+     * @return the running server
      */
     public static Server forRouter(Router router, int port) {
         return forRouter(router, Mode.TEST, port);
@@ -87,10 +87,10 @@ public class Server {
     /**
      * Create a server for the given router.
      *
-     * @param router The router for the server to serve.
-     * @param mode   The mode the server will run on.
-     * @param port   The port the server will run on.
-     * @return The running server.
+     * @param router The router for the server to serve
+     * @param mode   The mode the server will run on
+     * @param port   The port the server will run on
+     * @return the running server
      */
     public static Server forRouter(Router router, Mode mode, int port) {
         return new Server(JavaServerHelper.forRouter(router, JavaModeConverter.asScalaMode(mode), port));

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -74,7 +74,7 @@ trait Server extends ServerWithStop {
    *
    * This is useful when the port number has been automatically selected (by setting a port number of 0).
    *
-   * @return The HTTP port the server is bound to, if the HTTP connector is enabled.
+   * @return the HTTP port the server is bound to, if the HTTP connector is enabled
    */
   def httpPort: Option[Int]
 
@@ -83,7 +83,7 @@ trait Server extends ServerWithStop {
    *
    * This is useful when the port number has been automatically selected (by setting a port number of 0).
    *
-   * @return The HTTPS port the server is bound to, if the HTTPS connector is enabled.
+   * @return the HTTPS port the server is bound to, if the HTTPS connector is enabled
    */
   def httpsPort: Option[Int]
 
@@ -100,12 +100,12 @@ object Server {
    * The passed in block takes the port that the application is running on. By default, this will be a random ephemeral
    * port. This can be changed by passing in an explicit port with the config parameter.
    *
-   * @param application The application for the server to server.
+   * @param application The application for the server to server
    * @param config The configuration for the server. Defaults to test config with the http port bound to a random
    *               ephemeral port.
-   * @param block The block of code to run.
-   * @param provider The server provider.
-   * @return The result of the block of code.
+   * @param block The block of code to run
+   * @param provider The server provider
+   * @return the result of the block of code
    */
   def withApplication[T](application: Application, config: ServerConfig = ServerConfig(port = Some(0), mode = Mode.Test))(block: Port => T)(implicit provider: ServerProvider): T = {
     val server = provider.createServer(config, new TestApplication(application))
@@ -122,12 +122,12 @@ object Server {
    * The passed in block takes the port that the application is running on. By default, this will be a random ephemeral
    * port. This can be changed by passing in an explicit port with the config parameter.
    *
-   * @param routes The routes for the server to server.
+   * @param routes The routes for the server to server
    * @param config The configuration for the server. Defaults to test config with the http port bound to a random
    *               ephemeral port.
-   * @param block The block of code to run.
-   * @param provider The server provider.
-   * @return The result of the block of code.
+   * @param block The block of code to run
+   * @param provider The server provider
+   * @return the result of the block of code
    */
   def withRouter[T](config: ServerConfig = ServerConfig(port = Some(0), mode = Mode.Test))(routes: PartialFunction[RequestHeader, Handler])(block: Port => T)(implicit provider: ServerProvider): T = {
     val application = new BuiltInComponentsFromContext(ApplicationLoader.Context(

--- a/framework/src/play-server/src/main/scala/play/core/server/ServerConfig.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ServerConfig.scala
@@ -13,10 +13,10 @@ import play.api.{ Configuration, Mode }
  *
  * @param rootDir The root directory of the server. Used to find default locations of
  * files, log directories, etc.
- * @param port The HTTP port to use.
- * @param sslPort The HTTPS port to use.
- * @param address The socket address to bind to.
- * @param mode The run mode: dev, test or prod.
+ * @param port The HTTP port to use
+ * @param sslPort The HTTPS port to use
+ * @param address The socket address to bind to
+ * @param mode The run mode: dev, test or prod
  * @param configuration: The configuration to use for loading the server. This is not
  * the same as application configuration. This configuration is usually loaded from a
  * server.conf file, whereas the application configuration is usually loaded from an
@@ -60,7 +60,7 @@ object ServerConfig {
    * given some Properties. At this moment this just reads from server-reference.conf
    * and from the given properties.
    *
-   * @param properties The properties to base the configuration on.
+   * @param properties The properties to base the configuration on
    */
   def loadConfiguration(classLoader: ClassLoader, properties: Properties): Configuration = {
     Configuration(loadDefaultConfig(classLoader, properties).resolve())

--- a/framework/src/play-server/src/main/scala/play/core/server/ServerProvider.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ServerProvider.scala
@@ -21,9 +21,9 @@ object ServerProvider {
   /**
    * Load a server provider from the configuration and classloader.
    *
-   * @param classLoader The ClassLoader to load the class from.
-   * @param configuration The configuration to look the server provider up from.
-   * @return The server provider, if one was configured.
+   * @param classLoader The ClassLoader to load the class from
+   * @param configuration The configuration to look the server provider up from
+   * @return the server provider, if one was configured
    */
   def maybeServerProvider(classLoader: ClassLoader, configuration: Configuration): Option[ServerProvider] = {
     configuration.getString("play.server.provider").map(instantiateServerProvider(classLoader))

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/impl/EnumeratorPublisher.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/impl/EnumeratorPublisher.scala
@@ -39,7 +39,7 @@ private[streams] object EnumeratorSubscription {
   sealed trait State[+T]
   /**
    * An active Subscription with n outstanding requested elements.
-   * @param n Elements that have been requested by the Subscriber. May be 0.
+   * @param n Elements that have been requested by the Subscriber. May be 0
    * @param attached The attached Iteratee we're using to read from the
    * Enumerator. Will be Unattached until the first element is requested.
    */

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/impl/IterateeSubscriber.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/impl/IterateeSubscriber.scala
@@ -19,23 +19,23 @@ private[streams] object IterateeSubscriber {
    * Iteratee hasn't resolved to a Step yet. This is the initial state of the
    * Subscriber.
    *
-   * @param result A Promise of the eventual result of this Subscriber.
+   * @param result A Promise of the eventual result of this Subscriber
    */
   case class NotSubscribedNoStep[T, R](result: Promise[Iteratee[T, R]]) extends State[T, R]
   /**
    * A Subscriber that has had onSubscribe called on it but
    * doesn't yet know the current Step of its Iteratee.
    *
-   * @param subs The Subscription the Subscriber is subscribed to.
-   * @param result A Promise of the eventual result of this Subscriber.
+   * @param subs The Subscription the Subscriber is subscribed to
+   * @param result A Promise of the eventual result of this Subscriber
    */
   case class SubscribedNoStep[T, R](subs: Subscription, result: Promise[Iteratee[T, R]]) extends State[T, R]
   /**
    * A Subscriber that hasn't had onSubscribe called on it yet, but whose
    * Iteratee is known to have a Step of Cont.
    *
-   * @param cont The current Step of the Iteratee.
-   * @param result A Promise of the eventual result of this Subscriber.
+   * @param cont The current Step of the Iteratee
+   * @param result A Promise of the eventual result of this Subscriber
    */
   case class NotSubscribedWithCont[T, R](cont: Step.Cont[T, R], result: Promise[Iteratee[T, R]]) extends State[T, R]
   /**
@@ -43,9 +43,9 @@ private[streams] object IterateeSubscriber {
    * a Step of Cont and is currently waiting for an element that it has
    * requested from the Subscription.
    *
-   * @param subs The Subscription the Subscriber is subscribed to.
-   * @param cont The current Step of the Iteratee.
-   * @param result A Promise of the eventual result of this Subscriber.
+   * @param subs The Subscription the Subscriber is subscribed to
+   * @param cont The current Step of the Iteratee
+   * @param result A Promise of the eventual result of this Subscriber
    */
   case class SubscribedWithCont[T, R](subs: Subscription, cont: Step.Cont[T, R], result: Promise[Iteratee[T, R]]) extends State[T, R]
   /**
@@ -53,14 +53,14 @@ private[streams] object IterateeSubscriber {
    * hasn't resolved ot a Step yet. If the Iteratee resolves to Cont then it
    * Input.EOF will be fed to it.
    *
-   * @param result A Promise of the eventual result of this Subscriber.
+   * @param result A Promise of the eventual result of this Subscriber
    */
   case class CompletedNoStep[T, R](result: Promise[Iteratee[T, R]]) extends State[T, R]
   /**
    * A Subscriber that is finished. We don't track the precise reason for
    * being finished.
    *
-   * @param result The result of this Subscriber.
+   * @param result The result of this Subscriber
    */
   case class Finished[T, R](resultIteratee: Iteratee[T, R]) extends State[T, R]
 }

--- a/framework/src/play-test/src/main/java/play/test/TestBrowser.java
+++ b/framework/src/play-test/src/main/java/play/test/TestBrowser.java
@@ -20,8 +20,8 @@ public class TestBrowser extends FluentAdapter {
     /**
      * A test browser (Using Selenium WebDriver) with the FluentLenium API (https://github.com/Fluentlenium/FluentLenium).
      *
-     * @param webDriver The WebDriver instance to use.
-     * @param baseUrl The base url to use for relative requests.
+     * @param webDriver The WebDriver instance to use
+     * @param baseUrl The base url to use for relative requests
      */
     public TestBrowser(Class<? extends WebDriver> webDriver, String baseUrl) throws Exception {
         this(play.api.test.WebDriverFactory.apply(webDriver), baseUrl);
@@ -31,8 +31,8 @@ public class TestBrowser extends FluentAdapter {
     /**
      * A test browser (Using Selenium WebDriver) with the FluentLenium API (https://github.com/Fluentlenium/FluentLenium).
      *
-     * @param webDriver The WebDriver instance to use.
-     * @param baseUrl The base url to use for relative requests.
+     * @param webDriver The WebDriver instance to use
+     * @param baseUrl The base url to use for relative requests
      */
     public TestBrowser(WebDriver webDriver, String baseUrl) {
         super(webDriver);

--- a/framework/src/play-test/src/main/java/play/test/TestServer.java
+++ b/framework/src/play-test/src/main/java/play/test/TestServer.java
@@ -15,8 +15,8 @@ public class TestServer extends play.api.test.TestServer {
     /**
      * A test Netty web server.
      *
-     * @param port HTTP port to bind on.
-     * @param application The Application to load in this server.
+     * @param port HTTP port to bind on
+     * @param application The Application to load in this server
      */
     public TestServer(int port, Application application) {
         super(port, application.getWrappedApplication(), play.libs.Scala.<Object>None(), play.libs.Scala.<ServerProvider>None());

--- a/framework/src/play-test/src/main/java/play/test/WithApplication.java
+++ b/framework/src/play-test/src/main/java/play/test/WithApplication.java
@@ -21,7 +21,7 @@ public class WithApplication {
      *
      * By default this will call the old {@link #provideFakeApplication() provideFakeApplication} method.
      *
-     * @return The application to use
+     * @return the application to use
      */
     protected Application provideApplication() {
         return provideFakeApplication();
@@ -32,7 +32,7 @@ public class WithApplication {
      *
      * Override this method to setup the fake application to use.
      *
-     * @return The fake application to use
+     * @return the fake application to use
      */
     protected FakeApplication provideFakeApplication() {
         return Helpers.fakeApplication();

--- a/framework/src/play-test/src/main/java/play/test/WithServer.java
+++ b/framework/src/play-test/src/main/java/play/test/WithServer.java
@@ -23,7 +23,7 @@ public class WithServer {
      *
      * By default this will call the old {@link #provideFakeApplication() provideFakeApplication} method.
      *
-     * @return The application used by the server
+     * @return the application used by the server
      */
     protected Application provideApplication() {
         return provideFakeApplication();
@@ -34,7 +34,7 @@ public class WithServer {
      *
      * Override this method to setup the fake application to use.
      *
-     * @return The fake application used by the server
+     * @return the fake application used by the server
      */
     protected FakeApplication provideFakeApplication() {
         return Helpers.fakeApplication();
@@ -43,7 +43,7 @@ public class WithServer {
     /**
      * Override this method to setup the port to use.
      *
-     * @return The TCP port used by the server
+     * @return the TCP port used by the server
      */
     protected int providePort() {
         return play.api.test.Helpers.testServerPort();

--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -20,7 +20,7 @@ import play.api.libs.Files.TemporaryFile
 /**
  * Fake HTTP headers implementation.
  *
- * @param data Headers data.
+ * @param data Headers data
  */
 case class FakeHeaders(data: Seq[(String, String)] = Seq.empty) extends Headers(data)
 
@@ -28,11 +28,11 @@ case class FakeHeaders(data: Seq[(String, String)] = Seq.empty) extends Headers(
  * Fake HTTP request implementation.
  *
  * @tparam A The body type.
- * @param method The request HTTP method.
- * @param uri The request uri.
- * @param headers The request HTTP headers.
- * @param body The request body.
- * @param remoteAddress The client IP.
+ * @param method The request HTTP method
+ * @param uri The request uri
+ * @param headers The request HTTP headers
+ * @param body The request body
+ * @param remoteAddress The client IP
  */
 case class FakeRequest[A](method: String, uri: String, headers: Headers, body: A, remoteAddress: String = "127.0.0.1", version: String = "HTTP/1.1", id: Long = 666, tags: Map[String, String] = Map.empty[String, String], secure: Boolean = false) extends Request[A] {
 

--- a/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
@@ -18,7 +18,7 @@ import org.openqa.selenium.support.ui.FluentWait
 /**
  * A test browser (Using Selenium WebDriver) with the FluentLenium API (https://github.com/Fluentlenium/FluentLenium).
  *
- * @param webDriver The WebDriver instance to use.
+ * @param webDriver The WebDriver instance to use
  */
 case class TestBrowser(webDriver: WebDriver, baseUrl: Option[String]) extends FluentAdapter(webDriver) {
 
@@ -111,7 +111,7 @@ object WebDriverFactory {
   /**
    * Creates a Selenium Web Driver and configures it
    * @param clazz Type of driver to create
-   * @return The driver instance
+   * @return the driver instance
    */
   def apply[D <: WebDriver](clazz: Class[D]): WebDriver = {
     val driver = clazz.newInstance

--- a/framework/src/play-test/src/main/scala/play/api/test/TestServer.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/TestServer.scala
@@ -10,9 +10,9 @@ import scala.util.control.NonFatal
 /**
  * A test web server.
  *
- * @param port HTTP port to bind on.
- * @param application The Application to load in this server.
- * @param sslPort HTTPS port to bind on.
+ * @param port HTTP port to bind on
+ * @param application The Application to load in this server
+ * @param sslPort HTTPS port to bind on
  * @param serverProvider *Experimental API; subject to change* The type of
  * server to use. If not provided, uses Play's default provider.
  */

--- a/framework/src/play-ws/src/main/scala/play/api/libs/oauth/OAuth.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/oauth/OAuth.scala
@@ -13,7 +13,7 @@ import play.api.libs.ws.WSSignatureCalculator
 /**
  * Library to access resources protected by OAuth 1.0a.
  *  @param info the service information, including the required URLs and the application id and secret
- *  @param use10a whether the service should use the 1.0 version of the spec, or the 1.0a version fixing a security issue.
+ *  @param use10a whether the service should use the 1.0 version of the spec, or the 1.0a version fixing a security issue
  *  You must use the version corresponding to the
  */
 case class OAuth(info: ServiceInfo, use10a: Boolean = true) {
@@ -28,7 +28,7 @@ case class OAuth(info: ServiceInfo, use10a: Boolean = true) {
    * Request the request token and secret.
    *
    * @param callbackURL the URL where the provider should redirect to (usually a URL on the current app)
-   * @return A Right(RequestToken) in case of success, Left(OAuthException) otherwise
+   * @return a Right(RequestToken) in case of success, Left(OAuthException) otherwise
    */
   def retrieveRequestToken(callbackURL: String): Either[OAuthException, RequestToken] = {
     val consumer = new DefaultOAuthConsumer(info.key.key, info.key.secret)
@@ -45,7 +45,7 @@ case class OAuth(info: ServiceInfo, use10a: Boolean = true) {
    *
    * @param token the token/secret pair obtained from a previous call
    * @param verifier a string you got through your user, with redirection
-   * @return A Right(RequestToken) in case of success, Left(OAuthException) otherwise
+   * @return a Right(RequestToken) in case of success, Left(OAuthException) otherwise
    */
   def retrieveAccessToken(token: RequestToken, verifier: String): Either[OAuthException, RequestToken] = {
     val consumer = new DefaultOAuthConsumer(info.key.key, info.key.secret)

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -24,14 +24,14 @@ trait WSClient {
   /**
    * The underlying implementation of the client, if any.  You must cast explicitly to the type you want.
    * @tparam T the type you are expecting (i.e. isInstanceOf)
-   * @return the backing class.
+   * @return the backing class
    */
   def underlying[T]: T
 
   /**
    * Generates a request holder which can be used to build requests.
    *
-   * @param url The base URL to make HTTP requests to.
+   * @param url The base URL to make HTTP requests to
    * @return a WSRequestHolder
    */
   def url(url: String): WSRequest
@@ -116,7 +116,7 @@ object WS {
    * }}}
    *
    * @param url the URL to request
-   * @param app the implicit application to use.
+   * @param app the implicit application to use
    */
   def url(url: String)(implicit app: Application): play.api.libs.ws.WSRequest = wsapi(app).url(url)
 
@@ -140,7 +140,7 @@ object WS {
    * WS.url(client -> exampleURL).get()
    * }}}
    *
-   * @param magnet a magnet pattern.
+   * @param magnet a magnet pattern
    * @see <a href="http://spray.io/blog/2012-12-13-the-magnet-pattern/">The magnet pattern</a>
    */
   def url(magnet: WSRequestMagnet): play.api.libs.ws.WSRequest = magnet()
@@ -154,7 +154,7 @@ object WS {
    * }}}
    *
    * @param url the URL to request
-   * @param client the client to use to make the request.
+   * @param client the client to use to make the request
    */
   def clientUrl(url: String)(implicit client: WSClient): play.api.libs.ws.WSRequest = client.url(url)
 }

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingConfig.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingConfig.scala
@@ -23,18 +23,18 @@ import scala.concurrent.duration._
 /**
  * Ning client config.
  *
- * @param wsClientConfig The general WS client config.
- * @param allowPoolingConnection Whether connection pooling should be allowed.
- * @param allowSslConnectionPool Whether connection pooling should be allowed for SSL connections.
- * @param ioThreadMultiplier The multiplier to use for the number of IO threads.
- * @param maxConnectionsPerHost The maximum number of connections to make per host. -1 means no maximum.
- * @param maxConnectionsTotal The maximum total number of connections. -1 means no maximum.
- * @param maxConnectionLifetime The maximum time that a connection should live for in the pool.
- * @param idleConnectionInPoolTimeout The time after which a connection that has been idle in the pool should be closed.
- * @param webSocketIdleTimeout The time after which a websocket connection should be closed.
- * @param maxNumberOfRedirects The maximum number of redirects.
- * @param maxRequestRetry The maximum number of times to retry a request if it fails.
- * @param disableUrlEncoding Whether the raw URL should be used.
+ * @param wsClientConfig The general WS client config
+ * @param allowPoolingConnection Whether connection pooling should be allowed
+ * @param allowSslConnectionPool Whether connection pooling should be allowed for SSL connections
+ * @param ioThreadMultiplier The multiplier to use for the number of IO threads
+ * @param maxConnectionsPerHost The maximum number of connections to make per host. -1 means no maximum
+ * @param maxConnectionsTotal The maximum total number of connections. -1 means no maximum
+ * @param maxConnectionLifetime The maximum time that a connection should live for in the pool
+ * @param idleConnectionInPoolTimeout The time after which a connection that has been idle in the pool should be closed
+ * @param webSocketIdleTimeout The time after which a websocket connection should be closed
+ * @param maxNumberOfRedirects The maximum number of redirects
+ * @param maxRequestRetry The maximum number of times to retry a request if it fails
+ * @param disableUrlEncoding Whether the raw URL should be used
  */
 case class NingWSClientConfig(wsClientConfig: WSClientConfig = WSClientConfig(),
   allowPoolingConnection: Boolean = true,
@@ -103,7 +103,7 @@ class NingWSClientConfigParser @Inject() (wsClientConfig: WSClientConfig,
 /**
  * Builds a valid AsyncHttpClientConfig object from config.
  *
- * @param ningConfig the ning client configuration.
+ * @param ningConfig the ning client configuration
  */
 class NingAsyncHttpClientConfigBuilder(ningConfig: NingWSClientConfig = NingWSClientConfig()) {
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
@@ -560,7 +560,7 @@ case class NingWSResponse(ahcResponse: AHCResponse) extends WSResponse {
   }
 
   /**
-   * @return The underlying response object.
+   * @return the underlying response object
    */
   def underlying[T] = ahcResponse.asInstanceOf[T]
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/Config.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/Config.scala
@@ -15,10 +15,10 @@ import javax.net.ssl.{ TrustManagerFactory, KeyManagerFactory, HostnameVerifier 
  *
  * A key store must either provide a file path, or a data String.
  *
- * @param storeType The store type. Defaults to the platform default store type (ie, JKS).
- * @param filePath The path of the key store file.
- * @param data The data to load the key store file from.
- * @param password The password to use to load the key store file, if the file is password protected.
+ * @param storeType The store type. Defaults to the platform default store type (ie, JKS)
+ * @param filePath The path of the key store file
+ * @param data The data to load the key store file from
+ * @param password The password to use to load the key store file, if the file is password protected
  */
 case class KeyStoreConfig(storeType: String = KeyStore.getDefaultType,
     filePath: Option[String] = None,
@@ -33,9 +33,9 @@ case class KeyStoreConfig(storeType: String = KeyStore.getDefaultType,
  *
  * A trust store must either provide a file path, or a data String.
  *
- * @param storeType The store type. Defaults to the platform default store type (ie, JKS).
- * @param filePath The path of the key store file.
- * @param data The data to load the key store file from.
+ * @param storeType The store type. Defaults to the platform default store type (ie, JKS)
+ * @param filePath The path of the key store file
+ * @param data The data to load the key store file from
  */
 case class TrustStoreConfig(storeType: String = KeyStore.getDefaultType,
     filePath: Option[String],
@@ -47,8 +47,8 @@ case class TrustStoreConfig(storeType: String = KeyStore.getDefaultType,
 /**
  * The key manager config.
  *
- * @param algorithm The algoritm to use.
- * @param keyStoreConfigs The key stores to use.
+ * @param algorithm The algoritm to use
+ * @param keyStoreConfigs The key stores to use
  */
 case class KeyManagerConfig(
   algorithm: String = KeyManagerFactory.getDefaultAlgorithm,
@@ -57,8 +57,8 @@ case class KeyManagerConfig(
 /**
  * The trust manager config.
  *
- * @param algorithm The algorithm to use.
- * @param trustStoreConfigs The trust stores to use.
+ * @param algorithm The algorithm to use
+ * @param trustStoreConfigs The trust stores to use
  */
 case class TrustManagerConfig(
   algorithm: String = TrustManagerFactory.getDefaultAlgorithm,
@@ -137,14 +137,14 @@ case class SSLDebugRecordOptions(plaintext: Boolean = false, packet: Boolean = f
 /**
  * Configuration for specifying loose (potentially dangerous) ssl config.
  *
- * @param allowWeakCiphers Whether weak ciphers should be allowed or not.
- * @param allowWeakProtocols Whether weak protocols should be allowed or not.
+ * @param allowWeakCiphers Whether weak ciphers should be allowed or not
+ * @param allowWeakProtocols Whether weak protocols should be allowed or not
  * @param allowLegacyHelloMessages Whether legacy hello messages should be allowed or not.  If None, uses the platform
  *                                 default.
  * @param allowUnsafeRenegotiation Whether unsafe renegotiation should be allowed or not. If None, uses the platform
  *                                 default.
- * @param disableHostnameVerification Whether hostname verification should be disabled.
- * @param acceptAnyCertificate Whether any X.509 certificate should be accepted or not.
+ * @param disableHostnameVerification Whether hostname verification should be disabled
+ * @param acceptAnyCertificate Whether any X.509 certificate should be accepted or not
  */
 case class SSLLooseConfig(
   allowWeakCiphers: Boolean = false,
@@ -157,19 +157,19 @@ case class SSLLooseConfig(
 /**
  * The SSL configuration.
  *
- * @param default Whether we should use the default JVM SSL configuration or not.
- * @param protocol The SSL protocol to use. Defaults to TLSv1.2.
- * @param checkRevocation Whether revocation lists should be checked, if None, defaults to platform default setting.
- * @param revocationLists The revocation lists to check.
- * @param enabledCipherSuites If defined, override the platform default cipher suites.
- * @param enabledProtocols If defined, override the platform default protocols.
- * @param disabledSignatureAlgorithms The disabled signature algorithms.
- * @param disabledKeyAlgorithms The disabled key algorithms.
- * @param keyManagerConfig The key manager configuration.
- * @param trustManagerConfig The trust manager configuration.
- * @param hostnameVerifierClass The hostname verifier class.
- * @param secureRandom The SecureRandom instance to use. Let the platform choose if None.
- * @param debug The debug config.
+ * @param default Whether we should use the default JVM SSL configuration or not
+ * @param protocol The SSL protocol to use. Defaults to TLSv1.2
+ * @param checkRevocation Whether revocation lists should be checked, if None, defaults to platform default setting
+ * @param revocationLists The revocation lists to check
+ * @param enabledCipherSuites If defined, override the platform default cipher suites
+ * @param enabledProtocols If defined, override the platform default protocols
+ * @param disabledSignatureAlgorithms The disabled signature algorithms
+ * @param disabledKeyAlgorithms The disabled key algorithms
+ * @param keyManagerConfig The key manager configuration
+ * @param trustManagerConfig The trust manager configuration
+ * @param hostnameVerifierClass The hostname verifier class
+ * @param secureRandom The SecureRandom instance to use. Let the platform choose if None
+ * @param debug The debug config
  * @param loose Loose configuratino parameters
  */
 case class SSLConfig(

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/MonkeyPatcher.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/MonkeyPatcher.scala
@@ -23,7 +23,7 @@ trait MonkeyPatcher {
    * Monkeypatches any given field.
    *
    * @param field the field to change
-   * @param newObject the new object to place in the field.
+   * @param newObject the new object to place in the field
    */
   def monkeyPatchField(field: Field, newObject: AnyRef) {
     val base = unsafe.staticFieldBase(field)

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/SSLContextBuilder.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/SSLContextBuilder.scala
@@ -28,7 +28,7 @@ class SimpleSSLContextBuilder(protocol: String,
 
   /**
    * Builds the appropriate SSL context manager.
-   * @return a configured SSL context.
+   * @return a configured SSL context
    */
   def build(): SSLContext = {
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/debug/ClassFinder.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/debug/ClassFinder.scala
@@ -27,7 +27,7 @@ trait ClassFinder {
    * found classes are loaded into the current thread's classloader, even they are not returned.
    *
    * @param className
-   * @return true if this class should be returned in the set of findClasses, false otherwise.
+   * @return true if this class should be returned in the set of findClasses, false otherwise
    */
   def isValidClass(className: String): Boolean
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/debug/FixCertpathDebugLogging.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/debug/FixCertpathDebugLogging.scala
@@ -32,8 +32,8 @@ object FixCertpathDebugLogging {
     /**
      * Returns true if this class has an instance of {{Debug.getInstance("certpath")}}, false otherwise.
      *
-     * @param className the name of the class.
-     * @return true if this class should be returned in the set of findClasses, false otherwise.
+     * @param className the name of the class
+     * @return true if this class should be returned in the set of findClasses, false otherwise
      */
     def isValidClass(className: String): Boolean = {
       if (className.startsWith("java.security.cert")) return true
@@ -84,7 +84,7 @@ object FixCertpathDebugLogging {
   /**
    * Extends {{sun.security.util.Debug}} to delegate println to a logger.
    *
-   * @param logger the logger which will receive debug calls.
+   * @param logger the logger which will receive debug calls
    */
   class SunSecurityUtilDebugLogger(logger: org.slf4j.Logger) extends sun.security.util.Debug {
     override def println(message: String) {

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/debug/FixInternalDebugLogging.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/debug/FixInternalDebugLogging.scala
@@ -34,8 +34,8 @@ object FixInternalDebugLogging {
     /**
      * Returns true if this class has an instance of the class returned by debugClassName, false otherwise.
      *
-     * @param className the name of the class.
-     * @return true if this class should be returned in the set of findClasses, false otherwise.
+     * @param className the name of the class
+     * @return true if this class should be returned in the set of findClasses, false otherwise
      */
     def isValidClass(className: String): Boolean = {
       if (className.startsWith("com.sun.net.ssl.internal.ssl")) return true

--- a/framework/src/play-ws/src/main/scala/play/api/test/WSTestClient.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/test/WSTestClient.scala
@@ -50,7 +50,7 @@ trait WsTestClient {
    *
    * @param block The block of code to run
    * @param port The port
-   * @return The result of the block of code
+   * @return the result of the block of code
    */
   def withClient[T](block: WSClient => T)(implicit port: play.api.http.Port = new play.api.http.Port(-1)) = {
     // Don't retry for tests

--- a/framework/src/play/src/main/java/play/Application.java
+++ b/framework/src/play/src/main/java/play/Application.java
@@ -74,7 +74,7 @@ public interface Application {
      * Get a resource stream from the classpath.
      *
      * @param relativePath relative path of the resource to fetch
-     * @return InputStream to the resource (may be null)
+     * @return inputStream to the resource (may be null)
      */
     default InputStream resourceAsStream(String relativePath) {
         return Scala.orNull(getWrappedApplication().resourceAsStream(relativePath));

--- a/framework/src/play/src/main/java/play/Configuration.java
+++ b/framework/src/play/src/main/java/play/Configuration.java
@@ -85,8 +85,8 @@ public class Configuration {
     /**
      * Retrieves a sub-configuration, which is a configuration instance containing all keys that start with the given prefix.
      *
-     * @param key The root prefix for this sub configuration.
-     * @return Maybe a new configuration
+     * @param key The root prefix for this sub configuration
+     * @return maybe a new configuration
      */
     public Configuration getConfig(String key) {
         scala.Option<play.api.Configuration> nConf = conf.getConfig(key);
@@ -306,7 +306,7 @@ public class Configuration {
     /**
      * Returns the config as a map of plain old Java maps, lists and values.
      *
-     * @return The config map
+     * @return the config map
      */
     public Map<String, Object> asMap() {
         return conf.underlying().root().unwrapped();
@@ -315,7 +315,7 @@ public class Configuration {
     /**
      * Returns the underlying Typesafe config object.
      *
-     * @return The config
+     * @return the config
      */
     public Config underlying() {
         return conf.underlying();
@@ -326,7 +326,7 @@ public class Configuration {
      * different to {@link asMap()} in that it returns {@link com.typesafe.config.ConfigValue}
      * objects, and keys are recursively expanded to be pull path keys.
      *
-     * @return The config as an entry set
+     * @return the config as an entry set
      */
     public Set<Map.Entry<String, ConfigValue>> entrySet() {
         return conf.underlying().entrySet();

--- a/framework/src/play/src/main/java/play/Environment.java
+++ b/framework/src/play/src/main/java/play/Environment.java
@@ -113,7 +113,7 @@ public class Environment {
      * Retrieves a resource stream from the classpath.
      *
      * @param relativePath relative path of the resource to fetch
-     * @return InputStream to the resource (may be null)
+     * @return inputStream to the resource (may be null)
      */
     public InputStream resourceAsStream(String relativePath) {
         return Scala.orNull(env.resourceAsStream(relativePath));

--- a/framework/src/play/src/main/java/play/GlobalSettings.java
+++ b/framework/src/play/src/main/java/play/GlobalSettings.java
@@ -57,8 +57,8 @@ public class GlobalSettings {
      * The request and actionMethod values are passed for information.
      *
      * @param request The HTTP Request
-     * @param actionMethod The action method containing the user code for this Action.
-     * @return The default implementation returns a raw Action calling the method.
+     * @param actionMethod The action method containing the user code for this Action
+     * @return the default implementation returns a raw Action calling the method
      */
     @SuppressWarnings("rawtypes")
     public Action onRequest(Request request, Method actionMethod) {
@@ -93,7 +93,7 @@ public class GlobalSettings {
      * By overriding this method one can provide an alternative 404 page.
      *
      * @param request the HTTP request
-     * @return null in the default implementation, you can return your own custom Result in your Global class.
+     * @return null in the default implementation, you can return your own custom Result in your Global class
      */
     public F.Promise<Result> onHandlerNotFound(RequestHeader request) {
         return null;
@@ -108,7 +108,7 @@ public class GlobalSettings {
      * By overriding this method one can provide an alternative 400 page.
      *
      * @param request the HTTP request
-     * @return null in the default implementation, you can return your own custom Result in your Global class.
+     * @return null in the default implementation, you can return your own custom Result in your Global class
      */
     public F.Promise<Result> onBadRequest(RequestHeader request, String error) {
         return null;
@@ -120,7 +120,7 @@ public class GlobalSettings {
      * @param config the loaded configuration
      * @param path the application path
      * @param classloader The applications classloader
-     * @return The configuration that the application should use
+     * @return the configuration that the application should use
      */
     public Configuration onLoadConfig(Configuration config, File path, ClassLoader classloader) {
         return null;
@@ -133,7 +133,7 @@ public class GlobalSettings {
      * @param path the application path
      * @param classloader The applications classloader
      * @param mode The mode of the application
-     * @return The configuration that the application should use
+     * @return the configuration that the application should use
      */
     public Configuration onLoadConfig(Configuration config, File path, ClassLoader classloader, Mode mode) {
         return onLoadConfig(config, path, classloader);

--- a/framework/src/play/src/main/java/play/http/DefaultHttpErrorHandler.java
+++ b/framework/src/play/src/main/java/play/http/DefaultHttpErrorHandler.java
@@ -43,9 +43,9 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
     /**
      * Invoked when a client error occurs, that is, an error in the 4xx series.
      *
-     * @param request The request that caused the client error.
-     * @param statusCode The error status code.  Must be greater or equal to 400, and less than 500.
-     * @param message The error message.
+     * @param request The request that caused the client error
+     * @param statusCode The error status code.  Must be greater or equal to 400, and less than 500
+     * @param message The error message
      */
     @Override
     public F.Promise<Result> onClientError(RequestHeader request, int statusCode, String message) {
@@ -67,8 +67,8 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
     /**
      * Invoked when a client makes a bad request.
      *
-     * @param request The request that was bad.
-     * @param message The error message.
+     * @param request The request that was bad
+     * @param message The error message
      */
     protected F.Promise<Result> onBadRequest(RequestHeader request, String message) {
         return F.Promise.<Result>pure(Results.badRequest(views.html.defaultpages.badRequest.render(
@@ -79,8 +79,8 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
     /**
      * Invoked when a client makes a request that was forbidden.
      *
-     * @param request The forbidden request.
-     * @param message The error message.
+     * @param request The forbidden request
+     * @param message The error message
      */
     protected F.Promise<Result> onForbidden(RequestHeader request, String message) {
         return F.Promise.<Result>pure(Results.forbidden(views.html.defaultpages.unauthorized.render()));
@@ -89,8 +89,8 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
     /**
      * Invoked when a handler or resource is not found.
      *
-     * @param request The request that no handler was found to handle.
-     * @param message A message.
+     * @param request The request that no handler was found to handle
+     * @param message A message
      */
     protected F.Promise<Result> onNotFound(RequestHeader request, String message){
         if (environment.isProd()) {
@@ -110,8 +110,8 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
      * [[onDevServerError()]] in dev mode.  It is recommended, if you want Play's debug info on the error page in dev
      * mode, that you override [[onProdServerError()]] instead of this method.
      *
-     * @param request The request that triggered the server error.
-     * @param exception The server error.
+     * @param request The request that triggered the server error
+     * @param exception The server error
      */
     @Override
     public F.Promise<Result> onServerError(RequestHeader request, Throwable exception) {
@@ -137,8 +137,8 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
      *
      * This can be overridden to add additional logging information, eg. the id of the authenticated user.
      *
-     * @param request The request that triggered the server error.
-     * @param usefulException The server error.
+     * @param request The request that triggered the server error
+     * @param usefulException The server error
      */
     protected void logServerError(RequestHeader request, UsefulException usefulException) {
         Logger.error(String.format("\n\n! @%s - Internal server error, for (%s) [%s] ->\n",
@@ -160,8 +160,8 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
     /**
      * Invoked in dev mode when a server error occurs.
      *
-     * @param request The request that triggered the error.
-     * @param exception The exception.
+     * @param request The request that triggered the error
+     * @param exception The exception
      */
     protected F.Promise<Result> onDevServerError(RequestHeader request, UsefulException exception) {
         return F.Promise.<Result>pure(Results.internalServerError(views.html.defaultpages.devError.render(playEditor, exception)));
@@ -173,8 +173,8 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
      * Override this rather than [[onServerError()]] if you don't want to change Play's debug output when logging errors
      * in dev mode.
      *
-     * @param request The request that triggered the error.
-     * @param exception The exception.
+     * @param request The request that triggered the error
+     * @param exception The exception
      */
     protected F.Promise<Result> onProdServerError(RequestHeader request, UsefulException exception) {
         return F.Promise.<Result>pure(Results.internalServerError(views.html.defaultpages.error.render(exception)));

--- a/framework/src/play/src/main/java/play/http/HttpErrorHandler.java
+++ b/framework/src/play/src/main/java/play/http/HttpErrorHandler.java
@@ -17,17 +17,17 @@ public interface HttpErrorHandler {
     /**
      * Invoked when a client error occurs, that is, an error in the 4xx series.
      *
-     * @param request The request that caused the client error.
-     * @param statusCode The error status code.  Must be greater or equal to 400, and less than 500.
-     * @param message The error message.
+     * @param request The request that caused the client error
+     * @param statusCode The error status code.  Must be greater or equal to 400, and less than 500
+     * @param message The error message
      */
     F.Promise<Result> onClientError(RequestHeader request, int statusCode, String message);
 
     /**
      * Invoked when a server error occurs.
      *
-     * @param request The request that triggered the server error.
-     * @param exception The server error.
+     * @param request The request that triggered the server error
+     * @param exception The server error
      */
     F.Promise<Result> onServerError(RequestHeader request, Throwable exception);
 }

--- a/framework/src/play/src/main/java/play/http/HttpRequestHandler.java
+++ b/framework/src/play/src/main/java/play/http/HttpRequestHandler.java
@@ -20,8 +20,8 @@ public interface HttpRequestHandler {
      * an instance of Action that invokes the injected action delegate.
      *
      * @param request The HTTP Request
-     * @param actionMethod The action method containing the user code for this Action.
-     * @return The default implementation returns a raw Action calling the method.
+     * @param actionMethod The action method containing the user code for this Action
+     * @return the default implementation returns a raw Action calling the method
      */
     Action createAction(Request request, Method actionMethod);
 
@@ -31,8 +31,8 @@ public interface HttpRequestHandler {
      * This method is passed a fully composed action, allowing a last final global interceptor to be added to the
      * action if required.
      *
-     * @param action The action to wrap.
-     * @return A wrapped action.
+     * @param action The action to wrap
+     * @return a wrapped action
      */
     Action wrapAction(Action action);
 }

--- a/framework/src/play/src/main/java/play/i18n/Langs.java
+++ b/framework/src/play/src/main/java/play/i18n/Langs.java
@@ -39,7 +39,7 @@ public class Langs {
      * play.modules.i18n.langs="fr,en,de"
      * </pre>
      *
-     * @return The available languages.
+     * @return the available languages
      */
     public List<Lang> availables() {
         return availables;
@@ -52,7 +52,7 @@ public class Langs {
      * none of the candidates are available.
      *
      * @param candidates The candidate languages
-     * @return The preferred language
+     * @return the preferred language
      */
     public Lang preferred(Collection<Lang> candidates) {
         return new Lang(langs.preferred((scala.collection.Seq) JavaConversions.collectionAsScalaIterable(candidates).toSeq()));

--- a/framework/src/play/src/main/java/play/i18n/Messages.java
+++ b/framework/src/play/src/main/java/play/i18n/Messages.java
@@ -158,7 +158,7 @@ public class Messages {
     }
 
     /**
-     * @return The underlying API
+     * @return the underlying API
      */
     public MessagesApi messagesApi() {
         return messages;

--- a/framework/src/play/src/main/java/play/inject/Injector.java
+++ b/framework/src/play/src/main/java/play/inject/Injector.java
@@ -19,7 +19,7 @@ public interface Injector {
      * Get an instance of the given class from the injector.
      *
      * @param clazz The class to get the instance of
-     * @return The instance
+     * @return the instance
      */
     <T> T instanceOf(Class<T> clazz);
 }

--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -115,7 +115,7 @@ public class F {
          * The sequencing operations are performed in the default ExecutionContext.
          *
          * @param promises The promises to combine
-         * @return A single promise whose methods act on the list of redeemed promises
+         * @return a single promise whose methods act on the list of redeemed promises
          */
         public static <A> Promise<List<A>> sequence(Promise<A>... promises){
             return FPromiseHelper.<A>sequence(java.util.Arrays.asList(promises), HttpExecution.defaultContext());
@@ -124,9 +124,9 @@ public class F {
         /**
          * Combine the given promises into a single promise for the list of results.
          *
-         * @param ec Used to execute the sequencing operations.
+         * @param ec Used to execute the sequencing operations
          * @param promises The promises to combine
-         * @return A single promise whose methods act on the list of redeemed promises
+         * @return a single promise whose methods act on the list of redeemed promises
          */
         public static <A> Promise<List<A>> sequence(ExecutionContext ec, Promise<A>... promises){
             return FPromiseHelper.<A>sequence(java.util.Arrays.asList(promises), ec);
@@ -135,9 +135,9 @@ public class F {
         /**
          * Create a Promise that is redeemed after a timeout.
          *
-         * @param message The message to use to redeem the Promise.
-         * @param delay The delay (expressed with the corresponding unit).
-         * @param unit The Unit.
+         * @param message The message to use to redeem the Promise
+         * @param delay The delay (expressed with the corresponding unit)
+         * @param unit The Unit
          */
         public static <A> Promise<A> timeout(A message, long delay, TimeUnit unit) {
             return FPromiseHelper.timeout(message, delay, unit);
@@ -146,8 +146,8 @@ public class F {
         /**
          * Create a Promise that is redeemed after a timeout.
          *
-         * @param message The message to use to redeem the Promise.
-         * @param delay The delay expressed in milliseconds.
+         * @param message The message to use to redeem the Promise
+         * @param delay The delay expressed in milliseconds
          */
         public static <A> Promise<A> timeout(A message, long delay) {
             return timeout(message, delay, TimeUnit.MILLISECONDS);
@@ -160,7 +160,7 @@ public class F {
          * The returned Promise is usually combined with other Promises.
          *
          * @return a promise without a real value
-         * @param delay The delay expressed in milliseconds.
+         * @param delay The delay expressed in milliseconds
          */
         public static <A> Promise<scala.Unit> timeout(long delay) {
             return timeout(delay, TimeUnit.MILLISECONDS);
@@ -172,8 +172,8 @@ public class F {
          *
          * The returned Promise is usually combined with other Promises.
          *
-         * @param delay The delay (expressed with the corresponding unit).
-         * @param unit The Unit.
+         * @param delay The delay (expressed with the corresponding unit)
+         * @param unit The Unit
          * @return a promise without a real value
          */
         public static <A> Promise<scala.Unit> timeout(long delay, TimeUnit unit) {
@@ -186,7 +186,7 @@ public class F {
          * The sequencing operations are performed in the default ExecutionContext.
          *
          * @param promises The promises to combine
-         * @return A single promise whose methods act on the list of redeemed promises
+         * @return a single promise whose methods act on the list of redeemed promises
          */
         public static <A> Promise<List<A>> sequence(Iterable<Promise<A>> promises){
             return FPromiseHelper.<A>sequence(promises, HttpExecution.defaultContext());
@@ -196,8 +196,8 @@ public class F {
          * Combine the given promises into a single promise for the list of results.
          *
          * @param promises The promises to combine
-         * @param ec Used to execute the sequencing operations.
-         * @return A single promise whose methods act on the list of redeemed promises
+         * @param ec Used to execute the sequencing operations
+         * @return a single promise whose methods act on the list of redeemed promises
          */
         public static <A> Promise<List<A>> sequence(Iterable<Promise<A>> promises, ExecutionContext ec){
             return FPromiseHelper.<A>sequence(promises, ec);
@@ -225,7 +225,7 @@ public class F {
          *
          * The Function0 will be run in the default ExecutionContext.
          *
-         * @param function Used to fulfill the Promise.
+         * @param function Used to fulfill the Promise
          */
         public static <A> Promise<A> promise(Function0<A> function) {
             return FPromiseHelper.promise(function, HttpExecution.defaultContext());
@@ -234,8 +234,8 @@ public class F {
         /**
          * Create a Promise which will be redeemed with the result of a given Function0.
          *
-         * @param function Used to fulfill the Promise.
-         * @param ec The ExecutionContext to run the function in.
+         * @param function Used to fulfill the Promise
+         * @param ec The ExecutionContext to run the function in
          */
         public static <A> Promise<A> promise(Function0<A> function, ExecutionContext ec) {
             return FPromiseHelper.promise(function, ec);
@@ -247,9 +247,9 @@ public class F {
          *
          * The function will be run in the default ExecutionContext.
          *
-         * @param function The function to call to fulfill the Promise.
-         * @param delay The time to wait.
-         * @param unit The units to use for the delay.
+         * @param function The function to call to fulfill the Promise
+         * @param delay The time to wait
+         * @param unit The units to use for the delay
          */
         public static <A> Promise<A> delayed(Function0<A> function, long delay, TimeUnit unit) {
             return FPromiseHelper.delayed(function, delay, unit, HttpExecution.defaultContext());
@@ -259,10 +259,10 @@ public class F {
          * Create a Promise which, after a delay, will be redeemed with the result of a
          * given function. The function will be called after the delay.
          *
-         * @param function The function to call to fulfill the Promise.
-         * @param delay The time to wait.
-         * @param unit The units to use for the delay.
-         * @param ec The ExecutionContext to run the Function0 in.
+         * @param function The function to call to fulfill the Promise
+         * @param delay The time to wait
+         * @param unit The units to use for the delay
+         * @param ec The ExecutionContext to run the Function0 in
          */
         public static <A> Promise<A> delayed(Function0<A> function, long delay, TimeUnit unit, ExecutionContext ec) {
             return FPromiseHelper.delayed(function, delay, unit, ec);
@@ -275,7 +275,7 @@ public class F {
          * @param timeout A user defined timeout
          * @param unit timeout for timeout
          * @throws PromiseTimeoutException when the promise did timeout.
-         * @return The promised result
+         * @return the promised result
          *
          */
         public A get(long timeout, TimeUnit unit) {
@@ -288,7 +288,7 @@ public class F {
          *
          * @param timeout A user defined timeout in milliseconds
          * @throws PromiseTimeoutException when the promise did timeout.
-         * @return The promised result
+         * @return the promised result
          */
         public A get(long timeout) {
             return FPromiseHelper.get(this, timeout, TimeUnit.MILLISECONDS);
@@ -307,7 +307,7 @@ public class F {
          *
          * The callback will be run in the default execution context.
          *
-         * @param action The action to perform.
+         * @param action The action to perform
          */
         public void onRedeem(final Callback<A> action) {
             FPromiseHelper.onRedeem(this, action, HttpExecution.defaultContext());
@@ -316,8 +316,8 @@ public class F {
         /**
          * Perform the given <code>action</code> callback when the Promise is redeemed.
          *
-         * @param action The action to perform.
-         * @param ec The ExecutionContext to execute the action in.
+         * @param action The action to perform
+         * @param ec The ExecutionContext to execute the action in
          */
         public void onRedeem(final Callback<A> action, ExecutionContext ec) {
             FPromiseHelper.onRedeem(this, action, ec);
@@ -329,8 +329,8 @@ public class F {
          *
          * The function will be run in the default execution context.
          *
-         * @param function The function to map <code>A</code> to <code>B</code>.
-         * @return A wrapped promise that maps the type from <code>A</code> to <code>B</code>.
+         * @param function The function to map <code>A</code> to <code>B</code>
+         * @return a wrapped promise that maps the type from <code>A</code> to <code>B</code>
          */
         public <B> Promise<B> map(final Function<? super A, B> function) {
             return FPromiseHelper.map(this, function, HttpExecution.defaultContext());
@@ -340,9 +340,9 @@ public class F {
          * Maps this promise to a promise of type <code>B</code>.  The function <code>function</code> is applied as
          * soon as the promise is redeemed.
          *
-         * @param function The function to map <code>A</code> to <code>B</code>.
-         * @param ec The ExecutionContext to execute the function in.
-         * @return A wrapped promise that maps the type from <code>A</code> to <code>B</code>.
+         * @param function The function to map <code>A</code> to <code>B</code>
+         * @param ec The ExecutionContext to execute the function in
+         * @return a wrapped promise that maps the type from <code>A</code> to <code>B</code>
          */
         public <B> Promise<B> map(final Function<? super A, B> function, ExecutionContext ec) {
             return FPromiseHelper.map(this, function, ec);
@@ -355,7 +355,7 @@ public class F {
          *
          * @param function The function to handle the exception. This may, for example, convert the exception into something
          *      of type <code>T</code>, or it may throw another exception, or it may do some other handling.
-         * @return A wrapped promise that will only throw an exception if the supplied <code>function</code> throws an
+         * @return a wrapped promise that will only throw an exception if the supplied <code>function</code> throws an
          *      exception.
          */
         public Promise<A> recover(final Function<Throwable,A> function) {
@@ -367,8 +367,8 @@ public class F {
          *
          * @param function The function to handle the exception. This may, for example, convert the exception into something
          *      of type <code>T</code>, or it may throw another exception, or it may do some other handling.
-         * @param ec The ExecutionContext to execute the function in.
-         * @return A wrapped promise that will only throw an exception if the supplied <code>function</code> throws an
+         * @param ec The ExecutionContext to execute the function in
+         * @return a wrapped promise that will only throw an exception if the supplied <code>function</code> throws an
          *      exception.
          */
         public Promise<A> recover(final Function<Throwable,A> function, ExecutionContext ec) {
@@ -381,7 +381,7 @@ public class F {
          * The function will be run in the default execution context.
          *
          * @param function The function to handle the exception, and which returns another promise
-         * @return A promise that will delegate to another promise on failure
+         * @return a promise that will delegate to another promise on failure
          */
         public Promise<A> recoverWith(final Function<Throwable, Promise<A>> function) {
             return FPromiseHelper.recoverWith(this, function, HttpExecution.defaultContext());
@@ -392,7 +392,7 @@ public class F {
          *
          * @param function The function to handle the exception, and which returns another promise
          * @param ec The ExecutionContext to execute the function in
-         * @return A promise that will delegate to another promise on failure
+         * @return a promise that will delegate to another promise on failure
          */
         public Promise<A> recoverWith(final Function<Throwable, Promise<A>> function, ExecutionContext ec) {
             return FPromiseHelper.recoverWith(this, function, ec);
@@ -404,7 +404,7 @@ public class F {
          * If both promises failed, the resulting promise holds the throwable of this promise.
          *
          * @param fallback The promise to fallback to if this promise has failed
-         * @return A promise that will delegate to another promise on failure
+         * @return a promise that will delegate to another promise on failure
          */
         public Promise<A> fallbackTo(final Promise<A> fallback) {
             return FPromiseHelper.fallbackTo(this, fallback);
@@ -415,7 +415,7 @@ public class F {
          *
          * This action will be run in the default exceution context.
          *
-         * @param action The action to perform.
+         * @param action The action to perform
          */
         public void onFailure(final Callback<Throwable> action) {
             FPromiseHelper.onFailure(this, action, HttpExecution.defaultContext());
@@ -424,8 +424,8 @@ public class F {
         /**
          * Perform the given <code>action</code> callback if the promise encounters an exception.
          *
-         * @param action The action to perform.
-         * @param ec The ExecutionContext to execute the callback in.
+         * @param action The action to perform
+         * @param ec The ExecutionContext to execute the callback in
          */
         public void onFailure(final Callback<Throwable> action, ExecutionContext ec) {
             FPromiseHelper.onFailure(this, action, ec);
@@ -437,8 +437,8 @@ public class F {
          *
          * The function will be run in the default execution context.
          *
-         * @param function The function to map <code>A</code> to a promise for <code>B</code>.
-         * @return A wrapped promise for a result of type <code>B</code>
+         * @param function The function to map <code>A</code> to a promise for <code>B</code>
+         * @return a wrapped promise for a result of type <code>B</code>
          */
         public <B> Promise<B> flatMap(final Function<? super A,Promise<B>> function) {
             return FPromiseHelper.flatMap(this, function, HttpExecution.defaultContext());
@@ -448,9 +448,9 @@ public class F {
          * Maps the result of this promise to a promise for a result of type <code>B</code>, and flattens that to be
          * a single promise for <code>B</code>.
          *
-         * @param function The function to map <code>A</code> to a promise for <code>B</code>.
-         * @param ec The ExecutionContext to execute the function in.
-         * @return A wrapped promise for a result of type <code>B</code>
+         * @param function The function to map <code>A</code> to a promise for <code>B</code>
+         * @param ec The ExecutionContext to execute the function in
+         * @return a wrapped promise for a result of type <code>B</code>
          */
         public <B> Promise<B> flatMap(final Function<? super A,Promise<B>> function, ExecutionContext ec) {
             return FPromiseHelper.flatMap(this, function, ec);
@@ -460,8 +460,8 @@ public class F {
          * Creates a new promise by filtering the value of the current promise with a predicate.
          * If the predicate fails, the resulting promise will fail with a `NoSuchElementException`.
          *
-         * @param predicate The predicate to test the current value.
-         * @return A new promise with the current value, if the predicate is satisfied.
+         * @param predicate The predicate to test the current value
+         * @return a new promise with the current value, if the predicate is satisfied
          */
         public Promise<A> filter(final Predicate<? super A> predicate) {
             return FPromiseHelper.filter(this, predicate, HttpExecution.defaultContext());
@@ -471,9 +471,9 @@ public class F {
          * Creates a new promise by filtering the value of the current promise with a predicate.
          * If the predicate fails, the resulting promise will fail with a `NoSuchElementException`.
          *
-         * @param predicate The predicate to test the current value.
-         * @param ec The ExecutionContext to execute the filtering in.
-         * @return A new promise with the current value, if the predicate is satisfied.
+         * @param predicate The predicate to test the current value
+         * @param ec The ExecutionContext to execute the filtering in
+         * @return a new promise with the current value, if the predicate is satisfied
          */
         public Promise<A> filter(final Predicate<? super A> predicate, ExecutionContext ec) {
             return FPromiseHelper.filter(this, predicate, ec);
@@ -487,7 +487,7 @@ public class F {
          *
          * @param onSuccess The function to map a successful result from {@code A} to {@code B}
          * @param onFailure The function to map the {@code Throwable} when failed
-         * @return A new promise mapped by either the {@code onSuccess} or {@code onFailure} functions
+         * @return a new promise mapped by either the {@code onSuccess} or {@code onFailure} functions
          */
         public <B> Promise<B> transform(final Function<? super A, B> onSuccess, final Function<Throwable, Throwable> onFailure) {
             return FPromiseHelper.transform(this, onSuccess, onFailure, HttpExecution.defaultContext());
@@ -500,7 +500,7 @@ public class F {
          * @param onSuccess The function to map a successful result from {@code A} to {@code B}
          * @param onFailure The function to map the {@code Throwable} when failed
          * @param ec The ExecutionContext to execute functions in
-         * @return A new promise mapped by either the {@code onSuccess} or {@code onFailure} functions
+         * @return a new promise mapped by either the {@code onSuccess} or {@code onFailure} functions
          */
         public <B> Promise<B> transform(final Function<? super A, B> onSuccess, final Function<Throwable, Throwable> onFailure, ExecutionContext ec) {
             return FPromiseHelper.transform(this, onSuccess, onFailure, ec);
@@ -523,7 +523,7 @@ public class F {
         /**
          * Gets the Scala Future wrapped by this Promise.
          *
-         * @return The Scala Future
+         * @return the Scala Future
          */
         public Future<A> wrapped() {
             return future;
@@ -591,7 +591,7 @@ public class F {
          * Completes this promise with the specified Promise, once that Promise is completed.
          *
          * @param other The value to complete with
-         * @return A promise giving the result of attempting to complete this promise with the other
+         * @return a promise giving the result of attempting to complete this promise with the other
          *         promise. If the completion was successful then the result will be a null value,
          *         if the completion failed then the result will be an IllegalStateException.
          */
@@ -604,7 +604,7 @@ public class F {
          *
          * @param other The value to complete with
          * @param ec An execution context
-         * @return A promise giving the result of attempting to complete this promise with the other
+         * @return a promise giving the result of attempting to complete this promise with the other
          *         promise. If the completion was successful then the result will be a null value,
          *         if the completion failed then the result will be an IllegalStateException.
          */
@@ -617,7 +617,7 @@ public class F {
          * Completes this promise with the specified Promise, once that Promise is completed.
          *
          * @param other The value to complete with
-         * @return A promise giving the result of attempting to complete this promise with the other
+         * @return a promise giving the result of attempting to complete this promise with the other
          *         promise. If the completion was successful then the result will be true, if the
          *         completion couldn't occur then the result will be false.
          */
@@ -630,7 +630,7 @@ public class F {
          *
          * @param other The value to complete with
          * @param ec An execution context
-         * @return A promise giving the result of attempting to complete this promise with the other
+         * @return a promise giving the result of attempting to complete this promise with the other
          *         promise. If the completion was successful then the result will be true, if the
          *         completion couldn't occur then the result will be false.
          */
@@ -662,7 +662,7 @@ public class F {
         /**
          * Is the value of this option defined?
          *
-         * @return <code>true</code> if the value is defined, otherwise <code>false</code>.
+         * @return <code>true</code> if the value is defined, otherwise <code>false</code>
          */
         public abstract boolean isDefined();
 
@@ -674,7 +674,7 @@ public class F {
         /**
          * Returns the value if defined.
          *
-         * @return The value if defined, otherwise <code>null</code>.
+         * @return the value if defined, otherwise <code>null</code>
          */
         public abstract T get();
 
@@ -691,7 +691,7 @@ public class F {
          * Construct a <code>Some</code> value.
          *
          * @param value The value to make optional
-         * @return Some <code>T</code>.
+         * @return some <code>T</code>
          */
         public static <T> Some<T> Some(T value) {
             return new Some<T>(value);
@@ -701,7 +701,7 @@ public class F {
          * Get the value if defined, otherwise return the supplied <code>defaultValue</code>.
          *
          * @param defaultValue The value to return if the value of this option is not defined
-         * @return The value of this option, or <code>defaultValue</code>.
+         * @return the value of this option, or <code>defaultValue</code>
          */
         public T getOrElse(T defaultValue) {
             if(isDefined()) {
@@ -714,8 +714,8 @@ public class F {
         /**
          * Map this option to another value.
          *
-         * @param function The function to map the option using.
-         * @return The mapped option.
+         * @param function The function to map the option using
+         * @return the mapped option
          * @throws RuntimeException if <code>function</code> threw an Exception.  If the exception is a
          *      <code>RuntimeException</code>, it will be rethrown as is, otherwise it will be wrapped in a
          *      <code>RuntimeException</code>.
@@ -783,7 +783,7 @@ public class F {
      * Construct a <code>Some</code> value.
      *
      * @param value The value
-     * @return Some value.
+     * @return some value
      */
     public static <A> Some<A> Some(A value) {
         return new Some<A>(value);
@@ -792,7 +792,7 @@ public class F {
     /**
      * Constructs a <code>None</code> value.
      *
-     * @return None.
+     * @return None
      */
     public static None None() {
         return new None();
@@ -940,7 +940,7 @@ public class F {
          * Constructs a left side of the disjoint union, as opposed to the Right side.
          *
          * @param value The value of the left side
-         * @return A left sided disjoint union
+         * @return a left sided disjoint union
          */
         public static <A, B> Either<A, B> Left(A value) {
             return new Either<A, B>(Some(value), None());
@@ -950,7 +950,7 @@ public class F {
          * Constructs a right side of the disjoint union, as opposed to the Left side.
          *
          * @param value The value of the right side
-         * @return A right sided disjoint union
+         * @return a right sided disjoint union
          */
         public static <A, B> Either<A, B> Right(B value) {
             return new Either<A, B>(None(), Some(value));
@@ -1008,7 +1008,7 @@ public class F {
      *
      * @param a The a value
      * @param b The b value
-     * @return The tuple
+     * @return the tuple
      */
     public static <A, B> Tuple<A, B> Tuple(A a, B b) {
         return new Tuple<A, B>(a, b);
@@ -1066,7 +1066,7 @@ public class F {
      * @param a The a value
      * @param b The b value
      * @param c The c value
-     * @return The tuple
+     * @return the tuple
      */
     public static <A, B, C> Tuple3<A, B, C> Tuple3(A a, B b, C c) {
         return new Tuple3<A, B, C>(a, b, c);
@@ -1128,7 +1128,7 @@ public class F {
      * @param b The b value
      * @param c The c value
      * @param d The d value
-     * @return The tuple
+     * @return the tuple
      */
     public static <A, B, C, D> Tuple4<A, B, C, D> Tuple4(A a, B b, C c, D d) {
         return new Tuple4<A, B, C, D>(a, b, c, d);
@@ -1196,7 +1196,7 @@ public class F {
      * @param c The c value
      * @param d The d value
      * @param e The e value
-     * @return The tuple
+     * @return the tuple
      */
     public static <A, B, C, D, E> Tuple5<A, B, C, D, E> Tuple5(A a, B b, C c, D d, E e) {
         return new Tuple5<A, B, C, D, E>(a, b, c, d, e);

--- a/framework/src/play/src/main/java/play/mvc/Controller.java
+++ b/framework/src/play/src/main/java/play/mvc/Controller.java
@@ -42,7 +42,7 @@ public abstract class Controller extends Results implements Status, HeaderNames 
     /**
      * Change durably the lang for the current user
      * @param code New lang code to use (e.g. "fr", "en-US", etc.)
-     * @return true if the requested lang was supported by the application, otherwise false.
+     * @return true if the requested lang was supported by the application, otherwise false
      */
     public static boolean changeLang(String code) {
         return Http.Context.current().changeLang(code);
@@ -51,7 +51,7 @@ public abstract class Controller extends Results implements Status, HeaderNames 
     /**
      * Change durably the lang for the current user
      * @param lang New Lang object to use
-     * @return true if the requested lang was supported by the application, otherwise false.
+     * @return true if the requested lang was supported by the application, otherwise false
      */
     public static boolean changeLang(Lang lang) {
         return Http.Context.current().changeLang(lang);

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -156,7 +156,7 @@ public class Http {
         }
 
         /**
-         * @return the current lang.
+         * @return the current lang
          */
         public Lang lang() {
             if (lang != null) {
@@ -167,7 +167,7 @@ public class Http {
         }
 
         /**
-         * @return the messages for the current lang.
+         * @return the messages for the current lang
          */
         public Messages messages() {
             return Play.application().injector().instanceOf(MessagesApi.class).preferred(request());
@@ -176,7 +176,7 @@ public class Http {
         /**
          * Change durably the lang for the current user.
          * @param code New lang code to use (e.g. "fr", "en-US", etc.)
-         * @return true if the requested lang was supported by the application, otherwise false.
+         * @return true if the requested lang was supported by the application, otherwise false
          */
         public boolean changeLang(String code) {
             return changeLang(Lang.forCode(code));
@@ -184,8 +184,8 @@ public class Http {
 
         /**
          * Change durably the lang for the current user.
-         * @param lang New Lang object to use.
-         * @return true if the requested lang was supported by the application, otherwise false.
+         * @param lang New Lang object to use
+         * @return true if the requested lang was supported by the application, otherwise false
          */
         public boolean changeLang(Lang lang) {
             if (Lang.availables().contains(lang)) {
@@ -255,7 +255,7 @@ public class Http {
             }
 
             /**
-             * @return the messages for the current lang.
+             * @return the messages for the current lang
              */
             public static Messages messages() {
                 return Context.current().messages();
@@ -388,7 +388,7 @@ public class Http {
         List<play.i18n.Lang> acceptLanguages();
 
         /**
-         * @return The media types set in the request Accept header, sorted by preference (preferred first).
+         * @return the media types set in the request Accept header, sorted by preference (preferred first)
          */
         List<play.api.http.MediaRange> acceptedTypes();
 
@@ -415,7 +415,7 @@ public class Http {
 
         /**
          * @param name Name of the cookie to retrieve
-         * @return the cookie, if found, otherwise null.
+         * @return the cookie, if found, otherwise null
          */
         Cookie cookie(String name);
 
@@ -429,14 +429,14 @@ public class Http {
         /**
          * Retrieves a single header.
          *
-         * @param headerName The name of the header (case-insensitive).
+         * @param headerName The name of the header (case-insensitive)
          */
         String getHeader(String headerName);
 
         /**
          * Checks if the request has the header.
          *
-         * @param headerName The name of the header (case-insensitive).
+         * @param headerName The name of the header (case-insensitive)
          */
         boolean hasHeader(String headerName);
 
@@ -943,8 +943,8 @@ public class Http {
         /**
          * Returns the buffer content as a bytes array.
          *
-         * @param maxLength The max length allowed to be stored in memory.
-         * @return null if the content is too big to fit in memory.
+         * @param maxLength The max length allowed to be stored in memory
+         * @return null if the content is too big to fit in memory
          */
         public abstract byte[] asBytes(int maxLength);
 
@@ -1121,8 +1121,8 @@ public class Http {
         /**
          * Adds a new header to the response.
          *
-         * @param name The name of the header. Must not be null.
-         * @param value The value of the header. Must not be null.
+         * @param name The name of the header. Must not be null
+         * @param value The value of the header. Must not be null
          */
         public void setHeader(String name, String value) {
             this.headers.put(name, value);
@@ -1138,7 +1138,7 @@ public class Http {
         /**
          * Sets the content-type of the response.
          *
-         * @param contentType The content type.  Must not be null.
+         * @param contentType The content type.  Must not be null
          */
         public void setContentType(String contentType) {
             setHeader(CONTENT_TYPE, contentType);
@@ -1150,8 +1150,8 @@ public class Http {
          * <pre>
          * response().setCookie("theme", "blue");
          * </pre>
-         * @param name Cookie name.  Must not be null.
-         * @param value Cookie value.
+         * @param name Cookie name.  Must not be null
+         * @param value Cookie value
          */
         public void setCookie(String name, String value) {
             setCookie(name, value, null);
@@ -1159,9 +1159,9 @@ public class Http {
 
         /**
          * Set a new cookie with path "/"
-         * @param name Cookie name.  Must not be null.
-         * @param value Cookie value.
-         * @param maxAge Cookie duration (null for a transient cookie and 0 or less for a cookie that expires now).
+         * @param name Cookie name.  Must not be null
+         * @param value Cookie value
+         * @param maxAge Cookie duration (null for a transient cookie and 0 or less for a cookie that expires now)
          */
         public void setCookie(String name, String value, Integer maxAge) {
             setCookie(name, value, maxAge, "/");
@@ -1169,7 +1169,7 @@ public class Http {
 
         /**
          * Set a new cookie
-         * @param name Cookie name.  Must not be null.
+         * @param name Cookie name.  Must not be null
          * @param value Cookie value
          * @param maxAge Cookie duration (null for a transient cookie and 0 or less for a cookie that expires now)
          * @param path Cookie path
@@ -1180,7 +1180,7 @@ public class Http {
 
         /**
          * Set a new cookie
-         * @param name Cookie name.  Must not be null.
+         * @param name Cookie name.  Must not be null
          * @param value Cookie value
          * @param maxAge Cookie duration (null for a transient cookie and 0 or less for a cookie that expires now)
          * @param path Cookie path
@@ -1192,7 +1192,7 @@ public class Http {
 
         /**
          * Set a new cookie
-         * @param name Cookie name.  Must not be null.
+         * @param name Cookie name.  Must not be null
          * @param value Cookie value
          * @param maxAge Cookie duration (null for a transient cookie and 0 or less for a cookie that expires now)
          * @param path Cookie path
@@ -1207,7 +1207,7 @@ public class Http {
         /**
          * Discard a cookie on the default path ("/") with no domain and that's not secure
          *
-         * @param name The name of the cookie to discard.  Must not be null.
+         * @param name The name of the cookie to discard.  Must not be null
          */
         public void discardCookie(String name) {
             discardCookie(name, "/", null, false);
@@ -1216,7 +1216,7 @@ public class Http {
         /**
          * Discard a cookie on the given path with no domain and not that's secure
          *
-         * @param name The name of the cookie to discard.  Must not be null.
+         * @param name The name of the cookie to discard.  Must not be null
          * @param path The path of the cookie te discard, may be null
          */
         public void discardCookie(String name, String path) {
@@ -1226,7 +1226,7 @@ public class Http {
         /**
          * Discard a cookie on the given path and domain that's not secure
          *
-         * @param name The name of the cookie to discard.  Must not be null.
+         * @param name The name of the cookie to discard.  Must not be null
          * @param path The path of the cookie te discard, may be null
          * @param domain The domain of the cookie to discard, may be null
          */
@@ -1237,7 +1237,7 @@ public class Http {
         /**
          * Discard a cookie in this result
          *
-         * @param name The name of the cookie to discard.  Must not be null.
+         * @param name The name of the cookie to discard.  Must not be null
          * @param path The path of the cookie te discard, may be null
          * @param domain The domain of the cookie to discard, may be null
          * @param secure Whether the cookie to discard is secure

--- a/framework/src/play/src/main/java/play/mvc/PathBindable.java
+++ b/framework/src/play/src/main/java/play/mvc/PathBindable.java
@@ -53,7 +53,7 @@ public interface PathBindable<T extends PathBindable<T>> {
      *
      * @param key Parameter key
      * @param txt The value as String (extracted from the URL path)
-     * @return The object, may be this object
+     * @return the object, may be this object
      * @throws RuntimeException if this object could not be bound
      */
     public T bind(String key, String txt);
@@ -68,7 +68,7 @@ public interface PathBindable<T extends PathBindable<T>> {
     /**
      * Javascript function to unbind in the Javascript router.
      *
-     * @return The javascript function, or null if you want to use the default implementation.
+     * @return the javascript function, or null if you want to use the default implementation
      */
     public String javascriptUnbind();
 

--- a/framework/src/play/src/main/java/play/mvc/QueryStringBindable.java
+++ b/framework/src/play/src/main/java/play/mvc/QueryStringBindable.java
@@ -62,7 +62,7 @@ public interface QueryStringBindable<T extends QueryStringBindable<T>> {
      *
      * @param key Parameter key
      * @param data The query string data
-     * @return An instance of this class (it could be this class) if the query string data can be bound to this type,
+     * @return an instance of this class (it could be this class) if the query string data can be bound to this type,
      *      or None if it couldn't.
      */
     public Option<T> bind(String key, Map<String,String[]> data);

--- a/framework/src/play/src/main/java/play/mvc/Results.java
+++ b/framework/src/play/src/main/java/play/mvc/Results.java
@@ -202,7 +202,7 @@ public class Results {
     /**
      * Generates a 200 OK file result as an attachment.
      *
-     * @param content The file to send.
+     * @param content The file to send
      */
     public static Status ok(File content) {
         return new Status(play.core.j.JavaResults.Ok(), content);
@@ -211,8 +211,8 @@ public class Results {
     /**
      * Generates a 200 OK file result.
      *
-     * @param content The file to send.
-     * @param inline Whether the file should be sent inline, or as an attachment.
+     * @param content The file to send
+     * @param inline Whether the file should be sent inline, or as an attachment
      */
     public static Status ok(File content, boolean inline) {
         return new Status(JavaResults.Ok(), content, inline);
@@ -221,8 +221,8 @@ public class Results {
     /**
      * Generates a 200 OK file result as an attachment.
      *
-     * @param content The file to send.
-     * @param filename The name to send the file as.
+     * @param content The file to send
+     * @param filename The name to send the file as
      */
     public static Status ok(File content, String filename) {
         return new Status(JavaResults.Ok(), content, true, filename);
@@ -310,7 +310,7 @@ public class Results {
     /**
      * Generates a 201 CREATED file result as an attachment.
      *
-     * @param content The file to send.
+     * @param content The file to send
      */
     public static Status created(File content) {
         return new Status(play.core.j.JavaResults.Created(), content);
@@ -319,8 +319,8 @@ public class Results {
     /**
      * Generates a 201 CREATED file result.
      *
-     * @param content The file to send.
-     * @param inline Whether the file should be sent inline, or as an attachment.
+     * @param content The file to send
+     * @param inline Whether the file should be sent inline, or as an attachment
      */
     public static Status created(File content, boolean inline) {
         return new Status(JavaResults.Created(), content, inline);
@@ -329,8 +329,8 @@ public class Results {
     /**
      * Generates a 201 CREATED file result as an attachment.
      *
-     * @param content The file to send.
-     * @param filename The name to send the file as.
+     * @param content The file to send
+     * @param filename The name to send the file as
      */
     public static Status created(File content, String filename) {
         return new Status(JavaResults.Created(), content, true, filename);
@@ -427,7 +427,7 @@ public class Results {
     /**
      * Generates a 500 INTERNAL_SERVER_ERROR file result as an attachment.
      *
-     * @param content The file to send.
+     * @param content The file to send
      */
     public static Status internalServerError(File content) {
         return new Status(play.core.j.JavaResults.InternalServerError(), content);
@@ -436,8 +436,8 @@ public class Results {
     /**
      * Generates a 500 INTERNAL_SERVER_ERROR file result.
      *
-     * @param content The file to send.
-     * @param inline Whether the file should be sent inline, or as an attachment.
+     * @param content The file to send
+     * @param inline Whether the file should be sent inline, or as an attachment
      */
     public static Status internalServerError(File content, boolean inline) {
         return new Status(JavaResults.InternalServerError(), content, inline);
@@ -446,8 +446,8 @@ public class Results {
     /**
      * Generates a 500 INTERNAL_SERVER_ERROR file result as an attachment.
      *
-     * @param content The file to send.
-     * @param filename The name to send the file as.
+     * @param content The file to send
+     * @param filename The name to send the file as
      */
     public static Status internalServerError(File content, String filename) {
         return new Status(JavaResults.InternalServerError(), content, true, filename);
@@ -535,7 +535,7 @@ public class Results {
     /**
      * Generates a 404 NOT_FOUND file result as an attachment.
      *
-     * @param content The file to send.
+     * @param content The file to send
      */
     public static Status notFound(File content) {
         return new Status(play.core.j.JavaResults.NotFound(), content);
@@ -544,8 +544,8 @@ public class Results {
     /**
      * Generates a 404 NOT_FOUND file result.
      *
-     * @param content The file to send.
-     * @param inline Whether the file should be sent inline, or as an attachment.
+     * @param content The file to send
+     * @param inline Whether the file should be sent inline, or as an attachment
      */
     public static Status notFound(File content, boolean inline) {
         return new Status(JavaResults.NotFound(), content, inline);
@@ -554,8 +554,8 @@ public class Results {
     /**
      * Generates a 404 NOT_FOUND file result as an attachment.
      *
-     * @param content The file to send.
-     * @param filename The name to send the file as.
+     * @param content The file to send
+     * @param filename The name to send the file as
      */
     public static Status notFound(File content, String filename) {
         return new Status(JavaResults.NotFound(), content, true, filename);
@@ -643,7 +643,7 @@ public class Results {
     /**
      * Generates a 403 FORBIDDEN file result as an attachment.
      *
-     * @param content The file to send.
+     * @param content The file to send
      */
     public static Status forbidden(File content) {
         return new Status(play.core.j.JavaResults.Forbidden(), content);
@@ -652,8 +652,8 @@ public class Results {
     /**
      * Generates a 403 FORBIDDEN file result.
      *
-     * @param content The file to send.
-     * @param inline Whether the file should be sent inline, or as an attachment.
+     * @param content The file to send
+     * @param inline Whether the file should be sent inline, or as an attachment
      */
     public static Status forbidden(File content, boolean inline) {
         return new Status(JavaResults.Forbidden(), content, inline);
@@ -662,8 +662,8 @@ public class Results {
     /**
      * Generates a 403 FORBIDDEN file result as an attachment.
      *
-     * @param content The file to send.
-     * @param filename The name to send the file as.
+     * @param content The file to send
+     * @param filename The name to send the file as
      */
     public static Status forbidden(File content, String filename) {
         return new Status(JavaResults.Forbidden(), content, true, filename);
@@ -751,7 +751,7 @@ public class Results {
     /**
      * Generates a 401 UNAUTHORIZED file result as an attachment.
      *
-     * @param content The file to send.
+     * @param content The file to send
      */
     public static Status unauthorized(File content) {
         return new Status(play.core.j.JavaResults.Unauthorized(), content);
@@ -760,8 +760,8 @@ public class Results {
     /**
      * Generates a 401 UNAUTHORIZED file result.
      *
-     * @param content The file to send.
-     * @param inline Whether the file should be sent inline, or as an attachment.
+     * @param content The file to send
+     * @param inline Whether the file should be sent inline, or as an attachment
      */
     public static Status unauthorized(File content, boolean inline) {
         return new Status(JavaResults.Unauthorized(), content, inline);
@@ -770,8 +770,8 @@ public class Results {
     /**
      * Generates a 401 UNAUTHORIZED file result as an attachment.
      *
-     * @param content The file to send.
-     * @param filename The name to send the file as.
+     * @param content The file to send
+     * @param filename The name to send the file as
      */
     public static Status unauthorized(File content, String filename) {
         return new Status(JavaResults.Unauthorized(), content, true, filename);
@@ -859,7 +859,7 @@ public class Results {
     /**
      * Generates a 400 BAD_REQUEST file result as an attachment.
      *
-     * @param content The file to send.
+     * @param content The file to send
      */
     public static Status badRequest(File content) {
         return new Status(play.core.j.JavaResults.BadRequest(), content);
@@ -868,8 +868,8 @@ public class Results {
     /**
      * Generates a 400 BAD_REQUEST file result.
      *
-     * @param content The file to send.
-     * @param inline Whether the file should be sent inline, or as an attachment.
+     * @param content The file to send
+     * @param inline Whether the file should be sent inline, or as an attachment
      */
     public static Status badRequest(File content, boolean inline) {
         return new Status(JavaResults.BadRequest(), content, inline);
@@ -878,8 +878,8 @@ public class Results {
     /**
      * Generates a 400 BAD_REQUEST file result as an attachment.
      *
-     * @param content The file to send.
-     * @param filename The name to send the file as.
+     * @param content The file to send
+     * @param filename The name to send the file as
      */
     public static Status badRequest(File content, String filename) {
         return new Status(JavaResults.BadRequest(), content, true, filename);
@@ -897,7 +897,7 @@ public class Results {
     /**
      * Generates a 303 SEE_OTHER simple result.
      *
-     * @param url The url to redirect.
+     * @param url The url to redirect
      */
     public static Result redirect(String url) {
         return new Redirect(303, url);
@@ -906,7 +906,7 @@ public class Results {
     /**
      * Generates a 303 SEE_OTHER simple result.
      *
-     * @param call Call defining the url to redirect (typically comes from reverse router).
+     * @param call Call defining the url to redirect (typically comes from reverse router)
      */
     public static Result redirect(Call call) {
         return new Redirect(303, call.url());
@@ -917,7 +917,7 @@ public class Results {
     /**
      * Generates a 302 FOUND simple result.
      *
-     * @param url The url to redirect.
+     * @param url The url to redirect
      */
     public static Result found(String url) {
         return new Redirect(302, url);
@@ -926,7 +926,7 @@ public class Results {
     /**
      * Generates a 302 FOUND simple result.
      *
-     * @param call Call defining the url to redirect (typically comes from reverse router).
+     * @param call Call defining the url to redirect (typically comes from reverse router)
      */
     public static Result found(Call call) {
         return new Redirect(302, call.url());
@@ -937,7 +937,7 @@ public class Results {
     /**
      * Generates a 301 MOVED_PERMANENTLY simple result.
      *
-     * @param url The url to redirect.
+     * @param url The url to redirect
      */
     public static Result movedPermanently(String url) {
         return new Redirect(301, url);
@@ -946,7 +946,7 @@ public class Results {
     /**
      * Generates a 301 MOVED_PERMANENTLY simple result.
      *
-     * @param call Call defining the url to redirect (typically comes from reverse router).
+     * @param call Call defining the url to redirect (typically comes from reverse router)
      */
     public static Result movedPermanently(Call call) {
         return new Redirect(301, call.url());
@@ -957,7 +957,7 @@ public class Results {
     /**
      * Generates a 303 SEE_OTHER simple result.
      *
-     * @param url The url to redirect.
+     * @param url The url to redirect
      */
     public static Result seeOther(String url) {
         return new Redirect(303, url);
@@ -966,7 +966,7 @@ public class Results {
     /**
      * Generates a 303 SEE_OTHER simple result.
      *
-     * @param call Call defining the url to redirect (typically comes from reverse router).
+     * @param call Call defining the url to redirect (typically comes from reverse router)
      */
     public static Result seeOther(Call call) {
         return new Redirect(303, call.url());
@@ -977,7 +977,7 @@ public class Results {
     /**
      * Generates a 307 TEMPORARY_REDIRECT simple result.
      *
-     * @param url The url to redirect.
+     * @param url The url to redirect
      */
     public static Result temporaryRedirect(String url) {
         return new Redirect(307, url);
@@ -986,7 +986,7 @@ public class Results {
     /**
      * Generates a 307 TEMPORARY_REDIRECT simple result.
      *
-     * @param call Call defining the url to redirect (typically comes from reverse router).
+     * @param call Call defining the url to redirect (typically comes from reverse router)
      */
     public static Result temporaryRedirect(Call call) {
         return new Redirect(307, call.url());
@@ -1023,7 +1023,7 @@ public class Results {
         /**
          * Called when the Chunked stream is ready.
          *
-         * @param out The out stream.
+         * @param out The out stream
          */
         public abstract void onReady(Chunks.Out<A> out);
 
@@ -1247,7 +1247,7 @@ public class Results {
          *
          * The resource will be loaded from the same classloader that this class comes from.
          *
-         * @param resourceName The path of the resource to load.
+         * @param resourceName The path of the resource to load
          */
         public Status sendResource(String resourceName) {
             return sendResource(resourceName, true);
@@ -1256,8 +1256,8 @@ public class Results {
         /**
          * Send the given resource from the given classloader.
          *
-         * @param resourceName The path of the resource to load.
-         * @param classLoader The classloader to load it from.
+         * @param resourceName The path of the resource to load
+         * @param classLoader The classloader to load it from
          */
         public Status sendResource(String resourceName, ClassLoader classLoader) {
             return sendResource(resourceName, classLoader, true);
@@ -1268,8 +1268,8 @@ public class Results {
          *
          * The resource will be loaded from the same classloader that this class comes from.
          *
-         * @param resourceName The path of the resource to load.
-         * @param inline Whether it should be served as an inline file, or as an attachment.
+         * @param resourceName The path of the resource to load
+         * @param inline Whether it should be served as an inline file, or as an attachment
          */
         public Status sendResource(String resourceName, boolean inline) {
             return sendResource(resourceName, this.getClass().getClassLoader(), inline);
@@ -1278,9 +1278,9 @@ public class Results {
         /**
          * Send the given resource from the given classloader.
          *
-         * @param resourceName The path of the resource to load.
-         * @param classLoader The classloader to load it from.
-         * @param inline Whether it should be served as an inline file, or as an attachment.
+         * @param resourceName The path of the resource to load
+         * @param classLoader The classloader to load it from
+         * @param inline Whether it should be served as an inline file, or as an attachment
          */
         public Status sendResource(String resourceName, ClassLoader classLoader, boolean inline) {
             return new Status(wrappedStatus.sendResource(resourceName, classLoader, inline));

--- a/framework/src/play/src/main/java/play/mvc/Security.java
+++ b/framework/src/play/src/main/java/play/mvc/Security.java
@@ -76,7 +76,7 @@ public class Security {
         /**
          * Retrieves the username from the HTTP context; the default is to read from the session cookie.
          *
-         * @return null if the user is not authenticated.
+         * @return null if the user is not authenticated
          */
         public String getUsername(Context ctx) {
             return ctx.session().get("username");

--- a/framework/src/play/src/main/java/play/mvc/WebSocket.java
+++ b/framework/src/play/src/main/java/play/mvc/WebSocket.java
@@ -18,8 +18,8 @@ public abstract class WebSocket<A> {
     /**
      * Called when the WebSocket is ready
      *
-     * @param in The Socket in.
-     * @param out The Socket out.
+     * @param in The Socket in
+     * @param out The Socket out
      */
     public abstract void onReady(In<A> in, Out<A> out);
 
@@ -28,7 +28,7 @@ public abstract class WebSocket<A> {
      *
      * This method will be invoked before onReady.
      *
-     * @return The result to reject the WebSocket with, or null if the WebSocket shouldn't be rejected.
+     * @return the result to reject the WebSocket with, or null if the WebSocket shouldn't be rejected
      */
     public Result rejectWith() {
         return null;
@@ -45,8 +45,8 @@ public abstract class WebSocket<A> {
     /**
      * The props to create the actor to handle this WebSocket.
      *
-     * @param out The actor to send upstream messages to.
-     * @return The props of the actor to handle the WebSocket.  If isActor returns true, must not return null.
+     * @param out The actor to send upstream messages to
+     * @return the props of the actor to handle the WebSocket.  If isActor returns true, must not return null
      */
     public Props actorProps(ActorRef out) {
         return null;
@@ -114,8 +114,8 @@ public abstract class WebSocket<A> {
     /**
      * Rejects a WebSocket.
      *
-     * @param result The result that will be returned.
-     * @return A rejected WebSocket.
+     * @param result The result that will be returned
+     * @return a rejected WebSocket
      */
     public static <A> WebSocket<A> reject(final Result result) {
         return new WebSocket<A>() {
@@ -130,8 +130,8 @@ public abstract class WebSocket<A> {
     /**
      * Handles a WebSocket with an actor.
      *
-     * @param props The function used to create the props for the actor.  The passed in argument is the upstream actor.
-     * @return An actor WebSocket.
+     * @param props The function used to create the props for the actor.  The passed in argument is the upstream actor
+     * @return an actor WebSocket
      */
     public static <A> WebSocket<A> withActor(final Function<ActorRef, Props> props) {
         return new WebSocket<A>() {

--- a/framework/src/play/src/main/java/play/server/SSLEngineProvider.java
+++ b/framework/src/play/src/main/java/play/server/SSLEngineProvider.java
@@ -9,7 +9,7 @@ import javax.net.ssl.SSLEngine;
 public interface SSLEngineProvider {
 
     /**
-     * @return the SSL engine to be used for HTTPS connection.
+     * @return the SSL engine to be used for HTTPS connection
      */
     SSLEngine createSSLEngine();
 

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -82,7 +82,7 @@ trait Application {
    * }}}
    *
    * @tparam T the plugin type
-   * @return The plugin instance used by this application.
+   * @return the plugin instance used by this application
    * @throws Error if no plugins of type T are loaded by this application.
    */
   def plugin[T](implicit ct: ClassTag[T]): Option[T] = plugin(ct.runtimeClass).asInstanceOf[Option[T]]
@@ -199,7 +199,7 @@ trait Application {
   /**
    * Get the injector for this application.
    *
-   * @return The injector.
+   * @return the injector
    */
   def injector: Injector = NewInstanceInjector
 }

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -59,12 +59,12 @@ object ApplicationLoader {
    *
    * Locates and loads the necessary configuration files for the application.
    *
-   * @param environment The application environment.
+   * @param environment The application environment
    * @param initialSettings The initial settings. These settings are merged with the settings from the loaded
    *                        configuration files, and together form the initialConfiguration provided by the context.  It
    *                        is intended for use in dev mode, to allow the build system to pass additional configuration
    *                        into the application.
-   * @param sourceMapper An optional source mapper.
+   * @param sourceMapper An optional source mapper
    */
   def createContext(environment: Environment,
     initialSettings: Map[String, String] = Map.empty[String, String],

--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -60,7 +60,7 @@ object Configuration {
    *
    * Defaults to Mode.Dev
    *
-   * @param mode Application mode.
+   * @param mode Application mode
    * @return a `Configuration` instance
    */
   def load(appPath: File, mode: Mode.Mode = Mode.Dev, devSettings: Map[String, String] = Map.empty): Configuration = {

--- a/framework/src/play/src/main/scala/play/api/Environment.scala
+++ b/framework/src/play/src/main/scala/play/api/Environment.scala
@@ -10,9 +10,9 @@ import java.io.{ InputStream, File }
  *
  * Captures concerns relating to the classloader and the filesystem for the application.
  *
- * @param rootPath The root path that the application is deployed at.
- * @param classLoader The classloader that all application classes and resources can be loaded from.
- * @param mode The mode of the application.
+ * @param rootPath The root path that the application is deployed at
+ * @param classLoader The classloader that all application classes and resources can be loaded from
+ * @param mode The mode of the application
  */
 case class Environment(
     rootPath: File,

--- a/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
+++ b/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
@@ -94,7 +94,7 @@ trait GlobalSettings {
    * @param path the application path
    * @param classloader The applications classloader
    * @param mode The mode the application is running in
-   * @return The configuration that the application should use
+   * @return the configuration that the application should use
    */
   def onLoadConfig(config: Configuration, path: File, classloader: ClassLoader, mode: Mode.Mode): Configuration =
     config ++ configuration
@@ -173,7 +173,7 @@ trait GlobalSettings {
    *
    * @param request The HTTP request header
    * @param ex The exception
-   * @return The result to send to the client
+   * @return the result to send to the client
    */
   def onError(request: RequestHeader, ex: Throwable): Future[Result] =
     defaultErrorHandler.onServerError(request, ex)
@@ -216,8 +216,8 @@ object GlobalSettings {
   /**
    * Load the global object.
    *
-   * @param configuration The configuration to read the loading from.
-   * @param environment The environment to load the global object from.
+   * @param configuration The configuration to read the loading from
+   * @param environment The environment to load the global object from
    * @return
    */
   def apply(configuration: Configuration, environment: Environment): GlobalSettings = {

--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -121,8 +121,8 @@ object Play {
    * val maybeConf = application.resourceAsStream("conf/logger.xml")
    * }}}
    *
-   * @param name Absolute name of the resource (from the classpath root).
-   * @return Maybe a stream if found.
+   * @param name Absolute name of the resource (from the classpath root)
+   * @return maybe a stream if found
    */
   def resourceAsStream(name: String)(implicit app: Application): Option[InputStream] = {
     app.resourceAsStream(name)

--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -305,7 +305,7 @@ object Assets extends AssetsBuilder(LazyHttpErrorHandler) {
   /**
    * An asset.
    *
-   * @param name The name of the asset.
+   * @param name The name of the asset
    */
   case class Asset(name: String)
 
@@ -428,9 +428,9 @@ class AssetsBuilder(errorHandler: HttpErrorHandler) extends Controller {
   /**
    * Generates an `Action` that serves a static resource.
    *
-   * @param path the root folder for searching the static resource files, such as `"/public"`. Not URL encoded.
-   * @param file the file part extracted from the URL. May be URL encoded (note that %2F decodes to literal /).
-   * @param aggressiveCaching if true then an aggressive set of caching directives will be used. Defaults to false.
+   * @param path the root folder for searching the static resource files, such as `"/public"`. Not URL encoded
+   * @param file the file part extracted from the URL. May be URL encoded (note that %2F decodes to literal /)
+   * @param aggressiveCaching if true then an aggressive set of caching directives will be used. Defaults to false
    */
   def at(path: String, file: String, aggressiveCaching: Boolean = false): Action[AnyContent] = Action.async { implicit request =>
     assetAt(path, file, aggressiveCaching)
@@ -480,8 +480,8 @@ class AssetsBuilder(errorHandler: HttpErrorHandler) extends Controller {
   /**
    * Get the name of the resource for a static resource. Used by `at`.
    *
-   * @param path the root folder for searching the static resource files, such as `"/public"`. Not URL encoded.
-   * @param file the file part extracted from the URL. May be URL encoded (note that %2F decodes to literal /).
+   * @param path the root folder for searching the static resource files, such as `"/public"`. Not URL encoded
+   * @param file the file part extracted from the URL. May be URL encoded (note that %2F decodes to literal /)
    */
   private[controllers] def resourceNameAt(path: String, file: String): Option[String] = {
     val decodedFile = UriEncoding.decodePath(file, "utf-8")

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -133,7 +133,7 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
    * @tparam R common result type
    * @param hasErrors a function to handle forms with errors
    * @param success a function to handle form submission success
-   * @return a result `R`.
+   * @return a result `R`
    */
   def fold[R](hasErrors: Form[T] => R, success: T => R): R = value match {
     case Some(v) if errors.isEmpty => success(v)
@@ -197,14 +197,14 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
   /**
    * Retrieve the first error for this key.
    *
-   * @param key field name.
+   * @param key field name
    */
   def error(key: String): Option[FormError] = errors.find(_.key == key)
 
   /**
    * Retrieve all errors for this key.
    *
-   * @param key field name.
+   * @param key field name
    */
   def errors(key: String): Seq[FormError] = errors.filter(_.key == key)
 
@@ -297,7 +297,7 @@ case class Field(private val form: Form[_], name: String, constraints: Seq[(Stri
   /**
    * Retrieve a field from the same form, using a key relative to this field key.
    *
-   * @param key Relative key.
+   * @param key Relative key
    */
   def apply(key: String): Field = {
     form(Option(name).filterNot(_.isEmpty).map(_ + (if (key(0) == '[') "" else ".")).getOrElse("") + key)
@@ -393,9 +393,9 @@ private[data] object FormUtils {
 /**
  * A form error.
  *
- * @param key The error key (should be associated with a field using the same key).
- * @param message The form message (often a simple message key needing to be translated).
- * @param args Arguments used to format the message.
+ * @param key The error key (should be associated with a field using the same key)
+ * @param message The form message (often a simple message key needing to be translated)
+ * @param args Arguments used to format the message
  */
 case class FormError(key: String, messages: Seq[String], args: Seq[Any] = Nil) {
 
@@ -408,7 +408,7 @@ case class FormError(key: String, messages: Seq[String], args: Seq[Any] = Nil) {
   /**
    * Copy this error with a new Message.
    *
-   * @param message The new message.
+   * @param message The new message
    */
   def withMessage(message: String): FormError = FormError(key, message)
 }
@@ -833,7 +833,7 @@ case class OptionalMapping[T](wrapped: Mapping[T], val constraints: Seq[Constrai
  * A mapping for a single field.
  *
  * @param key the field key
- * @param constraints the constraints associated with this field.
+ * @param constraints the constraints associated with this field
  */
 case class FieldMapping[T](val key: String = "", val constraints: Seq[Constraint[T]] = Nil)(implicit val binder: Formatter[T]) extends Mapping[T] {
 

--- a/framework/src/play/src/main/scala/play/api/data/Forms.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Forms.scala
@@ -271,8 +271,8 @@ object Forms {
    * Form("username" -> nonEmptyText(minLength=3))
    * }}}
    *
-   * @param minLength Text min length.
-   * @param maxLength Text max length.
+   * @param minLength Text min length
+   * @param maxLength Text max length
    */
   def nonEmptyText(minLength: Int = 0, maxLength: Int = Int.MaxValue): Mapping[String] = text(minLength, maxLength) verifying Constraints.nonEmpty
 
@@ -436,7 +436,7 @@ object Forms {
    * Define a fixed value in a mapping.
    * This mapping will not participate to the binding.
    *
-   * @param value As we ignore this parameter in binding/unbinding we have to provide a default value.
+   * @param value As we ignore this parameter in binding/unbinding we have to provide a default value
    */
   def ignored[A](value: A): Mapping[A] = of(ignoredFormat(value))
 
@@ -449,7 +449,7 @@ object Forms {
    * )
    * }}}
    *
-   * @param mapping The mapping to make optional.
+   * @param mapping The mapping to make optional
    */
   def optional[A](mapping: Mapping[A]): Mapping[Option[A]] = OptionalMapping(mapping)
 
@@ -462,8 +462,8 @@ object Forms {
    * )
    * }}}
    *
-   * @param mapping The mapping to make optional.
-   * @param value The default value when mapping and the field is not present.
+   * @param mapping The mapping to make optional
+   * @param value The default value when mapping and the field is not present
    */
   def default[A](mapping: Mapping[A], value: A): Mapping[A] = OptionalMapping(mapping).transform(_.getOrElse(value), Some(_))
 
@@ -475,7 +475,7 @@ object Forms {
    * )
    * }}}
    *
-   * @param mapping The mapping to make repeated.
+   * @param mapping The mapping to make repeated
    */
   def list[A](mapping: Mapping[A]): Mapping[List[A]] = RepeatedMapping(mapping)
 
@@ -487,7 +487,7 @@ object Forms {
    * )
    * }}}
    *
-   * @param mapping The mapping to make repeated.
+   * @param mapping The mapping to make repeated
    */
   def seq[A](mapping: Mapping[A]): Mapping[Seq[A]] = RepeatedMapping(mapping).transform(_.toSeq, _.toList)
 
@@ -499,7 +499,7 @@ object Forms {
    * )
    * }}}
    *
-   * @param mapping The mapping to make repeated.
+   * @param mapping The mapping to make repeated
    */
   def set[A](mapping: Mapping[A]): Mapping[Set[A]] = RepeatedMapping(mapping).transform(_.toSet, _.toList)
 

--- a/framework/src/play/src/main/scala/play/api/data/format/Format.scala
+++ b/framework/src/play/src/main/scala/play/api/data/format/Format.scala
@@ -27,7 +27,7 @@ trait Formatter[T] {
    *
    * @param key the field key
    * @param data the submitted data
-   * @return Either a concrete value of type T or a set of error if the binding failed.
+   * @return either a concrete value of type T or a set of error if the binding failed
    */
   def bind(key: String, data: Map[String, String]): Either[Seq[FormError], T]
 
@@ -47,7 +47,7 @@ object Formats {
   /**
    * Formatter for ignored values.
    *
-   * @param value As we ignore this parameter in binding/unbinding we have to provide a default value.
+   * @param value As we ignore this parameter in binding/unbinding we have to provide a default value
    */
   def ignoredFormat[A](value: A): Formatter[A] = new Formatter[A] {
     def bind(key: String, data: Map[String, String]) = Right(value)
@@ -178,7 +178,7 @@ object Formats {
   /**
    * Formatter for the `java.util.Date` type.
    *
-   * @param pattern a date pattern, as specified in `org.joda.time.format.DateTimeFormat`.
+   * @param pattern a date pattern, as specified in `org.joda.time.format.DateTimeFormat`
    * @param timeZone the `java.util.TimeZone` to use for parsing and formatting
    */
   def dateFormat(pattern: String, timeZone: TimeZone = TimeZone.getDefault): Formatter[Date] = new Formatter[Date] {
@@ -202,7 +202,7 @@ object Formats {
   /**
    * Formatter for the `java.sql.Date` type.
    *
-   * @param pattern a date pattern as specified in `org.joda.time.format.DateTimeFormat`.
+   * @param pattern a date pattern as specified in `org.joda.time.format.DateTimeFormat`
    * @param timeZone the `java.util.TimeZone` to use for parsing and formatting
    */
   def sqlDateFormat(pattern: String, timeZone: TimeZone = TimeZone.getDefault): Formatter[java.sql.Date] = new Formatter[java.sql.Date] {
@@ -226,7 +226,7 @@ object Formats {
   /**
    * Formatter for the `org.joda.time.DateTime` type.
    *
-   * @param pattern a date pattern as specified in `org.joda.time.format.DateTimeFormat`.
+   * @param pattern a date pattern as specified in `org.joda.time.format.DateTimeFormat`
    * @param timeZone the `org.joda.time.DateTimeZone` to use for parsing and formatting
    */
   def jodaDateTimeFormat(pattern: String, timeZone: org.joda.time.DateTimeZone = org.joda.time.DateTimeZone.getDefault): Formatter[org.joda.time.DateTime] = new Formatter[org.joda.time.DateTime] {
@@ -243,14 +243,14 @@ object Formats {
   /**
    * Default formatter for `org.joda.time.DateTime` type with pattern `yyyy-MM-dd`.
    *
-   * @param pattern a date pattern as specified in `org.joda.time.format.DateTimeFormat`.
+   * @param pattern a date pattern as specified in `org.joda.time.format.DateTimeFormat`
    */
   implicit val jodaDateTimeFormat: Formatter[org.joda.time.DateTime] = jodaDateTimeFormat("yyyy-MM-dd")
 
   /**
    * Formatter for the `org.joda.time.LocalDate` type.
    *
-   * @param pattern a date pattern as specified in `org.joda.time.format.DateTimeFormat`.
+   * @param pattern a date pattern as specified in `org.joda.time.format.DateTimeFormat`
    */
   def jodaLocalDateFormat(pattern: String): Formatter[org.joda.time.LocalDate] = new Formatter[org.joda.time.LocalDate] {
 

--- a/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -49,8 +49,8 @@ case class FlashConfiguration(cookieName: String = "PLAY_FLASH", secure: Boolean
 /**
  * Configuration for body parsers.
  *
- * @param maxMemoryBuffer The maximum size that a request body that should be buffered in memory.
- * @param maxDiskBuffer The maximum size that a request body should be buffered on disk.
+ * @param maxMemoryBuffer The maximum size that a request body that should be buffered in memory
+ * @param maxDiskBuffer The maximum size that a request body should be buffered on disk
  */
 case class ParserConfiguration(
   maxMemoryBuffer: Int = 102400,

--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -28,17 +28,17 @@ trait HttpErrorHandler {
   /**
    * Invoked when a client error occurs, that is, an error in the 4xx series.
    *
-   * @param request The request that caused the client error.
-   * @param statusCode The error status code.  Must be greater or equal to 400, and less than 500.
-   * @param message The error message.
+   * @param request The request that caused the client error
+   * @param statusCode The error status code.  Must be greater or equal to 400, and less than 500
+   * @param message The error message
    */
   def onClientError(request: RequestHeader, statusCode: Int, message: String = ""): Future[Result]
 
   /**
    * Invoked when a server error occurs.
    *
-   * @param request The request that triggered the server error.
-   * @param exception The server error.
+   * @param request The request that triggered the server error
+   * @param exception The server error
    */
   def onServerError(request: RequestHeader, exception: Throwable): Future[Result]
 }
@@ -68,9 +68,9 @@ private[play] class GlobalSettingsHttpErrorHandler @Inject() (global: Provider[G
   /**
    * Invoked when a client error occurs, that is, an error in the 4xx series.
    *
-   * @param request The request that caused the client error.
-   * @param statusCode The error status code.  Must be greater or equal to 400, and less than 500.
-   * @param message The error message.
+   * @param request The request that caused the client error
+   * @param statusCode The error status code.  Must be greater or equal to 400, and less than 500
+   * @param message The error message
    */
   def onClientError(request: RequestHeader, statusCode: Int, message: String) = {
     statusCode match {
@@ -87,8 +87,8 @@ private[play] class GlobalSettingsHttpErrorHandler @Inject() (global: Provider[G
   /**
    * Invoked when a server error occurs.
    *
-   * @param request The request that triggered the server error.
-   * @param exception The server error.
+   * @param request The request that triggered the server error
+   * @param exception The server error
    */
   def onServerError(request: RequestHeader, exception: Throwable) =
     global.get.onError(request, exception)
@@ -100,7 +100,7 @@ private[play] class GlobalSettingsHttpErrorHandler @Inject() (global: Provider[G
  * This class is intended to be extended, allowing users to reuse some of the functionality provided here.
  *
  * @param environment The environment
- * @param router An optional router.
+ * @param router An optional router
  *               If provided, in dev mode, will be used to display more debug information when a handler can't be found.
  *               This is a lazy parameter, to avoid circular dependency issues, since the router may well depend on
  *               this.
@@ -120,9 +120,9 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
   /**
    * Invoked when a client error occurs, that is, an error in the 4xx series.
    *
-   * @param request The request that caused the client error.
-   * @param statusCode The error status code.  Must be greater or equal to 400, and less than 500.
-   * @param message The error message.
+   * @param request The request that caused the client error
+   * @param statusCode The error status code.  Must be greater or equal to 400, and less than 500
+   * @param message The error message
    */
   def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = statusCode match {
     case BAD_REQUEST => onBadRequest(request, message)
@@ -137,8 +137,8 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
   /**
    * Invoked when a client makes a bad request.
    *
-   * @param request The request that was bad.
-   * @param message The error message.
+   * @param request The request that was bad
+   * @param message The error message
    */
   protected def onBadRequest(request: RequestHeader, message: String): Future[Result] =
     Future.successful(BadRequest(views.html.defaultpages.badRequest(request.method, request.uri, message)))
@@ -146,8 +146,8 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
   /**
    * Invoked when a client makes a request that was forbidden.
    *
-   * @param request The forbidden request.
-   * @param message The error message.
+   * @param request The forbidden request
+   * @param message The error message
    */
   protected def onForbidden(request: RequestHeader, message: String): Future[Result] =
     Future.successful(Forbidden(views.html.defaultpages.unauthorized()))
@@ -155,8 +155,8 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
   /**
    * Invoked when a handler or resource is not found.
    *
-   * @param request The request that no handler was found to handle.
-   * @param message A message.
+   * @param request The request that no handler was found to handle
+   * @param message A message
    */
   protected def onNotFound(request: RequestHeader, message: String): Future[Result] = {
     Future.successful(NotFound(environment.mode match {
@@ -172,8 +172,8 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
    * [[onDevServerError()]] in dev mode.  It is recommended, if you want Play's debug info on the error page in dev
    * mode, that you override [[onProdServerError()]] instead of this method.
    *
-   * @param request The request that triggered the server error.
-   * @param exception The server error.
+   * @param request The request that triggered the server error
+   * @param exception The server error
    */
   def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
     try {
@@ -198,8 +198,8 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
    *
    * This can be overridden to add additional logging information, eg. the id of the authenticated user.
    *
-   * @param request The request that triggered the server error.
-   * @param usefulException The server error.
+   * @param request The request that triggered the server error
+   * @param usefulException The server error
    */
   protected def logServerError(request: RequestHeader, usefulException: UsefulException) {
     Logger.error("""
@@ -213,8 +213,8 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
   /**
    * Invoked in dev mode when a server error occurs.
    *
-   * @param request The request that triggered the error.
-   * @param exception The exception.
+   * @param request The request that triggered the error
+   * @param exception The exception
    */
   protected def onDevServerError(request: RequestHeader, exception: UsefulException): Future[Result] =
     Future.successful(InternalServerError(views.html.defaultpages.devError(playEditor, exception)))
@@ -225,8 +225,8 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
    * Override this rather than [[onServerError()]] if you don't want to change Play's debug output when logging errors
    * in dev mode.
    *
-   * @param request The request that triggered the error.
-   * @param exception The exception.
+   * @param request The request that triggered the error
+   * @param exception The exception
    */
   protected def onProdServerError(request: RequestHeader, exception: UsefulException): Future[Result] =
     Future.successful(InternalServerError(views.html.defaultpages.error(exception)))

--- a/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -32,7 +32,7 @@ trait HttpRequestHandler {
    * filters, and they will get the tagged/modified request.
    *
    * @param request The request to handle
-   * @return The possibly modified/tagged request, and a handler to handle it
+   * @return the possibly modified/tagged request, and a handler to handle it
    */
   def handlerForRequest(request: RequestHeader): (RequestHeader, Handler)
 }
@@ -153,7 +153,7 @@ class DefaultHttpRequestHandler(router: Router, errorHandler: HttpErrorHandler, 
    * routers based on various request parameters.
    *
    * @param request The request
-   * @return A handler to handle the request, if one can be found
+   * @return a handler to handle the request, if one can be found
    */
   def routeRequest(request: RequestHeader): Option[Handler] = {
     router.handlerFor(request)

--- a/framework/src/play/src/main/scala/play/api/i18n/I18nSupport.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/I18nSupport.scala
@@ -21,7 +21,7 @@ trait I18nSupport extends I18NSupportLowPriorityImplicits {
   def messagesApi: MessagesApi
 
   /**
-   * @return The preferred [[Messages]] according to the given [[RequestHeader]]
+   * @return the preferred [[Messages]] according to the given [[RequestHeader]]
    */
   implicit def request2Messages(implicit request: RequestHeader): Messages = messagesApi.preferred(request)
 
@@ -65,7 +65,7 @@ trait I18nSupport extends I18NSupportLowPriorityImplicits {
 trait I18NSupportLowPriorityImplicits { this: I18nSupport =>
 
   /**
-   * @return A [[Messages]] value that uses the [[Lang]] found in the implicit scope
+   * @return a [[Messages]] value that uses the [[Lang]] found in the implicit scope
    */
   implicit def lang2Messages(implicit lang: Lang): Messages = Messages(lang, messagesApi)
 

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -24,8 +24,8 @@ import scala.io.Codec
 /**
  * A Lang supported by the application.
  *
- * @param language a valid ISO Language Code.
- * @param country a valid ISO Country Code.
+ * @param language a valid ISO Language Code
+ * @param country a valid ISO Country Code
  */
 case class Lang(language: String, country: String = "") {
 

--- a/framework/src/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
@@ -58,7 +58,7 @@ class DefaultApplicationLifecycle extends ApplicationLifecycle {
   /**
    * Call to shutdown the application.
    *
-   * @return A future that will be redeemed once all hooks have executed.
+   * @return a future that will be redeemed once all hooks have executed
    */
   def stop(): Future[Unit] = {
 

--- a/framework/src/play/src/main/scala/play/api/inject/Binding.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Binding.scala
@@ -22,11 +22,11 @@ import com.google.inject.name.Names
  * binding may declare itself to be eagerly instantiated.  In which case, it should be eagerly instantiated when Play
  * starts up.
  *
- * @param key The binding key.
- * @param target The binding target.
- * @param scope The JSR-330 scope.
- * @param eager Whether the binding should be eagerly instantiated.
- * @param source Where this object was bound. Used in error reporting.
+ * @param key The binding key
+ * @param target The binding target
+ * @param scope The JSR-330 scope
+ * @param eager Whether the binding should be eagerly instantiated
+ * @param source Where this object was bound. Used in error reporting
  */
 final case class Binding[T](key: BindingKey[T], target: Option[BindingTarget[T]], scope: Option[Class[_ <: Annotation]], eager: Boolean, source: Object) {
 
@@ -61,8 +61,8 @@ object BindingKey {
  *
  * A binding key consists of a class and zero or more JSR-330 qualifiers.
  *
- * @param clazz The class to bind.
- * @param qualifier An optional qualifier.
+ * @param clazz The class to bind
+ * @param qualifier An optional qualifier
  */
 final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnotation]) {
 

--- a/framework/src/play/src/main/scala/play/api/inject/Injector.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Injector.scala
@@ -63,8 +63,8 @@ object NewInstanceInjector extends Injector {
  * It is intended to just hold built in Play components, but may be used to add additional components by end users when
  * required.
  *
- * @param fallback The injector to fallback to if no component can be found.
- * @param components The components that this injector provides.
+ * @param fallback The injector to fallback to if no component can be found
+ * @param components The components that this injector provides
  */
 class SimpleInjector(fallback: Injector, components: Map[Class[_], Any] = Map.empty) extends Injector {
   /**

--- a/framework/src/play/src/main/scala/play/api/inject/Module.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Module.scala
@@ -51,7 +51,7 @@ abstract class Module {
    *
    * @param environment The environment
    * @param configuration The configuration
-   * @return A sequence of bindings
+   * @return a sequence of bindings
    */
   def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]]
 
@@ -82,9 +82,9 @@ object Modules {
    * Loads all modules specified by the play.modules.enabled property, minus the modules specified by the
    * play.modules.disabled property.
    *
-   * @param environment The environment.
-   * @param configuration The configuration.
-   * @return A sequence of objects. This method makes no attempt to cast or check the types of the modules being loaded,
+   * @param environment The environment
+   * @param configuration The configuration
+   * @return a sequence of objects. This method makes no attempt to cast or check the types of the modules being loaded,
    *         allowing ApplicationLoader implementations to reuse the same mechanism to load modules specific to them.
    */
   def locate(environment: Environment, configuration: Configuration): Seq[Any] = {

--- a/framework/src/play/src/main/scala/play/api/libs/Collections.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Collections.scala
@@ -22,8 +22,8 @@ object Collections {
    *
    * @tparam A Type of the final List elements.
    * @tparam B Seed type
-   * @param seed Initial value.
-   * @param f Function producing the List elements.
+   * @param seed Initial value
+   * @param f Function producing the List elements
    */
   def unfoldLeft[A, B](seed: B)(f: B => Option[(B, A)]): Seq[A] = {
     def loop(seed: B)(ls: List[A]): List[A] = f(seed) match {

--- a/framework/src/play/src/main/scala/play/api/libs/Comet.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Comet.scala
@@ -48,7 +48,7 @@ object Comet {
    * Create a Comet Enumeratee.
    *
    * @tparam E Type of messages handled by this comet stream.
-   * @param callback Javascript function to call on the browser for each message.
+   * @param callback Javascript function to call on the browser for each message
    * @param initialChunk Initial chunk of data to send for browser compatibility (default to send 5Kb of blank data)
    */
   def apply[E](callback: String, initialChunk: Html = Html(Array.fill[Char](5 * 1024)(' ').mkString + "<html><body>"))(implicit encoder: CometMessage[E]) = new Enumeratee[E, Html] {

--- a/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
@@ -29,8 +29,8 @@ object Crypto {
 
   /**
    * Exception thrown by the Crypto APIs.
-   * @param message The error message.
-   * @param throwable The Throwable associated with the exception.
+   * @param message The error message
+   * @param throwable The Throwable associated with the exception
    */
   class CryptoException(val message: String = null, val throwable: Throwable = null) extends RuntimeException(message, throwable)
 
@@ -49,9 +49,9 @@ object Crypto {
    * By default this uses the platform default JSSE provider.  This can be overridden by defining
    * `play.crypto.provider` in `application.conf`.
    *
-   * @param message The message to sign.
-   * @param key The private key to sign with.
-   * @return A hexadecimal encoded signature.
+   * @param message The message to sign
+   * @param key The private key to sign with
+   * @return a hexadecimal encoded signature
    */
   def sign(message: String, key: Array[Byte]): String = crypto.sign(message, key)
 
@@ -61,8 +61,8 @@ object Crypto {
    * By default this uses the platform default JSSE provider.  This can be overridden by defining
    * `play.crypto.provider` in `application.conf`.
    *
-   * @param message The message to sign.
-   * @return A hexadecimal encoded signature.
+   * @param message The message to sign
+   * @return a hexadecimal encoded signature
    */
   def sign(message: String): String = crypto.sign(message)
 
@@ -73,15 +73,15 @@ object Crypto {
    * request, without actually changing the value.
    *
    * @param token The token to sign
-   * @return The signed token
+   * @return the signed token
    */
   def signToken(token: String): String = crypto.signToken(token)
 
   /**
    * Extract a signed token that was signed by [[play.api.libs.Crypto.signToken]].
    *
-   * @param token The signed token to extract.
-   * @return The verified raw token, or None if the token isn't valid.
+   * @param token The signed token to extract
+   * @return the verified raw token, or None if the token isn't valid
    */
   def extractSignedToken(token: String): Option[String] = crypto.extractSignedToken(token)
 
@@ -133,8 +133,8 @@ object Crypto {
    * `application.conf`.  Although any cipher transformation algorithm can be selected here, the secret key spec used
    * is always AES, so only AES transformation algorithms will work.
    *
-   * @param value The String to encrypt.
-   * @return An hexadecimal encrypted string.
+   * @param value The String to encrypt
+   * @return an hexadecimal encrypted string
    */
   def encryptAES(value: String): String = crypto.encryptAES(value)
 
@@ -153,9 +153,9 @@ object Crypto {
    * `application.conf`.  Although any cipher transformation algorithm can be selected here, the secret key spec used
    * is always AES, so only AES transformation algorithms will work.
    *
-   * @param value The String to encrypt.
-   * @param privateKey The key used to encrypt.
-   * @return An hexadecimal encrypted string.
+   * @param value The String to encrypt
+   * @param privateKey The key used to encrypt
+   * @return an hexadecimal encrypted string
    */
   def encryptAES(value: String, privateKey: String): String = crypto.encryptAES(value, privateKey)
 
@@ -169,8 +169,8 @@ object Crypto {
    * `play.crypto.aes.transformation` in `application.conf`.  Although any cipher transformation algorithm can
    * be selected here, the secret key spec used is always AES, so only AES transformation algorithms will work.
    *
-   * @param value An hexadecimal encrypted string.
-   * @return The decrypted String.
+   * @param value An hexadecimal encrypted string
+   * @return the decrypted String
    */
   def decryptAES(value: String): String = crypto.decryptAES(value)
 
@@ -186,9 +186,9 @@ object Crypto {
    * `play.crypto.aes.transformation` in `application.conf`.  Although any cipher transformation algorithm can
    * be selected here, the secret key spec used is always AES, so only AES transformation algorithms will work.
    *
-   * @param value An hexadecimal encrypted string.
-   * @param privateKey The key used to encrypt.
-   * @return The decrypted String.
+   * @param value An hexadecimal encrypted string
+   * @param privateKey The key used to encrypt
+   * @return the decrypted String
    */
   def decryptAES(value: String, privateKey: String): String = crypto.decryptAES(value, privateKey)
 }
@@ -289,9 +289,9 @@ class Crypto @Inject() (config: CryptoConfig) {
    * By default this uses the platform default JSSE provider.  This can be overridden by defining
    * `play.crypto.provider` in `application.conf`.
    *
-   * @param message The message to sign.
-   * @param key The private key to sign with.
-   * @return A hexadecimal encoded signature.
+   * @param message The message to sign
+   * @param key The private key to sign with
+   * @return a hexadecimal encoded signature
    */
   def sign(message: String, key: Array[Byte]): String = {
     val mac = config.provider.fold(Mac.getInstance("HmacSHA1"))(p => Mac.getInstance("HmacSHA1", p))
@@ -305,8 +305,8 @@ class Crypto @Inject() (config: CryptoConfig) {
    * By default this uses the platform default JSSE provider.  This can be overridden by defining
    * `play.crypto.provider` in `application.conf`.
    *
-   * @param message The message to sign.
-   * @return A hexadecimal encoded signature.
+   * @param message The message to sign
+   * @return a hexadecimal encoded signature
    */
   def sign(message: String): String = {
     sign(message, config.secret.getBytes("utf-8"))
@@ -319,7 +319,7 @@ class Crypto @Inject() (config: CryptoConfig) {
    * request, without actually changing the value.
    *
    * @param token The token to sign
-   * @return The signed token
+   * @return the signed token
    */
   def signToken(token: String): String = {
     val nonce = System.currentTimeMillis()
@@ -330,8 +330,8 @@ class Crypto @Inject() (config: CryptoConfig) {
   /**
    * Extract a signed token that was signed by [[play.api.libs.Crypto.signToken]].
    *
-   * @param token The signed token to extract.
-   * @return The verified raw token, or None if the token isn't valid.
+   * @param token The signed token to extract
+   * @return the verified raw token, or None if the token isn't valid
    */
   def extractSignedToken(token: String): Option[String] = {
     token.split("-", 3) match {
@@ -397,8 +397,8 @@ class Crypto @Inject() (config: CryptoConfig) {
    * `application.conf`.  Although any cipher transformation algorithm can be selected here, the secret key spec used
    * is always AES, so only AES transformation algorithms will work.
    *
-   * @param value The String to encrypt.
-   * @return An hexadecimal encrypted string.
+   * @param value The String to encrypt
+   * @return an hexadecimal encrypted string
    */
   def encryptAES(value: String): String = {
     encryptAES(value, config.secret)
@@ -420,9 +420,9 @@ class Crypto @Inject() (config: CryptoConfig) {
    * `application.conf`.  Although any cipher transformation algorithm can be selected here, the secret key spec used
    * is always AES, so only AES transformation algorithms will work.
    *
-   * @param value The String to encrypt.
-   * @param privateKey The key used to encrypt.
-   * @return A Base64 encrypted string.
+   * @param value The String to encrypt
+   * @param privateKey The key used to encrypt
+   * @return a Base64 encrypted string
    */
   def encryptAES(value: String, privateKey: String): String = {
     val skeySpec = secretKeyWithSha256(privateKey, "AES")
@@ -469,8 +469,8 @@ class Crypto @Inject() (config: CryptoConfig) {
    * `play.crypto.aes.transformation` in `application.conf`.  Although any cipher transformation algorithm can
    * be selected here, the secret key spec used is always AES, so only AES transformation algorithms will work.
    *
-   * @param value An hexadecimal encrypted string.
-   * @return The decrypted String.
+   * @param value An hexadecimal encrypted string
+   * @return the decrypted String
    */
   def decryptAES(value: String): String = {
     decryptAES(value, config.secret)
@@ -488,9 +488,9 @@ class Crypto @Inject() (config: CryptoConfig) {
    * `play.crypto.aes.transformation` in `application.conf`.  Although any cipher transformation algorithm can
    * be selected here, the secret key spec used is always AES, so only AES transformation algorithms will work.
    *
-   * @param value An hexadecimal encrypted string.
-   * @param privateKey The key used to encrypt.
-   * @return The decrypted String.
+   * @param value An hexadecimal encrypted string
+   * @param privateKey The key used to encrypt
+   * @return the decrypted String
    */
   def decryptAES(value: String, privateKey: String): String = {
     val seperator = "-"

--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -54,9 +54,9 @@ object Files {
      * val tempFile = TemporaryFile(prefix = "uploaded")
      * }}}
      *
-     * @param prefix The prefix used for the temporary file name.
-     * @param suffix The suffix used for the temporary file name.
-     * @return A temporary file instance.
+     * @param prefix The prefix used for the temporary file name
+     * @param suffix The suffix used for the temporary file name
+     * @return a temporary file instance
      */
     def apply(prefix: String = "", suffix: String = ""): TemporaryFile = {
       new TemporaryFile(File.createTempFile(prefix, suffix))
@@ -108,7 +108,7 @@ object Files {
   /**
    * Reads a file’s contents into a String.
    *
-   * @param path the file to read.
+   * @param path the file to read
    * @return the file contents
    */
   @deprecated("Use Java 7 Files API instead", "2.3")

--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -112,7 +112,7 @@ trait Action[A] extends EssentialAction {
   /**
    * The execution context to run this action in
    *
-   * @return The execution context to run the action in
+   * @return the execution context to run the action in
    */
   def executionContext: ExecutionContext = play.api.libs.concurrent.Execution.defaultContext
 
@@ -142,7 +142,7 @@ trait BodyParser[+A] extends Function1[RequestHeader, Iteratee[Array[Byte], Eith
    * when the request body has been parsed.
    *
    * @param f a function for transforming the computed result
-   * @param ec The context to execute the supplied function with.
+   * @param ec The context to execute the supplied function with
    *        The context is prepared on the calling thread.
    * @return the transformed body parser
    * @see [[play.api.libs.iteratee.Iteratee#map]]
@@ -161,7 +161,7 @@ trait BodyParser[+A] extends Function1[RequestHeader, Iteratee[Array[Byte], Eith
    * Like map but allows the map function to execute asynchronously.
    *
    * @param f the async function to map the result of the body parser
-   * @param ec The context to execute the supplied function with.
+   * @param ec The context to execute the supplied function with
    *        The context prepared on the calling thread.
    * @return the transformed body parser
    * @see [[map]]
@@ -192,7 +192,7 @@ trait BodyParser[+A] extends Function1[RequestHeader, Iteratee[Array[Byte], Eith
    * input.
    *
    * @param f the function to produce a new body parser from the result of this body parser
-   * @param ec The context to execute the supplied function with.
+   * @param ec The context to execute the supplied function with
    *        The context is prepared on the calling thread.
    * @return the transformed body parser
    * @see [[play.api.libs.iteratee.Iteratee#flatMap]]
@@ -213,7 +213,7 @@ trait BodyParser[+A] extends Function1[RequestHeader, Iteratee[Array[Byte], Eith
    * Like flatMap but allows the flatMap function to execute asynchronously.
    *
    * @param f the async function to produce a new body parser from the result of this body parser
-   * @param ec The context to execute the supplied function with.
+   * @param ec The context to execute the supplied function with
    *        The context is prepared on the calling thread.
    * @return the transformed body parser
    * @see [[flatMap]]
@@ -250,7 +250,7 @@ trait BodyParser[+A] extends Function1[RequestHeader, Iteratee[Array[Byte], Eith
    * }}}
    *
    * @param f the function to validate the computed result of this body parser
-   * @param ec The context to execute the supplied function with.
+   * @param ec The context to execute the supplied function with
    *        The context is prepared on the calling thread.
    * @return the transformed body parser
    */
@@ -270,7 +270,7 @@ trait BodyParser[+A] extends Function1[RequestHeader, Iteratee[Array[Byte], Eith
    * Like validate but allows the validate function to execute asynchronously.
    *
    * @param f the async function to validate the computed result of this body parser
-   * @param ec The context to execute the supplied function with.
+   * @param ec The context to execute the supplied function with
    *        The context is prepared on the calling thread.
    * @return the transformed body parser
    * @see [[validate]]
@@ -347,14 +347,14 @@ trait ActionFunction[-R[_], +P[_]] {
    *
    * @param request The request
    * @param block The block of code to invoke
-   * @return A future of the result
+   * @return a future of the result
    */
   def invokeBlock[A](request: R[A], block: P[A] => Future[Result]): Future[Result]
 
   /**
    * Get the execution context to run the request in.  Override this if you want a custom execution context
    *
-   * @return The execution context
+   * @return the execution context
    */
   protected def executionContext: ExecutionContext = play.api.libs.concurrent.Execution.defaultContext
 
@@ -362,7 +362,7 @@ trait ActionFunction[-R[_], +P[_]] {
    * Compose this ActionFunction with another, with this one applied first.
    *
    * @param other ActionFunction with which to compose
-   * @return The new ActionFunction
+   * @return the new ActionFunction
    */
   def andThen[Q[_]](other: ActionFunction[P, Q]): ActionFunction[R, Q] = new ActionFunction[R, Q] {
     def invokeBlock[A](request: R[A], block: Q[A] => Future[Result]) =
@@ -373,7 +373,7 @@ trait ActionFunction[-R[_], +P[_]] {
    * Compose another ActionFunction with this one, with this one applied last.
    *
    * @param other ActionFunction with which to compose
-   * @return The new ActionFunction
+   * @return the new ActionFunction
    */
   def compose[Q[_]](other: ActionFunction[Q, R]): ActionFunction[Q, P] =
     other.andThen(this)
@@ -504,7 +504,7 @@ trait ActionBuilder[+R[_]] extends ActionFunction[Request, R] {
    * Compose the parser.  This allows the action builder to potentially intercept requests before they are parsed.
    *
    * @param bodyParser The body parser to compose
-   * @return The composed body parser
+   * @return the composed body parser
    */
   protected def composeParser[A](bodyParser: BodyParser[A]): BodyParser[A] = bodyParser
 
@@ -512,7 +512,7 @@ trait ActionBuilder[+R[_]] extends ActionFunction[Request, R] {
    * Compose the action with other actions.  This allows mixing in of various actions together.
    *
    * @param action The action to compose
-   * @return The composed action
+   * @return the composed action
    */
   protected def composeAction[A](action: Action[A]): Action[A] = action
 
@@ -548,7 +548,7 @@ trait ActionRefiner[-R[_], +P[_]] extends ActionFunction[R, P] {
    * It can decide to immediately intercept the request and return a Result (Left), or continue processing with a new parameter of type P (Right).
    *
    * @param request the input request
-   * @return Either a result or a new parameter to pass to the Action block
+   * @return either a result or a new parameter to pass to the Action block
    */
   protected def refine[A](request: R[A]): Future[Either[Result, P[A]]]
 
@@ -566,7 +566,7 @@ trait ActionTransformer[-R[_], +P[_]] extends ActionRefiner[R, P] {
    * Augment or transform an existing request.  This is the main method that an ActionTransformer has to implement.
    *
    * @param request the input request
-   * @return The new parameter to pass to the Action block
+   * @return the new parameter to pass to the Action block
    */
   protected def transform[A](request: R[A]): Future[P[A]]
 
@@ -586,7 +586,7 @@ trait ActionFilter[R[_]] extends ActionRefiner[R, R] {
    * It can decide to immediately intercept the request and return a Result (Some), or continue processing (None).
    *
    * @param request the input request
-   * @return An optional Result with which to abort the request
+   * @return an optional Result with which to abort the request
    */
   protected def filter[A](request: R[A]): Future[Option[Result]]
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -84,7 +84,7 @@ trait QueryStringBindable[A] {
    * Unbind a query string parameter.
    *
    * @param key Parameter key
-   * @param value Parameter value.
+   * @param value Parameter value
    * @return a query string fragment containing the key and its value. E.g. "foo=42"
    */
   def unbind(key: String, value: A): String
@@ -169,7 +169,7 @@ trait PathBindable[A] {
    * Unbind a URL path  parameter.
    *
    * @param key Parameter key
-   * @param value Parameter value.
+   * @param value Parameter value
    */
   def unbind(key: String, value: A): String
 

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -167,7 +167,7 @@ object MultipartFormData {
 /**
  * Handle the request body a raw bytes data.
  *
- * @param memoryThreshold If the content size is bigger than this limit, the content is stored as file.
+ * @param memoryThreshold If the content size is bigger than this limit, the content is stored as file
  */
 case class RawBuffer(memoryThreshold: Int, initialData: Array[Byte] = Array.empty[Byte]) {
 
@@ -224,7 +224,7 @@ case class RawBuffer(memoryThreshold: Int, initialData: Array[Byte] = Array.empt
    *
    * @param maxLength The max length allowed to be stored in memory.  If this is smaller than memoryThreshold, and the
    *                  buffer is already in memory then None will still be returned.
-   * @return None if the content is greater than maxLength, otherwise, the data as bytes.
+   * @return None if the content is greater than maxLength, otherwise, the data as bytes
    */
   def asBytes(maxLength: Long = memoryThreshold): Option[Array[Byte]] = {
     if (size <= maxLength) {
@@ -309,7 +309,7 @@ trait BodyParsers {
     /**
      * Parse the body as text without checking the Content-Type.
      *
-     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response.
+     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response
      */
     def tolerantText(maxLength: Long): BodyParser[String] = BodyParser("text, maxLength=" + maxLength) { request =>
       // Encoding notes: RFC-2616 section 3.7.1 mandates ISO-8859-1 as the default charset if none is specified.
@@ -328,7 +328,7 @@ trait BodyParsers {
     /**
      * Parse the body as text if the Content-Type is text/plain.
      *
-     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response.
+     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response
      */
     def text(maxLength: Int): BodyParser[String] = when(
       _.contentType.exists(_.equalsIgnoreCase("text/plain")),
@@ -346,7 +346,7 @@ trait BodyParsers {
     /**
      * Store the body content in a RawBuffer.
      *
-     * @param memoryThreshold If the content size is bigger than this limit, the content is stored as file.
+     * @param memoryThreshold If the content size is bigger than this limit, the content is stored as file
      */
     def raw(memoryThreshold: Int = DefaultMaxTextLength, maxLength: Long = DefaultMaxDiskLength): BodyParser[RawBuffer] =
       BodyParser("raw, memoryThreshold=" + memoryThreshold) { request =>
@@ -370,7 +370,7 @@ trait BodyParsers {
     /**
      * Parse the body as Json without checking the Content-Type.
      *
-     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response.
+     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response
      */
     def tolerantJson(maxLength: Int): BodyParser[JsValue] =
       tolerantBodyParser[JsValue]("json", maxLength, "Invalid Json") { (request, bytes) =>
@@ -388,7 +388,7 @@ trait BodyParsers {
     /**
      * Parse the body as Json if the Content-Type is text/json or application/json.
      *
-     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response.
+     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response
      */
     def json(maxLength: Int): BodyParser[JsValue] = when(
       _.contentType.exists(m => m.equalsIgnoreCase("text/json") || m.equalsIgnoreCase("application/json")),
@@ -406,7 +406,7 @@ trait BodyParsers {
      * validating the result with the Json reader.
      *
      * @tparam A the type to read and validate from the body.
-     * @param reader a Json reader for type A.
+     * @param reader a Json reader for type A
      */
     def json[A](implicit reader: Reads[A]): BodyParser[A] =
       BodyParser("json reader") { request =>
@@ -440,7 +440,7 @@ trait BodyParsers {
      * }}}
      *
      * @param form Form model
-     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response. If `None`, the default `play.http.parser.maxMemoryBuffer` configuration value is used.
+     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response. If `None`, the default `play.http.parser.maxMemoryBuffer` configuration value is used
      * @param onErrors The result to reply in case of errors during the form binding process
      */
     def form[A](form: Form[A], maxLength: Option[Long] = None, onErrors: Form[A] => Result = (formErrors: Form[A]) => Results.BadRequest): BodyParser[A] =
@@ -471,7 +471,7 @@ trait BodyParsers {
     /**
      * Parse the body as Xml without checking the Content-Type.
      *
-     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response.
+     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response
      */
     def tolerantXml(maxLength: Int): BodyParser[NodeSeq] =
       tolerantBodyParser[NodeSeq]("xml", maxLength, "Invalid XML") { (request, bytes) =>
@@ -506,7 +506,7 @@ trait BodyParsers {
     /**
      * Parse the body as Xml if the Content-Type is application/xml, text/xml or application/XXX+xml.
      *
-     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response.
+     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response
      */
     def xml(maxLength: Int): BodyParser[NodeSeq] = when(
       _.contentType.exists { t =>
@@ -527,7 +527,7 @@ trait BodyParsers {
     /**
      * Store the body content into a file.
      *
-     * @param to The file used to store the content.
+     * @param to The file used to store the content
      */
     def file(to: File): BodyParser[File] = BodyParser("file, to=" + to) { request =>
       import play.core.Execution.Implicits.internalContext
@@ -555,7 +555,7 @@ trait BodyParsers {
     /**
      * Parse the body as Form url encoded without checking the Content-Type.
      *
-     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response.
+     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response
      */
     def tolerantFormUrlEncoded(maxLength: Int): BodyParser[Map[String, Seq[String]]] =
       tolerantBodyParser("urlFormEncoded", maxLength, "Error parsing application/x-www-form-urlencoded") { (request, bytes) =>
@@ -573,7 +573,7 @@ trait BodyParsers {
     /**
      * Parse the body as form url encoded if the Content-Type is application/x-www-form-urlencoded.
      *
-     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response.
+     * @param maxLength Max length allowed or returns EntityTooLarge HTTP response
      */
     def urlFormEncoded(maxLength: Int): BodyParser[Map[String, Seq[String]]] = when(
       _.contentType.exists(_.equalsIgnoreCase("application/x-www-form-urlencoded")),
@@ -659,7 +659,7 @@ trait BodyParsers {
     /**
      * Parse the content as multipart/form-data
      *
-     * @param filePartHandler Handles file parts.
+     * @param filePartHandler Handles file parts
      */
     def multipartFormData[A](filePartHandler: Multipart.PartHandler[FilePart[A]], maxLength: Long = DefaultMaxDiskLength): BodyParser[MultipartFormData[A]] = {
       BodyParser("multipartFormData") { request =>

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -109,7 +109,7 @@ package play.api.mvc {
     }
 
     /**
-     * @return The media types list of the request’s Accept header, sorted by preference (preferred first).
+     * @return the media types list of the request’s Accept header, sorted by preference (preferred first)
      */
     lazy val acceptedTypes: Seq[play.api.http.MediaRange] = {
       headers.get(HeaderNames.ACCEPT).toSeq.flatMap(MediaRange.parse.apply)
@@ -202,7 +202,7 @@ package play.api.mvc {
     val qPattern = ";\\s*q=([0-9.]+)".r
 
     /**
-     * @return The items of an Accept* header, with their q-value.
+     * @return the items of an Accept* header, with their q-value
      */
     private[play] def acceptHeader(headers: Headers, headerName: String): Seq[(Double, String)] = {
       for {

--- a/framework/src/play/src/main/scala/play/api/mvc/Render.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Render.scala
@@ -26,7 +26,7 @@ trait Rendering {
      * }}}
      *
      * @param f A partial function returning a `Result` for a given request media range
-     * @return A result provided by `f`, if it is defined for the current request media ranges, otherwise NotAcceptable
+     * @return a result provided by `f`, if it is defined for the current request media ranges, otherwise NotAcceptable
      */
     def apply(f: PartialFunction[MediaRange, Result])(implicit request: RequestHeader): Result = {
       def _render(ms: Seq[MediaRange]): Result = ms match {
@@ -57,7 +57,7 @@ trait Rendering {
      * }}}
      *
      * @param f A partial function returning a `Future[Result]` for a given request media range
-     * @return A result provided by `f`, if it is defined for the current request media ranges, otherwise NotAcceptable
+     * @return a result provided by `f`, if it is defined for the current request media ranges, otherwise NotAcceptable
      */
     def async(f: PartialFunction[MediaRange, Future[Result]])(implicit request: RequestHeader): Future[Result] = {
       def _render(ms: Seq[MediaRange]): Future[Result] = ms match {

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -94,7 +94,7 @@ case class Result(header: ResponseHeader, body: Enumerator[Array[Byte]],
    * Ok("Hello world").withHeaders(ETAG -> "0")
    * }}}
    *
-   * @param headers the headers to add to this result.
+   * @param headers the headers to add to this result
    * @return the new result
    */
   def withHeaders(headers: (String, String)*): Result = {
@@ -213,14 +213,14 @@ case class Result(header: ResponseHeader, body: Enumerator[Array[Byte]],
    * Ok("<text>Hello world</text>").as("application/xml")
    * }}}
    *
-   * @param contentType the new content type.
+   * @param contentType the new content type
    * @return the new result
    */
   def as(contentType: String): Result = withHeaders(CONTENT_TYPE -> contentType)
 
   /**
    * @param request Current request
-   * @return The session carried by this result. Reads the request’s session if this result does not modify the session.
+   * @return the session carried by this result. Reads the request’s session if this result does not modify the session
    */
   def session(implicit request: RequestHeader): Session =
     Cookies(header.headers.get(SET_COOKIE)).get(Session.COOKIE_NAME) match {
@@ -235,7 +235,7 @@ case class Result(header: ResponseHeader, body: Enumerator[Array[Byte]],
    * }}}
    * @param values (key -> value) pairs to add to this result’s session
    * @param request Current request
-   * @return A copy of this result with `values` added to its session scope.
+   * @return a copy of this result with `values` added to its session scope
    */
   def addingToSession(values: (String, String)*)(implicit request: RequestHeader): Result =
     withSession(new Session(session.data ++ values.toMap))
@@ -247,7 +247,7 @@ case class Result(header: ResponseHeader, body: Enumerator[Array[Byte]],
    * }}}
    * @param keys Keys to remove from session
    * @param request Current request
-   * @return A copy of this result with `keys` removed from its session scope.
+   * @return a copy of this result with `keys` removed from its session scope
    */
   def removingFromSession(keys: String*)(implicit request: RequestHeader): Result =
     withSession(new Session(session.data -- keys))
@@ -277,8 +277,8 @@ case class Result(header: ResponseHeader, body: Enumerator[Array[Byte]],
 /**
  * A Codec handle the conversion of String to Byte arrays.
  *
- * @param charset The charset to be sent to the client.
- * @param encode The transformation function.
+ * @param charset The charset to be sent to the client
+ * @param encode The transformation function
  */
 case class Codec(val charset: String)(val encode: String => Array[Byte], val decode: Array[Byte] => String)
 
@@ -369,7 +369,7 @@ trait Results {
     /**
      * Set the result's content.
      *
-     * @param content The content to send.
+     * @param content The content to send
      */
     def apply[C](content: C)(implicit writeable: Writeable[C]): Result = {
       Result(
@@ -381,9 +381,9 @@ trait Results {
     /**
      * Send a file.
      *
-     * @param content The file to send.
-     * @param inline Use Content-Disposition inline or attachment.
-     * @param fileName function to retrieve the file name (only used for Content-Disposition attachment).
+     * @param content The file to send
+     * @param inline Use Content-Disposition inline or attachment
+     * @param fileName function to retrieve the file name (only used for Content-Disposition attachment)
      */
     def sendFile(content: java.io.File, inline: Boolean = false, fileName: java.io.File => String = _.getName, onClose: () => Unit = () => ()): Result = {
       val name = fileName(content)
@@ -399,9 +399,9 @@ trait Results {
     /**
      * Send the given resource from the given classloader.
      *
-     * @param resource The path of the resource to load.
-     * @param classLoader The classloader to load it from, defaults to the classloader for this class.
-     * @param inline Whether it should be served as an inline file, or as an attachment.
+     * @param resource The path of the resource to load
+     * @param classLoader The classloader to load it from, defaults to the classloader for this class
+     * @param inline Whether it should be served as an inline file, or as an attachment
      * @return
      */
     def sendResource(resource: String, classLoader: ClassLoader = Results.getClass.getClassLoader,
@@ -426,7 +426,7 @@ trait Results {
      * Chunked encoding allows the server to send a response where the content length is not known, or for potentially
      * infinite streams, while still allowing the connection to be kept alive and reused for the next request.
      *
-     * @param content Enumerator providing the content to stream.
+     * @param content Enumerator providing the content to stream
      */
     def chunked[C](content: Enumerator[C])(implicit writeable: Writeable[C]): Result = {
       Result(header = ResponseHeader(status,
@@ -447,7 +447,7 @@ trait Results {
      * The connection will be closed after the response is sent, regardless of whether there is a content length or
      * transfer encoding defined.
      *
-     * @param content Enumerator providing the content to stream.
+     * @param content Enumerator providing the content to stream
      */
     def feed[C](content: Enumerator[C])(implicit writeable: Writeable[C]): Result = {
       Result(
@@ -463,7 +463,7 @@ trait Results {
      * If a content length is set, this will send the body as is, otherwise it may chunk or may not chunk depending on
      * whether HTTP/1.1 is used or not.
      *
-     * @param content Enumerator providing the content to stream.
+     * @param content Enumerator providing the content to stream
      */
     def stream[C](content: Enumerator[C])(implicit writeable: Writeable[C]): Result = {
       Result(

--- a/framework/src/play/src/main/scala/play/api/mvc/Security.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Security.scala
@@ -125,8 +125,8 @@ object Security {
    * }
    * }}}
    *
-   * @param userinfo The function that looks up the user info.
-   * @param onUnauthorized The function to get the result for when no authenticated user can be found.
+   * @param userinfo The function that looks up the user info
+   * @param onUnauthorized The function to get the result for when no authenticated user can be found
    */
   class AuthenticatedBuilder[U](userinfo: RequestHeader => Option[U],
     onUnauthorized: RequestHeader => Result = _ => Unauthorized(views.html.defaultpages.unauthorized()))
@@ -185,8 +185,8 @@ object Security {
     /**
      * Create an authenticated builder
      *
-     * @param userinfo The function that looks up the user info.
-     * @param onUnauthorized The function to get the result for when no authenticated user can be found.
+     * @param userinfo The function that looks up the user info
+     * @param onUnauthorized The function to get the result for when no authenticated user can be found
      */
     def apply[U](userinfo: RequestHeader => Option[U],
       onUnauthorized: RequestHeader => Result = _ => Unauthorized(views.html.defaultpages.unauthorized())): AuthenticatedBuilder[U] = new AuthenticatedBuilder(userinfo, onUnauthorized)

--- a/framework/src/play/src/main/scala/play/api/routing/Router.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/Router.scala
@@ -20,7 +20,7 @@ trait Router {
   /**
    * Documentation for the router.
    *
-   * @return A list of method, path pattern and controller/method invocations for each route.
+   * @return a list of method, path pattern and controller/method invocations for each route
    */
   def documentation: Seq[(String, String, String)]
 
@@ -52,7 +52,7 @@ object Router {
   /**
    * Try to load the configured router class.
    *
-   * @return The router class if configured or if a default one in the root package was detected.
+   * @return the router class if configured or if a default one in the root package was detected
    */
   def load(env: Environment, configuration: Configuration): Option[Class[_ <: Router]] = {
     val className = PlayConfig(configuration).getOptionalDeprecated[String]("play.http.router", "application.router")
@@ -87,7 +87,7 @@ object Router {
    * Create a new router from the given partial function
    *
    * @param routes The routes partial function
-   * @return A router that uses that partial function
+   * @return a router that uses that partial function
    */
   def from(routes: Router.Routes): Router = SimpleRouter(routes)
 

--- a/framework/src/play/src/main/scala/play/api/routing/sird/PathExtractor.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/sird/PathExtractor.scala
@@ -21,8 +21,8 @@ import scala.util.matching.Regex
  *   - java.net.URI
  *   - java.net.URL
  *
- * @param regex The regex that is used to extract the raw parts.
- * @param partDescriptors Descriptors saying whether each part should be decoded or not.
+ * @param regex The regex that is used to extract the raw parts
+ * @param partDescriptors Descriptors saying whether each part should be decoded or not
  */
 class PathExtractor(regex: Regex, partDescriptors: Seq[PathPart.Value]) {
   def unapplySeq(path: String): Option[List[String]] = extract(path)

--- a/framework/src/play/src/main/scala/play/core/actions/HeadAction.scala
+++ b/framework/src/play/src/main/scala/play/core/actions/HeadAction.scala
@@ -15,7 +15,7 @@ import HeaderNames._
 /**
  * RFC2616-compatible HEAD implementation: provides a full header set and empty body for a given GET resource
  *
- * @param action Action for the relevant GET path.
+ * @param action Action for the relevant GET path
  */
 class HeadAction(action: EssentialAction) extends EssentialAction with DefaultWriteables with HttpProtocol {
 

--- a/framework/src/play/src/main/scala/play/core/actors/WebSocketActor.scala
+++ b/framework/src/play/src/main/scala/play/core/actors/WebSocketActor.scala
@@ -93,12 +93,12 @@ private[play] object WebSocketActor {
     /**
      * Connect an actor to the WebSocket on the end of the given enumerator/iteratee.
      *
-     * @param requestId The requestId. Used to name the actor.
-     * @param enumerator The enumerator to send messages to.
-     * @param iteratee The iteratee to consume messages from.
+     * @param requestId The requestId. Used to name the actor
+     * @param enumerator The enumerator to send messages to
+     * @param iteratee The iteratee to consume messages from
      * @param createHandler A function that creates a handler to handle the WebSocket, given an actor to send messages
      *                      to.
-     * @param messageType The type of message this WebSocket deals with.
+     * @param messageType The type of message this WebSocket deals with
      */
     case class Connect[In, Out](requestId: Long, enumerator: Enumerator[In], iteratee: Iteratee[Out, Unit],
       createHandler: ActorRef => Props)(implicit val messageType: ClassTag[Out])

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -111,7 +111,7 @@ trait JavaHelpers {
    *
    * @param request The request
    * @param f The function to invoke
-   * @return The result
+   * @return the result
    */
   def invokeWithContextOpt(request: RequestHeader, f: JRequest => F.Promise[JResult]): Option[Future[Result]] = {
     Option(invokeWithContext(request, f))
@@ -126,7 +126,7 @@ trait JavaHelpers {
    *
    * @param request The request
    * @param f The function to invoke
-   * @return The result
+   * @return the result
    */
   def invokeWithContext(request: RequestHeader, f: JRequest => F.Promise[JResult]): Future[Result] = {
     withContext(request) { javaContext =>

--- a/framework/src/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
@@ -13,7 +13,7 @@ object FormUrlEncodedParser {
    * pairs, both of which are URL encoded.
    * @param data The body content of the request, or whatever needs to be so parsed
    * @param encoding The character encoding of data
-   * @return A ListMap of keys to the sequence of values for that key
+   * @return a ListMap of keys to the sequence of values for that key
    */
   def parseNotPreservingOrder(data: String, encoding: String = "utf-8"): Map[String, Seq[String]] = {
     // Generate the pairs of values from the string.
@@ -26,7 +26,7 @@ object FormUrlEncodedParser {
    * keys by using OrderPreserving.groupBy as some applications depend on the original browser ordering.
    * @param data The body content of the request, or whatever needs to be so parsed
    * @param encoding The character encoding of data
-   * @return A ListMap of keys to the sequence of values for that key
+   * @return a ListMap of keys to the sequence of values for that key
    */
   def parse(data: String, encoding: String = "utf-8"): Map[String, Seq[String]] = {
 
@@ -55,7 +55,7 @@ object FormUrlEncodedParser {
    * Do the basic parsing into a sequence of key/value pairs
    * @param data The data to parse
    * @param encoding The encoding to use for interpreting the data
-   * @return The sequence of key/value pairs
+   * @return the sequence of key/value pairs
    */
   private def parseToPairs(data: String, encoding: String): Seq[(String, String)] = {
 

--- a/framework/src/play/src/main/scala/play/core/routing/PathPattern.scala
+++ b/framework/src/play/src/main/scala/play/core/routing/PathPattern.scala
@@ -15,9 +15,9 @@ trait PathPart
 /**
  * A dynamically extracted part of the path.
  *
- * @param name The name of the part.
- * @param constraint The constraint - that is, the type.
- * @param encodeable Whether the path should be encoded/decoded.
+ * @param name The name of the part
+ * @param constraint The constraint - that is, the type
+ * @param encodeable Whether the path should be encoded/decoded
  */
 case class DynamicPart(name: String, constraint: String, encodeable: Boolean) extends PathPart {
   override def toString = """DynamicPart("""" + name + "\", \"\"\"" + constraint + "\"\"\")" // "
@@ -65,8 +65,8 @@ case class PathPattern(parts: Seq[PathPart]) {
   /**
    * Apply the path pattern to a given candidate path to see if it matches.
    *
-   * @param path The path to match against.
-   * @return The map of extracted parameters, or none if the path didn't match.
+   * @param path The path to match against
+   * @return the map of extracted parameters, or none if the path didn't match
    */
   def apply(path: String): Option[Map[String, Either[Throwable, String]]] = {
     val matcher = regex.matcher(path)

--- a/framework/src/play/src/main/scala/play/core/routing/ReverseRouteContext.scala
+++ b/framework/src/play/src/main/scala/play/core/routing/ReverseRouteContext.scala
@@ -11,7 +11,7 @@ package play.core.routing
  *
  * An empty reverse router context is made available implicitly to the router and JavaScript router.
  *
- * @param fixedParams The fixed params that this route passes to the action.
+ * @param fixedParams The fixed params that this route passes to the action
  */
 case class ReverseRouteContext(fixedParams: Map[String, Any])
 

--- a/framework/src/play/src/main/scala/play/core/websocket/BasicFrameFormatter.scala
+++ b/framework/src/play/src/main/scala/play/core/websocket/BasicFrameFormatter.scala
@@ -8,8 +8,8 @@ import play.api.mvc.WebSocket.FrameFormatter
 /**
  * A FrameFormatter that produces BasicFrames.
  *
- * @param toFrame Function to convert to a BasicFrame.
- * @param fromFrame PartialFunction to convert from a BasicFrame.
+ * @param toFrame Function to convert to a BasicFrame
+ * @param fromFrame PartialFunction to convert from a BasicFrame
  * @param handlesFromFrameClass Function to check if fromFrame would
  * handle a given BasicFrame class. Can be used instead of calling
  * fromFrame.isDefinedAt. The benefit of calling this function is that

--- a/framework/src/play/src/main/scala/play/server/api/SSLEngineProvider.scala
+++ b/framework/src/play/src/main/scala/play/server/api/SSLEngineProvider.scala
@@ -15,7 +15,7 @@ import play.core.ApplicationProvider
 trait SSLEngineProvider extends play.server.SSLEngineProvider {
 
   /**
-   * @return the SSL engine to be used for HTTPS connection.
+   * @return the SSL engine to be used for HTTPS connection
    */
   def createSSLEngine: SSLEngine
 

--- a/framework/src/play/src/main/scala/play/utils/Reflect.scala
+++ b/framework/src/play/src/main/scala/play/utils/Reflect.scala
@@ -35,7 +35,7 @@ object Reflect {
    * @tparam JavaInterface The Java interface for Java versions of the implementation
    * @tparam JavaAdapter An adapter class that depends on `JavaInterface` and provides `ScalaTrait`
    * @tparam Default The default implementation of `ScalaTrait` if no user implementation has been provided
-   * @return Zero or more bindings to provide `ScalaTrait`
+   * @return zero or more bindings to provide `ScalaTrait`
    */
   def bindingsFromConfiguration[ScalaTrait, JavaInterface, JavaAdapter <: ScalaTrait, Default <: ScalaTrait](
     environment: Environment, config: PlayConfig, key: String, defaultClassName: String)(implicit scalaTrait: SubClassOf[ScalaTrait],

--- a/framework/src/play/src/main/scala/play/utils/UriEncoding.scala
+++ b/framework/src/play/src/main/scala/play/utils/UriEncoding.scala
@@ -37,10 +37,10 @@ object UriEncoding {
    * not quite spec compliant. For example, it percent-encodes the `~` character when
    * really it should leave it as unencoded.)
    *
-   * @param s The string to encode.
-   * @param inputCharset The name of the encoding that the string `s` is encoded with.
+   * @param s The string to encode
+   * @param inputCharset The name of the encoding that the string `s` is encoded with
    *     The string `s` will be converted to octets (bytes) using this character encoding.
-   * @return An encoded string in the US-ASCII character set.
+   * @return an encoded string in the US-ASCII character set
    */
   def encodePathSegment(s: String, inputCharset: String): String = {
     val in = s.getBytes(inputCharset)
@@ -80,11 +80,11 @@ object UriEncoding {
    * for inclusion in the query part of a URI. But `URLDecoder.decoder` should not
    * be used for path segment encoding or decoding.
    *
-   * @param s The string to decode. Must use the US-ASCII character set.
-   * @param outputCharset The name of the encoding that the output should be encoded with.
+   * @param s The string to decode. Must use the US-ASCII character set
+   * @param outputCharset The name of the encoding that the output should be encoded with
    *     The output string will be converted from octets (bytes) using this character encoding.
    * @throws InvalidEncodingException If the input is not a valid encoded path segment.
-   * @return A decoded string in the `outputCharset` character set.
+   * @return a decoded string in the `outputCharset` character set
    */
   def decodePathSegment(s: String, outputCharset: String): String = {
     val in = s.getBytes("US-ASCII")
@@ -127,11 +127,11 @@ object UriEncoding {
    * Encoded slash characters are will appear as slashes in the output, thus "a/b"
    * will be indistinguishable from "a%2Fb".
    *
-   * @param s The string to decode. Must use the US-ASCII character set.
-   * @param outputCharset The name of the encoding that the output should be encoded with.
+   * @param s The string to decode. Must use the US-ASCII character set
+   * @param outputCharset The name of the encoding that the output should be encoded with
    *     The output string will be converted from octets (bytes) using this character encoding.
    * @throws InvalidEncodingException If the input is not a valid encoded path.
-   * @return A decoded string in the `outputCharset` character set.
+   * @return a decoded string in the `outputCharset` character set
    */
   def decodePath(s: String, outputCharset: String): String = {
     // Note: Could easily expose a method to return the decoded path as a Seq[String].

--- a/framework/src/play/src/main/scala/views/helper/Helpers.scala
+++ b/framework/src/play/src/main/scala/views/helper/Helpers.scala
@@ -77,10 +77,10 @@ package views.html.helper {
      *
      * Useful for repeated fields in forms.
      *
-     * @param field The field to repeat.
-     * @param min The minimum number of times the field should be repeated.
-     * @param fieldRenderer A function to render the field.
-     * @return The sequence of rendered fields.
+     * @param field The field to repeat
+     * @param min The minimum number of times the field should be repeated
+     * @param fieldRenderer A function to render the field
+     * @return the sequence of rendered fields
      */
     def apply(field: play.api.data.Field, min: Int = 1)(fieldRenderer: play.api.data.Field => Html): Seq[Html] = {
       val indexes = field.indexes match {

--- a/framework/src/play/src/main/scala/views/helper/checkbox.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/checkbox.scala.html
@@ -6,9 +6,9 @@
  * @checkbox(field = myForm("done"))
  * }}}
  *
- * @param field The form field.
- * @param args Set of extra HTML attributes ('''id''' and '''label''' are 2 special arguments).
- * @param handler The field constructor.
+ * @param field The form field
+ * @param args Set of extra HTML attributes ('''id''' and '''label''' are 2 special arguments)
+ * @param handler The field constructor
  *@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 

--- a/framework/src/play/src/main/scala/views/helper/defaultFieldConstructor.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/defaultFieldConstructor.scala.html
@@ -11,7 +11,7 @@
  * </dl>
  * }}}
  *
- * @param el The field informations.
+ * @param el The field informations
  *@
 @(elements: FieldElements)
 

--- a/framework/src/play/src/main/scala/views/helper/form.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/form.scala.html
@@ -8,9 +8,9 @@
  * }
  * }}}
  *
- * @param action The submit action.
- * @param args Set of extra HTML attributes.
- * @param body The form body.
+ * @param action The submit action
+ * @param args Set of extra HTML attributes
+ * @param body The form body
  *@
 @(action: play.api.mvc.Call, args: (Symbol,String)*)(body: => Html) 
 

--- a/framework/src/play/src/main/scala/views/helper/inputCheckboxGroup.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputCheckboxGroup.scala.html
@@ -11,10 +11,10 @@
 *
 * }}}
 *
-* @param field The form field.
+* @param field The form field
 * @param options Sequence of options as pairs of value and HTML
-* @param args Set of extra HTML attributes.
-* @param handler The field constructor.
+* @param args Set of extra HTML attributes
+* @param handler The field constructor
 *@
 @(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 

--- a/framework/src/play/src/main/scala/views/helper/inputDate.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputDate.scala.html
@@ -6,9 +6,9 @@
  * @inputDate(field = myForm("releaseDate"), args = 'size -> 10)
  * }}}
  *
- * @param field The form field.
- * @param args Set of extra attributes.
- * @param handler The field constructor.
+ * @param field The form field
+ * @param args Set of extra attributes
+ * @param handler The field constructor
  *@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 

--- a/framework/src/play/src/main/scala/views/helper/inputFile.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputFile.scala.html
@@ -6,9 +6,9 @@
  * @inputFile(field = myForm("name"), args = 'size -> 10)
  * }}}
  *
- * @param field The form field.
- * @param args Set of extra attributes.
- * @param handler The field constructor.
+ * @param field The form field
+ * @param args Set of extra attributes
+ * @param handler The field constructor
  *@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 

--- a/framework/src/play/src/main/scala/views/helper/inputPassword.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputPassword.scala.html
@@ -6,9 +6,9 @@
  * @inputPassword(field = myForm("password"), args = 'size -> 10)
  * }}}
  *
- * @param field The form field.
- * @param args Set of extra attributes.
- * @param handler The field constructor.
+ * @param field The form field
+ * @param args Set of extra attributes
+ * @param handler The field constructor
  *@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 

--- a/framework/src/play/src/main/scala/views/helper/inputRadioGroup.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputRadioGroup.scala.html
@@ -11,9 +11,9 @@
  *
  * }}}
  *
- * @param field The form field.
- * @param args Set of extra HTML attributes.
- * @param handler The field constructor.
+ * @param field The form field
+ * @param args Set of extra HTML attributes
+ * @param handler The field constructor
  *@
 @(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 

--- a/framework/src/play/src/main/scala/views/helper/inputText.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputText.scala.html
@@ -6,9 +6,9 @@
  * @inputText(field = myForm("name"), args = 'size -> 10, 'placeholder -> "Your name")
  * }}}
  *
- * @param field The form field.
- * @param args Set of extra attributes.
- * @param handler The field constructor.
+ * @param field The form field
+ * @param args Set of extra attributes
+ * @param handler The field constructor
  *@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 

--- a/framework/src/play/src/main/scala/views/helper/javascriptRouter.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/javascriptRouter.scala.html
@@ -18,8 +18,8 @@
  * * *type*: HTTP method
  * * *url*: the url to be used
  * 
- * @param name The javascript object name.
- * @param routes Set of routes to include in this javascript router.
+ * @param name The javascript object name
+ * @param routes Set of routes to include in this javascript router
  *@
 @(name:String = "Router")(routes: play.api.routing.JavaScriptReverseRoute*)(implicit request: play.api.mvc.RequestHeader)
 

--- a/framework/src/play/src/main/scala/views/helper/requireJs.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/requireJs.scala.html
@@ -6,10 +6,10 @@
  * @requireJs(core = routes.Assets.at("javascripts/require.js").url, module = routes.Assets.at("javascripts/main").url)
  * }}}
  *
- * @param module Javascript module in question.
- * @param core Reference to require.js.
- * @param productionFolderPrefix Prefix of Javascript production folder, defaut "-min".
- * @param folder Javascript folder, default "javascripts".
+ * @param module Javascript module in question
+ * @param core Reference to require.js
+ * @param productionFolderPrefix Prefix of Javascript production folder, defaut "-min"
+ * @param folder Javascript folder, default "javascripts"
  *@
 
 @(module: String, core: String, productionFolderPrefix: String = "-min", folder: String= "javascripts")

--- a/framework/src/play/src/main/scala/views/helper/select.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/select.scala.html
@@ -6,10 +6,10 @@
  * @select(field = myForm("isDone"), options = options(List("Yes","No")))
  * }}}
  *
- * @param field The form field.
- * @param options Sequence of options as pairs of value and HTML.
- * @param args Set of extra attributes ('''_default''' is a special argument).
- * @param handler The field constructor.
+ * @param field The form field
+ * @param options Sequence of options as pairs of value and HTML
+ * @param args Set of extra attributes ('''_default''' is a special argument)
+ * @param handler The field constructor
  *@
 @(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 

--- a/framework/src/play/src/main/scala/views/helper/textarea.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/textarea.scala.html
@@ -6,9 +6,9 @@
  * @textarea(field = myForm("address"), args = 'rows -> 3, 'cols -> 50)
  * }}}
  *
- * @param field The form field.
- * @param args Set of extra attributes.
- * @param handler The field constructor.
+ * @param field The form field
+ * @param args Set of extra attributes
+ * @param handler The field constructor
  *@
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
 

--- a/framework/src/play/src/main/scala/views/html/helper/package.scala
+++ b/framework/src/play/src/main/scala/views/html/helper/package.scala
@@ -23,7 +23,7 @@ package object helper {
   val defaultField = defaultFieldConstructor.f
 
   /**
-   * @return The url-encoded value of `string` using the charset provided by `codec`
+   * @return the url-encoded value of `string` using the charset provided by `codec`
    */
   def urlEncode(string: String)(implicit codec: play.api.mvc.Codec): String =
     java.net.URLEncoder.encode(string, codec.charset)

--- a/framework/src/play/src/main/scala/views/js/helper/package.scala
+++ b/framework/src/play/src/main/scala/views/js/helper/package.scala
@@ -20,7 +20,7 @@ package object helper {
    * }}}
    *
    * @param a The value to convert to JavaScript
-   * @return A JavaScript value
+   * @return a JavaScript value
    */
   def json[A: Writes](a: A): JavaScript = JavaScript(Json.stringify(Json.toJson(a)))
 

--- a/framework/src/play/src/test/scala/play/core/test/Fakes.scala
+++ b/framework/src/play/src/test/scala/play/core/test/Fakes.scala
@@ -21,7 +21,7 @@ object Fakes {
    * Create an injector from the given bindings.
    *
    * @param bindings The bindings
-   * @return The injector
+   * @return the injector
    */
   def injectorFromBindings(bindings: Seq[Binding[_]]): Injector = {
     new GuiceInjectorBuilder().bindings(bindings).injector
@@ -32,7 +32,7 @@ object Fakes {
 /**
  * Fake HTTP headers implementation.
  *
- * @param data Headers data.
+ * @param data Headers data
  */
 case class FakeHeaders(data: Seq[(String, String)] = Seq.empty) extends Headers(data)
 

--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesCompiler.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesCompiler.scala
@@ -61,11 +61,11 @@ object RoutesCompiler {
   /**
    * A routes compiler task.
    *
-   * @param file The routes file to compile.
-   * @param additionalImports The additional imports.
-   * @param forwardsRouter Whether a forwards router should be generated.
-   * @param reverseRouter Whether a reverse router should be generated.
-   * @param namespaceReverseRouter Whether the reverse router should be namespaced.
+   * @param file The routes file to compile
+   * @param additionalImports The additional imports
+   * @param forwardsRouter Whether a forwards router should be generated
+   * @param reverseRouter Whether a reverse router should be generated
+   * @param namespaceReverseRouter Whether the reverse router should be namespaced
    */
   case class RoutesCompilerTask(file: File, additionalImports: Seq[String], forwardsRouter: Boolean, reverseRouter: Boolean, namespaceReverseRouter: Boolean)
 
@@ -75,7 +75,7 @@ object RoutesCompiler {
    * @param task The routes compilation task
    * @param generator The routes generator
    * @param generatedDir The directory to place the generated source code in
-   * @return Either the list of files that were generated (right) or the routes compilation errors (left)
+   * @return either the list of files that were generated (right) or the routes compilation errors (left)
    */
   def compile(task: RoutesCompilerTask, generator: RoutesGenerator, generatedDir: File): Either[Seq[RoutesCompilationError], Seq[File]] = {
 

--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
@@ -18,7 +18,7 @@ object RoutesFileParser {
    * Parse the given routes file
    *
    * @param routesFile The routes file to parse
-   * @return Either the list of compilation errors encountered, or a list of routing rules
+   * @return either the list of compilation errors encountered, or a list of routing rules
    */
   def parse(routesFile: File): Either[Seq[RoutesCompilationError], List[Rule]] = {
 
@@ -32,7 +32,7 @@ object RoutesFileParser {
    *
    * @param routesContent The content of the routes file
    * @param routesFile The routes file (used for error reporting)
-   * @return Either the list of compilation errors encountered, or a list of routing rules
+   * @return either the list of compilation errors encountered, or a list of routing rules
    */
   def parseContent(routesContent: String, routesFile: File): Either[Seq[RoutesCompilationError], List[Rule]] = {
     val parser = new RoutesFileParser()

--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesGenerator.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesGenerator.scala
@@ -14,7 +14,7 @@ trait RoutesGenerator {
    * @param task The routes compile task
    * @param namespace The namespace of the router
    * @param rules The routing rules
-   * @return A sequence of output filenames to file contents
+   * @return a sequence of output filenames to file contents
    */
   def generate(task: RoutesCompilerTask, namespace: Option[String], rules: List[Rule]): Seq[(String, String)]
 

--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesModels.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesModels.scala
@@ -40,11 +40,11 @@ case class HttpVerb(value: String) {
 /**
  * A call to the handler.
  *
- * @param packageName The handlers package.
- * @param controller The controllers class name.
- * @param instantiate Whether the controller needs to be instantiated dynamically.
- * @param method The method to invoke on the controller.
- * @param parameters The parameters to pass to the method.
+ * @param packageName The handlers package
+ * @param controller The controllers class name
+ * @param instantiate Whether the controller needs to be instantiated dynamically
+ * @param method The method to invoke on the controller
+ * @param parameters The parameters to pass to the method
  */
 case class HandlerCall(packageName: String, controller: String, instantiate: Boolean, method: String, parameters: Option[Seq[Parameter]]) extends Positional {
   val dynamic = if (instantiate) "@" else ""
@@ -56,10 +56,10 @@ case class HandlerCall(packageName: String, controller: String, instantiate: Boo
 /**
  * A parameter for a controller method.
  *
- * @param name The name of the parameter.
- * @param typeName The type of the parameter.
- * @param fixed The fixed value for the parameter, if defined.
- * @param default A default value for the parameter, if defined.
+ * @param name The name of the parameter
+ * @param typeName The type of the parameter
+ * @param fixed The fixed value for the parameter, if defined
+ * @param default A default value for the parameter, if defined
  */
 case class Parameter(name: String, typeName: String, fixed: Option[String], default: Option[String]) extends Positional {
   override def toString = name + ":" + typeName + fixed.map(" = " + _).getOrElse("") + default.map(" ?= " + _).getOrElse("")
@@ -78,9 +78,9 @@ trait PathPart
 /**
  * A dynamic part, which gets extracted into a parameter.
  *
- * @param name The name of the parameter that this part of the path gets extracted into.
- * @param constraint The regular expression used to match this part.
- * @param encode Whether this part should be encoded or not.
+ * @param name The name of the parameter that this part of the path gets extracted into
+ * @param constraint The regular expression used to match this part
+ * @param encode Whether this part should be encoded or not
  */
 case class DynamicPart(name: String, constraint: String, encode: Boolean) extends PathPart with Positional {
   override def toString = """DynamicPart("""" + name + "\", \"\"\"" + constraint + "\"\"\"," + encode + ")" //"

--- a/framework/src/run-support/src/main/scala/play/runsupport/AssetsClassLoader.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/AssetsClassLoader.scala
@@ -12,7 +12,7 @@ import Path._
  *
  * Serves assets from the given directories, at the given prefix.
  *
- * @param assets A list of assets directories, paired with the prefix they should be served from.
+ * @param assets A list of assets directories, paired with the prefix they should be served from
  */
 class AssetsClassLoader(parent: ClassLoader, assets: Seq[(String, File)]) extends ClassLoader(parent) {
   override def findResource(name: String) = {

--- a/framework/src/run-support/src/main/scala/play/runsupport/FileWatchService.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/FileWatchService.scala
@@ -25,18 +25,18 @@ trait FileWatchService {
   /**
    * Watch the given sequence of files or directories.
    *
-   * @param filesToWatch The files to watch.
-   * @param onChange A callback that is executed whenever something changes.
-   * @return A watcher
+   * @param filesToWatch The files to watch
+   * @param onChange A callback that is executed whenever something changes
+   * @return a watcher
    */
   def watch(filesToWatch: Seq[File], onChange: () => Unit): FileWatcher
 
   /**
    * Watch the given sequence of files or directories.
    *
-   * @param filesToWatch The files to watch.
-   * @param onChange A callback that is executed whenever something changes.
-   * @return A watcher
+   * @param filesToWatch The files to watch
+   * @param onChange A callback that is executed whenever something changes
+   * @return a watcher
    */
   def watch(filesToWatch: List[File], onChange: Callable[Void]): FileWatcher = {
     watch(JavaConversions.asScalaBuffer(filesToWatch), () => { onChange.call })

--- a/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -100,7 +100,7 @@ object Reloader {
   /**
    * Start the Play server in dev mode
    *
-   * @return A closeable that can be closed to stop the server
+   * @return a closeable that can be closed to stop the server
    */
   def startDevMode(runHooks: Seq[RunHook], javaOptions: Seq[String],
     dependencyClasspath: Classpath, dependencyClassLoader: ClassLoaderCreator,
@@ -287,7 +287,7 @@ class Reloader(
    * Since this communicates across classloaders, it must return only simple objects.
    *
    *
-   * @return Either
+   * @return either
    * - Throwable - If something went wrong (eg, a compile error).
    * - ClassLoader - If the classloader has changed, and the application should be reloaded.
    * - null - If nothing changed.


### PR DESCRIPTION
In follow-up of https://github.com/playframework/playframework/pull/4170 I used a couple of regexes and fixed up the docstrings in regard to trailing periods after `@param` and `@return`. Additionally I changed words after `@return` that started with an uppercase letter to a lowercase, except when not required (e.g. None, URL).

Are these changes welcome or am I too nitpicky bringing this up?