### PR TITLE
Upgrade to webjars locator 0.26 to fix bug where some webjars like select2 are not working after we upgraded to 0.25

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -218,7 +218,7 @@ object Dependencies {
 
       sbtDep("com.typesafe.sbt" % "sbt-native-packager" % BuildInfo.sbtNativePackagerVersion),
 
-      sbtDep("com.typesafe.sbt" % "sbt-web" % "1.2.1"),
+      sbtDep("com.typesafe.sbt" % "sbt-web" % "1.2.2"),
       sbtDep("com.typesafe.sbt" % "sbt-js-engine" % "1.1.3")
     ) ++ javassist ++ specsBuild.map(_ % Test)
   }

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -23,7 +23,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 
 libraryDependencies ++= Seq(
   "org.scala-sbt" % "scripted-plugin" % sbtVersion.value,
-  "org.webjars" % "webjars-locator-core" % "0.25"
+  "org.webjars" % "webjars-locator-core" % "0.26"
 )
 
 // override scalariform version to get some fixes


### PR DESCRIPTION
Fix for https://github.com/playframework/playframework/issues/4736