### PR TITLE
Add missing 's' string interpolater to error message in NettyServer

### DIFF
--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -213,7 +213,7 @@ object NettyServer {
   implicit val provider = new NettyServerProvider
 
   def main(args: Array[String]) {
-    System.err.println("NettyServer.main is deprecated. Please start your Play server with the ${ProdServerStart.getClass.getName}.main.")
+    System.err.println(s"NettyServer.main is deprecated. Please start your Play server with the ${ProdServerStart.getClass.getName}.main.")
     ProdServerStart.main(args)
   }
 


### PR DESCRIPTION
Deprecation error message in NettyServer is missing string interpolator
on error message that informs a user that ProdServerStart has replaced
NettyServer as the preferred main class for Play apps.