### PR TITLE
Move OAuth examples to specs

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/JavaOAuth.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaOAuth.md
@@ -3,7 +3,7 @@
 
 [OAuth](http://oauth.net/) is a simple way to publish and interact with protected data. It's also a safer and more secure way for people to give you access. For example, it can be used to access your users' data on [Twitter](https://dev.twitter.com/docs/auth/using-oauth).
 
-There are 2 very different versions of OAuth: [OAuth 1.0](https://tools.ietf.org/html/rfc5849) and [OAuth 2.0](http://oauth.net/2/). Version 2 is simple enough to be implemented easily without library or helpers, so Play only provides support for OAuth 1.0.
+There are two very different versions of OAuth: [OAuth 1.0](https://tools.ietf.org/html/rfc5849) and [OAuth 2.0](http://oauth.net/2/). Version 2 is simple enough to be implemented easily without library or helpers, so Play only provides support for OAuth 1.0.
 
 ## Usage
 
@@ -38,6 +38,8 @@ Most of the flow will be done by the Play library.
 
 Now the /access token/ can be passed to any call to access protected data.
 
+More details on OAuth's process flow are available at [The OAuth Bible](http://oauthbible.com/).
+
 ## Example
 
 `conf/routes`:
@@ -47,3 +49,5 @@ Now the /access token/ can be passed to any call to access protected data.
 controller:
 
 @[ws-oauth-controller](code/javaguide/ws/controllers/Twitter.java)
+
+> **NOTE**: OAuth does not provide any protection against MITM attacks.  This example shows the OAuth token and secret stored in a session cookie -- for the best security, always use HTTPS with `play.http.session.cookie.secure=true` defined.

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOAuthSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOAuthSpec.scala
@@ -1,0 +1,96 @@
+package scalaguide.ws.scalaoauth
+
+import play.api.test._
+
+//#dependency
+import javax.inject.Inject
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import play.api._
+import play.api.mvc._
+import play.api.data._
+import play.api.data.Forms._
+import play.api.libs.oauth._
+import play.api.libs.ws._
+
+class Application @Inject()(wsClient:WSClient) extends Controller {
+
+}
+//#dependency
+
+
+object routes {
+  object Application {
+    val authenticate = Call("GET", "authenticate")
+    val index = Call("GET", "index")
+  }
+}
+
+
+object ScalaOAuthSpec extends PlaySpecification {
+
+  "Scala OAuth" should {
+    "be injectable" in new WithApplication() {
+      app.injector.instanceOf[Application] must beAnInstanceOf[Application]
+    }
+  }
+
+  def wsClient: WSClient = null
+
+  import play.api.mvc.Results._
+  //#flow
+  val KEY = ConsumerKey("xxxxx", "xxxxx")
+
+  val oauth = OAuth(ServiceInfo(
+    "https://api.twitter.com/oauth/request_token",
+    "https://api.twitter.com/oauth/access_token",
+    "https://api.twitter.com/oauth/authorize", KEY),
+    true)
+
+  def sessionTokenPair(implicit request: RequestHeader): Option[RequestToken] = {
+    for {
+      token <- request.session.get("token")
+      secret <- request.session.get("secret")
+    } yield {
+      RequestToken(token, secret)
+    }
+  }
+
+  def authenticate = Action { request =>
+    request.getQueryString("oauth_verifier").map { verifier =>
+      val tokenPair = sessionTokenPair(request).get
+      // We got the verifier; now get the access token, store it and back to index
+      oauth.retrieveAccessToken(tokenPair, verifier) match {
+        case Right(t) => {
+          // We received the authorized tokens in the OAuth object - store it before we proceed
+          Redirect(routes.Application.index).withSession("token" -> t.token, "secret" -> t.secret)
+        }
+        case Left(e) => throw e
+      }
+    }.getOrElse(
+      oauth.retrieveRequestToken("https://localhost:9000/auth") match {
+        case Right(t) => {
+          // We received the unauthorized tokens in the OAuth object - store it before we proceed
+          Redirect(oauth.redirectUrl(t.token)).withSession("token" -> t.token, "secret" -> t.secret)
+        }
+        case Left(e) => throw e
+      })
+  }
+  //#flow
+
+  //#extended
+  def timeline = Action.async { implicit request =>
+    sessionTokenPair match {
+      case Some(credentials) => {
+        wsClient.url("https://api.twitter.com/1.1/statuses/home_timeline.json")
+          .sign(OAuthCalculator(KEY, credentials))
+          .get
+          .map(result => Ok(result.json))
+      }
+      case _ => Future.successful(Redirect(routes.Application.authenticate))
+    }
+  }
+  //#extended
+
+}


### PR DESCRIPTION
Broke out the embedded OAuth scala examples so they are in specs files.

Also added some security best practices and a link to OAuth Bible, which goes deeper into OAuth. 