### PR TITLE
More standard application/x-www-form-urlencoded parsing

### DIFF
--- a/framework/src/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
@@ -3,6 +3,8 @@
  */
 package play.core.parsers
 
+import java.net.URLDecoder
+
 /** An object for parsing application/x-www-form-urlencoded data */
 object FormUrlEncodedParser {
 
@@ -63,6 +65,8 @@ object FormUrlEncodedParser {
     }.asJava
   }
 
+  private[this] val parameterDelimiter = "[&;]".r
+
   /**
    * Do the basic parsing into a sequence of key/value pairs
    * @param data The data to parse
@@ -70,19 +74,11 @@ object FormUrlEncodedParser {
    * @return The sequence of key/value pairs
    */
   private def parseToPairs(data: String, encoding: String): Seq[(String, String)] = {
-
-    import java.net._
-
-    // Generate all the pairs, with potentially redundant key values, by parsing the body content.
-    data.split('&').flatMap { param =>
-      if (param.contains("=") && !param.startsWith("=")) {
-        val parts = param.split("=")
-        val key = URLDecoder.decode(parts.head, encoding)
-        val value = URLDecoder.decode(parts.tail.headOption.getOrElse(""), encoding)
-        Seq(key -> value)
-      } else {
-        Nil
-      }
-    }.toSeq
+    parameterDelimiter.split(data).map { param =>
+      val parts = param.split("=", -1)
+      val key = URLDecoder.decode(parts(0), encoding)
+      val value = URLDecoder.decode(parts.lift(1).getOrElse(""), encoding)
+      key -> value
+    }
   }
 }

--- a/framework/src/play/src/test/scala/play/core/parsers/FormUrlEncodedParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/parsers/FormUrlEncodedParserSpec.scala
@@ -10,11 +10,24 @@ object FormUrlEncodedParserSpec extends Specification {
     "decode forms" in {
       FormUrlEncodedParser.parse("foo1=bar1&foo2=bar2") must_== Map("foo1" -> List("bar1"), "foo2" -> List("bar2"))
     }
+    "decode forms with semicolons" in {
+      // http://www.w3.org/TR/1999/REC-html401-19991224/appendix/notes.html#h-B.2.2
+      FormUrlEncodedParser.parse("foo1=bar1;foo2=bar2") must_== Map("foo1" -> List("bar1"), "foo2" -> List("bar2"))
+    }
+    "decode forms with ampersands and semicolons" in {
+      FormUrlEncodedParser.parse("foo1=bar1&foo2=bar2;foo3=bar3") must_== Map("foo1" -> List("bar1"), "foo2" -> List("bar2"), "foo3" -> List("bar3"))
+    }
     "decode form elements with multiple values" in {
       FormUrlEncodedParser.parse("foo=bar1&foo=bar2") must_== Map("foo" -> List("bar1", "bar2"))
     }
     "decode fields with empty names" in {
-      FormUrlEncodedParser.parse("foo=bar&=") must_== Map("foo" -> List("bar"))
+      FormUrlEncodedParser.parse("foo=bar&=") must_== Map("foo" -> List("bar"), "" -> List(""))
+    }
+    "decode fields with empty values" in {
+      FormUrlEncodedParser.parse("foo=bar&baz=") must_== Map("foo" -> List("bar"), "baz" -> List(""))
+    }
+    "decode fields with no value" in {
+      FormUrlEncodedParser.parse("foo=bar&baz") must_== Map("foo" -> List("bar"), "baz" -> List(""))
     }
     "ensure field order is retained, when requested" in {
       val url_encoded = "Zero=zero&One=one&Two=two&Three=three&Four=four&Five=five&Six=six&Seven=seven"


### PR DESCRIPTION
* Allow semicolon separators in addition to ampersands
* Parse empty/non-existant names and values

---

W3C [recommends](http://www.w3.org/TR/1999/REC-html401-19991224/appendix/notes.html#h-B.2.2) accepting semicolons separators.

> We recommend that HTTP server implementors, and in particular, CGI implementors support the use of ";" in place of "&"

Old stuff, but most parsers still follow the recommendation.

Also, most parsers accept empty names and values, and non-existent values. For example, the example request in [RFC 5849 3.4.1.3.1](http://tools.ietf.org/html/rfc5849#section-3.4.1.3.1) (OAuth 1.0) has the body

```
c2&a3=2+q
```

and requires parsing the `c2` parameter in order for OAuth to work.

---

Most parsers allow these two usages, for example `com.apache.http.client.utils.URLEncodedUtils` or `io.netty.handler.codec.http.QueryStringDecoder` (HTML forms put fields in GET query strings, hence the name).

I would have used one of those rather than implementing it myself, but the `play` project doesn't currently depend on either.