### PR TITLE
Fix mergeCookieHeader

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -942,7 +942,7 @@ package play.api.mvc {
      * @return a valid Cookie header value
      */
     def mergeCookieHeader(cookieHeader: String, cookies: Seq[Cookie]): String = {
-      val tupledCookies = (decodeCookieHeader(cookieHeader) ++ cookies).map(cookie => cookie.path -> cookie)
+      val tupledCookies = (decodeCookieHeader(cookieHeader) ++ cookies).map(cookie => cookie.name -> cookie)
       // Put cookies in a map
       // Note: Seq.toMap do not preserve order
       val uniqCookies = scala.collection.immutable.ListMap(tupledCookies: _*)

--- a/framework/src/play/src/test/scala/play/api/mvc/CookiesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/CookiesSpec.scala
@@ -87,4 +87,26 @@ object CookiesSpec extends Specification {
     }
   }
 
+  "merging cookies" should {
+    "replace old cookies with new cookies of the same name" in {
+      val originalRequest = FakeRequest().withCookies(Cookie("foo", "fooValue1"), Cookie("bar", "barValue2"))
+      val requestWithMoreCookies = originalRequest.withCookies(Cookie("foo", "fooValue2"), Cookie("baz", "bazValue"))
+      val cookies = requestWithMoreCookies.cookies
+      cookies.toSet must_== Set(
+        Cookie("foo", "fooValue2"),
+        Cookie("bar", "barValue2"),
+        Cookie("baz", "bazValue")
+      )
+    }
+    "return one cookie for each name" in {
+      val cookies = FakeRequest().withCookies(
+        Cookie("foo", "foo1"), Cookie("foo", "foo2"), Cookie("bar", "bar"), Cookie("baz", "baz")
+      ).cookies
+      cookies.toSet must_== Set(
+        Cookie("foo", "foo2"),
+        Cookie("bar", "bar"),
+        Cookie("baz", "baz")
+      )
+    }
+  }
 }


### PR DESCRIPTION
Fix #4467. We should be merging cookies by name instead of by path.