### PR TITLE
Added memory limits to the documentation build

### DIFF
--- a/documentation/project/Build.scala
+++ b/documentation/project/Build.scala
@@ -76,7 +76,8 @@ object ApplicationBuild extends Build {
     crossScalaVersions := Seq("2.10.5", "2.11.7"),
     scalaVersion := PlayVersion.scalaVersion,
 
-    fork in Test := true
+    fork in Test := true,
+    javaOptions in Test ++= Seq("-Xmx512m", "-Xms128m")
   ).settings(externalPlayModuleSettings:_*)
    .dependsOn(
       playDocs,


### PR DESCRIPTION
The documentation build tests appears to be being killed by Travis, possibly due to using too much memory. This will hopefully fix that.