### PR TITLE
Transparent HEAD with akka-http has request method set to GET

### DIFF
--- a/framework/src/play-akka-http-server/src/main/resources/play/reference-overrides.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/play/reference-overrides.conf
@@ -15,4 +15,7 @@ akka {
   # Turn off dead letters until Akka HTTP server is stable
   log-dead-letters = off
 
+  # Disable Akka-HTTP's transparent HEAD handling. so that play's HEAD handling can take action
+  http.server.transparent-head-requests = false
+
 }


### PR DESCRIPTION
As found out in #4896, with akka-http the request.method is set to GET for a transparent HEAD request.

Steps to reproduce:
- Start with some play-scala app, e.g. using the play-scala template from the templates dir
- Check that there's a route for GET and some path, but no related HEAD route
- Enable akka-http following [the documentation](https://playframework.com/documentation/2.4.x/AkkaHttpServer)
- Print the `request.method` in the route action
- Do a HEAD request for the previously checked route, e.g. `curl -X HEAD http://localhost:9000/`
- In my case (on master branch), using the play-scala template, the `println(s"method: ${request.method}")` results in `method: GET`
- Instead, this should be `method: HEAD`