### PR TITLE
Fixed fork run protocol compile flakiness

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -332,7 +332,7 @@ object PlayBuild extends Build {
   lazy val ForkRunProtocolProject = PlayDevelopmentProject("Fork-Run-Protocol", "fork-run-protocol")
     .settings(
       libraryDependencies ++= forkRunProtocolDependencies(scalaBinaryVersion.value),
-      compile in Compile <<= (compile in Compile) tag ProtocolCompile,
+      compileIncremental in Compile <<= (compileIncremental in Compile) tag ProtocolCompile,
       doc in Compile <<= (doc in Compile) tag ProtocolCompile)
     .dependsOn(RunSupportProject)
 
@@ -341,7 +341,7 @@ object PlayBuild extends Build {
     .settings(
       target := target.value / "sbt-fork-run-protocol",
       libraryDependencies ++= forkRunProtocolDependencies(scalaBinaryVersion.value),
-      compile in Compile <<= (compile in Compile) tag ProtocolCompile,
+      compileIncremental in Compile <<= (compileIncremental in Compile) tag ProtocolCompile,
       doc in Compile <<= (doc in Compile) tag ProtocolCompile)
     .dependsOn(SbtRunSupportProject)
 


### PR DESCRIPTION
A race condition in the Scala compiler that relates to global state and compiling the same code at the same time with two different instances of the Scala compiler causes intermittent build failures.  The existing work around that we had in place was to take the compile and doc tasks of the fork run protocol projects so they would not be done concurrently with each other.  SBT 0.13.8 split the compile task into multiple smaller tasks, meaning that the task that we now have to tag is compileIncremental.