### PR TITLE
Move implicit instances definitions in companion objects

### DIFF
--- a/framework/src/play-functional/src/main/scala/play/api/libs/functional/Applicative.scala
+++ b/framework/src/play-functional/src/main/scala/play/api/libs/functional/Applicative.scala
@@ -13,6 +13,20 @@ trait Applicative[M[_]] {
 
 }
 
+object Applicative {
+
+  implicit val applicativeOption: Applicative[Option] = new Applicative[Option] {
+
+    def pure[A](a: A): Option[A] = Some(a)
+
+    def map[A, B](m: Option[A], f: A => B): Option[B] = m.map(f)
+
+    def apply[A, B](mf: Option[A => B], ma: Option[A]): Option[B] = mf.flatMap(f => ma.map(f))
+
+  }
+
+}
+
 class ApplicativeOps[M[_], A](ma: M[A])(implicit a: Applicative[M]) {
 
   def ~>[B](mb: M[B]): M[B] = a(a(a.pure((_: A) => (b: B) => b), ma), mb)

--- a/framework/src/play-functional/src/main/scala/play/api/libs/functional/Functors.scala
+++ b/framework/src/play-functional/src/main/scala/play/api/libs/functional/Functors.scala
@@ -13,6 +13,14 @@ trait Functor[M[_]] extends Variant[M] {
 
 }
 
+object Functor {
+
+  implicit val functorOption: Functor[Option] = new Functor[Option] {
+    def fmap[A, B](a: Option[A], f: A => B): Option[B] = a.map(f)
+  }
+
+}
+
 trait InvariantFunctor[M[_]] extends Variant[M] {
 
   def inmap[A, B](m: M[A], f1: A => B, f2: B => A): M[B]

--- a/framework/src/play-functional/src/main/scala/play/api/libs/functional/Monoid.scala
+++ b/framework/src/play-functional/src/main/scala/play/api/libs/functional/Monoid.scala
@@ -10,6 +10,13 @@ trait Monoid[A] {
 
 }
 
+object Monoid {
+  implicit def endomorphismMonoid[A]: Monoid[A => A] = new Monoid[A => A] {
+    override def append(f1: A => A, f2: A => A) = f2 compose f1
+    override def identity = Predef.identity
+  }
+}
+
 class MonoidOps[A](m1: A)(implicit m: Monoid[A]) {
   def |+|(m2: A): A = m.append(m1, m2)
 }

--- a/framework/src/play-functional/src/main/scala/play/api/libs/functional/Products.scala
+++ b/framework/src/play-functional/src/main/scala/play/api/libs/functional/Products.scala
@@ -13,6 +13,15 @@ trait FunctionalCanBuild[M[_]] {
 
 }
 
+object FunctionalCanBuild {
+
+implicit def functionalCanBuildApplicative[M[_]](implicit app: Applicative[M]): FunctionalCanBuild[M] =
+  new FunctionalCanBuild[M] {
+    def apply[A, B](a: M[A], b: M[B]): M[A ~ B] = app.apply(app.map[A, B => A ~ B](a, a => ((b: B) => new ~(a, b))), b)
+  }
+
+}
+
 class FunctionalBuilderOps[M[_], A](ma: M[A])(implicit fcb: FunctionalCanBuild[M]) {
 
   def ~[B](mb: M[B]): FunctionalBuilder[M]#CanBuild2[A, B] = {

--- a/framework/src/play-functional/src/main/scala/play/api/libs/functional/syntax/package.scala
+++ b/framework/src/play-functional/src/main/scala/play/api/libs/functional/syntax/package.scala
@@ -20,40 +20,13 @@ object `package` {
 
   implicit def toFunctionalBuilderOps[M[_], A](a: M[A])(implicit fcb: FunctionalCanBuild[M]) = new FunctionalBuilderOps[M, A](a)(fcb)
 
-  implicit def functionalCanBuildApplicative[M[_]](implicit app: Applicative[M]): FunctionalCanBuild[M] = new FunctionalCanBuild[M] {
-
-    def apply[A, B](a: M[A], b: M[B]): M[A ~ B] = app.apply(app.map[A, B => A ~ B](a, a => ((b: B) => new ~(a, b))), b)
-
-  }
-
-  implicit def functorOption: Functor[Option] = new Functor[Option] {
-
-    def fmap[A, B](a: Option[A], f: A => B): Option[B] = a.map(f)
-
-  }
-
-  implicit def applicativeOption: Applicative[Option] = new Applicative[Option] {
-
-    def pure[A](a: A): Option[A] = Some(a)
-
-    def map[A, B](m: Option[A], f: A => B): Option[B] = m.map(f)
-
-    def apply[A, B](mf: Option[A => B], ma: Option[A]): Option[B] = mf.flatMap(f => ma.map(f))
-
-  }
-
-  implicit def functionMonoid[A] = new Monoid[A => A] {
-    override def append(f1: A => A, f2: A => A) = f2 compose f1
-    override def identity = Predef.identity
-  }
-
   implicit def toMonoidOps[A](a: A)(implicit m: Monoid[A]): MonoidOps[A] = new MonoidOps(a)
 
   implicit def toFunctorOps[M[_], A](ma: M[A])(implicit fu: Functor[M]): FunctorOps[M, A] = new FunctorOps(ma)
   implicit def toContraFunctorOps[M[_], A](ma: M[A])(implicit fu: ContravariantFunctor[M]): ContravariantFunctorOps[M, A] = new ContravariantFunctorOps(ma)
   implicit def toInvariantFunctorOps[M[_], A](ma: M[A])(implicit fu: InvariantFunctor[M]): InvariantFunctorOps[M, A] = new InvariantFunctorOps(ma)
 
-  def unapply[B, A](f: B => Option[A]) = { b: B => f(b).get }
+  def unapply[B, A](f: B => Option[A]): B => A = { b: B => f(b).get }
 
   def unlift[A, B](f: A => Option[B]): A => B = Function.unlift(f)
 


### PR DESCRIPTION
Every now and again, I ask for an implicit `FunctionalCanBuild[F]` for some `F` who as an implicit `Applicative[F]` instance and can not get it unless I explicitly import `play.api.libs.functional.syntax.functionalCanBuildApplicative`.

This PR fixes this situation so that no additional import is required. By the way, I also moved some other instances (of `Functor`, `Applicative` and `Monoid`) in thteir companion objects.