### PR TITLE
Code snippet for adding a value to a session in Scala now uses the addingToSession method.

### DIFF
--- a/documentation/manual/working/scalaGuide/main/http/ScalaSessionFlash.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaSessionFlash.md
@@ -22,7 +22,7 @@ As the Session is just a Cookie, it is also just an HTTP header. You can manipul
 @[store-session](code/ScalaSessionFlash.scala)
 
 
-Note that this will replace the whole session. If you need to add an element to an existing Session, just add an element to the incoming session, and specify that as new session:
+Note that this will replace the whole session. If you need to add an element to an existing Session, just use the `addingToSession` method:
 
 @[add-session](code/ScalaSessionFlash.scala)
 

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
@@ -44,8 +44,8 @@ package scalaguide.http.scalasessionflash {
       "add data in the Session" in {
         def addSession = Action { implicit request =>
           //#add-session
-          Ok("Hello World!").withSession(
-            request.session + ("saidHello" -> "yes"))
+          Ok("Hello World!").addingToSession(
+            "saidHello" -> "yes")
           //#add-session
         }
 


### PR DESCRIPTION
For adding a value to the current session using Scala, the current documentation suggests to use the `withSession` method, copying the current session and adding key/value pairs as needed.

    Ok("Hello World!").withSession(
      request.session + ("saidHello" -> "yes"))

However, this approach clears the flash scope when used in conjunction with flashing, e.g. 

    Ok(...).flashing("flashedVariable" -> "42").withSession(request.session + ("saidHello" -> "yes"))

would result in the session correctly copied but losing the `flashedVariable` in the `flash` scope. 
Using `addingToSession` doesn't lead to such behaviour, and it's possible to chain `flashing` and `addingToSession`.

Regardless of this, as a `addingToSession` method is available, that should be documented properly as its purpose is exactly what is covered by this bit of documentation. 