### PR TITLE
Bumped typetools' version so that codebase compiles w/ JDK 1.8.0_u60. Fix #5136

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -87,7 +87,7 @@ object Dependencies {
       .exclude("javassist", "javassist"),
 
     // Used by the Java routing DSL
-    "net.jodah" % "typetools" % "0.4.1",
+    "net.jodah" % "typetools" % "0.4.3",
 
     guava,
     findBugs,


### PR DESCRIPTION
PR #5137 requires this PR to be merged first.