### PR TITLE
Propagate failure in `EnumeratorPublisher` impl

### DIFF
--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/impl/EnumeratorPublisher.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/impl/EnumeratorPublisher.scala
@@ -177,9 +177,9 @@ private[streams] class EnumeratorSubscription[T, U >: T](
    * enters a failure state. This may indicate that an error occurred
    * during evaluation of the Enumerator.
    */
-  private def enumeratorApplicationFailed(): Unit = exclusive {
+  private def enumeratorApplicationFailed(t: Throwable): Unit = exclusive {
     case Requested(_, _) =>
-      subr.onComplete()
+      subr.onError(t)
       state = Completed
     case Cancelled =>
       ()
@@ -213,7 +213,7 @@ private[streams] class EnumeratorSubscription[T, U >: T](
     its match {
       case Unattached =>
         enum(iteratee).onFailure {
-          case _ => enumeratorApplicationFailed()
+          case t => enumeratorApplicationFailed(t)
         }(Execution.trampoline)
       case Attached(link0) =>
         link0.success(iteratee)

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/EnumeratorPublisherSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/EnumeratorPublisherSpec.scala
@@ -163,13 +163,14 @@ class EnumeratorPublisherSpec extends Specification {
     "handle errors when enumerating" in {
       val testEnv = new TestEnv[Int]
       val lotsOfItems = 0 until 25
-      val enum = Enumerator.flatten(Future.failed(new Exception("x")))
+      lazy val exception = new Exception("x")
+      val enum = Enumerator.flatten(Future.failed(exception))
       val pubr = new EnumeratorPublisher[Nothing](enum)
       pubr.subscribe(testEnv.subscriber)
       testEnv.next must_== OnSubscribe
       testEnv.request(1)
       testEnv.next must_== RequestMore(1)
-      testEnv.next must_== OnComplete
+      testEnv.next must_== OnError(exception)
       testEnv.isEmptyAfterDelay() must beTrue
     }
     "enumerate 25 items" in {


### PR DESCRIPTION
I'm working on #4686, but I've stumbled on this as it was causing a `WSSpec` test to fail after converting the WS API to use Akka streams instead of Iteratees/Enumerators.

review by @richdougherty ;-)