### PR TITLE
ApplicationLifecycle stop hook can take an existential type

### DIFF
--- a/framework/src/play-java/src/main/java/play/inject/DelegateApplicationLifecycle.java
+++ b/framework/src/play-java/src/main/java/play/inject/DelegateApplicationLifecycle.java
@@ -20,7 +20,7 @@ public class DelegateApplicationLifecycle implements ApplicationLifecycle {
     }
 
     @Override
-    public void addStopHook(final Callable<F.Promise<Void>> hook) {
+    public void addStopHook(final Callable<F.Promise<?>> hook) {
         delegate.addStopHook(hook);
     }
 }

--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -225,7 +225,7 @@ case class FakeApplication(
   override def plugins: Seq[Plugin.Deprecated] = app.plugins
   override def requestHandler: HttpRequestHandler = app.requestHandler
   override def errorHandler: HttpErrorHandler = app.errorHandler
-  override def stop(): Future[Unit] = app.stop()
+  override def stop(): Future[_] = app.stop()
   override def injector: Injector = app.injector
 }
 

--- a/framework/src/play/src/main/java/play/inject/ApplicationLifecycle.java
+++ b/framework/src/play/src/main/java/play/inject/ApplicationLifecycle.java
@@ -25,5 +25,5 @@ public interface ApplicationLifecycle {
      * The stop hook should redeem the returned future when it is finished shutting down.  It is acceptable to stop
      * immediately and return a successful future.
      */
-    public void addStopHook(Callable<F.Promise<Void>> hook);
+    public void addStopHook(Callable<F.Promise<?>> hook);
 }

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -204,7 +204,7 @@ trait Application {
   /**
    * Stop the application.  The returned future will be redeemed when all stop hooks have been run.
    */
-  def stop(): Future[Unit]
+  def stop(): Future[_]
 
   /**
    * Get the injector for this application.


### PR DESCRIPTION
Using an existential type instead of a specific `Unit` or `Void` allows
for better code reuse, and avoids having to map a `Future`/`CompletionStage`
just to make the compiler happy.

We do the same in many places when using an Akka Streams `Source`.

This change was inspired by #5137.