### PR TITLE
Improve + and - methods on JsObject

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
@@ -144,16 +144,18 @@ object Json {
    * Something to note due to `JsValueWrapper` extending `NotNull` :
    * `null` or `None` will end into compiling error : use JsNull instead.
    */
-  sealed trait JsValueWrapper extends NotNull
+  sealed trait JsValueWrapper extends Any with NotNull {
+    def value: JsValue
+  }
 
-  private case class JsValueWrapperImpl(field: JsValue) extends JsValueWrapper
+  private case class JsValueWrapperImpl(value: JsValue) extends AnyVal with JsValueWrapper
 
   import scala.language.implicitConversions
 
   implicit def toJsFieldJsValueWrapper[T](field: T)(implicit w: Writes[T]): JsValueWrapper = JsValueWrapperImpl(w.writes(field))
 
-  def obj(fields: (String, JsValueWrapper)*): JsObject = JsObject(fields.map(f => (f._1, f._2.asInstanceOf[JsValueWrapperImpl].field)))
-  def arr(fields: JsValueWrapper*): JsArray = JsArray(fields.map(_.asInstanceOf[JsValueWrapperImpl].field))
+  def obj(fields: (String, JsValueWrapper)*): JsObject = JsObject(fields.map { case (k, v) => k -> v.value })
+  def arr(fields: JsValueWrapper*): JsArray = JsArray(fields.map(_.value))
 
   import play.api.libs.iteratee.Enumeratee
 

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -132,6 +132,20 @@ object JsonSpec extends org.specs2.mutable.Specification {
       empty.tail.toOption must beNone
     }
 
+    "support adding and removing keys to JsObjects" in {
+      val obj = Json.obj("foo" -> 1, "bar" -> 2, "baz" -> 3)
+      obj - "foo" must_== Json.obj("bar" -> 2, "baz" -> 3)
+      obj + ("foo" -> "one") must_== Json.obj("foo" -> "one", "bar" -> 2, "baz" -> 3)
+      obj + ("foo" -> "one", "qux" -> "four") - ("bar", "baz") must_==
+        Json.obj("foo" -> "one", "qux" -> "four")
+    }
+
+    "support adding to JsArrays" in {
+      val arr = Json.arr("foo", "bar", "baz")
+      arr :+ "qux" must_== Json.arr("foo", "bar", "baz", "qux")
+      "qux" +: arr must_== Json.arr("qux", "foo", "bar", "baz")
+    }
+
     "serialize and deserialize maps properly" in {
       val c = Car(1, Map("ford" -> "1954 model"))
       val jsonCar = toJson(c)


### PR DESCRIPTION
Fixes #4747

The two main changes:
 - Overload `+` and `-` methods with ones that accept varargs.
 - Use `JsValueWrapper` to automatically convert values to their JSON equivalent in `JsArray`/`JsObject` methods.