### PR TITLE
Documentation for ws streaming request/response body for both Scala and Java

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -107,11 +107,31 @@ Similarly, you can process the response as XML by calling `response.asXml()`.
 
 ### Processing large responses
 
-When you are downloading a large file or document, `WS` allows you to get the response body as an `InputStream` so you can process the data without loading the entire content into memory at once.
+Calling `get()`, `post()` or `execute()` will cause the body of the response to be loaded into memory before the response is made available.  When you are downloading a large, multi-gigabyte file, this may result in unwelcomed garbage collection or even out of memory errors.
 
-@[ws-response-input-stream](code/javaguide/ws/JavaWS.java)
+`WS` lets you consume the response's body incrementally by using an Akka Streams `Sink`.  The `stream()` method on `WSRequest` returns a `CompletionStage<StreamedResponse>`. A `StreamedResponse` is a simple container holding together the response's headers and body.
 
-This example will read the response body and write it to a file in buffered increments.
+Any controller or component that wants to levearge the WS streaming functionality will have to add the following imports and dependencies:
+
+@[ws-streams-controller](code/javaguide/ws/MyController.java)
+
+Here is a trivial example that uses a folding `Sink` to count the number of bytes returned by the response:
+
+@[stream-count-bytes](code/javaguide/ws/JavaWS.java)
+
+Alternatively, you could also stream the body out to another location. For example, a file:
+
+@[stream-to-file](code/javaguide/ws/JavaWS.java)
+
+Another common destination for response bodies is to stream them back from a controller's `Action`:
+
+@[stream-to-result](code/javaguide/ws/JavaWS.java)
+
+As you may have noticed, before calling `stream()` we need to set the HTTP method to use by calling `setMethod` on the request. Here follows another example that uses `PUT` instead of `GET`:
+
+@[stream-put](code/javaguide/ws/JavaWS.java)
+
+Of course, you can use any other valid HTTP verb.
 
 ## Common Patterns and Use Cases
 

--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -79,6 +79,16 @@ The easiest way to post JSON data is to use the [[JSON library|JavaJsonActions]]
 
 @[ws-post-json](code/javaguide/ws/JavaWS.java)
 
+### Streaming data
+
+It's also possible to stream data.
+
+Here is an example showing how you could stream a large image to a different endpoint for further processing:
+
+@[ws-stream-request](code/javaguide/ws/JavaWS.java)
+
+The `largeImage` in the code snippet above is an Akka Streams `Source<ByteString, ?>`.
+
 ## Processing the Response
 
 Working with the [`WSResponse`](api/java/play/libs/ws/WSResponse.html) is done by mapping inside the `Promise`.

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -15,14 +15,24 @@ import com.fasterxml.jackson.databind.JsonNode;
 import play.libs.Json;
 // #json-imports
 
+import scala.compat.java8.FutureConverters;
+
 import java.io.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.*;
 
 import org.w3c.dom.Document;
 import play.mvc.Result;
 
 import javax.inject.Inject;
+
+import play.http.HttpEntity;
+import play.mvc.Http.Status;
 
 // #ws-custom-client-imports
 import org.asynchttpclient.*;
