### PR TITLE
Don't create an entire Application just to get an injector

### DIFF
--- a/documentation/manual/working/javaGuide/main/tests/code/tests/guice/JavaGuiceApplicationBuilderTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/tests/guice/JavaGuiceApplicationBuilderTest.java
@@ -175,7 +175,7 @@ public class JavaGuiceApplicationBuilderTest {
             .configure("key", "value")
             .bindings(new ComponentModule())
             .overrides(bind(Component.class).to(MockComponent.class))
-            .build();
+            .injector();
 
         Component component = injector.instanceOf(Component.class);
         // #injector-builder

--- a/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala
@@ -85,13 +85,13 @@ class ScalaGuiceApplicationBuilderSpec extends PlaySpecification {
 
     "add bindings" in {
       // #add-bindings
-      val application = new GuiceApplicationBuilder()
+      val injector = new GuiceApplicationBuilder()
         .bindings(new ComponentModule)
         .bindings(bind[Component].to[DefaultComponent])
-        .build
+        .injector
       // #add-bindings
 
-      application.injector.instanceOf[Component] must beAnInstanceOf[DefaultComponent]
+      injector.instanceOf[Component] must beAnInstanceOf[DefaultComponent]
     }
 
     "override bindings" in {
@@ -111,25 +111,25 @@ class ScalaGuiceApplicationBuilderSpec extends PlaySpecification {
 
     "load modules" in {
       // #load-modules
-      val application = new GuiceApplicationBuilder()
+      val injector = new GuiceApplicationBuilder()
         .load(
           new play.api.inject.BuiltinModule,
           bind[Component].to[DefaultComponent]
-        ).build
+        ).injector
       // #load-modules
 
-      application.injector.instanceOf[Component] must beAnInstanceOf[DefaultComponent]
+      injector.instanceOf[Component] must beAnInstanceOf[DefaultComponent]
     }
 
     "disable modules" in {
       // #disable-modules
-      val application = new GuiceApplicationBuilder()
+      val injector = new GuiceApplicationBuilder()
         .bindings(new ComponentModule) // ###skip
         .disable[ComponentModule]
-        .build
+        .injector
       // #disable-modules
 
-      application.injector.instanceOf[Component] must throwA[com.google.inject.ConfigurationException]
+      injector.instanceOf[Component] must throwA[com.google.inject.ConfigurationException]
     }
 
     "injector builder" in {
@@ -138,7 +138,7 @@ class ScalaGuiceApplicationBuilderSpec extends PlaySpecification {
         .configure("key" -> "value")
         .bindings(new ComponentModule)
         .overrides(bind[Component].to[MockComponent])
-        .build
+        .injector
 
       val component = injector.instanceOf[Component]
       // #injector-builder

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -161,7 +161,7 @@ object GzipFilterSpec extends PlaySpecification with DataTables {
             case _ => Action(result)
           }),
           bind[HttpFilters].to[Filters]
-        ).build()
+        ).build
     )(block)
   }
 

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
@@ -40,7 +40,7 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
           case _ => Action(result)
         }),
         bind[HttpFilters].to[Filters]
-      ).build()
+      ).build
     )(block)
   }
 

