### PR TITLE
Correctly close and unbind JPA EntityManager

### DIFF
--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -126,7 +126,7 @@ public class DefaultJPAApi implements JPAApi {
                 throw new RuntimeException("No JPA entity manager defined for '" + name + "'");
             }
 
-            JPA.bindForCurrentThread(em);
+            JPA.bindForSync(em);
 
             if (!readOnly) {
                 tx = em.getTransaction();
@@ -151,7 +151,7 @@ public class DefaultJPAApi implements JPAApi {
             }
             throw t;
         } finally {
-            JPA.bindForCurrentThread(null);
+            JPA.bindForSync(null);
             if (em != null) {
                 em.close();
             }
@@ -174,7 +174,7 @@ public class DefaultJPAApi implements JPAApi {
         try {
 
             em = em(name);
-            JPA.bindForCurrentThread(em);
+            JPA.bindForAsync(em);
 
             if (!readOnly) {
                 tx = em.getTransaction();
@@ -207,14 +207,14 @@ public class DefaultJPAApi implements JPAApi {
                 try {
                     fem.close();
                 } finally {
-                    JPA.bindForCurrentThread(null);
+                    JPA.bindForAsync(null);
                 }
             });
             committedResult.onRedeem(t -> {
                 try {
                     fem.close();
                 } finally {
-                    JPA.bindForCurrentThread(null);
+                    JPA.bindForAsync(null);
                 }
             });
 
@@ -228,7 +228,7 @@ public class DefaultJPAApi implements JPAApi {
                 try {
                     em.close();
                 } finally {
-                    JPA.bindForCurrentThread(null);
+                    JPA.bindForAsync(null);
                 }
             }
             throw t;

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -189,16 +189,12 @@ public class DefaultJPAApi implements JPAApi {
             F.Promise<T> committedResult = result.map(new F.Function<T, T>() {
                 @Override
                 public T apply(T t) throws Throwable {
-                    try {
-                        if (ftx != null) {
-                            if (ftx.getRollbackOnly()) {
-                                ftx.rollback();
-                            } else {
-                                ftx.commit();
-                            }
+                    if (ftx != null) {
+                        if (ftx.getRollbackOnly()) {
+                            ftx.rollback();
+                        } else {
+                            ftx.commit();
                         }
-                    } finally {
-                        fem.close();
                     }
                     return t;
                 }
@@ -206,9 +202,20 @@ public class DefaultJPAApi implements JPAApi {
 
             committedResult.onFailure(t -> {
                 if (ftx != null) {
-                    try { if (ftx.isActive()) ftx.rollback(); } catch (Throwable e) {}
+                    try { if (ftx.isActive()) { ftx.rollback(); } } catch (Throwable e) {}
                 }
-                fem.close();
+                try {
+                    fem.close();
+                } finally {
+                    JPA.bindForCurrentThread(null);
+                }
+            });
+            committedResult.onRedeem(t -> {
+                try {
+                    fem.close();
+                } finally {
+                    JPA.bindForCurrentThread(null);
+                }
             });
 
             return committedResult;
@@ -218,11 +225,13 @@ public class DefaultJPAApi implements JPAApi {
                 try { tx.rollback(); } catch (Throwable e) {}
             }
             if (em != null) {
-                em.close();
+                try {
+                    em.close();
+                } finally {
+                    JPA.bindForCurrentThread(null);
+                }
             }
             throw t;
-        } finally {
-            JPA.bindForCurrentThread(null);
         }
     }
 

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
@@ -17,6 +17,8 @@ public class JPA {
     // Only used when there's no HTTP context
     static ThreadLocal<EntityManager> currentEntityManager = new ThreadLocal<EntityManager>();
 
+    private static final String CURRENT_ENTITY_MANAGER = "currentEntityManager";
+
     /**
      * Create a default JPAApi with the given persistence unit configuration.
      * Automatically initialise the JPA entity manager factories.
@@ -62,9 +64,9 @@ public class JPA {
     public static EntityManager em() {
         Http.Context context = Http.Context.current.get();
         if (context != null) {
-            EntityManager em = (EntityManager) context.args.get("currentEntityManager");
+            EntityManager em = (EntityManager) context.args.get(CURRENT_ENTITY_MANAGER);
             if (em == null) {
-                throw new RuntimeException("No EntityManager bound to this thread. Try to annotate your action method with @play.db.jpa.Transactional");
+                throw new RuntimeException("No EntityManager found in the context. Try to annotate your action method with @play.db.jpa.Transactional");
             }
             return em;
         }
@@ -77,18 +79,42 @@ public class JPA {
     }
 
     /**
-     * Bind an EntityManager to the current thread.
+     * Bind an EntityManager to the current HTTP context.
+     * If no HTTP context is available the EntityManager gets bound to the current thread instead.
      */
-    public static void bindForCurrentThread(EntityManager em) {
+    public static void bindForSync(EntityManager em) {
+        bindForCurrentContext(em, true);
+    }
+
+    /**
+     * Bind an EntityManager to the current HTTP context.
+     *
+     * @throws RuntimeException if no HTTP context is present.
+     */
+    public static void bindForAsync(EntityManager em) {
+        bindForCurrentContext(em, false);
+    }
+
+    /**
+     * Bind an EntityManager to the current HTTP context.
+     *
+     * @throws RuntimeException if no HTTP context is present and {@code threadLocalFallback} is false.
+     */
+    private static void bindForCurrentContext(EntityManager em, boolean threadLocalFallback) {
         Http.Context context = Http.Context.current.get();
         if (context != null) {
             if (em == null) {
-                context.args.remove("currentEntityManager");
+                context.args.remove(CURRENT_ENTITY_MANAGER);
             } else {
-                context.args.put("currentEntityManager", em);
+                context.args.put(CURRENT_ENTITY_MANAGER, em);
             }
         } else {
-            currentEntityManager.set(em);
+            // Not a web request
+            if(threadLocalFallback) {
+                currentEntityManager.set(em);
+            } else {
+                throw new RuntimeException("No Http.Context is present. If you want to invoke this method outside of a HTTP request, you need to wrap the call with JPA.withTransaction instead.");
+            }
         }
     }
 


### PR DESCRIPTION
@jroper Unfortunately I can not re-open #4225 so I created this new PR.
I removed the commit which reverted your fix for #2042.
The rest is the same.
I believe the close/unbind of the em should still be in `onFailure` and `onRedeem` instead of the finally.