### PR TITLE
Map HikariCP connectionInitSql property - Backport #4901

### DIFF
--- a/framework/src/play-jdbc/src/main/resources/reference.conf
+++ b/framework/src/play-jdbc/src/main/resources/reference.conf
@@ -103,6 +103,9 @@ play {
         # If non null, sets the catalog that should be used on connections
         catalog = null
 
+        # A SQL statement that will be executed after every new connection creation before adding it to the pool
+        connectionInitSql = null
+
         # If non null, sets the transaction isolation level
         transactionIsolation = null
 

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
@@ -131,6 +131,7 @@ class HikariCPConfig(dbConfig: DatabaseConfig, configuration: PlayConfig) {
     hikariConfig.setAllowPoolSuspension(config.get[Boolean]("allowPoolSuspension"))
     hikariConfig.setReadOnly(config.get[Boolean]("readOnly"))
     hikariConfig.setRegisterMbeans(config.get[Boolean]("registerMbeans"))
+    config.getOptional[String]("connectionInitSql").foreach(hikariConfig.setConnectionInitSql)
     config.getOptional[String]("catalog").foreach(hikariConfig.setCatalog)
     config.getOptional[String]("transactionIsolation").foreach(hikariConfig.setTransactionIsolation)
     hikariConfig.setValidationTimeout(config.get[FiniteDuration]("validationTimeout").toMillis)

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
@@ -32,6 +32,11 @@ class HikariCPConfigSpec extends Specification {
       new HikariCPConfig(dbConfig, reference).toHikariConfig.getJdbcUrl must beEqualTo("jdbc:h2:mem:")
     }
 
+    "set connectionInitSql config" in new Configs {
+      val config = from("hikaricp.connectionInitSql" -> "SELECT 1")
+      new HikariCPConfig(dbConfig, config).toHikariConfig.getConnectionInitSql must beEqualTo("SELECT 1")
+    }
+
     "respect the defaults as" in {
       "autoCommit to true" in new Configs {
         new HikariCPConfig(dbConfig, reference).toHikariConfig.isAutoCommit must beTrue


### PR DESCRIPTION
Backport of #4901 to 2.4.x. See discussion here about why HikariCP upgrade was avoided:

https://groups.google.com/forum/#!topic/play-framework-dev/nb6HhpT8_-c