### PR TITLE
Remove trustxforwarded from HTTPServer document

### DIFF
--- a/documentation/manual/detailedTopics/production/HTTPServer.md
+++ b/documentation/manual/detailedTopics/production/HTTPServer.md
@@ -125,11 +125,7 @@ LoadModule proxy_module modules/mod_proxy.so
 
 When using an HTTP frontal server, request addresses are seen as coming from the HTTP server. In a usual set-up, where you both have the Play app and the proxy running on the same machine, the Play app will see the requests coming from 127.0.0.1.
 
-Proxy servers can add a specific header to the request to tell the proxied application where the request came from. Most web servers will add an X-Forwarded-For header with the remote client IP address as first argument. If the proxy server is running on localhost and connecting from 127.0.0.1, Play will trust its `X-Forwarded-For` header.  If you are running a reverse proxy on a different machine, you can set the `trustxforwarded` configuration item to true in the application configuration file, like so:
-
-```
-trustxforwarded=true
-```
+Proxy servers can add a specific header to the request to tell the proxied application where the request came from. Most web servers will add an X-Forwarded-For header with the remote client IP address as first argument. If the proxy server is running on localhost and connecting from 127.0.0.1, Play will trust its `X-Forwarded-For` header.
 
 However, the host header is untouched, it’ll remain issued by the proxy. If you use Apache 2.x, you can add a directive like:
 


### PR DESCRIPTION
> If you are running a reverse proxy on a different machine, you can set the trustxforwarded configuration item to true in the application configuration file, like

`trustxforwarded` property is invalid by #2094, and since Play 2.4.x