### PR TITLE
Java 8 static method in interface does not compile in Play 2.4.0-RC5

### DIFF
--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -13,6 +13,8 @@ java.lang.UnsupportedClassVersionError: play/runsupport/classloader/ApplicationC
 
 A [java.lang.UnsupportedClassVersionError](https://docs.oracle.com/javase/8/docs/api/java/lang/UnsupportedClassVersionError.html) means that reading a Java class file with an older version of Java than the class file was compiled with is unsupported.
 
+> **Note:** Scala 2.10 does not have full support to all Java 8 language features, like static methods on interfaces. If your project has Java code using these new features present in Java 8, upgrade to use Scala 2.11.6+. See [sbt docs](http://www.scala-sbt.org/0.13/docs/Howto-Scala.html) to learn how to set `scalaVersion` to your project.
+
 ## Build changes
 
 The following steps need to be taken to update your sbt build before you can load/run a Play project in sbt.


### PR DESCRIPTION
Given I have a static method in a Java interface

```java
public interface Java8Interface {
    static String foo() {
        return "foo";
    }
}
```

Then a Play 2.4.0-RC5 project fails to compile it

```
[error] /home/travis/build/schleichardt/play-2-4-java-8-compile-errors/app/demo/Java8Interface.java:4: `;' expected but `{' found.
[error]     static String foo() {
[error]                         ^
[error] one error found
[error] (root/compile:compileIncremental) Compilation failed
```

* test project to reproduce: https://github.com/schleichardt/play-2-4-java-8-compile-errors
* travis output for a plain sbt project which compiles the interface: https://travis-ci.org/schleichardt/play-2-4-java-8-compile-errors/builds/63322694#L786
    * see https://github.com/schleichardt/play-2-4-java-8-compile-errors/blob/master/build.sbt#L7
* travis output for failing compilation in play project: https://travis-ci.org/schleichardt/play-2-4-java-8-compile-errors/builds/63322694#L1301
* there is a related bug report in the mailing list https://groups.google.com/forum/#!topic/play-framework/JdyeQNycQPI