### PR TITLE
Support unbound regular expressions in routes

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/routing/JavaRoutingDsl.md
+++ b/documentation/manual/working/javaGuide/advanced/routing/JavaRoutingDsl.md
@@ -29,6 +29,10 @@ In the above examples, the type of the parameters in the lambdas is undeclared, 
 
 Supported types include `Integer`, `Long`, `Float`, `Double`, `Boolean`, and any type that extends [`PathBindable`](api/java/play/mvc/PathBindable.html).
 
+And you can use regular expressions without capturing the value of the match, using the `<regex>` syntax. For example, `/user<s?>` will match both `/user` and `/users`.
+
+Note: If you use regular expressions in a route, make sure they do not contain capturing groups, as these can interfere with the extraction of values.
+
 Asynchronous actions are of course also supported, using the `routeAsync` method:
 
 @[async](code/javaguide/advanced/routing/JavaRoutingDsl.java)

--- a/documentation/manual/working/javaGuide/main/http/JavaRouting.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaRouting.md
@@ -78,6 +78,10 @@ You can also define your own regular expression for a dynamic part, using the `$
     
 @[regex-path](code/javaguide.http.routing.routes)
 
+And you can use regular expressions without capturing the value of the match, using the `<regex>` syntax. For example, `/user<s?>` will match both `/user` and `/users`.
+
+Note: If you use regular expressions in a route, make sure they do not contain capturing groups, as these can interfere with the extraction of values.
+
 ## Call to action generator method
 
 The last part of a route definition is the call. This part must define a valid call to an action method.

--- a/documentation/manual/working/scalaGuide/advanced/routing/ScalaSirdRouter.md
+++ b/documentation/manual/working/scalaGuide/advanced/routing/ScalaSirdRouter.md
@@ -23,6 +23,10 @@ Regular expressions are also supported, by postfixing the parameter with a regul
 
 @[regexp](code/ScalaSirdRouter.scala)
 
+And you can use regular expressions without capturing the value of the match, using the `<regex>` syntax. For example, `/user<s?>` will match both `/user` and `/users`.
+
+Note: If you use regular expressions in a route, make sure they do not contain capturing groups, as these can interfere with the extraction of values.
+
 Query parameters can also be extracted, using the `?` operator to do further extractions on the request, and using the `q` extractor:
 
 @[required](code/ScalaSirdRouter.scala)

--- a/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
@@ -76,6 +76,10 @@ You can also define your own regular expression for the dynamic part, using the 
     
 @[regex-path](code/scalaguide.http.routing.routes)
 
+And you can use regular expressions without capturing the value of the match, using the `<regex>` syntax. For example, `/user<s?>` will match both `/user` and `/users`.
+
+Note: If you use regular expressions in a route, make sure they do not contain capturing groups, as these can interfere with the extraction of values.
+
 ## Call to the Action generator method
 
 The last part of a route definition is the call. This part must define a valid call to a method returning a `play.api.mvc.Action` value, which will typically be a controller action method.

--- a/framework/src/play-integration-test/src/test/java/play/routing/RoutingDslTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/routing/RoutingDslTest.java
@@ -194,7 +194,18 @@ public class RoutingDslTest {
         assertThat(makeRequest(router, "GET", "/hello/world"), equalTo("Hello world"));
         assertNull(makeRequest(router, "GET", "/hello/10"));
     }
-    
+
+    @Test
+    public void unboundRegex() {
+        Router router = new RoutingDsl()
+                .GET("/<(?:hello|hi)>/:to").routeTo((to) -> Results.ok("Hello " + to))
+                .build();
+
+        assertThat(makeRequest(router, "GET", "/hello/world"), equalTo("Hello world"));
+        assertThat(makeRequest(router, "GET", "/hi/world"), equalTo("Hello world"));
+        assertNull(makeRequest(router, "GET", "/foo/bar"));
+    }
+
     @Test
     public void multipleRoutes() {
         Router router = new RoutingDsl()

--- a/framework/src/play/src/main/scala/play/api/routing/sird/PathBindableExtractor.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/sird/PathBindableExtractor.scala
@@ -30,7 +30,7 @@ class PathBindableExtractor[T](implicit pb: PathBindable[T]) {
   }
 
   /**
-   * Extract Seq[T] only if ever element of s can be bound, otherwise don't match.
+   * Extract Seq[T] only if every element of s can be bound, otherwise don't match.
    */
   def unapply(s: Seq[String]): Option[Seq[T]] = {
     val bound = s.collect {

--- a/framework/src/play/src/main/scala/play/api/routing/sird/PathExtractor.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/sird/PathExtractor.scala
@@ -4,10 +4,9 @@
 package play.api.routing.sird
 
 import java.net.{ URL, URI }
-import java.util.regex.Pattern
 
 import play.api.mvc.RequestHeader
-import play.utils.UriEncoding
+import play.utils.{ Routing, UriEncoding }
 
 import scala.collection.concurrent.TrieMap
 import scala.util.matching.Regex
@@ -61,21 +60,19 @@ object PathExtractor {
 
         if (part.startsWith("*")) {
           // It's a .* matcher
-          "(.*)" + Pattern.quote(part.drop(1)) -> PathPart.Raw
+          "(.*)" + Routing.prepareString(part.drop(1)) -> PathPart.Raw
 
         } else if (part.startsWith("<") && part.contains(">")) {
           // It's a regex matcher
-          val splitted = part.split(">", 2)
-          val regex = splitted(0).drop(1)
-          "(" + regex + ")" + Pattern.quote(splitted(1)) -> PathPart.Raw
+          Routing.prepareString(part, captureFirstRegex = true) -> PathPart.Raw
 
         } else {
           // It's an ordinary path part matcher
-          "([^/]*)" + Pattern.quote(part) -> PathPart.Decoded
+          "([^/]*)" + Routing.prepareString(part) -> PathPart.Decoded
         }
       }.unzip
 
-      new PathExtractor(regexParts.mkString(Pattern.quote(parts.head), "", "/?").r, descs)
+      new PathExtractor(regexParts.mkString(Routing.prepareString(parts.head), "", "/?").r, descs)
     })
   }
 }

--- a/framework/src/play/src/main/scala/play/api/routing/sird/package.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/sird/package.scala
@@ -21,6 +21,12 @@ import scala.language.experimental.macros
  * - Regex values. This can be indicated by post fixing the value with a regular expression enclosed in angle brackets.
  *   For example, `p"/foo/$id<[0-9]+>`. The value will not be URI decoded.
  *
