### PR TITLE
Allow Guice modules to be constructed with Environment and Configuration

### DIFF
--- a/documentation/manual/detailedTopics/configuration/ThreadPools.md
+++ b/documentation/manual/detailedTopics/configuration/ThreadPools.md
@@ -30,8 +30,8 @@ In contrast, the following types of IO do not block:
 
 Play uses a number of different thread pools for different purposes:
 
-* **Netty boss/worker thread pools** - These are used internally by Netty for handling Netty IO.  An applications code should never be executed by a thread in these thread pools.
-* **Play default thread pool** - This is the thread pool in which all of your application code in Play Framework is executed.  It is an Akka dispatcher, and is used by the Application `ActorSystem`. It can be configured by configuring Akka, described below. By default, it has one thread per processor.
+* **Netty boss/worker thread pools** - These are used internally by Netty for handling Netty IO.  An application's code should never be executed by a thread in these thread pools.
+* **Play default thread pool** - This is the thread pool in which all of your application code in Play Framework is executed.  It is an Akka dispatcher, and is used by the application `ActorSystem`. It can be configured by configuring Akka, described below.
 
 > Note that in Play 2.4 several thread pools were combined together into the Play default thread pool.
 
@@ -45,11 +45,11 @@ In most situations, the appropriate execution context to use will be the **Play 
 
 ### Configuring the Play default thread pool
 
-The default thread pool can be configured using standard Akka configuration in `application.conf` under the `akka` namespace.  Here is the default configuration:
+The default thread pool can be configured using standard Akka configuration in `application.conf` under the `akka` namespace. Play uses Akka's default configuration:
 
 @[default-config](code/ThreadPools.scala)
 
