### PR TITLE
Preserve the order of loading enabled modules

### DIFF
--- a/framework/src/play/src/main/scala/play/api/inject/Module.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Module.scala
@@ -98,7 +98,7 @@ object Modules {
     val includes = configuration.getStringSeq("play.modules.enabled").getOrElse(Seq.empty)
     val excludes = configuration.getStringSeq("play.modules.disabled").getOrElse(Seq.empty)
 
-    val moduleClassNames = includes.toSet -- excludes
+    val moduleClassNames = includes.distinct.filterNot(excludes.contains)
 
     moduleClassNames.map { className =>
       try {
@@ -133,6 +133,6 @@ object Modules {
           "Module [" + className + "] cannot be instantiated.",
           e)
       }
-    }.toSeq
+    }
   }
 }


### PR DESCRIPTION
Some third-party play modules are sensitive about the order of loading.
For example, a db migration module has to be loaded before a db fixture module is loaded.

Currently, the order of loading modules are destroyed by `toSet` to remove duplicate modules.
This commit changed to use `distinct` instead.
`distinct` removes duplicate modules and the result sequence consists of the first occurence.
This works as if it preserves the order of modules in most cases.
