### PR TITLE
map should be replaced by flatMap to generate the correct result

### DIFF
--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
@@ -86,7 +86,7 @@ object ScalaAsyncSamples extends Controller {
     def index = Action.async {
       val futureInt = scala.concurrent.Future { intensiveComputation() }
       val timeoutFuture = play.api.libs.concurrent.Promise.timeout("Oops", 1.second)
-      Future.firstCompletedOf(Seq(futureInt, timeoutFuture)).map {
+      Future.firstCompletedOf(Seq(futureInt, timeoutFuture)).flatMap {
         case i: Int => Ok("Got result: " + i)
         case t: String => InternalServerError(t)
       }


### PR DESCRIPTION
Using `.map` resulted in type `Future[Object]` being inferred. This produces the correct output type, i.e. `Future[Result]`.