### PR TITLE
Make scala Helpers implement MimeTypes

### DIFF
--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -366,6 +366,7 @@ trait ResultExtractors {
 object Helpers extends PlayRunners
   with HeaderNames
   with Status
+  with MimeTypes
   with HttpProtocol
   with DefaultAwaitTimeout
   with ResultExtractors


### PR DESCRIPTION
Since `Helpers` implement `HeaderNames`, `Status` and `HttpProtocol`. Handy for testing: 

```
contentType(home) must beSome.which(_ == HTML)
```