### PR TITLE
Fixed the 2.3.x build

### DIFF
--- a/framework/build
+++ b/framework/build
@@ -1,6 +1,9 @@
-#! /usr/bin/env sh
+#! /bin/bash
 
 # Copyright (C) 2009-2013 Typesafe Inc. <http://www.typesafe.com>
+
+set -e
+set -o pipefail
 
 if [ -z "${PLAY_VERSION}" ]; then
   PLAY_VERSION="2.3-SNAPSHOT"


### PR DESCRIPTION
The 2.3.x build was not failing, even if the sbt command failed.