### PR TITLE
Add WOFF2 font MIME into MimeTypes.

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
@@ -530,6 +530,7 @@ object MimeTypes {
         wmls=text/vnd.wap.wmlscript
         wmlsc=application/vnd.wap.wmlscriptc
         woff=application/font-woff
+        woff2=application/font-woff2
         word=application/msword
         wp5=application/wordperfect
         wp6=application/wordperfect


### PR DESCRIPTION
Single-line commit.
Add support for detecting MIME for `.woff2` files.
Currently, `.woff2` files returned as `Content-Type: application/octet-stream`.

Short info about WOFF2:
https://gist.github.com/sergejmueller/cf6b4f2133bcb3e2f64a

Current support in browsers:
http://caniuse.com/#feat=woff2