### PR TITLE
Modified EhCacheApi.get[T](key: String) to correctly return cached va…

### DIFF
--- a/framework/src/play-cache/src/test/scala/play/api/cache/CachedSpec.scala
+++ b/framework/src/play-cache/src/test/scala/play/api/cache/CachedSpec.scala
@@ -219,12 +219,42 @@ class CachedSpec extends PlaySpecification {
       val defaultCache = app.injector.instanceOf[CacheApi]
       defaultCache.set("foo", "bar")
       defaultCache.get[String]("foo") must beSome("bar")
+
+      defaultCache.set("int", 31)
+      defaultCache.get[Int]("int") must beSome(31)
+
+      defaultCache.set("long", 31l)
+      defaultCache.get[Long]("long") must beSome(31l)
+
+      defaultCache.set("double", 3.14)
+      defaultCache.get[Double]("double") must beSome(3.14)
+
+      defaultCache.set("boolean", true)
+      defaultCache.get[Boolean]("boolean") must beSome(true)
+
+      defaultCache.set("unit", ())
+      defaultCache.get[Unit]("unit") must beSome(())
     }
 
     "doesnt give items from cache with wrong type" in new WithApplication() {
       val defaultCache = app.injector.instanceOf[CacheApi]
       defaultCache.set("foo", "bar")
+      defaultCache.set("int", 31)
+      defaultCache.set("long", 31l)
+      defaultCache.set("double", 3.14)
+      defaultCache.set("boolean", true)
+      defaultCache.set("unit", ())
+
       defaultCache.get[Int]("foo") must beNone
+      defaultCache.get[Long]("foo") must beNone
+      defaultCache.get[Double]("foo") must beNone
+      defaultCache.get[Boolean]("foo") must beNone
+      defaultCache.get[String]("int") must beNone
+      defaultCache.get[Long]("int") must beNone
+      defaultCache.get[Double]("int") must beNone
+      defaultCache.get[Boolean]("int") must beNone
+      defaultCache.get[Unit]("foo") must beNone
+      defaultCache.get[Int]("unit") must beNone
     }
 
     "get items from the cache without giving the type" in new WithApplication() {
@@ -236,6 +266,14 @@ class CachedSpec extends PlaySpecification {
       defaultCache.set("baz", false)
       defaultCache.get("baz") must beSome(false)
       defaultCache.get[Any]("baz") must beSome(false)
+
+      defaultCache.set("int", 31)
+      defaultCache.get("int") must beSome(31)
+      defaultCache.get[Any]("int") must beSome(31)
+
+      defaultCache.set("unit", ())
+      defaultCache.get("unit") must beSome(())
+      defaultCache.get[Any]("unit") must beSome(())
     }
   }
 


### PR DESCRIPTION
…lue for 'primitive' T. Fixes #4488 

I originally came up with a simpler looking fix which used the value returned by `ClassTag[T].unapply(x: Any): Option[T]` however this only worked for Scala 2.11+ because that method was considerably reworked from 2.10. I've basically taken the code from the 2.11 version and embedded it here.

https://github.com/scala/scala/blob/2.11.x/src/library/scala/reflect/ClassTag.scala