### PR TITLE
[doc] Add spacing in Migration24.md

### DIFF
--- a/documentation/manual/releases/Migration24.md
+++ b/documentation/manual/releases/Migration24.md
@@ -789,11 +789,13 @@ The [sbt-native-packager](https://github.com/sbt/sbt-native-packager) has been u
  * The syntax of the `/etc/default/$appname` file has changed from being a simple list of command line parameters to being a shell script that gets sourced by the start/stop scripts, allowing you to set environment variables.
  * The equivalent to the old syntax of the default file is an `application.ini` file in your archive's `conf` folder.
  * The default-file gets sourced by `SystemV` Init scripts only - Upstart ignores this file right now. To change your build to create `SystemV` compatible packages, add this to your build.sbt:
+
 ```
 import com.typesafe.sbt.packager.archetypes.ServerLoader.{SystemV, Upstart}
 
 serverLoading in Debian := SystemV
 ```
+
  * Other changes that might be necessary can be found in the [sbt-native-packager release notes](https://github.com/sbt/sbt-native-packager/releases).
 
 


### PR DESCRIPTION
The example given for sbt-native-packager did not have spacing and so was not showing up as a code example.  Should backport to 2.4.x