### PR TITLE
Fixes play-java templates references to play-ebean

### DIFF
--- a/templates/play-java-intro/build.sbt
+++ b/templates/play-java-intro/build.sbt
@@ -5,9 +5,11 @@ version := "1.0-SNAPSHOT"
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
 libraryDependencies ++= Seq(
+  // If you enable PlayEbean plugin you must remove these
+  // JPA dependencies to avoid conflicts.
   javaJpa,
   "org.hibernate" % "hibernate-entitymanager" % "4.3.7.Final"
-)     
+)
 
 // Play provides two styles of routers, one expects its actions to be injected, the
 // other, legacy style, accesses its actions statically.

--- a/templates/play-java-intro/project/plugins.sbt
+++ b/templates/play-java-intro/project/plugins.sbt
@@ -16,6 +16,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "%MOCHA_VERSION%")
 addSbtPlugin("com.typesafe.sbt" % "sbt-play-enhancer" % "%ENHANCER_VERSION%")
 
 // Play Ebean support, to enable, uncomment this line, and enable in your build.sbt using
-// enablePlugins(SbtEbean). Note, uncommenting this line will automatically bring in
-// Play enhancer, regardless of whether the line above is commented out or not.
+// enablePlugins(PlayEbean).
 // addSbtPlugin("com.typesafe.sbt" % "sbt-play-ebean" % "%EBEAN_VERSION%")

--- a/templates/play-java/project/plugins.sbt
+++ b/templates/play-java/project/plugins.sbt
@@ -16,6 +16,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "%MOCHA_VERSION%")
 addSbtPlugin("com.typesafe.sbt" % "sbt-play-enhancer" % "%ENHANCER_VERSION%")
 
 // Play Ebean support, to enable, uncomment this line, and enable in your build.sbt using
-// enablePlugins(SbtEbean). Note, uncommenting this line will automatically bring in
-// Play enhancer, regardless of whether the line above is commented out or not.
+// enablePlugins(PlayEbean).
 // addSbtPlugin("com.typesafe.sbt" % "sbt-play-ebean" % "%EBEAN_VERSION%")


### PR DESCRIPTION
This fixes playframework/play-ebean#45 by correcting some comments in play-java templates. Also, a warning was added to instruct users to remove JPA when activating play-ebean.