### PR TITLE
Removed used of `sequential` in many Spec test classes

### DIFF
--- a/framework/src/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHttpServerSpec.scala
+++ b/framework/src/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHttpServerSpec.scala
@@ -17,8 +17,6 @@ object AkkaHttpServerSpec extends PlaySpecification with WsTestClient {
   private val runTests: Boolean = (System.getProperty("run.akka.http.tests", "true") == "true")
   skipAllIf(!runTests)
 
-  sequential
-
   def requestFromServer[T](
     path: String)(
       exec: WSRequest => Future[WSResponse])(

--- a/framework/src/play-cache/src/test/scala/play/api/cache/SerializableResultSpec.scala
+++ b/framework/src/play-cache/src/test/scala/play/api/cache/SerializableResultSpec.scala
@@ -8,8 +8,6 @@ import play.api.mvc.{ Result, Results }
 
 class SerializableResultSpec extends PlaySpecification {
 
-  sequential
-
   "SerializableResult" should {
 
     def serializeAndDeserialize(result: Result): Result = {

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -26,8 +26,6 @@ import play.core.DefaultWebCommands
  */
 object CSRFFilterSpec extends CSRFCommonSpecs {
 
-  sequential
-
   "a CSRF filter also" should {
 
     // conditions for adding a token

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -25,8 +25,6 @@ import org.specs2.matcher.DataTables
 
 object GzipFilterSpec extends PlaySpecification with DataTables {
 
-  sequential
-
   "The GzipFilter" should {
 
     "gzip responses" in withApplication(Ok("hello")) { implicit mat =>

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
@@ -21,8 +21,6 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
 
   import SecurityHeadersFilter._
 
-  sequential
-
   class Filters @Inject() (securityHeadersFilter: SecurityHeadersFilter) extends HttpFilters {
     def filters = Seq(securityHeadersFilter)
   }

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
@@ -18,8 +18,6 @@ import scala.concurrent.duration._
 
 object AllowedHostsFilterSpec extends PlaySpecification {
 
-  sequential
-
   private def request(hostHeader: String, uri: String = "/", headers: Seq[(String, String)] = Seq()) = {
     val req = FakeRequest(method = "GET", path = uri)
       .withHeaders(headers: _*)

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
@@ -30,7 +30,6 @@ trait HeadActionSpec extends Specification with FutureAwaits with DefaultAwaitTi
   private def route(verb: String, path: String)(handler: EssentialAction): PartialFunction[(String, String), Handler] = {
     case (v, p) if v == verb && p == path => handler
   }
-  sequential
 
   "HEAD requests" should {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/bindings/GlobalSettingsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/bindings/GlobalSettingsSpec.scala
@@ -23,8 +23,6 @@ object NettyGlobalSettingsSpec extends GlobalSettingsSpec with NettyIntegrationS
 
 trait GlobalSettingsSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
 
-  sequential
-
   def withServer[T](applicationGlobal: Option[String])(uri: String)(block: String => T) = {
     implicit val port = testServerPort
     val additionalSettings = applicationGlobal.fold(Map.empty[String, String]) { s: String =>

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
@@ -12,8 +12,6 @@ object AkkaHttpFlashCookieSpec extends FlashCookieSpec with AkkaHttpIntegrationS
 
 trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecification with WsTestClient {
 
-  sequential
-
   def appWithRedirect = FakeApplication(withRoutes = {
     case ("GET", "/flash") =>
       Action {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -19,8 +19,6 @@ object AkkaHttpJavaResultsHandlingSpec extends JavaResultsHandlingSpec with Akka
 
 trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
 
-  sequential
-
   "Java results handling" should {
     def makeRequest[T](controller: MockController)(block: WSResponse => T) = {
       implicit val port = testServerPort

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -20,8 +20,6 @@ object AkkaHttpScalaResultsHandlingSpec extends ScalaResultsHandlingSpec with Ak
 
 trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
 
-  sequential
-
   "scala body handling" should {
 
     def tryRequest[T](result: Result)(block: Try[WSResponse] => T) = withServer(result) { implicit port =>

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/SecureFlagSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/SecureFlagSpec.scala
@@ -21,8 +21,6 @@ object AkkaHttpSecureFlagSpec extends SecureFlagSpec with AkkaHttpIntegrationSpe
  */
 trait SecureFlagSpec extends PlaySpecification with ServerIntegrationSpecification {
 
-  sequential
-
   /** An action whose result is just "true" or "false" depending on the value of result.secure */
   val secureFlagAction = Action {
     request => Results.Ok(request.secure.toString)

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
@@ -19,8 +19,6 @@ object AkkaHttpAssetsSpec extends AssetsSpec with AkkaHttpIntegrationSpecificati
 trait AssetsSpec extends PlaySpecification
     with WsTestClient with ServerIntegrationSpecification {
 
-  sequential
-
   "Assets controller" should {
 
     val defaultCacheControl = Some("public, max-age=3600")

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -28,8 +28,6 @@ object AkkaHttpWebSocketSpec extends WebSocketSpec with AkkaHttpIntegrationSpeci
 
 trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
 
-  sequential
-
   override implicit def defaultAwaitTimeout = 5.seconds
 
   def withServer[A](webSocket: Application => Handler)(block: => A): A = {

--- a/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
@@ -10,8 +10,6 @@ import play.api.Mode
 
 object MessagesSpec extends PlaySpecification with Controller {
 
-  sequential
-
   implicit val lang = Lang("en-US")
   import play.api.i18n.Messages.Implicits.applicationMessages
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
@@ -35,8 +35,6 @@ trait WSSpec extends PlaySpecification with ServerIntegrationSpecification {
 
   "Web service client" title
 
-  sequential
-
   def app = HttpBinApplication.app
 
   val foldingSink = Sink.fold[ByteString, ByteString](ByteString.empty)((state, bs) => state ++ bs)

--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -69,8 +69,6 @@ trait GlobalFiltersSpec extends FiltersSpec {
 
 trait FiltersSpec extends Specification with ServerIntegrationSpecification {
 
-  sequential
-
   "filters" should {
     "handle errors" in {
 

--- a/framework/src/play-java-ws/src/test/scala/play/libs/oauth/OAuthSpec.scala
+++ b/framework/src/play-java-ws/src/test/scala/play/libs/oauth/OAuthSpec.scala
@@ -15,8 +15,6 @@ import play.api.libs.oauth.OAuthRequestVerifier
 
 class OAuthSpec extends PlaySpecification {
 
-  sequential
-
   val javaConsumerKey = new ConsumerKey("someConsumerKey", "someVerySecretConsumerSecret")
   val javaRequestToken = new RequestToken("someRequestToken", "someVerySecretRequestSecret")
   val oauthCalculator = new OAuthCalculator(javaConsumerKey, javaRequestToken)

--- a/framework/src/play-java-ws/src/test/scala/play/libs/ws/WSSpec.scala
+++ b/framework/src/play-java-ws/src/test/scala/play/libs/ws/WSSpec.scala
@@ -6,8 +6,6 @@ import play.api.test._
 
 object WSSpec extends PlaySpecification {
 
-  sequential
-
   val uploadApp = FakeApplication(withRoutes = {
     case ("POST", "/") =>
       Action { request =>

--- a/framework/src/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
+++ b/framework/src/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
@@ -19,8 +19,6 @@ import scala.concurrent.duration.Duration
 
 object FakesSpec extends PlaySpecification {
 
-  sequential
-
   "FakeApplication" should {
 
     "allow adding routes inline" in {

--- a/framework/src/play-ws/src/test/scala/play/api/libs/oauth/OAuthSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/oauth/OAuthSpec.scala
@@ -13,8 +13,6 @@ import scala.concurrent.{ Future, Promise }
 
 class OAuthSpec extends PlaySpecification {
 
-  sequential
-
   val consumerKey = ConsumerKey("someConsumerKey", "someVerySecretConsumerSecret")
   val requestToken = RequestToken("someRequestToken", "someVerySecretRequestSecret")
   val oauthCalculator = OAuthCalculator(consumerKey, requestToken)

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
@@ -19,8 +19,6 @@ import akka.util.ByteString
 
 object NingWSSpec extends PlaySpecification with Mockito {
 
-  sequential
-
   "Ning WS" should {
 
     object PairMagnet {

--- a/framework/src/play/src/test/scala/play/utils/ResourcesSpec.scala
+++ b/framework/src/play/src/test/scala/play/utils/ResourcesSpec.scala
@@ -50,7 +50,6 @@ object ResourcesSpec extends Specification {
     def openConnection(u: URL): URLConnection = throw new Exception("should never happen")
   }
 
-  sequential
   "resources isDirectory" should {
 
     step {

--- a/framework/src/routes-compiler/src/test/scala/play/routes/compiler/RoutesCompilerSpec.scala
+++ b/framework/src/routes-compiler/src/test/scala/play/routes/compiler/RoutesCompilerSpec.scala
@@ -11,8 +11,6 @@ import play.routes.compiler.RoutesCompiler.RoutesCompilerTask
 
 object RoutesCompilerSpec extends Specification with FileMatchers {
 
-  sequential
-
   "route file compiler" should {
 
     def withTempDir[T](block: File => T) = {


### PR DESCRIPTION
I believe we are overusing the specs2 `sequential` keyword, which forces
examples (i.e., tests) within a Spec class to be ran sequentially. Ideally, we
should allow for as much parallelism as possible, as this should reduce the time
required to run the test suite, and it may help us catch race conditions and
other concurrency hiccups that are otherwise hard to reproduce.

Furthermore, forcing a sequential execution where it's not needed also sends the
wrong message to contributors, and incourage writing tests that cannot be run in
parallel (see the changes in this commit to `ResultSpec`).

Finally, note that the changes in this commit do not affect the way tests are
run in the CI server, because we are already forcing them to run on a single CPU
(check the .travis file, we are passing `"set concurrentRestrictions in Global
+= Tags.limitAll(1)"` to sbt).