### PR TITLE
Use Akka Streams for WS streamed response body handling

### DIFF
--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -11,6 +11,7 @@ import java.io._
 
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
+import org.specs2.specification.AfterAll
 
 //#dependency
 import javax.inject.Inject
@@ -19,6 +20,10 @@ import scala.concurrent.duration._
 
 import play.api.mvc._
 import play.api.libs.ws._
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl._
 
 class Application @Inject() (ws: WSClient) extends Controller {
 
@@ -35,13 +40,26 @@ case class Person(name: String, age: Int)
  * JVM implementation issue.
  */
 @RunWith(classOf[JUnitRunner])
-class ScalaWSSpec extends PlaySpecification with Results {
+class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
+
+  // This needs to be removed when https://github.com/playframework/playframework/issues/4688 is fixed.
+  import play.api.libs.iteratee._
+  implicit def source2enumerator[T](source: Source[T, _]): Enumerator[T] = {
+    import play.api.libs.streams.Streams
+    val publisher = source.runWith(Sink.publisher)
+    Streams.publisherToEnumerator(publisher)
+  }
 
   val url = s"http://localhost:$testServerPort/"
 
   // #scalaws-context
   implicit val context = play.api.libs.concurrent.Execution.Implicits.defaultContext
   // #scalaws-context
+
+  val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()(system)
+
+  def afterAll(): Unit = system.shutdown()
 
   def withSimpleServer[T](block: WSClient => T): T = withServer {
     case _ => Action(Ok)
@@ -265,18 +283,16 @@ class ScalaWSSpec extends PlaySpecification with Results {
         case ("GET", "/") => Action(Ok.chunked(largeEnumerator))
       } { ws =>
         //#stream-count-bytes
-        import play.api.libs.iteratee._
-
         // Make the request
-        val futureResponse: Future[(WSResponseHeaders, Enumerator[Array[Byte]])] =
+        val futureResponse: Future[(WSResponseHeaders, Source[Array[Byte], _])] =
           ws.url(url).getStream()
 
         val bytesReturned: Future[Long] = futureResponse.flatMap {
           case (headers, body) =>
             // Count the number of bytes returned
-            body |>>> Iteratee.fold(0l) { (total, bytes) =>
+            body.runWith(Sink.fold[Long, Array[Byte]](0L){ (total, bytes) =>
               total + bytes.length
-            }
+            })
         }
         //#stream-count-bytes
         await(bytesReturned) must_== 10000l
@@ -288,23 +304,21 @@ class ScalaWSSpec extends PlaySpecification with Results {
         val file = File.createTempFile("stream-to-file-", ".txt")
         try {
           //#stream-to-file
-          import play.api.libs.iteratee._
-
           // Make the request
-          val futureResponse: Future[(WSResponseHeaders, Enumerator[Array[Byte]])] =
+          val futureResponse: Future[(WSResponseHeaders, Source[Array[Byte], _])] =
             ws.url(url).getStream()
 
           val downloadedFile: Future[File] = futureResponse.flatMap {
             case (headers, body) =>
               val outputStream = new FileOutputStream(file)
 
-              // The iteratee that writes to the output stream
-              val iteratee = Iteratee.foreach[Array[Byte]] { bytes =>
+              // The sink that writes to the output stream
+              val sink = Sink.foreach[Array[Byte]] { bytes =>
                 outputStream.write(bytes)
               }
 
               // Feed the body into the iteratee
-              (body |>>> iteratee).andThen {
+              body.runWith(sink).andThen {
                 case result =>
                   // Close the output stream whether there was an error or not
                   outputStream.close()
@@ -324,8 +338,6 @@ class ScalaWSSpec extends PlaySpecification with Results {
         case ("GET", "/") => Action(Ok.chunked(largeEnumerator))
       } { ws =>
         val file = File.createTempFile("stream-to-file-", ".txt")
-        implicit val actorSystem = ActorSystem()
-        implicit val mat = ActorMaterializer()
         try {
           //#stream-to-result
           def downloadFile = Action.async {
@@ -361,7 +373,6 @@ class ScalaWSSpec extends PlaySpecification with Results {
 
         } finally {
           file.delete()
-          actorSystem.shutdown()
         }
       }
 
@@ -371,15 +382,15 @@ class ScalaWSSpec extends PlaySpecification with Results {
         import play.api.libs.iteratee._
 
         //#stream-put
-        val futureResponse: Future[(WSResponseHeaders, Enumerator[Array[Byte]])] =
+        val futureResponse: Future[(WSResponseHeaders, Source[Array[Byte], _])] =
           ws.url(url).withMethod("PUT").withBody("some body").stream()
         //#stream-put
 
         val bytesReturned: Future[Long] = futureResponse.flatMap {
           case (headers, body) =>
-            body |>>> Iteratee.fold(0l) { (total, bytes) =>
+            body.runWith(Sink.fold[Long, Array[Byte]](0L){ (total, bytes) =>
               total + bytes.length
-            }
+            })
         }
         //#stream-count-bytes
         await(bytesReturned) must_== 10000l

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
@@ -21,6 +21,7 @@ import java.io.IOException
 
 import akka.stream.scaladsl.Source
 import akka.stream.scaladsl.Sink
+import akka.util.ByteString
 
 object NettyWSSpec extends WSSpec with NettyIntegrationSpecification
 
@@ -177,7 +178,7 @@ trait WSSpec extends PlaySpecification with ServerIntegrationSpecification {
         val res = ws.url("/get").stream()
         val (_, body) = await(res)
 
-        new String(await(body |>>> Iteratee.consume[Array[Byte]]()), "utf-8").
+        await(body |>>> Iteratee.consume[ByteString]()).decodeString("utf-8").
           aka("streamed response") must_== "abc"
       }
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -3,20 +3,21 @@
  */
 package play.api.libs.ws
 
+import java.io.File
 import java.net.URI
 
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.xml.Elem
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
 
-import scala.concurrent.{ Future, ExecutionContext }
-import scala.concurrent.duration.Duration
-
-import java.io.File
-
+import play.api.Application
 import play.api.http.Writeable
-import play.api.libs.iteratee._
-
-import play.api._
-import scala.xml.Elem
 import play.api.libs.json.JsValue
 
 /**
@@ -248,9 +249,9 @@ case class InMemoryBody(bytes: ByteString) extends WSBody
 /**
  * A streamed body
  *
- * @param bytes An enumerator of the bytes of the body
+ * @param bytes A flow of the bytes of the body
  */
-case class StreamedBody(bytes: Enumerator[Array[Byte]]) extends WSBody {
+case class StreamedBody(bytes: Source[Array[Byte], Unit]) extends WSBody {
   throw new NotImplementedError("A streaming request body is not yet implemented")
 }
 
@@ -409,109 +410,113 @@ trait WSRequest {
   /**
    * performs a get
    */
-  def get() = withMethod("GET").execute()
+  def get(): Future[WSResponse] = withMethod("GET").execute()
 
   /**
    * performs a get
    * @param consumer that's handling the response
    */
-  def get[A](consumer: WSResponseHeaders => Iteratee[Array[Byte], A])(implicit ec: ExecutionContext): Future[Iteratee[Array[Byte], A]] = {
-    getStream().flatMap {
-      case (response, enumerator) =>
-        enumerator(consumer(response))
-    }
+  @deprecated("2.5.0", "Use `WS.get()` or `WS.getStream()`")
+  def get[A](consumer: WSResponseHeaders => Sink[Array[Byte], A])(implicit mat: Materializer): Future[A] = {
+    getStream().map {
+      case (response, source) =>
+        source.runWith(consumer(response))
+    }(mat.executionContext)
   }
 
   /**
    * performs a get
    */
-  def getStream(): Future[(WSResponseHeaders, Enumerator[Array[Byte]])] = {
+  def getStream(): Future[(WSResponseHeaders, Source[Array[Byte], Unit])] = {
     withMethod("GET").stream()
   }
 
   /**
    * Perform a PATCH on the request asynchronously.
    */
-  def patch[T](body: T)(implicit wrt: Writeable[T]) =
+  def patch[T](body: T)(implicit wrt: Writeable[T]): Future[WSResponse] =
     withMethod("PATCH").withBody(body).execute()
 
   /**
    * Perform a PATCH on the request asynchronously.
    * Request body won't be chunked
    */
-  def patch(body: File) = withMethod("PATCH").withBody(FileBody(body)).execute()
+  def patch(body: File): Future[WSResponse] = withMethod("PATCH").withBody(FileBody(body)).execute()
 
   /**
    * performs a POST with supplied body
    * @param consumer that's handling the response
    */
-  def patchAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Iteratee[Array[Byte], A])(implicit wrt: Writeable[T], ec: ExecutionContext): Future[Iteratee[Array[Byte], A]] = {
-    withMethod("PATCH").withBody(body).stream().flatMap {
-      case (response, enumerator) =>
-        enumerator(consumer(response))
-    }
+  @deprecated("2.5.0", "Use `WS.patch(body)`.")
+  def patchAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Sink[Array[Byte], A])(implicit wrt: Writeable[T], mat: Materializer): Future[A] = {
+    withMethod("PATCH").withBody(body).stream().map {
+      case (response, source) =>
+        source.runWith(consumer(response))
+    }(mat.executionContext)
   }
 
   /**
    * Perform a POST on the request asynchronously.
    */
-  def post[T](body: T)(implicit wrt: Writeable[T]) =
+  def post[T](body: T)(implicit wrt: Writeable[T]): Future[WSResponse] =
     withMethod("POST").withBody(body).execute()
 
   /**
    * Perform a POST on the request asynchronously.
    * Request body won't be chunked
    */
-  def post(body: File) = withMethod("POST").withBody(FileBody(body)).execute()
+  def post(body: File): Future[WSResponse] = withMethod("POST").withBody(FileBody(body)).execute()
 
   /**
    * performs a POST with supplied body
    * @param consumer that's handling the response
    */
-  def postAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Iteratee[Array[Byte], A])(implicit wrt: Writeable[T], ec: ExecutionContext): Future[Iteratee[Array[Byte], A]] = {
-    withMethod("POST").withBody(body).stream().flatMap {
-      case (response, enumerator) =>
-        enumerator(consumer(response))
-    }
+  @deprecated("2.5.0", "Use `WS.post(body)`.")
+  def postAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Sink[Array[Byte], A])(implicit wrt: Writeable[T], mat: Materializer): Future[A] = {
+    withMethod("POST").withBody(body).stream().map {
+      case (response, source) =>
+        source.runWith(consumer(response))
+    }(mat.executionContext)
   }
 
   /**
    * Perform a PUT on the request asynchronously.
    */
-  def put[T](body: T)(implicit wrt: Writeable[T]) =
+  def put[T](body: T)(implicit wrt: Writeable[T]): Future[WSResponse] =
     withMethod("PUT").withBody(body).execute()
 
   /**
    * Perform a PUT on the request asynchronously.
    * Request body won't be chunked
    */
-  def put(body: File) = withMethod("PUT").withBody(FileBody(body)).execute()
+  def put(body: File): Future[WSResponse] = withMethod("PUT").withBody(FileBody(body)).execute()
 
   /**
    * performs a PUT with supplied body
    * @param consumer that's handling the response
    */
-  def putAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Iteratee[Array[Byte], A])(implicit wrt: Writeable[T], ec: ExecutionContext): Future[Iteratee[Array[Byte], A]] = {
-    withMethod("PUT").withBody(body).stream().flatMap {
-      case (response, enumerator) =>
-        enumerator(consumer(response))
-    }
+  @deprecated("2.5.0", "Use `WS.put(body)`.")
+  def putAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Sink[Array[Byte], A])(implicit wrt: Writeable[T], mat: Materializer): Future[A] = {
+    withMethod("PUT").withBody(body).stream().map {
+      case (response, source) =>
+        source.runWith(consumer(response))
+    }(mat.executionContext)
   }
 
   /**
    * Perform a DELETE on the request asynchronously.
    */
-  def delete() = withMethod("DELETE").execute()
+  def delete(): Future[WSResponse] = withMethod("DELETE").execute()
 
   /**
    * Perform a HEAD on the request asynchronously.
    */
-  def head() = withMethod("HEAD").execute()
+  def head(): Future[WSResponse] = withMethod("HEAD").execute()
 
   /**
    * Perform a OPTIONS on the request asynchronously.
    */
-  def options() = withMethod("OPTIONS").execute()
+  def options(): Future[WSResponse] = withMethod("OPTIONS").execute()
 
   def execute(method: String): Future[WSResponse] = withMethod(method).execute()
 
@@ -521,9 +526,9 @@ trait WSRequest {
   def execute(): Future[WSResponse]
 
   /**
-   * Execute this request and stream the response body in an enumerator
+   * Execute this request and stream the response body.
    */
-  def stream(): Future[(WSResponseHeaders, Enumerator[Array[Byte]])]
+  def stream(): Future[(WSResponseHeaders, Source[Array[Byte], Unit])]
 }
 
 /**

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -229,9 +229,9 @@ trait WSResponse {
   def json: JsValue
 
   /**
-   * The response body as a byte array.
+   * The response body as a byte string.
    */
-  def bodyAsBytes: Array[Byte]
+  def bodyAsBytes: ByteString
 }
 
 /**
@@ -251,7 +251,7 @@ case class InMemoryBody(bytes: ByteString) extends WSBody
  *
  * @param bytes A flow of the bytes of the body
  */
-case class StreamedBody(bytes: Source[Array[Byte], Unit]) extends WSBody {
+case class StreamedBody(bytes: Source[ByteString, Unit]) extends WSBody {
   throw new NotImplementedError("A streaming request body is not yet implemented")
 }
 
@@ -417,7 +417,7 @@ trait WSRequest {
    * @param consumer that's handling the response
    */
   @deprecated("2.5.0", "Use `WS.get()` or `WS.getStream()`")
-  def get[A](consumer: WSResponseHeaders => Sink[Array[Byte], A])(implicit mat: Materializer): Future[A] = {
+  def get[A](consumer: WSResponseHeaders => Sink[ByteString, A])(implicit mat: Materializer): Future[A] = {
     getStream().map {
       case (response, source) =>
         source.runWith(consumer(response))
@@ -427,7 +427,7 @@ trait WSRequest {
   /**
    * performs a get
    */
-  def getStream(): Future[(WSResponseHeaders, Source[Array[Byte], Unit])] = {
+  def getStream(): Future[(WSResponseHeaders, Source[ByteString, Unit])] = {
     withMethod("GET").stream()
   }
 
@@ -448,7 +448,7 @@ trait WSRequest {
    * @param consumer that's handling the response
    */
   @deprecated("2.5.0", "Use `WS.patch(body)`.")
-  def patchAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Sink[Array[Byte], A])(implicit wrt: Writeable[T], mat: Materializer): Future[A] = {
+  def patchAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Sink[ByteString, A])(implicit wrt: Writeable[T], mat: Materializer): Future[A] = {
     withMethod("PATCH").withBody(body).stream().map {
       case (response, source) =>
         source.runWith(consumer(response))
@@ -472,7 +472,7 @@ trait WSRequest {
    * @param consumer that's handling the response
    */
   @deprecated("2.5.0", "Use `WS.post(body)`.")
-  def postAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Sink[Array[Byte], A])(implicit wrt: Writeable[T], mat: Materializer): Future[A] = {
+  def postAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Sink[ByteString, A])(implicit wrt: Writeable[T], mat: Materializer): Future[A] = {
     withMethod("POST").withBody(body).stream().map {
       case (response, source) =>
         source.runWith(consumer(response))
@@ -496,7 +496,7 @@ trait WSRequest {
    * @param consumer that's handling the response
    */
   @deprecated("2.5.0", "Use `WS.put(body)`.")
-  def putAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Sink[Array[Byte], A])(implicit wrt: Writeable[T], mat: Materializer): Future[A] = {
+  def putAndRetrieveStream[A, T](body: T)(consumer: WSResponseHeaders => Sink[ByteString, A])(implicit wrt: Writeable[T], mat: Materializer): Future[A] = {
     withMethod("PUT").withBody(body).stream().map {
       case (response, source) =>
         source.runWith(consumer(response))
@@ -528,7 +528,7 @@ trait WSRequest {
   /**
    * Execute this request and stream the response body.
    */
-  def stream(): Future[(WSResponseHeaders, Source[Array[Byte], Unit])]
+  def stream(): Future[(WSResponseHeaders, Source[ByteString, Unit])]
 }
 
 /**

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
@@ -6,8 +6,6 @@ package play.api.libs.ws.ning
 import java.io.UnsupportedEncodingException
 import java.nio.charset.{ Charset, StandardCharsets }
 import javax.inject.{ Inject, Provider, Singleton }
-
-import akka.util.ByteString
 import com.ning.http.client.{ Response => AHCResponse, ProxyServer => AHCProxyServer, _ }
 import com.ning.http.client.cookie.{ Cookie => AHCCookie }
 import com.ning.http.client.Realm.{ RealmBuilder, AuthScheme }
@@ -15,23 +13,21 @@ import com.ning.http.util.AsyncHttpProviderUtils
 import org.jboss.netty.handler.codec.http.HttpHeaders
 import play.api.inject.{ ApplicationLifecycle, Module }
 import play.core.parsers.FormUrlEncodedParser
-
 import collection.immutable.TreeMap
-
 import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration.Duration
-
 import play.api.libs.ws._
 import play.api.libs.ws.ssl._
-
 import play.api.libs.iteratee._
 import play.api._
 import play.core.utils.CaseInsensitiveOrdered
 import play.api.libs.ws.DefaultWSResponseHeaders
 import play.api.libs.iteratee.Input.El
 import play.api.libs.ws.ssl.debug._
-
 import scala.collection.JavaConverters._
+import akka.stream.scaladsl.Source
+import java.io.IOException
+import akka.util.ByteString
 
 /**
  * A WS client backed by a Ning AsyncHttpClient.
@@ -136,7 +132,7 @@ case class NingWSRequest(client: NingWSClient,
 
   def execute(): Future[WSResponse] = execute(buildRequest())
 
-  def stream(): Future[(WSResponseHeaders, Enumerator[Array[Byte]])] = executeStream(buildRequest())
+  def stream(): Future[(WSResponseHeaders, Source[Array[Byte], Unit])] = executeStream(buildRequest())
 
   /**
    * Returns the current headers of the request, using the request builder.  This may be signed,
@@ -324,7 +320,7 @@ case class NingWSRequest(client: NingWSClient,
     result.future
   }
 
-  private[libs] def executeStream(request: Request): Future[(WSResponseHeaders, Enumerator[Array[Byte]])] = {
+  private[libs] def executeStream(request: Request): Future[(WSResponseHeaders, Source[Array[Byte], Unit])] = {
 
     import com.ning.http.client.AsyncHandler
 
@@ -342,12 +338,14 @@ case class NingWSRequest(client: NingWSClient,
 
       import com.ning.http.client.AsyncHandler.STATE
 
-      override def onStatusReceived(status: HttpResponseStatus) = {
+      @throws(classOf[Exception])
+      override def onStatusReceived(status: HttpResponseStatus): STATE = {
         statusCode = status.getStatusCode
         STATE.CONTINUE
       }
 
-      override def onHeadersReceived(h: HttpResponseHeaders) = {
+      @throws(classOf[Exception])
+      override def onHeadersReceived(h: HttpResponseHeaders): STATE = {
         val headers = h.getHeaders
 
         val responseHeader = DefaultWSResponseHeaders(statusCode, ningHeadersToMap(headers))
@@ -386,7 +384,8 @@ case class NingWSRequest(client: NingWSClient,
         STATE.CONTINUE
       }
 
-      override def onBodyPartReceived(bodyPart: HttpResponseBodyPart) = {
+      @throws(classOf[Exception])
+      override def onBodyPartReceived(bodyPart: HttpResponseBodyPart): STATE = {
         if (!doneOrError) {
           import play.api.libs.concurrent.Execution.Implicits.defaultContext
           current = current.pureFlatFold {
@@ -411,16 +410,23 @@ case class NingWSRequest(client: NingWSClient,
         }
       }
 
-      override def onCompleted() = {
+      @throws(classOf[Exception])
+      override def onCompleted(): Unit = {
         Option(current).foreach(_.run)
       }
 
-      override def onThrowable(t: Throwable) = {
+      override def onThrowable(t: Throwable): Unit = {
         result.tryFailure(t)
         errorInStream.tryFailure(t)
       }
     })
-    result.future
+    import play.core.Execution.Implicits.internalContext
+    result.future.map {
+      case (response, enumerator) =>
+        import play.api.libs.streams.Streams
+        val publisher = Streams.enumeratorToPublisher(enumerator)
+        (response, Source(publisher))
+    }
   }
 
   private[libs] def createProxy(wsProxyServer: WSProxyServer): AHCProxyServer = {
@@ -628,6 +634,7 @@ case class NingWSResponse(ahcResponse: AHCResponse) extends WSResponse {
   /**
    * The response body as a byte array.
    */
+  @throws(classOf[IOException])
   def bodyAsBytes: Array[Byte] = ahcResponse.getResponseBodyAsBytes
 
   override def toString: String = {

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
@@ -15,6 +15,7 @@ import play.api.mvc._
 import java.util
 import play.api.libs.ws._
 import play.api.test._
+import akka.util.ByteString
 
 object NingWSSpec extends PlaySpecification with Mockito {
 
@@ -325,8 +326,8 @@ object NingWSSpec extends PlaySpecification with Mockito {
 
     "get the body as bytes from the AHC response" in {
       val ahcResponse: AHCResponse = mock[AHCResponse]
-      val bytes = Array[Byte](-87, -72, 96, -63, -32, 46, -117, -40, -128, -7, 61, 109, 80, 45, 44, 30)
-      ahcResponse.getResponseBodyAsBytes returns bytes
+      val bytes = ByteString(-87, -72, 96, -63, -32, 46, -117, -40, -128, -7, 61, 109, 80, 45, 44, 30)
+      ahcResponse.getResponseBodyAsBytes returns bytes.toArray
       val response = NingWSResponse(ahcResponse)
       response.bodyAsBytes must_== bytes
     }


### PR DESCRIPTION
One thing I didn't manage to do in this commit is reimplementing
`NingWS.executeStream` using Akka Stream. The problem is that I can't find a
convenient solution for attaching a listener to the Ning AsyncHttpClient, so
that the received (response) bytes can be pushed into an Akka Stream `Source`.

For instance, I've tried to use `Source.actorRef` as follow:

val (ref, publisher) = Source.actorRef[NingAsyncHandler].toMat(Sink.publisher)(Keep.both).run() val
source = Source(publisher)

(note: `NingAsyncHandler` is a type extending `akka.actor.Actor`)

The above would return a Reactive Stream `Publisher` (i.e., `publisher`) and an
`ActorRef` that I hoped I could use to feed the bytes to the `publisher` when
the Ning `AsyncHandler.onBodyPartReceived` method is called on the listener.

Unfortunately, this doesn't quite work because the type of `publisher` is
`Publisher[NingAsyncHandler]`, and `source` is of type `Source[NingAsyncHandler,
Unit]`.  While, what we would want is to have a `source` of type
`Source[ByteString,_]`.

Furthermore, when using `Source.actorRef` we need to materialize the stream,
which isn't ideal here. Interestingly, about this last point there is actually
a ticket in akka (17769) that would make it possible to avoid the stream
materialization. Though, even if this is fixed, I still don't see how to create
a properly typed source (see paragraph above).

I'm now wondering if it is possible to implement the desired behavior with Akka
Stream, or if we need to fallback to the Reactive Stream API (which, of course,
I'd very much like to avoid).
