### PR TITLE
Downgrade Akka to 2.3.9. Getting lots of errors with recently introduced 2.3.10

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -108,7 +108,7 @@ object Dependencies {
   def runtime(scalaVersion: String) =
     Seq("slf4j-api", "jul-to-slf4j", "jcl-over-slf4j").map("org.slf4j" % _ % "1.7.12") ++
     Seq("logback-core", "logback-classic").map("ch.qos.logback" % _ % "1.1.3") ++
-    Seq("akka-actor", "akka-slf4j").map("com.typesafe.akka" %% _ % "2.3.10") ++
+    Seq("akka-actor", "akka-slf4j").map("com.typesafe.akka" %% _ % "2.3.9") ++
     jacksons ++
     Seq(
       "org.scala-stm" %% "scala-stm" % "0.7",


### PR DESCRIPTION
Akka was just upgraded to 2.3.10 a couple days ago in https://github.com/playframework/playframework/pull/4358

It causes me to get tons of errors as reported in https://github.com/playframework/playframework/issues/4372

Meta comment - we probably want to slow down on the upgrades now that we've already released an RC and only upgrade libraries if there's a compelling reason