### PR TITLE
FileWatchService is in different package in 2.4

### DIFF
--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -45,6 +45,11 @@ IntelliJ is now able to import sbt projects natively, so we recommend using that
 
 The SBT setting key `playWatchService` has been renamed to `fileWatchService`.
 
+Also the corresponding class has changed. To set the FileWatchService to poll every two seconds, use it like this:
+```scala
+PlayKeys.fileWatchService := play.runsupport.FileWatchService.sbt(2000)
+```
+
 All classes in the SBT plugin are now in the package `play.sbt`, this is particularly pertinent if using `.scala` files to configure your build..
 
 ### Ebean dependency


### PR DESCRIPTION
The FileWatchService moved from 
play.sbtplugin.run to play.runsupport