### PR TITLE
Fixing nightly build

### DIFF
--- a/framework/project/Publish.scala
+++ b/framework/project/Publish.scala
@@ -57,7 +57,7 @@ object PublishSettings {
           publishTo.value
         }
       },
-      publishMavenStyle := !isSnapshot.value
+      publishMavenStyle := isSnapshot.value
     )
   }
 


### PR DESCRIPTION
Nightly build is failing because when we're publishing the sbt plugins, we're not publishing a pom files, so things built after them can't resolve them from OSS snapshots. Problem was, we should configure maven style publishing when it is a snapshot, not when it's not (when it's not, it gets published to an ivy repo, but snapshots get published to sonatype OSS snapshot repository).