### PR TITLE
Removed last reference to Scala 2.10

### DIFF
--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/Build.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/Build.scala
@@ -55,7 +55,7 @@ object ApplicationBuild extends Build {
         bufferLogger +: currentFunction(key)
       }
     },
-    scalaVersion := sys.props.get("scala.version").getOrElse("2.10.7"),
+    scalaVersion := sys.props.get("scala.version").getOrElse("2.11.7"),
     checkLogContainsTask,
     compileIgnoreErrorsTask
   )


### PR DESCRIPTION
This was missed in #5091, as pointed out by @cchantep