### PR TITLE
Java WebSocket with Akka streams support

### DIFF
--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
@@ -7,6 +7,7 @@ package javaguide.async;
 import akka.actor.*;
 import play.libs.F.*;
 import play.mvc.WebSocket;
+import play.mvc.LegacyWebSocket;
 //#imports
 
 import play.mvc.Controller;
@@ -19,7 +20,7 @@ public class JavaWebSockets {
     public static class ActorController1 {
 
         //#actor-accept
-        public static WebSocket<String> socket() {
+        public static LegacyWebSocket<String> socket() {
             return WebSocket.withActor(MyWebSocketActor::props);
         }
         //#actor-accept
@@ -55,7 +56,7 @@ public class JavaWebSockets {
 
     public static class ActorController2 extends Controller {
         //#actor-reject
-        public WebSocket<String> socket() {
+        public LegacyWebSocket<String> socket() {
             if (session().get("user") != null) {
                 return WebSocket.withActor(MyWebSocketActor::props);
             } else {
@@ -67,7 +68,7 @@ public class JavaWebSockets {
 
     public static class ActorController4 extends Controller {
         //#actor-json
-        public WebSocket<JsonNode> socket() {
+        public LegacyWebSocket<JsonNode> socket() {
             return WebSocket.withActor(MyWebSocketActor::props);
         }
         //#actor-json
@@ -77,7 +78,7 @@ public class JavaWebSockets {
 
     public static class Controller1 {
         //#websocket
-        public WebSocket<String> socket() {
+        public LegacyWebSocket<String> socket() {
             return WebSocket.whenReady((in, out) -> {
                 // For each event received on the socket,
                 in.onMessage(System.out::println);
@@ -94,7 +95,7 @@ public class JavaWebSockets {
 
     public static class Controller2 {
         //#discard-input
-        public WebSocket<String> socket() {
+        public LegacyWebSocket<String> socket() {
             return WebSocket.whenReady((in, out) -> {
                 out.write("Hello!");
                 out.close();

--- a/framework/src/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
+++ b/framework/src/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
@@ -1,0 +1,51 @@
+package play.it.http.websocket;
+
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.Keep;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import play.libs.F;
+import play.mvc.Results;
+import play.mvc.WebSocket;
+import scala.compat.java8.FutureConverters;
+import scala.concurrent.Promise;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+/**
+ * Java actions for WebSocket spec
+ */
+public class WebSocketSpecJavaActions {
+
+    private static <A> Sink<A, ?> getChunks(Consumer<List<A>> onDone) {
+        return Sink.<List<A>, A>fold(new ArrayList<A>(), (result, next) -> {
+            result.add(next);
+            return result;
+        }).mapMaterializedValue(future -> FutureConverters.toJava(future).thenAccept(onDone));
+    }
+
+    private static <A> Source<A, ?> emptySource() {
+        return Source.from(FutureConverters.toScala(new CompletableFuture<>()));
+    }
+
+    public static WebSocket allowConsumingMessages(Promise<List<String>> messages) {
+        return WebSocket.Text.accept(request -> Flow.wrap(getChunks(messages::success), emptySource(), Keep.none()));
+    }
+
+    public static WebSocket allowSendingMessages(List<String> messages) {
+        return WebSocket.Text.accept(request -> Flow.wrap(Sink.ignore(), Source.from(messages), Keep.none()));
+    }
+
+    public static WebSocket closeWhenTheConsumerIsDone() {
+        return WebSocket.Text.accept(request -> Flow.wrap(Sink.cancelled(), emptySource(), Keep.none()));
+    }
+
+    public static WebSocket allowRejectingAWebSocketWithAResult(int statusCode) {
+        return WebSocket.Text.acceptOrResult(request -> CompletableFuture.completedFuture(F.Either.Left(Results.status(statusCode))));
+    }
+
+
+}

--- a/framework/src/play/src/main/java/play/http/websocket/Message.java
+++ b/framework/src/play/src/main/java/play/http/websocket/Message.java
@@ -1,0 +1,212 @@
+package play.http.websocket;
+
+import akka.util.ByteString;
+
+import java.util.Optional;
+
+/**
+ * A WebSocket message.
+ */
+public abstract class Message {
+
+    // private constructor to seal it
+    private Message() {
+    }
+
+    /**
+     * A text WebSocket message
+     */
+    public static class Text extends Message {
+        private final String data;
+
+        public Text(String data) {
+            this.data = data;
+        }
+
+        public String data() {
+            return data;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Text text = (Text) o;
+
+            return data.equals(text.data);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "TextWebSocketMessage('" + data + "')";
+        }
+    }
+
+    /**
+     * A binary WebSocket message
+     */
+    public static class Binary extends Message {
+        private final ByteString data;
+
+        public Binary(ByteString data) {
+            this.data = data;
+        }
+
+        public ByteString data() {
+            return data;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Binary binary = (Binary) o;
+
+            return data.equals(binary.data);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "BinaryWebSocketMessage('" + data + "')";
+        }
+    }
+
+    /**
+     * A ping WebSocket message
+     */
+    public static class Ping extends Message {
+        private final ByteString data;
+
+        public Ping(ByteString data) {
+            this.data = data;
+        }
+
+        public ByteString data() {
+            return data;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Ping ping = (Ping) o;
+
+            return data.equals(ping.data);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "PingWebSocketMessage('" + data + "')";
+        }
+    }
+
+    /**
+     * A pong WebSocket message
+     */
+    public static class Pong extends Message {
+        private final ByteString data;
+
+        public Pong(ByteString data) {
+            this.data = data;
+        }
+
+        public ByteString data() {
+            return data;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Pong pong = (Pong) o;
+
+            return data.equals(pong.data);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return data.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "PongWebSocketMessage('" + data + "')";
+        }
+    }
+
+    /**
+     * A close WebSocket message
+     */
+    public static class Close extends Message {
+        private final Optional<Integer> statusCode;
+        private final String reason;
+
+        public Close(int statusCode) {
+            this(statusCode, "");
+        }
+
+        public Close(int statusCode, String reason) {
+            this(Optional.of(statusCode), reason);
+        }
+
+        public Close(Optional<Integer> statusCode, String reason) {
+            this.statusCode = statusCode;
+            this.reason = reason;
+        }
+
+        public Optional<Integer> code() {
+            return statusCode;
+        }
+
+        public String reason() {
+            return reason;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Close close = (Close) o;
+
+            return statusCode.equals(close.statusCode) && reason.equals(close.reason);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = statusCode.hashCode();
+            result = 31 * result + reason.hashCode();
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "CloseWebSocketMessage(" + statusCode + ", '" + reason + "')";
+        }
+    }
+
+
+}

--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -11,6 +11,7 @@ import java.util.function.Predicate;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import akka.japi.JavaPartialFunction;
 import play.core.j.FPromiseHelper;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;

--- a/framework/src/play/src/main/java/play/libs/streams/AkkaStreams.java
+++ b/framework/src/play/src/main/java/play/libs/streams/AkkaStreams.java
@@ -1,0 +1,86 @@
+package play.libs.streams;
+
+import akka.japi.Pair;
+import akka.stream.UniformFanInShape;
+import akka.stream.UniformFanOutShape;
+import akka.stream.scaladsl.Broadcast$;
+import akka.stream.javadsl.Flow;
+import akka.stream.scaladsl.FlexiMerge;
+import play.api.libs.streams.AkkaStreams$;
+import play.libs.F;
+import play.libs.Scala;
+import scala.runtime.AbstractFunction0;
+import scala.runtime.BoxedUnit;
+
+import java.util.function.Function;
+
+/**
+ * Akka streams utilities.
+ */
+public class AkkaStreams {
+
+    /**
+     * Bypass the given flow using the given splitter function.
+     *
+     * If the splitter function returns Left, they will go through the flow.  If it returns Right, they will bypass the
+     * flow.
+     */
+    public static <In, FlowIn, Out> Flow<In, Out, ?> bypassWith(Function<In, F.Either<FlowIn, Out>> splitter,
+                                                                Flow<FlowIn, Out, ?> flow) {
+        return bypassWith(Flow.<In>create().map(splitter::apply),
+                new play.api.libs.streams.AkkaStreams.OnlyFirstCanFinishMerge(2), flow);
+    }
+
+    /**
+     * Using the given splitter flow, allow messages to bypass a flow.
+     *
+     * If the splitter flow produces Left, they will be fed into the flow. If it produces Right, they will bypass the
+     * flow.
+     */
+    public static <In, FlowIn, Out> Flow<In, Out, ?> bypassWith(Flow<In, F.Either<FlowIn, Out>, ?> splitter,
+                                                             FlexiMerge<Out, UniformFanInShape<Out, Out>> mergeStrategy,
+                                                             Flow<FlowIn, Out, ?> flow) {
+        return splitter.via(Flow.<F.Either<FlowIn, Out>, Out>factory().create(builder -> {
+
+            // Eager cancel must be true so that if the flow cancels, that will be propagated upstream.
+            // However, that means the bypasser must block cancel, since when this flow finishes, the merge
+            // will result in a cancel flowing up through the bypasser, which could lead to dropped messages.
+            // Using scaladsl here because of https://github.com/akka/akka/issues/18384
+            UniformFanOutShape<F.Either<FlowIn, Out>, F.Either<FlowIn, Out>> broadcast = builder.graph(Broadcast$.MODULE$.apply(2, true));
+            UniformFanInShape<Out, Out> merge = builder.graph(mergeStrategy);
+
+            Flow<F.Either<FlowIn, Out>, FlowIn, ?> collectIn = Flow.<F.Either<FlowIn, Out>>create().collect(Scala.partialFunction(x -> {
+                if (x.left.isPresent()) {
+                    return x.left.get();
+                } else {
+                    throw Scala.noMatch();
+                }
+            }));
+
+            Flow<F.Either<FlowIn, Out>, Out, ?> collectOut = Flow.<F.Either<FlowIn, Out>>create().collect(Scala.partialFunction(x -> {
+                if (x.right.isPresent()) {
+                    return x.right.get();
+                } else {
+                    throw Scala.noMatch();
+                }
+            }));
+
+            Flow<F.Either<FlowIn, Out>, F.Either<FlowIn, Out>, ?> blockCancel =
+                    AkkaStreams$.MODULE$.<F.Either<FlowIn, Out>>blockCancel(new AbstractFunction0<BoxedUnit>() {
+                        @Override
+                        public BoxedUnit apply() {
+                            return BoxedUnit.UNIT;
+                        }
+                    }).asJava();
+
+            // Normal flow
+            builder.from(broadcast.out(0)).via(collectIn).via(flow).to(merge.in(0));
+
+            // Bypass flow, need to ignore downstream finish
+            builder.from(broadcast.out(1)).via(blockCancel).via(collectOut).to(merge.in(1));
+
+            return Pair.create(broadcast.in(), merge.out());
+        }));
+    }
+
+}

--- a/framework/src/play/src/main/java/play/mvc/LegacyWebSocket.java
+++ b/framework/src/play/src/main/java/play/mvc/LegacyWebSocket.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.mvc;
+
+import akka.actor.ActorRef;
+import akka.actor.Props;
+
+/**
+ * A legacy WebSocket result.
+ *
+ * @deprecated Use play.mvc.WebSocket instead.
+ */
+@Deprecated
+public abstract class LegacyWebSocket<A> {
+
+    /**
+     * Called when the WebSocket is ready
+     *
+     * @param in The Socket in.
+     * @param out The Socket out.
+     */
+    public abstract void onReady(WebSocket.In<A> in, WebSocket.Out<A> out);
+
+    /**
+     * If this method returns a result, the WebSocket will be rejected with that result.
+     *
+     * This method will be invoked before onReady.
+     *
+     * @return The result to reject the WebSocket with, or null if the WebSocket shouldn't be rejected.
+     */
+    public Result rejectWith() {
+        return null;
+    }
+
+    /**
+     * If this method returns true, then the WebSocket should be handled by an actor.  The actor will be obtained by
+     * passing an ActorRef representing to the actor method, which should return the props for creating the actor.
+     */
+    public boolean isActor() {
+        return false;
+    }
+
+    /**
+     * The props to create the actor to handle this WebSocket.
+     *
+     * @param out The actor to send upstream messages to.
+     * @return The props of the actor to handle the WebSocket.  If isActor returns true, must not return null.
+     */
+    public Props actorProps(ActorRef out) {
+        return null;
+    }
+}

--- a/framework/src/play/src/main/java/play/mvc/WebSocket.java
+++ b/framework/src/play/src/main/java/play/mvc/WebSocket.java
@@ -1,78 +1,203 @@
-/*
- * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
- */
 package play.mvc;
 
-import java.util.*;
+import akka.actor.ActorRef;
+import akka.actor.Props;
+import akka.stream.javadsl.Flow;
+import akka.util.ByteString;
+import com.fasterxml.jackson.databind.JsonNode;
+import play.api.http.websocket.CloseCodes;
+import play.http.websocket.Message;
+import play.libs.F;
+import play.libs.Scala;
+import play.libs.streams.AkkaStreams;
+import scala.PartialFunction;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import akka.actor.ActorRef;
-import akka.actor.Props;
-
 /**
- * A WebSocket result.
+ * A WebSocket handler.
+ *
+ * Migration note - the original WebSocket class was deprecated and renamed to LegacyWebSocket.  Existing code that
+ * provided implementations of that class can migrate by extending LegacyWebSocket instead.
  */
-public abstract class WebSocket<A> {
+public abstract class WebSocket {
 
     /**
-     * Called when the WebSocket is ready
+     * Invoke the WebSocket.
      *
-     * @param in The Socket in.
-     * @param out The Socket out.
+     * @param request The request for the WebSocket.
+     * @return A future of either a result to reject the WebSocket connection with, or a Flow to handle the WebSocket.
      */
-    public abstract void onReady(In<A> in, Out<A> out);
+    public abstract CompletionStage<F.Either<Result, Flow<Message, Message, ?>>> apply(Http.RequestHeader request);
 
     /**
-     * If this method returns a result, the WebSocket will be rejected with that result.
-     *
-     * This method will be invoked before onReady.
-     *
-     * @return The result to reject the WebSocket with, or null if the WebSocket shouldn't be rejected.
+     * Acceptor for text WebSockets.
      */
-    public Result rejectWith() {
-        return null;
+    public static final MappedWebSocketAcceptor<String, String> Text = new MappedWebSocketAcceptor<>(Scala.partialFunction(message -> {
+        if (message instanceof Message.Text) {
+            return F.Either.Left(((Message.Text) message).data());
+        } else if (message instanceof Message.Binary) {
+            return F.Either.Right(new Message.Close(CloseCodes.Unacceptable(), "This websocket only accepts text frames"));
+        } else {
+            throw Scala.noMatch();
+        }
+    }), Message.Text::new);
+
+    /**
+     * Acceptor for binary WebSockets.
+     */
+    public static final MappedWebSocketAcceptor<ByteString, ByteString> Binary = new MappedWebSocketAcceptor<>(Scala.partialFunction(message -> {
+        if (message instanceof Message.Binary) {
+            return F.Either.Left(((Message.Binary) message).data());
+        } else if (message instanceof Message.Text) {
+            return F.Either.Right(new Message.Close(CloseCodes.Unacceptable(), "This websocket only accepts binary frames"));
+        } else {
+            throw Scala.noMatch();
+        }
+    }), Message.Binary::new);
+
+    /**
+     * Acceptor for JSON WebSockets.
+     */
+    public static final MappedWebSocketAcceptor<JsonNode, JsonNode> Json = new MappedWebSocketAcceptor<>(Scala.partialFunction(message -> {
+        try {
+            if (message instanceof Message.Binary) {
+                return F.Either.Left(play.libs.Json.parse(((Message.Binary) message).data().iterator().asInputStream()));
+            } else if (message instanceof Message.Text) {
+                return F.Either.Left(play.libs.Json.parse(((Message.Text) message).data()));
+            }
+        } catch (RuntimeException e) {
+            return F.Either.Right(new Message.Close(CloseCodes.Unacceptable(), "Unable to parse JSON message"));
+        }
+        throw Scala.noMatch();
+    }), json -> new Message.Text(play.libs.Json.stringify(json)));
+
+    /**
+     * Acceptor for JSON WebSockets.
+     *
+     * @param in The class of the incoming messages, used to decode them from the JSON.
+     * @return The WebSocket acceptor.
+     */
+    public static <In, Out> MappedWebSocketAcceptor<In, Out> json(Class<In> in) {
+        return new MappedWebSocketAcceptor<>(Scala.partialFunction(message -> {
+            try {
+                if (message instanceof Message.Binary) {
+                    return F.Either.Left(play.libs.Json.mapper().readValue(((Message.Binary) message).data().iterator().asInputStream(), in));
+                } else if (message instanceof Message.Text) {
+                    return F.Either.Left(play.libs.Json.mapper().readValue(((Message.Text) message).data(), in));
+                }
+            } catch (Exception e) {
+                return F.Either.Right(new Message.Close(CloseCodes.Unacceptable(), e.getMessage()));
+            }
+            throw Scala.noMatch();
+        }), outMessage -> {
+            try {
+                return new Message.Text(play.libs.Json.mapper().writeValueAsString(outMessage));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 
     /**
-     * If this method returns true, then the WebSocket should be handled by an actor.  The actor will be obtained by
-     * passing an ActorRef representing to the actor method, which should return the props for creating the actor.
+     * Utility class for creating WebSockets.
      */
-    public boolean isActor() {
-        return false;
+    public static class MappedWebSocketAcceptor<In, Out> {
+        private final PartialFunction<Message, F.Either<In, Message>> inMapper;
+        private final Function<Out, Message> outMapper;
+
+        public MappedWebSocketAcceptor(PartialFunction<Message, F.Either<In, Message>> inMapper, Function<Out, Message> outMapper) {
+            this.inMapper = inMapper;
+            this.outMapper = outMapper;
+        }
+
+        /**
+         * Accept a WebSocket.
+         *
+         * @param f A function that takes the request header, and returns a future of either the result to reject the
+         *          WebSocket connection with, or a flow to handle the WebSocket messages.
+         * @return The WebSocket handler.
+         */
+        public WebSocket acceptOrResult(Function<Http.RequestHeader, CompletionStage<F.Either<Result, Flow<In, Out, ? >>>> f) {
+            return WebSocket.acceptOrResult(inMapper, f, outMapper);
+        }
+
+        /**
+         * Accept a WebSocket.
+         *
+         * @param f A function that takes the request header, and returns a flow to handle the WebSocket messages.
+         * @return The WebSocket handler.
+         */
+        public WebSocket accept(Function<Http.RequestHeader, Flow<In, Out, ? >> f) {
+            return acceptOrResult(request -> CompletableFuture.completedFuture(F.Either.Right(f.apply(request))));
+        }
     }
 
     /**
-     * The props to create the actor to handle this WebSocket.
+     * Helper to create handlers for WebSockets.
      *
-     * @param out The actor to send upstream messages to.
-     * @return The props of the actor to handle the WebSocket.  If isActor returns true, must not return null.
+     * @param inMapper Function to map input messages. If it produces left, the message will be passed to the WebSocket
+     *                 flow, if it produces right, the message will be sent back out to the client - this can be used
+     *                 to send errors directly to the client.
+     * @param f The function to handle the WebSocket.
+     * @param outMapper Function to map output messages.
+     * @return The WebSocket handler.
      */
-    public Props actorProps(ActorRef out) {
-        return null;
+    private static <In, Out> WebSocket acceptOrResult(
+            PartialFunction<Message, F.Either<In, Message>> inMapper,
+            Function<Http.RequestHeader, CompletionStage<F.Either<Result, Flow<In, Out, ?>>>> f,
+            Function<Out, Message> outMapper
+    ) {
+        return new WebSocket() {
+            @Override
+            public CompletionStage<F.Either<Result, Flow<Message, Message, ?>>> apply(Http.RequestHeader request) {
+                return f.apply(request).thenApply(resultOrFlow -> {
+                    if (resultOrFlow.left.isPresent()) {
+                        return F.Either.Left(resultOrFlow.left.get());
+                    } else {
+                        Flow<Message, Message, ?> flow = AkkaStreams.bypassWith(
+                                Flow.<Message>create().collect(inMapper),
+                                new play.api.libs.streams.AkkaStreams.OnlyFirstCanFinishMerge(2),
+                                resultOrFlow.right.get().map(outMapper::apply)
+                        );
+                        return F.Either.Right(flow);
+                    }
+                });
+            }
+        };
     }
 
     /**
      * A WebSocket out.
+     *
+     * @deprecated Use Akka Streams instead.
      */
-    public static interface Out<A> {
+    @Deprecated
+    public interface Out<A> {
 
         /**
          * Writes a frame.
          */
-        public void write(A frame);
+        void write(A frame);
 
         /**
          * Close this channel.
          */
-        public void close();
+        void close();
     }
 
     /**
      * A WebSocket in.
+     *
+     * @deprecated Use Akka Streams instead.
      */
+    @Deprecated
     public static class In<A> {
 
         /**
@@ -108,8 +233,10 @@ public abstract class WebSocket<A> {
      * @param callback the callback used to implement onReady
      * @return a new WebSocket
      * @throws NullPointerException if the specified callback is null
+     * @deprecated Use the WebSocket.accept* methods instead.
      */
-    public static <A> WebSocket<A> whenReady(BiConsumer<In<A>, Out<A>> callback) {
+    @Deprecated
+    public static <A> LegacyWebSocket<A> whenReady(BiConsumer<In<A>, Out<A>> callback) {
         return new WhenReadyWebSocket<A>(callback);
     }
 
@@ -118,9 +245,11 @@ public abstract class WebSocket<A> {
      *
      * @param result The result that will be returned.
      * @return A rejected WebSocket.
+     * @deprecated Use the WebSocket.accept*OrResult methods instead.
      */
-    public static <A> WebSocket<A> reject(final Result result) {
-        return new WebSocket<A>() {
+    @Deprecated
+    public static <A> LegacyWebSocket<A> reject(final Result result) {
+        return new LegacyWebSocket<A>() {
             public void onReady(In<A> in, Out<A> out) {
             }
             public Result rejectWith() {
@@ -134,9 +263,12 @@ public abstract class WebSocket<A> {
      *
      * @param props The function used to create the props for the actor.  The passed in argument is the upstream actor.
      * @return An actor WebSocket.
+     * @deprecated Use the WebSocket.accept* methods instead, with a flow created by wrapping a Sink.actorRef and
+     *             Source.actorRef.
      */
-    public static <A> WebSocket<A> withActor(final Function<ActorRef, Props> props) {
-        return new WebSocket<A>() {
+    @Deprecated
+    public static <A> LegacyWebSocket<A> withActor(final Function<ActorRef, Props> props) {
+        return new LegacyWebSocket<A>() {
             public void onReady(In<A> in, Out<A> out) {
             }
             public boolean isActor() {
@@ -159,8 +291,11 @@ public abstract class WebSocket<A> {
     /**
      * An extension of WebSocket that obtains its onReady from
      * the specified {@code Callback2<In<A>, Out<A>>}.
+     *
+     * @deprecated Use WebSocket.accept* instead.
      */
-    static final class WhenReadyWebSocket<A> extends WebSocket<A> {
+    @Deprecated
+    final static class WhenReadyWebSocket<A> extends LegacyWebSocket<A> {
 
         private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(WhenReadyWebSocket.class);
 

--- a/framework/src/play/src/main/scala/play/api/mvc/WebSocket.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/WebSocket.scala
@@ -101,6 +101,12 @@ object WebSocket {
 
   object MessageFlowTransformer {
 
+    implicit val identityMessageFlowTransformer: MessageFlowTransformer[Message, Message] = {
+      new MessageFlowTransformer[Message, Message] {
+        def transform(flow: Flow[Message, Message, _]) = flow
+      }
+    }
+
     /**
      * Converts text messages to/from Strings.
      */

--- a/framework/src/play/src/main/scala/play/core/routing/HandlerInvoker.scala
+++ b/framework/src/play/src/main/scala/play/core/routing/HandlerInvoker.scala
@@ -3,10 +3,15 @@
  */
 package play.core.routing
 
+import java.util.Optional
+
+import akka.stream.scaladsl.Flow
 import org.apache.commons.lang3.reflect.MethodUtils
 import play.api.mvc._
+import play.core.j
 import play.core.j.{ JavaHandlerComponents, JavaHandler, JavaActionAnnotations }
 
+import scala.compat.java8.{OptionConverters, FutureConverters}
 import scala.util.control.NonFatal
 
 /**
@@ -63,7 +68,7 @@ trait HandlerInvokerFactory[T] {
 object HandlerInvokerFactory {
 
   import play.libs.F.{ Promise => JPromise }
-  import play.mvc.{ Result => JResult, WebSocket => JWebSocket }
+  import play.mvc.{ Result => JResult, LegacyWebSocket, WebSocket => JWebSocket }
   import play.core.j.JavaWebSocket
   import com.fasterxml.jackson.databind.JsonNode
 
@@ -150,27 +155,57 @@ object HandlerInvokerFactory {
     }
   }
 
-  implicit def javaBytesWebSocket: HandlerInvokerFactory[JWebSocket[Array[Byte]]] = new JavaWebSocketInvokerFactory[JWebSocket[Array[Byte]], Array[Byte]] {
-    def webSocketCall(call: => JWebSocket[Array[Byte]]) = JavaWebSocket.ofBytes(call)
+  implicit def javaBytesWebSocket: HandlerInvokerFactory[LegacyWebSocket[Array[Byte]]] = new JavaWebSocketInvokerFactory[LegacyWebSocket[Array[Byte]], Array[Byte]] {
+    def webSocketCall(call: => LegacyWebSocket[Array[Byte]]) = JavaWebSocket.ofBytes(call)
   }
 
-  implicit def javaStringWebSocket: HandlerInvokerFactory[JWebSocket[String]] = new JavaWebSocketInvokerFactory[JWebSocket[String], String] {
-    def webSocketCall(call: => JWebSocket[String]) = JavaWebSocket.ofString(call)
+  implicit def javaStringWebSocket: HandlerInvokerFactory[LegacyWebSocket[String]] = new JavaWebSocketInvokerFactory[LegacyWebSocket[String], String] {
+    def webSocketCall(call: => LegacyWebSocket[String]) = JavaWebSocket.ofString(call)
   }
 
-  implicit def javaJsonWebSocket: HandlerInvokerFactory[JWebSocket[JsonNode]] = new JavaWebSocketInvokerFactory[JWebSocket[JsonNode], JsonNode] {
-    def webSocketCall(call: => JWebSocket[JsonNode]) = JavaWebSocket.ofJson(call)
+  implicit def javaJsonWebSocket: HandlerInvokerFactory[LegacyWebSocket[JsonNode]] = new JavaWebSocketInvokerFactory[LegacyWebSocket[JsonNode], JsonNode] {
+    def webSocketCall(call: => LegacyWebSocket[JsonNode]) = JavaWebSocket.ofJson(call)
   }
 
-  implicit def javaBytesPromiseWebSocket: HandlerInvokerFactory[JPromise[JWebSocket[Array[Byte]]]] = new JavaWebSocketInvokerFactory[JPromise[JWebSocket[Array[Byte]]], Array[Byte]] {
-    def webSocketCall(call: => JPromise[JWebSocket[Array[Byte]]]) = JavaWebSocket.promiseOfBytes(call)
+  implicit def javaBytesPromiseWebSocket: HandlerInvokerFactory[JPromise[LegacyWebSocket[Array[Byte]]]] = new JavaWebSocketInvokerFactory[JPromise[LegacyWebSocket[Array[Byte]]], Array[Byte]] {
+    def webSocketCall(call: => JPromise[LegacyWebSocket[Array[Byte]]]) = JavaWebSocket.promiseOfBytes(call)
   }
 
-  implicit def javaStringPromiseWebSocket: HandlerInvokerFactory[JPromise[JWebSocket[String]]] = new JavaWebSocketInvokerFactory[JPromise[JWebSocket[String]], String] {
-    def webSocketCall(call: => JPromise[JWebSocket[String]]) = JavaWebSocket.promiseOfString(call)
+  implicit def javaStringPromiseWebSocket: HandlerInvokerFactory[JPromise[LegacyWebSocket[String]]] = new JavaWebSocketInvokerFactory[JPromise[LegacyWebSocket[String]], String] {
+    def webSocketCall(call: => JPromise[LegacyWebSocket[String]]) = JavaWebSocket.promiseOfString(call)
   }
 
-  implicit def javaJsonPromiseWebSocket: HandlerInvokerFactory[JPromise[JWebSocket[JsonNode]]] = new JavaWebSocketInvokerFactory[JPromise[JWebSocket[JsonNode]], JsonNode] {
-    def webSocketCall(call: => JPromise[JWebSocket[JsonNode]]) = JavaWebSocket.promiseOfJson(call)
+  implicit def javaJsonPromiseWebSocket: HandlerInvokerFactory[JPromise[LegacyWebSocket[JsonNode]]] = new JavaWebSocketInvokerFactory[JPromise[LegacyWebSocket[JsonNode]], JsonNode] {
+    def webSocketCall(call: => JPromise[LegacyWebSocket[JsonNode]]) = JavaWebSocket.promiseOfJson(call)
+  }
+
+  implicit def javaWebSocket: HandlerInvokerFactory[JWebSocket] = new HandlerInvokerFactory[JWebSocket] {
+    import play.http.websocket.{ Message => JMessage }
+    import play.api.http.websocket._
+    import play.api.libs.iteratee.Execution.Implicits.trampoline
+    def createInvoker(fakeCall: => JWebSocket, handlerDef: HandlerDef) = new HandlerInvoker[JWebSocket] {
+      def call(call: => JWebSocket) = WebSocket.acceptOrResult[Message, Message] { request =>
+        FutureConverters.toScala(call(new j.RequestHeaderImpl(request))).map { resultOrFlow =>
+          if (resultOrFlow.left.isPresent) {
+            Left(resultOrFlow.left.get.asScala())
+          } else {
+            Right(Flow[Message].map {
+              case TextMessage(text) => new JMessage.Text(text)
+              case BinaryMessage(data) => new JMessage.Binary(data)
+              case PingMessage(data) => new JMessage.Ping(data)
+              case PongMessage(data) => new JMessage.Pong(data)
+              case CloseMessage(code, reason) => new JMessage.Close(OptionConverters.toJava(code).asInstanceOf[Optional[Integer]], reason)
+            }.via(resultOrFlow.right.get.asScala).map {
+              case text: JMessage.Text => TextMessage(text.data)
+              case binary: JMessage.Binary => BinaryMessage(binary.data)
+              case ping: JMessage.Ping => PingMessage(ping.data)
+              case pong: JMessage.Pong => PongMessage(pong.data)
+              case close: JMessage.Close => CloseMessage(OptionConverters.toScala(close.code).asInstanceOf[Option[Int]], close.reason)
+            })
+          }
+
+        }
+      }
+    }
   }
 }

--- a/framework/src/play/src/test/java/play/mvc/LegacyWebSocketTest.java
+++ b/framework/src/play/src/test/java/play/mvc/LegacyWebSocketTest.java
@@ -8,12 +8,11 @@ import java.util.function.Consumer;
 
 import org.junit.Test;
 import play.api.libs.iteratee.TestChannel;
-import play.libs.F;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertTrue;
 
-public class WebSocketTest {
+public class LegacyWebSocketTest {
 
     @Test
     public void testWebSocket() throws Throwable {
@@ -35,7 +34,7 @@ public class WebSocketTest {
 
         final WebSocket.In<String> wsIn = new WebSocket.In<>();
 
-        WebSocket<String> webSocket = WebSocket.whenReady((in, out) -> {
+        LegacyWebSocket<String> webSocket = WebSocket.whenReady((in, out) -> {
             ready.countDown();
             in.onMessage(m -> message.countDown());
             in.onClose(close::countDown);
@@ -69,7 +68,7 @@ public class WebSocketTest {
     public void testWhenReadyFactory() throws Exception {
         final CountDownLatch ready = new CountDownLatch(1);
 
-        WebSocket<String> webSocket = WebSocket.whenReady((in, out) -> ready.countDown());
+        LegacyWebSocket<String> webSocket = WebSocket.whenReady((in, out) -> ready.countDown());
 
         webSocket.onReady(null, null);
 


### PR DESCRIPTION
This makes the Java `WebSocket` a simple function that returns a future of either a result, or the flow to handle the WebSocket.

I renamed the existing `WebSocket` class to `LegacyWebSocket`.