### PR TITLE
use executableScriptName instead of normalizedName

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -19,6 +19,7 @@ import play.runsupport.classloader._
 import play.runsupport.{ AssetsClassLoader, FileWatchService, Reloader }
 
 import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport._
+import com.typesafe.sbt.packager.Keys.executableScriptName
 import com.typesafe.sbt.web.SbtWeb.autoImport._
 
 /**
@@ -216,7 +217,7 @@ object PlayRun {
         println()
         state.fail
       case Right(_) =>
-        val stagingBin = Some(extracted.get(stagingDirectory in Universal) / "bin" / extracted.get(normalizedName in Universal)).map {
+        val stagingBin = Some(extracted.get(stagingDirectory in Universal) / "bin" / extracted.get(executableScriptName)).map {
           f =>
             if (System.getProperty("os.name").toLowerCase.contains("win")) f.getAbsolutePath + ".bat" else f.getAbsolutePath
         }.get

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/build.sbt
@@ -1,4 +1,5 @@
 import java.net.URLClassLoader
+import com.typesafe.sbt.packager.Keys.executableScriptName
 
 name := "assets-sample"
 
@@ -43,7 +44,7 @@ InputKey[Unit]("checkOnTestClasspath") := {
 }
 
 TaskKey[Unit]("check-assets-jar-on-classpath") := {
-  val startScript = IO.read(target.value / "universal" / "stage" / "bin" / normalizedName.value)
+  val startScript = IO.read(target.value / "universal" / "stage" / "bin" / executableScriptName.value)
   val assetsJar = s"${organization.value}.${normalizedName.value}-${version.value}-assets.jar"
   if (startScript.contains(assetsJar)) {
     println("Found reference to " + assetsJar + " in start script")


### PR DESCRIPTION
default `executableScriptName` is `normalizedName`
https://github.com/sbt/sbt-native-packager/blob/v1.0.3/src/main/scala/com/typesafe/sbt/PackagerPlugin.scala#L100

In most cases, old code is fine if user does not change the default `executableScriptName`.
but can not execute [the "start" command](https://github.com/playframework/playframework/blob/2.4.2/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala#L190) when user change the `executableScriptName`