### PR TITLE
Replaces deprecated APIs with Java NIO

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -4,8 +4,7 @@
 package play.api.libs
 
 import java.io._
-import play.utils.PlayIO
-import scala.io.Codec
+import java.nio.file.{ FileAlreadyExistsException, StandardCopyOption }
 
 /**
  * FileSystem utilities.
@@ -28,14 +27,23 @@ object Files {
     /**
      * Move the file.
      */
-    def moveTo(to: File, replace: Boolean = false) {
-      Files.Deprecated.moveFile(file, to, replace = replace)
+    def moveTo(to: File, replace: Boolean = false): File = {
+      try {
+        if (replace)
+          java.nio.file.Files.move(file.toPath, to.toPath, StandardCopyOption.REPLACE_EXISTING)
+        else
+          java.nio.file.Files.move(file.toPath, to.toPath)
+      } catch {
+        case ex: FileAlreadyExistsException => to
+      }
+
+      to
     }
 
     /**
      * Delete this file on garbage collection.
      */
-    override def finalize {
+    override def finalize() {
       clean()
     }
 
@@ -63,124 +71,4 @@ object Files {
     }
 
   }
-
-  /**
-   * Copy a file.
-   */
-  @deprecated("Use Java 7 Files API instead", "2.3")
-  def copyFile(from: File, to: File, replaceExisting: Boolean = true): File = {
-    if (replaceExisting || !to.exists()) {
-      val in = new FileInputStream(from).getChannel
-      try {
-        val out = new FileOutputStream(to).getChannel
-        try {
-          out.transferFrom(in, 0, in.size())
-        } finally {
-          PlayIO.closeQuietly(out)
-        }
-      } finally {
-        PlayIO.closeQuietly(in)
-      }
-    }
-
-    to
-  }
-
-  /**
-   * Rename a file.
-   */
-  @deprecated("Use Java 7 Files API instead", "2.3")
-  def moveFile(from: File, to: File, replace: Boolean = true): File = {
-    if (to.exists() && replace) {
-      to.delete()
-    }
-
-    if (!to.exists()) {
-      if (!from.renameTo(to)) {
-        copyFile(from, to)
-        from.delete()
-      }
-    }
-
-    to
-  }
-
-  /**
-   * Reads a file’s contents into a String.
-   *
-   * @param path the file to read.
-   * @return the file contents
-   */
-  @deprecated("Use Java 7 Files API instead", "2.3")
-  def readFile(path: File): String = PlayIO.readFileAsString(path)(Codec.UTF8)
-
-  /**
-   * Write a file’s contents as a `String`.
-   *
-   * @param path the file to write to
-   * @param content the contents to write
-   */
-  @deprecated("Use Java 7 Files API instead", "2.3")
-  def writeFile(path: File, content: String): Unit = {
-    path.getParentFile.mkdirs()
-    val out = new FileOutputStream(path)
-    try {
-      val writer = new OutputStreamWriter(out, Codec.UTF8.name)
-      try {
-        writer.write(content)
-      } finally PlayIO.closeQuietly(writer)
-    } finally PlayIO.closeQuietly(out)
-  }
-
-  /**
-   * Creates a directory.
-   *
-   * @param path the directory to create
-   */
-  @deprecated("Use Java 7 Files API instead", "2.3")
-  def createDirectory(path: File): File = {
-    path.mkdirs()
-    path
-  }
-
-  /**
-   * Writes a file’s content as String, only touching the file if the actual file content is different.
-   *
-   * @param path the file to write to
-   * @param content the contents to write
-   */
-  @deprecated("Use Java 7 Files API instead", "2.3")
-  def writeFileIfChanged(path: File, content: String): Unit = {
-    if (content != Option(path).filter(_.exists).map(readFile(_)).getOrElse("")) {
-      writeFile(path, content)
-    }
-  }
-
-  /**
-   * Workaround to suppress deprecation warnings within the Play build.
-   * Based on https://issues.scala-lang.org/browse/SI-7934
-   */
-  @deprecated("", "")
-  private[play] class Deprecated {
-    def copyFile(from: File, to: File, replaceExisting: Boolean = true): File =
-      Files.copyFile(from, to, replaceExisting)
-
-    def moveFile(from: File, to: File, replace: Boolean = true): File =
-      Files.moveFile(from, to, replace)
-
-    def readFile(path: File): String =
-      Files.readFile(path)
-
-    def writeFile(path: File, content: String): Unit =
-      Files.writeFile(path, content)
-
-    def createDirectory(path: File): File =
-      Files.createDirectory(path)
-
-    def writeFileIfChanged(path: File, content: String): Unit =
-      Files.writeFileIfChanged(path, content)
-  }
-
-  private[play] object Deprecated extends Deprecated
-
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -3,7 +3,7 @@
  */
 package play.api.mvc
 
-import play.api.data.{ FormUtils, Form }
+import play.api.data.Form
 import play.core.parsers.Multipart
 
 import scala.language.reflectiveCalls
@@ -172,7 +172,6 @@ object MultipartFormData {
 case class RawBuffer(memoryThreshold: Int, initialData: Array[Byte] = Array.empty[Byte]) {
 
   import play.api.libs.Files._
-  import scala.collection.mutable._
 
   @volatile private var inMemory: List[Array[Byte]] = if (initialData.length == 0) Nil else List(initialData)
   @volatile private var inMemorySize = initialData.length

--- a/framework/src/play/src/test/scala/play/libs/FilesSpec.scala
+++ b/framework/src/play/src/test/scala/play/libs/FilesSpec.scala
@@ -1,0 +1,92 @@
+package play.libs
+
+import java.io.File
+import java.nio.charset.Charset
+
+import org.specs2.mutable.Specification
+import org.specs2.specification.After
+import play.api.libs.Files.TemporaryFile
+import play.utils.PlayIO
+
+object FilesSpec extends Specification with After {
+
+  val parentDirectory = new File("/tmp/play/specs/")
+  val utf8 = Charset.forName("UTF8")
+
+  override def after: Any = {
+    parentDirectory.listFiles().foreach(_.delete())
+    parentDirectory.delete()
+  }
+
+  "Files" should {
+
+    "Temporary files" should {
+
+      "delete file when cleaning" in {
+        val file = new File(parentDirectory, "delete.txt")
+        writeFile(file, "file to be delete")
+
+        TemporaryFile(file).clean()
+        new File(file.getAbsolutePath).exists() must beFalse
+      }
+
+      "replace file when moving with replace enabled" in {
+        val file = new File(parentDirectory, "move.txt")
+        writeFile(file, "file to be moved")
+
+        val destination = new File(file.getParentFile, "destination.txt")
+        TemporaryFile(file).moveTo(destination, replace = true)
+
+        new File(file.getAbsolutePath).exists() must beFalse
+        new File(destination.getAbsolutePath).exists() must beTrue
+      }
+
+      "do not replace file when moving with replace disabled" in {
+        val file = new File(parentDirectory, "do-not-replace.txt")
+        val destination = new File(parentDirectory, "already-exists.txt")
+
+        writeFile(file, "file that won't be replaced")
+        writeFile(destination, "already exists")
+
+        val to = TemporaryFile(file).moveTo(destination, replace = false)
+        new String(java.nio.file.Files.readAllBytes(to.toPath)) must contain("already exists")
+      }
+
+    }
+
+  }
+
+  "PlayIO" should {
+
+    "read file content" in {
+      val file = new File(parentDirectory, "file.txt")
+      writeFile(file, "file content")
+
+      new String(PlayIO.readFile(file), utf8) must beEqualTo("file content")
+    }
+
+    "read file content as a String" in {
+      val file = new File(parentDirectory, "file.txt")
+      writeFile(file, "file content")
+
+      PlayIO.readFileAsString(file) must beEqualTo("file content")
+    }
+
+    "read url content as a String" in {
+      val file = new File(parentDirectory, "file.txt")
+      writeFile(file, "file content")
+
+      val url = file.toURI.toURL
+
+      PlayIO.readUrlAsString(url) must beEqualTo("file content")
+    }
+  }
+
+  private def writeFile(file: File, content: String) = {
+    if (file.exists()) file.delete()
+
+    file.getParentFile.mkdirs()
+    java.nio.file.Files.write(file.toPath, content.getBytes(utf8))
+  }
+
+}


### PR DESCRIPTION
Also, TemporaryFile now has a real moveTo method which uses Java NIO to do the moving, instead of
a copy->delete of the file being moved.

This fixes #3913.