### PR TITLE
Allow devSettings to change port

### DIFF
--- a/documentation/manual/detailedTopics/configuration/Configuration.md
+++ b/documentation/manual/detailedTopics/configuration/Configuration.md
@@ -32,7 +32,7 @@ There are a couple of special things to know about configuration when running yo
 You can configure extra settings for the `run` command in your `build.sbt`. These settings won't be used when you deploy your application.
 
 ```
-devSettings := Map("play.server.http.port" -> "8080")
+PlayKeys.devSettings := Seq("play.server.http.port" -> "8080")
 ```
 
 ### HTTP server settings in `application.conf`

--- a/framework/src/fork-run/src/main/scala/play/forkrun/ForkRun.scala
+++ b/framework/src/fork-run/src/main/scala/play/forkrun/ForkRun.scala
@@ -115,7 +115,8 @@ object ForkRun {
 
   // reparse args to support https urls
   def serverUrl(args: Seq[String], defaultHttpPort: Int, defaultHttpAddress: String, address: InetSocketAddress): String = {
-    val (properties, httpPort, httpsPort, httpAddress) = Reloader.filterArgs(args, defaultHttpPort, defaultHttpAddress)
+    val devSettings: Seq[(String, String)] = Seq.empty
+    val (properties, httpPort, httpsPort, httpAddress) = Reloader.filterArgs(args, defaultHttpPort, defaultHttpAddress, devSettings)
     val host = if (httpAddress == "0.0.0.0") "localhost" else httpAddress
     if (httpPort.isDefined) s"http://$host:${httpPort.get}"
     else if (httpsPort.isDefined) s"https://$host:${httpsPort.get}"

--- a/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -63,7 +63,10 @@ object Reloader {
     }
   }
 
-  def filterArgs(args: Seq[String], defaultHttpPort: Int, defaultHttpAddress: String): (Seq[(String, String)], Option[Int], Option[Int], String) = {
+  def filterArgs(args: Seq[String],
+    defaultHttpPort: Int,
+    defaultHttpAddress: String,
+    devSettings: Seq[(String, String)]): (Seq[(String, String)], Option[Int], Option[Int], String) = {
     val (propertyArgs, otherArgs) = args.partition(_.startsWith("-D"))
 
     val properties = propertyArgs.map(_.drop(2).split('=')).map(a => a(0) -> a(1)).toSeq
@@ -81,15 +84,16 @@ object Reloader {
 
     // http port can be defined as the first non-property argument, or a -Dhttp.port argument or system property
     // the http port can be disabled (set to None) by setting any of the input methods to "disabled"
-    val httpPortString = otherArgs.headOption orElse prop("http.port")
-    val httpPort = parsePortValue(httpPortString, Option(defaultHttpPort))
+    // Or it can be defined in devSettings as "play.server.http.port"
+    val httpPortString: Option[String] = otherArgs.headOption orElse prop("http.port") orElse devSettings.toMap.get("play.server.http.port")
+    val httpPort: Option[Int] = parsePortValue(httpPortString, Option(defaultHttpPort))
 
     // https port can be defined as a -Dhttps.port argument or system property
-    val httpsPortString = prop("https.port")
+    val httpsPortString: Option[String] = prop("https.port") orElse devSettings.toMap.get("play.server.https.port")
     val httpsPort = parsePortValue(httpsPortString)
 
     // http address can be defined as a -Dhttp.address argument or system property
-    val httpAddress = prop("http.address") getOrElse defaultHttpAddress
+    val httpAddress = prop("http.address") orElse devSettings.toMap.get("play.server.http.address") getOrElse defaultHttpAddress
 
     (properties, httpPort, httpsPort, httpAddress)
   }
@@ -134,7 +138,7 @@ object Reloader {
     devSettings: Seq[(String, String)], args: Seq[String],
     runSbtTask: String => AnyRef, mainClassName: String): PlayDevServer = {
 
-    val (properties, httpPort, httpsPort, httpAddress) = filterArgs(args, defaultHttpPort, defaultHttpAddress)
+    val (properties, httpPort, httpsPort, httpAddress) = filterArgs(args, defaultHttpPort, defaultHttpAddress, devSettings)
     val systemProperties = extractSystemProperties(javaOptions)
 
     require(httpPort.isDefined || httpsPort.isDefined, "You have to specify https.port when http.port is disabled")

--- a/framework/src/run-support/src/test/scala/play/runsupport/FilterArgsSpec.scala
+++ b/framework/src/run-support/src/test/scala/play/runsupport/FilterArgsSpec.scala
@@ -15,9 +15,10 @@ object FilterArgsSpec extends Specification {
     properties: Seq[(String, String)] = Seq.empty,
     httpPort: Option[Int] = Some(defaultHttpPort),
     httpsPort: Option[Int] = None,
-    httpAddress: String = defaultHttpAddress): Result = {
+    httpAddress: String = defaultHttpAddress,
+    devSettings: Seq[(String, String)] = Seq.empty): Result = {
 
-    val result = Reloader.filterArgs(args, defaultHttpPort, defaultHttpAddress)
+    val result = Reloader.filterArgs(args, defaultHttpPort, defaultHttpAddress, devSettings)
     result must_== ((properties, httpPort, httpsPort, httpAddress))
   }
 
@@ -35,11 +36,17 @@ object FilterArgsSpec extends Specification {
       )
     }
 
-    "support port property" in {
+    "support port property with system property" in {
       check("-Dhttp.port=1234")(
         properties = Seq("http.port" -> "1234"),
         httpPort = Some(1234)
       )
+    }
+
+    "support port property with dev setting" in {
+      val devSettings: Seq[(String, String)] = Seq("play.server.http.port" -> "1234")
+      val result = Reloader.filterArgs(Seq.empty, defaultHttpPort, defaultHttpAddress, devSettings)
+      result must_== ((Seq.empty, Some(1234), None, defaultHttpAddress))
     }
 
     "support disabled port property" in {
@@ -64,6 +71,12 @@ object FilterArgsSpec extends Specification {
       )
     }
 
+    "support https port property with dev setting" in {
+      val devSettings: Seq[(String, String)] = Seq("play.server.https.port" -> "1234")
+      val result = Reloader.filterArgs(Seq.empty, defaultHttpPort, defaultHttpAddress, devSettings)
+      result must_== ((Seq.empty, Some(9000), Some(1234), defaultHttpAddress))
+    }
+
     "support https disabled" in {
       check("-Dhttps.port=disabled", "-Dhttp.port=1234")(
         properties = Seq("https.port" -> "disabled", "http.port" -> "1234"),
@@ -77,6 +90,12 @@ object FilterArgsSpec extends Specification {
         properties = Seq("http.address" -> "localhost"),
         httpAddress = "localhost"
       )
+    }
+
+    "support address property with dev setting" in {
+      val devSettings: Seq[(String, String)] = Seq("play.server.http.address" -> "not-default-address")
+      val result = Reloader.filterArgs(Seq.empty, defaultHttpPort, defaultHttpAddress, devSettings)
+      result must_== ((Seq.empty, Some(9000), None, "not-default-address"))
     }
 
     "support all options" in {

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -205,9 +205,10 @@ object PlayRun {
 
     val filter = Set("--no-exit-sbt")
     val filtered = args.filterNot(filter)
+    val devSettings = Seq.empty[(String, String)] // there are no dev settings in a prod website
 
     // Parse HTTP port argument
-    val (properties, httpPort, httpsPort, httpAddress) = Reloader.filterArgs(filtered, extracted.get(playDefaultPort), extracted.get(playDefaultAddress))
+    val (properties, httpPort, httpsPort, httpAddress) = Reloader.filterArgs(filtered, extracted.get(playDefaultPort), extracted.get(playDefaultAddress), devSettings)
     require(httpPort.isDefined || httpsPort.isDefined, "You have to specify https.port when http.port is disabled")
 
     Project.runTask(stage, state).get._2.toEither match {


### PR DESCRIPTION
Adds devSettings into filterArgs so that the port can be changed from build.sbt.

Fixes https://github.com/playframework/playframework/issues/4629