### PR TITLE
Fix crash when BoneCP is used

### DIFF
--- a/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
@@ -64,7 +64,7 @@ class BoneConnectionPool @Inject() (environment: Environment) extends Connection
       case unknown => throw config.reportError("bonecp.isolation",
         s"Unknown isolation level [$unknown]")
     }
-    val catalog = config.getOptionalDeprecated[String]("defaultCatalog", "bonecp.defaultCatalog")
+    val catalog = config.getOptionalDeprecated[String]("bonecp.defaultCatalog", "defaultCatalog")
     val readOnly = config.getDeprecated[Boolean]("bonecp.readOnly", "readOnly")
 
     datasource.setClassLoader(environment.classLoader)

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/ConnectionPoolConfigSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/ConnectionPoolConfigSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.db
+
+import javax.inject.Inject
+import play.api.test._
+
+class ConnectionPoolConfigSpec extends PlaySpecification {
+
+  "DBModule bindings" should {
+
+    "use HikariCP when default pool is default" in new WithApplication(FakeApplication(
+      additionalConfiguration = Map(
+        "db.default.url" -> "jdbc:h2:mem:default",
+        "db.other.driver" -> "org.h2.Driver",
+        "db.other.url" -> "jdbc:h2:mem:other"
+      )
+    )) {
+      val db = app.injector.instanceOf[DBApi]
+      db.database("default").withConnection { c =>
+        c.getClass.getName must contain("hikari")
+      }
+    }
+
+    "use HikariCP when default pool is 'hikaricp'" in new WithApplication(FakeApplication(
+      additionalConfiguration = Map(
+        "play.db.pool" -> "hikaricp",
+        "db.default.url" -> "jdbc:h2:mem:default",
+        "db.other.driver" -> "org.h2.Driver",
+        "db.other.url" -> "jdbc:h2:mem:other"
+      )
+    )) {
+      val db = app.injector.instanceOf[DBApi]
+      db.database("default").withConnection { c =>
+        c.getClass.getName must contain("hikari")
+      }
+    }
+
+    "use BoneCP when default pool is 'bonecp'" in new WithApplication(FakeApplication(
+      additionalConfiguration = Map(
+        "play.db.pool" -> "bonecp",
+        "db.default.url" -> "jdbc:h2:mem:default",
+        "db.other.driver" -> "org.h2.Driver",
+        "db.other.url" -> "jdbc:h2:mem:other"
+      )
+    )) {
+      val db = app.injector.instanceOf[DBApi]
+      db.database("default").withConnection { c =>
+        c.getClass.getName must contain("bonecp")
+      }
+    }
+
+    "use BoneCP when database-specific pool is 'bonecp'" in new WithApplication(FakeApplication(
+      additionalConfiguration = Map(
+        "db.default.pool" -> "bonecp",
+        "db.default.url" -> "jdbc:h2:mem:default",
+        "db.other.driver" -> "org.h2.Driver",
+        "db.other.url" -> "jdbc:h2:mem:other"
+      )
+    )) {
+      val db = app.injector.instanceOf[DBApi]
+      db.database("default").withConnection { c =>
+        c.getClass.getName must contain("bonecp")
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
Fixes #4448. Adds some very basic testing to check that BoneCP doesn't crash when loaded.

We could do a lot more testing on connection pools. The tests I added are very minimal, just enough to test that the crash bug is fixed, but not enough to verify individual connection pool configuration options.

If we care about more testing then I'd suggest merging this PR so that we can cut an RC and then maybe I can add more tests in a follow up PR. It's going to take me a while to work out how to "look into" the connection pool objects in order to check that they're properly configured. It may not even be possible to test if they're configured properly because they're pretty heavily buried in layers of Play and JDBC abstractions.