### PR TITLE
[2.4.0] [doc] Inconsistent number of threads in ThreadPools.md

### DIFF
--- a/documentation/manual/detailedTopics/configuration/ThreadPools.md
+++ b/documentation/manual/detailedTopics/configuration/ThreadPools.md
@@ -45,11 +45,17 @@ In most situations, the appropriate execution context to use will be the **Play 
 
 ### Configuring the Play default thread pool
 
-The default thread pool can be configured using standard Akka configuration in `application.conf` under the `akka` namespace. Play uses Akka's default configuration:
+The default thread pool can be configured using standard Akka configuration in `application.conf` under the `akka` namespace. Here is default configuration for Play's thread pool:
 
 @[default-config](code/ThreadPools.scala)
 
-This configuration instructs Akka to create 3 threads per available processor, with a minimum of 8 and a maximum of 64 threads in the pool.  The full configuration options available to you can be found [here](http://doc.akka.io/docs/akka/2.3.11/general/configuration.html#Listing_of_the_Reference_Configuration).
+This configuration instructs Akka to create 1 thread per available processor, with a maximum of 24 threads in the pool.
+
+You can also try the default Akka configuration:
+
+@[akka-default-config](code/ThreadPools.scala)
+
+The full configuration options available to you can be found [here](http://doc.akka.io/docs/akka/2.3.11/general/configuration.html#Listing_of_the_Reference_Configuration).
 
 ## Using other thread pools
 

--- a/framework/src/play/src/main/resources/play/reference-overrides.conf
+++ b/framework/src/play/src/main/resources/play/reference-overrides.conf
@@ -18,10 +18,10 @@ akka {
   actor {
     default-dispatcher = {
       fork-join-executor {
-        # Settings this to 1 instad of 3 seems to improve performance.
+        # Settings this to 1 instead of 3 seems to improve performance.
         parallelism-factor = 1.0
 
-        # @richdougherty: Not sure why this is is set below the Akka
+        # @richdougherty: Not sure why this is set below the Akka
         # default.
         parallelism-max = 24
 


### PR DESCRIPTION
https://www.playframework.com/documentation/2.4.x/ThreadPools

```
Since you are never blocking, the default configuration of one thread per processor suits your use case perfectly,
```

but later,

```
This configuration instructs Akka to create 3 threads per available processor
```

So is there one thread per processor, or three?