### PR TITLE
Fix up a few doc typos

### DIFF
--- a/documentation/manual/releases/Highlights24.md
+++ b/documentation/manual/releases/Highlights24.md
@@ -46,7 +46,7 @@ You can read about these new APIs here:
 
 ## Embedding Play
 
-It is now straight forward to embed a Play application.  Play 2.4 provides both APIs to start and stop a Play server, as well as routing DSLs for Java and Scala so that routes can be embedded directly in code.
+It is now straightforward to embed a Play application.  Play 2.4 provides both APIs to start and stop a Play server, as well as routing DSLs for Java and Scala so that routes can be embedded directly in code.
 
 In Java, see [[Embedding Play|JavaEmbeddingPlay]] as well as information about the [[Routing DSL|JavaRoutingDSL]].
 
@@ -113,7 +113,7 @@ play-ebean now supports Ebean 4.x.
 
 ## HikariCP
 
-[HikariCP](http://brettwooldridge.github.io/HikariCP/) is now the default JDBC connection pool. It's properties can be directly configured using `.conf` files and you should rename the configuration properties to match what is expected by HikariCP.
+[HikariCP](http://brettwooldridge.github.io/HikariCP/) is now the default JDBC connection pool. Its properties can be directly configured using `.conf` files and you should rename the configuration properties to match what is expected by HikariCP.
 
 ## Experimental Features
 

--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -111,7 +111,7 @@ class Routes(application: controllers.Application, assets: controllers.Assets) e
 }
 ```
 
-The default is to use the static routes generator.  You must use this if you are not ready to migrate all of your Java actions to be non static methods, or your Scala actions to be classes.  In most cases, this is quite straight forward to do, in Java it requires deleting the `static` keyword, in Scala it requires changing the word `object` to `class`.  The static router still supports the `@` operator, which will tell it to look up the action from a runtime `Injector`, you may find this useful if you are in a transitional period where some of your actions are static and some are injected.
+The default is to use the static routes generator.  You must use this if you are not ready to migrate all of your Java actions to be non static methods, or your Scala actions to be classes.  In most cases, this is quite straightforward to do, in Java it requires deleting the `static` keyword, in Scala it requires changing the word `object` to `class`.  The static router still supports the `@` operator, which will tell it to look up the action from a runtime `Injector`, you may find this useful if you are in a transitional period where some of your actions are static and some are injected.
 
 If you wish to switch to the injected generator, add the following to your build settings in `build.sbt`:
 

--- a/documentation/manual/working/javaGuide/advanced/embedding/JavaEmbeddingPlay.md
+++ b/documentation/manual/working/javaGuide/advanced/embedding/JavaEmbeddingPlay.md
@@ -3,7 +3,7 @@
 
 While Play apps are most commonly used as their own container, you can also embed a Play server into your own existing application.  This can be used in conjunction with the Twirl template compiler and Play routes compiler, but these are of course not necessary, a common use case for embedding a Play application will be because you only have a few very simple routes.
 
-The simplest way to start an embedded Play server is to use the [`Server`](api/java/play/server/Server.html) factory methods.  If all you need to do is provide some straight forward routes, you may decide to use the [[Routing DSL|JavaRoutingDsl]], so you will need the following imports:
+The simplest way to start an embedded Play server is to use the [`Server`](api/java/play/server/Server.html) factory methods.  If all you need to do is provide some straightforward routes, you may decide to use the [[Routing DSL|JavaRoutingDsl]], so you will need the following imports:
 
 @[imports](code/javaguide/advanced/embedding/JavaEmbeddingPlay.java)
 

--- a/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlay.md
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlay.md
@@ -3,7 +3,7 @@
 
 While Play apps are most commonly used as their own container, you can also embed a Play server into your own existing application.  This can be used in conjunction with the Twirl template compiler and Play routes compiler, but these are of course not necessary, a common use case for embedding a Play application will be because you only have a few very simple routes.
 
-The simplest way to start an embedded Play server is to use the [`NettyServer`](api/scala/index.html#play.core.server.NettyServer$) factory methods.  If all you need to do is provide some straight forward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouter` method:
+The simplest way to start an embedded Play server is to use the [`NettyServer`](api/scala/index.html#play.core.server.NettyServer$) factory methods.  If all you need to do is provide some straightforward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouter` method:
 
 @[simple](code/ScalaEmbeddingPlay.scala)
 

--- a/documentation/manual/working/scalaGuide/advanced/iteratees/Enumeratees.md
+++ b/documentation/manual/working/scalaGuide/advanced/iteratees/Enumeratees.md
@@ -117,7 +117,7 @@ val toIntOrEnd: Enumeratee[String,Int ] = Enumeratee.mapInput[String] {
 }
 ```
 
-`Enumeratee.map` and `Enumeratee.mapImput` are pretty straight forward, they operate on a per chunk basis and they convert them. Another useful `Enumeratee` is the `Enumeratee.filter` :
+`Enumeratee.map` and `Enumeratee.mapImput` are pretty straightforward, they operate on a per chunk basis and they convert them. Another useful `Enumeratee` is the `Enumeratee.filter` :
 
 ```scala
 def filter[E](predicate: E => Boolean): Enumeratee[E, E]

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithDatabases.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithDatabases.md
@@ -55,7 +55,7 @@ As with the generic database factory, ensure you always shut the in-memory datab
 
 @[in-memory-shutdown](code/database/ScalaTestingWithDatabases.scala)
 
-If you're not using a test frameworks before/after capabilities, you may want Play to manage the in-memory database lifecycle for you, this is straight forward using `withInMemory`:
+If you're not using a test frameworks before/after capabilities, you may want Play to manage the in-memory database lifecycle for you, this is straightforward using `withInMemory`:
 
 @[with-in-memory](code/database/ScalaTestingWithDatabases.scala)
 


### PR DESCRIPTION
Get rid of spaces in _straight forward_ and apostrophe in _it's_.