### PR TITLE
Fix java.time.Instant JSON Reads / Writes

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
@@ -5,9 +5,11 @@ package play.api.libs.json
 
 import java.time.{
   Clock,
+  DateTimeException,
   Instant,
   LocalDate,
   LocalDateTime,
+  OffsetDateTime,
   ZoneId,
   ZoneOffset,
   ZonedDateTime
@@ -333,14 +335,8 @@ trait DefaultReads extends LowPriorityDefaultReads {
   /** Parsing companion */
   object TemporalParser {
     /** Instance of local date/time based on specified pattern. */
-    implicit def LocalDateTimePatternParser(pattern: String): TemporalParser[LocalDateTime] = new TemporalParser[LocalDateTime] {
-      def parse(input: String): Option[LocalDateTime] = try {
-        Some(LocalDateTime.parse(input, DateTimeFormatter.ofPattern(pattern)))
-      } catch {
-        case _: DateTimeParseException => None
-        case _: UnsupportedTemporalTypeException => None
-      }
-    }
+    implicit def LocalDateTimePatternParser(pattern: String): TemporalParser[LocalDateTime] =
+      LocalDateTimeFormatterParser(DateTimeFormatter.ofPattern(pattern))
 
     /** Instance of local date/time based on formatter. */
     implicit def LocalDateTimeFormatterParser(formatter: DateTimeFormatter): TemporalParser[LocalDateTime] = new TemporalParser[LocalDateTime] {
@@ -352,15 +348,23 @@ trait DefaultReads extends LowPriorityDefaultReads {
       }
     }
 
-    /** Instance of date based on specified pattern. */
-    implicit def DatePatternParser(pattern: String): TemporalParser[LocalDate] = new TemporalParser[LocalDate] {
-      def parse(input: String): Option[LocalDate] = try {
-        Some(LocalDate.parse(input, DateTimeFormatter.ofPattern(pattern)))
+    /** Instance of offset date/time based on specified pattern. */
+    implicit def OffsetDateTimePatternParser(pattern: String): TemporalParser[OffsetDateTime] =
+      OffsetDateTimeFormatterParser(DateTimeFormatter.ofPattern(pattern))
+
+    /** Instance of offset date/time based on formatter. */
+    implicit def OffsetDateTimeFormatterParser(formatter: DateTimeFormatter): TemporalParser[OffsetDateTime] = new TemporalParser[OffsetDateTime] {
+      def parse(input: String): Option[OffsetDateTime] = try {
+        Some(OffsetDateTime.parse(input, formatter))
       } catch {
         case _: DateTimeParseException => None
         case _: UnsupportedTemporalTypeException => None
       }
     }
+
+    /** Instance of date based on specified pattern. */
+    implicit def DatePatternParser(pattern: String): TemporalParser[LocalDate] =
+      DateFormatterParser(DateTimeFormatter.ofPattern(pattern))
 
     /** Instance of date based on formatter. */
     implicit def DateFormatterParser(formatter: DateTimeFormatter): TemporalParser[LocalDate] = new TemporalParser[LocalDate] {
@@ -373,60 +377,30 @@ trait DefaultReads extends LowPriorityDefaultReads {
     }
 
     /** Instance of instant parser based on specified pattern. */
-    implicit def InstantPatternParser(pattern: String): TemporalParser[Instant] = new TemporalParser[Instant] {
-      def parse(input: String): Option[Instant] = try {
-        val time = LocalDateTime.parse(
-          input, DateTimeFormatter.ofPattern(pattern)).atZone(ZoneId.of("Z"))
-
-        Some(time.toInstant)
-      } catch {
-        case _: DateTimeParseException => None
-        case _: UnsupportedTemporalTypeException => None
-      }
-    }
+    implicit def InstantPatternParser(pattern: String): TemporalParser[Instant] =
+      InstantFormatterParser(DateTimeFormatter.ofPattern(pattern))
 
     /** Instance of instant parser based on formatter. */
     implicit def InstantFormatterParser(formatter: DateTimeFormatter): TemporalParser[Instant] = new TemporalParser[Instant] {
       def parse(input: String): Option[Instant] = try {
-        val time = LocalDateTime.parse(input, formatter).atZone(ZoneId.of("Z"))
-
-        Some(time.toInstant)
+        Some(Instant.from(formatter.parse(input)))
       } catch {
+        case _: DateTimeException => None
         case _: DateTimeParseException => None
         case _: UnsupportedTemporalTypeException => None
       }
     }
 
     /** Instance of zoned date/time based on specified pattern. */
-    implicit def ZonedDateTimePatternParser(pattern: String): TemporalParser[ZonedDateTime] = new TemporalParser[ZonedDateTime] {
-      def parse(input: String): Option[ZonedDateTime] = try {
-        Some(ZonedDateTime.parse(input, DateTimeFormatter.ofPattern(pattern)))
-      } catch {
-        case _: DateTimeParseException => try {
-          Some(LocalDateTime.parse(input,
-            DateTimeFormatter.ofPattern(pattern)).atZone(ZoneId.systemDefault))
-
-        } catch {
-          case _: DateTimeParseException => None
-          case _: UnsupportedTemporalTypeException => None
-        }
-        case _: UnsupportedTemporalTypeException => None
-      }
-    }
+    implicit def ZonedDateTimePatternParser(pattern: String): TemporalParser[ZonedDateTime] =
+      ZonedDateTimeFormatterParser(DateTimeFormatter.ofPattern(pattern))
 
     /** Instance of zoned date/time based on formatter. */
     implicit def ZonedDateTimeFormatterParser(formatter: DateTimeFormatter): TemporalParser[ZonedDateTime] = new TemporalParser[ZonedDateTime] {
       def parse(input: String): Option[ZonedDateTime] = try {
         Some(ZonedDateTime.parse(input, formatter))
       } catch {
-        case _: DateTimeParseException => try {
-          Some(LocalDateTime.parse(input, formatter).
-            atZone(ZoneId.systemDefault))
-
-        } catch {
-          case _: DateTimeParseException => None
-          case _: UnsupportedTemporalTypeException => None
-        }
+        case _: DateTimeParseException => None
         case _: UnsupportedTemporalTypeException => None
       }
     }
@@ -434,8 +408,6 @@ trait DefaultReads extends LowPriorityDefaultReads {
 
   /**
    * Reads for the `java.time.LocalDateTime` type.
-   * When input value doesn't specify the time zone,
-   * then `java.time.ZoneId.systemDefault` is used.
    *
    * @tparam T Type of argument to instantiate date/time parser
    * @param parsing Argument to instantiate date/time parser. Actually either a pattern (string) or a formatter (`java.time.format.DateTimeFormatter`)
@@ -465,7 +437,7 @@ trait DefaultReads extends LowPriorityDefaultReads {
     }
 
     @inline def epoch(millis: Long): LocalDateTime = LocalDateTime.ofInstant(
-      Instant.ofEpochMilli(millis), ZoneId.systemDefault)
+      Instant.ofEpochMilli(millis), ZoneOffset.UTC)
   }
 
   /**
@@ -476,9 +448,47 @@ trait DefaultReads extends LowPriorityDefaultReads {
     localDateTimeReads(DateTimeFormatter.ISO_DATE_TIME)
 
   /**
+   * Reads for the `java.time.OffsetDateTime` type.
+   *
+   * Note: it is intentionally not supported to read an OffsetDateTime from a
+   * number.
+   *
+   * @tparam T Type of argument to instantiate date/time parser
+   * @param parsing Argument to instantiate date/time parser. Actually either a pattern (string) or a formatter (`java.time.format.DateTimeFormatter`)
+   * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed.
+   * @param p Typeclass instance based on `parsing`
+   * @see [[TemporalFormatter]]
+   *
+   * {{{
+    * import play.api.libs.json.Reads.offsetDateTimeReads
+    *
+    * val customReads1 = offsetDateTimeReads("dd/MM/yyyy, HH:mm:ss (Z)")
+    * val customReads2 = offsetDateTimeReads(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+    * val customReads3 = offsetDateTimeReads(
+    *   DateTimeFormatter.ISO_OFFSET_DATE_TIME, _.drop(1))
+   * }}}
+   */
+  def offsetDateTimeReads[T](parsing: T, corrector: String => String = identity)(implicit p: T => TemporalParser[OffsetDateTime]): Reads[OffsetDateTime] = new Reads[OffsetDateTime] {
+    def reads(json: JsValue): JsResult[OffsetDateTime] = json match {
+      case JsString(s) => p(parsing).parse(corrector(s)) match {
+        case Some(d) => JsSuccess(d)
+        case None => JsError(Seq(JsPath() ->
+          Seq(ValidationError("error.expected.date.isoformat", parsing))))
+      }
+      case _ => JsError(Seq(JsPath() ->
+        Seq(ValidationError("error.expected.date"))))
+    }
+  }
+
+  /**
+   * The default typeclass to reads `java.time.OffsetDateTime` from JSON.
+   * Accepts date/time formats as '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30+01:00[Europe/Paris]'.
+   */
+  implicit val DefaultOffsetDateTimeReads =
+    offsetDateTimeReads(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+
+  /**
    * Reads for the `java.time.ZonedDateTime` type.
-   * When input value doesn't specify the time zone,
-   * then `java.time.ZoneId.systemDefault` is used.
    *
    * @tparam T Type of argument to instantiate date/time parser
    * @param parsing Argument to instantiate date/time parser. Actually either a pattern (string) or a formatter (`java.time.format.DateTimeFormatter`)
@@ -507,7 +517,7 @@ trait DefaultReads extends LowPriorityDefaultReads {
     }
 
     @inline def epoch(millis: Long): ZonedDateTime = ZonedDateTime.ofInstant(
-      Instant.ofEpochMilli(millis), ZoneId.systemDefault)
+      Instant.ofEpochMilli(millis), ZoneOffset.UTC)
   }
 
   /**
@@ -519,8 +529,6 @@ trait DefaultReads extends LowPriorityDefaultReads {
 
   /**
    * Reads for the `java.time.LocalDate` type.
-   * When input value doesn't specify the time zone,
-   * then `java.time.ZoneId.systemDefault` is used.
    *
    * @tparam T Type of argument to instantiate date parser
    * @param parsing Argument to instantiate date parser. Actually either a pattern (string) or a formatter (`java.time.format.DateTimeFormatter`)
@@ -549,7 +557,7 @@ trait DefaultReads extends LowPriorityDefaultReads {
       }
 
       @inline def epoch(millis: Long): LocalDate = LocalDate.now(
-        Clock.fixed(Instant.ofEpochMilli(millis), ZoneId.systemDefault))
+        Clock.fixed(Instant.ofEpochMilli(millis), ZoneOffset.UTC))
     }
 
   /**
@@ -561,8 +569,6 @@ trait DefaultReads extends LowPriorityDefaultReads {
 
   /**
    * Reads for the `java.time.Instant` type.
-   * When input value doesn't specify the time zone,
-   * then `java.time.ZoneId.systemDefault` is used.
    *
    * @tparam T Type of argument to instantiate date parser
    * @param parsing Argument to instantiate date parser. Actually either a pattern (string) or a formatter (`java.time.format.DateTimeFormatter`)

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/ReadsSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/ReadsSpec.scala
@@ -6,8 +6,10 @@ import java.time.{
   Instant,
   LocalDate,
   LocalDateTime,
+  OffsetDateTime,
   ZoneId,
-  ZonedDateTime
+  ZonedDateTime,
+  ZoneOffset
 }
 import java.time.format.DateTimeFormatter
 import play.api.data.validation.ValidationError
@@ -34,7 +36,8 @@ object ReadsSpec extends org.specs2.mutable.Specification {
     "be successfully read from number" in {
       reads(JsNumber(BigDecimal valueOf 123L)).
         aka("read date") must_== JsSuccess(LocalDateTime.ofInstant(
-          Instant.ofEpochMilli(123L), ZoneId.systemDefault))
+          Instant.ofEpochMilli(123L), ZoneOffset.UTC
+        ))
     }
 
     "not be read from invalid string" in {
@@ -98,59 +101,47 @@ object ReadsSpec extends org.specs2.mutable.Specification {
     }
   }
 
-  "Zoned date/time" should {
-    val DefaultReads = implicitly[Reads[ZonedDateTime]]
+  "Offset date/time" should {
+    val DefaultReads = implicitly[Reads[OffsetDateTime]]
     import DefaultReads.reads
 
-    val CustomReads1 = Reads.zonedDateTimeReads("dd/MM/yyyy, HH:mm:ss")
+    val CustomReads1 = Reads.offsetDateTimeReads("dd/MM/yyyy, HH:mm:ssXXX")
 
-    @inline def dateTime(input: String) = try {
-      ZonedDateTime.parse(input, DateTimeFormatter.ISO_DATE_TIME)
-    } catch {
-      case _: Throwable => LocalDateTime.parse(
-        input, DateTimeFormatter.ISO_DATE_TIME).atZone(ZoneId.systemDefault)
-    }
+    @inline def dateTime(input: String) = OffsetDateTime.parse(input)
 
-    lazy val correctedReads = Reads.zonedDateTimeReads(
-      DateTimeFormatter.ISO_DATE_TIME, _.drop(1))
+    lazy val correctedReads = Reads.offsetDateTimeReads(
+      DateTimeFormatter.ISO_OFFSET_DATE_TIME, _.drop(1)
+    )
 
-    val CustomReads2 = Reads.zonedDateTimeReads(
-      DateTimeFormatter.ofPattern("dd/MM/yyyy, HH:mm:ss"), _.drop(2))
+    val CustomReads2 = Reads.offsetDateTimeReads(
+      DateTimeFormatter.ofPattern("dd/MM/yyyy, HH:mm:ss ZZZ"), _.drop(2)
+    )
 
-    "be successfully read from number" in {
-      reads(JsNumber(BigDecimal valueOf 123L)).
-        aka("read date") must_== JsSuccess(ZonedDateTime.ofInstant(
-          Instant.ofEpochMilli(123L), ZoneId.systemDefault))
-    }
+    "not be read" >> {
+      "from an invalid string" in {
+        reads(JsString("invalid")) aka "read date" must beLike {
+          case JsError((_, ValidationError(
+            "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+        }
+      }
 
-    "not be read from invalid string" in {
-      reads(JsString("invalid")) aka "read date" must beLike {
-        case JsError((_, ValidationError(
-          "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+      "from a number" in {
+        reads(JsNumber(123L)) aka "read date" must beLike {
+          case JsError((_, ValidationError("error.expected.date" :: Nil) :: Nil) :: Nil) => ok
+        }
       }
     }
 
     "be successfully read with default implicit" >> {
-      "from '2011-12-03T10:15:30'" in {
-        reads(JsString("2011-12-03T10:15:30")).
-          aka("read date") must_== JsSuccess(dateTime("2011-12-03T10:15:30"))
-      }
-
-      "from '2011-12-03T10:15:30+01:00' (with TZ offset)" in {
-        reads(JsString("2011-12-03T10:15:30+01:00")) aka "read date" must_== (
-          JsSuccess(dateTime("2011-12-03T10:15:30+01:00")))
-      }
-
-      "from '2011-12-03T10:15:30+01:00[Europe/Paris]' (with time zone)" in {
-        reads(JsString("2011-12-03T10:15:30+01:00[Europe/Paris]")).
-          aka("read date") must_== (
-            JsSuccess(dateTime("2011-12-03T10:15:30+01:00[Europe/Paris]")))
+      "from '2011-12-03T10:15:30-05:00'" in {
+        reads(JsString("2011-12-03T10:15:30-05:00")).
+          aka("read date") must_== JsSuccess(dateTime("2011-12-03T10:15:30-05:00"))
       }
     }
 
     "be successfully read with custom pattern from '03/12/2011, 10:15:30'" in {
-      CustomReads1.reads(JsString("03/12/2011, 10:15:30")).
-        aka("read date") must_== JsSuccess(dateTime("2011-12-03T10:15:30"))
+      CustomReads1.reads(JsString("03/12/2011, 10:15:30-05:00")).
+        aka("read date") must_== JsSuccess(dateTime("2011-12-03T10:15:30-05:00"))
     }
 
     "not be read from invalid corrected string" >> {
@@ -170,15 +161,93 @@ object ReadsSpec extends org.specs2.mutable.Specification {
     }
 
     "be successfully read from corrected string" >> {
-      lazy val time = dateTime("2011-12-03T10:15:30")
+      lazy val time = dateTime("2011-12-03T10:15:30-05:00")
 
       "with default implicit" in {
-        correctedReads.reads(JsString("_2011-12-03T10:15:30")).
+        correctedReads.reads(JsString("_2011-12-03T10:15:30-05:00")).
           aka("read date") must_== JsSuccess(time)
       }
 
       "with custom formatter" in {
-        CustomReads2.reads(JsString("# 03/12/2011, 10:15:30")).
+        CustomReads2.reads(JsString("# 03/12/2011, 10:15:30 -0500")).
+          aka("read date") must_== JsSuccess(time)
+      }
+    }
+  }
+
+  "Zoned date/time" should {
+    val DefaultReads = implicitly[Reads[ZonedDateTime]]
+    import DefaultReads.reads
+
+    val CustomReads1 = Reads.zonedDateTimeReads("dd/MM/yyyy, HH:mm:ssXXX")
+
+    @inline def dateTime(input: String) = ZonedDateTime.parse(input)
+
+    lazy val correctedReads = Reads.zonedDateTimeReads(
+      DateTimeFormatter.ISO_DATE_TIME, _.drop(1))
+
+    val CustomReads2 = Reads.zonedDateTimeReads(
+      DateTimeFormatter.ofPattern("dd/MM/yyyy, HH:mm:ssVV"), _.drop(2)
+    )
+
+    "be successfully read from number" in {
+      reads(JsNumber(BigDecimal valueOf 123L)).
+        aka("read date") must_== JsSuccess(ZonedDateTime.ofInstant(
+          Instant.ofEpochMilli(123L), ZoneOffset.UTC
+        ))
+    }
+
+    "not be read from invalid string" in {
+      reads(JsString("invalid")) aka "read date" must beLike {
+        case JsError((_, ValidationError(
+          "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+      }
+    }
+
+    "be successfully read with default implicit" >> {
+      "from '2011-12-03T10:15:30+01:00' (with TZ offset)" in {
+        reads(JsString("2011-12-03T10:15:30+01:00")) aka "read date" must_== (
+          JsSuccess(dateTime("2011-12-03T10:15:30+01:00")))
+      }
+
+      "from '2011-12-03T10:15:30+01:00[Europe/Paris]' (with time zone)" in {
+        reads(JsString("2011-12-03T10:15:30+01:00[Europe/Paris]")).
+          aka("read date") must_== (
+            JsSuccess(dateTime("2011-12-03T10:15:30+01:00[Europe/Paris]")))
+      }
+    }
+
+    "be successfully read with custom pattern from '03/12/2011, 10:15:30+08:00'" in {
+      CustomReads1.reads(JsString("03/12/2011, 10:15:30+08:00")).
+        aka("read date") must_== JsSuccess(dateTime("2011-12-03T10:15:30+08:00"))
+    }
+
+    "not be read from invalid corrected string" >> {
+      "with default implicit" in {
+        correctedReads.reads(JsString("2011-12-03T10:15:30")) must beLike {
+          case JsError((_, ValidationError(
+            "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+        }
+      }
+
+      "with custom formatter" in {
+        CustomReads2.reads(JsString("03/12/2011, 10:15:30+08:00")) must beLike {
+          case JsError((_, ValidationError(
+            "error.expected.date.isoformat" :: Nil, _) :: Nil) :: Nil) => ok
+        }
+      }
+    }
+
+    "be successfully read from corrected string" >> {
+      lazy val time = dateTime("2011-12-03T10:15:30+08:00")
+
+      "with default implicit" in {
+        correctedReads.reads(JsString("_2011-12-03T10:15:30+08:00")).
+          aka("read date") must_== JsSuccess(time)
+      }
+
+      "with custom formatter" in {
+        CustomReads2.reads(JsString("# 03/12/2011, 10:15:30+08:00")).
           aka("read date") must_== JsSuccess(time)
       }
     }
@@ -190,8 +259,7 @@ object ReadsSpec extends org.specs2.mutable.Specification {
 
     val CustomReads1 = Reads.localDateReads("dd/MM/yyyy")
 
-    @inline def date(input: String) =
-      LocalDate.parse(input, DateTimeFormatter.ISO_DATE)
+    @inline def date(input: String) = LocalDate.parse(input)
 
     lazy val correctedReads = Reads.localDateReads(
       DateTimeFormatter.ISO_DATE, _.drop(1))
@@ -200,10 +268,10 @@ object ReadsSpec extends org.specs2.mutable.Specification {
       DateTimeFormatter.ofPattern("dd/MM/yyyy"), _.drop(2))
 
     "be successfully read from number" in {
-      val d = LocalDate.now(Clock.fixed(
-        Instant.ofEpochMilli(123L), ZoneId.systemDefault))
+      val beforeMidnight = Instant.parse("1970-01-01T23:55:00Z")
+      val d = LocalDate.parse("1970-01-01")
 
-      reads(JsNumber(BigDecimal valueOf 123L)).
+      reads(JsNumber(BigDecimal valueOf beforeMidnight.toEpochMilli)).
         aka("read date") must_== JsSuccess(d)
     }
 
@@ -259,17 +327,15 @@ object ReadsSpec extends org.specs2.mutable.Specification {
     val DefaultReads = implicitly[Reads[Instant]]
     import DefaultReads.reads
 
-    val CustomReads1 = Reads.instantReads("dd/MM/yyyy, HH:mm:ss")
-
-    @inline def instant(input: String): Instant =
-      LocalDateTime.parse(input, DateTimeFormatter.ISO_DATE_TIME).
-        atZone(ZoneId.of("Z")).toInstant
+    val CustomReads1 = Reads.instantReads("dd/MM/yyyy, HH:mm:ss X")
 
     lazy val correctedReads = Reads.instantReads(
-      DateTimeFormatter.ISO_DATE_TIME, _.drop(1))
+      DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneOffset.UTC), _.drop(1)
+    )
 
     val CustomReads2 = Reads.instantReads(
-      DateTimeFormatter.ofPattern("dd/MM/yyyy, HH:mm:ss"), _.drop(2))
+      DateTimeFormatter.ofPattern("dd/MM/yyyy, HH:mm:ss").withZone(ZoneOffset.UTC), _.drop(2)
+    )
 
     "be successfully read from number" in {
       reads(JsNumber(BigDecimal valueOf 123L)).
@@ -284,42 +350,46 @@ object ReadsSpec extends org.specs2.mutable.Specification {
     }
 
     "be successfully read with default implicit" >> {
-      "from '2015-05-01T13:00:00' (with zeros)" in {
-        reads(JsString("2015-05-01T00:00:00")).
-          aka("read data") must_== JsSuccess(instant("2015-05-01T00:00:00"))
+      "from '2015-05-01T13:00:00Z' (with zeros)" in {
+        reads(JsString("2015-05-01T00:00:00Z")).
+          aka("read data") must_== JsSuccess(Instant.parse("2015-05-01T00:00:00Z"))
       }
 
-      "from '2011-12-03T10:15:30'" in {
-        reads(JsString("2011-12-03T10:15:30")).
-          aka("read date") must_== JsSuccess(instant("2011-12-03T10:15:30"))
+      "from '2011-12-03T10:15:30Z'" in {
+        reads(JsString("2011-12-03T10:15:30Z")).
+          aka("read date") must_== JsSuccess(Instant.parse("2011-12-03T10:15:30Z"))
       }
 
       "from '2015-05-01T13:00:00+02:00' (with TZ offset and zeros)" in {
         reads(JsString("2015-05-01T13:00:00+02:00")) must_== JsSuccess(
-          instant("2015-05-01T13:00:00+02:00"))
+          Instant.parse("2015-05-01T11:00:00Z")
+        )
       }
 
       "from '2011-12-03T10:15:30+01:00' (with TZ offset)" in {
         reads(JsString("2011-12-03T10:15:30+01:00")) aka "read date" must_== (
-          JsSuccess(instant("2011-12-03T10:15:30+01:00")))
+          JsSuccess(Instant.parse("2011-12-03T09:15:30Z"))
+        )
       }
 
       "from '2011-12-03T10:15:30+01:00[Europe/Paris]' (with time zone)" in {
         reads(JsString("2011-12-03T10:15:30+01:00[Europe/Paris]")).
           aka("read date") must_== (
-            JsSuccess(instant("2011-12-03T10:15:30+01:00[Europe/Paris]")))
+            JsSuccess(Instant.parse("2011-12-03T09:15:30Z"))
+          )
       }
 
       "from '2011-12-03T00:00:00+01:00[Europe/Paris]' (with time zone)" in {
         reads(JsString("2011-12-03T00:00:00+01:00[Europe/Paris]")).
           aka("read date") must_== (
-            JsSuccess(instant("2011-12-03T00:00:00+01:00[Europe/Paris]")))
+            JsSuccess(Instant.parse("2011-12-02T23:00:00Z"))
+          )
       }
     }
 
-    "be successfully read with custom pattern from '03/12/2011, 10:15:30'" in {
-      CustomReads1.reads(JsString("03/12/2011, 10:15:30")).
-        aka("read date") must_== JsSuccess(instant("2011-12-03T10:15:30"))
+    "be successfully read with custom pattern from '03/12/2011, 10:15:30 Z'" in {
+      CustomReads1.reads(JsString("03/12/2011, 10:15:30 Z")).
+        aka("read date") must_== JsSuccess(Instant.parse("2011-12-03T10:15:30Z"))
     }
 
     "not be read from invalid corrected string" >> {
@@ -339,7 +409,7 @@ object ReadsSpec extends org.specs2.mutable.Specification {
     }
 
     "be successfully read from corrected string" >> {
-      lazy val time = instant("2011-12-03T10:15:30")
+      lazy val time = Instant.parse("2011-12-03T10:15:30Z")
 
       "with default implicit" in {
         correctedReads.reads(JsString("_2011-12-03T10:15:30")).

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/WritesSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/WritesSpec.scala
@@ -4,8 +4,9 @@ import java.time.{
   Instant,
   LocalDateTime,
   LocalDate,
+  OffsetDateTime,
   ZonedDateTime,
-  ZoneId
+  ZoneOffset
 }
 import java.time.format.DateTimeFormatter
 
@@ -13,27 +14,26 @@ object WritesSpec extends org.specs2.mutable.Specification {
 
   title("JSON Writes")
 
-  val testZone = ZoneId.of("UTC")
-
   "Local date/time" should {
     val DefaultWrites = implicitly[Writes[LocalDateTime]]
     import DefaultWrites.writes
 
-    @inline def dateTime(input: String) =
-      LocalDateTime.parse(input, DateTimeFormatter.ISO_DATE_TIME)
+    @inline def dateTime(input: String) = LocalDateTime.parse(input)
 
     val CustomWrites1 = Writes.
       temporalWrites[LocalDateTime, String]("dd/MM/yyyy, HH:mm:ss")
 
     "be written as number" in {
       Writes.LocalDateTimeNumberWrites.writes(LocalDateTime.ofInstant(
-        Instant.ofEpochMilli(1234567890L), testZone)).
-        aka("written date") must_== JsNumber(BigDecimal valueOf 1234567000L)
+        Instant.ofEpochMilli(1234567890L), ZoneOffset.UTC
+      )).
+        aka("written date") must_== JsNumber(BigDecimal valueOf 1234567890L)
     }
 
     "be written with default implicit as '2011-12-03T10:15:30'" in {
       writes(dateTime("2011-12-03T10:15:30")) aka "written date" must_== (
-        JsString("2011-12-03T10:15:30"))
+        JsString("2011-12-03T10:15:30")
+      )
     }
 
     "be written with custom pattern as '03/12/2011, 10:15:30'" in {
@@ -42,33 +42,55 @@ object WritesSpec extends org.specs2.mutable.Specification {
     }
   }
 
+  "Offset date/time" should {
+    val DefaultWrites = implicitly[Writes[OffsetDateTime]]
+    import DefaultWrites.writes
+
+    val CustomWrites1 = Writes.
+      temporalWrites[OffsetDateTime, String]("dd/MM/yyyy, HH:mm:ss (XXX)")
+
+    "be written with default implicit as '2011-12-03T10:15:30-01:30'" in {
+      writes(OffsetDateTime.parse("2011-12-03T10:15:30-01:30")) aka "written date" must_== (
+        JsString("2011-12-03T10:15:30-01:30")
+      )
+    }
+
+    "be written with custom pattern as '03/12/2011, 10:15:30 (-01:30)'" in {
+      CustomWrites1.writes(OffsetDateTime.parse("2011-12-03T10:15:30-01:30")).
+        aka("written date") must_== JsString("03/12/2011, 10:15:30 (-01:30)")
+    }
+  }
+
   "Zoned date/time" should {
     val DefaultWrites = implicitly[Writes[ZonedDateTime]]
     import DefaultWrites.writes
 
-    @inline def dateTime(input: String) = try {
-      ZonedDateTime.parse(input, DateTimeFormatter.ISO_DATE_TIME)
-    } catch {
-      case _: Throwable => LocalDateTime.parse(
-        input, DateTimeFormatter.ISO_DATE_TIME).atZone(testZone)
-    }
+    @inline def dateTime(input: String) = ZonedDateTime.parse(input)
 
     val CustomWrites1 = Writes.
       temporalWrites[ZonedDateTime, String]("dd/MM/yyyy, HH:mm:ss")
 
     "be written as number" in {
       Writes.ZonedDateTimeNumberWrites.writes(ZonedDateTime.ofInstant(
-        Instant.ofEpochMilli(1234567890L), testZone)).
+        Instant.ofEpochMilli(1234567890L), ZoneOffset.UTC
+      )).
         aka("written date") must_== JsNumber(BigDecimal valueOf 1234567890L)
     }
 
-    "be written with default implicit as '2011-12-03T10:15:30'" in {
-      writes(dateTime("2011-12-03T10:15:30")) aka "written date" must_== (
-        JsString("2011-12-03T10:15:30"))
+    "be written with default implicit as '2011-12-03T10:15:30+01:00[Europe/Paris]'" in {
+      writes(dateTime("2011-12-03T10:15:30+01:00[Europe/Paris]")) aka "written date" must_== (
+        JsString("2011-12-03T10:15:30+01:00[Europe/Paris]")
+      )
+    }
+
+    "be written with default implicit as '2011-12-03T10:15:30+06:30'" in {
+      writes(dateTime("2011-12-03T10:15:30+06:30")) aka "written date" must_== (
+        JsString("2011-12-03T10:15:30+06:30")
+      )
     }
 
     "be written with custom pattern as '03/12/2011, 10:15:30'" in {
-      CustomWrites1.writes(dateTime("2011-12-03T10:15:30")).
+      CustomWrites1.writes(dateTime("2011-12-03T10:15:30+05:30")).
         aka("written date") must_== JsString("03/12/2011, 10:15:30")
     }
   }
@@ -77,8 +99,7 @@ object WritesSpec extends org.specs2.mutable.Specification {
     val DefaultWrites = implicitly[Writes[LocalDate]]
     import DefaultWrites.writes
 
-    @inline def date(input: String) =
-      LocalDate.parse(input, DateTimeFormatter.ISO_DATE)
+    @inline def date(input: String) = LocalDate.parse(input)
 
     val CustomWrites1 = Writes.temporalWrites[LocalDate, String]("dd/MM/yyyy")
 
@@ -88,7 +109,7 @@ object WritesSpec extends org.specs2.mutable.Specification {
           BigDecimal valueOf 106666665696000000L)
     }
 
-    "be written with default implicit as '2011-12-03T10:15:30'" in {
+    "be written with default implicit as '2011-12-03'" in {
       writes(date("2011-12-03")) aka "written date" must_== JsString(
         "2011-12-03")
     }
@@ -105,10 +126,6 @@ object WritesSpec extends org.specs2.mutable.Specification {
 
     lazy val instant = Instant.parse("2011-12-03T10:15:30Z")
 
-    @inline def format(pattern: String, temporal: Instant) =
-      DateTimeFormatter.ofPattern(pattern).
-        format(LocalDateTime.ofInstant(temporal, ZoneId.systemDefault))
-
     val customPattern1 = "dd/MM/yyyy, HH:mm:ss"
     val CustomWrites1 = Writes.temporalWrites[Instant, String](customPattern1)
 
@@ -117,15 +134,13 @@ object WritesSpec extends org.specs2.mutable.Specification {
         aka("written date") must_== JsNumber(BigDecimal valueOf 1234567890L)
     }
 
-    "be written with default implicit as '2011-12-03T10:15:30'" in {
-
-      writes(instant) aka "written date" must_== JsString(
-        format("yyyy-MM-dd'T'HH:mm:ss", instant))
+    "be written with default implicit as '2011-12-03T10:15:30Z'" in {
+      writes(instant) aka "written date" must_== JsString("2011-12-03T10:15:30Z")
     }
 
     "be written with custom pattern as '03/12/2011, 10:15:30'" in {
       CustomWrites1.writes(instant).
-        aka("written date") must_== JsString(format(customPattern1, instant))
+        aka("written date") must_== JsString("03/12/2011, 10:15:30")
     }
   }
 


### PR DESCRIPTION
I already created an issue about this problem a few months back (https://github.com/playframework/playframework/pull/4872).

Also, I started a discussion on the user list which I tried to move to the dev list (https://groups.google.com/forum/#!topic/play-framework-dev/91PQ6Zal7f0) for some directions but there was no reply.

Currently, the Reads are still broken because the timezone offset is not taken into account when parsing an Instant. And writing is broken (IMO) because the output is ambiguous since it lacks timezone information.

When a user chooses an Instant to represent a point in time, he does that on purpose because of the inherent properties of an Instant (unambiguous representation of a point in time without timezone or offset information). Trying to guess the zone offset or even overriding it is a bad idea, I think.

This PR fixes that for the Instant type only. IMHO, other types suffer from similar defects because of the guesswork applied when date/time components are missing.

I would like to know how that should be handled. Keep the broken behavior until 3.0? Or rather fix it ASAP to minimize the damage that could result from invalid time / date information stored in the user's systems?

For me, the default Reads / Writes are unusable because of the aforementioned problems. So, I have overwritten them in our code base, but all members of the team always have to remember to explicitly use them instead of the default ones which is quite inconvenient. It would be nice if the default Reads / Writes would just work for the general case.