### PR TITLE
More fixes to forward header parsing

### DIFF
--- a/framework/src/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -4,7 +4,7 @@
 package play.core.server.common
 
 import java.net.InetAddress
-import play.api.{ Configuration, PlayException }
+import play.api.{ Configuration, Logger, PlayException }
 import play.api.mvc.Headers
 import play.core.server.common.NodeIdentifierParser.Ip
 import scala.annotation.tailrec
@@ -18,12 +18,15 @@ import ForwardedHeaderHandler._
  * algorithm it uses is as follows:
  *
  * 1. Start with the immediate connection to the application.
- * 2. If this address is in the subnet of our trusted proxies, then look for
- *    a Forward or X-Forward-* header sent by that proxy.
- * 2a. If the proxy sent a header, then go back to step 2 using the address
- *     that it sent.
- * 2b. If the proxy didn't send a header, then use the proxy's address.
- * 3. If the address is not a trusted proxy, use that address.
+ * 2. If the proxy *did not* send a valid Forward or X-Forward-* header then return
+ *    that connection and don't do any further processing.
+ * 3. If the proxy *did* send a valid header then work out whether we trust it by
+ *    checking whether the immediate connection is in our list of trusted
+ *    proxies.
+ * 4. If the immediate connection *is* a trusted proxy, then resume at step
+ *    1 using the connection info in the forwarded header.
+ * 5. If the immediate connection *is not* a trusted proxy, then return the
+ *    immediate connection info and don't do any further processing.
  *
  * Each address is associated with a secure or insecure protocol by pairing
  * it with a `proto` entry in the headers. If the `proto` entry is missing or
