### PR TITLE
Fix invalid session secure cookie setting

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/JavaOAuth.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaOAuth.md
@@ -50,4 +50,4 @@ controller:
 
 @[ws-oauth-controller](code/javaguide/ws/controllers/Twitter.java)
 
-> **NOTE**: OAuth does not provide any protection against [MITM attacks](http://en.wikipedia.org/wiki/Man-in-the-middle_attack).  This example shows the OAuth token and secret stored in a session cookie -- for the best security, always use HTTPS with `play.http.session.cookie.secure=true` defined.
+> **NOTE**: OAuth does not provide any protection against [MITM attacks](http://en.wikipedia.org/wiki/Man-in-the-middle_attack).  This example shows the OAuth token and secret stored in a session cookie -- for the best security, always use HTTPS with `play.http.session.secure=true` defined.


### PR DESCRIPTION
The configuration value should be "play.http.session.secure"

https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala#L128