### PR TITLE
Added async streaming to the Java WS API. Fix #4973

### DIFF
--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/StreamedResponse.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/StreamedResponse.java
@@ -1,0 +1,49 @@
+package play.libs.ws;
+
+import java.util.concurrent.CompletionStage;
+
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+import play.libs.ws.util.CollectionUtil;
+import scala.Tuple2;
+import scala.compat.java8.FutureConverters;
+import scala.concurrent.Future;
+
+/**
+ * A streamed response containing a response header and a streamable body. 
+ */
+public class StreamedResponse {
+
+	private final WSResponseHeaders headers;
+	private final Source<ByteString, ?> body;
+
+	private StreamedResponse(WSResponseHeaders headers, Source<ByteString, ?> body) {
+		this.headers = headers;
+		this.body = body;
+	}
+
+	public WSResponseHeaders getHeaders() {
+		return headers;
+	}
+
+	public Source<ByteString, ?> getBody() {
+		return body;
+	}
+	
+	public static CompletionStage<StreamedResponse> from(Future<play.api.libs.ws.StreamedResponse> from) {
+		CompletionStage<play.api.libs.ws.StreamedResponse> res = FutureConverters.toJava(from);
+		java.util.function.Function<play.api.libs.ws.StreamedResponse, StreamedResponse> mapper = response -> {
+			WSResponseHeaders headers = toJavaHeaders(response.headers());
+			Source<ByteString, ?> source = toJavaSource(response.body());
+			return new StreamedResponse(headers, source);
+	    };
+	    return res.thenApply(mapper);	
+	}
+
+	private static WSResponseHeaders toJavaHeaders(play.api.libs.ws.WSResponseHeaders from) {
+		return new DefaultWSResponseHeaders(from.status(), CollectionUtil.convert(from.headers()));
+	}
+	private static Source<ByteString, ?> toJavaSource(akka.stream.scaladsl.Source<ByteString, ?> source) {
+		return Source.adapt(source);
+	}	
+}

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSAPI.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSAPI.java
@@ -6,8 +6,8 @@ package play.libs.ws;
 
 public interface WSAPI {
 
-    public WSClient client();
+    WSClient client();
 
-    public WSRequest url(String url);
+    WSRequest url(String url);
 
 }

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSClient.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSClient.java
@@ -8,7 +8,11 @@ package play.libs.ws;
  */
 public interface WSClient extends java.io.Closeable {
 
-    public Object getUnderlying();
+    /**
+     * The underlying implementation of the client, if any.  You must cast the returned value to the type you want.
+     * @return the backing class.
+     */
+    Object getUnderlying();
 
     /**
      * Returns a WSRequest object representing the URL.  You can append additional
@@ -24,5 +28,5 @@ public interface WSClient extends java.io.Closeable {
      *
      * Use this for manually instantiated clients.
      */
-    public void close();
+    void close();
 }

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.CompletionStage;
 
 /**
  * This is the main interface to building a WS request in Java.
@@ -156,6 +157,11 @@ public interface WSRequest {
      * Execute an arbitrary method on the request asynchronously.  Should be used with setMethod().
      */
     F.Promise<WSResponse> execute();
+
+    /**
+     * Execute this request and stream the response body.
+     */
+    CompletionStage<StreamedResponse> stream(); 
 
     //-------------------------------------------------------------------------
     // Setters

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSResponseHeaders.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSResponseHeaders.java
@@ -1,0 +1,61 @@
+package play.libs.ws;
+
+import java.util.List;
+import java.util.Map;
+
+public interface WSResponseHeaders {
+    int getStatus();
+
+    Map<String, List<String>> getHeaders();
+}
+
+class DefaultWSResponseHeaders implements WSResponseHeaders {
+
+    private final int status;
+    private final Map<String, List<String>> headers;
+
+    public DefaultWSResponseHeaders(int status, Map<String, List<String>> headers) {
+        this.status = status;
+        this.headers = headers;
+    }
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    // hashcode and equals impl were generated with Eclipse
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((headers == null) ? 0 : headers.hashCode());
+        result = prime * result + status;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        DefaultWSResponseHeaders other = (DefaultWSResponseHeaders) obj;
+        if (headers == null) {
+            if (other.headers != null)
+                return false;
+        } else if (!headers.equals(other.headers))
+            return false;
+        if (status != other.status)
+            return false;
+        return true;
+    }
+}

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSClient.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSClient.java
@@ -6,19 +6,26 @@ package play.libs.ws.ning;
 
 import com.ning.http.client.AsyncHttpClient;
 import com.ning.http.client.AsyncHttpClientConfig;
