### PR TITLE
Use fewer threads in the ActorSystem

### DIFF
--- a/framework/src/play/src/main/resources/play/reference-overrides.conf
+++ b/framework/src/play/src/main/resources/play/reference-overrides.conf
@@ -15,4 +15,15 @@ akka {
   # Play applications don't want to exit when Akka receives a fatal error.
   jvm-exit-on-fatal-error = off
 
+
+  actor {
+    default-dispatcher = {
+      fork-join-executor {
+        # Settings this to 1 instad of 3 seems to improve performance.
+        parallelism-factor = 1.0
+        parallelism-max = 24
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
This reverts the thread pool configuration change in #4250. That change caused a 25% performance regression.