### PR TITLE
Added range request support

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
@@ -217,5 +217,17 @@ trait AssetsSpec extends PlaySpecification
         }
       }
     }
+
+    "serve a partial content if requested" in withServer { client =>
+      val result = await(client.url("/foo.txt")
+        .withHeaders(
+          RANGE -> "bytes=2-4"
+        ).get())
+
+      result.status must_== PARTIAL_CONTENT
+      result.header(CONTENT_RANGE) must beSome.which(_.startsWith("bytes 2-4/"))
+      result.header(CONTENT_LENGTH) must beSome("3")
+    }
+
   }
 }

--- a/framework/src/play/src/main/java/play/mvc/RangeResult.java
+++ b/framework/src/play/src/main/java/play/mvc/RangeResult.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.mvc;
+
+import play.core.j.JavaRangeResult;
+import play.api.mvc.Result;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+public class RangeResult {
+
+    public static Result ofPath(Path path, String range) {
+        return JavaRangeResult.ofPath(path, range);
+    }
+
+    public static Result ofPath(Path path, String range, String fileName) {
+        return JavaRangeResult.ofPath(path, range, fileName);
+    }
+
+    public static Result ofFile(File file, String range) {
+        return JavaRangeResult.ofFile(file, range);
+    }
+
+    public static Result ofFile(File file, String range, String fileName) {
+        return JavaRangeResult.ofFile(file, range, fileName);
+    }
+
+    public static Result ofStream(InputStream stream, String range) {
+        return JavaRangeResult.ofStream(stream, range);
+    }
+
+    public static Result ofStream(InputStream stream, String range, String fileName) {
+        return JavaRangeResult.ofStream(stream, range, fileName);
+    }
+
+}