+
 import play.libs.ws.WSClient;
 import play.libs.ws.WSRequest;
 
+/**
+ * A WS client backed by a Ning AsyncHttpClient.
+ *
+ * If you need to debug Ning, set logger.com.ning.http.client=DEBUG in your application.conf file.
+ */
 public class NingWSClient implements WSClient {
 
-    private AsyncHttpClient asyncHttpClient;
+    private final AsyncHttpClient asyncHttpClient;
 
     public NingWSClient(AsyncHttpClientConfig config) {
         this.asyncHttpClient = new AsyncHttpClient(config);
     }
 
+    @Override
     public Object getUnderlying() {
-        return this.asyncHttpClient;
+        return asyncHttpClient;
     }
 
     @Override
@@ -26,7 +33,8 @@ public class NingWSClient implements WSClient {
         return new NingWSRequest(this, url);
     }
 
+    @Override
     public void close() {
-        this.asyncHttpClient.close();
+        asyncHttpClient.close();
     }
 }

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSRequest.java
@@ -4,13 +4,17 @@
 
 package play.libs.ws.ning;
 
+import akka.stream.javadsl.*;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.ning.http.client.*;
 import com.ning.http.client.generators.FileBodyGenerator;
 import com.ning.http.client.generators.InputStreamBodyGenerator;
 import com.ning.http.client.oauth.OAuthSignatureCalculator;
 import com.ning.http.util.AsyncHttpProviderUtils;
+
 import org.jboss.netty.handler.codec.http.HttpHeaders;
+import play.api.libs.ws.ning.*;
 import play.core.parsers.FormUrlEncodedParser;
 import play.libs.F;
 import play.libs.Json;
