### PR TITLE
Fixed some Javadoc warnings ref issue #4995

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
@@ -14,7 +14,7 @@ import play.api.mvc.{ ActionBuilder, Request, Result }
 /**
  * An [[play.api.mvc.ActionBuilder]] that implements Cross-Origin Resource Sharing (CORS)
  *
- * @see [[CORSFilter]]
+ * @see [[play.filters.cors.CORSFilter]]
  * @see [[http://www.w3.org/TR/cors/ CORS specification]]
  */
 trait CORSActionBuilder extends ActionBuilder[Request] with AbstractCORSPolicy {
@@ -48,7 +48,7 @@ trait CORSActionBuilder extends ActionBuilder[Request] with AbstractCORSPolicy {
  * CORSActionBuilder(conf) { Ok } // an action that uses a locally defined configuration
  * }}}
  *
- * @see [[CORSFilter]]
+ * @see [[play.filters.cors.CORSFilter]]
  * @see [[http://www.w3.org/TR/cors/ CORS specification]]
  */
 object CORSActionBuilder {
@@ -77,7 +77,7 @@ object CORSActionBuilder {
    * Construct an action builder that uses locally defined configuration.
    *
    * @param  config  The local configuration to use in place of the global configuration.
-   * @see [[CORSConfig]]
+   * @see [[play.filters.cors.CORSConfig]]
    */
   def apply(config: CORSConfig, errorHandler: HttpErrorHandler): CORSActionBuilder = {
     val eh = errorHandler

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
@@ -8,7 +8,7 @@ import play.api.{ PlayConfig, Configuration }
 import scala.concurrent.duration._
 
 /**
- * Configuration for AbstractCORSPolicy
+ * Configuration for [[AbstractCORSPolicy]]
  *
  *  - allow only requests with origins from a whitelist (by default all origins are allowed)
  *  - allow only HTTP methods from a whitelist for preflight requests (by default all methods are allowed)
@@ -57,7 +57,7 @@ object CORSConfig {
       preflightMaxAge = 0.seconds)
 
   /**
-   * Build a [[CORSConfig]] from a [[play.api.Configuration]]
+   * Build a [[CORSConfig]]from a [[play.api.Configuration]]
    *
    * @example The configuration is as follows:
    * {{{

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
@@ -27,9 +27,9 @@ import play.api.mvc.{ Filter, RequestHeader, Result }
  * @param  corsConfig  configuration of the CORS policy
  * @param  pathPrefixes  whitelist of path prefixes to restrict the filter
  *
- * @see [[CORSConfig]]
- * @see AbstractCORSPolicy
- * @see [[CORSActionBuilder]]
+ * @see [[play.filters.cors.CORSConfig]]
+ * @see [[play.filters.cors.AbstractCORSPolicy]]
+ * @see [[play.filters.cors.CORSActionBuilder]]
  * @see [[http://www.w3.org/TR/cors/ CORS specification]]
  */
 class CORSFilter(

--- a/framework/src/play-java-jdbc/src/main/java/play/db/DB.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/DB.java
@@ -20,7 +20,9 @@ public final class DB {
 	private DB(){}
 
     /**
-     * @return the default datasource.
+     * Returns the default datasource.
+     *
+     * @return the default datasource
      */
     public static DataSource getDataSource() {
         return getDataSource("default");

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
@@ -144,7 +144,6 @@ public class JPA {
         return ems.peekFirst();
     }
 
-
     /**
      * Bind an EntityManager to the current HTTP context.
      * If no HTTP context is available the EntityManager gets bound to the current thread instead.

--- a/framework/src/play/src/main/scala/play/utils/UriEncoding.scala
+++ b/framework/src/play/src/main/scala/play/utils/UriEncoding.scala
@@ -84,7 +84,7 @@ object UriEncoding {
    * @param s The string to decode. Must use the US-ASCII character set.
    * @param outputCharset The name of the encoding that the output should be encoded with.
    *     The output string will be converted from octets (bytes) using this character encoding.
-   * @throws InvalidUriEncodingException If the input is not a valid encoded path segment.
+   * @throws play.utils.InvalidEncodingException If the input is not a valid encoded path segment.
    * @return A decoded string in the `outputCharset` character set.
    */
   def decodePathSegment(s: String, outputCharset: String): String = {
@@ -131,7 +131,7 @@ object UriEncoding {
    * @param s The string to decode. Must use the US-ASCII character set.
    * @param outputCharset The name of the encoding that the output should be encoded with.
    *     The output string will be converted from octets (bytes) using this character encoding.
-   * @throws InvalidUriEncodingException If the input is not a valid encoded path.
+   * @throws play.utils.InvalidEncodingException If the input is not a valid encoded path.
    * @return A decoded string in the `outputCharset` character set.
    */
   def decodePath(s: String, outputCharset: String): String = {


### PR DESCRIPTION
Feel free to use this if you like. Found a way to escape the warnings when using $var in comments.