### PR TITLE
Use quickPublish

### DIFF
--- a/framework/bin/test
+++ b/framework/bin/test
@@ -26,7 +26,7 @@ cd $FRAMEWORK
 echo "[info]"
 echo "[info] ---- BUILDING PLAY"
 echo "[info]"
-$BUILD "$@" "${CROSSBUILD} publishLocal"
+$BUILD "$@" quickPublish "${CROSSBUILD} publishLocal"
 
 echo "[info]"
 echo "[info] ---- RUNNING TESTS"

--- a/framework/bin/testSbtPlugins
+++ b/framework/bin/testSbtPlugins
@@ -16,7 +16,7 @@ cd $FRAMEWORK
 echo "[info]"
 echo "[info] ---- BUILDING PLAY"
 echo "[info]"
-$BUILD "$@" publishLocal
+$BUILD "$@" quickPublish publishLocal
 
 echo "[info]"
 echo "[info] ---- SCRIPTED TESTS"

--- a/framework/bin/testTemplates
+++ b/framework/bin/testTemplates
@@ -17,7 +17,7 @@ cd $FRAMEWORK
 echo "[info]"
 echo "[info] ---- BUILDING PLAY "
 echo "[info]"
-$BUILD "$@" publishLocal
+$BUILD "$@" quickPublish publishLocal
 
 echo "[info]"
 echo "[info] ---- TESTING TEMPLATES"


### PR DESCRIPTION
Turn on quickPublish mode (a command I wrote for Play that turns off generation of API docs and source artifacts) when running the build on Travis. This should shave a minute or two off build times.