### PR TITLE
enable field level validation errors when applying object-level const…

### DIFF
--- a/framework/src/play-datacommons/src/main/scala/play/api/data/validation/ValidationError.scala
+++ b/framework/src/play-datacommons/src/main/scala/play/api/data/validation/ValidationError.scala
@@ -9,14 +9,16 @@ package play.api.data.validation
  * @param message the error message
  * @param args the error message arguments
  */
-case class ValidationError(messages: Seq[String], args: Any*) {
-
+case class ValidationError private (messages: Seq[String], args: Seq[Any] = Seq.empty, fieldName: Option[String] = None) {
   lazy val message = messages.last
 
+  def forField(name: String) = this.copy(fieldName = Some(name))
 }
 
 object ValidationError {
 
-  def apply(message: String, args: Any*) = new ValidationError(Seq(message), args: _*)
+  def apply(message: String, args: Any*) = new ValidationError(Seq(message), args, None)
+
+  def apply(messages: Seq[String], args: Any*) = new ValidationError(messages, args, None)
 
 }

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/ReadsSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/ReadsSpec.scala
@@ -40,7 +40,7 @@ object ReadsSpec extends org.specs2.mutable.Specification {
     "not be read from invalid string" in {
       reads(JsString("invalid")) aka "read date" must beLike {
         case JsError((_, ValidationError(
-          "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+          "error.expected.date.isoformat" :: Nil, _, _) :: Nil) :: Nil) => ok
       }
     }
 
@@ -71,14 +71,14 @@ object ReadsSpec extends org.specs2.mutable.Specification {
       "with default implicit" in {
         correctedReads.reads(JsString("2011-12-03T10:15:30")) must beLike {
           case JsError((_, ValidationError(
-            "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+            "error.expected.date.isoformat" :: Nil, _, _) :: Nil) :: Nil) => ok
         }
       }
 
       "with custom formatter" in {
         CustomReads2.reads(JsString("03/12/2011, 10:15:30")) must beLike {
           case JsError((_, ValidationError(
-            "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+            "error.expected.date.isoformat" :: Nil, _, _) :: Nil) :: Nil) => ok
         }
       }
     }
@@ -126,7 +126,7 @@ object ReadsSpec extends org.specs2.mutable.Specification {
     "not be read from invalid string" in {
       reads(JsString("invalid")) aka "read date" must beLike {
         case JsError((_, ValidationError(
-          "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+          "error.expected.date.isoformat" :: Nil, _, _) :: Nil) :: Nil) => ok
       }
     }
 
@@ -157,14 +157,14 @@ object ReadsSpec extends org.specs2.mutable.Specification {
       "with default implicit" in {
         correctedReads.reads(JsString("2011-12-03T10:15:30")) must beLike {
           case JsError((_, ValidationError(
-            "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+            "error.expected.date.isoformat" :: Nil, _, _) :: Nil) :: Nil) => ok
         }
       }
 
       "with custom formatter" in {
         CustomReads2.reads(JsString("03/12/2011, 10:15:30")) must beLike {
           case JsError((_, ValidationError(
-            "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+            "error.expected.date.isoformat" :: Nil, _, _) :: Nil) :: Nil) => ok
         }
       }
     }
@@ -210,7 +210,7 @@ object ReadsSpec extends org.specs2.mutable.Specification {
     "not be read from invalid string" in {
       reads(JsString("invalid")) aka "read date" must beLike {
         case JsError((_, ValidationError(
-          "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+          "error.expected.date.isoformat" :: Nil, _, _) :: Nil) :: Nil) => ok
       }
     }
 
@@ -228,14 +228,14 @@ object ReadsSpec extends org.specs2.mutable.Specification {
       "with default implicit" in {
         correctedReads.reads(JsString("2011-12-03")) must beLike {
           case JsError((_, ValidationError(
-            "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+            "error.expected.date.isoformat" :: Nil, _, _) :: Nil) :: Nil) => ok
         }
       }
 
       "with custom formatter" in {
         CustomReads2.reads(JsString("03/12/2011")) must beLike {
           case JsError((_, ValidationError(
-            "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+            "error.expected.date.isoformat" :: Nil, _, _) :: Nil) :: Nil) => ok
         }
       }
     }
@@ -279,7 +279,7 @@ object ReadsSpec extends org.specs2.mutable.Specification {
     "not be read from invalid string" in {
       reads(JsString("invalid")) aka "read date" must beLike {
         case JsError((_, ValidationError(
-          "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+          "error.expected.date.isoformat" :: Nil, _, _) :: Nil) :: Nil) => ok
       }
     }
 
@@ -326,14 +326,14 @@ object ReadsSpec extends org.specs2.mutable.Specification {
       "with default implicit" in {
         correctedReads.reads(JsString("2011-12-03T10:15:30")) must beLike {
           case JsError((_, ValidationError(
-            "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+            "error.expected.date.isoformat" :: Nil, _, _) :: Nil) :: Nil) => ok
         }
       }
 
       "with custom formatter" in {
         CustomReads2.reads(JsString("03/12/2011, 10:15:30")) must beLike {
           case JsError((_, ValidationError(
-            "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+            "error.expected.date.isoformat" :: Nil, _, _) :: Nil) :: Nil) => ok
         }
       }
     }

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -556,7 +556,7 @@ trait Mapping[T] {
   protected def collectErrors(t: T): Seq[FormError] = {
     constraints.map(_(t)).collect {
       case Invalid(errors) => errors.toSeq
-    }.flatten.map(ve => FormError(key, ve.messages, ve.args))
+    }.flatten.map(ve => FormError(ve.fieldName.getOrElse(key), ve.messages, ve.args))
   }
 
 }


### PR DESCRIPTION
When using the verifying function on mapping objects it is only possible to return a collection of validation errors. Validation errors do not let you specify which field the error should be applied to.

This is a problem when you want to compare multiple values on an object and apply the resulting to error to just one of them. You can see the test I've added as a basic example. The idea is that if field2 has the same value as field1 the resulting error should be associated with one of those fields.

In the system I am currently building we shoved the field name inside the error message using a custom format and unpacked after calling bind on the form. This commit is a far nicer solution that also makes it easy for other users of the play framework to achieve the same goal.

I hope you like this feature and decide to merge it. If you do and would like me to add an example to the documentation, please just let me know. Likewise if you have any questions about the rationale or the implementation, I'll be more than happy to help.
