### PR TITLE
Fix many scaladoc and javadoc warnings in apiDocs task.

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -61,7 +61,9 @@ object BuildSettings {
     testListeners in (Test,test) := Nil,
     javaOptions in Test ++= Seq(maxMetaspace, "-Xmx512m", "-Xms128m"),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-v"),
-    bintrayPackage := "play-sbt-plugin"
+    bintrayPackage := "play-sbt-plugin",
+    autoAPIMappings := true,
+    apiMappings += scalaInstance.value.libraryJar -> url( raw"""http://scala-lang.org/files/archive/api/${scalaInstance.value.actualVersion}/index.html""")
   )
 
   /**

--- a/framework/project/Docs.scala
+++ b/framework/project/Docs.scala
@@ -99,6 +99,8 @@ object Docs {
       val javaCache = new File(targetDir, "javaapidocs.cache")
 
       val label = "Play " + version
+      val apiMappings = Keys.apiMappings.value
+      val externalDocsScalacOption = Opts.doc.externalAPI(apiMappings).head.replace("-doc-external-doc:", "")
 
       val options = Seq(
         // Note, this is used by the doc-source-url feature to determine the relative path of a given source file.
@@ -106,7 +108,9 @@ object Docs {
         // into the FILE_SOURCE variable below, which is definitely not what we want.
         // Hence it needs to be the base directory for the build, not the base directory for the play-docs project.
         "-sourcepath", (baseDirectory in ThisBuild).value.getAbsolutePath,
-        "-doc-source-url", "https://github.com/playframework/playframework/tree/" + sourceTree + "/framework€{FILE_PATH}.scala")
+        "-doc-source-url", "https://github.com/playframework/playframework/tree/" + sourceTree + "/framework€{FILE_PATH}.scala",
+        "-doc-external-doc", externalDocsScalacOption)
+
 
       val compilers = Keys.compilers.value
       val useCache = apiDocsUseCache.value
@@ -125,6 +129,7 @@ object Docs {
         "-windowtitle", label,
         "-notimestamp",
         "-subpackages", "play",
+        "-Xmaxwarns", "1000",
         "-exclude", "play.api:play.core"
       )
 

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/CharEncoding.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/CharEncoding.scala
@@ -11,6 +11,8 @@ import scala.annotation.tailrec
  *
  * These methods can handle cases where characters straddle a chunk boundary, and redistribute the data.
  * An erroneous encoding or an incompatible decoding causes a [[Step.Error]].
+ *
+ * @define javadoc http://docs.oracle.com/javase/8/docs/api
  */
 object CharEncoding {
 
@@ -93,7 +95,8 @@ object CharEncoding {
   }
 
   /**
-   * @throws UnsupportedCharsetException
+   * @throws scala.Exception [[$javadoc/java/nio/charset/UnsupportedCharsetException.html UnsupportedCharsetException]] if no
+   *                  charset could be found with the provided name
    */
   def decode(charset: String): Enumeratee[Array[Byte], String] = decode(Charset.forName(charset))
 
@@ -143,7 +146,8 @@ object CharEncoding {
   }
 
   /**
-   * @throws UnsupportedCharsetException
+   * @throws scala.Exception [[$javadoc/java/nio/charset/UnsupportedCharsetException.html UnsupportedCharsetException]] if no
+   *                  charset could be found with the provided name
    */
   def encode(charset: String): Enumeratee[String, Array[Byte]] = encode(Charset.forName(charset))
 

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
@@ -182,6 +182,8 @@ object Enumeratee {
 
   /**
    * A partially-applied function returned by the `mapInput` method.
+   *
+   * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
    */
   trait MapInput[From] {
     /**
@@ -215,6 +217,8 @@ object Enumeratee {
 
   /**
    * A partially-applied function returned by the `mapConcatInput` method.
+   *
+   * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
    */
   trait MapConcatInput[From] {
     /**
@@ -233,6 +237,8 @@ object Enumeratee {
 
   /**
    * A partially-applied function returned by the `mapConcat` method.
+   *
+   * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
    */
   trait MapConcat[From] {
     /**
@@ -251,6 +257,8 @@ object Enumeratee {
 
   /**
    * A partially-applied function returned by the `mapFlatten` method.
+   *
+   * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
    */
   trait MapFlatten[From] {
     /**
@@ -283,6 +291,8 @@ object Enumeratee {
 
   /**
    * A partially-applied function returned by the `mapInputFlatten` method.
+   *
+   * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
    */
   trait MapInputFlatten[From] {
     /**
@@ -310,6 +320,8 @@ object Enumeratee {
 
   /**
    * A partially-applied function returned by the `mapInputM` method.
+   *
+   * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
    */
   trait MapInputM[From] {
     /**
@@ -339,6 +351,8 @@ object Enumeratee {
 
   /**
    * A partially-applied function returned by the `mapM` method.
+   *
+   * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
    */
   trait MapM[E] {
     /**
@@ -361,6 +375,8 @@ object Enumeratee {
 
   /**
    * A partially-applied function returned by the `map` method.
+   *
+   * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
    */
   trait Map[E] {
     /**
@@ -522,11 +538,13 @@ object Enumeratee {
 
   /**
    * A partially-applied function returned by the `collect` method.
+   *
+   * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
    */
   trait Collect[From] {
     /**
      * @param transformer A function to transform and filter the input elements with.
-     * $paramSingleEc
+     * $paramEcSingle
      */
     def apply[To](transformer: PartialFunction[From, To])(implicit ec: ExecutionContext): Enumeratee[From, To]
   }
@@ -740,7 +758,7 @@ object Enumeratee {
    *
    * {{{
    *  Enumerator(0, 2, 4) &> Enumeratee.recover { (error, input) =>
-   *    Logger.error(f"oops failure occurred with input: $input", error)
+   *    Logger.error(f"oops failure occurred with input: \$input", error)
    *  } &> Enumeratee.map { i =>
    *    8 / i
    *  } |>>> Iteratee.getChunks // => List(4, 2)

--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumerator.scala
@@ -16,6 +16,7 @@ import scala.language.reflectiveCalls
  *
  * @define paramEcSingle @param ec The context to execute the supplied function with. The context is prepared on the calling thread before being used.
  * @define paramEcMultiple @param ec The context to execute the supplied functions with. The context is prepared on the calling thread before being used.
+ * @define javadoc http://docs.oracle.com/javase/8/docs/api
  */
 trait Enumerator[E] {
   parent =>
@@ -48,7 +49,7 @@ trait Enumerator[E] {
    * If the iteratee is left in a [[play.api.libs.iteratee.Done]]
    * state then the promise is completed with the iteratee's result.
    * If the iteratee is left in an [[play.api.libs.iteratee.Error]] state, then the
-   * promise is completed with a [[java.lang.RuntimeException]] containing the
+   * promise is completed with a [[$javadoc/java/lang/RuntimeException.html RuntimeException]] containing the
    * iteratee's error message.
    *
    * Unlike `apply` or `|>>`, this method does not allow you to access the

--- a/framework/src/play-cache/src/main/java/play/cache/Cache.java
+++ b/framework/src/play-cache/src/main/java/play/cache/Cache.java
@@ -17,7 +17,8 @@ public class Cache {
     /**
      * Retrieves an object by key.
      *
-     * @return object
+     * @param key the cache key
+     * @return the object or null
      */
     public static Object get(String key) {
         return cacheApi().get(key);
@@ -26,6 +27,7 @@ public class Cache {
     /**
      * Retrieve a value from the cache, or set it from a default Callable function.
      *
+     * @param <T>        the type of object being queried
      * @param key        Item key.
      * @param block      block returning value to set if key does not exist
      * @param expiration expiration period in seconds.
@@ -39,6 +41,8 @@ public class Cache {
     /**
      * Sets a value with expiration.
      *
+     * @param key the key to set
+     * @param value the value to set
      * @param expiration expiration in seconds
      */
     public static void set(String key, Object value, int expiration) {
@@ -47,11 +51,19 @@ public class Cache {
 
     /**
      * Sets a value without expiration.
+     *
+     * @param key the key to set
+     * @param value the value to set
      */
     public static void set(String key, Object value) {
         cacheApi().set(key, value);
     }
 
+    /**
+     * Removes the entry at a specific key
+     *
+     * @param key the key whose entry to remove
+     */
     public static void remove(String key) {
         cacheApi().remove(key);
     }

--- a/framework/src/play-cache/src/main/java/play/cache/CacheApi.java
+++ b/framework/src/play-cache/src/main/java/play/cache/CacheApi.java
@@ -12,13 +12,16 @@ public interface CacheApi {
     /**
      * Retrieves an object by key.
      *
-     * @return object
+     * @param <T> the type of the stored object
+     * @param key the key to look up
+     * @return the object or null
      */
     public <T> T get(String key);
 
     /**
      * Retrieve a value from the cache, or set it from a default Callable function.
      *
+     * @param <T> the type of the value
      * @param key Item key.
      * @param block block returning value to set if key does not exist
      * @param expiration expiration period in seconds.
@@ -31,6 +34,7 @@ public interface CacheApi {
      *
      * The value has no expiration.
      *
+     * @param <T> the type of the value
      * @param key Item key.
      * @param block block returning value to set if key does not exist
      * @return value

--- a/framework/src/play-cache/src/main/java/play/cache/Cached.java
+++ b/framework/src/play-cache/src/main/java/play/cache/Cached.java
@@ -20,6 +20,8 @@ public @interface Cached {
 
     /**
      * The duration the action should be cached for.  Defaults to 0.
+     *
+     * @return the duration
      */
     int duration() default 0;
 }

--- a/framework/src/play-exceptions/src/main/java/play/api/PlayException.java
+++ b/framework/src/play-exceptions/src/main/java/play/api/PlayException.java
@@ -14,14 +14,14 @@ import java.util.concurrent.atomic.AtomicLong;
 public class PlayException extends UsefulException {
 
     private final AtomicLong generator = new AtomicLong(System.currentTimeMillis());
-   
+
     /**
      * Generates a new unique exception ID.
      */
-    private String nextId() { 
+    private String nextId() {
         return java.lang.Long.toString(generator.incrementAndGet(), 26);
     }
-  
+
     public PlayException(String title, String description, Throwable cause) {
         super(title + "[" + description + "]",cause);
         this.title = title;
@@ -29,7 +29,7 @@ public class PlayException extends UsefulException {
         this.id = nextId();
         this.cause = cause;
     }
-    
+
     public PlayException(String title, String description) {
         super(title + "[" + description + "]");
         this.title = title;
@@ -37,44 +37,53 @@ public class PlayException extends UsefulException {
         this.id = nextId();
         this.cause = null;
     }
-  
+
     /**
      * Adds source attachment to a Play exception.
      */
     public static abstract class ExceptionSource extends PlayException {
-  
+
         public ExceptionSource(String title, String description, Throwable cause) {
           super(title, description,cause);
         }
-     
+
         public ExceptionSource(String title, String description) {
           super(title, description);
         }
-  
+
         /**
          * Error line number, if defined.
+         *
+         * @return Error line number, if defined.
          */
         public abstract Integer line();
-  
+
         /**
          * Column position, if defined.
+         *
+         * @return Column position, if defined.
          */
         public abstract Integer position();
-  
+
         /**
+         * @return Input stream used to read the source content.
+         *
          * Input stream used to read the source content.
          */
         public abstract String input();
-  
+
         /**
          * The source file name if defined.
+         *
+         * @return The source file name if defined.
          */
         public abstract String sourceName();
-  
+
         /**
          * Extracts interesting lines to be displayed to the user.
          *
          * @param border number of lines to use as a border
+         * @return the extracted lines
          */
         public InterestingLines interestingLines(int border) {
             try {
@@ -99,54 +108,60 @@ public class PlayException extends UsefulException {
             return super.toString() + " in " + sourceName() + ":" + line();
         }
     }
-  
+
     /**
      * Adds any attachment to a Play exception.
      */
     public static abstract class ExceptionAttachment extends PlayException {
-  
+
         public ExceptionAttachment(String title, String description, Throwable cause) {
             super(title, description, cause);
         }
-  
+
         public ExceptionAttachment(String title, String description) {
             super(title, description);
         }
-     
+
         /**
          * Content title.
+         *
+         * @return content title.
          */
-        public abstract String subTitle(); 
-  
+        public abstract String subTitle();
+
         /**
          * Content to be displayed.
+         *
+         * @return content to be displayed.
          */
         public abstract String content();
-  
+
     }
-  
+
     /**
      * Adds a rich HTML description to a Play exception.
      */
     public static abstract class RichDescription extends ExceptionAttachment {
-     
+
         public RichDescription(String title, String description, Throwable cause) {
             super(title, description, cause);
         }
-  
+
         public RichDescription(String title, String description) {
             super(title, description);
         }
-     
+
         /**
          * The new description formatted as HTML.
+         *
+         * @return the new description formatted as HTML.
          */
         public abstract String htmlDescription();
-  
+
     }
 
     public static class InterestingLines {
-  
+
         public final int firstLine;
         public final int errorLine;
         public final String[] focus;
@@ -158,5 +173,5 @@ public class PlayException extends UsefulException {
         }
 
     }
-  
+
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
@@ -12,7 +12,7 @@ import play.api.{ PlayConfig, Logger, Configuration, Play }
 import play.api.mvc.{ ActionBuilder, Request, Result }
 
 /**
- * An [[ActionBuilder]] that implements Cross-Origin Resource Sharing (CORS)
+ * An [[play.api.mvc.ActionBuilder]] that implements Cross-Origin Resource Sharing (CORS)
  *
  * @see [[CORSFilter]]
  * @see [[http://www.w3.org/TR/cors/ CORS specification]]
@@ -27,7 +27,7 @@ trait CORSActionBuilder extends ActionBuilder[Request] with AbstractCORSPolicy {
 }
 
 /**
- * An [[ActionBuilder]] that implements Cross-Origin Resource Sharing (CORS)
+ * An [[play.api.mvc.ActionBuilder]] that implements Cross-Origin Resource Sharing (CORS)
  *
  * It can be configured to...
  *

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
@@ -8,7 +8,7 @@ import play.api.{ PlayConfig, Configuration }
 import scala.concurrent.duration._
 
 /**
- * Configuration for [[AbstractCORSPolicy]]
+ * Configuration for AbstractCORSPolicy
  *
  *  - allow only requests with origins from a whitelist (by default all origins are allowed)
  *  - allow only HTTP methods from a whitelist for preflight requests (by default all methods are allowed)
@@ -57,7 +57,7 @@ object CORSConfig {
       preflightMaxAge = 0.seconds)
 
   /**
-   * Build a from a [[Configuration]]
+   * Build a [[CORSConfig]] from a [[play.api.Configuration]]
    *
    * @example The configuration is as follows:
    * {{{

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
@@ -12,7 +12,7 @@ import play.api.Logger
 import play.api.mvc.{ Filter, RequestHeader, Result }
 
 /**
- * A [[Filter]] that implements Cross-Origin Resource Sharing (CORS)
+ * A [[play.api.mvc.Filter]] that implements Cross-Origin Resource Sharing (CORS)
  *
  * It can be configured to...
  *
@@ -28,7 +28,7 @@ import play.api.mvc.{ Filter, RequestHeader, Result }
  * @param  pathPrefixes  whitelist of path prefixes to restrict the filter
  *
  * @see [[CORSConfig]]
- * @see [[AbstractCORSPolicy]]
+ * @see AbstractCORSPolicy
  * @see [[CORSActionBuilder]]
  * @see [[http://www.w3.org/TR/cors/ CORS specification]]
  */

--- a/framework/src/play-java-jdbc/src/main/java/play/db/DB.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/DB.java
@@ -20,7 +20,7 @@ public final class DB {
 	private DB(){}
 
     /**
-     * Returns the default datasource.
+     * @return the default datasource.
      */
     public static DataSource getDataSource() {
         return getDataSource("default");
@@ -30,6 +30,7 @@ public final class DB {
      * Returns specified database.
      *
      * @param name Datasource name
+     * @return the specified datasource.
      */
     public static DataSource getDataSource(String name) {
         return play.api.db.DB.getDataSource(name, play.api.Play.unsafeApplication());
@@ -38,6 +39,8 @@ public final class DB {
     /**
      * Returns a connection from the default datasource,
      * with auto-commit enabled.
+     *
+     * @return the connection
      */
     public static Connection getConnection() {
         return getConnection("default");
@@ -46,6 +49,9 @@ public final class DB {
     /**
      * Returns a connection from the default datasource,
      * with the specified auto-commit setting.
+     *
+     * @param autocommit true if the returned Connection should have autocommit enabled
+     * @return the connection, with the given autocommit setting
      */
     public static Connection getConnection(boolean autocommit) {
         return getConnection("default", autocommit);
@@ -55,6 +61,7 @@ public final class DB {
      * Returns a connection from any datasource, with auto-commit enabled.
      *
      * @param name Datasource name
+     * @return a connection from the specified datasource
      */
     public static Connection getConnection(String name) {
         return getConnection(name, true);
@@ -66,6 +73,7 @@ public final class DB {
      *
      * @param name Datasource name
      * @param autocommit Auto-commit setting
+     * @return a connection from the specified datasource with the specified autocommit setting
      */
     public static Connection getConnection(String name, boolean autocommit) {
         return play.api.db.DB.getConnection(name, autocommit, play.api.Play.unsafeApplication());
@@ -167,10 +175,12 @@ public final class DB {
      * Executes a block of code, providing a JDBC connection.
      * The connection and all created statements are automatically released.
      *
+     * @param <A> the provided code block's return type
      * @param name Datasource name
      * @param autocommit Auto-commit setting
      * @param block Code block to execute
      * @param application Play application (<tt>play.api.Play.unsafeApplication()</tt>)
+     * @return result of the code block, having closed the connection
      */
     public static <A> A withConnection(String name, boolean autocommit, ConnectionCallable<A> block, Application application) {
         return play.api.db.DB.withConnection(name, autocommit, connectionFunction(block), application);
@@ -180,9 +190,11 @@ public final class DB {
      * Executes a block of code, providing a JDBC connection.
      * The connection and all created statements are automatically released.
      *
+     * @param <A> the provided code block's return type
      * @param name Datasource name
      * @param block Code block to execute
      * @param application Play application (<tt>play.api.Play.unsafeApplication()</tt>)
+     * @return result of the code block, having closed the connection
      */
     public static <A> A withConnection(String name, ConnectionCallable<A> block, Application application) {
         return withConnection(name, true, block, application);
@@ -192,9 +204,11 @@ public final class DB {
      * Executes a block of code, providing a JDBC connection.
      * The connection and all created statements are automatically released.
      *
+     * @param <A> the provided code block's return type
      * @param autocommit Auto-commit setting
      * @param block Code block to execute
      * @param application Play application (<tt>play.api.Play.unsafeApplication()</tt>)
+     * @return result of the code block, having closed the connection
      */
     public static <A> A withConnection(boolean autocommit, ConnectionCallable<A> block, Application application) {
         return withConnection("default", autocommit, block, application);
@@ -204,8 +218,10 @@ public final class DB {
      * Execute a block of code, providing a JDBC connection.
      * The connection and all created statements are automatically released.
      *
+     * @param <A> the provided code block's return type
      * @param block Code block to execute
      * @param application Play application (<tt>play.api.Play.unsafeApplication()</tt>)
+     * @return result of the code block, having closed the connection
      */
     public static <A> A withConnection(ConnectionCallable<A> block, Application application) {
         return withConnection("default", true, block, application);
@@ -215,9 +231,11 @@ public final class DB {
      * Executes a block of code, providing a JDBC connection.
      * The connection and all created statements are automatically released.
      *
+     * @param <A> the provided code block's return type
      * @param name Datasource name
      * @param autocommit Auto-commit setting
      * @param block Code block to execute
+     * @return result of the code block, having closed the connection
      */
     public static <A> A withConnection(String name, boolean autocommit, ConnectionCallable<A> block) {
         return withConnection(name, autocommit, block, play.api.Play.unsafeApplication());
@@ -227,8 +245,10 @@ public final class DB {
      * Executes a block of code, providing a JDBC connection.
      * The connection and all created statements are automatically released.
      *
+     * @param <A> the provided code block's return type
      * @param name Datasource name
      * @param block Code block to execute
+     * @return result of the code block, having closed the connection
      */
     public static <A> A withConnection(String name, ConnectionCallable<A> block) {
         return withConnection(name, true, block);
@@ -238,8 +258,10 @@ public final class DB {
      * Executes a block of code, providing a JDBC connection.
      * The connection and all created statements are automatically released.
      *
+     * @param <A> the provided code block's return type
      * @param autocommit Auto-commit setting
      * @param block Code block to execute
+     * @return result of the code block, having closed the connection
      */
     public static <A> A withConnection(boolean autocommit, ConnectionCallable<A> block) {
         return withConnection("default", autocommit, block);
@@ -249,7 +271,9 @@ public final class DB {
      * Execute a block of code, providing a JDBC connection.
      * The connection and all created statements are automatically released.
      *
+     * @param <A> the provided code block's return type
      * @param block Code block to execute
+     * @return result of the code block, having closed the connection
      */
     public static <A> A withConnection(ConnectionCallable<A> block) {
         return withConnection("default", true, block);
@@ -309,9 +333,11 @@ public final class DB {
      * The connection and all created statements are automatically released.
      * The transaction is automatically committed, unless an exception occurs.
      *
+     * @param <A> the provided code block's return type
      * @param name Datasource name
      * @param block Code block to execute
      * @param application Play application (<tt>play.api.Play.unsafeApplication()</tt>)
+     * @return result of the code block, having committed the transaction (or rolled back if an exception occurred)
      */
     public static <A> A withTransaction(String name, ConnectionCallable<A> block, Application application) {
         return play.api.db.DB.withTransaction(name, connectionFunction(block), application);
@@ -322,8 +348,10 @@ public final class DB {
      * The connection and all created statements are automatically released.
      * The transaction is automatically committed, unless an exception occurs.
      *
+     * @param <A> the provided code block's return type
      * @param block Code block to execute
      * @param application Play application (<tt>play.api.Play.unsafeApplication()</tt>)
+     * @return result of the code block, having committed the transaction (or rolled back if an exception occurred)
      */
     public static <A> A withTransaction(ConnectionCallable<A> block, Application application) {
         return withTransaction("default", block, application);
@@ -335,8 +363,10 @@ public final class DB {
      * The connection and all created statements are automatically released.
      * The transaction is automatically committed, unless an exception occurs.
      *
+     * @param <A> the provided code block's return type
      * @param name Datasource name
      * @param block Code block to execute
+     * @return result of the code block, having committed the transaction (or rolled back if an exception occurred)
      */
     public static <A> A withTransaction(String name, ConnectionCallable<A> block) {
         return withTransaction(name, block, play.api.Play.unsafeApplication());
@@ -347,7 +377,9 @@ public final class DB {
      * The connection and all created statements are automatically released.
      * The transaction is automatically committed, unless an exception occurs.
      *
+     * @param <A> the provided code block's return type
      * @param block Code block to execute
+     * @return result of the code block, having committed the transaction (or rolled back if an exception occurred)
      */
     public static <A> A withTransaction(ConnectionCallable<A> block) {
         return withTransaction("default", block);
@@ -355,6 +387,9 @@ public final class DB {
 
     /**
      * Create a Scala function wrapper for ConnectionRunnable.
+     *
+     * @param block a Java functional interface instance to wrap
+     * @return a scala function that wraps the given block
      */
     public static final AbstractFunction1<Connection, BoxedUnit> connectionFunction(final ConnectionRunnable block) {
         return new AbstractFunction1<Connection, BoxedUnit>() {
@@ -371,6 +406,10 @@ public final class DB {
 
     /**
      * Create a Scala function wrapper for ConnectionCallable.
+     *
+     * @param block a Java functional interface instance to wrap
+     * @param <A> the provided block's return type
+     * @return a scala function wrapping the given block
      */
     public static final <A> AbstractFunction1<Connection, A> connectionFunction(final ConnectionCallable<A> block) {
         return new AbstractFunction1<Connection, A>() {

--- a/framework/src/play-java-jdbc/src/main/java/play/db/Databases.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/Databases.java
@@ -8,7 +8,7 @@ import com.google.common.collect.ImmutableMap;
  * Creation helpers for manually instantiating databases.
  */
 public final class Databases {
-// Databases is a final class and not an interface because an interface cannot be declared final. Also, that should 
+// Databases is a final class and not an interface because an interface cannot be declared final. Also, that should
 // clarify why the class' constructor is private: we really don't want this class to be either instantiated or subclassed.
 	private Databases() {}
     // ----------------
@@ -139,6 +139,10 @@ public final class Databases {
     /**
      * Create an in-memory H2 database with name "default" and with
      * extra configuration provided by the given entries.
+     *
+     * @param k1 an H2 configuration key.
+     * @param v1 configuration value corresponding to `k1`
+     * @return a configured in-memory H2 database
      */
     public static Database inMemoryWith(String k1, Object v1) {
         return inMemory(ImmutableMap.of(k1, v1));
@@ -147,6 +151,12 @@ public final class Databases {
     /**
      * Create an in-memory H2 database with name "default" and with
      * extra configuration provided by the given entries.
+     *
+     * @param k1 an H2 configuration key
+     * @param v1 H2 configuration value corresponding to `k1`
+     * @param k2 a second H2 configuration key
+     * @param v2 a configuration value corresponding to `k2`
+     * @return a configured in-memory H2 database
      */
     public static Database inMemoryWith(String k1, Object v1, String k2, Object v2) {
         return inMemory(ImmutableMap.of(k1, v1, k2, v2));
@@ -155,6 +165,14 @@ public final class Databases {
     /**
      * Create an in-memory H2 database with name "default" and with
      * extra configuration provided by the given entries.
+     *
+     * @param k1 an H2 configuration key
+     * @param v1 H2 configuration value corresponding to `k1`
+     * @param k2 a second H2 configuration key
+     * @param v2 a configuration value corresponding to `k2`
+     * @param k3 a third H2 configuraiton key
+     * @param v3 a configuration value corresponding to `k3`
+     * @return a configured in-memory H2 database
      */
     public static Database inMemoryWith(String k1, Object v1, String k2, Object v2, String k3, Object v3) {
         return inMemory(ImmutableMap.of(k1, v1, k2, v2, k3, v3));

--- a/framework/src/play-java-jdbc/src/main/java/play/db/DefaultDatabase.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/DefaultDatabase.java
@@ -24,6 +24,9 @@ public class DefaultDatabase implements Database {
 
     /**
      * Create a default BoneCP-backed database.
+     *
+     * @param name name for the db's underlying datasource
+     * @param configuration the database's configuration
      */
     public DefaultDatabase(String name, Configuration configuration) {
         this(new play.api.db.PooledDatabase(name, new play.api.Configuration(
@@ -34,6 +37,9 @@ public class DefaultDatabase implements Database {
 
     /**
      * Create a default BoneCP-backed database.
+     *
+     * @param name name for the db's underlying datasource
+     * @param config the db's configuration
      */
     public DefaultDatabase(String name, Map<String, ? extends Object> config) {
         this(new play.api.db.PooledDatabase(name, new play.api.Configuration(

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAConfig.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAConfig.java
@@ -59,7 +59,7 @@ public class DefaultJPAConfig implements JPAConfig {
 
     /**
      * Create a default JPA configuration with the given name and unit name.
-     * @param  name     the name for the enitity manager factory
+     * @param  name     the name for the entity manager factory
      * @param  unitName the persistence unit name as used in `persistence.xml`
      * @return          a default JPA configuration
      */
@@ -69,6 +69,12 @@ public class DefaultJPAConfig implements JPAConfig {
 
     /**
      * Create a default JPA configuration with the given names and unit names.
+     *
+     * @param n1 Name of the first entity manager factory
+     * @param u1 Name of the first unit
+     * @param n2 Name of the second entity manager factory
+     * @param u2 Name of the second unit
+     * @return a default JPA configuration with the provided persistence units.
      */
     public static JPAConfig of(String n1, String u1, String n2, String u2) {
         return new DefaultJPAConfig(
@@ -79,6 +85,13 @@ public class DefaultJPAConfig implements JPAConfig {
 
     /**
      * Create a default JPA configuration with the given names and unit names.
+     * @param n1 Name of the first entity manager factory
+     * @param u1 Name of the first unit
+     * @param n2 Name of the second entity manager factory
+     * @param u2 Name of the second unit
+     * @param n3 Name of the third entity manager factory
+     * @param u3 Name of the third unit
+     * @return a default JPA configuration with the provided persistence units.
      */
     public static JPAConfig of(String n1, String u1, String n2, String u2, String n3, String u3) {
         return new DefaultJPAConfig(
@@ -90,6 +103,9 @@ public class DefaultJPAConfig implements JPAConfig {
 
     /**
      * Create a default JPA configuration from a map of names to unit names.
+     *
+     * @param map Map of entity manager factory names to unit names
+     * @return a JPAConfig configured with the provided mapping
      */
     public static JPAConfig from(Map<String, String> map) {
         ImmutableSet.Builder<JPAConfig.PersistenceUnit> persistenceUnits = new ImmutableSet.Builder<JPAConfig.PersistenceUnit>();

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
@@ -24,6 +24,10 @@ public class JPA {
     /**
      * Create a default JPAApi with the given persistence unit configuration.
      * Automatically initialise the JPA entity manager factories.
+     *
+     * @param name the EntityManagerFactory's name
+     * @param unitName the persistence unit's name
+     * @return the configured JPAApi
      */
     public static JPAApi createFor(String name, String unitName) {
         return new DefaultJPAApi(DefaultJPAConfig.of(name, unitName)).start();
@@ -32,13 +36,18 @@ public class JPA {
     /**
      * Create a default JPAApi with name "default" and the given unit name.
      * Automatically initialise the JPA entity manager factories.
+     *
+     * @param unitName the persistence unit's name
+     * @return the configured JPAApi
      */
     public static JPAApi createFor(String unitName) {
         return new DefaultJPAApi(DefaultJPAConfig.of("default", unitName)).start();
     }
 
     /**
-     * Get the JPA api for the current play application.
+     * Get JPA api for the current play application.
+     *
+     * @return the JPAApi
      */
     public static JPAApi jpaApi() {
         Application app = Play.application();
@@ -49,7 +58,10 @@ public class JPA {
     }
 
     /**
-     * Get the EntityManager for specified persistence unit for this thread.
+     * Get the EntityManager for a particular persistence unit for this thread.
+     *
+     * @param key name of the EntityManager to return
+     * @return the EntityManager
      */
     public static EntityManager em(String key) {
         EntityManager em = jpaApi().em(key);
@@ -62,6 +74,8 @@ public class JPA {
 
     /**
      * Get the default EntityManager for this thread.
+     *
+     * @return the EntityManager
      */
     public static EntityManager em() {
         Http.Context context = Http.Context.current.get();
@@ -83,6 +97,8 @@ public class JPA {
     /**
      * Bind an EntityManager to the current HTTP context.
      * If no HTTP context is available the EntityManager gets bound to the current thread instead.
+     *
+     * @param em the EntityManager to bind to this HTTP context.
      */
     public static void bindForSync(EntityManager em) {
         bindForCurrentContext(em, true);
@@ -91,6 +107,7 @@ public class JPA {
     /**
      * Bind an EntityManager to the current HTTP context.
      *
+     * @param em the EntityManager to bind
      * @throws RuntimeException if no HTTP context is present.
      */
     public static void bindForAsync(EntityManager em) {
@@ -100,6 +117,9 @@ public class JPA {
     /**
      * Bind an EntityManager to the current HTTP context.
      *
+     * @param em the EntityManager to bind, or null to remove the manager from the context instead.
+     * @param threadLocalFallback true to attempt placing the EntityManager into a threadLocal in case placing it into
+     *                            the httpContext fails.
      * @throws RuntimeException if no HTTP context is present and {@code threadLocalFallback} is false.
      */
     private static void bindForCurrentContext(EntityManager em, boolean threadLocalFallback) {
@@ -124,6 +144,8 @@ public class JPA {
      * Run a block of code in a JPA transaction.
      *
      * @param block Block of code to execute.
+     * @param <T> return type of the block
+     * @return the result of the block, having already committed the transaction (or rolled it back in case of exception)
      */
     public static <T> T withTransaction(Supplier<T> block) {
         return jpaApi().withTransaction(block);
@@ -133,6 +155,9 @@ public class JPA {
      * Run a block of asynchronous code in a JPA transaction.
      *
      * @param block Block of code to execute.
+     * @param <T> return type of the block
+     * @return a future to the result of the block, having already committed the transaction
+     *         (or rolled it back in case of exception)
      *
      * @deprecated This may cause deadlocks
      */
@@ -156,6 +181,9 @@ public class JPA {
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
      * @param block Block of code to execute.
+     * @param <T> return type of the provided block
+     * @return a future to the result of the block, having already committed the transaction
+     *         (or rolled it back in case of exception)
      */
     public static <T> T withTransaction(String name, boolean readOnly, Supplier<T> block) {
         return jpaApi().withTransaction(name, readOnly, block);
@@ -167,6 +195,9 @@ public class JPA {
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
      * @param block Block of code to execute.
+     * @param <T> return type of the block
+     * @return a future to the result of the block, having already committed the transaction
+     *         (or rolled it back in case of exception)
      *
      * @deprecated This may cause deadlocks
      */

--- a/framework/src/play-java-ws/src/main/java/play/libs/oauth/OAuth.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/oauth/OAuth.java
@@ -44,7 +44,7 @@ public class OAuth {
     public OAuthProvider getProvider() {
         return provider;
     }
-    
+
     /**
      * Request the request token and secret.
      *
@@ -83,6 +83,7 @@ public class OAuth {
      * The URL where the user needs to be redirected to grant authorization to your application.
      *
      * @param token request token
+     * @return the url
      */
     public String redirectUrl(String token) {
         return oauth.signpost.OAuth.addQueryParameters(

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSClient.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSClient.java
@@ -22,6 +22,7 @@ public interface WSClient extends java.io.Closeable {
      * return an asynchronous {@code Promise<WSResponse>}.
      *
      * @param url the URL to request
+     * @return the request
      */
     WSRequest url(String url);
 

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSCookie.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSCookie.java
@@ -10,6 +10,10 @@ public interface WSCookie {
 
     /**
      * Returns the underlying "native" object for the cookie.
+     *
+     * This is probably an <code>org.asynchttpclient.cookie.Cookie</code>.
+     *
+     * @return the "native" object
      */
     public Object getUnderlying();
 

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
@@ -221,7 +221,7 @@ public interface WSRequest {
      * Set the body this request should use.
      *
      * @deprecated use {@link #setBody(Source)} instead.
-     * @input body Deprecated
+     * @param body Deprecated
      * @return Deprecated
      */
     @Deprecated

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
@@ -32,6 +32,8 @@ public interface WSRequest {
 
     /**
      * Perform a GET on the request asynchronously.
+     *
+     * @return a promise to the response
      */
     F.Promise<WSResponse> get();
 
@@ -43,6 +45,7 @@ public interface WSRequest {
      * Perform a PATCH on the request asynchronously.
      *
      * @param body represented as String
+     * @return a promise to the response
      */
     F.Promise<WSResponse> patch(String body);
 
@@ -50,6 +53,7 @@ public interface WSRequest {
      * Perform a PATCH on the request asynchronously.
      *
      * @param body represented as JSON
+     * @return a promise to the response
      */
     F.Promise<WSResponse> patch(JsonNode body);
 
@@ -57,6 +61,7 @@ public interface WSRequest {
      * Perform a PATCH on the request asynchronously.
      *
      * @param body represented as an InputStream
+     * @return a promise to the response
      */
     F.Promise<WSResponse> patch(InputStream body);
 
@@ -64,6 +69,7 @@ public interface WSRequest {
      * Perform a PATCH on the request asynchronously.
      *
      * @param body represented as a File
+     * @return a promise to the response
      */
     F.Promise<WSResponse> patch(File body);
 
@@ -75,6 +81,7 @@ public interface WSRequest {
      * Perform a POST on the request asynchronously.
      *
      * @param body represented as String
+     * @return a promise to the response
      */
     F.Promise<WSResponse> post(String body);
 
@@ -82,6 +89,7 @@ public interface WSRequest {
      * Perform a POST on the request asynchronously.
      *
      * @param body represented as JSON
+     * @return a promise to the response
      */
     F.Promise<WSResponse> post(JsonNode body);
 
@@ -89,6 +97,7 @@ public interface WSRequest {
      * Perform a POST on the request asynchronously.
      *
      * @param body represented as an InputStream
+     * @return a promise to the response
      */
     F.Promise<WSResponse> post(InputStream body);
 
@@ -96,6 +105,7 @@ public interface WSRequest {
      * Perform a POST on the request asynchronously.
      *
      * @param body represented as a File
+     * @return a promise to the response
      */
     F.Promise<WSResponse> post(File body);
 
@@ -107,6 +117,7 @@ public interface WSRequest {
      * Perform a PUT on the request asynchronously.
      *
      * @param body represented as String
+     * @return a promise to the response
      */
     F.Promise<WSResponse> put(String body);
 
@@ -114,6 +125,7 @@ public interface WSRequest {
      * Perform a PUT on the request asynchronously.
      *
      * @param body represented as JSON
+     * @return a promise to the response
      */
     F.Promise<WSResponse> put(JsonNode body);
 
@@ -121,6 +133,7 @@ public interface WSRequest {
      * Perform a PUT on the request asynchronously.
      *
      * @param body represented as an InputStream
+     * @return a promise to the response
      */
     F.Promise<WSResponse> put(InputStream body);
 
@@ -128,6 +141,7 @@ public interface WSRequest {
      * Perform a PUT on the request asynchronously.
      *
      * @param body represented as a File
+     * @return a promise to the response
      */
     F.Promise<WSResponse> put(File body);
 
@@ -137,16 +151,22 @@ public interface WSRequest {
 
     /**
      * Perform a DELETE on the request asynchronously.
+     *
+     * @return a promise to the response
      */
     F.Promise<WSResponse> delete();
 
     /**
      * Perform a HEAD on the request asynchronously.
+     *
+     * @return a promise to the response
      */
     F.Promise<WSResponse> head();
 
     /**
      * Perform an OPTIONS on the request asynchronously.
+     *
+     * @return a promise to the response
      */
     F.Promise<WSResponse> options();
 
@@ -154,18 +174,23 @@ public interface WSRequest {
      * Execute an arbitrary method on the request asynchronously.
      *
      * @param method The method to execute
+     * @return a promise to the response
      */
     F.Promise<WSResponse> execute(String method);
 
     /**
      * Execute an arbitrary method on the request asynchronously.  Should be used with setMethod().
+     *
+     * @return a promise to the response
      */
     F.Promise<WSResponse> execute();
 
     /**
      * Execute this request and stream the response body.
+     *
+     * @return a promise to the streaming response
      */
-    CompletionStage<StreamedResponse> stream(); 
+    CompletionStage<StreamedResponse> stream();
 
     //-------------------------------------------------------------------------
     // Setters
@@ -173,16 +198,22 @@ public interface WSRequest {
 
     /**
      * Set the HTTP method this request should use, where the no args execute() method is invoked.
+     *
+     * @return the modified WSRequest.
      */
     WSRequest setMethod(String method);
 
     /**
      * Set the body this request should use.
+     *
+     * @return the modified WSRequest.
      */
     WSRequest setBody(String body);
 
     /**
      * Set the body this request should use.
+     *
+     * @return the modified WSRequest.
      */
     WSRequest setBody(JsonNode body);
 
@@ -190,12 +221,16 @@ public interface WSRequest {
      * Set the body this request should use.
      *
      * @deprecated use {@link #setBody(Source)} instead.
+     * @input body Deprecated
+     * @return Deprecated
      */
     @Deprecated
     WSRequest setBody(InputStream body);
 
     /**
      * Set the body this request should use.
+     *
+     * @return the modified WSRequest.
      */
     WSRequest setBody(File body);
 
@@ -208,60 +243,76 @@ public interface WSRequest {
      * Adds a header to the request.  Note that duplicate headers are allowed
      * by the HTTP specification, and removing a header is not available
      * through this API.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the modified WSRequest.
      */
     WSRequest setHeader(String name, String value);
 
     /**
      * Sets the query string to query.
+     *
+     * @param query the fully formed query string
+     * @return the modified WSRequest.
      */
     WSRequest setQueryString(String query);
 
     /**
      * Sets a query parameter with the given name, this can be called repeatedly.  Duplicate query parameters are allowed.
      *
-     * @param name
-     * @param value
+     * @param name the query parameter name
+     * @param value the query parameter value
+     * @return the modified WSRequest.
      */
     WSRequest setQueryParameter(String name, String value);
 
     /**
      * Sets the authentication header for the current request using BASIC authentication.
      *
-     * @param userInfo
+     * @param userInfo a string formed as "username:password".
+     * @return the modified WSRequest.
      */
     WSRequest setAuth(String userInfo);
 
     /**
      * Sets the authentication header for the current request using BASIC authentication.
      *
-     * @param username
-     * @param password
+     * @param username the basic auth username
+     * @param password the basic auth password
      */
     WSRequest setAuth(String username, String password);
 
     /**
      * Sets the authentication header for the current request.
      *
-     * @param username
-     * @param password
+     * @param username the username
+     * @param password the password
      * @param scheme   authentication scheme
      */
     WSRequest setAuth(String username, String password, WSAuthScheme scheme);
 
     /**
      * Sets an (OAuth) signature calculator.
+     *
+     * @param calculator the signature calculator
+     * @return the modified WSRequest
      */
     WSRequest sign(WSSignatureCalculator calculator);
 
     /**
      * Sets whether redirects (301, 302) should be followed automatically.
      *
-     * @param followRedirects
+     * @param followRedirects true if the request should follow redirects
+     * @return the modified WSRequest
      */
     WSRequest setFollowRedirects(Boolean followRedirects);
 
     /**
      * Sets the virtual host as a "hostname:port" string.
+     *
+     * @param virtualHost the virtual host
+     * @return the modified WSRequest
      */
     WSRequest setVirtualHost(String virtualHost);
 
@@ -278,6 +329,7 @@ public interface WSRequest {
      * default to UTF-8.
      *
      * @param contentType The content type
+     * @return the modified WSRequest
      */
     WSRequest setContentType(String contentType);
 
@@ -323,6 +375,8 @@ public interface WSRequest {
     /**
      * Gets the original request timeout in milliseconds, passed into the
      * request as input.
+     *
+     * @return the timeout
      */
     long getRequestTimeout();
 

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSRequest.java
@@ -78,8 +78,9 @@ public class NingWSRequest implements WSRequest {
     /**
      * Sets a header with the given name, this can be called repeatedly.
      *
-     * @param name
-     * @param value
+     * @param name the header name
+     * @param value the header value
+     * @return the receiving WSRequest, with the new header set.
      */
     @Override
     public NingWSRequest setHeader(String name, String value) {

--- a/framework/src/play-java/src/main/java/play/data/format/Formats.java
+++ b/framework/src/play-java/src/main/java/play/data/format/Formats.java
@@ -15,16 +15,16 @@ import java.lang.annotation.*;
  * Defines several default formatters.
  */
 public class Formats {
-    
+
     // -- DATE
-    
+
     /**
      * Formatter for <code>java.util.Date</code> values.
      */
     public static class DateFormatter extends Formatters.SimpleFormatter<Date> {
-        
+
         private final String pattern;
-        
+
         /**
          * Creates a date formatter.
          *
@@ -33,7 +33,7 @@ public class Formats {
         public DateFormatter(String pattern) {
             this.pattern = pattern;
         }
-        
+
         /**
          * Binds the field - constructs a concrete value from submitted data.
          *
@@ -46,10 +46,10 @@ public class Formats {
                 return null;
             }
             SimpleDateFormat sdf = new SimpleDateFormat(pattern, locale);
-            sdf.setLenient(false);  
+            sdf.setLenient(false);
             return sdf.parse(text);
         }
-        
+
         /**
          * Unbinds this fields - converts a concrete value to a plain string.
          *
@@ -63,9 +63,9 @@ public class Formats {
             }
             return new SimpleDateFormat(pattern, locale).format(value);
         }
-        
+
     }
-    
+
     /**
      * Defines the format for a <code>Date</code> field.
      */
@@ -73,18 +73,20 @@ public class Formats {
     @Retention(RUNTIME)
     @play.data.Form.Display(name="format.date", attributes={"pattern"})
     public static @interface DateTime {
-        
+
         /**
          * Date pattern, as specified for {@link SimpleDateFormat}.
+         *
+         * @return the date pattern
          */
         String pattern();
     }
-    
+
     /**
      * Annotation formatter, triggered by the <code>@DateTime</code> annotation.
      */
     public static class AnnotationDateFormatter extends Formatters.AnnotationFormatter<DateTime,Date> {
-        
+
         /**
          * Binds the field - constructs a concrete value from submitted data.
          *
@@ -98,10 +100,10 @@ public class Formats {
                 return null;
             }
             SimpleDateFormat sdf = new SimpleDateFormat(annotation.pattern(), locale);
-            sdf.setLenient(false);  
+            sdf.setLenient(false);
             return sdf.parse(text);
         }
-        
+
         /**
          * Unbinds this field - converts a concrete value to plain string
          *
@@ -116,23 +118,23 @@ public class Formats {
             }
             return new SimpleDateFormat(annotation.pattern(), locale).format(value);
         }
-        
+
     }
-    
+
     // -- STRING
-    
+
     /**
      * Defines the format for a <code>String</code> field that cannot be empty.
      */
     @Target({FIELD})
     @Retention(RUNTIME)
     public static @interface NonEmpty {}
-    
+
     /**
      * Annotation formatter, triggered by the <code>@NonEmpty</code> annotation.
      */
     public static class AnnotationNonEmptyFormatter extends Formatters.AnnotationFormatter<NonEmpty,String> {
-        
+
         /**
          * Binds the field - constructs a concrete value from submitted data.
          *
@@ -147,7 +149,7 @@ public class Formats {
             }
             return text;
         }
-        
+
         /**
          * Unbinds this field - converts a concrete value to plain string
          *
@@ -162,8 +164,8 @@ public class Formats {
             }
             return value;
         }
-        
+
     }
-    
-    
+
+
 }

--- a/framework/src/play-java/src/main/java/play/data/format/Formatters.java
+++ b/framework/src/play-java/src/main/java/play/data/format/Formatters.java
@@ -24,6 +24,7 @@ public class Formatters {
      *
      * @param text the text to parse
      * @param clazz class representing the required type
+     * @param <T> the type to parse out of the text
      * @return the parsed value
      */
     public static <T> T parse(String text, Class<T> clazz) {
@@ -36,6 +37,7 @@ public class Formatters {
      * @param field the related field (custom formatters are extracted from this field annotation)
      * @param text the text to parse
      * @param clazz class representing the required type
+     * @param <T> the type to parse out of the text
      * @return the parsed value
      */
     @SuppressWarnings("unchecked")
@@ -47,6 +49,7 @@ public class Formatters {
      * Computes the display string for any value.
      *
      * @param t the value to print
+     * @param <T> the type to print
      * @return the formatted string
      */
     public static <T> String print(T t) {
@@ -65,6 +68,7 @@ public class Formatters {
      *
      * @param field the related field - custom formatters are extracted from this field annotation
      * @param t the value to print
+     * @param <T> the type to print
      * @return the formatted string
      */
     public static <T> String print(Field field, T t) {
@@ -76,6 +80,7 @@ public class Formatters {
      *
      * @param desc the field descriptor - custom formatters are extracted from this descriptor.
      * @param t the value to print
+     * @param <T> the type to print
      * @return the formatted string
      */
     public static <T> String print(TypeDescriptor desc, T t) {
@@ -107,6 +112,8 @@ public class Formatters {
 
     /**
      * Super-type for custom simple formatters.
+     *
+     * @param <T> the type that this formatter will parse and print
      */
     public static abstract class SimpleFormatter<T> {
 
@@ -115,6 +122,7 @@ public class Formatters {
          *
          * @param text the field text
          * @param locale the current Locale
+         * @throws java.text.ParseException if the text could not be parsed into T
          * @return a new value
          */
         public abstract T parse(String text, Locale locale) throws java.text.ParseException;
@@ -132,6 +140,9 @@ public class Formatters {
 
     /**
      * Super-type for annotation-based formatters.
+     *
+     * @param <A> the type of the annotation
+     * @param <T> the type that this formatter will parse and print
      */
     public static abstract class AnnotationFormatter<A extends Annotation,T> {
 
@@ -141,6 +152,7 @@ public class Formatters {
          * @param annotation the annotation that trigerred this formatter
          * @param text the field text
          * @param locale the current <code>Locale</code>
+         * @throws java.text.ParseException when the text could not be parsed
          * @return a new value
          */
         public abstract T parse(A annotation, String text, Locale locale) throws java.text.ParseException;
@@ -191,6 +203,7 @@ public class Formatters {
      * Registers a simple formatter.
      *
      * @param clazz class handled by this formatter
+     * @param <T> the type that this formatter will parse and print
      * @param formatter the formatter to register
      */
     public static <T> void register(final Class<T> clazz, final SimpleFormatter<T> formatter) {
@@ -216,6 +229,8 @@ public class Formatters {
      *
      * @param clazz class handled by this formatter
      * @param formatter the formatter to register
+     * @param <A> the annotation type
+     * @param <T> the type that will be parsed or printed
      */
     @SuppressWarnings("unchecked")
     public static <A extends Annotation,T> void register(final Class<T> clazz, final AnnotationFormatter<A,T> formatter) {

--- a/framework/src/play-java/src/main/java/play/inject/guice/GuiceApplicationBuilder.java
+++ b/framework/src/play-java/src/main/java/play/inject/guice/GuiceApplicationBuilder.java
@@ -29,6 +29,9 @@ public final class GuiceApplicationBuilder extends GuiceBuilder<GuiceApplication
     /**
      * Set the initial configuration loader.
      * Overrides the default or any previously configured values.
+     *
+     * @param load the configuration loader
+     * @return the configured application builder
      */
     public GuiceApplicationBuilder loadConfig(Function<Environment, Configuration> load) {
         return newBuilder(delegate.loadConfig(func((play.api.Environment env) -> load.apply(new Environment(env)).getWrappedConfiguration())));
@@ -37,6 +40,9 @@ public final class GuiceApplicationBuilder extends GuiceBuilder<GuiceApplication
     /**
      * Set the initial configuration.
      * Overrides the default or any previously configured values.
+     *
+     * @param conf the configuration
+     * @return the configured application builder
      */
     public GuiceApplicationBuilder loadConfig(Configuration conf) {
         return loadConfig(env -> conf);
@@ -45,6 +51,9 @@ public final class GuiceApplicationBuilder extends GuiceBuilder<GuiceApplication
     /**
      * Set the global settings object.
      * Overrides the default or any previously configured values.
+     *
+     * @param global the configuration
+     * @return the configured application builder
      */
     public GuiceApplicationBuilder global(GlobalSettings global) {
         return newBuilder(delegate.global(new JavaGlobalSettingsAdapter(global)));
@@ -53,6 +62,9 @@ public final class GuiceApplicationBuilder extends GuiceBuilder<GuiceApplication
     /**
      * Set the module loader.
      * Overrides the default or any previously configured values.
+     *
+     * @param loader the configuration
+     * @return the configured application builder
      */
     public GuiceApplicationBuilder load(BiFunction<Environment, Configuration, List<GuiceableModule>> loader) {
         return newBuilder(delegate.load(func((play.api.Environment env, play.api.Configuration conf) ->
@@ -62,6 +74,9 @@ public final class GuiceApplicationBuilder extends GuiceBuilder<GuiceApplication
 
     /**
      * Override the module loader with the given guiceable modules.
+     *
+     * @param modules the set of overriding modules
+     * @return an application builder that incorporates the overrides
      */
     public GuiceApplicationBuilder load(GuiceableModule... modules) {
         return newBuilder(delegate.load(Scala.varargs(modules)));
@@ -69,6 +84,9 @@ public final class GuiceApplicationBuilder extends GuiceBuilder<GuiceApplication
 
     /**
      * Override the module loader with the given Guice modules.
+     *
+     * @param modules the set of overriding modules
+     * @return an application builder that incorporates the overrides
      */
     public GuiceApplicationBuilder load(com.google.inject.Module... modules) {
         return load(Guiceable.modules(modules));
@@ -76,6 +94,9 @@ public final class GuiceApplicationBuilder extends GuiceBuilder<GuiceApplication
 
     /**
      * Override the module loader with the given Play modules.
+     *
+     * @param modules the set of overriding modules
+     * @return an application builder that incorporates the overrides
      */
     public GuiceApplicationBuilder load(play.api.inject.Module... modules) {
         return load(Guiceable.modules(modules));
@@ -83,6 +104,9 @@ public final class GuiceApplicationBuilder extends GuiceBuilder<GuiceApplication
 
     /**
      * Override the module loader with the given Play bindings.
+     *
+     * @param bindings the set of binding override
+     * @return an application builder that incorporates the overrides
      */
     public GuiceApplicationBuilder load(play.api.inject.Binding<?>... bindings) {
         return load(Guiceable.bindings(bindings));
@@ -90,6 +114,8 @@ public final class GuiceApplicationBuilder extends GuiceBuilder<GuiceApplication
 
     /**
      * Create a new Play Application using this configured builder.
+     *
+     * @return the application
      */
     public Application build() {
         return injector().instanceOf(Application.class);
@@ -97,6 +123,8 @@ public final class GuiceApplicationBuilder extends GuiceBuilder<GuiceApplication
 
     /**
      * Implementation of Self creation for GuiceBuilder.
+     *
+     * @return the application builder
      */
     protected GuiceApplicationBuilder newBuilder(play.api.inject.guice.GuiceApplicationBuilder builder) {
         return new GuiceApplicationBuilder(builder);

--- a/framework/src/play-java/src/main/java/play/inject/guice/GuiceApplicationLoader.java
+++ b/framework/src/play-java/src/main/java/play/inject/guice/GuiceApplicationLoader.java
@@ -36,6 +36,9 @@ public class GuiceApplicationLoader implements ApplicationLoader {
 
     /**
      * Construct a builder to use for loading the given context.
+     *
+     * @param context the context the returned builder will load
+     * @return the builder
      */
     public GuiceApplicationBuilder builder(ApplicationLoader.Context context) {
         return initialBuilder
@@ -45,9 +48,11 @@ public class GuiceApplicationLoader implements ApplicationLoader {
     }
 
     /**
-     * Override some bindings using information from the context. The default
-     * implementation of this method provides bindings that most applications
-     * should include.
+     * Identify some bindings that should be used as overrides when loading an application using this context. The default
+     * implementation of this method provides bindings that most applications should include.
+     *
+     * @param context the context that should be searched for overrides
+     * @return the bindings that should be used to override
      */
     protected GuiceableModule[] overrides(ApplicationLoader.Context context) {
         scala.collection.Seq<GuiceableModule> seq = play.api.inject.guice.GuiceApplicationLoader$.MODULE$.defaultOverrides(context.underlying());

--- a/framework/src/play-java/src/main/java/play/inject/guice/GuiceBuilder.java
+++ b/framework/src/play-java/src/main/java/play/inject/guice/GuiceBuilder.java
@@ -17,6 +17,9 @@ import play.Mode;
 
 /**
  * A builder for creating Guice-backed Play Injectors.
+ *
+ * @param <Self> the concrete type that is extending this class
+ * @param <Delegate> a scala GuiceBuilder type.
  */
 public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.GuiceBuilder<Delegate>> {
 
@@ -28,6 +31,9 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Set the environment.
+     *
+     * @param env the environment to configure into this application
+     * @return a copy of this builder with the new environment
      */
     public final Self in(Environment env) {
         return newBuilder(delegate.in(env.underlying()));
@@ -35,6 +41,9 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Set the environment path.
+     *
+     * @param path the path to configure
+     * @return a copy of this builder with the new path
      */
     public final Self in(File path) {
         return newBuilder(delegate.in(path));
@@ -42,6 +51,9 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Set the environment mode.
+     *
+     * @param mode the mode to configure
+     * @return a copy of this build configured with this mode
      */
     public final Self in(Mode mode) {
         return newBuilder(delegate.in(play.api.Mode.apply(mode.ordinal())));
@@ -49,6 +61,9 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Set the environment class loader.
+     *
+     * @param classLoader the class loader to use
+     * @return a copy of this builder configured with the class loader
      */
     public final Self in(ClassLoader classLoader) {
         return newBuilder(delegate.in(classLoader));
@@ -56,6 +71,9 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Add additional configuration.
+     *
+     * @param conf the configuration to add
+     * @return a copy of this builder configured with the supplied configuration
      */
     public final Self configure(Configuration conf) {
         return newBuilder(delegate.configure(conf.getWrappedConfiguration()));
@@ -63,6 +81,9 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Add additional configuration.
+     *
+     * @param conf the configuration to add
+     * @return a copy of this builder configured with the supplied configuration
      */
     public final Self configure(Map<String, Object> conf) {
         return configure(new Configuration(conf));
@@ -70,6 +91,10 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Add additional configuration.
+     *
+     * @param key a configuration key to set
+     * @param value the associated value for <code>key</code>
+     * @return a copy of this builder configured with the key=value
      */
     public final Self configure(String key, Object value) {
         return configure(ImmutableMap.of(key, value));
@@ -77,6 +102,9 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Add bindings from guiceable modules.
+     *
+     * @param modules the set of modules to bind
+     * @return a copy of this builder configured with those modules
      */
     public final Self bindings(GuiceableModule... modules) {
         return newBuilder(delegate.bindings(Scala.varargs(modules)));
@@ -84,6 +112,9 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Add bindings from Guice modules.
+     *
+     * @param modules the set of Guice modules whose bindings to apply
+     * @return a copy of this builder configured with the provided bindings
      */
     public final Self bindings(com.google.inject.Module... modules) {
         return bindings(Guiceable.modules(modules));
@@ -91,6 +122,9 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Add bindings from Play modules.
+     *
+     * @param modules the set of Guice modules whose bindings to apply
+     * @return a copy of this builder configured with the provided bindings
      */
     public final Self bindings(play.api.inject.Module... modules) {
         return bindings(Guiceable.modules(modules));
@@ -98,6 +132,9 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Add Play bindings.
+     *
+     * @param bindings the set of play bindings to apply
+     * @return a copy of this builder configured with the provided bindings
      */
     public final Self bindings(play.api.inject.Binding<?>... bindings) {
         return bindings(Guiceable.bindings(bindings));
@@ -105,6 +142,9 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Override bindings using guiceable modules.
+     *
+     * @param modules the set of Guice modules whose bindings override some previously configured ones
+     * @return a copy of this builder re-configured with the provided bindings
      */
     public final Self overrides(GuiceableModule... modules) {
         return newBuilder(delegate.overrides(Scala.varargs(modules)));
@@ -112,6 +152,9 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Override bindings using Guice modules.
+     *
+     * @param modules the set of Guice modules whose bindings override some previously configured ones
+     * @return a copy of this builder re-configured with the provided bindings
      */
     public final Self overrides(com.google.inject.Module... modules) {
         return overrides(Guiceable.modules(modules));
@@ -119,6 +162,9 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Override bindings using Play modules.
+     *
+     * @param modules the set of Play modules whose bindings override some previously configured ones
+     * @return a copy of this builder re-configured with the provided bindings
      */
     public final Self overrides(play.api.inject.Module... modules) {
         return overrides(Guiceable.modules(modules));
@@ -126,6 +172,9 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Override bindings using Play bindings.
+     *
+     * @param bindings a set of Play bindings that override some previously configured ones
+     * @return a copy of this builder re-configured with the provided bindings
      */
     public final Self overrides(play.api.inject.Binding<?>... bindings) {
         return overrides(Guiceable.bindings(bindings));
@@ -133,6 +182,9 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Disable modules by class.
+     *
+     * @param moduleClasses the module classes whose bindings should be disabled
+     * @return a copy of this builder configured to ignore the provided module classes
      */
     public final Self disable(Class<?>... moduleClasses) {
         return newBuilder(delegate.disable(Scala.toSeq(moduleClasses)));
@@ -140,6 +192,8 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Create a Guice module that can be used to inject an Application.
+     *
+     * @return the module
      */
     public Module applicationModule() {
         return delegate.applicationModule();
@@ -147,6 +201,8 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
 
     /**
      * Create a Play Injector backed by Guice using this configured builder.
+     *
+     * @return the injector
      */
     public Injector injector() {
         return delegate.injector().instanceOf(Injector.class);

--- a/framework/src/play-java/src/main/java/play/inject/guice/GuiceInjectorBuilder.java
+++ b/framework/src/play-java/src/main/java/play/inject/guice/GuiceInjectorBuilder.java
@@ -24,6 +24,8 @@ public final class GuiceInjectorBuilder extends GuiceBuilder<GuiceInjectorBuilde
 
     /**
      * Create a Play Injector backed by Guice using this configured builder.
+     *
+     * @return the injector
      */
     public Injector build() {
         return injector();

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
@@ -441,7 +441,7 @@ trait DefaultReads extends LowPriorityDefaultReads {
    * @param parsing Argument to instantiate date/time parser. Actually either a pattern (string) or a formatter (`java.time.format.DateTimeFormatter`)
    * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed.
    * @param p Typeclass instance based on `parsing`
-   * @see [[TemporalFormatter]]
+   * @see [[DefaultWrites.TemporalFormatter]]
    *
    * {{{
    * import play.api.libs.json.Java8Reads.localDateTimeReads
@@ -484,8 +484,7 @@ trait DefaultReads extends LowPriorityDefaultReads {
    * @param parsing Argument to instantiate date/time parser. Actually either a pattern (string) or a formatter (`java.time.format.DateTimeFormatter`)
    * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed.
    * @param p Typeclass instance based on `parsing`
-   * @see [[TemporalFormatter]]
-   *
+   * @see [[DefaultWrites.TemporalFormatter]]
    * {{{
    * import play.api.libs.json.Java8Reads.zonedDateTimeReads
    *
@@ -527,8 +526,7 @@ trait DefaultReads extends LowPriorityDefaultReads {
    * @param parsing Argument to instantiate date parser. Actually either a pattern (string) or a formatter (`java.time.format.DateTimeFormatter`)
    * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed.
    * @param p Typeclass instance based on `parsing`
-   * @see [[TemporalFormatter]]
-   *
+   * @see [[DefaultWrites.TemporalFormatter]]
    * {{{
    * import play.api.libs.json.Java8Reads.localDateReads
    *
@@ -570,8 +568,7 @@ trait DefaultReads extends LowPriorityDefaultReads {
    * @param parsing Argument to instantiate date parser. Actually either a pattern (string) or a formatter (`java.time.format.DateTimeFormatter`)
    * @param corrector a simple string transformation function that can be used to transform input String before parsing. Useful when standards are not exactly respected and require a few tweaks. Function `identity` can be passed if no correction is needed.
    * @param p Typeclass instance based on `parsing`
-   * @see [[TemporalFormatter]]
-   *
+   * @see [[DefaultWrites.TemporalFormatter]]
    * {{{
    * import play.api.libs.json.Java8Reads.instantReads
    *

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
@@ -15,10 +15,10 @@ object ActorFlow {
    * Create a flow that is handled by an actor.
    *
    * Messages can be sent downstream by sending them to the actor passed into the props function.  This actor meets
-   * the contract of the actor returned by [[Source.actorRef()]].
+   * the contract of the actor returned by [[akka.stream.scaladsl.Source.actorRef]].
    *
    * The props function should return the props for an actor to handle the flow. This actor will be created using the
-   * passed in [[ActorRefFactory]]. Each message received will be sent to the actor - there is no back pressure,
+   * passed in [[akka.actor.ActorRefFactory]]. Each message received will be sent to the actor - there is no back pressure,
    * if the actor is unable to process the messages, they will queue up in the actors mailbox. The upstream can be
    * cancelled by the actor terminating itself.
    *

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
@@ -52,7 +52,7 @@ case class NingWSClient(config: AsyncHttpClientConfig)(implicit materializer: Ma
 
 object NingWSClient {
   /**
-   * Convenient factory method that uses a [[WSClientConfig]] value for configuration instead of an [[AsyncHttpClientConfig]].
+   * Convenient factory method that uses a [[WSClientConfig]] value for configuration instead of an [[https://asynchttpclient.github.io/async-http-client/apidocs/com/ning/http/client/AsyncHttpClientConfig.html org.asynchttpclient.AsyncHttpClientConfig]].
    *
    * Typical usage:
    *

--- a/framework/src/play-ws/src/main/scala/play/api/test/WSTestClient.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/test/WSTestClient.scala
@@ -42,7 +42,7 @@ trait WsTestClient {
    *
    * {{{
    * Server.withRouter() {
-   *   case GET(p"/hello/$who") => Action(Ok("Hello " + who))
+   *   case GET(p"/hello/\$who") => Action(Ok("Hello " + who))
    * } { implicit port =>
    *   withClient { ws =>
    *     await(ws.url("/hello/world").get()).body must_== "Hello world"

--- a/framework/src/play/src/main/java/play/Application.java
+++ b/framework/src/play/src/main/java/play/Application.java
@@ -19,16 +19,22 @@ public interface Application {
 
     /**
      * Get the underlying Scala application.
+     *
+     * @return the application
      */
     play.api.Application getWrappedApplication();
 
     /**
      * Get the application configuration.
+     *
+     * @return the configuration
      */
     Configuration configuration();
 
     /**
      * Get the injector for this application.
+     *
+     * @return the injector
      */
     Injector injector();
 
@@ -84,6 +90,7 @@ public interface Application {
      * Get the {@link play.Plugin} instance for the given class.
      *
      * @param pluginClass the Class of the plugin
+     * @param <T> the type of the plugin
      * @return an instance of the plugin (if found, otherwise null)
      */
     default <T> T plugin(Class<T> pluginClass) {

--- a/framework/src/play/src/main/java/play/ApplicationLoader.java
+++ b/framework/src/play/src/main/java/play/ApplicationLoader.java
@@ -30,6 +30,9 @@ public interface ApplicationLoader {
 
   /**
    * Load an application given the context.
+   *
+   * @param context the context the apps hould be loaded into
+   * @return the loaded application
    */
   Application load(ApplicationLoader.Context context);
 
@@ -77,6 +80,8 @@ public interface ApplicationLoader {
 
     /**
      * Get the wrapped Scala context.
+     *
+     * @return the wrapped scala context
      */
     public play.api.ApplicationLoader.Context underlying() {
         return underlying;
@@ -84,6 +89,8 @@ public interface ApplicationLoader {
 
     /**
      * Get the environment from the context.
+     *
+     * @return the environment
      */
     public Environment environment() {
         return new Environment(underlying.environment());
@@ -93,6 +100,8 @@ public interface ApplicationLoader {
      * Get the configuration from the context. This configuration is not necessarily the same
      * configuration used by the application, as the ApplicationLoader may, through it's own
      * mechanisms, modify it or completely ignore it.
+     *
+     * @return the initial configuration
      */
     public Configuration initialConfiguration() {
         return new Configuration(underlying.initialConfiguration());
@@ -100,6 +109,9 @@ public interface ApplicationLoader {
 
     /**
      * Create a new context with a different environment.
+     *
+     * @param environment the environment this context should use
+     * @return a context using the specified environment
      */
     public Context withEnvironment(Environment environment) {
         play.api.ApplicationLoader.Context scalaContext = new play.api.ApplicationLoader.Context(
@@ -112,6 +124,9 @@ public interface ApplicationLoader {
 
     /**
      * Create a new context with a different configuration.
+     *
+     * @param initialConfiguration the configuration to use in the created context
+     * @return the created context
      */
     public Context withConfiguration(Configuration initialConfiguration) {
         play.api.ApplicationLoader.Context scalaContext = new play.api.ApplicationLoader.Context(
@@ -137,6 +152,7 @@ public interface ApplicationLoader {
      *                        configuration files, and together form the initialConfiguration provided by the context.  It
      *                        is intended for use in dev mode, to allow the build system to pass additional configuration
      *                        into the application.
+     * @return the created context
      */
     public static Context create(Environment environment, Map<String, Object> initialSettings) {
         play.api.ApplicationLoader.Context scalaContext = play.api.ApplicationLoader$.MODULE$.createContext(
@@ -153,6 +169,7 @@ public interface ApplicationLoader {
      * Locates and loads the necessary configuration files for the application.
      *
      * @param environment The application environment.
+     * @return a context created with the provided underlying environment
      */
     public static Context create(Environment environment) {
         return create(environment, Collections.emptyMap());

--- a/framework/src/play/src/main/java/play/Configuration.java
+++ b/framework/src/play/src/main/java/play/Configuration.java
@@ -35,6 +35,9 @@ public class Configuration {
 
     /**
      * Load a new configuration from an environment.
+     *
+     * @param env the environment used to initialize the created config
+     * @return the created config
      */
     public static Configuration load(Environment env) {
         return new Configuration(play.api.Configuration.load(env.underlying()));
@@ -42,6 +45,8 @@ public class Configuration {
 
     /**
      * A new empty configuration.
+     *
+     * @return a new empty configuration
      */
     public static Configuration empty() {
         return new Configuration(ConfigFactory.empty());
@@ -49,6 +54,8 @@ public class Configuration {
 
     /**
      * A new reference configuration.
+     *
+     * @return the configuration
      */
     public static Configuration reference() {
         return new Configuration(ConfigFactory.defaultReference());
@@ -60,6 +67,8 @@ public class Configuration {
 
     /**
      * Creates a new configuration from a Typesafe Config object.
+     *
+     * @param conf the typesafe config
      */
     public Configuration(Config conf) {
         this(new play.api.Configuration(conf));
@@ -67,6 +76,8 @@ public class Configuration {
 
     /**
      * Creates a new configuration from a map.
+     *
+     * @param conf the configuration map
      */
     public Configuration(Map<String, Object> conf) {
         this(ConfigFactory.parseMap(conf));
@@ -74,6 +85,8 @@ public class Configuration {
 
     /**
      * Creates a new configuration by parsing a string in HOCON format.
+     *
+     * @param s the HOCON-formatted string
      */
     public Configuration(String s) {
         this(ConfigFactory.parseString(s));
@@ -81,6 +94,8 @@ public class Configuration {
 
     /**
      * Creates a new configuration from a Scala-based configuration.
+     *
+     * @param conf the scala-based configuration
      */
     @Inject
     public Configuration(play.api.Configuration conf) {
@@ -330,7 +345,7 @@ public class Configuration {
 
     /**
      * Returns the config as a set of full paths to config values.  This is
-     * different to {@link asMap()} in that it returns {@link com.typesafe.config.ConfigValue}
+     * different to {@link #asMap()} in that it returns {@link com.typesafe.config.ConfigValue}
      * objects, and keys are recursively expanded to be pull path keys.
      *
      * @return The config as an entry set
@@ -663,6 +678,9 @@ public class Configuration {
 
     /**
      * Extend this configuration with fallback configuration.
+     *
+     * @param fallback the configuration to fall back on if no value is found for a key
+     * @return a new configuration that falls back on the provided one
      */
     public Configuration withFallback(Configuration fallback) {
         return new Configuration(underlying().withFallback(fallback.underlying()));

--- a/framework/src/play/src/main/java/play/DefaultApplication.java
+++ b/framework/src/play/src/main/java/play/DefaultApplication.java
@@ -21,6 +21,10 @@ public class DefaultApplication implements Application {
 
     /**
      * Create an application that wraps a Scala application.
+     *
+     * @param application the application to wrap
+     * @param configuration the new application's configuration
+     * @param injector the new application's injector
      */
     @Inject
     public DefaultApplication(play.api.Application application, Configuration configuration, Injector injector) {
@@ -31,6 +35,9 @@ public class DefaultApplication implements Application {
 
     /**
      * Create an application that wraps a Scala application.
+     *
+     * @param application the application to wrap
+     * @param injector the new application's injector
      */
     public DefaultApplication(play.api.Application application, Injector injector) {
         this(application, new Configuration(application.configuration()), injector);
@@ -38,6 +45,8 @@ public class DefaultApplication implements Application {
 
     /**
      * Get the underlying Scala application.
+     *
+     * @return the underlying application
      */
     public play.api.Application getWrappedApplication() {
       return application;
@@ -45,6 +54,8 @@ public class DefaultApplication implements Application {
 
     /**
      * Get the application configuration.
+     *
+     * @return the configuration
      */
     public Configuration configuration() {
         return configuration;
@@ -52,6 +63,8 @@ public class DefaultApplication implements Application {
 
     /**
      * Get the injector for this application.
+     *
+     * @return the injector
      */
     public Injector injector() {
         return injector;

--- a/framework/src/play/src/main/java/play/Environment.java
+++ b/framework/src/play/src/main/java/play/Environment.java
@@ -43,6 +43,8 @@ public class Environment {
 
     /**
      * The root path that the application is deployed at.
+     *
+     * @return the path
      */
     public File rootPath() {
         return env.rootPath();
@@ -50,6 +52,8 @@ public class Environment {
 
     /**
      * The classloader that all application classes and resources can be loaded from.
+     *
+     * @return the class loader
      */
     public ClassLoader classLoader() {
         return env.classLoader();
@@ -57,6 +61,8 @@ public class Environment {
 
     /**
      * The mode of the application.
+     *
+     * @return the mode
      */
     public Mode mode() {
         if (env.mode().equals(play.api.Mode.Prod())) {
@@ -70,6 +76,8 @@ public class Environment {
 
     /**
      * Returns `true` if the application is `DEV` mode.
+     *
+     * @return `true` if the application is `DEV` mode.
      */
     public boolean isDev() {
         return mode().equals(Mode.DEV);
@@ -77,6 +85,8 @@ public class Environment {
 
     /**
      * Returns `true` if the application is `PROD` mode.
+     *
+     * @return `true` if the application is `PROD` mode.
      */
     public boolean isProd() {
         return mode().equals(Mode.PROD);
@@ -84,6 +94,8 @@ public class Environment {
 
     /**
      * Returns `true` if the application is `TEST` mode.
+     *
+     * @return `true` if the application is `TEST` mode.
      */
     public boolean isTest() {
         return mode().equals(Mode.TEST);
@@ -124,6 +136,8 @@ public class Environment {
      *
      * Uses the same classloader that the environment classloader is defined in,
      * the current working directory as the path and test mode.
+     *
+     * @return the environment
      */
     public static Environment simple() {
         return new Environment(new File("."), Environment.class.getClassLoader(), Mode.TEST);
@@ -132,6 +146,8 @@ public class Environment {
     /**
      * The underlying Scala API Environment object that this Environment
      * wraps.
+     *
+     * @return the environemnt
      */
     public play.api.Environment underlying() {
         return env;

--- a/framework/src/play/src/main/java/play/GlobalSettings.java
+++ b/framework/src/play/src/main/java/play/GlobalSettings.java
@@ -20,6 +20,8 @@ public class GlobalSettings {
 
     /**
      * Executed before any plugin - you can set-up your database schema here, for instance.
+     *
+     * @param app the bootstrapping application
      */
     public void beforeStart(Application app) {
     }
@@ -27,12 +29,16 @@ public class GlobalSettings {
     /**
      * Executed after all plugins, including the database set-up with Evolutions and the EBean wrapper.
      * This is a good place to execute some of your application code to create entries, for instance.
+     *
+     * @param app the bootstrapped application
      */
     public void onStart(Application app) {
     }
 
     /**
      * Executed when the application stops.
+     *
+     * @param app the application that is shutting down
      */
     public void onStop(Application app) {
     }
@@ -45,6 +51,7 @@ public class GlobalSettings {
      *
      * By overriding this method one can provide an alternative error page.
      *
+     * @param request header of the HTTP request being processed
      * @param t is any throwable
      * @return null as the default implementation
      */
@@ -108,6 +115,7 @@ public class GlobalSettings {
      * By overriding this method one can provide an alternative 400 page.
      *
      * @param request the HTTP request
+     * @param error an arbitrary string describing the error
      * @return null in the default implementation, you can return your own custom Result in your Global class.
      */
     public CompletionStage<Result> onBadRequest(RequestHeader request, String error) {
@@ -118,6 +126,11 @@ public class GlobalSettings {
      * @deprecated This method does not do anything.
      * Instead, specify configuration in your config file
      * or make your own ApplicationLoader (see GuiceApplicationBuilder.loadConfig).
+     *
+     * @param config deprecated
+     * @param path deprecated
+     * @param classloader deprecated
+     * @return deprecated
      */
     @Deprecated
     public final Configuration onLoadConfig(Configuration config, File path, ClassLoader classloader) {
@@ -128,6 +141,12 @@ public class GlobalSettings {
      * @deprecated This method does not do anything.
      * Instead, specify configuration in your config file
      * or make your own ApplicationLoader (see GuiceApplicationBuilder.loadConfig).
+     *
+     * @param config deprecated
+     * @param path deprecated
+     * @param classloader deprecated
+     * @param mode deprecated
+     * @return deprecated
      */
     @Deprecated
     public final Configuration onLoadConfig(Configuration config, File path, ClassLoader classloader, Mode mode) {
@@ -136,6 +155,9 @@ public class GlobalSettings {
 
     /**
      * Get the filters that should be used to handle each request.
+     *
+     * @param <T> the filter type
+     * @return an instance of the filter type
      */
     public <T extends play.api.mvc.EssentialFilter> Class<T>[] filters() {
         return new Class[0];

--- a/framework/src/play/src/main/java/play/Logger.java
+++ b/framework/src/play/src/main/java/play/Logger.java
@@ -59,6 +59,8 @@ public class Logger {
 
     /**
      * Get the underlying application SLF4J logger.
+     *
+     * @return the underlying logger
      */
     public static org.slf4j.Logger underlying() {
         return logger.underlying();
@@ -66,6 +68,8 @@ public class Logger {
 
     /**
      * Returns <code>true</code> if the logger instance enabled for the TRACE level?
+     *
+     * @return <code>true</code> if the logger instance enabled for the TRACE level?
      */
     public static boolean isTraceEnabled() {
         return logger.isTraceEnabled();
@@ -73,6 +77,8 @@ public class Logger {
 
     /**
      * Returns <code>true</code> if the logger instance enabled for the DEBUG level?
+     *
+     * @return <code>true</code> if the logger instance enabled for the DEBUG level?
      */
     public static boolean isDebugEnabled() {
         return logger.isDebugEnabled();
@@ -80,6 +86,8 @@ public class Logger {
 
     /**
      * Returns <code>true</code> if the logger instance enabled for the INFO level?
+     *
+     * @return <code>true</code> if the logger instance enabled for the INFO level?
      */
     public static boolean isInfoEnabled() {
         return logger.isInfoEnabled();
@@ -87,6 +95,8 @@ public class Logger {
 
     /**
      * Returns <code>true</code> if the logger instance enabled for the WARN level?
+     *
+     * @return <code>true</code> if the logger instance enabled for the WARN level?
      */
     public static boolean isWarnEnabled() {
         return logger.isWarnEnabled();
@@ -94,6 +104,8 @@ public class Logger {
 
     /**
      * Returns <code>true</code> if the logger instance enabled for the ERROR level?
+     *
+     * @return <code>true</code> if the logger instance enabled for the ERROR level?
      */
     public static boolean isErrorEnabled() {
         return logger.isWarnEnabled();
@@ -257,6 +269,8 @@ public class Logger {
 
         /**
          * Get the underlying SLF4J logger.
+         *
+         * @return the SLF4J loger
          */
         public org.slf4j.Logger underlying() {
             return logger.underlyingLogger();
@@ -264,6 +278,8 @@ public class Logger {
 
         /**
          * Returns <code>true</code> if the logger instance has TRACE level logging enabled.
+         *
+         * @return <code>true</code> if the logger instance has TRACE level logging enabled.
          */
         public boolean isTraceEnabled() {
             return logger.isTraceEnabled();
@@ -271,6 +287,8 @@ public class Logger {
 
         /**
          * Returns <code>true</code> if the logger instance has DEBUG level logging enabled.
+         *
+         * @return <code>true</code> if the logger instance has DEBUG level logging enabled.
          */
         public boolean isDebugEnabled() {
             return logger.isDebugEnabled();
@@ -278,6 +296,8 @@ public class Logger {
 
         /**
          * Returns <code>true</code> if the logger instance has INFO level logging enabled.
+         *
+         * @return <code>true</code> if the logger instance has INFO level logging enabled.
          */
         public boolean isInfoEnabled() {
             return logger.isInfoEnabled();
@@ -285,6 +305,8 @@ public class Logger {
 
         /**
          * Returns <code>true</code> if the logger instance has WARN level logging enabled.
+         *
+         * @return <code>true</code> if the logger instance has WARN level logging enabled.
          */
         public boolean isWarnEnabled() {
             return logger.isWarnEnabled();
@@ -292,6 +314,8 @@ public class Logger {
 
         /**
          * Returns <code>true</code> if the logger instance has ERROR level logging enabled.
+         *
+         * @return <code>true</code> if the logger instance has ERROR level logging enabled.
          */
         public boolean isErrorEnabled() {
             return logger.isWarnEnabled();

--- a/framework/src/play/src/main/java/play/Play.java
+++ b/framework/src/play/src/main/java/play/Play.java
@@ -12,6 +12,7 @@ public class Play {
 
     /**
      * @deprecated inject the {@link play.Application} instead
+     * @return Deprecated
      */
     @Deprecated
     public static Application application() {
@@ -20,6 +21,7 @@ public class Play {
 
     /**
      * @deprecated inject the {@link play.Environment} instead
+     * @return Deprecated
      */
     @Deprecated
     public static Mode mode() {
@@ -28,6 +30,7 @@ public class Play {
 
     /**
      * @deprecated inject the {@link play.Environment} instead
+     * @return Deprecated
      */
     @Deprecated
     public static boolean isDev() {
@@ -36,6 +39,7 @@ public class Play {
 
     /**
      * @deprecated inject the {@link play.Environment} instead
+     * @return Deprecated
      */
     @Deprecated
     public static boolean isProd() {
@@ -44,6 +48,7 @@ public class Play {
 
     /**
      * @deprecated inject the {@link play.Environment} instead
+     * @return Deprecated
      */
     @Deprecated
     public static boolean isTest() {

--- a/framework/src/play/src/main/java/play/Routes.java
+++ b/framework/src/play/src/main/java/play/Routes.java
@@ -18,6 +18,10 @@ public class Routes {
 
     /**
      * Generates a JavaScript router.
+     *
+     * @param name the router's name
+     * @param routes the reverse routes for this router
+     * @return the router
      */
     public static JavaScript javascriptRouter(String name, play.api.routing.JavaScriptReverseRoute... routes) {
         return javascriptRouter(name, "jQuery.ajax", routes);
@@ -25,11 +29,15 @@ public class Routes {
 
     /**
      * Generates a JavaScript router.
+     *
+     * @param name the router's name
+     * @param ajaxMethod which asynchronous call method the user's browser will use (e.g. "jQuery.ajax")
+     * @param routes the reverse routes for this router
+     * @return the router
      */
     public static JavaScript javascriptRouter(String name, String ajaxMethod, play.api.routing.JavaScriptReverseRoute... routes) {
         return play.api.Routes.javascriptRouter(
             name, Scala.Option(ajaxMethod), play.mvc.Http.Context.current().request().host(), Scala.toSeq(routes)
         );
     }
-
 }

--- a/framework/src/play/src/main/java/play/i18n/Lang.java
+++ b/framework/src/play/src/main/java/play/i18n/Lang.java
@@ -10,35 +10,35 @@ import play.libs.*;
  * A Lang supported by the application.
  */
 public class Lang extends play.api.i18n.Lang {
-    
+
     public final play.api.i18n.Lang underlyingLang;
-    
+
     public Lang(play.api.i18n.Lang underlyingLang) {
         super(underlyingLang.language(), underlyingLang.country());
         this.underlyingLang = underlyingLang;
     }
-    
+
     /**
      * A valid ISO Language Code.
      */
     public String language() {
         return underlyingLang.language();
     }
-    
+
     /**
      * A valid ISO Country Code.
      */
     public String country() {
         return underlyingLang.country();
     }
-    
+
     /**
      * The Lang code (such as fr or en-US).
      */
     public String code() {
         return underlyingLang.code();
     }
-    
+
     /**
      * Convert to a Java Locale value.
      */
@@ -55,9 +55,12 @@ public class Lang extends play.api.i18n.Lang {
     public int hashCode() {
         return underlyingLang.hashCode();
     }
-    
+
     /**
      * Create a Lang value from a code (such as fr or en-US).
+     *
+     * @param code the language code
+     * @return the Lang for the code, or null of no matching lang was found.
      */
     public static Lang forCode(String code) {
         try {
@@ -66,9 +69,11 @@ public class Lang extends play.api.i18n.Lang {
             return null;
         }
     }
-    
+
     /**
      * Retrieve Lang availables from the application configuration.
+     *
+     * @return the available languages
      */
     public static List<Lang> availables() {
         List<play.api.i18n.Lang> langs = Scala.asJava(play.api.i18n.Lang.availables(play.api.Play.current()));
@@ -78,10 +83,13 @@ public class Lang extends play.api.i18n.Lang {
         }
         return result;
     }
-    
+
     /**
      * Guess the preferred lang in the langs set passed as argument.
      * The first Lang that matches an available Lang wins, otherwise returns the first Lang available in this application.
+     *
+     * @param langs the set of langs from which to guess the preferred
+     * @return the preferred lang.
      */
     public static Lang preferred(List<Lang> langs) {
         List<play.api.i18n.Lang> result = new ArrayList<play.api.i18n.Lang>();

--- a/framework/src/play/src/main/java/play/i18n/Messages.java
+++ b/framework/src/play/src/main/java/play/i18n/Messages.java
@@ -39,10 +39,10 @@ public class Messages {
     }
 
     /**
-     * Converts the varargs to a scala buffer, 
+     * Converts the varargs to a scala buffer,
      * takes care of wrapping varargs into a intermediate list if necessary
-     * 
-     * @param args the message arguments 
+     *
+     * @param args the message arguments
      * @return scala type for message processing
      */
     private static Buffer<Object> convertArgsToScalaBuffer(final Object... args) {
@@ -50,9 +50,9 @@ public class Messages {
     }
 
     /**
-     * Wraps arguments passed into a list if necessary. 
+     * Wraps arguments passed into a list if necessary.
      *
-     * Returns the first value as is if it is the only argument and a subtype of `java.util.List` 
+     * Returns the first value as is if it is the only argument and a subtype of `java.util.List`
      * Otherwise, it calls Arrays.asList on args
      * @param args arguments as a List
      */
@@ -152,6 +152,8 @@ public class Messages {
 
     /**
      * The lang for these messages
+     *
+     * @return the language
      */
     public Lang lang() {
         return lang;

--- a/framework/src/play/src/main/java/play/i18n/MessagesApi.java
+++ b/framework/src/play/src/main/java/play/i18n/MessagesApi.java
@@ -110,6 +110,9 @@ public class MessagesApi {
      *
      * Will select a language from the candidates, based on the languages available, and fallback to the default language
      * if none of the candidates are available.
+     *
+     * @param candidates the candidate languages
+     * @return the most appropriate Messages instance given the candidate languages
      */
     public Messages preferred(Collection<Lang> candidates) {
         Seq<Lang> cs = JavaConversions.collectionAsScalaIterable(candidates).toSeq();
@@ -123,6 +126,9 @@ public class MessagesApi {
      *
      * Will select a language from the candidates, based on the languages available, and fallback to the default language
      * if none of the candidates are available.
+     *
+     * @param request the incoming request
+     * @return the preferred messages context for the request
      */
     public Messages preferred(Http.RequestHeader request) {
         play.api.i18n.Messages msgs = messages.preferred(request);

--- a/framework/src/play/src/main/java/play/mvc/Action.java
+++ b/framework/src/play/src/main/java/play/mvc/Action.java
@@ -11,25 +11,28 @@ import java.util.concurrent.CompletionStage;
  * An action acts as decorator for the action method call.
  */
 public abstract class Action<T> extends Results {
-    
+
     /**
      * The action configuration - typically the annotation used to decorate the action method.
      */
     public T configuration;
-    
+
     /**
      * The wrapped action.
      */
     public Action<?> delegate;
-    
+
     /**
      * Executes this action with the given HTTP context and returns the result.
+     *
+     * @param ctx the http context in which to execute this action
+     * @return a promise to the action's result
      */
     public abstract CompletionStage<Result> call(Context ctx);
-    
+
     /**
      * A simple action with no configuration.
      */
     public static abstract class Simple extends Action<Void> {}
-    
+
 }

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -53,6 +53,8 @@ public interface BodyParser<A> {
 
         /**
          * The class of the body parser to use.
+         *
+         * @return the class
          */
         Class<? extends BodyParser> value();
 
@@ -62,6 +64,8 @@ public interface BodyParser<A> {
          * play.http.parser.maxMemoryBuffer and play.http.parser.maxDiskBuffer. To define a custom max length for a
          * particular action, create a custom body parser, optionally extending one of the existing ones and passing
          * the max length into their constructors.
+         *
+         * @return Deprecated
          */
         @Deprecated
         long maxLength() default -1;
@@ -371,6 +375,9 @@ public interface BodyParser<A> {
 
         /**
          * Implement this method to implement the actual body parser.
+         *
+         * @param request header for the request to parse
+         * @return the accumulator that parses the request
          */
         protected abstract Accumulator<ByteString, F.Either<Result, A>> apply1(Http.RequestHeader request);
     }

--- a/framework/src/play/src/main/java/play/mvc/BodyParsers.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParsers.java
@@ -26,7 +26,8 @@ public class BodyParsers {
      * @param errorMessage The error message to pass to the error handler if the content type is not valid.
      * @param validate The validation function.
      * @param parser The parser to use if the content type is valid.
-     * @return An accumulator to parse tho body.
+     * @param <A> The type to be parsed by the parser
+     * @return An accumulator to parse the body.
      */
     public static <A> Accumulator<ByteString, F.Either<Result, A>> validateContentType(HttpErrorHandler errorHandler,
                Http.RequestHeader request, String errorMessage, Function<String, Boolean> validate,

--- a/framework/src/play/src/main/java/play/mvc/Call.java
+++ b/framework/src/play/src/main/java/play/mvc/Call.java
@@ -14,21 +14,29 @@ public abstract class Call {
 
     /**
      * The request URL.
+     *
+     * @return the url
      */
     public abstract String url();
 
     /**
      * The request HTTP method.
+     *
+     * @return the http method (e.g. "GET")
      */
     public abstract String method();
 
     /**
      * The fragment of the URL.
+     *
+     * @return the fragment (without leading '#' character)
      */
     public abstract String fragment();
 
     /**
      * Append a unique identifier to the URL.
+     *
+     * @return a copy if this call with a unique identifier to this url
      */
     public Call unique() {
         return new play.api.mvc.Call(method(), this.uniquify(this.url()), fragment());
@@ -40,6 +48,9 @@ public abstract class Call {
 
     /**
      * Returns a new Call with the given fragment.
+     *
+     * @param fragment the URL fragment
+     * @return a copy of this call that contains the fragment
      */
     public Call withFragment(String fragment) {
         return new play.api.mvc.Call(method(), url(), fragment);
@@ -47,6 +58,8 @@ public abstract class Call {
 
     /**
      * Returns the fragment (including the leading "#") if this call has one.
+     *
+     * @return the fragment, with leading "#"
      */
     protected String appendFragment() {
         if (this.fragment() != null && !this.fragment().trim().isEmpty()) {
@@ -58,6 +71,9 @@ public abstract class Call {
 
     /**
      * Transform this call to an absolute URL.
+     *
+     * @param request used to identify the host and protocol that should base this absolute URL
+     * @return the absolute URL string
      */
     public String absoluteURL(Http.Request request) {
         return absoluteURL(request.secure(), request.host());
@@ -65,6 +81,10 @@ public abstract class Call {
 
     /**
      * Transform this call to an absolute URL.
+     *
+     * @param request used to identify the host that should base this absolute URL
+     * @param secure true if the absolute URL should use HTTPS protocol
+     * @return the absolute URL string
      */
     public String absoluteURL(Http.Request request, boolean secure) {
         return absoluteURL(secure, request.host());
@@ -72,6 +92,10 @@ public abstract class Call {
 
     /**
      * Transform this call to an absolute URL.
+     *
+     * @param secure true if the absolute URL should use HTTPS protocol instead of HTTP
+     * @param host the absolute URL's domain
+     * @return the absolute URL string
      */
     public String absoluteURL(boolean secure, String host) {
         return "http" + (secure ? "s" : "") + "://" + host + this.url() + this.appendFragment();
@@ -79,6 +103,9 @@ public abstract class Call {
 
     /**
      * Transform this call to an WebSocket URL.
+     *
+     * @param request used as the base for forming the WS url
+     * @return the websocket url string
      */
     public String webSocketURL(Http.Request request) {
         return webSocketURL(request.secure(), request.host());
@@ -86,6 +113,10 @@ public abstract class Call {
 
     /**
      * Transform this call to an WebSocket URL.
+     *
+     * @param request used to identify the host for the absolute URL
+     * @param secure true if it should be a wss rather than ws URL
+     * @return the websocket URL string
      */
     public String webSocketURL(Http.Request request, boolean secure) {
       return webSocketURL(secure, request.host());
@@ -93,6 +124,10 @@ public abstract class Call {
 
     /**
      * Transform this call to an WebSocket URL.
+     *
+     * @param host the host for the absolute URL.
+     * @param secure true if it should be a wss rather than ws URL
+     * @return the url string
      */
     public String webSocketURL(boolean secure, String host) {
       return "ws" + (secure ? "s" : "") + "://" + host + this.url();

--- a/framework/src/play/src/main/java/play/mvc/Controller.java
+++ b/framework/src/play/src/main/java/play/mvc/Controller.java
@@ -20,6 +20,8 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 
     /**
      * Returns the current HTTP context.
+     *
+     * @return the context
      */
     public static Context ctx() {
         return Http.Context.current();
@@ -27,6 +29,8 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 
     /**
      * Returns the current HTTP request.
+     *
+     * @return the request
      */
     public static Request request() {
         return Http.Context.current().request();
@@ -34,6 +38,8 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 
     /**
      * Returns the current lang.
+     *
+     * @return the language
      */
     public static Lang lang() {
         return Http.Context.current().lang();
@@ -41,6 +47,7 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 
     /**
      * Change durably the lang for the current user
+     *
      * @param code New lang code to use (e.g. "fr", "en-US", etc.)
      * @return true if the requested lang was supported by the application, otherwise false.
      */
@@ -50,6 +57,7 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 
     /**
      * Change durably the lang for the current user
+     *
      * @param lang New Lang object to use
      * @return true if the requested lang was supported by the application, otherwise false.
      */
@@ -66,6 +74,8 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 
     /**
      * Returns the current HTTP response.
+     *
+     * @return the response
      */
     public static Response response() {
         return Http.Context.current().response();
@@ -73,6 +83,8 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 
     /**
      * Returns the current HTTP session.
+     *
+     * @return the session
      */
     public static Session session() {
         return Http.Context.current().session();
@@ -80,6 +92,9 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 
     /**
      * Puts a new value into the current session.
+     *
+     * @param key the key to set into the session
+     * @param value the value to set for <code>key</code>
      */
     public static void session(String key, String value) {
         session().put(key, value);
@@ -87,6 +102,9 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 
     /**
      * Returns a value from the session.
+     *
+     * @param key the session key
+     * @return the value for the provided key, or null if there was no value
      */
     public static String session(String key) {
         return session().get(key);
@@ -94,6 +112,8 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 
     /**
      * Returns the current HTTP flash scope.
+     *
+     * @return the flash scope
      */
     public static Flash flash() {
         return Http.Context.current().flash();
@@ -101,6 +121,9 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 
     /**
      * Puts a new value into the flash scope.
+     *
+     * @param key the key to put into the flash scope
+     * @param value the value corresponding to <code>key</code>
      */
     public static void flash(String key, String value) {
         flash().put(key, value);
@@ -108,6 +131,9 @@ public abstract class Controller extends Results implements Status, HeaderNames 
 
     /**
      * Returns a value from the flash scope.
+     *
+     * @param key the key to look up in the flash scope
+     * @return the value corresponding to <code>key</code> from the flash scope, or null if there was none
      */
     public static String flash(String key) {
         return flash().get(key);

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -61,6 +61,8 @@ public class Http {
 
         /**
          * Retrieves the current HTTP context, for the current thread.
+         *
+         * @return the context
          */
         public static Context current() {
             Context c = current.get();
@@ -109,9 +111,12 @@ public class Http {
         /**
          * Creates a new HTTP context.
          *
-         * @param request the HTTP request
+         * @param id the unique context ID
+         * @param header the request header
+         * @param request the request with body
          * @param sessionData the session data extracted from the session cookie
          * @param flashData the flash data extracted from the flash cookie
+         * @param args any arbitrary data to associate with this request context.
          */
         public Context(Long id, play.api.mvc.RequestHeader header, Request request, Map<String,String> sessionData, Map<String,String> flashData, Map<String,Object> args) {
             this.id = id;
@@ -125,6 +130,8 @@ public class Http {
 
         /**
          * The context id (unique)
+         *
+         * @return the id
          */
         public Long id() {
             return id;
@@ -132,6 +139,8 @@ public class Http {
 
         /**
          * Returns the current request.
+         *
+         * @return the request
          */
         public Request request() {
             return request;
@@ -139,6 +148,8 @@ public class Http {
 
         /**
          * Returns the current response.
+         *
+         * @return the response
          */
         public Response response() {
             return response;
@@ -146,6 +157,8 @@ public class Http {
 
         /**
          * Returns the current session.
+         *
+         * @return the session
          */
         public Session session() {
             return session;
@@ -153,6 +166,8 @@ public class Http {
 
         /**
          * Returns the current flash scope.
+         *
+         * @return the flash scope
          */
         public Flash flash() {
             return flash;
@@ -161,12 +176,16 @@ public class Http {
         /**
          * The original Play request Header used to create this context.
          * For internal usage only.
+         *
+         * @return the original request header.
          */
         public play.api.mvc.RequestHeader _requestHeader() {
             return header;
         }
 
         /**
+         * The current lang
+         *
          * @return the current lang
          */
         public Lang lang() {
@@ -186,6 +205,7 @@ public class Http {
 
         /**
          * Change durably the lang for the current user.
+         *
          * @param code New lang code to use (e.g. "fr", "en-US", etc.)
          * @return true if the requested lang was supported by the application, otherwise false
          */
@@ -195,6 +215,7 @@ public class Http {
 
         /**
          * Change durably the lang for the current user.
+         *
          * @param lang New Lang object to use
          * @return true if the requested lang was supported by the application, otherwise false
          */
@@ -226,6 +247,7 @@ public class Http {
          * will be set for this request, but will not change for
          * future requests.
          *
+         * @param code the language code to set (e.g. "en-US")
          * @throws IllegalArgumentException If the given language
          * is not supported by the application.
          */
@@ -239,6 +261,7 @@ public class Http {
          * will be set for this request, but will not change for
          * future requests.
          *
+         * @param lang the language to set
          * @throws IllegalArgumentException If the given language
          * is not supported by the application.
          */
@@ -272,6 +295,8 @@ public class Http {
 
             /**
              * Returns the current response.
+             *
+             * @return the current response.
              */
             public static Response response() {
                 return Context.current().response();
@@ -279,6 +304,8 @@ public class Http {
 
             /**
              * Returns the current request.
+             *
+             * @return the current request.
              */
             public static Request request() {
                 return Context.current().request();
@@ -286,6 +313,8 @@ public class Http {
 
             /**
              * Returns the current flash scope.
+             *
+             * @return the current flash scope.
              */
             public static Flash flash() {
                 return Context.current().flash();
@@ -293,6 +322,8 @@ public class Http {
 
             /**
              * Returns the current session.
+             *
+             * @return the current session.
              */
             public static Session session() {
                 return Context.current().session();
@@ -300,12 +331,16 @@ public class Http {
 
             /**
              * Returns the current lang.
+             *
+             * @return the current lang.
              */
             public static Lang lang() {
                 return Context.current().lang();
             }
 
             /**
+             * Returns the messages for the current lang
+             *
              * @return the messages for the current lang
              */
             public static Messages messages() {
@@ -314,6 +349,8 @@ public class Http {
 
             /**
              * Returns the current context.
+             *
+             * @return the current context.
              */
             public static Context ctx() {
                 return Context.current();
@@ -349,7 +386,7 @@ public class Http {
         private final Context wrapped;
 
         /**
-         * @param wrapped
+         * @param wrapped the context the created instance will wrap
          */
         public WrappedContext(Context wrapped) {
             super(wrapped.id(), wrapped._requestHeader(), wrapped.request(), wrapped.session(), wrapped.flash(), wrapped.args);
@@ -412,16 +449,22 @@ public class Http {
 
         /**
          * The complete request URI, containing both path and query string.
+         *
+         * @return the uri
          */
         String uri();
 
         /**
          * The HTTP Method.
+         *
+         * @return the http method
          */
         String method();
 
         /**
          * The HTTP version.
+         *
+         * @return the version
          */
         String version();
 
@@ -430,27 +473,36 @@ public class Http {
          *
          * retrieves the last untrusted proxy
          * from the Forwarded-Headers or the X-Forwarded-*-Headers.
+         *
+         * @return the remote address
          */
         String remoteAddress();
 
         /**
          * Is the client using SSL?
          *
+         * @return true that the client is using SSL
          */
         boolean secure();
 
         /**
          * The request host.
+         *
+         * @return the host
          */
         String host();
 
         /**
          * The URI path.
+         *
+         * @return the path
          */
         String path();
 
         /**
          * The Request Langs extracted from the Accept-Language header and sorted by preference (preferred first).
+         *
+         * @return the preference-ordered list of languages accepted by the client
          */
         List<play.i18n.Lang> acceptLanguages();
 
@@ -461,17 +513,24 @@ public class Http {
 
         /**
          * Check if this request accepts a given media type.
+         *
+         * @param mimeType the mimeType to check for support.
          * @return true if <code>mimeType</code> is in the Accept header, otherwise false
          */
         boolean accepts(String mimeType);
 
         /**
          * The query string content.
+         *
+         * @return the query string map
          */
         Map<String,String[]> queryString();
 
         /**
          * Helper method to access a queryString parameter.
+         *
+         * @param key the query string parameter to look up
+         * @return the value for the provided <code>key</code>.
          */
         String getQueryString(String key);
 
@@ -497,6 +556,7 @@ public class Http {
          * Retrieves a single header.
          *
          * @param headerName The name of the header (case-insensitive)
+         * @return the value corresponding to <code>headerName</code>, or null if it was not present
          */
         String getHeader(String headerName);
 
@@ -504,6 +564,7 @@ public class Http {
          * Checks if the request has the header.
          *
          * @param headerName The name of the header (case-insensitive)
+         * @return <code>true</code> if the request did contain the header.
          */
         boolean hasHeader(String headerName);
 
@@ -523,6 +584,8 @@ public class Http {
 
         /**
          * For internal Play-use only
+         *
+         * @return the underlying request
          */
         play.api.mvc.RequestHeader _underlyingHeader();
     }
@@ -534,29 +597,39 @@ public class Http {
 
         /**
          * The request body.
+         *
+         * @return the body
          */
         RequestBody body();
 
         /**
          * The user name for this request, if defined.
          * This is usually set by annotating your Action with <code>@Authenticated</code>.
+         *
+         * @return the username
          */
         String username();
 
         /**
          * Defines the user name for this request.
+         *
          * @deprecated As of release 2.4, use {@link #withUsername}
+         * @param username Deprecated
          */
         @Deprecated void setUsername(String username);
 
         /**
          * Returns a request updated with specified user name
+         *
          * @param username the new user name
+         * @return a copy of the request containing the specified user name
          */
         Request withUsername(String username);
 
         /**
          * For internal Play-use only
+         *
+         * @return the underlying request
          */
         play.api.mvc.Request<RequestBody> _underlyingRequest();
     }
@@ -677,7 +750,7 @@ public class Http {
 
         /**
          * @param username the username for the request
-         * @return the builder
+         * @return the modified builder
          */
         public RequestBuilder username(String username) {
             this.username = username;
@@ -689,6 +762,7 @@ public class Http {
          *
          * @param body the body
          * @param contentType Content-Type header value
+         * @return the modified builder
          */
         protected RequestBuilder body(RequestBody body, String contentType) {
             header("Content-Type", contentType);
@@ -700,6 +774,7 @@ public class Http {
          * Set the body of the request.
          *
          * @param body The body.
+         * @return the modified builder
          */
         protected RequestBuilder body(RequestBody body) {
             this.body = body;
@@ -709,7 +784,9 @@ public class Http {
         /**
          * Set a Binary Data to this request.
          * The <tt>Content-Type</tt> header of the request is set to <tt>application/octet-stream</tt>.
+         *
          * @param data the Binary Data
+         * @return the modified builder
          */
         public RequestBuilder bodyRaw(ByteString data) {
             play.api.mvc.RawBuffer buffer = new play.api.mvc.RawBuffer(data.size(), data);
@@ -719,7 +796,9 @@ public class Http {
         /**
          * Set a Binary Data to this request.
          * The <tt>Content-Type</tt> header of the request is set to <tt>application/octet-stream</tt>.
+         *
          * @param data the Binary Data
+         * @return the modified builder
          */
         public RequestBuilder bodyRaw(byte[] data) {
             return bodyRaw(ByteString.fromArray(data));
@@ -727,6 +806,9 @@ public class Http {
 
         /**
          * Set a Form url encoded body to this request.
+         *
+         * @param data the x-www-form-urlencoded parameters
+         * @return the modified builder
          */
         public RequestBuilder bodyFormArrayValues(Map<String, String[]> data) {
             return body(new RequestBody(data), "application/x-www-form-urlencoded");
@@ -734,6 +816,9 @@ public class Http {
 
         /**
          * Set a Form url encoded body to this request.
+         *
+         * @param data the x-www-form-urlencoded parameters
+         * @return the modified builder
          */
         public RequestBuilder bodyForm(Map<String, String> data) {
             Map<String, String[]> arrayValues = new HashMap<>();
@@ -746,7 +831,9 @@ public class Http {
         /**
          * Set a Json Body to this request.
          * The <tt>Content-Type</tt> header of the request is set to <tt>application/json</tt>.
+         *
          * @param node the Json Node
+         * @return this builder, updated
          */
         public RequestBuilder bodyJson(JsonNode node) {
             return body(new RequestBody(node), "application/json");
@@ -755,7 +842,9 @@ public class Http {
         /**
          * Set a Json Body to this request.
          * The <tt>Content-Type</tt> header of the request is set to <tt>application/json</tt>.
+         *
          * @param json the JsValue
+         * @return the modified builder
          */
         public RequestBuilder bodyJson(JsValue json) {
             return bodyJson(Json.parse(play.api.libs.json.Json.stringify(json)));
@@ -764,7 +853,9 @@ public class Http {
         /**
          * Set a XML to this request.
          * The <tt>Content-Type</tt> header of the request is set to <tt>application/xml</tt>.
+         *
          * @param xml the XML
+         * @return the modified builder
          */
         public RequestBuilder bodyXml(InputSource xml) {
             return bodyXml(XML.fromInputSource(xml));
@@ -772,8 +863,11 @@ public class Http {
 
         /**
          * Set a XML to this request.
+         *
          * The <tt>Content-Type</tt> header of the request is set to <tt>application/xml</tt>.
+         *
          * @param xml the XML
+         * @return the modified builder
          */
         public RequestBuilder bodyXml(Document xml) {
             return body(new RequestBody(xml), "application/xml");
@@ -782,7 +876,9 @@ public class Http {
         /**
          * Set a Text to this request.
          * The <tt>Content-Type</tt> header of the request is set to <tt>text/plain</tt>.
+         *
          * @param text the text
+         * @return this builder, updated
          */
         public RequestBuilder bodyText(String text) {
             return body(new RequestBody(text), "text/plain");
@@ -790,6 +886,7 @@ public class Http {
 
         /**
          * Builds the request.
+         *
          * @return a build of the given parameters
          */
         public RequestImpl build() {
@@ -1203,6 +1300,8 @@ public class Http {
 
         /**
          * Buffer size.
+         *
+         * @return the buffer size
          */
         public abstract Long size();
 
@@ -1216,11 +1315,15 @@ public class Http {
 
         /**
          * Returns the buffer content as a bytes array
+         *
+         * @return the bytes
          */
         public abstract ByteString asBytes();
 
         /**
          * Returns the buffer content as File
+         *
+         * @return the file
          */
         public abstract File asFile();
 
@@ -1277,6 +1380,8 @@ public class Http {
 
             /**
              * The part name.
+             *
+             * @return the part name
              */
             public String getKey() {
                 return key;
@@ -1284,6 +1389,8 @@ public class Http {
 
             /**
              * The file name.
+             *
+             * @return the file name
              */
             public String getFilename() {
                 return filename;
@@ -1291,6 +1398,8 @@ public class Http {
 
             /**
              * The file Content-Type
+             *
+             * @return the content type
              */
             public String getContentType() {
                 return contentType;
@@ -1298,6 +1407,8 @@ public class Http {
 
             /**
              * The File.
+             *
+             * @return the file
              */
             public A getFile() {
                 return file;
@@ -1307,16 +1418,23 @@ public class Http {
 
         /**
          * Extract the data parts as Form url encoded.
+         *
+         * @return the data that was URL encoded
          */
         public abstract Map<String, String[]> asFormUrlEncoded();
 
         /**
          * Retrieves all file parts.
+         *
+         * @return the file parts
          */
         public abstract List<FilePart<A>> getFiles();
 
         /**
          * Access a file part.
+         *
+         * @param key name of the file part to access
+         * @return the file part specified by key
          */
         public FilePart<A> getFile(String key) {
             for(FilePart filePart: getFiles()) {
@@ -1341,6 +1459,9 @@ public class Http {
 
         /**
          * The request content parsed as multipart form data.
+         *
+         * @param <A> the file type (e.g. play.api.libs.Files.TemporaryFile)
+         * @return the content parsed as multipart form data
          */
         public <A> MultipartFormData<A> asMultipartFormData() {
             return as(MultipartFormData.class);
@@ -1348,6 +1469,8 @@ public class Http {
 
         /**
          * The request content parsed as URL form-encoded.
+         *
+         * @return the request content parsed as URL form-encoded.
          */
         public Map<String,String[]> asFormUrlEncoded() {
             // Best effort, check if it's a map, then check if the first element in that map is String -> String[].
@@ -1366,6 +1489,8 @@ public class Http {
 
         /**
          * The request content as Array bytes.
+         *
+         * @return The request content as Array bytes.
          */
         public RawBuffer asRaw() {
             return as(RawBuffer.class);
@@ -1373,6 +1498,8 @@ public class Http {
 
         /**
          * The request content as text.
+         *
+         * @return The request content as text.
          */
         public String asText() {
             return as(String.class);
@@ -1380,6 +1507,8 @@ public class Http {
 
         /**
          * The request content as XML.
+         *
+         * @return The request content as XML.
          */
         public Document asXml() {
             return as(Document.class);
@@ -1387,6 +1516,8 @@ public class Http {
 
         /**
          * The request content as Json.
+         *
+         * @return The request content as Json.
          */
         public JsonNode asJson() {
             return as(JsonNode.class);
@@ -1398,6 +1529,8 @@ public class Http {
          * This makes a best effort attempt to convert the parsed body to a ByteString, if it knows how. This includes
          * String, json, XML and form bodies.  It doesn't include multipart/form-data or raw bodies that don't fit in
          * the configured max memory buffer, nor does it include custom output types from custom body parsers.
+         *
+         * @return the request content as a ByteString
          */
         public ByteString asBytes() {
             if (body instanceof Optional) {
@@ -1442,6 +1575,10 @@ public class Http {
 
         /**
          * Cast this RequestBody as T if possible.
+         *
+         * @param tType class that we are trying to cast the body as
+         * @param <T> type of the provided <code>tType</code>
+         * @return either a successful cast into T or null
          */
         public <T> T as(Class<T> tType) {
             if (tType.isInstance(body)) {
@@ -1477,6 +1614,8 @@ public class Http {
 
         /**
          * Gets the current response headers.
+         *
+         * @return the current response headers.
          */
         public Map<String,String> getHeaders() {
             return headers;
@@ -1484,6 +1623,8 @@ public class Http {
 
         /**
          * @deprecated noop. Use {@link Result#as(String)} instead.
+         *
+         * @param contentType Deprecated
          */
         @Deprecated
         public void setContentType(String contentType) {
@@ -1495,9 +1636,10 @@ public class Http {
          * <pre>
          * response().setCookie("theme", "blue");
          * </pre>
+         *
          * @param name Cookie name, must not be null
          * @param value Cookie value
-         * @deprecated Use {@link Response#setCookie(Cookie)} instead.
+         * @deprecated Use {@link #setCookie(Http.Cookie)} instead.
          */
         @Deprecated
         public void setCookie(String name, String value) {
@@ -1509,7 +1651,7 @@ public class Http {
          * @param name Cookie name, must not be null
          * @param value Cookie value
          * @param maxAge Cookie duration (null for a transient cookie and 0 or less for a cookie that expires now)
-         * @deprecated Use {@link Response#setCookie(Cookie)} instead.
+         * @deprecated Use {@link #setCookie(Http.Cookie)} instead.
          */
         @Deprecated
         public void setCookie(String name, String value, Integer maxAge) {
@@ -1522,7 +1664,7 @@ public class Http {
          * @param value Cookie value
          * @param maxAge Cookie duration (null for a transient cookie and 0 or less for a cookie that expires now)
          * @param path Cookie path
-         * @deprecated Use {@link Response#setCookie(Cookie)} instead.
+         * @deprecated Use {@link #setCookie(Http.Cookie)} instead.
          */
         @Deprecated
         public void setCookie(String name, String value, Integer maxAge, String path) {
@@ -1536,7 +1678,7 @@ public class Http {
          * @param maxAge Cookie duration (null for a transient cookie and 0 or less for a cookie that expires now)
          * @param path Cookie path
          * @param domain Cookie domain
-         * @deprecated Use {@link Response#setCookie(Cookie)} instead.
+         * @deprecated Use {@link #setCookie(Http.Cookie)} instead.
          */
         @Deprecated
         public void setCookie(String name, String value, Integer maxAge, String path, String domain) {
@@ -1552,7 +1694,7 @@ public class Http {
          * @param domain Cookie domain
          * @param secure Whether the cookie is secured (for HTTPS requests)
          * @param httpOnly Whether the cookie is HTTP only (i.e. not accessible from client-side JavaScript code)
-         * @deprecated Use {@link Response#setCookie(Cookie)} instead.
+         * @deprecated Use {@link #setCookie(Http.Cookie)} instead.
          */
         public void setCookie(String name, String value, Integer maxAge, String path, String domain, boolean secure, boolean httpOnly) {
             cookies.add(new Cookie(name, value, maxAge, path, domain, secure, httpOnly));
@@ -1560,6 +1702,7 @@ public class Http {
 
         /**
          * Set a new cookie.
+         *
          * @param cookie to set
          */
         public void setCookie(Cookie cookie) {

--- a/framework/src/play/src/main/java/play/mvc/LegacyWebSocket.java
+++ b/framework/src/play/src/main/java/play/mvc/LegacyWebSocket.java
@@ -36,6 +36,8 @@ public abstract class LegacyWebSocket<A> {
     /**
      * If this method returns true, then the WebSocket should be handled by an actor.  The actor will be obtained by
      * passing an ActorRef representing to the actor method, which should return the props for creating the actor.
+     *
+     * @return true if the websocket should be handled by an actor.
      */
     public boolean isActor() {
         return false;

--- a/framework/src/play/src/main/java/play/mvc/PathBindable.java
+++ b/framework/src/play/src/main/java/play/mvc/PathBindable.java
@@ -62,6 +62,7 @@ public interface PathBindable<T extends PathBindable<T>> {
      * Unbind a URL path parameter.
      *
      * @param key Parameter key
+     * @return a suitable string representation of T for use in constructing a new URL path
      */
     public String unbind(String key);
 

--- a/framework/src/play/src/main/java/play/mvc/QueryStringBindable.java
+++ b/framework/src/play/src/main/java/play/mvc/QueryStringBindable.java
@@ -54,7 +54,7 @@ import java.util.*;
  * size parameters if you pleased.
  */
 public interface QueryStringBindable<T extends QueryStringBindable<T>> {
-    
+
     /**
      * Bind a query string parameter.
      *
@@ -64,19 +64,23 @@ public interface QueryStringBindable<T extends QueryStringBindable<T>> {
      *      or None if it couldn't.
      */
     Optional<T> bind(String key, Map<String,String[]> data);
-    
+
     /**
      * Unbind a query string parameter.  This should return a query string fragment, in the form
      * <code>key=value[&amp;key2=value2...]</code>.
      *
      * @param key Parameter key
+     * @return this key's query-string fragment.
      */
     String unbind(String key);
-    
+
     /**
      * Javascript function to unbind in the Javascript router.
      *
      * If this bindable just represents a single value, you may return null to let the default implementation handle it.
+     *
+     * @return null for default behavior, otherwise a valid javascript function that accepts the key and value as
+     *         arguments and returns a valid query string fragment (in the format <code>key=value</code>)
      */
     String javascriptUnbind();
 }

--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -88,13 +88,17 @@ public class Result {
 
     /**
      * Get the status.
+     *
+     * @return the status
      */
     public int status() {
         return header.status();
     }
 
     /**
-     * Get the reason phrase.
+     * Get the reason phrase, if it was set.
+     *
+     * @return the reason phrase (e.g. "NOT FOUND")
      */
     public Optional<String> reasonPhrase() {
         return OptionConverters.toJava(header.reasonPhrase());
@@ -102,6 +106,8 @@ public class Result {
 
     /**
      * Get the response header
+     *
+     * @return the header
      */
     protected ResponseHeader header() {
         return header;
@@ -109,6 +115,8 @@ public class Result {
 
     /**
      * Get the body of this result.
+     *
+     * @return the body
      */
     public HttpEntity body() {
         return body;
@@ -116,6 +124,8 @@ public class Result {
 
     /**
      * Extracts the Location header of this Result value if this Result is a Redirect.
+     *
+     * @return the location (if it was set)
      */
     public Optional<String> redirectLocation() {
         return header(LOCATION);
@@ -123,6 +133,8 @@ public class Result {
 
     /**
      * Extracts an Header value of this Result value.
+     *
+     * @return the header (if it was set)
      */
     public Optional<String> header(String header) {
         return OptionConverters.<String>toJava(this.header.headers().get(header));
@@ -132,6 +144,8 @@ public class Result {
      * Extracts all Headers of this Result value.
      *
      * The returned map is not modifiable.
+     *
+     * @return the immutable map of headers
      */
     public Map<String, String> headers() {
         return Collections.unmodifiableMap(JavaConversions.mapAsJavaMap(this.header.headers()));
@@ -139,6 +153,8 @@ public class Result {
 
     /**
      * Extracts the Content-Type of this Result value.
+     *
+     * @return the content type (if it was set)
      */
     public Optional<String> contentType() {
         return body.contentType().map(h -> {
@@ -152,6 +168,8 @@ public class Result {
 
     /**
      * Extracts the Charset of this Result value.
+     *
+     * @return the charset (if it was set)
      */
     public Optional<String> charset() {
         return body.contentType().flatMap(h -> {
@@ -165,6 +183,8 @@ public class Result {
 
     /**
      * Extracts the Flash values of this Result value.
+     *
+     * @return the flash (if it was set)
      */
     public Flash flash() {
         return JavaResultExtractor.getFlash(header);
@@ -172,6 +192,8 @@ public class Result {
 
     /**
      * Extracts the Session of this Result value.
+     *
+     * @return the session (if it was set)
      */
     public Session session() {
         return JavaResultExtractor.getSession(header);
@@ -179,6 +201,8 @@ public class Result {
 
     /**
      * Extracts a Cookie value from this Result value
+     *
+     * @return the cookie (if it was set)
      */
     public Cookie cookie(String name) {
         return JavaResultExtractor.getCookies(header).get(name);
@@ -186,6 +210,8 @@ public class Result {
 
     /**
      * Extracts the Cookies (an iterator) from this result value.
+     *
+     * @return the cookies (if they were set)
      */
     public Cookies cookies() {
         return JavaResultExtractor.getCookies(header);
@@ -193,6 +219,8 @@ public class Result {
 
     /**
      * Return a copy of this result with the given header.
+     *
+     * @return the transformed copy
      */
     public Result withHeader(String name, String value) {
         return new Result(JavaResultExtractor.withHeader(header, name, value), body);
@@ -200,13 +228,17 @@ public class Result {
 
     /**
      * Return a copy of this result with the given headers.
+     *
+     * @return the transformed copy
      */
     public Result withHeaders(String... nameValues) {
         return new Result(JavaResultExtractor.withHeader(header, nameValues), body);
     }
 
     /**
-     * Change the Content-Type header for this result.
+     * Return a copy of the result with a different Content-Type header.
+     *
+     * @return the transformed copy
      */
     public Result as(String contentType) {
         return new Result(header, body.as(contentType));
@@ -214,6 +246,8 @@ public class Result {
 
     /**
      * Convert this result to a Scala result.
+     *
+     * @return the Scala result.
      */
     public play.api.mvc.Result asScala() {
         return new play.api.mvc.Result(header, body.asScala());

--- a/framework/src/play/src/main/java/play/mvc/Results.java
+++ b/framework/src/play/src/main/java/play/mvc/Results.java
@@ -42,6 +42,9 @@ public class Results {
 
     /**
      * Generates a simple result.
+     *
+     * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+     * @return the header-only result
      */
     public static StatusHeader status(int status) {
         return new StatusHeader(status);
@@ -49,6 +52,10 @@ public class Results {
 
     /**
      * Generates a simple result.
+     *
+     * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+     * @param content the result's body content
+     * @return the result
      */
     public static Result status(int status, Content content) {
         return status(status, content, UTF8);
@@ -56,6 +63,10 @@ public class Results {
 
     /**
      * Generates a simple result.
+     * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+     * @param content the result's body content
+     * @param charset the charset to encode the content with (e.g. "UTF-8")
+     * @return the result
      */
     public static Result status(int status, Content content, String charset) {
         if (content == null) {
@@ -66,6 +77,10 @@ public class Results {
 
     /**
      * Generates a simple result.
+     *
+     * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+     * @param content the result's body content. It will be encoded as a UTF-8 string.
+     * @return the result
      */
     public static Result status(int status, String content) {
         return status(status, content, UTF8);
@@ -73,6 +88,11 @@ public class Results {
 
     /**
      * Generates a simple result.
+     *
+     * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+     * @param content the result's body content.
+     * @param charset the charset in which to encode the content (e.g. "UTF-8")
+     * @return the result
      */
     public static Result status(int status, String content, String charset) {
         if (content == null) {
@@ -82,14 +102,25 @@ public class Results {
     }
 
     /**
-     * Generates a simple result.
+     * Generates a simple result with json content and UTF8 encoding.
+     *
+     * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+     * @param content the result's body content as a play-json object
+     * @return the result
+     *
      */
     public static Result status(int status, JsonNode content) {
         return status(status, content, UTF8);
     }
 
     /**
-     * Generates a simple result.
+     * Generates a simple result with json content.
+     *
+     * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+     * @param content the result's body content, as a play-json object
+     * @param charset the charset into which the json should be encoded
+     * @return the result
+     *
      */
     public static Result status(int status, JsonNode content, String charset) {
         if (content == null) {
@@ -99,7 +130,11 @@ public class Results {
     }
 
     /**
-     * Generates a simple result.
+     * Generates a simple result with byte-array content.
+     *
+     * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+     * @param content the result's body content, as a byte array
+     * @return the result
      */
     public static Result status(int status, byte[] content) {
         if (content == null) {
@@ -110,6 +145,10 @@ public class Results {
 
     /**
      * Generates a simple result.
+     *
+     * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+     * @param content the result's body content
+     * @return the result
      */
     public static Result status(int status, ByteString content) {
         if (content == null) {
@@ -120,6 +159,10 @@ public class Results {
 
     /**
      * Generates a chunked result.
+     *
+     * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+     * @param content the input stream containing data to chunk over
+     * @return the result
      */
     public static Result status(int status, InputStream content) {
         return status(status).sendInputStream(content);
@@ -127,20 +170,35 @@ public class Results {
 
     /**
      * Generates a chunked result.
+     *
+     * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+     * @param content the input stream containing data to chunk over
+     * @param contentLength the length of the provided content in bytes.
+     * @return the result
      */
     public static Result status(int status, InputStream content, long contentLength) {
         return status(status).sendInputStream(content, contentLength);
     }
 
     /**
-     * Generates a result.
+     * Generates a result with file contents.
+     *
+     * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+     * @param content the file to send
+     * @return the result
      */
     public static Result status(int status, File content) {
         return status(status, content, true);
     }
 
     /**
-     * Generates a result.
+     * Generates a result with file content.
+     *
+     * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+     * @param content the file to send
+     * @param inline <code>true</code> to have it sent with inline Content-Disposition.
+     * @return the result
+     *
      */
     public static Result status(int status, File content, boolean inline) {
         return status(status).sendFile(content, inline);
@@ -148,6 +206,11 @@ public class Results {
 
     /**
      * Generates a result.
+     *
+     * @param status the HTTP status for this result e.g. 200 (OK), 404 (NOT_FOUND)
+     * @param content the file to send
+     * @param fileName the name that the client should receive this file as
+     * @return the result
      */
     public static Result status(int status, File content, String fileName) {
         return status(status).sendFile(content, fileName);
@@ -211,6 +274,8 @@ public class Results {
 
             /**
              * Write a Chunk.
+             *
+             * @param chunk the chunk to write
              */
             public void write(A chunk) {
                 channel.push(chunk);
@@ -218,6 +283,8 @@ public class Results {
 
             /**
              * Attach a callback to be called when the socket is disconnected.
+             *
+             * @param callback the function to run when the socket is disconnected
              */
             public void onDisconnected(final Runnable callback) {
                 disconnected.onRedeem(ignored -> callback.run());
@@ -379,8 +446,11 @@ public class Results {
     // See https://github.com/jroper/play-source-generator
     //////////////////////////////////////////////////////
 
+
     /**
      * Generates a 200 OK result.
+     *
+     * @return the result
      */
     public static StatusHeader ok() {
         return new StatusHeader(OK);
@@ -388,6 +458,9 @@ public class Results {
 
     /**
      * Generates a 200 OK result.
+     *
+     * @param content the HTTP response body
+     * @return the result
      */
     public static Result ok(Content content) {
         return status(OK, content);
@@ -395,6 +468,10 @@ public class Results {
 
     /**
      * Generates a 200 OK result.
+     *
+     * @param content the HTTP response body
+     * @param charset the charset into which the content should be encoded (e.g. "UTF-8")
+     * @return the result
      */
     public static Result ok(Content content, String charset) {
         return status(OK, content, charset);
@@ -402,6 +479,9 @@ public class Results {
 
     /**
      * Generates a 200 OK result.
+     *
+     * @param content HTTP response body, encoded as a UTF-8 string
+     * @return the result
      */
     public static Result ok(String content) {
         return status(OK, content);
@@ -409,13 +489,21 @@ public class Results {
 
     /**
      * Generates a 200 OK result.
+     *
+     * @param content the HTTP response body
+     * @param charset the charset into which the content should be encoded (e.g. "UTF-8")
+     * @return the result
      */
     public static Result ok(String content, String charset) {
         return status(OK, content, charset);
     }
 
     /**
-     * Generates a $status.code OK result.
+     * Generates a 200 OK result.
+     *
+     * @param content the result's body content as a play-json object. It will be encoded
+     *        as a UTF-8 string.
+     * @return the result
      */
     public static Result ok(JsonNode content) {
         return status(OK, content);
@@ -423,6 +511,10 @@ public class Results {
 
     /**
      * Generates a 200 OK result.
+     *
+     * @param content the result's body content as a play-json object
+     * @param charset the charset into which the json should be encoded
+     * @return the result
      */
     public static Result ok(JsonNode content, String charset) {
         return status(OK, content, charset);
@@ -430,6 +522,9 @@ public class Results {
 
     /**
      * Generates a 200 OK result.
+     *
+     * @param content the result's body content
+     * @return the result
      */
     public static Result ok(byte[] content) {
         return status(OK, content);
@@ -437,6 +532,9 @@ public class Results {
 
     /**
      * Generates a 200 OK result.
+     *
+     * @param content the input stream containing data to chunk over
+     * @return the result
      */
     public static Result ok(InputStream content) {
         return status(OK, content);
@@ -444,6 +542,10 @@ public class Results {
 
     /**
      * Generates a 200 OK result.
+     *
+     * @param content the input stream containing data to chunk over
+     * @param contentLength the length of the provided content in bytes.
+     * @return the result
      */
     public static Result ok(InputStream content, long contentLength) {
         return status(OK, content, contentLength);
@@ -453,6 +555,7 @@ public class Results {
      * Generates a 200 OK result.
      *
      * @param content The file to send.
+     * @return the result
      */
     public static Result ok(File content) {
         return status(OK, content);
@@ -463,6 +566,7 @@ public class Results {
      *
      * @param content The file to send.
      * @param inline Whether the file should be sent inline, or as an attachment.
+     * @return the result
      */
     public static Result ok(File content, boolean inline) {
         return status(OK, content, inline);
@@ -473,6 +577,7 @@ public class Results {
      *
      * @param content The file to send.
      * @param filename The name to send the file as.
+     * @return the result
      */
     public static Result ok(File content, String filename) {
         return status(OK, content, filename);
@@ -483,14 +588,19 @@ public class Results {
      *
      * @deprecated Use {@link #ok } with {@link StatusHeader#chunked(akka.stream.javadsl.Source) }
      * instead.
+     * @param chunks Deprecated
+     * @return Deprecated
      */
     @Deprecated
     public static Result ok(Chunks<?> chunks) {
         return status(OK, chunks);
     }
 
+
     /**
      * Generates a 201 Created result.
+     *
+     * @return the result
      */
     public static StatusHeader created() {
         return new StatusHeader(CREATED);
@@ -498,6 +608,9 @@ public class Results {
 
     /**
      * Generates a 201 Created result.
+     *
+     * @param content the HTTP response body
+     * @return the result
      */
     public static Result created(Content content) {
         return status(CREATED, content);
@@ -505,6 +618,10 @@ public class Results {
 
     /**
      * Generates a 201 Created result.
+     *
+     * @param content the HTTP response body
+     * @param charset the charset into which the content should be encoded (e.g. "UTF-8")
+     * @return the result
      */
     public static Result created(Content content, String charset) {
         return status(CREATED, content, charset);
@@ -512,6 +629,9 @@ public class Results {
 
     /**
      * Generates a 201 Created result.
+     *
+     * @param content HTTP response body, encoded as a UTF-8 string
+     * @return the result
      */
     public static Result created(String content) {
         return status(CREATED, content);
@@ -519,13 +639,21 @@ public class Results {
 
     /**
      * Generates a 201 Created result.
+     *
+     * @param content the HTTP response body
+     * @param charset the charset into which the content should be encoded (e.g. "UTF-8")
+     * @return the result
      */
     public static Result created(String content, String charset) {
         return status(CREATED, content, charset);
     }
 
     /**
-     * Generates a $status.code Created result.
+     * Generates a 201 Created result.
+     *
+     * @param content the result's body content as a play-json object. It will be encoded
+     *        as a UTF-8 string.
+     * @return the result
      */
     public static Result created(JsonNode content) {
         return status(CREATED, content);
@@ -533,6 +661,10 @@ public class Results {
 
     /**
      * Generates a 201 Created result.
+     *
+     * @param content the result's body content as a play-json object
+     * @param charset the charset into which the json should be encoded
+     * @return the result
      */
     public static Result created(JsonNode content, String charset) {
         return status(CREATED, content, charset);
@@ -540,6 +672,9 @@ public class Results {
 
     /**
      * Generates a 201 Created result.
+     *
+     * @param content the result's body content
+     * @return the result
      */
     public static Result created(byte[] content) {
         return status(CREATED, content);
@@ -547,6 +682,9 @@ public class Results {
 
     /**
      * Generates a 201 Created result.
+     *
+     * @param content the input stream containing data to chunk over
+     * @return the result
      */
     public static Result created(InputStream content) {
         return status(CREATED, content);
@@ -554,6 +692,10 @@ public class Results {
 
     /**
      * Generates a 201 Created result.
+     *
+     * @param content the input stream containing data to chunk over
+     * @param contentLength the length of the provided content in bytes.
+     * @return the result
      */
     public static Result created(InputStream content, long contentLength) {
         return status(CREATED, content, contentLength);
@@ -563,6 +705,7 @@ public class Results {
      * Generates a 201 Created result.
      *
      * @param content The file to send.
+     * @return the result
      */
     public static Result created(File content) {
         return status(CREATED, content);
@@ -573,6 +716,7 @@ public class Results {
      *
      * @param content The file to send.
      * @param inline Whether the file should be sent inline, or as an attachment.
+     * @return the result
      */
     public static Result created(File content, boolean inline) {
         return status(CREATED, content, inline);
@@ -583,6 +727,7 @@ public class Results {
      *
      * @param content The file to send.
      * @param filename The name to send the file as.
+     * @return the result
      */
     public static Result created(File content, String filename) {
         return status(CREATED, content, filename);
@@ -593,14 +738,19 @@ public class Results {
      *
      * @deprecated Use {@link #created } with {@link StatusHeader#chunked(akka.stream.javadsl.Source) }
      * instead.
+     * @param chunks Deprecated
+     * @return Deprecated
      */
     @Deprecated
     public static Result created(Chunks<?> chunks) {
         return status(CREATED, chunks);
     }
 
+
     /**
      * Generates a 400 Bad Request result.
+     *
+     * @return the result
      */
     public static StatusHeader badRequest() {
         return new StatusHeader(BAD_REQUEST);
@@ -608,6 +758,9 @@ public class Results {
 
     /**
      * Generates a 400 Bad Request result.
+     *
+     * @param content the HTTP response body
+     * @return the result
      */
     public static Result badRequest(Content content) {
         return status(BAD_REQUEST, content);
@@ -615,6 +768,10 @@ public class Results {
 
     /**
      * Generates a 400 Bad Request result.
+     *
+     * @param content the HTTP response body
+     * @param charset the charset into which the content should be encoded (e.g. "UTF-8")
+     * @return the result
      */
     public static Result badRequest(Content content, String charset) {
         return status(BAD_REQUEST, content, charset);
@@ -622,6 +779,9 @@ public class Results {
 
     /**
      * Generates a 400 Bad Request result.
+     *
+     * @param content HTTP response body, encoded as a UTF-8 string
+     * @return the result
      */
     public static Result badRequest(String content) {
         return status(BAD_REQUEST, content);
@@ -629,13 +789,21 @@ public class Results {
 
     /**
      * Generates a 400 Bad Request result.
+     *
+     * @param content the HTTP response body
+     * @param charset the charset into which the content should be encoded (e.g. "UTF-8")
+     * @return the result
      */
     public static Result badRequest(String content, String charset) {
         return status(BAD_REQUEST, content, charset);
     }
 
     /**
-     * Generates a $status.code Bad Request result.
+     * Generates a 400 Bad Request result.
+     *
+     * @param content the result's body content as a play-json object. It will be encoded
+     *        as a UTF-8 string.
+     * @return the result
      */
     public static Result badRequest(JsonNode content) {
         return status(BAD_REQUEST, content);
@@ -643,6 +811,10 @@ public class Results {
 
     /**
      * Generates a 400 Bad Request result.
+     *
+     * @param content the result's body content as a play-json object
+     * @param charset the charset into which the json should be encoded
+     * @return the result
      */
     public static Result badRequest(JsonNode content, String charset) {
         return status(BAD_REQUEST, content, charset);
@@ -650,6 +822,9 @@ public class Results {
 
     /**
      * Generates a 400 Bad Request result.
+     *
+     * @param content the result's body content
+     * @return the result
      */
     public static Result badRequest(byte[] content) {
         return status(BAD_REQUEST, content);
@@ -657,6 +832,9 @@ public class Results {
 
     /**
      * Generates a 400 Bad Request result.
+     *
+     * @param content the input stream containing data to chunk over
+     * @return the result
      */
     public static Result badRequest(InputStream content) {
         return status(BAD_REQUEST, content);
@@ -664,6 +842,10 @@ public class Results {
 
     /**
      * Generates a 400 Bad Request result.
+     *
+     * @param content the input stream containing data to chunk over
+     * @param contentLength the length of the provided content in bytes.
+     * @return the result
      */
     public static Result badRequest(InputStream content, long contentLength) {
         return status(BAD_REQUEST, content, contentLength);
@@ -673,6 +855,7 @@ public class Results {
      * Generates a 400 Bad Request result.
      *
      * @param content The file to send.
+     * @return the result
      */
     public static Result badRequest(File content) {
         return status(BAD_REQUEST, content);
@@ -683,6 +866,7 @@ public class Results {
      *
      * @param content The file to send.
      * @param inline Whether the file should be sent inline, or as an attachment.
+     * @return the result
      */
     public static Result badRequest(File content, boolean inline) {
         return status(BAD_REQUEST, content, inline);
@@ -693,6 +877,7 @@ public class Results {
      *
      * @param content The file to send.
      * @param filename The name to send the file as.
+     * @return the result
      */
     public static Result badRequest(File content, String filename) {
         return status(BAD_REQUEST, content, filename);
@@ -703,14 +888,19 @@ public class Results {
      *
      * @deprecated Use {@link #badRequest } with {@link StatusHeader#chunked(akka.stream.javadsl.Source) }
      * instead.
+     * @param chunks Deprecated
+     * @return Deprecated
      */
     @Deprecated
     public static Result badRequest(Chunks<?> chunks) {
         return status(BAD_REQUEST, chunks);
     }
 
+
     /**
      * Generates a 401 Unauthorized result.
+     *
+     * @return the result
      */
     public static StatusHeader unauthorized() {
         return new StatusHeader(UNAUTHORIZED);
@@ -718,6 +908,9 @@ public class Results {
 
     /**
      * Generates a 401 Unauthorized result.
+     *
+     * @param content the HTTP response body
+     * @return the result
      */
     public static Result unauthorized(Content content) {
         return status(UNAUTHORIZED, content);
@@ -725,6 +918,10 @@ public class Results {
 
     /**
      * Generates a 401 Unauthorized result.
+     *
+     * @param content the HTTP response body
+     * @param charset the charset into which the content should be encoded (e.g. "UTF-8")
+     * @return the result
      */
     public static Result unauthorized(Content content, String charset) {
         return status(UNAUTHORIZED, content, charset);
@@ -732,6 +929,9 @@ public class Results {
 
     /**
      * Generates a 401 Unauthorized result.
+     *
+     * @param content HTTP response body, encoded as a UTF-8 string
+     * @return the result
      */
     public static Result unauthorized(String content) {
         return status(UNAUTHORIZED, content);
@@ -739,13 +939,21 @@ public class Results {
 
     /**
      * Generates a 401 Unauthorized result.
+     *
+     * @param content the HTTP response body
+     * @param charset the charset into which the content should be encoded (e.g. "UTF-8")
+     * @return the result
      */
     public static Result unauthorized(String content, String charset) {
         return status(UNAUTHORIZED, content, charset);
     }
 
     /**
-     * Generates a $status.code Unauthorized result.
+     * Generates a 401 Unauthorized result.
+     *
+     * @param content the result's body content as a play-json object. It will be encoded
+     *        as a UTF-8 string.
+     * @return the result
      */
     public static Result unauthorized(JsonNode content) {
         return status(UNAUTHORIZED, content);
@@ -753,6 +961,10 @@ public class Results {
 
     /**
      * Generates a 401 Unauthorized result.
+     *
+     * @param content the result's body content as a play-json object
+     * @param charset the charset into which the json should be encoded
+     * @return the result
      */
     public static Result unauthorized(JsonNode content, String charset) {
         return status(UNAUTHORIZED, content, charset);
@@ -760,6 +972,9 @@ public class Results {
 
     /**
      * Generates a 401 Unauthorized result.
+     *
+     * @param content the result's body content
+     * @return the result
      */
     public static Result unauthorized(byte[] content) {
         return status(UNAUTHORIZED, content);
@@ -767,6 +982,9 @@ public class Results {
 
     /**
      * Generates a 401 Unauthorized result.
+     *
+     * @param content the input stream containing data to chunk over
+     * @return the result
      */
     public static Result unauthorized(InputStream content) {
         return status(UNAUTHORIZED, content);
@@ -774,6 +992,10 @@ public class Results {
 
     /**
      * Generates a 401 Unauthorized result.
+     *
+     * @param content the input stream containing data to chunk over
+     * @param contentLength the length of the provided content in bytes.
+     * @return the result
      */
     public static Result unauthorized(InputStream content, long contentLength) {
         return status(UNAUTHORIZED, content, contentLength);
@@ -783,6 +1005,7 @@ public class Results {
      * Generates a 401 Unauthorized result.
      *
      * @param content The file to send.
+     * @return the result
      */
     public static Result unauthorized(File content) {
         return status(UNAUTHORIZED, content);
@@ -793,6 +1016,7 @@ public class Results {
      *
      * @param content The file to send.
      * @param inline Whether the file should be sent inline, or as an attachment.
+     * @return the result
      */
     public static Result unauthorized(File content, boolean inline) {
         return status(UNAUTHORIZED, content, inline);
@@ -803,6 +1027,7 @@ public class Results {
      *
      * @param content The file to send.
      * @param filename The name to send the file as.
+     * @return the result
      */
     public static Result unauthorized(File content, String filename) {
         return status(UNAUTHORIZED, content, filename);
@@ -813,14 +1038,19 @@ public class Results {
      *
      * @deprecated Use {@link #unauthorized } with {@link StatusHeader#chunked(akka.stream.javadsl.Source) }
      * instead.
+     * @param chunks Deprecated
+     * @return Deprecated
      */
     @Deprecated
     public static Result unauthorized(Chunks<?> chunks) {
         return status(UNAUTHORIZED, chunks);
     }
 
+
     /**
      * Generates a 402 Payment Required result.
+     *
+     * @return the result
      */
     public static StatusHeader paymentRequired() {
         return new StatusHeader(PAYMENT_REQUIRED);
@@ -828,6 +1058,9 @@ public class Results {
 
     /**
      * Generates a 402 Payment Required result.
+     *
+     * @param content the HTTP response body
+     * @return the result
      */
     public static Result paymentRequired(Content content) {
         return status(PAYMENT_REQUIRED, content);
@@ -835,6 +1068,10 @@ public class Results {
 
     /**
      * Generates a 402 Payment Required result.
+     *
+     * @param content the HTTP response body
+     * @param charset the charset into which the content should be encoded (e.g. "UTF-8")
+     * @return the result
      */
     public static Result paymentRequired(Content content, String charset) {
         return status(PAYMENT_REQUIRED, content, charset);
@@ -842,6 +1079,9 @@ public class Results {
 
     /**
      * Generates a 402 Payment Required result.
+     *
+     * @param content HTTP response body, encoded as a UTF-8 string
+     * @return the result
      */
     public static Result paymentRequired(String content) {
         return status(PAYMENT_REQUIRED, content);
@@ -849,13 +1089,21 @@ public class Results {
 
     /**
      * Generates a 402 Payment Required result.
+     *
+     * @param content the HTTP response body
+     * @param charset the charset into which the content should be encoded (e.g. "UTF-8")
+     * @return the result
      */
     public static Result paymentRequired(String content, String charset) {
         return status(PAYMENT_REQUIRED, content, charset);
     }
 
     /**
-     * Generates a $status.code Payment Required result.
+     * Generates a 402 Payment Required result.
+     *
+     * @param content the result's body content as a play-json object. It will be encoded
+     *        as a UTF-8 string.
+     * @return the result
      */
     public static Result paymentRequired(JsonNode content) {
         return status(PAYMENT_REQUIRED, content);
@@ -863,6 +1111,10 @@ public class Results {
 
     /**
      * Generates a 402 Payment Required result.
+     *
+     * @param content the result's body content as a play-json object
+     * @param charset the charset into which the json should be encoded
+     * @return the result
      */
     public static Result paymentRequired(JsonNode content, String charset) {
         return status(PAYMENT_REQUIRED, content, charset);
@@ -870,6 +1122,9 @@ public class Results {
 
     /**
      * Generates a 402 Payment Required result.
+     *
+     * @param content the result's body content
+     * @return the result
      */
     public static Result paymentRequired(byte[] content) {
         return status(PAYMENT_REQUIRED, content);
@@ -877,6 +1132,9 @@ public class Results {
 
     /**
      * Generates a 402 Payment Required result.
+     *
+     * @param content the input stream containing data to chunk over
+     * @return the result
      */
     public static Result paymentRequired(InputStream content) {
         return status(PAYMENT_REQUIRED, content);
@@ -884,6 +1142,10 @@ public class Results {
 
     /**
      * Generates a 402 Payment Required result.
+     *
+     * @param content the input stream containing data to chunk over
+     * @param contentLength the length of the provided content in bytes.
+     * @return the result
      */
     public static Result paymentRequired(InputStream content, long contentLength) {
         return status(PAYMENT_REQUIRED, content, contentLength);
@@ -893,6 +1155,7 @@ public class Results {
      * Generates a 402 Payment Required result.
      *
      * @param content The file to send.
+     * @return the result
      */
     public static Result paymentRequired(File content) {
         return status(PAYMENT_REQUIRED, content);
@@ -903,6 +1166,7 @@ public class Results {
      *
      * @param content The file to send.
      * @param inline Whether the file should be sent inline, or as an attachment.
+     * @return the result
      */
     public static Result paymentRequired(File content, boolean inline) {
         return status(PAYMENT_REQUIRED, content, inline);
@@ -913,6 +1177,7 @@ public class Results {
      *
      * @param content The file to send.
      * @param filename The name to send the file as.
+     * @return the result
      */
     public static Result paymentRequired(File content, String filename) {
         return status(PAYMENT_REQUIRED, content, filename);
@@ -923,14 +1188,19 @@ public class Results {
      *
      * @deprecated Use {@link #paymentRequired } with {@link StatusHeader#chunked(akka.stream.javadsl.Source) }
      * instead.
+     * @param chunks Deprecated
+     * @return Deprecated
      */
     @Deprecated
     public static Result paymentRequired(Chunks<?> chunks) {
         return status(PAYMENT_REQUIRED, chunks);
     }
 
+
     /**
      * Generates a 403 Forbidden result.
+     *
+     * @return the result
      */
     public static StatusHeader forbidden() {
         return new StatusHeader(FORBIDDEN);
@@ -938,6 +1208,9 @@ public class Results {
 
     /**
      * Generates a 403 Forbidden result.
+     *
+     * @param content the HTTP response body
+     * @return the result
      */
     public static Result forbidden(Content content) {
         return status(FORBIDDEN, content);
@@ -945,6 +1218,10 @@ public class Results {
 
     /**
      * Generates a 403 Forbidden result.
+     *
+     * @param content the HTTP response body
+     * @param charset the charset into which the content should be encoded (e.g. "UTF-8")
+     * @return the result
      */
     public static Result forbidden(Content content, String charset) {
         return status(FORBIDDEN, content, charset);
@@ -952,6 +1229,9 @@ public class Results {
 
     /**
      * Generates a 403 Forbidden result.
+     *
+     * @param content HTTP response body, encoded as a UTF-8 string
+     * @return the result
      */
     public static Result forbidden(String content) {
         return status(FORBIDDEN, content);
@@ -959,13 +1239,21 @@ public class Results {
 
     /**
      * Generates a 403 Forbidden result.
+     *
+     * @param content the HTTP response body
+     * @param charset the charset into which the content should be encoded (e.g. "UTF-8")
+     * @return the result
      */
     public static Result forbidden(String content, String charset) {
         return status(FORBIDDEN, content, charset);
     }
 
     /**
-     * Generates a $status.code Forbidden result.
+     * Generates a 403 Forbidden result.
+     *
+     * @param content the result's body content as a play-json object. It will be encoded
+     *        as a UTF-8 string.
+     * @return the result
      */
     public static Result forbidden(JsonNode content) {
         return status(FORBIDDEN, content);
@@ -973,6 +1261,10 @@ public class Results {
 
     /**
      * Generates a 403 Forbidden result.
+     *
+     * @param content the result's body content as a play-json object
+     * @param charset the charset into which the json should be encoded
+     * @return the result
      */
     public static Result forbidden(JsonNode content, String charset) {
         return status(FORBIDDEN, content, charset);
@@ -980,6 +1272,9 @@ public class Results {
 
     /**
      * Generates a 403 Forbidden result.
+     *
+     * @param content the result's body content
+     * @return the result
      */
     public static Result forbidden(byte[] content) {
         return status(FORBIDDEN, content);
@@ -987,6 +1282,9 @@ public class Results {
 
     /**
      * Generates a 403 Forbidden result.
+     *
+     * @param content the input stream containing data to chunk over
+     * @return the result
      */
     public static Result forbidden(InputStream content) {
         return status(FORBIDDEN, content);
@@ -994,6 +1292,10 @@ public class Results {
 
     /**
      * Generates a 403 Forbidden result.
+     *
+     * @param content the input stream containing data to chunk over
+     * @param contentLength the length of the provided content in bytes.
+     * @return the result
      */
     public static Result forbidden(InputStream content, long contentLength) {
         return status(FORBIDDEN, content, contentLength);
@@ -1003,6 +1305,7 @@ public class Results {
      * Generates a 403 Forbidden result.
      *
      * @param content The file to send.
+     * @return the result
      */
     public static Result forbidden(File content) {
         return status(FORBIDDEN, content);
@@ -1013,6 +1316,7 @@ public class Results {
      *
      * @param content The file to send.
      * @param inline Whether the file should be sent inline, or as an attachment.
+     * @return the result
      */
     public static Result forbidden(File content, boolean inline) {
         return status(FORBIDDEN, content, inline);
@@ -1023,6 +1327,7 @@ public class Results {
      *
      * @param content The file to send.
      * @param filename The name to send the file as.
+     * @return the result
      */
     public static Result forbidden(File content, String filename) {
         return status(FORBIDDEN, content, filename);
@@ -1033,14 +1338,19 @@ public class Results {
      *
      * @deprecated Use {@link #forbidden } with {@link StatusHeader#chunked(akka.stream.javadsl.Source) }
      * instead.
+     * @param chunks Deprecated
+     * @return Deprecated
      */
     @Deprecated
     public static Result forbidden(Chunks<?> chunks) {
         return status(FORBIDDEN, chunks);
     }
 
+
     /**
      * Generates a 404 Not Found result.
+     *
+     * @return the result
      */
     public static StatusHeader notFound() {
         return new StatusHeader(NOT_FOUND);
@@ -1048,6 +1358,9 @@ public class Results {
 
     /**
      * Generates a 404 Not Found result.
+     *
+     * @param content the HTTP response body
+     * @return the result
      */
     public static Result notFound(Content content) {
         return status(NOT_FOUND, content);
@@ -1055,6 +1368,10 @@ public class Results {
 
     /**
      * Generates a 404 Not Found result.
+     *
+     * @param content the HTTP response body
+     * @param charset the charset into which the content should be encoded (e.g. "UTF-8")
+     * @return the result
      */
     public static Result notFound(Content content, String charset) {
         return status(NOT_FOUND, content, charset);
@@ -1062,6 +1379,9 @@ public class Results {
 
     /**
      * Generates a 404 Not Found result.
+     *
+     * @param content HTTP response body, encoded as a UTF-8 string
+     * @return the result
      */
     public static Result notFound(String content) {
         return status(NOT_FOUND, content);
@@ -1069,13 +1389,21 @@ public class Results {
 
     /**
      * Generates a 404 Not Found result.
+     *
+     * @param content the HTTP response body
+     * @param charset the charset into which the content should be encoded (e.g. "UTF-8")
+     * @return the result
      */
     public static Result notFound(String content, String charset) {
         return status(NOT_FOUND, content, charset);
     }
 
     /**
-     * Generates a $status.code Not Found result.
+     * Generates a 404 Not Found result.
+     *
+     * @param content the result's body content as a play-json object. It will be encoded
+     *        as a UTF-8 string.
+     * @return the result
      */
     public static Result notFound(JsonNode content) {
         return status(NOT_FOUND, content);
@@ -1083,6 +1411,10 @@ public class Results {
 
     /**
      * Generates a 404 Not Found result.
+     *
+     * @param content the result's body content as a play-json object
+     * @param charset the charset into which the json should be encoded
+     * @return the result
      */
     public static Result notFound(JsonNode content, String charset) {
         return status(NOT_FOUND, content, charset);
@@ -1090,6 +1422,9 @@ public class Results {
 
     /**
      * Generates a 404 Not Found result.
+     *
+     * @param content the result's body content
+     * @return the result
      */
     public static Result notFound(byte[] content) {
         return status(NOT_FOUND, content);
@@ -1097,6 +1432,9 @@ public class Results {
 
     /**
      * Generates a 404 Not Found result.
+     *
+     * @param content the input stream containing data to chunk over
+     * @return the result
      */
     public static Result notFound(InputStream content) {
         return status(NOT_FOUND, content);
@@ -1104,6 +1442,10 @@ public class Results {
 
     /**
      * Generates a 404 Not Found result.
+     *
+     * @param content the input stream containing data to chunk over
+     * @param contentLength the length of the provided content in bytes.
+     * @return the result
      */
     public static Result notFound(InputStream content, long contentLength) {
         return status(NOT_FOUND, content, contentLength);
@@ -1113,6 +1455,7 @@ public class Results {
      * Generates a 404 Not Found result.
      *
      * @param content The file to send.
+     * @return the result
      */
     public static Result notFound(File content) {
         return status(NOT_FOUND, content);
@@ -1123,6 +1466,7 @@ public class Results {
      *
      * @param content The file to send.
      * @param inline Whether the file should be sent inline, or as an attachment.
+     * @return the result
      */
     public static Result notFound(File content, boolean inline) {
         return status(NOT_FOUND, content, inline);
@@ -1133,6 +1477,7 @@ public class Results {
      *
      * @param content The file to send.
      * @param filename The name to send the file as.
+     * @return the result
      */
     public static Result notFound(File content, String filename) {
         return status(NOT_FOUND, content, filename);
@@ -1143,14 +1488,19 @@ public class Results {
      *
      * @deprecated Use {@link #notFound } with {@link StatusHeader#chunked(akka.stream.javadsl.Source) }
      * instead.
+     * @param chunks Deprecated
+     * @return Deprecated
      */
     @Deprecated
     public static Result notFound(Chunks<?> chunks) {
         return status(NOT_FOUND, chunks);
     }
 
+
     /**
      * Generates a 500 Internal Server Error result.
+     *
+     * @return the result
      */
     public static StatusHeader internalServerError() {
         return new StatusHeader(INTERNAL_SERVER_ERROR);
@@ -1158,6 +1508,9 @@ public class Results {
 
     /**
      * Generates a 500 Internal Server Error result.
+     *
+     * @param content the HTTP response body
+     * @return the result
      */
     public static Result internalServerError(Content content) {
         return status(INTERNAL_SERVER_ERROR, content);
@@ -1165,6 +1518,10 @@ public class Results {
 
     /**
      * Generates a 500 Internal Server Error result.
+     *
+     * @param content the HTTP response body
+     * @param charset the charset into which the content should be encoded (e.g. "UTF-8")
+     * @return the result
      */
     public static Result internalServerError(Content content, String charset) {
         return status(INTERNAL_SERVER_ERROR, content, charset);
@@ -1172,6 +1529,9 @@ public class Results {
 
     /**
      * Generates a 500 Internal Server Error result.
+     *
+     * @param content HTTP response body, encoded as a UTF-8 string
+     * @return the result
      */
     public static Result internalServerError(String content) {
         return status(INTERNAL_SERVER_ERROR, content);
@@ -1179,13 +1539,21 @@ public class Results {
 
     /**
      * Generates a 500 Internal Server Error result.
+     *
+     * @param content the HTTP response body
+     * @param charset the charset into which the content should be encoded (e.g. "UTF-8")
+     * @return the result
      */
     public static Result internalServerError(String content, String charset) {
         return status(INTERNAL_SERVER_ERROR, content, charset);
     }
 
     /**
-     * Generates a $status.code Internal Server Error result.
+     * Generates a 500 Internal Server Error result.
+     *
+     * @param content the result's body content as a play-json object. It will be encoded
+     *        as a UTF-8 string.
+     * @return the result
      */
     public static Result internalServerError(JsonNode content) {
         return status(INTERNAL_SERVER_ERROR, content);
@@ -1193,6 +1561,10 @@ public class Results {
 
     /**
      * Generates a 500 Internal Server Error result.
+     *
+     * @param content the result's body content as a play-json object
+     * @param charset the charset into which the json should be encoded
+     * @return the result
      */
     public static Result internalServerError(JsonNode content, String charset) {
         return status(INTERNAL_SERVER_ERROR, content, charset);
@@ -1200,6 +1572,9 @@ public class Results {
 
     /**
      * Generates a 500 Internal Server Error result.
+     *
+     * @param content the result's body content
+     * @return the result
      */
     public static Result internalServerError(byte[] content) {
         return status(INTERNAL_SERVER_ERROR, content);
@@ -1207,6 +1582,9 @@ public class Results {
 
     /**
      * Generates a 500 Internal Server Error result.
+     *
+     * @param content the input stream containing data to chunk over
+     * @return the result
      */
     public static Result internalServerError(InputStream content) {
         return status(INTERNAL_SERVER_ERROR, content);
@@ -1214,6 +1592,10 @@ public class Results {
 
     /**
      * Generates a 500 Internal Server Error result.
+     *
+     * @param content the input stream containing data to chunk over
+     * @param contentLength the length of the provided content in bytes.
+     * @return the result
      */
     public static Result internalServerError(InputStream content, long contentLength) {
         return status(INTERNAL_SERVER_ERROR, content, contentLength);
@@ -1223,6 +1605,7 @@ public class Results {
      * Generates a 500 Internal Server Error result.
      *
      * @param content The file to send.
+     * @return the result
      */
     public static Result internalServerError(File content) {
         return status(INTERNAL_SERVER_ERROR, content);
@@ -1233,6 +1616,7 @@ public class Results {
      *
      * @param content The file to send.
      * @param inline Whether the file should be sent inline, or as an attachment.
+     * @return the result
      */
     public static Result internalServerError(File content, boolean inline) {
         return status(INTERNAL_SERVER_ERROR, content, inline);
@@ -1243,6 +1627,7 @@ public class Results {
      *
      * @param content The file to send.
      * @param filename The name to send the file as.
+     * @return the result
      */
     public static Result internalServerError(File content, String filename) {
         return status(INTERNAL_SERVER_ERROR, content, filename);
@@ -1253,6 +1638,8 @@ public class Results {
      *
      * @deprecated Use {@link #internalServerError } with {@link StatusHeader#chunked(akka.stream.javadsl.Source) }
      * instead.
+     * @param chunks Deprecated
+     * @return Deprecated
      */
     @Deprecated
     public static Result internalServerError(Chunks<?> chunks) {
@@ -1263,6 +1650,7 @@ public class Results {
      * Generates a 301 Moved Permanently result.
      *
      * @param url The url to redirect.
+     * @return the result
      */
     public static Result movedPermanently(String url) {
         return new Result(MOVED_PERMANENTLY, Collections.singletonMap(LOCATION, url));
@@ -1272,6 +1660,7 @@ public class Results {
      * Generates a 301 Moved Permanently result.
      *
      * @param call Call defining the url to redirect (typically comes from reverse router).
+     * @return the result
      */
     public static Result movedPermanently(Call call) {
         return new Result(MOVED_PERMANENTLY, Collections.singletonMap(LOCATION, call.url()));
@@ -1281,6 +1670,7 @@ public class Results {
      * Generates a 302 Found result.
      *
      * @param url The url to redirect.
+     * @return the result
      */
     public static Result found(String url) {
         return new Result(FOUND, Collections.singletonMap(LOCATION, url));
@@ -1290,6 +1680,7 @@ public class Results {
      * Generates a 302 Found result.
      *
      * @param call Call defining the url to redirect (typically comes from reverse router).
+     * @return the result
      */
     public static Result found(Call call) {
         return new Result(FOUND, Collections.singletonMap(LOCATION, call.url()));
@@ -1299,6 +1690,7 @@ public class Results {
      * Generates a 303 See Other result.
      *
      * @param url The url to redirect.
+     * @return the result
      */
     public static Result seeOther(String url) {
         return new Result(SEE_OTHER, Collections.singletonMap(LOCATION, url));
@@ -1308,6 +1700,7 @@ public class Results {
      * Generates a 303 See Other result.
      *
      * @param call Call defining the url to redirect (typically comes from reverse router).
+     * @return the result
      */
     public static Result seeOther(Call call) {
         return new Result(SEE_OTHER, Collections.singletonMap(LOCATION, call.url()));
@@ -1317,6 +1710,7 @@ public class Results {
      * Generates a 303 See Other result.
      *
      * @param url The url to redirect.
+     * @return the result
      */
     public static Result redirect(String url) {
         return new Result(SEE_OTHER, Collections.singletonMap(LOCATION, url));
@@ -1326,6 +1720,7 @@ public class Results {
      * Generates a 303 See Other result.
      *
      * @param call Call defining the url to redirect (typically comes from reverse router).
+     * @return the result
      */
     public static Result redirect(Call call) {
         return new Result(SEE_OTHER, Collections.singletonMap(LOCATION, call.url()));
@@ -1335,6 +1730,7 @@ public class Results {
      * Generates a 307 Temporary Redirect result.
      *
      * @param url The url to redirect.
+     * @return the result
      */
     public static Result temporaryRedirect(String url) {
         return new Result(TEMPORARY_REDIRECT, Collections.singletonMap(LOCATION, url));
@@ -1344,9 +1740,9 @@ public class Results {
      * Generates a 307 Temporary Redirect result.
      *
      * @param call Call defining the url to redirect (typically comes from reverse router).
+     * @return the result
      */
     public static Result temporaryRedirect(Call call) {
         return new Result(TEMPORARY_REDIRECT, Collections.singletonMap(LOCATION, call.url()));
     }
-
 }

--- a/framework/src/play/src/main/java/play/mvc/Security.java
+++ b/framework/src/play/src/main/java/play/mvc/Security.java
@@ -15,7 +15,7 @@ import javax.inject.Inject;
  * Defines several security helpers.
  */
 public class Security {
-    
+
     /**
      * Wraps the annotated action in an <code>AuthenticatedAction</code>.
      */
@@ -25,7 +25,7 @@ public class Security {
     public @interface Authenticated {
         Class<? extends Authenticator> value() default Authenticator.class;
     }
-    
+
     /**
      * Wraps another action, allowing only authenticated HTTP requests.
      * <p>
@@ -67,29 +67,33 @@ public class Security {
         }
 
     }
-    
+
     /**
      * Handles authentication.
      */
     public static class Authenticator extends Results {
-        
+
         /**
          * Retrieves the username from the HTTP context; the default is to read from the session cookie.
          *
+         * @param ctx the current request context
          * @return null if the user is not authenticated.
          */
         public String getUsername(Context ctx) {
             return ctx.session().get("username");
         }
-        
+
         /**
          * Generates an alternative result if the user is not authenticated; the default a simple '401 Not Authorized' page.
+         *
+         * @param ctx the current request context
+         * @return a <code>401 Not Authorized</code> result
          */
         public Result onUnauthorized(Context ctx) {
             return unauthorized(views.html.defaultpages.unauthorized.render());
         }
-        
+
     }
-    
-    
+
+
 }

--- a/framework/src/play/src/main/java/play/mvc/StatusHeader.java
+++ b/framework/src/play/src/main/java/play/mvc/StatusHeader.java
@@ -73,6 +73,7 @@ public class StatusHeader extends Result {
      * The resource will be loaded from the same classloader that this class comes from.
      *
      * @param resourceName The path of the resource to load.
+     * @return an inlined '200 OK' result containing the resource in the body with in-line content disposition.
      */
     public Result sendResource(String resourceName) {
         return sendResource(resourceName, true);
@@ -83,6 +84,7 @@ public class StatusHeader extends Result {
      *
      * @param resourceName The path of the resource to load.
      * @param classLoader  The classloader to load it from.
+     * @return a '200 OK' result containing the resource in the body with in-line content disposition.
      */
     public Result sendResource(String resourceName, ClassLoader classLoader) {
         return sendResource(resourceName, classLoader, true);
@@ -95,6 +97,7 @@ public class StatusHeader extends Result {
      *
      * @param resourceName The path of the resource to load.
      * @param inline       Whether it should be served as an inline file, or as an attachment.
+     * @return a '200 OK' result containing the resource in the body with in-line content disposition.
      */
     public Result sendResource(String resourceName, boolean inline) {
         return sendResource(resourceName, this.getClass().getClassLoader(), inline);
@@ -106,6 +109,7 @@ public class StatusHeader extends Result {
      * @param resourceName The path of the resource to load.
      * @param classLoader  The classloader to load it from.
      * @param inline       Whether it should be served as an inline file, or as an attachment.
+     * @return a '200 OK' result containing the resource in the body.
      */
     public Result sendResource(String resourceName, ClassLoader classLoader, boolean inline) {
         return doSendResource(Streams.resourceToSource(classLoader, resourceName, 8192).asJava(),
@@ -113,30 +117,33 @@ public class StatusHeader extends Result {
     }
 
     /**
-     * Sends the given path.
+     * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions.
      *
      * @param path The path to send.
+     * @return a '200 OK' result containing the file at the provided path with inline content disposition.
      */
     public Result sendPath(Path path) {
         return sendPath(path, false);
     }
 
     /**
-     * Sends the given path.
+     * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions.
      *
      * @param path   The path to send.
      * @param inline Whether it should be served as an inline file, or as an attachment.
+     * @return a '200 OK' result containing the file at the provided path
      */
     public Result sendPath(Path path, boolean inline) {
         return sendPath(path, inline, path.getFileName().toString());
     }
 
     /**
-     * Sends the given path.
+     * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions
      *
      * @param path     The path to send.
      * @param inline   Whether it should be served as an inline file, or as an attachment.
      * @param filename The file name of the path.
+     * @return a '200 OK' result containing the file at the provided path
      */
     public Result sendPath(Path path, boolean inline, String filename) {
         if (path == null) {
@@ -164,6 +171,7 @@ public class StatusHeader extends Result {
      *
      * @param file The file to send.
      * @param inline  True if the file should be sent inline, false if it should be sent as an attachment.
+     * @return a '200 OK' result containing the file
      */
     public Result sendFile(File file, boolean inline) {
         if (file == null) {
@@ -178,6 +186,7 @@ public class StatusHeader extends Result {
      *
      * @param file The file to send.
      * @param fileName The name of the attachment
+     * @return a '200 OK' result containing the file
      */
     public Result sendFile(File file, String fileName) {
         if (file == null) {
@@ -203,6 +212,9 @@ public class StatusHeader extends Result {
 
     /**
      * Send a chunked response with the given chunks.
+     *
+     * @param chunks the chunks to send
+     * @return a '200 OK' response with the given chunks.
      */
     public Result chunked(Source<ByteString, ?> chunks) {
         return new Result(status(), HttpEntity.chunked(chunks, Optional.empty()));
@@ -212,6 +224,9 @@ public class StatusHeader extends Result {
      * Send a chunked response with the given chunks.
      *
      * @deprecated Use {@link #chunked(Source)} instead.
+     * @param chunks Deprecated
+     * @param <T> Deprecated
+     * @return Deprecated
      */
     public <T> Result chunked(Results.Chunks<T> chunks) {
         return new Result(status(), HttpEntity.chunked(
@@ -223,6 +238,9 @@ public class StatusHeader extends Result {
 
     /**
      * Send a json result.
+     *
+     * @param json the json node to send
+     * @return a '200 OK' result containing the json encoded as UTF-8.
      */
     public Result sendJson(JsonNode json) {
         return sendJson(json, "utf-8");
@@ -230,6 +248,10 @@ public class StatusHeader extends Result {
 
     /**
      * Send a json result.
+     *
+     * @param json the json to send
+     * @param charset the charset in which to encode the json (e.g. "UTF-8")
+     * @return a '200 OK' result containing the json encoded with the given charset
      */
     public Result sendJson(JsonNode json, String charset) {
         if (json == null) {

--- a/framework/src/play/src/main/java/play/mvc/WebSocket.java
+++ b/framework/src/play/src/main/java/play/mvc/WebSocket.java
@@ -82,6 +82,8 @@ public abstract class WebSocket {
      * Acceptor for JSON WebSockets.
      *
      * @param in The class of the incoming messages, used to decode them from the JSON.
+     * @param <In> The websocket's input type (what it receives from clients)
+     * @param <Out> The websocket's output type (what it writes to clients)
      * @return The WebSocket acceptor.
      */
     public static <In, Out> MappedWebSocketAcceptor<In, Out> json(Class<In> in) {
@@ -107,6 +109,9 @@ public abstract class WebSocket {
 
     /**
      * Utility class for creating WebSockets.
+     *
+     * @param <In> the type the websocket reads from clients (e.g. String, JsonNode)
+     * @param <Out> the type the websocket outputs back to remote clients (e.g. String, JsonNode)
      */
     public static class MappedWebSocketAcceptor<In, Out> {
         private final PartialFunction<Message, F.Either<In, Message>> inMapper;
@@ -183,6 +188,8 @@ public abstract class WebSocket {
 
         /**
          * Writes a frame.
+         *
+         * @param frame the frame to write
          */
         void write(A frame);
 
@@ -212,6 +219,8 @@ public abstract class WebSocket {
 
         /**
          * Registers a message callback.
+         *
+         * @param callback the function to execute when a message is received
          */
         public void onMessage(Consumer<A> callback) {
             callbacks.add(callback);
@@ -219,6 +228,8 @@ public abstract class WebSocket {
 
         /**
          * Registers a close callback.
+         *
+         * @param callback the function to execute when a socket closes
          */
         public void onClose(Runnable callback) {
             closeCallbacks.add(callback);
@@ -231,6 +242,7 @@ public abstract class WebSocket {
      * implemented using the specified {@code Callback2<In<A>, Out<A>>}
      *
      * @param callback the callback used to implement onReady
+     * @param <A> the in/out type of the legacy websocket
      * @return a new WebSocket
      * @throws NullPointerException if the specified callback is null
      * @deprecated Use the WebSocket.accept* methods instead.
@@ -244,6 +256,7 @@ public abstract class WebSocket {
      * Rejects a WebSocket.
      *
      * @param result The result that will be returned.
+     * @param <A> the socket's in/out type
      * @return A rejected WebSocket.
      * @deprecated Use the WebSocket.accept*OrResult methods instead.
      */
@@ -262,6 +275,7 @@ public abstract class WebSocket {
      * Handles a WebSocket with an actor.
      *
      * @param props The function used to create the props for the actor.  The passed in argument is the upstream actor.
+     * @param <A> the socket's in/out type
      * @return An actor WebSocket.
      * @deprecated Use the WebSocket.accept* methods instead, with a flow created by wrapping a Sink.actorRef and
      *             Source.actorRef.

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -72,7 +72,7 @@ trait Application {
    * @tparam T the plugin type
    * @param  pluginClass the plugin’s class
    * @return the plugin instance, wrapped in an option, used by this application
-   * @throws Error if no plugins of type `T` are loaded by this application
+   * @throws scala.Error if no plugins of type `T` are loaded by this application
    */
   def plugin[T](pluginClass: Class[T]): Option[T] =
     plugins.find(p => pluginClass.isAssignableFrom(p.getClass)).map(_.asInstanceOf[T])
@@ -87,7 +87,7 @@ trait Application {
    *
    * @tparam T the plugin type
    * @return The plugin instance used by this application.
-   * @throws Error if no plugins of type T are loaded by this application.
+   * @throws scala.Error if no plugins of type `T` are loaded by this application.
    */
   def plugin[T](implicit ct: ClassTag[T]): Option[T] = plugin(ct.runtimeClass).asInstanceOf[Option[T]]
 

--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -182,9 +182,9 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
   /**
    * Invoked when a server error occurs.
    *
-   * By default, the implementation of this method delegates to [[onProdServerError()]] when in prod mode, and
-   * [[onDevServerError()]] in dev mode.  It is recommended, if you want Play's debug info on the error page in dev
-   * mode, that you override [[onProdServerError()]] instead of this method.
+   * By default, the implementation of this method delegates to [[onProdServerError]] when in prod mode, and
+   * [[onDevServerError]] in dev mode.  It is recommended, if you want Play's debug info on the error page in dev
+   * mode, that you override [[onProdServerError]] instead of this method.
    *
    * @param request The request that triggered the server error.
    * @param exception The server error.
@@ -236,7 +236,7 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
   /**
    * Invoked in prod mode when a server error occurs.
    *
-   * Override this rather than [[onServerError()]] if you don't want to change Play's debug output when logging errors
+   * Override this rather than [[onServerError]] if you don't want to change Play's debug output when logging errors
    * in dev mode.
    *
    * @param request The request that triggered the error.

--- a/framework/src/play/src/main/scala/play/api/http/HttpFilters.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpFilters.scala
@@ -10,7 +10,7 @@ import play.api.mvc.EssentialFilter
 import play.utils.Reflect
 
 /**
- * Provides filters to the [[play.http.HttpRequestHandler]].
+ * Provides filters to the [[play.api.http.HttpRequestHandler]].
  */
 trait HttpFilters {
 

--- a/framework/src/play/src/main/scala/play/api/i18n/I18nSupport.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/I18nSupport.scala
@@ -3,7 +3,7 @@ package play.api.i18n
 import play.api.mvc.{ RequestHeader, Result }
 
 /**
- * Brings a convenient implicit conversion from [[RequestHeader]] to [[Messages]].
+ * Brings a convenient implicit conversion from [[play.api.mvc.RequestHeader]] to [[Messages]].
  *
  * Example:
  * {{{
@@ -21,7 +21,7 @@ trait I18nSupport extends I18NSupportLowPriorityImplicits {
   def messagesApi: MessagesApi
 
   /**
-   * @return The preferred [[Messages]] according to the given [[RequestHeader]]
+   * @return The preferred [[Messages]] according to the given [[play.api.mvc.RequestHeader]]
    */
   implicit def request2Messages(implicit request: RequestHeader): Messages = messagesApi.preferred(request)
 

--- a/framework/src/play/src/main/scala/play/api/inject/Binding.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Binding.scala
@@ -18,7 +18,7 @@ import com.google.inject.name.Names
  * Bindings are used to bind classes, optionally qualified by a JSR-330 qualifier annotation, to instances, providers or
  * implementation classes.
  *
- * Bindings may also specify a JSR-330 scope.  If, and only if that scope is [[javax.inject.Singleton]], then the
+ * Bindings may also specify a JSR-330 scope.  If, and only if that scope is [[$javadoc/javax/inject/Singleton javax.inject.Singleton]], then the
  * binding may declare itself to be eagerly instantiated.  In which case, it should be eagerly instantiated when Play
  * starts up.
  *
@@ -28,6 +28,8 @@ import com.google.inject.name.Names
  * @param eager Whether the binding should be eagerly instantiated.
  * @param source Where this object was bound. Used in error reporting.
  * @see The [[Module]] class for information on how to provide bindings.
+ *
+ * @define javadoc http://docs.oracle.com/javase/8/docs/api
  */
 final case class Binding[T](key: BindingKey[T], target: Option[BindingTarget[T]], scope: Option[Class[_ <: Annotation]], eager: Boolean, source: Object) {
 

--- a/framework/src/play/src/main/scala/play/api/inject/Injector.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Injector.scala
@@ -13,7 +13,9 @@ import scala.reflect.ClassTag
  *
  * This abstraction is primarily provided for libraries that want to remain agnostic to the type of dependency
  * injection being used. End users are encouraged to use the facilities provided by the dependency injection framework
- * they are using directly, for example, if using Guice, use [[com.google.inject.Injector]] instead of this.
+ * they are using directly, for example, if using Guice, use [[http://google.github.io/guice/api-docs/latest/javadoc/index.html?com/google/inject/Injector.html com.google.inject.Injector]]
+ * instead of this.
+ *
  */
 trait Injector {
 

--- a/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
@@ -53,7 +53,8 @@ object EventSource {
   object EventIdExtractor extends LowPriorityEventIdExtractor
 
   /**
-   * Makes an `Enumeratee[E, Event]`, that is an [[Enumeratee]] transforming [[E]] values into [[Event]] values.
+   * Makes an `Enumeratee[E, Event]`, that is an [[iteratee.Enumeratee]] transforming `E` values
+   * into [[Event]] values.
    *
    * Usage example:
    *
@@ -61,6 +62,8 @@ object EventSource {
    *   val someDataStream: Enumerator[SomeData] = ???
    *   Ok.chunked(someDataStream &> EventSource())
    * }}}
+   *
+   * @tparam E from type of the Enumeratee
    */
   def apply[E: EventDataExtractor: EventNameExtractor: EventIdExtractor](): Enumeratee[E, Event] =
     Enumeratee.map[E] { e => Event(e) }

--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -146,7 +146,7 @@ trait BodyParser[+A] extends (RequestHeader => Accumulator[ByteString, Either[Re
    * @param ec The context to execute the supplied function with.
    *        The context is prepared on the calling thread.
    * @return the transformed body parser
-   * @see [[play.api.libs.iteratee.Iteratee#map]]
+   * @see [[play.api.libs.iteratee.Iteratee.map]]
    */
   def map[B](f: A => B)(implicit ec: ExecutionContext): BodyParser[B] = {
     // prepare execution context as body parser object may cross thread boundary
@@ -166,7 +166,7 @@ trait BodyParser[+A] extends (RequestHeader => Accumulator[ByteString, Either[Re
    *        The context prepared on the calling thread.
    * @return the transformed body parser
    * @see [[map]]
-   * @see [[play.api.libs.iteratee.Iteratee#mapM]]
+   * @see [[play.api.libs.iteratee.Iteratee.mapM]]
    */
   def mapM[B](f: A => Future[B])(implicit ec: ExecutionContext): BodyParser[B] = {
     // prepare execution context as body parser object may cross thread boundary

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -432,7 +432,7 @@ trait BodyParsers {
      *   val userForm: Form[User] = Form(mapping("name" -> nonEmptyText)(User.apply)(User.unapply))
      *
      *   Action(parse.form(userForm)) { request =>
-     *     Ok(s"Hello, ${request.body.name}!")
+     *     Ok(s"Hello, \${request.body.name}!")
      *   }
      * }}}
      *

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -340,7 +340,7 @@ package play.api.mvc {
      *
      * implicit val req: RequestHeader = myRequest
      * val url: String = Call("GET", "/url").absoluteURL()
-     * // == "http://$host/url", or "https://$host/url" if secure
+     * // == "http://\$host/url", or "https://\$host/url" if secure
      * }}}
      */
     def absoluteURL()(implicit request: RequestHeader): String =
@@ -360,7 +360,7 @@ package play.api.mvc {
      *
      * implicit val req: RequestHeader = myRequest
      * val url: String = Call("GET", "/url").webSocketURL()
-     * // == "ws://$host/url", or "wss://$host/url" if secure
+     * // == "ws://\$host/url", or "wss://\$host/url" if secure
      * }}}
      */
     def webSocketURL()(implicit request: RequestHeader): String =

--- a/framework/src/play/src/main/scala/play/api/routing/sird/PathBindableExtractor.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/sird/PathBindableExtractor.scala
@@ -6,7 +6,7 @@ package play.api.routing.sird
 import play.api.mvc.PathBindable
 
 /**
- * An extractor that extracts from a String using a [[PathBindable]].
+ * An extractor that extracts from a String using a [[play.api.mvc.PathBindable]].
  */
 class PathBindableExtractor[T](implicit pb: PathBindable[T]) {
   self =>
@@ -45,7 +45,7 @@ class PathBindableExtractor[T](implicit pb: PathBindable[T]) {
 }
 
 /**
- * Extractors that bind types from paths using [[PathBindable]].
+ * Extractors that bind types from paths using [[play.api.mvc.PathBindable]].
  */
 trait PathBindableExtractors {
   /**

--- a/framework/src/play/src/main/scala/play/api/routing/sird/package.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/sird/package.scala
@@ -15,13 +15,13 @@ import scala.language.experimental.macros
  * The request method extractors return the original request for further extraction.
  *
  * The path extractor supports three kinds of extracted values:
- * - Path segment values. This is the default, eg `p"/foo/$id"`. The value will be URI decoded, and may not traverse /'s.
- * - Full path values. This can be indicated by post fixing the value with a *, eg `p"/assets/$path*"`. The value will
+ * - Path segment values. This is the default, eg `p"/foo/\$id"`. The value will be URI decoded, and may not traverse /'s.
+ * - Full path values. This can be indicated by post fixing the value with a *, eg `p"/assets/\$path*"`. The value will
  *   not be URI decoded, as that will make it impossible to distinguish between / and %2F.
  * - Regex values. This can be indicated by post fixing the value with a regular expression enclosed in angle brackets.
- *   For example, `p"/foo/$id<[0-9]+>`. The value will not be URI decoded.
+ *   For example, `p"/foo/\$id<[0-9]+>`. The value will not be URI decoded.
  *
- * The extractors for primitive types are merely provided for convenience, for example, `p"/foo/${int(id)}"` will
+ * The extractors for primitive types are merely provided for convenience, for example, `p"/foo/\${int(id)}"` will
  * extract `id` as an integer.  If `id` is not an integer, the match will simply fail.
  *
  * Example usage:
@@ -32,12 +32,12 @@ import scala.language.experimental.macros
  *  import play.api.mvc._
  *
  *  Router.from {
- *    case GET(p"/hello/$to") => Action {
- *      Results.Ok(s"Hello $to")
+ *    case GET(p"/hello/\$to") => Action {
+ *      Results.Ok(s"Hello \$to")
  *    }
- *    case PUT(p"/api/items/${int(id)}") => Action.async { req =>
+ *    case PUT(p"/api/items/\${int(id)}") => Action.async { req =>
  *      Items.save(id, req.body.json.as[Item]).map { _ =>
- *        Results.Ok(s"Saved item $id")
+ *        Results.Ok(s"Saved item \$id")
  *      }
  *    }
  *  }
@@ -59,28 +59,28 @@ package object sird extends RequestMethodExtractors with PathBindableExtractors 
     /**
      * String interpolator for required query parameters out of query strings.
      *
-     * The format must match `q"paramName=${param}"`.
+     * The format must match `q"paramName=\${param}"`.
      */
     def q: RequiredQueryStringParameter = macro macroimpl.QueryStringParameterMacros.required
 
     /**
      * String interpolator for optional query parameters out of query strings.
      *
-     * The format must match `q_?"paramName=${param}"`.
+     * The format must match `q_?"paramName=\${param}"`.
      */
     def q_? : OptionalQueryStringParameter = macro macroimpl.QueryStringParameterMacros.optional
 
     /**
      * String interpolator for multi valued query parameters out of query strings.
      *
-     * The format must match `q_*"paramName=${params}"`.
+     * The format must match `q_*"paramName=\${params}"`.
      */
     def q_* : SeqQueryStringParameter = macro macroimpl.QueryStringParameterMacros.seq
 
     /**
      * String interpolator for optional query parameters out of query strings.
      *
-     * The format must match `qo"paramName=${param}"`.
+     * The format must match `qo"paramName=\${param}"`.
      *
      * The `q_?` interpolator is preferred, however Scala 2.10 does not support operator characters in String
      * interpolator methods.
@@ -90,7 +90,7 @@ package object sird extends RequestMethodExtractors with PathBindableExtractors 
     /**
      * String interpolator for multi valued query parameters out of query strings.
      *
-     * The format must match `qs"paramName=${params}"`.
+     * The format must match `qs"paramName=\${params}"`.
      *
      * The `q_*` interpolator is preferred, however Scala 2.10 does not support operator characters in String
      * interpolator methods.

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -28,7 +28,7 @@ object Multipart {
   private final val maxHeaderBuffer = 4096
 
   /**
-   * Parses the stream into a stream of [[Part]] to be handled by `partHandler`.
+   * Parses the stream into a stream of [[play.api.mvc.MultipartFormData.Part]] to be handled by `partHandler`.
    *
    * @param maxMemoryBufferSize The maximum amount of data to parse into memory.
    * @param partHandler The accumulator to handle the parts.

--- a/framework/src/play/src/main/scala/play/utils/UriEncoding.scala
+++ b/framework/src/play/src/main/scala/play/utils/UriEncoding.scala
@@ -10,6 +10,7 @@ import java.io.ByteArrayOutputStream
  * Provides support for correctly encoding pieces of URIs.
  *
  * @see http://www.ietf.org/rfc/rfc3986.txt
+ * @define javadoc http://docs.oracle.com/javase/8/docs/api
  */
 object UriEncoding {
 
@@ -28,7 +29,7 @@ object UriEncoding {
    * other differences too.
    *
    * When encoding path segments the `encodePathSegment` method should always
-   * be used in preference to the [[java.net.URLEncoder.encode(String,String)]]
+   * be used in preference to the [[$javadoc/java/net/URLEncoder.html#encode-java.lang.String-java.lang.String- java.net.URLEncoder.encode]]
    * method. `URLEncoder.encode`, despite its name, actually provides encoding
    * in the `application/x-www-form-urlencoded` MIME format which is the encoding
    * used for form data in HTTP GET and POST requests. This encoding is suitable
@@ -73,7 +74,7 @@ object UriEncoding {
    * other differences too.
    *
    * When decoding path segments the `decodePathSegment` method should always
-   * be used in preference to the [[java.net.URLDecoder.decode(String,String)]]
+   * be used in preference to the [[$javadoc/java/net/URLDecoder.html java.net.URLDecoder.decode]]
    * method. `URLDecoder.decode`, despite its name, actually decodes
    * the `application/x-www-form-urlencoded` MIME format which is the encoding
    * used for form data in HTTP GET and POST requests. This format is suitable
@@ -83,7 +84,7 @@ object UriEncoding {
    * @param s The string to decode. Must use the US-ASCII character set.
    * @param outputCharset The name of the encoding that the output should be encoded with.
    *     The output string will be converted from octets (bytes) using this character encoding.
-   * @throws InvalidEncodingException If the input is not a valid encoded path segment.
+   * @throws InvalidUriEncodingException If the input is not a valid encoded path segment.
    * @return A decoded string in the `outputCharset` character set.
    */
   def decodePathSegment(s: String, outputCharset: String): String = {
@@ -130,7 +131,7 @@ object UriEncoding {
    * @param s The string to decode. Must use the US-ASCII character set.
    * @param outputCharset The name of the encoding that the output should be encoded with.
    *     The output string will be converted from octets (bytes) using this character encoding.
-   * @throws InvalidEncodingException If the input is not a valid encoded path.
+   * @throws InvalidUriEncodingException If the input is not a valid encoded path.
    * @return A decoded string in the `outputCharset` character set.
    */
   def decodePath(s: String, outputCharset: String): String = {


### PR DESCRIPTION
Also:
  * Add autoAPIMappings to SBT build so we can link into the scala standard library
  * Get inter-project external refs working in apiDocs
  * Remove javadoc links in scaladoc, and hardcode them as web links instead

Addresses #4995 

Also, sorry for this grossly large PR. Made my best stab on some of this documentation but would definitely appreciate any fixes on accuracy.