### PR TITLE
Ensure a single flow materializer is used to handle requests

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
@@ -4,11 +4,10 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.Expect
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl._
 import java.net.InetSocketAddress
 import akka.util.ByteString
-import org.reactivestreams.{ Subscription, Subscriber, Publisher }
 import play.api._
 import play.api.http.DefaultHttpErrorHandler
 import play.api.libs.streams.Accumulator
@@ -28,6 +27,7 @@ class AkkaHttpServer(
     config: ServerConfig,
     val applicationProvider: ApplicationProvider,
     actorSystem: ActorSystem,
+    materializer: Materializer,
     stopHook: () => Future[Unit]) extends Server {
 
   import AkkaHttpServer._
@@ -40,7 +40,7 @@ class AkkaHttpServer(
   // Remember that some user config may not be available in development mode due to
   // its unusual ClassLoader.
   implicit val system = actorSystem
-  implicit val materializer = ActorMaterializer()
+  implicit val mat = materializer
 
   val address: InetSocketAddress = {
     // Listen for incoming connections and handle them with the `handleRequest` method.
@@ -216,5 +216,6 @@ object AkkaHttpServer {
  */
 class AkkaHttpServerProvider extends ServerProvider {
   def createServer(context: ServerProvider.Context) =
-    new AkkaHttpServer(context.config, context.appProvider, context.actorSystem, context.stopHook)
+    new AkkaHttpServer(context.config, context.appProvider, context.actorSystem, context.materializer,
+      context.stopHook)
 }

--- a/framework/src/play-docs/src/main/scala/play/docs/DocServerStart.scala
+++ b/framework/src/play-docs/src/main/scala/play/docs/DocServerStart.scala
@@ -61,6 +61,7 @@ class DocServerStart {
       config,
       applicationProvider,
       application.actorSystem,
+      application.materializer,
       stopHook = () => Future.successful(())
     )
     serverProvider.createServer(context)

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/EssentialActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/EssentialActionSpec.scala
@@ -3,7 +3,6 @@
  */
 package play.it.action
 
-import akka.stream.ActorMaterializer
 import play.api.mvc.{ Action, EssentialAction }
 import play.api.mvc.Results._
 import play.api.test.{ FakeApplication, PlaySpecification, FakeRequest }
@@ -24,7 +23,7 @@ object EssentialActionSpec extends PlaySpecification {
       // start fake application with its own classloader
       val applicationClassLoader = new ClassLoader() {}
       val fakeApplication = FakeApplication(classloader = applicationClassLoader)
-      implicit val mat = ActorMaterializer()(fakeApplication.actorSystem)
+      import fakeApplication.materializer
 
       running(fakeApplication) {
         // run the test with the classloader of the current thread

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayDefaultUpstreamHandler.scala
@@ -3,7 +3,7 @@
  */
 package play.core.server.netty
 
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.util.ByteString
 import org.jboss.netty.buffer.ChannelBuffers
 import org.jboss.netty.channel._
@@ -202,7 +202,7 @@ private[play] class PlayDefaultUpstreamHandler(server: NettyServer, allChannels:
           logger.trace("Serving this request with: " + action)
 
           val actorSystem = app.fold(server.actorSystem)(_.actorSystem)
-          implicit val mat = ActorMaterializer()(actorSystem)
+          implicit val mat: Materializer = app.fold(server.materializer)(_.materializer)
           val bodyParser = Iteratee.flatten(
             Future(Streams.accumulatorToIteratee(action(requestHeader)))(actorSystem.dispatcher)
           )

--- a/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -5,6 +5,7 @@ package play.core.server
 
 import java.io._
 import java.util.Properties
+import akka.stream.ActorMaterializer
 import play.api._
 import play.api.mvc._
 import play.api.libs.concurrent.ActorSystemProvider
@@ -203,7 +204,8 @@ object DevServerStart {
           configuration = Configuration.load(classLoader, System.getProperties, dirAndDevSettings, allowMissingApplicationConf = true)
         )
         val (actorSystem, actorSystemStopHook) = ActorSystemProvider.start(classLoader, serverConfig.configuration)
-        val serverContext = ServerProvider.Context(serverConfig, appProvider, actorSystem, actorSystemStopHook)
+        val serverContext = ServerProvider.Context(serverConfig, appProvider, actorSystem,
+          ActorMaterializer()(actorSystem), actorSystemStopHook)
         val serverProvider = ServerProvider.fromConfiguration(classLoader, serverConfig.configuration)
         serverProvider.createServer(serverContext)
       } catch {

--- a/framework/src/play-server/src/main/scala/play/core/server/ServerProvider.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ServerProvider.scala
@@ -4,6 +4,7 @@
 package play.core.server
 
 import akka.actor.ActorSystem
+import akka.stream.Materializer
 import play.api.{ Application, Configuration }
 import play.core.ApplicationProvider
 import scala.concurrent.Future
@@ -21,7 +22,7 @@ trait ServerProvider {
    * Create a server for a given application.
    */
   final def createServer(config: ServerConfig, app: Application): Server =
-    createServer(ServerProvider.Context(config, ApplicationProvider(app), app.actorSystem, () => Future.successful(())))
+    createServer(ServerProvider.Context(config, ApplicationProvider(app), app.actorSystem, app.materializer, () => Future.successful(())))
 }
 
 object ServerProvider {
@@ -39,6 +40,7 @@ object ServerProvider {
     config: ServerConfig,
     appProvider: ApplicationProvider,
     actorSystem: ActorSystem,
+    materializer: Materializer,
     stopHook: () => Future[Unit])
 
   /**

--- a/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala
+++ b/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala
@@ -3,7 +3,6 @@
  */
 package play.api.test
 
-import akka.stream.ActorMaterializer
 import org.openqa.selenium.WebDriver
 import org.specs2.execute.{ AsResult, Result }
 import org.specs2.mutable.Around
@@ -36,7 +35,7 @@ abstract class WithApplicationLoader(applicationLoader: ApplicationLoader = new 
  */
 abstract class WithApplication(val app: Application = FakeApplication()) extends Around with Scope {
   implicit def implicitApp = app
-  implicit def implicitFlowMaterializer = ActorMaterializer()(app.actorSystem)
+  implicit def implicitFlowMaterializer = app.materializer
   override def around[T: AsResult](t: => T): Result = {
     Helpers.running(app)(AsResult.effectively(t))
   }

--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -6,6 +6,7 @@ package play.api.test
 import javax.inject.{ Inject, Provider }
 
 import akka.actor.ActorSystem
+import akka.stream.Materializer
 import akka.util.ByteString
 import play.api._
 import play.api.http._
@@ -220,6 +221,7 @@ case class FakeApplication(
   override def global: GlobalSettings = app.global
   override def configuration: Configuration = app.configuration
   override def actorSystem: ActorSystem = app.actorSystem
+  override implicit def materializer: Materializer = app.materializer
   override def plugins: Seq[Plugin.Deprecated] = app.plugins
   override def requestHandler: HttpRequestHandler = app.requestHandler
   override def errorHandler: HttpErrorHandler = app.errorHandler

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -3,7 +3,7 @@
  */
 package play.api.test
 
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 
 import scala.language.reflectiveCalls
@@ -233,7 +233,7 @@ trait RouteInvokers extends EssentialActionCaller {
    */
   def route[T](app: Application, rh: RequestHeader, body: T)(implicit w: Writeable[T]): Option[Future[Result]] = {
     val (taggedRh, handler) = app.requestHandler.handlerForRequest(rh)
-    implicit val mat = ActorMaterializer()(app.actorSystem)
+    import app.materializer
     handler match {
       case a: EssentialAction =>
         Some(call(a, taggedRh, body))

--- a/framework/src/play/src/test/scala/play/api/FakeApplication.scala
+++ b/framework/src/play/src/test/scala/play/api/FakeApplication.scala
@@ -3,12 +3,10 @@
  */
 package play.api
 
+import akka.stream.ActorMaterializer
 import play.api.http.{ NotImplementedHttpRequestHandler, DefaultHttpErrorHandler }
 import play.api.libs.concurrent.ActorSystemProvider
-import play.core.Router
 import java.io.File
-
-import scala.concurrent.Future
 
 /**
  * Fake application as used by Play core tests.  This is needed since Play core can't depend on the Play test API.
@@ -23,6 +21,7 @@ case class FakeApplication(config: Map[String, Any] = Map(),
   lazy val configuration = Configuration.from(config)
   private val lazyActorSystem = ActorSystemProvider.lazyStart(classloader, configuration)
   def actorSystem = lazyActorSystem.get()
+  lazy val materializer = ActorMaterializer()(actorSystem)
   def stop() = lazyActorSystem.close()
   val errorHandler = DefaultHttpErrorHandler
   val requestHandler = NotImplementedHttpRequestHandler

--- a/framework/src/play/src/test/scala/play/api/mvc/RawBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RawBodyParserSpec.scala
@@ -22,9 +22,13 @@ import scala.concurrent.duration.Duration
 
 object RawBodyParserSpec extends Specification with AfterAll {
 
-  implicit val materializer = ActorMaterializer()(ActorSystem("content-types-spec"))
+  implicit val system = ActorSystem("content-types-spec")
+  implicit val materializer = ActorMaterializer()(system)
 
-  def afterAll(): Unit = materializer.shutdown()
+  def afterAll(): Unit = {
+    materializer.shutdown()
+    system.shutdown()
+  }
 
   val config = ParserConfiguration()
 


### PR DESCRIPTION
Play was instantiating a new flow materializer for every test. Each one instantiated created a new actor, leading to an actor leak.

The impact on performance is massive.