### PR TITLE
Update sample controller test for ScalaTest

### DIFF
--- a/documentation/manual/working/scalaGuide/main/tests/code-scalatestplus-play/ExampleControllerSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code-scalatestplus-play/ExampleControllerSpec.scala
@@ -20,7 +20,7 @@ class ExampleControllerSpec extends PlaySpec with Results {
   "Example Page#index" should {
     "should be valid" in {
       val controller = new TestController()
-      val result: Future[SimpleResult] = controller.index().apply(FakeRequest())
+      val result: Future[Result] = controller.index().apply(FakeRequest())
       val bodyText: String = contentAsString(result)
       bodyText mustBe "ok"
     }

--- a/framework/src/build-link/src/main/java/play/core/BuildDocHandler.java
+++ b/framework/src/build-link/src/main/java/play/core/BuildDocHandler.java
@@ -20,7 +20,7 @@ public interface BuildDocHandler {
    * Given a request, either handle it and return some result, or don't, and return none.
    *
    * @param request A request of type {@code play.api.mvc.RequestHeader}.
-   * @return A value of type {@code Option<play.api.mvc.SimpleResult>}, Some if the result was
+   * @return A value of type {@code Option<play.api.mvc.Result>}, Some if the result was
    *        handled, None otherwise.
    */
   public Object maybeHandleDocRequest(Object request);


### PR DESCRIPTION
SimpleResult changed for Result as SimpleResult was deprecated in 2.3.