### PR TITLE
Add a JsLiteral class.

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
@@ -154,3 +154,24 @@ object JsObject {
    */
   def apply(fields: Seq[(String, JsValue)]): JsObject = new JsObject(mutable.LinkedHashMap(fields: _*))
 }
+
+/**
+ * Represents literal Json text.
+ * The content is assumed to be valid Json and is serialized as is.
+ */
+case class JsLiteral(content: String) extends JsValue {
+
+  lazy val parsed: JsValue = Json.parse(content)
+
+  override def validate[A](implicit rds: Reads[A]) = parsed.validate(rds)
+
+  override def validateOpt[T](implicit rds: Reads[A]) = parsed.validate(rds)
+
+  override def toString = content
+
+}
+
+object JsLiteral {
+  import scala.language.implicitConversions
+  implicit def jsLiteralToJsLookup(value: JsLiteral): JsLookup = JsLookup(JsDefined(value.parsed))
+}

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -72,6 +72,7 @@ private[jackson] object JsValueSerializer extends JsonSerializer[JsValue] {
         }
         json.writeEndObject()
       }
+      case JsLiteral(content) => json.writeRawValue(content)
       case JsNull => json.writeNull()
     }
   }


### PR DESCRIPTION
JsLiteral provides a way to include a raw json string in a Json AST.
For example if the application want to create a json object which
contains Json stored in a database a JsLiteral can be used to avoid
having to parse and then reserialize the data.