### PR TITLE
Don't log when Akka is started

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -289,10 +289,10 @@ object ActorSystemProvider {
 
     val name = config.get[String]("play.akka.actor-system")
     val system = ActorSystem(name, akkaConfig, classLoader)
-    logger.info(s"Starting application default Akka system: $name")
+    logger.debug(s"Starting application default Akka system: $name")
 
     val stopHook = { () =>
-      logger.info(s"Shutdown application default Akka system: $name")
+      logger.debug(s"Shutdown application default Akka system: $name")
       system.shutdown()
 
       config.get[Duration]("play.akka.shutdown-timeout") match {


### PR DESCRIPTION
This has been reported in #4554 and #4561  and fixed in #4743, though the fix has been merged to master and not to 2.4.x. Would it be possible to backport this fix?

Fix for #5024 - Changed log level to debug for actor system initialization.