### PR TITLE
Have a way to log SQL statements

### DIFF
--- a/documentation/manual/working/javaGuide/main/sql/JavaDatabase.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaDatabase.md
@@ -107,7 +107,30 @@ db.default.url="jdbc:h2:mem:play"
 db.default.jndiName=DefaultDS
 ```
 
-## Importing a Database Driver
+## How to configure SQL log statement
+
+Not all connection pools offer (out of the box) a way to log SQL statements. HikariCP, per instance, suggests that you use the log capacities of your database vendor. From [HikariCP docs](https://github.com/brettwooldridge/HikariCP/tree/dev#log-statement-text--slow-query-logging):
+
+#### *Log Statement Text / Slow Query Logging*
+
+*Like Statement caching, most major database vendors support statement logging through properties of their own driver. This includes Oracle, MySQL, Derby, MSSQL, and others. Some even support slow query logging. We consider this a "development-time" feature. For those few databases that do not support it, jdbcdslog-exp is a good option. Great stuff during development and pre-Production.*
+
+Because of that, Play uses [jdbcdslog-exp](https://github.com/jdbcdslog/jdbcdslog) to enable consistent SQL log statement support for supported pools. The SQL log statement can be configured by database, using `logSql` property:
+
+```properties
+# Default database configuration using PostgreSQL database engine
+db.default.driver=org.postgresql.Driver
+db.default.url="jdbc:postgresql://database.example.com/playdb"
+db.default.logSql=true
+```
+
+After that, you can configure the jdbcdslog-exp [log level as explained in their manual](https://code.google.com/p/jdbcdslog/wiki/UserGuide#Setup_logging_engine). Basically, you need to configure your root logger to `INFO` and then decide what jdbcdslog-exp will log (connections, statements and result sets). Here is an example using `logback.xml` to configure the logs:
+
+@[](/confs/play/logback-play-logSql.xml)
+
+> **Warning**: Keep in mind that this is intended to be used just in development environments and you should not configure it in production, since there is a performance degradation and it will pollute your logs.
+
+## Configuring the JDBC Driver dependency
 
 Other than for the h2 in-memory database, useful mostly in development mode, Play does not provide any database drivers. Consequently, to deploy in production you will have to add your database driver as an application dependency.
 

--- a/documentation/manual/working/scalaGuide/main/sql/ScalaDatabase.md
+++ b/documentation/manual/working/scalaGuide/main/sql/ScalaDatabase.md
@@ -78,7 +78,30 @@ db.customers.driver=org.h2.Driver
 db.customers.url="jdbc:h2:mem:customers"
 ```
 
