### PR TITLE
Add JsReadable#validateOpt

### DIFF
--- a/documentation/manual/releases/migration24/Migration24.md
+++ b/documentation/manual/releases/migration24/Migration24.md
@@ -371,11 +371,11 @@ As a result of these changes, your code can now assume that all values of type `
 
 ### Reading Options
 
-`OptionReads` is no longer available by default in 2.4. If you have code of the form `jsv.validate[Option[A]]`, you'll need to either rewrite it or add an additional import:
+`OptionReads` is no longer available by default in 2.4. If you have code of the form `jsv.validate[Option[A]]`, you'll need to rewrite it:
 
 * To get the same result as in 2.3, you can use `JsSuccess(jsv.asOpt[A])`. This will map all validation errors to `None`.
-* To map `JsNull` to `None` and validate the value if it exists, use `jsv.validate(optionWithNull[A])`.
-* To map both `JsNull` and an undefined lookup result to `None`, use `jsLookupResult.getOrElse(JsNull).validate(optionWithNull[A])` or similar.
+* To map both `JsNull` and an undefined lookup result to `None`, use `jsv.validateOpt[A]`.
+* To map `JsNull` to `None` and validate the value if it exists, use `jsv.validate(Reads.optionWithNull[A])`. If the value does not exist the result will be a `JsError`.
 
 ## Testing changes
 

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsLookup.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsLookup.scala
@@ -102,6 +102,15 @@ sealed trait JsLookupResult extends Any with JsReadable {
     case JsDefined(v) => v.validate[A]
     case undef: JsUndefined => JsError(undef.validationError)
   }
+
+  /**
+   * If this result contains `JsNull` or is undefined, returns `JsSuccess(None)`.
+   * Otherwise returns the result of validating as an `A` and wrapping the result in a `Some`.
+   */
+  def validateOpt[A](implicit rds: Reads[A]): JsResult[Option[A]] = this match {
+    case JsUndefined() => JsSuccess(None)
+    case JsDefined(a) => Reads.optionWithNull(rds).reads(a)
+  }
 }
 object JsLookupResult {
   import scala.language.implicitConversions

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
@@ -16,6 +16,8 @@ sealed trait JsValue extends JsReadable {
   override def toString = Json.stringify(this)
 
   def validate[A](implicit rds: Reads[A]) = rds.reads(this)
+
+  def validateOpt[A](implicit rds: Reads[A]): JsResult[Option[A]] = JsDefined(this).validateOpt[A]
 }
 
 object JsValue {

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
@@ -198,6 +198,15 @@ object JsonValidSpec extends Specification {
       val resultPost = json.validate((__ \ "field").read(Reads.optionWithNull[String]))
       resultPost.get must equalTo(None)
     }
+
+    "Validate options using validateOpt" in {
+      val json = Json.obj("foo" -> JsNull, "bar" -> "bar")
+
+      (json \ "foo").validateOpt[String] must_== JsSuccess(None)
+      (json \ "bar").validateOpt[Int] must_== JsError("error.expected.jsnumber")
+      (json \ "bar").validateOpt[String] must_== JsSuccess(Some("bar"))
+      (json \ "baz").validateOpt[String] must_== JsSuccess(None)
+    }
   }
 
   "JSON JsResult" should {


### PR DESCRIPTION
I think this is a good idea for 2.4.0 since it implements validating `Option` types the "right" way. I'd rather have people migrate from `validate[Option[A]]` to `validateOpt[A]` than to some other more verbose solution.