### PR TITLE
Update documentation -mem is not valid any more

### DIFF
--- a/documentation/manual/detailedTopics/production/ProductionConfiguration.md
+++ b/documentation/manual/detailedTopics/production/ProductionConfiguration.md
@@ -269,10 +269,3 @@ You can specify any JVM arguments to the application startup script. Otherwise t
 ```
 $ /path/to/bin/<project-name> -J-Xms128M -J-Xmx512m -J-server
 ```
-
-As a convenience you can also set memory min, max, permgen and the reserved code cache size in one go; a formula is used to
-determine these values given the supplied parameter (which represents maximum memory):
-
-```
-$ /path/to/bin/<project-name> -mem 512 -J-server
-```


### PR DESCRIPTION
If this is related to https://github.com/sbt/sbt-native-packager/commit/62362c237793da9441fcfe8d22a06a220f36445f the -mem Parameter was removed in sbt.