### PR TITLE
Allow lang to be set without cookie

### DIFF
--- a/documentation/manual/working/javaGuide/main/i18n/JavaI18N.md
+++ b/documentation/manual/working/javaGuide/main/i18n/JavaI18N.md
@@ -17,25 +17,49 @@ You can externalize messages in the `conf/messages.xxx` files.
 
 The default `conf/messages` file matches all languages. You can specify additional language messages files, such as `conf/messages.fr` or `conf/messages.en-US`.
 
-You can retrieve messages for the current language using the `play.i18n.Messages` object:
+You can retrieve messages for the _current language_ using the `play.i18n.Messages` object:
 
 ```
 String title = Messages.get("home.title")
 ```
 
-You can also specify the language explicitly:
+The _current language_ is found by looking at the `lang` field in the current [`Context`](api/java/play/mvc/Http.Context.html). If there's no current `Context` then the default language is used. The `Context`'s `lang` value is determined by:
+
+1. Seeing if the `Context`'s `lang` field has been set explicitly.
+2. Looking for a `PLAY_LANG` cookie in the request.
+3. Looking at the `Accept-Language` headers of the request.
+4. Using the application's default language.
+
+You can change the `Context`'s `lang` field by calling `changeLang` or `setTransientLang`. The `changeLang` method will change the field and also set a `PLAY_LANG` cookie for future requests. The `setTransientLang` will set the field for the current request, but doesn't set a cookie. See [below](#Use-in-templates) for example usage.
+
+If you don't want to use the current language you can specify a message's language explicitly:
 
 ```
 String title = Messages.get(new Lang(Lang.forCode("fr")), "home.title")
 ```
 
-> **Note:** If you have a `Request` in the scope, it will use the preferred language extracted from the `Accept-Language` header and matching one of the application’s supported languages.
-
 ## Use in templates
-```
-@import play.i18n._
-@Messages.get("key")
-```
+
+You can use the `Messages.get` method from within a template. This will localize a message with the current language.
+
+@[template](code/javaguide/i18n/hellotemplate.scala.html)
+
+You can also use the Scala `Messages` object from within templates. The Scala `Messages` object has a shorter form that's equivalent to `Messages.get` which many people find useful. If you use the Scala `Messages` object remember not to import the Java `play.i18n.Messages` class or they will conflict!
+
+@[template](code/javaguide/i18n/helloscalatemplate.scala.html)
+
+Localized templates that use `Messages.get` or the Scala `Messages` object are invoked like normal:
+
+@[default-lang-render](code/javaguide/i18n/JavaI18N.java)
+
+If you want to change the language for the template you can call `changeLang` on the current [`Context`](api/java/play/mvc/Http.Context.html). This will change the language for the current request, and set the language into a cookie so that the language is changed for future requests:
+
+@[change-lang-render](code/javaguide/i18n/JavaI18N.java)
+
+If you just want to change the language, but only for the current request and not for future requests, call `setTransientLang`:
+
+@[set-transient-lang-render](code/javaguide/i18n/JavaI18N.java)
+
 ## Formatting messages
 
 Messages are formatted using the `java.text.MessageFormat` library. For example, if you have defined a message like this:

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/JavaI18N.java
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/JavaI18N.java
@@ -5,12 +5,19 @@ package javaguide.i18n;
 
 import org.junit.Test;
 import org.junit.Before;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
+import javaguide.testhelpers.MockJavaAction;
+import javaguide.testhelpers.MockJavaActionHelper;
+import javaguide.i18n.html.hellotemplate;
+import javaguide.i18n.html.helloscalatemplate;
 import play.Application;
+import play.mvc.Result;
 import play.test.WithApplication;
 import static play.test.Helpers.*;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import play.i18n.Messages;
@@ -20,7 +27,66 @@ public class JavaI18N extends WithApplication {
 
     @Override
     public Application provideApplication() {
-        return fakeApplication(ImmutableMap.of("messages.path", "javaguide/i18n"));
+        return fakeApplication(ImmutableMap.of(
+            "play.i18n.langs", ImmutableList.of("en", "en-US", "fr"),
+            "messages.path", "javaguide/i18n"
+            ));
+    }
+
+    @Test
+    public void checkDefaultHello() {
+        Result result = MockJavaActionHelper.call(new DefaultLangController(), fakeRequest("GET", "/"));
+        assertThat(contentAsString(result), containsString("hello"));
+    }
+
+    public static class DefaultLangController extends MockJavaAction {
+        //#default-lang-render
+        public Result index() {
+            return ok(hellotemplate.render()); // "hello"
+        }
+        //#default-lang-render
+    }
+
+    @Test
+    public void checkDefaultScalaHello() {
+        Result result = MockJavaActionHelper.call(new DefaultScalaLangController(), fakeRequest("GET", "/"));
+        assertThat(contentAsString(result), containsString("hello"));
+    }
+
+    public static class DefaultScalaLangController extends MockJavaAction {
+        public Result index() {
+            return ok(helloscalatemplate.render()); // "hello"
+        }
+    }
+
+    @Test
+    public void checkChangeLangHello() {
+        Result result = MockJavaActionHelper.call(new ChangeLangController(), fakeRequest("GET", "/"));
+        assertThat(contentAsString(result), containsString("bonjour"));
+    }
+
+    public static class ChangeLangController extends MockJavaAction {
+        //#change-lang-render
+        public Result index() {
+            ctx().changeLang("fr");
+            return ok(hellotemplate.render()); // "bonjour"
+        }
+        //#change-lang-render
+    }
+
+    @Test
+    public void checkSetTransientLangHello() {
+        Result result = MockJavaActionHelper.call(new SetTransientLangController(), fakeRequest("GET", "/"));
+        assertThat(contentAsString(result), containsString("howdy"));
+    }
+
+    public static class SetTransientLangController extends MockJavaAction {
+        //#set-transient-lang-render
+        public Result index() {
+            ctx().setTransientLang("en-US");
+            return ok(hellotemplate.render()); // "howdy"
+        }
+        //#set-transient-lang-render
     }
 
     @Test

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/helloscalatemplate.scala.html
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/helloscalatemplate.scala.html
@@ -1,0 +1,3 @@
+@* #template *@
+@Messages("hello")
+@* #template *@

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/hellotemplate.scala.html
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/hellotemplate.scala.html
@@ -1,0 +1,4 @@
+@* #template *@
+@import play.i18n.Messages
+@Messages.get("hello")
+@* #template *@

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/messages
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/messages
@@ -5,3 +5,5 @@ info.error=You aren''t logged in!
 #parameter-escaping
 example.formatting=When using MessageFormat, '''{0}''' is replaced with the first parameter.
 #parameter-escaping
+
+hello=hello

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/messages.en-US
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/messages.en-US
@@ -1,0 +1,1 @@
+hello=howdy

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/messages.fr
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/messages.fr
@@ -1,0 +1,1 @@
+hello=bonjour

--- a/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
@@ -1,0 +1,147 @@
+package play.mvc;
+
+import com.typesafe.config.ConfigFactory;
+import play.Application;
+import play.Configuration;
+import play.Environment;
+import play.Play;
+import play.inject.guice.GuiceApplicationBuilder;
+import play.mvc.Http.*;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static play.Play.langCookieName;
+
+/**
+ * Tests for the Http class. This test is in the play-java project
+ * because we want to use some of the play-java classes, e.g.
+ * the GuiceApplicationBuilder.
+ */
+public class HttpTest {
+
+    /** Gets the PLAY_LANG cookie, or the last one if there is more than one */
+    private String responseLangCookie(Context ctx) {
+        String value = null;
+        for (Cookie c : ctx.response().cookies()) {
+          if (c.name().equals(Play.langCookieName())) {
+            value = c.value();
+          }
+        }
+        return value;
+    }
+
+    private static Configuration addLangs(Environment environment) {
+      Configuration langOverrides = new Configuration(ConfigFactory.parseString("play.i18n.langs = [\"en\", \"en-US\", \"fr\" ]"));
+      Configuration loaded = Configuration.load(environment);
+      return langOverrides.withFallback(loaded);
+    }
+
+    private static void withApplication(Runnable r) {
+        Application app = new GuiceApplicationBuilder()
+          .loadConfig(HttpTest::addLangs)
+          .build();
+        play.api.Play.start(app.getWrappedApplication());
+        try {
+            r.run();
+        } finally {
+            play.api.Play.stop(app.getWrappedApplication());
+        }
+    }
+
+    @Test
+    public void testChangeLang() {
+        withApplication(() -> {
+            Context ctx = new Context(new RequestBuilder());
+            // Start off as 'en' with no cookie set
+            assertThat(ctx.lang().code()).isEqualTo("en");
+            assertThat(responseLangCookie(ctx)).isNull();
+            // Change the language to 'en-US'
+            assertThat(ctx.changeLang("en-US")).isTrue();
+            // The language and cookie should now be 'en-US'
+            assertThat(ctx.lang().code()).isEqualTo("en-US");
+            assertThat(responseLangCookie(ctx)).isEqualTo("en-US");
+        });
+    }
+
+    @Test
+    public void testChangeLangFailure() {
+        withApplication(() -> {
+            Context ctx = new Context(new RequestBuilder());
+            // Start off as 'en' with no cookie set
+            assertThat(ctx.lang().code()).isEqualTo("en");
+            assertThat(responseLangCookie(ctx)).isNull();
+            // Try to change the language to 'en-NZ' - which will fail and return false
+            assertThat(ctx.changeLang("en-NZ")).isFalse();
+            // The language should still be 'en' and cookie should still be empty
+            assertThat(ctx.lang().code()).isEqualTo("en");
+            assertThat(responseLangCookie(ctx)).isNull();
+        });
+    }
+
+    @Test
+    public void testClearLang() {
+        withApplication(() -> {
+            Context ctx = new Context(new RequestBuilder());
+            // Set 'fr' as our initial language
+            assertThat(ctx.changeLang("fr")).isTrue();
+            assertThat(ctx.lang().code()).isEqualTo("fr");
+            assertThat(responseLangCookie(ctx)).isEqualTo("fr");
+            // Clear language
+            ctx.clearLang();
+            // The language should now be 'en' and the cookie should be null
+            assertThat(ctx.lang().code()).isEqualTo("en");
+            assertThat(responseLangCookie(ctx)).isEqualTo("");
+        });
+    }
+
+    @Test
+    public void testSetTransientLang() {
+        withApplication(() -> {
+            Context ctx = new Context(new RequestBuilder());
+            // Start off as 'en' with no cookie set
+            assertThat(ctx.lang().code()).isEqualTo("en");
+            assertThat(responseLangCookie(ctx)).isNull();
+            // Change the language to 'en-US'
+            ctx.setTransientLang("en-US");
+            // The language should now be 'en-US', but the cookie mustn't be set
+            assertThat(ctx.lang().code()).isEqualTo("en-US");
+            assertThat(responseLangCookie(ctx)).isNull();
+        });
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testSetTransientLangFailure() {
+        withApplication(() -> {
+            Context ctx = new Context(new RequestBuilder());
+            // Start off as 'en' with no cookie set
+            assertThat(ctx.lang().code()).isEqualTo("en");
+            assertThat(responseLangCookie(ctx)).isNull();
+            // Try to change the language to 'en-NZ' - which will throw an exception
+            ctx.setTransientLang("en-NZ");
+        });
+    }
+
+    @Test
+    public void testClearTransientLang() {
+        withApplication(() -> {
+            Cookie frCookie = new Cookie("PLAY_LANG", "fr", null, "/", null, false, false);
+            RequestBuilder rb = new RequestBuilder().cookie(frCookie);
+            Context ctx = new Context(rb);
+            // Start off as 'en' with no cookie set
+            assertThat(ctx.lang().code()).isEqualTo("fr");
+            assertThat(responseLangCookie(ctx)).isNull();
+            // Change the language to 'en-US'
+            ctx.setTransientLang("en-US");
+            // The language should now be 'en-US', but the cookie mustn't be set
+            assertThat(ctx.lang().code()).isEqualTo("en-US");
+            assertThat(responseLangCookie(ctx)).isNull();
+            // Clear the language to the default for the current request
+            ctx.clearTransientLang();
+            // The language should now be back to 'fr', and the cookie still mustn't be set
+            assertThat(ctx.lang().code()).isEqualTo("fr");
+            assertThat(responseLangCookie(ctx)).isNull();
+        });
+    }
+
+
+}

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -209,6 +209,46 @@ public class Http {
         }
 
         /**
+         * Set the language for the current request, but don't
+         * change the language cookie. This means the language
+         * will be set for this request, but will not change for
+         * future requests.
+         *
+         * @throws IllegalArgumentException If the given language
+         * is not supported by the application.
+         */
+        public void setTransientLang(String code) {
+            setTransientLang(Lang.forCode(code));
+        }
+
+        /**
+         * Set the language for the current request, but don't
+         * change the language cookie. This means the language
+         * will be set for this request, but will not change for
+         * future requests.
+         *
+         * @throws IllegalArgumentException If the given language
+         * is not supported by the application.
+         */
+        public void setTransientLang(Lang lang) {
+            if (Lang.availables().contains(lang)) {
+                this.lang = lang;
+            } else {
+                throw new IllegalArgumentException("Language not supported in this application: " + lang + " not in Lang.availables()");
+            }
+        }
+
+        /**
+         * Clear the language for the current request, but don't
+         * change the language cookie. This means the language
+         * will be cleared for this request (so a default will be
+         * used), but will not change for future requests.
+         */
+        public void clearTransientLang() {
+            this.lang = null;
+        }
+
+        /**
          * Free space to store your request specific data.
          */
         public Map<String, Object> args;


### PR DESCRIPTION
Currently in the Java API it's impossible to set the current Context's language without also setting a cookie. That means that it's impossible to just change the language for a single request. This change adds new necessary methods to support changing and clearing the language without changing the cookie.

Other changes:
* Added unit tests for changing the language.
* Added documentation tests for Java internationalization.

While writing the documentation tests I discovered that `import play.i18n._` is no longer supported in templates in 2.4 because it conflicts with the default `import play.api.i18n._`. It didn't conflict in 2.3. I'll create an issue to track this regression so we can decide whether to fix it.