### PR TITLE
Update docs to use jdk 8

### DIFF
--- a/documentation/manual/detailedTopics/configuration/ThreadPools.md
+++ b/documentation/manual/detailedTopics/configuration/ThreadPools.md
@@ -77,7 +77,7 @@ Class loaders and thread locals need special handling in a multithreaded environ
 
 ### Application class loader
 
-In a Play application the [thread context class loader](http://docs.oracle.com/javase/6/docs/api/java/lang/Thread.html#getContextClassLoader\(\)) may not always be able to load application classes. You should explicitly use the application class loader to load classes.
+In a Play application the [thread context class loader](http://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#getContextClassLoader--) may not always be able to load application classes. You should explicitly use the application class loader to load classes.
 
 Java
 : @[using-app-classloader](code/ThreadPoolsJava.java)
@@ -87,7 +87,7 @@ Scala
 
 Being explicit about loading classes is most important when running Play in development mode (using `run`) rather than production mode. That's because Play's development mode uses multiple class loaders so that it can support automatic application reloading. Some of Play's threads might be bound to a class loader that only knows about a subset of your application's classes.
 
-In some cases you may not be able to explicitly use the application classloader. This is sometimes the case when using third party libraries. In this case you may need to set the [thread context class loader](http://docs.oracle.com/javase/6/docs/api/java/lang/Thread.html#getContextClassLoader\(\)) explicitly before you call the third party code. If you do, remember to restore the context class loader back to its previous value once you've finished calling the third party code.
+In some cases you may not be able to explicitly use the application classloader. This is sometimes the case when using third party libraries. In this case you may need to set the [thread context class loader](http://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#getContextClassLoader--) explicitly before you call the third party code. If you do, remember to restore the context class loader back to its previous value once you've finished calling the third party code.
 
 ### Java thread locals
 
@@ -122,9 +122,9 @@ In this profile, you would simply use the default execution context everywhere, 
 
 This profile is recommended for Java applications that do synchronous IO, since it is harder in Java to dispatch work to other threads.
 
-Note that we use the same value for `parallelism-min` and `parallelism-max`. The reason is that the number of threads is defined by the following formulas : 
+Note that we use the same value for `parallelism-min` and `parallelism-max`. The reason is that the number of threads is defined by the following formulas :
 
->base-nb-threads = nb-processors * parallelism-factor  
+>base-nb-threads = nb-processors * parallelism-factor
  parallelism-min <= actual-nb-threads <= parallelism-max
 
 So if you don't have enough available processors, you will never be able to reach the `parallelism-max` setting.

--- a/documentation/manual/detailedTopics/configuration/ws/CertificateRevocation.md
+++ b/documentation/manual/detailedTopics/configuration/ws/CertificateRevocation.md
@@ -7,7 +7,7 @@ Certificate Revocation can be very useful in situations where a server's private
 
 Certificate Revocation is disabled by default in JSSE.  It is defined in two places:
 
-* [PKI Programmer's Guide, Appendix C](http://docs.oracle.com/javase/6/docs/technotes/guides/security/certpath/CertPathProgGuide.html#AppC)
+* [PKI Programmer's Guide, Appendix C](http://docs.oracle.com/javase/8/docs/technotes/guides/security/certpath/CertPathProgGuide.html#AppC)
 * [Enable OCSP Checking](https://blogs.oracle.com/xuelei/entry/enable_ocsp_checking)
 
 To enable OCSP, you must set the following system properties on the command line:

--- a/documentation/manual/detailedTopics/configuration/ws/WsSSL.md
+++ b/documentation/manual/detailedTopics/configuration/ws/WsSSL.md
@@ -32,19 +32,3 @@ JDK 1.8:
 * [SunJSSE Providers](http://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider)
 * [PKI Programmer's Guide](http://docs.oracle.com/javase/8/docs/technotes/guides/security/certpath/CertPathProgGuide.html)
 * [keytool](http://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html)
-
-JDK 1.7:
-
-* [JSSE Reference Guide](http://docs.oracle.com/javase/7/docs/technotes/guides/security/jsse/JSSERefGuide.html)
-* [JSSE Crypto Spec](http://docs.oracle.com/javase/7/docs/technotes/guides/security/crypto/CryptoSpec.html#SSLTLS)
-* [SunJSSE Providers](http://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider)
-* [PKI Programmer's Guide](http://docs.oracle.com/javase/7/docs/technotes/guides/security/certpath/CertPathProgGuide.html)
-* [keytool](http://docs.oracle.com/javase/7/docs/technotes/tools/solaris/keytool.html)
-
-JDK 1.6:
-
-* [JSSE Reference Guide](http://docs.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html)
-* [JSSE Crypto Spec](http://docs.oracle.com/javase/6/docs/technotes/guides/security/crypto/CryptoSpec.html#SSLTLS)
-* [SunJSSE Providers](http://docs.oracle.com/javase/6/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider)
-* [PKI Programmer's Guide](http://docs.oracle.com/javase/6/docs/technotes/guides/security/certpath/CertPathProgGuide.html)
-* [keytool](http://docs.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html)

--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -227,11 +227,11 @@ The reverse ref router used in Java tests has been removed. Any call to `Helpers
 
 ## Java TimeoutExceptions
 
-If you use the Java API, the [`F.Promise`](api/java/play/libs/F.Promise.html) class now throws unchecked [`F.PromiseTimeoutException`s](api/java/play/libs/F.PromiseTimeoutException.html) instead of Java's checked [`TimeoutException`s](http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/TimeoutException.html). The `TimeoutExceptions`s which were previously used were not properly declared with the `throws` keyword. Rather than changing the API to use the `throws` keyword, which would mean users would have to declare `throws` on their methods, the exception was changed to a new unchecked type instead. See [#1227](https://github.com/playframework/playframework/pull/1227) for more information.
+If you use the Java API, the [`F.Promise`](api/java/play/libs/F.Promise.html) class now throws unchecked [`F.PromiseTimeoutException`s](api/java/play/libs/F.PromiseTimeoutException.html) instead of Java's checked [`TimeoutException`s](http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/TimeoutException.html). The `TimeoutExceptions`s which were previously used were not properly declared with the `throws` keyword. Rather than changing the API to use the `throws` keyword, which would mean users would have to declare `throws` on their methods, the exception was changed to a new unchecked type instead. See [#1227](https://github.com/playframework/playframework/pull/1227) for more information.
 
 | Old API | New API | Comments |
 | ------- | --------| -------- |
-| [`TimeoutException`](http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/TimeoutException.html) | [`F.PromiseTimeoutException`](api/java/play/libs/F.PromiseTimeoutException.html) | |
+| [`TimeoutException`](http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/TimeoutException.html) | [`F.PromiseTimeoutException`](api/java/play/libs/F.PromiseTimeoutException.html) | |
 
 ## Crypto APIs
 
@@ -249,7 +249,7 @@ If you wish to continue using the older format of encryption decryption, here is
 
 The new Anorm version includes various fixes and improvements.
 
-Following [BatchSQL #3016](https://github.com/playframework/playframework/commit/722cd55a3a5369f911f5d11f7c93ba4bf100ca23), `SqlQuery` case class is refactored as a trait with companion object. 
+Following [BatchSQL #3016](https://github.com/playframework/playframework/commit/722cd55a3a5369f911f5d11f7c93ba4bf100ca23), `SqlQuery` case class is refactored as a trait with companion object.
 Consequently, `BatchSql` is now created by passing a raw statement which is validated internally.
 
 ```scala
@@ -284,11 +284,11 @@ val res: (String, Int) = SQL"SELECT text, count AS i".map(row =>
 New `fold` and `foldWhile` functions to work with result stream.
 
 ```scala
-val countryCount: Either[List[Throwable], Long] = 
+val countryCount: Either[List[Throwable], Long] =
   SQL"Select count(*) as c from Country".fold(0l) { (c, _) => c + 1 }
 
 val books: Either[List[Throwable], List[String]] =
- SQL("Select name from Books").foldWhile(List[String]()) { (list, row) => 
+ SQL("Select name from Books").foldWhile(List[String]()) { (list, row) =>
   foldWhile(List[String]()) { (list, row) =>
     if (list.size == 100) (list -> false) // stop with `list`
     else (list := row[String]("name")) -> true // continue with one more name

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/CertificateGenerator.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/CertificateGenerator.scala
@@ -19,7 +19,7 @@ import scala.util.Properties.isJavaAtLeast
  */
 object CertificateGenerator {
 
-  // http://docs.oracle.com/javase/6/docs/technotes/guides/security/StandardNames.html#KeyPairGenerator
+  // http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#KeyPairGenerator
   // http://www.keylength.com/en/4/
 
   /**

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/Debug.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/Debug.scala
@@ -6,7 +6,7 @@
 package play.api.libs.ws.ssl
 
 /**
- * @see http://docs.oracle.com/javase/6/docs/technotes/guides/security/certpath/CertPathProgGuide.html
+ * @see http://docs.oracle.com/javase/8/docs/technotes/guides/security/certpath/CertPathProgGuide.html
  */
 class JavaSecurityDebugBuilder(c: SSLDebugConfig) {
 
@@ -30,8 +30,8 @@ class JavaSecurityDebugBuilder(c: SSLDebugConfig) {
  * A builder for setting the system property options in "javax.net.debug" and in "java.security.debug' (in
  * the case of "certpath").
  *
- * @see http://docs.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#Debug
- * @see http://docs.oracle.com/javase/6/docs/technotes/guides/security/jsse/ReadDebug.html
+ * @see http://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#Debug
+ * @see http://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/ReadDebug.html
  */
 class JavaxNetDebugBuilder(c: SSLDebugConfig) {
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/DefaultHostnameVerifier.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/DefaultHostnameVerifier.scala
@@ -24,7 +24,7 @@ class DefaultHostnameVerifier extends HostnameVerifier {
   // AsyncHttpClient issue #197: "SSL host name verification disabled by default"
   // https://github.com/AsyncHttpClient/async-http-client/issues/197
   //
-  // From http://docs.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#HostnameVerifier
+  // From http://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#HostnameVerifier
   //
   // "When using raw SSLSockets/SSLEngines you should always check the peer's credentials before sending any data.
   // The SSLSocket and SSLEngine classes do not automatically verify that the hostname in a URL matches the

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/SystemConfiguration.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/SystemConfiguration.scala
@@ -38,7 +38,7 @@ class SystemConfiguration {
   }
 
   def configureCheckRevocation(checkRevocation: Boolean) {
-    // http://docs.oracle.com/javase/6/docs/technotes/guides/security/certpath/CertPathProgGuide.html#AppC
+    // http://docs.oracle.com/javase/8/docs/technotes/guides/security/certpath/CertPathProgGuide.html#AppC
     // https://blogs.oracle.com/xuelei/entry/enable_ocsp_checking
 
     // 1.7: PXIXCertPathValidator.populateVariables, it is dynamic so no override needed.


### PR DESCRIPTION
There were a lot of links pointing to Java 6. I've manually check them all to ensure that the new links are still correct.