### PR TITLE
Transparent HEAD request does not contain tags (like e.g. Routes.ROUTE_PATTERN)

### DIFF
--- a/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -121,17 +121,19 @@ class DefaultHttpRequestHandler(router: Router, errorHandler: HttpErrorHandler, 
 
       // We automatically permit HEAD requests against any GETs without the need to
       // add an explicit mapping in Routes
-      val missingHandler: Handler = request.method match {
+      request.method match {
         case HttpVerbs.HEAD =>
-          val headAction = routeRequest(request.copy(method = HttpVerbs.GET)) match {
-            case Some(action: EssentialAction) => action
-            case _ => notFoundHandler
+          val (routedRequest, headAction) = routeRequest(request.copy(method = HttpVerbs.GET)) match {
+            case Some(action: EssentialAction) => action match {
+              case handler: RequestTaggingHandler => (handler.tagRequest(request), action)
+              case _ => (request, action)
+            }
+            case None => (request, notFoundHandler)
           }
-          new HeadAction(headAction)
+          (routedRequest, new HeadAction(headAction))
         case _ =>
-          notFoundHandler
+          (request, notFoundHandler)
       }
-      (request, missingHandler)
     }
 
     (routedRequest, filterHandler(rh => handler)(routedRequest))


### PR DESCRIPTION
Transparent HEAD request handling (in [DefaultHttpRequestHandler.handlerForRequest](https://github.com/playframework/playframework/blob/2.4.x/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala#L125) and [GlobalSettings.onRequestReceived](https://github.com/playframework/playframework/blob/2.4.x/framework/src/play/src/main/scala/play/api/GlobalSettings.scala#L118)) does not tag the request.

This may cause issues for tools that build upon request tags like e.g. [play-statsd](https://github.com/typesafehub/play-plugins/tree/master/statsd) (see [StatsdFilter](https://github.com/typesafehub/play-plugins/blob/master/statsd/src/main/scala/play/modules/statsd/api/StatsdFilter.scala#L47)) or the kamon-play plugin.

Is it intentional, that transparent HEAD requests are not tagged, or would you accept a pull request for this?