### PR TITLE
Update documentation on PathBindable to valid code

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -142,7 +142,7 @@ trait QueryStringBindable[A] {
  *         } yield user
  *       }
  *       override def unbind(key: String, user: User): String = {
- *         intBinder.unbind(user.id)
+ *         intBinder.unbind(key, user.id)
  *       }
  *     }
  *   }


### PR DESCRIPTION
Documentation on `PathBindable` contains sample code that will not compile as it calls a method that doesn't exist: `intBinder.unbind` with only one argument. This commit simply fixes it to the correct call passing `key` along.