### PR TITLE
Fixes to 2.4.x WS docs

### DIFF
--- a/documentation/manual/detailedTopics/configuration/ws/LooseSSL.md
+++ b/documentation/manual/detailedTopics/configuration/ws/LooseSSL.md
@@ -103,5 +103,3 @@ play.ws.ssl.loose.allowWeakProtocols=true
 ```
 
 SSLv2 and SSLv2Hello (there is no v1) are obsolete and usage in the field is [down to 25% on the public Internet](https://www.trustworthyinternet.org/ssl-pulse/).  SSLv3 is known to have [security issues](http://www.yaksman.org/~lweith/ssl.pdf) compared to TLS.  The only reason to turn this on is if you are connecting to a legacy server, but doing so does not make you vulnerable per se.
-
-> **Next**:  [[Testing SSL|TestingSSL]]

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -163,7 +163,7 @@ When making a request from a controller, you can map the response to a `Future[R
 
 WSClient is a wrapper around the underlying AsyncHttpClient.  It is useful for defining multiple clients with different profiles, or using a mock.
 
-You can define a WS client directly from code without having it injected by WS, and then use it implicitly with `WS.clientUrl()`. Note that you should always use `NingAsyncHttpClientConfigBuilder` when configuring your client, for secure TLS configuration:
+You can define a WS client directly from code without having it injected by WS, and then use it implicitly with `WS.clientUrl()`:
 
 @[implicit-client](code/ScalaWSSpec.scala)
 
@@ -213,7 +213,7 @@ There are 3 different timeouts in WS. Reaching a timeout causes the WS request t
 
 The request timeout can be overridden for a specific connection with `withRequestTimeout()` (see "Making a Request" section).
 
-### Configuring AsyncClientConfig
+### Configuring AsyncHttpClientConfig
 
 The following advanced settings can be configured on the underlying AsyncHttpClientConfig.
 Please refer to the [AsyncHttpClientConfig Documentation](http://asynchttpclient.github.io/async-http-client/apidocs/com/ning/http/client/AsyncHttpClientConfig.Builder.html) for more information.
@@ -225,7 +225,7 @@ Please refer to the [AsyncHttpClientConfig Documentation](http://asynchttpclient
 * `play.ws.ning.maxConnectionsTotal`
 * `play.ws.ning.maxConnectionLifeTime`
 * `play.ws.ning.idleConnectionInPoolTimeout`
-* `ws.ning.webSocketIdleTimeout`
+* `play.ws.ning.webSocketIdleTimeout`
 * `play.ws.ning.maxNumberOfRedirects`
 * `play.ws.ning.maxRequestRetry`
 * `play.ws.ning.disableUrlEncoding`

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -431,17 +431,11 @@ class ScalaWSSpec extends PlaySpecification with Results {
 
       //#implicit-client
       import play.api.libs.ws.ning._
-      import com.ning.http.client.AsyncHttpClientConfig
 
-      val clientConfig = new NingWSClientConfig()
-      val secureDefaults: AsyncHttpClientConfig = new NingAsyncHttpClientConfigBuilder(clientConfig).build()
-      // You can directly use the builder for specific options once you have secure TLS defaults...
-      val builder = new AsyncHttpClientConfig.Builder(secureDefaults)
-      builder.setCompressionEnforced(true)
-      val secureDefaultsWithSpecificOptions: AsyncHttpClientConfig = builder.build()
-      implicit val sslClient = new NingWSClient(secureDefaultsWithSpecificOptions)
-
+      implicit val sslClient = NingWSClient()
+      // close with sslClient.close() when finished with client
       val response = WS.clientUrl(url).get()
+
       //#implicit-client
       await(response).status must_== OK
 
@@ -514,5 +508,3 @@ class ScalaWSSpec extends PlaySpecification with Results {
 
   }
 }
-
-


### PR DESCRIPTION
* Remove LooseSSL repeated link.
* Change ScalaWS to use the default NingWSClient() apply method in docs (which is secure by default)
* Fix @marcospereira's catch where `play.ws.ning.webSocketIdleTimeout` was not updated.