### PR TITLE
Use akka streams for WebSockets API

### DIFF
--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/impl/EnumeratorPublisher.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/impl/EnumeratorPublisher.scala
@@ -177,9 +177,9 @@ private[streams] class EnumeratorSubscription[T, U >: T](
    * enters a failure state. This may indicate that an error occurred
    * during evaluation of the Enumerator.
    */
-  private def enumeratorApplicationFailed(): Unit = exclusive {
+  private def enumeratorApplicationFailed(t: Throwable): Unit = exclusive {
     case Requested(_, _) =>
-      subr.onComplete()
+      subr.onError(t)
       state = Completed
     case Cancelled =>
       ()
@@ -213,7 +213,7 @@ private[streams] class EnumeratorSubscription[T, U >: T](
     its match {
       case Unattached =>
         enum(iteratee).onFailure {
-          case _ => enumeratorApplicationFailed()
+          case t => enumeratorApplicationFailed(t)
         }(Execution.trampoline)
       case Attached(link0) =>
         link0.success(iteratee)

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/EnumeratorPublisherSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/impl/EnumeratorPublisherSpec.scala
@@ -163,13 +163,14 @@ class EnumeratorPublisherSpec extends Specification {
     "handle errors when enumerating" in {
       val testEnv = new TestEnv[Int]
       val lotsOfItems = 0 until 25
-      val enum = Enumerator.flatten(Future.failed(new Exception("x")))
+      lazy val exception = new Exception("x")
+      val enum = Enumerator.flatten(Future.failed(exception))
       val pubr = new EnumeratorPublisher[Nothing](enum)
       pubr.subscribe(testEnv.subscriber)
       testEnv.next must_== OnSubscribe
       testEnv.request(1)
       testEnv.next must_== RequestMore(1)
-      testEnv.next must_== OnComplete
+      testEnv.next must_== OnError(exception)
       testEnv.isEmptyAfterDelay() must beTrue
     }
     "enumerate 25 items" in {

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -3,19 +3,22 @@
  */
 package play.api.libs.ws
 
-import java.net.URI
-
-import scala.concurrent.{ Future, ExecutionContext }
-import scala.concurrent.duration.Duration
-
 import java.io.File
-
-import play.api.http.Writeable
-import play.api.libs.iteratee._
-
-import play.api._
+import java.net.URI
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.language.implicitConversions
 import scala.xml.Elem
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Source
+import play.api.Application
+import play.api.http.Writeable
 import play.api.libs.json.JsValue
+import play.api.libs.iteratee.Enumerator
+import play.api.libs.iteratee.Iteratee
 
 /**
  * The WSClient holds the configuration information needed to build a request, and provides a way to get a request holder.
@@ -246,9 +249,9 @@ case class InMemoryBody(bytes: Array[Byte]) extends WSBody
 /**
  * A streamed body
  *
- * @param bytes An enumerator of the bytes of the body
+ * @param bytes A flow of the bytes of the body
  */
-case class StreamedBody(bytes: Enumerator[Array[Byte]]) extends WSBody {
+case class StreamedBody(bytes: Source[Array[Byte], Unit]) extends WSBody {
   throw new NotImplementedError("A streaming request body is not yet implemented")
 }
 
@@ -413,17 +416,17 @@ trait WSRequest {
    * performs a get
    * @param consumer that's handling the response
    */
-  def get[A](consumer: WSResponseHeaders => Iteratee[Array[Byte], A])(implicit ec: ExecutionContext): Future[Iteratee[Array[Byte], A]] = {
-    getStream().flatMap {
-      case (response, enumerator) =>
-        enumerator(consumer(response))
+  def get[A](consumer: WSResponseHeaders => Flow[Array[Byte], Array[Byte], A])(implicit ec: ExecutionContext): Future[Source[Array[Byte], A]] = {
+    getStream().map {
+      case (response, source) =>
+        source.viaMat(consumer(response))(Keep.right)
     }
   }
 
   /**
    * performs a get
    */
-  def getStream(): Future[(WSResponseHeaders, Enumerator[Array[Byte]])] = {
+  def getStream(): Future[(WSResponseHeaders, Source[Array[Byte], Unit])] = {
     withMethod("GET").stream()
   }
 
@@ -443,10 +446,10 @@ trait WSRequest {
    * performs a POST with supplied body
    * @param consumer that's handling the response
    */
-  def patchAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Iteratee[Array[Byte], A])(implicit wrt: Writeable[T], ec: ExecutionContext): Future[Iteratee[Array[Byte], A]] = {
-    withMethod("PATCH").withBody(body).stream().flatMap {
-      case (response, enumerator) =>
-        enumerator(consumer(response))
+  def patchAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Flow[Array[Byte], Array[Byte], A])(implicit wrt: Writeable[T], ec: ExecutionContext): Future[Source[Array[Byte], A]] = {
+    withMethod("PATCH").withBody(body).stream().map {
+      case (response, source) =>
+        source.viaMat(consumer(response))(Keep.right)
     }
   }
 
@@ -466,10 +469,10 @@ trait WSRequest {
    * performs a POST with supplied body
    * @param consumer that's handling the response
    */
-  def postAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Iteratee[Array[Byte], A])(implicit wrt: Writeable[T], ec: ExecutionContext): Future[Iteratee[Array[Byte], A]] = {
-    withMethod("POST").withBody(body).stream().flatMap {
-      case (response, enumerator) =>
-        enumerator(consumer(response))
+  def postAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Flow[Array[Byte], Array[Byte], A])(implicit wrt: Writeable[T], ec: ExecutionContext): Future[Source[Array[Byte], A]] = {
+    withMethod("POST").withBody(body).stream().map {
+      case (response, source) =>
+        source.viaMat(consumer(response))(Keep.right)
     }
   }
 
@@ -489,10 +492,10 @@ trait WSRequest {
    * performs a PUT with supplied body
    * @param consumer that's handling the response
    */
-  def putAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Iteratee[Array[Byte], A])(implicit wrt: Writeable[T], ec: ExecutionContext): Future[Iteratee[Array[Byte], A]] = {
-    withMethod("PUT").withBody(body).stream().flatMap {
-      case (response, enumerator) =>
-        enumerator(consumer(response))
+  def putAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Flow[Array[Byte], Array[Byte], A])(implicit wrt: Writeable[T], ec: ExecutionContext): Future[Source[Array[Byte], A]] = {
+    withMethod("PUT").withBody(body).stream().map {
+      case (response, source) =>
+        source.viaMat(consumer(response))(Keep.right)
     }
   }
 
@@ -519,9 +522,9 @@ trait WSRequest {
   def execute(): Future[WSResponse]
 
   /**
-   * Execute this request and stream the response body in an enumerator
+   * Execute this request and stream the response body.
    */
-  def stream(): Future[(WSResponseHeaders, Enumerator[Array[Byte]])]
+  def stream(): Future[(WSResponseHeaders, Source[Array[Byte], Unit])]
 }
 
 /**

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -407,7 +407,7 @@ trait WSRequest {
   /**
    * performs a get
    */
-  def get() = withMethod("GET").execute()
+  def get(): Future[WSResponse] = withMethod("GET").execute()
 
   /**
    * performs a get
@@ -453,14 +453,14 @@ trait WSRequest {
   /**
    * Perform a POST on the request asynchronously.
    */
-  def post[T](body: T)(implicit wrt: Writeable[T]) =
+  def post[T](body: T)(implicit wrt: Writeable[T]): Future[WSResponse] =
     withMethod("POST").withBody(body).execute()
 
   /**
    * Perform a POST on the request asynchronously.
    * Request body won't be chunked
    */
-  def post(body: File) = withMethod("POST").withBody(FileBody(body)).execute()
+  def post(body: File): Future[WSResponse] = withMethod("POST").withBody(FileBody(body)).execute()
 
   /**
    * performs a POST with supplied body
@@ -476,14 +476,14 @@ trait WSRequest {
   /**
    * Perform a PUT on the request asynchronously.
    */
-  def put[T](body: T)(implicit wrt: Writeable[T]) =
+  def put[T](body: T)(implicit wrt: Writeable[T]): Future[WSResponse] =
     withMethod("PUT").withBody(body).execute()
 
   /**
    * Perform a PUT on the request asynchronously.
    * Request body won't be chunked
    */
-  def put(body: File) = withMethod("PUT").withBody(FileBody(body)).execute()
+  def put(body: File): Future[WSResponse] = withMethod("PUT").withBody(FileBody(body)).execute()
 
   /**
    * performs a PUT with supplied body
@@ -499,17 +499,17 @@ trait WSRequest {
   /**
    * Perform a DELETE on the request asynchronously.
    */
-  def delete() = withMethod("DELETE").execute()
+  def delete(): Future[WSResponse] = withMethod("DELETE").execute()
 
   /**
    * Perform a HEAD on the request asynchronously.
    */
-  def head() = withMethod("HEAD").execute()
+  def head(): Future[WSResponse] = withMethod("HEAD").execute()
 
   /**
    * Perform a OPTIONS on the request asynchronously.
    */
-  def options() = withMethod("OPTIONS").execute()
+  def options(): Future[WSResponse] = withMethod("OPTIONS").execute()
 
   def execute(method: String): Future[WSResponse] = withMethod(method).execute()
 


### PR DESCRIPTION
**This is working in progress, so please don't merge it just yet.**

In this commit the signature of several WS API methods was changed and it's no longer source compatible. In the linked ticket, @jroper hinted that we should have provided overloads ffor the new methods. While that would be desiderable, it's unfortunately not achievable, because the erased signature of the overloads would be the same. I guess the only alternative is to rename the existing methods, deprecate them in favour of the new ones using akka stream's types, and document the changes in the migration guide. Since this is a change that may be controversial, I'd like to gather feedback before investing time in this task.

\cc @jroper @richdougherty @wsargent