### PR TITLE
Upgrade Akka HTTP, fix and turn on integration tests

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -297,7 +297,11 @@ object PlayBuild extends Build {
   import ScriptedPlugin._
 
   lazy val PlayAkkaHttpServerProject = PlayCrossBuiltProject("Play-Akka-Http-Server-Experimental", "play-akka-http-server")
-    .settings(libraryDependencies ++= akkaHttp)
+    .settings(
+      libraryDependencies ++= akkaHttp,
+      // FIXME: These overrides are no longer needed once
+      // Akka fixes: https://github.com/akka/akka/pull/17390
+      dependencyOverrides := dependencyOverrides.value ++ akkaHttpOverrides)
      // Include scripted tests here as well as in the SBT Plugin, because we
      // don't want the SBT Plugin to have a dependency on an experimental module.
     .settings(playScriptedSettings: _*)

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -105,10 +105,12 @@ object Dependencies {
   val jodatime = "joda-time" % "joda-time" % "2.7"
   val jodaConvert = "org.joda" % "joda-convert" % "1.7"
 
+  private val akkaCoreDeps = Seq("akka-actor", "akka-slf4j").map("com.typesafe.akka" %% _ % "2.3.9")
+
   def runtime(scalaVersion: String) =
     Seq("slf4j-api", "jul-to-slf4j", "jcl-over-slf4j").map("org.slf4j" % _ % "1.7.12") ++
     Seq("logback-core", "logback-classic").map("ch.qos.logback" % _ % "1.1.3") ++
-    Seq("akka-actor", "akka-slf4j").map("com.typesafe.akka" %% _ % "2.3.9") ++
+    akkaCoreDeps ++
     jacksons ++
     Seq(
       "org.scala-stm" %% "scala-stm" % "0.7",
@@ -139,8 +141,12 @@ object Dependencies {
   ) ++ specsBuild.map(_ % Test)
 
   val akkaHttp = Seq(
-    "com.typesafe.akka" %% "akka-http-core-experimental" % "1.0-M4"
+    "com.typesafe.akka" %% "akka-http-core-experimental" % "1.0-RC2"
   )
+
+  // FIXME: These overrides are no longer needed once
+  // Akka fixes: https://github.com/akka/akka/pull/17390
+  val akkaHttpOverrides = akkaCoreDeps
 
   val routesCompilerDependencies =  Seq(
     "commons-io" % "commons-io" % "2.4"
@@ -235,7 +241,7 @@ object Dependencies {
   ) ++ specsBuild.map(_ % Test)
 
   val streamsDependencies = Seq(
-    "org.reactivestreams" % "reactive-streams" % "1.0.0.RC1"
+    "org.reactivestreams" % "reactive-streams" % "1.0.0"
   ) ++ specsBuild.map(_ % "test")
 
   def jsonDependencies(scalaVersion: String) = Seq(

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
@@ -1,9 +1,9 @@
 package play.core.server.akkahttp
 
 import akka.actor.ActorSystem
-import akka.http.Http
-import akka.http.model._
-import akka.http.model.headers.{ `Content-Length`, `Content-Type` }
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{ `Content-Length`, `Content-Type` }
 import akka.pattern.ask
 import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl._

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -1,9 +1,8 @@
 package play.core.server.akkahttp
 
-import akka.http.model._
-import akka.http.model.ContentType
-import akka.http.model.headers._
-import akka.http.model.parser.HeaderParser
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.ContentType
+import akka.http.scaladsl.model.headers._
 import akka.stream.FlowMaterializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
@@ -221,22 +220,28 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
     }
   }
 
+  private def convertHeaders(headers: Iterable[(String, String)]): immutable.Seq[HttpHeader] = {
+    headers.map {
+      case (name, value) =>
+        HttpHeader.parse(name, value) match {
+          case HttpHeader.ParsingResult.Ok(header, errors /* errors are ignored if Ok */ ) =>
+            header
+          case HttpHeader.ParsingResult.Error(error) =>
+            sys.error(s"Error parsing header: $error")
+        }
+    }.to[immutable.Seq]
+  }
+
   /**
    * Given a chunk encoded stream, decode it and reencode it in Akka's chunk format.
    */
   private def dechunkAndRechunk(chunkEncodedEnum: Enumerator[Array[Byte]]): Source[HttpEntity.ChunkStreamPart, Unit] = {
     import Execution.Implicits.trampoline
     val rechunkEnee = Results.dechunkWithTrailers ><> Enumeratee.map[Either[Array[Byte], Seq[(String, String)]]][HttpEntity.ChunkStreamPart] {
-      case Left(bytes) => HttpEntity.ChunkStreamPart(bytes)
+      case Left(bytes) =>
+        HttpEntity.ChunkStreamPart(bytes)
       case Right(rawHeaderStrings) =>
-        val rawHeaders = rawHeaderStrings.map {
-          case (name, value) => RawHeader(name, value)
-        }
-        val convertedHeaders: List[HttpHeader] = HeaderParser.parseHeaders(rawHeaders.to[List]) match {
-          case (Nil, headers) => headers
-          case (errors, _) => sys.error(s"Error parsing trailers: $errors")
-        }
-        HttpEntity.LastChunk(trailer = convertedHeaders)
+        HttpEntity.LastChunk(trailer = convertHeaders(rawHeaderStrings))
     }
     val akkaChunksEnum: Enumerator[HttpEntity.ChunkStreamPart] = (chunkEncodedEnum &> rechunkEnee) >>> Enumerator.eof
     AkkaStreamsConversion.enumeratorToSource(akkaChunksEnum)
@@ -264,13 +269,8 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
    */
   private def convertResponseHeaders(
     playHeaders: Map[String, String]): AkkaHttpHeaders = {
-    val rawHeaders = ServerResultUtils.splitSetCookieHeaders(playHeaders).map {
-      case (name, value) => RawHeader(name, value)
-    }
-    val convertedHeaders: List[HttpHeader] = HeaderParser.parseHeaders(rawHeaders.to[List]) match {
-      case (Nil, headers) => headers
-      case (errors, _) => sys.error(s"Error parsing response headers: $errors")
-    }
+    val rawHeaders: Iterable[(String, String)] = ServerResultUtils.splitSetCookieHeaders(playHeaders)
+    val convertedHeaders: Seq[HttpHeader] = convertHeaders(rawHeaders)
     val emptyHeaders = AkkaHttpHeaders(immutable.Seq.empty, ContentTypes.`application/octet-stream`, None, None)
     convertedHeaders.foldLeft(emptyHeaders) {
       case (accum, ct: `Content-Type`) =>

--- a/framework/src/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHttpServerSpec.scala
+++ b/framework/src/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHttpServerSpec.scala
@@ -13,8 +13,8 @@ import scala.concurrent.duration._
 import akka.util.Timeout
 
 object AkkaHttpServerSpec extends PlaySpecification with WsTestClient {
-  // Disable Akka HTTP tests by default until issues in Continuous Integration are resolved
-  private val runTests: Boolean = (System.getProperty("run.akka.http.tests", "false") == "true")
+  // Provide a flag to disable Akka HTTP tests
+  private val runTests: Boolean = (System.getProperty("run.akka.http.tests", "true") == "true")
   skipAllIf(!runTests)
 
   sequential

--- a/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
@@ -64,8 +64,8 @@ trait NettyIntegrationSpecification extends ServerIntegrationSpecification {
 }
 trait AkkaHttpIntegrationSpecification extends ServerIntegrationSpecification {
   self: Specification =>
-  // Disable Akka HTTP tests by default until issues in Continuous Integration are resolved
-  private val runTests: Boolean = (System.getProperty("run.akka.http.tests", "false") == "true")
+  // Provide a flag to disable Akka HTTP tests
+  private val runTests: Boolean = (System.getProperty("run.akka.http.tests", "true") == "true")
   skipAllIf(!runTests)
   override def integrationServerProvider: ServerProvider = AkkaHttpServer.provider
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -65,7 +65,7 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
           response.body must_== "Hello"
         case Failure(t) =>
           t must haveClass[IOException]
-          t.getMessage must_== "Remotely Closed"
+          t.getMessage.toLowerCase must_== "remotely closed"
       }
     }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -107,7 +107,7 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
           BasicRequest("GET", "/", "HTTP/1.0", Map("Connection" -> "keep-alive"), "")
         )(0)
         response.status must_== 200
-        response.headers.get(CONNECTION) must beNone
+        response.headers.get(CONNECTION).map(_.toLowerCase) must beOneOf(None, Some("close"))
       }
 
     "close the connection when the connection close header is present" in withServer(
@@ -346,7 +346,7 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
           BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
         ).apply(0)
         response.status must_== Status.INTERNAL_SERVER_ERROR
-        (response.headers -- Set(CONTENT_LENGTH, DATE)) must be(Map.empty)
-      }.pendingUntilAkkaHttpFixed // https://github.com/akka/akka/issues/16988
+        (response.headers -- Set(CONNECTION, CONTENT_LENGTH, DATE, SERVER)) must be(Map.empty)
+      }
   }
 }


### PR DESCRIPTION
Even though Akka HTTP is on a new version I've kept the other Akka libraries on version 2.3.9 due to #4381.

Commits are split into several logical parts so don't need further squashing. More info in the commit messages.