### PR TITLE
fix small mistake in "Building from source" doc

### DIFF
--- a/documentation/manual/hacking/BuildingFromSource.md
+++ b/documentation/manual/hacking/BuildingFromSource.md
@@ -27,7 +27,7 @@ This will build and publish Play for the default Scala version (currently 2.10.5
 Or to publish for a specific Scala version:
 
 ```bash
-> +++2.11.6 publishLocal
+> ++2.11.6 publishLocal
 ```
 
 ## Build the documentation


### PR DESCRIPTION
as per http://www.scala-sbt.org/0.13/docs/Cross-Build.html,
the syntax for sbt crossbuilding is `++` not `+++`