### PR TITLE
Migration doc for GlobalSettings

### DIFF
--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -188,6 +188,7 @@ While Play 2.4 won't force you to use the dependency injected versions of compon
 | [`Akka`](api/scala/play/api/libs/concurrent/Akka$.html) | N/A | No longer needed, just declare a dependency on `ActorSystem` |
 | [`WS`](api/scala/play/api/libs/ws/WS$.html) | [`WSClient`](api/scala/play/api/libs/ws/WSClient.html) | |
 | [`Crypto`](api/scala/play/api/libs/Crypto$.html) | [`Crypto`](api/scala/play/api/libs/Crypto.html) | |
+| [`GlobalSettings`](api/scala/play/api/GlobalSettings.html) | [`HttpErrorHandler`](api/scala/play/api/http/HttpErrorHandler.html), [`HttpRequestHandler`](api/scala/play/api/http/HttpRequestHandler.html), and [`HttpFilters`](api/scala/play/api/http/HttpFilters.html)| Read the details in the [[GlobalSettings|Migration24#GlobalSettings]] section below. |
 
 #### Java
 
@@ -201,6 +202,89 @@ While Play 2.4 won't force you to use the dependency injected versions of compon
 | [`Akka`](api/java/play/libs/Akka.html) | N/A | No longer needed, just declare a dependency on `ActorSystem` |
 | [`WS`](api/java/play/libs/ws/WS.html) | [`WSClient`](api/java/play/libs/ws/WSClient.html) | |
 | [`Crypto`](api/java/play/libs/Crypto.html) | [`Crypto`](api/java/play/libs/Crypto.html) | The old static methods have been removed, an instance can statically be accessed using `play.Play.application().injector().instanceOf(Crypto.class)` |
+| [`GlobalSettings`](api/java/play/GlobalSettings.html) | [`HttpErrorHandler`](api/java/play/http/HttpErrorHandler.html), [`HttpRequestHandler`](api/java/play/http/HttpRequestHandler.html), and [`HttpFilters`](api/java/play/http/HttpFilters.html)| Read the details in the [[GlobalSettings|Migration24#GlobalSettings]] section below. |
+
+### GlobalSettings
+
+If you are keen to use dependency injection, we are recommending that you move out of your `GlobalSettings` implementation class as much code as possible. Ideally, you should be able to refactor your code so that it is possible to eliminate your `GlobalSettings` class altogether.
+
+Next follows a method-by-method guide for refactoring your code. Because the APIs are slightly different for Java and Scala, make sure to jump to the appropriate subsection.
+
+> Note: If you haven't yet read about dependency injection in Play, make a point to do it now. Follow the appropriate link to learn about dependency injection in Play with [[Java|JavaDependencyInjection]] or [[Scala|ScalaDependencyInjection]].
+
+#### Scala
+
+* `GlobalSettings.beforeStart` and `GlobalSettings.onStart`:  Anything that needs to happen on start up should now be happening in the constructor of a dependency injected class. A class will perform its initialisation when the dependency injection framework loads it. If you need eager initialisation (because you need to execute some code *before* the application is actually started), [[define an eager binding|ScalaDependencyInjection#Eager-bindings]].
+
+* `GlobalSettings.onStop`: Add a dependency to [`ApplicationLifecycle`](api/scala/play/api/inject/ApplicationLifecycle.html) on the class that needs to register a stop hook. Then, move the implementation of your `GlobalSettings.onStop` method inside the `Future` passed to the `ApplicationLifecycle.addStopHook`. Read [[Stopping/cleaning-up|ScalaDependencyInjection#Stopping/cleaning-up]] for more information.
+
+* `GlobalSettings.onError`: Create a class that inherits from [`HttpErrorHandler`](api/scala/play/api/http/HttpErrorHandler.html), and move the implementation of your `GlobalSettings.onError` inside the `HttpErrorHandler.onServerError` method. Read [[Error Handling|ScalaErrorHandling]] for more information.
+
+* `GlobalSettings.onRequestReceived`:  Create a class that inherits from [`HttpRequestHandler`](api/scala/play/api/http/HttpRequestHandler.html), and move the implementation of your `GlobalSettings.onRequestReceived` inside the `HttpRequestHandler.handlerForRequest` method.  Read [[Request Handlers|ScalaHttpRequestHandlers]] for more information. 
+Be aware that if in your `GlobalSettings.onRequestReceived` implementation you are calling `super.onRequestReceived`, then you should inherits from [`DefaultHttpRequestHandler`](api/scala/play/api/http/DefaultHttpRequestHandler.html) instead of `HttpRequestHandler`, and replace all calls to `super.onRequestReceived` with `super.handlerForRequest`.
+
+* `GlobalSettings.onRouteRequest`: Create a class that inherits from [`DefaultHttpRequestHandler`](api/scala/play/api/http/DefaultHttpRequestHandler.html), and move the impementation of your `GlobalSettings.onRouteRequest` method inside the `DefaultHttpRequestHandler.routeRequest` method. Read [[Request Handlers|ScalaHttpRequestHandlers]] for more information.
+
+* `GlobalSettings.onRequestCompletion`: This method is deprecated, and it is *no longer invoked by Play*. Instead, create a custom filter that attaches an `onDoneEnumerating` callback onto the returned `Enumerator` result. Read [[Scala Http Filters|ScalaHttpFilters]] for details on how to create a http filter.
+
+* `GlobalSettings.onHandlerNotFound`: Create a class that inherits from [`HttpErrorHandler`](api/scala/play/api/http/HttpErrorHandler.html), and provide an implementation for `HttpErrorHandler.onClientError`. Read [[Error Handling|ScalaErrorHandling]] for more information.
+Note that `HttpErrorHandler.onClientError` takes a `statusCode` in argument, hence your implementation should boil down to:
+
+```scala
+if(statusCode == play.api.http.Status.NOT_FOUND) {
+  // move your implementation of `GlobalSettings.onHandlerNotFound` here
+}
+```
+
+* `GlobalSettings.onBadRequest`: Create a class that inherits from [`HttpErrorHandler`](api/scala/play/api/http/HttpErrorHandler.html), and provide an implementation for `HttpErrorHandler.onClientError`. Read [[Error Handling|ScalaErrorHandling]] for more information.
+Note that `HttpErrorHandler.onClientError` takes a `statusCode` in argument, hence your implementation should boil down to:
+
+```scala
+if(statusCode == play.api.http.Status.BAD_REQUEST) {
+  // move your implementation of `GlobalSettings.onBadRequest` here
+}
+```
+
+* `GlobalSettings.configure` and `GlobalSettings.onLoadConfig`: Specify all configuration in your config file or create your own ApplicationLoader (see [[GuiceApplicationBuilder.loadConfig|ScalaDependencyInjection#advanced-extending-the-guiceapplicationloader]]).
+
+* `GlobalSettings.doFilter`: Create a class that inherits from [`HttpFilters`](api/scala/play/api/http/HttpFilters.html), and provide an implementation for `HttpFilter.filters`. Read [[Http Filters|ScalaHttpFilters]] for more information.
+
+Also, mind that if your `Global` class is mixing the `WithFilters` trait, you should now create a Filter class that inherits from [`HttpFilters`](api/scala/play/api/http/HttpFilters.html), and place it in the empty package. Read [[here|ScalaHttpFilters]] for more details.
+
+
+#### Java
+
+* `GlobalSettings.beforeStart` and `GlobalSettings.onStart`:  Anything that needs to happen on start up should now be happening in the constructor of a dependency injected class. A class will perform its initialisation when the dependency injection framework loads it. If you need eager initialisation (for example, because you need to execute some code *before* the application is actually started), [[define an eager binding|JavaDependencyInjection#Eager-bindings]].
+
+* `GlobalSettings.onStop`: Add a dependency to [`ApplicationLifecycle`](api/java/play/inject/ApplicationLifecycle.html) on the class that needs to register a stop hook. Then, move the implementation of your `GlobalSettings.onStop` method inside the `Promise` passed to the `ApplicationLifecycle.addStopHook`. Read [[Stopping/cleaning-up|JavaDependencyInjection#Stopping/cleaning-up]] for more information.
+
+* `GlobalSettings.onError`: Create a class that inherits from [`HttpErrorHandler`](api/java/play/http/HttpErrorHandler.html), and move the implementation of your `GlobalSettings.onError` inside the `HttpErrorHandler.onServerError` method. Read [[Error Handling|JavaErrorHandling]] for more information.
+
+* `GlobalSettings.onRequest`: Create a class that inherits from [`DefaultHttpRequestHandler`](api/java/play/http/DefaultHttpRequestHandler.html), and move the implementation of your `GlobalSettings.onRequest` method inside the `DefaultHttpRequestHandler.createAction` method. Read [[Request Handlers|JavaHttpRequestHandlers]] for more information.
+
+* `GlobalSettings.onRouteRequest`: There is no simple migration for this method when using the Java API. If you need this, you will have to keep your Global class around for a little longer.
+
+* `GlobalSettings.onHandlerNotFound`: Create a class that inherits from [`HttpErrorHandler`](api/java/play/http/HttpErrorHandler.html), and provide an implementation for `HttpErrorHandler.onClientError`. Read [[Error Handling|JavaErrorHandling]] for more information.
+Note that `HttpErrorHandler.onClientError` takes a `statusCode` in argument, hence your implementation should boil down to:
+
+```java
+if(statusCode == play.mvc.Http.Status.NOT_FOUND) {
+  // move your implementation of `GlobalSettings.onHandlerNotFound` here
+}
+```
+
+* `GlobalSettings.onBadRequest`: Create a class that inherits from [`HttpErrorHandler`](api/java/play/http/HttpErrorHandler.html), and provide an implementation for `HttpErrorHandler.onClientError`. Read [[Error Handling|JavaErrorHandling]] for more information.
+Note that `HttpErrorHandler.onClientError` takes a `statusCode` in argument, hence your implementation should boil down to:
+
+```java
+if(statusCode == play.mvc.Http.Status.BAD_REQUEST) {
+  // move your implementation of `GlobalSettings.onBadRequest` here
+}
+```
+
+* `GlobalSettings.onLoadConfig`: Specify all configuration in your config file or create your own ApplicationLoader (see [[GuiceApplicationBuilder.loadConfig|JavaDependencyInjection#advanced-extending-the-guiceapplicationloader]]).
+
+* `GlobalSettings.filters`: Create a class that inherits from [`HttpFilters`](api/java/play/http/HttpFilters.html), and provide an implementation for `HttpFilter.filters`. Read [[Http Filters|JavaHttpFilters]] for more information.
 
 ## Configuration changes
 

--- a/documentation/manual/working/javaGuide/advanced/http/JavaHttpFilters.md
+++ b/documentation/manual/working/javaGuide/advanced/http/JavaHttpFilters.md
@@ -1,0 +1,38 @@
+<!--- Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com> -->
+# Filters
+
+Play provides a simple filter API for applying global filters to each request.
+
+## Filters vs action composition
+
+The filter API is intended for cross cutting concerns that are applied indiscriminately to all routes.  For example, here are some common use cases for filters:
+
+* Logging/metrics collection
+* [[GZIP encoding|GzipEncoding]]
+* [[Security headers|SecurityHeaders]]
+
+In contrast, [[action composition|JavaActionsComposition]] is intended for route specific concerns, such as authentication and authorisation, caching and so on.  If your filter is not one that you want applied to every route, consider using action composition instead, it is far more powerful.  And don't forget that you can create your own action builders that compose your own custom defined sets of actions to each route, to minimise boilerplate.
+
+## Using filters
+
+The simplest way to use a filter is to provide an implementation of the [`HttpFilters`](api/java/play/http/HttpFilters.html) interface in the root package called `Filters`:
+
+@[filters](code/javaguide/httpfilters/Filters.java)
+
+If you want to have different filters in different environments, or would prefer not putting this class in the root package, you can configure where Play should find the class by setting `play.http.filters` in `application.conf` to the fully qualified class name of the class.  For example:
+
+    play.http.filters=com.example.Filters
+
+## Where do filters fit in?
+
+Filters wrap the action after the action has been looked up by the router.  This means you cannot use a filter to transform a path, method or query parameter to impact the router.  However you can direct the request to a different action by invoking that action directly from the filter, though be aware that this will bypass the rest of the filter chain.  If you do need to modify the request before the router is invoked, a better way to do this would be to place your logic in `Global.onRouteRequest` instead.
+
+Since filters are applied after routing is done, it is possible to access routing information from the request, via the `tags` map on the `RequestHeader`.  For example, you might want to log the time against the action method.  In that case, you might update the `logTime` method to look like this:
+
+> Routing tags are a feature of the Play router.  If you use a custom router, or return a custom action in `Global.onRouteRequest`, these parameters may not be available.
+
+## Creating a filter
+
+Creating a filter using Java is currently not ideal because you will need to work with Scala types such as `Iteratee`, which have been originally designed to be consumed from Scala code, and can be quite cumbersome to use in Java. Our reccomendation is to create your custom filters using Scala, and then use them from Java as explained in [[this section|JavaHttpFilters#Using-filters]].
+
+Read [[here|ScalaHttpFilters]] to learn how to create a custom filter in Scala.

--- a/documentation/manual/working/javaGuide/advanced/http/JavaHttpRequestHandlers.md
+++ b/documentation/manual/working/javaGuide/advanced/http/JavaHttpRequestHandlers.md
@@ -1,0 +1,31 @@
+<!--- Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com> -->
+# HTTP Request Handlers
+
+Play abstraction for handling requests is less sophisticated in the Play Java API, when compared to its Scala counterpart. However, it may still be enough if you only need to execute some code before the controller's action method associated to the passed request is executed. If that's not enough, then you should fall back to the [[Scala API|ScalaHttpRequestHandlers]] for creating a HTTP request handler.
+
+## Implementing a custom request handler
+
+The [`HttpRequestHandler`](api/java/play/http/HttpRequestHandler.html) interface has two methods that needs to be implemented: 
+
+* `createAction`: Takes the request and the controller's action method associated with the passed request.
+*  `wrapAction`: Takes the action to be run and allows for a final global interceptor to be added to the action.
+
+There is also a [`DefaultHttpRequestHandler`](api/java/play/http/DefaultHttpRequestHandler.html) class that can be used if you don't want to implement both methods.
+
+>> Note: If you are providing an implementation of `wrapAction` because you need to apply a cross cutting concern to an action before is executed, creating a [[filter|JavaHttpFilters]] is a more idiomatic way of achieving the same.
+
+## Configuring the http request handler
+
+A custom http handler can be supplied by creating a class in the root package called `RequestHandler` that implements `HttpRequestHandler`, for example:
+
+@[default](code/javaguide/RequestHandler.java)
+
+If you don’t want to place your request handler in the root package, or if you want to be able to configure different request handlers for different environments, you can do this by configuring the `play.http.requestHandler` configuration property in `application.conf`:
+
+    play.http.requestHandler = "com.example.RequestHandler"
+    
+### Performance notes
+
+The http request handler that Play uses if none is configured is one that delegates to the legacy `GlobalSettings` methods.  This may have a performance impact as it will mean your application has to do many lookups out of Guice to handle a single request.  If you are not using a `Global` object, then you don't need this, instead you can configure Play to use the default http request handler:
+
+    play.http.requestHandler = "play.http.DefaultHttpRequestHandler"

--- a/documentation/manual/working/javaGuide/advanced/http/code/javaguide/RequestHandler.java
+++ b/documentation/manual/working/javaGuide/advanced/http/code/javaguide/RequestHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+//#default
+import play.http.HttpRequestHandler;
+import play.libs.F;
+import play.mvc.Action;
+import play.mvc.Http;
+import play.mvc.Result;
+
+import java.lang.reflect.Method;
+
+public class RequestHandler implements HttpRequestHandler {
+
+    @Override
+    public Action createAction(Http.Request request, Method actionMethod) {
+        return new Action.Simple() {
+            @Override
+            public F.Promise<Result> call(Http.Context ctx) throws Throwable {
+                return delegate.call(ctx);
+            }
+        };
+    }
+
+    @Override
+    public Action wrapAction(Action action) {
+        return action;
+    }
+}
+//#default

--- a/documentation/manual/working/javaGuide/advanced/http/code/javaguide/httpfilters/Filters.java
+++ b/documentation/manual/working/javaGuide/advanced/http/code/javaguide/httpfilters/Filters.java
@@ -1,0 +1,24 @@
+package httpfilters;
+
+// #filters
+import play.api.Logger;
+import play.api.mvc.EssentialFilter;
+import play.http.HttpFilters;
+import play.filters.gzip.GzipFilter;
+import javax.inject.Inject;
+
+public class Filters implements HttpFilters {
+
+  private final GzipFilter gzip;
+
+  @Inject
+  public Filters(GzipFilter gzip) {
+    this.gzip = gzip;
+  }
+
+  @Override
+  public EssentialFilter[] filters() {
+    return new EssentialFilter[] { gzip };
+  }
+}
+//#filters

--- a/documentation/manual/working/javaGuide/advanced/http/index.toc
+++ b/documentation/manual/working/javaGuide/advanced/http/index.toc
@@ -1,0 +1,2 @@
+JavaHttpFilters:HTTP filters
+JavaHttpRequestHandlers:HTTP request handlers

--- a/documentation/manual/working/javaGuide/advanced/index.toc
+++ b/documentation/manual/working/javaGuide/advanced/index.toc
@@ -1,4 +1,5 @@
 dependencyinjection:Dependency injection
+http:HTTP architecture
 routing:Advanced routing
 extending:Extending Play
 embedding:Embedding Play

--- a/documentation/manual/working/scalaGuide/advanced/http/ScalaHttpRequestHandlers.md
+++ b/documentation/manual/working/scalaGuide/advanced/http/ScalaHttpRequestHandlers.md
@@ -25,9 +25,11 @@ One use case for a custom request handler may be that you want to delegate to a 
 
 ## Configuring the http request handler
 
-To tell Play to use your custom http request handler, simply configure `play.http.requestHandler` in `application.conf` to point to the fully qualified class name of your handler:
+A custom http handler can be supplied by creating a class in the root package called `RequestHandler` that implements `HttpRequestHandler`.
 
-    play.http.requestHandler = "com.example.MyHttpRequestHandler"
+If you don’t want to place your request handler in the root package, or if you want to be able to configure different request handlers for different environments, you can do this by configuring the `play.http.requestHandler` configuration property in `application.conf`:
+
+    play.http.requestHandler = "com.example.RequestHandler"
     
 ### Performance notes
 


### PR DESCRIPTION
Migration doc for helping users moving away from `GlobalSettings` in the upcoming Play 2.4 release.

Note that some of the links I used are broken (missing page). For instance, we don't have a `JavaHttpRequestHandlers` page in the doc. I've worked under the assumption that we will create the missing pages before 2.4 final is published. Let me know if I'm wrong.