### PR TITLE
Prevent misleading 413 error when multipart parser recieved a bad request.

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -69,6 +69,18 @@ object MultipartFormDataParserSpec extends PlaySpecification {
       checkResult(result)
     }
 
+    "return bad request for invalid body" in new WithApplication() {
+      val parser = parse.multipartFormData.apply(FakeRequest().withHeaders(
+        CONTENT_TYPE -> "multipart/form-data" // no boundary
+      ))
+
+      val result = await(Enumerator(body.getBytes("utf-8")).run(parser))
+
+      result must beLeft.like {
+        case error => error.header.status must_== BAD_REQUEST
+      }
+    }
+
     "validate the full length of the body" in new WithApplication(FakeApplication(
       additionalConfiguration = Map("play.http.parser.maxDiskBuffer" -> "100")
     )) {

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -666,7 +666,10 @@ trait BodyParsers {
 
         val parser = Traversable.takeUpTo[Array[Byte]](maxLength).transform(
           Multipart.multipartParser(DefaultMaxTextLength, filePartHandler)(request)
-        ).flatMap(Iteratee.eofOrElse(Results.EntityTooLarge))
+        ).flatMap {
+            case d @ Left(r) => Iteratee.eofOrElse(r)(d)
+            case d => Iteratee.eofOrElse(Results.EntityTooLarge)(d)
+          }
 
         parser.map {
           case Left(tooLarge) => Left(tooLarge)


### PR DESCRIPTION
Currently, when the `Multipart.multipartParser` creates a bad-request result, for instance when there's a missing boundary header, this will be thrown away and replaced with a 413 entity-too-large no matter what the size of the entity actually is.