### PR TITLE
Allow backticks quoted parameters in routes

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
@@ -174,7 +174,11 @@ private[routes] class RoutesFileParser extends JavaTokenParsers {
   // https://github.com/scala/scala/pull/1466
   def javaIdent: Parser[String] = """\p{javaJavaIdentifierStart}\p{javaJavaIdentifierPart}*""".r
 
+  def tickedIdent: Parser[String] = """`[^`]+`""".r
+
   def identifier: Parser[String] = namedError(javaIdent, "Identifier expected")
+
+  def tickedIdentifier: Parser[String] = namedError(tickedIdent, "Identifier expected")
 
   def end: util.matching.Regex = """\s*""".r
 
@@ -272,7 +276,7 @@ private[routes] class RoutesFileParser extends JavaTokenParsers {
     case a ~ _ ~ b => a + b
   }
 
-  def parameter: Parser[Parameter] = (identifier <~ ignoreWhiteSpace) ~ opt(parameterType) ~ (ignoreWhiteSpace ~> opt(parameterDefaultValue | parameterFixedValue)) ^^ {
+  def parameter: Parser[Parameter] = ((identifier | tickedIdentifier) <~ ignoreWhiteSpace) ~ opt(parameterType) ~ (ignoreWhiteSpace ~> opt(parameterDefaultValue | parameterFixedValue)) ^^ {
     case name ~ t ~ d => Parameter(name, t.getOrElse("String"), d.filter(_.startsWith("=")).map(_.drop(1)), d.filter(_.startsWith("?")).map(_.drop(2)))
   }
 

--- a/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/javascriptReverseRouter.scala.twirl
+++ b/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/javascriptReverseRouter.scala.twirl
@@ -29,8 +29,8 @@ package @(packageName).javascript @ob
     def @method: JavaScriptReverseRoute = JavaScriptReverseRoute(
       "@(packageName).@(controller).@(method)",
       @tq
-        function(@reverseParameters(routes).map(_._1.name).mkString(",")) @ob
-          @javascriptCall(route)
+        function(@reverseParametersJavascript(routes).map(_._1.name).mkString(",")) @ob
+          @javascriptCall(route, reverseLocalNames(route, reverseParametersJavascript(routes)))
         @cb
       @tq
     )
@@ -40,7 +40,7 @@ package @(packageName).javascript @ob
     def @method: JavaScriptReverseRoute = JavaScriptReverseRoute(
       "@(packageName).@(controller).@(method)",
       @tq
-        function(@reverseParameters(routes).map(_._1.name).mkString(",")) @ob
+        function(@reverseParametersJavascript(routes).map(_._1.name).mkString(",")) @ob
         @for((route, localNames, constraints) <- javascriptCollectNonDeadRoutes(routes)) {
           if (@constraints) @ob
             @javascriptCall(route, localNames)

--- a/framework/src/routes-compiler/src/test/resources/complexNames.routes
+++ b/framework/src/routes-compiler/src/test/resources/complexNames.routes
@@ -1,0 +1,1 @@
+GET    /foo     controllers.FooController.foo(`bar[]`: List[String])

--- a/framework/src/routes-compiler/src/test/scala/play/routes/compiler/RoutesCompilerSpec.scala
+++ b/framework/src/routes-compiler/src/test/scala/play/routes/compiler/RoutesCompilerSpec.scala
@@ -52,5 +52,10 @@ object RoutesCompilerSpec extends Specification with FileMatchers {
       val file = new File(this.getClass.getClassLoader.getResource("complexTypes.routes").toURI)
       RoutesCompiler.compile(RoutesCompilerTask(file, Seq.empty, true, true, false), StaticRoutesGenerator, tmp) must beRight
     }
+
+    "check if routes with complex names are compiled" in withTempDir { tmp =>
+      val file = new File(this.getClass.getClassLoader.getResource("complexNames.routes").toURI)
+      RoutesCompiler.compile(RoutesCompilerTask(file, Seq.empty, true, true, false), StaticRoutesGenerator, tmp) must beRight
+    }
   }
 }

--- a/framework/src/routes-compiler/src/test/scala/play/routes/compiler/RoutesFileParserSpec.scala
+++ b/framework/src/routes-compiler/src/test/scala/play/routes/compiler/RoutesFileParserSpec.scala
@@ -107,6 +107,11 @@ object RoutesFileParserSpec extends Specification {
       parseRoute("GET /s p.c.m(i: Int = 3)").call.parameters.get.head.fixed must beSome("3")
     }
 
+    "parse argument with complex name" in {
+      parseRoute("GET /s p.c.m(`b[]`: List[String] ?= [])").call.parameters must_== Some(Seq(
+        Parameter("`b[]`", "List[String]", None, Some("[]"))))
+    }
+
     "parse a non instantiating route" in {
       parseRoute("GET /s p.c.m").call.instantiate must_== false
     }

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/controllers/Application.scala
@@ -28,6 +28,12 @@ class Application extends Controller {
   def takeList(x: List[Int]) = Action {
     Ok(x.mkString(","))
   }
+  def takeListTickedParam(`b[]`: List[Int]) = Action {
+    Ok(`b[]`.mkString(","))
+  }
+  def takeTickedParams(`b[]`: List[Int], `b%%`: String) = Action {
+    Ok(`b[]`mkString(",") + " " + `b%%`)
+  }
   def takeJavaList(x: java.util.List[Integer]) = Action {
     Ok(x.mkString(","))
   }

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/utils/JavaScriptRouterGenerator.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/utils/JavaScriptRouterGenerator.scala
@@ -12,7 +12,9 @@ object JavaScriptRouterGenerator extends App {
     Application.index,
     Application.post,
     Application.withParam,
-    Application.takeBool
+    Application.takeBool,
+    Application.takeListTickedParam,
+    Application.takeTickedParams
   ).body
 
   // Add module exports for node

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/conf/routes
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/conf/routes
@@ -13,7 +13,9 @@ GET         /escapes/$i<\d+>        controllers.Application.takeInt(i: Int)
 GET         /take-bool              controllers.Application.takeBool(b: Boolean)
 GET         /take-bool-2/:b         controllers.Application.takeBool2(b: Boolean)
 GET         /take-list              controllers.Application.takeList(x: List[Int])
+GET         /take-list-tick-param   controllers.Application.takeListTickedParam(`b[]`: List[Int])
 GET         /take-java-list         controllers.Application.takeJavaList(x: java.util.List[java.lang.Integer])
+GET         /take-ticked-params     controllers.Application.takeTickedParams(`b[]`: List[Int], `b%%`: String)
 
 GET         /urlcoding/:d/*s        controllers.Application.urlcoding(d, s, q)
 

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/tests/RouterSpec.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/tests/RouterSpec.scala
@@ -58,6 +58,14 @@ object RouterSpec extends PlaySpecification {
       val Some(result) = route(FakeRequest(GET, "/take-java-list?x=1&x=2&x=3"))
       contentAsString(result) must equalTo("1,2,3")
     }
+    "using backticked names on route params" in new WithApplication() {
+      val Some(result) = route(FakeRequest(GET, "/take-list-tick-param?b[]=4&b[]=5&b[]=6"))
+      contentAsString(result) must equalTo("4,5,6")
+    }
+    "using backticked names urlencoded on route params" in new WithApplication() {
+      val Some(result) = route(FakeRequest(GET, "/take-list-tick-param?b%5B%5D=4&b%5B%5D=5&b%5B%5D=6"))
+      contentAsString(result) must equalTo("4,5,6")
+    }
   }
 
   "use a new instance for each instantiated controller" in new WithApplication() {
@@ -125,6 +133,10 @@ object RouterSpec extends PlaySpecification {
     val route = someRoute.get
     route._2 must_== "/with/$param<[^/]+>"
     route._3 must startWith("controllers.Application.withParam")
+  }
+
+  "reverse routes complex query params " in new WithApplication() {
+    controllers.routes.Application.takeListTickedParam(List(1,2,3)).url must_== "/take-list-tick-param?b[]=1&b[]=2&b[]=3"
   }
 
   "choose the first matching route for a call in reverse routes" in new WithApplication() {

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/tests/assets/JavaScriptRouterSpec.js
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/tests/assets/JavaScriptRouterSpec.js
@@ -26,6 +26,19 @@ describe("The JavaScript router", function() {
         var data = jsRoutes.controllers.Application.takeBool(true);
         assert.equal("/take-bool?b=true", data.url);
     });
+    it("should add complex named parameters to the query string", function() {
+        var data = jsRoutes.controllers.Application.takeListTickedParam([1,2,3]);
+        var pname = encodeURI('b[]');
+        qs = [1,2,3].map(function(i){return pname + '=' + i}).join('&');
+        assert.equal("/take-list-tick-param?" + qs, data.url);
+    });
+    it("should avoid name colisions on query string with complex names", function() {
+        var data = jsRoutes.controllers.Application.takeTickedParams([1,2,3], "c");
+        var pname1 = encodeURI('b[]');
+        var pname2 = encodeURI('b%%')
+        qs = [1,2,3].map(function(i){return pname1 + '=' + i}).concat(pname2 + '=c').join('&');
+        assert.equal("/take-ticked-params?" + qs, data.url);
+    });
     it("should properly escape the host", function() {
         var data = jsRoutesBadHost.controllers.Application.index();
         assert(data.absoluteURL().indexOf("'}}};alert(1);a={a:{a:{a:'") >= 0)


### PR DESCRIPTION
fix #4693

Parameter identifiers are being checked against Java identifiers policy,
this adds support for valid backticked Scala identifiers.