### PR TITLE
Action composition annotation order can be configured

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/JavaActionsComposition.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaActionsComposition.md
@@ -62,6 +62,8 @@ public class Admin extends Controller {
 }
 ```
 
+> **Note:** If you want the action composition annotation(s) put on a ```Controller``` class to be executed before the one(s) put on action methods set ```play.http.actionComposition.controllerAnnotationsFirst = true``` in ```application.conf```. However, be aware that if you use a third party module in your project it may rely on a certain execution order of its annotations.
+
 ## Passing objects from action to controller
 
 You can pass an object from an action to a controller by utilizing the context args map.

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -63,6 +63,13 @@ play {
       maxDiskBuffer = 10m
     }
 
+    # Action composition configuration
+    actionComposition = {
+
+      # If annotations put directly on Controller classes should be executed before the ones put on action methods
+      controllerAnnotationsFirst = false
+    }
+
     # Cookies configuration
     cookies = {
 

--- a/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -22,6 +22,7 @@ import scala.concurrent.duration.FiniteDuration
 case class HttpConfiguration(
   context: String = "/",
   parser: ParserConfiguration = ParserConfiguration(),
+  actionComposition: ActionCompositionConfiguration = ActionCompositionConfiguration(),
   cookies: CookiesConfiguration = CookiesConfiguration(),
   session: SessionConfiguration = SessionConfiguration(),
   flash: FlashConfiguration = FlashConfiguration())
@@ -84,6 +85,14 @@ case class ParserConfiguration(
   maxMemoryBuffer: Int = 102400,
   maxDiskBuffer: Long = 10485760)
 
+/**
+ * Configuration for action composition.
+ *
+ * @param controllerAnnotationsFirst If annotations put on controllers should be executed before the ones put on actions.
+ */
+case class ActionCompositionConfiguration(
+  controllerAnnotationsFirst: Boolean = false)
+
 object HttpConfiguration {
 
   @Singleton
@@ -108,6 +117,9 @@ object HttpConfiguration {
         maxMemoryBuffer = config.getDeprecated[ConfigMemorySize]("play.http.parser.maxMemoryBuffer", "parsers.text.maxLength")
           .toBytes.toInt,
         maxDiskBuffer = config.get[ConfigMemorySize]("play.http.parser.maxDiskBuffer").toBytes
+      ),
+      actionComposition = ActionCompositionConfiguration(
+        controllerAnnotationsFirst = config.get[Boolean]("play.http.actionComposition.controllerAnnotationsFirst")
       ),
       cookies = CookiesConfiguration(
         strict = config.get[Boolean]("play.http.cookies.strict")

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -5,7 +5,7 @@ package play.core.j
 
 import javax.inject.Inject
 
-import play.api.http.HttpRequestHandler
+import play.api.http.{ HttpConfiguration, HttpRequestHandler }
 import play.api.inject.{ Injector, NewInstanceInjector }
 
 import scala.language.existentials
@@ -36,7 +36,12 @@ class JavaActionAnnotations(val controller: Class[_], val method: java.lang.refl
   }.flatten
 
   val actionMixins = {
-    (method.getDeclaredAnnotations ++ controllerAnnotations).collect {
+    val allDeclaredAnnotations: Seq[java.lang.annotation.Annotation] = if (HttpConfiguration.current.actionComposition.controllerAnnotationsFirst) {
+        (controllerAnnotations ++ method.getDeclaredAnnotations)
+    } else {
+        (method.getDeclaredAnnotations ++ controllerAnnotations)
+    }
+    allDeclaredAnnotations.collect {
       case a: play.mvc.With => a.value.map(c => (a, c)).toSeq
       case a if a.annotationType.isAnnotationPresent(classOf[play.mvc.With]) =>
         a.annotationType.getAnnotation(classOf[play.mvc.With]).value.map(c => (a, c)).toSeq


### PR DESCRIPTION
It is now possible to control if action composition annotations put directly on controller classes should be executed before the ones put on action methods by setting `play.http.actionComposition.controllerAnnotationsFirst = true` in `application.conf` (Right now the methods ones are executed first and also stays the default).

There have been discussions (like [this one](https://groups.google.com/forum/#!topic/play-framework/AY4NuQziYyM)) going on, plus there was [a rejected PR](https://github.com/playframework/playframework/pull/156) long time ago, so hopefully with this fix the issue can finally be settled.

This change is not really disruptive and also completely backwards compatible so hopefully it makes it in 2.4 - I even added documentation :smile: 