### PR TITLE
update documentation for #4585 and #4586

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/routing/JavaRoutingDsl.md
+++ b/documentation/manual/working/javaGuide/advanced/routing/JavaRoutingDsl.md
@@ -32,3 +32,24 @@ Supported types include `Integer`, `Long`, `Float`, `Double`, `Boolean`, and any
 Asynchronous actions are of course also supported, using the `routeAsync` method:
 
 @[async](code/javaguide/advanced/routing/JavaRoutingDsl.java)
+
+## Binding Routing DSL
+
+Configuring an application to use a Routing DSL can be achieved in many ways, depending on use case:
+
+### Embedding play
+An example of embedding a play server with Routing DSL can be found in [[Embedding Play|JavaEmbeddingPlay]] section.
+
+### Providing a DI router
+
+A router can be provided to the application similarly as detailed in [[Application Entry point|ScalaCompileTimeDependencyInjection#Application-entry-point]] and [[Providing a router|ScalaCompileTimeDependencyInjection#Providing-a-router]], using e.g. a java builder class:
+
+@[](code/router/RoutingDslBuilder.java)
+
+and in the application loader:
+
+@[load](code/AppLoader.scala)
+
+### Overriding binding
+
+A router can also be provided using e.g. GuiceApplicationBuilder in the application loader to override with custom router binding or module as detailed in [[Bindings and Modules|JavaTestingWithGuice#Override-bindings]] 

--- a/documentation/manual/working/javaGuide/advanced/routing/RequestBinders.md
+++ b/documentation/manual/working/javaGuide/advanced/routing/RequestBinders.md
@@ -1,0 +1,53 @@
+# Custom Routing
+
+Play provides a mechanism to bind types from path or query string parameters. 
+
+## PathBindable
+
+PathBindable allows to bind business objects from the URL path; this means we’ll be able to define routes like `/user/3` to call an action such as the following:
+
+- `controller`
+
+@[path](code/javaguide/binder/controllers/BinderApplication.java)
+
+The `user` parameter will automatically be retrieved using the id extracted from the URL path, e.g. with the following route definition:
+
+- `/conf/routes`
+
+@[user](code/javaguide.binder.routes)
+
+Any type T that implements [`PathBindable`](api/java/play/mvc/PathBindable.html) can be bound to/from a path parameter.
+It defines abstract methods `bind` (build a value from the path) and `unbind` (build a path fragment from a value).
+
+For a class like:
+
+@[declaration](code/javaguide/binder/models/User.java)
+
+A simple example of the binder's use binding the `:id` path parameter:
+
+@[bind](code/javaguide/binder/models/User.java)
+
+
+In this example findById method is invoked to retrieve `User` instance; note that in real world such method should be lightweight and not involve e.g. DB access, because the code is called on the server IO thread and must be totally non-blocking.
+
+You would therefore for example use simple objects identifier as path bindable, and retrieve the real values using action composition.
+
+## QueryStringBindable
+
+A similar mechanism is used for query string parameters; a route like `/age` can be defined to call an action such as:
+
+- `controller`
+
+@[query](code/javaguide/binder/controllers/BinderApplication.java)
+
+The `age` parameter will automatically be retrieved using parameters extracted from the query string e.g. `/age?from=1&to=10`
+
+Any type T that implements [`QueryStringBindable`](api/java/play/mvc/QueryStringBindable.html) can be bound to/from query one or more query string parameters. Similar to [`PathBindable`](api/java/play/mvc/PathBindable.html), it defines abstract methods `bind` and `unbind`.
+
+For a class like:
+
+@[declaration](code/javaguide/binder/models/AgeRange.java)
+
+A simple example of the binder's use binding the `:from` and `:to` query string parameters:
+
+@[bind](code/javaguide/binder/models/AgeRange.java)

--- a/documentation/manual/working/javaGuide/advanced/routing/code/AppLoader.scala
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/AppLoader.scala
@@ -1,0 +1,25 @@
+import play.api.ApplicationLoader.Context
+import play.api._
+import play.api.libs.concurrent.Execution.Implicits._
+import play.api.mvc.Results._
+import play.api.mvc._
+import play.api.routing.Router
+import play.api.routing.sird._
+import scala.concurrent.Future
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.inject.bind
+import router.RoutingDslBuilder
+
+//#load
+class AppLoader extends ApplicationLoader {
+  def load(context: Context) = {
+    new MyComponents(context).application
+  }
+}
+
+class MyComponents(context: Context) extends BuiltInComponentsFromContext(context) {
+  lazy val router = Router.from {
+       RoutingDslBuilder.getRouter().routes
+  }
+}
+//#load

--- a/documentation/manual/working/javaGuide/advanced/routing/code/javaguide.binder.routes
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/javaguide.binder.routes
@@ -1,0 +1,7 @@
+# #user
+GET     /user/:user            controllers.BinderApplication.user(user: javaguide.binder.models.User)
+# #user
+
+# #ageRange
+GET     /ageRange                     controllers.BinderApplication.age(age: javaguide.binder.models.AgeRange)
+# #ageRange

--- a/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/controllers/BinderApplication.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/controllers/BinderApplication.java
@@ -1,0 +1,22 @@
+package javaguide.binder.controllers;
+
+import javaguide.binder.models.User;
+import javaguide.binder.models.AgeRange;
+import play.mvc.Controller;
+import play.mvc.Result;
+
+public class BinderApplication extends Controller {
+
+	//#path
+    public Result user(User user){
+    	return ok(user.name);
+    }    
+	//#path
+    
+	//#query
+    public Result age(AgeRange ageRange){
+    	return ok(String.valueOf(ageRange.from));
+    }    
+	//#query    
+}
+

--- a/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/models/AgeRange.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/models/AgeRange.java
@@ -1,0 +1,51 @@
+package javaguide.binder.models;
+
+import java.util.Map;
+import java.util.Optional;
+import play.libs.F;
+import play.libs.F.*;
+import play.mvc.QueryStringBindable;
+//import java.util.Optional;
+
+//#declaration
+public class AgeRange implements QueryStringBindable<AgeRange> {
+
+    public Integer from;
+    public Integer to;
+//#declaration
+    
+//#bind
+@Override
+public Optional<AgeRange> bind(String key, Map<String, String[]> data) {
+	
+	try{
+		from = new Integer(data.get("from")[0]);
+		to = new Integer(data.get("to")[0]);
+		return Optional.of(this);
+		
+	} catch (Exception e){ // no parameter match return None
+		return Optional.of(null);
+	}
+}
+
+@Override
+public String unbind(String key) {
+	return new StringBuilder()
+		.append("from=")
+		.append(from)
+		.append("&to=")
+		.append(to)
+		.toString();
+}
+//#bind
+	
+	@Override
+	public String javascriptUnbind() {
+		return new StringBuilder()
+		.append("from=")
+		.append(from)
+		.append(";to=")
+		.append(to)
+		.toString();
+	}
+}

--- a/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/models/User.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/models/User.java
@@ -1,0 +1,48 @@
+package javaguide.binder.models;
+
+import play.mvc.PathBindable;
+
+//#declaration
+public class User implements PathBindable<User> {
+	
+    public Long id;
+    public String name;
+  //#declaration
+    
+//#bind
+@Override
+public User bind(String key, String id) {
+
+	// findById meant to be lightweight operation
+	User user = findById(new Long(id));
+	if (user == null) {
+		throw new IllegalArgumentException("User with id " + id + " not found");
+	}
+	return user;
+}
+
+@Override
+public String unbind(String key) {
+	return String.valueOf(id);
+}
+//#bind
+	
+	@Override
+	public String javascriptUnbind() {
+		return "function(k,v) {\n" +
+	             "    return v.id;" +
+	             "}";
+	}
+	
+	// stubbed test 
+	// designed to be lightweight operation
+	private User findById(Long id){
+		if (id>3) return null;
+		User user = new User();
+		user.id = id;
+		user.name = "User " + String.valueOf(id);
+		return user;
+    	
+	}
+
+}

--- a/documentation/manual/working/javaGuide/advanced/routing/code/router/RoutingDslBuilder.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/router/RoutingDslBuilder.java
@@ -1,0 +1,15 @@
+package router;
+
+import play.api.routing.Router;
+import play.mvc.Controller;
+import play.routing.RoutingDsl;
+
+public class RoutingDslBuilder extends Controller{
+
+  public static Router getRouter() {
+    return new RoutingDsl()
+      .GET("/hello/:to").routeTo(to -> ok("Hello " + to))
+      .build();
+  }
+}
+

--- a/documentation/manual/working/javaGuide/advanced/routing/index.toc
+++ b/documentation/manual/working/javaGuide/advanced/routing/index.toc
@@ -1,1 +1,2 @@
 JavaRoutingDsl:Embedded Routing DSL
+RequestBinders:Custom Binding

--- a/documentation/manual/working/javaGuide/main/http/JavaRouting.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaRouting.md
@@ -153,3 +153,7 @@ You can then reverse the URL to the `hello` action method, by using the `control
 @[reverse-redirect](code/javaguide/http/routing/controllers/Application.java)
 
 > **Note:** There is a `routes` subpackage for each controller package. So the action `controllers.admin.Application.hello` can be reversed via `controllers.admin.routes.Application.hello`.
+
+## Advanced Routing
+
+See [[Routing DSL|JavaRoutingDsl]]

--- a/documentation/manual/working/scalaGuide/advanced/routing/ScalaRequestBinders.md
+++ b/documentation/manual/working/scalaGuide/advanced/routing/ScalaRequestBinders.md
@@ -1,0 +1,53 @@
+# Custom Routing
+
+Play provides a mechanism to bind types from path or query string parameters. 
+
+## PathBindable
+
+PathBindable allows to bind business objects from the URL path; this means we’ll be able to define routes like `/user/3` to call an action such as the following:
+
+- `controller`
+
+@[path](code/scalaguide/binder/controllers/BinderApplication.scala)
+
+The `user` parameter will automatically be retrieved using the id extracted from the URL path, e.g. with the following route definition:
+
+- `/conf/routes`
+
+@[user](code/scalaguide.binder.routes)
+
+You can provide an implementation of [`PathBindable[A]`](api/scala/play/api/mvc/PathBindable.html) for any type A you want to be able to bind directly from the request path. It defines abstract methods `bind` (build a value from the path) and `unbind` (build a path fragment from a value).
+
+For a class definition:
+
+@[declaration](code/scalaguide/binder/models/User.scala)
+
+A simple example of the binder's use binding the `:id` path parameter:
+
+@[bind](code/scalaguide/binder/models/User.scala)
+
+
+In this example findById method is invoked to retrieve `User` instance; note that in real world such method should be lightweight and not involve e.g. DB access, because the code is called on the server IO thread and must be totally non-blocking.
+
+You would therefore for example use simple objects identifier as path bindable, and retrieve the real values using action composition.
+
+## QueryStringBindable
+
+A similar mechanism is used for query string parameters; a route like `/age` can be defined to call an action such as:
+
+- `controller`
+
+@[query](code/scalaguide/binder/controllers/BinderApplication.scala)
+
+The `age` parameter will automatically be retrieved using parameters extracted from the query string e.g. `/age?from=1&to=10`
+
+You can provide an implementation of [`QueryStringBindable[A]`](api/scala/play/api/mvc/QueryStringBindable.html) for any type A you want to be able to bind directly from the request query string. Similar to [`PathBindable`](api/scala/play/api/mvc/PathBindable.html), it defines abstract methods `bind` and `unbind`.
+
+For a class definition:
+
+@[declaration](code/scalaguide/binder/models/AgeRange.scala)
+
+A simple example of the binder's use binding the `:from` and `:to` query string parameters:
+
+@[bind](code/scalaguide/binder/models/AgeRange.scala)
+

--- a/documentation/manual/working/scalaGuide/advanced/routing/ScalaSirdRouter.md
+++ b/documentation/manual/working/scalaGuide/advanced/routing/ScalaSirdRouter.md
@@ -53,3 +53,19 @@ To further the point that these are just regular extractor objects, you can see 
 
 @[complex](code/ScalaSirdRouter.scala)
 
+## Binding sird Router
+
+Configuring an application to use a sird Router can be achieved in many ways, depending on use case:
+
+### Embedding play
+An example of embedding a play server with sird router can be found in [[Embedding Play|ScalaEmbeddingPlay]] section.
+
+### Providing a DI router
+
+A router can be provided to the application as detailed in [[Application Entry point|ScalaCompileTimeDependencyInjection#Application-entry-point]] and [[Providing a router|ScalaCompileTimeDependencyInjection#Providing-a-router]]:
+
+@[load](code/SirdAppLoader.scala)
+
+### Overriding binding
+
+A router can also be provided using e.g. GuiceApplicationBuilder in the application loader to override with custom router binding or module as detailed in [[Bindings and Modules|ScalaTestingWithGuice#Override-bindings]] 

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/SirdAppLoader.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/SirdAppLoader.scala
@@ -1,0 +1,26 @@
+import play.api.ApplicationLoader.Context
+import play.api._
+import play.api.libs.concurrent.Execution.Implicits._
+import play.api.mvc.Results._
+import play.api.mvc._
+import play.api.routing.Router
+import play.api.routing.sird._
+import scala.concurrent.Future
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.inject.bind
+
+//#load
+class SirdAppLoader extends ApplicationLoader {
+  def load(context: Context) = {
+    new SirdComponents(context).application
+  }
+}
+
+class SirdComponents(context: Context) extends BuiltInComponentsFromContext(context) {
+  lazy val router = Router.from {
+       case GET(p"/hello/$to") => Action {
+        Ok(s"Hello $to")
+        }
+  }
+}
+//#load

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide.binder.routes
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide.binder.routes
@@ -1,0 +1,7 @@
+# #user
+GET     /user/:user            controllers.BinderApplication.user(user: scalaguide.binder.models.User)
+# #user
+
+# #ageRange
+GET     /ageRange                     controllers.BinderApplication.age(age: scalaguide.binder.models.AgeRange)
+# #ageRange

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/controllers/BinderApplication.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/controllers/BinderApplication.scala
@@ -1,0 +1,22 @@
+package scalaguide.binder.controllers
+
+
+import play.api._
+import play.api.mvc._
+import scalaguide.binder.models._
+
+class BinderApplication extends Controller{
+ 
+  //#path
+  def user(user: User) = Action {
+    Ok(user.name)
+  }
+  //#path
+
+  //#query
+  def age(age: AgeRange) = Action {
+    Ok(age.from.toString)
+  }
+  //#query
+
+}

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/AgeRange.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/AgeRange.scala
@@ -1,0 +1,33 @@
+package scalaguide.binder.models
+
+import scala.Left
+import scala.Right
+import play.api.mvc.PathBindable
+import play.Logger
+import play.api.mvc.QueryStringBindable
+
+//#declaration
+case class AgeRange(from: Int, to: Int) {}
+//#declaration
+object AgeRange {
+  
+  //#bind
+  implicit def queryStringBindable(implicit intBinder: QueryStringBindable[Int]) = new QueryStringBindable[AgeRange] {
+    override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, AgeRange]] = {
+      for {
+        from <- intBinder.bind("from", params)
+        to <- intBinder.bind("to", params)
+      } yield {
+        (from, to) match {
+          case (Right(from), Right(to)) => Right(AgeRange(from, to))
+          case _ => Left("Unable to bind an AgeRange")
+        }
+      }
+    }
+    override def unbind(key: String, ageRange: AgeRange): String = {
+      intBinder.unbind("from", ageRange.from) + "&" + intBinder.unbind("to", ageRange.to)
+    }
+  }
+	//#bind
+}
+

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/User.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/scalaguide/binder/models/User.scala
@@ -1,0 +1,36 @@
+package scalaguide.binder.models
+
+import scala.Left
+import scala.Right
+import play.api.mvc.PathBindable
+import play.Logger
+
+//#declaration
+case class User(id: Int, name: String) {}
+//#declaration
+object User {
+  
+  // stubbed test 
+	// designed to be lightweight operation
+  def findById(id: Int): Option[User] = {
+    Logger.info("findById: " + id.toString)
+    if (id > 3) None
+    var user = new User(id, "User " + String.valueOf(id))
+    Some(user)
+  }
+
+  //#bind
+  implicit def pathBinder(implicit intBinder: PathBindable[Int]) = new PathBindable[User] {
+    override def bind(key: String, value: String): Either[String, User] = {
+      for {
+        id <- intBinder.bind(key, value).right
+        user <- User.findById(id).toRight("User not found").right
+      } yield user
+    }
+    override def unbind(key: String, user: User): String = {
+      user.id.toString
+    }
+  }
+	//#bind
+}
+

--- a/documentation/manual/working/scalaGuide/advanced/routing/index.toc
+++ b/documentation/manual/working/scalaGuide/advanced/routing/index.toc
@@ -1,2 +1,3 @@
 ScalaSirdRouter:String Interpolating Routing DSL
 ScalaJavascriptRouting:Javascript routing
+ScalaRequestBinders:Custom Binding

--- a/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
@@ -147,3 +147,7 @@ And if you map it in the `conf/routes` file:
 You can then reverse the URL to the `hello` action method, by using the `controllers.routes.Application` reverse controller:
 
 @[reverse-router](code/ScalaRouting.scala)
+
+## Custom routing
+
+See [[String Interpolating Routing DSL|ScalaSirdRouter]]


### PR DESCRIPTION
Following discussion with @benmccann  with reference to issue #4586 and #4587, updates documentation basically in 2 areas.

1 - Custom binding
2 - Router config

1 - Custom binding with `PathBindable` and `QueryStringBindable` is described in new pages `RequestBinders` and `ScalaRequestBinders` under `advanced routing`,  providing code examples on how to use binders.

2 - Router config includes a new link to `advanced routing` page in last section of `JavaRouting` and `ScalaRouting`, and a new section at the end of `ScalaSirdRouter` and `JavaRoutingDsl` with possible  alternatives to provide a custom sird/DSL router to the application.