### PR TITLE
Add crypto module for 2.5.x

### DIFF
--- a/documentation/manual/releases/release25/migration25/CryptoMigration25.md
+++ b/documentation/manual/releases/release25/migration25/CryptoMigration25.md
@@ -1,0 +1,99 @@
+# Crypto Migration Guide
+
+From Play 1.x, Play has come with a Crypto object that provides some cryptographic operations.  This used internally by Play.  The Crypto object is not mentioned in the documentation, but is mentioned as "cryptographic utilities" in the scaladoc:
+
+"These utilities are intended as a convenience, however it is important to read each methods documentation and understand the concepts behind encryption to use this class properly.  Safe encryption is hard, and there is no substitute for an adequate understanding of cryptography.  These methods will not be suitable for all encryption needs."
+
+For a variety of reasons, providing cryptographic utilities as a convenience has turned out not to be workable.   In 2.5.x, Crypto will be defined as an internal library, part of Play’s private API, with an explicit note that user level cryptographic operations should not call out to Crypto methods.
+
+The remainder of this document will discuss internal functionality behind Crypto, the suitability (and unsuitability) of cryptographic operations, and migration paths for users moving off Crypto functionality.
+
+For more information about cryptography, we recommend reading the [OWASP Cryptographic Storage Cheatsheet](https://www.owasp.org/index.php/Cryptographic_Storage_Cheat_Sheet).
+
+## Message Authentication
+
+Play uses the Crypto.sign method to provide message authentication for session cookies.   There are several reasons why Crypto.sign should not be used outside the purpose of signing cookies: MAC algorithm independence, additional functionality, and potential misuse of HMAC as a password hashing algorithm.
+
+### MAC Algorithm Independence
+
+Play currently uses HMAC-SHA1 for signing and verifying session cookies.  An [HMAC](https://en.wikipedia.org/wiki/Hash-based_message_authentication_code) is a cryptographic function that authenticates that data has not been tampered with, using a secret key (the [application secret](https://www.playframework.com/documentation/2.4.x/ApplicationSecret) defined as play.crypto.secret) together with a message digest function (in this case [SHA-1](https://en.wikipedia.org/wiki/SHA-1)).  SHA-1 has suffered [some attacks recently](https://sites.google.com/site/itstheshappening/), but it remains secure when used with an HMAC for [message authenticity](http://killring.org/2014/01/05/how-broken-is-sha1/).  
+
+Play needs to have the flexibility be able to move to a different HMAC function [as needed](http://valerieaurora.org/hash.html) and so, should not be part of the public API.
+
+### Potential New Functionality
+
+Play currently signs the session cookie, but does not add any session timeout or expiration date to the session cookie.  This means that, given the appropriate opening, an active attacker could swap out one session cookie for another one.  
+
+Play may potentially add [session timeout functionality](https://github.com/google/keyczar/blob/master/java/code/src/org/keyczar/TimeoutSigner.java#L109) to Crypto.sign, which again would result in breaking user level functionality if this is marked as public API.
+
+### Misuse as a Password Hash
+
+Please do not use Crypto.sign or any kind of HMAC, as they are not designed for password hashing.  MACs are designed to be fast and cheap, while password hashing should be slow and expensive.  Please look at scrypt, bcrypt, or PBKDF2 -- [jBCrypt](http://www.mindrot.org/projects/jBCrypt/) in particular is well known as a bcrypt implementation in Java.
+
+## Symmetric Encryption
+
+Crypto contains two methods for symmetric encryption, Crypto.encryptAES and Crypto.decryptAES. These methods are not used internally by Play, but [significant](https://github.com/playframework/playframework/issues/4407) [developer](https://groups.google.com/d/msg/play-framework-dev/Rlrt89Ky_Rk/j6Iq6-snDw8J) [effort](https://groups.google.com/forum/#!topic/play-framework/Pao8MnADAqw) [has](https://ipsec.pl/play-framework/2014/session-variables-encryption-play-framework.html) gone into reviewing these methods.  These methods will be deprecated, and may be removed in future versions.
+
+As alluded to in the warning, these methods are not generally "safe" -- there are some common modes of operation that are not secure using these methods.   Here follows a brief description of some cryptographic issues using Crypto.encryptAES.
+
+Again, Crypto.encryptAES is never used directly in Play, so this isn’t a security vulnerability in Play itself.   
+
+### Use of Stream Cipher without Authentication
+
+Crypto.encryptAES is, by default, using AES-CTR, a mode of AES that provides encryption but does not provide authentication -- this means that an active attacker can swap out the contents of the encrypted text with something else.  This property, known as "malleability", means that it’s possible to [recover plaintext](https://news.ycombinator.com/item?id=639761) under certain conditions, and alter the message.  There are two constructions that are used to mitigate this: either the encrypted text is signed (known as “Encrypt Then MAC”) or authenticated encryption, such as AES-GCM, can be used.
+
+Play uses Crypto.encryptAES to encrypt the contents of a session cookie (which has a MAC applied).  Since Play uses "Encrypt Then MAC", it is not vulnerable to attack -- however, users who are making use of symmetric encryption without a MAC are potentially vulnerable.
+
+Users are encouraged not to implement their own Encrypt-Then-MAC construction.  Instead, the appropriate solution here is authenticated encryption, which both authenticates and encrypts data at the same time -- see the migration section for details.  
+
+### Violation of Key Separation Principle
+
+Although using AES with an HMAC is considered a secure construction, there is a problem in the way that Play uses the secret key for encryption.  The "key separation principle" says that you should only ever use one key for one purpose.  In this case, not only is play.crypto.secret is used for signing, but also encryption in Crypto.encryptAES.
+
+For customers who are using Crypto.encryptAES, there is no immediate security vulnerability that results from the mixing of key usage here:
+
+"With HMAC vs AES, no such interference is known. The *general feeling* of cryptographers is that AES and SHA-1 (or SHA-256) are "sufficiently different" that there should be no practical issue with using the same key for AES and HMAC/SHA-1."
+
+[http://crypto.stackexchange.com/a/8086](http://crypto.stackexchange.com/a/8086)
+
+Once the application gets larger, the key separation principle might be also violated in another way: If Crypto.encryptAES is used for multiple purposes, using separate keys is also advised.
+
+### Global configuration of mode
+
+As mentioned above, AES can be used with various modes of operation. Using a different mode might require different additional security measures.
+
+Play, however, offers configuring mode of operation globally by configuring the play.crypto.aes.transformation configuration option. That is, it influences whole application, including all libraries that use Crypto.encryptAES. As a result, it is hard to know exactly what the impact of changing the option on the whole application.
+
+## Migration
+
+There are several migration paths from Crypto functionality.  In order of preference, they are Kalium, Keyczar, or pure JCA.
+
+### Kalium
+
+If you have control over binaries in your production environment and do not have external requirements for NIST approved algorithms: use [Kalium](https://abstractj.github.io/kalium/), a wrapper over the libsodium library.
+
+If you need a MAC replacement for Crypto.sign, use org.abstractj.kalium.keys.AuthenticationKey, which implements HMAC-SHA512/256.
+
+If you want a symmetric encryption replacement for Crypto.encryptAES, then use org.abstractj.kalium.crypto.SecretBox, which implements [secret-key authenticated encryption](http://doc.libsodium.org/secret-key_cryptography/authenticated_encryption.html).  
+
+Note that Kalium does require that a libsodium binary be [installed](http://doc.libsodium.org/installation/index.html), preferably from source that you have verified.
+
+### Keyczar
+
+If you are looking for a pure Java solution or depend on NIST approved algorithms, [Keyczar](https://tersesystems.com/2015/10/05/effective-cryptography-in-the-jvm/) provides a high level cryptographic library on top of JCA.  Note that Keyczar does not have the same level of support as libsodium / Kalium, and so Kalium is preferred.
+
+If you need a MAC replacement for Crypto.sign, use org.keyczar.Signer.
+
+If you need a symmetric encryption replacement for Crypto.encryptAES, then use org.keyczar.Crypter.
+
+### JCA
+
+Both Kalium and Keyczar use different cryptographic primitives than Crypto.  For users who intend to migrate from Crypto functionality without changing the underlying algorithms, the best option is probably to extract the code from the Crypto library to a user level class.
+
+### Further Reading
+
+There are some papers available on cryptographic design that go over some of the issues addressed by crypto APIs and the complexities involved:
+
+* [The Long Journey from Papers to Software: Crypto APIs](http://crypto.junod.info/IACR15_crypto_school_talk.pdf)
+* [What’s Wrong with Crypto API Design](http://spar.isi.jhu.edu/~mgreen/CryptoAPIs.pdf)
+* [Real World Crypto 2015: Error-prone cryptographic designs (djb)](http://bristolcrypto.blogspot.com/2015/01/real-world-crypto-2015-error-prone.html) and [slides](http://cr.yp.to/talks/2015.01.07/slides-djb-20150107-a4.pdf)

--- a/documentation/manual/releases/release25/migration25/Migration25.md
+++ b/documentation/manual/releases/release25/migration25/Migration25.md
@@ -241,3 +241,15 @@ Previously, a CSRF token could be retrieved from the HTTP request in any action.
 Also, a minor bug was fixed in this release in which the CSRF token would be empty (throwing an exception in the template helper) if its signature was invalid. Now it will be regenerated on the same request so a token is still available from the template helpers and `CSRF.getToken`.
 
 For more details, please read the CSRF documentation for [[Java|JavaCsrf]] and [[Scala|ScalaCsrf]].
+
+## Crypto Deprecated
+
+From Play 1.x, Play has come with a Crypto object that provides some cryptographic operations.  This used internally by Play.  The Crypto object is not mentioned in the documentation, but is mentioned as “cryptographic utilities” in the scaladoc.  
+
+For a variety of reasons, providing cryptographic utilities as a convenience has turned out not to be workable.   In 2.5.x, Crypto will be defined as an internal library, part of Play’s private API, with an explicit note that user level cryptographic operations should not call out to Crypto methods.   Please see [[Crypto Migration|CryptoMigration25]] for more details.
+
+### How to Migrate
+
+Cryptographic migration will depend on your use case, especially if there is unsafe construction of the cryptographic primitives.  The short version is to use [Kalium](https://abstractj.github.io/kalium/) if possible, otherwise use [KeyCzar](https://github.com/google/keyczar) or straight [JCA](https://docs.oracle.com/javase/8/docs/technotes/guides/security/crypto/CryptoSpec.html).
+
+Please see [[Crypto Migration|CryptoMigration25]] for more details.

--- a/documentation/manual/releases/release25/migration25/index.toc
+++ b/documentation/manual/releases/release25/migration25/index.toc
@@ -1,3 +1,4 @@
 Migration25:Migration Guide
 StreamsMigration25:Streams Migration Guide
 JavaMigration25:Java Migration Guide
+CryptoMigration25:Crypto Migration Guide

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -5,7 +5,7 @@ package play.filters.csrf;
 
 import java.util.concurrent.CompletionStage;
 
-import play.api.libs.Crypto;
+import play.api.libs.crypto.CSRFTokenSigner;
 import play.api.mvc.RequestHeader;
 import play.api.mvc.Session;
 import play.mvc.Action;
@@ -21,13 +21,13 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
 
     private final CSRFConfig config;
     private final CSRF.TokenProvider tokenProvider;
-    private final Crypto crypto;
+    private final CSRFTokenSigner tokenSigner;
 
     @Inject
-    public AddCSRFTokenAction(CSRFConfig config, CSRF.TokenProvider tokenProvider, Crypto crypto) {
+    public AddCSRFTokenAction(CSRFConfig config, CSRF.TokenProvider tokenProvider, CSRFTokenSigner tokenSigner) {
         this.config = config;
         this.tokenProvider = tokenProvider;
-        this.crypto = crypto;
+        this.tokenSigner = tokenSigner;
     }
 
     private final CSRF.Token$ Token = CSRF.Token$.MODULE$;
@@ -35,9 +35,9 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
 
     @Override
     public CompletionStage<Result> call(Http.Context ctx) {
-        RequestHeader request = CSRFAction.tagRequestFromHeader(ctx._requestHeader(), config, crypto);
+        RequestHeader request = CSRFAction.tagRequestFromHeader(ctx._requestHeader(), config, tokenSigner);
 
-        if (CSRFAction.getTokenToValidate(request, config, crypto).isEmpty()) {
+        if (CSRFAction.getTokenToValidate(request, config, tokenSigner).isEmpty()) {
             // No token in header and we have to create one if not found, so create a new token
             String newToken = tokenProvider.generateToken();
 

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -16,7 +16,6 @@ import play.api.mvc._
 import play.api.libs.json.Json
 import play.api.test._
 import scala.util.Random
-import play.api.libs.Crypto
 import play.api.inject.guice.{ GuiceApplicationBuilder, GuiceApplicationLoader }
 import play.api.{ Mode, Configuration, Environment }
 import play.api.ApplicationLoader.Context
@@ -80,7 +79,7 @@ object CSRFFilterSpec extends CSRFCommonSpecs {
             .map(Results.Ok(_))
             .getOrElse(Results.NotFound))
       } {
-        val token = Crypto.generateSignedToken
+        val token = crypto.generateSignedToken
         import play.api.Play.current
         await(WS.url("http://localhost:" + testServerPort).withSession(TokenName -> token)
           .post(Map("foo" -> "bar", TokenName -> token))).body must_== "bar"
@@ -109,7 +108,7 @@ object CSRFFilterSpec extends CSRFCommonSpecs {
       .build()
 
     "feed a not fully buffered body once a check has been done and passes" in new WithServer(notBufferedFakeApp, testServerPort) {
-      val token = Crypto.generateSignedToken
+      val token = crypto.generateSignedToken
       val response = await(WS.url("http://localhost:" + port).withSession(TokenName -> token)
         .withHeaders(CONTENT_TYPE -> "application/x-www-form-urlencoded")
         .post(
@@ -130,10 +129,10 @@ object CSRFFilterSpec extends CSRFCommonSpecs {
     "work with a Java error handler" in {
       def csrfCheckRequest = buildCsrfCheckRequestWithJavaHandler()
       def csrfAddToken = buildCsrfAddToken("csrf.cookie.name" -> "csrf")
-      def generate = Crypto.generateSignedToken
+      def generate = crypto.generateSignedToken
       def addToken(req: WSRequest, token: String) = req.withCookies("csrf" -> token)
       def getToken(response: WSResponse) = response.cookies.find(_.name.exists(_ == "csrf")).flatMap(_.value)
-      def compareTokens(a: String, b: String) = Crypto.compareSignedTokens(a, b) must beTrue
+      def compareTokens(a: String, b: String) = crypto.compareSignedTokens(a, b) must beTrue
 
       sharedTests(csrfCheckRequest, csrfAddToken, generate, addToken, getToken, compareTokens, UNAUTHORIZED)
     }

--- a/framework/src/play-java/src/main/java/play/libs/Crypto.java
+++ b/framework/src/play-java/src/main/java/play/libs/Crypto.java
@@ -3,23 +3,23 @@
  */
 package play.libs;
 
+import play.libs.crypto.CSRFTokenSigner;
+import play.libs.crypto.CookieSigner;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**
- * Cryptographic utilities.
- * <br>
- * These utilities are intended as a convenience, however it is important to read each methods documentation and
- * understand the concepts behind encryption to use this class properly.  Safe encryption is hard, and there is no
- * substitute for an adequate understanding of cryptography.  These methods will not be suitable for all encryption
- * needs.
+ * This class is not suitable for use as a general cryptographic library, and is not used internally by Play.
+ * It will be removed in future versions.
  *
- * For more information about cryptography, we recommend reading the OWASP Cryptographic Storage Cheatsheet:
+ * Please see <a href="https://www.playframework.com/documentation/2.5.x/CryptoMigration25">Crypto Migration Guide</a> for details, including how to migrate to another crypto system.
  *
- * https://www.owasp.org/index.php/Cryptographic_Storage_Cheat_Sheet
+ * @deprecated This class is deprecated and will be removed in future versions.
  */
+@Deprecated
 @Singleton
-public class Crypto {
+public class Crypto implements CSRFTokenSigner, CookieSigner {
 
     private final play.api.libs.Crypto crypto;
 
@@ -42,9 +42,9 @@ public class Crypto {
      * @param key     The private key to sign with.
      * @return A hexadecimal encoded signature.
      */
-    public String sign(String message, byte[] key) {
-        return crypto.sign(message, key);
-    }
+    //public String sign(String message, byte[] key) {
+    //      return crypto.sign(message, key);
+    //}
 
     /**
      * Signs the given String with HMAC-SHA1 using the application's secret key.
@@ -133,9 +133,11 @@ public class Crypto {
      * <code>application.conf</code>.  Although any cipher transformation algorithm can be selected here, the secret key
      * spec used is always AES, so only AES transformation algorithms will work.
      *
+     * @deprecated This method is deprecated and will be removed in future versions.
      * @param value The String to encrypt.
      * @return An hexadecimal encrypted string.
      */
+    @Deprecated
     public String encryptAES(String value) {
         return crypto.encryptAES(value);
     }
@@ -157,10 +159,12 @@ public class Crypto {
      * <code>application.conf</code>.  Although any cipher transformation algorithm can be selected here, the secret key
      * spec used is always AES, so only AES transformation algorithms will work.
      *
+     * @deprecated This method is deprecated and will be removed in future versions.
      * @param value      The String to encrypt.
      * @param privateKey The key used to encrypt.
      * @return An hexadecimal encrypted string.
      */
+    @Deprecated
     public String encryptAES(String value, String privateKey) {
         return crypto.encryptAES(value, privateKey);
     }
@@ -176,9 +180,11 @@ public class Crypto {
      * transformation algorithm can be selected here, the secret key spec used is always AES, so only AES transformation
      * algorithms will work.
      *
+     * @deprecated This method is deprecated and will be removed in future versions.
      * @param value An hexadecimal encrypted string.
      * @return The decrypted String.
      */
+    @Deprecated
     public String decryptAES(String value) {
         return crypto.decryptAES(value);
     }
@@ -196,10 +202,12 @@ public class Crypto {
      * transformation algorithm can be selected here, the secret key spec used is always AES, so only AES transformation
      * algorithms will work.
      *
+     * @deprecated This method is deprecated and will be removed in future versions.
      * @param value      An hexadecimal encrypted string.
      * @param privateKey The key used to encrypt.
      * @return The decrypted String.
      */
+    @Deprecated
     public String decryptAES(String value, String privateKey) {
         return crypto.decryptAES(value, privateKey);
     }

--- a/framework/src/play-java/src/main/java/play/libs/crypto/CSRFTokenSigner.java
+++ b/framework/src/play-java/src/main/java/play/libs/crypto/CSRFTokenSigner.java
@@ -1,0 +1,17 @@
+package play.libs.crypto;
+
+
+public interface CSRFTokenSigner {
+
+    public play.api.libs.crypto.CSRFTokenSigner asScala();
+
+    public String extractSignedToken(String token);
+
+    public String generateToken();
+
+    public String generateSignedToken();
+
+    public boolean compareSignedTokens(String tokenA, String tokenB);
+
+    public boolean constantTimeEquals(String a, String b);
+}

--- a/framework/src/play-java/src/main/java/play/libs/crypto/CookieSigner.java
+++ b/framework/src/play-java/src/main/java/play/libs/crypto/CookieSigner.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.libs.crypto;
+
+/**
+ *
+ */
+public interface CookieSigner {
+
+    public String sign(String message);
+
+    public String signToken(String token);
+}

--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -12,7 +12,7 @@ import play.api._
 import play.api.http._
 import play.api.libs.Files.{ DefaultTemporaryFileCreator, TemporaryFileCreator }
 import play.api.libs.concurrent.{ ActorSystemProvider, ExecutionContextProvider, MaterializerProvider }
-import play.api.libs.{ Crypto, CryptoConfig, CryptoConfigParser }
+import play.api.libs.crypto._
 import play.api.routing.Router
 import play.core.j.JavaRouterAdapter
 import play.libs.concurrent.HttpExecutionContext
@@ -55,7 +55,10 @@ class BuiltinModule extends Module {
       bind[HttpExecutionContext].toSelf,
 
       bind[CryptoConfig].toProvider[CryptoConfigParser],
-      bind[Crypto].toSelf,
+      bind[CookieSigner].toProvider[CookieSignerProvider],
+      bind[CSRFTokenSigner].toProvider[CSRFTokenSignerProvider],
+      bind[AESCrypter].toProvider[AESCrypterProvider],
+      bind[play.api.libs.Crypto].toSelf,
       bind[TemporaryFileCreator].to[DefaultTemporaryFileCreator]
     ) ++ dynamicBindings(
         HttpErrorHandler.bindingsFromConfiguration,

--- a/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
@@ -3,544 +3,88 @@
  */
 package play.api.libs
 
-import java.security.{ MessageDigest, SecureRandom }
-import javax.crypto._
-import javax.crypto.spec.{ IvParameterSpec, SecretKeySpec }
-import javax.inject.{ Inject, Provider, Singleton }
+import javax.inject.Inject
 
-import org.apache.commons.codec.binary.{ Base64, Hex }
-import org.apache.commons.codec.digest.DigestUtils
 import play.api._
-import play.api.libs.Crypto.CryptoException
+import play.api.libs.crypto._
+
+@javax.inject.Singleton
+@deprecated("This class is deprecated and will be removed in future versions", "2.5.0")
+class Crypto @Inject() (signer: CookieSigner, tokenSigner: CSRFTokenSigner, aesCrypter: AESCrypter) extends CookieSigner with CSRFTokenSigner with AESCrypter {
+
+  override def signToken(token: String): String = tokenSigner.signToken(token)
+
+  override def extractSignedToken(token: String): Option[String] = tokenSigner.extractSignedToken(token)
+
+  override def compareSignedTokens(tokenA: String, tokenB: String): Boolean = tokenSigner.compareSignedTokens(tokenA, tokenB)
+
+  override def generateToken: String = tokenSigner.generateToken
+
+  override def constantTimeEquals(a: String, b: String): Boolean = tokenSigner.constantTimeEquals(a, b)
+
+  override def generateSignedToken: String = tokenSigner.generateSignedToken
+
+  override def decryptAES(value: String): String = aesCrypter.decryptAES(value)
+
+  override def decryptAES(value: String, privateKey: String): String = aesCrypter.decryptAES(value, privateKey)
+
+  override def encryptAES(value: String): String = aesCrypter.encryptAES(value)
+
+  override def encryptAES(value: String, privateKey: String): String = aesCrypter.encryptAES(value, privateKey)
+
+  override def sign(message: String, key: Array[Byte]): String = signer.sign(message)
+
+  override def sign(message: String): String = signer.sign(message)
+}
 
 /**
- * Cryptographic utilities.
+ * This class is not suitable for use as a general cryptographic library.
  *
- * These utilities are intended as a convenience, however it is important to read each methods documentation and
- * understand the concepts behind encryption to use this class properly.  Safe encryption is hard, and there is no
- * substitute for an adequate understanding of cryptography.  These methods will not be suitable for all encryption
- * needs.
+ * Please see <a href="https://www.playframework.com/documentation/2.5.x/CryptoMigration25">Crypto Migration Guide</a> for details, including how to migrate to another crypto system.
  *
- * For more information about cryptography, we recommend reading the OWASP Cryptographic Storage Cheatsheet:
- *
- * https://www.owasp.org/index.php/Cryptographic_Storage_Cheat_Sheet
+ * @deprecated The singleton crypto object is deprecated as of 2.5.0
  */
+@deprecated("This class is deprecated and will be removed in future versions", "2.5.0")
 object Crypto {
 
-  /**
-   * Exception thrown by the Crypto APIs.
-   * @param message The error message.
-   * @param throwable The Throwable associated with the exception.
-   */
-  class CryptoException(val message: String = null, val throwable: Throwable = null) extends RuntimeException(message, throwable)
+  type CryptoException = play.api.libs.crypto.CryptoException
 
-  private val cryptoCache = Application.instanceCache[Crypto]
-  private[play] def crypto = {
-    Play.privateMaybeApplication.fold(
-      new Crypto(new CryptoConfigParser(
+  private val cryptoCache: (Application) => Crypto = Application.instanceCache[Crypto]
+
+  def crypto: Crypto = {
+    Play.privateMaybeApplication.fold {
+      val config = new CryptoConfigParser(
         Environment.simple(), Configuration.from(Map("play.crypto.aes.transformation" -> "AES/CTR/NoPadding"))
-      ).get)
-    )(cryptoCache)
+      ).get
+      val cookieSigner = new CookieSignerProvider(config).get
+      val tokenSigner = new CSRFTokenSignerProvider(cookieSigner).get
+      val crypter = new AESCTRCrypter(config)
+      new Crypto(cookieSigner, tokenSigner, crypter)
+    }(cryptoCache)
   }
 
-  /**
-   * Signs the given String with HMAC-SHA1 using the given key.
-   *
-   * By default this uses the platform default JSSE provider.  This can be overridden by defining
-   * `play.crypto.provider` in `application.conf`.
-   *
-   * @param message The message to sign.
-   * @param key The private key to sign with.
-   * @return A hexadecimal encoded signature.
-   */
   def sign(message: String, key: Array[Byte]): String = crypto.sign(message, key)
 
-  /**
-   * Signs the given String with HMAC-SHA1 using the application’s secret key.
-   *
-   * By default this uses the platform default JSSE provider.  This can be overridden by defining
-   * `play.crypto.provider` in `application.conf`.
-   *
-   * @param message The message to sign.
-   * @return A hexadecimal encoded signature.
-   */
   def sign(message: String): String = crypto.sign(message)
 
-  /**
-   * Sign a token.  This produces a new token, that has this token signed with a nonce.
-   *
-   * This primarily exists to defeat the BREACH vulnerability, as it allows the token to effectively be random per
-   * request, without actually changing the value.
-   *
-   * @param token The token to sign
-   * @return The signed token
-   */
   def signToken(token: String): String = crypto.signToken(token)
 
-  /**
-   * Extract a signed token that was signed by [[play.api.libs.Crypto.signToken]].
-   *
-   * @param token The signed token to extract.
-   * @return The verified raw token, or None if the token isn't valid.
-   */
   def extractSignedToken(token: String): Option[String] = crypto.extractSignedToken(token)
 
-  /**
-   * Generate a cryptographically secure token
-   */
   def generateToken: String = crypto.generateToken
 
-  /**
-   * Generate a signed token
-   */
   def generateSignedToken: String = crypto.generateSignedToken
 
-  /**
-   * Compare two signed tokens
-   */
   def compareSignedTokens(tokenA: String, tokenB: String): Boolean = crypto.compareSignedTokens(tokenA, tokenB)
 
-  /**
-   * Constant time equals method.
-   *
-   * Given a length that both Strings are equal to, this method will always run in constant time.  This prevents
-   * timing attacks.
-   */
-  def constantTimeEquals(a: String, b: String): Boolean = {
-    if (a.length != b.length) {
-      false
-    } else {
-      var equal = 0
-      for (i <- 0 until a.length) {
-        equal |= a(i) ^ b(i)
-      }
-      equal == 0
-    }
-  }
+  def constantTimeEquals(a: String, b: String): Boolean = crypto.constantTimeEquals(a, b)
 
-  /**
-   * Encrypt a String with the AES encryption standard using the application's secret key.
-   *
-   * The provider used is by default this uses the platform default JSSE provider.  This can be overridden by defining
-   * `play.crypto.provider` in `application.conf`.
-   *
-   * The transformation algorithm used is the provider specific implementation of the `AES` name.  On Oracles JDK,
-   * this is `AES/CTR/NoPadding`.  This algorithm is suitable for small amounts of data, typically less than 32
-   * bytes, hence is useful for encrypting credit card numbers, passwords etc.  For larger blocks of data, this
-   * algorithm may expose patterns and be vulnerable to repeat attacks.
-   *
-   * The transformation algorithm can be configured by defining `play.crypto.aes.transformation` in
-   * `application.conf`.  Although any cipher transformation algorithm can be selected here, the secret key spec used
-   * is always AES, so only AES transformation algorithms will work.
-   *
-   * @param value The String to encrypt.
-   * @return An hexadecimal encrypted string.
-   */
   def encryptAES(value: String): String = crypto.encryptAES(value)
 
-  /**
-   * Encrypt a String with the AES encryption standard and the supplied private key.
-   *
-   * The provider used is by default this uses the platform default JSSE provider.  This can be overridden by defining
-   * `play.crypto.provider` in `application.conf`.
-   *
-   * The transformation algorithm used is the provider specific implementation of the `AES` name.  On Oracles JDK,
-   * this is `AES/CTR/NoPadding`.  This algorithm is suitable for small amounts of data, typically less than 32
-   * bytes, hence is useful for encrypting credit card numbers, passwords etc.  For larger blocks of data, this
-   * algorithm may expose patterns and be vulnerable to repeat attacks.
-   *
-   * The transformation algorithm can be configured by defining `play.crypto.aes.transformation` in
-   * `application.conf`.  Although any cipher transformation algorithm can be selected here, the secret key spec used
-   * is always AES, so only AES transformation algorithms will work.
-   *
-   * @param value The String to encrypt.
-   * @param privateKey The key used to encrypt.
-   * @return An hexadecimal encrypted string.
-   */
   def encryptAES(value: String, privateKey: String): String = crypto.encryptAES(value, privateKey)
 
-  /**
-   * Decrypt a String with the AES encryption standard using the application's secret key.
-   *
-   * The provider used is by default this uses the platform default JSSE provider.  This can be overridden by defining
-   * `play.crypto.provider` in `application.conf`.
-   *
-   * The transformation used is by default `AES/CTR/NoPadding`.  It can be configured by defining
-   * `play.crypto.aes.transformation` in `application.conf`.  Although any cipher transformation algorithm can
-   * be selected here, the secret key spec used is always AES, so only AES transformation algorithms will work.
-   *
-   * @param value An hexadecimal encrypted string.
-   * @return The decrypted String.
-   */
   def decryptAES(value: String): String = crypto.decryptAES(value)
 
-  /**
-   * Decrypt a String with the AES encryption standard.
-   *
-   * The private key must have a length of 16 bytes.
-   *
-   * The provider used is by default this uses the platform default JSSE provider.  This can be overridden by defining
-   * `play.crypto.provider` in `application.conf`.
-   *
-   * The transformation used is by default `AES/CTR/NoPadding`.  It can be configured by defining
-   * `play.crypto.aes.transformation` in `application.conf`.  Although any cipher transformation algorithm can
-   * be selected here, the secret key spec used is always AES, so only AES transformation algorithms will work.
-   *
-   * @param value An hexadecimal encrypted string.
-   * @param privateKey The key used to encrypt.
-   * @return The decrypted String.
-   */
   def decryptAES(value: String, privateKey: String): String = crypto.decryptAES(value, privateKey)
-}
 
-@Singleton
-class CryptoConfigParser @Inject() (environment: Environment, configuration: Configuration) extends Provider[CryptoConfig] {
-
-  private val Blank = """\s*""".r
-
-  private val logger = Logger(classOf[CryptoConfigParser])
-
-  lazy val get = {
-
-    val config = PlayConfig(configuration)
-
-    /*
-     * The Play secret.
-     *
-     * We want to:
-     *
-     * 1) Encourage the practice of *not* using the same secret in dev and prod.
-     * 2) Make it obvious that the secret should be changed.
-     * 3) Ensure that in dev mode, the secret stays stable across restarts.
-     * 4) Ensure that in dev mode, sessions do not interfere with other applications that may be or have been running
-     *   on localhost.  Eg, if I start Play app 1, and it stores a PLAY_SESSION cookie for localhost:9000, then I stop
-     *   it, and start Play app 2, when it reads the PLAY_SESSION cookie for localhost:9000, it should not see the
-     *   session set by Play app 1.  This can be achieved by using different secrets for the two, since if they are
-     *   different, they will simply ignore the session cookie set by the other.
-     *
-     * To achieve 1 and 2, we will, in Activator templates, set the default secret to be "changeme".  This should make
-     * it obvious that the secret needs to be changed and discourage using the same secret in dev and prod.
-     *
-     * For safety, if the secret is not set, or if it's changeme, and we are in prod mode, then we will fail fatally.
-     * This will further enforce both 1 and 2.
-     *
-     * To achieve 3, if in dev or test mode, if the secret is either changeme or not set, we will generate a secret
-     * based on the location of application.conf.  This should be stable across restarts for a given application.
-     *
-     * To achieve 4, using the location of application.conf to generate the secret should ensure this.
-     */
-    val secret = config.getDeprecated[Option[String]]("play.crypto.secret", "application.secret") match {
-      case (Some("changeme") | Some(Blank()) | None) if environment.mode == Mode.Prod =>
-        logger.error("The application secret has not been set, and we are in prod mode. Your application is not secure.")
-        logger.error("To set the application secret, please read http://playframework.com/documentation/latest/ApplicationSecret")
-        throw new PlayException("Configuration error", "Application secret not set")
-      case Some("changeme") | Some(Blank()) | None =>
-        val appConfLocation = environment.resource("application.conf")
-        // Try to generate a stable secret. Security is not the issue here, since this is just for tests and dev mode.
-        val secret = appConfLocation.fold(
-          // No application.conf?  Oh well, just use something hard coded.
-          "she sells sea shells on the sea shore"
-        )(_.toString)
-        val md5Secret = DigestUtils.md5Hex(secret)
-        logger.debug(s"Generated dev mode secret $md5Secret for app at ${appConfLocation.getOrElse("unknown location")}")
-        md5Secret
-      case Some(s) => s
-    }
-
-    val provider = config.get[Option[String]]("play.crypto.provider")
-    val transformation = config.get[String]("play.crypto.aes.transformation")
-
-    CryptoConfig(secret, provider, transformation)
-  }
-}
-
-/**
- * Configuration for Crypto
- *
- * @param secret The application secret
- * @param aesTransformation The AES transformation to use
- * @param provider The crypto provider to use
- */
-case class CryptoConfig(
-  secret: String,
-  provider: Option[String] = None,
-  aesTransformation: String = "AES/CTR/NoPadding")
-
-/**
- * Cryptographic utilities.
- *
- * These utilities are intended as a convenience, however it is important to read each methods documentation and
- * understand the concepts behind encryption to use this class properly.  Safe encryption is hard, and there is no
- * substitute for an adequate understanding of cryptography.  These methods will not be suitable for all encryption
- * needs.
- *
- * For more information about cryptography, we recommend reading the OWASP Cryptographic Storage Cheatsheet:
- *
- * https://www.owasp.org/index.php/Cryptographic_Storage_Cheat_Sheet
- */
-@Singleton
-class Crypto @Inject() (config: CryptoConfig) {
-
-  private val random = new SecureRandom()
-
-  /**
-   * Signs the given String with HMAC-SHA1 using the given key.
-   *
-   * By default this uses the platform default JSSE provider.  This can be overridden by defining
-   * `play.crypto.provider` in `application.conf`.
-   *
-   * @param message The message to sign.
-   * @param key The private key to sign with.
-   * @return A hexadecimal encoded signature.
-   */
-  def sign(message: String, key: Array[Byte]): String = {
-    val mac = config.provider.fold(Mac.getInstance("HmacSHA1"))(p => Mac.getInstance("HmacSHA1", p))
-    mac.init(new SecretKeySpec(key, "HmacSHA1"))
-    Codecs.toHexString(mac.doFinal(message.getBytes("utf-8")))
-  }
-
-  /**
-   * Signs the given String with HMAC-SHA1 using the application’s secret key.
-   *
-   * By default this uses the platform default JSSE provider.  This can be overridden by defining
-   * `play.crypto.provider` in `application.conf`.
-   *
-   * @param message The message to sign.
-   * @return A hexadecimal encoded signature.
-   */
-  def sign(message: String): String = {
-    sign(message, config.secret.getBytes("utf-8"))
-  }
-
-  /**
-   * Sign a token.  This produces a new token, that has this token signed with a nonce.
-   *
-   * This primarily exists to defeat the BREACH vulnerability, as it allows the token to effectively be random per
-   * request, without actually changing the value.
-   *
-   * @param token The token to sign
-   * @return The signed token
-   */
-  def signToken(token: String): String = {
-    val nonce = System.currentTimeMillis()
-    val joined = nonce + "-" + token
-    sign(joined) + "-" + joined
-  }
-
-  /**
-   * Extract a signed token that was signed by [[play.api.libs.Crypto.signToken]].
-   *
-   * @param token The signed token to extract.
-   * @return The verified raw token, or None if the token isn't valid.
-   */
-  def extractSignedToken(token: String): Option[String] = {
-    token.split("-", 3) match {
-      case Array(signature, nonce, raw) if constantTimeEquals(signature, sign(nonce + "-" + raw)) => Some(raw)
-      case _ => None
-    }
-  }
-
-  /**
-   * Generate a cryptographically secure token
-   */
-  def generateToken: String = {
-    val bytes = new Array[Byte](12)
-    random.nextBytes(bytes)
-    new String(Hex.encodeHex(bytes))
-  }
-
-  /**
-   * Generate a signed token
-   */
-  def generateSignedToken: String = signToken(generateToken)
-
-  /**
-   * Compare two signed tokens
-   */
-  def compareSignedTokens(tokenA: String, tokenB: String): Boolean = {
-    (for {
-      rawA <- extractSignedToken(tokenA)
-      rawB <- extractSignedToken(tokenB)
-    } yield constantTimeEquals(rawA, rawB)).getOrElse(false)
-  }
-
-  /**
-   * Constant time equals method.
-   *
-   * Given a length that both Strings are equal to, this method will always run in constant time.  This prevents
-   * timing attacks.
-   */
-  def constantTimeEquals(a: String, b: String): Boolean = {
-    if (a.length != b.length) {
-      false
-    } else {
-      var equal = 0
-      for (i <- 0 until a.length) {
-        equal |= a(i) ^ b(i)
-      }
-      equal == 0
-    }
-  }
-
-  /**
-   * Encrypt a String with the AES encryption standard using the application's secret key.
-   *
-   * The provider used is by default this uses the platform default JSSE provider.  This can be overridden by defining
-   * `play.crypto.provider` in `application.conf`.
-   *
-   * The transformation algorithm used is the provider specific implementation of the `AES` name.  On Oracles JDK,
-   * this is `AES/CTR/NoPadding`.  This algorithm is suitable for small amounts of data, typically less than 32
-   * bytes, hence is useful for encrypting credit card numbers, passwords etc.  For larger blocks of data, this
-   * algorithm may expose patterns and be vulnerable to repeat attacks.
-   *
-   * The transformation algorithm can be configured by defining `play.crypto.aes.transformation` in
-   * `application.conf`.  Although any cipher transformation algorithm can be selected here, the secret key spec used
-   * is always AES, so only AES transformation algorithms will work.
-   *
-   * @param value The String to encrypt.
-   * @return An hexadecimal encrypted string.
-   */
-  def encryptAES(value: String): String = {
-    encryptAES(value, config.secret)
-  }
-
-  /**
-   * Encrypt a String with the AES encryption standard and the supplied private key.
-   *
-   *
-   * The provider used is by default this uses the platform default JSSE provider.  This can be overridden by defining
-   * `play.crypto.provider` in `application.conf`.
-   *
-   * The transformation algorithm used is the provider specific implementation of the `AES` name.  On Oracles JDK,
-   * this is `AES/CTR/NoPadding`.  This algorithm is suitable for small amounts of data, typically less than 32
-   * bytes, hence is useful for encrypting credit card numbers, passwords etc.  For larger blocks of data, this
-   * algorithm may expose patterns and be vulnerable to repeat attacks.
-   *
-   * The transformation algorithm can be configured by defining `play.crypto.aes.transformation` in
-   * `application.conf`.  Although any cipher transformation algorithm can be selected here, the secret key spec used
-   * is always AES, so only AES transformation algorithms will work.
-   *
-   * @param value The String to encrypt.
-   * @param privateKey The key used to encrypt.
-   * @return A Base64 encrypted string.
-   */
-  def encryptAES(value: String, privateKey: String): String = {
-    val skeySpec = secretKeyWithSha256(privateKey, "AES")
-    val cipher = getCipherWithConfiguredProvider(config.aesTransformation)
-    cipher.init(Cipher.ENCRYPT_MODE, skeySpec)
-    val encryptedValue = cipher.doFinal(value.getBytes("utf-8"))
-    // return a formatted, versioned encrypted string
-    // '2-*' represents an encrypted payload with an IV
-    // '1-*' represents an encrypted payload without an IV
-    Option(cipher.getIV()) match {
-      case Some(iv) => s"2-${Base64.encodeBase64String(iv ++ encryptedValue)}"
-      case None => s"1-${Base64.encodeBase64String(encryptedValue)}"
-    }
-  }
-
-  /**
-   * Generates the SecretKeySpec, given the private key and the algorithm.
-   */
-  private def secretKeyWithSha256(privateKey: String, algorithm: String) = {
-    val messageDigest = MessageDigest.getInstance("SHA-256")
-    messageDigest.update(privateKey.getBytes("utf-8"))
-    // max allowed length in bits / (8 bits to a byte)
-    val maxAllowedKeyLength = Cipher.getMaxAllowedKeyLength(algorithm) / 8
-    val raw = messageDigest.digest().slice(0, maxAllowedKeyLength)
-    new SecretKeySpec(raw, algorithm)
-  }
-
-  /**
-   * Gets a Cipher with a configured provider, and a configurable AES transformation method.
-   */
-  private def getCipherWithConfiguredProvider(transformation: String): Cipher = {
-    config.provider.fold(Cipher.getInstance(transformation)) { p =>
-      Cipher.getInstance(transformation, p)
-    }
-  }
-
-  /**
-   * Decrypt a String with the AES encryption standard using the application's secret key.
-   *
-   * The provider used is by default this uses the platform default JSSE provider.  This can be overridden by defining
-   * `play.crypto.provider` in `application.conf`.
-   *
-   * The transformation used is by default `AES/CTR/NoPadding`.  It can be configured by defining
-   * `play.crypto.aes.transformation` in `application.conf`.  Although any cipher transformation algorithm can
-   * be selected here, the secret key spec used is always AES, so only AES transformation algorithms will work.
-   *
-   * @param value An hexadecimal encrypted string.
-   * @return The decrypted String.
-   */
-  def decryptAES(value: String): String = {
-    decryptAES(value, config.secret)
-  }
-
-  /**
-   * Decrypt a String with the AES encryption standard.
-   *
-   * The private key must have a length of 16 bytes.
-   *
-   * The provider used is by default this uses the platform default JSSE provider.  This can be overridden by defining
-   * `play.crypto.provider` in `application.conf`.
-   *
-   * The transformation used is by default `AES/CTR/NoPadding`.  It can be configured by defining
-   * `play.crypto.aes.transformation` in `application.conf`.  Although any cipher transformation algorithm can
-   * be selected here, the secret key spec used is always AES, so only AES transformation algorithms will work.
-   *
-   * @param value An hexadecimal encrypted string.
-   * @param privateKey The key used to encrypt.
-   * @return The decrypted String.
-   */
-  def decryptAES(value: String, privateKey: String): String = {
-    val seperator = "-"
-    val sepIndex = value.indexOf(seperator)
-    if (sepIndex < 0) {
-      decryptAESVersion0(value, privateKey)
-    } else {
-      val version = value.substring(0, sepIndex)
-      val data = value.substring(sepIndex + 1, value.length())
-      version match {
-        case "1" => {
-          decryptAESVersion1(data, privateKey)
-        }
-        case "2" => {
-          decryptAESVersion2(data, privateKey)
-        }
-        case _ => {
-          throw new CryptoException("Unknown version")
-        }
-      }
-    }
-  }
-
-  /** Backward compatible AES ECB mode decryption support. */
-  private def decryptAESVersion0(value: String, privateKey: String): String = {
-    val raw = privateKey.substring(0, 16).getBytes("utf-8")
-    val skeySpec = new SecretKeySpec(raw, "AES")
-    val cipher = getCipherWithConfiguredProvider("AES")
-    cipher.init(Cipher.DECRYPT_MODE, skeySpec)
-    new String(cipher.doFinal(Codecs.hexStringToByte(value)))
-  }
-
-  /** V1 decryption algorithm (No IV). */
-  private def decryptAESVersion1(value: String, privateKey: String): String = {
-    val data = Base64.decodeBase64(value)
-    val skeySpec = secretKeyWithSha256(privateKey, "AES")
-    val cipher = getCipherWithConfiguredProvider(config.aesTransformation)
-    cipher.init(Cipher.DECRYPT_MODE, skeySpec)
-    new String(cipher.doFinal(data), "utf-8")
-  }
-
-  /** V2 decryption algorithm (IV present). */
-  private def decryptAESVersion2(value: String, privateKey: String): String = {
-    val data = Base64.decodeBase64(value)
-    val skeySpec = secretKeyWithSha256(privateKey, "AES")
-    val cipher = getCipherWithConfiguredProvider(config.aesTransformation)
-    val blockSize = cipher.getBlockSize
-    val iv = data.slice(0, blockSize)
-    val payload = data.slice(blockSize, data.size)
-    cipher.init(Cipher.DECRYPT_MODE, skeySpec, new IvParameterSpec(iv))
-    new String(cipher.doFinal(payload), "utf-8")
-  }
 }

--- a/framework/src/play/src/main/scala/play/api/libs/crypto/Crypto.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/crypto/Crypto.scala
@@ -1,0 +1,519 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.libs.crypto
+
+import java.security.{ MessageDigest, SecureRandom }
+import java.time.Clock
+import javax.crypto.spec.{ IvParameterSpec, SecretKeySpec }
+import javax.crypto.{ Cipher, Mac }
+import javax.inject.{ Inject, Provider, Singleton }
+
+import org.apache.commons.codec.binary.{ Base64, Hex }
+import org.apache.commons.codec.digest.DigestUtils
+import play.api._
+import play.api.libs.Codecs
+
+/**
+ * Authenticates a cookie by returning a message authentication code (MAC).
+ *
+ * This trait should not be used as a general purpose MAC utility.
+ */
+trait CookieSigner {
+
+  /**
+   * Signs (MAC) the given String using the given secret key.
+   *
+   * By default this uses the platform default JCE provider.  This can be overridden by defining
+   * `play.crypto.provider` in `application.conf`.
+   *
+   * @param message The message to sign.
+   * @param key     The private key to sign with.
+   * @return A hexadecimal encoded signature.
+   */
+  def sign(message: String, key: Array[Byte]): String
+
+  /**
+   * Signs (MAC) the given String using the application’s secret key.
+   *
+   * By default this uses the platform default JCE provider.  This can be overridden by defining
+   * `play.crypto.provider` in `application.conf`.
+   *
+   * @param message The message to sign.
+   * @return A hexadecimal encoded signature.
+   */
+  def sign(message: String): String
+}
+
+/**
+ * Cryptographic utilities for generating and validating CSRF tokens.
+ *
+ * This trait should not be used as a general purpose encryption utility.
+ */
+trait CSRFTokenSigner {
+
+  /**
+   * Sign a token.  This produces a new token, that has this token signed with a nonce.
+   *
+   * This primarily exists to defeat the BREACH vulnerability, as it allows the token to effectively be random per
+   * request, without actually changing the value.
+   *
+   * @param token The token to sign
+   * @return The signed token
+   */
+  def signToken(token: String): String
+
+  /**
+   * Generates a cryptographically secure token.
+   */
+  def generateToken: String
+
+  /**
+   * Generates a signed token.
+   */
+  def generateSignedToken: String
+
+  /**
+   * Extract a signed token that was signed by [[play.api.libs.Crypto.signToken]].
+   *
+   * @param token The signed token to extract.
+   * @return The verified raw token, or None if the token isn't valid.
+   */
+  def extractSignedToken(token: String): Option[String]
+
+  /**
+   * Compare two signed tokens
+   */
+  def compareSignedTokens(tokenA: String, tokenB: String): Boolean
+
+  /**
+   * Constant time equals method.
+   *
+   * Given a length that both Strings are equal to, this method will always run in constant time.  This prevents
+   * timing attacks.
+   */
+  def constantTimeEquals(a: String, b: String): Boolean
+}
+
+/**
+ * Encrypts and decrypts strings using AES.
+ *
+ * Note that the output from AES/CTR is vulnerable to malleability attacks unless signed with a MAC.
+ *
+ * In addition, because this class is hardcoded to use AES, it cannot be used a general purpose Crypter.
+ *
+ * It is also not used anywhere internally to the Play code base.
+ */
+@deprecated(message = "This method is deprecated and will be removed in future versions.", since = "2.5.0")
+trait AESCrypter {
+
+  /**
+   * Encrypt a String with the AES encryption standard using the application's secret key.
+   *
+   * The provider used is by default this uses the platform default JSSE provider.  This can be overridden by defining
+   * `play.crypto.provider` in `application.conf`.
+   *
+   * The transformation algorithm used is the provider specific implementation of the `AES` name.  On Oracles JDK,
+   * this is `AES/CTR/NoPadding`.  This algorithm is suitable for small amounts of data, typically less than 32
+   * bytes, hence is useful for encrypting credit card numbers, passwords etc.  For larger blocks of data, this
+   * algorithm may expose patterns and be vulnerable to repeat attacks.
+   *
+   * The transformation algorithm can be configured by defining `play.crypto.aes.transformation` in
+   * `application.conf`.  Although any cipher transformation algorithm can be selected here, the secret key spec used
+   * is always AES, so only AES transformation algorithms will work.
+   *
+   * @deprecated This method is deprecated and will be removed in future versions.
+   * @param value The String to encrypt.
+   * @return An hexadecimal encrypted string.
+   */
+  @deprecated(message = "This method is deprecated and will be removed in future versions.", since = "2.5.0")
+  def encryptAES(value: String): String
+
+  /**
+   * Encrypt a String with the AES encryption standard and the supplied private key.
+   *
+   * The provider used is by default this uses the platform default JSSE provider.  This can be overridden by defining
+   * `play.crypto.provider` in `application.conf`.
+   *
+   * The transformation algorithm used is the provider specific implementation of the `AES` name.  On Oracles JDK,
+   * this is `AES/CTR/NoPadding`.  This algorithm is suitable for small amounts of data, typically less than 32
+   * bytes, hence is useful for encrypting credit card numbers, passwords etc.  For larger blocks of data, this
+   * algorithm may expose patterns and be vulnerable to repeat attacks.
+   *
+   * The transformation algorithm can be configured by defining `play.crypto.aes.transformation` in
+   * `application.conf`.  Although any cipher transformation algorithm can be selected here, the secret key spec used
+   * is always AES, so only AES transformation algorithms will work.
+   *
+   * @deprecated This method is deprecated and will be removed in future versions.
+   * @param value The String to encrypt.
+   * @param privateKey The key used to encrypt.
+   * @return An hexadecimal encrypted string.
+   */
+  @deprecated(message = "This method is deprecated and will be removed in future versions.", since = "2.5.0")
+  def encryptAES(value: String, privateKey: String): String
+
+  /**
+   * Decrypt a String with the AES encryption standard using the application's secret key.
+   *
+   * The provider used is by default this uses the platform default JSSE provider.  This can be overridden by defining
+   * `play.crypto.provider` in `application.conf`.
+   *
+   * The transformation used is by default `AES/CTR/NoPadding`.  It can be configured by defining
+   * `play.crypto.aes.transformation` in `application.conf`.  Although any cipher transformation algorithm can
+   * be selected here, the secret key spec used is always AES, so only AES transformation algorithms will work.
+   *
+   * @deprecated This method is deprecated and will be removed in future versions.
+   * @param value An hexadecimal encrypted string.
+   * @return The decrypted String.
+   */
+  @deprecated(message = "This method is deprecated and will be removed in future versions.", since = "2.5.0")
+  def decryptAES(value: String): String
+
+  /**
+   * Decrypt a String with the AES encryption standard.
+   *
+   * The private key must have a length of 16 bytes.
+   *
+   * The provider used is by default this uses the platform default JSSE provider.  This can be overridden by defining
+   * `play.crypto.provider` in `application.conf`.
+   *
+   * The transformation used is by default `AES/CTR/NoPadding`.  It can be configured by defining
+   * `play.crypto.aes.transformation` in `application.conf`.  Although any cipher transformation algorithm can
+   * be selected here, the secret key spec used is always AES, so only AES transformation algorithms will work.
+   *
+   * @deprecated This method is deprecated and will be removed in future versions.
+   * @param value An hexadecimal encrypted string.
+   * @param privateKey The key used to encrypt.
+   * @return The decrypted String.
+   */
+  @deprecated(message = "This method is deprecated and will be removed in future versions.", since = "2.5.0")
+  def decryptAES(value: String, privateKey: String): String
+
+}
+
+/**
+ * Exception thrown by the Crypto APIs.
+ *
+ * @param message The error message.
+ * @param throwable The Throwable associated with the exception.
+ */
+class CryptoException(val message: String = null, val throwable: Throwable = null) extends RuntimeException(message, throwable)
+
+@Singleton
+class CookieSignerProvider @Inject() (config: CryptoConfig) extends Provider[CookieSigner] {
+  lazy val get: CookieSigner = new HMACSHA1CookieSigner(config)
+}
+
+/**
+ * Uses an HMAC-SHA1 for signing cookies.
+ */
+class HMACSHA1CookieSigner @Inject() (config: CryptoConfig) extends CookieSigner {
+
+  /**
+   * Signs the given String with HMAC-SHA1 using the given key.
+   *
+   * By default this uses the platform default JSSE provider.  This can be overridden by defining
+   * `play.crypto.provider` in `application.conf`.
+   *
+   * @param message The message to sign.
+   * @param key The private key to sign with.
+   * @return A hexadecimal encoded signature.
+   */
+  def sign(message: String, key: Array[Byte]): String = {
+    val mac = config.provider.fold(Mac.getInstance("HmacSHA1"))(p => Mac.getInstance("HmacSHA1", p))
+    mac.init(new SecretKeySpec(key, "HmacSHA1"))
+    Codecs.toHexString(mac.doFinal(message.getBytes("utf-8")))
+  }
+
+  /**
+   * Signs the given String with HMAC-SHA1 using the application’s secret key.
+   *
+   * By default this uses the platform default JSSE provider.  This can be overridden by defining
+   * `play.crypto.provider` in `application.conf`.
+   *
+   * @param message The message to sign.
+   * @return A hexadecimal encoded signature.
+   */
+  def sign(message: String): String = {
+    sign(message, config.secret.getBytes("utf-8"))
+  }
+
+}
+
+@Singleton
+class CSRFTokenSignerProvider @Inject() (signer: CookieSigner) extends Provider[CSRFTokenSigner] {
+  lazy val get: CSRFTokenSigner = new DefaultCSRFTokenSigner(signer, Clock.systemUTC())
+}
+
+/**
+ * This class is used for generating random tokens for CSRF.
+ */
+class DefaultCSRFTokenSigner @Inject() (signer: CookieSigner, clock: Clock) extends CSRFTokenSigner {
+
+  // If you're running on an older version of Windows, you may be using
+  // SHA1PRNG.  So immediately calling nextBytes with a seed length
+  // of 440 bits (NIST SP800-90A) will do a more than decent
+  // self-seeding for a SHA-1 based PRNG.
+  private val random = new SecureRandom()
+  random.nextBytes(new Array[Byte](55))
+
+  /**
+   * Sign a token.  This produces a new token, that has this token signed with a nonce.
+   *
+   * This primarily exists to defeat the BREACH vulnerability, as it allows the token to effectively be random per
+   * request, without actually changing the value.
+   *
+   * @param token The token to sign
+   * @return The signed token
+   */
+  def signToken(token: String): String = {
+    val nonce = clock.millis()
+    val joined = nonce + "-" + token
+    signer.sign(joined) + "-" + joined
+  }
+
+  /**
+   * Extract a signed token that was signed by [[CSRFTokenSigner.signToken]].
+   *
+   * @param token The signed token to extract.
+   * @return The verified raw token, or None if the token isn't valid.
+   */
+  def extractSignedToken(token: String): Option[String] = {
+    token.split("-", 3) match {
+      case Array(signature, nonce, raw) if constantTimeEquals(signature, signer.sign(nonce + "-" + raw)) => Some(raw)
+      case _ => None
+    }
+  }
+
+  /**
+   * Generate a cryptographically secure token
+   */
+  def generateToken: String = {
+    val bytes = new Array[Byte](12)
+    random.nextBytes(bytes)
+    new String(Hex.encodeHex(bytes))
+  }
+
+  /**
+   * Generate a signed token
+   */
+  def generateSignedToken: String = signToken(generateToken)
+
+  /**
+   * Compare two signed tokens
+   */
+  def compareSignedTokens(tokenA: String, tokenB: String): Boolean = {
+    (for {
+      rawA <- extractSignedToken(tokenA)
+      rawB <- extractSignedToken(tokenB)
+    } yield CSRFTokenSigner.constantTimeEquals(rawA, rawB)).getOrElse(false)
+  }
+
+  /**
+   * Constant time equals method.
+   *
+   * Given a length that both Strings are equal to, this method will always run in constant time.  This prevents
+   * timing attacks.
+   */
+  override def constantTimeEquals(a: String, b: String): Boolean = CSRFTokenSigner.constantTimeEquals(a, b)
+}
+
+object CSRFTokenSigner {
+
+  /**
+   * Constant time equals method.
+   *
+   * Given a length that both Strings are equal to, this method will always run in constant time.  This prevents
+   * timing attacks.
+   */
+  def constantTimeEquals(a: String, b: String): Boolean = {
+    if (a.length != b.length) {
+      false
+    } else {
+      var equal = 0
+      for (i <- 0 until a.length) {
+        equal |= a(i) ^ b(i)
+      }
+      equal == 0
+    }
+  }
+}
+
+@Singleton
+class AESCrypterProvider @Inject() (config: CryptoConfig) extends Provider[AESCrypter] {
+  lazy val get = new AESCTRCrypter(config)
+}
+
+/**
+ * Symmetric encryption using AES/CTR/NoPadding.
+ */
+class AESCTRCrypter @Inject() (config: CryptoConfig) extends AESCrypter {
+
+  def encryptAES(value: String): String = {
+    encryptAES(value, config.secret)
+  }
+
+  @deprecated("This method will be removed in future versions ", "2.5.0")
+  def encryptAES(value: String, privateKey: String): String = {
+    val skeySpec = secretKeyWithSha256(privateKey, "AES")
+    val cipher = getCipherWithConfiguredProvider(config.aesTransformation)
+    cipher.init(Cipher.ENCRYPT_MODE, skeySpec)
+    val encryptedValue = cipher.doFinal(value.getBytes("utf-8"))
+    // return a formatted, versioned encrypted string
+    // '2-*' represents an encrypted payload with an IV
+    // '1-*' represents an encrypted payload without an IV
+    Option(cipher.getIV()) match {
+      case Some(iv) => s"2-${Base64.encodeBase64String(iv ++ encryptedValue)}"
+      case None => s"1-${Base64.encodeBase64String(encryptedValue)}"
+    }
+  }
+
+  /**
+   * Generates the SecretKeySpec, given the private key and the algorithm.
+   */
+  private def secretKeyWithSha256(privateKey: String, algorithm: String) = {
+    val messageDigest = MessageDigest.getInstance("SHA-256")
+    messageDigest.update(privateKey.getBytes("utf-8"))
+    // max allowed length in bits / (8 bits to a byte)
+    val maxAllowedKeyLength = Cipher.getMaxAllowedKeyLength(algorithm) / 8
+    val raw = messageDigest.digest().slice(0, maxAllowedKeyLength)
+    new SecretKeySpec(raw, algorithm)
+  }
+
+  /**
+   * Gets a Cipher with a configured provider, and a configurable AES transformation method.
+   */
+  private def getCipherWithConfiguredProvider(transformation: String): Cipher = {
+    config.provider.fold(Cipher.getInstance(transformation)) { p =>
+      Cipher.getInstance(transformation, p)
+    }
+  }
+
+  @deprecated("This method will be removed in future versions ", "2.5.0")
+  def decryptAES(value: String): String = {
+    decryptAES(value, config.secret)
+  }
+
+  @deprecated("This method will be removed in future versions ", "2.5.0")
+  def decryptAES(value: String, privateKey: String): String = {
+    val seperator = "-"
+    val sepIndex = value.indexOf(seperator)
+    if (sepIndex < 0) {
+      decryptAESVersion0(value, privateKey)
+    } else {
+      val version = value.substring(0, sepIndex)
+      val data = value.substring(sepIndex + 1, value.length())
+      version match {
+        case "1" => {
+          decryptAESVersion1(data, privateKey)
+        }
+        case "2" => {
+          decryptAESVersion2(data, privateKey)
+        }
+        case _ => {
+          throw new CryptoException("Unknown version")
+        }
+      }
+    }
+  }
+
+  /** Backward compatible AES ECB mode decryption support. */
+  private def decryptAESVersion0(value: String, privateKey: String): String = {
+    val raw = privateKey.substring(0, 16).getBytes("utf-8")
+    val skeySpec = new SecretKeySpec(raw, "AES")
+    val cipher = getCipherWithConfiguredProvider("AES")
+    cipher.init(Cipher.DECRYPT_MODE, skeySpec)
+    new String(cipher.doFinal(Codecs.hexStringToByte(value)))
+  }
+
+  /** V1 decryption algorithm (No IV). */
+  private def decryptAESVersion1(value: String, privateKey: String): String = {
+    val data = Base64.decodeBase64(value)
+    val skeySpec = secretKeyWithSha256(privateKey, "AES")
+    val cipher = getCipherWithConfiguredProvider(config.aesTransformation)
+    cipher.init(Cipher.DECRYPT_MODE, skeySpec)
+    new String(cipher.doFinal(data), "utf-8")
+  }
+
+  /** V2 decryption algorithm (IV present). */
+  private def decryptAESVersion2(value: String, privateKey: String): String = {
+    val data = Base64.decodeBase64(value)
+    val skeySpec = secretKeyWithSha256(privateKey, "AES")
+    val cipher = getCipherWithConfiguredProvider(config.aesTransformation)
+    val blockSize = cipher.getBlockSize
+    val iv = data.slice(0, blockSize)
+    val payload = data.slice(blockSize, data.size)
+    cipher.init(Cipher.DECRYPT_MODE, skeySpec, new IvParameterSpec(iv))
+    new String(cipher.doFinal(payload), "utf-8")
+  }
+}
+
+/**
+ * Configuration for Crypto
+ *
+ * @param secret The application secret
+ * @param aesTransformation The AES transformation to use
+ * @param provider The crypto provider to use
+ */
+case class CryptoConfig(secret: String,
+  provider: Option[String] = None,
+  @deprecated("This field is deprecated and will be removed in future versions", "2.5.0") aesTransformation: String = "AES/CTR/NoPadding")
+
+@Singleton
+class CryptoConfigParser @Inject() (environment: Environment, configuration: Configuration) extends Provider[CryptoConfig] {
+
+  lazy val get = {
+
+    val config = PlayConfig(configuration)
+
+    /*
+     * The Play secret.
+     *
+     * We want to:
+     *
+     * 1) Encourage the practice of *not* using the same secret in dev and prod.
+     * 2) Make it obvious that the secret should be changed.
+     * 3) Ensure that in dev mode, the secret stays stable across restarts.
+     * 4) Ensure that in dev mode, sessions do not interfere with other applications that may be or have been running
+     *   on localhost.  Eg, if I start Play app 1, and it stores a PLAY_SESSION cookie for localhost:9000, then I stop
+     *   it, and start Play app 2, when it reads the PLAY_SESSION cookie for localhost:9000, it should not see the
+     *   session set by Play app 1.  This can be achieved by using different secrets for the two, since if they are
+     *   different, they will simply ignore the session cookie set by the other.
+     *
+     * To achieve 1 and 2, we will, in Activator templates, set the default secret to be "changeme".  This should make
+     * it obvious that the secret needs to be changed and discourage using the same secret in dev and prod.
+     *
+     * For safety, if the secret is not set, or if it's changeme, and we are in prod mode, then we will fail fatally.
+     * This will further enforce both 1 and 2.
+     *
+     * To achieve 3, if in dev or test mode, if the secret is either changeme or not set, we will generate a secret
+     * based on the location of application.conf.  This should be stable across restarts for a given application.
+     *
+     * To achieve 4, using the location of application.conf to generate the secret should ensure this.
+     */
+    val secret = config.getDeprecated[Option[String]]("play.crypto.secret", "application.secret") match {
+      case (Some("changeme") | Some(Blank()) | None) if environment.mode == Mode.Prod =>
+        logger.error("The application secret has not been set, and we are in prod mode. Your application is not secure.")
+        logger.error("To set the application secret, please read http://playframework.com/documentation/latest/ApplicationSecret")
+        throw new PlayException("Configuration error", "Application secret not set")
+      case Some("changeme") | Some(Blank()) | None =>
+        val appConfLocation = environment.resource("application.conf")
+        // Try to generate a stable secret. Security is not the issue here, since this is just for tests and dev mode.
+        val secret = appConfLocation.fold(
+          // No application.conf?  Oh well, just use something hard coded.
+          "she sells sea shells on the sea shore"
+        )(_.toString)
+        val md5Secret = DigestUtils.md5Hex(secret)
+        logger.debug(s"Generated dev mode secret $md5Secret for app at ${appConfLocation.getOrElse("unknown location")}")
+        md5Secret
+      case Some(s) => s
+    }
+
+    val provider = config.get[Option[String]]("play.crypto.provider")
+    val transformation = config.get[String]("play.crypto.aes.transformation")
+
+    CryptoConfig(secret, provider, transformation)
+  }
+  private val Blank = """\s*""".r
+  private val logger = Logger(classOf[CryptoConfigParser])
+}

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -8,7 +8,7 @@ package play.api.mvc {
   import play.api._
   import play.api.http._
   import play.api.i18n.Lang
-  import play.api.libs.Crypto
+  import play.api.libs.crypto.CookieSigner
   import play.core.utils.CaseInsensitiveOrdered
 
   import scala.annotation._
@@ -176,6 +176,7 @@ package play.api.mvc {
 
     /**
       * Convenience method for adding a single tag to this request
+      *
       * @return the tagged request
       */
     def withTag(tagName: String, tagValue: String): RequestHeader = {
@@ -525,6 +526,11 @@ package play.api.mvc {
     def path = "/"
 
     /**
+     * The cookie signer.
+     */
+    def cookieSigner: CookieSigner
+
+    /**
      * Encodes the data as a `String`.
      */
     def encode(data: Map[String, String]): String = {
@@ -532,7 +538,7 @@ package play.api.mvc {
         case (k, v) => URLEncoder.encode(k, "UTF-8") + "=" + URLEncoder.encode(v, "UTF-8")
       }.mkString("&")
       if (isSigned)
-        Crypto.sign(encoded) + "-" + encoded
+        cookieSigner.sign(encoded) + "-" + encoded
       else
         encoded
     }
@@ -569,7 +575,7 @@ package play.api.mvc {
         if (isSigned) {
           val splitted = data.split("-", 2)
           val message = splitted.tail.mkString("-")
-          if (safeEquals(splitted(0), Crypto.sign(message)))
+          if (safeEquals(splitted(0), cookieSigner.sign(message)))
             urldecode(message)
           else
             Map.empty[String, String]
@@ -693,6 +699,7 @@ package play.api.mvc {
     override def httpOnly = config.httpOnly
     override def path = httpConfiguration.context
     override def domain = config.domain
+    override def cookieSigner = play.api.libs.Crypto.crypto
 
     def deserialize(data: Map[String, String]) = new Session(data)
 
@@ -765,6 +772,7 @@ package play.api.mvc {
     override def secure = config.secure
     override def httpOnly = config.httpOnly
     override def domain = sessionConfig.domain
+    override def cookieSigner = play.api.libs.Crypto.crypto
 
     val emptyCookie = new Flash
 

--- a/framework/src/play/src/test/scala/play/api/libs/crypto/AESCTRCrypterSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/crypto/AESCTRCrypterSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.libs.crypto
+
+import javax.crypto.Cipher
+import javax.crypto.spec.SecretKeySpec
+
+import org.specs2.mutable.Specification
+import play.api.libs.Codecs
+
+class AESCTRCrypterSpec extends Specification {
+
+  val key = "0123456789abcdef"
+  val cryptoConfig = CryptoConfig(key, None, "AES")
+
+  "Crypto api using symmetrical encryption" should {
+
+    val crypter = new AESCTRCrypter(cryptoConfig)
+
+    "be able to encrypt/decrypt text using AES algorithm" in {
+      val text = "Play Framework 2.0"
+      crypter.decryptAES(crypter.encryptAES(text, key), key) must be equalTo text
+    }
+
+    "be able to encrypt/decrypt text using other AES transformations" in {
+      val text = "Play Framework 2.0"
+      crypter.decryptAES(crypter.encryptAES(text, key), key) must be equalTo text
+    }
+
+    "be able to decrypt text generated using the old transformation methods" in {
+      val text = "Play Framework 2.0"
+      val key = "0123456789abcdef"
+      // old way to encrypt things
+      val cipher = Cipher.getInstance("AES")
+      val skeySpec = new SecretKeySpec(key.substring(0, 16).getBytes("utf-8"), "AES")
+      cipher.init(Cipher.ENCRYPT_MODE, skeySpec)
+      val encrypted = Codecs.toHexString(cipher.doFinal(text.getBytes("utf-8")))
+      val cryptoConfig = CryptoConfig(key, None, "AES/CTR/NoPadding")
+      // should be decryptable
+      crypter.decryptAES(encrypted) must be equalTo text
+    }
+  }
+
+}

--- a/framework/src/play/src/test/scala/play/api/libs/crypto/CSRFTokenSignerSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/crypto/CSRFTokenSignerSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.libs.crypto
+
+import java.time.{ Clock, Instant, ZoneId }
+
+import org.specs2.mutable._
+
+class CSRFTokenSignerSpec extends Specification {
+
+  val key = "0123456789abcdef"
+  val cryptoConfig = CryptoConfig(key, None, "AES")
+  val clock = Clock.fixed(Instant.ofEpochMilli(0L), ZoneId.systemDefault)
+  val signer = new HMACSHA1CookieSigner(cryptoConfig)
+  val tokenSigner = new DefaultCSRFTokenSigner(signer, clock)
+
+  "tokenSigner.generateToken" should {
+    "be successful" in {
+      val token = tokenSigner.generateToken
+      token.length must beEqualTo(24)
+    }
+  }
+
+  "tokenSigner.signToken" should {
+    "be successful" in {
+      val token: String = "0FFFFFFFFFFFFFFFFFFFFF24"
+      token.length must be_==(24)
+      val signedToken = tokenSigner.signToken(token)
+      signedToken must beEqualTo("77adb3c3dfe5ee567556b259549a4ddfa6797c05-0-0FFFFFFFFFFFFFFFFFFFFF24")
+    }
+  }
+
+  "tokenSigner.compareSignedTokens" should {
+    "be successful" in {
+      val token1: String = "b3ba23c672b5e115b0c44335544dbf42934f70f5-1445022964749-0FFFFFFFFFFFFFFFFFFFFF24"
+      val token2: String = "b3ba23c672b5e115b0c44335544dbf42934f70f5-1445022964749-0FFFFFFFFFFFFFFFFFFFFF24"
+      val actual = tokenSigner.compareSignedTokens(token1, token2)
+      actual must beTrue
+    }
+  }
+
+}
+

--- a/framework/src/play/src/test/scala/play/api/libs/crypto/CookieSignerSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/crypto/CookieSignerSpec.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package play.api.libs.crypto
+
+import org.specs2.mutable.Specification
+
+class CookieSignerSpec extends Specification {
+
+  "signer.sign" should {
+
+    "be able to sign input using HMAC-SHA1 using the config secret" in {
+      val text = "Play Framework 2.0"
+      val key = "0123456789abcdef"
+      val cryptoConfig = CryptoConfig(key, None, "AES")
+      val signer = new HMACSHA1CookieSigner(cryptoConfig)
+      signer.sign(text) must be_==("94f63b1470ee74e15dc15fd704e26b0df36ef848")
+    }
+
+    "be able to sign input using HMAC-SHA1 using an explicitly passed in key" in {
+      val text = "Play Framework 2.0"
+      val key = "different key"
+      val cryptoConfig = CryptoConfig(key, None, "AES")
+      val signer = new HMACSHA1CookieSigner(cryptoConfig)
+      signer.sign(text, key.getBytes("UTF-8")) must be_==("470037631bddcbd13bb85d80d531c97a340f836f")
+    }
+
+    "be able to sign input using HMAC-SHA1 using an explicitly passed in key (same as secret)" in {
+      val text = "Play Framework 2.0"
+      val key = "0123456789abcdef"
+      val cryptoConfig = CryptoConfig(key, None, "AES")
+      val signer = new HMACSHA1CookieSigner(cryptoConfig)
+      signer.sign(text, key.getBytes("UTF-8")) must be_==("94f63b1470ee74e15dc15fd704e26b0df36ef848")
+    }
+
+  }
+
+}

--- a/framework/src/play/src/test/scala/play/api/libs/crypto/CryptoConfigParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/crypto/CryptoConfigParserSpec.scala
@@ -1,51 +1,15 @@
 /*
  * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
  */
-package play.api.libs
+package play.api.libs.crypto
 
-import javax.crypto.Cipher
-import javax.crypto.spec.SecretKeySpec
+import org.specs2.mutable.Specification
+import play.api.{ PlayException, Configuration, Environment, Mode }
 
-import org.specs2.mutable._
-import play.api._
-
-object CryptoSpec extends Specification {
-
-  "Crypto api" should {
-    "be able to encrypt/decrypt text using AES algorithm" in {
-      val text = "Play Framework 2.0"
-      val key = "0123456789abcdef"
-      val cryptoConfig = CryptoConfig(key, None, "AES")
-      val crypto = new Crypto(cryptoConfig)
-      crypto.decryptAES(crypto.encryptAES(text, key), key) must be equalTo text
-    }
-  }
-
-  "Crypto api" should {
-    "be able to encrypt/decrypt text using other AES transformations" in {
-      val text = "Play Framework 2.0"
-      val key = "0123456789abcdef"
-      val cryptoConfig = CryptoConfig(key, None, "AES/CTR/NoPadding")
-      val crypto = new Crypto(cryptoConfig)
-      crypto.decryptAES(crypto.encryptAES(text, key), key) must be equalTo text
-    }
-  }
-
-  "Crypto api" should {
-    "be able to decrypt text generated using the old transformation methods" in {
-      val text = "Play Framework 2.0"
-      val key = "0123456789abcdef"
-      // old way to encrypt things
-      val cipher = Cipher.getInstance("AES")
-      val skeySpec = new SecretKeySpec(key.substring(0, 16).getBytes("utf-8"), "AES")
-      cipher.init(Cipher.ENCRYPT_MODE, skeySpec)
-      val encrypted = Codecs.toHexString(cipher.doFinal(text.getBytes("utf-8")))
-      val cryptoConfig = CryptoConfig(key, None, "AES/CTR/NoPadding")
-      val crypto = new Crypto(cryptoConfig)
-      // should be decryptable
-      crypto.decryptAES(encrypted) must be equalTo text
-    }
-  }
+/**
+ *
+ */
+class CryptoConfigParserSpec extends Specification {
 
   "Crypto config parser" should {
     "parse the secret" in {
@@ -94,6 +58,4 @@ object CryptoSpec extends Specification {
       }
     }
   }
-
 }
-


### PR DESCRIPTION
A more ambitious Crypto module.

Breaks out Crypto into a trait and adds Guice bindings.
Deprecates AES methods (see #4407)
Adds more tests of signing, generating random methods.
Does a random.nextBytes() with 55 bytes, because why not.