### PR TITLE
Added ',' to fix json syntax of given example.

### DIFF
--- a/documentation/manual/working/scalaGuide/main/json/ScalaJsonTransformers.md
+++ b/documentation/manual/working/scalaGuide/main/json/ScalaJsonTransformers.md
@@ -92,7 +92,7 @@ In the code samples below, we’ll use the following JSON:
   "key2" : {
     "key21" : 123,
     "key22" : true,
-    "key23" : [ "alpha", "beta", "gamma"]
+    "key23" : [ "alpha", "beta", "gamma"],
     "key24" : {
       "key241" : 234.123,
       "key242" : "value242"


### PR DESCRIPTION
I was copy pasting and getting error, later I figured out this syntax error.