### PR TITLE
Exclude externalized resources from application jar in dist

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -97,6 +97,8 @@ object PlayImport {
     val playInteractionMode = SettingKey[PlayInteractionMode]("playInteractionMode", "Hook to configure how Play blocks when running")
 
     val externalizeResources = SettingKey[Boolean]("playExternalizeResources", "Whether resources should be externalized into the conf directory when Play is packaged as a distribution.")
+    val playExternalizedResources = TaskKey[Seq[(File, String)]]("playExternalizedResources", "The resources to externalize")
+    val playJarSansExternalized = TaskKey[File]("playJarSansExternalized", "Creates a jar file that has all the externalized resources excluded")
 
     val playOmnidoc = SettingKey[Boolean]("playOmnidoc", "Determines whether to use the aggregated Play documentation")
     val playDocsName = SettingKey[String]("playDocsName", "Artifact name of the Play documentation")

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/controllers/Application.scala
@@ -6,6 +6,7 @@ package controllers
 import play.api._
 import play.api.mvc._
 import play.api.Play.current
+import scala.collection.JavaConverters._
 
 object Application extends Controller {
 
@@ -15,5 +16,10 @@ object Application extends Controller {
 
   def config = Action {
     Ok(Play.configuration.underlying.getString("some.config"))
+  }
+
+  def count = Action {
+    val num = Play.classloader.getResources("application.conf").asScala.toSeq.size
+    Ok(num.toString)
   }
 }

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
@@ -58,3 +58,14 @@ InputKey[Unit]("checkConfig") := {
     sys.error(s"Expected config $expected but got $config")
   }
 }
+
+InputKey[Unit]("countApplicationConf") := {
+  val expected = Def.spaceDelimited().parsed.head
+  import java.net.URL
+  val count = retry() {
+    IO.readLinesURL(new URL("http://localhost:9000/countApplicationConf")).mkString("\n")
+  }
+  if (expected != count) {
+    sys.error(s"Expected application.conf to be $expected times on classpath, but it was there $count times")
+  }
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/conf/routes
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/conf/routes
@@ -6,6 +6,7 @@
 GET        /                    controllers.Application.index
 
 GET        /config              controllers.Application.config
+GET				 /countApplicationConf controllers.Application.count
 
 # Map static resources from the /public folder to the /assets URL path
 GET        /assets/*file        controllers.Assets.at(path="/public", file)

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/test
@@ -3,6 +3,8 @@
 $ exists target/universal/stage/README
 $ exists target/universal/stage/SomeFile.txt
 $ exists target/universal/stage/SomeFolder/SomeOtherFile.txt
+$ exists target/universal/stage/lib/dist-sample.dist-sample-1.0-SNAPSHOT-sans-externalized.jar
+-$ exists target/universal/stage/lib/dist-sample.dist-sample-1.0-SNAPSHOT.jar
 
 > checkStartScript
 $ exists target/universal/stage/conf/application.conf
@@ -12,6 +14,7 @@ $ exists target/universal/stage/share/doc/api
 # Run it to make sure everything works
 > testProd --no-exit-sbt
 > checkConfig foo
+> countApplicationConf 1
 > stopProd --no-exit-sbt
 
 # Change the configuration in the conf directory, make sure it takes effect
@@ -24,4 +27,10 @@ $ copy-file conf/alternate.conf target/universal/stage/conf/application.conf
 > set PlayKeys.externalizeResources := false
 > stage
 -$ exists target/dist/conf/application.conf
+-$ exists target/universal/stage/lib/dist-sample.dist-sample-1.0-SNAPSHOT-sans-externalized.jar
+$ exists target/universal/stage/lib/dist-sample.dist-sample-1.0-SNAPSHOT.jar
 > checkStartScript no-conf
+> testProd --no-exit-sbt
+> checkConfig foo
+> countApplicationConf 1
+> stopProd --no-exit-sbt


### PR DESCRIPTION
Fixes #4512

* Build an additional sans-externalized jar that doesn't contain the externalized resources when externalized resources is true
* Include this jar in the script classpath, and exclude the normal jar, when externalized resources is true