### PR TITLE
Parse and apply 'play.modules.evolutions.enabled' config option.

### DIFF
--- a/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
@@ -224,12 +224,13 @@ class DefaultEvolutionsConfigParser @Inject() (configuration: Configuration) ext
     }
 
     // Load defaults
+    val enabled = loadBoolean("enabled", None, true)
     val autocommit = loadBoolean("autocommit", Some("evolutions.autocommit"), true)
     val useLocks = loadBoolean("useLocks", Some("evolutions.use.locks"), false)
     val autoApply = loadBoolean("autoApply", None, false)
     val autoApplyDowns = loadBoolean("autoApplyDowns", None, false)
 
-    val defaultConfig = new DefaultEvolutionsDatasourceConfig(true, autocommit, useLocks, autoApply,
+    val defaultConfig = new DefaultEvolutionsDatasourceConfig(enabled, autocommit, useLocks, autoApply,
       autoApplyDowns)
 
     // Load config specific to datasources
@@ -238,7 +239,7 @@ class DefaultEvolutionsConfigParser @Inject() (configuration: Configuration) ext
         def loadDsBoolean(key: String, oldKey: Option[String], default: Boolean) = {
           loadBoolean(s"db.$datasource.$key", oldKey.map(_ + "." + datasource), default)
         }
-        val enabled = loadDsBoolean("enabled", None, true)
+        val enabled = loadDsBoolean("enabled", None, defaultConfig.enabled)
         val autocommit = loadDsBoolean("autocommit", None, defaultConfig.autocommit)
         val useLocks = loadDsBoolean("useLocks", None, defaultConfig.useLocks)
         val autoApply = loadDsBoolean("autoApply", Some("applyEvolutions"), defaultConfig.autoApply)

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/evolutions/DefaultEvolutionsConfigParserSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/evolutions/DefaultEvolutionsConfigParserSpec.scala
@@ -39,6 +39,9 @@ object DefaultEvolutionsConfigParserSpec extends Specification {
       }
     }
     "parse global configuration" in {
+      "enabled" in {
+        testN("enabled")(_.enabled)
+      }
       "autocommit" in {
         testN("autocommit")(_.autocommit)
       }


### PR DESCRIPTION
[Documentation](https://www.playframework.com/documentation/2.4.x/Evolutions) says that setting `play.modules.evolutions.enabled` to `false` should disable evolutions for all datasources, but it was not happening. Only per datasource config (e.g. `play.modules.evolutions.db.default.enabled = false`) worked.

This patch makes Evolutions Module behave as described in docs.