### PR TITLE
Introduce alias of index access on JsPath

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsLookup.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsLookup.scala
@@ -51,6 +51,13 @@ case class JsLookup(result: JsLookupResult) extends AnyVal {
   }
 
   /**
+   * Access a value of this array.
+   *
+   * @param index Element index
+   */
+  def \(index: Int): JsLookupResult = apply(index)
+
+  /**
    * Return the property corresponding to the fieldName, supposing we have a JsObject.
    *
    * @param fieldName the name of the property to look up

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsPath.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsPath.scala
@@ -163,6 +163,7 @@ case class JsPath(path: List[PathNode] = List()) {
   def \\(child: Symbol) = JsPath(path :+ RecursiveSearch(child.name))
 
   def apply(idx: Int): JsPath = JsPath(path :+ IdxPathNode(idx))
+  def \(idx: Int): JsPath = apply(idx)
 
   def apply(json: JsValue): List[JsValue] = path.foldLeft(List(json))((s, p) => s.flatMap(p.apply))
 

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsPathSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsPathSpec.scala
@@ -21,6 +21,12 @@ object JsPathSpec extends Specification {
       (JsPath \ "key1" \ "key11")(obj) must equalTo(Seq(JsString("value11")))
     }
 
+    "retrieve path with array index" in {
+      val obj = Json.obj("key1" -> Json.arr(Json.obj("key11" -> "value11")))
+
+      (JsPath \ "key1" \ 0 \ "key11")(obj) must equalTo(Seq(JsString("value11")))
+    }
+
     "retrieve 1-level recursive path" in {
       val obj = Json.obj(
         "key1" -> Json.obj(


### PR DESCRIPTION
This method alias introduces more better path expression.
```scala
((JsPath \ "key1")(0) \ "key11")(obj)
```
is now also written as
```scala
(JsPath \ "key1" \ 0 \ "key11")(obj)
```

By using this alias, we can remove needless parentheses and path expression becomes clear.

## why \

First, I want to use "!!" as haskell. However "!!" cannot be used because it have to start by 'all other special characters' (ref. [6.12.3 Infix Operations](http://www.scala-lang.org/files/archive/spec/2.11/06-expressions.html#infix-operations) ).
I dont have other good ideas anymore, then use same method \ as property access.
It may cause confusing sometimes, but in many case it will be benefit for unified method name.