### PR TITLE
Replaced `F.Predicate` with Java8 `java.util.function.Predicate`

### DIFF
--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -10,6 +10,7 @@ import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.Arrays;
 
 import play.core.j.FPromiseHelper;
@@ -47,13 +48,6 @@ public class F {
      */
     public static interface Function3<A,B,C,R> {
         public R apply(A a, B b, C c) throws Throwable;
-    }
-
-    /**
-     * A Predicate (boolean-valued function) with a single argument.
-     */
-    public static interface Predicate<A> {
-        public boolean test(A a) throws Throwable;
     }
 
     /**

--- a/framework/src/play/src/main/scala/play/core/j/FPromiseHelper.scala
+++ b/framework/src/play/src/main/scala/play/core/j/FPromiseHelper.scala
@@ -15,6 +15,7 @@ import scala.concurrent.duration.{ Duration, MILLISECONDS }
 import scala.util.{ Failure, Success, Try }
 import play.core.Execution.internalContext
 import java.util.function.Consumer
+import java.util.function.Predicate
 
 /**
  * Support code for the play.libs.F.Promise class. All public methods of this
@@ -105,7 +106,7 @@ private[play] object FPromiseHelper {
   def flatMap[A, B, T >: A](promise: F.Promise[A], function: F.Function[T, F.Promise[B]], ec: ExecutionContext): F.Promise[B] =
     F.Promise.wrap[B](promise.wrapped().flatMap((a: A) => function.apply(a).wrapped())(ec.prepare()))
 
-  def filter[A, T >: A](promise: F.Promise[A], predicate: F.Predicate[T], ec: ExecutionContext): F.Promise[A] =
+  def filter[A, T >: A](promise: F.Promise[A], predicate: Predicate[T], ec: ExecutionContext): F.Promise[A] =
     F.Promise.wrap[A](promise.wrapped().filter(predicate.test)(ec.prepare()))
 
   def recover[A](promise: F.Promise[A], function: F.Function[Throwable, A], ec: ExecutionContext): F.Promise[A] =

--- a/framework/src/play/src/test/scala/play/libs/FSpec.scala
+++ b/framework/src/play/src/test/scala/play/libs/FSpec.scala
@@ -11,6 +11,7 @@ import play.api.libs.iteratee.ExecutionSpecification
 import scala.collection.JavaConverters
 import scala.concurrent.{ Future, Promise }
 import java.util.function.Consumer
+import java.util.function.Predicate
 
 object FSpec extends Specification
     with ExecutionSpecification {
@@ -198,7 +199,7 @@ object FSpec extends Specification
     "filter its value (with default ExecutionContext)" in {
       val p = Promise[Int]()
       val fp = F.Promise.wrap(p.future)
-      val filtered = fp.filter(new F.Predicate[Int] {
+      val filtered = fp.filter(new Predicate[Int] {
         def test(x: Int) = x > 0
       })
       p.success(1)
@@ -209,7 +210,7 @@ object FSpec extends Specification
       val p = Promise[Int]()
       val fp = F.Promise.wrap(p.future)
       mustExecute(1) { ec =>
-        val filtered = fp.filter(new F.Predicate[Int] {
+        val filtered = fp.filter(new Predicate[Int] {
           def test(x: Int) = x > 0
         }, ec)
         p.success(1)
@@ -220,7 +221,7 @@ object FSpec extends Specification
     "filter to failure (with default ExecutionContext)" in {
       val p = Promise[Int]()
       val fp = F.Promise.wrap(p.future)
-      val filtered = fp.filter(new F.Predicate[Int] {
+      val filtered = fp.filter(new Predicate[Int] {
         def test(x: Int) = x > 0
       })
       p.success(-1)
@@ -231,7 +232,7 @@ object FSpec extends Specification
       val p = Promise[Int]()
       val fp = F.Promise.wrap(p.future)
       mustExecute(1) { ec =>
-        val filtered = fp.filter(new F.Predicate[Int] {
+        val filtered = fp.filter(new Predicate[Int] {
           def test(x: Int) = x > 0
         }, ec)
         p.success(-1)


### PR DESCRIPTION
As explained in d24c79d85eb9f71499588d2180bfb29e6b73d55f, we are embracing Java8
functional interfaces. This commit replaces `F.Predicate` with
`java.util.function.Predicate`.

The change is source compatible if the lambda's body passed to `F.Predicate`
does not throw a checked exception. Otherwise, users will need to update their
code to catch the exception and provide the necessary logic to deal with it.

By the way, I'm also working on replacing `F.Function` but it's a bit trickier. Hence I thought I'd start pushing this simple commit for today, and hope that by tomorrow I'll sort out the `F.Function` replacement.