### PR TITLE
Fix the template build

### DIFF
--- a/templates/play-java-intro/conf/logback.xml
+++ b/templates/play-java-intro/conf/logback.xml
@@ -1,4 +1,6 @@
 <configuration>
+    
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>

--- a/templates/play-java/conf/logback.xml
+++ b/templates/play-java/conf/logback.xml
@@ -1,4 +1,6 @@
 <configuration>
+    
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>

--- a/templates/play-scala-intro/conf/logback.xml
+++ b/templates/play-scala-intro/conf/logback.xml
@@ -1,4 +1,6 @@
 <configuration>
+    
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>

--- a/templates/play-scala/conf/logback.xml
+++ b/templates/play-scala/conf/logback.xml
@@ -1,4 +1,6 @@
 <configuration>
+    
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>

--- a/templates/project/Build.scala
+++ b/templates/project/Build.scala
@@ -5,6 +5,20 @@ import sbt.Keys._
 import com.typesafe.sbt.S3Plugin._
 import sbt.complete.{Parsers, Parser}
 
+/**
+ * This must be here, and not in build.sbt, since Project.setSbtFiles only works from a .scala file
+ */
+object TemplatesBuild extends Build {
+  lazy val root = (project in file("."))
+    .setSbtFiles(
+      // Load the version from Play's version.sbt
+      // Order is important, load the version first, then load build.sbt which may modify it with the play.version
+      // system property.
+      file("../framework/version.sbt"),
+      file("./build.sbt")
+    )
+}
+
 object Templates {
 
   val templates = SettingKey[Seq[File]]("activatorTemplates")
@@ -134,7 +148,7 @@ object Templates {
       }
     },
 
-    publishTemplatesTo := "typesafe.com",
+    publishTemplatesTo := "api.typesafe.com",
     doPublishTemplates := {
       val host = publishTemplatesTo.value
       val creds = Credentials.forHost(credentials.value, host).getOrElse {
@@ -314,4 +328,6 @@ object Templates {
     .map(_.trim)
     .filterNot(_.isEmpty)
     .map(_.replaceAll("<p>", "").replaceAll("</p>", ""))
+
+  play.api.Logger.configure(play.api.Environment.simple())
 }

--- a/templates/project/plugins.sbt
+++ b/templates/project/plugins.sbt
@@ -1,5 +1,11 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-s3" % "0.5")
 
-lazy val plugins = (project in file(".")).dependsOn(playWs)
+// Depend on hard coded play-ws version, since we don't need/want the latest, and the system
+// properties from this build interfere with the system properties from Play's build.  This
+// can be updated to something else when needed, but doesn't need to be.
+libraryDependencies += "com.typesafe.play" %% "play-ws" % "2.4.0"
 
-lazy val playWs = ProjectRef(Path.fileProperty("user.dir").getParentFile / "framework", "Play-WS")
+// Add a resources directory, so that we can include a logback configuration, otherwise we
+// get debug logs for everything which is huge.
+resourceDirectories in Compile += baseDirectory.value / "resources"
+resources in Compile ++= (baseDirectory.value / "resources").***.get

--- a/templates/project/resources/logback.xml
+++ b/templates/project/resources/logback.xml
@@ -1,0 +1,17 @@
+<!--
+  ~ Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+  -->
+<!-- The default logback configuration that Play uses if no other configuration is provided -->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%level %logger{15} - %message%n%xException</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
* Made template build no longer depend on the Play build - this was causing big issues and confusion with scala versions etc. Instead it now depends on a static version of play-ws, which is ok.
* Made template build read Play version from version.sbt, but make it overridable for when we publish templates.
* Made template build default to Scala 2.10.5 for snapshots (this means it will work in CI) and 2.11.6 for production versions (which is what we want when we deploy the templates).
* Fixed #4551, logback.xml configuration was missing coloredLevel configuration.
* Provided a logback.xml to template build so that s3 plugin and template publishing doesn't spew massive amounts of debug to console.