### PR TITLE
Allow to send a file with the Java nio API to allow to change the underlying filesystem

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
@@ -3,6 +3,8 @@
  */
 package play.api.libs.iteratee
 
+import java.nio.file.Files
+
 import play.api.libs.iteratee.Execution.Implicits.{ defaultExecutionContext => dec }
 import play.api.libs.iteratee.internal.{ eagerFuture, executeFuture }
 import scala.concurrent.{ ExecutionContext, Future, Promise, blocking }
@@ -580,6 +582,18 @@ object Enumerator {
    */
   def fromFile(file: java.io.File, chunkSize: Int = 1024 * 8)(implicit ec: ExecutionContext): Enumerator[Array[Byte]] = {
     fromStream(new java.io.FileInputStream(file), chunkSize)(ec)
+  }
+
+  /**
+   * Create an enumerator from the given input stream.
+   *
+   * Note that this enumerator will block when it reads from the file.
+   *
+   * @param path The file path to create the enumerator from.
+   * @param chunkSize The size of chunks to read from the file.
+   */
+  def fromPath(path: java.nio.file.Path, chunkSize: Int = 1024 * 8)(implicit ec: ExecutionContext): Enumerator[Array[Byte]] = {
+    fromStream(Files.newInputStream(path), chunkSize)(ec)
   }
 
   /**

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumeratorsSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumeratorsSpec.scala
@@ -3,6 +3,8 @@
  */
 package play.api.libs.iteratee
 
+import java.nio.file.Files
+
 import org.specs2.mutable._
 import java.io.{ ByteArrayInputStream, File, FileOutputStream, OutputStream }
 import java.util.concurrent.{ CountDownLatch, TimeUnit }
@@ -302,6 +304,24 @@ object EnumeratorsSpec extends Specification
           mustEnumerateTo(s)(enumerator)
         } finally {
           f.delete()
+        }
+      }
+    }
+  }
+
+  "Enumerator.fromPath" should {
+    "read bytes from a path" in {
+      mustExecute(3) { fromPathEC =>
+        val f = Files.createTempFile("EnumeratorSpec", "fromPath")
+        try {
+          val s = "hello"
+          val out = Files.newOutputStream(f)
+          out.write(s.getBytes)
+          out.close()
+          val enumerator = Enumerator.fromPath(f)(fromPathEC).map(new String(_))
+          mustEnumerateTo(s)(enumerator)
+        } finally {
+          Files.delete(f)
         }
       }
     }

--- a/framework/src/play/src/main/scala/play/core/j/JavaResults.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaResults.scala
@@ -43,7 +43,9 @@ object JavaResults extends Results with DefaultWriteables with DefaultContentTyp
   //play.api.libs.iteratee.Enumerator.imperative[A](onComplete = onDisconnected)
   def chunked(stream: java.io.InputStream, chunkSize: Int): Enumerator[Array[Byte]] = Enumerator.fromStream(stream, chunkSize)
   def chunked(file: java.io.File, chunkSize: Int) = Enumerator.fromFile(file, chunkSize)
+  def chunked(file: java.nio.file.Path, chunkSize: Int) = Enumerator.fromPath(file, chunkSize)
   def sendFile(status: play.api.mvc.Results.Status, file: java.io.File, inline: Boolean, filename: String) = status.sendFile(file, inline, _ => filename)
+  def sendPath(status: play.api.mvc.Results.Status, path: java.nio.file.Path, inline: Boolean, filename: String) = status.sendPath(path, inline, _ => filename)
 }
 
 object JavaResultExtractor {

--- a/framework/src/play/src/test/java/play/mvc/ResultsTest.java
+++ b/framework/src/play/src/test/java/play/mvc/ResultsTest.java
@@ -1,0 +1,78 @@
+package play.mvc;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+
+public class ResultsTest {
+
+  @Test(expected = NullPointerException.class)
+  public void shouldThrowNullPointerExceptionIfPathIsNull() throws IOException {
+    Results.ok().sendPath(null);
+  }
+
+  @Test
+  public void sendPathWithOKStatus() throws IOException {
+    Path file = Paths.get("test.tmp");
+    Files.createFile(file);
+    Results.Status status = Results.ok().sendPath(file);
+    Files.delete(file);
+
+    assertEquals(status.status(), Http.Status.OK);
+    assertEquals(status.header(Result.CONTENT_DISPOSITION), "attachment; filename=\"test.tmp\"");
+  }
+
+  @Test
+  public void sendPathWithUnauthorizedStatus() throws IOException {
+    Path file = Paths.get("test.tmp");
+    Files.createFile(file);
+    Results.Status status = Results.unauthorized().sendPath(file);
+    Files.delete(file);
+
+    assertEquals(status.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(status.header(Result.CONTENT_DISPOSITION), "attachment; filename=\"test.tmp\"");
+  }
+
+  @Test
+  public void sendPathInlineWithUnauthorizedStatus() throws IOException {
+    Path file = Paths.get("test.tmp");
+    Files.createFile(file);
+    Results.Status status = Results.unauthorized().sendPath(file, true);
+    Files.delete(file);
+
+    assertEquals(status.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(status.header(Result.CONTENT_DISPOSITION), null);
+  }
+
+  @Test
+  public void sendPathWithFileName() throws IOException {
+    Path file = Paths.get("test.tmp");
+    Files.createFile(file);
+    Results.Status status = Results.unauthorized().sendPath(file, false, "foo.bar");
+    Files.delete(file);
+
+    assertEquals(status.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(status.header(Result.CONTENT_DISPOSITION), "attachment; filename=\"foo.bar\"");
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void shouldThrowNullPointerExceptionIfPathIsNullForChunkedTransferEncoding() throws IOException {
+    Results.unauthorized().sendPath(null, 100);
+  }
+
+  @Test
+  public void sendPathWithChunkedTransferEncoding() throws IOException {
+    Path file = Paths.get("test.tmp");
+    Files.createFile(file);
+    Results.Status status = Results.unauthorized().sendPath(file, 100);
+    Files.delete(file);
+
+    assertEquals(status.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(status.header(Result.TRANSFER_ENCODING), "chunked");
+  }
+}

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -3,6 +3,8 @@
  */
 package play.api.mvc
 
+import java.nio.file.{ Files, Paths }
+
 import org.specs2.mutable._
 import play.api.libs.iteratee.{ Iteratee, Enumerator }
 import scala.concurrent.Await
@@ -136,6 +138,7 @@ object ResultsSpec extends Specification {
       (rh.status aka "status" must_== OK) and
         (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome("""attachment; filename="test.tmp""""))
     }
+
     "support sending a file with Unauthorized status" in {
       val file = new java.io.File("test.tmp")
       file.createNewFile()
@@ -151,6 +154,36 @@ object ResultsSpec extends Specification {
       file.createNewFile()
       val rh = Unauthorized.sendFile(file, inline = true).header
       file.delete()
+
+      (rh.status aka "status" must_== UNAUTHORIZED) and
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beNone)
+    }
+
+    "support sending a path with Ok status" in {
+      val file = Paths.get("test.tmp")
+      Files.createFile(file)
+      val rh = Ok.sendPath(file).header
+      Files.delete(file)
+
+      (rh.status aka "status" must_== OK) and
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome("""attachment; filename="test.tmp""""))
+    }
+
+    "support sending a path with Unauthorized status" in {
+      val file = Paths.get("test.tmp")
+      Files.createFile(file)
+      val rh = Unauthorized.sendPath(file).header
+      Files.delete(file)
+
+      (rh.status aka "status" must_== UNAUTHORIZED) and
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome("""attachment; filename="test.tmp""""))
+    }
+
+    "support sending a path inline with Unauthorized status" in {
+      val file = Paths.get("test.tmp")
+      Files.createFile(file)
+      val rh = Unauthorized.sendPath(file, inline = true).header
+      Files.delete(file)
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
         (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beNone)


### PR DESCRIPTION
This pull request allows to send a file with the `java.nio.file.Path` API in addition to the old `java.io.File` API. This allows a user to change the underlying filesystem during testing.

This is a WIP pull request, because I would like to discuss some implementation details. The current implementation adds a new method `sendPath` because it isn't possible to overload the method `sendFile` because of its default arguments. An other possibility would be to add an implicit converter which converts a `java.io.File` instance into a `java.nio.file.Path` instance. This converter could be placed into the `play.api.mvc.Results` trait. But this had the disadvantage that `Ok.sendFile` would work but `Results.Ok.sendFile` would not based on the used import.

Any suggestion would be highly appreciated.