### PR TITLE
2.4.x - WS Migration Guide

### DIFF
--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -211,6 +211,7 @@ Additionally, Play has now better namespaced a large number of its configuration
 | `csrf`                    | `play.filters.csrf`                |
 | `evolutions.*`            | `play.evolutions.*`                |
 | `applyEvolutions.<db>`    | `play.evolutions.db.<db>.autoApply`|
+| `ws`                      | `play.ws`                          |
 
 ### Akka configuration
 
@@ -306,6 +307,12 @@ If you use the Java API, the [`F.Promise`](api/java/play/libs/F.Promise.html) cl
 | Old API | New API | Comments |
 | ------- | --------| -------- |
 | [`TimeoutException`](http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/TimeoutException.html) | [`F.PromiseTimeoutException`](api/java/play/libs/F.PromiseTimeoutException.html) | |
+
+## WS client
+
+`WSRequestHolder` has been renamed to `WSRequest` in [Scala](api/scala/index.html#play.api.libs.ws.WSRequest) and [Java](api/java/play/libs/ws/WSRequest.html).
+
+Play has upgraded from AsyncHttpClient 1.8 to 1.9, which includes a number of breaking changes if using or configuring that library directly.  Please see the [AsyncHttpClient Migration Guide](https://github.com/AsyncHttpClient/async-http-client/blob/master/MIGRATION.md) for more details.
 
 ## Crypto APIs
 


### PR DESCRIPTION
WS needs a migration page to go over the changes.  (Someone please stick a "Documentation" label on this.)

Rough overview:

WS upgrades the underlying AsyncHttpClient engine to 1.9.11!

Now supports SNI for HTTPS.

AHC 1.9.x supports DefaultHostnameVerifier and acceptAnyCertificate natively.

The configuration options for Play WS have changed.  AHC 1.9.x also removed a number of configuration options and renamed others (i.e. compressionEnabled is now compressionEnforced).  

WSRequestHolder is now WSRequest.  WSRequestHolder is still available, but has been deprecated.

Options that were already deprecated in 2.3.x have been removed in 2.4.

Signpost OAuth has been mostly replaced by the internal AHC SignatureCalculator (Signpost is still doing the request token retrieval for now).

The internal logic for constructing an AHC request has been cleaned up and centralized in buildRequest().

Java WS and Scala WS have slightly different logic for determining an automatic content type and character encoding when given POST body input -- not sure that this is meaningful, but it stands out more.