-## Configuring the JDBC Driver
+## How to configure SQL log statement
+
+Not all connection pools offer (out of the box) a way to log SQL statements. HikariCP, per instance, suggests that you use the log capacities of your database vendor. From [HikariCP docs](https://github.com/brettwooldridge/HikariCP/tree/dev#log-statement-text--slow-query-logging):
+
+#### *Log Statement Text / Slow Query Logging*
+
+*Like Statement caching, most major database vendors support statement logging through properties of their own driver. This includes Oracle, MySQL, Derby, MSSQL, and others. Some even support slow query logging. We consider this a "development-time" feature. For those few databases that do not support it, jdbcdslog-exp is a good option. Great stuff during development and pre-Production.*
+
+Because of that, Play uses [jdbcdslog-exp](https://github.com/jdbcdslog/jdbcdslog) to enable consistent SQL log statement support for supported pools. The SQL log statement can be configured by database, using `logSql` property:
+
+```properties
+# Default database configuration using PostgreSQL database engine
+db.default.driver=org.postgresql.Driver
+db.default.url="jdbc:postgresql://database.example.com/playdb"
+db.default.logSql=true
+```
+
+After that, you can configure the jdbcdslog-exp [log level as explained in their manual](https://code.google.com/p/jdbcdslog/wiki/UserGuide#Setup_logging_engine). Basically, you need to configure your root logger to `INFO` and then decide what jdbcdslog-exp will log (connections, statements and result sets). Here is an example using `logback.xml` to configure the logs:
+
+@[](/confs/play/logback-play-logSql.xml)
+
+> **Warning**: Keep in mind that this is intended to be used just in development environments and you should not configure it in production, since there is a performance degradation and it will pollute your logs.
+
+## Configuring the JDBC Driver dependency
 
 Play is bundled only with an [H2](http://www.h2database.com) database driver. Consequently, to deploy in production you will need to add your database driver as a dependency.
 

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -37,7 +37,8 @@ object Dependencies {
 
   val jdbcDeps = Seq(
     "com.jolbox" % "bonecp" % "0.8.0.RELEASE",
-    "com.zaxxer" % "HikariCP" % "2.3.7",
+    "com.zaxxer" % "HikariCP" % "2.3.8",
+    "com.googlecode.usc" % "jdbcdslog" % "1.0.6.2",
     h2database,
     acolyte % Test,
     "tyrex" % "tyrex" % "1.0.1") ++ specsBuild.map(_ % Test)

--- a/framework/src/play-jdbc/src/main/resources/reference.conf
+++ b/framework/src/play-jdbc/src/main/resources/reference.conf
@@ -50,6 +50,9 @@ play {
       # If non null, binds the JNDI name to this data source to the given JNDI name.
       jndiName = null
 
+      # If it should log sql statements
+      logSql = false
+
       # HikariCP configuration options
       hikaricp {
 

--- a/framework/src/play-jdbc/src/main/scala/org/jdbcdslog/LogSqlDataSource.scala
+++ b/framework/src/play-jdbc/src/main/scala/org/jdbcdslog/LogSqlDataSource.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package org.jdbcdslog
+
+import java.sql.SQLFeatureNotSupportedException
+import java.util.logging.Logger
+import javax.sql.DataSource
+
+/**
+ * This class is necessary because jdbcdslog proxies does not
+ * exposes the target dataSource, which is necessary to shutdown
+ * the pool.
+ */
+class LogSqlDataSource extends ConnectionPoolDataSourceProxy {
+
+  override def getParentLogger: Logger = throw new SQLFeatureNotSupportedException
+
+  def getTargetDatasource = this.targetDS.asInstanceOf[DataSource]
+
+}

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
@@ -15,7 +15,7 @@ import play.api.libs.JNDI
 import com.jolbox.bonecp._
 import com.jolbox.bonecp.hooks._
 
-import scala.concurrent.duration.{ FiniteDuration, Duration }
+import scala.concurrent.duration.FiniteDuration
 
 /**
  * BoneCP runtime inject module.
@@ -91,7 +91,7 @@ class BoneConnectionPool @Inject() (environment: Environment) extends Connection
       override def onQueryExecuteTimeLimitExceeded(handle: ConnectionHandle, statement: Statement, sql: String, logParams: java.util.Map[AnyRef, AnyRef], timeElapsedInNs: Long) {
         val timeMs = timeElapsedInNs / 1000
         val query = PoolUtil.fillLogParams(sql, logParams)
-        logger.warn(s"Query execute time limit exceeded (${timeMs}ms) - query: ${query}")
+        logger.warn(s"Query execute time limit exceeded (${timeMs}ms) - query: $query")
       }
 
     })

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
@@ -5,6 +5,7 @@ package play.api.db
 
 import java.sql.SQLException
 import com.zaxxer.hikari.HikariDataSource
+import org.jdbcdslog.LogSqlDataSource
 import org.specs2.mutable.{ After, Specification }
 
 object DatabasesSpec extends Specification {
@@ -27,6 +28,12 @@ object DatabasesSpec extends Specification {
       val db = Databases(driver = "org.h2.Driver", url = "jdbc:h2:mem:default")
       db.name must_== "default"
       db.url must_== "jdbc:h2:mem:default"
+    }
+
+    "create database with log sql" in new WithDatabase {
+      val config = Map("logSql" -> "true")
+      val db = Databases(driver = "org.h2.Driver", url = "jdbc:h2:mem:default", config = config)
+      db.dataSource must beAnInstanceOf[LogSqlDataSource]
     }
 
     "create default in-memory database" in new WithDatabase {
@@ -122,6 +129,15 @@ object DatabasesSpec extends Specification {
       db.getConnection.close() must throwA[SQLException].like {
         case e => e.getMessage must startWith("Pool has been shutdown")
       }
+    }
+
+    "not supply connections after shutdown a database with log sql" in {
+      val config = Map("logSql" -> "true")
+      val db = Databases(driver = "org.h2.Driver", url = "jdbc:h2:mem:default", config = config)
+
+      db.getConnection.close()
+      db.shutdown()
+      db.getConnection.close() must throwA[SQLException]
     }
 
   }

--- a/framework/src/play/src/main/resources/logback-play-logSql.xml
+++ b/framework/src/play/src/main/resources/logback-play-logSql.xml
@@ -1,0 +1,42 @@
+<!--
+  ~ Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+  -->
+<!-- The default logback configuration that Play uses if no other configuration is provided -->
+<configuration>
+    
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
+
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+     <file>${application.home}/logs/application.log</file>
+     <encoder>
+       <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
+     </encoder>
+  </appender>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="FILE" />
+  </appender>
+
+  <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="STDOUT" />
+  </appender>
+
+  <logger name="play" level="INFO" />
+  <logger name="application" level="DEBUG" />
+
+  <logger name="logger.org.jdbcdslog.ConnectionLogger" level="OFF"  /> <!-- Won' log connections -->
+  <logger name="logger.org.jdbcdslog.StatementLogger"  level="INFO" /> <!-- Will log all statements -->
+  <logger name="logger.org.jdbcdslog.ResultSetLogger"  level="OFF"  /> <!-- Won' log result sets -->
+
+  <root level="WARN">
+    <appender-ref ref="ASYNCFILE" />
+    <appender-ref ref="ASYNCSTDOUT" />
+  </root>
+  
+</configuration>


### PR DESCRIPTION
Based on this discussion:

https://groups.google.com/forum/#!topic/play-framework-dev/GK3ywRTMexg

----------

What I'm planning to do:

1. Have a boolean configuration (`play.db.logSql`) that controls if statements will be logged or not
2. Use [jdbcdslog-exp](https://github.com/adrianshum/jdbcdslog) to wrap the created datasource when configured to do so
3. Support both HikariCP and BoneCP connection pools.