### PR TITLE
Uncomment ContravariantFunctor instance for Writes

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
@@ -13,6 +13,7 @@ import java.time.{
 import java.time.temporal.Temporal
 import java.time.format.DateTimeFormatter
 
+import play.api.libs.functional.ContravariantFunctor
 import play.api.libs.json.jackson.JacksonJson
 
 import scala.annotation.implicitNotFound
@@ -95,11 +96,11 @@ object Writes extends PathWrites with ConstraintWrites with DefaultWrites {
   val constraints: ConstraintWrites = this
   val path: PathWrites = this
 
-  /*implicit val contravariantfunctorWrites:ContravariantFunctor[Writes] = new ContravariantFunctor[Writes] {
+  implicit val contravariantfunctorWrites: ContravariantFunctor[Writes] = new ContravariantFunctor[Writes] {
 
-    def contramap[A,B](wa:Writes[A], f: B => A):Writes[B] = Writes[B]( b => wa.writes(f(b)) )
+    def contramap[A, B](wa: Writes[A], f: B => A): Writes[B] = Writes[B](b => wa.writes(f(b)))
 
-  }*/
+  }
 
   def apply[A](f: A => JsValue): Writes[A] = new Writes[A] {
     def writes(a: A): JsValue = f(a)


### PR DESCRIPTION
The ContravariantFunctor instance for Writes was commented out in 2be3e0815dc5b4e8629bbbc. I have found that this instance could have been useful in a few cases, and it seems like there is currently no problem in enabling it.