### PR TITLE
Add support for unquoted Content-Disposition parameters

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -131,6 +131,18 @@ object MultipartFormDataParserSpec extends PlaySpecification {
       result must not(beEmpty)
       result.get must equalTo(("document", """quotes"".jpg""", Option("image/jpeg")))
     }
+
+    "parse unquoted content disposition" in {
+      val result = FileInfoMatcher.unapply(Map("content-disposition" -> """form-data; name=document; filename=hello.txt"""))
+      result must not(beEmpty)
+      result.get must equalTo(("document", "hello.txt", None))
+    }
+
+    "ignore extended filename in content disposition" in {
+      val result = FileInfoMatcher.unapply(Map("content-disposition" -> """form-data; name=document; filename=hello.txt; filename*=utf-8''ignored.txt"""))
+      result must not(beEmpty)
+      result.get must equalTo(("document", "hello.txt", None))
+    }
   }
 
 }

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -215,7 +215,7 @@ object Multipart {
 
     def unapply(headers: Map[String, String]): Option[(String, String, Option[String])] = {
 
-      val KeyValue = """^([a-zA-Z_0-9]+)="(.*)"$""".r
+      val KeyValue = """^([a-zA-Z_0-9]+)="?(.*?)"?$""".r
 
       for {
         values <- headers.get("content-disposition").


### PR DESCRIPTION
[RFC6266](https://tools.ietf.org/html/rfc6266#section-4.1) allows both quoted and unquoted values.

The .NET HTTP client (specifically `System.Net.Http.MultipartFormDataContent`) formats the header like this:
```
Content-Disposition: form-data; name=document; filename=hello.txt; filename*=utf-8''hello.txt
```