@@ -44,6 +54,7 @@ public class JavaWS {
     public static class Controller0 extends MockJavaAction {
 
         private WSClient ws;
+        private Materializer materializer;
 
         public void requestExamples() {
             // #ws-holder
@@ -113,7 +124,7 @@ public class JavaWS {
 
         public void responseExamples() {
 
-          String url = "http://example.com";
+            String url = "http://example.com";
 
             // #ws-response-json
             Promise<JsonNode> jsonPromise = ws.url(url).get().map(response -> {
@@ -126,31 +137,118 @@ public class JavaWS {
                 return response.asXml();
             });
             // #ws-response-xml
-
-            // #ws-response-input-stream
-            Promise<File> filePromise = ws.url(url).get().map(response -> {
-                // write the inputStream to a File
-                File file = new File("/tmp/response.txt");
-
-                try(
-                    InputStream inputStream = response.getBodyAsStream();
-                    OutputStream outputStream = new FileOutputStream(file)
-                ) {
-                    int read = 0;
-                    byte[] buffer = new byte[1024];
-
-                    while ((read = inputStream.read(buffer)) != -1) {
-                        outputStream.write(buffer, 0, read);
-                    }
-
-                    return file;
-                } catch(IOException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-            // #ws-response-input-stream
         }
 
+        public void streamSimpleRequest() {
+            String url = "http://example.com";
+            // #stream-count-bytes
+            // Make the request
+            CompletionStage<StreamedResponse> futureResponse = 
+                ws.url(url).setMethod("GET").stream();
+
+            CompletionStage<Long> bytesReturned = futureResponse.thenCompose(res -> {
+                Source<ByteString, ?> responseBody = res.getBody();
+
+                // Count the number of bytes returned
+                Sink<ByteString, scala.concurrent.Future<Long>> bytesSum =
+                    Sink.fold(0L, (total, bytes) -> total + bytes.length());
+
+                // Converts the materialized Scala Future into a Java8 `CompletionStage`
+                Sink<ByteString, CompletionStage<Long>> convertedBytesSum =
+                    bytesSum.mapMaterializedValue(FutureConverters::toJava);
+
+                return responseBody.runWith(convertedBytesSum, materializer);
+            });
+            // #stream-count-bytes
+        }
+
+        public void streamFile() throws IOException, FileNotFoundException, InterruptedException, ExecutionException {
+            String url = "http://example.com";
+            //#stream-to-file
+            File file = File.createTempFile("stream-to-file-", ".txt");
+            FileOutputStream outputStream = new FileOutputStream(file);
+
+            // Make the request
+            CompletionStage<StreamedResponse> futureResponse =
+                ws.url(url).setMethod("GET").stream();
+
+            CompletionStage<File> downloadedFile = futureResponse.thenCompose(res -> {
+                Source<ByteString, ?> responseBody = res.getBody();
+
+                // The sink that writes to the output stream
+                Sink<ByteString,scala.concurrent.Future<scala.runtime.BoxedUnit>> outputWriter = 
+                    Sink.<ByteString>foreach(bytes -> outputStream.write(bytes.toArray()));
+
+                // Converts the materialized Scala Future into a Java8 `CompletionStage`
+                Sink<ByteString, CompletionStage<?>> convertedOutputWriter =
+                    outputWriter.mapMaterializedValue(FutureConverters::toJava);
+
+                // materialize and run the stream
+                CompletionStage<File> result = responseBody.runWith(convertedOutputWriter, materializer)
+                    .whenComplete((value, error) -> {
+                        // Close the output stream whether there was an error or not
+                        try { outputStream.close(); }
+                        catch(IOException e) {}
+                    })
+                    .thenApply(v -> file);
+                return result;
+            });
+            //#stream-to-file
+            downloadedFile.toCompletableFuture().get();
+            file.delete();
+        }
+
+        public void streamResponse() {
+            String url = "http://example.com";
+            //#stream-to-result
+            // Make the request
+            CompletionStage<StreamedResponse> futureResponse = ws.url(url).setMethod("GET").stream();
+
+            CompletionStage<Result> result = futureResponse.thenApply(response -> {
+                WSResponseHeaders responseHeaders = response.getHeaders();
+                Source<ByteString, ?> body = response.getBody();
+                // Check that the response was successful
+                if (responseHeaders.getStatus() == 200) {
+                    // Get the content type
+                    String contentType =
+                        Optional.ofNullable(responseHeaders.getHeaders().get("Content-Type"))
+                        .map(contentTypes -> contentTypes.get(0)).
+                        orElse("application/octet-stream");
+
+                    // If there's a content length, send that, otherwise return the body chunked
+                    Optional<String> contentLength = Optional.ofNullable(responseHeaders.getHeaders()
+                        .get("Content-Length"))
+                        .map(contentLengths -> contentLengths.get(0));
+                    if(contentLength.isPresent()) {
+                        return ok().sendEntity(new HttpEntity.Streamed(
+                            body, 
+                            Optional.of(Long.parseLong(contentLength.get())), 
+                            Optional.of(contentType)
+                        ));
+                    }
+                    else {
+                        return ok().chunked(body).as(contentType);
+                    }
+                }
+                else {
+                    return new Result(Status.BAD_GATEWAY);
+                }
+            });
+            // Your controller's action method should return a `Promise<Result>`, and here we 
+            // shows how the conversion from  `CompletionStage` to `Promise` can be done. This 
+            // won't be needed once https://github.com/playframework/playframework/issues/4691 
+            // is fixed.
+            Promise<Result> actionResult = Promise.wrap(FutureConverters.toScala(result));
+            //#stream-to-result
+        }
+
+        public void streamPut() {
+            String url = "http://example.com";
+            //#stream-put
+            CompletionStage<StreamedResponse> futureResponse  =
+                ws.url(url).setMethod("PUT").setBody("some body").stream();
+            //#stream-put
+        }
         public void patternExamples() {
             String urlOne = "http://localhost:3333/one";
             // #ws-composition
@@ -196,7 +294,7 @@ public class JavaWS {
                             .setProxyServer(new org.asynchttpclient.proxy.ProxyServer("127.0.0.1", 38080))
                             .setCompressionEnforced(true)
                             .build();
-            Materializer materializer = play.api.Play.current().materializer();
+
             WSClient customClient = new play.libs.ws.ning.NingWSClient(customConfig, materializer);
 
             Promise<WSResponse> responsePromise = customClient.url("http://example.com/feed").get();
@@ -237,5 +335,4 @@ public class JavaWS {
         }
         // #composed-call
     }
-
 }

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -17,6 +17,7 @@ import play.libs.Json;
 
 import java.io.*;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.*;
 
 import org.w3c.dom.Document;
 import play.mvc.Result;
@@ -31,7 +32,10 @@ import play.api.libs.ws.ning.NingWSClientConfigFactory;
 import play.api.libs.ws.ssl.SSLConfigFactory;
 import play.api.libs.ws.ning.NingAsyncHttpClientConfigBuilder;
 import scala.concurrent.duration.Duration;
+
 import akka.stream.Materializer;
+import akka.stream.javadsl.*;
+import akka.util.ByteString;
 // #ws-custom-client-imports
 
 public class JavaWS {
@@ -96,6 +100,15 @@ public class JavaWS {
 
             ws.url(url).post(json);
             // #ws-post-json
+
+            String value = IntStream.range(0,100).boxed().
+                map(i -> "abcdefghij").reduce("", (a,b) -> a + b);
+            ByteString seedValue = ByteString.fromString(value);
+            Stream<ByteString> largeSource = IntStream.range(0,10).boxed().map(i -> seedValue);
+            Source<ByteString, ?> largeImage = Source.from(largeSource.collect(Collectors.toList()));
+            // #ws-stream-request
+            Promise<WSResponse> wsResponse = ws.url(url).setBody(largeImage).execute("PUT");
+            // #ws-stream-request
         }
 
         public void responseExamples() {

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/MyController.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/MyController.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package javaguide.ws;
+
+// #ws-streams-controller
+import javax.inject.Inject;
+
+import akka.stream.Materializer;
+import akka.stream.javadsl.*;
+import akka.util.ByteString;
+
+import play.mvc.*;
+import play.libs.ws.*;
+import play.libs.F.Promise;
+
+import scala.compat.java8.FutureConverters;
+
+public class MyController extends Controller {
+
+    @Inject WSClient ws;
+    @Inject Materializer materializer;
+
+    // ...
+}
+// #ws-streams-controller

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -93,6 +93,16 @@ The easiest way to post XML data is to use XML literals.  XML literals are conve
 
 @[scalaws-post-xml](code/ScalaWSSpec.scala)
 
+### Streaming data
+
+It's also possible to stream data.
+
+For example, imagine you have executed a database query that is returning a large image, and you would like to forward that data to a different endpoint for further processing. Ideally, if you can send the data as you receive it from the database, you will reduce latency and also avoid problems resulting from loading in memory a large set of data. If your database access library supports [Reactive Streams](http://www.reactive-streams.org/) (for instance, [Slick](http://slick.typesafe.com/) does), here is an example showing how you could implement the described behavior:
+
+@[scalaws-stream-request](code/ScalaWSSpec.scala)
+
+The `largeImageFromDB` in the code snippet above is an Akka Streams `Source[ByteString, _]`.
+
 ## Processing the Response
 
 Working with the [Response](api/scala/play/api/libs/ws/WSResponse.html) is easily done by mapping inside the [Future](http://www.scala-lang.org/api/current/index.html#scala.concurrent.Future).

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -159,6 +159,8 @@ As you may have noticed, before calling `stream()` we need to set the HTTP metho
 
 @[stream-put](code/ScalaWSSpec.scala)
 
+Of course, you can use any other valid HTTP verb.
+
 ## Common Patterns and Use Cases
 
 ### Chaining WS calls

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -386,7 +386,19 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
         //#stream-count-bytes
         await(bytesReturned) must_== 10000l
       }
-    }
+
+
+    "stream request body" in withServer {
+        case ("PUT", "/") => Action(Ok(""))
+      } { ws =>
+        def largeImageFromDB: Source[ByteString, _] = largeSource
+        //#scalaws-stream-request
+        val wsResponse: Future[WSResponse] = ws.url(url)
+          .withBody(StreamedBody(largeImageFromDB)).execute("PUT")
+        //#scalaws-stream-request
+        await(wsResponse).status must_== 200
+      }
+    }    
 
     "work with for comprehensions" in withServer {
       case ("GET", "/one") =>

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -27,6 +27,8 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import akka.util.ByteString
 
+import scala.concurrent.ExecutionContext
+
 class Application @Inject() (ws: WSClient) extends Controller {
 
 }
@@ -44,6 +46,11 @@ case class Person(name: String, age: Int)
 @RunWith(classOf[JUnitRunner])
 class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
 
+  // #scalaws-context-injected
+  class PersonService @Inject()(implicit context: ExecutionContext) {
+    // ...
+  }
+  // #scalaws-context-injected
   val url = s"http://localhost:$testServerPort/"
 
   // #scalaws-context
@@ -67,17 +74,13 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
   }
 
   /**
-   * An enumerator that produces a large result.
+   * A source that produces a "large" result.
    *
-   * In this case, 10 chunks, each containing abcdefghij repeated 100 times.
+   * In this case, 9 chunks, each containing abcdefghij repeated 100 times.
    */
-  val largeEnumerator = {
-    val bytes = ("abcdefghij" * 100).getBytes("utf-8")
-    import play.api.libs.iteratee._
-    Enumerator.unfold(10) {
-      case 0 => None
-      case seq => Some((seq - 1, bytes))
-    }
+  val largeSource: Source[ByteString, _] = {
+    val source = Source.single(ByteString("abcdefghij" * 100))
+    (1 to 9).foldLeft(source){(acc, _) => (acc ++ source).mapMaterializedValue(_=> ())}
   }
 
   "WS" should {
@@ -274,7 +277,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
       }
 
       "handle as stream" in withServer {
-        case ("GET", "/") => Action(Ok.chunked(largeEnumerator))
+        case ("GET", "/") => Action(Ok.chunked(largeSource))
       } { ws =>
         //#stream-count-bytes
         // Make the request
@@ -293,7 +296,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
       }
 
       "stream to a file" in withServer {
-        case ("GET", "/") => Action(Ok.chunked(largeEnumerator))
+        case ("GET", "/") => Action(Ok.chunked(largeSource))
       } { ws =>
         val file = File.createTempFile("stream-to-file-", ".txt")
         try {
@@ -311,7 +314,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
                 outputStream.write(bytes.toArray)
               }
 
-              // Feed the body into the iteratee
+              // materialize and run the stream
               res.body.runWith(sink).andThen {
                 case result =>
                   // Close the output stream whether there was an error or not
@@ -329,10 +332,8 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
       }
 
       "stream to a result" in withServer {
-        case ("GET", "/") => Action(Ok.chunked(largeEnumerator))
+        case ("GET", "/") => Action(Ok.chunked(largeSource))
       } { ws =>
-        val file = File.createTempFile("stream-to-file-", ".txt")
-        try {
           //#stream-to-result
           def downloadFile = Action.async {
 
@@ -360,21 +361,17 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
             }
           }
           //#stream-to-result
+          val file = File.createTempFile("stream-to-file-", ".txt")
           await(
             downloadFile(FakeRequest())
               .flatMap(_.body.dataStream.runFold(0l)((t, b) => t + b.length))
           ) must_== 10000l
-
-        } finally {
           file.delete()
-        }
       }
 
       "stream when request is a PUT" in withServer {
-        case ("PUT", "/") => Action(Ok.chunked(largeEnumerator))
+        case ("PUT", "/") => Action(Ok.chunked(largeSource))
       } { ws =>
-        import play.api.libs.iteratee._
-
         //#stream-put
         val futureResponse: Future[StreamedResponse] =
           ws.url(url).withMethod("PUT").withBody("some body").stream()

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -253,7 +253,7 @@ case class InMemoryBody(bytes: ByteString) extends WSBody
  *
  * @param bytes A flow of the bytes of the body
  */
-case class StreamedBody(bytes: Source[ByteString, Unit]) extends WSBody
+case class StreamedBody(bytes: Source[ByteString, _]) extends WSBody
 
 /**
  * A file body

--- a/framework/src/play/src/main/java/play/mvc/StatusHeader.java
+++ b/framework/src/play/src/main/java/play/mvc/StatusHeader.java
@@ -250,4 +250,8 @@ public class StatusHeader extends Result {
             throw new RuntimeException(e);
         }
     }
+
+    public Result sendEntity(HttpEntity entity) {
+        return new Result(status(),entity);
+    }
 }


### PR DESCRIPTION
* Added `sendEntity` to the Java Results API
* Improvements in Scala WS documentation
* Documentation for streaming request's bodies for Scala/Java
* Java documentation for streaming response bodies