### PR TITLE
Documentation fix and example custom Router

### DIFF
--- a/documentation/manual/working/scalaGuide/advanced/dependencyinjection/ScalaCompileTimeDependencyInjection.md
+++ b/documentation/manual/working/scalaGuide/advanced/dependencyinjection/ScalaCompileTimeDependencyInjection.md
@@ -44,7 +44,11 @@ By default Play will generate a static router that requires all of your actions 
 
 When you do this, Play will generate a router with a constructor that accepts each of the controllers and included routers from your routes file, in the order they appear in your routes file.  The routers constructor will also, as its first argument, accept an [`HttpErrorHandler`](api/scala/play/api/http/HttpErrorHandler.html), which is used to handle parameter binding errors.  The primary constructor will also accept a prefix String as the last argument, but an overloaded constructor that defaults this to `"/"` will also be provided.
 
-The following routes:
+Should you wish to implement a custom `Router`, you can do so by extending `SimpleRouter` as follows:
+
+@[content](code/scalaguide.advanced.dependencyinjection.bar.routes)
+
+When using the `InjectedRoutesGenerator`, the following routes:
 
 @[content](code/scalaguide.advanced.dependencyinjection.routes)
 

--- a/documentation/manual/working/scalaGuide/advanced/dependencyinjection/code/scalaguide.advanced.dependencyinjection.bar.routes
+++ b/documentation/manual/working/scalaGuide/advanced/dependencyinjection/code/scalaguide.advanced.dependencyinjection.bar.routes
@@ -1,0 +1,16 @@
+#injected
+package bar
+
+import com.google.inject.Inject
+import play.api.http.HttpErrorHandler
+import play.api.mvc.RequestHeader
+import play.api.routing.SimpleRouter
+
+class Routes(val httpErrorHandler: HttpErrorHandler) extends SimpleRouter{
+  override def routes = {
+    case header: RequestHeader => controllers.Staties.hello("")
+  }
+
+}
+#injected
+


### PR DESCRIPTION
The documentation for Scala Compile Time Dependency Injection references
a custom router which is not documented. This results in the provided
example code not being aligned with what actually gets generated by the
InjectedRoutesGenerator.

This is a documentation fix related to issue [#5208]