### PR TITLE
Replaced iteratees with Akka streams in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ target
 RUNNING_PID
 generated.keystore
 generated.truststore
+*.log
 
 # Scala-IDE specific
 .scala_dependencies

--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -1,4 +1,4 @@
-/*
+/* 
  * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
  */
 
@@ -393,9 +393,7 @@ object PlayBuild extends Build {
   lazy val PlayIntegrationTestProject = PlayCrossBuiltProject("Play-Integration-Test", "play-integration-test")
     .settings(
       parallelExecution in Test := false,
-      previousArtifact := None,
-      // The integration test WebSocket client need a recent version of Netty 3.x
-      libraryDependencies += "io.netty" % "netty" % "3.10.4.Final" % Test
+      previousArtifact := None
     )
     .dependsOn(PlayProject % "test->test", PlayLogback % "test->test", PlayWsProject, PlayWsJavaProject, PlaySpecs2Project)
     .dependsOn(PlayFiltersHelpersProject)

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -19,7 +19,6 @@ import java.util.zip.GZIPInputStream
 import java.io.ByteArrayInputStream
 import org.apache.commons.io.IOUtils
 import scala.concurrent.Future
-import play.api.libs.iteratee.Enumerator
 import scala.util.Random
 import org.specs2.matcher.DataTables
 

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipSpec.scala
@@ -7,7 +7,6 @@ import java.io.ByteArrayOutputStream
 import java.util.zip.GZIPOutputStream
 
 import org.apache.commons.io.IOUtils
-import scala.concurrent.duration._
 
 import concurrent.Await
 import play.api.libs.iteratee.{ Iteratee, Enumeratee, Enumerator }

--- a/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
@@ -25,7 +25,7 @@ trait ServerIntegrationSpecification extends PendingUntilFixed with AroundEach {
    * Retry up to 3 times.
    */
   def around[R: AsResult](r: => R) = {
-    AsResult(EventuallyResults.eventually(3, 20.milliseconds)(r))
+    AsResult(EventuallyResults.eventually(1, 20.milliseconds)(r))
   }
 
   implicit class UntilAkkaHttpFixed[T: AsResult](t: => T) {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.it.http
 
-import java.io.{ ByteArrayInputStream, IOException }
+import java.io.ByteArrayInputStream
 import play.api.Application
 import play.api.test._
 import play.api.libs.ws.WSResponse
@@ -12,7 +12,6 @@ import play.libs.EventSource
 import play.libs.EventSource.Event
 import play.mvc.Results
 import play.mvc.Results.Chunks
-import scala.util.{ Failure, Success, Try }
 
 object NettyJavaResultsHandlingSpec extends JavaResultsHandlingSpec with NettyIntegrationSpecification
 object AkkaHttpJavaResultsHandlingSpec extends JavaResultsHandlingSpec with AkkaHttpIntegrationSpecification

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
@@ -5,20 +5,29 @@
  */
 package play.it.http.websocket
 
-import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
 
-import org.jboss.netty.bootstrap.ClientBootstrap
-import org.jboss.netty.channel._
-import socket.nio.NioClientSocketChannelFactory
-import java.util.concurrent.Executors
-import org.jboss.netty.handler.codec.http._
-import collection.JavaConversions._
-import websocketx._
-import java.net.{ InetSocketAddress, URI }
-import org.jboss.netty.util.CharsetUtil
+import akka.stream.scaladsl._
+import akka.stream.stage.{ Context, PushStage }
+import akka.util.ByteString
+import com.typesafe.netty.{ HandlerPublisher, HandlerSubscriber }
+import io.netty.bootstrap.Bootstrap
+import io.netty.buffer.{ ByteBufHolder, Unpooled }
+import io.netty.channel.socket.SocketChannel
+import io.netty.channel._
+import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.socket.nio.NioSocketChannel
+import io.netty.handler.codec.http._
+import io.netty.handler.codec.http.websocketx._
+
+import java.net.URI
+import io.netty.util.ReferenceCountUtil
+import play.api.http.websocket._
+import play.api.libs.streams.AkkaStreams.EagerFinishMerge
+import play.it.http.websocket.WebSocketClient.ExtendedMessage
+
 import scala.concurrent.{ Promise, Future }
-import play.api.libs.iteratee.Execution.Implicits.trampoline
-import play.api.libs.iteratee._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 /**
  * A basic WebSocketClient.  Basically wraps Netty's WebSocket support into something that's much easier to use and much
@@ -26,14 +35,12 @@ import play.api.libs.iteratee._
  */
 trait WebSocketClient {
 
-  import WebSocketClient._
-
   /**
    * Connect to the given URI.
    *
    * @return A future that will be redeemed when the connection is closed.
    */
-  def connect(url: URI, version: WebSocketVersion = WebSocketVersion.V13)(onConnect: Handler): Future[Unit]
+  def connect(url: URI, version: WebSocketVersion = WebSocketVersion.V13)(onConnect: Flow[ExtendedMessage, ExtendedMessage, _] => Unit): Future[_]
 
   /**
    * Shutdown the client and release all associated resources.
@@ -43,7 +50,15 @@ trait WebSocketClient {
 
 object WebSocketClient {
 
-  type Handler = (Enumerator[WebSocketFrame], Iteratee[WebSocketFrame, _]) => Unit
+  trait ExtendedMessage {
+    def finalFragment: Boolean
+  }
+  object ExtendedMessage {
+    implicit def messageToExtendedMessage(message: Message): ExtendedMessage =
+      SimpleMessage(message, finalFragment = true)
+  }
+  case class SimpleMessage(message: Message, finalFragment: Boolean) extends ExtendedMessage
+  case class ContinuationMessage(data: ByteString, finalFragment: Boolean) extends ExtendedMessage
 
   def create(): WebSocketClient = new DefaultWebSocketClient
 
@@ -62,11 +77,11 @@ object WebSocketClient {
       chf.addListener(new ChannelFutureListener {
         def operationComplete(future: ChannelFuture) = {
           if (future.isSuccess) {
-            promise.success(future.getChannel)
+            promise.success(future.channel())
           } else if (future.isCancelled) {
             promise.failure(new RuntimeException("Future cancelled"))
           } else {
-            promise.failure(future.getCause)
+            promise.failure(future.cause())
           }
         }
       })
@@ -76,22 +91,22 @@ object WebSocketClient {
   }
 
   private class DefaultWebSocketClient extends WebSocketClient {
-    val bootstrap = new ClientBootstrap(new NioClientSocketChannelFactory(Executors.newSingleThreadExecutor(),
-      Executors.newSingleThreadExecutor(), 1, 1))
 
-    bootstrap.setPipelineFactory(new ChannelPipelineFactory {
-      def getPipeline = {
-        val pipeline = Channels.pipeline()
-        pipeline.addLast("decoder", new HttpResponseDecoder)
-        pipeline.addLast("encoder", new HttpRequestEncoder)
-        pipeline
-      }
-    })
+    val eventLoop = new NioEventLoopGroup()
+    val client = new Bootstrap()
+      .group(eventLoop)
+      .channel(classOf[NioSocketChannel])
+      .option(ChannelOption.AUTO_READ, java.lang.Boolean.FALSE)
+      .handler(new ChannelInitializer[SocketChannel] {
+        def initChannel(ch: SocketChannel) = {
+          ch.pipeline().addLast(new HttpClientCodec, new HttpObjectAggregator(8192))
+        }
+      })
 
     /**
      * Connect to the given URI
      */
-    def connect(url: URI, version: WebSocketVersion)(onConnected: (Enumerator[WebSocketFrame], Iteratee[WebSocketFrame, _]) => Unit) = {
+    def connect(url: URI, version: WebSocketVersion)(onConnected: (Flow[ExtendedMessage, ExtendedMessage, _]) => Unit) = {
 
       val normalized = url.normalize()
       val tgt = if (normalized.getPath == null || normalized.getPath.trim().isEmpty) {
@@ -100,10 +115,11 @@ object WebSocketClient {
 
       val disconnected = Promise[Unit]()
 
-      bootstrap.connect(new InetSocketAddress(tgt.getHost, tgt.getPort)).toScala.map { channel =>
-        val handshaker = new WebSocketClientHandshakerFactory().newHandshaker(tgt, version, null, false, Map.empty[String, String])
-        channel.getPipeline.addLast("supervisor", new WebSocketSupervisor(disconnected, handshaker, onConnected))
+      client.connect(tgt.getHost, tgt.getPort).toScala.map { channel =>
+        val handshaker = WebSocketClientHandshakerFactory.newHandshaker(tgt, version, null, false, new DefaultHttpHeaders())
+        channel.pipeline().addLast("supervisor", new WebSocketSupervisor(disconnected, handshaker, onConnected))
         handshaker.handshake(channel)
+        channel.read()
       }.onFailure {
         case t => disconnected.tryFailure(t)
       }
@@ -111,83 +127,141 @@ object WebSocketClient {
       disconnected.future
     }
 
-    def shutdown() = bootstrap.releaseExternalResources()
+    def shutdown() = eventLoop.shutdownGracefully()
   }
 
   private class WebSocketSupervisor(disconnected: Promise[Unit], handshaker: WebSocketClientHandshaker,
-      onConnected: Handler) extends SimpleChannelUpstreamHandler {
-    override def messageReceived(ctx: ChannelHandlerContext, e: MessageEvent) {
-      e.getMessage match {
+      onConnected: Flow[ExtendedMessage, ExtendedMessage, _] => Unit) extends ChannelInboundHandlerAdapter {
+    override def channelRead(ctx: ChannelHandlerContext, msg: Object) {
+      msg match {
         case resp: HttpResponse if handshaker.isHandshakeComplete =>
-          throw new WebSocketException("Unexpected HttpResponse (status=" + resp.getStatus +
-            ", content=" + resp.getContent.toString(CharsetUtil.UTF_8) + ")")
-        case resp: HttpResponse =>
-          handshaker.finishHandshake(ctx.getChannel, e.getMessage.asInstanceOf[HttpResponse])
-          val handler = new WebSocketClientHandler(ctx.getChannel, disconnected)
-          ctx.getPipeline.addLast("websocket", handler)
-          onConnected(handler.enumerator, handler.iteratee)
-        case _: WebSocketFrame => ctx.sendUpstream(e)
-        case _ => throw new WebSocketException("Unexpected event: " + e)
+          throw new WebSocketException("Unexpected HttpResponse (status=" + resp.getStatus + ")")
+        case resp: FullHttpResponse =>
+
+          // Setup the pipeline
+          val publisher = new HandlerPublisher(ctx.executor, classOf[WebSocketFrame])
+          val subscriber = new HandlerSubscriber[WebSocketFrame](ctx.executor)
+          ctx.pipeline.addAfter(ctx.executor, ctx.name, "websocket-subscriber", subscriber)
+          ctx.pipeline.addAfter(ctx.executor, ctx.name, "websocket-publisher", publisher)
+
+          // Now remove ourselves from the chain
+          ctx.pipeline.remove(ctx.name)
+
+          handshaker.finishHandshake(ctx.channel(), resp)
+
+          val clientConnection = Flow.wrap(Sink(subscriber), Source(publisher))(Keep.none)
+
+          onConnected(webSocketProtocol(clientConnection))
+
+        case _ => throw new WebSocketException("Unexpected message: " + msg)
       }
     }
 
-    override def exceptionCaught(ctx: ChannelHandlerContext, e: ExceptionEvent) {
-      disconnected.tryFailure(e.getCause)
-      ctx.getChannel.close()
-      ctx.sendDownstream(e)
-    }
-  }
+    val serverInitiatedClose = new AtomicBoolean
 
-  private class WebSocketClientHandler(out: Channel, disconnected: Promise[Unit]) extends SimpleChannelUpstreamHandler {
+    def webSocketProtocol(clientConnection: Flow[WebSocketFrame, WebSocketFrame, _]): Flow[ExtendedMessage, ExtendedMessage, _] = {
+      val clientInitiatedClose = new AtomicBoolean
 
-    @volatile var clientInitiatedClose = false
-    val (enumerator, in) = Concurrent.broadcast[WebSocketFrame]
-
-    val iteratee: Iteratee[WebSocketFrame, _] = Cont {
-      case Input.El(wsf) =>
-        if (wsf.isInstanceOf[CloseWebSocketFrame]) {
-          clientInitiatedClose = true
+      val captureClientClose = Flow[WebSocketFrame].transform(() => new PushStage[WebSocketFrame, WebSocketFrame] {
+        def onPush(elem: WebSocketFrame, ctx: Context[WebSocketFrame]) = elem match {
+          case close: CloseWebSocketFrame =>
+            clientInitiatedClose.set(true)
+            ctx.push(close)
+          case other =>
+            ctx.push(other)
         }
-        Iteratee.flatten(out.write(wsf).toScala.map(_ => iteratee))
-      case Input.EOF =>
-        disconnected.trySuccess(())
-        Iteratee.flatten(out.close().toScala.map(_ => Done((), Input.EOF)))
-      case Input.Empty => iteratee
-    }
+      })
 
-    override def messageReceived(ctx: ChannelHandlerContext, e: MessageEvent) {
-      e.getMessage match {
-        case close: CloseWebSocketFrame =>
-          in.push(close)
-          if (!clientInitiatedClose) {
-            out.write(close)
+      val messagesToFrames = Flow[ExtendedMessage].map {
+        case SimpleMessage(TextMessage(data), finalFragment) => new TextWebSocketFrame(finalFragment, 0, data)
+        case SimpleMessage(BinaryMessage(data), finalFragment) => new BinaryWebSocketFrame(finalFragment, 0, Unpooled.wrappedBuffer(data.asByteBuffer))
+        case SimpleMessage(PingMessage(data), finalFragment) => new PingWebSocketFrame(finalFragment, 0, Unpooled.wrappedBuffer(data.asByteBuffer))
+        case SimpleMessage(PongMessage(data), finalFragment) => new PongWebSocketFrame(finalFragment, 0, Unpooled.wrappedBuffer(data.asByteBuffer))
+        case SimpleMessage(CloseMessage(statusCode, reason), finalFragment) => new CloseWebSocketFrame(finalFragment, 0, statusCode.getOrElse(CloseCodes.NoStatus), reason)
+        case ContinuationMessage(data, finalFragment) => new ContinuationWebSocketFrame(finalFragment, 0, Unpooled.wrappedBuffer(data.asByteBuffer))
+      }
+
+      val framesToMessages = Flow[WebSocketFrame].map { frame =>
+        val message = frame match {
+          case text: TextWebSocketFrame => SimpleMessage(TextMessage(text.text()), text.isFinalFragment)
+          case binary: BinaryWebSocketFrame => SimpleMessage(BinaryMessage(toByteString(binary)), binary.isFinalFragment)
+          case ping: PingWebSocketFrame => SimpleMessage(PingMessage(toByteString(ping)), ping.isFinalFragment)
+          case pong: PongWebSocketFrame => SimpleMessage(PongMessage(toByteString(pong)), pong.isFinalFragment)
+          case close: CloseWebSocketFrame => SimpleMessage(CloseMessage(Some(close.statusCode()), close.reasonText()), close.isFinalFragment)
+          case continuation: ContinuationWebSocketFrame => ContinuationMessage(toByteString(continuation), continuation.isFinalFragment)
+        }
+        ReferenceCountUtil.release(frame)
+        message
+      }
+
+      messagesToFrames via captureClientClose via Flow() { implicit b =>
+        import FlowGraph.Implicits._
+
+        val broadcast = b.add(Broadcast[WebSocketFrame](2))
+        val merge = b.add(EagerFinishMerge[WebSocketFrame](2))
+
+        val handleServerClose = Flow[WebSocketFrame].filter { frame =>
+          if (frame.isInstanceOf[CloseWebSocketFrame] && !clientInitiatedClose.get()) {
+            serverInitiatedClose.set(true)
+            true
+          } else {
+            // If we're going to drop it, we need to release it first
+            ReferenceCountUtil.release(frame)
+            false
           }
-        case wsf: WebSocketFrame =>
-          in.push(wsf)
-        case _ => throw new WebSocketException("Unexpected event: " + e)
-      }
+        }
+
+        val handleConnectionTerminated = Flow[WebSocketFrame].transform(() => new PushStage[WebSocketFrame, WebSocketFrame] {
+          def onPush(elem: WebSocketFrame, ctx: Context[WebSocketFrame]) = ctx.push(elem)
+          override def onUpstreamFinish(ctx: Context[WebSocketFrame]) = {
+            disconnected.trySuccess(())
+            super.onUpstreamFinish(ctx)
+          }
+          override def onUpstreamFailure(cause: Throwable, ctx: Context[WebSocketFrame]) = {
+            if (serverInitiatedClose.get()) {
+              disconnected.trySuccess(())
+              ctx.finish()
+            } else {
+              disconnected.tryFailure(cause)
+              ctx.fail(cause)
+            }
+          }
+        })
+
+        /**
+         * Since we've got two consumers of the messages when we broadcast, we need to ensure that they get retained for each.
+         */
+        val retainForBroadcast = Flow[WebSocketFrame].map { frame =>
+          ReferenceCountUtil.retain(frame)
+          frame
+        }
+
+        merge.out ~> clientConnection ~> handleConnectionTerminated ~> retainForBroadcast ~> broadcast.in
+        merge.in(0) <~ handleServerClose <~ broadcast.out(0)
+
+        (merge.in(1), broadcast.out(1))
+      } via framesToMessages
     }
 
-    override def exceptionCaught(ctx: ChannelHandlerContext, e: ExceptionEvent) {
-      e.getCause match {
-        case io: IOException =>
-          // We're talking to loopback, an IO exception is probably fine to ignore, if there's a problem, the tests
-          // should catch it.
-          println("IO exception caught in WebSocket client: " + io)
-          disconnected.success(())
-          in.end()
-          out.close()
-        case other =>
-          val exception = new RuntimeException("Exception caught in web socket handler", other)
-          disconnected.tryFailure(exception)
-          in.end(exception)
-          out.close()
-      }
+    def toByteString(data: ByteBufHolder) = {
+      val builder = ByteString.newBuilder
+      data.content().readBytes(builder.asOutputStream, data.content().readableBytes())
+      val bytes = builder.result()
+      bytes
     }
 
-    override def channelClosed(ctx: ChannelHandlerContext, e: ChannelStateEvent) = {
+    override def exceptionCaught(ctx: ChannelHandlerContext, e: Throwable) {
+      if (serverInitiatedClose.get()) {
+        disconnected.trySuccess(())
+      } else {
+        disconnected.tryFailure(e)
+      }
+      ctx.channel.close()
+      ctx.fireExceptionCaught(e)
+    }
+
+    override def channelInactive(ctx: ChannelHandlerContext) = {
       disconnected.trySuccess(())
-      in.end()
     }
   }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -3,24 +3,23 @@
  */
 package play.it.http.websocket
 
-import java.nio.charset.Charset
+import akka.actor._
 import akka.stream.scaladsl._
 import akka.util.ByteString
+import org.specs2.matcher.Matcher
+import play.api.http.websocket._
 import play.api.test._
 import play.api.Application
-import scala.concurrent.{ Future, Promise }
-import scala.concurrent.duration._
 import play.api.mvc.{ Handler, Results, WebSocket }
 import play.api.libs.iteratee._
-import play.it._
-import java.net.URI
-import org.jboss.netty.handler.codec.http.websocketx._
-import org.specs2.matcher.Matcher
-import akka.actor._
 import play.core.routing.HandlerDef
-import java.util.concurrent.atomic.AtomicReference
-import org.jboss.netty.buffer.ChannelBuffers
+import play.it._
+import play.it.http.websocket.WebSocketClient.{ContinuationMessage, SimpleMessage, ExtendedMessage}
+import scala.concurrent.{ Future, Promise }
+import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import java.net.URI
+import java.util.concurrent.atomic.AtomicReference
 import java.util.function.{ Consumer, Function }
 
 object NettyWebSocketSpec extends WebSocketSpec with NettyIntegrationSpecification
@@ -32,7 +31,7 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
 
   override implicit def defaultAwaitTimeout = 5.seconds
 
-  def withServer[A](webSocket: Application => Handler)(block: => A): A = {
+  def withServer[A](webSocket: Application => Handler)(block: Application => A): A = {
     val currentApp = new AtomicReference[FakeApplication]
     val app = FakeApplication(
       withRoutes = {
@@ -40,65 +39,62 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
       }
     )
     currentApp.set(app)
-    running(TestServer(testServerPort, app))(block)
+    running(TestServer(testServerPort, app))(block(app))
   }
 
-  def runWebSocket[A](handler: (Enumerator[WebSocketFrame], Iteratee[WebSocketFrame, _]) => Future[A]): A = {
+  def runWebSocket[A](handler: (Flow[ExtendedMessage, ExtendedMessage, _]) => Future[A]): A = {
     WebSocketClient { client =>
       val innerResult = Promise[A]()
-      await(client.connect(URI.create("ws://localhost:" + testServerPort + "/stream")) { (in, out) =>
-        innerResult.completeWith(handler(in, out))
+      await(client.connect(URI.create("ws://localhost:" + testServerPort + "/stream")) { flow =>
+        innerResult.completeWith(handler(flow))
       })
       await(innerResult.future)
     }
   }
 
-  def pongFrame(matcher: Matcher[String]): Matcher[WebSocketFrame] = beLike {
-    case t: PongWebSocketFrame => t.getBinaryData.toString(Charset.forName("utf-8")) must matcher
+  def pongFrame(matcher: Matcher[String]): Matcher[ExtendedMessage] = beLike {
+    case SimpleMessage(PongMessage(data), _) => data.utf8String must matcher
   }
 
-  def textFrame(matcher: Matcher[String]): Matcher[WebSocketFrame] = beLike {
-    case t: TextWebSocketFrame => t.getText must matcher
+  def textFrame(matcher: Matcher[String]): Matcher[ExtendedMessage] = beLike {
+    case SimpleMessage(TextMessage(text), _) => text must matcher
   }
 
-  def closeFrame(status: Int = 1000): Matcher[WebSocketFrame] = beLike {
-    case close: CloseWebSocketFrame => close.getStatusCode must_== status
+  def closeFrame(status: Int = 1000): Matcher[ExtendedMessage] = beLike {
+    case SimpleMessage(CloseMessage(statusCode, _), _) => statusCode must beSome(status)
   }
 
-  def binaryBuffer(text: String) = ChannelBuffers.wrappedBuffer(text.getBytes("utf-8"))
-
-  /**
-   * Iteratee getChunks that invokes a callback as soon as it's done.
-   */
-  def getChunks[A](chunks: List[A], onDone: List[A] => _): Iteratee[A, List[A]] = Cont {
-    case Input.El(c) => getChunks(c :: chunks, onDone)
-    case Input.EOF =>
-      val result = chunks.reverse
-      onDone(result)
-      Done(result, Input.EOF)
-    case Input.Empty => getChunks(chunks, onDone)
-  }
-
-  /**
-   * Akka streams get chunks
-   */
-  def akkaStreamsGetChunks[A](onDone: List[A] => _): Sink[A, _] =
+  def consumeFrames[A]: Sink[A, Future[List[A]]] =
     Sink.fold[List[A], A](Nil)((result, next) => next :: result).mapMaterializedValue { future =>
-      future.onSuccess {
-        case result => onDone(result.reverse)
-      }
+      future.map(_.reverse)
     }
 
-  def akkaStreamsEmptySource[A] = Source(Promise[A]().future)
+  def onFramesConsumed[A](onDone: List[A] => Unit): Sink[A, _] = consumeFrames[A].mapMaterializedValue { future =>
+    future.onSuccess {
+      case list => onDone(list)
+    }
+  }
+
+  // We concat with an empty source because otherwise the connection will be closed immediately after the last
+  // frame is sent, but WebSockets require that the client waits for the server to echo the close back, and
+  // let the server close.
+  def sendFrames(frames: ExtendedMessage*) = Source(frames.toList).concat(emptySource)
+
+  def emptySource[A] = Source(Promise[A]().future)
 
   /*
    * Shared tests
    */
   def allowConsumingMessages(webSocket: Application => Promise[List[String]] => Handler) = {
     val consumed = Promise[List[String]]()
-    withServer(app => webSocket(app)(consumed)) {
-      val result = runWebSocket { (in, out) =>
-        Enumerator(new TextWebSocketFrame("a"), new TextWebSocketFrame("b"), new CloseWebSocketFrame(1000, "")) |>> out
+    withServer(app => webSocket(app)(consumed)) { app =>
+      import app.materializer
+      val result = runWebSocket { (flow) =>
+        sendFrames(
+          TextMessage("a"),
+          TextMessage("b"),
+          CloseMessage(1000)
+        ).via(flow).runWith(Sink.cancelled)
         consumed.future
       }
       result must_== Seq("a", "b")
@@ -106,9 +102,10 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
   }
 
   def allowSendingMessages(webSocket: Application => List[String] => Handler) = {
-    withServer(app => webSocket(app)(List("a", "b"))) {
-      val frames = runWebSocket { (in, out) =>
-        in |>>> Iteratee.getChunks[WebSocketFrame]
+    withServer(app => webSocket(app)(List("a", "b"))) { app =>
+      import app.materializer
+      val frames = runWebSocket { (flow) =>
+        emptySource[ExtendedMessage].via(flow).runWith(consumeFrames)
       }
       frames must contain(exactly(
         textFrame(be_==("a")),
@@ -120,19 +117,20 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
 
   def cleanUpWhenClosed(webSocket: Application => Promise[Boolean] => Handler) = {
     val cleanedUp = Promise[Boolean]()
-    withServer(app => webSocket(app)(cleanedUp)) {
-      runWebSocket { (in, out) =>
-        out.run
+    withServer(app => webSocket(app)(cleanedUp)) { app =>
+      import app.materializer
+      runWebSocket { flow =>
+        Source.empty[ExtendedMessage].via(flow).runWith(Sink.ignore)
         cleanedUp.future
       } must beTrue
     }
   }
 
   def closeWhenTheConsumerIsDone(webSocket: Application => Handler) = {
-    withServer(app => webSocket(app)) {
-      val frames = runWebSocket { (in, out) =>
-        Enumerator[WebSocketFrame](new TextWebSocketFrame("a")) |>> out
-        in |>>> Iteratee.getChunks[WebSocketFrame]
+    withServer(app => webSocket(app)) { app =>
+      import app.materializer
+      val frames = runWebSocket { flow =>
+        Source.repeat[ExtendedMessage](TextMessage("a")).via(flow).runWith(consumeFrames)
       }
       frames must contain(exactly(
         closeFrame()
@@ -141,7 +139,7 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
   }
 
   def allowRejectingTheWebSocketWithAResult(webSocket: Application => Int => Handler) = {
-    withServer(app => webSocket(app)(FORBIDDEN)) {
+    withServer(app => webSocket(app)(FORBIDDEN)) { app =>
       implicit val port = testServerPort
       await(wsUrl("/stream").withHeaders(
         "Upgrade" -> "websocket",
@@ -158,8 +156,8 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
       "allow consuming messages" in allowConsumingMessages { _ =>
         consumed =>
           WebSocket.accept[String, String] { req =>
-            Flow.wrap(akkaStreamsGetChunks[String](consumed.success _),
-              akkaStreamsEmptySource[String])(Keep.none)
+            Flow.wrap(onFramesConsumed[String](consumed.success(_)),
+              emptySource[String])(Keep.none)
           }
       }
 
@@ -172,7 +170,7 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
 
       "close when the consumer is done" in closeWhenTheConsumerIsDone { _ =>
         WebSocket.accept[String, String] { req =>
-          Flow.wrap(Sink.cancelled, akkaStreamsEmptySource[String])(Keep.none)
+          Flow.wrap(Sink.cancelled, emptySource[String])(Keep.none)
         }
       }
 
@@ -186,17 +184,19 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
       "aggregate text frames" in {
         val consumed = Promise[List[String]]()
         withServer(app => WebSocket.accept[String, String] { req =>
-          Flow.wrap(akkaStreamsGetChunks[String](consumed.success _),
-            akkaStreamsEmptySource[String])(Keep.none)
-        }) {
-          val result = runWebSocket { (in, out) =>
-            Enumerator(
-              new TextWebSocketFrame("first"),
-              new TextWebSocketFrame(false, 0, "se"),
-              new ContinuationWebSocketFrame(false, 0, "co"),
-              new ContinuationWebSocketFrame(true, 0, "nd"),
-              new TextWebSocketFrame("third"),
-              new CloseWebSocketFrame(1000, "")) |>> out
+          Flow.wrap(onFramesConsumed[String](consumed.success(_)),
+            emptySource[String])(Keep.none)
+        }) { app =>
+          import app.materializer
+          val result = runWebSocket { flow =>
+            sendFrames(
+              TextMessage("first"),
+              SimpleMessage(TextMessage("se"), false),
+              ContinuationMessage(ByteString("co"), false),
+              ContinuationMessage(ByteString("nd"), true),
+              TextMessage("third"),
+              CloseMessage(1000)
+            ).via(flow).runWith(Sink.ignore)
             consumed.future
           }
           result must_== Seq("first", "second", "third")
@@ -207,17 +207,19 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
         val consumed = Promise[List[ByteString]]()
 
         withServer(app => WebSocket.accept[ByteString, ByteString] { req =>
-          Flow.wrap(akkaStreamsGetChunks[ByteString](consumed.success _),
-            akkaStreamsEmptySource[ByteString])(Keep.none)
-        }) {
-          val result = runWebSocket { (in, out) =>
-            Enumerator(
-              new BinaryWebSocketFrame(binaryBuffer("first")),
-              new BinaryWebSocketFrame(false, 0, binaryBuffer("se")),
-              new ContinuationWebSocketFrame(false, 0, binaryBuffer("co")),
-              new ContinuationWebSocketFrame(true, 0, binaryBuffer("nd")),
-              new BinaryWebSocketFrame(binaryBuffer("third")),
-              new CloseWebSocketFrame(1000, "")) |>> out
+          Flow.wrap(onFramesConsumed[ByteString](consumed.success(_)),
+            emptySource[ByteString])(Keep.none)
+        }) { app =>
+          import app.materializer
+          val result = runWebSocket { flow =>
+            sendFrames(
+              BinaryMessage(ByteString("first")),
+              SimpleMessage(BinaryMessage(ByteString("se")), false),
+              ContinuationMessage(ByteString("co"), false),
+              ContinuationMessage(ByteString("nd"), true),
+              BinaryMessage(ByteString("third")),
+              CloseMessage(1000)
+            ).via(flow).runWith(Sink.ignore)
             consumed.future
           }
           result.map(b => b.utf8String) must_== Seq("first", "second", "third")
@@ -226,14 +228,14 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
 
       "close the websocket when the buffer limit is exceeded" in {
         withServer(app => WebSocket.accept[String, String] { req =>
-          Flow.wrap(Sink.ignore, akkaStreamsEmptySource[String])(Keep.none)
-        }) {
-          val frames = runWebSocket { (in, out) =>
-            Enumerator[WebSocketFrame](
-              new TextWebSocketFrame(false, 0, "first frame"),
-              new ContinuationWebSocketFrame(true, 0, new String(Array.range(1, 65530).map(_ => 'a')))
-            ) |>> out
-            in |>>> Iteratee.getChunks[WebSocketFrame]
+          Flow.wrap(Sink.ignore, emptySource[String])(Keep.none)
+        }) { app =>
+          import app.materializer
+          val frames = runWebSocket { flow =>
+            sendFrames(
+              SimpleMessage(TextMessage("first frame"), false),
+              ContinuationMessage(ByteString(new String(Array.range(1, 65530).map(_ => 'a'))), true)
+            ).via(flow).runWith(consumeFrames)
           }
           frames must contain(exactly(
             closeFrame(1009)
@@ -243,13 +245,14 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
 
       "close the websocket when the wrong type of frame is received" in {
         withServer(app => WebSocket.accept[String, String] { req =>
-          Flow.wrap(Sink.ignore, akkaStreamsEmptySource[String])(Keep.none)
-        }) {
-          val frames = runWebSocket { (in, out) =>
-            Enumerator[WebSocketFrame](
-              new BinaryWebSocketFrame(binaryBuffer("first")),
-              new TextWebSocketFrame("foo")) |>> out
-            in |>>> Iteratee.getChunks[WebSocketFrame]
+          Flow.wrap(Sink.ignore, emptySource[String])(Keep.none)
+        }) { app =>
+          import app.materializer
+          val frames = runWebSocket { flow =>
+            sendFrames(
+              BinaryMessage(ByteString("first")),
+              TextMessage("foo")
+            ).via(flow).runWith(consumeFrames)
           }
           frames must contain(exactly(
             closeFrame(1003)
@@ -259,14 +262,14 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
 
       "respond to pings" in {
         withServer(app => WebSocket.accept[String, String] { req =>
-          Flow.wrap(Sink.ignore, akkaStreamsEmptySource[String])(Keep.none)
-        }) {
-          val frames = runWebSocket { (in, out) =>
-            Enumerator[WebSocketFrame](
-              new PingWebSocketFrame(binaryBuffer("hello")),
-              new CloseWebSocketFrame(1000, "")
-            ) |>> out
-            in |>>> Iteratee.getChunks[WebSocketFrame]
+          Flow.wrap(Sink.ignore, emptySource[String])(Keep.none)
+        }) { app =>
+          import app.materializer
+          val frames = runWebSocket { flow =>
+            sendFrames(
+              PingMessage(ByteString("hello")),
+              CloseMessage(1000)
+            ).via(flow).runWith(consumeFrames)
           }
           frames must contain(exactly(
             pongFrame(be_==("hello")),
@@ -277,14 +280,14 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
 
       "not respond to pongs" in {
         withServer(app => WebSocket.accept[String, String] { req =>
-          Flow.wrap(Sink.ignore, akkaStreamsEmptySource[String])(Keep.none)
-        }) {
-          val frames = runWebSocket { (in, out) =>
-            Enumerator[WebSocketFrame](
-              new PongWebSocketFrame(),
-              new CloseWebSocketFrame(1000, "")
-            ) |>> out
-            in |>>> Iteratee.getChunks[WebSocketFrame]
+          Flow.wrap(Sink.ignore, emptySource[String])(Keep.none)
+        }) { app =>
+          import app.materializer
+          val frames = runWebSocket { flow =>
+            sendFrames(
+              PongMessage(ByteString("hello")),
+              CloseMessage(1000)
+            ).via(flow).runWith(consumeFrames)
           }
           frames must contain(exactly(
             closeFrame()
@@ -299,7 +302,9 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
       "allow consuming messages" in allowConsumingMessages { _ =>
         consumed =>
           WebSocket.using[String] { req =>
-            (getChunks[String](Nil, consumed.success _), Enumerator.empty)
+            (Iteratee.getChunks[String].map { result =>
+              consumed.success(result)
+            }, Enumerator.empty)
           }
       }
 
@@ -316,10 +321,15 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
         }
       }
 
-      "clean up when closed" in cleanUpWhenClosed { _ =>
+      "clean up when closed" in cleanUpWhenClosed { app =>
         cleanedUp =>
           WebSocket.using[String] { req =>
-            (Iteratee.ignore, Enumerator.repeat("foo").onDoneEnumerating {
+            val tick = Enumerator.unfoldM(()) { _ =>
+              val p = Promise[Option[(Unit, String)]]()
+              app.actorSystem.scheduler.scheduleOnce(100.millis)(p.success(Some(() -> "foo")))
+              p.future
+            }
+            (Iteratee.ignore, tick.onDoneEnumerating {
               cleanedUp.success(true)
             })
           }

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
@@ -7,19 +7,15 @@ import akka.util.ByteString
 import akka.stream.scaladsl.Source
 import akka.stream.scaladsl.Sink
 
-import java.io.IOException
-
 import org.asynchttpclient.{ RequestBuilderBase, SignatureCalculator }
 
-import play.api.http.{ HttpEntity, Port }
-import play.api.libs.iteratee._
+import play.api.http.Port
 import play.api.libs.oauth._
 import play.api.mvc._
 import play.api.test._
 import play.core.server.Server
 import play.it._
 import play.it.tools.HttpBinApplication
-import play.api.mvc.BodyParsers.parse
 import play.api.mvc.Results.Ok
 import play.api.libs.streams.Accumulator
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
@@ -5,6 +5,7 @@
 package play.it.tools
 
 import akka.stream.Materializer
+import akka.stream.scaladsl.Source
 import play.api.libs.ws.ning.NingWSComponents
 import play.api.routing.SimpleRouter
 import play.api.routing.Router.Routes
@@ -201,7 +202,6 @@ object HttpBinApplication {
 
   val stream: Routes = {
     case GET(p"/stream/$param<[0-9]+>") =>
-      import play.api.libs.iteratee.Enumerator
       Action { request =>
         val body = requestHeaderWriter.writes(request).as[JsObject]
 
@@ -209,7 +209,7 @@ object HttpBinApplication {
           body ++ Json.obj("id" -> index)
         }
 
-        Ok.chunked(Enumerator(content: _*)).as("application/json")
+        Ok.chunked(Source(content)).as("application/json")
       }
   }
 

--- a/framework/src/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/framework/src/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -5,10 +5,10 @@ package play.api.test
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.test.Helpers._
 import play.api.mvc.Results._
-import play.api.libs.iteratee.Enumerator
 import play.twirl.api.Content
 import scala.concurrent.Future
 
@@ -61,7 +61,7 @@ class HelpersSpec extends Specification {
       implicit val system = ActorSystem()
       try {
         implicit val mat = ActorMaterializer()
-        contentAsBytes(Future.successful(Ok.chunked(Enumerator("a", "b", "c")))) must_== ByteString(97, 98, 99)
+        contentAsBytes(Future.successful(Ok.chunked(Source(List("a", "b", "c"))))) must_== ByteString(97, 98, 99)
       } finally {
         system.shutdown()
       }

--- a/framework/src/play/src/main/scala/play/api/http/websocket/CloseCodes.scala
+++ b/framework/src/play/src/main/scala/play/api/http/websocket/CloseCodes.scala
@@ -8,6 +8,7 @@ object CloseCodes {
   val GoingAway = 1001
   val ProtocolError = 1002
   val Unacceptable = 1003
+  val NoStatus = 1005
   val ConnectionAbort = 1006
   val InconsistentData = 1007
   val PolicyViolated = 1008

--- a/framework/src/play/src/main/scala/play/api/http/websocket/Message.scala
+++ b/framework/src/play/src/main/scala/play/api/http/websocket/Message.scala
@@ -32,6 +32,14 @@ case class BinaryMessage(data: ByteString) extends Message
  * @param reason The reason it was closed.
  */
 case class CloseMessage(statusCode: Option[Int] = Some(CloseCodes.Regular), reason: String = "") extends Message
+
+object CloseMessage {
+  def apply(statusCode: Int): CloseMessage =
+    CloseMessage(Some(statusCode), "")
+  def apply(statusCode: Int, reason: String): CloseMessage =
+    CloseMessage(Some(statusCode), reason)
+}
+
 /**
  * A ping message.
  *


### PR DESCRIPTION
Removed all uses of iteratees in tests where Akka streams is appropriate.  Of course, when testing things that use iteratees, it still uses iteratees.

One of the bigger tasks were was converting the WebSocket client to use Akka streams, and I also upgraded it to Netty 4.