### PR TITLE
 Allow '*' to be set as a CORS allowed origin

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
@@ -309,7 +309,7 @@ private[cors] trait AbstractCORSPolicy {
   }
 
   private def isOriginAllowed(origin: String): Boolean = {
-    corsConfig.anyOriginAllowed || corsConfig.allowedOrigins.contains(origin)
+    corsConfig.anyOriginAllowed || corsConfig.allowedOrigins.contains(origin) || corsConfig.allowedOrigins.contains("*")
   }
 
   // http://tools.ietf.org/html/rfc6454#section-7.1


### PR DESCRIPTION
This would allow people to have wildcard "*" in their CORS allowed origins configuration. For example:

```
play.filters.cors {
  ...
  allowedOrigins = ["*"]
  ...
}
```