@@ -59,10 +62,6 @@ private[server] class ForwardedHeaderHandler(configuration: ForwardedHeaderHandl
 
   def remoteConnection(rawConnection: ConnectionInfo, headers: Headers): ConnectionInfo = {
 
-    def isTrustedProxy(connection: ConnectionInfo): Boolean = {
-      configuration.trustedProxies.exists(_.isInRange(connection.address))
-    }
-
     // Use a mutable iterator for performance when scanning the
     // header entries. Go through the headers in reverse order because
     // the nearest proxies will be at the end of the list and we need
@@ -71,42 +70,30 @@ private[server] class ForwardedHeaderHandler(configuration: ForwardedHeaderHandl
 
     @tailrec
     def scan(prev: ConnectionInfo): ConnectionInfo = {
-      if (isTrustedProxy(prev)) {
-        // 'prev' is a trusted proxy, so we look to see if there are any
-        // headers from prev about forwarding
-        if (headerEntries.hasNext) {
-          // There is a forwarded header from 'prev', so lets process it and get the
-          // address.
+      // Check if there's a forwarded header for us to scan.
+      if (headerEntries.hasNext) {
+        // There is a forwarded header from 'prev', so lets check if 'prev' is trusted.
+        // If it's a trusted proxy then process the header, otherwise just use 'prev'.
+
+        if (configuration.isTrustedProxy(prev)) {
+          // 'prev' is a trusted proxy, so we process the next entry.
           val entry = headerEntries.next()
-          val addressString: String = entry.addressString.getOrElse(throw new PlayException(
-            "Invalid forwarded header",
-            s"""|Forwarding header supplied by trusted proxy $prev is missing an
-                |address entry: fix proxy header or remove proxy from
-                |$TrustedProxiesConfigPath config entry""".stripMargin))
-          val address: InetAddress = NodeIdentifierParser.parseNode(addressString) match {
-            case Right((Ip(address), _)) => address
-            case Right((nonIpAddress, _)) => throw new PlayException(
-              "Invalid forwarded header",
-              s"""|Forwarding header '$addressString' supplied by trusted proxy
-                  |$prev has a non-IP address '$nonIpAddress': fix proxy header
-                  |or remove proxy from $TrustedProxiesConfigPath config entry""".stripMargin)
-            case Left(error) => throw new PlayException(
-              "Invalid forwarded header",
-              s"""|Forwarding header '$addressString' supplied by trusted proxy
-                  |$prev could not be parsed: $error: fix proxy header or
-                  |remove proxy from $TrustedProxiesConfigPath config entry""".stripMargin)
+          configuration.parseEntry(entry) match {
+            case Left(error) =>
+              ForwardedHeaderHandler.logger.debug(
+                s"Error with info in forwarding header $entry, using $prev instead: $error."
+              )
+              prev
+            case Right(connection) =>
+              scan(connection)
           }
-          val secure = entry.protoString.fold(false)(_ == "https") // Assume insecure by default
-          val connection = ConnectionInfo(address, secure)
-          scan(connection)
         } else {
-          // No more headers to process. Even though we trust 'prev' as a proxy,
-          // it hasn't sent us any headers, so just use its address.
+          // 'prev' is not a trusted proxy, so we don't scan ahead in the list of
+          // forwards, we just return 'prev'.
           prev
         }
       } else {
-        // 'prev' is not a trusted proxy, so we don't scan ahead in the list of
-        // forwards, we just return 'prev'.
+        // No more headers to process, so just use its address.
         prev
       }
     }
@@ -120,48 +107,107 @@ private[server] class ForwardedHeaderHandler(configuration: ForwardedHeaderHandl
 
 private[server] object ForwardedHeaderHandler {
 
-  sealed trait Version
-  case object Rfc7239 extends Version
-  case object Xforwarded extends Version
+  private val logger = Logger(getClass)
+
+  /**
+   * The verison of headers that this Play application understands.
+   */
+  sealed trait ForwardedHeaderVersion
+  case object Rfc7239 extends ForwardedHeaderVersion
+  case object Xforwarded extends ForwardedHeaderVersion
 
   type HeaderParser = Headers => Seq[ForwardedEntry]
 
+  /**
+   * An unparsed address and protocol pair from a forwarded header. Both values are
+   * optional.
+   */
   final case class ForwardedEntry(addressString: Option[String], protoString: Option[String])
 
-  case class ForwardedHeaderHandlerConfig(version: Version, trustedProxies: List[Subnet]) {
-    def forwardedHeaders: HeaderParser = version match {
-      case Rfc7239 => rfc7239Headers
-      case Xforwarded => xforwardedHeaders
+  case class ForwardedHeaderHandlerConfig(version: ForwardedHeaderVersion, trustedProxies: List[Subnet]) {
+
+    val nodeIdentifierParser = new NodeIdentifierParser(version)
+
+    /**
+     * Removes surrounding quotes if present, otherwise returns original string.
+     * Not RFC compliant. To be compliant we need proper header field parsing.
+     */
+    private def unquote(s: String): String = {
+      if (s.length >= 2 && s.charAt(0) == '"' && s.charAt(s.length - 1) == '"') {
+        s.substring(1, s.length - 1)
+      } else s
     }
 
-    private val rfc7239Headers: HeaderParser = { (headers: Headers) =>
-      (for {
-        fhs <- headers.getAll("Forwarded")
-        fh <- fhs.split(",\\s*")
-      } yield fh).map(_.split(";").map(s => {
-        val splitted = s.split("=", 2)
-        splitted(0).toLowerCase(java.util.Locale.ENGLISH) -> splitted(1)
-      }).toMap).map { paramMap: Map[String, String] =>
-        ForwardedEntry(paramMap.get("for"), paramMap.get("proto"))
+    /**
+     * Parse any Forward or X-Forwarded-* headers into a sequence of ForwardedEntry
+     * objects. Each object a pair with an optional unparsed address and an
+     * optional unparsed protocol. Further parsing may happen later, see `remoteConnection`.
+     */
+    def forwardedHeaders(headers: Headers): Seq[ForwardedEntry] = version match {
+      case Rfc7239 =>
+        (for {
+          fhs <- headers.getAll("Forwarded")
+          fh <- fhs.split(",\\s*")
+        } yield fh).map(_.split(";").flatMap(s => {
+          val splitted = s.split("=", 2)
+          if (splitted.length < 2) Seq.empty else {
+            // Remove surrounding quotes
+            val name = splitted(0).toLowerCase(java.util.Locale.ENGLISH)
+            val value = unquote(splitted(1))
+            Seq(name -> value)
+          }
+        }).toMap).map { paramMap: Map[String, String] =>
+          ForwardedEntry(paramMap.get("for"), paramMap.get("proto"))
+        }
+      case Xforwarded =>
+        def h(h: Headers, key: String) = h.getAll(key).flatMap(s => s.split(",\\s*")).map(unquote)
+        val forHeaders = h(headers, "X-Forwarded-For")
+        val protoHeaders = h(headers, "X-Forwarded-Proto")
+        if (forHeaders.length == protoHeaders.length) {
+          forHeaders.zip(protoHeaders).map {
+            case (f, p) => ForwardedEntry(Some(f), Some(p))
+          }
+        } else {
+          // If the lengths vary, then discard the protoHeaders because we can't tell which
+          // proto matches which header. The connections will all appear to be insecure by
+          // default.
+          forHeaders.map {
+            case f => ForwardedEntry(Some(f), None)
+          }
+        }
+    }
+
+    /**
+     * Try to parse a `ForwardedEntry` into a valid `ConnectionInfo` with an IP address
+     * and information about the protocol security. If this cannot happen, either because
+     * parsing fails or because the connection info doesn't include an IP address, this
+     * method will return `Left` with an error message.
+     */
+    def parseEntry(entry: ForwardedEntry): Either[String, ConnectionInfo] = {
+      entry.addressString match {
+        case None =>
+          // We had a forwarding header, but it was missing the address entry for some reason.
+          Left("No address")
+        case Some(addressString) =>
+          nodeIdentifierParser.parseNode(addressString) match {
+            case Right((Ip(address), _)) =>
+              // Parsing was successful, use this connection and scan for another connection.
+              val secure = entry.protoString.fold(false)(_ == "https") // Assume insecure by default
+              val connection = ConnectionInfo(address, secure)
+              Right(connection)
+            case errorOrNonIp =>
+              // The forwarding address entry couldn't be parsed for some reason.
+              Left(s"Parse error: $errorOrNonIp")
+          }
       }
     }
 
-    private val xforwardedHeaders: HeaderParser = { (headers: Headers) =>
-      def h(h: Headers, key: String) = h.getAll(key).flatMap(s => s.split(",\\s*"))
-      val forHeaders = h(headers, "X-Forwarded-For")
-      val protoHeaders = h(headers, "X-Forwarded-Proto")
-      if (forHeaders.length == protoHeaders.length) {
-        forHeaders.zip(protoHeaders).map {
-          case (f, p) => ForwardedEntry(Some(f), Some(p))
-        }
-      } else {
-        // If the lengths vary, then discard the protoHeaders because we can't tell which
-        // proto matches which header. The connections will all appear to be insecure by
-        // default.
-        forHeaders.map {
-          case f => ForwardedEntry(Some(f), None)
-        }
-      }
+    /**
+     * Check if a connection is considered to be a trusted proxy, i.e. a proxy whose
+     * forwarding headers we will process.
+     */
+    def isTrustedProxy(connection: ConnectionInfo): Boolean = {
+      trustedProxies.exists(_.isInRange(connection.address))
     }
   }
 
@@ -169,14 +215,15 @@ private[server] object ForwardedHeaderHandler {
   val TrustedProxiesConfigPath = "play.http.forwarded.trustedProxies"
 
   object ForwardedHeaderHandlerConfig {
+    private def defaultTrustedProxies = List("::1", "127.0.0.1")
     def apply(configuration: Option[Configuration]): ForwardedHeaderHandlerConfig = configuration.map { c =>
       ForwardedHeaderHandlerConfig(
         c.getString(ForwardingVersionConfigPath, Some(Set("x-forwarded", "rfc7239")))
-          .fold(Xforwarded: Version)(version => if (version == "rfc7239") Rfc7239 else Xforwarded),
+          .fold[ForwardedHeaderVersion](Xforwarded)(version => if (version == "rfc7239") Rfc7239 else Xforwarded),
         c.getStringSeq(TrustedProxiesConfigPath)
-          .getOrElse(List("::1", "127.0.0.1"))
+          .getOrElse(defaultTrustedProxies)
           .map(Subnet.apply).toList
       )
-    }.getOrElse(ForwardedHeaderHandlerConfig(Xforwarded, List(Subnet("::1"), Subnet("172.0.0.1"))))
+    }.getOrElse(ForwardedHeaderHandlerConfig(Xforwarded, defaultTrustedProxies.map(Subnet.apply)))
   }
 }

--- a/framework/src/play-server/src/main/scala/play/core/server/common/NodeIdentifierParser.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/NodeIdentifierParser.scala
@@ -4,23 +4,19 @@
 package play.core.server.common
 
 import java.net.{ Inet6Address, InetAddress, Inet4Address }
-
 import scala.util.Try
 import scala.util.parsing.combinator.RegexParsers
 
+import ForwardedHeaderHandler.{ ForwardedHeaderVersion, Rfc7239, Xforwarded }
+import NodeIdentifierParser._
+
 /**
  * The NodeIdentifierParser object can parse node identifiers described in RFC 7239.
+ *
+ * @param version The version of the forwarded headers that we want to parse nodes for.
+ * The version is used to switch between IP address parsing behavior.
  */
-private[common] object NodeIdentifierParser extends RegexParsers {
-
-  sealed trait Port
-  case class PortNumber(number: Int) extends Port
-  case class ObfuscatedPort(s: String) extends Port
-
-  sealed trait IpAddress
-  case class Ip(ip: InetAddress) extends IpAddress
-  case class ObfuscatedIp(s: String) extends IpAddress
-  case object UnknownIp extends IpAddress
+private[common] class NodeIdentifierParser(version: ForwardedHeaderVersion) extends RegexParsers {
 
   def parseNode(s: String): Either[String, (IpAddress, Option[Port])] = {
     parse(node, s) match {
@@ -34,11 +30,21 @@ private[common] object NodeIdentifierParser extends RegexParsers {
     case x ~ y => x -> y
   }
 
-  private lazy val nodename = ("[" ~> ipv6Address <~ "]" | ipv4Address | "unknown" | obfnode) ^^ {
-    case x: Inet4Address => Ip(x)
-    case x: Inet6Address => Ip(x)
-    case "unknown" => UnknownIp
-    case x => ObfuscatedIp(x.toString)
+  private lazy val nodename = version match {
+    case Rfc7239 =>
+      // RFC 7239 recognises IPv4 addresses, escaped IPv6 addresses, unknown and obfuscated addresses
+      (ipv4Address | "[" ~> ipv6Address <~ "]" | "unknown" | obfnode) ^^ {
+        case x: Inet4Address => Ip(x)
+        case x: Inet6Address => Ip(x)
+        case "unknown" => UnknownIp
+        case x => ObfuscatedIp(x.toString)
+      }
+    case Xforwarded =>
+      // X-Forwarded-For recognises IPv4 and escaped or unescaped IPv6 addresses
+      (ipv4Address | "[" ~> ipv6Address <~ "]" | ipv6Address) ^^ {
+        case x: Inet4Address => Ip(x)
+        case x: Inet6Address => Ip(x)
+      }
   }
 
   private lazy val ipv4Address = regex("[\\d\\.]{7,15}".r) ^? inetAddress
@@ -62,4 +68,15 @@ private[common] object NodeIdentifierParser extends RegexParsers {
     def isDefinedAt(s: String) = Try { InetAddress.getByName(s) }.isSuccess
     def apply(s: String) = Try { InetAddress.getByName(s) }.get
   }
+}
+
+private[common] object NodeIdentifierParser {
+  sealed trait Port
+  case class PortNumber(number: Int) extends Port
+  case class ObfuscatedPort(s: String) extends Port
+
+  sealed trait IpAddress
+  case class Ip(ip: InetAddress) extends IpAddress
+  case class ObfuscatedIp(s: String) extends IpAddress
+  case object UnknownIp extends IpAddress
 }

--- a/framework/src/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -8,7 +8,7 @@ import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import play.api.mvc.Headers
 import play.api.{ PlayException, Configuration }
-import play.core.server.common.ForwardedHeaderHandler.ForwardedHeaderHandlerConfig
+import play.core.server.common.ForwardedHeaderHandler._
 
 class ForwardedHeaderHandlerSpec extends Specification {
 
@@ -17,8 +17,75 @@ class ForwardedHeaderHandlerSpec extends Specification {
       handler(version("rfc7240")) must throwA[PlayException]
     }
 
+    "parse rfc7239 entries" in {
+      val results = processHeaders(version("rfc7239") ++ trustedProxies("192.0.2.60/24"), headers(
+        """
+          |Forwarded: for="_gazonk"
+          |Forwarded: For="[2001:db8:cafe::17]:4711"
+          |Forwarded: for=192.0.2.60;proto=http;by=203.0.113.43
+          |Forwarded: for=192.0.2.43, for=198.51.100.17, for=127.0.0.1
+          |Forwarded: for=192.0.2.61;proto=https
+          |Forwarded: for=unknown
+        """.stripMargin
+      ))
+      results.length must_== 8
+      results(0)._1 must_== ForwardedEntry(Some("_gazonk"), None)
+      results(0)._2 must beLeft
+      results(0)._3 must beNone
+      results(1)._1 must_== ForwardedEntry(Some("[2001:db8:cafe::17]:4711"), None)
+      results(1)._2 must beRight(ConnectionInfo(addr("2001:db8:cafe::17"), false))
+      results(1)._3 must beSome(false)
+      results(2)._1 must_== ForwardedEntry(Some("192.0.2.60"), Some("http"))
+      results(2)._2 must beRight(ConnectionInfo(addr("192.0.2.60"), false))
+      results(2)._3 must beSome(true)
+      results(3)._1 must_== ForwardedEntry(Some("192.0.2.43"), None)
+      results(3)._2 must beRight(ConnectionInfo(addr("192.0.2.43"), false))
+      results(3)._3 must beSome(true)
+      results(4)._1 must_== ForwardedEntry(Some("198.51.100.17"), None)
+      results(4)._2 must beRight(ConnectionInfo(addr("198.51.100.17"), false))
+      results(4)._3 must beSome(false)
+      results(5)._1 must_== ForwardedEntry(Some("127.0.0.1"), None)
+      results(5)._2 must beRight(ConnectionInfo(addr("127.0.0.1"), false))
+      results(5)._3 must beSome(false)
+      results(6)._1 must_== ForwardedEntry(Some("192.0.2.61"), Some("https"))
+      results(6)._2 must beRight(ConnectionInfo(addr("192.0.2.61"), true))
+      results(6)._3 must beSome(true)
+      results(7)._1 must_== ForwardedEntry(Some("unknown"), None)
+      results(7)._2 must beLeft
+      results(7)._3 must beNone
+    }
+
+    "parse x-forwarded entries" in {
+      val results = processHeaders(version("x-forwarded") ++ trustedProxies("2001:db8:cafe::17"), headers(
+        """
+          |X-Forwarded-For: 192.168.1.1, ::1, [2001:db8:cafe::17], 127.0.0.1
+          |X-Forwarded-Proto: https, http, https, http
+        """.stripMargin
+      ))
+      results.length must_== 4
+      results(0)._1 must_== ForwardedEntry(Some("192.168.1.1"), Some("https"))
+      results(0)._2 must beRight(ConnectionInfo(addr("192.168.1.1"), true))
+      results(0)._3 must beSome(false)
+      results(1)._1 must_== ForwardedEntry(Some("::1"), Some("http"))
+      results(1)._2 must beRight(ConnectionInfo(addr("::1"), false))
+      results(1)._3 must beSome(false)
+      results(2)._1 must_== ForwardedEntry(Some("[2001:db8:cafe::17]"), Some("https"))
+      results(2)._2 must beRight(ConnectionInfo(addr("2001:db8:cafe::17"), true))
+      results(2)._3 must beSome(true)
+      results(3)._1 must_== ForwardedEntry(Some("127.0.0.1"), Some("http"))
+      results(3)._2 must beRight(ConnectionInfo(addr("127.0.0.1"), false))
+      results(3)._3 must beSome(false)
+    }
+
+    "default to trusting IPv4 and IPv6 localhost with rfc7239 when there is config with default settings" in {
+      handler(version("rfc7239")).remoteConnection(localhost, false, headers(
+        """
+          |Forwarded: for=192.0.2.43;proto=https, for="[::1]"
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.0.2.43"), true)
+    }
+
     "ignore proxy hosts with rfc7239 when no proxies are trusted" in {
-      handler(version("rfc7239") ++ trustedProxies(Nil)).remoteConnection(localhost, false, headers(
+      handler(version("rfc7239") ++ trustedProxies()).remoteConnection(localhost, false, headers(
         """
           |Forwarded: for="_gazonk"
           |Forwarded: For="[2001:db8:cafe::17]:4711"
@@ -48,7 +115,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
     }
 
     "get first untrusted proxy with rfc7239 with trusted proxy subnet" in {
-      handler(version("rfc7239") ++ trustedProxies("192.168.1.1/24" :: "127.0.0.1" :: Nil)).remoteConnection(localhost, false, headers(
+      handler(version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1")).remoteConnection(localhost, false, headers(
         """
           |Forwarded: for="_gazonk"
           |Forwarded: For="[2001:db8:cafe::17]:4711"
@@ -58,7 +125,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
     }
 
     "get first untrusted proxy protocol with rfc7239 with trusted localhost proxy" in {
-      handler(version("rfc7239") ++ trustedProxies("127.0.0.1" :: Nil)).remoteConnection(localhost, false, headers(
+      handler(version("rfc7239") ++ trustedProxies("127.0.0.1")).remoteConnection(localhost, false, headers(
         """
           |Forwarded: for="_gazonk"
           |Forwarded: For="[2001:db8:cafe::17]:4711"
@@ -68,7 +135,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
     }
 
     "get first untrusted proxy protocol with rfc7239 with subnet mask" in {
-      handler(version("rfc7239") ++ trustedProxies("192.168.1.1/24" :: "127.0.0.1" :: Nil)).remoteConnection(localhost, false, headers(
+      handler(version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1")).remoteConnection(localhost, false, headers(
         """
           |Forwarded: for="_gazonk"
           |Forwarded: For="[2001:db8:cafe::17]:4711"
@@ -77,8 +144,115 @@ class ForwardedHeaderHandlerSpec extends Specification {
         """.stripMargin)) mustEqual ConnectionInfo(addr("192.0.2.60"), true)
     }
 
+    "handle IPv6 addresses with rfc7239" in {
+      handler(version("rfc7239") ++ trustedProxies("127.0.0.1")).remoteConnection(localhost, false, headers(
+        """
+          |Forwarded: For=[2001:db8:cafe::17]:4711
+        """.stripMargin)) mustEqual ConnectionInfo(addr("2001:db8:cafe::17"), false)
+    }
+
+    "handle quoted IPv6 addresses with rfc7239" in {
+      handler(version("rfc7239") ++ trustedProxies("127.0.0.1")).remoteConnection(localhost, false, headers(
+        """
+          |Forwarded: For="[2001:db8:cafe::17]:4711"
+        """.stripMargin)) mustEqual ConnectionInfo(addr("2001:db8:cafe::17"), false)
+    }
+
+    "ignore obfuscated addresses with rfc7239" in {
+      handler(version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1")).remoteConnection(localhost, false, headers(
+        """
+          |Forwarded: for="_gazonk"
+          |Forwarded: for=192.168.1.10, for=127.0.0.1
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.168.1.10"), false)
+    }
+
+    "ignore unknown addresses with rfc7239" in {
+      handler(version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1")).remoteConnection(localhost, false, headers(
+        """
+          |Forwarded: for=unknown
+          |Forwarded: for=192.168.1.10, for=127.0.0.1
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.168.1.10"), false)
+    }
+
+    "ignore rfc7239 header with empty addresses" in {
+      handler(version("rfc7239") ++ trustedProxies("192.0.2.43")).remoteConnection(addr("192.0.2.43"), true, headers(
+        """
+          |Forwarded: for=""
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.0.2.43"), true)
+    }
+
+    "partly ignore rfc7239 header with some empty addresses" in {
+      handler(version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1")).remoteConnection(localhost, false, headers(
+        """
+          |Forwarded: for=, for=
+          |Forwarded: for=192.168.1.10, for=127.0.0.1
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.168.1.10"), false)
+    }
+
+    "ignore rfc7239 header field with missing = sign" in {
+      handler(version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1")).remoteConnection(localhost, false, headers(
+        """
+          |Forwarded: for
+          |Forwarded: for=192.168.1.10, for=127.0.0.1
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.168.1.10"), false)
+    }
+
+    "ignore rfc7239 header field with two == signs" in {
+      handler(version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1")).remoteConnection(localhost, false, headers(
+        """
+          |Forwarded: for==
+          |Forwarded: for=192.168.1.10, for=127.0.0.1
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.168.1.10"), false)
+    }
+
+    // This quotation handling is not RFC-compliant but we want to make sure we
+    // at least handle the case gracefully.
+    "don't unquote rfc7239 header field with one \" character" in {
+      handler(version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1")).remoteConnection(localhost, false, headers(
+        """
+          |Forwarded: for==
+          |Forwarded: for=192.168.1.10, for=127.0.0.1
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.168.1.10"), false)
+    }
+
+    // This quotation handling is not RFC-compliant but we want to make sure we
+    // at least handle the case gracefully.
+    "unquote and ignore rfc7239 empty quoted header field" in {
+      handler(version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1")).remoteConnection(localhost, false, headers(
+        """
+          |Forwarded: for=""
+          |Forwarded: for=192.168.1.10, for=127.0.0.1
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.168.1.10"), false)
+    }
+
+    // This quotation handling is not RFC-compliant but we want to make sure we
+    // at least handle the case gracefully.
+    "kind of unquote rfc7239 header field with three \" characters" in {
+      handler(version("rfc7239") ++ trustedProxies("192.168.1.1/24", "127.0.0.1")).remoteConnection(localhost, false, headers(
+        """
+          |Forwarded: for=""" + '"' + '"' + '"' + """
+          |Forwarded: for=192.168.1.10, for=127.0.0.1
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.168.1.10"), false)
+    }
+
+    "default to trusting IPv4 and IPv6 localhost with x-forwarded when there is no config" in {
+      noConfigHandler.remoteConnection(localhost, false, headers(
+        """
+          |X-Forwarded-For: 192.0.2.43, ::1, 127.0.0.1, [::1]
+          |X-Forwarded-Proto: https, http, http, https
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.0.2.43"), true)
+    }
+
+    "trust IPv4 and IPv6 localhost with x-forwarded when there is config with default settings" in {
+      handler(version("x-forwarded")).remoteConnection(localhost, false, headers(
+        """
+          |X-Forwarded-For: 192.0.2.43, ::1
+          |X-Forwarded-Proto: https, https
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.0.2.43"), true)
+    }
+
     "get first untrusted proxy with x-forwarded with subnet mask" in {
-      handler(version("x-forwarded") ++ trustedProxies("192.168.1.1/24" :: "127.0.0.1" :: Nil)).remoteConnection(localhost, false, headers(
+      handler(version("x-forwarded") ++ trustedProxies("192.168.1.1/24", "127.0.0.1")).remoteConnection(localhost, false, headers(
         """
           |X-Forwarded-For: 203.0.113.43, 192.168.1.43
           |X-Forwarded-Proto: https, http
@@ -86,7 +260,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
     }
 
     "not treat the first x-forwarded entry as a proxy even if it is in trustedProxies range" in {
-      handler(version("x-forwarded") ++ trustedProxies("192.168.1.1/24" :: "127.0.0.1" :: Nil)).remoteConnection(localhost, true, headers(
+      handler(version("x-forwarded") ++ trustedProxies("192.168.1.1/24", "127.0.0.1")).remoteConnection(localhost, true, headers(
         """
           |X-Forwarded-For: 192.168.1.2, 192.168.1.3
           |X-Forwarded-Proto: http, http
@@ -94,14 +268,14 @@ class ForwardedHeaderHandlerSpec extends Specification {
     }
 
     "assume http protocol with x-forwarded when proto list is missing" in {
-      handler(version("x-forwarded") ++ trustedProxies("192.168.1.1/24" :: "127.0.0.1" :: Nil)).remoteConnection(localhost, false, headers(
+      handler(version("x-forwarded") ++ trustedProxies("192.168.1.1/24", "127.0.0.1")).remoteConnection(localhost, false, headers(
         """
           |X-Forwarded-For: 203.0.113.43
         """.stripMargin)) mustEqual ConnectionInfo(addr("203.0.113.43"), false)
     }
 
     "assume http protocol with x-forwarded when proto list is shorter than for list" in {
-      handler(version("x-forwarded") ++ trustedProxies("192.168.1.1/24" :: "127.0.0.1" :: Nil)).remoteConnection(localhost, false, headers(
+      handler(version("x-forwarded") ++ trustedProxies("192.168.1.1/24", "127.0.0.1")).remoteConnection(localhost, false, headers(
         """
           |X-Forwarded-For: 203.0.113.43, 192.168.1.43
           |X-Forwarded-Proto: https
@@ -109,7 +283,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
     }
 
     "assume http protocol with x-forwarded when proto list is shorter than for list and all addresses are trusted" in {
-      handler(version("x-forwarded") ++ trustedProxies("0.0.0.0/0" :: Nil)).remoteConnection(localhost, false, headers(
+      handler(version("x-forwarded") ++ trustedProxies("0.0.0.0/0")).remoteConnection(localhost, false, headers(
         """
           |X-Forwarded-For: 203.0.113.43, 192.168.1.43
           |X-Forwarded-Proto: https
@@ -117,14 +291,81 @@ class ForwardedHeaderHandlerSpec extends Specification {
     }
 
     "assume http protocol with x-forwarded when proto list is longer than for list" in {
-      handler(version("x-forwarded") ++ trustedProxies("192.168.1.1/24" :: "127.0.0.1" :: Nil)).remoteConnection(localhost, false, headers(
+      handler(version("x-forwarded") ++ trustedProxies("192.168.1.1/24", "127.0.0.1")).remoteConnection(localhost, false, headers(
         """
           |X-Forwarded-For: 203.0.113.43, 192.168.1.43
           |X-Forwarded-Proto: https, https, https
         """.stripMargin)) mustEqual ConnectionInfo(addr("203.0.113.43"), false)
     }
 
+    "assume http protocol with x-forwarded when proto is unrecognized" in {
+      handler(version("x-forwarded") ++ trustedProxies("127.0.0.1")).remoteConnection(localhost, false, headers(
+        """
+          |X-Forwarded-For: 203.0.113.43
+          |X-Forwarded-Proto: smtp
+        """.stripMargin)) mustEqual ConnectionInfo(addr("203.0.113.43"), false)
+    }
+
+    "fall back to connection when single x-forwarded-for entry cannot be parsed" in {
+      handler(version("x-forwarded") ++ trustedProxies("127.0.0.1")).remoteConnection(localhost, false, headers(
+        """
+          |X-Forwarded-For: ???
+        """.stripMargin)) mustEqual ConnectionInfo(localhost, false)
+    }
+
+    // example from issue #5299
+    "handle single unquoted IPv6 addresses in x-forwarded-for headers" in {
+      handler(version("x-forwarded") ++ trustedProxies("127.0.0.1")).remoteConnection(localhost, false, headers(
+        """
+          |X-Forwarded-For: ::1
+        """.stripMargin)) mustEqual ConnectionInfo(addr("::1"), false)
+    }
+
+    // example from RFC 7239 section 7.4
+    "handle unquoted IPv6 addresses in x-forwarded-for headers" in {
+      handler(version("x-forwarded") ++ trustedProxies("127.0.0.1", "2001:db8:cafe::17")).remoteConnection(localhost, false, headers(
+        """
+          |X-Forwarded-For: 192.0.2.43, 2001:db8:cafe::17
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.0.2.43"), false)
+    }
+
+    // We're really forgiving about quoting for X-Forwarded-For headers,
+    // since there isn't a real spec to follow.
+    "handle lots of different IPv6 address quoting in x-forwarded-for headers" in {
+      handler(version("x-forwarded")).remoteConnection(localhost, false, headers(
+        """
+          |X-Forwarded-For: 192.0.2.43, "::1", ::1, "[::1]", [::1]
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.0.2.43"), false)
+    }
+
+    // We're really forgiving about quoting for X-Forwarded-For headers,
+    // since there isn't a real spec to follow.
+    "handle lots of different IPv6 address and proto quoting in x-forwarded-for headers" in {
+      handler(version("x-forwarded")).remoteConnection(localhost, false, headers(
+        """
+          |X-Forwarded-For: 192.0.2.43, "::1", ::1, "[::1]", [::1]
+          |X-Forwarded-Proto: "https", http, http,    "http", http
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.0.2.43"), true)
+    }
+
+    "ignore x-forward header with empty addresses" in {
+      handler(version("x-forwarded") ++ trustedProxies("192.0.2.43")).remoteConnection(addr("192.0.2.43"), true, headers(
+        """
+          |X-Forwarded-For: ,,
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.0.2.43"), true)
+    }
+
+    "partly ignore x-forward header with some empty addresses" in {
+      handler(version("x-forwarded")).remoteConnection(localhost, false, headers(
+        """
+          |X-Forwarded-For: ,,192.0.2.43
+        """.stripMargin)) mustEqual ConnectionInfo(addr("192.0.2.43"), false)
+    }
+
   }
+
+  def noConfigHandler =
+    new ForwardedHeaderHandler(ForwardedHeaderHandlerConfig(None))
 
   def handler(config: Map[String, Any]) =
     new ForwardedHeaderHandler(ForwardedHeaderHandlerConfig(Some(Configuration.from(config))))
@@ -133,7 +374,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
     Map("play.http.forwarded.version" -> s)
   }
 
-  def trustedProxies(s: List[String]) = {
+  def trustedProxies(s: String*) = {
     Map("play.http.forwarded.trustedProxies" -> s)
   }
 
@@ -145,6 +386,18 @@ class ForwardedHeaderHandlerSpec extends Specification {
     }
 
     new Headers(s.split("\n").flatMap(split(_, ":\\s*")))
+  }
+
+  def processHeaders(config: Map[String, Any], headers: Headers): Seq[(ForwardedEntry, Either[String, ConnectionInfo], Option[Boolean])] = {
+    val configuration = ForwardedHeaderHandlerConfig(Some(Configuration.from(config)))
+    configuration.forwardedHeaders(headers).map { forwardedEntry =>
+      val errorOrConnection = configuration.parseEntry(forwardedEntry)
+      val trusted = errorOrConnection match {
+        case Left(_) => None
+        case Right(connection) => Some(configuration.isTrustedProxy(connection))
+      }
+      (forwardedEntry, errorOrConnection, trusted)
+    }
   }
 
   def addr(ip: String): InetAddress = InetAddress.getByName(ip)

--- a/framework/src/play-server/src/test/scala/play/core/server/common/NodeIdentifierParserSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/NodeIdentifierParserSpec.scala
@@ -2,33 +2,49 @@ package play.core.server.common
 
 import java.net.InetAddress.getByName
 import org.specs2.mutable.Specification
-import play.core.server.common.NodeIdentifierParser._
+
+import ForwardedHeaderHandler.{ ForwardedHeaderVersion, Rfc7239, Xforwarded }
+import NodeIdentifierParser._
 
 class NodeIdentifierParserSpec extends Specification {
+
+  def parseNode(version: ForwardedHeaderVersion, str: String) = {
+    val parser = new NodeIdentifierParser(version)
+    parser.parseNode(str)
+  }
+
   "NodeIdentifierParser" should {
 
     "parse an ip v6 address with port" in {
-      parseNode("[8F:F3B::FF]:9000").right.get mustEqual Ip(getByName("8F:F3B::FF")) -> Some(PortNumber(9000))
+      parseNode(Rfc7239, "[8F:F3B::FF]:9000") must beRight(Ip(getByName("8F:F3B::FF")) -> Some(PortNumber(9000)))
+    }
+
+    "not parse unescaped ip v6 address in rfc7239 header" in {
+      parseNode(Rfc7239, "8F:F3B::FF") must beLeft
+    }
+
+    "parse unescaped ip v6 address in x-forwarded-for header" in {
+      parseNode(Xforwarded, "8F:F3B::FF") must beRight(Ip(getByName("8F:F3B::FF")) -> None)
     }
 
     "parse an ip v6 address with obfuscated port" in {
-      parseNode("[::FF]:_obf").right.get mustEqual Ip(getByName("::FF")) -> Some(ObfuscatedPort("_obf"))
+      parseNode(Rfc7239, "[::FF]:_obf") must beRight(Ip(getByName("::FF")) -> Some(ObfuscatedPort("_obf")))
     }
 
     "parse an ip v4 address with port" in {
-      parseNode("127.0.0.1:8080").right.get mustEqual Ip(getByName("127.0.0.1")) -> Some(PortNumber(8080))
+      parseNode(Rfc7239, "127.0.0.1:8080") must beRight(Ip(getByName("127.0.0.1")) -> Some(PortNumber(8080)))
     }
 
     "parse an ip v4 address without port" in {
-      parseNode("192.168.0.1").right.get mustEqual Ip(getByName("192.168.0.1")) -> None
+      parseNode(Rfc7239, "192.168.0.1") must beRight(Ip(getByName("192.168.0.1")) -> None)
     }
 
     "parse an unknown ip address without port" in {
-      parseNode("unknown").right.get mustEqual UnknownIp -> None
+      parseNode(Rfc7239, "unknown") must beRight(UnknownIp -> None)
     }
 
     "parse an obfuscated ip address without port" in {
-      parseNode("_harry").right.get mustEqual ObfuscatedIp("_harry") -> None
+      parseNode(Rfc7239, "_harry") must beRight(ObfuscatedIp("_harry") -> None)
     }
   }
 }

--- a/framework/src/play-server/src/test/scala/play/core/server/common/SubnetSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/SubnetSpec.scala
@@ -16,7 +16,8 @@ class SubnetSpec extends Specification with DataTables {
         "fe80::/64" !! "fe80::54ff:fffe:32fe" ! true |
         "2001:db8::/32" !! "2001:db9::1" ! false |
         "2001:dbfe::/31" !! "2001:dbff::" ! true |
-        "2001:dbfe::/31" !! "2001:dbff::" ! true |>
+        "2001:dbfe::/31" !! "2001:dbff::" ! true |
+        "2001:db8:cafe::17" !! "2001:db8:cafe::17" ! true |>
         {
           (a, b, c) => Subnet(a).isInRange(InetAddress.getByName(b)) mustEqual c
         }


### PR DESCRIPTION
Fixes #5299.

Parsing for `Forward` and `X-Forwarded-*` headers no longer throws exceptions if an invalid header is found. Now a debug log message is thrown instead. This reverses the stricter errors introduced in #5266.

Additional changes were made:
- Don't bother parsing the supplied IP address headers if we don't trust the connection that supplied it.
- Support values in Forward headers surrounded with double quotes. This is needed to support IPv6.
- Support IPv6 values in X-Forwarded-For headers even when they don't have surrounding square brackets. This format is commonly supplied by proxies.