@@ -23,6 +27,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.*;
+import java.util.concurrent.CompletionStage;
 
 /**
  * provides the User facing API for building WS request.
@@ -395,6 +400,13 @@ public class NingWSRequest implements WSRequest {
         return execute(request);
     }
 
+    @Override
+    public CompletionStage<StreamedResponse> stream() {
+    	AsyncHttpClient asyncClient = (AsyncHttpClient) client.getUnderlying();
+    	Request request = buildRequest();
+    	return StreamedResponse.from(StreamedRequest.execute(asyncClient, request));
+    }
+
     Request buildRequest() {
         RequestBuilder builder = new RequestBuilder(method);
 
@@ -534,6 +546,4 @@ public class NingWSRequest implements WSRequest {
                 .setUsePreemptiveAuth(true)
                 .build();
     }
-
-
 }

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/util/CollectionUtil.scala
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/util/CollectionUtil.scala
@@ -1,0 +1,13 @@
+package play.libs.ws.util
+
+import java.{util =>ju}
+import scala.collection.convert.WrapAsJava._
+
+/** Utility class for converting a Scala `Map` with a nested collection type into its idiomatic Java counterpart. 
+ *  The reason why this source is written in Scala is that doing the conversion using Java is a lot more involved. 
+ *  This utility class is used by `play.libs.ws.StreamedResponse`.
+ */
+private[ws] object CollectionUtil {
+  def convert(headers: Map[String, Seq[String]]): ju.Map[String, ju.List[String]] =
+    mapAsJavaMap(headers.map { case (k, v) => k -> seqAsJavaList(v)})
+}

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/StreamedRequest.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/StreamedRequest.scala
@@ -1,0 +1,140 @@
+package play.api.libs.ws.ning
+
+import scala.concurrent.Future
+import scala.concurrent.Promise
+
+import com.ning.http.client.AsyncHandler
+import com.ning.http.client.AsyncHandler.STATE
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.HttpResponseBodyPart
+import com.ning.http.client.HttpResponseHeaders
+import com.ning.http.client.HttpResponseStatus
+import com.ning.http.client.Request
+
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import play.api.libs.iteratee.Done
+import play.api.libs.iteratee.Enumerator
+import play.api.libs.iteratee.Error
+import play.api.libs.iteratee.Input.El
+import play.api.libs.iteratee.Iteratee
+import play.api.libs.iteratee.Step
+import play.api.libs.streams.Streams
+import play.api.libs.ws.DefaultWSResponseHeaders
+import play.api.libs.ws.WSResponseHeaders
+import play.api.libs.ws.StreamedResponse
+
+private[play] object StreamedRequest {
+
+  def execute(client: AsyncHttpClient, request: Request): Future[StreamedResponse] = {
+    val result = executeAndReturnEnumerator(client, request)
+    import play.core.Execution.Implicits.internalContext
+    result.map {
+      case (response, enumerator) =>
+        val publisher = Streams.enumeratorToPublisher(enumerator)
+        StreamedResponse(response, Source(publisher).map(ByteString(_)))
+    }
+  }
+
+  def executeAndReturnEnumerator(client: AsyncHttpClient, request: Request): Future[(WSResponseHeaders, Enumerator[Array[Byte]])] = {
+    import com.ning.http.client.AsyncHandler
+
+    val result = Promise[(WSResponseHeaders, Enumerator[Array[Byte]])]()
+
+    val errorInStream = Promise[Unit]()
+
+    val promisedIteratee = Promise[Iteratee[Array[Byte], Unit]]()
+
+    @volatile var doneOrError = false
+    @volatile var statusCode = 0
+    @volatile var current: Iteratee[Array[Byte], Unit] = Iteratee.flatten(promisedIteratee.future)
+
+    client.executeRequest(request, new AsyncHandler[Unit]() {
+
+      import com.ning.http.client.AsyncHandler.STATE
+
+      @throws(classOf[Exception])
+      override def onStatusReceived(status: HttpResponseStatus): STATE = {
+        statusCode = status.getStatusCode
+        STATE.CONTINUE
+      }
+
+      @throws(classOf[Exception])
+      override def onHeadersReceived(h: HttpResponseHeaders): STATE = {
+        val headers = h.getHeaders
+
+        val responseHeader = DefaultWSResponseHeaders(statusCode, NingWSRequest.ningHeadersToMap(headers))
+        val enumerator = new Enumerator[Array[Byte]]() {
+          def apply[A](i: Iteratee[Array[Byte], A]) = {
+
+            val doneIteratee = Promise[Iteratee[Array[Byte], A]]()
+
+            import play.api.libs.iteratee.Execution.Implicits.trampoline
+
+            // Map it so that we can complete the iteratee when it returns
+            val mapped = i.map {
+              a =>
+                doneIteratee.trySuccess(Done(a))
+                ()
+            }.recover {
+              // but if an error happens, we want to propogate that
+              case e =>
+                doneIteratee.tryFailure(e)
+                throw e
+            }
+
+            // Redeem the iteratee that we promised to the AsyncHandler
+            promisedIteratee.trySuccess(mapped)
+
+            // If there's an error in the stream from upstream, then fail this returned future with that
+            errorInStream.future.onFailure {
+              case e => doneIteratee.tryFailure(e)
+            }
+
+            doneIteratee.future
+          }
+        }
+
+        result.trySuccess((responseHeader, enumerator))
+        STATE.CONTINUE
+      }
+
+      @throws(classOf[Exception])
+      override def onBodyPartReceived(bodyPart: HttpResponseBodyPart): STATE = {
+        if (!doneOrError) {
+          import play.api.libs.concurrent.Execution.Implicits.defaultContext
+          current = current.pureFlatFold {
+            case Step.Done(a, e) =>
+              doneOrError = true
+              Done(a, e)
+
+            case Step.Cont(k) =>
+              k(El(bodyPart.getBodyPartBytes))
+
+            case Step.Error(e, input) =>
+              doneOrError = true
+              Error(e, input)
+
+          }
+          STATE.CONTINUE
+        } else {
+          current = null
+          // Must close underlying connection, otherwise async http client will drain the stream
+          bodyPart.markUnderlyingConnectionAsToBeClosed()
+          STATE.ABORT
+        }
+      }
+
+      @throws(classOf[Exception])
+      override def onCompleted(): Unit = {
+        Option(current).foreach(_.run)
+      }
+
+      override def onThrowable(t: Throwable): Unit = {
+        result.tryFailure(t)
+        errorInStream.tryFailure(t)
+      }
+    })
+    result.future
+  }
+}


### PR DESCRIPTION
Introduced a `stream()` method in the Java WS API that closely emulates its
Scala counterpart. The only difference is that instead of returning a `Tuple2`,
it returns a `StreamedResponse`. I felt this is more idiomatic for Java users,
and I'm actually of the idea that we may want to do the same in Scala (but this
might be a matter of personal taste, so I'm raising the point here to see what
you think).

Currently, the Java WS streaming functionality relies on the Scala one, which is
based on iteratees. The plan is to change this and use akka stream, but #4952
needs to be addressed first.