### PR TITLE
Correct Play2.4 Migration doc about Ebean

### DIFF
--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -76,7 +76,7 @@ ebean.default = ["models.*"]
 ebean.orders = ["models.Order", "models.OrderItem"]
 ```
 
-Additionally, Ebean has been upgraded to 4.5.x, which pulls in a few of the features that Play previously added itself, including the `Model` class.  Consequently, the Play `Model` class has been deprecated, in favour of using `org.avaje.ebean.Model`.
+Additionally, Ebean has been upgraded to 4.5.x, which pulls in a few of the features that Play previously added itself, including the `Model` class.  Consequently, the Play `Model` class has been deprecated, in favour of using `com.avaje.ebean.Model`.
 
 ### Anorm dependency
 


### PR DESCRIPTION
In this document: https://www.playframework.com/documentation/2.4.0-RC1/Migration24
1)It is not "org.avaje.ebean.Model." but "com.avaje.ebean.Model."
2)You forgot to mention enabling the SbtEbean plugin in project
<code>lazy val myProject = (project in file(".")).enablePlugins(PlayJava, SbtEbean)</code>