### PR TITLE
Play WS only parses form body when used with OAuth - 2.4.x

### DIFF
--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSRequest.java
@@ -431,7 +431,9 @@ public class NingWSRequest implements WSRequest {
             // If using a POST with OAuth signing, the builder looks at
             // getFormParams() rather than getBody() and constructs the signature
             // based on the form params.
-            if (contentType.equals(HttpHeaders.Values.APPLICATION_X_WWW_FORM_URLENCODED)) {
+            if (contentType.equals(HttpHeaders.Values.APPLICATION_X_WWW_FORM_URLENCODED) && calculator != null) {
+                headers.remove(HttpHeaders.Names.CONTENT_LENGTH);
+
                 Map<String, List<String>> stringListMap = FormUrlEncodedParser.parseAsJava(stringBody, "utf-8");
                 for (String key : stringListMap.keySet()) {
                     List<String> values = stringListMap.get(key);

--- a/framework/src/play-java-ws/src/test/scala/play/libs/ws/ning/NingWSRequestSpec.scala
+++ b/framework/src/play-java-ws/src/test/scala/play/libs/ws/ning/NingWSRequestSpec.scala
@@ -2,6 +2,8 @@ package play.libs.ws.ning
 
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
+import play.api.test.WithApplication
+import play.libs.oauth.OAuth
 
 class NingWSRequestSpec extends Specification with Mockito {
 
@@ -19,6 +21,63 @@ class NingWSRequestSpec extends Specification with Mockito {
       request.setVirtualHost("foo.com")
       val actual = request.buildRequest().getVirtualHost()
       actual must beEqualTo("foo.com")
+    }
+
+    "Have form body on POST of content type text/plain" in new WithApplication {
+      val client = mock[NingWSClient]
+      val formEncoding = java.net.URLEncoder.encode("param1=value1", "UTF-8")
+
+      val ningRequest = new NingWSRequest(client, "http://playframework.com/")
+        .setHeader("Content-Type", "text/plain")
+        .setBody("HELLO WORLD")
+        .asInstanceOf[NingWSRequest]
+      val req = ningRequest.buildRequest()
+      req.getStringData must be_==("HELLO WORLD")
+    }
+
+    "Have form body on POST of content type application/x-www-form-urlencoded explicitly set" in new WithApplication {
+      import scala.collection.JavaConverters._
+      val client = mock[NingWSClient]
+      val req = new NingWSRequest(client, "http://playframework.com/")
+        .setHeader("Content-Type", "application/x-www-form-urlencoded") // set content type by hand
+        .setBody("HELLO WORLD") // and body is set to string (see #5221)
+        .asInstanceOf[NingWSRequest]
+        .buildRequest()
+      req.getStringData must be_==("HELLO WORLD") // should result in byte data.
+    }
+
+    "Have form params on POST of content type application/x-www-form-urlencoded when signed" in new WithApplication {
+      import scala.collection.JavaConverters._
+      val client = mock[NingWSClient]
+      val consumerKey = new OAuth.ConsumerKey("key", "secret")
+      val token = new OAuth.RequestToken("token", "secret")
+      val calc = new OAuth.OAuthCalculator(consumerKey, token)
+      val req = new NingWSRequest(client, "http://playframework.com/")
+        .setHeader("Content-Type", "application/x-www-form-urlencoded") // set content type by hand
+        .setBody("param1=value1")
+        .sign(calc)
+        .asInstanceOf[NingWSRequest]
+        .buildRequest()
+      // Note we use getFormParams instead of getByteData here.
+      req.getFormParams.asScala must containTheSameElementsAs(List(new com.ning.http.client.Param("param1", "value1")))
+    }
+
+    "Remove a user defined content length header if we are parsing body explicitly when signed" in new WithApplication {
+      import scala.collection.JavaConverters._
+      val client = mock[NingWSClient]
+      val consumerKey = new OAuth.ConsumerKey("key", "secret")
+      val token = new OAuth.RequestToken("token", "secret")
+      val calc = new OAuth.OAuthCalculator(consumerKey, token)
+      val req = new NingWSRequest(client, "http://playframework.com/")
+        .setHeader("Content-Type", "application/x-www-form-urlencoded") // set content type by hand
+        .setBody("param1=value1")
+        .setHeader("Content-Length", "9001") // add a meaningless content length here...
+        .sign(calc)
+        .asInstanceOf[NingWSRequest]
+        .buildRequest()
+
+      val headers = req.getHeaders
+      headers.getFirstValue("Content-Length") must beNull // no content length!
     }
 
     "should support setting a request timeout" in {


### PR DESCRIPTION
Fixes #5221 in 2.4.x, by only parsing WS request body if signature calculator is present.