### PR TITLE
Allow Authenticator for Security.Authenticated to be injected

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Security.java
+++ b/framework/src/play/src/main/java/play/mvc/Security.java
@@ -3,10 +3,12 @@
  */
 package play.mvc;
 
+import play.inject.Injector;
 import play.libs.F;
 import play.mvc.Http.*;
 
 import java.lang.annotation.*;
+import javax.inject.Inject;
 
 /**
  * Defines several security helpers.
@@ -30,10 +32,17 @@ public class Security {
      * <code>username</code> attribute.
      */
     public static class AuthenticatedAction extends Action<Authenticated> {
-        
+
+        private final Injector injector;
+
+        @Inject
+        public AuthenticatedAction(Injector injector) {
+            this.injector = injector;
+        }
+
         public F.Promise<Result> call(final Context ctx) {
             try {
-                Authenticator authenticator = configuration.value().newInstance();
+                Authenticator authenticator = injector.instanceOf(configuration.value());
                 String username = authenticator.getUsername(ctx);
                 if(username == null) {
                     Result unauthorized = authenticator.onUnauthorized(ctx);

--- a/framework/src/play/src/test/java/play/mvc/SecurityTest.java
+++ b/framework/src/play/src/test/java/play/mvc/SecurityTest.java
@@ -7,6 +7,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
+
+import play.inject.Injector;
 import play.libs.F;
 
 import static org.mockito.Mockito.*;
@@ -16,6 +18,7 @@ public class SecurityTest {
     public static class AuthenticatedActionTest {
         Http.Context ctx;
         Http.Request req;
+        Injector injector;
         Security.AuthenticatedAction action;
 
         RuntimeException exception = new RuntimeException("test exception");
@@ -25,13 +28,15 @@ public class SecurityTest {
         public void setUp() {
             ctx = mock(Http.Context.class);
             req = mock(Http.Request.class);
+            injector = mock(Injector.class);
 
             when(ctx.session()).thenReturn(new Http.Session(ImmutableMap.of("username", "test_user")));
             when(ctx.request()).thenReturn(req);
             doNothing().when(req).setUsername(anyString());
             doNothing().when(req).setUsername(null);
+            when(injector.instanceOf(Security.Authenticator.class)).thenReturn(new Security.Authenticator());
 
-            action = new Security.AuthenticatedAction();
+            action = new Security.AuthenticatedAction(injector);
             action.configuration = new Security.Authenticated() {
                 @Override
                 public Class<? extends Security.Authenticator> value() {


### PR DESCRIPTION
I believe this one simply slid out from 2.4
For reference https://github.com/playframework/playframework/blob/master/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java receives a class as parameter too (the error); and already is using the injector.