### PR TITLE
Bumped akka-stream and akka-http to 1.0-RC4. Fix #4774

### DIFF
--- a/documentation/manual/detailedTopics/configuration/filters/code/GzipEncoding.scala
+++ b/documentation/manual/detailedTopics/configuration/filters/code/GzipEncoding.scala
@@ -3,7 +3,7 @@
  */
 package detailedtopics.configuration.gzipencoding
 
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import play.api.test._
 
 object GzipEncoding extends PlaySpecification {
@@ -31,7 +31,7 @@ object GzipEncoding extends PlaySpecification {
       import play.api.mvc._
       val app = FakeApplication()
       running(app) {
-        implicit val mat = ActorFlowMaterializer()(app.actorSystem)
+        implicit val mat = ActorMaterializer()(app.actorSystem)
         header(CONTENT_ENCODING,
           filter(Action(Results.Ok("foo")))(gzipRequest).run()
         ) must beNone

--- a/documentation/manual/working/javaGuide/code/MockJavaAction.scala
+++ b/documentation/manual/working/javaGuide/code/MockJavaAction.scala
@@ -3,7 +3,7 @@
  */
 package javaguide.testhelpers
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import play.api.mvc.{Action, Request}
 import play.core.j.{JavaHandlerComponents, JavaHelpers, JavaActionAnnotations, JavaAction}
 import play.http.DefaultHttpRequestHandler
@@ -45,7 +45,7 @@ object MockJavaActionHelper {
     }
   }
 
-  def callWithStringBody(action: Action[Http.RequestBody], requestBuilder: play.mvc.Http.RequestBuilder, body: String)(implicit mat: FlowMaterializer): Result = {
+  def callWithStringBody(action: Action[Http.RequestBody], requestBuilder: play.mvc.Http.RequestBuilder, body: String)(implicit mat: Materializer): Result = {
     val result = Helpers.await(Helpers.call(action, requestBuilder.build()._underlyingRequest, body))
     new Result {
       def toScala = result

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaBodyParsers.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaBodyParsers.java
@@ -3,7 +3,7 @@
  */
 package javaguide.http;
 
-import akka.stream.FlowMaterializer;
+import akka.stream.Materializer;
 import org.junit.Before;
 import org.junit.Test;
 import play.libs.Json;
@@ -73,7 +73,7 @@ public class JavaBodyParsers extends WithApplication {
         for (int i = 0; i < 1100; i++) {
             body.append("1234567890");
         }
-        FlowMaterializer mat = app.injector().instanceOf(FlowMaterializer.class);
+        Materializer mat = app.injector().instanceOf(Materializer.class);
         assertThat(callWithStringBody(new MockJavaAction() {
                     //#max-length
                     // Accept only 10KB of data.

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaRouting.scala
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaRouting.scala
@@ -3,7 +3,7 @@
  */
 package javaguide.http
 
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import org.specs2.mutable.Specification
 import play.api.mvc.{EssentialAction, RequestHeader}
 import play.api.routing.Router
@@ -52,7 +52,7 @@ object JavaRouting extends Specification {
     "support reverse routing" in {
       val app = FakeApplication()
       running(app) {
-        implicit val mat = ActorFlowMaterializer()(app.actorSystem)
+        implicit val mat = ActorMaterializer()(app.actorSystem)
         header("Location", call(new MockJavaAction {
           override def invocation = F.Promise.pure(new javaguide.http.routing.controllers.Application().index())
         }, FakeRequest())) must beSome("/hello/Bob")
@@ -64,7 +64,7 @@ object JavaRouting extends Specification {
   def contentOf(rh: RequestHeader, router: Class[_ <: Router] = classOf[Routes]) = {
     val app = FakeApplication(additionalConfiguration = Map("play.http.router" -> router.getName))
     running(app) {
-      implicit val mat = ActorFlowMaterializer()(app.actorSystem)
+      implicit val mat = ActorMaterializer()(app.actorSystem)
       contentAsString(app.requestHandler.handlerForRequest(rh)._2 match {
         case e: EssentialAction => e(rh).run()
       })

--- a/documentation/manual/working/scalaGuide/advanced/http/code/FiltersRouting.scala
+++ b/documentation/manual/working/scalaGuide/advanced/http/code/FiltersRouting.scala
@@ -2,14 +2,14 @@ package scalaguide.advanced.filters.routing
 
 // #routing-info-access
 import javax.inject.Inject
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import play.api.mvc.{Result, RequestHeader, Filter}
 import play.api.Logger
 import play.api.routing.Router.Tags
 import scala.concurrent.Future
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-class LoggingFilter @Inject() (implicit val mat: FlowMaterializer) extends Filter {
+class LoggingFilter @Inject() (implicit val mat: Materializer) extends Filter {
   def apply(nextFilter: RequestHeader => Future[Result])
            (requestHeader: RequestHeader): Future[Result] = {
 

--- a/documentation/manual/working/scalaGuide/advanced/http/code/ScalaHttpFilters.scala
+++ b/documentation/manual/working/scalaGuide/advanced/http/code/ScalaHttpFilters.scala
@@ -4,13 +4,13 @@ package simple {
 
 // #simple-filter
 import javax.inject.Inject
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import play.api.Logger
 import play.api.mvc._
 import scala.concurrent.Future
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-class LoggingFilter @Inject() (implicit val mat: FlowMaterializer) extends Filter {
+class LoggingFilter @Inject() (implicit val mat: Materializer) extends Filter {
 
   def apply(nextFilter: RequestHeader => Future[Result])
            (requestHeader: RequestHeader): Future[Result] = {

--- a/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
+++ b/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
@@ -4,7 +4,7 @@
  */
 package scalaguide.cache {
 
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 
@@ -87,7 +87,7 @@ class ScalaCacheSpec extends PlaySpecification with Controller {
     "cached page" in {
       val app = FakeApplication()
       running(app) {
-        implicit val mat = ActorFlowMaterializer()(app.actorSystem)
+        implicit val mat = ActorMaterializer()(app.actorSystem)
         val cachedApp = app.injector.instanceOf[cachedaction.Application1]
         val result = cachedApp.index(FakeRequest()).run()
         status(result) must_== 200
@@ -105,7 +105,7 @@ class ScalaCacheSpec extends PlaySpecification with Controller {
     "control cache" in {
       val app = FakeApplication()
       running(app) {
-        implicit val mat = ActorFlowMaterializer()(app.actorSystem)
+        implicit val mat = ActorMaterializer()(app.actorSystem)
         val cachedApp = app.injector.instanceOf[cachedaction.Application1]
         val result0 = cachedApp.get(1)(FakeRequest("GET", "/resource/1")).run()
         status(result0) must_== 200
@@ -118,7 +118,7 @@ class ScalaCacheSpec extends PlaySpecification with Controller {
     "control cache" in {
       val app = FakeApplication()
       running(app) {
-        implicit val mat = ActorFlowMaterializer()(app.actorSystem)
+        implicit val mat = ActorMaterializer()(app.actorSystem)
         val cachedApp = app.injector.instanceOf[cachedaction.Application2]
         val result0 = cachedApp.get(1)(FakeRequest("GET", "/resource/1")).run()
         status(result0) must_== 200
@@ -139,7 +139,7 @@ class ScalaCacheSpec extends PlaySpecification with Controller {
   def assertAction[A, T: AsResult](action: EssentialAction, request: => Request[A] = FakeRequest(), expectedResponse: Int = OK)(assertions: Future[Result] => T) = {
     val app = FakeApplication()
     running(app) {
-      implicit val mat = ActorFlowMaterializer()(app.actorSystem)
+      implicit val mat = ActorMaterializer()(app.actorSystem)
       val result = action(request).run()
       status(result) must_== expectedResponse
       assertions(result)

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -4,7 +4,7 @@
  */
 package scalaguide.http.scalaactionscomposition {
 
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import play.api.test._
   import play.api.test.Helpers._
   import org.specs2.mutable.Specification
@@ -251,7 +251,7 @@ import play.api.test._
     def assertAction[A, T: AsResult](action: EssentialAction, request: => Request[A] = FakeRequest(), expectedResponse: Int = OK)(assertions: Future[Result] => T) = {
       val app = FakeApplication()
       running(app) {
-        implicit val mat = ActorFlowMaterializer()(app.actorSystem)
+        implicit val mat = ActorMaterializer()(app.actorSystem)
         val result = action(request).run()
         status(result) must_== expectedResponse
         assertions(result)

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParser.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParser.scala
@@ -3,7 +3,7 @@
  */
 package scalaguide.http.scalabodyparsers {
 
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import play.api.http.Writeable
 import play.api.mvc._
   import play.api.test._
@@ -86,7 +86,7 @@ import play.api.mvc._
       "body parser limit file" in {
         val app = FakeApplication()
         running(app) {
-          implicit val mat = ActorFlowMaterializer()(app.actorSystem)
+          implicit val mat = ActorMaterializer()(app.actorSystem)
           val storeInUserFile = scalaguide.http.scalabodyparsers.full.Application.storeInUserFile
           //#body-parser-limit-file
           // Accept only 10KB of data.
@@ -108,7 +108,7 @@ import play.api.mvc._
     def assertAction[A: Writeable, T: AsResult](action: EssentialAction, request: => FakeRequest[A], expectedResponse: Int = OK)(assertions: Future[Result] => T) = {
       val app = FakeApplication()
       running(app) {
-        implicit val mat = ActorFlowMaterializer()(app.actorSystem)
+        implicit val mat = ActorMaterializer()(app.actorSystem)
         val result = call(action, request)
         status(result) must_== expectedResponse
         assertions(result)

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
@@ -3,7 +3,7 @@
  */
 package scalaguide.http.routing
 
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import org.specs2.mutable.Specification
 import play.api.test.FakeRequest
 import play.api.mvc._
@@ -142,7 +142,7 @@ object ScalaRoutingSpec extends Specification {
   def contentOf(rh: RequestHeader, router: Class[_ <: Router] = classOf[Routes]) = {
     val app = FakeApplication()
     running(app) {
-      implicit val mat = ActorFlowMaterializer()(app.actorSystem)
+      implicit val mat = ActorMaterializer()(app.actorSystem)
       contentAsString(app.injector.instanceOf(router).routes(rh) match {
         case e: EssentialAction => e(rh).run()
       })

--- a/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
@@ -126,14 +126,14 @@ class ScalaLoggingSpec extends Specification with Mockito {
     "allow for use in filters" in {
       //#logging-pattern-filter
       import javax.inject.Inject
-      import akka.stream.FlowMaterializer
+      import akka.stream.Materializer
       import scala.concurrent.ExecutionContext.Implicits.global
       import scala.concurrent.Future
       import play.api.Logger
       import play.api.mvc._
       import play.api._
       
-      class AccessLoggingFilter @Inject() (implicit val mat: FlowMaterializer) extends Filter {
+      class AccessLoggingFilter @Inject() (implicit val mat: Materializer) extends Filter {
         
         val accessLogger = Logger("access")
         

--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -27,7 +27,6 @@ import interplay.PlayBuildBase.autoImport._
 import scala.util.control.NonFatal
 
 object BuildSettings {
-
   // Binary compatibility is tested against this version
   val previousVersion = "2.5.0"
 

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -142,7 +142,7 @@ object Dependencies {
   val nettyUtilsDependencies = slf4j
 
   val akkaHttp = Seq(
-    "com.typesafe.akka" %% "akka-http-core-experimental" % "1.0-RC3"
+    "com.typesafe.akka" %% "akka-http-core-experimental" % "1.0-RC4"
   )
 
   val routesCompilerDependencies =  Seq(
@@ -239,7 +239,7 @@ object Dependencies {
 
   val streamsDependencies = Seq(
     "org.reactivestreams" % "reactive-streams" % "1.0.0",
-    "com.typesafe.akka" %% "akka-stream-experimental" % "1.0-RC3",
+    "com.typesafe.akka" %% "akka-stream-experimental" % "1.0-RC4",
     scalaJava8Compat
   ) ++ specsBuild.map(_ % "test") ++ javaTestDeps
 

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.Expect
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import java.net.InetSocketAddress
 import akka.util.ByteString
@@ -40,7 +40,7 @@ class AkkaHttpServer(
   // Remember that some user config may not be available in development mode due to
   // its unusual ClassLoader.
   implicit val system = actorSystem
-  implicit val materializer = ActorFlowMaterializer()
+  implicit val materializer = ActorMaterializer()
 
   val address: InetSocketAddress = {
     // Listen for incoming connections and handle them with the `handleRequest` method.

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaStreamsConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaStreamsConversion.scala
@@ -1,6 +1,6 @@
 package play.core.server.akkahttp
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl._
 import org.reactivestreams._
 import play.api.libs.iteratee._
@@ -14,7 +14,7 @@ import play.api.libs.streams.Streams
  * Streams API is in flux at the moment so this isn't worth doing yet.
  */
 object AkkaStreamsConversion {
-  def sourceToEnumerator[Out, Mat](source: Source[Out, Mat])(implicit fm: FlowMaterializer): Enumerator[Out] = {
+  def sourceToEnumerator[Out, Mat](source: Source[Out, Mat])(implicit fm: Materializer): Enumerator[Out] = {
     val pubr: Publisher[Out] = source.runWith(Sink.publisher[Out])
     Streams.publisherToEnumerator(pubr)
   }

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/MaterialiseOnDemandPublisher.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/MaterialiseOnDemandPublisher.scala
@@ -1,6 +1,6 @@
 package play.core.server.akkahttp
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.{ Sink, Source }
 import org.reactivestreams.{ Subscriber, Publisher, Subscription }
 import play.api.libs.concurrent.StateMachine
@@ -41,7 +41,7 @@ import MaterialiseOnDemandPublisher._
  *
  * This is used to work around https://github.com/akka/akka/issues/17782.
  */
-private[akkahttp] class MaterialiseOnDemandPublisher[T](source: Source[T, _])(implicit mat: FlowMaterializer) extends StateMachine[State](AwaitingDemand) with Publisher[T] {
+private[akkahttp] class MaterialiseOnDemandPublisher[T](source: Source[T, _])(implicit mat: Materializer) extends StateMachine[State](AwaitingDemand) with Publisher[T] {
 
   def subscribe(subscriber: Subscriber[_ >: T]) = {
     subscriber.onSubscribe(new ForwardingSubscription(subscriber))

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -3,7 +3,7 @@ package play.core.server.akkahttp
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.ContentType
 import akka.http.scaladsl.model.headers._
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import java.net.InetSocketAddress
@@ -32,7 +32,7 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
     requestId: Long,
     remoteAddress: InetSocketAddress,
     secureProtocol: Boolean,
-    request: HttpRequest)(implicit fm: FlowMaterializer): (RequestHeader, Source[ByteString, Any]) = {
+    request: HttpRequest)(implicit fm: Materializer): (RequestHeader, Source[ByteString, Any]) = {
     (
       convertRequestHeader(requestId, remoteAddress, secureProtocol, request),
       convertRequestBody(request)
@@ -99,7 +99,7 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
    * Convert an Akka `HttpRequest` to an `Enumerator` of the request body.
    */
   private def convertRequestBody(
-    request: HttpRequest)(implicit fm: FlowMaterializer): Source[ByteString, Any] = {
+    request: HttpRequest)(implicit fm: Materializer): Source[ByteString, Any] = {
     import play.api.libs.iteratee.Execution.Implicits.trampoline
     request.entity match {
       case HttpEntity.Strict(_, data) if data.isEmpty =>

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
@@ -3,7 +3,7 @@
  */
 package play.filters.cors
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
 
 import scala.concurrent.Future
@@ -35,7 +35,7 @@ import play.api.mvc.{ Filter, RequestHeader, Result }
 class CORSFilter(
     override protected val corsConfig: CORSConfig = CORSConfig(),
     override protected val errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
-    private val pathPrefixes: Seq[String] = Seq("/"))(override implicit val mat: FlowMaterializer) extends Filter with AbstractCORSPolicy {
+    private val pathPrefixes: Seq[String] = Seq("/"))(override implicit val mat: Materializer) extends Filter with AbstractCORSPolicy {
 
   override protected val logger = Logger(classOf[CORSFilter])
 
@@ -51,7 +51,7 @@ class CORSFilter(
 object CORSFilter {
 
   def apply(corsConfig: CORSConfig = CORSConfig(), errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
-    pathPrefixes: Seq[String] = Seq("/"))(implicit mat: FlowMaterializer) =
+    pathPrefixes: Seq[String] = Seq("/"))(implicit mat: Materializer) =
     new CORSFilter(corsConfig, errorHandler, pathPrefixes)
 
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
@@ -5,7 +5,7 @@ package play.filters.cors
 
 import javax.inject.{ Inject, Provider }
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import play.api.http.HttpErrorHandler
 import play.api.{ Environment, PlayConfig, Configuration }
 import play.api.inject.Module
@@ -21,7 +21,7 @@ class CORSConfigProvider @Inject() (configuration: Configuration) extends Provid
  * Provider for CORSFilter.
  */
 class CORSFilterProvider @Inject() (configuration: Configuration, errorHandler: HttpErrorHandler, corsConfig: CORSConfig,
-    flowMaterializer: FlowMaterializer) extends Provider[CORSFilter] {
+    flowMaterializer: Materializer) extends Provider[CORSFilter] {
   lazy val get = {
     val pathPrefixes = PlayConfig(configuration).get[Seq[String]]("play.filters.cors.pathPrefixes")
     new CORSFilter(corsConfig, errorHandler, pathPrefixes)(flowMaterializer)
@@ -44,7 +44,7 @@ class CORSModule extends Module {
 trait CORSComponents {
   def configuration: Configuration
   def httpErrorHandler: HttpErrorHandler
-  implicit def flowMaterializer: FlowMaterializer
+  implicit def flowMaterializer: Materializer
 
   lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(configuration)
   lazy val corsFilter: CORSFilter = new CORSFilter(corsConfig, httpErrorHandler, corsPathPrefixes)

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -3,7 +3,7 @@
  */
 package play.filters.csrf
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.util.ByteString
 import play.api.libs.streams.{ Streams, Accumulator }
 import play.api.mvc._
@@ -24,7 +24,7 @@ import scala.concurrent.Future
 class CSRFAction(next: EssentialAction,
     config: CSRFConfig = CSRFConfig(),
     tokenProvider: TokenProvider = SignedTokenProvider,
-    errorHandler: => ErrorHandler = CSRF.DefaultErrorHandler)(implicit mat: FlowMaterializer) extends EssentialAction {
+    errorHandler: => ErrorHandler = CSRF.DefaultErrorHandler)(implicit mat: Materializer) extends EssentialAction {
 
   import CSRFAction._
   import play.api.libs.iteratee.Execution.Implicits.trampoline

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
@@ -4,7 +4,7 @@
 package play.filters.csrf
 
 import javax.inject.{ Provider, Inject }
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import play.api.mvc._
 import play.filters.csrf.CSRF._
 
@@ -22,17 +22,17 @@ import play.filters.csrf.CSRF._
 class CSRFFilter(
     config: => CSRFConfig,
     val tokenProvider: TokenProvider = SignedTokenProvider,
-    val errorHandler: ErrorHandler = CSRF.DefaultErrorHandler)(implicit mat: FlowMaterializer) extends EssentialFilter {
+    val errorHandler: ErrorHandler = CSRF.DefaultErrorHandler)(implicit mat: Materializer) extends EssentialFilter {
 
   @Inject
-  def this(config: Provider[CSRFConfig], tokenProvider: TokenProvider, errorHandler: ErrorHandler, mat: FlowMaterializer) = {
+  def this(config: Provider[CSRFConfig], tokenProvider: TokenProvider, errorHandler: ErrorHandler, mat: Materializer) = {
     this(config.get, tokenProvider, errorHandler)(mat)
   }
 
   /**
    * Default constructor, useful from Java
    */
-  def this()(implicit mat: FlowMaterializer) = this(CSRFConfig.global, new ConfigTokenProvider(CSRFConfig.global), DefaultErrorHandler)
+  def this()(implicit mat: Materializer) = this(CSRFConfig.global, new ConfigTokenProvider(CSRFConfig.global), DefaultErrorHandler)
 
   def apply(next: EssentialAction): EssentialAction = new CSRFAction(next, config, tokenProvider, errorHandler)
 }
@@ -41,7 +41,7 @@ object CSRFFilter {
   def apply(
     config: => CSRFConfig = CSRFConfig.global,
     tokenProvider: TokenProvider = new ConfigTokenProvider(CSRFConfig.global),
-    errorHandler: ErrorHandler = DefaultErrorHandler)(implicit mat: FlowMaterializer): CSRFFilter = {
+    errorHandler: ErrorHandler = DefaultErrorHandler)(implicit mat: Materializer): CSRFFilter = {
     new CSRFFilter(config, tokenProvider, errorHandler)
   }
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -5,7 +5,7 @@ package play.filters.csrf
 
 import java.util.Optional
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import com.typesafe.config.ConfigMemorySize
 import play.filters.csrf.CSRF.{ CSRFHttpErrorHandler, ErrorHandler }
 import play.mvc.Http
@@ -236,7 +236,7 @@ class CSRFModule extends Module {
 trait CSRFComponents {
   def configuration: Configuration
   def httpErrorHandler: HttpErrorHandler
-  implicit def flowMaterializer: FlowMaterializer
+  implicit def flowMaterializer: Materializer
 
   lazy val csrfConfig: CSRFConfig = CSRFConfig.fromConfiguration(configuration)
   lazy val csrfTokenProvider: CSRF.TokenProvider = new CSRF.TokenProviderProvider(csrfConfig).get

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/EssentialActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/EssentialActionSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.it.action
 
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import play.api.mvc.{ Action, EssentialAction }
 import play.api.mvc.Results._
 import play.api.test.{ FakeApplication, PlaySpecification, FakeRequest }
@@ -24,7 +24,7 @@ object EssentialActionSpec extends PlaySpecification {
       // start fake application with its own classloader
       val applicationClassLoader = new ClassLoader() {}
       val fakeApplication = FakeApplication(classloader = applicationClassLoader)
-      implicit val mat = ActorFlowMaterializer()(fakeApplication.actorSystem)
+      implicit val mat = ActorMaterializer()(fakeApplication.actorSystem)
 
       running(fakeApplication) {
         // run the test with the classloader of the current thread

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -19,6 +19,8 @@ object AkkaHttpJavaResultsHandlingSpec extends JavaResultsHandlingSpec with Akka
 
 trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
 
+  sequential
+
   "Java results handling" should {
     def makeRequest[T](controller: MockController)(block: WSResponse => T) = {
       implicit val port = testServerPort

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -18,6 +18,8 @@ object AkkaHttpScalaResultsHandlingSpec extends ScalaResultsHandlingSpec with Ak
 
 trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
 
+  sequential
+
   "scala body handling" should {
 
     def tryRequest[T](result: Result)(block: Try[WSResponse] => T) = withServer(result) { implicit port =>

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/AnyContentBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/AnyContentBodyParserSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.it.http.parsing
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.mvc._
@@ -13,7 +13,7 @@ object AnyContentBodyParserSpec extends PlaySpecification {
 
   "The anyContent body parser" should {
 
-    def parse(method: String, contentType: Option[String], body: ByteString)(implicit mat: FlowMaterializer) = {
+    def parse(method: String, contentType: Option[String], body: ByteString)(implicit mat: Materializer) = {
       val request = FakeRequest(method, "/x").withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*)
       await(BodyParsers.parse.anyContent(request).run(Source.single(body)))
     }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/BodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/BodyParserSpec.scala
@@ -4,7 +4,7 @@
 package play.it.http.parsing
 
 import akka.actor.ActorSystem
-import akka.stream.{ ActorFlowMaterializer, FlowMaterializer }
+import akka.stream.{ ActorMaterializer, Materializer }
 import akka.stream.scaladsl.Source
 import play.api.libs.streams.Accumulator
 
@@ -22,7 +22,7 @@ object BodyParserSpec extends PlaySpecification with ExecutionSpecification with
   def run[A](bodyParser: BodyParser[A]) = {
     import scala.concurrent.ExecutionContext.Implicits.global
     val system = ActorSystem()
-    implicit val mat = ActorFlowMaterializer()(system)
+    implicit val mat = ActorMaterializer()(system)
     try {
       await {
         Future {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.it.http.parsing
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.mvc._
@@ -13,7 +13,7 @@ object DefaultBodyParserSpec extends PlaySpecification {
 
   "The default body parser" should {
 
-    def parse(method: String, contentType: Option[String], body: ByteString)(implicit mat: FlowMaterializer) = {
+    def parse(method: String, contentType: Option[String], body: ByteString)(implicit mat: Materializer) = {
       val request = FakeRequest(method, "/x").withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*)
       await(BodyParsers.parse.default(request).run(Source.single(body)))
     }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/EmptyBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/EmptyBodyParserSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.it.http.parsing
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.test._
@@ -13,7 +13,7 @@ object EmptyBodyParserSpec extends PlaySpecification {
 
   "The empty body parser" should {
 
-    def parse(bytes: ByteString, contentType: Option[String], encoding: String)(implicit mat: FlowMaterializer) = {
+    def parse(bytes: ByteString, contentType: Option[String], encoding: String)(implicit mat: Materializer) = {
       await(
         BodyParsers.parse.empty(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*))
           .run(Source.single(bytes))

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/FormBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/FormBodyParserSpec.scala
@@ -1,6 +1,6 @@
 package play.it.http.parsing
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.data.Form
@@ -17,7 +17,7 @@ class FormBodyParserSpec extends PlaySpecification {
 
   "The form body parser" should {
 
-    def parse[A, B](body: B, bodyParser: BodyParser[A])(implicit W: Writeable[B], mat: FlowMaterializer): Either[Result, A] = {
+    def parse[A, B](body: B, bodyParser: BodyParser[A])(implicit W: Writeable[B], mat: Materializer): Either[Result, A] = {
       await(
         bodyParser(FakeRequest().withHeaders(W.contentType.map(CONTENT_TYPE -> _).toSeq: _*))
           .run(Source.single(ByteString(W.transform(body))))

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/IgnoreBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/IgnoreBodyParserSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.it.http.parsing
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.test._
@@ -13,7 +13,7 @@ object IgnoreBodyParserSpec extends PlaySpecification {
 
   "The ignore body parser" should {
 
-    def parse[A](value: A, bytes: ByteString, contentType: Option[String], encoding: String)(implicit mat: FlowMaterializer) = {
+    def parse[A](value: A, bytes: ByteString, contentType: Option[String], encoding: String)(implicit mat: Materializer) = {
       await(
         BodyParsers.parse.ignore(value)(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*))
           .run(Source.single(bytes))

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/JsonBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/JsonBodyParserSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.it.http.parsing
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.libs.json.{ Json, JsError }
@@ -18,7 +18,7 @@ object JsonBodyParserSpec extends PlaySpecification {
 
   "The JSON body parser" should {
 
-    def parse[A](json: String, contentType: Option[String], encoding: String, bodyParser: BodyParser[A] = BodyParsers.parse.tolerantJson)(implicit mat: FlowMaterializer) = {
+    def parse[A](json: String, contentType: Option[String], encoding: String, bodyParser: BodyParser[A] = BodyParsers.parse.tolerantJson)(implicit mat: Materializer) = {
       await(
         bodyParser(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*))
           .run(Source.single(ByteString(json.getBytes(encoding))))

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/TextBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/TextBodyParserSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.it.http.parsing
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.test._
@@ -13,7 +13,7 @@ object TextBodyParserSpec extends PlaySpecification {
 
   "The text body parser" should {
 
-    def parse(text: String, contentType: Option[String], encoding: String, bodyParser: BodyParser[String] = BodyParsers.parse.tolerantText)(implicit mat: FlowMaterializer) = {
+    def parse(text: String, contentType: Option[String], encoding: String, bodyParser: BodyParser[String] = BodyParsers.parse.tolerantText)(implicit mat: Materializer) = {
       await(
         bodyParser(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*))
           .run(Source.single(ByteString(text, encoding)))

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/XmlBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/XmlBodyParserSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.it.http.parsing
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.test._
@@ -16,7 +16,7 @@ object XmlBodyParserSpec extends PlaySpecification {
 
   "The XML body parser" should {
 
-    def parse(xml: String, contentType: Option[String], encoding: String, bodyParser: BodyParser[NodeSeq] = BodyParsers.parse.tolerantXml(1048576))(implicit mat: FlowMaterializer) = {
+    def parse(xml: String, contentType: Option[String], encoding: String, bodyParser: BodyParser[NodeSeq] = BodyParsers.parse.tolerantXml(1048576))(implicit mat: Materializer) = {
       await(
         bodyParser(FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*))
           .run(Source.single(ByteString(xml, encoding)))

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -3,7 +3,7 @@
  */
 package play.core.server.netty
 
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import akka.util.ByteString
 import org.jboss.netty.buffer.ChannelBuffers
 import org.jboss.netty.channel._
@@ -202,7 +202,7 @@ private[play] class PlayDefaultUpstreamHandler(server: NettyServer, allChannels:
           logger.trace("Serving this request with: " + action)
 
           val actorSystem = app.fold(server.actorSystem)(_.actorSystem)
-          implicit val mat = ActorFlowMaterializer()(actorSystem)
+          implicit val mat = ActorMaterializer()(actorSystem)
           val bodyParser = Iteratee.flatten(
             Future(Streams.accumulatorToIteratee(action(requestHeader)))(actorSystem.dispatcher)
           )

--- a/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala
+++ b/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala
@@ -3,7 +3,7 @@
  */
 package play.api.test
 
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import org.openqa.selenium.WebDriver
 import org.specs2.execute.{ AsResult, Result }
 import org.specs2.mutable.Around
@@ -36,7 +36,7 @@ abstract class WithApplicationLoader(applicationLoader: ApplicationLoader = new 
  */
 abstract class WithApplication(val app: Application = FakeApplication()) extends Around with Scope {
   implicit def implicitApp = app
-  implicit def implicitFlowMaterializer = ActorFlowMaterializer()(app.actorSystem)
+  implicit def implicitFlowMaterializer = ActorMaterializer()(app.actorSystem)
   override def around[T: AsResult](t: => T): Result = {
     Helpers.running(app)(AsResult.effectively(t))
   }

--- a/framework/src/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
+++ b/framework/src/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
@@ -5,7 +5,7 @@ package play.api.test
 
 import java.util.concurrent.TimeUnit
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.util.ByteString
 import play.api.mvc._
 
@@ -100,7 +100,7 @@ object FakesSpec extends PlaySpecification {
     }
   }
 
-  def contentTypeForFakeRequest[T](request: FakeRequest[AnyContentAsJson])(implicit mat: FlowMaterializer): String = {
+  def contentTypeForFakeRequest[T](request: FakeRequest[AnyContentAsJson])(implicit mat: Materializer): String = {
     var testContentType: Option[String] = None
     val action = Action { request => testContentType = request.headers.get(CONTENT_TYPE); Ok }
     val headers = new WrappedRequest(request)

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
@@ -1,6 +1,6 @@
 package play.api.libs.streams
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.{ Source, Keep, Flow, Sink }
 import org.reactivestreams.{ Publisher, Subscription, Subscriber }
 
@@ -61,14 +61,14 @@ final class Accumulator[-E, +A](sink: Sink[E, Future[A]]) {
   /**
    * Run this accumulator by feeding in the given source.
    */
-  def run(source: Source[E, _])(implicit materializer: FlowMaterializer): Future[A] = {
+  def run(source: Source[E, _])(implicit materializer: Materializer): Future[A] = {
     source.toMat(sink)(Keep.right).run()
   }
 
   /**
    * Run this accumulator by feeding a completed source into it.
    */
-  def run()(implicit materializer: FlowMaterializer): Future[A] = {
+  def run()(implicit materializer: Materializer): Future[A] = {
     run(Source.empty)
   }
 
@@ -83,7 +83,7 @@ final class Accumulator[-E, +A](sink: Sink[E, Future[A]]) {
    *   val intFuture = source ~>: intAccumulator
    * }}}
    */
-  def ~>:(source: Source[E, _])(implicit materializer: FlowMaterializer): Future[A] = run(source)
+  def ~>:(source: Source[E, _])(implicit materializer: Materializer): Future[A] = run(source)
 
   /**
    * Convert this accumulator to a Sink that gets materialised to a Future.
@@ -126,7 +126,7 @@ object Accumulator {
   /**
    * Flatten a future of an accumulator to an accumulator.
    */
-  def flatten[E, A](future: Future[Accumulator[E, A]])(implicit materializer: FlowMaterializer): Accumulator[E, A] = {
+  def flatten[E, A](future: Future[Accumulator[E, A]])(implicit materializer: Materializer): Accumulator[E, A] = {
     import play.api.libs.iteratee.Execution.Implicits.trampoline
 
     // Ideally, we'd use the following code, except due to akka streams bugs...

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/Streams.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/Streams.scala
@@ -1,6 +1,6 @@
 package play.api.libs.streams
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.{ Keep, Source, Flow, Sink }
 import org.reactivestreams._
 import play.api.libs.iteratee._
@@ -183,7 +183,7 @@ object Streams {
    * the subscriber, however it does not materialize the subscriber until the
    * iteratees fold method has been invoked.
    */
-  def accumulatorToIteratee[T, U](accumulator: Accumulator[T, U])(implicit mat: FlowMaterializer): Iteratee[T, U] = {
+  def accumulatorToIteratee[T, U](accumulator: Accumulator[T, U])(implicit mat: Materializer): Iteratee[T, U] = {
     new Iteratee[T, U] {
       def fold[B](folder: (Step[T, U]) => Future[B])(implicit ec: ExecutionContext) = {
         Source.subscriber.toMat(accumulator.toSink) { (subscriber, result) =>

--- a/framework/src/play-streams/src/test/java/play/libs/streams/AccumulatorTest.java
+++ b/framework/src/play-streams/src/test/java/play/libs/streams/AccumulatorTest.java
@@ -1,8 +1,8 @@
 package play.libs.streams;
 
 import akka.actor.ActorSystem;
-import akka.stream.ActorFlowMaterializer;
-import akka.stream.FlowMaterializer;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
@@ -18,7 +18,7 @@ import java.util.function.Function;
 
 public class AccumulatorTest {
 
-    private FlowMaterializer mat;
+    private Materializer mat;
     private ActorSystem system;
     private Executor ec;
 
@@ -101,7 +101,7 @@ public class AccumulatorTest {
     @Before
     public void setUp() {
         system = ActorSystem.create();
-        mat = ActorFlowMaterializer.create(system);
+        mat = ActorMaterializer.create(system);
         ec = system.dispatcher();
     }
 

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
@@ -4,7 +4,7 @@ import java.lang
 
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{ Flow, Source, Sink }
-import akka.stream.{ ActorFlowMaterializer, FlowMaterializer }
+import akka.stream.{ ActorMaterializer, Materializer }
 import org.reactivestreams.{ Subscription, Subscriber, Publisher }
 import org.specs2.mutable.Specification
 
@@ -15,10 +15,10 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 object AccumulatorSpec extends Specification {
 
-  def withMaterializer[T](block: FlowMaterializer => T) = {
+  def withMaterializer[T](block: Materializer => T) = {
     val system = ActorSystem("test")
     try {
-      block(ActorFlowMaterializer()(system))
+      block(ActorMaterializer()(system))
     } finally {
       system.shutdown()
       system.awaitTermination()

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -3,7 +3,7 @@
  */
 package play.api.test
 
-import akka.stream.{ ActorFlowMaterializer, FlowMaterializer }
+import akka.stream.{ ActorMaterializer, Materializer }
 import akka.stream.scaladsl.Source
 
 import scala.language.reflectiveCalls
@@ -190,7 +190,7 @@ trait EssentialActionCaller {
    *
    * The body is serialised using the implicit writable, so that the action body parser can deserialise it.
    */
-  def call[T](action: EssentialAction, req: Request[T])(implicit w: Writeable[T], mat: FlowMaterializer): Future[Result] =
+  def call[T](action: EssentialAction, req: Request[T])(implicit w: Writeable[T], mat: Materializer): Future[Result] =
     call(action, req, req.body)
 
   /**
@@ -198,7 +198,7 @@ trait EssentialActionCaller {
    *
    * The body is serialised using the implicit writable, so that the action body parser can deserialise it.
    */
-  def call[T](action: EssentialAction, rh: RequestHeader, body: T)(implicit w: Writeable[T], mat: FlowMaterializer): Future[Result] = {
+  def call[T](action: EssentialAction, rh: RequestHeader, body: T)(implicit w: Writeable[T], mat: Materializer): Future[Result] = {
     import play.api.http.HeaderNames._
     val newContentType = rh.headers.get(CONTENT_TYPE).fold(w.contentType)(_ => None)
     val rhWithCt = newContentType.map { ct =>
@@ -233,7 +233,7 @@ trait RouteInvokers extends EssentialActionCaller {
    */
   def route[T](app: Application, rh: RequestHeader, body: T)(implicit w: Writeable[T]): Option[Future[Result]] = {
     val (taggedRh, handler) = app.requestHandler.handlerForRequest(rh)
-    implicit val mat = ActorFlowMaterializer()(app.actorSystem)
+    implicit val mat = ActorMaterializer()(app.actorSystem)
     handler match {
       case a: EssentialAction =>
         Some(call(a, taggedRh, body))

--- a/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -5,7 +5,6 @@ package play.api.http
 
 import javax.inject.{ Provider, Inject }
 
-import akka.stream.FlowMaterializer
 import play.api.inject.{ BindingKey, Binding }
 import play.api.libs.streams.Accumulator
 import play.api.{ PlayConfig, Configuration, Environment, GlobalSettings }

--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -5,11 +5,11 @@ package play.api.inject
 
 import akka.actor.ActorSystem
 import javax.inject.{ Singleton, Inject, Provider }
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import play.api._
 import play.api.http._
 import play.api.libs.{ CryptoConfig, Crypto, CryptoConfigParser }
-import play.api.libs.concurrent.{ FlowMaterializerProvider, ExecutionContextProvider, ActorSystemProvider }
+import play.api.libs.concurrent.{ MaterializerProvider, ExecutionContextProvider, ActorSystemProvider }
 import play.api.routing.Router
 
 import scala.concurrent.ExecutionContext
@@ -42,7 +42,7 @@ class BuiltinModule extends Module {
 
       bind[Router].toProvider[RoutesProvider],
       bind[ActorSystem].toProvider[ActorSystemProvider],
-      bind[FlowMaterializer].toProvider[FlowMaterializerProvider],
+      bind[Materializer].toProvider[MaterializerProvider],
       bind[ExecutionContext].toProvider[ExecutionContextProvider],
       bind[Plugins].toProvider[PluginsProvider],
 

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -5,7 +5,7 @@ package play.api.libs.concurrent
 
 import java.lang.reflect.Method
 
-import akka.stream.{ ActorFlowMaterializer, FlowMaterializer }
+import akka.stream.{ ActorMaterializer, Materializer }
 import com.google.inject.util.Types
 import com.google.inject.{ Binder, Key, AbstractModule }
 import com.google.inject.assistedinject.FactoryModuleBuilder
@@ -265,8 +265,8 @@ class ActorSystemProvider @Inject() (environment: Environment, configuration: Co
  * Provider for the default flow materializer
  */
 @Singleton
-class FlowMaterializerProvider @Inject() (actorSystem: ActorSystem) extends Provider[FlowMaterializer] {
-  lazy val get: FlowMaterializer = ActorFlowMaterializer()(actorSystem)
+class MaterializerProvider @Inject() (actorSystem: ActorSystem) extends Provider[Materializer] {
+  lazy val get: Materializer = ActorMaterializer()(actorSystem)
 }
 
 /**

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -22,7 +22,7 @@ import scala.util.control.NonFatal
 import play.api.http.{ LazyHttpErrorHandler, ParserConfiguration, HttpConfiguration, HttpVerbs }
 import play.utils.PlayIO
 import play.api.http.Status._
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.{ Keep, Flow, Sink }
 import akka.stream.stage.{ Context, PushStage, SyncDirective, TerminationDirective }
 
@@ -687,7 +687,7 @@ trait BodyParsers {
      * @param maxLength The max length allowed
      * @param parser The BodyParser to wrap
      */
-    def maxLength[A](maxLength: Long, parser: BodyParser[A])(implicit mat: FlowMaterializer): BodyParser[Either[MaxSizeExceeded, A]] = BodyParser.iteratee("maxLength=" + maxLength + ", wrapping=" + parser.toString) { request =>
+    def maxLength[A](maxLength: Long, parser: BodyParser[A])(implicit mat: Materializer): BodyParser[Either[MaxSizeExceeded, A]] = BodyParser.iteratee("maxLength=" + maxLength + ", wrapping=" + parser.toString) { request =>
       import play.api.libs.iteratee.Execution.Implicits.trampoline
       Traversable.takeUpTo[ByteString](maxLength).transform(Streams.accumulatorToIteratee(parser(request))).flatMap(Iteratee.eofOrElse(MaxSizeExceeded(maxLength))).map {
         case Right(Right(result)) => Right(Right(result))

--- a/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
@@ -3,7 +3,7 @@
  */
 package play.api.mvc
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.util.ByteString
 import play.api._
 import play.api.libs.iteratee._
@@ -28,7 +28,7 @@ trait EssentialFilter {
 trait Filter extends EssentialFilter {
   self =>
 
-  implicit def mat: FlowMaterializer
+  implicit def mat: Materializer
 
   /**
    * Apply the filter, given the request header and a function to call the next
@@ -88,7 +88,7 @@ trait Filter extends EssentialFilter {
 }
 
 object Filter {
-  def apply(filter: (RequestHeader => Future[Result], RequestHeader) => Future[Result])(implicit m: FlowMaterializer): Filter = new Filter {
+  def apply(filter: (RequestHeader => Future[Result], RequestHeader) => Future[Result])(implicit m: Materializer): Filter = new Filter {
     implicit def mat = m
     def apply(f: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result] = filter(f, rh)
   }

--- a/framework/src/play/src/test/scala/play/api/mvc/RawBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RawBodyParserSpec.scala
@@ -6,7 +6,7 @@ package play.api.mvc
 import akka.util.ByteString
 import akka.stream.scaladsl.Source
 import akka.actor.ActorSystem
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 
 import java.io.IOException
 
@@ -22,10 +22,9 @@ import scala.concurrent.duration.Duration
 
 object RawBodyParserSpec extends Specification with AfterAll {
 
-  val system = ActorSystem("content-types-spec")
-  implicit val materializer = ActorFlowMaterializer()(system)
+  implicit val materializer = ActorMaterializer()(ActorSystem("content-types-spec"))
 
-  def afterAll(): Unit = system.shutdown()
+  def afterAll(): Unit = materializer.shutdown()
 
   val config = ParserConfiguration()
 


### PR DESCRIPTION
*This PR was built on top of https://github.com/playframework/playframework/pull/4768 (hence, the linked PR must be merged before this).*

[The only commit relevant for this PR is https://github.com/playframework/playframework/commit/eea1b3112a2be1e38787b3dda83b818f914f6d5f] 

* Moving from RC3 to RC4 had quite an impact because of the many class'
  renamings.

* It seems there is an overloading issue with `Flow.to` (see comment in
  `play.libs.streams.Accumulator.through`). We should report the problem
  to the akka team.

* Had to make `play.it.http.JavaResultsHandlingSpec` and
  `play.it.http.ScalaResultsHandlingSpec` running sequentially because they
  would fail otherwise (not sure what has changed in akka-http to cause it, but
  I assumed it may have been caused by additional asynchronism in the impl).

One thing that worries me is that some akka-strems type leak into the Play user
API (for instance, see `FlowMaterializer` in `play.api.mvc.Filters`), ~~and the
name changes that occurred between RC3 and RC4 are such that I don't think this
commit can be backported to the 2.4.x branch (because of binary compatibility).~~ 
and akka-streams is an experimental module that hence doesn't ensure backward 
binary compatibility across releases. I'm not sure if this is actually going to be an 
issue, but I think we should keep it in mind.

~~Because of the above, I'm wondering if we should have a 2.5 release that only
upgrades Play 2.4 to use akka-streams 1.0 final (once 1.0 is actually out, which
should happen soon enough).~~ (EDIT: We don't use akka-stream in Play 2.4, so 
forget about what I said).