### PR TITLE
Ensure CORS headers get added to failed responses

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
@@ -4,6 +4,7 @@
 package play.filters.cors
 
 import com.typesafe.config.Config
+import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
 
 import scala.concurrent.Future
 
@@ -58,12 +59,17 @@ object CORSActionBuilder {
    * @param  configuration  The configuration to load the config from
    * @param  configPath  The path to the subtree of the application configuration.
    */
-  def apply(configuration: Configuration, configPath: String = "play.filters.cors"): CORSActionBuilder = new CORSActionBuilder {
-    override protected def corsConfig = {
-      val config = PlayConfig(configuration)
-      val prototype = config.get[Config]("play.filters.cors")
-      val corsConfig = PlayConfig(config.get[Config](configPath).withFallback(prototype))
-      CORSConfig.fromUnprefixedConfiguration(corsConfig)
+  def apply(configuration: Configuration, errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
+    configPath: String = "play.filters.cors"): CORSActionBuilder = {
+    val eh = errorHandler
+    new CORSActionBuilder {
+      override protected def corsConfig = {
+        val config = PlayConfig(configuration)
+        val prototype = config.get[Config]("play.filters.cors")
+        val corsConfig = PlayConfig(config.get[Config](configPath).withFallback(prototype))
+        CORSConfig.fromUnprefixedConfiguration(corsConfig)
+      }
+      override protected val errorHandler = eh
     }
   }
 
@@ -73,7 +79,11 @@ object CORSActionBuilder {
    * @param  config  The local configuration to use in place of the global configuration.
    * @see [[CORSConfig]]
    */
-  def apply(config: CORSConfig): CORSActionBuilder = new CORSActionBuilder {
-    override protected val corsConfig = config
+  def apply(config: CORSConfig, errorHandler: HttpErrorHandler): CORSActionBuilder = {
+    val eh = errorHandler
+    new CORSActionBuilder {
+      override protected val corsConfig = config
+      override protected val errorHandler = eh
+    }
   }
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
@@ -3,6 +3,8 @@
  */
 package play.filters.cors
 
+import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
+
 import scala.concurrent.Future
 
 import play.api.Logger
@@ -31,6 +33,7 @@ import play.api.mvc.{ Filter, RequestHeader, Result }
  */
 class CORSFilter(
     override protected val corsConfig: CORSConfig = CORSConfig(),
+    override protected val errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
     private val pathPrefixes: Seq[String] = Seq("/")) extends Filter with AbstractCORSPolicy {
 
   override protected val logger = Logger(classOf[CORSFilter])
@@ -46,7 +49,8 @@ class CORSFilter(
 
 object CORSFilter {
 
-  def apply(corsConfig: CORSConfig = CORSConfig(), pathPrefixes: Seq[String] = Seq("/")) =
-    new CORSFilter(corsConfig, pathPrefixes)
+  def apply(corsConfig: CORSConfig = CORSConfig(), errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
+    pathPrefixes: Seq[String] = Seq("/")) =
+    new CORSFilter(corsConfig, errorHandler, pathPrefixes)
 
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
@@ -5,6 +5,7 @@ package play.filters.cors
 
 import javax.inject.{ Inject, Provider }
 
+import play.api.http.HttpErrorHandler
 import play.api.{ Environment, PlayConfig, Configuration }
 import play.api.inject.Module
 
@@ -18,10 +19,10 @@ class CORSConfigProvider @Inject() (configuration: Configuration) extends Provid
 /**
  * Provider for CORSFilter.
  */
-class CORSFilterProvider @Inject() (configuration: Configuration, corsConfig: CORSConfig) extends Provider[CORSFilter] {
+class CORSFilterProvider @Inject() (configuration: Configuration, errorHandler: HttpErrorHandler, corsConfig: CORSConfig) extends Provider[CORSFilter] {
   lazy val get = {
     val pathPrefixes = PlayConfig(configuration).get[Seq[String]]("play.filters.cors.pathPrefixes")
-    new CORSFilter(corsConfig, pathPrefixes)
+    new CORSFilter(corsConfig, errorHandler, pathPrefixes)
   }
 }
 
@@ -40,8 +41,9 @@ class CORSModule extends Module {
  */
 trait CORSComponents {
   def configuration: Configuration
+  def httpErrorHandler: HttpErrorHandler
 
   lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(configuration)
-  lazy val corsFilter: CORSFilter = new CORSFilter(corsConfig, corsPathPrefixes)
+  lazy val corsFilter: CORSFilter = new CORSFilter(corsConfig, httpErrorHandler, corsPathPrefixes)
   lazy val corsPathPrefixes: Seq[String] = PlayConfig(configuration).get[Seq[String]]("play.filters.cors.pathPrefixes")
 }

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -37,9 +37,9 @@ class JavaActionAnnotations(val controller: Class[_], val method: java.lang.refl
 
   val actionMixins = {
     val allDeclaredAnnotations: Seq[java.lang.annotation.Annotation] = if (HttpConfiguration.current.actionComposition.controllerAnnotationsFirst) {
-        (controllerAnnotations ++ method.getDeclaredAnnotations)
+      (controllerAnnotations ++ method.getDeclaredAnnotations)
     } else {
-        (method.getDeclaredAnnotations ++ controllerAnnotations)
+      (method.getDeclaredAnnotations ++ controllerAnnotations)
     }
     allDeclaredAnnotations.collect {
       case a: play.mvc.With => a.value.map(c => (a, c)).toSeq


### PR DESCRIPTION
If an action fails due to an exception being thrown, the headers still need to be added so that the cross origin client can process the failed response.