### PR TITLE
Add logger through file watch service

### DIFF
--- a/documentation/manual/releases/migration24/Migration24.md
+++ b/documentation/manual/releases/migration24/Migration24.md
@@ -78,7 +78,7 @@ The SBT setting key `playWatchService` has been renamed to `fileWatchService`.
 
 Also the corresponding class has changed. To set the FileWatchService to poll every two seconds, use it like this:
 ```scala
-PlayKeys.fileWatchService := play.runsupport.FileWatchService.sbt(2000)
+PlayKeys.fileWatchService := play.runsupport.FileWatchService.sbt(Keys.sLog.value, 2000)
 ```
 
 ### Play Slick dependency
@@ -541,13 +541,12 @@ The mysterious `OrderedExecutionContext` had [[been retained|Migration22#Concurr
 
 ### SubProject Assets
 
-Any assets in sub projects are now by default placed into /lib/[subproject] to allow files with the same name in the root project / different subprojects without causing them to interfere with each other. 
+Any assets in sub projects are now by default placed into /lib/[subproject] to allow files with the same name in the root project / different subprojects without causing them to interfere with each other.
 
-To get the asset routing to work correctly in your app, you'll need to change: 
+To get the asset routing to work correctly in your app, you'll need to change:
 
     GET     /assets/*file               controllers.myModule.Assets.at(path="/public", file)
 
 to this
 
     GET     /assets/*file               controllers.myModule.Assets.at(path="/public/lib/myModule", file)
-

--- a/framework/src/fork-run/src/main/scala/play/forkrun/SbtClient.scala
+++ b/framework/src/fork-run/src/main/scala/play/forkrun/SbtClient.scala
@@ -5,6 +5,7 @@ package play.forkrun
 
 import akka.actor._
 import java.io.File
+import play.runsupport.Logger
 import sbt.client.actors.{ SbtClientProxy, SbtConnectionProxy }
 import sbt.client.{ SbtConnector, TaskKey }
 import sbt.protocol.{ ScopedKey, TaskResult, TaskFailure }

--- a/framework/src/run-support/src/main/scala/play/runsupport/Logger.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/Logger.scala
@@ -1,10 +1,11 @@
 /*
  * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
  */
-package play.forkrun
+package play.runsupport
 
 import java.io.{ PrintStream, PrintWriter, StringWriter }
-import play.runsupport.{ Colors, LoggerProxy }
+
+import scala.util.Properties
 
 object Logger {
   case class Level(value: Int, name: String, label: String) {
@@ -19,6 +20,10 @@ object Logger {
 
     val levels = Seq(Debug, Info, Warn, Error)
 
+    def apply(): Option[Level] = {
+      val logLevel = Properties.propOrElse("play.run.log.level", "info")
+      apply(logLevel)
+    }
     def apply(value: Int): Option[Level] = levels find (_.value == value)
     def apply(name: String): Option[Level] = levels find (_.name == name)
   }
@@ -32,6 +37,10 @@ object Logger {
   }
 
   val NewLine = sys.props("line.separator")
+
+  def apply(): Logger = {
+    new Logger(Level().getOrElse(Level.Info))
+  }
 
   def apply(level: Level): Logger = new Logger(level)
   def apply(level: String): Logger = new Logger(Level(level).getOrElse(Level.Info))

--- a/framework/src/sbt-fork-run-plugin/src/main/scala/play/sbt/forkrun/PlayForkProcess.scala
+++ b/framework/src/sbt-fork-run-plugin/src/main/scala/play/sbt/forkrun/PlayForkProcess.scala
@@ -29,7 +29,7 @@ case class PlayForkOptions(
  */
 object PlayForkProcess {
   def apply(options: PlayForkOptions, args: Seq[String], log: Logger): Unit = {
-    val logProperties = Seq("-Dfork.run.log.level=" + options.logLevel.toString, "-Dfork.run.log.events=" + options.logSbtEvents)
+    val logProperties = Seq("-Dplay.run.log.level=" + options.logLevel.toString, "-Dplay.run.log.events=" + options.logSbtEvents)
     val jvmOptions = options.jvmOptions ++ logProperties
     val arguments = Seq(options.baseDirectory.getAbsolutePath, options.configKey) ++ args
     run(options.workingDirectory, jvmOptions, options.classpath, "play.forkrun.ForkRun", arguments, log, options.shutdownTimeout)

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -22,6 +22,8 @@ import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport._
 import com.typesafe.sbt.packager.Keys.executableScriptName
 import com.typesafe.sbt.web.SbtWeb.autoImport._
 
+import scala.util.Properties
+
 /**
  * Provides mechanisms for running a Play application in SBT
  */
@@ -52,6 +54,7 @@ object PlayRun {
     reloaderClasspath: TaskKey[Classpath], reloaderClassLoader: TaskKey[ClassLoaderCreator],
     assetsClassLoader: TaskKey[ClassLoader => ClassLoader]): Def.Initialize[InputTask[Unit]] = Def.inputTask {
 
+    val log = Keys.sLog.value
     val args = Def.spaceDelimited().parsed
 
     val state = Keys.state.value
@@ -90,8 +93,8 @@ object PlayRun {
       devSettings.value,
       args,
       runSbtTask,
-      (mainClass in (Compile, Keys.run)).value.get
-    )
+      (mainClass in (Compile, Keys.run)).value.get,
+      log)
 
     interaction match {
       case nonBlocking: PlayNonBlockingInteractionMode =>

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
@@ -5,7 +5,7 @@ scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.10.5")
 PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode
 
 // Start by using the sbt watcher
-PlayKeys.fileWatchService := play.runsupport.FileWatchService.sbt(pollInterval.value)
+PlayKeys.fileWatchService := play.runsupport.FileWatchService.sbt(pollInterval.value, play.runsupport.Logger())
 
 TaskKey[Unit]("resetReloads") := {
   (target.value / "reload.log").delete()

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/Build.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/Build.scala
@@ -11,17 +11,19 @@ import scala.util.Properties
 
 object DevModeBuild {
 
+  private val log = play.runsupport.Logger()
+
   def jdk7WatchService = Def.setting {
     if (Properties.isJavaAtLeast("1.7")) {
-      FileWatchService.jdk7(Keys.sLog.value)
+      FileWatchService.jdk7(log)
     } else {
       println("Not testing JDK7 watch service because we're not on JDK7")
-      FileWatchService.sbt(Keys.pollInterval.value)
+      FileWatchService.sbt(Keys.pollInterval.value, log)
     }
   }
 
   def jnotifyWatchService = Def.setting {
-    FileWatchService.jnotify(Keys.target.value)
+    FileWatchService.jnotify(Keys.target.value, log)
   }
 
   val MaxAttempts = 10
@@ -37,7 +39,7 @@ object DevModeBuild {
       val url = new java.net.URL("http://localhost:9000" + path)
       val conn = url.openConnection().asInstanceOf[java.net.HttpURLConnection]
       conn.setConnectTimeout(ConnectTimeout)
-      conn.setReadTimeout(ReadTimeout)      
+      conn.setReadTimeout(ReadTimeout)
 
       if (status == conn.getResponseCode) {
         messages += s"Resource at $path returned $status as expected"


### PR DESCRIPTION
Add debug logging to FileWatchService so we can debug what is changing.  Note that this applies to the 2.4.x branch, not master.

There are two different loggers depending on whether you run from ForkRun or from PlayRun.  I gave them different settings since it seemed odd to have a `fork.run.log.level` without a fork -- on the other hand, since I had to move the Logger from `play.forkrun.Logger` to `play.runsupport.Logger`, we may want to have `runsupport.log.level` as the property.  I'm fine either way.

```
 activator -Dfork.run.log.level=debug -Dfork.run.log.events=true -Dplay.run.log.level=debug
```    

