### PR TITLE
Routes compiler doesn't generate interpolator warnings

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
@@ -363,6 +363,28 @@ package object templates {
     }
   }
 
+  /**
+   * Encode the given String constant as a triple quoted String.
+   *
+   * This will split the String at any $ characters, and use concatenation to concatenate a single $ String followed
+   * be the remainder, this is to avoid "possible missing interpolator" false positive warnings.
+   *
+   * That is to say:
+   *
+   * {{{
+   * /foo/$id<[^/]+>
+   * }}}
+   *
+   * Will be encoded as:
+   *
+   * {{{
+   *   """/foo/""" + "$" + """id<[^/]+>"""
+   * }}}
+   */
+  def encodeStringConstant(constant: String) = {
+    constant.split('$').mkString(tq, s"""$tq + "$$" + $tq""", tq)
+  }
+
   private def encodeable(paramType: String): Boolean = paramType == "String"
 
   def groupRoutesByPackage(routes: Seq[Route]): Map[String, Seq[Route]] = routes.groupBy(_.call.packageName)

--- a/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
+++ b/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
@@ -45,7 +45,7 @@ class Routes(
   def documentation = List(@for((dep, index) <- rules.zipWithIndex) {
     @dep.rule match {
       case Route(verb, path, call, _) if path.parts.isEmpty => {(@tq@verb@tq, this.prefix, @tq@call@tq)}
-      case Route(verb, path, call, _) => {(@tq@verb@tq, this.prefix + (if(this.prefix.endsWith("/")) "" else "/") + @tq@path@tq, @tq@call@tq)}
+      case Route(verb, path, call, _) => {(@tq@verb@tq, this.prefix + (if(this.prefix.endsWith("/")) "" else "/") + @encodeStringConstant(path.toString), @tq@call@tq)}
       case include: Include => {prefixed_@(dep.ident)_@(index).router.documentation}
   },}
     Nil
@@ -68,8 +68,8 @@ case route @ Route(verb, path, call, comments) => {
       "@call.method",
       @call.parameters.filterNot(_.isEmpty).map(params => params.map("classOf[" + _.typeName + "]").mkString(", ")).map("Seq(" + _ + ")").getOrElse("Nil"),
       "@verb",
-      @tq@comments.map(_.comment).mkString("\n")@tq,
-      this.prefix + @tq@path@tq
+      @encodeStringConstant(comments.map(_.comment).mkString("\n")),
+      this.prefix + @encodeStringConstant(path.toString)
     )
   )
 }

--- a/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/forwardsRouter.scala.twirl
+++ b/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/forwardsRouter.scala.twirl
@@ -43,7 +43,7 @@ class Routes extends GeneratedRouter {
   def documentation: Seq[(String, String, String)] = List(@for((rule, index) <- rules.zipWithIndex) {
     @rule match {
       case Route(verb, path, call, _) if path.parts.isEmpty => {(@tq@verb@tq, prefix, @tq@call@tq)}
-      case Route(verb, path, call, _) => {(@tq@verb@tq, prefix + (if(prefix.endsWith("/")) "" else "/") + @tq@path@tq, @tq@call@tq)}
+      case Route(verb, path, call, _) => {(@tq@verb@tq, prefix + (if(prefix.endsWith("/")) "" else "/") + @encodeStringConstant(path.toString), @tq@call@tq)}
       case include: Include => {@(routerIdentifier(include, index)).router.documentation}
   },}
     Nil
@@ -66,8 +66,8 @@ case (route @ Route(verb, path, call, comments), index) => {
       "@call.method",
       @call.parameters.filterNot(_.isEmpty).map(params => params.map("classOf[" + _.typeName + "]").mkString(", ")).map("Seq(" + _ + ")").getOrElse("Nil"),
       "@verb",
-      @tq@comments.map(_.comment).mkString("\n")@tq,
-      this.prefix + @tq@path@tq
+      @encodeStringConstant(comments.map(_.comment).mkString("\n")),
+      this.prefix + @encodeStringConstant(path.toString)
     )
   )
 }

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/controllers/Application.scala
@@ -46,4 +46,7 @@ class Application extends Controller {
   def hello = Action {
     Ok("Hello world!")
   }
+  def interpolatorWarning(parameter: String) = Action {
+    Ok(parameter)
+  }
 }

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/conf/routes
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/conf/routes
@@ -68,3 +68,7 @@ GET         /routestest             controllers.Application.routetest(yield)
 GET         /routesdefault          controllers.Application.routedefault(type ?= "x")
 
 GET         /public/*file           controllers.Assets.versioned(path="/public", file: Asset)
+
+# This triggers a string interpolation warning, since there is an identifier called "routes" in scope, and it
+# generates a non interpolated string containing $routes. As does this comment.
+GET					/intwarn/:routes        controllers.Application.interpolatorWarning(routes)

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/controllers/Application.scala
@@ -46,4 +46,7 @@ object Application extends Controller {
   def hello = Action {
     Ok("Hello world!")
   }
+  def interpolatorWarning(parameter: String) = Action {
+    Ok(parameter)
+  }
 }

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/conf/routes
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/conf/routes
@@ -68,3 +68,7 @@ GET         /routestest             controllers.Application.routetest(yield)
 GET         /routesdefault          controllers.Application.routedefault(type ?= "x")
 
 GET         /public/*file           controllers.Assets.versioned(path="/public", file: Asset)
+
+# This triggers a string interpolation warning, since there is an identifier called "routes" in scope, and it
+# generates a non interpolated string containing $routes. As does this comment.
+GET         /intwarn/:routes        controllers.Application.interpolatorWarning(routes)


### PR DESCRIPTION
Fixes #5134

The routes generator generates a number of String constants. If these constants contain something that look like an interpolated string, eg, they have "$foo" and foo is an identifier in scope, the Scala compiler will output a warning about a possible missing interpolator.  This change encodes Strings to work around this heuristic, avoiding false positive warnings, both from the generated path String (which uses $ to indicate path parameters), and from comments.