### PR TITLE
Fixing #2042: Correctly close and unbind JPA EntityManager.

### DIFF
--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -131,7 +131,7 @@ public class DefaultJPAApi implements JPAApi {
                 throw new RuntimeException("No JPA entity manager defined for '" + name + "'");
             }
 
-            JPA.bindForCurrentThread(em);
+            JPA.bindForSync(em);
 
             if (!readOnly) {
                 tx = em.getTransaction();
@@ -156,7 +156,7 @@ public class DefaultJPAApi implements JPAApi {
             }
             throw t;
         } finally {
-            JPA.bindForCurrentThread(null);
+            JPA.bindForSync(null);
             if (em != null) {
                 em.close();
             }
@@ -176,7 +176,7 @@ public class DefaultJPAApi implements JPAApi {
         try {
 
             em = em(name);
-            JPA.bindForCurrentThread(em);
+            JPA.bindForAsync(em);
 
             if (!readOnly) {
                 tx = em.getTransaction();
@@ -211,7 +211,7 @@ public class DefaultJPAApi implements JPAApi {
                     try {
                         fem.close();
                     } finally {
-                        JPA.bindForCurrentThread(null);
+                        JPA.bindForAsync(null);
                     }
                 }
             });
@@ -221,7 +221,7 @@ public class DefaultJPAApi implements JPAApi {
                     try {
                         fem.close();
                     } finally {
-                        JPA.bindForCurrentThread(null);
+                        JPA.bindForAsync(null);
                     }
                 }
             });
