### PR TITLE
[WS] Add info and warnings to sunset SHA1 signatures

### DIFF
--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/CertificateGenerator.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/CertificateGenerator.scala
@@ -11,7 +11,7 @@ import java.security._
 import java.math.BigInteger
 import java.util.Date
 import sun.security.util.ObjectIdentifier
-import org.joda.time.Instant
+import org.joda.time.{ Duration, Days, Instant }
 import scala.util.Properties.isJavaAtLeast
 
 /**
@@ -25,7 +25,7 @@ object CertificateGenerator {
   /**
    * Generates a certificate using RSA (which is available in 1.6).
    */
-  def generateRSAWithSHA256(keySize: Int = 2048, from: Instant = Instant.now, duration: Int = 5000000): X509Certificate = {
+  def generateRSAWithSHA256(keySize: Int = 2048, from: Instant = Instant.now, duration: Duration = Days.days(365).toStandardDuration): X509Certificate = {
     val dn = "CN=localhost, OU=Unit Testing, O=Mavericks, L=Moon Base 1, ST=Cyberspace, C=CY"
     val to = from.plus(duration)
 
@@ -33,6 +33,16 @@ object CertificateGenerator {
     keyGen.initialize(keySize, new SecureRandom())
     val pair = keyGen.generateKeyPair()
     generateCertificate(dn, pair, from.toDate, to.toDate, "SHA256withRSA", AlgorithmId.sha256WithRSAEncryption_oid)
+  }
+
+  def generateRSAWithSHA1(keySize: Int = 2048, from: Instant = Instant.now, duration: Duration = Days.days(365).toStandardDuration): X509Certificate = {
+    val dn = "CN=localhost, OU=Unit Testing, O=Mavericks, L=Moon Base 1, ST=Cyberspace, C=CY"
+    val to = from.plus(duration)
+
+    val keyGen = KeyPairGenerator.getInstance("RSA")
+    keyGen.initialize(keySize, new SecureRandom())
+    val pair = keyGen.generateKeyPair()
+    generateCertificate(dn, pair, from.toDate, to.toDate, "SHA1withRSA", AlgorithmId.sha256WithRSAEncryption_oid)
   }
 
   def toPEM(certificate: X509Certificate) = {
@@ -47,7 +57,7 @@ object CertificateGenerator {
     pemCert
   }
 
-  def generateRSAWithMD5(keySize: Int = 2048, from: Instant = Instant.now, duration: Int = 5000000): X509Certificate = {
+  def generateRSAWithMD5(keySize: Int = 2048, from: Instant = Instant.now, duration: Duration = Days.days(365).toStandardDuration): X509Certificate = {
     val dn = "CN=localhost, OU=Unit Testing, O=Mavericks, L=Moon Base 1, ST=Cyberspace, C=CY"
     val to = from.plus(duration)
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmCheckerSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmCheckerSpec.scala
@@ -5,10 +5,10 @@
  */
 package play.api.libs.ws.ssl
 
-import java.security.cert._
+import java.security.cert.{ CertPathValidatorException, Certificate, X509Certificate }
 import java.util.Collections._
 
-import org.joda.time._
+import org.joda.time.{ DateTime, Days, Instant }
 import org.specs2.mutable._
 import play.api.libs.ws.ssl.AlgorithmConstraintsParser._
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmCheckerSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmCheckerSpec.scala
@@ -5,10 +5,12 @@
  */
 package play.api.libs.ws.ssl
 
-import org.specs2.mutable._
-import java.security.cert.{ CertPathValidatorException, Certificate }
+import java.security.cert._
 import java.util.Collections._
-import AlgorithmConstraintsParser._
+
+import org.joda.time._
+import org.specs2.mutable._
+import play.api.libs.ws.ssl.AlgorithmConstraintsParser._
 
 object AlgorithmCheckerSpec extends Specification {
 
@@ -39,6 +41,56 @@ object AlgorithmCheckerSpec extends Specification {
     "fail a bad signature algorithm (MD5)" in {
       val intermediateCert: Certificate = CertificateGenerator.generateRSAWithMD5(2048)
       checker(Seq("MD5"), Nil).check(intermediateCert, emptySet()).must(throwA[CertPathValidatorException])
+    }
+
+    "neither info nor warning on a signature containing sha-1 that expires before 1 June 2016" in {
+      val oneHundredAndEightyDays = Days.days(180).toStandardDuration
+      val certificate = CertificateGenerator.generateRSAWithSHA1(2048, from = Instant.parse("2015-06-01T12:00:00Z"), duration = oneHundredAndEightyDays)
+
+      var infoCalled = false
+      var warningCalled = false
+      val checker = new AlgorithmChecker(Set.empty, Set.empty) {
+        override def infoOnSunset(x509Cert: X509Certificate, expirationDate: DateTime): Unit = {
+          infoCalled = true
+        }
+        override def warnOnSunset(x509Cert: X509Certificate, expirationDate: DateTime): Unit = {
+          warningCalled = true
+        }
+      }
+
+      checker.check(certificate, emptySet())
+      infoCalled must beFalse
+      warningCalled must beFalse
+    }
+
+    "info on a signature containing sha-1 that expires between 1 June 2016 to 31 December 2016" in {
+      val thirtyDays = Days.days(30).toStandardDuration
+      val certificate = CertificateGenerator.generateRSAWithSHA1(2048, from = Instant.parse("2016-06-01T12:00:00Z"), duration = thirtyDays)
+
+      var infoCalled = false
+      val checker = new AlgorithmChecker(Set.empty, Set.empty) {
+        override def infoOnSunset(x509Cert: X509Certificate, expirationDate: DateTime): Unit = {
+          infoCalled = true
+        }
+      }
+
+      checker.check(certificate, emptySet())
+      infoCalled must beTrue
+    }
+
+    "warn on a signature containing sha-1 that expires after 2017" in {
+      val tenYears = Days.days(365 * 10).toStandardDuration
+      val certificate = CertificateGenerator.generateRSAWithSHA1(2048, from = Instant.parse("2016-06-01T12:00:00Z"), duration = tenYears)
+
+      var warningCalled = false
+      val checker = new AlgorithmChecker(Set.empty, Set.empty) {
+        override def warnOnSunset(x509Cert: X509Certificate, expirationDate: DateTime): Unit = {
+          warningCalled = true
+        }
+      }
+
+      checker.check(certificate, emptySet())
+      warningCalled must beTrue
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/playframework/playframework/issues/4241

The algorithm to note SHA-1 certificates is based on the expiration date -- a certificate expiring from 6/2016 to 12/2016 gets an info, but expiration after that gets a warning, based on http://googleonlinesecurity.blogspot.com/2014/09/gradually-sunsetting-sha-1.html