### PR TITLE
Remove unused Tasks object

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -204,7 +204,6 @@ object PlayBuild extends Build {
   import Dependencies._
   import BuildSettings._
   import Generators._
-  import Tasks._
 
   lazy val BuildLinkProject = PlayNonCrossBuiltProject("Build-Link", "build-link")
     .settings(libraryDependencies ++= link)

--- a/framework/project/Tasks.scala
+++ b/framework/project/Tasks.scala
@@ -28,15 +28,6 @@ object Generators {
   }
 }
 
-object Tasks {
-
-  def scalaTemplateSourceMappings = (excludeFilter in unmanagedSources, unmanagedSourceDirectories in Compile, baseDirectory) map {
-    (excludes, sdirs, base) =>
-      val scalaTemplateSources = sdirs.descendantsExcept("*.scala.html", excludes)
-      ((scalaTemplateSources --- sdirs --- base) pair (relativeTo(sdirs) | relativeTo(base) | flat)).toSeq
-  }
-}
-
 object Commands {
   val quickPublish = Command("quickPublish", Help.more("quickPublish", "Toggles quick publish mode, disabling/enabling build of documentation/source jars"))(_ => Parsers.EOF) { (state, _) =>
     val x = Project.extract(state)


### PR DESCRIPTION
I should have removed this when I changed the way scala template sources are bundled, it's not used anymore.