### PR TITLE
Implicit ConfigLoader for Option

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
@@ -79,17 +79,17 @@ object CORSConfig {
   }
 
   private[cors] def fromUnprefixedConfiguration(config: PlayConfig): CORSConfig = {
-    val origins = config.getOptional[Seq[String]]("allowedOrigins")
+    val origins = config.get[Option[Seq[String]]]("allowedOrigins")
     CORSConfig(
       anyOriginAllowed = origins.isEmpty,
       allowedOrigins = origins.map(_.toSet).getOrElse(Set.empty),
       isHttpMethodAllowed =
-        config.getOptional[Seq[String]]("allowedHttpMethods").map { methods =>
+        config.get[Option[Seq[String]]]("allowedHttpMethods").map { methods =>
           val s = methods.toSet
           s.contains _
         }.getOrElse(_ => true),
       isHttpHeaderAllowed =
-        config.getOptional[Seq[String]]("allowedHttpHeaders").map { headers =>
+        config.get[Option[Seq[String]]]("allowedHttpHeaders").map { headers =>
           val s = headers.map(_.toLowerCase).toSet
           s.contains _
         }.getOrElse(_ => true),

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -85,7 +85,7 @@ object CSRFConfig {
 
     CSRFConfig(
       tokenName = config.get[String]("token.name"),
-      cookieName = config.getOptional[String]("cookie.name"),
+      cookieName = config.get[Option[String]]("cookie.name"),
       secureCookie = config.get[Boolean]("cookie.secure"),
       httpOnlyCookie = config.get[Boolean]("cookie.httpOnly"),
       postBodyBuffer = config.get[ConfigMemorySize]("body.bufferSize").toBytes,

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
@@ -83,11 +83,11 @@ object SecurityHeadersConfig {
     val config = PlayConfig(conf).get[PlayConfig]("play.filters.headers")
 
     SecurityHeadersConfig(
-      frameOptions = config.getOptional[String]("frameOptions"),
-      xssProtection = config.getOptional[String]("xssProtection"),
-      contentTypeOptions = config.getOptional[String]("contentTypeOptions"),
-      permittedCrossDomainPolicies = config.getOptional[String]("permittedCrossDomainPolicies"),
-      contentSecurityPolicy = config.getOptional[String]("contentSecurityPolicy"))
+      frameOptions = config.get[Option[String]]("frameOptions"),
+      xssProtection = config.get[Option[String]]("xssProtection"),
+      contentTypeOptions = config.get[Option[String]]("contentTypeOptions"),
+      permittedCrossDomainPolicies = config.get[Option[String]]("permittedCrossDomainPolicies"),
+      contentSecurityPolicy = config.get[Option[String]]("contentSecurityPolicy"))
   }
 }
 

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
@@ -55,7 +55,7 @@ class BoneConnectionPool @Inject() (environment: Environment) extends Connection
     val datasource = new BoneCPDataSource
 
     val autocommit = config.getDeprecated[Boolean]("bonecp.autoCommit", "autocommit")
-    val isolation = config.getOptionalDeprecated[String]("bonecp.isolation", "isolation").map {
+    val isolation = config.getDeprecated[Option[String]]("bonecp.isolation", "isolation").map {
       case "NONE" => Connection.TRANSACTION_NONE
       case "READ_COMMITTED" => Connection.TRANSACTION_READ_COMMITTED
       case "READ_UNCOMMITTED" => Connection.TRANSACTION_READ_UNCOMMITTED
@@ -64,7 +64,7 @@ class BoneConnectionPool @Inject() (environment: Environment) extends Connection
       case unknown => throw config.reportError("bonecp.isolation",
         s"Unknown isolation level [$unknown]")
     }
-    val catalog = config.getOptionalDeprecated[String]("bonecp.defaultCatalog", "defaultCatalog")
+    val catalog = config.getDeprecated[Option[String]]("bonecp.defaultCatalog", "defaultCatalog")
     val readOnly = config.getDeprecated[Boolean]("bonecp.readOnly", "readOnly")
 
     datasource.setClassLoader(environment.classLoader)
@@ -120,8 +120,8 @@ class BoneConnectionPool @Inject() (environment: Environment) extends Connection
     datasource.setDetectUnresolvedTransactions(config.getDeprecated[Boolean]("bonecp.detectUnresolvedTransactions", "detectUnresolvedTransactions"))
     datasource.setLogStatementsEnabled(config.getDeprecated[Boolean]("bonecp.logStatements", "logStatements"))
 
-    config.getOptionalDeprecated[String]("bonecp.initSQL", "initSQL").foreach(datasource.setInitSQL)
-    config.getOptionalDeprecated[String]("bonecp.connectionTestStatement", "connectionTestStatement").foreach(datasource.setConnectionTestStatement)
+    config.getDeprecated[Option[String]]("bonecp.initSQL", "initSQL").foreach(datasource.setInitSQL)
+    config.getDeprecated[Option[String]]("bonecp.connectionTestStatement", "connectionTestStatement").foreach(datasource.setConnectionTestStatement)
 
     // Bind in JNDI
     dbConfig.jndiName foreach { name =>

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DatabaseConfig.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DatabaseConfig.scala
@@ -20,11 +20,11 @@ object DatabaseConfig {
 
   def fromConfig(config: PlayConfig, environment: Environment) = {
 
-    val driver = config.getOptional[String]("driver")
-    val (url, userPass) = ConnectionPool.extractUrl(config.getOptional[String]("url"), environment.mode)
-    val username = config.getOptionalDeprecated[String]("username", "user").orElse(userPass.map(_._1))
-    val password = config.getOptionalDeprecated[String]("password", "pass").orElse(userPass.map(_._2))
-    val jndiName = config.getOptional[String]("jndiName")
+    val driver = config.get[Option[String]]("driver")
+    val (url, userPass) = ConnectionPool.extractUrl(config.get[Option[String]]("url"), environment.mode)
+    val username = config.getDeprecated[Option[String]]("username", "user").orElse(userPass.map(_._1))
+    val password = config.getDeprecated[Option[String]]("password", "pass").orElse(userPass.map(_._2))
+    val jndiName = config.get[Option[String]]("jndiName")
 
     DatabaseConfig(driver, url, username, password, jndiName)
   }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
@@ -96,7 +96,7 @@ class HikariCPConfig(dbConfig: DatabaseConfig, configuration: PlayConfig) {
     val config = configuration.get[PlayConfig]("hikaricp")
 
     // Essentials configurations
-    config.getOptional[String]("dataSourceClassName").foreach(hikariConfig.setDataSourceClassName)
+    config.get[Option[String]]("dataSourceClassName").foreach(hikariConfig.setDataSourceClassName)
 
     dbConfig.url.foreach(hikariConfig.setJdbcUrl)
     dbConfig.driver.foreach(hikariConfig.setDriverClassName)
@@ -121,10 +121,10 @@ class HikariCPConfig(dbConfig: DatabaseConfig, configuration: PlayConfig) {
     hikariConfig.setConnectionTimeout(toMillis(config.get[Duration]("connectionTimeout")))
     hikariConfig.setIdleTimeout(toMillis(config.get[Duration]("idleTimeout")))
     hikariConfig.setMaxLifetime(toMillis(config.get[Duration]("maxLifetime")))
-    config.getOptional[String]("connectionTestQuery").foreach(hikariConfig.setConnectionTestQuery)
-    config.getOptional[Int]("minimumIdle").foreach(hikariConfig.setMinimumIdle)
+    config.get[Option[String]]("connectionTestQuery").foreach(hikariConfig.setConnectionTestQuery)
+    config.get[Option[Int]]("minimumIdle").foreach(hikariConfig.setMinimumIdle)
     hikariConfig.setMaximumPoolSize(config.get[Int]("maximumPoolSize"))
-    config.getOptional[String]("poolName").foreach(hikariConfig.setPoolName)
+    config.get[Option[String]]("poolName").foreach(hikariConfig.setPoolName)
 
     // Infrequently used
     hikariConfig.setInitializationFailFast(config.get[Boolean]("initializationFailFast"))
@@ -132,8 +132,8 @@ class HikariCPConfig(dbConfig: DatabaseConfig, configuration: PlayConfig) {
     hikariConfig.setAllowPoolSuspension(config.get[Boolean]("allowPoolSuspension"))
     hikariConfig.setReadOnly(config.get[Boolean]("readOnly"))
     hikariConfig.setRegisterMbeans(config.get[Boolean]("registerMbeans"))
-    config.getOptional[String]("catalog").foreach(hikariConfig.setCatalog)
-    config.getOptional[String]("transactionIsolation").foreach(hikariConfig.setTransactionIsolation)
+    config.get[Option[String]]("catalog").foreach(hikariConfig.setCatalog)
+    config.get[Option[String]]("transactionIsolation").foreach(hikariConfig.setTransactionIsolation)
     hikariConfig.setValidationTimeout(config.get[FiniteDuration]("validationTimeout").toMillis)
     hikariConfig.setLeakDetectionThreshold(toMillis(config.get[Duration]("leakDetectionThreshold")))
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/Config.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/Config.scala
@@ -43,7 +43,7 @@ class WSConfigParser @Inject() (configuration: Configuration, environment: Envir
     val followRedirects = config.get[Boolean]("followRedirects")
     val useProxyProperties = config.get[Boolean]("useProxyProperties")
 
-    val userAgent = config.getOptional[String]("useragent")
+    val userAgent = config.get[Option[String]]("useragent")
 
     val compressionEnabled = config.get[Boolean]("compressionEnabled")
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/Config.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/Config.scala
@@ -206,7 +206,7 @@ class SSLConfigParser(c: PlayConfig, classLoader: ClassLoader) {
 
     val default = c.get[Boolean]("default")
     val protocol = c.get[String]("protocol")
-    val checkRevocation = c.getOptional[Boolean]("checkRevocation")
+    val checkRevocation = c.get[Option[Boolean]]("checkRevocation")
     val revocationLists: Option[Seq[URL]] = Some(
       c.get[Seq[String]]("revocationLists").map(new URL(_))
     ).filter(_.nonEmpty)
@@ -217,7 +217,7 @@ class SSLConfigParser(c: PlayConfig, classLoader: ClassLoader) {
     val ciphers = Some(c.get[Seq[String]]("enabledCipherSuites")).filter(_.nonEmpty)
     val protocols = Some(c.get[Seq[String]]("enabledProtocols")).filter(_.nonEmpty)
 
-    val hostnameVerifierClass = c.getOptional[String]("hostnameVerifierClass") match {
+    val hostnameVerifierClass = c.get[Option[String]]("hostnameVerifierClass") match {
       case None => classOf[DefaultHostnameVerifier]
       case Some(fqcn) => classLoader.loadClass(fqcn).asSubclass(classOf[HostnameVerifier])
     }
@@ -253,8 +253,8 @@ class SSLConfigParser(c: PlayConfig, classLoader: ClassLoader) {
 
     val allowWeakProtocols = config.get[Boolean]("allowWeakProtocols")
     val allowWeakCiphers = config.get[Boolean]("allowWeakCiphers")
-    val allowMessages = config.getOptional[Boolean]("allowLegacyHelloMessages")
-    val allowUnsafeRenegotiation = config.getOptional[Boolean]("allowUnsafeRenegotiation")
+    val allowMessages = config.get[Option[Boolean]]("allowLegacyHelloMessages")
+    val allowUnsafeRenegotiation = config.get[Option[Boolean]]("allowUnsafeRenegotiation")
     val disableHostnameVerification = config.get[Boolean]("disableHostnameVerification")
     val acceptAnyCertificate = config.get[Boolean]("acceptAnyCertificate")
 
@@ -322,10 +322,10 @@ class SSLConfigParser(c: PlayConfig, classLoader: ClassLoader) {
    * Parses the "ws.ssl.keyManager { stores = [ ... ]" section of configuration.
    */
   def parseKeyStoreInfo(config: PlayConfig): KeyStoreConfig = {
-    val storeType = config.getOptional[String]("type").getOrElse(KeyStore.getDefaultType)
-    val path = config.getOptional[String]("path")
-    val data = config.getOptional[String]("data")
-    val password = config.getOptional[String]("password")
+    val storeType = config.get[Option[String]]("type").getOrElse(KeyStore.getDefaultType)
+    val path = config.get[Option[String]]("path")
+    val data = config.get[Option[String]]("data")
+    val password = config.get[Option[String]]("password")
 
     KeyStoreConfig(filePath = path, storeType = storeType, data = data, password = password)
   }
@@ -334,9 +334,9 @@ class SSLConfigParser(c: PlayConfig, classLoader: ClassLoader) {
    * Parses the "ws.ssl.trustManager { stores = [ ... ]" section of configuration.
    */
   def parseTrustStoreInfo(config: PlayConfig): TrustStoreConfig = {
-    val storeType = config.getOptional[String]("type").getOrElse(KeyStore.getDefaultType)
-    val path = config.getOptional[String]("path")
-    val data = config.getOptional[String]("data")
+    val storeType = config.get[Option[String]]("type").getOrElse(KeyStore.getDefaultType)
+    val path = config.get[Option[String]]("path")
+    val data = config.get[Option[String]]("data")
 
     TrustStoreConfig(filePath = path, storeType = storeType, data = data)
   }
@@ -346,7 +346,7 @@ class SSLConfigParser(c: PlayConfig, classLoader: ClassLoader) {
    */
   def parseKeyManager(config: PlayConfig): KeyManagerConfig = {
 
-    val algorithm = config.getOptional[String]("algorithm") match {
+    val algorithm = config.get[Option[String]]("algorithm") match {
       case None => KeyManagerFactory.getDefaultAlgorithm
       case Some(other) => other
     }
@@ -363,7 +363,7 @@ class SSLConfigParser(c: PlayConfig, classLoader: ClassLoader) {
    */
 
   def parseTrustManager(config: PlayConfig): TrustManagerConfig = {
-    val algorithm = config.getOptional[String]("algorithm") match {
+    val algorithm = config.get[Option[String]]("algorithm") match {
       case None => TrustManagerFactory.getDefaultAlgorithm
       case Some(other) => other
     }

--- a/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -126,9 +126,9 @@ object HttpConfiguration {
       session = SessionConfiguration(
         cookieName = config.getDeprecated[String]("play.http.session.cookieName", "session.cookieName"),
         secure = config.getDeprecated[Boolean]("play.http.session.secure", "session.secure"),
-        maxAge = config.getOptionalDeprecated[FiniteDuration]("play.http.session.maxAge", "session.maxAge"),
+        maxAge = config.getDeprecated[Option[FiniteDuration]]("play.http.session.maxAge", "session.maxAge"),
         httpOnly = config.getDeprecated[Boolean]("play.http.session.httpOnly", "session.httpOnly"),
-        domain = config.getOptionalDeprecated[String]("play.http.session.domain", "session.domain")
+        domain = config.getDeprecated[Option[String]]("play.http.session.domain", "session.domain")
       ),
       flash = FlashConfiguration(
         cookieName = config.getDeprecated[String]("play.http.flash.cookieName", "flash.cookieName"),

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -237,7 +237,7 @@ object Messages {
    * Parse all messages of a given input.
    */
   def parse(messageSource: MessageSource, messageSourceName: String): Either[PlayException.ExceptionSource, Map[String, String]] = {
-    new Messages.MessagesParser(messageSource, messageSourceName).parse.right.map { messages =>
+    new Messages.MessagesParser(messageSource, "").parse.right.map { messages =>
       messages.map { message => message.key -> message.pattern }.toMap
     }
   }
@@ -473,7 +473,7 @@ class DefaultMessagesApi @Inject() (environment: Environment, configuration: Con
   import java.text._
 
   protected val messagesPrefix =
-    config.getOptionalDeprecated[String]("play.i18n.path", "messages.path")
+    config.getDeprecated[Option[String]]("play.i18n.path", "messages.path")
   val messages: Map[String, Map[String, String]] = loadAllMessages
 
   def preferred(candidates: Seq[Lang]) = Messages(langs.preferred(candidates), this)

--- a/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
@@ -229,7 +229,7 @@ class CryptoConfigParser @Inject() (environment: Environment, configuration: Con
      *
      * To achieve 4, using the location of application.conf to generate the secret should ensure this.
      */
-    val secret = config.getOptionalDeprecated[String]("play.crypto.secret", "application.secret") match {
+    val secret = config.getDeprecated[Option[String]]("play.crypto.secret", "application.secret") match {
       case (Some("changeme") | Some(Blank()) | None) if environment.mode == Mode.Prod =>
         logger.error("The application secret has not been set, and we are in prod mode. Your application is not secure.")
         logger.error("To set the application secret, please read http://playframework.com/documentation/latest/ApplicationSecret")
@@ -247,7 +247,7 @@ class CryptoConfigParser @Inject() (environment: Environment, configuration: Con
       case Some(s) => s
     }
 
-    val provider = config.getOptional[String]("play.crypto.provider")
+    val provider = config.get[Option[String]]("play.crypto.provider")
     val transformation = config.get[String]("play.crypto.aes.transformation")
 
     CryptoConfig(secret, provider, transformation)

--- a/framework/src/play/src/main/scala/play/api/routing/Router.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/Router.scala
@@ -55,7 +55,7 @@ object Router {
    * @return The router class if configured or if a default one in the root package was detected.
    */
   def load(env: Environment, configuration: Configuration): Option[Class[_ <: Router]] = {
-    val className = PlayConfig(configuration).getOptionalDeprecated[String]("play.http.router", "application.router")
+    val className = PlayConfig(configuration).getDeprecated[Option[String]]("play.http.router", "application.router")
 
     try {
       Some(Reflect.getClass[Router](className.getOrElse("router.Routes"), env.classLoader))

--- a/framework/src/play/src/main/scala/play/utils/Reflect.scala
+++ b/framework/src/play/src/main/scala/play/utils/Reflect.scala
@@ -100,7 +100,7 @@ object Reflect {
       }
     }
 
-    val maybeClass = config.getOptional[String](key) match {
+    val maybeClass = config.get[Option[String]](key) match {
       // If provided, don't bind anything
       case Some("provided") => None
       // If empty, use the default

--- a/framework/src/play/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/ConfigurationSpec.scala
@@ -111,13 +111,13 @@ object PlayConfigSpec extends Specification {
   "PlayConfig" should {
     "support getting optional values" in {
       "when null" in {
-        config("foo.bar" -> null).getOptional[String]("foo.bar") must beNone
+        config("foo.bar" -> null).get[Option[String]]("foo.bar") must beNone
       }
       "when set" in {
-        config("foo.bar" -> "bar").getOptional[String]("foo.bar") must beSome("bar")
+        config("foo.bar" -> "bar").get[Option[String]]("foo.bar") must beSome("bar")
       }
       "when undefined" in {
-        config().getOptional[String]("foo.bar") must throwA[ConfigException.Missing]
+        config().get[Option[String]]("foo.bar") must throwA[ConfigException.Missing]
       }
     }
     "support getting prototyped seqs" in {


### PR DESCRIPTION
This lets us remove the special getOptionalX methods and just use getX instead. These methods were private to Play so it's OK to remove them without deprecation.