### PR TITLE
Changing RoutesCompiler and Router to work with controller definitions with 22+ parameters

### DIFF
--- a/framework/src/play/src/main/scala/play/core/routing/GeneratedRouter.scala
+++ b/framework/src/play/src/main/scala/play/core/routing/GeneratedRouter.scala
@@ -99,6 +99,8 @@ abstract class GeneratedRouter extends Router {
     pa.value.fold(badRequest, generator)
   }
 
+  //Keep the old versions for avoiding compiler failures while building for Scala 2.10,
+  // and for avoiding warnings when building for Scala 2.11
   def call[A1, A2](pa1: Param[A1], pa2: Param[A2])(generator: Function2[A1, A2, Handler]): Handler = {
     (for (a1 <- pa1.value.right; a2 <- pa2.value.right)
       yield (a1, a2))
@@ -219,6 +221,8 @@ abstract class GeneratedRouter extends Router {
       .fold(badRequest, { case (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21) => generator(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21) })
   }
 
+  def call[T](params: List[Param[_]])(generator: (Seq[_]) => Handler): Handler =
+    (params.foldLeft[Either[String, Seq[_]]](Right(Seq[T]())) { (seq, param) => seq.right.flatMap(s => param.value.right.map(s :+ _)) }).fold(badRequest, generator)
   def fakeValue[A]: A = throw new UnsupportedOperationException("Can't get a fake value")
 
   /**

--- a/framework/src/routes-compiler/src/test/resources/generating.routes
+++ b/framework/src/routes-compiler/src/test/resources/generating.routes
@@ -1,1 +1,2 @@
 GET    /foo     controllers.FooController.foo(bar: Boolean = false)
+GET /foo/lotsOfParams controller.FooController.lotsOfParams(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int, i: Int, j: Int, k: String, l: String, m: String, n: String, o: String, p: String, q: Option[Int], r: Option[Int], s: Option[Int], t: Option[Int], u: Option[String], v: Float, w: Float, x: Int)

--- a/framework/src/routes-compiler/src/test/scala/play/routes/compiler/RoutesFileParserSpec.scala
+++ b/framework/src/routes-compiler/src/test/scala/play/routes/compiler/RoutesFileParserSpec.scala
@@ -83,6 +83,18 @@ object RoutesFileParserSpec extends Specification {
       parseRoute("GET /s p.c.m(s1, s2)").call.parameters must_== Some(Seq(Parameter("s1", "String", None, None), Parameter("s2", "String", None, None)))
     }
 
+    "parse method with more than 22 arguments" in {
+      parseRoute("GET /s p.c.m(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int, i: Int, j: Int, k: String, l: String, m: String, n: String, " +
+        "o: String, p: String, q: Option[Int], r: Option[Int], s: Option[Int], t: Option[Int], u: Option[String], v: Float, w: Float, x: Int)").call.parameters must_==
+        Some(Seq(Parameter("a", "Int", None, None), Parameter("b", "Int", None, None), Parameter("c", "Int", None, None), Parameter("d", "Int", None, None),
+          Parameter("e", "Int", None, None), Parameter("f", "Int", None, None), Parameter("g", "Int", None, None), Parameter("h", "Int", None, None),
+          Parameter("i", "Int", None, None), Parameter("j", "Int", None, None), Parameter("k", "String", None, None), Parameter("l", "String", None, None),
+          Parameter("m", "String", None, None), Parameter("n", "String", None, None), Parameter("o", "String", None, None), Parameter("p", "String", None, None),
+          Parameter("q", "Option[Int]", None, None), Parameter("r", "Option[Int]", None, None), Parameter("s", "Option[Int]", None, None),
+          Parameter("t", "Option[Int]", None, None), Parameter("u", "Option[String]", None, None), Parameter("v", "Float", None, None),
+          Parameter("w", "Float", None, None), Parameter("x", "Int", None, None)))
+    }
+
     "parse argument type" in {
       parseRoute("GET /s p.c.m(i: Int)").call.parameters.get.head.typeName must_== "Int"
     }


### PR DESCRIPTION
Fixes #4243 
The change intends to be as minimal and as less intrusive as possible. It removes the coupling between call method and FunctionN, so that controllers with an arbitrary amount of parameters can be used in routes definitions.
Quoting @jroper:
Performance wise, it introduces a new instanceof check for each parameter, since the type information is lost and then regained in the extractor.  I don't think that's anything to worry about, our performance tests should pick up any regressions here anyway.  If it were a problem, we could keep the callN methods for, say, up to 6 parameters, and switch to using a list for anything over that.  But I don't think it's a big deal.

