### PR TITLE
Doc multi-projects missing Assets HttpErrorHandler argument

### DIFF
--- a/documentation/manual/detailedTopics/build/SBTSubProjects.md
+++ b/documentation/manual/detailedTopics/build/SBTSubProjects.md
@@ -178,10 +178,7 @@ GET /assets/*file           controllers.admin.Assets.at(path="/public", file)
 
 `modules/admin/controllers/Assets.scala`:
 
-```scala
-package controllers.admin
-object Assets extends controllers.AssetsBuilder
-```
+@[assets-builder](code/SubProjectsAssetsBuilder.scala)
 
 > **Note:** Java users can do something very similar i.e.:
 

--- a/documentation/manual/detailedTopics/build/code/SubProjectsAssetsBuilder.scala
+++ b/documentation/manual/detailedTopics/build/code/SubProjectsAssetsBuilder.scala
@@ -1,0 +1,5 @@
+//#assets-builder
+package controllers.admin
+import play.api.http.LazyHttpErrorHandler
+object Assets extends controllers.AssetsBuilder(LazyHttpErrorHandler)
+//#assets-builder


### PR DESCRIPTION
Which cause this compilation error :

```
not enough arguments for constructor AssetsBuilder: (errorHandler: play.api.http.HttpErrorHandler)controllers.AssetsBuilder
```