### PR TITLE
Fix Controller scaladoc

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
@@ -40,7 +40,7 @@ trait Controller extends Results with BodyParsers with HttpProtocol with Status 
    * For example:
    * {{{
    * def index(name:String) = Action { implicit request =>
-   *   val username = session("username")
+   *   val username = request2session("username")
    *   Ok("Hello " + username)
    * }
    * }}}
@@ -53,13 +53,24 @@ trait Controller extends Results with BodyParsers with HttpProtocol with Status 
    * For example:
    * {{{
    * def index(name:String) = Action { implicit request =>
-   *   val message = flash("message")
+   *   val message = request2flash("message")
    *   Ok("Got " + message)
    * }
    * }}}
    */
   implicit def request2flash(implicit request: RequestHeader): Flash = request.flash
 
+  /**
+   * Retrieve the language implicitly from the request.
+   *
+   * For example:
+   * {{{
+   * def index(name:String) = Action { implicit request =>
+   *   val lang: Lang = request2lang
+   *   Ok("Got " + lang)
+   * }
+   * }}}
+   */
   implicit def request2lang(implicit request: RequestHeader): Lang = {
     play.api.Play.maybeApplication.map(app => play.api.i18n.Messages.messagesApiCache(app).preferred(request).lang)
       .getOrElse(request.acceptLanguages.headOption.getOrElse(play.api.i18n.Lang.defaultLang))


### PR DESCRIPTION
The scaladoc for Controller.scala doesn't compile.   Tweaked the docs to use the current methods.