### PR TITLE
Escape strings in JS reverse router

### DIFF
--- a/framework/src/play/src/main/scala/play/api/routing/JavascriptReverseRouter.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/JavascriptReverseRouter.scala
@@ -38,34 +38,23 @@ object JavaScriptReverseRouter {
     apply(name, ajaxMethod, request.host, routes: _*)
   }
 
-  private val jsReservedWords = Seq("break", "case", "catch", "continue", "debugger",
-    "default", "delete", "do", "else", "finally", "for", "function", "if",
-    "in", "instanceof", "new", "return", "switch", "this", "throw", "try",
-    "typeof", "var", "void", "while", "with")
-
   def apply(name: String, ajaxMethod: Option[String], host: String, routes: JavaScriptReverseRoute*): JavaScript = JavaScript {
-    """|var %s = {}; (function(_root){
+    import org.apache.commons.lang3.StringEscapeUtils.{ escapeEcmaScript => esc }
+    val ajaxField = ajaxMethod.fold("")(m => s"ajax:function(c){c=c||{};c.url=r.url;c.type=r.method;return $m(c)},")
+    val routesStr = routes.map { route =>
+      val nameParts = route.name.split('.')
+      val controllerName = nameParts.dropRight(1).mkString(".")
+      val prop = "_root" + nameParts.map(p => s"['${esc(p)}']").mkString
+      s"_nS('${esc(controllerName)}'); $prop = ${route.f};"
+    }.mkString("\n")
+    s"""
+      |var $name = {}; (function(_root){
       |var _nS = function(c,f,b){var e=c.split(f||"."),g=b||_root,d,a;for(d=0,a=e.length;d<a;d++){g=g[e[d]]=g[e[d]]||{}}return g}
       |var _qS = function(items){var qs = ''; for(var i=0;i<items.length;i++) {if(items[i]) qs += (qs ? '&' : '') + items[i]}; return qs ? ('?' + qs) : ''}
       |var _s = function(p,s){return p+((s===true||(s&&s.secure))?'s':'')+'://'}
-      |var _wA = function(r){return {%s method:r.method,type:r.method,url:r.url,absoluteURL: function(s){return _s('http',s)+'%s'+r.url},webSocketURL: function(s){return _s('ws',s)+'%s'+r.url}}}
-      |%s
-      |})(%s)
-    """.stripMargin.format(
-      name,
-      ajaxMethod.map("ajax:function(c){c=c||{};c.url=r.url;c.type=r.method;return " + _ + "(c)},").getOrElse(""),
-      host,
-      host,
-      routes.map { route =>
-        "_nS('%s'); _root.%s = %s".format(
-          route.name.split('.').dropRight(1).mkString("."),
-          route.name.split('.').map(name => if (jsReservedWords.contains(name)) {
-            "['" + name + "']"
-          } else {
-            "." + name
-          }).mkString("").tail,
-          route.f)
-      }.mkString("\n"),
-      name)
+      |var _wA = function(r){return {$ajaxField method:r.method,type:r.method,url:r.url,absoluteURL: function(s){return _s('http',s)+'${esc(host)}'+r.url},webSocketURL: function(s){return _s('ws',s)+'${esc(host)}'+r.url}}}
+      |$routesStr
+      |})($name)
+    """.stripMargin.trim
   }
 }

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/utils/JavaScriptRouterGenerator.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/utils/JavaScriptRouterGenerator.scala
@@ -1,12 +1,14 @@
 package utils
 
-import java.io._
+import java.nio.file.{Paths, Files}
 
 object JavaScriptRouterGenerator extends App {
 
   import controllers.routes.javascript._
 
-  val jsFile = play.api.routing.JavaScriptReverseRouter("jsRoutes", None, "localhost",
+  val host = if (args.length > 1) args(1) else "localhost"
+
+  val jsFile = play.api.routing.JavaScriptReverseRouter("jsRoutes", None, host,
     Application.index,
     Application.post,
     Application.withParam,
@@ -16,14 +18,11 @@ object JavaScriptRouterGenerator extends App {
   // Add module exports for node
   val jsModule = jsFile +
     """
-      |
       |module.exports = jsRoutes
     """.stripMargin
-
-  val file = new File(args(0))
-  file.getParentFile.mkdirs()
-  val writer = new FileWriter(file)
-  writer.write(jsModule)
-  writer.close()
+  
+  val path = Paths.get(args(0))
+  Files.createDirectories(path.getParent)
+  Files.write(path, jsModule.getBytes("UTF-8"))
 
 }

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/build.sbt
@@ -11,13 +11,21 @@ scalaSource in Test := baseDirectory.value / "tests"
 
 // Generate a js router so we can test it with mocha
 val generateJsRouter = TaskKey[Seq[File]]("generate-js-router")
+val generateJsRouterBadHost = TaskKey[Seq[File]]("generate-js-router-bad-host")
 
 generateJsRouter := {
   (runMain in Compile).toTask(" utils.JavaScriptRouterGenerator target/web/jsrouter/jsRoutes.js").value
   Seq(target.value / "web" / "jsrouter" / "jsRoutes.js")
 }
 
+generateJsRouterBadHost := {
+  (runMain in Compile).toTask(
+    """ utils.JavaScriptRouterGenerator target/web/jsrouter/jsRoutesBadHost.js "'}}};alert(1);a={a:{a:{a:'" """).value
+  Seq(target.value / "web" / "jsrouter" / "jsRoutesBadHost.js")
+}
+
 resourceGenerators in TestAssets <+= generateJsRouter
+resourceGenerators in TestAssets <+= generateJsRouterBadHost
 
 managedResourceDirectories in TestAssets += target.value / "web" / "jsrouter"
 

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/tests/assets/JavaScriptRouterSpec.js
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/tests/assets/JavaScriptRouterSpec.js
@@ -3,6 +3,7 @@
  */
 var assert = require("assert");
 var jsRoutes = require("./jsRoutes");
+var jsRoutesBadHost = require("./jsRoutesBadHost");
 
 describe("The JavaScript router", function() {
     it("should generate a url", function() {
@@ -24,5 +25,9 @@ describe("The JavaScript router", function() {
     it("should add parameters to the query string", function() {
         var data = jsRoutes.controllers.Application.takeBool(true);
         assert.equal("/take-bool?b=true", data.url);
+    });
+    it("should properly escape the host", function() {
+        var data = jsRoutesBadHost.controllers.Application.index();
+        assert(data.absoluteURL().indexOf("'}}};alert(1);a={a:{a:{a:'") >= 0)
     });
 });

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/utils/JavaScriptRouterGenerator.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/utils/JavaScriptRouterGenerator.scala
@@ -1,6 +1,6 @@
 package utils
 
-import java.io._
+import java.nio.file.{Files, Paths}
 
 object JavaScriptRouterGenerator extends App {
 
@@ -16,14 +16,11 @@ object JavaScriptRouterGenerator extends App {
   // Add module exports for node
   val jsModule = jsFile +
     """
-      |
       |module.exports = jsRoutes
     """.stripMargin
 
-  val file = new File(args(0))
-  file.getParentFile.mkdirs()
-  val writer = new FileWriter(file)
-  writer.write(jsModule)
-  writer.close()
+  val path = Paths.get(args(0))
+  Files.createDirectories(path.getParent)
+  Files.write(path, jsModule.getBytes("UTF-8"))
 
 }


### PR DESCRIPTION
I rewrote the code for generating the reverse router to make it more readable as well. I'm not sure if it's possible to have invalid JS string characters in controller names but I escaped those too.