### PR TITLE
ApplicationLifecycle.addStopHook has bad example

### DIFF
--- a/framework/src/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
@@ -39,7 +39,7 @@ import scala.concurrent.Future
  *
  *     private val connectionPool = new SomeConnectionPool()
  *     applicationLifecycle.addStopHook { () =>
- *       connectionPool.shutdown()
+ *       Future.successful(connectionPool.shutdown())
  *     }
  *
  *     ...


### PR DESCRIPTION
The scaladoc implies that the return type is Unit, when it is Future[Unit] -- the example won't compile.