### PR TITLE
Fix routes prefix file missing for forwardsRouter

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesGenerator.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesGenerator.scala
@@ -53,6 +53,12 @@ object StaticRoutesGenerator extends RoutesGenerator {
     val sourceInfo = RoutesSourceInfo(task.file.getCanonicalPath.replace(File.separator, "/"), new java.util.Date().toString)
     val routes = rules.collect { case r: Route => r }
 
+    val coreRouterFiles = if (task.forwardsRouter || task.reverseRouter) {
+      Seq(folder + RoutesPrefixFile -> generateRoutesPrefix(sourceInfo, namespace))
+    } else {
+      Nil
+    }
+
     val forwardsRoutesFiles = if (task.forwardsRouter) {
       Seq(folder + ForwardsRoutesFile -> generateRouter(sourceInfo, namespace, task.additionalImports, rules))
     } else {
@@ -60,15 +66,14 @@ object StaticRoutesGenerator extends RoutesGenerator {
     }
 
     val reverseRoutesFiles = if (task.reverseRouter) {
-      Seq(folder + RoutesPrefixFile -> generateRoutesPrefix(sourceInfo, namespace)) ++
-        generateReverseRouters(sourceInfo, namespace, task.additionalImports, routes, task.namespaceReverseRouter) ++
+      generateReverseRouters(sourceInfo, namespace, task.additionalImports, routes, task.namespaceReverseRouter) ++
         generateJavaScriptReverseRouters(sourceInfo, namespace, task.additionalImports, routes, task.namespaceReverseRouter) ++
         generateJavaWrappers(sourceInfo, namespace, rules, task.namespaceReverseRouter)
     } else {
       Nil
     }
 
-    forwardsRoutesFiles ++ reverseRoutesFiles
+    coreRouterFiles ++ forwardsRoutesFiles ++ reverseRoutesFiles
   }
 
   private def generateRouter(sourceInfo: RoutesSourceInfo, namespace: Option[String], additionalImports: Seq[String], rules: List[Rule]) =
@@ -150,6 +155,12 @@ object InjectedRoutesGenerator extends RoutesGenerator {
     val sourceInfo = RoutesSourceInfo(task.file.getCanonicalPath.replace(File.separator, "/"), new java.util.Date().toString)
     val routes = rules.collect { case r: Route => r }
 
+    val coreRouterFiles = if (task.forwardsRouter || task.reverseRouter) {
+      Seq(folder + RoutesPrefixFile -> generateRoutesPrefix(sourceInfo, namespace))
+    } else {
+      Nil
+    }
+
     val forwardsRoutesFiles = if (task.forwardsRouter) {
       Seq(folder + ForwardsRoutesFile -> generateRouter(sourceInfo, namespace, task.additionalImports, rules))
     } else {
@@ -157,15 +168,14 @@ object InjectedRoutesGenerator extends RoutesGenerator {
     }
 
     val reverseRoutesFiles = if (task.reverseRouter) {
-      Seq(folder + RoutesPrefixFile -> generateRoutesPrefix(sourceInfo, namespace)) ++
-        generateReverseRouters(sourceInfo, namespace, task.additionalImports, routes, task.namespaceReverseRouter) ++
+      generateReverseRouters(sourceInfo, namespace, task.additionalImports, routes, task.namespaceReverseRouter) ++
         generateJavaScriptReverseRouters(sourceInfo, namespace, task.additionalImports, routes, task.namespaceReverseRouter) ++
         generateJavaWrappers(sourceInfo, namespace, rules, task.namespaceReverseRouter)
     } else {
       Nil
     }
 
-    forwardsRoutesFiles ++ reverseRoutesFiles
+    coreRouterFiles ++ forwardsRoutesFiles ++ reverseRoutesFiles
   }
 
   private def generateRouter(sourceInfo: RoutesSourceInfo, namespace: Option[String], additionalImports: Seq[String], rules: List[Rule]) = {

--- a/framework/src/routes-compiler/src/test/scala/play/routes/compiler/RoutesCompilerSpec.scala
+++ b/framework/src/routes-compiler/src/test/scala/play/routes/compiler/RoutesCompilerSpec.scala
@@ -43,6 +43,39 @@ object RoutesCompilerSpec extends Specification with FileMatchers {
       new File(tmp, "controllers/routes.java") must exist
     }
 
+    "do not generate reverse routes when told so" in withTempDir { tmp =>
+      val file = new File(this.getClass.getClassLoader.getResource("generating.routes").toURI)
+      RoutesCompiler.compile(RoutesCompilerTask(file, Seq.empty, true, false, false), StaticRoutesGenerator, tmp)
+
+      new File(tmp, "generating/Routes.scala") must exist
+      new File(tmp, "generating/RoutesPrefix.scala") must exist
+      new File(tmp, "controllers/ReverseRoutes.scala") mustNotEqual exist
+      new File(tmp, "controllers/javascript/JavaScriptReverseRoutes.scala") mustNotEqual exist
+      new File(tmp, "controllers/routes.java") mustNotEqual exist
+    }
+
+    "do not generate forward routes when told so" in withTempDir { tmp =>
+      val file = new File(this.getClass.getClassLoader.getResource("generating.routes").toURI)
+      RoutesCompiler.compile(RoutesCompilerTask(file, Seq.empty, false, true, false), StaticRoutesGenerator, tmp)
+
+      new File(tmp, "generating/Routes.scala") mustNotEqual exist
+      new File(tmp, "generating/RoutesPrefix.scala") must exist
+      new File(tmp, "controllers/ReverseRoutes.scala") must exist
+      new File(tmp, "controllers/javascript/JavaScriptReverseRoutes.scala") must exist
+      new File(tmp, "controllers/routes.java") must exist
+    }
+
+    "generate nothing when everything is disabled" in withTempDir { tmp =>
+      val file = new File(this.getClass.getClassLoader.getResource("generating.routes").toURI)
+      RoutesCompiler.compile(RoutesCompilerTask(file, Seq.empty, false, false, false), StaticRoutesGenerator, tmp)
+
+      new File(tmp, "generating/Routes.scala") mustNotEqual exist
+      new File(tmp, "generating/RoutesPrefix.scala") mustNotEqual exist
+      new File(tmp, "controllers/ReverseRoutes.scala") mustNotEqual exist
+      new File(tmp, "controllers/javascript/JavaScriptReverseRoutes.scala") mustNotEqual exist
+      new File(tmp, "controllers/routes.java") mustNotEqual exist
+    }
+
     "check if there are no routes using overloaded handler methods" in withTempDir { tmp =>
       val file = new File(this.getClass.getClassLoader.getResource("duplicateHandlers.routes").toURI)
       RoutesCompiler.compile(RoutesCompilerTask(file, Seq.empty, true, true, false), StaticRoutesGenerator, tmp) must beLeft

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/test
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/test
@@ -18,19 +18,19 @@ $ exists common/target/routes/main/controllers/c/routes.java
 -$ exists common/target/routes/main/b/Routes.scala
 -$ exists common/target/routes/main/c/Routes.scala
 
--$ exists a/target/routes/main/a/RoutesPrefix.scala
+$ exists a/target/routes/main/a/RoutesPrefix.scala
 -$ exists a/target/routes/main/controllers/a/ReverseRoutes.scala
 -$ exists a/target/routes/main/controllers/a/javascript/JavaScriptReverseRoutes.scala
 -$ exists a/target/routes/main/controllers/a/routes.java
 $ exists a/target/routes/main/a/Routes.scala
 
--$ exists b/target/routes/main/b/RoutesPrefix.scala
+$ exists b/target/routes/main/b/RoutesPrefix.scala
 -$ exists b/target/routes/main/controllers/b/ReverseRoutes.scala
 -$ exists b/target/routes/main/controllers/b/javascript/JavaScriptReverseRoutes.scala
 -$ exists b/target/routes/main/controllers/b/routes.java
 $ exists b/target/routes/main/b/Routes.scala
 
--$ exists c/target/routes/main/c/RoutesPrefix.scala
+$ exists c/target/routes/main/c/RoutesPrefix.scala
 -$ exists c/target/routes/main/controllers/c/ReverseRoutes.scala
 -$ exists c/target/routes/main/controllers/c/javascript/JavaScriptReverseRoutes.scala
 -$ exists c/target/routes/main/controllers/c/routes.java


### PR DESCRIPTION
When you'd disable the reverseRouter, forwardsRouter would fail because it can't find the RoutesPrefix class.
This change makes routes-compiler generate it whenever forwardsRouter and/or reverseRouter are enabled.

Originally reported to me by @wbouvy