### PR TITLE
Update ScalaEmbeddingPlay.md

### DIFF
--- a/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlay.md
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlay.md
@@ -7,7 +7,7 @@ The simplest way to start an embedded Play server is to use the [`NettyServer`](
 
 @[simple](code/ScalaEmbeddingPlay.scala)
 
-By default, this will start a server on port 9000 in prod mode.  You can configure the server by passing in a [`ServerConfig`](api/scala/play/core/server/ServerConfig.html):
+By default, this will start a server on port 19000 in prod mode.  You can configure the server by passing in a [`ServerConfig`](api/scala/play/core/server/ServerConfig.html):
 
 @[config](code/ScalaEmbeddingPlay.scala)
 


### PR DESCRIPTION
Code uses port 19000, comment says 9000.
The java template uses port 19000 in the code, so I assume the comment for the scala equivalent is incorrect.