### PR TITLE
Docs server should be started with a Test Environment. Fix #4483

### DIFF
--- a/framework/src/play-docs/src/main/scala/play/docs/DocServerStart.scala
+++ b/framework/src/play-docs/src/main/scala/play/docs/DocServerStart.scala
@@ -22,7 +22,7 @@ class DocServerStart {
     forceTranslationReport: Callable[File], port: java.lang.Integer): ServerWithStop = {
 
     val application: Application = {
-      val environment = Environment(projectPath, this.getClass.getClassLoader, Mode.Dev)
+      val environment = Environment(projectPath, this.getClass.getClassLoader, Mode.Test)
       val context = ApplicationLoader.createContext(environment)
       val components = new BuiltInComponentsFromContext(context) {
         lazy val router = Router.empty


### PR DESCRIPTION
This should be cherry-picked to 2.4.x before cutting the next release.