--- a/framework/src/play/src/main/scala/play/api/mvc/RangeResult.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/RangeResult.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.mvc
+
+import akka.util.ByteString
+import play.api.http.{ ContentTypes, HttpEntity, Status, HeaderNames }
+import play.api.libs.concurrent.Execution
+import play.api.libs.iteratee.Enumerator
+import play.api.libs.iteratee.Traversable
+import play.api.libs.streams.Streams
+
+/** Utility to help send content using range headers. */
+object RangeResult {
+
+  /** The HTTP Range header pattern */
+  private lazy val RangeHeader = """^bytes=(\d*)-?(\d*)$""".r
+
+  /**
+   * Stream path using range headers.
+   *
+   * @param path The path.
+   * @param rangeHeader The HTTP Range header from user's request.
+   * @param contentType The HTTP Content Type header for the response.
+   */
+  def ofPath(path: java.nio.file.Path, rangeHeader: Option[String], contentType: Option[String]): Result = {
+    ofPath(path, rangeHeader, path.getFileName.toString, contentType)
+  }
+
+  /**
+   * Stream path using range headers.
+   *
+   * @param path The path.
+   * @param rangeHeader The HTTP Range header from user's request.
+   * @param fileName The file name for the HTTP Content-Disposition header as attachment attribute.
+   * @param contentType The HTTP Content Type header for the response.
+   */
+  def ofPath(path: java.nio.file.Path, rangeHeader: Option[String], fileName: String, contentType: Option[String]): Result = {
+    val stream = java.nio.file.Files.newInputStream(path)
+    ofStream(stream, rangeHeader, Option(fileName), contentType)
+  }
+
+  /**
+   * Stream file using range headers.
+   *
+   * @param file The file.
+   * @param rangeHeader The HTTP Range header from user's request.
+   * @param contentType The HTTP Content Type header for the response.
+   */
+  def ofFile(file: java.io.File, rangeHeader: Option[String], contentType: Option[String]): Result = {
+    ofFile(file, rangeHeader, file.getName, contentType)
+  }
+
+  /**
+   * Stream file using range headers.
+   *
+   * @param file The file.
+   * @param rangeHeader The HTTP Range header from user's request.
+   * @param fileName The file name for the HTTP Content-Disposition header as attachment attribute.
+   * @param contentType The HTTP Content Type header for the response.
+   */
+  def ofFile(file: java.io.File, rangeHeader: Option[String], fileName: String, contentType: Option[String]): Result = {
+    val stream = new java.io.FileInputStream(file)
+    ofStream(stream, rangeHeader, Option(fileName), contentType)
+  }
+
+  /**
+   * Stream content using range headers.
+   *
+   * @param stream The stream content.
+   * @param rangeHeader The HTTP Range header from user's request.
+   * @param contentType The HTTP Content Type header for the response.
+   */
+  def ofStream(stream: java.io.InputStream, rangeHeader: Option[String], contentType: Option[String]): Result = {
+    ofStream(stream, rangeHeader, None, contentType)
+  }
+
+  /**
+   * Stream content using range headers.
+   *
+   * @param stream The stream content.
+   * @param rangeHeader The HTTP Range header from user's request.
+   * @param fileName The file name for the HTTP Content-Disposition header as attachment attribute.
+   * @param contentType The HTTP Content Type header for the response.
+   */
+  def ofStream(stream: java.io.InputStream, rangeHeader: Option[String], fileName: Option[String], contentType: Option[String]): Result = {
+
+    val (rangedStatus: Int, rangedHeaders: Map[String, String], range: Option[(Long, Long)]) = rangeHeader match {
+      case Some(RangeHeader(f, l)) =>
+        // serving a partial content request
+        val firstBytePos = f.toLong
+        val lastBytePos = if (l != "") l.toLong else stream.available - 1
+        val headers = Map(
+          HeaderNames.CONTENT_RANGE -> s"bytes $firstBytePos-$lastBytePos/${stream.available}",
+          HeaderNames.CONTENT_LENGTH -> s"${lastBytePos - firstBytePos + 1}"
+        )
+        (Status.PARTIAL_CONTENT, headers, Option(firstBytePos, lastBytePos))
+      case _ =>
+        // serving a non-partial content request
+        val headers: Map[String, String] = Map(
+          HeaderNames.ACCEPT_RANGES -> "bytes",
+          HeaderNames.CONTENT_LENGTH -> s"${stream.available}"
+        )
+        (Status.OK, headers, None)
+    }
+
+    val allHeaders = rangedHeaders ++ Seq(
+      Some(HeaderNames.CONTENT_TYPE -> contentType.getOrElse(ContentTypes.BINARY)),
+      fileName.map(f => HeaderNames.CONTENT_DISPOSITION -> ("attachment; filename=\"" + f + "\""))
+    ).flatten.toMap
+
+    // enumerate the content
+    val (enumerator, length) = range match {
+      case Some((firstBytePos, lastBytePos)) =>
+        (enumerate(stream, firstBytePos, lastBytePos), lastBytePos - firstBytePos)
+      case _ =>
+        (Enumerator.fromStream(stream)(Execution.defaultContext), stream.available().toLong)
+    }
+    val data = akka.stream.scaladsl.Source.fromPublisher(Streams.enumeratorToPublisher(enumerator)).map(ByteString.apply)
+
+    Result(
+      ResponseHeader(rangedStatus, allHeaders),
+      HttpEntity.Streamed(data, Option(length), contentType)
+    )
+  }
+
+  private def enumerate(is: java.io.InputStream, firstBytePos: Long, lastBytePos: Long): Enumerator[Array[Byte]] = {
+    is.skip(firstBytePos)
+    Enumerator.fromStream(is)(Execution.defaultContext) &> Traversable.takeUpTo(lastBytePos - firstBytePos + 1)
+  }
+
+}

--- a/framework/src/play/src/main/scala/play/core/j/JavaRangeResult.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaRangeResult.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.core.j
+
+import java.io.{ InputStream, File }
+import java.nio.file.Path
+
+import play.api.mvc.{ RangeResult, Result }
+
+/**
+ * Java compatible RangeResult
+ */
+object JavaRangeResult {
+
+  def ofPath(path: Path, rangeHeader: String): Result = RangeResult.ofPath(path, Option(rangeHeader), None)
+  def ofPath(path: Path, rangeHeader: String, fileName: String): Result = RangeResult.ofPath(path, Option(rangeHeader), fileName, None)
+  def ofPath(path: Path, rangeHeader: String, fileName: String, contentType: String): Result = RangeResult.ofPath(path, Option(rangeHeader), fileName, Option(contentType))
+  def ofFile(file: File, rangeHeader: String): Result = RangeResult.ofFile(file, Option(rangeHeader), None)
+  def ofFile(file: File, rangeHeader: String, fileName: String): Result = RangeResult.ofFile(file, Option(rangeHeader), fileName, None)
+  def ofFile(file: File, rangeHeader: String, fileName: String, contentType: String): Result = RangeResult.ofFile(file, Option(rangeHeader), fileName, Option(contentType))
+  def ofStream(stream: InputStream, rangeHeader: String): Result = RangeResult.ofStream(stream, Option(rangeHeader), None)
+  def ofStream(stream: InputStream, rangeHeader: String, fileName: String): Result = RangeResult.ofStream(stream, Option(rangeHeader), Option(fileName), None)
+  def ofStream(stream: InputStream, rangeHeader: String, fileName: String, contentType: String): Result = RangeResult.ofStream(stream, Option(rangeHeader), Option(fileName), Option(contentType))
+
+}

