### PR TITLE
Update IDE.md

### DIFF
--- a/documentation/manual/gettingStarted/IDE.md
+++ b/documentation/manual/gettingStarted/IDE.md
@@ -84,6 +84,8 @@ To create a Play application:
 
 IntelliJ IDEA creates an empty application using SBT.
 
+Currently, for Play 2.4.x, instead of using the IntelliJ wizard to create a new project, we suggest that you create it using Activator and then Import it to IntelliJ.
+
 You can also import an existing Play project.
 
 To import a Play project:


### PR DESCRIPTION
Creating new play 2.x projects in intelJ does not work, first there are deprecated errors in tests files, second IntelJ does not download 2.4 version but older one that is not working (no main class found). Only quick and straight solution is to create play 2.4 projects with Activator directly and then import. This should be mentioned in specification.