### PR TITLE
Bumped akka-http to 1.0-RC4. Re #4774

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -282,11 +282,23 @@ object PlayBuild extends Build {
     .settings(libraryDependencies ++= netty)
     .dependsOn(PlayServerProject)
 
+  // ignored binary incompatibilities for PlayAkkaHttpServerProject since it's an experimental project
+  val ignoredABIProblemsPlayAkkaHttpServerProject = {
+    import com.typesafe.tools.mima.core._
+    import com.typesafe.tools.mima.core.ProblemFilters._
+    Seq(
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.core.server.akkahttp.ModelConversion.convertRequest"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.core.server.akkahttp.AkkaHttpServer.materializer"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.core.server.akkahttp.AkkaStreamsConversion.sourceToEnumerator")
+    )
+  }
+
   lazy val PlayAkkaHttpServerProject = PlayCrossBuiltProject("Play-Akka-Http-Server-Experimental", "play-akka-http-server")
     .settings(libraryDependencies ++= akkaHttp)
      // Include scripted tests here as well as in the SBT Plugin, because we
      // don't want the SBT Plugin to have a dependency on an experimental module.
     .settings(playFullScriptedSettings: _*)
+    .settings(binaryIssueFilters ++= ignoredABIProblemsPlayAkkaHttpServerProject)
     .dependsOn(PlayServerProject, StreamsProject)
     .dependsOn(PlaySpecs2Project % "test", PlayWsProject % "test")
 

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -142,7 +142,7 @@ object Dependencies {
   val nettyUtilsDependencies = slf4j
 
   val akkaHttp = Seq(
-    "com.typesafe.akka" %% "akka-http-core-experimental" % "1.0-RC2"
+    "com.typesafe.akka" %% "akka-http-core-experimental" % "1.0-RC4"
   )
 
   val routesCompilerDependencies =  Seq(

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{ `Content-Length`, `Content-Type` }
 import akka.pattern.ask
-import akka.stream.ActorFlowMaterializer
+import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import akka.util.{ ByteString, Timeout }
 import java.net.InetSocketAddress
@@ -42,7 +42,7 @@ class AkkaHttpServer(
   // Remember that some user config may not be available in development mode due to
   // its unusual ClassLoader.
   implicit val system = actorSystem
-  implicit val materializer = ActorFlowMaterializer()
+  implicit val materializer = ActorMaterializer()
 
   val address: InetSocketAddress = {
     // Listen for incoming connections and handle them with the `handleRequest` method.

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaStreamsConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaStreamsConversion.scala
@@ -1,6 +1,6 @@
 package play.core.server.akkahttp
 
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl._
 import org.reactivestreams._
 import play.api.libs.iteratee._
@@ -14,7 +14,7 @@ import play.api.libs.streams.Streams
  * Streams API is in flux at the moment so this isn't worth doing yet.
  */
 object AkkaStreamsConversion {
-  def sourceToEnumerator[Out, Mat](source: Source[Out, Mat])(implicit fm: FlowMaterializer): Enumerator[Out] = {
+  def sourceToEnumerator[Out, Mat](source: Source[Out, Mat])(implicit fm: Materializer): Enumerator[Out] = {
     val pubr: Publisher[Out] = source.runWith(Sink.publisher[Out])
     Streams.publisherToEnumerator(pubr)
   }

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -3,7 +3,7 @@ package play.core.server.akkahttp
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.ContentType
 import akka.http.scaladsl.model.headers._
-import akka.stream.FlowMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import java.net.InetSocketAddress
@@ -32,7 +32,7 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
     requestId: Long,
     remoteAddress: InetSocketAddress,
     secureProtocol: Boolean,
-    request: HttpRequest)(implicit fm: FlowMaterializer): (RequestHeader, Enumerator[Array[Byte]]) = {
+    request: HttpRequest)(implicit fm: Materializer): (RequestHeader, Enumerator[Array[Byte]]) = {
     (
       convertRequestHeader(requestId, remoteAddress, secureProtocol, request),
       convertRequestBody(request)
@@ -99,7 +99,7 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
    * Convert an Akka `HttpRequest` to an `Enumerator` of the request body.
    */
   private def convertRequestBody(
-    request: HttpRequest)(implicit fm: FlowMaterializer): Enumerator[Array[Byte]] = {
+    request: HttpRequest)(implicit fm: Materializer): Enumerator[Array[Byte]] = {
     import play.api.libs.iteratee.Execution.Implicits.trampoline
     request.entity match {
       case HttpEntity.Strict(_, data) if data.isEmpty =>

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -19,6 +19,8 @@ object AkkaHttpJavaResultsHandlingSpec extends JavaResultsHandlingSpec with Akka
 
 trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
 
+  sequential
+
   "Java results handling" should {
     def makeRequest[T](controller: MockController)(block: WSResponse => T) = {
       implicit val port = testServerPort

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -18,6 +18,8 @@ object AkkaHttpScalaResultsHandlingSpec extends ScalaResultsHandlingSpec with Ak
 
 trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
 
+  sequential
+
   "scala body handling" should {
 
     def tryRequest[T](result: Result)(block: Try[WSResponse] => T) = withServer(result) { implicit port =>


### PR DESCRIPTION
*This PR is basically a backport of https://github.com/playframework/playframework/pull/4776, but can be merged independently of it.*

* Moving akka-http from RC2 to RC4.

* Ignored some binary incompatibility reported by MiMa on the
  Play-Akka-Http-Server-Experimental project due to the akka-http version bump
  (this is OK because the module is experimental, hence we give no binary
  compatibility guarantees).

* Had to make `play.it.http.JavaResultsHandlingSpec` and
  `play.it.http.ScalaResultsHandlingSpec` running sequentially because they
  would fail otherwise (not sure what has changed in akka-http to cause it, but
  I assumed it may have been caused by additional asynchronism in the impl).

This is basically a backport of 80a9740c5b325747cb985794dd03accdcf4cef7a