### PR TITLE
WS adds percent encoding when signing with OAuth

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -272,7 +272,7 @@ object Dependencies {
 
   val playWsDeps = Seq(
     guava,
-    "com.ning" % "async-http-client" % "1.9.21"
+    "com.ning" % "async-http-client" % "1.9.29"
   ) ++ Seq("signpost-core", "signpost-commonshttp4").map("oauth.signpost" % _  % "1.2.1.2") ++
   (specsBuild :+ specsMatcherExtra).map(_ % Test) :+
   mockitoAll % Test

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
@@ -3,7 +3,7 @@ package play.it.http
 import play.api.test._
 import play.api.mvc.{ Cookie, Flash, Action }
 import play.api.mvc.Results._
-import play.api.libs.ws.{ WSClient, WSCookie, WSResponse, WS }
+import play.api.libs.ws.{ WSClient, WSCookie, WSResponse }
 import play.core.server.Server
 import play.it._
 
@@ -47,7 +47,6 @@ trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecificat
       val flashCookie = readFlashCookie(response)
       flashCookie must beSome.like {
         case cookie =>
-          cookie.expires must beNone
           cookie.maxAge must beNone
       }
     }
@@ -59,10 +58,7 @@ trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecificat
       flashCookie must beSome.like {
         case cookie =>
           cookie.value must beNone
-          cookie.expires must beSome.like {
-            case expires => expires must be lessThan System.currentTimeMillis()
-          }
-          cookie.maxAge must beSome(0)
+          cookie.maxAge must beSome(0L)
       }
     }
 

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSCookie.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSCookie.java
@@ -22,9 +22,7 @@ public interface WSCookie {
 
     public String getPath();
 
-    public Long getExpires();
-
-    public Integer getMaxAge();
+    public Long getMaxAge();
 
     public Boolean isSecure();
 

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSCookie.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSCookie.java
@@ -40,11 +40,7 @@ public class NingWSCookie implements WSCookie {
         return ahcCookie.getPath();
     }
 
-    public Long getExpires() {
-        return ahcCookie.getExpires();
-    }
-
-    public Integer getMaxAge() {
+    public Long getMaxAge() {
         return ahcCookie.getMaxAge();
     }
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -576,14 +576,9 @@ trait WSCookie {
   def path: String
 
   /**
-   * The expiry date.
-   */
-  def expires: Option[Long]
-
-  /**
    * The maximum age.
    */
-  def maxAge: Option[Int]
+  def maxAge: Option[Long]
 
   /**
    * If the cookie is secure.

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
@@ -524,14 +524,9 @@ private class NingWSCookie(ahcCookie: AHCCookie) extends WSCookie {
   def path: String = ahcCookie.getPath
 
   /**
-   * The expiry date.
-   */
-  def expires: Option[Long] = if (ahcCookie.getExpires <= -1) None else Some(ahcCookie.getExpires)
-
-  /**
    * The maximum age.
    */
-  def maxAge: Option[Int] = if (ahcCookie.getMaxAge <= -1) None else Some(ahcCookie.getMaxAge)
+  def maxAge: Option[Long] = if (ahcCookie.getMaxAge <= -1) None else Some(ahcCookie.getMaxAge)
 
   /**
    * If the cookie is secure.

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
@@ -256,10 +256,10 @@ object NingWSSpec extends PlaySpecification with Mockito {
     "get cookies from an AHC response" in {
 
       val ahcResponse: AHCResponse = mock[AHCResponse]
-      val (name, value, wrap, domain, path, expires, maxAge, secure, httpOnly) =
-        ("someName", "someValue", true, "example.com", "/", 2000L, 1000, false, false)
+      val (name, value, wrap, domain, path, maxAge, secure, httpOnly) =
+        ("someName", "someValue", true, "example.com", "/", 1000L, false, false)
 
-      val ahcCookie: AHCCookie = new AHCCookie(name, value, wrap, domain, path, expires, maxAge, secure, httpOnly)
+      val ahcCookie: AHCCookie = new AHCCookie(name, value, wrap, domain, path, maxAge, secure, httpOnly)
       ahcResponse.getCookies returns util.Arrays.asList(ahcCookie)
 
       val response = NingWSResponse(ahcResponse)
@@ -271,17 +271,16 @@ object NingWSSpec extends PlaySpecification with Mockito {
       cookie.name must beSome(name)
       cookie.value must beSome(value)
       cookie.path must ===(path)
-      cookie.expires must beSome(expires)
       cookie.maxAge must beSome(maxAge)
       cookie.secure must beFalse
     }
 
     "get a single cookie from an AHC response" in {
       val ahcResponse: AHCResponse = mock[AHCResponse]
-      val (name, value, wrap, domain, path, expires, maxAge, secure, httpOnly) =
-        ("someName", "someValue", true, "example.com", "/", 2000L, 1000, false, false)
+      val (name, value, wrap, domain, path, maxAge, secure, httpOnly) =
+        ("someName", "someValue", true, "example.com", "/", 1000L, false, false)
 
-      val ahcCookie: AHCCookie = new AHCCookie(name, value, wrap, domain, path, expires, maxAge, secure, httpOnly)
+      val ahcCookie: AHCCookie = new AHCCookie(name, value, wrap, domain, path, maxAge, secure, httpOnly)
       ahcResponse.getCookies returns util.Arrays.asList(ahcCookie)
 
       val response = NingWSResponse(ahcResponse)
@@ -293,7 +292,6 @@ object NingWSSpec extends PlaySpecification with Mockito {
           cookie.value must beSome(value)
           cookie.domain must ===(domain)
           cookie.path must ===(path)
-          cookie.expires must beSome(expires)
           cookie.maxAge must beSome(maxAge)
           cookie.secure must beFalse
       }
@@ -302,14 +300,13 @@ object NingWSSpec extends PlaySpecification with Mockito {
     "return -1 values of expires and maxAge as None" in {
       val ahcResponse: AHCResponse = mock[AHCResponse]
 
-      val ahcCookie: AHCCookie = new AHCCookie("someName", "value", true, "domain", "path", -1L, -1, false, false)
+      val ahcCookie: AHCCookie = new AHCCookie("someName", "value", true, "domain", "path", -1L, false, false)
       ahcResponse.getCookies returns util.Arrays.asList(ahcCookie)
 
       val response = NingWSResponse(ahcResponse)
 
       val optionCookie = response.cookie("someName")
       optionCookie must beSome[WSCookie].which { cookie =>
-        cookie.expires must beNone
         cookie.maxAge must beNone
       }
     }


### PR DESCRIPTION
This is a bug in AHC that results from double encoding the request:

https://github.com/AsyncHttpClient/async-http-client/pull/914

Fix will be to upgrade AHC to the newer version once the fix is in.