### PR TITLE
Fix binary compatibility error in invokeWithContext

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -330,7 +330,8 @@ object PlayBuild extends Build {
   lazy val PlayTestProject = PlayCrossBuiltProject("Play-Test", "play-test")
     .settings(
       libraryDependencies ++= testDependencies,
-      parallelExecution in Test := false
+      parallelExecution in Test := false,
+      binaryIssueFilters += ProblemFilters.exclude[MissingMethodProblem]("play.test.Helpers.invokeWithContext")
     ).dependsOn(PlayNettyServerProject)
 
   lazy val PlaySpecs2Project = PlayCrossBuiltProject("Play-Specs2", "play-specs2")


### PR DESCRIPTION
This is a binary compatibility, since converting a method to a static method is binary incompatible.  However, this is a test helper, that will not likely be used by a library, so binary incompatibilities are not likely to be of a high impact.