### PR TITLE
Don't overwrite existing host header if uri is a relative path

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -893,7 +893,9 @@ public class Http {
                 this.secure = uri.getScheme().equals("https");
             }
             this.uri = uri;
-            host(uri.getHost());
+            if (uri.getHost() != null) {
+              host(uri.getHost());
+            }
             return this;
         }
 


### PR DESCRIPTION
This fixes a bug where if the request builder gets a relative uri the default localhost host header is overwritten to null.

E.g. ```new RequestBuilder().uri("/foo")``` would have the host header set to null

If this could be backported to 2.4.x I'd appreciate it.