### PR TITLE
Replaced `F.Function` with Java8 friends. Fix #4690

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/http/code/javaguide/RequestHandler.java
+++ b/documentation/manual/working/javaGuide/advanced/http/code/javaguide/RequestHandler.java
@@ -17,7 +17,7 @@ public class RequestHandler implements HttpRequestHandler {
     public Action createAction(Http.Request request, Method actionMethod) {
         return new Action.Simple() {
             @Override
-            public F.Promise<Result> call(Http.Context ctx) throws Throwable {
+            public F.Promise<Result> call(Http.Context ctx) {
                 return delegate.call(ctx);
             }
         };

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaAsync.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaAsync.java
@@ -4,8 +4,6 @@
 package javaguide.async;
 
 import org.junit.Test;
-import play.libs.F.Function;
-import play.libs.F.Function0;
 import play.libs.F.Promise;
 import play.mvc.Result;
 

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/controllers/Application.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/controllers/Application.java
@@ -4,8 +4,6 @@
 package javaguide.async.controllers;
 
 import play.mvc.Result;
-import play.libs.F.Function;
-import play.libs.F.Function0;
 import play.libs.F.Promise;
 import play.mvc.Controller;
 //#async-explicit-ec-imports

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActionsComposition.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActionsComposition.java
@@ -18,7 +18,7 @@ public class JavaActionsComposition extends Controller {
 
     // #verbose-action
     public class VerboseAction extends play.mvc.Action.Simple {
-        public F.Promise<Result> call(Http.Context ctx) throws Throwable {
+        public F.Promise<Result> call(Http.Context ctx) {
             Logger.info("Calling action for " + ctx);
             return delegate.call(ctx);
         }
@@ -58,7 +58,7 @@ public class JavaActionsComposition extends Controller {
 
     // #verbose-annotation-action
     public class VerboseAnnotationAction extends Action<VerboseAnnotation> {
-        public F.Promise<Result> call(Http.Context ctx) throws Throwable {
+        public F.Promise<Result> call(Http.Context ctx) {
             if (configuration.value()) {
                 Logger.info("Calling action for " + ctx);
             }
@@ -73,7 +73,7 @@ public class JavaActionsComposition extends Controller {
 
     // #pass-arg-action
     public class PassArgAction extends play.mvc.Action.Simple {
-        public F.Promise<Result> call(Http.Context ctx) throws Throwable {
+        public F.Promise<Result> call(Http.Context ctx) {
             ctx.args.put("user", User.findById(1234));
             return delegate.call(ctx);
         }

--- a/documentation/manual/working/javaGuide/main/logging/code/javaguide/logging/Application.java
+++ b/documentation/manual/working/javaGuide/main/logging/code/javaguide/logging/Application.java
@@ -36,7 +36,7 @@ class AccessLoggingAction extends Action.Simple {
   
   private ALogger accessLogger = Logger.of("access");
   
-  public F.Promise<Result> call(Http.Context ctx) throws Throwable {
+  public F.Promise<Result> call(Http.Context ctx) {
     final Request request = ctx.request();
     accessLogger.info("method=" + request.method() + " uri=" + request.uri() + " remote-address=" + request.remoteAddress());
     

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/Application.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/Application.java
@@ -8,7 +8,6 @@ import javax.inject.Inject;
 
 import play.mvc.*;
 import play.libs.ws.*;
-import play.libs.F.Function;
 import play.libs.F.Promise;
 
 public class Application extends Controller {

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -7,7 +7,6 @@ import javaguide.testhelpers.MockJavaAction;
 
 // #ws-imports
 import play.libs.ws.*;
-import play.libs.F.Function;
 import play.libs.F.Promise;
 // #ws-imports
 
@@ -116,15 +115,13 @@ public class JavaWS {
 
             // #ws-response-input-stream
             Promise<File> filePromise = ws.url(url).get().map(response -> {
-                InputStream inputStream = null;
-                OutputStream outputStream = null;
-                try {
-                    inputStream = response.getBodyAsStream();
+                // write the inputStream to a File
+                File file = new File("/tmp/response.txt");
 
-                    // write the inputStream to a File
-                    final File file = new File("/tmp/response.txt");
-                    outputStream = new FileOutputStream(file);
-
+                try(
+                    InputStream inputStream = response.getBodyAsStream();
+                    OutputStream outputStream = new FileOutputStream(file)
+                ) {
                     int read = 0;
                     byte[] buffer = new byte[1024];
 
@@ -133,11 +130,8 @@ public class JavaWS {
                     }
 
                     return file;
-                } catch (IOException e) {
-                    throw e;
-                } finally {
-                    if (inputStream != null) {inputStream.close();}
-                    if (outputStream != null) {outputStream.close();}
+                } catch(IOException e) {
+                    throw new RuntimeException(e);
                 }
             });
             // #ws-response-input-stream

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/controllers/Twitter.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/controllers/Twitter.java
@@ -1,7 +1,6 @@
 package javaguide.ws.controllers;
 
 //#ws-oauth-controller
-import play.libs.F.Function;
 import play.libs.F.Option;
 import play.libs.F.Promise;
 import play.libs.oauth.OAuth;
@@ -41,12 +40,7 @@ public class Twitter extends Controller {
       return ws.url("https://api.twitter.com/1.1/statuses/home_timeline.json")
           .sign(new OAuthCalculator(Twitter.KEY, sessionTokenPair.get()))
           .get()
-          .map(new Function<WSResponse, Result>(){
-            @Override
-            public Result apply(WSResponse result) throws Throwable {
-              return ok(result.asJson());
-            }
-       });
+          .map(result -> ok(result.asJson()));
     }
     return Promise.pure(redirect(routes.Twitter.auth()));
   }

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -31,7 +31,7 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
     private final CSRFAction$ CSRFAction = CSRFAction$.MODULE$;
 
     @Override
-    public F.Promise<Result> call(Http.Context ctx) throws Throwable {
+    public F.Promise<Result> call(Http.Context ctx) {
         RequestHeader request = ctx._requestHeader();
 
         if (CSRFAction.getTokenFromHeader(request, config).isEmpty()) {

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
@@ -30,7 +30,7 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
     private final CSRFAction$ CSRFAction = CSRFAction$.MODULE$;
 
     @Override
-    public F.Promise<Result> call(Http.Context ctx) throws Throwable {
+    public F.Promise<Result> call(Http.Context ctx) {
         RequestHeader request = ctx._requestHeader();
         // Check for bypass
         if (CSRFAction.checkCsrfBypass(request, config)) {
@@ -76,7 +76,7 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
         }
     }
 
-    private F.Promise<Result> handleTokenError(Http.Context ctx, RequestHeader request, String msg) throws Exception {
+    private F.Promise<Result> handleTokenError(Http.Context ctx, RequestHeader request, String msg) {
 
         if (CSRF.getToken(request).isEmpty()) {
             if (config.cookieName().isDefined()) {

--- a/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionOrderTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionOrderTest.java
@@ -21,7 +21,7 @@ public class ActionCompositionOrderTest {
 
     static class ControllerComposition extends Action<ControllerAnnotation> {
         @Override
-        public F.Promise<Result> call(Http.Context ctx) throws Throwable {
+        public F.Promise<Result> call(Http.Context ctx) {
             return delegate.call(ctx).map(result -> {
                 String newContent = "controller" + Helpers.contentAsString(result);
                 return Results.ok(newContent);
@@ -36,7 +36,7 @@ public class ActionCompositionOrderTest {
 
     static class ActionComposition extends Action<ControllerAnnotation> {
         @Override
-        public F.Promise<Result> call(Http.Context ctx) throws Throwable {
+        public F.Promise<Result> call(Http.Context ctx) {
             return delegate.call(ctx).map(result -> {
                 String newContent = "action" + Helpers.contentAsString(result);
                 return Results.ok(newContent);
@@ -53,7 +53,7 @@ public class ActionCompositionOrderTest {
 
     static class WithUsernameAction extends Action<WithUsername> {
         @Override
-        public F.Promise<Result> call(Http.Context ctx) throws Throwable {
+        public F.Promise<Result> call(Http.Context ctx) {
             return delegate.call(ctx.withRequest(ctx.request().withUsername(configuration.value())));
         }
     }

--- a/framework/src/play-integration-test/src/test/java/play/routing/RoutingDslTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/routing/RoutingDslTest.java
@@ -34,11 +34,7 @@ public class RoutingDslTest {
     @Test
     public void oneParameter() {
         Router router = new RoutingDsl()
-                .GET("/hello/:to").routeTo(new F.Function<String, Result>() {
-                    public Result apply(String to) {
-                        return Results.ok("Hello " + to);
-                    }
-                })
+                .GET("/hello/:to").routeTo(to -> Results.ok("Hello " + to))
                 .build();
 
         assertThat(makeRequest(router, "GET", "/hello/world"), equalTo("Hello world"));

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -19,7 +19,7 @@ import play.core.routing.HandlerDef
 import java.util.concurrent.atomic.AtomicReference
 import org.jboss.netty.buffer.ChannelBuffers
 import scala.concurrent.ExecutionContext.Implicits.global
-import java.util.function.Consumer
+import java.util.function.{ Consumer, Function }
 
 object NettyWebSocketSpec extends WebSocketSpec with NettyIntegrationSpecification
 object AkkaHttpWebSocketSpec extends WebSocketSpec with AkkaHttpIntegrationSpecification
@@ -402,7 +402,7 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
 
       "allow handling a websocket with an actor" in allowSendingMessages { _ =>
         messages =>
-          JWebSocket.withActor[String](new F.Function[ActorRef, Props]() {
+          JWebSocket.withActor[String](new Function[ActorRef, Props]() {
             def apply(out: ActorRef) = {
               Props(new Actor() {
                 messages.foreach { msg =>

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -8,6 +8,7 @@ import play.inject.ApplicationLifecycle;
 import play.libs.F;
 
 import java.util.*;
+import java.util.function.Supplier;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -76,7 +77,7 @@ public class DefaultJPAApi implements JPAApi {
      *
      * @param block Block of code to execute
      */
-    public <T> T withTransaction(play.libs.F.Function0<T> block) throws Throwable {
+    public <T> T withTransaction(Supplier<T> block) {
         return withTransaction("default", false, block);
     }
 
@@ -88,7 +89,7 @@ public class DefaultJPAApi implements JPAApi {
      * @deprecated This may cause deadlocks
      */
     @Deprecated
-    public <T> F.Promise<T> withTransactionAsync(play.libs.F.Function0<F.Promise<T>> block) throws Throwable {
+    public <T> F.Promise<T> withTransactionAsync(Supplier<F.Promise<T>> block) {
         return withTransactionAsync("default", false, block);
     }
 
@@ -115,7 +116,7 @@ public class DefaultJPAApi implements JPAApi {
      * @param readOnly Is the transaction read-only?
      * @param block Block of code to execute
      */
-    public <T> T withTransaction(String name, boolean readOnly, play.libs.F.Function0<T> block) throws Throwable {
+    public <T> T withTransaction(String name, boolean readOnly, Supplier<T> block) {
         EntityManager entityManager = null;
         EntityTransaction tx = null;
 
@@ -133,7 +134,7 @@ public class DefaultJPAApi implements JPAApi {
                 tx.begin();
             }
 
-            T result = block.apply();
+            T result = block.get();
 
             if (tx != null) {
                 if(tx.getRollbackOnly()) {
@@ -168,7 +169,7 @@ public class DefaultJPAApi implements JPAApi {
      * @deprecated This may cause deadlocks
      */
     @Deprecated
-    public <T> F.Promise<T> withTransactionAsync(String name, boolean readOnly, play.libs.F.Function0<F.Promise<T>> block) throws Throwable {
+    public <T> F.Promise<T> withTransactionAsync(String name, boolean readOnly, Supplier<F.Promise<T>> block) {
         EntityManager entityManager = null;
         EntityTransaction tx = null;
 
@@ -186,7 +187,7 @@ public class DefaultJPAApi implements JPAApi {
                 tx.begin();
             }
 
-            F.Promise<T> result = block.apply();
+            F.Promise<T> result = block.get();
 
             final EntityManager fem = entityManager;
             final EntityTransaction ftx = tx;

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
@@ -7,6 +7,8 @@ import play.*;
 import play.libs.F;
 import play.mvc.Http;
 
+import java.util.function.Supplier;
+
 import javax.persistence.*;
 
 /**
@@ -123,7 +125,7 @@ public class JPA {
      *
      * @param block Block of code to execute.
      */
-    public static <T> T withTransaction(play.libs.F.Function0<T> block) throws Throwable {
+    public static <T> T withTransaction(Supplier<T> block) {
         return jpaApi().withTransaction(block);
     }
 
@@ -135,7 +137,7 @@ public class JPA {
      * @deprecated This may cause deadlocks
      */
     @Deprecated
-    public static <T> F.Promise<T> withTransactionAsync(play.libs.F.Function0<F.Promise<T>> block) throws Throwable {
+    public static <T> F.Promise<T> withTransactionAsync(Supplier<F.Promise<T>> block) {
         return jpaApi().withTransactionAsync(block);
     }
 
@@ -155,7 +157,7 @@ public class JPA {
      * @param readOnly Is the transaction read-only?
      * @param block Block of code to execute.
      */
-    public static <T> T withTransaction(String name, boolean readOnly, play.libs.F.Function0<T> block) throws Throwable {
+    public static <T> T withTransaction(String name, boolean readOnly, Supplier<T> block) {
         return jpaApi().withTransaction(name, readOnly, block);
     }
 
@@ -169,7 +171,7 @@ public class JPA {
      * @deprecated This may cause deadlocks
      */
     @Deprecated
-    public static <T> F.Promise<T> withTransactionAsync(String name, boolean readOnly, play.libs.F.Function0<F.Promise<T>> block) throws Throwable {
+    public static <T> F.Promise<T> withTransactionAsync(String name, boolean readOnly, Supplier<F.Promise<T>> block) {
         return jpaApi().withTransactionAsync(name, readOnly, block);
     }
 }

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
@@ -3,6 +3,8 @@
  */
 package play.db.jpa;
 
+import java.util.function.Supplier;
+
 import javax.persistence.EntityManager;
 import play.libs.F;
 
@@ -28,7 +30,7 @@ public interface JPAApi {
      *
      * @param block Block of code to execute
      */
-    public <T> T withTransaction(play.libs.F.Function0<T> block) throws Throwable;
+    public <T> T withTransaction(Supplier<T> block);
 
     /**
      * Run a block of asynchronous code in a JPA transaction.
@@ -38,7 +40,7 @@ public interface JPAApi {
      * @deprecated This may cause deadlocks
      */
     @Deprecated
-    public <T> F.Promise<T> withTransactionAsync(play.libs.F.Function0<F.Promise<T>> block) throws Throwable;
+    public <T> F.Promise<T> withTransactionAsync(Supplier<F.Promise<T>> block);
 
     /**
      * Run a block of code in a JPA transaction.
@@ -54,7 +56,7 @@ public interface JPAApi {
      * @param readOnly Is the transaction read-only?
      * @param block Block of code to execute
      */
-    public <T> T withTransaction(String name, boolean readOnly, play.libs.F.Function0<T> block) throws Throwable;
+    public <T> T withTransaction(String name, boolean readOnly, Supplier<T> block);
 
     /**
      * Run a block of asynchronous code in a JPA transaction.
@@ -66,7 +68,7 @@ public interface JPAApi {
      * @deprecated This may cause deadlocks
      */
     @Deprecated
-    public <T> F.Promise<T> withTransactionAsync(String name, boolean readOnly, play.libs.F.Function0<F.Promise<T>> block) throws Throwable;
+    public <T> F.Promise<T> withTransactionAsync(String name, boolean readOnly, Supplier<F.Promise<T>> block);
 
     /**
      * Close all entity manager factories.

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/TransactionalAction.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/TransactionalAction.java
@@ -12,7 +12,7 @@ import play.mvc.Http.*;
  */
 public class TransactionalAction extends Action<Transactional> {
 
-    public F.Promise<Result> call(final Context ctx) throws Throwable {
+    public F.Promise<Result> call(final Context ctx) {
         return JPA.withTransaction(
             configuration.value(),
             configuration.readOnly(),

--- a/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
+++ b/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
@@ -13,8 +13,12 @@ import scala.reflect.ClassTag;
 import scala.reflect.ClassTag$;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -210,7 +214,15 @@ public class RoutingDsl {
 
         Method actionMethod = null;
         for (Method m : actionFunction.getMethods()) {
-            if (!m.isDefault()) {
+        	// Here I assume that we are always passing a `actionFunction` type that:
+        	// 1) defines exactly one abstract method, and 
+        	// 2) the abstract method is the method that we want to invoke.
+        	// This works fine with the current implementation of `PathPatternMatcher`, but I wouldn't be 
+        	// surprised if it breaks in the future, which is why this comment exists.
+        	// Also, the former implementation (which was checking for the first non default method), was 
+        	// not working when using a `java.util.function.Function` type (Function.identity was being 
+        	// returned, instead of Function.apply).
+            if (Modifier.isAbstract(m.getModifiers())) {
                 actionMethod = m;
             }
         }
@@ -284,8 +296,8 @@ public class RoutingDsl {
          * @param action The action to execute.
          * @return This router builder.
          */
-        public RoutingDsl routeTo(F.Function0<Result> action) {
-            return build(0, action, F.Function0.class);
+        public RoutingDsl routeTo(Supplier<Result> action) {
+            return build(0, action, Supplier.class);
         }
 
         /**
@@ -294,8 +306,8 @@ public class RoutingDsl {
          * @param action The action to execute.
          * @return This router builder.
          */
-        public <A1> RoutingDsl routeTo(F.Function<A1, Result> action) {
-            return build(1, action, F.Function.class);
+        public <A1> RoutingDsl routeTo(Function<A1, Result> action) {
+            return build(1, action, Function.class);
         }
 
         /**
@@ -304,8 +316,8 @@ public class RoutingDsl {
          * @param action The action to execute.
          * @return This router builder.
          */
-        public <A1, A2> RoutingDsl routeTo(F.Function2<A1, A2, Result> action) {
-            return build(2, action, F.Function2.class);
+        public <A1, A2> RoutingDsl routeTo(BiFunction<A1, A2, Result> action) {
+            return build(2, action, BiFunction.class);
         }
 
         /**
@@ -324,8 +336,8 @@ public class RoutingDsl {
          * @param action The action to execute.
          * @return This router builder.
          */
-        public RoutingDsl routeAsync(F.Function0<F.Promise<Result>> action) {
-            return build(0, action, F.Function0.class);
+        public RoutingDsl routeAsync(Supplier<F.Promise<Result>> action) {
+            return build(0, action, Supplier.class);
         }
 
         /**
@@ -334,8 +346,8 @@ public class RoutingDsl {
          * @param action The action to execute.
          * @return This router builder.
          */
-        public <A1> RoutingDsl routeAsync(F.Function<A1, F.Promise<Result>> action) {
-            return build(1, action, F.Function.class);
+        public <A1> RoutingDsl routeAsync(Function<A1, F.Promise<Result>> action) {
+            return build(1, action, Function.class);
         }
 
         /**
@@ -344,8 +356,8 @@ public class RoutingDsl {
          * @param action The action to execute.
          * @return This router builder.
          */
-        public <A1, A2> RoutingDsl routeAsync(F.Function2<A1, A2, F.Promise<Result>> action) {
-            return build(2, action, F.Function2.class);
+        public <A1, A2> RoutingDsl routeAsync(BiFunction<A1, A2, F.Promise<Result>> action) {
+            return build(2, action, BiFunction.class);
         }
 
         /**
@@ -358,7 +370,7 @@ public class RoutingDsl {
             return build(3, action, F.Function3.class);
         }
 
-        private <T> RoutingDsl build(int arity, Object action, Class<?> actionFunction) {
+        private <T> RoutingDsl build(int arity, T action, Class<T> actionFunction) {
             return with(method, pathPattern, arity, action, actionFunction);
         }
     }

--- a/framework/src/play/src/main/java/play/GlobalSettings.java
+++ b/framework/src/play/src/main/java/play/GlobalSettings.java
@@ -63,7 +63,7 @@ public class GlobalSettings {
     @SuppressWarnings("rawtypes")
     public Action onRequest(Request request, Method actionMethod) {
         return new Action.Simple() {
-            public F.Promise<Result> call(Context ctx) throws Throwable {
+            public F.Promise<Result> call(Context ctx) {
                 return delegate.call(ctx);
             }
         };

--- a/framework/src/play/src/main/java/play/http/DefaultHttpRequestHandler.java
+++ b/framework/src/play/src/main/java/play/http/DefaultHttpRequestHandler.java
@@ -16,7 +16,7 @@ public class DefaultHttpRequestHandler implements HttpRequestHandler {
     public Action createAction(Http.Request request, Method actionMethod) {
         return new Action.Simple() {
             @Override
-            public F.Promise<Result> call(Http.Context ctx) throws Throwable {
+            public F.Promise<Result> call(Http.Context ctx) {
                 return delegate.call(ctx);
             }
         };

--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -12,6 +12,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.Arrays;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import play.core.j.FPromiseHelper;
 import scala.concurrent.ExecutionContext;
@@ -21,27 +23,6 @@ import scala.concurrent.Future;
  * Defines a set of functional programming style helpers.
  */
 public class F {
-
-    /**
-     * A Function with no arguments.
-     */
-    public static interface Function0<R> {
-        public R apply() throws Throwable;
-    }
-
-    /**
-     * A Function with a single argument.
-     */
-    public static interface Function<A,R> {
-        public R apply(A a) throws Throwable;
-    }
-
-    /**
-     * A Function with 2 arguments.
-     */
-    public static interface Function2<A,B,R> {
-        public R apply(A a, B b) throws Throwable;
-    }
 
     /**
      * A Function with 3 arguments.
@@ -194,7 +175,7 @@ public class F {
          *
          * @param function Used to fulfill the Promise.
          */
-        public static <A> Promise<A> promise(Function0<A> function) {
+        public static <A> Promise<A> promise(Supplier<A> function) {
             return FPromiseHelper.promise(function, HttpExecution.defaultContext());
         }
 
@@ -204,7 +185,7 @@ public class F {
          * @param function Used to fulfill the Promise.
          * @param ec The ExecutionContext to run the function in.
          */
-        public static <A> Promise<A> promise(Function0<A> function, ExecutionContext ec) {
+        public static <A> Promise<A> promise(Supplier<A> function, ExecutionContext ec) {
             return FPromiseHelper.promise(function, ec);
         }
 
@@ -218,7 +199,7 @@ public class F {
          * @param delay The time to wait.
          * @param unit The units to use for the delay.
          */
-        public static <A> Promise<A> delayed(Function0<A> function, long delay, TimeUnit unit) {
+        public static <A> Promise<A> delayed(Supplier<A> function, long delay, TimeUnit unit) {
             return FPromiseHelper.delayed(function, delay, unit, HttpExecution.defaultContext());
         }
 
@@ -231,7 +212,7 @@ public class F {
          * @param unit The units to use for the delay.
          * @param ec The ExecutionContext to run the Function0 in.
          */
-        public static <A> Promise<A> delayed(Function0<A> function, long delay, TimeUnit unit, ExecutionContext ec) {
+        public static <A> Promise<A> delayed(Supplier<A> function, long delay, TimeUnit unit, ExecutionContext ec) {
             return FPromiseHelper.delayed(function, delay, unit, ec);
         }
 

--- a/framework/src/play/src/main/java/play/mvc/Action.java
+++ b/framework/src/play/src/main/java/play/mvc/Action.java
@@ -24,7 +24,7 @@ public abstract class Action<T> extends Results {
     /**
      * Executes this action with the given HTTP context and returns the result.
      */
-    public abstract Promise<Result> call(Context ctx) throws Throwable;
+    public abstract Promise<Result> call(Context ctx);
     
     /**
      * A simple action with no configuration.

--- a/framework/src/play/src/main/java/play/mvc/Security.java
+++ b/framework/src/play/src/main/java/play/mvc/Security.java
@@ -42,17 +42,14 @@ public class Security {
                     try {
                         ctx.request().setUsername(username);
                         return delegate.call(ctx).transform(
-                            new F.Function<Result, Result>() {
-                                @Override
-                                public Result apply(Result result) throws Throwable {
-                                    ctx.request().setUsername(null);
-                                    return result;
-                                }
+                            result -> {
+                                ctx.request().setUsername(null);
+                                return result;
                             },
-                                throwable -> {
-                                    ctx.request().setUsername(null);
-                                    return throwable;
-                                }
+                            throwable -> {
+                                ctx.request().setUsername(null);
+                                return throwable;
+                            }
                         );
                     } catch(Exception e) {
                         ctx.request().setUsername(null);

--- a/framework/src/play/src/main/java/play/mvc/WebSocket.java
+++ b/framework/src/play/src/main/java/play/mvc/WebSocket.java
@@ -7,10 +7,10 @@ import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import akka.actor.ActorRef;
 import akka.actor.Props;
-import play.libs.F.*;
 
 /**
  * A WebSocket result.

--- a/framework/src/play/src/test/java/play/PromiseTest.java
+++ b/framework/src/play/src/test/java/play/PromiseTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
+import java.util.function.Function;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,11 +35,7 @@ public class PromiseTest extends ExecutionTest {
     public void testEmptyPromise() {
         F.RedeemablePromise<Integer> a = F.RedeemablePromise.empty();
 
-        F.Promise<String> b = a.map(new F.Function<Integer, String>() {
-          public String apply(Integer i) {
-            return i.toString();
-          }
-        });
+        F.Promise<String> b = a.map(Object::toString);
 
         a.success(1);
 
@@ -236,7 +233,7 @@ public class PromiseTest extends ExecutionTest {
     @Test
     public void testSupertypeMap() {
         F.Promise<Integer> a = F.Promise.pure(1);
-        F.Function<Object, String> f = Object::toString;
+        Function<Object, String> f = Object::toString;
         F.Promise<String> b = a.map(f);
         assertThat(b.get(t)).isEqualTo("1");
     }
@@ -260,7 +257,7 @@ public class PromiseTest extends ExecutionTest {
     @Test
     public void testSupertypeFlatMap() {
         F.Promise<Integer> a = F.Promise.pure(1);
-        F.Function<Object, F.Promise<String>> f = o -> F.Promise.pure(o.toString());
+        Function<Object, F.Promise<String>> f = o -> F.Promise.pure(o.toString());
         F.Promise<String> b = a.flatMap(f);
         assertThat(b.get(t)).isEqualTo("1");
     }

--- a/framework/src/play/src/test/java/play/mvc/SecurityTest.java
+++ b/framework/src/play/src/test/java/play/mvc/SecurityTest.java
@@ -18,7 +18,7 @@ public class SecurityTest {
         Http.Request req;
         Security.AuthenticatedAction action;
 
-        Exception exception = new Exception("test exception");
+        RuntimeException exception = new RuntimeException("test exception");
         final Result ok = Results.ok();
 
         @Before
@@ -59,7 +59,7 @@ public class SecurityTest {
         public void testSetUsernameToNullWhenExceptionRaised() {
             action.delegate = new Action<Object>() {
                 @Override
-                public F.Promise<Result> call(Http.Context ctx) throws Throwable {
+                public F.Promise<Result> call(Http.Context ctx) {
                     throw exception;
                 }
             };
@@ -67,7 +67,7 @@ public class SecurityTest {
             try {
                 action.call(ctx);
             } catch (RuntimeException e) {
-                Assert.assertEquals(exception, e.getCause());
+                Assert.assertEquals(exception, e);
             }
 
             verify(req).setUsername("test_user");
@@ -77,7 +77,7 @@ public class SecurityTest {
         private void runSetUsernameToNullInCallback(final boolean shouldRaiseException) {
             action.delegate = new Action<Object>() {
                 @Override
-                public F.Promise<Result> call(Http.Context ctx) throws Throwable {
+                public F.Promise<Result> call(Http.Context ctx) {
                     return F.Promise.promise(() -> {
                         if (shouldRaiseException) {
                             throw exception;

--- a/framework/src/play/src/test/scala/play/api/libs/iteratee/ExecutionTest.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/iteratee/ExecutionTest.scala
@@ -7,6 +7,8 @@ import play.libs.F
 import scala.concurrent.ExecutionContext
 import java.util.function.Consumer
 import java.util.function.BiConsumer
+import java.util.function.Function
+import java.util.function.BiFunction
 
 /**
  * Common functionality for Java tests that use execution contexts.
@@ -20,11 +22,11 @@ class ExecutionTest {
     result
   }
 
-  def testExecution[A](f: F.Function[TestExecutionContext, A]): A = {
+  def testExecution[A](f: Function[TestExecutionContext, A]): A = {
     _testExecution(f.apply)
   }
 
-  def testExecution[A](f: F.Function2[TestExecutionContext, TestExecutionContext, A]): A = {
+  def testExecution[A](f: BiFunction[TestExecutionContext, TestExecutionContext, A]): A = {
     _testExecution(ec1 => _testExecution(ec2 => f(ec1, ec2)))
   }
 

--- a/framework/src/play/src/test/scala/play/api/libs/iteratee/TestChannel.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/iteratee/TestChannel.scala
@@ -5,7 +5,7 @@ package play.api.libs.iteratee
 
 import java.lang.{ Boolean => JBoolean }
 import java.util.concurrent.LinkedBlockingQueue
-import play.libs.F
+import java.util.function.{ BiFunction, Function }
 import scala.concurrent.duration._
 
 /**
@@ -41,9 +41,9 @@ class TestChannel[A](defaultTimeout: Duration) extends Concurrent.Channel[A] {
 
   def expect(expected: A, timeout: Duration): A = expect(expected, timeout, _ == _)
 
-  def expect(expected: A, test: F.Function2[A, A, JBoolean]): A = expect(expected, defaultTimeout, test)
+  def expect(expected: A, test: BiFunction[A, A, JBoolean]): A = expect(expected, defaultTimeout, test)
 
-  def expect(expected: A, timeout: Duration, test: F.Function2[A, A, JBoolean]): A = expect(expected, timeout, test.apply(_, _))
+  def expect(expected: A, timeout: Duration, test: BiFunction[A, A, JBoolean]): A = expect(expected, timeout, test.apply(_, _))
 
   def expect(expected: A, test: (A, A) => Boolean): A = expect(expected, defaultTimeout, test)
 

--- a/framework/src/play/src/test/scala/play/libs/FSpec.scala
+++ b/framework/src/play/src/test/scala/play/libs/FSpec.scala
@@ -10,8 +10,7 @@ import org.specs2.mutable._
 import play.api.libs.iteratee.ExecutionSpecification
 import scala.collection.JavaConverters
 import scala.concurrent.{ Future, Promise }
-import java.util.function.Consumer
-import java.util.function.Predicate
+import java.util.function.{ Consumer, Function, Predicate, Supplier }
 
 object FSpec extends Specification
     with ExecutionSpecification {
@@ -39,29 +38,29 @@ object FSpec extends Specification
     }
 
     "be able to be created from a function (with default ExecutionContext)" in {
-      F.Promise.promise(new F.Function0[Int] {
-        def apply() = 1
+      F.Promise.promise(new Supplier[Int] {
+        def get() = 1
       }).get(5, SECONDS) must equalTo(1)
     }
 
     "be able to be created from a function (with explicit ExecutionContext)" in {
       mustExecute(1) { ec =>
-        F.Promise.promise(new F.Function0[Int] {
-          def apply() = 1
+        F.Promise.promise(new Supplier[Int] {
+          def get() = 1
         }, ec).get(5, SECONDS) must equalTo(1)
       }
     }
 
     "be able to be created after a delay (with default ExecutionContext)" in {
-      F.Promise.delayed(new F.Function0[Int] {
-        def apply() = 1
+      F.Promise.delayed(new Supplier[Int] {
+        def get() = 1
       }, 1, MILLISECONDS).get(5, SECONDS) must equalTo(1)
     }
 
     "be able to be created after a delay (with explicit ExecutionContext)" in {
       mustExecute(1) { ec =>
-        F.Promise.delayed(new F.Function0[Int] {
-          def apply() = 1
+        F.Promise.delayed(new Supplier[Int] {
+          def get() = 1
         }, 1, MILLISECONDS, ec).get(5, SECONDS) must equalTo(1)
       }
     }
@@ -93,7 +92,7 @@ object FSpec extends Specification
     "map its value (with default ExecutionContext)" in {
       val p = Promise[Int]()
       val fp = F.Promise.wrap(p.future)
-      val mapped = fp.map(new F.Function[Int, Int] {
+      val mapped = fp.map(new Function[Int, Int] {
         def apply(x: Int) = 2 * x
       })
       p.success(111)
@@ -104,7 +103,7 @@ object FSpec extends Specification
       val p = Promise[Int]()
       val fp = F.Promise.wrap(p.future)
       mustExecute(1) { ec =>
-        val mapped = fp.map(new F.Function[Int, Int] {
+        val mapped = fp.map(new Function[Int, Int] {
           def apply(x: Int) = 2 * x
         }, ec)
         p.success(111)
@@ -115,7 +114,7 @@ object FSpec extends Specification
     "recover from a thrown exception (with default ExecutionContext)" in {
       val p = Promise[Int]()
       val fp = F.Promise.wrap(p.future)
-      val recovered = fp.recover(new F.Function[Throwable, Int] {
+      val recovered = fp.recover(new Function[Throwable, Int] {
         def apply(x: Throwable): Int = 99
       })
       p.failure(new RuntimeException("x"))
@@ -126,7 +125,7 @@ object FSpec extends Specification
       val p = Promise[Int]()
       val fp = F.Promise.wrap(p.future)
       mustExecute(1) { ec =>
-        val recovered = fp.recover(new F.Function[Throwable, Int] {
+        val recovered = fp.recover(new Function[Throwable, Int] {
           def apply(x: Throwable): Int = 99
         }, ec)
         p.failure(new RuntimeException("x"))
@@ -137,7 +136,7 @@ object FSpec extends Specification
     "recoverWith from a thrown exception (with default ExecutionContext)" in {
       val p = Promise[Int]()
       val fp = F.Promise.wrap(p.future)
-      val recovered = fp.recoverWith(new F.Function[Throwable, F.Promise[Int]] {
+      val recovered = fp.recoverWith(new Function[Throwable, F.Promise[Int]] {
         def apply(x: Throwable) = F.Promise.pure(99)
       })
       p.failure(new RuntimeException("x"))
@@ -148,7 +147,7 @@ object FSpec extends Specification
       val p = Promise[Int]()
       val fp = F.Promise.wrap(p.future)
       mustExecute(1) { ec =>
-        val recovered = fp.recoverWith(new F.Function[Throwable, F.Promise[Int]] {
+        val recovered = fp.recoverWith(new Function[Throwable, F.Promise[Int]] {
           def apply(x: Throwable) = F.Promise.pure(99)
         }, ec)
         p.failure(new RuntimeException("x"))
@@ -177,7 +176,7 @@ object FSpec extends Specification
     "flatMap its value (with default ExecutionContext)" in {
       val p = Promise[Int]()
       val fp = F.Promise.wrap(p.future)
-      val flatMapped = fp.flatMap(new F.Function[Int, F.Promise[Int]] {
+      val flatMapped = fp.flatMap(new Function[Int, F.Promise[Int]] {
         def apply(x: Int) = F.Promise.wrap(Future.successful(2 * x))
       })
       p.success(111)
@@ -188,7 +187,7 @@ object FSpec extends Specification
       val p = Promise[Int]()
       val fp = F.Promise.wrap(p.future)
       mustExecute(1) { ec =>
-        val flatMapped = fp.flatMap(new F.Function[Int, F.Promise[Int]] {
+        val flatMapped = fp.flatMap(new Function[Int, F.Promise[Int]] {
           def apply(x: Int) = F.Promise.wrap(Future.successful(2 * x))
         }, ec)
         p.success(111)
@@ -243,10 +242,10 @@ object FSpec extends Specification
     "transform its successful value (with default ExecutionContext)" in {
       val p = F.Promise.pure(1)
       val mapped = p.transform(
-        new F.Function[Int, Int] {
+        new Function[Int, Int] {
           def apply(x: Int) = 2 * x
         },
-        new F.Function[Throwable, Throwable] {
+        new Function[Throwable, Throwable] {
           def apply(t: Throwable) = t
         }
       )
@@ -257,10 +256,10 @@ object FSpec extends Specification
       val p = F.Promise.pure(1)
       mustExecute(1) { ec =>
         val mapped = p.transform(
-          new F.Function[Int, Int] {
+          new Function[Int, Int] {
             def apply(x: Int) = 2 * x
           },
-          new F.Function[Throwable, Throwable] {
+          new Function[Throwable, Throwable] {
             def apply(t: Throwable) = t
           },
           ec
@@ -272,10 +271,10 @@ object FSpec extends Specification
     "transform its failed throwable (with default ExecutionContext)" in {
       val p = F.Promise.throwing(new RuntimeException("1"))
       val mapped = p.transform(
-        new F.Function[Int, Int] {
+        new Function[Int, Int] {
           def apply(x: Int) = x
         },
-        new F.Function[Throwable, Throwable] {
+        new Function[Throwable, Throwable] {
           def apply(t: Throwable) = new RuntimeException("2")
         }
       )
@@ -286,10 +285,10 @@ object FSpec extends Specification
       val p = F.Promise.throwing(new RuntimeException("1"))
       mustExecute(1) { ec =>
         val mapped = p.transform(
-          new F.Function[Int, Int] {
+          new Function[Int, Int] {
             def apply(x: Int) = x
           },
-          new F.Function[Throwable, Throwable] {
+          new Function[Throwable, Throwable] {
             def apply(t: Throwable) = new RuntimeException("2")
           },
           ec


### PR DESCRIPTION
Replaced `F.Function` with Java8 friends. Fix #4690

As explained in d24c79d85eb9f71499588d2180bfb29e6b73d55f, we are embracing Java8
functional interfaces. This commit makes the following changes:

* `F.Function0` -> `java.util.function.Supplier`
* `F.Function1` -> `java.util.function.Function`
* `F.Function2` -> `java.util.function.BiFunction`

The change is source compatible if the lambda's body passed to either of the
former `F.Function` types does not throw a checked exception. Otherwise, users
will need to update their code to catch the exception and provide the necessary
logic to deal with it.

There is however an important change affecting source compatibility, as several
of the methods in `F.Promise` used to throw (Throwable), while they don't now (
Ref #4691).

There is one additional function type that has no corresponding in the Java8
library: `F.Function3`. This type is currently only used in the `RoutingDsl`, so
I initially thought we could remove it. However, it's tricky to remove
functionality, so I decided to leave it alone for the moment, as we can always
revisit this in the future.