### PR TITLE
Wip/ws request streaming

### DIFF
--- a/documentation/manual/detailedTopics/configuration/ws/code/HowsMySSLSpec.scala
+++ b/documentation/manual/detailedTopics/configuration/ws/code/HowsMySSLSpec.scala
@@ -4,6 +4,9 @@ package detailedtopics.configuration.ws {
 
 import java.io.File
 
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+
 import play.api.{Mode, Environment}
 import play.api.libs.json.JsSuccess
 import play.api.libs.ws._
@@ -13,7 +16,15 @@ import play.api.test._
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import scala.concurrent.duration._
 
-class HowsMySSLSpec extends PlaySpecification {
+import org.specs2.specification.AfterAll
+
+class HowsMySSLSpec extends PlaySpecification with AfterAll {
+  val system = ActorSystem("howsMySSLSpec")
+  implicit val materializer = ActorMaterializer()(system)
+
+  def afterAll(): Unit = {
+    system.shutdown()
+  }
 
   def createClient(rawConfig: play.api.Configuration): WSClient = {
     val classLoader = Thread.currentThread().getContextClassLoader

--- a/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaEmbeddingPlay.java
+++ b/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaEmbeddingPlay.java
@@ -4,6 +4,8 @@
 package javaguide.advanced.embedding;
 
 import org.asynchttpclient.AsyncHttpClientConfig;
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import play.libs.F;
@@ -13,10 +15,13 @@ import play.libs.ws.ning.NingWSClient;
 import java.util.function.Consumer;
 
 //#imports
+import javax.inject.Inject;
+import play.api.Play;
 import play.Mode;
 import play.routing.RoutingDsl;
 import play.server.Server;
 import static play.mvc.Controller.*;
+import akka.stream.Materializer;
 //#imports
 
 import static org.hamcrest.CoreMatchers.*;
@@ -73,7 +78,8 @@ public class JavaEmbeddingPlay {
     }
 
     private void withClient(Consumer<WSClient> callback) {
-        try (WSClient client = new NingWSClient(new AsyncHttpClientConfig.Builder().build())) {
+        Materializer materializer = Play.current().materializer();
+        try (WSClient client = new NingWSClient(new AsyncHttpClientConfig.Builder().build(), materializer)) {
             callback.accept(client);
         }
     }

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -31,6 +31,7 @@ import play.api.libs.ws.ning.NingWSClientConfigFactory;
 import play.api.libs.ws.ssl.SSLConfigFactory;
 import play.api.libs.ws.ning.NingAsyncHttpClientConfigBuilder;
 import scala.concurrent.duration.Duration;
+import akka.stream.Materializer;
 // #ws-custom-client-imports
 
 public class JavaWS {
@@ -182,7 +183,8 @@ public class JavaWS {
                             .setProxyServer(new org.asynchttpclient.proxy.ProxyServer("127.0.0.1", 38080))
                             .setCompressionEnforced(true)
                             .build();
-            WSClient customClient = new play.libs.ws.ning.NingWSClient(customConfig);
+            Materializer materializer = play.api.Play.current().materializer();
+            WSClient customClient = new play.libs.ws.ning.NingWSClient(customConfig, materializer);
 
             Promise<WSResponse> responsePromise = customClient.url("http://example.com/feed").get();
             // #ws-custom-client

--- a/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
@@ -28,6 +28,7 @@ import client._
 
 //#full-test
 import play.core.server.Server
+import play.api.Play
 import play.api.routing.sird._
 import play.api.mvc._
 import play.api.libs.json._
@@ -49,6 +50,7 @@ object GitHubClientSpec extends Specification with NoTimeConversions {
           Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
         }
       } { implicit port =>
+        implicit val materializer = Play.current.materializer
         WsTestClient.withClient { client =>
           val result = Await.result(
             new GitHubClient(client, "").repositories(), 10.seconds)
@@ -91,6 +93,7 @@ object ScalaTestingWebServiceClients extends Specification with NoTimeConversion
 
     "allow sending a resource" in {
       //#send-resource
+      import play.api.Play
       import play.api.mvc._
       import play.api.routing.sird._
       import play.api.test._
@@ -101,6 +104,7 @@ object ScalaTestingWebServiceClients extends Specification with NoTimeConversion
           Results.Ok.sendResource("github/repositories.json")
         }
       } { implicit port =>
+        implicit val materializer = Play.current.materializer
         //#send-resource
         WsTestClient.withClient { client =>
           Await.result(new GitHubClient(client, "").repositories(), 10.seconds) must_== Seq("octocat/Hello-World")
@@ -110,6 +114,7 @@ object ScalaTestingWebServiceClients extends Specification with NoTimeConversion
 
     "allow being dry" in {
       //#with-github-client
+      import play.api.Play
       import play.api.mvc._
       import play.api.routing.sird._
       import play.core.server.Server
@@ -121,6 +126,7 @@ object ScalaTestingWebServiceClients extends Specification with NoTimeConversion
             Results.Ok.sendResource("github/repositories.json")
           }
         } { implicit port =>
+          implicit val materializer = Play.current.materializer
           WsTestClient.withClient { client =>
             block(new GitHubClient(client, ""))
           }

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -55,7 +55,7 @@ object Dependencies {
   )
   val javassist = link
 
-  val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.5.0"
+  val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.7.0"
   val scalaParserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1"
 
   val springFrameworkVersion = "4.1.6.RELEASE"

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -108,9 +108,8 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
         // FIXME: should do something with the content-length?
         pubr
       case HttpEntity.Chunked(contentType, chunks) =>
-        // FIXME: Don't enumerate LastChunk?
         // FIXME: do something with trailing headers?
-        chunks.map(_.data())
+        chunks.takeWhile(!_.isLastChunk).map(_.data())
     }
   }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
@@ -5,6 +5,7 @@
 package play.it.action
 
 import org.specs2.mutable.Specification
+import play.api.Play
 import play.api.http.HeaderNames._
 import play.api.http.Status._
 import play.api.libs.iteratee.Enumerator
@@ -52,6 +53,7 @@ trait HeadActionSpec extends Specification with FutureAwaits with DefaultAwaitTi
     def withServer[T](block: WSClient => T): T = {
       // Routes from HttpBinApplication
       Server.withRouter()(routes) { implicit port =>
+        implicit val mat = Play.current.materializer
         WsTestClient.withClient(block)
       }
     }
@@ -60,6 +62,7 @@ trait HeadActionSpec extends Specification with FutureAwaits with DefaultAwaitTi
       Server.withRouter() {
         case _ => action
       } { implicit port =>
+        implicit val mat = Play.current.materializer
         WsTestClient.withClient(block)
       }
     }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
@@ -32,7 +32,9 @@ trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecificat
   })
 
   def withClientAndServer[T](block: WSClient => T) = {
-    Server.withApplication(appWithRedirect) { implicit port =>
+    val app = appWithRedirect
+    import app.materializer
+    Server.withApplication(app) { implicit port =>
       withClient(block)
     }
   }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
@@ -4,6 +4,7 @@
 package play.it.http.assets
 
 import controllers.Assets
+import play.api.Play
 import play.api.libs.ws.WSClient
 import play.api.test._
 import org.apache.commons.io.IOUtils
@@ -29,6 +30,7 @@ trait AssetsSpec extends PlaySpecification
       Server.withRouter(ServerConfig(mode = Mode.Prod, port = Some(0))) {
         case req => Assets.versioned("/testassets", req.path)
       } { implicit port =>
+        implicit val materializer = Play.current.materializer
         withClient(block)
       }
     }
@@ -208,6 +210,7 @@ trait AssetsSpec extends PlaySpecification
         Server.withRouter() {
           case req => Assets.versioned("/scala", req.path)
         } { implicit port =>
+          implicit val materializer = Play.current.materializer
           withClient { client =>
             await(client.url("/collection").get()).status must_== NOT_FOUND
           }

--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -37,6 +37,7 @@ trait DefaultFiltersSpec extends FiltersSpec {
     }.application
 
     Server.withApplication(app) { implicit port =>
+      import app.materializer
       WsTestClient.withClient(block)
     }
 
@@ -48,7 +49,7 @@ trait GlobalFiltersSpec extends FiltersSpec {
 
     import play.api.inject.bind
 
-    val appBuilder = new GuiceApplicationBuilder()
+    val app = new GuiceApplicationBuilder()
       .configure(settings)
       .overrides(bind[Router].toInstance(testRouter))
       .global(
@@ -57,9 +58,10 @@ trait GlobalFiltersSpec extends FiltersSpec {
             errorHandler.fold(super.onHandlerNotFound(request))(_.onClientError(request, 404, ""))
           }
         }
-      )
+      ).build()
 
-    Server.withApplication(appBuilder.build()) { implicit port =>
+    Server.withApplication(app) { implicit port =>
+      import app.materializer
       WsTestClient.withClient(block)
     }
   }

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
@@ -5,6 +5,10 @@ package play.libs.ws;
 
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+
 import play.libs.F;
 
 import java.io.File;
@@ -184,13 +188,21 @@ public interface WSRequest {
 
     /**
      * Set the body this request should use.
+     *
+     * @deprecated use {@link #setBody(Source)} instead.
      */
+    @Deprecated
     WSRequest setBody(InputStream body);
 
     /**
      * Set the body this request should use.
      */
     WSRequest setBody(File body);
+
+    /**
+     * Set the body this request should use.
+     */
+    WSRequest setBody(Source<ByteString,?> body);
 
     /**
      * Adds a header to the request.  Note that duplicate headers are allowed

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSAPI.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSAPI.java
@@ -14,6 +14,10 @@ import play.libs.ws.WSRequest;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.asynchttpclient.AsyncHttpClientConfig;
+
+import akka.stream.Materializer;
+
 /**
  *
  */
@@ -23,10 +27,9 @@ public class NingWSAPI implements WSAPI {
     private final NingWSClient client;
 
     @Inject
-    public NingWSAPI(NingWSClientConfig clientConfig, ApplicationLifecycle lifecycle) {
-        client = new NingWSClient(
-                new NingAsyncHttpClientConfigBuilder(clientConfig).build()
-        );
+    public NingWSAPI(NingWSClientConfig clientConfig, ApplicationLifecycle lifecycle, Materializer materializer) {
+        AsyncHttpClientConfig config = new NingAsyncHttpClientConfigBuilder(clientConfig).build();
+        client = new NingWSClient(config, materializer);
         lifecycle.addStopHook(() -> {
             client.close();
             return F.Promise.pure(null);

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSClient.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSClient.java
@@ -4,6 +4,8 @@
 
 package play.libs.ws.ning;
 
+import akka.stream.Materializer;
+
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.AsyncHttpClientConfig;
 import org.asynchttpclient.DefaultAsyncHttpClient;
@@ -19,9 +21,11 @@ import play.libs.ws.WSRequest;
 public class NingWSClient implements WSClient {
 
     private final AsyncHttpClient asyncHttpClient;
+    private final Materializer materializer;
 
-    public NingWSClient(AsyncHttpClientConfig config) {
+    public NingWSClient(AsyncHttpClientConfig config, Materializer materializer) {
         this.asyncHttpClient = new DefaultAsyncHttpClient(config);
+        this.materializer = materializer;
     }
 
     @Override
@@ -31,7 +35,7 @@ public class NingWSClient implements WSClient {
 
     @Override
     public WSRequest url(String url) {
-        return new NingWSRequest(this, url);
+        return new NingWSRequest(this, url, materializer);
     }
 
     @Override

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSRequest.java
@@ -406,7 +406,7 @@ public class NingWSRequest implements WSRequest {
     public CompletionStage<StreamedResponse> stream() {
     	AsyncHttpClient asyncClient = (AsyncHttpClient) client.getUnderlying();
     	Request request = buildRequest();
-    	return StreamedResponse.from(StreamedRequest.execute(asyncClient, request));
+    	return StreamedResponse.from(Streamed.execute(asyncClient, request));
     }
 
     Request buildRequest() {

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSRequest.java
@@ -4,14 +4,19 @@
 
 package play.libs.ws.ning;
 
+import akka.stream.Materializer;
 import akka.stream.javadsl.*;
+import akka.util.ByteString;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
 import org.asynchttpclient.*;
 import org.asynchttpclient.request.body.generator.FileBodyGenerator;
 import org.asynchttpclient.request.body.generator.InputStreamBodyGenerator;
 import org.asynchttpclient.oauth.OAuthSignatureCalculator;
 import org.asynchttpclient.util.AsyncHttpProviderUtils;
+
+import org.reactivestreams.Publisher;
 
 import io.netty.handler.codec.http.HttpHeaders;
 import play.api.libs.ws.ning.*;
@@ -26,6 +31,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -42,22 +48,24 @@ public class NingWSRequest implements WSRequest {
     private Map<String, Collection<String>> headers = new HashMap<String, Collection<String>>();
     private Map<String, Collection<String>> queryParameters = new HashMap<String, Collection<String>>();
 
-    private String username = null;
-    private String password = null;
-    private WSAuthScheme scheme = null;
-    private WSSignatureCalculator calculator = null;
-    private NingWSClient client = null;
+    private String username;
+    private String password;
+    private WSAuthScheme scheme;
+    private WSSignatureCalculator calculator;
+    private final NingWSClient client;
+
+    private final Materializer materializer;
 
     private int timeout = 0;
     private Boolean followRedirects = null;
     private String virtualHost = null;
 
-    public NingWSRequest(NingWSClient client, String url) {
+    public NingWSRequest(NingWSClient client, String url, Materializer materializer) {
         this.client = client;
         URI reference = URI.create(url);
 
         this.url = url;
-
+        this.materializer = materializer;
         String userInfo = reference.getUserInfo();
         if (userInfo != null) {
             this.setAuth(userInfo);
@@ -222,6 +230,12 @@ public class NingWSRequest implements WSRequest {
     public WSRequest setBody(File body) {
         this.body = body;
         return this;
+    }
+
+    @Override
+    public WSRequest setBody(Source<ByteString,?> body) {
+      this.body = body;
+      return this;
     }
 
     @Override
@@ -480,6 +494,10 @@ public class NingWSRequest implements WSRequest {
             InputStream inputStreamBody = (InputStream) body;
             InputStreamBodyGenerator bodyGenerator = new InputStreamBodyGenerator(inputStreamBody);
             builder.setBody(bodyGenerator);
+        } else if (body instanceof Source) {
+          Source<ByteString,?> sourceBody = (Source<ByteString,?>) body;
+          Publisher<ByteBuffer> publisher = sourceBody.map(ByteString::toByteBuffer).runWith(Sink.publisher(), materializer);
+          builder.setBody(publisher);
         } else {
             throw new IllegalStateException("Impossible body: " + body);
         }

--- a/framework/src/play-java-ws/src/test/scala/play/libs/ws/ning/NingWSRequestSpec.scala
+++ b/framework/src/play-java-ws/src/test/scala/play/libs/ws/ning/NingWSRequestSpec.scala
@@ -9,13 +9,13 @@ class NingWSRequestSpec extends Specification with Mockito {
 
     "should respond to getMethod" in {
       val client = mock[NingWSClient]
-      val request = new NingWSRequest(client, "http://example.com")
+      val request = new NingWSRequest(client, "http://example.com", /*materializer*/ null)
       request.buildRequest().getMethod must be_==("GET")
     }
 
     "should set virtualHost appropriately" in {
       val client = mock[NingWSClient]
-      val request = new NingWSRequest(client, "http://example.com")
+      val request = new NingWSRequest(client, "http://example.com", /*materializer*/ null)
       request.setVirtualHost("foo.com")
       val actual = request.buildRequest().getVirtualHost()
       actual must beEqualTo("foo.com")
@@ -40,7 +40,7 @@ class NingWSRequestSpec extends Specification with Mockito {
 
   def requestWithTimeout(timeout: Long) = {
     val client = mock[NingWSClient]
-    val request = new NingWSRequest(client, "http://example.com")
+    val request = new NingWSRequest(client, "http://example.com", /*materializer*/ null)
     request.setRequestTimeout(timeout)
     request.buildRequest().getRequestTimeout()
   }

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -253,9 +253,7 @@ case class InMemoryBody(bytes: ByteString) extends WSBody
  *
  * @param bytes A flow of the bytes of the body
  */
-case class StreamedBody(bytes: Source[ByteString, Unit]) extends WSBody {
-  throw new NotImplementedError("A streaming request body is not yet implemented")
-}
+case class StreamedBody(bytes: Source[ByteString, Unit]) extends WSBody
 
 /**
  * A file body

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
@@ -139,10 +139,10 @@ case class NingWSRequest(client: NingWSClient,
 
   def execute(): Future[WSResponse] = execute(buildRequest())
 
-  def stream(): Future[StreamedResponse] = StreamedRequest.execute(client.underlying, buildRequest())
+  def stream(): Future[StreamedResponse] = Streamed.execute(client.underlying, buildRequest())
 
   @deprecated("2.5", "Use `stream()` instead.")
-  def streamWithEnumerator(): Future[(WSResponseHeaders, Enumerator[Array[Byte]])] = StreamedRequest.execute2(client.underlying, buildRequest())
+  def streamWithEnumerator(): Future[(WSResponseHeaders, Enumerator[Array[Byte]])] = Streamed.execute2(client.underlying, buildRequest())
 
   /**
    * Returns the current headers of the request, using the request builder.  This may be signed,

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
@@ -3,6 +3,7 @@
  */
 package play.api.libs.ws.ning
 
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import org.asynchttpclient.{ Response => AHCResponse, _ }
@@ -27,6 +28,7 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.TreeMap
 import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration.Duration
+import akka.stream.scaladsl.Sink
 
 /**
  * A WS client backed by a Ning AsyncHttpClient.
@@ -35,7 +37,7 @@ import scala.concurrent.duration.Duration
  *
  * @param config a client configuration object
  */
-case class NingWSClient(config: AsyncHttpClientConfig) extends WSClient {
+case class NingWSClient(config: AsyncHttpClientConfig)(implicit materializer: Materializer) extends WSClient {
 
   private val asyncHttpClient = new DefaultAsyncHttpClient(config)
 
@@ -65,7 +67,7 @@ object NingWSClient {
    *
    * @param config configuration settings
    */
-  def apply(config: NingWSClientConfig = NingWSClientConfig()): NingWSClient = {
+  def apply(config: NingWSClientConfig = NingWSClientConfig())(implicit materializer: Materializer): NingWSClient = {
     val client = new NingWSClient(new NingAsyncHttpClientConfigBuilder(config).build())
     new SystemConfiguration().configure(config.wsClientConfig)
     client
@@ -95,7 +97,7 @@ case class NingWSRequest(client: NingWSClient,
     requestTimeout: Option[Int],
     virtualHost: Option[String],
     proxyServer: Option[WSProxyServer],
-    disableUrlEncoding: Option[Boolean]) extends WSRequest {
+    disableUrlEncoding: Option[Boolean])(implicit materializer: Materializer) extends WSRequest {
 
   def sign(calc: WSSignatureCalculator): WSRequest = copy(calc = Some(calc))
 
@@ -285,8 +287,8 @@ case class NingWSRequest(client: NingWSClient,
         }
 
         builder
-      case StreamedBody(bytes) =>
-        builder
+      case StreamedBody(source) =>
+        builder.setBody(source.map(_.toByteBuffer).runWith(Sink.publisher))
     }
 
     // headers
@@ -371,7 +373,7 @@ class WSClientProvider @Inject() (wsApi: WSAPI) extends Provider[WSClient] {
 }
 
 @Singleton
-class NingWSAPI @Inject() (environment: Environment, clientConfig: NingWSClientConfig, lifecycle: ApplicationLifecycle) extends WSAPI {
+class NingWSAPI @Inject() (environment: Environment, clientConfig: NingWSClientConfig, lifecycle: ApplicationLifecycle)(implicit materializer: Materializer) extends WSAPI {
 
   private val logger = Logger(classOf[NingWSAPI])
 
@@ -544,10 +546,11 @@ trait NingWSComponents {
   def environment: Environment
   def configuration: Configuration
   def applicationLifecycle: ApplicationLifecycle
+  def materializer: Materializer
 
   lazy val wsClientConfig: WSClientConfig = new WSConfigParser(configuration, environment).parse()
   lazy val ningWsClientConfig: NingWSClientConfig =
     new NingWSClientConfigParser(wsClientConfig, configuration, environment).parse()
-  lazy val wsApi: WSAPI = new NingWSAPI(environment, ningWsClientConfig, applicationLifecycle)
+  lazy val wsApi: WSAPI = new NingWSAPI(environment, ningWsClientConfig, applicationLifecycle)(materializer)
   lazy val wsClient: WSClient = wsApi.client
 }

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/Streamed.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/Streamed.scala
@@ -21,7 +21,7 @@ import play.api.libs.ws.StreamedResponse
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 
-private[play] object StreamedRequest {
+private[play] object Streamed {
 
   def execute(client: AsyncHttpClient, request: Request): Future[StreamedResponse] = {
     val promise = Promise[(WSResponseHeaders, Publisher[HttpResponseBodyPart])]()

--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -263,7 +263,7 @@ object BodyParser {
    * }
    * }}}
    */
-  @deprecated("Use Akka streams instead", "2.5.0")
+  @deprecated("Use apply instead", "2.5.0")
   def iteratee[T](f: RequestHeader => Iteratee[ByteString, Either[Result, T]]): BodyParser[T] = {
     iteratee("(no name)")(f)
   }
@@ -278,7 +278,7 @@ object BodyParser {
    * }
    * }}}
    */
-  @deprecated("Use Akka streams instead", "2.5.0")
+  @deprecated("Use apply instead", "2.5.0")
   def iteratee[T](debugName: String)(f: RequestHeader => Iteratee[ByteString, Either[Result, T]]): BodyParser[T] = new BodyParser[T] {
     def apply(rh: RequestHeader) = Streams.iterateeToAccumulator(f(rh))
     override def toString = "BodyParser(" + debugName + ")"


### PR DESCRIPTION
**This PR depends on #5082**

* Bumped version of scala-java8-compat to 0.7.0 ( I thought this was done by @jroper already, but it doesn't look like it's the case) - a590932703aa045de07c5ef08fc31ba60b7864d5
* Improved deprecation message for `Action.iteratee` - 2c4c79cb649f3acc2bcf99b838d8b14ce30e1c8c
* Renamed StreamedRequest into Streamed - 231628da07303306a4ca4d1602c728572a72cd0b
* Don't enumerate request body last chunk in akka-http server - 8597b238ce5c832a7863874562d267ac71f97cba
* Implemented request body streaming for both Java/Scala. Fix #3351 - 1d96a4b2cc9239411a48e0fb2217e398f67780d4

Missing:
* Documentation for request body streaming