### PR TITLE
enable compilation on encrypted systems where filenames are otherwis…

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -60,6 +60,7 @@ object BuildSettings {
     parallelExecution in Test := false,
     testListeners in (Test,test) := Nil,
     javaOptions in Test ++= Seq(maxMetaspace, "-Xmx512m", "-Xms128m"),
+    scalacOptions in Compile ++= Seq("-Xmax-classfile-name", "128"),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-v"),
     bintrayPackage := "play-sbt-plugin"
   )


### PR DESCRIPTION
I tried to compile on my encrypted ubuntu hard drive but the compilation failed due to excessive file name lengths (caused by encrypting my hard drive). This change allows longer file names. Accordingly, I can now build play framework on my encrypted ubuntu laptop.

If you think this could be useful for other people, please merge. I couldn't find any reason why this would cause harm or problems, but please let me know if it does.