### PR TITLE
fix dev-mode memory leaks (#4649)

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Logger.scala
+++ b/framework/src/play/src/main/scala/play/api/Logger.scala
@@ -302,6 +302,8 @@ object Logger extends LoggerLike {
 
     val ctx = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
     ctx.stop()
+
+    org.slf4j.bridge.SLF4JBridgeHandler.uninstall()
   }
 
   import ch.qos.logback.classic._

--- a/framework/src/run-support/src/main/scala/play/runsupport/DelegatedResourcesClassLoader.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/DelegatedResourcesClassLoader.scala
@@ -1,0 +1,11 @@
+package play.runsupport
+
+import java.net.URL
+
+/**
+ * A ClassLoader that only uses resources from its parent
+ */
+class DelegatedResourcesClassLoader(name: String, urls: Array[URL], parent: ClassLoader) extends NamedURLClassLoader(name, urls, parent) {
+  require(parent ne null)
+  override def getResources(name: String): java.util.Enumeration[java.net.URL] = getParent.getResources(name)
+}

--- a/framework/src/run-support/src/main/scala/play/runsupport/NamedURLClassLoader.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/NamedURLClassLoader.scala
@@ -1,0 +1,10 @@
+package play.runsupport
+
+import java.net.{ URL, URLClassLoader }
+
+/**
+ * A ClassLoader with a toString() that prints name/urls.
+ */
+class NamedURLClassLoader(name: String, urls: Array[URL], parent: ClassLoader) extends URLClassLoader(urls, parent) {
+  override def toString = name + "{" + getURLs.map(_.toString).mkString(", ") + "}"
+}


### PR DESCRIPTION
This PR fixes these two memory leaks of #4649:
- `org.slf4j.bridge.SLF4JBridgeHandler`
- `scala.tools.nsc.interactive.PresentationCompilerThread`

I DID NOT fix this leak:
- `javax.xml.bind.DatatypeConverterImpl.datatypeFactory`: This field [is final](http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/8u40-b25/javax/xml/bind/DatatypeConverterImpl.java#886). You can change a final field via reflection but after reading [this StackOverflow answer](http://stackoverflow.com/a/3301720/3005340)...not worth it.

I did not add any tests because it would fail all the time (at least one leak not fixed).