### PR TITLE
Update deployment documentation

### DIFF
--- a/documentation/manual/detailedTopics/production/Production.md
+++ b/documentation/manual/detailedTopics/production/Production.md
@@ -123,6 +123,12 @@ Play manages its own PID, which is described in the [[Production configuration|P
 # Add all other startup settings here, too
 ```
 
+To prevent Play from creating a PID just set the property to `/dev/null`:
+
+```bash
+-Dpidfile.path=/dev/null
+```
+
 For a full list of replacements take a closer look at the [customize java server documentation](http://www.scala-sbt.org/sbt-native-packager/archetypes/java_server/customize.html) and [customize java app documentation](http://www.scala-sbt.org/sbt-native-packager/archetypes/java_app/customize.html).
 
 ## Publishing to a Maven (or Ivy) repository
@@ -198,4 +204,3 @@ $ java -jar target/scala-2.XX/<yourprojectname>-assembly-<version>.jar -Dplay.cr
 ```
 
 You'll need to substitute in the right project name, version and scala version, of course.
-

--- a/documentation/manual/detailedTopics/production/ProductionConfiguration.md
+++ b/documentation/manual/detailedTopics/production/ProductionConfiguration.md
@@ -87,6 +87,12 @@ Using this file, you can stop your application using the `kill` command, for exa
 $ kill $(cat /var/run/play.pid)
 ```
 
+To prevent Play from creating it's own PID, you can set the path to `/dev/null` in your `application.conf` file:
+
+```
+pidfile.path = "/dev/null"
+```
+
 ### Using environment variables
 
 You can also reference environment variables from your `application.conf` file:

--- a/documentation/manual/detailedTopics/production/code/assembly.sbt
+++ b/documentation/manual/detailedTopics/production/code/assembly.sbt
@@ -3,7 +3,7 @@ import AssemblyKeys._
 
 assemblySettings
 
-mainClass in assembly := Some("play.core.server.NettyServer")
+mainClass in assembly := Some("play.core.server.ProdServerStart")
 
 fullClasspath in assembly += Attributed.blank(PlayKeys.playPackageAssets.value)
 //#assembly


### PR DESCRIPTION
Getting a new Play application live required some research on how to prevent PID file creation and build a correct uberjar. Both was easy to do, but I could not find it in the documentation.

So here is the fix.