### PR TITLE
Add method to handle various 4xx client errors to DefaultHttpErrorHandler

### DIFF
--- a/framework/src/play/src/main/java/play/http/DefaultHttpErrorHandler.java
+++ b/framework/src/play/src/main/java/play/http/DefaultHttpErrorHandler.java
@@ -56,9 +56,7 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
         } else if (statusCode == 404) {
             return onNotFound(request, message);
         } else if (statusCode >= 400 && statusCode < 500) {
-            return F.Promise.<Result>pure(Results.status(statusCode, views.html.defaultpages.badRequest.render(
-                request.method(), request.uri(), message
-            )));
+            return onOtherClientError(request, statusCode, message);
         } else {
             throw new IllegalArgumentException("onClientError invoked with non client error status code " + statusCode + ": " + message);
         }
@@ -101,6 +99,20 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
                     request.method(), request.uri(), Some.apply(routes.get())
             )));
         }
+    }
+
+    /**
+     * Invoked when a client error occurs, that is, an error in the 4xx series, which is not handled 
+     * by any of the other methods in this class already.
+     *
+     * @param request The request that caused the client error.
+     * @param statusCode The error status code.  Must be greater or equal to 400, and less than 500.
+     * @param message The error message.
+     */
+    protected F.Promise<Result> onOtherClientError(RequestHeader request, int statusCode, String message) {
+        return F.Promise.<Result>pure(Results.status(statusCode, views.html.defaultpages.badRequest.render(
+            request.method(), request.uri(), message
+        )));
     }
 
     /**


### PR DESCRIPTION
This PR splits a part of the `DefaultHttpErrorHandler.onClientError` method into the new `onOtherClientError` method, so it can easily be overriden.

Right now when you want to handle a 4xx response (except 400, 403 or 404, which have their own handler methods)  your only choice is to override `onClientError` itself, which IMHO isn't the best idea.

If someone comes up with a better name instead of `onOtherClientError` please tell me :smile: 

I would like to have this in 2.4.1 if it's OK for you guys, thanks!