### PR TITLE
Caveat of using H2 Postgres compat mode to 2.4.x

### DIFF
--- a/documentation/manual/detailedTopics/database/Developing-with-the-H2-Database.md
+++ b/documentation/manual/detailedTopics/database/Developing-with-the-H2-Database.md
@@ -58,7 +58,11 @@ db.default.url="jdbc:h2:mem:play;MODE=MYSQL"
 
 ## Prevent in memory DB reset
 
-H2 drops your database if there are no connections.  You probably don't want this to happen.  To prevent this add `DB_CLOSE_DELAY=-1` to the url (use a semicolon as a separator) eg: `jdbc:h2:mem:play;MODE=MYSQL;DB_CLOSE_DELAY=-1`
+H2, by default, drops your in memory database if there are no connections to it anymore.  You probably don't want this to happen.  To prevent this add `DB_CLOSE_DELAY=-1` to the url (use a semicolon as a separator) eg: `jdbc:h2:mem:play;MODE=MYSQL;DB_CLOSE_DELAY=-1`
+
+## Caveats
+
+H2, by default, creates tables with upper case names. Sometimes you don't want this to happen, for example when using H2 with Play evolutions in some compatibility modes. To prevent this add `DATABASE_TO_UPPER=FALSE` to the url (use a semicolon as a separator) eg: `jdbc:h2:mem:play;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=FALSE`
 
 ## H2 Browser
 


### PR DESCRIPTION
Added a caveat section to H2 page mentioning `DATABASE_TO_UPPER flag + minor improvement in Prevent in memory DB reset section.

Adding this flag to the database url was the only way I found to make H2 in Postgres mode work with Play Evolutions. Mentioning it here is harmless as well and might save some time from other developers.