### PR TITLE
Remove onLoadConfig from GlobalSettings

### DIFF
--- a/documentation/manual/detailedTopics/configuration/code/ThreadPools.scala
+++ b/documentation/manual/detailedTopics/configuration/code/ThreadPools.scala
@@ -155,12 +155,8 @@ object ThreadPoolsSpec extends PlaySpecification {
   }
 
   def runningWithConfig[T: AsResult](config: String )(block: Application => T) = {
-    val parsed = ConfigFactory.parseString(config)
-    val app = FakeApplication(withGlobal = Some(new GlobalSettings {
-      override def onLoadConfig(config: Configuration, path: File, classloader: ClassLoader, mode: Mode.Mode) = {
-        config ++ Configuration(parsed)
-      }
-    }))
+    val parsed: java.util.Map[String,Object] = ConfigFactory.parseString(config).root.unwrapped
+    val app = FakeApplication(additionalConfiguration = collection.JavaConversions.mapAsScalaMap(parsed).toMap)
     running(app)(block(app))
   }
 }

--- a/framework/src/play-java/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
+++ b/framework/src/play-java/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
@@ -87,23 +87,6 @@ public class GuiceApplicationBuilderTest {
     }
 
     @Test
-    public void setGlobal() {
-        GlobalSettings global = new GlobalSettings() {
-            @Override
-            public Configuration onLoadConfig(Configuration config, File path, ClassLoader classloader) {
-                Configuration extra = new Configuration(ImmutableMap.of("a", 1));
-                return extra.withFallback(config);
-            }
-        };
-
-        Application app = new GuiceApplicationBuilder()
-            .global(global)
-            .build();
-
-        assertThat(app.configuration().getInt("a"), is(1));
-    }
-
-    @Test
     public void setModuleLoader() {
         Application app = new GuiceApplicationBuilder()
             .load((env, conf) -> ImmutableList.of(

--- a/framework/src/play/src/main/java/play/GlobalSettings.java
+++ b/framework/src/play/src/main/java/play/GlobalSettings.java
@@ -115,26 +115,21 @@ public class GlobalSettings {
     }
 
     /**
-     * Called just after configuration has been loaded, to give the application an opportunity to modify it.
-     *
-     * @param config the loaded configuration
-     * @param path the application path
-     * @param classloader The applications classloader
-     * @return The configuration that the application should use
+     * @deprecated This method does not do anything.
+     * Instead, specify configuration in your config file
+     * or make your own ApplicationLoader (see GuiceApplicationBuilder.loadConfig).
      */
+    @Deprecated
     public Configuration onLoadConfig(Configuration config, File path, ClassLoader classloader) {
         return null;
     }
 
     /**
-     * Called just after configuration has been loaded, to give the application an opportunity to modify it.
-     *
-     * @param config the loaded configuration
-     * @param path the application path
-     * @param classloader The applications classloader
-     * @param mode The mode of the application
-     * @return The configuration that the application should use
+     * @deprecated This method does not do anything.
+     * Instead, specify configuration in your config file
+     * or make your own ApplicationLoader (see GuiceApplicationBuilder.loadConfig).
      */
+    @Deprecated
     public Configuration onLoadConfig(Configuration config, File path, ClassLoader classloader, Mode mode) {
         return onLoadConfig(config, path, classloader);
     }

--- a/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
+++ b/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
@@ -82,20 +82,19 @@ trait GlobalSettings {
   }
 
   /**
-   * Additional configuration provided by the application.  This is invoked by the default implementation of
-   * onLoadConfig, so if you override that, this won't be invoked.
+   * @deprecated This method does not do anything.
+   * Instead, specify configuration in your config file
+   * or make your own ApplicationLoader (see GuiceApplicationBuilder.loadConfig).
    */
+  @Deprecated
   def configuration: Configuration = Configuration.empty
 
   /**
-   * Called just after configuration has been loaded, to give the application an opportunity to modify it.
-   *
-   * @param config the loaded configuration
-   * @param path the application path
-   * @param classloader The applications classloader
-   * @param mode The mode the application is running in
-   * @return The configuration that the application should use
+   * @deprecated This method does not do anything.
+   * Instead, specify configuration in your config file
+   * or make your own ApplicationLoader (see GuiceApplicationBuilder.loadConfig).
    */
+  @Deprecated
   def onLoadConfig(config: Configuration, path: File, classloader: ClassLoader, mode: Mode.Mode): Configuration =
     config ++ configuration
 

--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
@@ -65,8 +65,7 @@ final class GuiceApplicationBuilder(
   override def injector(): PlayInjector = {
     val initialConfiguration = loadConfiguration(environment)
     val globalSettings = global.getOrElse(GlobalSettings(initialConfiguration, environment))
-    val loadedConfiguration = globalSettings.onLoadConfig(initialConfiguration, environment.rootPath, environment.classLoader, environment.mode)
-    val appConfiguration = loadedConfiguration ++ configuration
+    val appConfiguration = initialConfiguration ++ configuration
 
     // TODO: Logger should be application specific, and available via dependency injection.
     //       Creating multiple applications will stomp on the global logger configuration.

--- a/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
@@ -57,18 +57,6 @@ object GuiceApplicationBuilderSpec extends Specification {
       app.configuration.getInt("a") must beSome(1)
     }
 
-    "set global settings" in {
-      val global = new GlobalSettings {
-        override def configuration = Configuration("a" -> 1)
-      }
-
-      val app = new GuiceApplicationBuilder()
-        .global(global)
-        .build
-
-      app.configuration.getInt("a") must beSome(1)
-    }
-
     "set module loader" in {
       val app = new GuiceApplicationBuilder()
         .load((env, conf) => Seq(new BuiltinModule, bind[A].to[A1]))


### PR DESCRIPTION
@jroper I thought I would split https://github.com/playframework/playframework/pull/4296 into two PRs to make it easier. I updated this one to deprecate the method as you suggested. I'm not sure that's actually clearer though... I think it's more confusing as a user because you can have lots of warnings in your project and not necessarily pay attention and then spend time tracking down why it's not working. But if it's an error, then you will be forced to update your code. As long as we put it in the migration guide, I think it'd be clearer to actually remove it.