### PR TITLE
Bumped HikariCP version to 2.4.0

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -37,7 +37,7 @@ object Dependencies {
 
   val jdbcDeps = Seq(
     "com.jolbox" % "bonecp" % "0.8.0.RELEASE",
-    "com.zaxxer" % "HikariCP" % "2.3.9",
+    "com.zaxxer" % "HikariCP" % "2.4.0",
     "com.googlecode.usc" % "jdbcdslog" % "1.0.6.2",
     h2database,
     acolyte % Test,

--- a/framework/src/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
+++ b/framework/src/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
@@ -184,7 +184,7 @@ public class DatabaseTest {
         db.getConnection().close();
         db.shutdown();
         exception.expect(SQLException.class);
-        exception.expectMessage(startsWith("Pool has been shutdown"));
+        exception.expectMessage(endsWith("has been shutdown"));
         db.getConnection().close();
     }
 }

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
@@ -127,7 +127,7 @@ object DatabasesSpec extends Specification {
       db.getConnection.close()
       db.shutdown()
       db.getConnection.close() must throwA[SQLException].like {
-        case e => e.getMessage must startWith("Pool has been shutdown")
+        case e => e.getMessage must endWith("has been shutdown")
       }
     }
 

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
@@ -79,7 +79,7 @@ class HikariCPConfigSpec extends Specification {
       }
 
       "readOnly to false" in new Configs {
-        new HikariCPConfig(dbConfig, reference).toHikariConfig.isReadOnly must beFalse
+        (new HikariCPConfig(dbConfig, reference).toHikariConfig.isReadOnly: Boolean) must beFalse
       }
 
       "registerMBeans to false" in new Configs {
@@ -147,7 +147,7 @@ class HikariCPConfigSpec extends Specification {
 
       "readOnly" in new Configs {
         val config = from("hikaricp.readOnly" -> "true")
-        new HikariCPConfig(dbConfig, config).toHikariConfig.isReadOnly must beTrue
+        (new HikariCPConfig(dbConfig, config).toHikariConfig.isReadOnly: Boolean) must beTrue
       }
 
       "leakDetectionThreshold" in new Configs {


### PR DESCRIPTION
Also, note that HikariCP 2.4.x stream will be binary compatible with 2.4.0 as
mentioned in
https://groups.google.com/forum/#!topic/play-framework-dev/iqKgOqa3McM

do NOT backport :-)