-This configuration instructs Akka to create one thread per available processor, with a maximum of 24 threads in the pool.  The full configuration options available to you can be found [here](http://doc.akka.io/docs/akka/2.3.0/general/configuration.html#Listing_of_the_Reference_Configuration).
+This configuration instructs Akka to create 3 threads per available processor, with a minimum of 8 and a maximum of 64 threads in the pool.  The full configuration options available to you can be found [here](http://doc.akka.io/docs/akka/2.3.0/general/configuration.html#Listing_of_the_Reference_Configuration).
 
 > Note that this configuration is the same configuration that the Play Akka plugin uses. Before Play 2.4 the Play Akka plugin had different configuration options.
 

--- a/documentation/manual/detailedTopics/configuration/code/ThreadPools.scala
+++ b/documentation/manual/detailedTopics/configuration/code/ThreadPools.scala
@@ -26,15 +26,17 @@ object ThreadPoolsSpec extends PlaySpecification {
     "have a global configuration" in {
       val config = """#default-config
         akka {
-          akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
-          loglevel = WARNING
-          actor {
-            default-dispatcher = {
-              fork-join-executor {
-                parallelism-factor = 1.0
-                parallelism-max = 24
-              }
-            }
+          fork-join-executor {
+            # The parallelism factor is used to determine thread pool size using the
+            # following formula: ceil(available processors * factor). Resulting size
+            # is then bounded by the parallelism-min and parallelism-max values.
+            parallelism-factor = 3.0
+     
+            # Min number of threads to cap factor-based parallelism number to
+            parallelism-min = 8
+
+            # Max number of threads to cap factor-based parallelism number to
+            parallelism-max = 64
           }
         }
       #default-config """

--- a/documentation/manual/working/javaGuide/advanced/dependencyinjection/JavaDependencyInjection.md
+++ b/documentation/manual/working/javaGuide/advanced/dependencyinjection/JavaDependencyInjection.md
@@ -77,7 +77,11 @@ In some more complex situations, you may want to provide more complex bindings, 
 
 @[guice-module](code/javaguide/advanced/di/guice/HelloModule.java)
 
-To register this module with Play, append it's fully qualified class name to the `play.modules.enabled` list in `application.conf`:
+In even more complex situations you might want to access the Play configuration or ClassLoader when you configure Guice bindings. You can get access to these objects by adding them to your module's constructor.
+
+@[dynamic-guice-module](code/javaguide/advanced/di/guice/dynamic/HelloModule.java)
+
+To register either of these HelloWorld modules with Play, append the fully qualified class name to the `play.modules.enabled` list in `application.conf`:
 
     play.modules.enabled += "modules.HelloModule"
 

--- a/documentation/manual/working/javaGuide/advanced/dependencyinjection/code/javaguide/advanced/di/guice/dynamic/HelloModule.java
+++ b/documentation/manual/working/javaGuide/advanced/dependencyinjection/code/javaguide/advanced/di/guice/dynamic/HelloModule.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package javaguide.advanced.di.guice.configured;
+
+import javaguide.advanced.di.*;
+
+//#dynamic-guice-module
+import com.google.inject.AbstractModule;
+import com.google.inject.ConfigurationException;
+import com.google.inject.name.Names;
+import play.Configuration;
+import play.Environment;
+
+public class HelloModule extends AbstractModule {
+
+    private final Environment environment;
+    private final Configuration configuration;
+
+    public HelloModule(
+          Environment environment,
+          Configuration configuration) {
+        this.environment = environment;
+        this.configuration = configuration;
+    }
+
+    protected void configure() {
+        // Expect configuration like:
+        // hello.en = "myapp.EnglishHello"
+        // hello.de = "myapp.GermanHello"
+        Configuration helloConf = configuration.getConfig("hello");
+        // Iterate through all the languages and bind the
+        // class associated with that language. Use Play's
+        // ClassLoader to load the classes.
+        for (String l: helloConf.subKeys()) {
+            try {
+                String bindingClassName = helloConf.getString(l);
+                Class<? extends Hello> bindingClass =
+                  environment.classLoader().loadClass(bindingClassName)
+                  .asSubclass(Hello.class);
+                bind(Hello.class)
+                        .annotatedWith(Names.named(l))
+                        .to(bindingClass);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}
+//#dynamic-guice-module

--- a/documentation/manual/working/scalaGuide/advanced/dependencyinjection/ScalaDependencyInjection.md
+++ b/documentation/manual/working/scalaGuide/advanced/dependencyinjection/ScalaDependencyInjection.md
@@ -73,7 +73,11 @@ In some more complex situations, you may want to provide more complex bindings, 
 
 @[guice-module](code/RuntimeDependencyInjection.scala)
 
-To register this module with Play, append it's fully qualified class name to the `play.modules.enabled` list in `application.conf`:
+In even more complex situations you might want to access the Play configuration or ClassLoader when you configure Guice bindings. You can get access to these objects by adding them to your module's constructor.
+
+@[dynamic-guice-module](code/RuntimeDependencyInjection.scala)
+
+To register either of these HelloWorld modules with Play, append the fully qualified class name to the `play.modules.enabled` list in `application.conf`:
 
     play.modules.enabled += "modules.HelloModule"
 

--- a/framework/src/play/src/main/scala/play/api/inject/Module.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Module.scala
@@ -3,6 +3,8 @@
  */
 package play.api.inject
 
+import java.lang.reflect.Constructor
+import play.{ Configuration => JavaConfiguration, Environment => JavaEnvironment }
 import play.api._
 import play.utils.PlayIO
 import scala.annotation.varargs
@@ -80,7 +82,8 @@ object Modules {
    * Locate the modules from the environment.
    *
    * Loads all modules specified by the play.modules.enabled property, minus the modules specified by the
-   * play.modules.disabled property.
+   * play.modules.disabled property. If the modules have constructors that take an `Environment` and a
+   * `Configuration`, then these constructors are called first; otherwise default constructors are called.
    *
    * @param environment The environment.
    * @param configuration The configuration.
@@ -96,7 +99,28 @@ object Modules {
 
     moduleClassNames.map { className =>
       try {
-        environment.classLoader.loadClass(className).newInstance()
+        val clazz = environment.classLoader.loadClass(className)
+
+        def tryConstruct(args: AnyRef*): Option[Any] = {
+          val ctor: Option[Constructor[_]] = try {
+            val argTypes = args.map(_.getClass)
+            Some(clazz.getConstructor(argTypes: _*))
+          } catch {
+            case _: NoSuchMethodException => None
+            case _: SecurityException => None
+          }
+          ctor.map(_.newInstance(args: _*))
+        }
+
+        {
+          tryConstruct(environment, configuration)
+        } orElse {
+          tryConstruct(new JavaEnvironment(environment), new JavaConfiguration(configuration))
+        } orElse {
+          tryConstruct()
+        } getOrElse {
+          throw new PlayException("No valid constructors", "Module [" + className + "] cannot be instantiated.")
+        }
       } catch {
         case e: PlayException => throw e
         case e: VirtualMachineError => throw e

--- a/framework/src/play/src/test/scala/play/api/inject/ModulesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/ModulesSpec.scala
@@ -1,0 +1,70 @@
+package play.api.inject
+
+import org.specs2.mutable.Specification
+
+import com.google.inject.AbstractModule
+
+import play.{ Configuration => JavaConfiguration, Environment => JavaEnvironment }
+import play.api.{ Configuration, Environment }
+
+class ModulesSpec extends Specification {
+
+  "Modules.locate" should {
+
+    "load simple Guice modules" in {
+      val env = Environment.simple()
+      val conf = Configuration("play.modules.enabled" -> Seq(
+        classOf[PlainGuiceModule].getName
+      ))
+      val located: Seq[Any] = Modules.locate(env, conf)
+      located.size must_== 1
+      located(0) must haveClass[PlainGuiceModule]
+    }
+
+    "load Guice modules that take a Scala Environment and Configuration" in {
+      val env = Environment.simple()
+      val conf = Configuration("play.modules.enabled" -> Seq(
+        classOf[ScalaGuiceModule].getName
+      ))
+      val located: Seq[Any] = Modules.locate(env, conf)
+      located.size must_== 1
+      located(0) must beLike {
+        case mod: ScalaGuiceModule =>
+          mod.environment must_== env
+          mod.configuration must_== conf
+      }
+    }
+
+    "load Guice modules that take a Java Environment and Configuration" in {
+      val env = Environment.simple()
+      val conf = Configuration("play.modules.enabled" -> Seq(
+        classOf[JavaGuiceModule].getName
+      ))
+      val located: Seq[Any] = Modules.locate(env, conf)
+      located.size must_== 1
+      located(0) must beLike {
+        case mod: JavaGuiceModule =>
+          mod.environment.underlying must_== env
+          mod.configuration.underlying must_== conf.underlying
+      }
+    }
+
+  }
+
+}
+
+class PlainGuiceModule extends AbstractModule {
+  def configure(): Unit = ()
+}
+
+class ScalaGuiceModule(
+    val environment: Environment,
+    val configuration: Configuration) extends AbstractModule {
+  def configure(): Unit = ()
+}
+
+class JavaGuiceModule(
+    val environment: JavaEnvironment,
+    val configuration: JavaConfiguration) extends AbstractModule {
+  def configure(): Unit = ()
+}


### PR DESCRIPTION
This allows Guice modules to, for example, dynamically create bindings from configuration. You can see an example of this in the updated docs.