### PR TITLE
Fix dev-mode test stability

### DIFF
--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
@@ -41,10 +41,11 @@ $ delete public/new/new.css
 # Two files with the same name change detection
 > verifyResourceContains /assets/a/some.txt 200 original
 > verifyResourceContains /assets/b/some.txt 200 original
-# This sleep doesn't seem necessary, but adding it to see if it impacts CI stability
+# These sleeps are necessary to ensure a full second has ticked by since the last modified timestamp was captured
 $ sleep 1000
 $ copy-file changes/some.txt.1 public/a/some.txt
 > verifyResourceContains /assets/a/some.txt 200 changed
+$ sleep 1000
 $ copy-file changes/some.txt.1 public/b/some.txt
 > verifyResourceContains /assets/b/some.txt 200 changed
 


### PR DESCRIPTION
These sleeps are necessary.  The following is what happens:

* Play detects a changed, stores the last modified timestamp, lets say it's 123 seconds since epoch.
* We then run some assertions, make sure the change was picked up.
* We then modify another file. Less than a second has passed, so its last modified has the timestamp of 123.
* Since it's not less than the last timestamp, that change doesn't get detected.
* Sleeping for a second solves this, ensuring it will tick over to 124 before we modify the file.