### PR TITLE
Fix Json.format macro for classes with custom apply method

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -105,7 +105,7 @@ object JsMacroImpl {
     val applies =
       companionType.decl(TermName("apply")) match {
         case NoSymbol => c.abort(c.enclosingPosition, "No apply function found")
-        case s => s.asMethod.alternatives
+        case s => s.asTerm.alternatives
       }
 
     // Find an apply method that matches the unapply

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -71,6 +71,11 @@ object Person2 {
   implicit val person2Fmt: OFormat[Person2] = Json.format[Person2]
 }
 
+case class CustomApply(a: Int, b: String)
+object CustomApply {
+  def apply(): CustomApply = apply(10, "foo")
+}
+
 object JsonExtensionSpec extends Specification {
 
   "JsonExtension" should {
@@ -544,6 +549,16 @@ object JsonExtensionSpec extends Specification {
       implicit val toto2Writes = Json.writes[Toto2]
       implicit val toto2Format = Json.format[Toto2]
       success
+    }
+
+    "create a format[CustomApply]" in {
+      import play.api.libs.json.Json
+
+      implicit val fmt = Json.format[CustomApply]
+
+      Json.fromJson[CustomApply](Json.obj("a" -> 5, "b" -> "foo")) must beEqualTo(JsSuccess(CustomApply(5, "foo")))
+      Json.toJson(CustomApply(5, "foo")) must beEqualTo(Json.obj("a" -> 5, "b" -> "foo"))
+      Json.toJson(CustomApply()) must beEqualTo(Json.obj("a" -> 10, "b" -> "foo"))
     }
 
   }


### PR DESCRIPTION
Fixes #2031 

The json macro should always generate using the primary constructor of the case class.

As far as I can tell this was 99% implemented already. There was some logic to detect the correct apply method from several alternatives. We just need to use `asTerm` instead of `asMethod` as the error in #2031 indicates.