--- a/framework/src/play-java/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
+++ b/framework/src/play-java/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
@@ -29,13 +29,13 @@ public class GuiceApplicationBuilderTest {
 
     @Test
     public void addBindings() {
-        Application app = new GuiceApplicationBuilder()
+        Injector injector = new GuiceApplicationBuilder()
             .bindings(new AModule())
             .bindings(bind(B.class).to(B1.class))
-            .build();
+            .injector();
 
-        assertThat(app.injector().instanceOf(A.class), instanceOf(A1.class));
-        assertThat(app.injector().instanceOf(B.class), instanceOf(B1.class));
+        assertThat(injector.instanceOf(A.class), instanceOf(A1.class));
+        assertThat(injector.instanceOf(B.class), instanceOf(B1.class));
     }
 
     @Test
@@ -48,7 +48,8 @@ public class GuiceApplicationBuilderTest {
                 // also override the java api configuration
                 bind(Configuration.class).to(new ExtendConfiguration(new Configuration(ImmutableMap.of("b", 2)))),
                 bind(A.class).to(A2.class))
-            .build();
+            .injector()
+            .instanceOf(Application.class);
 
         assertThat(app.configuration().getInt("a"), is(1));
         assertThat(app.configuration().getInt("b"), is(2));
@@ -57,23 +58,23 @@ public class GuiceApplicationBuilderTest {
 
     @Test
     public void disableModules() {
-        Application app = new GuiceApplicationBuilder()
+        Injector injector = new GuiceApplicationBuilder()
             .bindings(new AModule())
             .disable(AModule.class)
-            .build();
+            .injector();
 
         exception.expect(com.google.inject.ConfigurationException.class);
-        app.injector().instanceOf(A.class);
+        injector.instanceOf(A.class);
     }
 
     @Test
     public void disableLoadedModules() {
-        Application app = new GuiceApplicationBuilder()
+        Injector injector = new GuiceApplicationBuilder()
             .disable(play.api.i18n.I18nModule.class)
-            .build();
+            .injector();
 
         exception.expect(com.google.inject.ConfigurationException.class);
-        app.injector().instanceOf(play.api.i18n.Langs.class);
+        injector.instanceOf(play.api.i18n.Langs.class);
     }
 
     @Test
@@ -88,24 +89,24 @@ public class GuiceApplicationBuilderTest {
 
     @Test
     public void setModuleLoader() {
-        Application app = new GuiceApplicationBuilder()
+        Injector injector = new GuiceApplicationBuilder()
             .load((env, conf) -> ImmutableList.of(
                 Guiceable.modules(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule()),
                 Guiceable.bindings(bind(A.class).to(A1.class))))
-            .build();
+            .injector();
 
-        assertThat(app.injector().instanceOf(A.class), instanceOf(A1.class));
+        assertThat(injector.instanceOf(A.class), instanceOf(A1.class));
     }
 
     @Test
     public void setLoadedModulesDirectly() {
-        Application app = new GuiceApplicationBuilder()
+        Injector injector = new GuiceApplicationBuilder()
             .load(
                 Guiceable.modules(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule()),
                 Guiceable.bindings(bind(A.class).to(A1.class)))
-            .build();
+            .injector();
 
-        assertThat(app.injector().instanceOf(A.class), instanceOf(A1.class));
+        assertThat(injector.instanceOf(A.class), instanceOf(A1.class));
     }
 
     public static interface A {}

--- a/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
@@ -15,14 +15,14 @@ object GuiceApplicationBuilderSpec extends Specification {
   "GuiceApplicationBuilder" should {
 
     "add bindings" in {
-      val app = new GuiceApplicationBuilder()
+      val injector = new GuiceApplicationBuilder()
         .bindings(
           new AModule,
           bind[B].to[B1])
-        .build
+        .injector
 
-      app.injector.instanceOf[A] must beAnInstanceOf[A1]
-      app.injector.instanceOf[B] must beAnInstanceOf[B1]
+      injector.instanceOf[A] must beAnInstanceOf[A1]
+      injector.instanceOf[B] must beAnInstanceOf[B1]
     }
 
     "override bindings" in {
@@ -38,14 +38,14 @@ object GuiceApplicationBuilderSpec extends Specification {
     }
 
     "disable modules" in {
-      val app = new GuiceApplicationBuilder()
+      val injector = new GuiceApplicationBuilder()
         .bindings(new AModule)
         .disable[play.api.i18n.I18nModule]
         .disable(classOf[AModule])
-        .build
+        .injector
 
-      app.injector.instanceOf[play.api.i18n.Langs] must throwA[com.google.inject.ConfigurationException]
-      app.injector.instanceOf[A] must throwA[com.google.inject.ConfigurationException]
+      injector.instanceOf[play.api.i18n.Langs] must throwA[com.google.inject.ConfigurationException]
+      injector.instanceOf[A] must throwA[com.google.inject.ConfigurationException]
     }
 
     "set initial configuration loader" in {
@@ -58,19 +58,19 @@ object GuiceApplicationBuilderSpec extends Specification {
     }
 
     "set module loader" in {
-      val app = new GuiceApplicationBuilder()
+      val injector = new GuiceApplicationBuilder()
         .load((env, conf) => Seq(new BuiltinModule, bind[A].to[A1]))
-        .build
+        .injector
 
-      app.injector.instanceOf[A] must beAnInstanceOf[A1]
+      injector.instanceOf[A] must beAnInstanceOf[A1]
     }
 
     "set loaded modules directly" in {
-      val app = new GuiceApplicationBuilder()
+      val injector = new GuiceApplicationBuilder()
         .load(new BuiltinModule, bind[A].to[A1])
-        .build
+        .injector
 
-      app.injector.instanceOf[A] must beAnInstanceOf[A1]
+      injector.instanceOf[A] must beAnInstanceOf[A1]
     }
 
   }


### PR DESCRIPTION
All of the fields in my tests are injected. I've gotten stuck on migrating to 2.4 when I got to my tests because it seems that Play 2.4 isn't really setup to have injectable tests. In Guice 3 you'd typically use something like [Guiceberry](https://code.google.com/p/guiceberry/) and [in Guice 4 you'd typically use Guice's built-in BoundFieldModule](https://github.com/google/guice/wiki/BoundFields). The typical setup is that you create an injector which injects the tests. The problem is that in Play 2.4 the Injector is hidden within the ApplicationLoader.

This PR helps by making the injector less hidden in the internals. You can see in fact that many of the existing tests had to inject an entire application and then get the injector from it to then inject some other object instead of being able to inject that object directly.

Ideally Guice 4 will be released before Play 2.4. In that case I'd really love to add a documentation example showing how to write a test with BoundFieldModule.