### PR TITLE
Remove onLoadConfig from GlobalSettings

### DIFF
--- a/documentation/manual/detailedTopics/configuration/code/ThreadPools.scala
+++ b/documentation/manual/detailedTopics/configuration/code/ThreadPools.scala
@@ -154,13 +154,9 @@ object ThreadPoolsSpec extends PlaySpecification {
 
   }
 
-  def runningWithConfig[T: AsResult](config: String )(block: Application => T) = {
-    val parsed = ConfigFactory.parseString(config)
-    val app = FakeApplication(withGlobal = Some(new GlobalSettings {
-      override def onLoadConfig(config: Configuration, path: File, classloader: ClassLoader, mode: Mode.Mode) = {
-        config ++ Configuration(parsed)
-      }
-    }))
+  def runningWithConfig[T: AsResult](config: String)(block: Application => T) = {
+    val parsed: java.util.Map[String,Object] = ConfigFactory.parseString(config).root.unwrapped
+    val app = FakeApplication(additionalConfiguration = collection.JavaConversions.mapAsScalaMap(parsed).toMap)
     running(app)(block(app))
   }
 }

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ApplicationTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ApplicationTest.java
@@ -25,7 +25,7 @@ public class ApplicationTest extends WithApplication {
   @Override
   protected FakeApplication provideFakeApplication() {
     return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(),
-        ImmutableMap.of("play.http.router", "javaguide.tests.Routes"), new ArrayList<String>(), null);
+        ImmutableMap.of("play.http.router", "javaguide.tests.Routes"), new ArrayList<String>());
   }
 
   @Test

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/FakeApplicationTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/FakeApplicationTest.java
@@ -41,13 +41,6 @@ public class FakeApplicationTest {
       //#test-fakeapp
       Application fakeApp = Helpers.fakeApplication();
 
-      Application fakeAppWithGlobal = fakeApplication(new GlobalSettings() {
-        @Override
-        public void onStart(Application app) {
-          System.out.println("Starting FakeApplication");
-        }
-      });
-
       Application fakeAppWithMemoryDb = fakeApplication(inMemoryDatabase("test"));
       //#test-fakeapp
     }

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ScalaFunctionalTestSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ScalaFunctionalTestSpec.scala
@@ -28,9 +28,7 @@ class ScalaFunctionalTestSpec extends PlaySpecification with Results {
   "Scala Functional Test" should {
 
     // #scalafunctionaltest-fakeApplication
-    val fakeApplicationWithGlobal = FakeApplication(withGlobal = Some(new GlobalSettings() {
-      override def onStart(app: Application) { println("Hello world!") }
-    }))
+    val fakeApp = FakeApplication()
     // #scalafunctionaltest-fakeApplication
 
     val fakeApplication = FakeApplication(withRoutes = {

--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -18,7 +18,6 @@ import scala.concurrent._
 import play.api.libs.concurrent.Execution.{ defaultContext => ec }
 
 object NettyDefaultFiltersSpec extends DefaultFiltersSpec with NettyIntegrationSpecification
-object NettyGlobalFiltersSpec extends GlobalFiltersSpec with NettyIntegrationSpecification
 object AkkaDefaultHttpFiltersSpec extends DefaultFiltersSpec with AkkaHttpIntegrationSpecification
 
 trait DefaultFiltersSpec extends FiltersSpec {
@@ -39,28 +38,6 @@ trait DefaultFiltersSpec extends FiltersSpec {
       WsTestClient.withClient(block)
     }
 
-  }
-}
-
-trait GlobalFiltersSpec extends FiltersSpec {
-  def withServer[T](settings: Map[String, String] = Map.empty, errorHandler: Option[HttpErrorHandler] = None)(filters: EssentialFilter*)(block: WSClient => T) = {
-
-    import play.api.inject.bind
-
-    val appBuilder = new GuiceApplicationBuilder()
-      .configure(settings)
-      .overrides(bind[Router].toInstance(testRouter))
-      .global(
-        new WithFilters(filters: _*) {
-          override def onHandlerNotFound(request: RequestHeader) = {
-            errorHandler.fold(super.onHandlerNotFound(request))(_.onClientError(request, 404, ""))
-          }
-        }
-      )
-
-    Server.withApplication(appBuilder.build()) { implicit port =>
-      WsTestClient.withClient(block)
-    }
   }
 }
 

--- a/framework/src/play-java/src/main/java/play/inject/guice/GuiceApplicationBuilder.java
+++ b/framework/src/play-java/src/main/java/play/inject/guice/GuiceApplicationBuilder.java
@@ -9,9 +9,7 @@ import java.util.List;
 import play.api.inject.guice.GuiceableModule;
 import play.Application;
 import play.Configuration;
-import play.core.j.JavaGlobalSettingsAdapter;
 import play.Environment;
-import play.GlobalSettings;
 import play.libs.Scala;
 
 import static scala.compat.java8.JFunction.func;
@@ -40,14 +38,6 @@ public final class GuiceApplicationBuilder extends GuiceBuilder<GuiceApplication
      */
     public GuiceApplicationBuilder loadConfig(Configuration conf) {
         return loadConfig(env -> conf);
-    }
-
-    /**
-     * Set the global settings object.
-     * Overrides the default or any previously configured values.
-     */
-    public GuiceApplicationBuilder global(GlobalSettings global) {
-        return newBuilder(delegate.global(new JavaGlobalSettingsAdapter(global)));
     }
 
     /**

--- a/framework/src/play-java/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
+++ b/framework/src/play-java/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
@@ -87,23 +87,6 @@ public class GuiceApplicationBuilderTest {
     }
 
     @Test
-    public void setGlobal() {
-        GlobalSettings global = new GlobalSettings() {
-            @Override
-            public Configuration onLoadConfig(Configuration config, File path, ClassLoader classloader) {
-                Configuration extra = new Configuration(ImmutableMap.of("a", 1));
-                return extra.withFallback(config);
-            }
-        };
-
-        Application app = new GuiceApplicationBuilder()
-            .global(global)
-            .build();
-
-        assertThat(app.configuration().getInt("a"), is(1));
-    }
-
-    @Test
     public void setModuleLoader() {
         Application app = new GuiceApplicationBuilder()
             .load((env, conf) -> ImmutableList.of(

--- a/framework/src/play-test/src/main/java/play/test/FakeApplication.java
+++ b/framework/src/play-test/src/main/java/play/test/FakeApplication.java
@@ -30,7 +30,6 @@ public class FakeApplication implements play.Application {
      * @param additionalConfiguration additional configuration for the application
      * @param additionalPlugins additional plugins to load
      * @param withoutPlugins plugins to disable
-     * @param global global settings to use in place of default global
      */
     @SuppressWarnings("unchecked")
     public FakeApplication(
@@ -38,10 +37,7 @@ public class FakeApplication implements play.Application {
         ClassLoader classloader,
         Map<String, ? extends Object> additionalConfiguration,
         List<String> additionalPlugins,
-        List<String> withoutPlugins,
-        play.GlobalSettings global) {
-
-        play.api.GlobalSettings scalaGlobal = (global != null) ? new play.core.j.JavaGlobalSettingsAdapter(global) : null;
+        List<String> withoutPlugins) {
 
         this.application = new play.api.test.FakeApplication(
             path,
@@ -49,7 +45,6 @@ public class FakeApplication implements play.Application {
             Scala.toSeq(additionalPlugins),
             Scala.toSeq(withoutPlugins),
             Scala.asScala((Map<String, Object>) additionalConfiguration),
-            scala.Option.apply(scalaGlobal),
             scala.PartialFunction$.MODULE$.<scala.Tuple2<String, String>, Handler>empty()
         );
         this.configuration = application.injector().instanceOf(Configuration.class);
@@ -63,11 +58,10 @@ public class FakeApplication implements play.Application {
      * @param classloader application environment class loader
      * @param additionalConfiguration additional configuration for the application
      * @param additionalPlugins additional plugins to load
-     * @param global global settings to use in place of default global
      */
     public FakeApplication(File path, ClassLoader classloader, Map<String, ? extends Object> additionalConfiguration,
-                           List<String> additionalPlugins, play.GlobalSettings global) {
-        this(path, classloader, additionalConfiguration, additionalPlugins, Collections.<String>emptyList(), global);
+                           List<String> additionalPlugins) {
+        this(path, classloader, additionalConfiguration, additionalPlugins, Collections.<String>emptyList());
     }
 
     /**

--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -115,14 +115,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * Build a new fake application.
      */
     public static FakeApplication fakeApplication() {
-        return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(), new HashMap<String,Object>(), new ArrayList<String>(), null);
-    }
-
-    /**
-     * Build a new fake application.
-     */
-    public static FakeApplication fakeApplication(GlobalSettings global) {
-        return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(), new HashMap<String,Object>(), new ArrayList<String>(), global);
+        return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(), new HashMap<String,Object>(), new ArrayList<String>());
     }
 
     /**
@@ -157,43 +150,21 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * Build a new fake application.
      */
     public static FakeApplication fakeApplication(Map<String, ? extends Object> additionalConfiguration) {
-        return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(), additionalConfiguration, new ArrayList<String>(), null);
-    }
-
-    /**
-     * Build a new fake application.
-     */
-    public static FakeApplication fakeApplication(Map<String, ? extends Object> additionalConfiguration, GlobalSettings global) {
-        return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(), additionalConfiguration, new ArrayList<String>(), global);
+        return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(), additionalConfiguration, new ArrayList<String>());
     }
 
     /**
      * Build a new fake application.
      */
     public static FakeApplication fakeApplication(Map<String, ? extends Object> additionalConfiguration, List<String> additionalPlugin) {
-        return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(), additionalConfiguration, additionalPlugin, null);
-    }
-
-
-    /**
-     * Build a new fake application.
-     */
-    public static FakeApplication fakeApplication(Map<String, ? extends Object> additionalConfiguration, List<String> additionalPlugin, GlobalSettings global) {
-        return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(), additionalConfiguration, additionalPlugin, global);
+        return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(), additionalConfiguration, additionalPlugin);
     }
 
     /**
      * Build a new fake application.
      */
     public static FakeApplication fakeApplication(Map<String, ? extends Object> additionalConfiguration, List<String> additionalPlugins, List<String> withoutPlugins) {
-        return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(), additionalConfiguration, additionalPlugins, withoutPlugins, null);
-    }
-
-    /**
-     * Build a new fake application.
-     */
-    public static FakeApplication fakeApplication(Map<String, ? extends Object> additionalConfiguration, List<String> additionalPlugins, List<String> withoutPlugins, GlobalSettings global) {
-        return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(), additionalConfiguration, additionalPlugins, withoutPlugins, global);
+        return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(), additionalConfiguration, additionalPlugins, withoutPlugins);
     }
 
     /**

--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -200,12 +200,10 @@ case class FakeApplication(
     additionalPlugins: Seq[String] = Nil,
     withoutPlugins: Seq[String] = Nil,
     additionalConfiguration: Map[String, _ <: Any] = Map.empty,
-    withGlobal: Option[play.api.GlobalSettings] = None,
     withRoutes: PartialFunction[(String, String), Handler] = PartialFunction.empty) extends Application {
 
   private val app: Application = new GuiceApplicationBuilder()
     .in(Environment(path, classloader, Mode.Test))
-    .global(withGlobal.orNull)
     .configure(additionalConfiguration)
     .bindings(
       bind[FakePluginsConfig] to FakePluginsConfig(additionalPlugins, withoutPlugins),
@@ -216,7 +214,6 @@ case class FakeApplication(
     .build
 
   override def mode: Mode.Mode = app.mode
-  override def global: GlobalSettings = app.global
   override def configuration: Configuration = app.configuration
   override def actorSystem: ActorSystem = app.actorSystem
   override def plugins: Seq[Plugin.Deprecated] = app.plugins

--- a/framework/src/play/src/main/java/play/GlobalSettings.java
+++ b/framework/src/play/src/main/java/play/GlobalSettings.java
@@ -115,31 +115,6 @@ public class GlobalSettings {
     }
 
     /**
-     * Called just after configuration has been loaded, to give the application an opportunity to modify it.
-     *
-     * @param config the loaded configuration
-     * @param path the application path
-     * @param classloader The applications classloader
-     * @return The configuration that the application should use
-     */
-    public Configuration onLoadConfig(Configuration config, File path, ClassLoader classloader) {
-        return null;
-    }
-
-    /**
-     * Called just after configuration has been loaded, to give the application an opportunity to modify it.
-     *
-     * @param config the loaded configuration
-     * @param path the application path
-     * @param classloader The applications classloader
-     * @param mode The mode of the application
-     * @return The configuration that the application should use
-     */
-    public Configuration onLoadConfig(Configuration config, File path, ClassLoader classloader, Mode mode) {
-        return onLoadConfig(config, path, classloader);
-    }
-
-    /**
      * Get the filters that should be used to handle each request.
      */
     public <T extends play.api.mvc.EssentialFilter> Class<T>[] filters() {

--- a/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
+++ b/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
@@ -82,24 +82,6 @@ trait GlobalSettings {
   }
 
   /**
-   * Additional configuration provided by the application.  This is invoked by the default implementation of
-   * onLoadConfig, so if you override that, this won't be invoked.
-   */
-  def configuration: Configuration = Configuration.empty
-
-  /**
-   * Called just after configuration has been loaded, to give the application an opportunity to modify it.
-   *
-   * @param config the loaded configuration
-   * @param path the application path
-   * @param classloader The applications classloader
-   * @param mode The mode the application is running in
-   * @return The configuration that the application should use
-   */
-  def onLoadConfig(config: Configuration, path: File, classloader: ClassLoader, mode: Mode.Mode): Configuration =
-    config ++ configuration
-
-  /**
    * Retrieve the (RequestHeader,Handler) to use to serve this request.
    * Default is: route, tag request, then apply filters
    */

--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
@@ -17,7 +17,6 @@ final class GuiceApplicationBuilder(
   overrides: Seq[GuiceableModule] = Seq.empty,
   disabled: Seq[Class[_]] = Seq.empty,
   loadConfiguration: Environment => Configuration = Configuration.load,
-  global: Option[GlobalSettings] = None,
   loadModules: (Environment, Configuration) => Seq[GuiceableModule] = GuiceableModule.loadModules) extends GuiceBuilder[GuiceApplicationBuilder](
   environment, configuration, modules, overrides, disabled
 ) {
@@ -40,13 +39,6 @@ final class GuiceApplicationBuilder(
     loadConfig(env => conf)
 
   /**
-   * Set the global settings object.
-   * Overrides the default or any previously configured values.
-   */
-  def global(globalSettings: GlobalSettings): GuiceApplicationBuilder =
-    copy(global = Option(globalSettings))
-
-  /**
    * Set the module loader.
    * Overrides the default or any previously configured values.
    */
@@ -64,7 +56,7 @@ final class GuiceApplicationBuilder(
    */
   override def injector(): PlayInjector = {
     val initialConfiguration = loadConfiguration(environment)
-    val globalSettings = global.getOrElse(GlobalSettings(initialConfiguration, environment))
+    val globalSettings = GlobalSettings(initialConfiguration, environment)
     val appConfiguration = initialConfiguration ++ configuration
 
     // TODO: Logger should be application specific, and available via dependency injection.
@@ -101,9 +93,8 @@ final class GuiceApplicationBuilder(
     overrides: Seq[GuiceableModule] = overrides,
     disabled: Seq[Class[_]] = disabled,
     loadConfiguration: Environment => Configuration = loadConfiguration,
-    global: Option[GlobalSettings] = global,
     loadModules: (Environment, Configuration) => Seq[GuiceableModule] = loadModules): GuiceApplicationBuilder =
-    new GuiceApplicationBuilder(environment, configuration, modules, overrides, disabled, loadConfiguration, global, loadModules)
+    new GuiceApplicationBuilder(environment, configuration, modules, overrides, disabled, loadConfiguration, loadModules)
 
   /**
    * Implementation of Self creation for GuiceBuilder.

--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
@@ -65,8 +65,7 @@ final class GuiceApplicationBuilder(
   override def injector(): PlayInjector = {
     val initialConfiguration = loadConfiguration(environment)
     val globalSettings = global.getOrElse(GlobalSettings(initialConfiguration, environment))
-    val loadedConfiguration = globalSettings.onLoadConfig(initialConfiguration, environment.rootPath, environment.classLoader, environment.mode)
-    val appConfiguration = loadedConfiguration ++ configuration
+    val appConfiguration = initialConfiguration ++ configuration
 
     // TODO: Logger should be application specific, and available via dependency injection.
     //       Creating multiple applications will stomp on the global logger configuration.

--- a/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
@@ -46,12 +46,6 @@ class JavaGlobalSettingsAdapter(val underlying: play.GlobalSettings) extends Glo
       .getOrElse(super.onBadRequest(request, error))
   }
 
-  override def onLoadConfig(config: Configuration, path: File, classloader: ClassLoader, mode: Mode.Mode) = {
-    import JavaModeConverter.asJavaMode
-    Option(underlying.onLoadConfig(new play.Configuration(config), path, classloader, mode))
-      .map(_.getWrappedConfiguration).getOrElse(super.onLoadConfig(config, path, classloader, mode))
-  }
-
   override def doFilter(a: EssentialAction): EssentialAction = {
     try {
       Filters(super.doFilter(a), underlying.filters.map(_.newInstance: play.api.mvc.EssentialFilter): _*)

--- a/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
@@ -57,18 +57,6 @@ object GuiceApplicationBuilderSpec extends Specification {
       app.configuration.getInt("a") must beSome(1)
     }
 
-    "set global settings" in {
-      val global = new GlobalSettings {
-        override def configuration = Configuration("a" -> 1)
-      }
-
-      val app = new GuiceApplicationBuilder()
-        .global(global)
-        .build
-
-      app.configuration.getInt("a") must beSome(1)
-    }
-
     "set module loader" in {
       val app = new GuiceApplicationBuilder()
         .load((env, conf) => Seq(new BuiltinModule, bind[A].to[A1]))


### PR DESCRIPTION
The addition of the `onLoadConfig` method stops GlobalSettings from being able to be dependency injected. The configuration needs to be created before the injector or GlobalSettings are created. Otherwise you'd end up with a circular dependency where GlobalSettings depends on the Injector depends on the Config depends on GlobalSettings.

There are already other ways to override config. You can just specify the config in your config file. Or if you really want to do it in code, you can make your own `ApplicationLoader` (see `GuiceApplicationBuilder.loadConfig`)