### PR TITLE
Use Typesafe config system property config cache

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -55,6 +55,7 @@ object BuildSettings {
     ivyLoggingLevel := UpdateLogging.DownloadOnly,
     resolvers ++= Seq(
       Resolver.typesafeRepo("releases"),
+      Resolver.typesafeIvyRepo("releases"),
       "Scalaz Bintray Repo" at "https://dl.bintray.com/scalaz/releases"
     ),
 


### PR DESCRIPTION
This should improve our build stability, which is failing with ConcurrentModificationExceptions when we attempt to parse configuration from system properties.