### PR TITLE
[doc] Fix ws.ssl settings

### DIFF
--- a/documentation/manual/detailedTopics/configuration/ws/CipherSuites.md
+++ b/documentation/manual/detailedTopics/configuration/ws/CipherSuites.md
@@ -22,7 +22,7 @@ In 1.6, the out of the box list is [out of order](http://op-co.de/blog/posts/and
   "TLS_EMPTY_RENEGOTIATION_INFO_SCSV" // per RFC 5746
 ```
 
-The list of cipher suites can be configured manually using the `ws.ssl.enabledCiphers` setting:
+The list of cipher suites can be configured manually using the `play.ws.ssl.enabledCiphers` setting:
 
 ```
 play.ws.ssl.enabledCiphers = [

--- a/documentation/manual/detailedTopics/configuration/ws/LooseSSL.md
+++ b/documentation/manual/detailedTopics/configuration/ws/LooseSSL.md
@@ -47,7 +47,7 @@ If you must turn on loose options, there are a couple of things you can do to mi
 
 **Environment Scoping**: You can define [environment variables in HOCON](https://github.com/typesafehub/config/blob/master/HOCON.md#substitution-fallback-to-environment-variables) to ensure that any loose options are not hardcoded in configuration files, and therefore cannot escape an development environment.
 
-**Runtime / Deployment Checks**: You can add code to your deployment scripts or program that checks that `ws.ssl.loose` options are not enabled in a production environment.  The runtime mode can be found in the [`Application.mode`](api/scala/play/api/Application.html) method.
+**Runtime / Deployment Checks**: You can add code to your deployment scripts or program that checks that `play.ws.ssl.loose` options are not enabled in a production environment.  The runtime mode can be found in the [`Application.mode`](api/scala/play/api/Application.html) method.
 
 ## Loose Options
 

--- a/documentation/manual/detailedTopics/configuration/ws/Protocols.md
+++ b/documentation/manual/detailedTopics/configuration/ws/Protocols.md
@@ -30,7 +30,7 @@ play.ws.ssl.enabledProtocols = [
 
 If you are on JDK 1.8, you can also set the `jdk.tls.client.protocols` system property to enable client protocols globally.
 
-WS recognizes "SSLv3", "SSLv2" and "SSLv2Hello" as weak protocols with a number of [security issues](https://www.schneier.com/paper-ssl.pdf), and will throw an exception if they are in the `ws.ssl.enabledProtocols` list.  Virtually all servers support `TLSv1`, so there is no advantage in using these older protocols.
+WS recognizes "SSLv3", "SSLv2" and "SSLv2Hello" as weak protocols with a number of [security issues](https://www.schneier.com/paper-ssl.pdf), and will throw an exception if they are in the `play.ws.ssl.enabledProtocols` list.  Virtually all servers support `TLSv1`, so there is no advantage in using these older protocols.
 
 ## Debugging
 

--- a/documentation/manual/detailedTopics/configuration/ws/code/HowsMySSLSpec.scala
+++ b/documentation/manual/detailedTopics/configuration/ws/code/HowsMySSLSpec.scala
@@ -70,11 +70,11 @@ class HowsMySSLSpec extends PlaySpecification {
         """.stripMargin
 
       val configString = """
-         |//ws.ssl.debug=["certpath", "ssl", "trustmanager"]
-         |ws.ssl.protocol="TLSv1"
-         |ws.ssl.enabledProtocols=["TLSv1"]
+         |//play.ws.ssl.debug=["certpath", "ssl", "trustmanager"]
+         |play.ws.ssl.protocol="TLSv1"
+         |play.ws.ssl.enabledProtocols=["TLSv1"]
          |
-         |ws.ssl.trustManager = {
+         |play.ws.ssl.trustManager = {
          |  stores = [
          |    { type: "PEM", data = ${geotrust.pem} }
          |  ]


### PR DESCRIPTION
Some parts of the WS SSL documentation were still referencing the old ws.ssl configuration settings.