### PR TITLE
Make JSON macros return OFormat/OWrites.

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -9,17 +9,16 @@ import language.experimental.macros
 
 object JsMacroImpl {
 
-  def formatImpl[A: c.WeakTypeTag](c: Context): c.Expr[Format[A]] =
-    macroImpl[A, Format](c, "format", "inmap", reads = true, writes = true)
+  def formatImpl[A: c.WeakTypeTag](c: Context): c.Expr[OFormat[A]] =
+    macroImpl[A, OFormat, Format](c, "format", "inmap", reads = true, writes = true)
 
   def readsImpl[A: c.WeakTypeTag](c: Context): c.Expr[Reads[A]] =
-    macroImpl[A, Reads](c, "read", "map", reads = true, writes = false)
+    macroImpl[A, Reads, Reads](c, "read", "map", reads = true, writes = false)
 
-  def writesImpl[A: c.WeakTypeTag](c: Context): c.Expr[Writes[A]] =
-    macroImpl[A, Writes](c, "write", "contramap", reads = false, writes = true)
+  def writesImpl[A: c.WeakTypeTag](c: Context): c.Expr[OWrites[A]] =
+    macroImpl[A, OWrites, Writes](c, "write", "contramap", reads = false, writes = true)
 
-  def macroImpl[A, M[_]](c: Context, methodName: String, mapLikeMethod: String, reads: Boolean, writes: Boolean)(implicit atag: c.WeakTypeTag[A], matag: c.WeakTypeTag[M[A]]): c.Expr[M[A]] = {
-
+  def macroImpl[A, M[_], N[_]](c: Context, methodName: String, mapLikeMethod: String, reads: Boolean, writes: Boolean)(implicit atag: c.WeakTypeTag[A], matag: c.WeakTypeTag[M[A]], natag: c.WeakTypeTag[N[A]]): c.Expr[M[A]] = {
     val nullableMethodName = s"${methodName}Nullable"
     val lazyMethodName = s"lazy${methodName.capitalize}"
 
@@ -126,7 +125,7 @@ object JsMacroImpl {
       }
 
       // builds M implicit from expected type
-      val neededImplicitType = appliedType(matag.tpe.typeConstructor, tpe :: Nil)
+      val neededImplicitType = appliedType(natag.tpe.typeConstructor, tpe :: Nil)
       // infers implicit
       val neededImplicit = c.inferImplicitValue(neededImplicitType)
       Implicit(name, implType, neededImplicit, isRecursive, tpe)
@@ -238,7 +237,7 @@ object JsMacroImpl {
         List(importFunctionalSyntax),
         finalTree
       )
-      //println("block:"+block)
+      //println(s"nonrec block:$block")
       c.Expr[M[A]](block)
     } else {
       val block = Select(
@@ -292,7 +291,7 @@ object JsMacroImpl {
         newTermName("lazyStuff")
       )
 
-      // println("block:" + block)
+      //println(s"is rec block:$block")
 
       c.Expr[M[A]](block)
     }

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
@@ -201,7 +201,7 @@ object Json {
    *   )(User)
    * }}}
    */
-  def reads[A] = macro JsMacroImpl.readsImpl[A]
+  def reads[A]: Reads[A] = macro JsMacroImpl.readsImpl[A]
 
   /**
    * Creates a Writes[T] by resolving case class fields & required implcits at COMPILE-time
@@ -221,7 +221,7 @@ object Json {
    *   )(unlift(User.unapply))
    * }}}
    */
-  def writes[A] = macro JsMacroImpl.writesImpl[A]
+  def writes[A]: OWrites[A] = macro JsMacroImpl.writesImpl[A]
 
   /**
    * Creates a Format[T] by resolving case class fields & required implicits at COMPILE-time
@@ -241,6 +241,6 @@ object Json {
    *   )(User.apply, unlift(User.unapply))
    * }}}
    */
-  def format[A] = macro JsMacroImpl.formatImpl[A]
+  def format[A]: OFormat[A] = macro JsMacroImpl.formatImpl[A]
 
 }

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -43,16 +43,16 @@ object Program {
 
 case class Person(name: String, age: Int)
 object Person {
-  implicit val personReads = Json.reads[Person]
-  implicit val personWrites = Json.writes[Person]
+  implicit val personReads: Reads[Person] = Json.reads[Person]
+  implicit val personWrites: OWrites[Person] = Json.writes[Person]
 }
 
 package foreign {
   case class Foreigner(name: String)
 }
 object ForeignTest {
-  implicit val foreignerReads = Json.reads[foreign.Foreigner]
-  implicit val foreignerWrites = Json.writes[foreign.Foreigner]
+  implicit val foreignerReads: Reads[foreign.Foreigner] = Json.reads[foreign.Foreigner]
+  implicit val foreignerWrites: OWrites[foreign.Foreigner] = Json.writes[foreign.Foreigner]
 }
 
 import play.api.libs.json._
@@ -68,7 +68,7 @@ case class VarArgsOnly(ints: Int*)
 case class LastVarArg(name: String, ints: Int*)
 
 object Person2 {
-  implicit val person2Fmt = Json.format[Person2]
+  implicit val person2Fmt: OFormat[Person2] = Json.format[Person2]
 }
 
 object JsonExtensionSpec extends Specification {


### PR DESCRIPTION
The JSON macros remove the boilerplate for creating `Reads`/`Writes`/`Format` for case classes.

But given that a case class will always serialise to a `JsObject` then .writes/.format could return
`OWrites`/`OFormat` respectively.

This allows for type-safety in manipulating a statically known `JsObject`, rather than a `JsValue`.

Given that `OWrites` and `OFormat` are subtypes of `Writes`/`Format` this is a backwards-compatible change.