### PR TITLE
Fixed issue #5187, broken link in documentation.

### DIFF
--- a/documentation/manual/gettingStarted/Tutorials.md
+++ b/documentation/manual/gettingStarted/Tutorials.md
@@ -20,6 +20,6 @@ Some tutorials we recommend:
 
 ## Java
 
-* [Play Java Intro](https://typesafe.com/activator/template/play-java-intro-reactive-platform-15v01): Introduction to create a simple CRUD application with Play Java.
+* [Play Java Intro](https://www.typesafe.com/activator/template/play-java-intro-reactive-platform-15v09): Introduction to create a simple CRUD application with Play Java.
 * [Reactive Maps in Java](https://typesafe.com/activator/template/reactive-maps-java): This template and tutorial shows how the Typesafe Reactive Platform can be used to implement scalable, resilient, responsive event driven apps.
 * [Play with Spring Data JPA](https://typesafe.com/activator/template/play-spring-data-jpa): This is a Play example that uses [Spring Data JPA](https://projects.spring.io/spring-data-jpa/).


### PR DESCRIPTION
Simply updated the link to point at the proper tutorial. Just a new version of the tutorial.
Contributor licence agreement should be signed and in order.