### PR TITLE
Backport of #4524 - Ensure CORS headers get added to failed responses

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -403,7 +403,16 @@ object PlayBuild extends Build {
 
   lazy val PlayFiltersHelpersProject = PlayCrossBuiltProject("Filters-Helpers", "play-filters-helpers")
     .settings(
-      parallelExecution in Test := false
+      parallelExecution in Test := false,
+      binaryIssueFilters := Seq(
+        // AbstractCORSPolicy was never intended to be extended by anything other than Play. It has been made private
+        // to reinforce this. The chance that a third party library will have provided an extension to it is very low.
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.cors.AbstractCORSPolicy.errorHandler"),
+        // As *Components classes are generally only implemented by end applications, this shouldn't cause a problem.
+        // Also, most existing implementations will already have an implementation of this by virtue of the fact that
+        // they must implement it for other common *Components interfaces.
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.cors.CORSComponents.httpErrorHandler")
+      )
     ).dependsOn(PlayProject, PlaySpecs2Project % "test", PlayJavaProject % "test", PlayWsProject % "test")
 
   // This project is just for testing Play, not really a public artifact

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
@@ -4,6 +4,7 @@
 package play.filters.cors
 
 import com.typesafe.config.Config
+import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
 
 import scala.concurrent.Future
 
@@ -58,12 +59,17 @@ object CORSActionBuilder {
    * @param  configuration  The configuration to load the config from
    * @param  configPath  The path to the subtree of the application configuration.
    */
-  def apply(configuration: Configuration, configPath: String = "play.filters.cors"): CORSActionBuilder = new CORSActionBuilder {
-    override protected def corsConfig = {
-      val config = PlayConfig(configuration)
-      val prototype = config.get[Config]("play.filters.cors")
-      val corsConfig = PlayConfig(config.get[Config](configPath).withFallback(prototype))
-      CORSConfig.fromUnprefixedConfiguration(corsConfig)
+  def apply(configuration: Configuration, errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
+    configPath: String = "play.filters.cors"): CORSActionBuilder = {
+    val eh = errorHandler
+    new CORSActionBuilder {
+      override protected def corsConfig = {
+        val config = PlayConfig(configuration)
+        val prototype = config.get[Config]("play.filters.cors")
+        val corsConfig = PlayConfig(config.get[Config](configPath).withFallback(prototype))
+        CORSConfig.fromUnprefixedConfiguration(corsConfig)
+      }
+      override protected val errorHandler = eh
     }
   }
 
@@ -73,7 +79,11 @@ object CORSActionBuilder {
    * @param  config  The local configuration to use in place of the global configuration.
    * @see [[CORSConfig]]
    */
-  def apply(config: CORSConfig): CORSActionBuilder = new CORSActionBuilder {
-    override protected val corsConfig = config
+  def apply(config: CORSConfig, errorHandler: HttpErrorHandler): CORSActionBuilder = {
+    val eh = errorHandler
+    new CORSActionBuilder {
+      override protected val corsConfig = config
+      override protected val errorHandler = eh
+    }
   }
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
@@ -59,8 +59,16 @@ object CORSActionBuilder {
    * @param  configuration  The configuration to load the config from
    * @param  configPath  The path to the subtree of the application configuration.
    */
-  def apply(configuration: Configuration, errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
-    configPath: String = "play.filters.cors"): CORSActionBuilder = {
+  def apply(configuration: Configuration, configPath: String = "play.filters.cors"): CORSActionBuilder =
+    apply(configuration, DefaultHttpErrorHandler, configPath)
+
+  /**
+   * Construct an action builder that uses a subtree of the application configuration.
+   *
+   * @param  configuration  The configuration to load the config from
+   * @param  configPath  The path to the subtree of the application configuration.
+   */
+  def apply(configuration: Configuration, errorHandler: HttpErrorHandler, configPath: String): CORSActionBuilder = {
     val eh = errorHandler
     new CORSActionBuilder {
       override protected def corsConfig = {
@@ -72,6 +80,14 @@ object CORSActionBuilder {
       override protected val errorHandler = eh
     }
   }
+
+  /**
+   * Construct an action builder that uses locally defined configuration.
+   *
+   * @param  config  The local configuration to use in place of the global configuration.
+   * @see [[CORSConfig]]
+   */
+  def apply(config: CORSConfig): CORSActionBuilder = apply(config, DefaultHttpErrorHandler)
 
   /**
    * Construct an action builder that uses locally defined configuration.

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
@@ -3,6 +3,8 @@
  */
 package play.filters.cors
 
+import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
+
 import scala.concurrent.Future
 
 import play.api.Logger
@@ -31,6 +33,7 @@ import play.api.mvc.{ Filter, RequestHeader, Result }
  */
 class CORSFilter(
     override protected val corsConfig: CORSConfig = CORSConfig(),
+    override protected val errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
     private val pathPrefixes: Seq[String] = Seq("/")) extends Filter with AbstractCORSPolicy {
 
   override protected val logger = Logger(classOf[CORSFilter])
@@ -46,7 +49,8 @@ class CORSFilter(
 
 object CORSFilter {
 
-  def apply(corsConfig: CORSConfig = CORSConfig(), pathPrefixes: Seq[String] = Seq("/")) =
-    new CORSFilter(corsConfig, pathPrefixes)
+  def apply(corsConfig: CORSConfig = CORSConfig(), errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
+    pathPrefixes: Seq[String] = Seq("/")) =
+    new CORSFilter(corsConfig, errorHandler, pathPrefixes)
 
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
@@ -32,9 +32,12 @@ import play.api.mvc.{ Filter, RequestHeader, Result }
  * @see [[http://www.w3.org/TR/cors/ CORS specification]]
  */
 class CORSFilter(
-    override protected val corsConfig: CORSConfig = CORSConfig(),
-    override protected val errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
-    private val pathPrefixes: Seq[String] = Seq("/")) extends Filter with AbstractCORSPolicy {
+    override protected val corsConfig: CORSConfig,
+    override protected val errorHandler: HttpErrorHandler,
+    private val pathPrefixes: Seq[String]) extends Filter with AbstractCORSPolicy {
+
+  def this(corsConfig: CORSConfig = CORSConfig(), pathPrefixes: Seq[String] = Seq("/")) =
+    this(corsConfig, DefaultHttpErrorHandler, pathPrefixes)
 
   override protected val logger = Logger(classOf[CORSFilter])
 
@@ -49,8 +52,10 @@ class CORSFilter(
 
 object CORSFilter {
 
-  def apply(corsConfig: CORSConfig = CORSConfig(), errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
-    pathPrefixes: Seq[String] = Seq("/")) =
+  def apply(corsConfig: CORSConfig, errorHandler: HttpErrorHandler, pathPrefixes: Seq[String]) =
     new CORSFilter(corsConfig, errorHandler, pathPrefixes)
+
+  def apply(corsConfig: CORSConfig = CORSConfig(), pathPrefixes: Seq[String] = Seq("/")) =
+    new CORSFilter(corsConfig, DefaultHttpErrorHandler, pathPrefixes)
 
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
@@ -5,6 +5,7 @@ package play.filters.cors
 
 import javax.inject.{ Inject, Provider }
 
+import play.api.http.HttpErrorHandler
 import play.api.{ Environment, PlayConfig, Configuration }
 import play.api.inject.Module
 
@@ -18,10 +19,10 @@ class CORSConfigProvider @Inject() (configuration: Configuration) extends Provid
 /**
  * Provider for CORSFilter.
  */
-class CORSFilterProvider @Inject() (configuration: Configuration, corsConfig: CORSConfig) extends Provider[CORSFilter] {
+class CORSFilterProvider @Inject() (configuration: Configuration, errorHandler: HttpErrorHandler, corsConfig: CORSConfig) extends Provider[CORSFilter] {
   lazy val get = {
     val pathPrefixes = PlayConfig(configuration).get[Seq[String]]("play.filters.cors.pathPrefixes")
-    new CORSFilter(corsConfig, pathPrefixes)
+    new CORSFilter(corsConfig, errorHandler, pathPrefixes)
   }
 }
 
@@ -40,8 +41,9 @@ class CORSModule extends Module {
  */
 trait CORSComponents {
   def configuration: Configuration
+  def httpErrorHandler: HttpErrorHandler
 
   lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(configuration)
-  lazy val corsFilter: CORSFilter = new CORSFilter(corsConfig, corsPathPrefixes)
+  lazy val corsFilter: CORSFilter = new CORSFilter(corsConfig, httpErrorHandler, corsPathPrefixes)
   lazy val corsPathPrefixes: Seq[String] = PlayConfig(configuration).get[Seq[String]]("play.filters.cors.pathPrefixes")
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
@@ -5,7 +5,7 @@ package play.filters.cors
 
 import javax.inject.{ Inject, Provider }
 
-import play.api.http.HttpErrorHandler
+import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
 import play.api.{ Environment, PlayConfig, Configuration }
 import play.api.inject.Module
 
@@ -20,6 +20,9 @@ class CORSConfigProvider @Inject() (configuration: Configuration) extends Provid
  * Provider for CORSFilter.
  */
 class CORSFilterProvider @Inject() (configuration: Configuration, errorHandler: HttpErrorHandler, corsConfig: CORSConfig) extends Provider[CORSFilter] {
+
+  def this(configuration: Configuration, corsConfig: CORSConfig) = this(configuration, DefaultHttpErrorHandler, corsConfig)
+
   lazy val get = {
     val pathPrefixes = PlayConfig(configuration).get[Seq[String]]("play.filters.cors.pathPrefixes")
     new CORSFilter(corsConfig, errorHandler, pathPrefixes)

--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -341,10 +341,10 @@ object QueryStringBindable {
   /**
    * QueryString binder for Char.
    */
-  implicit object bindableChar extends QueryStringBindable[Char]{
+  implicit object bindableChar extends QueryStringBindable[Char] {
     def bind(key: String, params: Map[String, Seq[String]]) = params.get(key).flatMap(_.headOption).map { value =>
-      if(value.length != 1) Left(s"Cannot parse parameter $key with value '$value' as Char: $key must be exactly one digit in length.")
-      else Right( value.charAt(0) )
+      if (value.length != 1) Left(s"Cannot parse parameter $key with value '$value' as Char: $key must be exactly one digit in length.")
+      else Right(value.charAt(0))
     }
     def unbind(key: String, value: Char) = key + "=" + value.toString
   }
@@ -584,10 +584,10 @@ object PathBindable {
   /**
    * Path binder for Char.
    */
-  implicit object bindableChar extends PathBindable[Char]{
+  implicit object bindableChar extends PathBindable[Char] {
     def bind(key: String, value: String) = {
-      if(value.length != 1) Left(s"Cannot parse parameter $key with value '$value' as Char: $key must be exactly one digit in length.")
-      else Right( value.charAt(0) )
+      if (value.length != 1) Left(s"Cannot parse parameter $key with value '$value' as Char: $key must be exactly one digit in length.")
+      else Right(value.charAt(0))
     }
     def unbind(key: String, value: Char) = value.toString
   }


### PR DESCRIPTION
Fixed binary compatibility issues with CORS error handling backport

* Two binary compatibility issues remain and are filtered. See comments on the filters for justifications as to why this is ok.