### PR TITLE
Replaced `F.Callback` with Java8 `Runnable`, `Consumer` and `BiConsumer`

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -4,7 +4,6 @@
 package play.it.http.websocket
 
 import java.nio.charset.Charset
-
 import play.api.test._
 import play.api.Application
 import scala.concurrent.{ Future, Promise }
@@ -19,8 +18,8 @@ import play.mvc.WebSocket.{ Out, In }
 import play.core.routing.HandlerDef
 import java.util.concurrent.atomic.AtomicReference
 import org.jboss.netty.buffer.ChannelBuffers
-
 import scala.concurrent.ExecutionContext.Implicits.global
+import java.util.function.Consumer
 
 object NettyWebSocketSpec extends WebSocketSpec with NettyIntegrationSpecification
 object AkkaHttpWebSocketSpec extends WebSocketSpec with AkkaHttpIntegrationSpecification
@@ -363,11 +362,11 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
           new JWebSocket[String] {
             @volatile var messages = List.empty[String]
             def onReady(in: In[String], out: Out[String]) = {
-              in.onMessage(new F.Callback[String] {
-                def invoke(msg: String) = messages = msg :: messages
+              in.onMessage(new Consumer[String] {
+                def accept(msg: String) = messages = msg :: messages
               })
-              in.onClose(new F.Callback0 {
-                def invoke() = consumed.success(messages.reverse)
+              in.onClose(new Runnable {
+                def run() = consumed.success(messages.reverse)
               })
             }
           }
@@ -389,8 +388,8 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
         cleanedUp =>
           new JWebSocket[String] {
             def onReady(in: In[String], out: Out[String]) = {
-              in.onClose(new F.Callback0 {
-                def invoke() = cleanedUp.success(true)
+              in.onClose(new Runnable {
+                def run() = cleanedUp.success(true)
               })
             }
           }
@@ -413,7 +412,8 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
                 def receive = PartialFunction.empty
               })
             }
-          })
+          }
+          )
       }.pendingUntilAkkaHttpFixed
     }
   }

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -97,10 +97,10 @@ public class DefaultJPAApi implements JPAApi {
      *
      * @param block Block of code to execute
      */
-    public void withTransaction(final play.libs.F.Callback0 block) {
+    public void withTransaction(final Runnable block) {
         try {
             withTransaction("default", false, () -> {
-                block.invoke();
+                block.run();
                 return null;
             });
         } catch (Throwable t) {

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
@@ -144,7 +144,7 @@ public class JPA {
      *
      * @param block Block of code to execute.
      */
-    public static void withTransaction(final play.libs.F.Callback0 block) {
+    public static void withTransaction(final Runnable block) {
         jpaApi().withTransaction(block);
     }
 

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
@@ -45,7 +45,7 @@ public interface JPAApi {
      *
      * @param block Block of code to execute
      */
-    public void withTransaction(final play.libs.F.Callback0 block);
+    public void withTransaction(final Runnable block);
 
     /**
      * Run a block of code in a JPA transaction.

--- a/framework/src/play-java/src/main/java/play/libs/Comet.java
+++ b/framework/src/play-java/src/main/java/play/libs/Comet.java
@@ -10,6 +10,7 @@ import play.libs.F.*;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.*;
+import java.util.function.Consumer;
 
 /**
  * A Chunked stream sending Comet messages.
@@ -66,7 +67,7 @@ public abstract class Comet extends Chunks<String> {
     /**
      * Add a callback to be notified when the client has disconnected.
      */
-    public void onDisconnected(Callback0 callback) {
+    public void onDisconnected(Runnable callback) {
         out.onDisconnected(callback);
     }
 
@@ -87,7 +88,7 @@ public abstract class Comet extends Chunks<String> {
      * @return a new Comet
      * @throws NullPointerException if the specified callback is null
      */
-    public static Comet whenConnected(String jsMethod, Callback<Comet> callback) {
+    public static Comet whenConnected(String jsMethod, Consumer<Comet> callback) {
         return new WhenConnectedComet(jsMethod, callback);
     }
 
@@ -99,9 +100,9 @@ public abstract class Comet extends Chunks<String> {
 
         private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Comet.class);
 
-        private final Callback<Comet> callback;
+        private final Consumer<Comet> callback;
 
-        WhenConnectedComet(String jsMethod, Callback<Comet> callback) {
+        WhenConnectedComet(String jsMethod, Consumer<Comet> callback) {
             super(jsMethod);
             if (callback == null) throw new NullPointerException("Comet onConnected callback cannot be null");
             this.callback = callback;
@@ -110,7 +111,7 @@ public abstract class Comet extends Chunks<String> {
         @Override
         public void onConnected() {
             try {
-                callback.invoke(this);
+                callback.accept(this);
             } catch (Throwable e) {
                 logger.error("Exception in Comet.onConnected", e);
             }

--- a/framework/src/play-java/src/main/java/play/libs/EventSource.java
+++ b/framework/src/play-java/src/main/java/play/libs/EventSource.java
@@ -3,6 +3,8 @@
  */
 package play.libs;
 
+import java.util.function.Consumer;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import play.mvc.Results.*;
 
@@ -43,7 +45,7 @@ public abstract class EventSource extends Chunks<String> {
     /**
      * Add a callback to be notified when the client has disconnected.
      */
-    public void onDisconnected(F.Callback0 callback) {
+    public void onDisconnected(Runnable callback) {
         out.onDisconnected(callback);
     }
 
@@ -63,7 +65,7 @@ public abstract class EventSource extends Chunks<String> {
      * @return a new EventSource
      * @throws NullPointerException if the specified callback is null
      */
-    public static EventSource whenConnected(F.Callback<EventSource> callback) {
+    public static EventSource whenConnected(Consumer<EventSource> callback) {
         return new WhenConnectedEventSource(callback);
     }
 
@@ -75,9 +77,9 @@ public abstract class EventSource extends Chunks<String> {
 
         private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(WhenConnectedEventSource.class);
 
-        private final F.Callback<EventSource> callback;
+        private final Consumer<EventSource> callback;
 
-        WhenConnectedEventSource(F.Callback<EventSource> callback) {
+        WhenConnectedEventSource(Consumer<EventSource> callback) {
             super();
             if (callback == null) throw new NullPointerException("EventSource onConnected callback cannot be null");
             this.callback = callback;
@@ -86,7 +88,7 @@ public abstract class EventSource extends Chunks<String> {
         @Override
         public void onConnected() {
             try {
-                callback.invoke(this);
+                callback.accept(this);
             } catch (Throwable e) {
                 logger.error("Exception in EventSource.onConnected", e);
             }

--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -23,6 +23,7 @@ import org.openqa.selenium.htmlunit.*;
 
 import java.util.*;
 import java.util.concurrent.Callable;
+import java.util.function.Consumer;
 
 import static play.mvc.Http.*;
 
@@ -531,14 +532,14 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Executes a block of code in a running server, with a test browser.
      */
-    public static void running(TestServer server, Class<? extends WebDriver> webDriver, final Callback<TestBrowser> block) {
+    public static void running(TestServer server, Class<? extends WebDriver> webDriver, final Consumer<TestBrowser> block) {
         running(server, play.api.test.WebDriverFactory.apply(webDriver), block);
     }
 
     /**
      * Executes a block of code in a running server, with a test browser.
      */
-    public static void running(TestServer server, WebDriver webDriver, final Callback<TestBrowser> block) {
+    public static void running(TestServer server, WebDriver webDriver, final Consumer<TestBrowser> block) {
         synchronized (PlayRunners$.MODULE$.mutex()) {
             TestBrowser browser = null;
             TestServer startedServer = null;
@@ -546,14 +547,9 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
                 start(server);
                 startedServer = server;
                 browser = testBrowser(webDriver);
-                block.invoke(browser);
-            } catch (Error e) {
-                throw e;
-            } catch (RuntimeException re) {
-                throw re;
-            } catch (Throwable t) {
-                throw new RuntimeException(t);
-            } finally {
+                block.accept(browser);
+            } 
+            finally {
                 if (browser != null) {
                     browser.quit();
                 }
@@ -611,5 +607,4 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     public static TestBrowser testBrowser(WebDriver of) {
         return testBrowser(of, Helpers$.MODULE$.testServerPort());
     }
-
 }

--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import java.util.Arrays;
 
 import play.core.j.FPromiseHelper;
@@ -19,34 +20,6 @@ import scala.concurrent.Future;
  * Defines a set of functional programming style helpers.
  */
 public class F {
-
-    /**
-     * A Callback with no arguments.
-     */
-    public static interface Callback0 {
-        public void invoke() throws Throwable;
-    }
-
-    /**
-     * A Callback with a single argument.
-     */
-    public static interface Callback<A> {
-        public void invoke(A a) throws Throwable;
-    }
-
-    /**
-     * A Callback with 2 arguments.
-     */
-    public static interface Callback2<A,B> {
-        public void invoke(A a, B b) throws Throwable;
-    }
-
-    /**
-     * A Callback with 3 arguments.
-     */
-    public static interface Callback3<A,B,C> {
-        public void invoke(A a, B b, C c) throws Throwable;
-    }
 
     /**
      * A Function with no arguments.
@@ -309,7 +282,7 @@ public class F {
          *
          * @param action The action to perform.
          */
-        public void onRedeem(final Callback<A> action) {
+        public void onRedeem(final Consumer<A> action) {
             FPromiseHelper.onRedeem(this, action, HttpExecution.defaultContext());
         }
 
@@ -319,7 +292,7 @@ public class F {
          * @param action The action to perform.
          * @param ec The ExecutionContext to execute the action in.
          */
-        public void onRedeem(final Callback<A> action, ExecutionContext ec) {
+        public void onRedeem(final Consumer<A> action, ExecutionContext ec) {
             FPromiseHelper.onRedeem(this, action, ec);
         }
 
@@ -417,7 +390,7 @@ public class F {
          *
          * @param action The action to perform.
          */
-        public void onFailure(final Callback<Throwable> action) {
+        public void onFailure(final Consumer<Throwable> action) {
             FPromiseHelper.onFailure(this, action, HttpExecution.defaultContext());
         }
 
@@ -427,7 +400,7 @@ public class F {
          * @param action The action to perform.
          * @param ec The ExecutionContext to execute the callback in.
          */
-        public void onFailure(final Callback<Throwable> action, ExecutionContext ec) {
+        public void onFailure(final Consumer<Throwable> action, ExecutionContext ec) {
             FPromiseHelper.onFailure(this, action, ec);
         }
 

--- a/framework/src/play/src/main/scala/play/core/j/FPromiseHelper.scala
+++ b/framework/src/play/src/main/scala/play/core/j/FPromiseHelper.scala
@@ -13,8 +13,8 @@ import scala.collection.JavaConverters
 import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
 import scala.concurrent.duration.{ Duration, MILLISECONDS }
 import scala.util.{ Failure, Success, Try }
-
 import play.core.Execution.internalContext
+import java.util.function.Consumer
 
 /**
  * Support code for the play.libs.F.Promise class. All public methods of this
@@ -96,8 +96,8 @@ private[play] object FPromiseHelper {
   def timeout[A](delay: Long, unit: TimeUnit): F.Promise[A] =
     timeoutWith(Failure(new F.PromiseTimeoutException("Timeout in promise")), delay, unit)
 
-  def onRedeem[A](promise: F.Promise[A], action: F.Callback[A], ec: ExecutionContext): Unit =
-    promise.wrapped().onSuccess { case a => action.invoke(a) }(ec.prepare())
+  def onRedeem[A](promise: F.Promise[A], action: Consumer[A], ec: ExecutionContext): Unit =
+    promise.wrapped().onSuccess { case a => action.accept(a) }(ec.prepare())
 
   def map[A, B, T >: A](promise: F.Promise[A], function: F.Function[T, B], ec: ExecutionContext): F.Promise[B] =
     F.Promise.wrap[B](promise.wrapped().map((a: A) => function.apply(a))(ec.prepare()))
@@ -117,8 +117,8 @@ private[play] object FPromiseHelper {
   def fallbackTo[A](promise: F.Promise[A], fallback: F.Promise[A]): F.Promise[A] =
     F.Promise.wrap[A](promise.wrapped.fallbackTo(fallback.wrapped))
 
-  def onFailure[A](promise: F.Promise[A], action: F.Callback[Throwable], ec: ExecutionContext) {
-    promise.wrapped().onFailure { case t => action.invoke(t) }(ec.prepare())
+  def onFailure[A](promise: F.Promise[A], action: Consumer[Throwable], ec: ExecutionContext) {
+    promise.wrapped().onFailure { case t => action.accept(t) }(ec.prepare())
   }
 
   def transform[A, B, T >: A](promise: F.Promise[A], s: F.Function[T, B], f: F.Function[Throwable, Throwable], ec: ExecutionContext): F.Promise[B] =

--- a/framework/src/play/src/main/scala/play/core/j/JavaWebSocket.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaWebSocket.scala
@@ -71,8 +71,8 @@ object JavaWebSocket extends JavaHelpers {
             jws.onReady(socketIn, socketOut)
 
             in |>> {
-              Iteratee.foreach[A](msg => socketIn.callbacks.asScala.foreach(_.invoke(msg))).map { _ =>
-                socketIn.closeCallbacks.asScala.foreach(_.invoke())
+              Iteratee.foreach[A](msg => socketIn.callbacks.asScala.foreach(_.accept(msg))).map { _ =>
+                socketIn.closeCallbacks.asScala.foreach(_.run())
               }
             }
           }

--- a/framework/src/play/src/test/java/play/PromiseTest.java
+++ b/framework/src/play/src/test/java/play/PromiseTest.java
@@ -206,13 +206,14 @@ public class PromiseTest extends ExecutionTest {
     }
 
     @Test
-    public void testRedeemValueWithEC() throws Exception {
+    public void testRedeemValueWithEC() {
         mustExecute(1, ec -> {
             F.RedeemablePromise<Integer> p = F.RedeemablePromise.empty();
             LinkedBlockingQueue<Integer> invocations = new LinkedBlockingQueue<>();
             p.onRedeem(invocations::offer, ec);
             p.success(99);
-            assertThat(invocations.poll(5, SECONDS)).isEqualTo(99);
+            try { assertThat(invocations.poll(5, SECONDS)).isEqualTo(99); }
+            catch(InterruptedException e) { throw new RuntimeException(e); }
         });
     }
 

--- a/framework/src/play/src/test/java/play/mvc/WebSocketTest.java
+++ b/framework/src/play/src/test/java/play/mvc/WebSocketTest.java
@@ -4,6 +4,8 @@
 package play.mvc;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
+
 import org.junit.Test;
 import play.api.libs.iteratee.TestChannel;
 import play.libs.F;
@@ -45,14 +47,14 @@ public class WebSocketTest {
 
         assertTrue("WebSocket.onReady callback was not invoked", ready.await(1, SECONDS));
 
-        for (F.Callback<String> callback : wsIn.callbacks) {
-            callback.invoke("message");
+        for (Consumer<String> callback : wsIn.callbacks) {
+            callback.accept("message");
         }
 
         assertTrue("WebSocket.In.onMessage callback was not invoked", message.await(1, SECONDS));
 
-        for (F.Callback0 callback : wsIn.closeCallbacks) {
-            callback.invoke();
+        for (Runnable callback : wsIn.closeCallbacks) {
+            callback.run();
         }
 
         assertTrue("WebSocket.In.onClose callback was not invoked", close.await(1, SECONDS));

--- a/framework/src/play/src/test/scala/play/api/libs/iteratee/ExecutionTest.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/iteratee/ExecutionTest.scala
@@ -5,6 +5,8 @@ package play.api.libs.iteratee
 
 import play.libs.F
 import scala.concurrent.ExecutionContext
+import java.util.function.Consumer
+import java.util.function.BiConsumer
 
 /**
  * Common functionality for Java tests that use execution contexts.
@@ -38,12 +40,12 @@ class ExecutionTest {
     }
   }
 
-  def mustExecute(expectedCount: Int, c: F.Callback[ExecutionContext]): Unit = {
-    _mustExecute(expectedCount)(c.invoke)
+  def mustExecute(expectedCount: Int, c: Consumer[ExecutionContext]): Unit = {
+    _mustExecute(expectedCount)(c.accept)
   }
 
-  def mustExecute(expectedCount1: Int, expectedCount2: Int, c: F.Callback2[ExecutionContext, ExecutionContext]): Unit = {
-    _mustExecute(expectedCount1)(ec1 => _mustExecute(expectedCount2)(ec2 => c.invoke(ec1, ec2)))
+  def mustExecute(expectedCount1: Int, expectedCount2: Int, c: BiConsumer[ExecutionContext, ExecutionContext]): Unit = {
+    _mustExecute(expectedCount1)(ec1 => _mustExecute(expectedCount2)(ec2 => c.accept(ec1, ec2)))
   }
 
 }

--- a/framework/src/play/src/test/scala/play/api/libs/iteratee/ExecutionTest.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/iteratee/ExecutionTest.scala
@@ -46,8 +46,4 @@ class ExecutionTest {
     _mustExecute(expectedCount1)(ec1 => _mustExecute(expectedCount2)(ec2 => c.invoke(ec1, ec2)))
   }
 
-  def mustExecute(expectedCount1: Int, expectedCount2: Int, expectedCount3: Int, c: F.Callback3[ExecutionContext, ExecutionContext, ExecutionContext]): Unit = {
-    _mustExecute(expectedCount1)(ec1 => _mustExecute(expectedCount2)(ec2 => _mustExecute(expectedCount3)(ec3 => c.invoke(ec1, ec2, ec3))))
-  }
-
 }

--- a/framework/src/play/src/test/scala/play/libs/FSpec.scala
+++ b/framework/src/play/src/test/scala/play/libs/FSpec.scala
@@ -10,6 +10,7 @@ import org.specs2.mutable._
 import play.api.libs.iteratee.ExecutionSpecification
 import scala.collection.JavaConverters
 import scala.concurrent.{ Future, Promise }
+import java.util.function.Consumer
 
 object FSpec extends Specification
     with ExecutionSpecification {
@@ -68,8 +69,8 @@ object FSpec extends Specification
       val p = Promise[Int]()
       val fp = F.Promise.wrap(p.future)
       val invocations = new LinkedBlockingQueue[Int]()
-      fp.onRedeem(new F.Callback[Int] {
-        def invoke(x: Int) { invocations.offer(x) }
+      fp.onRedeem(new Consumer[Int] {
+        def accept(x: Int) { invocations.offer(x) }
       })
       p.success(99)
       invocations.poll(5, SECONDS) must equalTo(99)
@@ -80,8 +81,8 @@ object FSpec extends Specification
       val fp = F.Promise.wrap(p.future)
       mustExecute(1) { ec =>
         val invocations = new LinkedBlockingQueue[Int]()
-        fp.onRedeem(new F.Callback[Int] {
-          def invoke(x: Int) { invocations.offer(x) }
+        fp.onRedeem(new Consumer[Int] {
+          def accept(x: Int) { invocations.offer(x) }
         }, ec)
         p.success(99)
         invocations.poll(5, SECONDS) must equalTo(99)

--- a/templates/play-java-intro/test/IntegrationTest.java
+++ b/templates/play-java-intro/test/IntegrationTest.java
@@ -2,7 +2,6 @@ import org.junit.*;
 
 import play.mvc.*;
 import play.test.*;
-import play.libs.F.*;
 
 import static play.test.Helpers.*;
 import static org.junit.Assert.*;
@@ -18,11 +17,9 @@ public class IntegrationTest {
      */
     @Test
     public void test() {
-        running(testServer(3333, fakeApplication(inMemoryDatabase())), HTMLUNIT, new Callback<TestBrowser>() {
-            public void invoke(TestBrowser browser) {
-                browser.goTo("http://localhost:3333");
-                assertThat(browser.pageSource(), containsString("Add Person"));
-            }
+        running(testServer(3333, fakeApplication(inMemoryDatabase())), HTMLUNIT, browser -> {
+            browser.goTo("http://localhost:3333");
+            assertThat(browser.pageSource(), containsString("Add Person"));
         });
     }
 

--- a/templates/play-java/test/IntegrationTest.java
+++ b/templates/play-java/test/IntegrationTest.java
@@ -2,7 +2,6 @@ import org.junit.*;
 
 import play.mvc.*;
 import play.test.*;
-import play.libs.F.*;
 
 import static play.test.Helpers.*;
 import static org.junit.Assert.*;
@@ -17,11 +16,9 @@ public class IntegrationTest {
      */
     @Test
     public void test() {
-        running(testServer(3333, fakeApplication(inMemoryDatabase())), HTMLUNIT, new Callback<TestBrowser>() {
-            public void invoke(TestBrowser browser) {
-                browser.goTo("http://localhost:3333");
-                assertTrue(browser.pageSource().contains("Your new application is ready."));
-            }
+        running(testServer(3333, fakeApplication(inMemoryDatabase())), HTMLUNIT, browser -> {
+            browser.goTo("http://localhost:3333");
+            assertTrue(browser.pageSource().contains("Your new application is ready."));
         });
     }
 


### PR DESCRIPTION
We are embracing Java8 functional interfaces and hence this commit replaces all
occurrences of Play `F.Callback` with the Java8 counterpart. Types are mapped as
follow:

* `F.Callback0`          -> `java.lang.Runnable`
* `F.Callback<A>`        -> `java.util.function.Consumer<A>`
* `F.Callback2<A,B>`     -> `java.util.function.BiConsumer<A,B>`
* `F.Callback3<A,B,C>`   -> no counterpart in Java8

One important difference between the Play `F.Callback` and the new Java8 types
is that, while the Play Callback types can all throw `Exception`, the new
corresponding Java8 functional interface types can't. This entails that
existing code may need to be changed when moving from the Play `Callable` types
to the Java8 types (for an example of this, see `PromiseTest.java` in this
commit). If interested, there is an interesting article that discusses the
problem of "Exception transparency in Java" by Brian Goetz:
https://blogs.oracle.com/briangoetz/entry/exception_transparency_in_java.

There is no Java8 counterpart for `F.Callback3<A,B,C>`. Because this type wasn't
used anywhere in the Play codebase, I've simply removed it. User needing this
will either create their own type, or use a library that provides the additional
functional types (for instance, see http://javaslang.com/), or simply declare a
curried function3 type, i.e., `Function<ExecutionContext,
Function<ExecutionContext, Consumer<ExecutionContext>>>`. In short, this is a
Java8 limitation and I don't think Play should be opinionated about it: let the
users decide what fits them best.

Also, note that `java.util.concurrent.Callable` is a functional interface
similar to `java.lang.Runnable`. The important difference between the two is
that `Callable` can throw a checked `Exception`. I've decided to map
`F.Callback0` to `java.lang.Runnable` and not `java.util.concurrent.Callable`
for consistency wrt the `Consumer` and `BiConsumer` types. Because the latter do
not throw, then we should map `F.Callback0` to a type that doesn't throw, i.e.,
`Runnable`.

A further aspect that is not covered by this commit is the usage of specialized
types. For instance, Java8 offers specialized `Consumer` for all primitive
types, i.e., `IntConsumer`, `DoubleConsumer`, etc. Using the specialized
consumer is interesting to avoid boxing/unboxing of primitive types, and hence
achieve more efficient execution.  The tradeoff is that we will need to provide
several overloads. My take is that we should delay more specific work around
specialization until we break apart the Play Scala and Java API.