### PR TITLE
Fix BodyParser diskbuffer scaladoc

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -293,12 +293,12 @@ trait BodyParsers {
     def DefaultMaxTextLength: Int = config.maxMemoryBuffer
 
     /**
-     * Default max length allowed for text based body.
+     * Default max length allowed for disk based body.
      *
      * You can configure it in application.conf:
      *
      * {{{
-     * parsers.disk.maxLength = 512k
+     * play.http.parser.maxDiskBuffer = 512k
      * }}}
      */
     def DefaultMaxDiskLength: Long = config.maxDiskBuffer


### PR DESCRIPTION
The configuration doc for the max disk buffer setting was set to an invalid value "parsers.disk.maxLength" that would never have any effect.  Looked through some old docs and it shows up here: 

https://www.playframework.com/documentation/2.4.0-M3/ScalaBodyParsers

But it's not showing in 2.3.x so it looks like a new setting that was changed in code but not in docs.

Changed code comment from "parsers.disk.maxLength" to match the HTTPConfiguration value "play.http.parser.maxDiskBuffer"

The test configuration for the property is here:

https://github.com/playframework/playframework/blob/master/framework/src/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala#L21