### PR TITLE
Added warning about possible routing errors if singleton pattern is used...

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/JavaActionsComposition.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaActionsComposition.md
@@ -1,4 +1,4 @@
-<!--- Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com> -->
+﻿<!--- Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com> -->
 # Action composition
 
 This chapter introduces several ways to define generic action functionality.
@@ -32,6 +32,8 @@ You also mix several actions by using custom action annotations:
 @[authenticated-cached-index](code/javaguide/http/JavaActionsComposition.java)
 
 > **Note:**  ```play.mvc.Security.Authenticated``` and ```play.cache.Cached``` annotations and the corresponding predefined Actions are shipped with Play. See the relevant API documentation for more information.
+
+> **Note:**  Every request must be served by a distinct instance of your `play.mvc.Action`. If a singleton pattern is used, requests will be routed incorrectly during multiple request scenarios.
 
 ## Defining custom action annotations
 


### PR DESCRIPTION
The Play documentation does not clearly stress that `you` the programmer must supply a distinct instance of the `Action` for every request you serve. Otherwise some pretty terrible routing errors will occur where `RequestA` is sent to the controller method for `RequestB` and thus receives the response for the wrong request.

The documentation also does not speak at all to how to properly do this will DI frameworks like Spring, where `@Component`, `@Named`, `@Bean`, `@Repository`, and `@Service` will default to singleton scoped beans. I've added the warning which will hopefully save many other programmers this headache.

See prior issue #1313 @fabiankessler chime in if you wish.