### PR TITLE
[2.4] Corrects evolutions configuration keys

### DIFF
--- a/documentation/manual/detailedTopics/production/cloud/Deploying-CleverCloud.md
+++ b/documentation/manual/detailedTopics/production/cloud/Deploying-CleverCloud.md
@@ -51,7 +51,7 @@ The file must contain the following fields:
 
 That field can contain additional configuration like:
 
-`"-Dconfig.resource=clevercloud.conf"`, `"-Dplay.version=2.0.4"` or `"-Dplay.modules.evolutions.autoApply=true"`.
+`"-Dconfig.resource=clevercloud.conf"`, `"-Dplay.version=2.0.4"` or `"-Dplay.evolutions.autoApply=true"`.
 
 ## Connecting to a database
 

--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
@@ -63,13 +63,13 @@ class ApplicationEvolutions @Inject() (
             case Mode.Prod if hasDown && dbConfig.autoApply && dbConfig.autoApplyDowns => evolutions.evolve(db, scripts, autocommit)
             case Mode.Prod if hasDown =>
               logger.warn(s"Your production database [$db] needs evolutions, including downs! \n\n${toHumanReadableScript(scripts)}")
-              logger.warn(s"Run with -Dplay.modules.evolutions.db.$db.autoApply=true and -Dplay.modules.evolutions.db.$db.autoApplyDowns=true if you want to run them automatically, including downs (be careful, especially if your down evolutions drop existing data)")
+              logger.warn(s"Run with -Dplay.evolutions.db.$db.autoApply=true and -Dplay.evolutions.db.$db.autoApplyDowns=true if you want to run them automatically, including downs (be careful, especially if your down evolutions drop existing data)")
 
               throw InvalidDatabaseRevision(db, toHumanReadableScript(scripts))
 
             case Mode.Prod =>
               logger.warn(s"Your production database [$db] needs evolutions! \n\n${toHumanReadableScript(scripts)}")
-              logger.warn(s"Run with -Dplay.modules.evolutions.db.$db.autoApply=true if you want to run them automatically (be careful)")
+              logger.warn(s"Run with -Dplay.evolutions.db.$db.autoApply=true if you want to run them automatically (be careful)")
 
               throw InvalidDatabaseRevision(db, toHumanReadableScript(scripts))
 

--- a/templates/play-java-intro/conf/application.conf
+++ b/templates/play-java-intro/conf/application.conf
@@ -43,7 +43,7 @@ jpa.default=defaultPersistenceUnit
 # Evolutions
 # ~~~~~
 # You can disable evolutions if needed
-# play.modules.evolutions.enabled=false
+# play.evolutions.enabled=false
 
 # You can disable evolutions for a specific datasource if necessary
-# play.modules.evolutions.db.default.enabled=false
+# play.evolutions.db.default.enabled=false

--- a/templates/play-java/conf/application.conf
+++ b/templates/play-java/conf/application.conf
@@ -38,7 +38,7 @@ play.i18n.langs = [ "en" ]
 # Evolutions
 # ~~~~~
 # You can disable evolutions if needed
-# play.modules.evolutions.enabled=false
+# play.evolutions.enabled=false
 
 # You can disable evolutions for a specific datasource if necessary
-# play.modules.evolutions.db.default.enabled=false
+# play.evolutions.db.default.enabled=false

--- a/templates/play-scala-intro/conf/application.conf
+++ b/templates/play-scala-intro/conf/application.conf
@@ -39,7 +39,7 @@ slick.default="models.*"
 # Evolutions
 # ~~~~~
 # You can disable evolutions if needed
-# play.modules.evolutions.enabled=false
+# play.evolutions.enabled=false
 
 # You can disable evolutions for a specific datasource if necessary
-# play.modules.evolutions.db.default.enabled=false
+# play.evolutions.db.default.enabled=false

--- a/templates/play-scala/conf/application.conf
+++ b/templates/play-scala/conf/application.conf
@@ -38,7 +38,7 @@ play.i18n.langs = [ "en" ]
 # Evolutions
 # ~~~~~
 # You can disable evolutions if needed
-# play.modules.evolutions.enabled=false
+# play.evolutions.enabled=false
 
 # You can disable evolutions for a specific datasource if necessary
-# play.modules.evolutions.db.default.enabled=false
+# play.evolutions.db.default.enabled=false


### PR DESCRIPTION
Fix in the code and documentation the configuration keys about evolutions (`play.modules.evolutions` -> `play.evolutions`)

Fixes for #4533 