### PR TITLE
JNDI binding logs "null" as datasource

### DIFF
--- a/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
@@ -58,10 +58,9 @@ class HikariCPConnectionPool @Inject() (environment: Environment) extends Connec
       val datasource = new HikariDataSource(hikariConfig)
 
       // Bind in JNDI
-      dbConfig.jndiName.foreach { name =>
-        JNDI.initialContext.rebind(name, datasource)
-        val visibleUrl = datasource.getJdbcUrl
-        logger.info(s"""datasource [$visibleUrl] bound to JNDI as $name""")
+      dbConfig.jndiName.foreach { jndiName =>
+        JNDI.initialContext.rebind(jndiName, datasource)
+        logger.info(s"datasource [$name] bound to JNDI as $jndiName")
       }
 
       datasource


### PR DESCRIPTION
I am using `dataSourceClassName` to configure a database connection (instead of the "classic" jdbc-url style) and also bind the datasource via JNDI:

```
db.default.hikaricp.dataSourceClassName=org.postgresql.ds.PGSimpleDataSource
db.default.hikaricp.dataSource.user=myuser
db.default.hikaricp.dataSource.password=mypassword
db.default.hikaricp.dataSource.databaseName=mydb
db.default.hikaricp.dataSource.serverName=localhost

db.default.jndiName=DefaultDS
```
The log now gives me `...datasource [null]...`:
```
[info] p.a.d.HikariCPConnectionPool - datasource [null] bound to JNDI as DefaultDS
```

The problem is [here](https://github.com/playframework/playframework/blob/cf60c65b551cedf99a5cceaee5b15cc9cff8a37b/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala#L63-L64): I don't use the url style.