### PR TITLE
Modified WsRequest to take -1 as timeout parameter, which sets infini…

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -61,7 +61,7 @@ For example, if you are sending plain text in a particular format, you may want 
 
 ### Request with time out
 
-If you wish to specify a request timeout, you can use `setTimeout` to set a value in milliseconds.
+If you wish to specify a request timeout, you can use `setRequestTimeout` to set a value in milliseconds. A value of `-1` can be used to set an infinite timeout. 
 
 @[ws-timeout](code/javaguide/ws/JavaWS.java)
 

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -71,7 +71,7 @@ A virtual host can be specified as a string.
 
 ### Request with timeout
 
-If you wish to specify a request timeout, you can use `withRequestTimeout` to set a value in milliseconds.
+If you wish to specify a request timeout, you can use `withRequestTimeout` to set a value in milliseconds. A value of `-1` can be used to set an infinite timeout. 
 
 @[request-timeout](code/ScalaWSSpec.scala)
 

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
@@ -250,7 +250,7 @@ public interface WSRequest {
     /**
      * Sets the request timeout in milliseconds.
      *
-     * @param timeout the request timeout in milliseconds.
+     * @param timeout the request timeout in milliseconds. A value of -1 indicates an infinite request timeout.
      * @return the modified WSRequest.
      */
     WSRequest setRequestTimeout(long timeout);

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSRequest.java
@@ -175,8 +175,8 @@ public class NingWSRequest implements WSRequest {
 
     @Override
     public WSRequest setRequestTimeout(long timeout) {
-        if (timeout < 0 || timeout > Integer.MAX_VALUE) {
-            throw new IllegalArgumentException("Timeout must be between 0 and " + Integer.MAX_VALUE + " inclusive");
+        if (timeout < -1 || timeout > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Timeout must be between -1 and " + Integer.MAX_VALUE + " inclusive");
         }
         this.timeout = (int) timeout;
         return this;
@@ -474,7 +474,7 @@ public class NingWSRequest implements WSRequest {
             throw new IllegalStateException("Impossible body: " + body);
         }
 
-        if (this.timeout > 0) {
+        if (this.timeout == -1 || this.timeout > 0) {
             builder.setRequestTimeout(this.timeout);
         }
 

--- a/framework/src/play-java-ws/src/test/scala/play/libs/ws/ning/NingWSRequestSpec.scala
+++ b/framework/src/play-java-ws/src/test/scala/play/libs/ws/ning/NingWSRequestSpec.scala
@@ -21,6 +21,27 @@ class NingWSRequestSpec extends Specification with Mockito {
       actual must beEqualTo("foo.com")
     }
 
+    "should support setting a request timeout" in {
+      requestWithTimeout(1000) must beEqualTo(1000)
+    }
+
+    "should support setting an infinite request timeout" in {
+      requestWithTimeout(-1) must beEqualTo(-1)
+    }
+
+    "should not support setting a request timeout < -1" in {
+      requestWithTimeout(-2) must throwA[IllegalArgumentException]
+    }
+
+    "should not support setting a request timeout > Integer.MAX_VALUE" in {
+      requestWithTimeout(Int.MaxValue.toLong + 1) must throwA[IllegalArgumentException]
+    }
   }
 
+  def requestWithTimeout(timeout: Long) = {
+    val client = mock[NingWSClient]
+    val request = new NingWSRequest(client, "http://example.com")
+    request.setRequestTimeout(timeout)
+    request.buildRequest().getRequestTimeout()
+  }
 }

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -364,7 +364,7 @@ trait WSRequest {
 
   /**
    * Sets the maximum time in milliseconds you expect the request to take.
-   * Warning: a stream consumption will be interrupted when this time is reached.
+   * Warning: a stream consumption will be interrupted when this time is reached unless -1 is set.
    */
   def withRequestTimeout(timeout: Long): WSRequest
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
@@ -113,7 +113,7 @@ case class NingWSRequest(client: NingWSClient,
   def withFollowRedirects(follow: Boolean): WSRequest = copy(followRedirects = Some(follow))
 
   def withRequestTimeout(timeout: Long): WSRequest = {
-    require(timeout >= 0 && timeout <= Int.MaxValue, s"Request timeout must be between 0 and ${Int.MaxValue}")
+    require(timeout >= -1 && timeout <= Int.MaxValue, s"Request timeout must be between -1 and ${Int.MaxValue}")
     copy(requestTimeout = Some(timeout.toInt))
   }
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
@@ -165,15 +165,26 @@ object NingWSSpec extends PlaySpecification with Mockito {
       req.getFollowRedirect must beEqualTo(true)
     }
 
-    "support timeout" in new WithApplication {
+    "support finite timeout" in new WithApplication {
       val req: client.Request = WS.url("http://playframework.com/")
         .withRequestTimeout(1000).asInstanceOf[NingWSRequest]
         .buildRequest()
       req.getRequestTimeout must be equalTo 1000
     }
 
+    "support infinite timeout" in new WithApplication {
+      val req: client.Request = WS.url("http://playframework.com/")
+        .withRequestTimeout(-1).asInstanceOf[NingWSRequest]
+        .buildRequest()
+      req.getRequestTimeout must be equalTo -1
+    }
+
     "not support invalid timeout" in new WithApplication {
-      WS.url("http://playframework.com/").withRequestTimeout(-1) should throwAn[IllegalArgumentException]
+      WS.url("http://playframework.com/").withRequestTimeout(-2) should throwAn[IllegalArgumentException]
+    }
+
+    "not support a timeout greater than Int.MaxValue" in new WithApplication {
+      WS.url("http://playframework.com/").withRequestTimeout(Int.MaxValue.toLong + 1) should throwAn[IllegalArgumentException]
     }
 
     "support a proxy server" in new WithApplication {


### PR DESCRIPTION
Modified WsRequest to take -1 as timeout parameter, which sets infinite timeout. Fixes #4846

Fix for 2.4.x branch. I have modified the solution to take -1 as infinite parameter in scala-ws api.