### PR TITLE
Update SubProjectsAssetsBuilder.scala

### DIFF
--- a/documentation/manual/detailedTopics/build/code/SubProjectsAssetsBuilder.scala
+++ b/documentation/manual/detailedTopics/build/code/SubProjectsAssetsBuilder.scala
@@ -1,5 +1,5 @@
 //#assets-builder
 package controllers.admin
 import play.api.http.LazyHttpErrorHandler
-object Assets extends controllers.AssetsBuilder(LazyHttpErrorHandler)
+class Assets extends controllers.AssetsBuilder(LazyHttpErrorHandler)
 //#assets-builder


### PR DESCRIPTION
Declaring Assets as object doesn't work in Play 2.4.x. It should be defined as a class in order that it works correctly