### PR TITLE
2.4.0-RC1 Docs For Static Routes With Twirl, Also Guice Problem

### DIFF
--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -422,12 +422,17 @@ This means that you should change your templates to take an implicit `Messages` 
 From you controllers you can get such an implicit `Messages` value by mixing the [`play.api.i18n.I18nSupport`](api/scala/index.html#play.api.i18n.I18nSupport) trait in your controller that gives you an implicit `Messages` value as long as there is a `RequestHeader` value in the implicit scope. The `I18nSupport` trait has an abstract member `def messagesApi: MessagesApi` so your code will typically look like the following:
 
 ```scala
-class MyController(val messagesApi: MessagesApi) extends I18nSupport {
-  // ...
+import javax.inject.Inject
+import play.api.i18n.{MessagesApi, I18nSupport}
+import play.api.mvc.Controller
+
+class MyController @Inject() (val messagesApi: MessagesApi) 
+  extends Controller with I18nSupport {
+
 }
 ```
 
-A simpler migration path is also supported if you want your controller to be still an `object` instead of a `class` or don’t want to use the `I18nSupport` trait. Just add the following import:
+A simpler migration path is also supported if you want your controller to be still use static controller objects rather than injected classes with the `I18nSupport` trait. After modifying your templates to take an implicit `Messages` parameter, as described above, add the following import to your controllers:
 
 ```scala
 import play.api.i18n.Messages.Implicits._

--- a/framework/src/play/src/main/scala/play/api/inject/Binding.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Binding.scala
@@ -27,6 +27,7 @@ import com.google.inject.name.Names
  * @param scope The JSR-330 scope.
  * @param eager Whether the binding should be eagerly instantiated.
  * @param source Where this object was bound. Used in error reporting.
+ * @see The [[Module]] class for information on how to provide bindings.
  */
 final case class Binding[T](key: BindingKey[T], target: Option[BindingTarget[T]], scope: Option[Class[_ <: Annotation]], eager: Boolean, source: Object) {
 
@@ -52,6 +53,11 @@ final case class Binding[T](key: BindingKey[T], target: Option[BindingTarget[T]]
   }
 }
 
+/**
+ * Constructor for a binding Key that doesn't have a qualifier.
+ *
+ * @see The [[Module]] class for information on how to provide bindings.
+ */
 object BindingKey {
   def apply[T](clazz: Class[T]): BindingKey[T] = new BindingKey(clazz)
 }
@@ -63,6 +69,7 @@ object BindingKey {
  *
  * @param clazz The class to bind.
  * @param qualifier An optional qualifier.
+ * @see The [[Module]] class for information on how to provide bindings.
  */
 final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnotation]) {
 
@@ -229,21 +236,29 @@ final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnot
  * A binding target.
  *
  * This trait captures the four possible types of targets.
+ *
+ * @see The [[Module]] class for information on how to provide bindings.
  */
 sealed trait BindingTarget[T]
 
 /**
  * A binding target that is provided by a provider instance.
+ *
+ * @see The [[Module]] class for information on how to provide bindings.
  */
 final case class ProviderTarget[T](provider: Provider[_ <: T]) extends BindingTarget[T]
 
 /**
  * A binding target that is provided by a provider class.
+ *
+ * @see The [[Module]] class for information on how to provide bindings.
  */
 final case class ProviderConstructionTarget[T](provider: Class[_ <: Provider[T]]) extends BindingTarget[T]
 
 /**
  * A binding target that is provided by a class.
+ *
+ * @see The [[play.api.inject.Module]] class for information on how to provide bindings.
  */
 final case class ConstructionTarget[T](implementation: Class[_ <: T]) extends BindingTarget[T]
 
@@ -257,16 +272,22 @@ final case class BindingKeyTarget[T](key: BindingKey[_ <: T]) extends BindingTar
  *
  * Since bindings may specify either annotations, or instances of annotations, this abstraction captures either of
  * those two possibilities.
+ *
+ * @see The [[Module]] class for information on how to provide bindings.
  */
 sealed trait QualifierAnnotation
 
 /**
  * A qualifier annotation instance.
+ *
+ * @see The [[Module]] class for information on how to provide bindings.
  */
 final case class QualifierInstance[T <: Annotation](instance: T) extends QualifierAnnotation
 
 /**
  * A qualifier annotation class.
+ *
+ * @see The [[Module]] class for information on how to provide bindings.
  */
 final case class QualifierClass[T <: Annotation](clazz: Class[T]) extends QualifierAnnotation
 

--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -13,6 +13,12 @@ import play.api.routing.Router
 
 import scala.concurrent.ExecutionContext
 
+/**
+ * The Play BuiltinModule.
+ *
+ * Provides all the core components of a Play application. This is typically automatically enabled by Play for an
+ * application.
+ */
 class BuiltinModule extends Module {
   def bindings(env: Environment, configuration: Configuration): Seq[Binding[_]] = {
     def dynamicBindings(factories: ((Environment, Configuration) => Seq[Binding[_]])*) = {

--- a/framework/src/play/src/main/scala/play/api/inject/Injector.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Injector.scala
@@ -57,11 +57,18 @@ object NewInstanceInjector extends Injector {
 /**
  * A simple map backed injector.
  *
- * This injector is intended for use in the transitional period between when Play fully supports dependency injection
- * across the whole code base, and when some parts of Play still access core components through Play's global state.
+ * This injector is intended for use by compile time injected applications in the transitional period between when Play
+ * fully supports dependency injection across the whole code base, and when some parts of Play still access core
+ * components through Play's global state. Since Play's global state requires that some components are still dynamically
+ * looked up from an injector, when using a compile time DI approach, there is typically no way to dynamically look up
+ * components, so this provides a simple implementation of the [[Injector]] trait to allow components
+ * that Play requires to be dynamically looked up.
  *
  * It is intended to just hold built in Play components, but may be used to add additional components by end users when
  * required.
+ *
+ * The injector is an immutable structure, new components can be added using the `+` convenience method, which returns
+ * a new injector with that component included.
  *
  * @param fallback The injector to fallback to if no component can be found.
  * @param components The components that this injector provides.

--- a/framework/src/play/src/main/scala/play/api/inject/Module.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Module.scala
@@ -17,12 +17,12 @@ import scala.reflect.ClassTag
  * ApplicationLoaders.  Any plugin that wants to provide components that a Play application can use may implement
  * one of these.
  *
- * Providing custom modules can be done by creating a resource on the classpath called `play.modules`. This file is
- * expected to contain a list of module classes, one class per line.  For example:
+ * Providing custom modules can be done by appending their fully qualified class names to `play.modules.enabled` in
+ * `application.conf`, for example
  *
  * {{{
- *   com.example.FooModule
- *   com.example.BarModule
+ *   play.modules.enabled += "com.example.FooModule"
+ *   play.modules.enabled += "com.example.BarModule"
  * }}}
  *
  * It is strongly advised that in addition to providing a module for JSR-330 DI, that plugins also provide a Scala
@@ -76,6 +76,9 @@ abstract class Module {
   final def seq(bindings: Binding[_]*): Seq[Binding[_]] = bindings
 }
 
+/**
+ * Locates and loads modules from the Play environment.
+ */
 object Modules {
 
   /**

--- a/framework/src/play/src/main/scala/play/api/inject/package.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/package.scala
@@ -5,15 +5,41 @@ package play.api
 
 import scala.reflect.ClassTag
 
+/**
+ * Play's runtime dependency injection abstraction.
+ *
+ * Play's runtime dependency injection support is built on JSR-330, which provides a specification for declaring how
+ * dependencies get wired to components.  JSR-330 however does not address how components are provided to or located
+ * by a DI container.  Play's API seeks to address this in a DI container agnostic way.
+ *
+ * The reason for providing this abstraction is so that Play, the modules it provides, and third party modules can all
+ * express their bindings in a way that is not specific to any one DI container.
+ *
+ * Components are bound in the DI container.  Each binding is identified by a [[play.api.inject.BindingKey BindingKey]], which is
+ * typically an interface that the component implements, and may be optionally qualified by a JSR-330 qualifier
+ * annotation. A binding key is bound to a [[play.api.inject.BindingTarget BindingTarget]], which describes how the implementation
+ * of the interface that the binding key represents is constructed or provided.  Bindings may also be scoped using
+ * JSR-330 scope annotations.
+ *
+ * Bindings are provided by instances of [[play.api.inject.Module Module]].
+ *
+ * Out of the box, Play provides an implementation of this abstraction using Guice.
+ *
+ * @see The [[play.api.inject.Module Module]] class for information on how to provide bindings.
+ */
 package object inject {
 
   /**
    * Create a binding key for the given class.
+   *
+   * @see The [[play.api.inject.Module Module]] class for information on how to provide bindings.
    */
   def bind[T](clazz: Class[T]): BindingKey[T] = BindingKey(clazz)
 
   /**
    * Create a binding key for the given class.
+   *
+   * @see The [[play.api.inject.Module Module]] class for information on how to provide bindings.
    */
   def bind[T: ClassTag]: BindingKey[T] = BindingKey(implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]])
 


### PR DESCRIPTION
With 2.3.8, this dependency:

    "org.webjars" %% "webjars-play" % "2.4.0-M3-1"
And this route:

    GET    /thing/create       controllers.ThingController.create

And this static Controller:
````
object ThingController extends Controller {
  def create = Action { implicit request =>
    Ok(thingViews.edit(newThingForm, None))
  }
}
````

Caused this Twirl template to render properly:

````
@(thingForm: Form[model.Thing], maybeThingId: Option[Long])(implicit request: RequestHeader)
@import helper._
// blah blah
inputText(thingForm("sku"))
// blah blah
}
````
However, after changing `plugins.sbt` to use Play 2.4.0-RC1 the above gives the following error for each inputText in the Twirl view:

    could not find implicit value for parameter messages: play.api.i18n.Messages

I tried adding the following imports to the controller as per the [migration docs](https://www.playframework.com/documentation/2.4.0-RC1/Migration24#Scala1):

    import play.api.i18n.Messages.Implicits._
    import play.api.Play.current

... but I got the same error message. I realized I also had to change the Twirl template to this:

    @(thingForm: Form[model.Thing], maybeThingId: Option[Long])(implicit request: RequestHeader, messages: Messages)

... and it worked. The docs imply this change is necessary but dummies like me would benefit from a more explicit statement, something like "Add an extra implicit parameter of type Messages to Twirl templates that handle forms".

## Part II

Changing the route to this:

    GET         /thing/create            @controllers.ThingController.create

and changing the controller to this:

    class ThingController(val messagesApi: MessagesApi) extends Controller with I18nSupport

And changing the Twirl template to this:

    @(thingForm: Form[model.Thing], maybeThingId: Option[Long])(implicit request: RequestHeader, messages: Messages)

Gives the error:

````
[ConfigurationException: Guice configuration errors:

1) Could not find a suitable constructor in controllers.ThingController. Classes must have either one (and only one) constructor annotated with @Inject or a zero-argument constructor that is not private.
  at controllers.ThingController.class(Unknown Source)
  while locating controllers.ThingController

1 error]
````