### PR TITLE
Bumped async-http-client version to 2.0.0-alpha12

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -275,7 +275,7 @@ object Dependencies {
 
   val playWsDeps = Seq(
     guava,
-    "org.asynchttpclient" % "async-http-client-netty4" % "2.0.0-alpha11"
+    "org.asynchttpclient" % "async-http-client-netty4" % "2.0.0-alpha12"
   ) ++ Seq("signpost-core", "signpost-commonshttp4").map("oauth.signpost" % _  % "1.2.1.2") ++
   (specsBuild :+ specsMatcherExtra).map(_ % Test) :+
   mockitoAll % Test

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
@@ -329,8 +329,7 @@ case class NingWSRequest(client: NingWSClient,
     import org.asynchttpclient.proxy.ProxyServer.Protocol
 
     val protocol: Protocol = wsProxyServer.protocol.getOrElse("http").toLowerCase(java.util.Locale.ENGLISH) match {
-      case "http" => Protocol.HTTP
-      case "https" => Protocol.HTTPS
+      case "http" | "https" => Protocol.HTTP
       case "kerberos" => Protocol.KERBEROS
       case "ntlm" => Protocol.NTLM
       case "spnego" => Protocol.SPNEGO

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
@@ -6,6 +6,7 @@ package play.api.libs.ws.ning
 import akka.util.{ ByteString, Timeout }
 import org.asynchttpclient.cookie.{ Cookie => AHCCookie }
 import org.asynchttpclient.{ AsyncHttpClient, AsyncHttpClientConfig, FluentCaseInsensitiveStringsMap, Param, Response => AHCResponse, Request => AHCRequest }
+import org.asynchttpclient.proxy.ProxyServer
 import org.specs2.mock.Mockito
 import scala.concurrent.duration._
 
@@ -192,7 +193,7 @@ object NingWSSpec extends PlaySpecification with Mockito {
       val req: AHCRequest = WS.url("http://playframework.com/").withProxyServer(proxy).asInstanceOf[NingWSRequest].buildRequest()
       val actual = req.getProxyServer
 
-      actual.getProtocol.getProtocol must be equalTo "https"
+      actual.getProtocol.getProtocol must be equalTo ProxyServer.Protocol.HTTP.getProtocol
       actual.getHost must be equalTo "localhost"
       actual.getPort must be equalTo 8080
       actual.getPrincipal must be equalTo "principal"
@@ -204,7 +205,7 @@ object NingWSSpec extends PlaySpecification with Mockito {
       val req: AHCRequest = WS.url("http://playframework.com/").withProxyServer(proxy).asInstanceOf[NingWSRequest].buildRequest()
       val actual = req.getProxyServer
 
-      actual.getProtocol.getProtocol must be equalTo "http"
+      actual.getProtocol.getProtocol must be equalTo ProxyServer.Protocol.HTTP.getProtocol
       actual.getHost must be equalTo "localhost"
       actual.getPort must be equalTo 8080
       actual.getPrincipal must beNull


### PR DESCRIPTION
The Proxi API has changed a bit in this async-http-client (AHC) release.
Specifically, `HTTPS` protocol can no longer be specified for a proxy instance.
The reason is that  now you can configure both regular and secured ports on a
single instance, hence the `HTTPS` protocol is not needed anymore.

An additional feature offered by AHC is that it now allows to configure different
ports for HTTP and HTTPS. Exposing this feature in Play would require us to
change the Play `WSProxyServer` and add a new member to configure a secure port.
This should be straightforward to implement, but I'm not sure we need it, so I
haven't done it.