### PR TITLE
Response should include Date header by default

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -40,6 +40,10 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       }
     }
 
+    "add Date header" in makeRequest(Results.Ok("Hello world")) { response =>
+      response.header(DATE) must beSome
+    }
+
     "add Content-Length when enumerator contains a single item" in makeRequest(Results.Ok("Hello world")) { response =>
       response.header(CONTENT_LENGTH) must beSome("11")
       response.body must_== "Hello world"
@@ -335,7 +339,7 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       }
 
     "return a 500 response if a forbidden character is used in a response's header field" in withServer(
-      // both colon and space characters are not allowed in a header's field name 
+      // both colon and space characters are not allowed in a header's field name
       Results.Ok.withHeaders("BadFieldName: " -> "SomeContent")
     ) { port =>
         val response = BasicHttpClient.makeRequests(port)(

--- a/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
+++ b/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
@@ -140,9 +140,10 @@ trait GlobalSettings {
       val context = Play.maybeApplication.fold("") { app =>
         httpConfigurationCache(app).context.stripSuffix("/")
       }
+      val inContext = context.isEmpty || request.path == context || request.path.startsWith(context + "/")
       next(request) match {
-        case action: EssentialAction if context.isEmpty || request.path == context || request.path.startsWith(context + "/") =>
-          doFilter(action)
+        case action: EssentialAction =>
+          HttpRequestHandler.defaultFilter(if (inContext) doFilter(action) else action)
         case handler => handler
       }
   }

--- a/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -3,9 +3,9 @@
  */
 package play.api.http
 
-import java.util.regex.Pattern
 import javax.inject.{ Provider, Inject }
 
+import org.joda.time.DateTime
 import play.api.inject.{ BindingKey, Binding }
 import play.api.libs.iteratee.Done
 import play.api.{ PlayConfig, Configuration, Environment, GlobalSettings }
@@ -61,6 +61,20 @@ object HttpRequestHandler {
             javaComponentsBinding
           )
       }
+  }
+
+  // This filter, applied to all requests, can be used to make sure required headers are present
+  private[play] val defaultFilter: EssentialFilter = new EssentialFilter {
+    import play.api.libs.concurrent.Execution.Implicits._
+    def apply(next: EssentialAction) = new EssentialAction {
+      def apply(rh: RequestHeader) = next(rh) map { result =>
+        if (result.header.headers.get(HeaderNames.DATE).isDefined) {
+          result
+        } else {
+          result.withDateHeaders(HeaderNames.DATE -> DateTime.now())
+        }
+      }
+    }
   }
 }
 
@@ -144,7 +158,8 @@ class DefaultHttpRequestHandler(router: Router, errorHandler: HttpErrorHandler, 
   protected def filterHandler(next: RequestHeader => Handler): (RequestHeader => Handler) = {
     (request: RequestHeader) =>
       next(request) match {
-        case action: EssentialAction if inContext(request.path) => filterAction(action)
+        case action: EssentialAction =>
+          HttpRequestHandler.defaultFilter(if (inContext(request.path)) filterAction(action) else action)
         case handler => handler
       }
   }

--- a/framework/src/play/src/test/scala/play/api/controllers/AssetsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/controllers/AssetsSpec.scala
@@ -4,6 +4,7 @@
 package controllers
 
 import org.specs2.mutable.Specification
+import play.api.mvc.ResponseHeader
 import play.utils.InvalidUriEncodingException
 
 object AssetsSpec extends Specification {
@@ -102,7 +103,7 @@ object AssetsSpec extends Specification {
     "use the unescaped path when finding the last modified date of an asset" in {
       val url = AssetsSpec.getClass.getClassLoader.getResource("file withspace.css")
       val assetInfo = new AssetInfo("file withspace.css", url, None, None)
-      val lastModified = AssetInfo.dateFormat.parseDateTime(assetInfo.lastModified.get)
+      val lastModified = ResponseHeader.httpDateFormat.parseDateTime(assetInfo.lastModified.get)
       // If it uses the escaped path, the file won't be found, and so last modified will be 0
       lastModified.toDate.getTime must_!= 0
     }

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -5,6 +5,7 @@ package play.api.mvc
 
 import java.nio.file.{ Files, Paths }
 
+import org.joda.time.{ DateTimeZone, DateTime }
 import org.specs2.mutable._
 import play.api.libs.iteratee.{ Iteratee, Enumerator }
 import scala.concurrent.Await
@@ -38,11 +39,18 @@ object ResultsSpec extends Specification {
       val Result(ResponseHeader(_, headers, _), _, _) =
         Ok("hello").as("text/html").withHeaders("Set-Cookie" -> "yes", "X-YOP" -> "1", "X-Yop" -> "2")
 
-      headers.size must be_==(3)
+      headers.size must_== 3
       headers must havePair("Content-Type" -> "text/html")
       headers must havePair("Set-Cookie" -> "yes")
       headers must not havePair ("X-YOP" -> "1")
       headers must havePair("X-Yop" -> "2")
+    }
+
+    "support date headers manipulation" in {
+      val Result(ResponseHeader(_, headers, _), _, _) =
+        Ok("hello").as("text/html").withDateHeaders(DATE ->
+          new DateTime(2015, 4, 1, 0, 0).withZoneRetainFields(DateTimeZone.UTC))
+      headers must havePair(DATE -> "Wed, 01 Apr 2015 00:00:00 GMT")
     }
 
     "support cookies helper" in {


### PR DESCRIPTION
Per https://tools.ietf.org/html/rfc7231#section-7.1.1.2

```
   An origin server MUST NOT send a Date header field if it does not
   have a clock capable of providing a reasonable approximation of the
   current instance in Coordinated Universal Time.  An origin server MAY
   send a Date header field if the response is in the 1xx
   (Informational) or 5xx (Server Error) class of status codes.  An
   origin server MUST send a Date header field in all other cases.
```

It's that **An origin server MUST send a Date header field in all other cases** that is the issue -- Play does not currently include a Date header in a generated response by default, only for Assets:

https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/api/controllers/Assets.scala#L395