@@ -236,7 +236,7 @@ public class DefaultJPAApi implements JPAApi {
                 try {
                     em.close();
                 } finally {
-                    JPA.bindForCurrentThread(null);
+                    JPA.bindForAsync(null);
                 }
             }
             throw t;

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -90,10 +90,7 @@ public class DefaultJPAApi implements JPAApi {
      * Run a block of asynchronous code in a JPA transaction.
      *
      * @param block Block of code to execute
-     *
-     * @deprecated This may cause deadlocks
      */
-    @Deprecated
     public <T> F.Promise<T> withTransactionAsync(play.libs.F.Function0<F.Promise<T>> block) throws Throwable {
         return withTransactionAsync("default", false, block);
     }
@@ -172,10 +169,7 @@ public class DefaultJPAApi implements JPAApi {
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
      * @param block Block of code to execute.
-     *
-     * @deprecated This may cause deadlocks
      */
-    @Deprecated
     public <T> F.Promise<T> withTransactionAsync(String name, boolean readOnly, play.libs.F.Function0<F.Promise<T>> block) throws Throwable {
         EntityManager em = null;
         EntityTransaction tx = null;

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
@@ -105,10 +105,7 @@ public class JPA {
      * Run a block of asynchronous code in a JPA transaction.
      *
      * @param block Block of code to execute.
-     *
-     * @deprecated This may cause deadlocks
      */
-    @Deprecated
     public static <T> F.Promise<T> withTransactionAsync(play.libs.F.Function0<F.Promise<T>> block) throws Throwable {
         return jpaApi().withTransactionAsync(block);
     }
@@ -139,10 +136,7 @@ public class JPA {
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
      * @param block Block of code to execute.
-     *
-     * @deprecated This may cause deadlocks
      */
-    @Deprecated
     public static <T> F.Promise<T> withTransactionAsync(String name, boolean readOnly, play.libs.F.Function0<F.Promise<T>> block) throws Throwable {
         return jpaApi().withTransactionAsync(name, readOnly, block);
     }

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
@@ -17,6 +17,8 @@ public class JPA {
     // Only used when there's no HTTP context
     static ThreadLocal<EntityManager> currentEntityManager = new ThreadLocal<EntityManager>();
 
+    private static final String CURRENT_ENTITY_MANAGER = "currentEntityManager";
+
     /**
      * Create a default JPAApi with the given persistence unit configuration.
      * Automatically initialise the JPA entity manager factories.
@@ -62,9 +64,9 @@ public class JPA {
     public static EntityManager em() {
         Http.Context context = Http.Context.current.get();
         if (context != null) {
-            EntityManager em = (EntityManager) context.args.get("currentEntityManager");
+            EntityManager em = (EntityManager) context.args.get(CURRENT_ENTITY_MANAGER);
             if (em == null) {
-                throw new RuntimeException("No EntityManager bound to this thread. Try to annotate your action method with @play.db.jpa.Transactional");
+                throw new RuntimeException("No EntityManager found in the context. Try to annotate your action method with @play.db.jpa.Transactional");
             }
             return em;
         }
@@ -77,18 +79,42 @@ public class JPA {
     }
 
     /**
-     * Bind an EntityManager to the current thread.
+     * Bind an EntityManager to the current HTTP context.
+     * If no HTTP context is available the EntityManager gets bound to the current thread instead.
      */
-    public static void bindForCurrentThread(EntityManager em) {
+    public static void bindForSync(EntityManager em) {
+        bindForCurrentContext(em, true);
+    }
+
+    /**
+     * Bind an EntityManager to the current HTTP context.
+     *
+     * @throws RuntimeException if no HTTP context is present.
+     */
+    public static void bindForAsync(EntityManager em) {
+        bindForCurrentContext(em, false);
+    }
+
+    /**
+     * Bind an EntityManager to the current HTTP context.
+     *
+     * @throws RuntimeException if no HTTP context is present and {@code threadLocalFallback} is false.
+     */
+    private static void bindForCurrentContext(EntityManager em, boolean threadLocalFallback) {
         Http.Context context = Http.Context.current.get();
         if (context != null) {
             if (em == null) {
-                context.args.remove("currentEntityManager");
+                context.args.remove(CURRENT_ENTITY_MANAGER);
             } else {
-                context.args.put("currentEntityManager", em);
+                context.args.put(CURRENT_ENTITY_MANAGER, em);
             }
         } else {
-            currentEntityManager.set(em);
+            // Not a web request
+            if(threadLocalFallback) {
+                currentEntityManager.set(em);
+            } else {
+                throw new RuntimeException("No Http.Context is present. If you want to invoke this method outside of a HTTP request, you need to wrap the call with JPA.withTransaction instead.");
+            }
         }
     }
 

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
@@ -34,10 +34,7 @@ public interface JPAApi {
      * Run a block of asynchronous code in a JPA transaction.
      *
      * @param block Block of code to execute
-     *
-     * @deprecated This may cause deadlocks
      */
-    @Deprecated
     public <T> F.Promise<T> withTransactionAsync(play.libs.F.Function0<F.Promise<T>> block) throws Throwable;
 
     /**
@@ -62,10 +59,7 @@ public interface JPAApi {
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
      * @param block Block of code to execute.
-     *
-     * @deprecated This may cause deadlocks
      */
-    @Deprecated
     public <T> F.Promise<T> withTransactionAsync(String name, boolean readOnly, play.libs.F.Function0<F.Promise<T>> block) throws Throwable;
 
     /**

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/TransactionalAction.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/TransactionalAction.java
@@ -15,7 +15,7 @@ import javax.persistence.*;
 public class TransactionalAction extends Action<Transactional> {
     
     public F.Promise<Result> call(final Context ctx) throws Throwable {
-        return JPA.withTransaction(
+        return JPA.withTransactionAsync(
             configuration.value(),
             configuration.readOnly(),
             new play.libs.F.Function0<F.Promise<Result>>() {


### PR DESCRIPTION
This PR is based on @schaloner's [work](https://github.com/schaloner/async-transactions/blob/master/code/app/be/objectify/as/AsyncJPA.java) to fix #2042:
```
[RuntimeException: No EntityManager bound to this thread. Try to annotate your action method with @play.db.jpa.Transactional] 
```
A detailed discussion around this issue can also be found [at this deadbolt issue](https://github.com/schaloner/deadbolt-2-java/issues/7).

Basically the `EntityManager` was [removed from the thread](https://github.com/playframework/playframework/blob/ca664a7d108c24e08e86fb815e7104fcf326bf6e/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java#L235-L237) to early, often before the code block accessing the `EntityManager` [had a chance to be executed](https://github.com/playframework/playframework/blob/ca664a7d108c24e08e86fb815e7104fcf326bf6e/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java#L192-L213) resulting in the above exception. This fix now moves the unbind/close of the em from the last finally block into the `onFailure()` and `onRedeem()` handlers where it belongs. Crucially, when using `withTransactionAsync()`, we can not use a `ThreadLocal` anymore to bind the `EntityManager`, because the `onFailure()` and `onRedeem()` could be executed in a different thread.

The PR [attached to #2042](https://github.com/playframework/playframework/pull/2042/files) from @jroper did not target nor fix this issue at all so I reverted it.