### PR TITLE
Removed dependency on Typesafe releases repo

### DIFF
--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -25,10 +25,12 @@ sbt.version=0.13.8
 
 ### Specs2 support in a separate module
 
-If you were previously using Play's specs2 support, you now need to explicitly add a dependency on that to your project:
+If you were previously using Play's specs2 support, you now need to explicitly add a dependency on that to your project.  Additionally, specs2 now requires `scalaz-stream` which isn't available on maven central or any other repositories that sbt uses by default, so you need to add the `scalaz-stream` repository as a resolver:
 
 ```scala
 libraryDependencies += specs2 % Test
+
+resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 ```
 
 ### IntelliJ IDEA

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -139,7 +139,7 @@ object Dependencies {
 
   val netty = Seq(
     "io.netty"           % "netty"                 % "3.10.1.Final",
-    "com.typesafe.netty" % "netty-http-pipelining" % "1.1.3"
+    "com.typesafe.netty" % "netty-http-pipelining" % "1.1.4"
   ) ++ specsBuild.map(_ % Test)
 
   val akkaHttp = Seq(

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -48,10 +48,6 @@ object PlaySettings {
 
     playPlugin := false,
 
-    resolvers ++= Seq(
-      "Typesafe Releases Repository" at "https://repo.typesafe.com/typesafe/releases/"
-    ),
-
     externalizeResources := true,
 
     javacOptions in (Compile, doc) := List("-encoding", "utf8"),

--- a/templates/play-scala/build.sbt
+++ b/templates/play-scala/build.sbt
@@ -13,6 +13,8 @@ libraryDependencies ++= Seq(
   specs2 % Test
 )
 
+resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
+
 // Play provides two styles of routers, one expects its actions to be injected, the
 // other, legacy style, accesses its actions statically.
 routesGenerator := InjectedRoutesGenerator


### PR DESCRIPTION
Fixes #3436.

* Upgraded to netty-http-pipelining 1.1.4 (which is now deployed to maven central)
* Removed Typesafe releases repo resolvers from play settings

I tested this locally with a clean ivy cache, and found an additional issue that specs2 now depends on scalaz-stream as a required dependency, so a note was added to the migration guide and the play scala template has been updated.

Note that this only removes the dependency on the Typesafe releases repo for compile/runtime dependencies.  For build dependencies (sbt plugins etc) this is being tracked in #4223.