--- a/framework/src/play/src/test/scala/play/api/mvc/RangeResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RangeResultsSpec.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.mvc
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.util.ByteString
+import org.specs2.mutable._
+import play.api.http.HttpEntity
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
+import scala.collection.mutable
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+object RangeResultsSpec extends Specification {
+
+  "Result" should {
+
+    "have status" in {
+      val stream = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3))
+      val Result(ResponseHeader(status, _, _), _) = RangeResult.ofStream(stream, None, None)
+      status must_== 200
+    }
+
+    "have headers" in {
+      val stream = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3))
+      val Result(ResponseHeader(_, headers, _), _) = RangeResult.ofStream(stream, None, None, None)
+      headers must havePair("Accept-Ranges" -> "bytes")
+      headers must havePair("Content-Length" -> "3")
+      headers must havePair("Content-Type" -> "application/octet-stream")
+    }
+
+    "support Content-Disposition header" in {
+      val stream = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3))
+      val Result(ResponseHeader(_, headers, _), _) = RangeResult.ofStream(stream, None, Some("video.mp4"), None)
+      headers must havePair("Content-Disposition" -> "attachment; filename=\"video.mp4\"")
+    }
+
+    "support first byte position" in {
+      val stream = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3))
+      val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(data, _, _)) = RangeResult.ofStream(stream, Some("bytes=1-"), None)
+      headers must havePair("Content-Range" -> "bytes 1-2/3")
+      headers must havePair("Content-Length" -> "2")
+      implicit val system = ActorSystem()
+      implicit val materializer = ActorMaterializer()
+      val result = Await.result(data.runFold(ByteString.empty)(_ ++ _).map(_.toArray), Duration.Inf)
+      mutable.WrappedArray.make(result) must be_==(mutable.WrappedArray.make(Array[Byte](2, 3)))
+    }
+
+    "support last byte position" in {
+      val stream = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3, 4, 5, 6))
+      val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(data, _, _)) = RangeResult.ofStream(stream, Some("bytes=2-4"), None)
+      headers must havePair("Content-Range" -> "bytes 2-4/6")
+      headers must havePair("Content-Length" -> "3")
+      implicit val system = ActorSystem()
+      implicit val materializer = ActorMaterializer()
+      val result = Await.result(data.runFold(ByteString.empty)(_ ++ _).map(_.toArray), Duration.Inf)
+      mutable.WrappedArray.make(result) must be_==(mutable.WrappedArray.make(Array[Byte](3, 4, 5)))
+    }
+
+    "support sending path" in {
+      val path = java.nio.file.Paths.get("path.mp4")
+      java.nio.file.Files.createFile(path)
+      try {
+        val Result(ResponseHeader(_, headers, _), _) = RangeResult.ofPath(path, None, Some("video/mp4"))
+        headers must havePair("Content-Disposition" -> "attachment; filename=\"path.mp4\"")
+        headers must havePair("Content-Type" -> "video/mp4")
+      } finally {
+        java.nio.file.Files.delete(path)
+      }
+    }
+
+    "support sending file" in {
+      val file = new java.io.File("file.mp4")
+      file.createNewFile()
+      try {
+        val Result(ResponseHeader(_, headers, _), _) = RangeResult.ofFile(file, None, Some("video/mp4"))
+        headers must havePair("Content-Disposition" -> "attachment; filename=\"file.mp4\"")
+        headers must havePair("Content-Type" -> "video/mp4")
+      } finally {
+        file.delete()
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
Does this new `RangeRequest` API for Scala look good to you?

I've not done the Java assets controller yet. I can do this later.

See the old pull request #4770 for some API discussion around this. Particularly my first comment: https://github.com/playframework/playframework/pull/4770#issue-91083774 and @jroper's comment: https://github.com/playframework/playframework/pull/4770#issuecomment-116436485. The code for that old pull request, should you wish to see it, is here: https://github.com/bjfletcher/playframework/tree/ranged-sendFile (it was on my `master` - should have branched before the pull request!)

Many thanks for any feedback.