### PR TITLE
Don't add manual content length and type headers

### DIFF
--- a/framework/src/play-docs/src/main/scala/play/docs/DocumentationHandler.scala
+++ b/framework/src/play-docs/src/main/scala/play/docs/DocumentationHandler.scala
@@ -48,13 +48,8 @@ class DocumentationHandler(repo: FileRepository, apiRepo: FileRepository) extend
 
     // Assumes caller consumes result, closing entry
     def sendFileInline(repo: FileRepository, path: String): Option[Result] = {
-      import play.api.libs.concurrent.Execution.Implicits.defaultContext
       repo.handleFile(path) { handle =>
-        Result(
-          ResponseHeader(Status.OK, Map(
-            HeaderNames.CONTENT_LENGTH -> handle.size.toString,
-            HeaderNames.CONTENT_TYPE -> play.api.libs.MimeTypes.forFileName(handle.name).getOrElse(play.api.http.ContentTypes.BINARY)
-          )),
+        Results.Ok.sendEntity(
           HttpEntity.Streamed(
             Source(Streams.enumeratorToPublisher(Enumerator.fromStream(handle.is) &> Enumeratee.onIterateeDone(handle.close)))
               .map(ByteString.apply),


### PR DESCRIPTION
The docs server was manually adding content length and type headers, as well as attaching them to the entity, which resulted in warnings in the logs like these:

```
16:19:56.174 [application-akka.actor.default-dispatcher-2] WARN  p.c.s.netty.NettyModelConversion - Content-Length header was set manually in the header, ignoring manual header
16:19:56.174 [application-akka.actor.default-dispatcher-7] WARN  p.c.s.netty.NettyModelConversion - Content-Type set both in header (text/css) and attached to entity (text/css), ignoring content type from entity. To remove this warning, use Result.as(...) to set the content type, rather than setting the header manually.
```