### PR TITLE
Switch to Akka streams for request body processing

### DIFF
--- a/documentation/manual/detailedTopics/configuration/filters/code/GzipEncoding.scala
+++ b/documentation/manual/detailedTopics/configuration/filters/code/GzipEncoding.scala
@@ -3,6 +3,7 @@
  */
 package detailedtopics.configuration.gzipencoding
 
+import akka.stream.ActorFlowMaterializer
 import play.api.test._
 
 object GzipEncoding extends PlaySpecification {
@@ -28,9 +29,11 @@ object GzipEncoding extends PlaySpecification {
         //#should-gzip
 
       import play.api.mvc._
-      running(FakeApplication()) {
+      val app = FakeApplication()
+      running(app) {
+        implicit val mat = ActorFlowMaterializer()(app.actorSystem)
         header(CONTENT_ENCODING,
-          filter(Action(Results.Ok("foo")))(gzipRequest).run
+          filter(Action(Results.Ok("foo")))(gzipRequest).run()
         ) must beNone
       }
     }

--- a/documentation/manual/working/javaGuide/code/MockJavaAction.scala
+++ b/documentation/manual/working/javaGuide/code/MockJavaAction.scala
@@ -3,6 +3,7 @@
  */
 package javaguide.testhelpers
 
+import akka.stream.FlowMaterializer
 import play.api.mvc.{Action, Request}
 import play.core.j.{JavaHandlerComponents, JavaHelpers, JavaActionAnnotations, JavaAction}
 import play.http.DefaultHttpRequestHandler
@@ -44,7 +45,7 @@ object MockJavaActionHelper {
     }
   }
 
-  def callWithStringBody(action: Action[Http.RequestBody], requestBuilder: play.mvc.Http.RequestBuilder, body: String): Result = {
+  def callWithStringBody(action: Action[Http.RequestBody], requestBuilder: play.mvc.Http.RequestBuilder, body: String)(implicit mat: FlowMaterializer): Result = {
     val result = Helpers.await(Helpers.call(action, requestBuilder.build()._underlyingRequest, body))
     new Result {
       def toScala = result

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaBodyParsers.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaBodyParsers.java
@@ -3,6 +3,7 @@
  */
 package javaguide.http;
 
+import akka.stream.FlowMaterializer;
 import org.junit.Before;
 import org.junit.Test;
 import play.libs.Json;
@@ -72,6 +73,7 @@ public class JavaBodyParsers extends WithApplication {
         for (int i = 0; i < 1100; i++) {
             body.append("1234567890");
         }
+        FlowMaterializer mat = app.injector().instanceOf(FlowMaterializer.class);
         assertThat(callWithStringBody(new MockJavaAction() {
                     //#max-length
                     // Accept only 10KB of data.
@@ -80,7 +82,7 @@ public class JavaBodyParsers extends WithApplication {
                         return ok("Got body: " + request().body().asText());
                     }
                     //#max-length
-                }, fakeRequest(), body.toString()).status(),
+                }, fakeRequest(), body.toString(), mat).status(),
                 equalTo(413));
     }
 

--- a/documentation/manual/working/scalaGuide/advanced/http/code/FiltersRouting.scala
+++ b/documentation/manual/working/scalaGuide/advanced/http/code/FiltersRouting.scala
@@ -1,12 +1,15 @@
 package scalaguide.advanced.filters.routing
 
 // #routing-info-access
+import javax.inject.Inject
+import akka.stream.FlowMaterializer
 import play.api.mvc.{Result, RequestHeader, Filter}
-import play.api.{Logger, Routes}
+import play.api.Logger
+import play.api.routing.Router.Tags
 import scala.concurrent.Future
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-object LoggingFilter extends Filter {
+class LoggingFilter @Inject() (implicit val mat: FlowMaterializer) extends Filter {
   def apply(nextFilter: RequestHeader => Future[Result])
            (requestHeader: RequestHeader): Future[Result] = {
 
@@ -14,8 +17,8 @@ object LoggingFilter extends Filter {
 
     nextFilter(requestHeader).map { result =>
 
-      val action = requestHeader.tags(Routes.ROUTE_CONTROLLER) +
-        "." + requestHeader.tags(Routes.ROUTE_ACTION_METHOD)
+      val action = requestHeader.tags(Tags.RouteController) +
+        "." + requestHeader.tags(Tags.RouteActionMethod)
       val endTime = System.currentTimeMillis
       val requestTime = endTime - startTime
 

--- a/documentation/manual/working/scalaGuide/advanced/http/code/ScalaHttpFilters.scala
+++ b/documentation/manual/working/scalaGuide/advanced/http/code/ScalaHttpFilters.scala
@@ -3,12 +3,14 @@ package scalaguide.advanced.filters
 package simple {
 
 // #simple-filter
+import javax.inject.Inject
+import akka.stream.FlowMaterializer
 import play.api.Logger
 import play.api.mvc._
 import scala.concurrent.Future
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-class LoggingFilter extends Filter {
+class LoggingFilter @Inject() (implicit val mat: FlowMaterializer) extends Filter {
 
   def apply(nextFilter: RequestHeader => Future[Result])
            (requestHeader: RequestHeader): Future[Result] = {

--- a/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
+++ b/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
@@ -4,6 +4,7 @@
  */
 package scalaguide.cache {
 
+import akka.stream.ActorFlowMaterializer
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 
@@ -86,8 +87,9 @@ class ScalaCacheSpec extends PlaySpecification with Controller {
     "cached page" in {
       val app = FakeApplication()
       running(app) {
+        implicit val mat = ActorFlowMaterializer()(app.actorSystem)
         val cachedApp = app.injector.instanceOf[cachedaction.Application1]
-        val result = cachedApp.index(FakeRequest()).run
+        val result = cachedApp.index(FakeRequest()).run()
         status(result) must_== 200
       }
     }
@@ -103,10 +105,11 @@ class ScalaCacheSpec extends PlaySpecification with Controller {
     "control cache" in {
       val app = FakeApplication()
       running(app) {
+        implicit val mat = ActorFlowMaterializer()(app.actorSystem)
         val cachedApp = app.injector.instanceOf[cachedaction.Application1]
-        val result0 = cachedApp.get(1)(FakeRequest("GET", "/resource/1")).run
+        val result0 = cachedApp.get(1)(FakeRequest("GET", "/resource/1")).run()
         status(result0) must_== 200
-        val result1 = cachedApp.get(-1)(FakeRequest("GET", "/resource/-1")).run
+        val result1 = cachedApp.get(-1)(FakeRequest("GET", "/resource/-1")).run()
         status(result1) must_== 404
       }
 
@@ -115,10 +118,11 @@ class ScalaCacheSpec extends PlaySpecification with Controller {
     "control cache" in {
       val app = FakeApplication()
       running(app) {
+        implicit val mat = ActorFlowMaterializer()(app.actorSystem)
         val cachedApp = app.injector.instanceOf[cachedaction.Application2]
-        val result0 = cachedApp.get(1)(FakeRequest("GET", "/resource/1")).run
+        val result0 = cachedApp.get(1)(FakeRequest("GET", "/resource/1")).run()
         status(result0) must_== 200
-        val result1 = cachedApp.get(2)(FakeRequest("GET", "/resource/2")).run
+        val result1 = cachedApp.get(2)(FakeRequest("GET", "/resource/2")).run()
         status(result1) must_== 404
       }
     }
@@ -133,8 +137,10 @@ class ScalaCacheSpec extends PlaySpecification with Controller {
   }
 
   def assertAction[A, T: AsResult](action: EssentialAction, request: => Request[A] = FakeRequest(), expectedResponse: Int = OK)(assertions: Future[Result] => T) = {
-    running(FakeApplication()) {
-      val result = action(request).run
+    val app = FakeApplication()
+    running(app) {
+      implicit val mat = ActorFlowMaterializer()(app.actorSystem)
+      val result = action(request).run()
       status(result) must_== expectedResponse
       assertions(result)
     }

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -4,7 +4,8 @@
  */
 package scalaguide.http.scalaactionscomposition {
 
-  import play.api.test._
+import akka.stream.ActorFlowMaterializer
+import play.api.test._
   import play.api.test.Helpers._
   import org.specs2.mutable.Specification
   import org.junit.runner.RunWith
@@ -248,8 +249,10 @@ package scalaguide.http.scalaactionscomposition {
     }
 
     def assertAction[A, T: AsResult](action: EssentialAction, request: => Request[A] = FakeRequest(), expectedResponse: Int = OK)(assertions: Future[Result] => T) = {
-      running(FakeApplication()) {
-        val result = action(request).run
+      val app = FakeApplication()
+      running(app) {
+        implicit val mat = ActorFlowMaterializer()(app.actorSystem)
+        val result = action(request).run()
         status(result) must_== expectedResponse
         assertions(result)
       }

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
@@ -3,6 +3,7 @@
  */
 package scalaguide.http.routing
 
+import akka.stream.ActorFlowMaterializer
 import org.specs2.mutable.Specification
 import play.api.test.FakeRequest
 import play.api.mvc._
@@ -141,8 +142,9 @@ object ScalaRoutingSpec extends Specification {
   def contentOf(rh: RequestHeader, router: Class[_ <: Router] = classOf[Routes]) = {
     val app = FakeApplication()
     running(app) {
+      implicit val mat = ActorFlowMaterializer()(app.actorSystem)
       contentAsString(app.injector.instanceOf(router).routes(rh) match {
-        case e: EssentialAction => e(rh).run
+        case e: EssentialAction => e(rh).run()
       })
     }
   }

--- a/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
@@ -7,8 +7,6 @@ import org.junit.runner.RunWith
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-import play.api.data.validation.ValidationError
-import play.api.LoggerLike
 
 @RunWith(classOf[JUnitRunner])
 class ScalaLoggingSpec extends Specification with Mockito {
@@ -127,13 +125,15 @@ class ScalaLoggingSpec extends Specification with Mockito {
     
     "allow for use in filters" in {
       //#logging-pattern-filter
+      import javax.inject.Inject
+      import akka.stream.FlowMaterializer
       import scala.concurrent.ExecutionContext.Implicits.global
       import scala.concurrent.Future
       import play.api.Logger
       import play.api.mvc._
       import play.api._
       
-      object AccessLoggingFilter extends Filter {
+      class AccessLoggingFilter @Inject() (implicit val mat: FlowMaterializer) extends Filter {
         
         val accessLogger = Logger("access")
         
@@ -149,20 +149,9 @@ class ScalaLoggingSpec extends Specification with Mockito {
           resultFuture
         }
       }
-
-      object Global extends WithFilters(AccessLoggingFilter) {
-        
-        override def onStart(app: Application) {
-          Logger.info("Application has started")
-        }
-
-        override def onStop(app: Application) {
-          Logger.info("Application has stopped")
-        }
-      }
       //#logging-pattern-filter
       
-      AccessLoggingFilter.accessLogger.underlyingLogger.getName must equalTo("access")
+      ok
     }
     
   }

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleEssentialActionSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleEssentialActionSpec.scala
@@ -12,7 +12,7 @@ import play.api.libs.json.Json
 object ExampleEssentialActionSpec extends PlaySpecification {
 
   "An essential action" should {
-    "can parse a JSON body" in {
+    "can parse a JSON body" in new WithApplication() {
       val action: EssentialAction = Action { request =>
         val value = (request.body.asJson.get \ "field").as[String]
         Ok(value)

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ScalaFunctionalTestSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ScalaFunctionalTestSpec.scala
@@ -28,7 +28,7 @@ class ScalaFunctionalTestSpec extends PlaySpecification with Results {
   "Scala Functional Test" should {
 
     // #scalafunctionaltest-fakeApplication
-    val fakeApplicationWithGlobal = FakeApplication(withGlobal = Some(new GlobalSettings() {
+    def fakeApplicationWithGlobal = FakeApplication(withGlobal = Some(new GlobalSettings() {
       override def onStart(app: Application) { println("Hello world!") }
     }))
     // #scalafunctionaltest-fakeApplication
@@ -60,7 +60,7 @@ class ScalaFunctionalTestSpec extends PlaySpecification with Results {
     // #scalafunctionaltest-testview
 
     // #scalafunctionaltest-testmodel
-    val appWithMemoryDatabase = FakeApplication(additionalConfiguration = inMemoryDatabase("test"))
+    def appWithMemoryDatabase = FakeApplication(additionalConfiguration = inMemoryDatabase("test"))
     "run an application" in new WithApplication(appWithMemoryDatabase) {
 
       val Some(macintosh) = Computer.findById(21)
@@ -71,7 +71,7 @@ class ScalaFunctionalTestSpec extends PlaySpecification with Results {
     // #scalafunctionaltest-testmodel
 
     // #scalafunctionaltest-testwithbrowser
-    val fakeApplicationWithBrowser = FakeApplication(withRoutes = {
+    def fakeApplicationWithBrowser = FakeApplication(withRoutes = {
       case ("GET", "/") =>
         Action {
           Ok(
@@ -126,7 +126,7 @@ class ScalaFunctionalTestSpec extends PlaySpecification with Results {
     // #scalafunctionaltest-testpaymentgateway
 
     // #scalafunctionaltest-testws
-    val appWithRoutes = FakeApplication(withRoutes = {
+    def appWithRoutes = FakeApplication(withRoutes = {
       case ("GET", "/") =>
         Action {
           Ok("ok")

--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -210,7 +210,7 @@ object PlayBuild extends Build {
   lazy val IterateesProject = PlayCrossBuiltProject("Play-Iteratees", "iteratees")
     .settings(libraryDependencies ++= iterateesDependencies)
 
-  lazy val StreamsProject = PlayCrossBuiltProject("Play-Streams-Experimental", "play-streams")
+  lazy val StreamsProject = PlayCrossBuiltProject("Play-Streams", "play-streams")
     .settings(libraryDependencies ++= streamsDependencies)
     .dependsOn(IterateesProject)
 
@@ -259,7 +259,9 @@ object PlayBuild extends Build {
       BuildLinkProject,
       IterateesProject % "test->test;compile->compile",
       JsonProject,
-      PlayNettyUtilsProject)
+      PlayNettyUtilsProject,
+      StreamsProject
+    )
 
   lazy val PlayServerProject = PlayCrossBuiltProject("Play-Server", "play-server")
     .settings(libraryDependencies ++= playServerDependencies)

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -142,7 +142,7 @@ object Dependencies {
   val nettyUtilsDependencies = slf4j
 
   val akkaHttp = Seq(
-    "com.typesafe.akka" %% "akka-http-core-experimental" % "1.0-RC2"
+    "com.typesafe.akka" %% "akka-http-core-experimental" % "1.0-RC3"
   )
 
   val routesCompilerDependencies =  Seq(
@@ -238,7 +238,8 @@ object Dependencies {
   ) ++ specsBuild.map(_ % Test)
 
   val streamsDependencies = Seq(
-    "org.reactivestreams" % "reactive-streams" % "1.0.0"
+    "org.reactivestreams" % "reactive-streams" % "1.0.0",
+    "com.typesafe.akka" %% "akka-stream-experimental" % "1.0-RC3"
   ) ++ specsBuild.map(_ % "test")
 
   def jsonDependencies(scalaVersion: String) = Seq(

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/MaterialiseOnDemandPublisher.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/MaterialiseOnDemandPublisher.scala
@@ -1,0 +1,96 @@
+package play.core.server.akkahttp
+
+import akka.stream.FlowMaterializer
+import akka.stream.scaladsl.{ Sink, Source }
+import org.reactivestreams.{ Subscriber, Publisher, Subscription }
+import play.api.libs.concurrent.StateMachine
+
+private[akkahttp] object MaterialiseOnDemandPublisher {
+  sealed trait State
+
+  /**
+   * The publisher is waiting for demand from the subscriber.
+   */
+  case object AwaitingDemand extends State
+
+  /**
+   * The publisher is caching demand from the subscriber.
+   *
+   * At this point, the source has been materialised with a forwarding subscriber, but it has not
+   * yet invoked the onSubscribe method on that subscriber.
+   */
+  case class CachingDemand(demand: Long) extends State
+
+  /**
+   * The subscriber has cancelled.
+   */
+  case object Cancelled extends State
+
+  /**
+   * Demand is being forwarded through the subscription obtained by the forwarding subscriber.
+   */
+  case class ForwardingDemand(subscription: Subscription) extends State
+}
+
+import MaterialiseOnDemandPublisher._
+
+/**
+ * A publisher that only materialises a flow to the given source when its subscriber signals demand.
+ *
+ * If the subscriber never signals demand (ie, it just cancels), the source will never be materialised.
+ *
+ * This is used to work around https://github.com/akka/akka/issues/17782.
+ */
+private[akkahttp] class MaterialiseOnDemandPublisher[T](source: Source[T, _])(implicit mat: FlowMaterializer) extends StateMachine[State](AwaitingDemand) with Publisher[T] {
+
+  def subscribe(subscriber: Subscriber[_ >: T]) = {
+    subscriber.onSubscribe(new ForwardingSubscription(subscriber))
+  }
+
+  class ForwardingSubscription(subscriber: Subscriber[_ >: T]) extends Subscription {
+    def cancel() = exclusive {
+      case ForwardingDemand(subscription) =>
+        state = Cancelled
+        subscription.cancel()
+      case _ =>
+        // If we're still awaiting demand, we go cancelled, and the source is never materialised.
+        // If we're already cancelled, we stay cancelled.
+        // If we're caching demand, we short circuit that, and just cancel.
+        state = Cancelled
+    }
+
+    def request(n: Long) = exclusive {
+      case AwaitingDemand =>
+        state = CachingDemand(n)
+        source.runWith(Sink(new ForwardingSubscriber(subscriber)))
+      case CachingDemand(demand) =>
+        state = CachingDemand(n + demand)
+      case Cancelled =>
+      // nop, as required by the spec
+      case ForwardingDemand(subscription) =>
+        subscription.request(n)
+    }
+  }
+
+  class ForwardingSubscriber[S >: T](subscriber: Subscriber[S]) extends Subscriber[S] {
+
+    def onSubscribe(subscription: Subscription) = exclusive {
+      case CachingDemand(demand) =>
+        state = ForwardingDemand(subscription)
+        subscription.request(demand)
+      case Cancelled =>
+        state = ForwardingDemand(subscription)
+        subscription.cancel()
+      case ForwardingDemand(_) =>
+        throw new IllegalStateException("Subscribe invoked twice")
+      case AwaitingDemand =>
+        throw new IllegalStateException("Impossible state: awaiting demand when a forwarding subscriber has already been created")
+    }
+
+    def onError(t: Throwable) = subscriber.onError(t)
+
+    def onComplete() = subscriber.onComplete()
+
+    def onNext(s: S) = subscriber.onNext(s)
+  }
+}

--- a/framework/src/play-cache/src/test/scala/play/api/cache/CachedSpec.scala
+++ b/framework/src/play-cache/src/test/scala/play/api/cache/CachedSpec.scala
@@ -22,10 +22,10 @@ class CachedSpec extends PlaySpecification {
   "the cached action" should {
     "cache values using injected CachedApi" in new WithApplication() {
       val controller = app.injector.instanceOf[CachedController]
-      val result1 = controller.action(FakeRequest()).run
+      val result1 = controller.action(FakeRequest()).run()
       contentAsString(result1) must_== "1"
       controller.invoked.get() must_== 1
-      val result2 = controller.action(FakeRequest()).run
+      val result2 = controller.action(FakeRequest()).run()
       contentAsString(result2) must_== "1"
       controller.invoked.get() must_== 1
 
@@ -38,10 +38,10 @@ class CachedSpec extends PlaySpecification {
       additionalConfiguration = Map("play.cache.bindCaches" -> Seq("custom"))
     )) {
       val controller = app.injector.instanceOf[NamedCachedController]
-      val result1 = controller.action(FakeRequest()).run
+      val result1 = controller.action(FakeRequest()).run()
       contentAsString(result1) must_== "1"
       controller.invoked.get() must_== 1
-      val result2 = controller.action(FakeRequest()).run
+      val result2 = controller.action(FakeRequest()).run()
       contentAsString(result2) must_== "1"
       controller.invoked.get() must_== 1
 
@@ -75,10 +75,10 @@ class CachedSpec extends PlaySpecification {
       val diskCached = new Cached(diskCache)
       val invoked = new AtomicInteger()
       val action = diskCached(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
-      val result1 = action(FakeRequest()).run
+      val result1 = action(FakeRequest()).run()
       contentAsString(result1) must_== "1"
       invoked.get() must_== 1
-      val result2 = action(FakeRequest()).run
+      val result2 = action(FakeRequest()).run()
       contentAsString(result2) must_== "1"
 
       // Test that the same headers are added
@@ -91,10 +91,10 @@ class CachedSpec extends PlaySpecification {
     "cache values using Application's Cached" in new WithApplication() {
       val invoked = new AtomicInteger()
       val action = Cached(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
-      val result1 = action(FakeRequest()).run
+      val result1 = action(FakeRequest()).run()
       contentAsString(result1) must_== "1"
       invoked.get() must_== 1
-      val result2 = action(FakeRequest()).run
+      val result2 = action(FakeRequest()).run()
       contentAsString(result2) must_== "1"
 
       // Test that the same headers are added
@@ -107,12 +107,12 @@ class CachedSpec extends PlaySpecification {
     "use etags for values" in new WithApplication() {
       val invoked = new AtomicInteger()
       val action = Cached(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
-      val result1 = action(FakeRequest()).run
+      val result1 = action(FakeRequest()).run()
       status(result1) must_== 200
       invoked.get() must_== 1
       val etag = header(ETAG, result1)
       etag must beSome(matching("""([wW]/)?"([^"]|\\")*"""")) //"""
-      val result2 = action(FakeRequest().withHeaders(IF_NONE_MATCH -> etag.get)).run
+      val result2 = action(FakeRequest().withHeaders(IF_NONE_MATCH -> etag.get)).run()
       status(result2) must_== NOT_MODIFIED
       invoked.get() must_== 1
     }
@@ -120,17 +120,17 @@ class CachedSpec extends PlaySpecification {
     "support wildcard etags" in new WithApplication() {
       val invoked = new AtomicInteger()
       val action = Cached(_ => "foo")(Action(Results.Ok("" + invoked.incrementAndGet())))
-      val result1 = action(FakeRequest()).run
+      val result1 = action(FakeRequest()).run()
       status(result1) must_== 200
       invoked.get() must_== 1
-      val result2 = action(FakeRequest().withHeaders(IF_NONE_MATCH -> "*")).run
+      val result2 = action(FakeRequest().withHeaders(IF_NONE_MATCH -> "*")).run()
       status(result2) must_== NOT_MODIFIED
       invoked.get() must_== 1
     }
 
     "work with etag cache misses" in new WithApplication() {
       val action = Cached(_.uri)(Action(Results.Ok))
-      val resultA = action(FakeRequest("GET", "/a")).run
+      val resultA = action(FakeRequest("GET", "/a")).run()
       status(resultA) must_== 200
       status(action(FakeRequest("GET", "/a").withHeaders(IF_NONE_MATCH -> "foo")).run) must_== 200
       status(action(FakeRequest("GET", "/b").withHeaders(IF_NONE_MATCH -> header(ETAG, resultA).get)).run) must_== 200
@@ -157,15 +157,15 @@ class CachedSpec extends PlaySpecification {
       val actionOk = cacheOk.build(dummyAction)
       val actionNotFound = cacheOk.build(notFoundAction)
 
-      val res0 = contentAsString(actionOk(FakeRequest("GET", "/a")).run)
-      val res1 = contentAsString(actionOk(FakeRequest("GET", "/a")).run)
+      val res0 = contentAsString(actionOk(FakeRequest("GET", "/a")).run())
+      val res1 = contentAsString(actionOk(FakeRequest("GET", "/a")).run())
 
       // println(("res0", header(EXPIRES, actionOk(FakeRequest("GET", "/a")).run)))
 
       res0 must equalTo(res1)
 
-      val res2 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run)
-      val res3 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run)
+      val res2 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run())
+      val res3 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run())
 
       res2 must not equalTo (res3)
     }
@@ -178,13 +178,13 @@ class CachedSpec extends PlaySpecification {
       val actionOk = cache.build(dummyAction)
       val actionNotFound = cache.build(notFoundAction)
 
-      val res0 = contentAsString(actionOk(FakeRequest("GET", "/a")).run)
+      val res0 = contentAsString(actionOk(FakeRequest("GET", "/a")).run())
       val res1 = contentAsString(actionOk(FakeRequest("GET", "/a")).run)
 
       res0 must equalTo(res1)
 
-      val res2 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run)
-      val res3 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run)
+      val res2 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run())
+      val res3 = contentAsString(actionNotFound(FakeRequest("GET", "/b")).run())
 
       res2 must equalTo(res3)
     }
@@ -195,8 +195,8 @@ class CachedSpec extends PlaySpecification {
       val actionOk = cache.build(dummyAction)
       val actionNotFound = cache.build(notFoundAction)
 
-      val res0 = header(EXPIRES, actionOk(FakeRequest("GET", "/a")).run)
-      val res1 = header(EXPIRES, actionNotFound(FakeRequest("GET", "/b")).run)
+      val res0 = header(EXPIRES, actionOk(FakeRequest("GET", "/a")).run())
+      val res1 = header(EXPIRES, actionNotFound(FakeRequest("GET", "/b")).run())
 
       def toDuration(header: String) = {
         val now = DateTime.now().getMillis

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
@@ -3,6 +3,7 @@
  */
 package play.filters.cors
 
+import akka.stream.FlowMaterializer
 import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
 
 import scala.concurrent.Future
@@ -34,7 +35,7 @@ import play.api.mvc.{ Filter, RequestHeader, Result }
 class CORSFilter(
     override protected val corsConfig: CORSConfig = CORSConfig(),
     override protected val errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
-    private val pathPrefixes: Seq[String] = Seq("/")) extends Filter with AbstractCORSPolicy {
+    private val pathPrefixes: Seq[String] = Seq("/"))(override implicit val mat: FlowMaterializer) extends Filter with AbstractCORSPolicy {
 
   override protected val logger = Logger(classOf[CORSFilter])
 
@@ -50,7 +51,7 @@ class CORSFilter(
 object CORSFilter {
 
   def apply(corsConfig: CORSConfig = CORSConfig(), errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
-    pathPrefixes: Seq[String] = Seq("/")) =
+    pathPrefixes: Seq[String] = Seq("/"))(implicit mat: FlowMaterializer) =
     new CORSFilter(corsConfig, errorHandler, pathPrefixes)
 
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
@@ -5,6 +5,7 @@ package play.filters.cors
 
 import javax.inject.{ Inject, Provider }
 
+import akka.stream.FlowMaterializer
 import play.api.http.HttpErrorHandler
 import play.api.{ Environment, PlayConfig, Configuration }
 import play.api.inject.Module
@@ -19,10 +20,11 @@ class CORSConfigProvider @Inject() (configuration: Configuration) extends Provid
 /**
  * Provider for CORSFilter.
  */
-class CORSFilterProvider @Inject() (configuration: Configuration, errorHandler: HttpErrorHandler, corsConfig: CORSConfig) extends Provider[CORSFilter] {
+class CORSFilterProvider @Inject() (configuration: Configuration, errorHandler: HttpErrorHandler, corsConfig: CORSConfig,
+    flowMaterializer: FlowMaterializer) extends Provider[CORSFilter] {
   lazy val get = {
     val pathPrefixes = PlayConfig(configuration).get[Seq[String]]("play.filters.cors.pathPrefixes")
-    new CORSFilter(corsConfig, errorHandler, pathPrefixes)
+    new CORSFilter(corsConfig, errorHandler, pathPrefixes)(flowMaterializer)
   }
 }
 
@@ -42,6 +44,7 @@ class CORSModule extends Module {
 trait CORSComponents {
   def configuration: Configuration
   def httpErrorHandler: HttpErrorHandler
+  implicit def flowMaterializer: FlowMaterializer
 
   lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(configuration)
   lazy val corsFilter: CORSFilter = new CORSFilter(corsConfig, httpErrorHandler, corsPathPrefixes)

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -3,6 +3,8 @@
  */
 package play.filters.csrf
 
+import akka.stream.FlowMaterializer
+import play.api.libs.streams.{ Streams, Accumulator }
 import play.api.mvc._
 import play.api.http.HeaderNames._
 import play.filters.csrf.CSRF._
@@ -21,14 +23,17 @@ import scala.concurrent.Future
 class CSRFAction(next: EssentialAction,
     config: CSRFConfig = CSRFConfig(),
     tokenProvider: TokenProvider = SignedTokenProvider,
-    errorHandler: => ErrorHandler = CSRF.DefaultErrorHandler) extends EssentialAction {
+    errorHandler: => ErrorHandler = CSRF.DefaultErrorHandler)(implicit mat: FlowMaterializer) extends EssentialAction {
 
   import CSRFAction._
   import play.api.libs.iteratee.Execution.Implicits.trampoline
 
   // An iteratee that returns a forbidden result saying the CSRF check failed
-  private def checkFailed(req: RequestHeader, msg: String): Iteratee[Array[Byte], Result] =
-    Iteratee.flatten(clearTokenIfInvalid(req, config, errorHandler, msg) map (Done(_)))
+  private def checkFailedIteratee(req: RequestHeader, msg: String): Iteratee[Array[Byte], Result] =
+    Iteratee.flatten(clearTokenIfInvalid(req, config, errorHandler, msg).map(r => Done(r)))
+
+  private def checkFailed(req: RequestHeader, msg: String): Accumulator[Array[Byte], Result] =
+    Accumulator.done(clearTokenIfInvalid(req, config, errorHandler, msg))
 
   def apply(request: RequestHeader) = {
 
@@ -60,8 +65,12 @@ class CSRFAction(next: EssentialAction,
 
             // Check the body
             request.contentType match {
-              case Some("application/x-www-form-urlencoded") => checkFormBody(request, headerToken, config.tokenName, next)
-              case Some("multipart/form-data") => checkMultipartBody(request, headerToken, config.tokenName, next)
+              case Some("application/x-www-form-urlencoded") => Streams.iterateeToAccumulator(
+                checkFormBody(request, headerToken, config.tokenName, next)
+              )
+              case Some("multipart/form-data") => Streams.iterateeToAccumulator(
+                checkMultipartBody(request, headerToken, config.tokenName, next)
+              )
               // No way to extract token from other content types
               case Some(content) =>
                 filterLogger.trace(s"[CSRF] Check failed because $content request")
@@ -109,7 +118,7 @@ class CSRFAction(next: EssentialAction,
 
     firstPartOfBody.flatMap { bytes: Array[Byte] =>
       // Parse the first 100kb
-      val parsedBody = Enumerator(bytes) |>>> parser(request)
+      val parsedBody = Enumerator(bytes) |>>> Streams.accumulatorToIteratee(parser(request))
 
       Iteratee.flatten(parsedBody.map { parseResult =>
         val validToken = parseResult.fold(
@@ -125,10 +134,10 @@ class CSRFAction(next: EssentialAction,
         if (validToken) {
           // Feed the buffered bytes into the next request, and return the iteratee
           filterLogger.trace("[CSRF] Valid token found in body")
-          Iteratee.flatten(Enumerator(bytes) |>> next(request))
+          Iteratee.flatten(Enumerator(bytes) |>> Streams.accumulatorToIteratee(next(request)))
         } else {
           filterLogger.trace("[CSRF] Check failed because no or invalid token found in body")
-          checkFailed(request, "Invalid CSRF token found in form body")
+          checkFailedIteratee(request, "Invalid CSRF token found in form body")
         }
       })
     }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -5,6 +5,7 @@ package play.filters.csrf
 
 import java.util.Optional
 
+import akka.stream.FlowMaterializer
 import com.typesafe.config.ConfigMemorySize
 import play.filters.csrf.CSRF.{ CSRFHttpErrorHandler, ErrorHandler }
 import play.mvc.Http
@@ -235,6 +236,7 @@ class CSRFModule extends Module {
 trait CSRFComponents {
   def configuration: Configuration
   def httpErrorHandler: HttpErrorHandler
+  implicit def flowMaterializer: FlowMaterializer
 
   lazy val csrfConfig: CSRFConfig = CSRFConfig.fromConfiguration(configuration)
   lazy val csrfTokenProvider: CSRF.TokenProvider = new CSRF.TokenProviderProvider(csrfConfig).get

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -51,7 +51,7 @@ class GzipFilter @Inject() (config: GzipFilterConfig) extends EssentialFilter {
   def apply(next: EssentialAction) = new EssentialAction {
     def apply(request: RequestHeader) = {
       if (mayCompress(request)) {
-        next(request).mapM(result => handleResult(request, result))
+        next(request).mapFuture(result => handleResult(request, result))
       } else {
         next(request)
       }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -2,9 +2,11 @@ package play.filters.hosts
 
 import javax.inject.{ Inject, Provider, Singleton }
 
+import akka.stream.scaladsl.Sink
 import play.api.http.{ HttpErrorHandler, Status }
 import play.api.inject.Module
 import play.api.libs.iteratee.Iteratee
+import play.api.libs.streams.Accumulator
 import play.api.mvc.{ EssentialAction, EssentialFilter }
 import play.api.{ Configuration, Environment, PlayConfig }
 
@@ -20,10 +22,7 @@ case class AllowedHostsFilter @Inject() (config: AllowedHostsConfig, errorHandle
     if (hostMatchers.exists(_(req.host))) {
       next(req)
     } else {
-      import play.api.libs.iteratee.Execution.Implicits.trampoline
-      Iteratee.ignore[Array[Byte]].mapM { _ =>
-        errorHandler.onClientError(req, Status.BAD_REQUEST, s"Host not allowed: ${req.host}")
-      }
+      Accumulator.done(errorHandler.onClientError(req, Status.BAD_REQUEST, s"Host not allowed: ${req.host}"))
     }
   }
 }

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
@@ -46,12 +46,12 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
 
   "security headers" should {
 
-    "work with default singleton apply method with all default options" in new WithApplication {
+    "work with default singleton apply method with all default options" in new WithApplication() {
       val filter = SecurityHeadersFilter()
       // Play.current is set at this point...
       val rh = FakeRequest()
       val action = Action(Ok("success"))
-      val result = filter(action)(rh).run
+      val result = filter(action)(rh).run()
 
       header(X_FRAME_OPTIONS_HEADER, result) must beSome("DENY")
       header(X_XSS_PROTECTION_HEADER, result) must beSome("1; mode=block")
@@ -60,11 +60,11 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
       header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src 'self'")
     }
 
-    "work with singleton apply method using configuration" in {
+    "work with singleton apply method using configuration" in new WithApplication() {
       val filter = SecurityHeadersFilter(Configuration.reference)
       val rh = FakeRequest()
       val action = Action(Ok("success"))
-      val result = filter(action)(rh).run
+      val result = filter(action)(rh).run()
 
       header(X_FRAME_OPTIONS_HEADER, result) must beSome("DENY")
       header(X_XSS_PROTECTION_HEADER, result) must beSome("1; mode=block")

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/EssentialActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/EssentialActionSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.it.action
 
-import play.api.libs.json.Json
+import akka.stream.ActorFlowMaterializer
 import play.api.mvc.{ Action, EssentialAction }
 import play.api.mvc.Results._
 import play.api.test.{ FakeApplication, PlaySpecification, FakeRequest }
@@ -12,20 +12,6 @@ import scala.concurrent.Promise
 object EssentialActionSpec extends PlaySpecification {
 
   "an EssentialAction" should {
-    "be tested without any started FakeApplication" in {
-
-      val action: EssentialAction = Action { request =>
-        val value = (request.body.asJson.get \ "field").as[String]
-        Ok(value)
-      }
-
-      val request = FakeRequest(POST, "/").withJsonBody(Json.parse("""{ "field": "value" }"""))
-
-      val result = call(action, request)
-
-      status(result) mustEqual OK
-      contentAsString(result) mustEqual "value"
-    }
 
     "use the classloader of the running application" in {
 
@@ -38,6 +24,7 @@ object EssentialActionSpec extends PlaySpecification {
       // start fake application with its own classloader
       val applicationClassLoader = new ClassLoader() {}
       val fakeApplication = FakeApplication(classloader = applicationClassLoader)
+      implicit val mat = ActorFlowMaterializer()(fakeApplication.actorSystem)
 
       running(fakeApplication) {
         // run the test with the classloader of the current thread

--- a/framework/src/play-integration-test/src/test/scala/play/it/bindings/GlobalSettingsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/bindings/GlobalSettingsSpec.scala
@@ -64,11 +64,11 @@ trait GlobalSettingsSpec extends PlaySpecification with WsTestClient with Server
 }
 
 /** Inserts an X-Foo header with a custom value. */
-class FooFilter(headerValue: String) extends Filter {
+class FooFilter(headerValue: String) extends EssentialFilter {
   def this() = this("filter-default-constructor")
-  override def apply(f: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] = {
-    val fooBarHeaders = rh.copy(headers = rh.headers.add("X-Foo" -> headerValue))
-    f(fooBarHeaders)
+  def apply(next: EssentialAction) = EssentialAction { request =>
+    val fooBarHeaders = request.copy(headers = request.headers.add("X-Foo" -> headerValue))
+    next(fooBarHeaders)
   }
 
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/Expect100ContinueSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/Expect100ContinueSpec.scala
@@ -3,10 +3,10 @@
  */
 package play.it.http
 
+import play.api.libs.streams.Accumulator
 import play.it._
 import play.api.mvc._
 import play.api.test._
-import play.api.test.TestServer
 import play.api.libs.iteratee._
 
 object NettyExpect100ContinueSpec extends Expect100ContinueSpec with NettyIntegrationSpecification
@@ -37,7 +37,7 @@ trait Expect100ContinueSpec extends PlaySpecification with ServerIntegrationSpec
     }
 
     "not read body when expecting 100 continue but action iteratee is done" in withServer(
-      EssentialAction(_ => Done(Results.Ok))
+      EssentialAction(_ => Accumulator.done(Results.Ok))
     ) { port =>
         val responses = BasicHttpClient.makeRequests(port)(
           BasicRequest("POST", "/", "HTTP/1.1", Map("Expect" -> "100-continue", "Content-Length" -> "100000"), "foo")
@@ -54,7 +54,7 @@ trait Expect100ContinueSpec extends PlaySpecification with ServerIntegrationSpec
     //
     // See https://issues.jboss.org/browse/NETTY-390 for more details.
     "close the connection after rejecting a Expect: 100-continue body" in withServer(
-      EssentialAction(_ => Done(Results.Ok))
+      EssentialAction(_ => Accumulator.done(Results.Ok))
     ) { port =>
         val responses = BasicHttpClient.makeRequests(port, checkClosed = true)(
           BasicRequest("POST", "/", "HTTP/1.1", Map("Expect" -> "100-continue", "Content-Length" -> "100000"), "foo")

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
@@ -3,12 +3,15 @@
  */
 package play.it.http
 
+import akka.stream.scaladsl.Sink
+import play.api.libs.streams.{ Streams, Accumulator }
 import play.api.mvc._
 import play.api.test._
 import play.api.test.TestServer
 import play.api.libs.iteratee._
 import play.it._
 import scala.concurrent.ExecutionContext.Implicits._
+import scala.concurrent.Future
 import scala.util.Random
 
 object NettyRequestBodyHandlingSpec extends RequestBodyHandlingSpec with NettyIntegrationSpecification
@@ -30,7 +33,7 @@ trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSp
     }
 
     "handle large bodies" in withServer(EssentialAction { rh =>
-      Iteratee.ignore[Array[Byte]].map(_ => Results.Ok)
+      Accumulator(Sink.ignore.mapMaterializedValue(_ => Future.successful(Results.Ok)))
     }) { port =>
       val body = new String(Random.alphanumeric.take(50 * 1024).toArray)
       val responses = BasicHttpClient.makeRequests(port, trickleFeed = Some(100L))(
@@ -44,7 +47,9 @@ trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSp
     }
 
     "gracefully handle early body parser termination" in withServer(EssentialAction { rh =>
-      Traversable.takeUpTo[Array[Byte]](20 * 1024) &>> Iteratee.ignore[Array[Byte]].map(_ => Results.Ok)
+      Streams.iterateeToAccumulator(
+        Traversable.takeUpTo[Array[Byte]](20 * 1024) &>> Iteratee.ignore[Array[Byte]].map(_ => Results.Ok)
+      )
     }) { port =>
       val body = new String(Random.alphanumeric.take(50 * 1024).toArray)
       // Trickle feed is important, otherwise it won't switch to ignoring the body.

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/AnyContentBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/AnyContentBodyParserSpec.scala
@@ -3,18 +3,18 @@
  */
 package play.it.http.parsing
 
+import akka.stream.FlowMaterializer
+import akka.stream.scaladsl.Source
 import play.api.mvc._
-import play.api.libs.iteratee.Enumerator
-import play.api.libs.json.{ Json, JsError }
 import play.api.test._
 
 object AnyContentBodyParserSpec extends PlaySpecification {
 
   "The anyContent body parser" should {
 
-    def parse(method: String, contentType: Option[String], body: Array[Byte]) = {
+    def parse(method: String, contentType: Option[String], body: Array[Byte])(implicit mat: FlowMaterializer) = {
       val request = FakeRequest(method, "/x").withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*)
-      await(Enumerator(body) |>>> BodyParsers.parse.anyContent(request))
+      await(BodyParsers.parse.anyContent(request).run(Source.single(body)))
     }
 
     "parse text bodies for DELETE requests" in new WithApplication() {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
@@ -3,17 +3,18 @@
  */
 package play.it.http.parsing
 
+import akka.stream.FlowMaterializer
+import akka.stream.scaladsl.Source
 import play.api.mvc._
-import play.api.libs.iteratee.Enumerator
 import play.api.test._
 
 object DefaultBodyParserSpec extends PlaySpecification {
 
   "The default body parser" should {
 
-    def parse(method: String, contentType: Option[String], body: Array[Byte]) = {
+    def parse(method: String, contentType: Option[String], body: Array[Byte])(implicit mat: FlowMaterializer) = {
       val request = FakeRequest(method, "/x").withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*)
-      await(Enumerator(body) |>>> BodyParsers.parse.default(request))
+      await(BodyParsers.parse.default(request).run(Source.single(body)))
     }
 
     "ignore text bodies for DELETE requests" in new WithApplication() {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/EmptyBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/EmptyBodyParserSpec.scala
@@ -3,17 +3,20 @@
  */
 package play.it.http.parsing
 
+import akka.stream.FlowMaterializer
+import akka.stream.scaladsl.Source
 import play.api.test._
-import play.api.mvc.{ BodyParser, BodyParsers }
-import play.api.libs.iteratee.Enumerator
+import play.api.mvc.BodyParsers
 
 object EmptyBodyParserSpec extends PlaySpecification {
 
   "The empty body parser" should {
 
-    def parse(bytes: Seq[Byte], contentType: Option[String], encoding: String) = {
-      await(Enumerator(bytes.to[Array]) |>>>
-        BodyParsers.parse.empty(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*)))
+    def parse(bytes: Seq[Byte], contentType: Option[String], encoding: String)(implicit mat: FlowMaterializer) = {
+      await(
+        BodyParsers.parse.empty(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*))
+          .run(Source.single(bytes.toArray))
+      )
     }
 
     "parse empty bodies" in new WithApplication() {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -3,8 +3,8 @@
  */
 package play.it.http.parsing
 
+import akka.stream.scaladsl.Source
 import play.api.libs.Files.TemporaryFile
-import play.api.libs.iteratee.Enumerator
 import play.api.mvc.{ Result, MultipartFormData, BodyParsers }
 import play.api.test._
 import play.core.parsers.Multipart.FileInfoMatcher
@@ -64,7 +64,7 @@ object MultipartFormDataParserSpec extends PlaySpecification {
         CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
       ))
 
-      val result = await(Enumerator(body.getBytes("utf-8")).run(parser))
+      val result = await(parser.run(Source.single(body.getBytes("utf-8"))))
 
       checkResult(result)
     }
@@ -74,7 +74,7 @@ object MultipartFormDataParserSpec extends PlaySpecification {
         CONTENT_TYPE -> "multipart/form-data" // no boundary
       ))
 
-      val result = await(Enumerator(body.getBytes("utf-8")).run(parser))
+      val result = await(parser.run(Source.single(body.getBytes("utf-8"))))
 
       result must beLeft.like {
         case error => error.header.status must_== BAD_REQUEST
@@ -88,7 +88,7 @@ object MultipartFormDataParserSpec extends PlaySpecification {
         CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
       ))
 
-      val result = await(Enumerator(body.getBytes("utf-8")).run(parser))
+      val result = await(parser.run(Source.single(body.getBytes("utf-8"))))
 
       result must beLeft.like {
         case error => error.header.status must_== REQUEST_ENTITY_TOO_LARGE
@@ -102,7 +102,7 @@ object MultipartFormDataParserSpec extends PlaySpecification {
         CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
       ))
 
-      val result = await(Enumerator(body.getBytes("utf-8")).run(parser))
+      val result = await(parser.run(Source.single(body.getBytes("utf-8"))))
 
       result must beLeft.like {
         case error => error.header.status must_== REQUEST_ENTITY_TOO_LARGE
@@ -114,7 +114,7 @@ object MultipartFormDataParserSpec extends PlaySpecification {
         CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
       ))
 
-      val result = await(Enumerator(body.trim.getBytes("utf-8")).run(parser))
+      val result = await(parser.run(Source.single(body.getBytes("utf-8"))))
 
       checkResult(result)
     }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/TextBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/TextBodyParserSpec.scala
@@ -3,17 +3,20 @@
  */
 package play.it.http.parsing
 
+import akka.stream.FlowMaterializer
+import akka.stream.scaladsl.Source
 import play.api.test._
 import play.api.mvc.{ BodyParser, BodyParsers }
-import play.api.libs.iteratee.Enumerator
 
 object TextBodyParserSpec extends PlaySpecification {
 
   "The text body parser" should {
 
-    def parse(text: String, contentType: Option[String], encoding: String, bodyParser: BodyParser[String] = BodyParsers.parse.tolerantText) = {
-      await(Enumerator(text.getBytes(encoding)) |>>>
-        bodyParser(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*)))
+    def parse(text: String, contentType: Option[String], encoding: String, bodyParser: BodyParser[String] = BodyParsers.parse.tolerantText)(implicit mat: FlowMaterializer) = {
+      await(
+        bodyParser(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*))
+          .run(Source.single(text.getBytes(encoding)))
+      )
     }
 
     "parse text bodies" in new WithApplication() {

--- a/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala
+++ b/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala
@@ -3,6 +3,7 @@
  */
 package play.api.test
 
+import akka.stream.ActorFlowMaterializer
 import org.openqa.selenium.WebDriver
 import org.specs2.execute.{ AsResult, Result }
 import org.specs2.mutable.Around
@@ -35,6 +36,7 @@ abstract class WithApplicationLoader(applicationLoader: ApplicationLoader = new 
  */
 abstract class WithApplication(val app: Application = FakeApplication()) extends Around with Scope {
   implicit def implicitApp = app
+  implicit def implicitFlowMaterializer = ActorFlowMaterializer()(app.actorSystem)
   override def around[T: AsResult](t: => T): Result = {
     Helpers.running(app)(AsResult.effectively(t))
   }

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
@@ -1,0 +1,159 @@
+package play.api.libs.streams
+
+import akka.stream.FlowMaterializer
+import akka.stream.scaladsl.{ Source, Keep, Flow, Sink }
+import org.reactivestreams.{ Publisher, Subscription, Subscriber }
+
+import scala.concurrent.{ Promise, ExecutionContext, Future }
+import scala.util.{ Failure, Success }
+
+/**
+ * An accumulator of elements into a future of a result.
+ *
+ * This is essentially a lightweight wrapper around a Sink that gets materialised to a Future, but provides convenient
+ * methods for working directly with that future as well as transforming the input.
+ */
+final class Accumulator[-E, +A](sink: Sink[E, Future[A]]) {
+
+  /**
+   * Map the result of this accumulator to something else.
+   */
+  def map[B](f: A => B)(implicit executor: ExecutionContext): Accumulator[E, B] =
+    new Accumulator(sink.mapMaterializedValue(_.map(f)))
+
+  /**
+   * Map the result of this accumulator to a future of something else.
+   */
+  def mapFuture[B](f: A => Future[B])(implicit executor: ExecutionContext): Accumulator[E, B] =
+    new Accumulator(sink.mapMaterializedValue(_.flatMap(f)))
+
+  /**
+   * Recover from errors encountered by this accumulator.
+   */
+  def recover[B >: A](pf: PartialFunction[Throwable, B])(implicit executor: ExecutionContext): Accumulator[E, B] =
+    new Accumulator(sink.mapMaterializedValue(_.recover(pf)))
+
+  /**
+   * Recover from errors encountered by this accumulator.
+   */
+  def recoverWith[B >: A](pf: PartialFunction[Throwable, Future[B]])(implicit executor: ExecutionContext): Accumulator[E, B] =
+    new Accumulator(sink.mapMaterializedValue(_.recoverWith(pf)))
+
+  /**
+   * Return a new accumulator that first feeds the input through the given flow before it goes through this accumulator.
+   */
+  def through[F](flow: Flow[F, E, _]): Accumulator[F, A] =
+    new Accumulator(flow.toMat(sink)(Keep.right))
+
+  /**
+   * Right associative operator alias for through.
+   *
+   * This can be used for a more fluent DSL that matches the flow of the data, for example:
+   *
+   * {{{
+   *   val intAccumulator: Accumulator[Int, Unit] = ...
+   *   val toInt = Flow[String].map(_.toInt)
+   *   val stringAccumulator = toInt ~>: intAccumulator
+   * }}}
+   */
+  def ~>:[F](flow: Flow[F, E, _]): Accumulator[F, A] = through(flow)
+
+  /**
+   * Run this accumulator by feeding in the given source.
+   */
+  def run(source: Source[E, _])(implicit materializer: FlowMaterializer): Future[A] = {
+    source.toMat(sink)(Keep.right).run()
+  }
+
+  /**
+   * Run this accumulator by feeding a completed source into it.
+   */
+  def run()(implicit materializer: FlowMaterializer): Future[A] = {
+    run(Source.empty)
+  }
+
+  /**
+   * Right associative operator alias for run.
+   *
+   * This can be used for a more fluent DSL that matches the flow of the data, for example:
+   *
+   * {{{
+   *   val intAccumulator: Accumulator[Int, Int] = ...
+   *   val source = Source(1 to 3)
+   *   val intFuture = source ~>: intAccumulator
+   * }}}
+   */
+  def ~>:(source: Source[E, _])(implicit materializer: FlowMaterializer): Future[A] = run(source)
+
+  /**
+   * Convert this accumulator to a Sink that gets materialised to a Future.
+   */
+  def toSink: Sink[E, Future[A]] = sink
+}
+
+object Accumulator {
+
+  /**
+   * Create a new accumulator from the given Sink.
+   */
+  def apply[E, A](sink: Sink[E, Future[A]]): Accumulator[E, A] = new Accumulator(sink)
+
+  /**
+   * Create a done accumulator.
+   *
+   * The underlying sink will cancel as soon as its onSubscribe method is called, and the materialized value will be
+   * an immediately available future of `a`.
+   */
+  def done[A](a: A): Accumulator[Any, A] = new Accumulator(Sink.cancelled[Any].mapMaterializedValue(_ => Future.successful(a)))
+
+  /**
+   * Create a done accumulator.
+   *
+   * The underlying sink will cancel as soon as its onSubscribe method is called, and the materialized value will be
+   * the passed in future.
+   */
+  def done[A](a: Future[A]): Accumulator[Any, A] = new Accumulator(Sink.cancelled[Any].mapMaterializedValue(_ => a))
+
+  /**
+   * Flatten a future of an accumulator to an accumulator.
+   */
+  def flatten[E, A](future: Future[Accumulator[E, A]])(implicit materializer: FlowMaterializer): Accumulator[E, A] = {
+    import play.api.libs.iteratee.Execution.Implicits.trampoline
+
+    // Ideally, we'd use the following code, except due to akka streams bugs...
+    // new Accumulator(Sink.publisher[E].mapMaterializedValue { publisher =>
+    //  future.recover {
+    //    case error => new Accumulator(Sink.cancelled[E].mapMaterializedValue(_ => Future.failed(error)))
+    //  }.flatMap { accumulator =>
+    //    Source(publisher).toMat(accumulator.toSink)(Keep.right).run()
+    //  }
+    //})
+
+    val result = Promise[A]()
+    val sink = Sink(new Subscriber[E] {
+      @volatile var subscriber: Subscriber[_ >: E] = _
+
+      def onSubscribe(sub: Subscription) = future.onComplete {
+        case Success(accumulator) =>
+          Source(new Publisher[E]() {
+            def subscribe(s: Subscriber[_ >: E]) = {
+              subscriber = s
+              s.onSubscribe(sub)
+            }
+          }).runWith(accumulator.toSink.mapMaterializedValue { fA =>
+            result.completeWith(fA)
+          })
+        case Failure(error) =>
+          sub.cancel()
+          result.failure(error)
+      }
+
+      def onError(t: Throwable) = subscriber.onError(t)
+      def onComplete() = subscriber.onComplete()
+      def onNext(t: E) = subscriber.onNext(t)
+    })
+
+    new Accumulator(sink.mapMaterializedValue(_ => result.future))
+  }
+
+}

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/impl/SubscriberIteratee.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/impl/SubscriberIteratee.scala
@@ -1,0 +1,128 @@
+package play.api.libs.streams.impl
+
+import org.reactivestreams.{ Subscription, Subscriber }
+import play.api.libs.concurrent.StateMachine
+import play.api.libs.iteratee._
+
+import scala.concurrent.{ Promise, ExecutionContext, Future }
+
+private[streams] object SubscriberIteratee {
+
+  sealed trait State
+
+  /**
+   * The iteratees fold method has not been called, and so it hasn't
+   * subscribed to the subscriber yet.
+   */
+  case object NotSubscribed extends State
+
+  /**
+   * There is currently no demand, and the iteratee isn't interested in any
+   * demand. The stream is effectively idle.
+   */
+  case object NoDemand extends State
+
+  /**
+   * The iteratee fold method has been invoked, so the iteratee is able to
+   * consume elements, but there is no demand.
+   *
+   * @param demand A callback to be executed when there is demand
+   * @param cancelled A callback to be executed if the subscription is cancelled
+   */
+  case class AwaitingDemand(demand: () => Unit, cancelled: () => Unit) extends State
+
+  /**
+   * There is demand, but the iteratee is no elements to supply.
+   *
+   * @param n The number of elements demanded.
+   */
+  case class Demand(n: Long) extends State
+
+  /**
+   * The subscription has been cancelled, the iteratee is done.
+   */
+  case object Cancelled extends State
+
+}
+
+import SubscriberIteratee._
+
+private[streams] class SubscriberIteratee[T](subscriber: Subscriber[T]) extends StateMachine[State](NotSubscribed)
+    with Subscription with Iteratee[T, Unit] { self =>
+
+  def fold[B](folder: (Step[T, Unit]) => Future[B])(implicit ec: ExecutionContext): Future[B] = {
+    val promise = Promise[B]()
+    val pec = ec.prepare()
+    exclusive {
+      case NotSubscribed =>
+        state = awaitDemand(promise, folder, pec)
+        subscriber.onSubscribe(this)
+      case NoDemand =>
+        state = awaitDemand(promise, folder, pec)
+      case AwaitingDemand(_, _) =>
+        throw new IllegalStateException("fold invoked while already waiting for demand")
+      case Demand(n) =>
+        if (n == 1) {
+          state = NoDemand
+        } else {
+          state = Demand(n - 1)
+        }
+        demand(promise, folder, pec)
+      case Cancelled =>
+        cancelled(promise, folder, pec)
+    }
+
+    promise.future
+  }
+
+  private def awaitDemand[B](promise: Promise[B], folder: (Step[T, Unit]) => Future[B], ec: ExecutionContext): AwaitingDemand = {
+    AwaitingDemand(() => demand(promise, folder, ec), () => cancelled(promise, folder, ec))
+  }
+
+  private def demand[B](promise: Promise[B], folder: (Step[T, Unit]) => Future[B], ec: ExecutionContext): Unit = {
+    Future {
+      promise.completeWith(folder(Step.Cont[T, Unit] {
+        case Input.EOF =>
+          subscriber.onComplete()
+          Done(())
+        case Input.El(t) =>
+          subscriber.onNext(t)
+          self
+        case Input.Empty =>
+          self
+      }))
+    }(ec)
+  }
+
+  private def cancelled[B](promise: Promise[B], folder: (Step[T, Unit]) => Future[B], ec: ExecutionContext): Unit = {
+    Future {
+      promise.completeWith(folder(Step.Done((), Input.Empty)))
+    }(ec)
+  }
+
+  def cancel() = exclusive {
+    case AwaitingDemand(_, cancelled) =>
+      cancelled()
+      state = Cancelled
+    case _ =>
+      state = Cancelled
+  }
+
+  def request(n: Long) = exclusive {
+    case NoDemand =>
+      state = Demand(n)
+    case AwaitingDemand(demand, _) =>
+      demand()
+      if (n == 1) {
+        state = NoDemand
+      } else {
+        state = Demand(n - 1)
+      }
+    case Demand(old) =>
+      state = Demand(old + n)
+    case Cancelled =>
+    // nop, 3.6 of reactive streams spec
+    case NotSubscribed =>
+      throw new IllegalStateException("Demand requested before subscription made")
+  }
+}

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
@@ -1,0 +1,106 @@
+package play.api.libs.streams
+
+import java.lang
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.{ Flow, Source, Sink }
+import akka.stream.{ ActorFlowMaterializer, FlowMaterializer }
+import org.reactivestreams.{ Subscription, Subscriber, Publisher }
+import org.specs2.mutable.Specification
+
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object AccumulatorSpec extends Specification {
+
+  def withMaterializer[T](block: FlowMaterializer => T) = {
+    val system = ActorSystem("test")
+    try {
+      block(ActorFlowMaterializer()(system))
+    } finally {
+      system.shutdown()
+      system.awaitTermination()
+    }
+  }
+
+  def sum = Accumulator(Sink.fold[Int, Int](0)(_ + _))
+  def source = Source(1 to 3)
+  def await[T](f: Future[T]) = Await.result(f, 10.seconds)
+  def error[T](any: Any): T = throw sys.error("error")
+  def errorSource[T] = Source(new Publisher[T] {
+    def subscribe(s: Subscriber[_ >: T]) = {
+      s.onSubscribe(new Subscription {
+        def cancel() = s.onComplete()
+        def request(n: Long) = s.onError(new RuntimeException("error"))
+      })
+    }
+  })
+
+  "an accumulator" should {
+
+    "provide map" in withMaterializer { implicit m =>
+      await(sum.map(_ + 10).run(source)) must_== 16
+    }
+
+    "provide mapFuture" in withMaterializer { implicit m =>
+      await(sum.mapFuture(r => Future(r + 10)).run(source)) must_== 16
+    }
+
+    "be recoverable" in {
+
+      "when the exception is introduced in the materialized value" in withMaterializer { implicit m =>
+        await(sum.map(error[Int]).recover {
+          case e => 20
+        }.run(source)) must_== 20
+      }
+
+      "when the exception comes from the stream" in withMaterializer { implicit m =>
+        await(sum.recover {
+          case e => 20
+        }.run(errorSource)) must_== 20
+      }
+    }
+
+    "be recoverable with a future" in {
+
+      "when the exception is introduced in the materialized value" in withMaterializer { implicit m =>
+        await(sum.map(error[Int]).recoverWith {
+          case e => Future(20)
+        }.run(source)) must_== 20
+      }
+
+      "when the exception comes from the stream" in withMaterializer { implicit m =>
+        await(sum.recoverWith {
+          case e => Future(20)
+        }.run(errorSource)) must_== 20
+      }
+    }
+
+    "be able to be composed with a flow" in withMaterializer { implicit m =>
+      await(sum.through(Flow[Int].map(_ * 2)).run(source)) must_== 12
+    }
+
+    "be able to be composed in a left to right asociate way" in withMaterializer { implicit m =>
+      await(source ~>: Flow[Int].map(_ * 2) ~>: sum) must_== 12
+    }
+
+    "be flattenable from a future of itself" in {
+
+      "for a successful future" in withMaterializer { implicit m =>
+        await(Accumulator.flatten(Future(sum)).run(source)) must_== 6
+      }
+
+      "for a failed future" in withMaterializer { implicit m =>
+        val result = Accumulator.flatten[Int, Int](Future.failed(new RuntimeException("failed"))).run(source)
+        await(result) must throwA[RuntimeException]("failed")
+      }
+
+      "for a failed stream" in withMaterializer { implicit m =>
+        await(Accumulator.flatten(Future(sum)).run(errorSource)) must throwA[RuntimeException]("error")
+      }
+    }
+
+  }
+
+}

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/EventRecorder.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/EventRecorder.scala
@@ -16,13 +16,13 @@ class EventRecorder(
     nextTimeout: FiniteDuration = FiniteDuration(20, SECONDS),
     isEmptyDelay: FiniteDuration = FiniteDuration(200, MILLISECONDS)) {
 
-  private val events = new LinkedBlockingQueue[Any]
+  private val events = new LinkedBlockingQueue[AnyRef]
 
   /** Record an event. */
-  def record(e: Any) = events.add(e)
+  def record(e: AnyRef) = events.add(e)
 
   /** Pull the next event, waiting up to `nextTimeout`. */
-  def next(): Any = {
+  def next(): AnyRef = {
     events.poll(nextTimeout.length, nextTimeout.unit)
   }
 

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/SubscriberEvents.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/SubscriberEvents.scala
@@ -1,0 +1,23 @@
+package play.api.libs.streams.impl
+
+import org.reactivestreams.{ Subscriber, Subscription }
+
+object SubscriberEvents {
+  case object OnComplete
+  case class OnError(t: Throwable)
+  case class OnSubscribe(s: Subscription)
+  case class OnNext(t: Int)
+}
+
+trait SubscriberEvents {
+  self: EventRecorder =>
+
+  import SubscriberEvents._
+
+  object subscriber extends Subscriber[Int] {
+    def onError(t: Throwable) = record(OnError(t))
+    def onSubscribe(s: Subscription) = record(OnSubscribe(s))
+    def onComplete() = record(OnComplete)
+    def onNext(t: Int) = record(OnNext(t))
+  }
+}

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/SubscriberIterateeSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/SubscriberIterateeSpec.scala
@@ -1,0 +1,110 @@
+package play.api.libs.streams.impl
+
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import play.api.libs.iteratee.{ Step, Iteratee, Enumerator }
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent._
+import scala.concurrent.duration._
+
+object SubscriberIterateeSpec extends Specification {
+
+  import SubscriberEvents._
+
+  def await[T](f: Future[T]) = Await.result(f, 5.seconds)
+
+  trait TestEnv extends EventRecorder with SubscriberEvents with Scope {
+    val iteratee = new SubscriberIteratee(subscriber)
+  }
+
+  "a subscriber iteratee" should {
+    "not subscribe until fold is invoked" in new TestEnv {
+      isEmptyAfterDelay() must beTrue
+    }
+
+    "not consume anything from the enumerator while there is no demand" in new TestEnv {
+      iteratee.fold { folder =>
+        // Record if the folder was invoked
+        record(folder)
+        Future.successful(())
+      }
+      next() must beAnInstanceOf[OnSubscribe]
+      isEmptyAfterDelay() must beTrue
+    }
+
+    "not enter cont state until demand is requested" in new TestEnv {
+      val step = iteratee.unflatten
+      next() must beLike {
+        case OnSubscribe(sub) =>
+          isEmptyAfterDelay() must beTrue
+          step.isCompleted must beFalse
+          sub.request(1)
+          await(step) must beAnInstanceOf[Step.Cont[_, _]]
+      }
+    }
+
+    "publish events one at a time in response to demand" in new TestEnv {
+      val result = Enumerator(10, 20, 30) |>>> iteratee
+      next() must beLike {
+        case OnSubscribe(sub) =>
+          isEmptyAfterDelay() must beTrue
+          sub.request(1)
+          next() must_== OnNext(10)
+          isEmptyAfterDelay() must beTrue
+          sub.request(1)
+          next() must_== OnNext(20)
+          isEmptyAfterDelay() must beTrue
+          sub.request(1)
+          next() must_== OnNext(30)
+          isEmptyAfterDelay() must beTrue
+          sub.request(1)
+          next() must_== OnComplete
+      }
+      await(result) must_== ()
+    }
+
+    "publish events in batches in response to demand" in new TestEnv {
+      val result = Enumerator(10, 20, 30) |>>> iteratee
+      next() must beLike {
+        case OnSubscribe(sub) =>
+          isEmptyAfterDelay() must beTrue
+          sub.request(2)
+          next() must_== OnNext(10)
+          next() must_== OnNext(20)
+          isEmptyAfterDelay() must beTrue
+          sub.request(2)
+          next() must_== OnNext(30)
+          next() must_== OnComplete
+      }
+      await(result) must_== ()
+    }
+
+    "publish events all at once in response to demand" in new TestEnv {
+      val result = Enumerator(10, 20, 30) |>>> iteratee
+      next() must beLike {
+        case OnSubscribe(sub) =>
+          isEmptyAfterDelay() must beTrue
+          sub.request(10)
+          next() must_== OnNext(10)
+          next() must_== OnNext(20)
+          next() must_== OnNext(30)
+          next() must_== OnComplete
+      }
+      await(result) must_== ()
+    }
+
+    "become done when the stream is cancelled" in new TestEnv {
+      val result = Enumerator(10, 20, 30) |>>> iteratee.flatMap(_ => Iteratee.getChunks[Int])
+      next() must beLike {
+        case OnSubscribe(sub) =>
+          sub.request(1)
+          next() must_== OnNext(10)
+          sub.cancel()
+          isEmptyAfterDelay() must beTrue
+      }
+      await(result) must_== Seq(20, 30)
+    }
+
+  }
+
+}

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -3,6 +3,9 @@
  */
 package play.api.test
 
+import akka.stream.{ ActorFlowMaterializer, FlowMaterializer }
+import akka.stream.scaladsl.Source
+
 import scala.language.reflectiveCalls
 
 import play.api._
@@ -187,7 +190,7 @@ trait EssentialActionCaller {
    *
    * The body is serialised using the implicit writable, so that the action body parser can deserialise it.
    */
-  def call[T](action: EssentialAction, req: Request[T])(implicit w: Writeable[T]): Future[Result] =
+  def call[T](action: EssentialAction, req: Request[T])(implicit w: Writeable[T], mat: FlowMaterializer): Future[Result] =
     call(action, req, req.body)
 
   /**
@@ -195,15 +198,15 @@ trait EssentialActionCaller {
    *
    * The body is serialised using the implicit writable, so that the action body parser can deserialise it.
    */
-  def call[T](action: EssentialAction, rh: RequestHeader, body: T)(implicit w: Writeable[T]): Future[Result] = {
+  def call[T](action: EssentialAction, rh: RequestHeader, body: T)(implicit w: Writeable[T], mat: FlowMaterializer): Future[Result] = {
     import play.api.http.HeaderNames._
     val newContentType = rh.headers.get(CONTENT_TYPE).fold(w.contentType)(_ => None)
     val rhWithCt = newContentType.map { ct =>
       rh.copy(headers = rh.headers.replace(CONTENT_TYPE -> ct))
     }.getOrElse(rh)
 
-    val requestBody = Enumerator(body) &> w.toEnumeratee
-    requestBody |>>> action(rhWithCt)
+    val requestBody = Source.single(w.transform(body))
+    action(rhWithCt).run(requestBody)
   }
 }
 
@@ -230,6 +233,7 @@ trait RouteInvokers extends EssentialActionCaller {
    */
   def route[T](app: Application, rh: RequestHeader, body: T)(implicit w: Writeable[T]): Option[Future[Result]] = {
     val (taggedRh, handler) = app.requestHandler.handlerForRequest(rh)
+    implicit val mat = ActorFlowMaterializer()(app.actorSystem)
     handler match {
       case a: EssentialAction =>
         Some(call(a, taggedRh, body))

--- a/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -5,8 +5,9 @@ package play.api.http
 
 import javax.inject.{ Provider, Inject }
 
+import akka.stream.FlowMaterializer
 import play.api.inject.{ BindingKey, Binding }
-import play.api.libs.iteratee.Done
+import play.api.libs.streams.Accumulator
 import play.api.{ PlayConfig, Configuration, Environment, GlobalSettings }
 import play.api.http.Status._
 import play.api.mvc._
@@ -67,7 +68,7 @@ object HttpRequestHandler {
  * Implementation of a [HttpRequestHandler] that always returns NotImplemented results
  */
 object NotImplementedHttpRequestHandler extends HttpRequestHandler {
-  def handlerForRequest(request: RequestHeader) = request -> EssentialAction(_ => Done(Results.NotImplemented))
+  def handlerForRequest(request: RequestHeader) = request -> EssentialAction(_ => Accumulator.done(Results.NotImplemented))
 }
 
 /**

--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -5,10 +5,11 @@ package play.api.inject
 
 import akka.actor.ActorSystem
 import javax.inject.{ Singleton, Inject, Provider }
+import akka.stream.FlowMaterializer
 import play.api._
 import play.api.http._
 import play.api.libs.{ CryptoConfig, Crypto, CryptoConfigParser }
-import play.api.libs.concurrent.{ ExecutionContextProvider, ActorSystemProvider }
+import play.api.libs.concurrent.{ FlowMaterializerProvider, ExecutionContextProvider, ActorSystemProvider }
 import play.api.routing.Router
 
 import scala.concurrent.ExecutionContext
@@ -41,6 +42,7 @@ class BuiltinModule extends Module {
 
       bind[Router].toProvider[RoutesProvider],
       bind[ActorSystem].toProvider[ActorSystemProvider],
+      bind[FlowMaterializer].toProvider[FlowMaterializerProvider],
       bind[ExecutionContext].toProvider[ExecutionContextProvider],
       bind[Plugins].toProvider[PluginsProvider],
 

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -5,6 +5,7 @@ package play.api.libs.concurrent
 
 import java.lang.reflect.Method
 
+import akka.stream.{ ActorFlowMaterializer, FlowMaterializer }
 import com.google.inject.util.Types
 import com.google.inject.{ Binder, Key, AbstractModule }
 import com.google.inject.assistedinject.FactoryModuleBuilder
@@ -258,6 +259,14 @@ class ActorSystemProvider @Inject() (environment: Environment, configuration: Co
     system
   }
 
+}
+
+/**
+ * Provider for the default flow materializer
+ */
+@Singleton
+class FlowMaterializerProvider @Inject() (actorSystem: ActorSystem) extends Provider[FlowMaterializer] {
+  lazy val get: FlowMaterializer = ActorFlowMaterializer()(actorSystem)
 }
 
 /**

--- a/framework/src/play/src/main/scala/play/api/mvc/Security.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Security.scala
@@ -4,9 +4,9 @@
 package play.api.mvc
 
 import play.api._
+import play.api.libs.streams.Accumulator
 import play.api.mvc.Results._
 
-import play.api.libs.iteratee._
 import scala.concurrent.Future
 
 /**
@@ -48,7 +48,7 @@ object Security {
       userinfo(request).map { user =>
         action(user)(request)
       }.getOrElse {
-        Done(onUnauthorized(request), Input.Empty)
+        Accumulator.done(onUnauthorized(request))
       }
     }
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaGlobalSettingsAdapter.scala
@@ -4,10 +4,9 @@
 package play.core.j
 
 import play.api._
+import play.api.libs.streams.Accumulator
 import play.api.mvc._
-import java.io.File
 import scala.concurrent.Future
-import play.api.libs.iteratee._
 import scala.util.control.NonFatal
 
 /** Adapter that holds the Java `GlobalSettings` and acts as a Scala `GlobalSettings` for the framework. */
@@ -51,8 +50,7 @@ class JavaGlobalSettingsAdapter(val underlying: play.GlobalSettings) extends Glo
       Filters(super.doFilter(a), underlying.filters.map(_.newInstance: play.api.mvc.EssentialFilter): _*)
     } catch {
       case NonFatal(e) => {
-        import play.api.libs.iteratee.Execution.Implicits.trampoline
-        EssentialAction(req => Iteratee.flatten(onError(req, e).map(result => Done(result, Input.Empty))))
+        EssentialAction(req => Accumulator.done(onError(req, e)))
       }
     }
   }

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -25,7 +25,7 @@ object Multipart {
 
   def multipartParser[A](
     maxDataLength: Int,
-    filePartHandler: PartHandler[FilePart[A]]): BodyParser[MultipartFormData[A]] = BodyParser("multipartFormData") { request =>
+    filePartHandler: PartHandler[FilePart[A]]): RequestHeader => Iteratee[Array[Byte], Either[Result, MultipartFormData[A]]] = { request =>
 
     val maybeBoundary = for {
       mt <- request.mediaType


### PR DESCRIPTION
* Implemented new Accumulator abstraction, based on Sink[E, Future[A]]
* Implemented subscriber to iteratee reactive streams conversion
* Changed EssentialAction and BodyParser APIs to use Accumulator
* Left most of everything else untouched, just used conversions to to convert to/from iteratees

Implements #4687