### PR TITLE
Play WS only parses form body when used with OAuth - master

### DIFF
--- a/documentation/manual/releases/release25/migration25/Migration25.md
+++ b/documentation/manual/releases/release25/migration25/Migration25.md
@@ -70,10 +70,9 @@ The new configuration after the change will look something like this:
 
 You can find more details on how to set up Play with different logging frameworks are in [[Configuring logging|SettingsLogger#Using-a-Custom-Logging-Framework]] section of the documentation.
 
+## Play WS upgrades to AsyncHttpClient 2
 
-## Upgrade to AsyncHttpClient 2
-
-Play WS has been upgraded to use [AsyncHttpClient](https://github.com/AsyncHttpClient/async-http-client) 2.  This is a major upgrade that uses Netty 4.0. Most of the changes in AHC 2.0 are under the hood, but AHC has some significant refactorings which require breaking changes to the WS API:
+Play WS has been upgraded to use [AsyncHttpClient 2](https://github.com/AsyncHttpClient/async-http-client).  This is a major upgrade that uses Netty 4.0. Most of the changes in AHC 2.0 are under the hood, but AHC has some significant refactorings which require breaking changes to the WS API:
 
 * `AsyncHttpClientConfig` replaced by [`DefaultAsyncHttpClientConfig`](https://static.javadoc.io/org.asynchttpclient/async-http-client/2.0.0-RC7/org/asynchttpclient/DefaultAsyncHttpClientConfig.html).
 * [`allowPoolingConnection`](https://static.javadoc.io/com.ning/async-http-client/1.9.32/com/ning/http/client/AsyncHttpClientConfig.html#allowPoolingConnections) and `allowSslConnectionPool` are combined in AsyncHttpClient into a single `keepAlive` variable.  As such, `play.ws.ning.allowPoolingConnection` and `play.ws.ning.allowSslConnectionPool` are not valid and will throw an exception if configured.
@@ -88,6 +87,7 @@ In addition, there are number of small changes:
 * The deprecated interface `play.libs.ws.WSRequestHolder` has been removed.
 * The `play.libs.ws.play.WSRequest` interface now returns `java.util.concurrent.CompletionStage` instead of `F.Promise`.
 * Static methods that rely on `Play.current` or `Play.application` have been deprecated.
+* Play WS would infer a charset from the content type and append a charset to the `Content-Type` header of the request if one was not already set.  This caused some confusion and bugs, and so in 2.5.x the `Content-Type` header does not automatically include an inferred charset.  If you explicitly set a `Content-Type` header, the setting is honored as is. 
 
 ## Deprecated `GlobalSettings`
 

--- a/framework/src/play-java-ws/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/framework/src/play-java-ws/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -6,7 +6,7 @@ package play.libs.ws.ahc
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
 import play.libs.ws.{ WSRequestExecutor, WSRequestFilter }
-import play.test.WithApplication
+import play.libs.oauth.OAuth
 
 class AhcWSRequestSpec extends Specification with Mockito {
 
@@ -26,6 +26,64 @@ class AhcWSRequestSpec extends Specification with Mockito {
       actual must beEqualTo("foo.com")
     }
 
+    "Have form body on POST of content type text/plain" in {
+      val client = mock[AhcWSClient]
+      val formEncoding = java.net.URLEncoder.encode("param1=value1", "UTF-8")
+
+      val ahcRequest = new AhcWSRequest(client, "http://playframework.com/", null)
+        .setHeader("Content-Type", "text/plain")
+        .setBody("HELLO WORLD")
+        .asInstanceOf[AhcWSRequest]
+      val req = ahcRequest.buildRequest()
+      req.getStringData must be_==("HELLO WORLD")
+    }
+
+    "Have form body on POST of content type application/x-www-form-urlencoded explicitly set" in {
+      import scala.collection.JavaConverters._
+      val client = mock[AhcWSClient]
+      val req = new AhcWSRequest(client, "http://playframework.com/", null)
+        .setHeader("Content-Type", "application/x-www-form-urlencoded") // set content type by hand
+        .setBody("HELLO WORLD") // and body is set to string (see #5221)
+        .asInstanceOf[AhcWSRequest]
+        .buildRequest()
+      req.getStringData must be_==("HELLO WORLD") // should result in byte data.
+    }
+
+    "Have form params on POST of content type application/x-www-form-urlencoded when signed" in {
+      import scala.collection.JavaConverters._
+      val client = mock[AhcWSClient]
+      val consumerKey = new OAuth.ConsumerKey("key", "secret")
+      val token = new OAuth.RequestToken("token", "secret")
+      val calc = new OAuth.OAuthCalculator(consumerKey, token)
+      val req = new AhcWSRequest(client, "http://playframework.com/", null)
+        .setHeader("Content-Type", "application/x-www-form-urlencoded") // set content type by hand
+        .setBody("param1=value1")
+        .sign(calc)
+        .asInstanceOf[AhcWSRequest]
+        .buildRequest()
+      // Note we use getFormParams instead of getByteData here.
+      req.getFormParams.asScala must containTheSameElementsAs(List(new org.asynchttpclient.Param("param1", "value1")))
+    }
+
+    "Remove a user defined content length header if we are parsing body explicitly when signed" in {
+      import scala.collection.JavaConverters._
+      val client = mock[AhcWSClient]
+      val consumerKey = new OAuth.ConsumerKey("key", "secret")
+      val token = new OAuth.RequestToken("token", "secret")
+      val calc = new OAuth.OAuthCalculator(consumerKey, token)
+      val req = new AhcWSRequest(client, "http://playframework.com/", null)
+        .setHeader("Content-Type", "application/x-www-form-urlencoded") // set content type by hand
+        .setBody("param1=value1")
+        .setHeader("Content-Length", "9001") // add a meaningless content length here...
+        .sign(calc)
+        .asInstanceOf[AhcWSRequest]
+        .buildRequest()
+
+      val headers = req.getHeaders
+      req.getFormParams.asScala must containTheSameElementsAs(List(new org.asynchttpclient.Param("param1", "value1")))
+      headers.get("Content-Length") must beNull // no content length!
+    }
+
     "should support setting a request timeout" in {
       requestWithTimeout(1000) must beEqualTo(1000)
     }
@@ -42,7 +100,7 @@ class AhcWSRequestSpec extends Specification with Mockito {
       requestWithTimeout(Int.MaxValue.toLong + 1) must throwA[IllegalArgumentException]
     }
 
-    "Only send first content type header and add charset=utf-8 to the Content-Type header if it's manually adding but lacking charset" in {
+    "Only send first content type header" in {
       import scala.collection.JavaConverters._
       val client = mock[AhcWSClient]
       val request = new AhcWSRequest(client, "http://example.com", /*materializer*/ null)
@@ -50,7 +108,7 @@ class AhcWSRequestSpec extends Specification with Mockito {
       request.setHeader("Content-Type", "application/json")
       request.setHeader("Content-Type", "application/xml")
       val req = request.buildRequest()
-      req.getHeaders.get("Content-Type") must be_==("application/json; charset=utf-8")
+      req.getHeaders.get("Content-Type") must be_==("application/json")
     }
 
     "Only send first content type header and keep the charset if it has been set manually with a charset" in {


### PR DESCRIPTION
Fixes #5221 in master, by only parsing WS request body if signature calculator is present.