### PR TITLE
2.4.x Migration Guide - Crypto missing from "Dependency Injected Components"

### DIFF
--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -167,6 +167,7 @@ While Play 2.4 won't force you to use the dependency injected versions of compon
 | [`Cached` object](api/scala/index.html#play.api.cache.Cached$) | [`Cached` instance](api/scala/index.html#play.api.cache.Cached) | Use an injected instance instead of the companion object. You can use the `@NamedCache` annotation. |
 | [`Akka`](api/scala/index.html#play.api.libs.concurrent.Akka$) | N/A | No longer needed, just declare a dependency on `ActorSystem` |
 | [`WS`](api/scala/index.html#play.api.libs.ws.WS$) | [`WSClient`](api/scala/index.html#play.api.libs.ws.WSClient) | |
+| [`Crypto`](api/scala/index.html#play.api.libs.Crypto$) | [`Crypto`](api/scala/index.html#play.api.libs.Crypto) | |
 
 #### Java
 
@@ -179,6 +180,7 @@ While Play 2.4 won't force you to use the dependency injected versions of compon
 | [`Cache`](api/java/play/cache/Cache.html) | [`CacheApi`](api/java/play/cache/CacheApi.html) | You can get a particular cache using the [`@NamedCache`](api/java/play/cache/NamedCache.html) annotation. |
 | [`Akka`](api/java/play/libs/Akka.html) | N/A | No longer needed, just declare a dependency on `ActorSystem` |
 | [`WS`](api/java/play/libs/ws/WS.html) | [`WSClient`](api/java/play/libs/ws/WSClient.html) | |
+| [`Crypto`](api/java/play/libs/Crypto.html) | [`Crypto`](api/java/play/libs/Crypto.html) | The old static methods have been removed, an instance can statically be accessed using `play.Play.application().injector().instanceOf(Crypto.class)` |
 
 ## Configuration changes
 


### PR DESCRIPTION
The [migration guide](https://www.playframework.com/documentation/2.4.x/Migration24) has a section called "Dependency Injected Components". [`play.libs.Crypto`](https://github.com/playframework/playframework/blob/master/framework/src/play-java/src/main/java/play/libs/Crypto.java) is missing from this section.

Also, the text states:
> While Play 2.4 won’t force you to use the dependency injected versions of components, we do encourage you to start switching to them.

This isn't true for `Crypto` as far as I can tell. It looks like you have to use the dependency injected version because the old version went away. Not sure if that's a big issue, but wanted to mention that I noticed it