### PR TITLE
Do not include netty-transport-native-epoll automatically

### DIFF
--- a/documentation/manual/detailedTopics/configuration/SettingsNetty.md
+++ b/documentation/manual/detailedTopics/configuration/SettingsNetty.md
@@ -22,6 +22,15 @@ play.server {
 }
 ```
 
+You need as well to add `netty-transport-native-epoll` as a dependency:
+
+```scala
+libraryDependencies ++= Seq(
+    "io.netty" % "netty-transport-native-epoll" % "4.0.33.final" classifier "linux-x86_64"
+)
+```
+
+
 ## Configuring channel options
 
 The available options are defined in [Netty channel option documentation](http://netty.io/4.0/api/io/netty/channel/ChannelOption.htm).

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -140,13 +140,8 @@ object Dependencies {
     specsBuild.map(_ % Test) ++ logback.map(_ % Test) ++
     javaTestDeps
 
-  val nettyVersion = "4.0.33.Final"
-
   val netty = Seq(
-    "com.typesafe.netty" % "netty-reactive-streams-http" % "1.0.0",
-    "io.netty" % "netty-handler" % nettyVersion,
-    "io.netty" % "netty-codec-http" % nettyVersion,
-    "io.netty" % "netty-transport-native-epoll" % nettyVersion classifier "linux-x86_64"
+    "com.typesafe.netty" % "netty-reactive-streams-http" % "1.0.1"
   ) ++ specsBuild.map(_ % Test)++ logback.map(_ % Test)
 
   val nettyUtilsDependencies = slf4j


### PR DESCRIPTION
When [adding support for netty native socket transport](https://github.com/playframework/playframework/pull/5273/files) we included a dependency to `netty-transport-native-epoll` with a classifier. But as the build is on `linux` the dependency was always added to the build package which is not what was intended. The associated changes remove that dependency and explain in the documentation that it should be rather added as a app library dependency.

The changes also update `netty-reactive-streams` to `1.0.1` which includes `netty` `4.0.33.final` and fixes #5331 

  