### PR TITLE
Add AllowedHostsFilter to deny requests with invalid hosts

### DIFF
--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -2,6 +2,7 @@ play.modules {
   enabled += "play.filters.csrf.CSRFModule"
   enabled += "play.filters.cors.CORSModule"
   enabled += "play.filters.headers.SecurityHeadersModule"
+  enabled += "play.filters.hosts.AllowedHostsModule"
   enabled += "play.filters.gzip.GzipFilterModule"
 }
 
@@ -75,7 +76,7 @@ play.filters {
     # HttpRequestHandler.
     errorHandler = null
   }
-  
+
   # Security headers filter configuration
   headers {
 
@@ -93,6 +94,15 @@ play.filters {
 
     # The Content-Security-Policy header. If null, the header is not set.
     contentSecurityPolicy = "default-src 'self'"
+  }
+
+  # Allowed hosts filter configuration
+  hosts {
+
+    # A list of valid hosts (e.g. "example.com") or suffixes of valid hosts (e.g. ".example.com")
+    # Note that ".example.com" will match example.com and any subdomain of example.com, with or without a trailing dot.
+    # "." matches all domains, and "" matches an empty or nonexistent host.
+    allowed = ["localhost", ".local"]
   }
 
   # CORS filter configuration

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -1,0 +1,86 @@
+package play.filters.hosts
+
+import javax.inject.{ Inject, Provider, Singleton }
+
+import play.api.http.{ HttpErrorHandler, Status }
+import play.api.inject.Module
+import play.api.libs.iteratee.Iteratee
+import play.api.mvc.{ EssentialAction, EssentialFilter }
+import play.api.{ Configuration, Environment, PlayConfig }
+
+/**
+ * A filter that denies requests by hosts that do not match a configured list of allowed hosts.
+ */
+case class AllowedHostsFilter @Inject() (config: AllowedHostsConfig, errorHandler: HttpErrorHandler)
+    extends EssentialFilter {
+
+  private val hostMatchers: Seq[HostMatcher] = config.allowed map HostMatcher.apply
+
+  override def apply(next: EssentialAction) = EssentialAction { req =>
+    if (hostMatchers.exists(_(req.host))) {
+      next(req)
+    } else {
+      import play.api.libs.iteratee.Execution.Implicits.trampoline
+      Iteratee.ignore[Array[Byte]].mapM { _ =>
+        errorHandler.onClientError(req, Status.BAD_REQUEST, s"Host not allowed: ${req.host}")
+      }
+    }
+  }
+}
+
+/**
+ * A utility class for matching a host header with a pattern
+ */
+private[hosts] case class HostMatcher(pattern: String) {
+  val isSuffix = pattern startsWith "."
+  val (hostPattern, port) = getHostAndPort(pattern)
+
+  def apply(hostHeader: String): Boolean = {
+    val (headerHost, headerPort) = getHostAndPort(hostHeader)
+    val hostMatches = if (isSuffix) s".$headerHost" endsWith hostPattern else headerHost == hostPattern
+    val portMatches = headerPort.forall(_ > 0) && (port.isEmpty || port == headerPort)
+    hostMatches && portMatches
+  }
+
+  // Get and normalize the host and port
+  // Returns None for no port but Some(-1) for an invalid/non-numeric port
+  private def getHostAndPort(s: String) = {
+    val (h, p) = s.trim.split(":", 2) match {
+      case Array(h, p) if p.nonEmpty && p.forall(_.isDigit) => (h, Some(p.toInt))
+      case Array(h, _) => (h, Some(-1))
+      case Array(h, _*) => (h, None)
+    }
+    (h.toLowerCase.stripSuffix("."), p)
+  }
+}
+
+case class AllowedHostsConfig(allowed: Seq[String])
+
+object AllowedHostsConfig {
+  /**
+   * Parses out the AllowedHostsConfig from play.api.Configuration (usually this means application.conf).
+   */
+  def fromConfiguration(conf: Configuration): AllowedHostsConfig = {
+    AllowedHostsConfig(PlayConfig(conf).get[Seq[String]]("play.filters.hosts.allowed"))
+  }
+}
+
+@Singleton
+class AllowedHostsConfigProvider @Inject() (configuration: Configuration) extends Provider[AllowedHostsConfig] {
+  lazy val get = AllowedHostsConfig.fromConfiguration(configuration)
+}
+
+class AllowedHostsModule extends Module {
+  def bindings(environment: Environment, configuration: Configuration) = Seq(
+    bind[AllowedHostsConfig].toProvider[AllowedHostsConfigProvider],
+    bind[AllowedHostsFilter].toSelf
+  )
+}
+
+trait AllowedHostsComponents {
+  def configuration: Configuration
+  def httpErrorHandler: HttpErrorHandler
+
+  lazy val allowedHostsConfig: AllowedHostsConfig = AllowedHostsConfig.fromConfiguration(configuration)
+  lazy val allowedHostsFilter: AllowedHostsFilter = AllowedHostsFilter(allowedHostsConfig, httpErrorHandler)
+}

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
@@ -1,0 +1,152 @@
+package play.filters.hosts
+
+import javax.inject.Inject
+
+import com.typesafe.config.ConfigFactory
+import play.api.http.HttpFilters
+import play.api.inject._
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws.{ WSClient, WS }
+import play.api.mvc.Results._
+import play.api.mvc.{ Action, RequestHeader, Result }
+import play.api.routing.Router
+import play.api.test.{ FakeRequest, PlaySpecification, TestServer }
+import play.api.{ Application, Configuration }
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object AllowedHostsFilterSpec extends PlaySpecification {
+
+  sequential
+
+  private def request(hostHeader: String, uri: String = "/", headers: Seq[(String, String)] = Seq()) = {
+    val req = FakeRequest(method = "GET", path = uri)
+      .withHeaders(headers: _*)
+      .withHeaders(HOST -> hostHeader)
+    route(req).get
+  }
+
+  private val okWithHost = (req: RequestHeader) => Ok(req.host)
+
+  class Filters @Inject() (allowedHostsFilter: AllowedHostsFilter) extends HttpFilters {
+    def filters = Seq(allowedHostsFilter)
+  }
+
+  def newApplication(result: RequestHeader => Result, config: String): Application = {
+    new GuiceApplicationBuilder()
+      .configure(Configuration(ConfigFactory.parseString(config)))
+      .overrides(
+        bind[Router].to(Router.from { case request => Action(result(request)) }),
+        bind[HttpFilters].to[Filters]
+      )
+      .build()
+  }
+
+  def withApplication[T](result: RequestHeader => Result, config: String)(block: => T): T = {
+    running(newApplication(result, config))(block)
+  }
+
+  val TestServerPort = 8192
+  def withServer[T](result: RequestHeader => Result, config: String)(block: WSClient => T): T = {
+    val app = newApplication(result, config)
+    running(TestServer(TestServerPort, app))(block(app.injector.instanceOf[WSClient]))
+  }
+
+  "the allowed hosts filter" should {
+    "disallow non-local hosts with default config" in withApplication(okWithHost, "") {
+      status(request("localhost")) must_== OK
+      status(request("typesafe.com")) must_== BAD_REQUEST
+      status(request("")) must_== BAD_REQUEST
+    }
+
+    "only allow specific hosts specified in configuration" in withApplication(okWithHost,
+      """
+        |play.filters.hosts.allowed = ["example.com", "example.net"]
+      """.stripMargin) {
+        status(request("example.com")) must_== OK
+        status(request("EXAMPLE.net")) must_== OK
+        status(request("example.org")) must_== BAD_REQUEST
+        status(request("foo.example.com")) must_== BAD_REQUEST
+      }
+
+    "allow defining host suffixes in configuration" in withApplication(okWithHost,
+      """
+        |play.filters.hosts.allowed = [".example.com"]
+      """.stripMargin) {
+        status(request("foo.example.com")) must_== OK
+        status(request("example.com")) must_== OK
+      }
+
+    "support FQDN format for hosts" in withApplication(okWithHost,
+      """
+        |play.filters.hosts.allowed = [".example.com", "example.net"]
+      """.stripMargin) {
+        status(request("foo.example.com.")) must_== OK
+        status(request("example.net.")) must_== OK
+      }
+
+    "support allowing empty hosts" in withApplication(okWithHost,
+      """
+        |play.filters.hosts.allowed = [".example.com", ""]
+      """.stripMargin) {
+        status(request("")) must_== OK
+        status(request("example.net")) must_== BAD_REQUEST
+        status(route(FakeRequest()).get) must_== OK
+      }
+
+    "support host headers with ports" in withApplication(okWithHost,
+      """
+        |play.filters.hosts.allowed = ["example.com"]
+      """.stripMargin) {
+        status(request("example.com:80")) must_== OK
+        status(request("google.com:80")) must_== BAD_REQUEST
+      }
+
+    "restrict host headers based on port" in withApplication(okWithHost,
+      """
+        |play.filters.hosts.allowed = [".example.com:8080"]
+      """.stripMargin) {
+        status(request("example.com:80")) must_== BAD_REQUEST
+        status(request("www.example.com:8080")) must_== OK
+        status(request("example.com:8080")) must_== OK
+      }
+
+    "support matching all hosts" in withApplication(okWithHost,
+      """
+        |play.filters.hosts.allowed = ["."]
+      """.stripMargin) {
+        status(request("example.net")) must_== OK
+        status(request("amazon.com")) must_== OK
+        status(request("")) must_== OK
+      }
+
+    // See http://www.skeletonscribe.net/2013/05/practical-http-host-header-attacks.html
+
+    "not allow malformed ports" in withApplication(okWithHost,
+      """
+        |play.filters.hosts.allowed = [".mozilla.org"]
+      """.stripMargin) {
+        status(request("addons.mozilla.org:@passwordreset.net")) must_== BAD_REQUEST
+        status(request("addons.mozilla.org: www.securepasswordreset.com")) must_== BAD_REQUEST
+      }
+
+    "validate hosts in absolute URIs" in withApplication(okWithHost,
+      """
+        |play.filters.hosts.allowed = [".mozilla.org"]
+      """.stripMargin) {
+        status(request("www.securepasswordreset.com", "https://addons.mozilla.org/en-US/firefox/users/pwreset")) must_== OK
+        status(request("addons.mozilla.org", "https://www.securepasswordreset.com/en-US/firefox/users/pwreset")) must_== BAD_REQUEST
+      }
+
+    "not allow bypassing with X-Forwarded-Host header" in withServer(okWithHost,
+      """
+        |play.filters.hosts.allowed = ["localhost"]
+      """.stripMargin) { ws =>
+        val wsRequest = ws.url(s"http://localhost:$TestServerPort").withHeaders(X_FORWARDED_HOST -> "evil.com").get()
+        val wsResponse = Await.result(wsRequest, 1.second)
+        wsResponse.status must_== OK
+        wsResponse.body must_== s"localhost:$TestServerPort"
+      }
+  }
+}

--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -341,10 +341,10 @@ object QueryStringBindable {
   /**
    * QueryString binder for Char.
    */
-  implicit object bindableChar extends QueryStringBindable[Char]{
+  implicit object bindableChar extends QueryStringBindable[Char] {
     def bind(key: String, params: Map[String, Seq[String]]) = params.get(key).flatMap(_.headOption).map { value =>
-      if(value.length != 1) Left(s"Cannot parse parameter $key with value '$value' as Char: $key must be exactly one digit in length.")
-      else Right( value.charAt(0) )
+      if (value.length != 1) Left(s"Cannot parse parameter $key with value '$value' as Char: $key must be exactly one digit in length.")
+      else Right(value.charAt(0))
     }
     def unbind(key: String, value: Char) = key + "=" + value.toString
   }
@@ -584,10 +584,10 @@ object PathBindable {
   /**
    * Path binder for Char.
    */
-  implicit object bindableChar extends PathBindable[Char]{
+  implicit object bindableChar extends PathBindable[Char] {
     def bind(key: String, value: String) = {
-      if(value.length != 1) Left(s"Cannot parse parameter $key with value '$value' as Char: $key must be exactly one digit in length.")
-      else Right( value.charAt(0) )
+      if (value.length != 1) Left(s"Cannot parse parameter $key with value '$value' as Char: $key must be exactly one digit in length.")
+      else Right(value.charAt(0))
     }
     def unbind(key: String, value: Char) = value.toString
   }


### PR DESCRIPTION
Fixes #4513.

You can configure the filter with a list of allowed hosts, which can either be exact hostnames like `example.com` or suffix hostnames like `.example.com`, which matches `example.com` as well as `www.example.com` and other subdomains.

