### PR TITLE
Format `build.sbt` as code

### DIFF
--- a/framework/src/play/src/main/scala/views/play20/welcome.scala.html
+++ b/framework/src/play/src/main/scala/views/play20/welcome.scala.html
@@ -120,7 +120,7 @@ db.default.url="jdbc:h2:mem:play"</code></pre>
 
             <p>
                 If you need to connect to another JDBC-compliant database, first add the corresponding driver library 
-                to your application dependencies in build.sbt e.g.:
+                to your application dependencies in <code>build.sbt</code> e.g.:
             </p>
 
 <pre><code>libraryDependencies += "mysql" % "mysql-connector-java" % "5.1.36"
@@ -260,7 +260,7 @@ db.default.url="jdbc:h2:mem:play"</code></pre>
 
             <p>
                 If you need to connect to another JDBC-compliant database, first add the corresponding driver library 
-                to your application dependencies in build.sbt e.g.:
+                to your application dependencies in <code>build.sbt</code> e.g.:
             </p>
 
 <pre><code>libraryDependencies += "mysql" % "mysql-connector-java" % "5.1.36"


### PR DESCRIPTION
Just a minor fix to the formatting on the welcome page.