### PR TITLE
Fix versioned assets on Windows

### DIFF
--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -412,8 +412,8 @@ class AssetsBuilder(errorHandler: HttpErrorHandler) extends Controller {
     // otherwise we can't.
     val requestedDigest = f.getName.takeWhile(_ != '-')
     if (!requestedDigest.isEmpty) {
-      val bareFile = new File(f.getParent, f.getName.drop(requestedDigest.size + 1)).getPath
-      val bareFullPath = new File(path + File.separator + bareFile).getPath
+      val bareFile = new File(f.getParent, f.getName.drop(requestedDigest.size + 1)).getPath.replace('\\', '/')
+      val bareFullPath = path + "/" + bareFile
       blocking(digest(bareFullPath)) match {
         case Some(`requestedDigest`) => assetAt(path, bareFile, aggressiveCaching = true)
         case _ => assetAt(path, file.name, false)


### PR DESCRIPTION
Fixes the `InvalidUriEncodingException` exception in #3532 

There was already a failing test for this:
```
> test-only *.NettyAssetsSpec

ERROR application -

! @6mf7op276 - Internal server error, for (GET) [/versioned/sub/12345678901234567890123456789012-foo.txt] ->

play.api.UnexpectedException: Unexpected exception[InvalidUriEncodingException: Cannot decode \versioned\sub\foo.txt: illegal character at position 1.]
        at play.api.http.HttpErrorHandlerExceptions$.throwableToUsefulException(HttpErrorHandler.scala:250) ~[classes/:na]
        at play.api.http.DefaultHttpErrorHandler.onServerError(HttpErrorHandler.scala:180) ~[classes/:na]
        at play.core.server.netty.PlayDefaultUpstreamHandler$$anonfun$9$$anonfun$apply$1.applyOrElse(PlayDefaultUpstreamHandler.scala:158) [classes/:na]
        at play.core.server.netty.PlayDefaultUpstreamHandler$$anonfun$9$$anonfun$apply$1.applyOrElse(PlayDefaultUpstreamHandler.scala:155) [classes/:na]
        at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:33) [scala-library-2.10.5.jar:na]
        at scala.util.Failure$$anonfun$recover$1.apply(Try.scala:185) [scala-library-2.10.5.jar:na]
        at scala.util.Try$.apply(Try.scala:161) [scala-library-2.10.5.jar:na]
        at scala.util.Failure.recover(Try.scala:185) [scala-library-2.10.5.jar:na]
        at scala.concurrent.Future$$anonfun$recover$1.apply(Future.scala:324) [scala-library-2.10.5.jar:na]
        at scala.concurrent.Future$$anonfun$recover$1.apply(Future.scala:324) [scala-library-2.10.5.jar:na]
        at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:32) [scala-library-2.10.5.jar:na]
        at play.api.libs.iteratee.Execution$trampoline$.executeScheduled(Execution.scala:109) [classes/:na]
        at play.api.libs.iteratee.Execution$trampoline$.execute(Execution.scala:71) [classes/:na]
        at scala.concurrent.impl.CallbackRunnable.executeWithValue(Promise.scala:40) [scala-library-2.10.5.jar:na]
        at scala.concurrent.impl.Promise$DefaultPromise.tryComplete(Promise.scala:248) [scala-library-2.10.5.jar:na]
        at scala.concurrent.Promise$class.complete(Promise.scala:55) [scala-library-2.10.5.jar:na]
        at scala.concurrent.impl.Promise$DefaultPromise.complete(Promise.scala:153) [scala-library-2.10.5.jar:na]
        at scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:23) [scala-library-2.10.5.jar:na]
        at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:40) [akka-actor_2.10-2.3.11.jar:na]
        at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(AbstractDispatcher.scala:397) [akka-actor_2.10-2.3.11.jar:na]
        at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260) [scala-library-2.10.5.jar:na]
        at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339) [scala-library-2.10.5.jar:na]
        at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979) [scala-library-2.10.5.jar:na]
        at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107) [scala-library-2.10.5.jar:na]
Caused by: play.utils.InvalidUriEncodingException: Cannot decode \versioned\sub\foo.txt: illegal character at position 1.
        at play.utils.UriEncoding$.decodePathSegment(UriEncoding.scala:115) ~[classes/:na]
        at play.utils.UriEncoding$$anonfun$decodePath$1.apply(UriEncoding.scala:140) ~[classes/:na]
        at play.utils.UriEncoding$$anonfun$decodePath$1.apply(UriEncoding.scala:140) ~[classes/:na]
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244) ~[scala-library-2.10.5.jar:na]
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244) ~[scala-library-2.10.5.jar:na]
        at scala.collection.immutable.List.foreach(List.scala:318) ~[scala-library-2.10.5.jar:na]
        at scala.collection.generic.TraversableForwarder$class.foreach(TraversableForwarder.scala:32) ~[scala-library-2.10.5.jar:na]
        at scala.collection.mutable.ListBuffer.foreach(ListBuffer.scala:45) ~[scala-library-2.10.5.jar:na]
        at scala.collection.TraversableLike$class.map(TraversableLike.scala:244) ~[scala-library-2.10.5.jar:na]
        at scala.collection.AbstractTraversable.map(Traversable.scala:105) ~[scala-library-2.10.5.jar:na]
        at play.utils.UriEncoding$.decodePath(UriEncoding.scala:140) ~[classes/:na]
        at controllers.AssetsBuilder.resourceNameAt(Assets.scala:488) ~[classes/:na]
        at controllers.AssetsBuilder.controllers$AssetsBuilder$$assetAt(Assets.scala:442) ~[classes/:na]
        at controllers.AssetsBuilder$$anonfun$versioned$1.apply(Assets.scala:421) ~[classes/:na]
        at controllers.AssetsBuilder$$anonfun$versioned$1.apply(Assets.scala:410) ~[classes/:na]
        at play.api.mvc.Action$.invokeBlock(Action.scala:533) ~[classes/:na]
        at play.api.mvc.Action$.invokeBlock(Action.scala:530) ~[classes/:na]
        at play.api.mvc.ActionBuilder$$anon$1.apply(Action.scala:493) ~[classes/:na]
        at play.api.mvc.Action$$anonfun$apply$1$$anonfun$apply$4$$anonfun$apply$5.apply(Action.scala:105) ~[classes/:na]
        at play.api.mvc.Action$$anonfun$apply$1$$anonfun$apply$4$$anonfun$apply$5.apply(Action.scala:105) ~[classes/:na]
        at play.utils.Threads$.withContextClassLoader(Threads.scala:21) ~[classes/:na]
        at play.api.mvc.Action$$anonfun$apply$1$$anonfun$apply$4.apply(Action.scala:104) ~[classes/:na]
        at play.api.mvc.Action$$anonfun$apply$1$$anonfun$apply$4.apply(Action.scala:103) ~[classes/:na]
        at scala.Option.map(Option.scala:145) ~[scala-library-2.10.5.jar:na]
        at play.api.mvc.Action$$anonfun$apply$1.apply(Action.scala:103) ~[classes/:na]
        at play.api.mvc.Action$$anonfun$apply$1.apply(Action.scala:96) ~[classes/:na]
        at play.api.libs.iteratee.DoneIteratee$$anonfun$mapM$2.apply(Iteratee.scala:741) ~[classes/:na]
        at play.api.libs.iteratee.DoneIteratee$$anonfun$mapM$2.apply(Iteratee.scala:741) ~[classes/:na]
        at scala.concurrent.impl.Future$PromiseCompletingRunnable.liftedTree1$1(Future.scala:24) [scala-library-2.10.5.jar:na]
        at scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:24) [scala-library-2.10.5.jar:na]
        ... 6 common frames omitted
[info] NettyAssetsSpec
[info]
[info] Assets controller should
[error]   x serve a versioned asset
[error]    '500' is not equal to '200' (AssetsSpec.scala:193)
[info]
[info]   return not found when the path is a directory
[info]     + if the directory is on the file system
[info]     + if the directory is a jar entry
[info]
[info] Total for specification NettyAssetsSpec
[info] Finished in 2 seconds, 691 ms
[info] 3 examples, 1 failure, 0 error
[info]
[error] Failed: Total 3, Failed 1, Errors 0, Passed 2
[error] Failed tests:
[error]         play.it.http.assets.NettyAssetsSpec
[error] (Play-Integration-Test/test:testOnly) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 11 s, completed Jun 15, 2015 10:48:47 AM
```

This PR also fixes an issue which is not addressed by the monkey patch in #3532. Aggressive caching was never being used on Windows because `digest(path)` always returns `None` for a `\windows\style\path` (it uses the class loader).