### PR TITLE
Include PATCH in Scala routing docs

### DIFF
--- a/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
@@ -40,7 +40,7 @@ You can also add comments to the route file, with the `#` character.
 
 ## The HTTP method
 
-The HTTP method can be any of the valid methods supported by HTTP (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`).
+The HTTP method can be any of the valid methods supported by HTTP (`GET`, `PATCH`, `POST`, `PUT`, `DELETE`, `HEAD`).
 
 ## The URI pattern
 


### PR DESCRIPTION
PATCH was added in https://github.com/playframework/playframework/issues/1066 and appears in the Java routing docs, but was not updated in the Scala docs.