### PR TITLE
GzipFilter shouldn't add duplicate ACCEPT-ENCODING to VARY header

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -178,6 +178,7 @@ class GzipFilter @Inject() (config: GzipFilterConfig) extends EssentialFilter {
   private def addToVaryHeader(existingHeaders: Map[String, String], headerName: String, headerValue: String): (String, String) = {
     existingHeaders.get(headerName) match {
       case None => (headerName, headerValue)
+      case Some(existing) if (existing.split(",").exists(_.trim.equalsIgnoreCase(headerValue))) => (headerName, existing)
       case Some(existing) => (headerName, s"$existing,$headerValue")
     }
   }

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -139,6 +139,12 @@ object GzipFilterSpec extends PlaySpecification with DataTables {
       checkGzipped(result)
       header(VARY, result) must beSome.which(header => header contains "original,")
     }
+
+    "preserve original Vary header values and not duplicate case-insensitive ACCEPT-ENCODING" in withApplication(Ok("hello").withHeaders(VARY -> "original,ACCEPT-encoding")) {
+      val result = makeGzipRequest
+      checkGzipped(result)
+      header(VARY, result) must beSome.which(header => header.split(",").filter(_.toLowerCase == ACCEPT_ENCODING.toLowerCase()).size == 1)
+    }
   }
 
   class Filters @Inject() (gzipFilter: GzipFilter) extends HttpFilters {


### PR DESCRIPTION
We have a case where an app adds vary:accept-encoding to every response, and the gzip filter is adding a duplicate.