### PR TITLE
Always cancel subscription when Iteratee finishes

### DIFF
--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/impl/IterateeSubscriber.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/impl/IterateeSubscriber.scala
@@ -189,6 +189,7 @@ private[streams] class IterateeSubscriber[T, R, S](iter0: Iteratee[T, R])
     case NotSubscribedNoStep(result) =>
       finishWithDoneOrErrorStep(doneOrError, result)
     case SubscribedNoStep(subs, result) =>
+      subs.cancel()
       finishWithDoneOrErrorStep(doneOrError, result)
     case NotSubscribedWithCont(cont, result) =>
       throw new IllegalStateException("Can't get done or error while has cont")

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/IterateeSubscriberSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/IterateeSubscriberSpec.scala
@@ -178,6 +178,18 @@ class IterateeSubscriberSpec extends Specification {
       testEnv.isEmptyAfterDelay() must beTrue
     }
 
+    "finish when iteratee is done after subscribe, cancel subscription (on-subscribe/done-step)" in {
+      val testEnv = new TestEnv[Int]
+
+      testEnv.onSubscribe()
+      testEnv.isEmptyAfterDelay() must beTrue
+
+      testEnv.doneStep(333, Input.El(99))
+      testEnv.next must_== Cancel
+      testEnv.next must_== Result(Success(Done(333, Input.El(99))))
+      testEnv.isEmptyAfterDelay() must beTrue
+    }
+
     "finish when iteratee is done immediately, ignore complete (done-step/on-complete)" in {
       val testEnv = new TestEnv[Int]
 
@@ -209,6 +221,18 @@ class IterateeSubscriberSpec extends Specification {
 
       testEnv.onSubscribe()
       testEnv.next must_== Cancel
+      testEnv.isEmptyAfterDelay() must beTrue
+    }
+
+    "finish when iteratee errors after subscribe, cancel subscription (on-subscribe/done-step)" in {
+      val testEnv = new TestEnv[Int]
+
+      testEnv.onSubscribe()
+      testEnv.isEmptyAfterDelay() must beTrue
+
+      testEnv.errorStep("iteratee error", Input.El(99))
+      testEnv.next must_== Cancel
+      testEnv.next must_== Result(Success(Error("iteratee error", Input.El(99))))
       testEnv.isEmptyAfterDelay() must beTrue
     }
 


### PR DESCRIPTION
This handles a case that was missed: when onSubscribe is called and then the iteratee enters a Done or Error state.

We may wish to backport this to 2.4.