### PR TITLE
Bumped HikariCP version to 2.4.1

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -37,7 +37,7 @@ object Dependencies {
 
   val jdbcDeps = Seq(
     "com.jolbox" % "bonecp" % "0.8.0.RELEASE",
-    "com.zaxxer" % "HikariCP" % "2.3.9",
+    "com.zaxxer" % "HikariCP" % "2.4.1",
     "com.googlecode.usc" % "jdbcdslog" % "1.0.6.2",
     h2database,
     acolyte % Test,

--- a/framework/src/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
+++ b/framework/src/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
@@ -184,7 +184,7 @@ public class DatabaseTest {
         db.getConnection().close();
         db.shutdown();
         exception.expect(SQLException.class);
-        exception.expectMessage(startsWith("Pool has been shutdown"));
+        exception.expectMessage(endsWith("has been closed."));
         db.getConnection().close();
     }
 }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
@@ -78,7 +78,7 @@ class HikariCPConnectionPool @Inject() (environment: Environment) extends Connec
   override def close(dataSource: DataSource) = {
     Logger.info("Shutting down connection pool.")
     dataSource match {
-      case ds: HikariDataSource => ds.shutdown()
+      case ds: HikariDataSource => ds.close()
       case _ => sys.error("Unable to close data source: not a HikariDataSource")
     }
   }

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
@@ -127,7 +127,7 @@ object DatabasesSpec extends Specification {
       db.getConnection.close()
       db.shutdown()
       db.getConnection.close() must throwA[SQLException].like {
-        case e => e.getMessage must startWith("Pool has been shutdown")
+        case e => e.getMessage must endWith("has been closed.")
       }
     }
 


### PR DESCRIPTION
HikariCP 2.4.x stream will be binary compatible with 2.4.1 as mentioned in
https://groups.google.com/forum/#!topic/play-framework-dev/iqKgOqa3McM.

The changelog for this release can be read here:
https://groups.google.com/forum/#!topic/hikari-cp/FGygaj_yrxg

Also, note that HikariCP 2.4.0 inadvertently broke binary compatibility and
hence was flagged as a bad release.

Finally, the `HikariDataSource.shutdown` method was deprecated, so I've replaced
it with the `close` method.