### PR TITLE
Added Scalaz Bintray Repo into build.sbt

### DIFF
--- a/templates/play-scala-intro/build.sbt
+++ b/templates/play-scala-intro/build.sbt
@@ -8,6 +8,8 @@ scalaVersion := "%SCALA_VERSION%"
 
 resolvers += "sorm Scala 2.11 fork" at "http://markusjura.github.io/sorm"
 
+resolvers += "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases"
+
 libraryDependencies ++= Seq(  
   "org.sorm-framework" % "sorm" % "0.4.1",
   "com.h2database" % "h2" % "1.4.177",


### PR DESCRIPTION
Hello everyone, I'm learning Scala and Play.

I tried creating a new application using the ``play-scala-intro`` activator template.
Everything went smoothly, but when trying to run ``activator run``, the app would show the following problem:

```
$ sbt update
[info] Loading project definition from /Users/jojo/code/play/play-scala-intro/project
[info] Updating {file:/Users/jojo/code/play/play-scala-intro/project/}play-scala-intro-build...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] Done updating.
[info] Set current project to play-scala-intro (in build file:/Users/jojo/code/play/play-scala-intro/)
[info] Updating {file:/Users/jojo/code/play/play-scala-intro/}root...
[info] Resolving org.scalaz.stream#scalaz-stream_2.11;0.7a ...
[warn] 	module not found: org.scalaz.stream#scalaz-stream_2.11;0.7a
[warn] ==== local: tried
[warn]   /Users/jojo/.ivy2/local/org.scalaz.stream/scalaz-stream_2.11/0.7a/ivys/ivy.xml
[warn] ==== public: tried
[warn]   https://repo1.maven.org/maven2/org/scalaz/stream/scalaz-stream_2.11/0.7a/scalaz-stream_2.11-0.7a.pom
[warn] ==== sorm Scala 2.11 fork: tried
[warn]   http://markusjura.github.io/sorm/org/scalaz/stream/scalaz-stream_2.11/0.7a/scalaz-stream_2.11-0.7a.pom
[info] Resolving jline#jline;2.12.1 ...
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	::          UNRESOLVED DEPENDENCIES         ::
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	:: org.scalaz.stream#scalaz-stream_2.11;0.7a: not found
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn]
[warn] 	Note: Unresolved dependencies path:
[warn] 		org.scalaz.stream:scalaz-stream_2.11:0.7a
[warn] 		  +- org.specs2:specs2-common_2.11:3.6
[warn] 		  +- org.specs2:specs2-matcher_2.11:3.6
[warn] 		  +- org.specs2:specs2-core_2.11:3.6
[warn] 		  +- org.specs2:specs2-junit_2.11:3.6
[warn] 		  +- com.typesafe.play:play-specs2_2.11:2.4.0 (/Users/jojo/code/play/play-scala-intro/build.sbt#L11-17)
[warn] 		  +- play-scala-intro:play-scala-intro_2.11:1.0-SNAPSHOT
sbt.ResolveException: unresolved dependency: org.scalaz.stream#scalaz-stream_2.11;0.7a: not found
	at sbt.IvyActions$.sbt$IvyActions$$resolve(IvyActions.scala:291)
	at sbt.IvyActions$$anonfun$updateEither$1.apply(IvyActions.scala:188)
	at sbt.IvyActions$$anonfun$updateEither$1.apply(IvyActions.scala:165)
	at sbt.IvySbt$Module$$anonfun$withModule$1.apply(Ivy.scala:155)
	at sbt.IvySbt$Module$$anonfun$withModule$1.apply(Ivy.scala:155)
	at sbt.IvySbt$$anonfun$withIvy$1.apply(Ivy.scala:132)
	at sbt.IvySbt.sbt$IvySbt$$action$1(Ivy.scala:57)
	at sbt.IvySbt$$anon$4.call(Ivy.scala:65)
	at xsbt.boot.Locks$GlobalLock.withChannel$1(Locks.scala:93)
	at xsbt.boot.Locks$GlobalLock.xsbt$boot$Locks$GlobalLock$$withChannelRetries$1(Locks.scala:78)
	at xsbt.boot.Locks$GlobalLock$$anonfun$withFileLock$1.apply(Locks.scala:97)
	at xsbt.boot.Using$.withResource(Using.scala:10)
	at xsbt.boot.Using$.apply(Using.scala:9)
	at xsbt.boot.Locks$GlobalLock.ignoringDeadlockAvoided(Locks.scala:58)
	at xsbt.boot.Locks$GlobalLock.withLock(Locks.scala:48)
	at xsbt.boot.Locks$.apply0(Locks.scala:31)
	at xsbt.boot.Locks$.apply(Locks.scala:28)
	at sbt.IvySbt.withDefaultLogger(Ivy.scala:65)
	at sbt.IvySbt.withIvy(Ivy.scala:127)
	at sbt.IvySbt.withIvy(Ivy.scala:124)
	at sbt.IvySbt$Module.withModule(Ivy.scala:155)
	at sbt.IvyActions$.updateEither(IvyActions.scala:165)
	at sbt.Classpaths$$anonfun$sbt$Classpaths$$work$1$1.apply(Defaults.scala:1369)
	at sbt.Classpaths$$anonfun$sbt$Classpaths$$work$1$1.apply(Defaults.scala:1365)
	at sbt.Classpaths$$anonfun$doWork$1$1$$anonfun$87.apply(Defaults.scala:1399)
	at sbt.Classpaths$$anonfun$doWork$1$1$$anonfun$87.apply(Defaults.scala:1397)
	at sbt.Tracked$$anonfun$lastOutput$1.apply(Tracked.scala:37)
	at sbt.Classpaths$$anonfun$doWork$1$1.apply(Defaults.scala:1402)
	at sbt.Classpaths$$anonfun$doWork$1$1.apply(Defaults.scala:1396)
	at sbt.Tracked$$anonfun$inputChanged$1.apply(Tracked.scala:60)
	at sbt.Classpaths$.cachedUpdate(Defaults.scala:1419)
	at sbt.Classpaths$$anonfun$updateTask$1.apply(Defaults.scala:1348)
	at sbt.Classpaths$$anonfun$updateTask$1.apply(Defaults.scala:1310)
	at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
	at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:235)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
[error] (*:update) sbt.ResolveException: unresolved dependency: org.scalaz.stream#scalaz-stream_2.11;0.7a: not found
[error] Total time: 4 s, completed Jun 13, 2015 8:38:47 PM

jojo at mackie in ~/code/play/play-scala-intro
```

Found out through https://github.com/playframework/playframework/issues/3716#issuecomment-71176262 that adding the following line into my ``build.sbt`` file would fix the problem:

```
resolvers += "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases"
```

Is this the right place to report this problem?