### PR TITLE
Attempted build stability improvements

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -349,20 +349,26 @@ object PlayBuild extends Build {
 
   val ProtocolCompile = Tags.Tag("protocol-compile")
 
+  val tagProtocolCompileSettings: Seq[Setting[_]] = {
+    val settings: Seq[Setting[_]] = Seq(
+      compileIncremental <<= compileIncremental tag ProtocolCompile,
+      doc <<= doc tag ProtocolCompile
+    )
+    inConfig(Compile)(settings) ++ inConfig(Test)(settings)
+  }
+
   lazy val ForkRunProtocolProject = PlayDevelopmentProject("Fork-Run-Protocol", "fork-run-protocol")
     .settings(
-      libraryDependencies ++= forkRunProtocolDependencies(scalaBinaryVersion.value),
-      compileIncremental in Compile <<= (compileIncremental in Compile) tag ProtocolCompile,
-      doc in Compile <<= (doc in Compile) tag ProtocolCompile)
+      libraryDependencies ++= forkRunProtocolDependencies(scalaBinaryVersion.value)
+    ).settings(tagProtocolCompileSettings: _*)
     .dependsOn(RunSupportProject)
 
   // extra fork-run-protocol project that is only compiled against sbt scala version
   lazy val SbtForkRunProtocolProject = PlaySbtProject("SBT-Fork-Run-Protocol", "fork-run-protocol")
     .settings(
       target := target.value / "sbt-fork-run-protocol",
-      libraryDependencies ++= forkRunProtocolDependencies(scalaBinaryVersion.value),
-      compileIncremental in Compile <<= (compileIncremental in Compile) tag ProtocolCompile,
-      doc in Compile <<= (doc in Compile) tag ProtocolCompile)
+      libraryDependencies ++= forkRunProtocolDependencies(scalaBinaryVersion.value)
+    ).settings(tagProtocolCompileSettings: _*)
     .dependsOn(SbtRunSupportProject)
 
   lazy val ForkRunProject = PlayDevelopmentProject("Fork-Run", "fork-run")

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
@@ -41,6 +41,8 @@ $ delete public/new/new.css
 # Two files with the same name change detection
 > verifyResourceContains /assets/a/some.txt 200 original
 > verifyResourceContains /assets/b/some.txt 200 original
+# This sleep doesn't seem necessary, but adding it to see if it impacts CI stability
+$ sleep 1000
 $ copy-file changes/some.txt.1 public/a/some.txt
 > verifyResourceContains /assets/a/some.txt 200 changed
 $ copy-file changes/some.txt.1 public/b/some.txt


### PR DESCRIPTION
This attempts to fix two build stability problems. One is an OOME from scalac when compiling tests. Hard to know what's causing this, but we know that scalac has problems compiling the same source code twice in the same JVM, these processes are isolated in the Compile scope due to a specific bug with macros, but maybe there are more bugs, so isolating them so the run sequentially in the Test scope may work.

The other is random failures in the dev mode scripted test, and I can't see what the problem is. I'm inserting a sleep at an opportune time, not because I think it should be there, but because I want to know if that makes a difference.