### PR TITLE
Don't swallow the stacktrace when an error occurs

### DIFF
--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -269,7 +269,7 @@ private[play] class PlayDefaultUpstreamHandler(server: Server, allChannels: Defa
 
           val sent = eventuallyResultWithSequence.recoverWith {
             case error =>
-              logger.error("Cannot invoke the action, eventually got an error: " + error)
+              logger.error("Cannot invoke the action", error)
               e.getChannel.setReadable(true)
               errorHandler(app).onServerError(requestHeader, error)
                 .map((_, 0))


### PR DESCRIPTION
I'm not sure if there's a reason for the current behavior. We're getting a NullPointerException in https://github.com/playframework/playframework/issues/4323, but there's no details as to where it's occurring, so the message is next to useless. This makes it obvious where the NPE is occurring.