### PR TITLE
Replace uses of F.Promise with CompletableFuture

### DIFF
--- a/framework/src/play-cache/src/main/java/play/cache/CachedAction.java
+++ b/framework/src/play-cache/src/main/java/play/cache/CachedAction.java
@@ -3,11 +3,12 @@
  */
 package play.cache;
 
-import play.libs.F;
-import play.mvc.*;
-import play.mvc.Http.*;
-
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+
+import play.mvc.Action;
+import play.mvc.Http.Context;
+import play.mvc.Result;
 
 /**
  * Cache another action.
@@ -27,7 +28,7 @@ public class CachedAction extends Action<Cached> {
                     return result;
                 });
             } else {
-                return F.Promise.pure(cacheResult);
+                return CompletableFuture.completedFuture(cacheResult);
             }
 
         } catch (RuntimeException e) {

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -3,10 +3,10 @@
  */
 package play.filters.csrf
 
+import java.util.concurrent.CompletableFuture
 import javax.inject.Inject
 
 import play.api.http.HttpFilters
-import play.libs.F.Promise
 import play.mvc.Http
 
 import scala.concurrent.Future
@@ -210,7 +210,7 @@ object CSRFFilterSpec extends CSRFCommonSpecs {
 }
 
 class JavaErrorHandler extends CSRFErrorHandler {
-  def handle(req: Http.RequestHeader, msg: String) = Promise.pure(play.mvc.Results.unauthorized())
+  def handle(req: Http.RequestHeader, msg: String) = CompletableFuture.completedFuture(play.mvc.Results.unauthorized())
 }
 
 class CsrfFilters @Inject() (filter: CSRFFilter) extends HttpFilters {

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
@@ -3,17 +3,17 @@
  */
 package play.filters.csrf
 
+import java.util.concurrent.CompletableFuture
+
 import play.api.libs.Crypto
 import play.api.mvc.Session
 import play.core.routing.HandlerInvokerFactory
-import play.libs.F.Promise
 import play.mvc.Http.{ RequestHeader, Context }
 
 import scala.concurrent.Future
 import play.api.libs.ws._
 import play.mvc.{ Results, Result, Controller }
 import play.core.j.{ JavaHandlerComponents, JavaActionAnnotations, JavaAction }
-import play.libs.F
 
 import scala.reflect.ClassTag
 
@@ -29,7 +29,7 @@ object JavaCSRFActionSpec extends CSRFCommonSpecs {
     def parser = HandlerInvokerFactory.javaBodyParserToScala(
       javaHandlerComponents.injector.instanceOf(annotations.parser)
     )
-    def invocation = F.Promise.pure(inv)
+    def invocation = CompletableFuture.completedFuture(inv)
     val annotations = new JavaActionAnnotations(clazz, clazz.getMethod(method))
   }
 
@@ -122,7 +122,7 @@ object JavaCSRFActionSpec extends CSRFCommonSpecs {
 
   class CustomErrorHandler extends CSRFErrorHandler {
     def handle(req: RequestHeader, msg: String) = {
-      Promise.pure(Results.unauthorized(msg))
+      CompletableFuture.completedFuture(Results.unauthorized(msg))
     }
   }
 }

--- a/framework/src/play-integration-test/src/test/java/play/routing/RoutingDslTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/routing/RoutingDslTest.java
@@ -12,6 +12,7 @@ import play.mvc.Results;
 import play.test.WithApplication;
 
 import java.io.InputStream;
+import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
@@ -65,7 +66,7 @@ public class RoutingDslTest extends WithApplication {
     @Test
     public void noParametersAsync() {
         Router router = new RoutingDsl()
-                .GET("/hello/world").routeAsync(() -> F.Promise.pure(Results.ok("Hello world")))
+                .GET("/hello/world").routeAsync(() -> CompletableFuture.completedFuture(Results.ok("Hello world")))
                 .build();
 
         assertThat(makeRequest(router, "GET", "/hello/world"), equalTo("Hello world"));
@@ -75,7 +76,7 @@ public class RoutingDslTest extends WithApplication {
     @Test
     public void oneParameterAsync() {
         Router router = new RoutingDsl()
-                .GET("/hello/:to").routeAsync(to -> F.Promise.pure(Results.ok("Hello " + to)))
+                .GET("/hello/:to").routeAsync(to -> CompletableFuture.completedFuture(Results.ok("Hello " + to)))
                 .build();
 
         assertThat(makeRequest(router, "GET", "/hello/world"), equalTo("Hello world"));
@@ -85,7 +86,7 @@ public class RoutingDslTest extends WithApplication {
     @Test
     public void twoParametersAsync() {
         Router router = new RoutingDsl()
-                .GET("/:say/:to").routeAsync((say, to) -> F.Promise.pure(Results.ok(say + " " + to)))
+                .GET("/:say/:to").routeAsync((say, to) -> CompletableFuture.completedFuture(Results.ok(say + " " + to)))
                 .build();
 
         assertThat(makeRequest(router, "GET", "/Hello/world"), equalTo("Hello world"));
@@ -95,7 +96,8 @@ public class RoutingDslTest extends WithApplication {
     @Test
     public void threeParametersAsync() {
         Router router = new RoutingDsl()
-                .GET("/:say/:to/:extra").routeAsync((say, to, extra) -> F.Promise.pure(Results.ok(say + " " + to + extra)))
+                .GET("/:say/:to/:extra").routeAsync((say, to, extra) -> CompletableFuture.completedFuture(
+                Results.ok(say + " " + to + extra)))
                 .build();
 
         assertThat(makeRequest(router, "GET", "/Hello/world/!"), equalTo("Hello world!"));
@@ -191,7 +193,7 @@ public class RoutingDslTest extends WithApplication {
         assertThat(makeRequest(router, "GET", "/hello/world"), equalTo("Hello world"));
         assertNull(makeRequest(router, "GET", "/hello/10"));
     }
-    
+
     @Test
     public void multipleRoutes() {
         Router router = new RoutingDsl()

--- a/framework/src/play-integration-test/src/test/scala/play/it/bindings/GlobalSettingsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/bindings/GlobalSettingsSpec.scala
@@ -4,12 +4,11 @@
 package play.it.bindings
 
 import java.lang.reflect.Method
+import java.util.concurrent.CompletableFuture
 
-import org.specs2.mutable.Specification
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.ws._
 import play.api.routing.Router
-import play.api.{ Application, Configuration, GlobalSettings }
+import play.api.Application
 import play.api.mvc._
 import play.api.mvc.Results._
 import play.api.test._
@@ -17,7 +16,6 @@ import play.it._
 import play.it.http.{ MockController, JAction }
 import play.mvc.Http
 import play.mvc.Http.Context
-import scala.concurrent._
 
 object NettyGlobalSettingsSpec extends GlobalSettingsSpec with NettyIntegrationSpecification
 
@@ -88,7 +86,7 @@ class FooFilteringJavaGlobal extends play.GlobalSettings {
 class OnRequestJavaGlobal extends play.GlobalSettings {
   override def onRequest(request: Http.Request, actionMethod: Method) = {
     new play.mvc.Action.Simple {
-      def call(ctx: Context) = play.libs.F.Promise.pure(play.mvc.Results.ok("intercepted"))
+      def call(ctx: Context) = CompletableFuture.completedFuture(play.mvc.Results.ok("intercepted"))
     }
   }
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JAction.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JAction.scala
@@ -3,13 +3,13 @@
  */
 package play.it.http
 
+import java.util.concurrent.{ CompletionStage, CompletableFuture }
+
 import play.api._
 import play.api.mvc.EssentialAction
 import play.core.j.{ JavaHandlerComponents, JavaActionAnnotations, JavaAction }
 import play.core.routing.HandlerInvokerFactory
-import play.http.DefaultHttpRequestHandler
 import play.mvc.{ Http, Result }
-import play.libs.F.Promise
 
 /**
  * Use this to mock Java actions, eg:
@@ -37,7 +37,7 @@ object JAction {
 }
 
 trait AbstractMockController {
-  def invocation: Promise[Result]
+  def invocation: CompletionStage[Result]
 
   def ctx = Http.Context.current()
   def response = ctx.response()
@@ -48,10 +48,10 @@ trait AbstractMockController {
 
 abstract class MockController extends AbstractMockController {
   def action: Result
-  def invocation: Promise[Result] = Promise.pure(action)
+  def invocation: CompletionStage[Result] = CompletableFuture.completedFuture(action)
 }
 
 abstract class AsyncMockController extends AbstractMockController {
-  def action: Promise[Result]
-  def invocation: Promise[Result] = action
+  def action: CompletionStage[Result]
+  def invocation: CompletionStage[Result] = action
 }

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -8,6 +8,7 @@ import play.inject.ApplicationLifecycle;
 import play.libs.F;
 
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 import javax.inject.Inject;
@@ -38,7 +39,7 @@ public class DefaultJPAApi implements JPAApi {
             jpaApi = new DefaultJPAApi(jpaConfig);
             lifecycle.addStopHook(() -> {
                 jpaApi.shutdown();
-                return F.Promise.pure(null);
+                return CompletableFuture.completedFuture(null);
             });
             jpaApi.start();
         }

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSAPI.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSAPI.java
@@ -3,10 +3,11 @@
  */
 package play.libs.ws.ning;
 
+import java.util.concurrent.CompletableFuture;
+
 import play.api.libs.ws.ning.NingAsyncHttpClientConfigBuilder;
 import play.api.libs.ws.ning.NingWSClientConfig;
 import play.inject.ApplicationLifecycle;
-import play.libs.F;
 import play.libs.ws.WSAPI;
 import play.libs.ws.WSClient;
 import play.libs.ws.WSRequest;
@@ -32,7 +33,7 @@ public class NingWSAPI implements WSAPI {
         client = new NingWSClient(config, materializer);
         lifecycle.addStopHook(() -> {
             client.close();
-            return F.Promise.pure(null);
+            return CompletableFuture.completedFuture(null);
         });
     }
 

--- a/framework/src/play/src/test/java/play/mvc/SecurityTest.java
+++ b/framework/src/play/src/test/java/play/mvc/SecurityTest.java
@@ -2,6 +2,8 @@ package play.mvc;
 
 import com.google.common.collect.ImmutableMap;
 import java.lang.annotation.Annotation;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -12,7 +14,6 @@ import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
 import play.inject.Injector;
-import play.libs.F;
 
 import static org.mockito.Mockito.*;
 
@@ -67,7 +68,7 @@ public class SecurityTest {
         public void testSetUsernameToNullWhenExceptionRaised() {
             action.delegate = new Action<Object>() {
                 @Override
-                public F.Promise<Result> call(Http.Context ctx) {
+                public CompletionStage<Result> call(Http.Context ctx) {
                     throw exception;
                 }
             };
@@ -85,8 +86,8 @@ public class SecurityTest {
         private void runSetUsernameToNullInCallback(final boolean shouldRaiseException) throws Exception {
             action.delegate = new Action<Object>() {
                 @Override
-                public F.Promise<Result> call(Http.Context ctx) {
-                    return F.Promise.promise(() -> {
+                public CompletionStage<Result> call(Http.Context ctx) {
+                    return CompletableFuture.supplyAsync(() -> {
                         if (shouldRaiseException) {
                             throw exception;
                         } else {

--- a/framework/src/play/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
@@ -3,6 +3,8 @@
  */
 package play.api.http
 
+import java.util.concurrent.CompletableFuture
+
 import org.specs2.mutable.Specification
 import play.api.inject.BindingKey
 import play.api.{ OptionalSourceMapper, Configuration, Mode, Environment }
@@ -83,9 +85,9 @@ object HttpErrorHandlerSpec extends Specification {
 
   class CustomJavaErrorHandler extends play.http.HttpErrorHandler {
     def onClientError(req: play.mvc.Http.RequestHeader, status: Int, msg: String) =
-      play.libs.F.Promise.pure(play.mvc.Results.ok())
+      CompletableFuture.completedFuture(play.mvc.Results.ok())
     def onServerError(req: play.mvc.Http.RequestHeader, exception: Throwable) =
-      play.libs.F.Promise.pure(play.mvc.Results.ok())
+      CompletableFuture.completedFuture(play.mvc.Results.ok())
   }
 
 }


### PR DESCRIPTION
All of these instances seemed pretty safe to replace. I didn't change any of the public APIs.