### PR TITLE
Correct typo in ScalaAkka.md

### DIFF
--- a/documentation/manual/working/scalaGuide/main/akka/ScalaAkka.md
+++ b/documentation/manual/working/scalaGuide/main/akka/ScalaAkka.md
@@ -72,7 +72,7 @@ Let's say you have the following actor, which depends configuration to be inject
 
 Note that the `key` parameter is declared to be `@Assisted`, this tells that it's going to be manually provided.
 
-We've also defined a `Factory` trait, this takes the `key`, and returns an `Actor`.  We won't implement this, Guice will do that for us, providing an implementation that not only passes our `key` parameter, but also locates the `Configuration` dependency and injects that.  Since the trait just returns an `Actor`, when testing this actor we can inject a factor that returns any actor, for example this allows us to inject a mocked child actor, instead of the actual one.
+We've also defined a `Factory` trait, this takes the `key`, and returns an `Actor`.  We won't implement this, Guice will do that for us, providing an implementation that not only passes our `key` parameter, but also locates the `Configuration` dependency and injects that.  Since the trait just returns an `Actor`, when testing this actor we can inject a factory that returns any actor, for example this allows us to inject a mocked child actor, instead of the actual one.
 
 Now, the actor that depends on this can extend [`InjectedActorSupport`](api/scala/index.html#play.api.libs.concurrent.InjectedActorSupport), and it can depend on the factory we created:
 


### PR DESCRIPTION
Change  type `factor` to `factory`