### PR TITLE
Documentation for Scala/Java about JDBC Database outdated

### DIFF
--- a/documentation/manual/working/javaGuide/main/sql/JavaDatabase.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaDatabase.md
@@ -80,21 +80,22 @@ db.default.password="a strong password"
 
 ## Accessing the JDBC datasource
 
-The `play.db` package provides access to the configured data sources:
+The `play.db` package provides access to the default datasource.
 
-```java
-import play.db.*;
+@[](code/JavaApplicationDatabase.java)
 
-DataSource ds = DB.getDatasource();
-```
+For a database other than the default:
+
+@[](code/JavaNamedDatabase.java)
 
 ## Obtaining a JDBC connection
 
 You can retrieve a JDBC connection the same way:
 
-```
+```java
 Connection connection = DB.getConnection();
 ```
+
 It is important to note that resulting Connections are not automatically disposed at the end of the request cycle. In other words, you are responsible for calling their close() method somewhere in your code so that they can be immediately returned to the pool.
 
 ## Exposing the datasource through JNDI

--- a/documentation/manual/working/javaGuide/main/sql/code/JavaApplicationDatabase.java
+++ b/documentation/manual/working/javaGuide/main/sql/code/JavaApplicationDatabase.java
@@ -1,0 +1,11 @@
+package javaguide.sql;
+
+import javax.inject.Inject;
+
+import play.mvc.*;
+import play.db.*;
+
+class JavaApplicationDatabase extends Controller {
+    @Inject Database db;
+    // ...
+}

--- a/documentation/manual/working/javaGuide/main/sql/code/JavaNamedDatabase.java
+++ b/documentation/manual/working/javaGuide/main/sql/code/JavaNamedDatabase.java
@@ -1,0 +1,13 @@
+package javaguide.sql;
+
+import javax.inject.Inject;
+
+import play.mvc.Controller;
+import play.db.NamedDatabase;
+import play.db.Database;
+
+// inject "orders" database instead of "default"
+class JavaNamedDatabase extends Controller {
+    @Inject @NamedDatabase("orders") Database db;
+    // do whatever you need with the db
+}

--- a/documentation/manual/working/scalaGuide/main/sql/ScalaDatabase.md
+++ b/documentation/manual/working/scalaGuide/main/sql/ScalaDatabase.md
@@ -125,54 +125,15 @@ val ds = DB.getDataSource()
 
 ## Obtaining a JDBC connection
 
-There are several ways to retrieve a JDBC connection. The simplest way is:
+There are several ways to retrieve a JDBC connection. The following code show you a JDBC example very simple, working with MySQL 5.*:
 
-```scala
-val connection = DB.getConnection()
-```
-
-Following code show you a JDBC example very simple, working with MySQL 5.*:
-
-```scala
-package controllers
-import play.api.Play.current
-import play.api.mvc._
-import play.api.db._
-
-object Application extends Controller {
-
-  def index = Action {
-    var outString = "Number is "
-    val conn = DB.getConnection()
-    try {
-      val stmt = conn.createStatement
-      val rs = stmt.executeQuery("SELECT 9 as testkey ")
-      while (rs.next()) {
-        outString += rs.getString("testkey")
-      }
-    } finally {
-      conn.close()
-    }
-    Ok(outString)
-  }
-
-}
-```
+@[](code/ScalaControllerInject.scala)
 
 But of course you need to call `close()` at some point on the opened connection to return it to the connection pool. Another way is to let Play manage closing the connection for you:
 
 ```scala
 // access "default" database
-DB.withConnection { conn =>
-  // do whatever you need with the connection
-}
-```
-
-For a database other than the default:
-
-```scala
-// access "orders" database instead of "default"
-DB.withConnection("orders") { conn =>
+db.withConnection { conn =>
   // do whatever you need with the connection
 }
 ```
@@ -188,6 +149,10 @@ DB.withTransaction { conn =>
   // do whatever you need with the connection
 }
 ```
+
+For a database other than the default:
+
+@[](code/ScalaInjectNamed.scala)
 
 ## Selecting and configuring the connection pool
 

--- a/documentation/manual/working/scalaGuide/main/sql/code/ScalaControllerInject.scala
+++ b/documentation/manual/working/scalaGuide/main/sql/code/ScalaControllerInject.scala
@@ -1,0 +1,28 @@
+package scalaguide.sql
+
+import javax.inject.Inject
+
+import play.api.Play.current
+import play.api.mvc._
+import play.api.db._
+
+class ScalaControllerInject @Inject()(db: Database) extends Controller {
+
+  def index = Action {
+    var outString = "Number is "
+    val conn = db.getConnection()
+    
+    try {
+      val stmt = conn.createStatement
+      val rs = stmt.executeQuery("SELECT 9 as testkey ")
+      
+      while (rs.next()) {
+        outString += rs.getString("testkey")
+      }
+    } finally {
+      conn.close()
+    }
+    Ok(outString)
+  }
+
+}

--- a/documentation/manual/working/scalaGuide/main/sql/code/ScalaInjectNamed.scala
+++ b/documentation/manual/working/scalaGuide/main/sql/code/ScalaInjectNamed.scala
@@ -1,0 +1,11 @@
+package scalaguide.sql
+
+import javax.inject.Inject
+import play.api.db.{ Database, NamedDatabase }
+import play.api.mvc.Controller
+
+// inject "orders" database instead of "default"
+class ScalaInjectNamed @Inject()(
+  @NamedDatabase("orders") db: Database) extends Controller {
+  // do whatever you need with the db
+}


### PR DESCRIPTION
Currently both links:
https://www.playframework.com/documentation/2.4.x/ScalaDatabase
https://www.playframework.com/documentation/2.4.x/JavaDatabase

containing the old database access API, we should upgrade these Docs that ```DB``` is removed in favor of ```@Inject()(db: Database) or @Inject()(@NamedDatabase("default") db: Database) or @Inject()(dbApi: DBApi)````

As seen here:
http://localhost:9000/@documentation/Migration24