### PR TITLE
Allow PathBindables to supply a regex, for DRY in the routes file

### DIFF
--- a/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
+++ b/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
@@ -198,7 +198,10 @@ public class RoutingDsl {
                     params.add(new RouteParam(name, false, pathBindable));
                     break;
                 default:
-                    sb.append("(").append(result.group(3)).append(")");
+                    Optional<String> suppliedRegex = Optional.ofNullable(result.group(3));
+                    Optional<String> bindableRegex = Scala.asOptional(pathBindable.regex()).map(r -> r.toString());
+                    String paramRegex = suppliedRegex.orElseGet(bindableRegex::get);
+                    sb.append("(").append(paramRegex).append(")");
                     params.add(new RouteParam(name, false, pathBindable));
                     break;
             }

--- a/framework/src/play/src/main/java/play/libs/Scala.java
+++ b/framework/src/play/src/main/java/play/libs/Scala.java
@@ -25,6 +25,16 @@ public class Scala {
     }
 
     /**
+     * Convert a Scala Option to a Java 8 Optional.
+     */
+    public static <T> Optional<T> asOptional(scala.Option<T> opt) {
+        if(opt.isDefined()) {
+            return Optional.of(opt.get());
+        }
+        return Optional.empty();
+    }
+
+    /**
      * Wrap a Scala Option, handling None by returning a defaultValue
      */
     public static <T> T orElse(scala.Option<T> opt, T defaultValue) {

--- a/framework/src/play/src/main/java/play/mvc/PathBindable.java
+++ b/framework/src/play/src/main/java/play/mvc/PathBindable.java
@@ -3,6 +3,9 @@
  */
 package play.mvc;
 
+import java.util.Optional;
+import java.util.regex.Pattern;
+
 /**
  * Binder for path parameters.
  *
@@ -72,4 +75,13 @@ public interface PathBindable<T extends PathBindable<T>> {
      */
     public String javascriptUnbind();
 
+    /**
+     * An optional custom regular expression (eg <code>([^/]+)/([^/]+)</code>) for matching the
+     * <code>T</code> type against a dynamic path part. If specified, the regex can be omitted
+     * from the routes file, defined as simply <code>/$thing</code> rather than
+     * <code>/$thing&lt;([^/]+)/([^/]+)&gt;</code>.
+     */
+    default Optional<Pattern> regex() {
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
This change removes the need for repeat declarations of custom regex in the routes file where custom `PathBindable`s are used. Instead of declaring:

```
GET   /$thing<([^/]+)/([^/]+)>   controllers.App.hit(thing: MyThing)
```

...the user can specify the regex in the `PathBindable` for `MyThing`, then omitting the regex from the routes file:

```
GET   /$thing   controllers.App.hit(thing: MyThing)
```

Play's HTTP router allows users to bind [dynamic path parts to custom types](http://julien.richard-foy.fr/blog/2012/04/09/how-to-implement-a-custom-pathbindable-with-play-2/
), and also define path parts with [custom regular expressions](https://www.playframework.com/documentation/2.3.x/ScalaRouting#Dynamic-parts-with-custom-regular-expressions), but the regular expressions declared in the routes file can become unwieldy, given the delicate nature of correct regexes and multiple paths with identical regexs:

```
GET         /$repo<[^/]+/[^/]+>/pulls                            controllers.Application.listPullRequests(repo: lib.github.RepoName)
GET         /$pr<[^/]+/[^/]+/pull/[\d]+>                         controllers.Application.reviewPullRequest(pr: PullRequestId)
POST        /$pr<[^/]+/[^/]+/pull/[\d]+>/:submitType             controllers.Application.mailPullRequest(pr: PullRequestId, submitType: MailType)
GET         /$pr<[^/]+/[^/]+/pull/[\d]+>/:headCommit/:sig        controllers.Application.acknowledgePreview(pr: PullRequestId, headCommit: ObjectId, sig: String)
```
https://github.com/rtyley/submitgit/blob/1b6ba4ac/conf/routes#L7-L10

This change makes use of several Java 8 features, most importantly 'default methods' to extend the Java `PathBindable` interface with a default `regex()` method, so as not to break existing implementations. Play 2.4 requires Java 8:

https://www.playframework.com/documentation/2.4.x/Highlights24#Java-8-support

If a regex _is_ specified in the routes file, it overrides the `PathBindable`s supplied regex.

cc @jroper 