### PR TITLE
Increase heap for CI

### DIFF
--- a/framework/build
+++ b/framework/build
@@ -23,4 +23,4 @@ JAVA_VERSION=$("$JAVA" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 
 DIR=`dirname "$0"`
 
-"$JAVA" ${DEBUG_PARAM} -Xms512M -Xmx1536M -Xss2M -XX:ReservedCodeCacheSize=192m -XX:+CMSClassUnloadingEnabled ${JAVA_OPTS} -Dfile.encoding=UTF-8 -jar "$DIR/sbt/sbt-launch.jar" "$@"
+"$JAVA" ${DEBUG_PARAM} -Xms512M -Xmx4G -Xss2M -XX:ReservedCodeCacheSize=192m -XX:+CMSClassUnloadingEnabled ${JAVA_OPTS} -Dfile.encoding=UTF-8 -jar "$DIR/sbt/sbt-launch.jar" "$@"


### PR DESCRIPTION
After discussing with the Scala team, it seems our out of memory errors
may just be expected, given that we are compiling so many projects
together at once.  Increasing the heap to 4G.