### PR TITLE
Two files with same name are both watched

### DIFF
--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/some.txt.0
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/some.txt.0
@@ -1,0 +1,1 @@
+original

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/some.txt.1
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/some.txt.1
@@ -1,0 +1,1 @@
+changed

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/public/a/some.txt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/public/a/some.txt
@@ -1,0 +1,1 @@
+original

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/public/b/some.txt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/public/b/some.txt
@@ -1,0 +1,1 @@
+original

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
@@ -38,8 +38,18 @@ $ copy-file changes/new.css.1 public/new/new.css
 $ delete public/new/new.css
 > verifyResourceContains /assets/new/new.css 404
 
+# Two files with the same name change detection
+> verifyResourceContains /assets/a/some.txt 200 original
+> verifyResourceContains /assets/b/some.txt 200 original
+$ copy-file changes/some.txt.1 public/a/some.txt
+> verifyResourceContains /assets/a/some.txt 200 changed
+$ copy-file changes/some.txt.1 public/b/some.txt
+> verifyResourceContains /assets/b/some.txt 200 changed
+
 > playStop
 $ copy-file changes/some.css.0 public/css/some.css
+$ copy-file changes/some.txt.0 public/a/some.txt
+$ copy-file changes/some.txt.0 public/b/some.txt
 $ delete public/new
 
 # JDK7 watcher
@@ -68,8 +78,18 @@ $ copy-file changes/new.css.1 public/new/new.css
 $ delete public/new/new.css
 > verifyResourceContains /assets/new/new.css 404
 
+# Two files with the same name change detection
+> verifyResourceContains /assets/a/some.txt 200 original
+> verifyResourceContains /assets/b/some.txt 200 original
+$ copy-file changes/some.txt.1 public/a/some.txt
+> verifyResourceContains /assets/a/some.txt 200 changed
+$ copy-file changes/some.txt.1 public/b/some.txt
+> verifyResourceContains /assets/b/some.txt 200 changed
+
 > playStop
 $ copy-file changes/some.css.0 public/css/some.css
+$ copy-file changes/some.txt.0 public/a/some.txt
+$ copy-file changes/some.txt.0 public/b/some.txt
 $ delete public/new
 
 # JNotify watch service
@@ -98,8 +118,18 @@ $ copy-file changes/new.css.1 public/new/new.css
 $ delete public/new/new.css
 > verifyResourceContains /assets/new/new.css 404
 
+# Two files with the same name change detection
+> verifyResourceContains /assets/a/some.txt 200 original
+> verifyResourceContains /assets/b/some.txt 200 original
+$ copy-file changes/some.txt.1 public/a/some.txt
+> verifyResourceContains /assets/a/some.txt 200 changed
+$ copy-file changes/some.txt.1 public/b/some.txt
+> verifyResourceContains /assets/b/some.txt 200 changed
+
 > playStop
 $ copy-file changes/some.css.0 public/css/some.css
+$ copy-file changes/some.txt.0 public/a/some.txt
+$ copy-file changes/some.txt.0 public/b/some.txt
 $ delete public/new
 
 # Reloader tests


### PR DESCRIPTION
Fixes #4208

If two files had the same name (in different directories), the sbt watcher only watched one of them.  This fixes that.