### PR TITLE
Added SubTypesScanner when ReflectionsCache is instantiated

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -321,6 +321,7 @@ object PlayBuild extends Build {
   lazy val PlayJavaProject = PlayCrossBuiltProject("Play-Java", "play-java")
     .settings(libraryDependencies ++= javaDeps ++ javaTestDeps)
     .dependsOn(PlayProject % "compile;test->test")
+    .dependsOn(PlayTestProject % "test")
 
   lazy val PlayDocsProject = PlayCrossBuiltProject("Play-Docs", "play-docs")
     .settings(Docs.settings: _*)

--- a/framework/src/play-java/src/main/java/play/libs/Classpath.java
+++ b/framework/src/play-java/src/main/java/play/libs/Classpath.java
@@ -48,11 +48,7 @@ public class Classpath {
         if (app.isTest()) {
             return ReflectionsCache$.MODULE$.getReflections(app.classloader(), packageName);
         } else {
-            return new Reflections(
-                new ConfigurationBuilder()
-                    .addUrls(ClasspathHelper.forPackage(packageName, app.classloader()))
-                    .filterInputsBy(new FilterBuilder().include(FilterBuilder.prefix(packageName + ".")))
-                    .setScanners(new TypeElementsScanner(), new TypeAnnotationsScanner()));
+            return new Reflections(getReflectionsConfiguration(packageName, app.classloader()));
         }
     }
 
@@ -91,12 +87,22 @@ public class Classpath {
         if (env.isTest()) {
             return ReflectionsCache$.MODULE$.getReflections(env.classLoader(), packageName);
         } else {
-            return new Reflections(
-                new ConfigurationBuilder()
-                    .addUrls(ClasspathHelper.forPackage(packageName, env.classLoader()))
-                    .filterInputsBy(new FilterBuilder().include(FilterBuilder.prefix(packageName + ".")))
-                    .setScanners(new TypeElementsScanner(), new TypeAnnotationsScanner()));
+            return new Reflections(getReflectionsConfiguration(packageName, env.classLoader()));
         }
+    }
+
+    /**
+     * Create {@link org.reflections.Configuration} object for given package name and class loader.
+     *
+     * @param packageName the root package to scan
+     * @param classLoader class loader to be used in reflections
+     * @return
+     */
+    public static ConfigurationBuilder getReflectionsConfiguration(String packageName, ClassLoader classLoader) {
+        return new ConfigurationBuilder()
+            .addUrls(ClasspathHelper.forPackage(packageName, classLoader))
+            .filterInputsBy(new FilterBuilder().include(FilterBuilder.prefix(packageName + ".")))
+            .setScanners(new TypeElementsScanner(), new TypeAnnotationsScanner(), new SubTypesScanner());
     }
 
 }

--- a/framework/src/play-java/src/main/scala/play/libs/ReflectionsCache.scala
+++ b/framework/src/play-java/src/main/scala/play/libs/ReflectionsCache.scala
@@ -32,10 +32,7 @@ object ReflectionsCache {
     }
     reflectionsMap.get(pkg).getOrElse {
 
-      val reflections = new Reflections(new util.ConfigurationBuilder()
-        .addUrls(util.ClasspathHelper.forPackage(pkg, classLoader))
-        .filterInputsBy(new FilterBuilder().include(FilterBuilder.prefix(pkg + ".")))
-        .setScanners(new scanners.TypeAnnotationsScanner, new scanners.TypeElementsScanner))
+      val reflections = new Reflections(Classpath.getReflectionsConfiguration(pkg, classLoader))
 
       reflectionsMap.putIfAbsent(pkg, reflections).getOrElse(reflections)
     }

--- a/framework/src/play-java/src/test/java/play/libs/ClasspathTest.java
+++ b/framework/src/play-java/src/test/java/play/libs/ClasspathTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.libs;
+
+import org.junit.Test;
+import play.Environment;
+import play.libs.testmodel.*;
+import play.test.WithApplication;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import static org.junit.Assert.assertTrue;
+
+public class ClasspathTest extends WithApplication {
+
+    @Test
+    public void testGetTypesApplication() {
+        Set<String> set = Classpath.getTypes(app, "play.libs.testmodel");
+        String[] result = {"play.libs.testmodel.AC1", "play.libs.testmodel.C1"};
+        assertTrue(set.containsAll(Arrays.asList(result)));
+    }
+
+    @Test
+    public void testGetTypesAnnotatedWithApplication() {
+        Set set = Classpath.getTypesAnnotatedWith(app, "play.libs.testmodel", AC1.class);
+        assertTrue(set.contains(C1.class));
+    }
+
+    @Test
+    public void testGetTypesEnvironment() {
+        Set<String> set = Classpath.getTypes(Environment.simple(), "play.libs.testmodel");
+        String[] result = {"play.libs.testmodel.AC1", "play.libs.testmodel.C1"};
+        assertTrue(set.containsAll(Arrays.asList(result)));
+    }
+
+    @Test
+    public void testGetTypesAnnotatedWithEnvironment() {
+        Set set = Classpath.getTypesAnnotatedWith(Environment.simple(), "play.libs.testmodel", AC1.class);
+        assertTrue(set.contains(C1.class));
+    }
+}

--- a/framework/src/play-java/src/test/java/play/libs/testmodel/AC1.java
+++ b/framework/src/play-java/src/test/java/play/libs/testmodel/AC1.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.libs.testmodel;
+
+public @interface AC1 {
+}

--- a/framework/src/play-java/src/test/java/play/libs/testmodel/C1.java
+++ b/framework/src/play-java/src/test/java/play/libs/testmodel/C1.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.libs.testmodel;
+
+public @AC1 class C1 {
+}


### PR DESCRIPTION
Added SubTypesScanner when ReflectionsCache is instantiated since
getTypesAnnotatedWith method requires SubTypesScanner to be configured since Reflections version 0.9.9.

http://reflections.googlecode.com/svn/trunk/reflections/javadoc/apidocs/org/reflections/Reflections.html#getTypesAnnotatedWith(java.lang.Class)