### PR TITLE
Java / 2.4.0-RC2 Every UnexpectedException is being logged twice in prod mode.

### DIFF
--- a/framework/src/play/src/main/resources/logback-play-default.xml
+++ b/framework/src/play/src/main/resources/logback-play-default.xml
@@ -24,7 +24,7 @@
   </appender>
 
   <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
-    <appender-ref ref="FILE" />
+    <appender-ref ref="STDOUT" />
   </appender>
 
   <logger name="play" level="INFO" />


### PR DESCRIPTION
…at least with the default logging settings. Not related to #4323, was present already in RC1.