### PR TITLE
Tests for action composition order and http configuration

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ActionCompositionOrderTest.java
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ActionCompositionOrderTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.it.http;
+
+import play.libs.F;
+import play.mvc.*;
+import play.test.Helpers;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+public class ActionCompositionOrderTest {
+
+    @With(ControllerComposition.class)
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ControllerAnnotation {}
+
+    static class ControllerComposition extends Action<ControllerAnnotation> {
+        @Override
+        public F.Promise<Result> call(Http.Context ctx) throws Throwable {
+            return delegate.call(ctx).map(result -> {
+                String newContent = "controller" + Helpers.contentAsString(result);
+                return Results.ok(newContent);
+            });
+        }
+    }
+
+    @With(ActionComposition.class)
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface ActionAnnotation {}
+
+    static class ActionComposition extends Action<ControllerAnnotation> {
+        @Override
+        public F.Promise<Result> call(Http.Context ctx) throws Throwable {
+            return delegate.call(ctx).map(result -> {
+                String newContent = "action" + Helpers.contentAsString(result);
+                return Results.ok(newContent);
+            });
+        }
+    }
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -1,0 +1,67 @@
+package play.it.http
+
+import play.api.Application
+import play.api.libs.ws.WSResponse
+import play.api.test.{ WsTestClient, TestServer, FakeApplication, PlaySpecification }
+import play.it.http.ActionCompositionOrderTest.{ ActionAnnotation, ControllerAnnotation }
+import play.mvc.{ Results, Result }
+
+object JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
+
+  def makeRequest[T](controller: MockController, configuration: Map[String, _ <: Any] = Map.empty)(block: WSResponse => T) = {
+    implicit val port = testServerPort
+    lazy val app: Application = FakeApplication(
+      withRoutes = {
+        case _ => JAction(app, controller)
+      },
+      additionalConfiguration = configuration
+    )
+
+    running(TestServer(port, app)) {
+      val response = await(wsUrl("/").get())
+      block(response)
+    }
+  }
+
+  "When action composition is configured to invoke controller first" should {
+    "execute controller composition before action composition" in makeRequest(new ComposedController {
+      @ActionAnnotation
+      override def action: Result = Results.ok()
+    }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "true")) { response =>
+      response.body must beEqualTo("controlleraction")
+    }
+
+    "execute controller composition when action is not annotated" in makeRequest(new ComposedController {
+      override def action: Result = Results.ok()
+    }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "true")) { response =>
+      response.body must beEqualTo("controller")
+    }
+  }
+
+  "When action composition is configured to invoke action first" should {
+    "execute action composition before controller composition" in makeRequest(new ComposedController {
+      @ActionAnnotation
+      override def action: Result = Results.ok()
+    }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false")) { response =>
+      response.body must beEqualTo("actioncontroller")
+    }
+
+    "execute action composition when controller is not annotated" in makeRequest(new MockController {
+      @ActionAnnotation
+      override def action: Result = Results.ok()
+    }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false")) { response =>
+      response.body must beEqualTo("action")
+    }
+
+    "execute action composition first is the default" in makeRequest(new ComposedController {
+      @ActionAnnotation
+      override def action: Result = Results.ok()
+    }) { response =>
+      response.body must beEqualTo("actioncontroller")
+    }
+  }
+
+}
+
+@ControllerAnnotation
+abstract class ComposedController extends MockController {}

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -162,9 +162,9 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
       )
 
       running(TestServer(port, app)) {
-        val response = BasicHttpClient.makeRequests(testServerPort, true)(
+        val response = BasicHttpClient.makeRequests(testServerPort, checkClosed = true)(
           BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
-        )(0)
+        ).head
         response.headers.get(CONTENT_LENGTH) must beNone
         response.headers.get(TRANSFER_ENCODING) must beNone
         response.body must beLeft("hello")

--- a/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -101,8 +101,7 @@ object HttpConfiguration {
   }
 
   def fromConfiguration(configuration: Configuration) = {
-    val config = PlayConfig(configuration
-    )
+    val config = PlayConfig(configuration)
     val context = {
       val ctx = config.getDeprecated[String]("play.http.context", "application.context")
       if (!ctx.startsWith("/")) {

--- a/framework/src/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.http
+
+import com.typesafe.config.ConfigFactory
+import org.specs2.mutable.Specification
+import play.api.{ PlayException, Configuration }
+import play.core.netty.utils.{ ClientCookieEncoder, ClientCookieDecoder, ServerCookieDecoder, ServerCookieEncoder }
+
+object HttpConfigurationSpec extends Specification {
+
+  "HttpConfiguration" should {
+
+    import scala.collection.JavaConversions._
+
+    def properties = {
+      Map(
+        "play.http.context" -> "/",
+        "play.http.parser.maxMemoryBuffer" -> "10k",
+        "play.http.parser.maxDiskBuffer" -> "20k",
+        "play.http.actionComposition.controllerAnnotationsFirst" -> "true",
+        "play.http.cookies.strict" -> "true",
+        "play.http.session.cookieName" -> "PLAY_SESSION",
+        "play.http.session.secure" -> "true",
+        "play.http.session.maxAge" -> "10s",
+        "play.http.session.httpOnly" -> "true",
+        "play.http.session.domain" -> "playframework.com",
+        "play.http.flash.cookieName" -> "PLAY_FLASH",
+        "play.http.flash.secure" -> "true",
+        "play.http.flash.httpOnly" -> "true"
+      )
+    }
+
+    val configuration = new Configuration(ConfigFactory.parseMap(properties))
+
+    "configure a context" in {
+      val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
+      httpConfiguration.context must beEqualTo("/")
+    }
+
+    "throw an error when context does not starts with /" in {
+      val config = properties + ("play.http.context" -> "something")
+      val wrongConfiguration = Configuration(ConfigFactory.parseMap(config))
+      new HttpConfiguration.HttpConfigurationProvider(wrongConfiguration).get must throwA[PlayException]
+    }
+
+    "configure max memory buffer" in {
+      val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
+      httpConfiguration.parser.maxMemoryBuffer must beEqualTo(10 * 1024)
+    }
+
+    "configure max disk buffer" in {
+      val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
+      httpConfiguration.parser.maxDiskBuffer must beEqualTo(20 * 1024)
+    }
+
+    "configure cookies encoder/decoder" in {
+      val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
+      httpConfiguration.cookies.strict must beTrue
+    }
+
+    "configure session should set" in {
+
+      "cookie name" in {
+        val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
+        httpConfiguration.session.cookieName must beEqualTo("PLAY_SESSION")
+      }
+
+      "cookie security" in {
+        val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
+        httpConfiguration.session.secure must beTrue
+      }
+
+      "cookie maxAge" in {
+        val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
+        httpConfiguration.session.maxAge.map(_.toSeconds) must beEqualTo(Some(10))
+      }
+
+      "cookie httpOnly" in {
+        val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
+        httpConfiguration.session.httpOnly must beTrue
+      }
+
+      "cookie domain" in {
+        val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
+        httpConfiguration.session.domain must beEqualTo(Some("playframework.com"))
+      }
+    }
+
+    "configure flash should set" in {
+
+      "cookie name" in {
+        val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
+        httpConfiguration.flash.cookieName must beEqualTo("PLAY_FLASH")
+      }
+
+      "cookie security" in {
+        val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
+        httpConfiguration.flash.secure must beTrue
+      }
+
+      "cookie httpOnly" in {
+        val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
+        httpConfiguration.flash.httpOnly must beTrue
+      }
+    }
+  }
+
+  "Cookies configuration" should {
+
+    "be configured as strict" in {
+
+      val cookieConfiguration = CookiesConfiguration(strict = true)
+
+      "for server encoder" in {
+        cookieConfiguration.serverEncoder must beEqualTo(ServerCookieEncoder.STRICT)
+      }
+
+      "for server decoder" in {
+        cookieConfiguration.serverDecoder must beEqualTo(ServerCookieDecoder.STRICT)
+      }
+
+      "for client encoder" in {
+        cookieConfiguration.clientEncoder must beEqualTo(ClientCookieEncoder.STRICT)
+      }
+
+      "for client decoder" in {
+        cookieConfiguration.clientDecoder must beEqualTo(ClientCookieDecoder.STRICT)
+      }
+    }
+
+    "be configured as lax" in {
+
+      val cookieConfiguration = CookiesConfiguration(strict = false)
+
+      "for server encoder" in {
+        cookieConfiguration.serverEncoder must beEqualTo(ServerCookieEncoder.LAX)
+      }
+
+      "for server decoder" in {
+        cookieConfiguration.serverDecoder must beEqualTo(ServerCookieDecoder.LAX)
+      }
+
+      "for client encoder" in {
+        cookieConfiguration.clientEncoder must beEqualTo(ClientCookieEncoder.LAX)
+      }
+
+      "for client decoder" in {
+        cookieConfiguration.clientDecoder must beEqualTo(ClientCookieDecoder.LAX)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds tests for action composition order configuration, which was added by PR #4461. It also adds tests for HttpConfiguration provider.