### PR TITLE
Set the ForkJoinPool to use LIFO scheduling

### DIFF
--- a/framework/src/play/src/main/resources/play/reference-overrides.conf
+++ b/framework/src/play/src/main/resources/play/reference-overrides.conf
@@ -15,13 +15,29 @@ akka {
   # Play applications don't want to exit when Akka receives a fatal error.
   jvm-exit-on-fatal-error = off
 
-
   actor {
     default-dispatcher = {
+      # Use this so we can support the 'async-mode' option in our fork-join-executor
+      type = "play.api.libs.concurrent.PlayAkkaDispatcherConfigurator"
+
       fork-join-executor {
         # Settings this to 1 instad of 3 seems to improve performance.
         parallelism-factor = 1.0
+
+        # @richdougherty: Not sure why this is is set below the Akka
+        # default.
         parallelism-max = 24
+
+        # This is a custom setting applied by Play's Akka plugin.
+        # Akka's default is 'true', Play and the JRE's default is
+        # 'false'. Setting this to false changes the fork-join-executor
+        # to use a LIFO discipline for task scheduling. This usually
+        # improves throughput at the cost of possibly increasing
+        # latency and risking task starvation (which should be rare).
+        #
+        # To use this setting you need to ensure the dispatcher uses
+        # the play.api.libs.concurrent.PlayAkkaDispatcherConfigurator.
+        async-mode = false
       }
     }
   }

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/PlayAkkaDispatcherConfigurator.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/PlayAkkaDispatcherConfigurator.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.libs.concurrent
+
+import com.typesafe.config.Config
+import akka.dispatch._
+import java.util.concurrent._
+import scala.concurrent.duration._
+import scala.concurrent.forkjoin.{ ForkJoinTask, ForkJoinPool }
+
+/**
+ * Clone of Akka's DispatcherConfigurator that adds the `async-mode`
+ * option to the `fork-join-executor`.
+ */
+class PlayAkkaDispatcherConfigurator(config: Config, prerequisites: DispatcherPrerequisites)
+    extends MessageDispatcherConfigurator(config, prerequisites) {
+
+  private def durationConfig(key: String, tu: TimeUnit): FiniteDuration = {
+    Duration(config.getDuration(key, tu), tu)
+  }
+
+  private val instance = new Dispatcher(
+    this,
+    config.getString("id"),
+    config.getInt("throughput"),
+    durationConfig("throughput-deadline-time", TimeUnit.NANOSECONDS),
+    configureExecutor(),
+    durationConfig("shutdown-timeout", TimeUnit.MILLISECONDS))
+
+  override def dispatcher(): MessageDispatcher = instance
+
+  final override def configureExecutor(): ExecutorServiceConfigurator = {
+    def configurator(executor: String): ExecutorServiceConfigurator = executor match {
+      case null | "" | "fork-join-executor" ⇒ new PlayAkkaForkJoinExecutorConfigurator(config.getConfig("fork-join-executor"), prerequisites)
+      case "thread-pool-executor" ⇒ new ThreadPoolExecutorConfigurator(config.getConfig("thread-pool-executor"), prerequisites)
+      case fqcn ⇒
+        val args = List(
+          classOf[Config] -> config,
+          classOf[DispatcherPrerequisites] -> prerequisites)
+        prerequisites.dynamicAccess.createInstanceFor[ExecutorServiceConfigurator](fqcn, args).recover({
+          case exception ⇒ throw new IllegalArgumentException(
+            ("""Cannot instantiate ExecutorServiceConfigurator ("executor = [%s]"), defined in [%s],
+                make sure it has an accessible constructor with a [%s,%s] signature""")
+              .format(fqcn, config.getString("id"), classOf[Config], classOf[DispatcherPrerequisites]), exception)
+        }).get
+    }
+
+    config.getString("executor") match {
+      case "default-executor" ⇒ new DefaultExecutorServiceConfigurator(config.getConfig("default-executor"), prerequisites, configurator(config.getString("default-executor.fallback")))
+      case other ⇒ configurator(other)
+    }
+  }
+
+}
+
+object PlayAkkaForkJoinExecutorConfigurator {
+
+  /**
+   * Clone of Akka's AkkaForkJoinPool that supports the
+   * asyncMode argument.
+   */
+  final class PlayAkkaForkJoinPool(
+    parallelism: Int,
+    threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
+    unhandledExceptionHandler: Thread.UncaughtExceptionHandler,
+    asyncMode: Boolean)
+      extends ForkJoinPool(parallelism, threadFactory, unhandledExceptionHandler, asyncMode) /* not visible outside Akka: with LoadMetrics */ {
+    override def execute(r: Runnable): Unit =
+      if (r eq null) throw new NullPointerException else super.execute(new ForkJoinExecutorConfigurator.AkkaForkJoinTask(r))
+
+    def atFullThrottle(): Boolean = this.getActiveThreadCount() >= this.getParallelism()
+  }
+
+}
+
+/**
+ * Clone of Akka's ForkJoinExecutorConfigurator that supports the `async-mode`
+ * option.
+ */
+class PlayAkkaForkJoinExecutorConfigurator(config: Config, prerequisites: DispatcherPrerequisites) extends ExecutorServiceConfigurator(config, prerequisites) {
+  import ForkJoinExecutorConfigurator._
+
+  def validate(t: ThreadFactory): ForkJoinPool.ForkJoinWorkerThreadFactory = t match {
+    case correct: ForkJoinPool.ForkJoinWorkerThreadFactory ⇒ correct
+    case x ⇒ throw new IllegalStateException("The prerequisites for the ForkJoinExecutorConfigurator is a ForkJoinPool.ForkJoinWorkerThreadFactory!")
+  }
+
+  class ForkJoinExecutorServiceFactory(val threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
+      val parallelism: Int,
+      val asyncMode: Boolean) extends ExecutorServiceFactory {
+    def createExecutorService: ExecutorService = new PlayAkkaForkJoinExecutorConfigurator.PlayAkkaForkJoinPool(
+      parallelism,
+      threadFactory,
+      MonitorableThreadFactory.doNothing,
+      asyncMode
+    )
+  }
+  final override def createExecutorServiceFactory(id: String, threadFactory: ThreadFactory): ExecutorServiceFactory = {
+    val tf = threadFactory match {
+      case m: MonitorableThreadFactory ⇒
+        // add the dispatcher id to the thread names
+        m.withName(m.name + "-" + id)
+      case other ⇒ other
+    }
+    // We actually provide a default under the 'akka' config path, but the user can set a
+    // different config path.
+    val asyncMode = if (config.hasPath("async-mode")) config.getBoolean("async-mode") else true
+    new ForkJoinExecutorServiceFactory(
+      threadFactory = validate(tf),
+      parallelism = ThreadPoolConfig.scaledPoolSize(
+        config.getInt("parallelism-min"),
+        config.getDouble("parallelism-factor"),
+        config.getInt("parallelism-max")),
+      asyncMode = asyncMode
+    )
+  }
+}


### PR DESCRIPTION
This improves the throughput of Play under most workloads. There may be a small latency difference, but it shouldn't be significant.

In tests I got a 5% performance improvement.

In rare circumstances it may be possible to starve tasks, indefinitely, e.g. if there are infinite async loops on each thread without any IO, but LIFO scheduling is the default in the JRE ForkJoinPool so it should be pretty safe.

We needed to clone some Akka config code in order to get the new LIFO config setting into the ForkJoinPool constructor. I'll raise an Akka issue to ask for this option to be supported.