### PR TITLE
Improvements to Call + support for fragments in form actions

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Call.java
+++ b/framework/src/play/src/main/java/play/mvc/Call.java
@@ -31,13 +31,11 @@ public abstract class Call {
      * Append a unique identifier to the URL.
      */
     public Call unique() {
-        String url = this.url();
-        if(url.indexOf('?') == -1) {
-            url = url + "?" + rand.nextLong();
-        } else {
-            url = url + "&" + rand.nextLong();
-        }
-        return new play.api.mvc.Call(method(), url, fragment());
+        return new play.api.mvc.Call(method(), this.uniquify(this.url()), fragment());
+    }
+
+    protected final String uniquify(String url) {
+        return url + ((url.indexOf('?') == -1) ? "?" : "&") + rand.nextLong();
     }
 
     /**
@@ -98,6 +96,15 @@ public abstract class Call {
      */
     public String webSocketURL(boolean secure, String host) {
       return "ws" + (secure ? "s" : "") + "://" + host + this.url();
+    }
+
+    public String path() {
+        return this.url() + this.appendFragment();
+    }
+
+    @Override
+    public String toString() {
+        return this.path();
     }
 
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -328,6 +328,10 @@ package play.api.mvc {
    */
   case class Call(method: String, url: String, fragment: String = null) extends play.mvc.Call {
 
+    override def unique(): Call = copy(url = uniquify(url))
+
+    override def withFragment(fragment: String): Call = copy(fragment = fragment)
+
     /**
      * Transform this call to an absolute URL.
      *
@@ -366,8 +370,6 @@ package play.api.mvc {
      * Transform this call to an WebSocket URL.
      */
     def webSocketURL(secure: Boolean)(implicit request: RequestHeader): String = "ws" + (if (secure) "s" else "") + "://" + request.host + this.url
-
-    override def toString = this.url + this.appendFragment
 
   }
 

--- a/framework/src/play/src/main/scala/views/helper/form.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/form.scala.html
@@ -14,6 +14,6 @@
  *@
 @(action: play.api.mvc.Call, args: (Symbol,String)*)(body: => Html) 
 
-<form action="@action.url" method="@action.method" @toHtmlArgs(args.toMap)>
+<form action="@action.path" method="@action.method" @toHtmlArgs(args.toMap)>
     @body
 </form>

--- a/framework/src/play/src/test/java/play/mvc/CallTest.java
+++ b/framework/src/play/src/test/java/play/mvc/CallTest.java
@@ -17,6 +17,24 @@ import static org.junit.Assert.assertEquals;
 public final class CallTest {
 
     @Test
+    public void testHttpURL1() throws Throwable {
+        final TestCall call = new TestCall("/myurl", "GET");
+
+        assertEquals("Call should return correct url in path()",
+                     "/myurl",
+                     call.path());
+    }
+
+    @Test
+    public void testHttpURL2() throws Throwable {
+        final Call call = new TestCall("/myurl", "GET").withFragment("myfragment");
+
+        assertEquals("Call should return correct url and fragment in path()",
+                     "/myurl#myfragment",
+                     call.path());
+    }
+
+    @Test
     public void testHttpAbsoluteURL1() throws Throwable {
         final Request req = new RequestBuilder()
             .uri("http://playframework.com/playframework").build();


### PR DESCRIPTION
Starting with Play 2.4 a `Call` now has a `withFragment` method (see #4152).
In a template when writing
```
@routes.Application.index.withFragment("some-id")
```
gives you `/index#some-id`. So that's fine. :+1: 

However when using the form helper with the **exact** same Call  
```
@helper.form(action = routes.Application.index.withFragment("some-id")) { }
```
the fragment is missing:
```html
<form action="/index" method="POST">
```

Description of the changes in this PR:
1) Changed `views/helper/form.scala.html` so it uses `toString` instead of `url`, because `toString` also [returns the fragment](https://github.com/playframework/playframework/blob/5de8000b32bdc6d8abc408c2b677ff606884475d/framework/src/play/src/main/scala/play/api/mvc/Http.scala#L370). This fixed my original problem.

2) Added tests. To make the work I moved the `toString` method into the superclass.

3) Because the return type of `play.mvc.Call.withFragment(...)` is `play.mvc.Call` but `views/helper/form.scala.html` wants a `play.api.mvc.Call` as first argument I overwrote `withFragment` in the `play.mvc.api.Call` subclass (calling the super method) - so we don't need a cast `@helper.form(action = routes.Application.index.withFragment("some-id").asInstanceOf[play.api.mvc.Call]) { }` to make it work. (Being there, I did the same for the `unique` method).

All changes are backwards compatible, I would like to backport this to 2.4 as well.