+ * It also supports matching with regular expressions outside of path segment values.  For example, `p"/foo/ba<[rz]>"`
+ * will match both `"/foo/bar"` and `"/foo/baz"`.
+ *
+ * Regular expressions inside routes must not contain capturing groups, as these can interfere with the extraction of
+ * values.
+ *
  * The extractors for primitive types are merely provided for convenience, for example, `p"/foo/${int(id)}"` will
  * extract `id` as an integer.  If `id` is not an integer, the match will simply fail.
  *

--- a/framework/src/play/src/main/scala/play/core/routing/PathPattern.scala
+++ b/framework/src/play/src/main/scala/play/core/routing/PathPattern.scala
@@ -5,6 +5,8 @@ package play.core.routing
 
 import java.net.URI
 
+import play.utils.Routing
+
 import scala.util.control.Exception
 
 /**
@@ -50,7 +52,7 @@ case class PathPattern(parts: Seq[PathPart]) {
   private lazy val (regex, groups) = {
     Some(parts.foldLeft("", Map.empty[String, Matcher => Either[Throwable, String]], 0) { (s, e) =>
       e match {
-        case StaticPart(p) => ((s._1 + Pattern.quote(p)), s._2, s._3)
+        case StaticPart(p) => ((s._1 + Routing.prepareString(p)), s._2, s._3)
         case DynamicPart(k, r, encodeable) => {
           ((s._1 + "(" + r + ")"),
             (s._2 + (k -> decodeIfEncoded(encodeable, s._3 + 1))),

--- a/framework/src/play/src/main/scala/play/utils/Routing.scala
+++ b/framework/src/play/src/main/scala/play/utils/Routing.scala
@@ -1,0 +1,19 @@
+package play.utils
+
+import java.util.regex.Pattern
+
+object Routing {
+  def prepareString(string: String, captureFirstRegex: Boolean = false): String = {
+    // Quote plain (non-regex) pieces. Leave regexes as is, but if wrapFirstRegex is true, wrap the first
+    // regex in parentheses beause it's part of a route matcher.
+    val regexStart = string.indexOf("<")
+    val regexEnd = string.indexOf(">")
+    if (regexStart > -1 && regexEnd > regexStart) {
+      val regexBody = string.slice(regexStart + 1, regexEnd)
+      val regex = if (captureFirstRegex) "(" + regexBody + ")" else regexBody
+      prepareString(string.take(regexStart)) + regex + prepareString(string.drop(regexEnd + 1))
+    } else {
+      if (string.isEmpty) "" else Pattern.quote(string)
+    }
+  }
+}

--- a/framework/src/play/src/main/scala/play/utils/UriEncoding.scala
+++ b/framework/src/play/src/main/scala/play/utils/UriEncoding.scala
@@ -119,7 +119,7 @@ object UriEncoding {
   }
 
   /**
-   * Decode the path path of a URI. Each path segment will be decoded
+   * Decode the path of a URI. Each path segment will be decoded
    * using the same rules as ``decodePathSegment``. No normalization is performed:
    * leading, trailing and duplicated slashes, if present are left as they are and
    * if absent remain absent; dot-segments (".." and ".") are ignored.

--- a/framework/src/play/src/test/scala/play/api/routing/sird/UrlContextSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/routing/sird/UrlContextSpec.scala
@@ -45,6 +45,25 @@ object UrlContextSpec extends Specification {
       }
     }
 
+    "support unmatched regexes" in {
+      "by themselves" in {
+        "/foobar/123" must beLike {
+          case p"/fooba<[rz]>/123" => ok
+        }
+      }
+      "after a matcher" in {
+        "/foo/123/bar" must beLike {
+          case p"/foo/$id/ba<[rz]>" => id must_== "123"
+        }
+      }
+      "no match" in {
+        "/foobar" must beLike {
+          case p"/fooba<[sz]>" => ko
+          case _ => ok
+        }
+      }
+    }
+
     "match a regex path" in {
       "match" in {
         "/foo/1234/bar" must beLike {

--- a/framework/src/play/src/test/scala/play/core/routing/RouterSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/routing/RouterSpec.scala
@@ -62,6 +62,15 @@ object RouterSpec extends Specification {
     "Bind Path with incorrectly encoded string as string" in {
       pathPattern(pathNonEncodedString2).get("foo") must beEqualTo(Right("bar: baz"))
     }
+    "Bind Path string with regex in static part" in {
+      val pathPattern = PathPattern(Seq(StaticPart("/path<s?>/<(?:to|for)>/"), DynamicPart("foo", "[^/]+", true)))
+      val pathString1 = "/path/to/file"
+      val pathString2 = "/paths/to/file"
+      val pathString3 = "/paths/for/file"
+      pathPattern(pathString1).get("foo") must beEqualTo(Right("file"))
+      pathPattern(pathString2).get("foo") must beEqualTo(Right("file"))
+      pathPattern(pathString3).get("foo") must beEqualTo(Right("file"))
+    }
     "Fail on unparseable Path string" in {
       val Left(e) = pathPattern(pathStringInvalid).get("foo")
       e.getMessage must beEqualTo("Malformed escape pair at index 9: /invalide%2")

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/controllers/Application.scala
@@ -46,4 +46,7 @@ class Application extends Controller {
   def hello = Action {
     Ok("Hello world!")
   }
+  def regexes = Action {
+    Ok("Regexes")
+  }
 }

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/conf/routes
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/conf/routes
@@ -22,6 +22,8 @@ GET         /ident/:è27             controllers.πø$7ß.ôü65$t(è27: Int)
 GET         /hello                  controllers.Application.hello
 GET         /hello2                 controllers.Application.hello
 
+GET         /regex<?es>             controllers.Application.regexes
+
 ->          /module                 module.Routes
 
 GET         /routes                 controllers.Application.route(abstract)

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/tests/RouterSpec.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/tests/RouterSpec.scala
@@ -13,7 +13,7 @@ object RouterSpec extends PlaySpecification {
       controllers.routes.Application.takeBool(true).url must equalTo ("/take-bool?b=true")
       controllers.routes.Application.takeBool(false).url must equalTo ("/take-bool?b=false")
     }
-    "in the  path" in {
+    "in the path" in {
       controllers.routes.Application.takeBool2(true).url must equalTo ("/take-bool-2/true")
       controllers.routes.Application.takeBool2(false).url must equalTo ("/take-bool-2/false")
     }
@@ -38,6 +38,11 @@ object RouterSpec extends PlaySpecification {
       contentAsString(route(FakeRequest(GET, "/take-bool-2/1")).get) must equalTo ("true")
       contentAsString(route(FakeRequest(GET, "/take-bool-2/0")).get) must equalTo ("false")
     }
+  }
+
+  "accept regular expressions not bound to parameters" in new WithApplication() {
+    val Some(result) = route(FakeRequest(GET, "/regexes"))
+    contentAsString(result) must equalTo ("Regexes")
   }
 
   "bind int parameters from the query string as a list" in {

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/controllers/Application.scala
@@ -46,4 +46,7 @@ object Application extends Controller {
   def hello = Action {
     Ok("Hello world!")
   }
+  def regexes = Action {
+    Ok("Regexes")
+  }
 }

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/conf/routes
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/conf/routes
@@ -22,6 +22,8 @@ GET         /ident/:è27             controllers.πø$7ß.ôü65$t(è27: Int)
 GET         /hello                  controllers.Application.hello
 GET         /hello2                 controllers.Application.hello
 
+GET         /regex<?es>             controllers.Application.regexes
+
 ->          /module                 module.Routes
 
 GET         /routes                 controllers.Application.route(abstract)

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/tests/RouterSpec.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/tests/RouterSpec.scala
@@ -10,7 +10,7 @@ object RouterSpec extends PlaySpecification {
       controllers.routes.Application.takeBool(true).url must equalTo ("/take-bool?b=true")
       controllers.routes.Application.takeBool(false).url must equalTo ("/take-bool?b=false")
     }
-    "in the  path" in {
+    "in the path" in {
       controllers.routes.Application.takeBool2(true).url must equalTo ("/take-bool-2/true")
       controllers.routes.Application.takeBool2(false).url must equalTo ("/take-bool-2/false")
     }
@@ -35,6 +35,11 @@ object RouterSpec extends PlaySpecification {
       contentAsString(route(FakeRequest(GET, "/take-bool-2/1")).get) must equalTo ("true")
       contentAsString(route(FakeRequest(GET, "/take-bool-2/0")).get) must equalTo ("false")
     }
+  }
+
+  "accept regular expressions not bound to parameters" in new WithApplication() {
+    val Some(result) = route(FakeRequest(GET, "/regexes"))
+    contentAsString(result) must equalTo ("Regexes")
   }
 
   "bind int parameters from the query string as a list" in {


### PR DESCRIPTION
Closes #3346

Allows using `<regex>` syntax by itself (rather than `$id<regex>`) in
routes. Also includes a typo fix and notes to the documentation
pointing out that regular expressions in routes should not contain
capturing groups.

Pretty new to Scala and entirely new to Play, so I apologize if it's unidiomatic/divergent in style/not sufficiently tested/wrong/etc.  Regarding the warning about capturing groups in regexes (where capturing groups in one user-supplied regex can cause a later regex to not capture what is should), I didn't know of a simple way to avoid such a problem, so I figured a warning in the documentation was warranted.

Another small point is that for `""` pieces this will insert `"\Q\E"` into the regex since it calls `Pattern.quote` on them.  This would be easy to avoid (via another if/else) if it meant a meaningful runtime performance improvement.  I don't really know, since the regex is compiled and I don't know the details of how regex matching is implemented or what the performance picture is in general.  At any rate I'd be happy to make the change if it's desirable.