### PR TITLE
Treat the first Forwarded header as non-proxy

### DIFF
--- a/framework/src/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -80,6 +80,14 @@ class ForwardedHeaderHandlerSpec extends Specification {
           |X-Forwarded-Proto: https, http
         """.stripMargin)) mustEqual Some("https")
     }
+
+    "not treat the first x-forwarded entry as a proxy even if it is in trustedProxies range" in new TestData {
+      handler(version("x-forwarded") ++ trustedProxies("192.168.1.1/24" :: "127.0.0.1" :: Nil)).remoteAddress(headers(
+        """
+          |X-Forwarded-For: 192.168.1.2, 192.168.1.3
+          |X-Forwarded-Proto: http, http
+        """.stripMargin)) mustEqual Some("192.168.1.2")
+    }
   }
 
   trait TestData extends Scope {


### PR DESCRIPTION
I have a Play application that serves an internal API accessed from another server in the same network. The caller hits the api through a reverse proxy which also sits in the same network.

So it's like the following situation and I have the `trustedProxies` set to `192.168.1.1/24`.

```
  Client    ->    Proxy    ->     API
192.168.1.1    192.168.1.2    192.168.1.3
```

The proxy sets the `X-Forwarded-For` header to `192.168.1.1`. ForwardedHeaderHandler currently drops hosts within the range of `trustedProxies`, so Play handles the request as if there were no Forwarded headers at all, and therefore the `remoteAddr` becomes `192.168.1.2`.

ForwardedHeaderHandler should not drop the first entry of Forwarded header even if it's in the `trustedProxies` range.