### PR TITLE
Better hygiene for the JSON macro

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -241,14 +241,6 @@ object JsMacroImpl {
       //println("block:"+block)
       c.Expr[M[A]](block)
     } else {
-      val helper = newTermName("helper")
-      val helperVal = ValDef(
-        Modifiers(),
-        helper,
-        Ident(weakTypeOf[play.api.libs.json.util.LazyHelper[M, A]].typeSymbol),
-        Apply(Ident(newTermName("LazyHelper")), List(finalTree))
-      )
-
       val block = Select(
         Block(
           List(

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -34,15 +34,21 @@ object JsMacroImpl {
     val companionSymbol = companioned.companionSymbol
     val companionType = companionSymbol.typeSignature
 
-    val libsPkg = Select(Select(Ident(newTermName("play")), newTermName("api")), newTermName("libs"))
-    val jsonPkg = Select(libsPkg, newTermName("json"))
-    val functionalSyntaxPkg = Select(Select(libsPkg, newTermName("functional")), newTermName("syntax"))
-    val utilPkg = Select(jsonPkg, newTermName("util"))
+    def selectTerm(qual: Tree, names: String*) =
+      names.foldLeft(qual)((z, b) => Select(z, newTermName(b)))
 
-    val jsPathSelect = Select(jsonPkg, newTermName("JsPath"))
-    val readsSelect = Select(jsonPkg, newTermName("Reads"))
-    val writesSelect = Select(jsonPkg, newTermName("Writes"))
-    val unliftIdent = Select(functionalSyntaxPkg, newTermName("unlift"))
+    def selectFromRoot(names: String*) =
+      selectTerm(Ident(rootMirror.RootPackage), names: _*)
+
+    val libsPkg = selectFromRoot("play", "api", "libs")
+    val jsonPkg = selectTerm(libsPkg, "json")
+    val functionalSyntaxPkg = selectTerm(libsPkg, "functional", "syntax")
+    val utilPkg = selectTerm(jsonPkg, "util")
+
+    val jsPathSelect = selectTerm(jsonPkg, "JsPath")
+    val readsSelect = selectTerm(jsonPkg, "Reads")
+    val writesSelect = selectTerm(jsonPkg, "Writes")
+    val unliftIdent = selectTerm(functionalSyntaxPkg, "unlift")
     val lazyHelperSelect = Select(utilPkg, newTypeName("LazyHelper"))
 
     val unapply = companionType.declaration(stringToTermName("unapply"))

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -531,6 +531,14 @@ object JsonExtensionSpec extends Specification {
       Json.fromJson[Person2](Json.toJson(Person2(List("bob", "bobby")))).get must beEqualTo(Person2(List("bob", "bobby")))
     }
 
+    "test hygiene" in {
+      val play = ""
+      implicit val toto2Reads = Json.reads[Toto2]
+      implicit val toto2Writes = Json.writes[Toto2]
+      implicit val toto2Format = Json.format[Toto2]
+      success
+    }
+
   }
 
 }

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -533,6 +533,8 @@ object JsonExtensionSpec extends Specification {
 
     "test hygiene" in {
       val play = ""
+      type LazyHelper = Any; val LazyHelper = ()
+
       implicit val toto2Reads = Json.reads[Toto2]
       implicit val toto2Writes = Json.writes[Toto2]
       implicit val toto2Format = Json.format[Toto2]

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -534,6 +534,11 @@ object JsonExtensionSpec extends Specification {
     "test hygiene" in {
       val play = ""
       type LazyHelper = Any; val LazyHelper = ()
+      val scala = ""
+      type String = Any; val String = ""
+      type Unit = Any; val Unit = ""
+      type Any = Nothing; val Any = ""
+      type Int = String; val Int = ""
 
       implicit val toto2Reads = Json.reads[Toto2]
       implicit val toto2Writes = Json.writes[Toto2]


### PR DESCRIPTION
Public Service Announcement: Fully qualify references in macros, and
test that you've done this by putting some unusually named identifiers
in scope before calling the macro.