### PR TITLE
Bumped akka-stream and akka-http to 1.0 (fixes tests flakiness)

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -143,7 +143,7 @@ object Dependencies {
   val nettyUtilsDependencies = slf4j
 
   val akkaHttp = Seq(
-    "com.typesafe.akka" %% "akka-http-core-experimental" % "1.0-RC4"
+    "com.typesafe.akka" %% "akka-http-core-experimental" % "1.0"
   )
 
   val routesCompilerDependencies =  Seq(
@@ -240,7 +240,7 @@ object Dependencies {
 
   val streamsDependencies = Seq(
     "org.reactivestreams" % "reactive-streams" % "1.0.0",
-    "com.typesafe.akka" %% "akka-stream-experimental" % "1.0-RC4",
+    "com.typesafe.akka" %% "akka-stream-experimental" % "1.0",
     scalaJava8Compat
   ) ++ specsBuild.map(_ % "test") ++ javaTestDeps
 

--- a/framework/src/play-streams/src/main/java/play/libs/streams/Accumulator.java
+++ b/framework/src/play-streams/src/main/java/play/libs/streams/Accumulator.java
@@ -108,10 +108,7 @@ public final class Accumulator<E, A> {
      * @return A new accumulator with the given flow in its graph.
      */
     public <D> Accumulator<D, A> through(Flow<D, E, ?> flow) {
-    	// This should be written: new Accumulator<>(flow.to(sink, Keep.right()));
-    	// However, that doesn't compile anymore, and it seems there is an issue with the `Flow.to` (overloaded) method.
-    	// The solution I used here is to inline the implementation of `Flow.to` until the overloading issue is fixed.
-        return new Accumulator<>(new Sink(flow.asScala().toMat(sink, akka.stream.javadsl.package$.MODULE$.combinerToScala(Keep.right()))));
+        return new Accumulator<>(flow.toMat(sink, Keep.right()));
     }
 
     /**


### PR DESCRIPTION
This commit also seems to fix the tests flakiness that was causing and error
(`Connection reset`) in a few tests.

See https://groups.google.com/forum/#!topic/play-framework-dev/AFLWU-RX4lg for
details.

*Should be backported to 2.4.x*