### PR TITLE
Added WebM to list of types

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
@@ -521,6 +521,7 @@ object MimeTypes {
         wb1=application/x-qpro
         wbmp=image/vnd.wap.wbmp
         web=application/vndxara
+        webm=video/webm
         wiz=application/msword
         wk1=application/x-123
         wmf=windows/metafile


### PR DESCRIPTION
In using `.webm` video files as assets, I noticed that this type wasn't on the list of default types. The [best default](https://www.google.co.uk/search?q=WebM+file+extension&oq=WebM+file+extension&aqs=chrome..69i57j0l5.254j0j4&sourceid=chrome&es_sm=91&ie=UTF-8) for `.webm` seems to be `video/webm`. They use `audio/webm` for the audio-only version however in the link you'll see that `video/webm` is far more common than `audio/webm` and therefore should be the default.

WebM documentation on their website: http://www.webmproject.org/docs/container/

Without this, the default would be `application/octet-stream` which couldn't play WebM videos on the browsers that I tested.  The user would have to explicitly specify the `Content-Type` header.


