### PR TITLE
Removed publishLocal from testDocumentation script

### DIFF
--- a/framework/bin/testDocumentation
+++ b/framework/bin/testDocumentation
@@ -12,13 +12,6 @@ BUILD="$FRAMEWORK/build --warn"
 
 export FILTER_LOGGING=true
 
-cd $FRAMEWORK
-
-echo "[info]"
-echo "[info] ---- BUILDING PLAY "
-echo "[info]"
-$BUILD "$@" publishLocal
-
 echo "[info]"
 echo "[info] ---- RUNNING DOCUMENTATION TESTS"
 echo "[info]"


### PR DESCRIPTION
We don't actually need to do a publish local on Play from test documentation since the documentation project depends directly on Play, so I've removed this.  This should shave a small amount of time off the documentation build.