### PR TITLE
Solve dead link in Tutorials.md

### DIFF
--- a/documentation/manual/gettingStarted/Tutorials.md
+++ b/documentation/manual/gettingStarted/Tutorials.md
@@ -20,6 +20,6 @@ Some tutorials we recommend:
 
 ## Java
 
-* [Play Java Intro](https://typesafe.com/activator/template/play-java-intro-reactive-platform-15v01): Introduction to create a simple CRUD application with Play Java.
+* [Play Java Intro](https://typesafe.com/activator/template/play-java-intro): Introduction to create a simple CRUD application with Play Java.
 * [Reactive Maps in Java](https://typesafe.com/activator/template/reactive-maps-java): This template and tutorial shows how the Typesafe Reactive Platform can be used to implement scalable, resilient, responsive event driven apps.
 * [Play with Spring Data JPA](https://typesafe.com/activator/template/play-spring-data-jpa): This is a Play example that uses [Spring Data JPA](https://projects.spring.io/spring-data-jpa/).


### PR DESCRIPTION
The Play Java Intro link goes to a missing page. The correct URL is https://typesafe.com/activator/template/play-java-intro