### PR TITLE
Don't catch and rethrow exceptions in AuthenticatedAction

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Security.java
+++ b/framework/src/play/src/main/java/play/mvc/Security.java
@@ -4,10 +4,10 @@
 package play.mvc;
 
 import play.inject.Injector;
-import play.libs.F;
 import play.mvc.Http.*;
 
 import java.lang.annotation.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
 
@@ -15,7 +15,7 @@ import javax.inject.Inject;
  * Defines several security helpers.
  */
 public class Security {
-    
+
     /**
      * Wraps the annotated action in an <code>AuthenticatedAction</code>.
      */
@@ -25,7 +25,7 @@ public class Security {
     public @interface Authenticated {
         Class<? extends Authenticator> value() default Authenticator.class;
     }
-    
+
     /**
      * Wraps another action, allowing only authenticated HTTP requests.
      * <p>
@@ -42,37 +42,31 @@ public class Security {
         }
 
         public CompletionStage<Result> call(final Context ctx) {
-            try {
-                Authenticator authenticator = injector.instanceOf(configuration.value());
-                String username = authenticator.getUsername(ctx);
-                if(username == null) {
-                    Result unauthorized = authenticator.onUnauthorized(ctx);
-                    return F.Promise.pure(unauthorized);
-                } else {
-                    try {
-                        ctx.request().setUsername(username);
-                        return delegate.call(ctx).whenComplete(
-                                (result, error) -> ctx.request().setUsername(null)
-                        );
-                    } catch(Exception e) {
-                        ctx.request().setUsername(null);
-                        throw e;
-                    }
+            Authenticator authenticator = injector.instanceOf(configuration.value());
+            String username = authenticator.getUsername(ctx);
+            if(username == null) {
+                Result unauthorized = authenticator.onUnauthorized(ctx);
+                return CompletableFuture.completedFuture(unauthorized);
+            } else {
+                try {
+                    ctx.request().setUsername(username);
+                    return delegate.call(ctx).whenComplete(
+                        (result, error) -> ctx.request().setUsername(null)
+                    );
+                } catch (Exception e) {
+                    ctx.request().setUsername(null);
+                    throw e;
                 }
-            } catch(RuntimeException e) {
-                throw e;
-            } catch(Throwable t) {
-                throw new RuntimeException(t);
             }
         }
 
     }
-    
+
     /**
      * Handles authentication.
      */
     public static class Authenticator extends Results {
-        
+
         /**
          * Retrieves the username from the HTTP context; the default is to read from the session cookie.
          *
@@ -81,15 +75,15 @@ public class Security {
         public String getUsername(Context ctx) {
             return ctx.session().get("username");
         }
-        
+
         /**
          * Generates an alternative result if the user is not authenticated; the default a simple '401 Not Authorized' page.
          */
         public Result onUnauthorized(Context ctx) {
             return unauthorized(views.html.defaultpages.unauthorized.render());
         }
-        
+
     }
-    
-    
+
+
 }


### PR DESCRIPTION
As far as I can tell there's no reason to rethrow exceptions as `RuntimeException`. We can just let all exceptions pass through.

Fixes #5200