### PR TITLE
Configure the logger for compile time DI

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -282,4 +282,13 @@ trait BuiltInComponents {
 
   lazy val cryptoConfig: CryptoConfig = new CryptoConfigParser(environment, configuration).get
   lazy val crypto: Crypto = new Crypto(cryptoConfig)
+
+  // TODO: Logger should be application specific, and available via dependency injection.
+  //       Creating multiple applications will stomp on the global logger configuration.
+  Logger.configure(environment)
+
+  if (configuration.underlying.hasPath("logger")) {
+    Logger.warn("Logger configuration in conf files is deprecated and has no effect. Use a logback configuration file instead.")
+  }
+
 }


### PR DESCRIPTION
The logger was not configured for compile time DI helpers like it was configured under the covers for the default Guice based injection. This can lead developers and ops teams into a frenzy trying to figure out why logging won't work via the custom configuration using -Dlogger.resource and -Dlogger.file as the documentation says it should.

The proposed solution is to apply the same setup as what is happening in the GuiceApplicationBuilder in the BuiltInComponents trait. I feel that we need to provide these settings by default, or we're going to need to make really clear documentation that if you use compile time DI, you must configure the logger yourself in your Custom Application Loader (workaround for now)