### PR TITLE
Add documentation about JPA with Play 2.4 in dist mode

### DIFF
--- a/documentation/manual/releases/migration24/Migration24.md
+++ b/documentation/manual/releases/migration24/Migration24.md
@@ -515,6 +515,8 @@ Previously, Play added all the resources to the the `conf` directory in the dist
 
 This can be turned off by setting `PlayKeys.externalizeResources := false`, which will cause no `conf` directory to be created in the distribution, and it will not be on the classpath.  The contents of the applications `conf` directory will still be on the classpath by virtue of the fact that it's included in the applications jar file.
 
+Please note that if you're using the Java Persistence API (JPA) you will need to set this option to false in order to deploy your application. Otherwise you will get an error message: `Entity X is not mapped`. This is not required for local development.
+
 ### Changes in Debian Package creation
 
 The [sbt-native-packager](https://github.com/sbt/sbt-native-packager) has been upgraded. Due to this, the following adjustments might be necessary:

--- a/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
@@ -53,6 +53,15 @@ Finally you have to tell Play, which persistent unit should be used by your JPA 
 jpa.default=defaultPersistenceUnit
 ```
 
+## Deploying Play with JPA
+
+Running Play in development mode while using JPA will work fine, but in order to deploy the application you will need to add this to your `build.sbt` file.
+
+@[](code/jpa.sbt)
+
+Since Play 2.4 the contents of the `conf` directory are added to the classpath by default. This option will disable that behavior and allow a JPA application to be deployed. Note that the content of conf directory will still be available in the classpath due to it being inclued in the applications jar file.
+
+
 ## Annotating JPA actions with `@Transactional`
 
 Every JPA call must be done in a transaction so, to enable JPA for a particular action, annotate it with `@play.db.jpa.Transactional`. This will compose your action method with a JPA `Action` that manages the transaction for you:

--- a/documentation/manual/working/javaGuide/main/sql/code/jpa.sbt
+++ b/documentation/manual/working/javaGuide/main/sql/code/jpa.sbt
@@ -1,0 +1,1 @@
+PlayKeys.externalizeResources := false


### PR DESCRIPTION
Add notice to the documentation that we need the
PlayKeys.externalizeResources to be false in order to deploy a Play 2.4
App with JPA enabled.