### PR TITLE
Keep JsObject specificity when transforming OWrites

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
@@ -30,19 +30,18 @@ import Json._
   "No Json serializer found for type ${A}. Try to implement an implicit Writes or Format for this type."
 )
 trait Writes[-A] {
-
   /**
    * Convert the object into a JsValue
    */
   def writes(o: A): JsValue
 
   /**
-   * transforms the resulting JsValue using transformer function
+   * Transforms the resulting [[JsValue]] using transformer function
    */
   def transform(transformer: JsValue => JsValue): Writes[A] = Writes[A] { a => transformer(this.writes(a)) }
 
   /**
-   * transforms resulting JsValue using Writes[JsValue]
+   * Transforms resulting [[JsValue]] using Writes[JsValue]
    */
   def transform(transformer: Writes[JsValue]): Writes[A] = Writes[A] { a => transformer.writes(this.writes(a)) }
 
@@ -52,8 +51,19 @@ trait Writes[-A] {
   "No Json serializer as JsObject found for type ${A}. Try to implement an implicit OWrites or OFormat for this type."
 )
 trait OWrites[-A] extends Writes[A] {
-
   def writes(o: A): JsObject
+
+  /**
+   * Transforms the resulting [[JsValue]] using transformer function
+   */
+  def transform(transformer: JsObject => JsObject): OWrites[A] =
+    OWrites[A] { a => transformer(this.writes(a)) }
+
+  /**
+   * Transforms resulting [[JsValue]] using Writes[JsValue]
+   */
+  def transform(transformer: OWrites[JsObject]): OWrites[A] =
+    OWrites[A] { a => transformer.writes(this.writes(a)) }
 
 }
 
@@ -75,7 +85,6 @@ object OWrites extends PathWrites with ConstraintWrites {
   def apply[A](f: A => JsObject): OWrites[A] = new OWrites[A] {
     def writes(a: A): JsObject = f(a)
   }
-
 }
 
 /**
@@ -93,11 +102,8 @@ object Writes extends PathWrites with ConstraintWrites with DefaultWrites {
   }*/
 
   def apply[A](f: A => JsValue): Writes[A] = new Writes[A] {
-
     def writes(a: A): JsValue = f(a)
-
   }
-
 }
 
 /**

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/WritesSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/WritesSpec.scala
@@ -128,4 +128,34 @@ object WritesSpec extends org.specs2.mutable.Specification {
         aka("written date") must_== JsString(format(customPattern1, instant))
     }
   }
+
+  "OWrites" should {
+    val writes = OWrites[Foo] { foo =>
+      Json.obj("bar" -> foo.bar)
+    }
+    val time = System.currentTimeMillis()
+
+    "be transformed with JsObject function" in {
+      val transformed: OWrites[Foo] = writes.transform({ obj: JsObject =>
+        obj ++ Json.obj("time" -> time)
+      })
+      val written: JsObject = transformed.writes(Foo("Lorem"))
+
+      written must_== Json.obj("bar" -> "Lorem", "time" -> time)
+    }
+
+    "be transformed with another OWrites" in {
+      val transformed: OWrites[Foo] =
+        writes.transform(OWrites[JsObject] { obj =>
+          obj ++ Json.obj("time" -> time)
+        })
+      val written: JsObject = transformed.writes(Foo("Lorem"))
+
+      written must_== Json.obj("bar" -> "Lorem", "time" -> time)
+    }
+  }
+
+  // ---
+
+  case class Foo(bar: String)
 }


### PR DESCRIPTION
The `transform` operations on `OWrites` inherited from `Writes` works with `JsValue` rather than `JsObject`.

Considering...

```scala
val writes = OWrites[Foo] { foo => Json.obj("bar" -> foo.bar) }
```

... the result before transformation is `JsObject` ...

```scala
val result: JsObject = writes(Foo("bar"))
```

..., but if using `.transform`, it works with `JsValue` and result in a `Writes`.

```scala
val transformed = writes.transform { js: JsValue => ??? }
val written: JsValue = transformed.writes(Foo("bar"))
```

After the changes, it can works with `JsObject` and results in a `OWrites`:

```scala
val transformed: OWrites[Foo] = writes.transform { obj: JsObject =>
  obj ++ Json.obj("time" -> time)
}
val result: JsObject = transformed.writes(Foo("Lorem"))
```