### PR TITLE
Generate self-signed certificates with SHA-256 - 2.4.x

### DIFF
--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
@@ -22,6 +22,8 @@ object FakeKeyStore {
   private val logger = Logger(FakeKeyStore.getClass)
   val GeneratedKeyStore = "conf/generated.keystore"
   val DnName = "CN=localhost, OU=Unit Testing, O=Mavericks, L=Moon Base 1, ST=Cyberspace, C=CY"
+  val SignatureAlgorithmOID = AlgorithmId.sha256WithRSAEncryption_oid
+  val SignatureAlgorithmName = "SHA256withRSA"
 
   def shouldGenerate(keyStoreFile: File): Boolean = {
     import scala.collection.JavaConverters._
@@ -43,7 +45,7 @@ object FakeKeyStore {
         Option(store.getCertificate(alias)).map {
           c =>
             val key: RSAPublicKey = c.getPublicKey.asInstanceOf[RSAPublicKey]
-            if (key.getModulus.bitLength < 2048) {
+            if (key.getModulus.bitLength < 2048 || key.getAlgorithm != SignatureAlgorithmName) {
               return true
             }
         }
@@ -115,19 +117,19 @@ object FakeKeyStore {
 
     // Key and algorithm
     certInfo.set(X509CertInfo.KEY, new CertificateX509Key(keyPair.getPublic))
-    val algorithm = new AlgorithmId(AlgorithmId.sha1WithRSAEncryption_oid)
+    val algorithm = new AlgorithmId(SignatureAlgorithmOID)
     certInfo.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algorithm))
 
     // Create a new certificate and sign it
     val cert = new X509CertImpl(certInfo)
-    cert.sign(keyPair.getPrivate, "SHA1withRSA")
+    cert.sign(keyPair.getPrivate, SignatureAlgorithmName)
 
-    // Since the SHA1withRSA provider may have a different algorithm ID to what we think it should be,
+    // Since the signature provider may have a different algorithm ID to what we think it should be,
     // we need to reset the algorithm ID, and resign the certificate
     val actualAlgorithm = cert.get(X509CertImpl.SIG_ALG).asInstanceOf[AlgorithmId]
     certInfo.set(CertificateAlgorithmId.NAME + "." + CertificateAlgorithmId.ALGORITHM, actualAlgorithm)
     val newCert = new X509CertImpl(certInfo)
-    newCert.sign(keyPair.getPrivate, "SHA1withRSA")
+    newCert.sign(keyPair.getPrivate, SignatureAlgorithmName)
     newCert
   }
 }


### PR DESCRIPTION
- Add the signature algorithm to the key rebuild check criteria

- Chrome and FireFox are both aggresssively deprecating SHA1 signatures,
  making it difficult to use https for local development. This change
  creates the default self-signed certs with SHA256-RSA, eliminating
  the deprecation errors.