### PR TITLE
Cross-build support for routes compiler

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -184,12 +184,20 @@ object PlayBuild extends Build {
       libraryDependencies ++= runSupportDependencies(sbtVersion.value, scalaVersion.value)
     ).dependsOn(BuildLinkProject)
 
-  lazy val RoutesCompilerProject = PlaySbtProject("Routes-Compiler", "routes-compiler")
+  lazy val RoutesCompilerProject = PlayDevelopmentProject("Routes-Compiler", "routes-compiler")
     .enablePlugins(SbtTwirl)
     .settings(
-      libraryDependencies ++= routesCompilerDependencies,
+      libraryDependencies ++= routesCompilerDependencies(scalaVersion.value),
       TwirlKeys.templateFormats := Map("twirl" -> "play.routes.compiler.ScalaFormat")
     )
+
+  lazy val SbtRoutesCompilerProject = PlaySbtProject("SBT-Routes-Compiler", "routes-compiler")
+    .enablePlugins(SbtTwirl)
+    .settings(
+      target := target.value / "sbt-routes-compiler",
+      libraryDependencies ++= routesCompilerDependencies(scalaVersion.value),
+      TwirlKeys.templateFormats := Map("twirl" -> "play.routes.compiler.ScalaFormat")
+  )
 
   lazy val IterateesProject = PlayCrossBuiltProject("Play-Iteratees", "iteratees")
     .settings(libraryDependencies ++= iterateesDependencies)
@@ -325,7 +333,7 @@ object PlayBuild extends Build {
         val () = publishLocal.value
         val () = (publishLocal in RoutesCompilerProject).value
       }
-    ).dependsOn(RoutesCompilerProject, SbtRunSupportProject)
+    ).dependsOn(SbtRoutesCompilerProject, SbtRunSupportProject)
 
   lazy val ForkRunProtocolProject = PlayDevelopmentProject("Fork-Run-Protocol", "fork-run-protocol")
     .settings(
@@ -356,7 +364,7 @@ object PlayBuild extends Build {
       scriptedDependencies := {
         val () = publishLocal.value
         val () = (publishLocal in SbtPluginProject).value
-        val () = (publishLocal in RoutesCompilerProject).value
+        val () = (publishLocal in SbtRoutesCompilerProject).value
       })
     .dependsOn(SbtForkRunProtocolProject, SbtPluginProject)
 
@@ -421,6 +429,7 @@ object PlayBuild extends Build {
     DataCommonsProject,
     JsonProject,
     RoutesCompilerProject,
+    SbtRoutesCompilerProject,
     PlayAkkaHttpServerProject,
     PlayCacheProject,
     PlayJdbcApiProject,

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -59,7 +59,10 @@ object Dependencies {
   val javassist = link
 
   val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.7.0"
-  val scalaParserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.1"
+  def scalaParserCombinators(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, major)) if major >= 11 => Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4")
+    case _ => Nil
+  }
 
   val springFrameworkVersion = "4.1.6.RELEASE"
 
@@ -134,9 +137,8 @@ object Dependencies {
       guava % Test,
 
       "org.scala-lang" % "scala-reflect" % scalaVersion,
-      scalaParserCombinators,
       scalaJava8Compat
-    ) ++
+    ) ++ scalaParserCombinators(scalaVersion) ++
     specsBuild.map(_ % Test) ++ logback.map(_ % Test) ++
     javaTestDeps
 
@@ -152,10 +154,10 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-http-core-experimental" % "1.0"
   )
 
-  val routesCompilerDependencies =  Seq(
+  def routesCompilerDependencies(scalaVersion: String) = Seq(
     "commons-io" % "commons-io" % "2.4",
     specsMatcherExtra % Test
-  ) ++ specsBuild.map(_ % Test) ++ logback.map(_ % Test)
+  ) ++ specsBuild.map(_ % Test) ++ logback.map(_ % Test) ++ scalaParserCombinators(scalaVersion)
 
   private def sbtPluginDep(sbtVersion: String, scalaVersion: String, moduleId: ModuleID) = {
     moduleId.extra(


### PR DESCRIPTION
Builds the routes compiler library for 2.11 as well as 2.10. Based on @jroper's [suggestion](https://github.com/playframework/playframework/pull/5291#issuecomment-160805748).

See #5290 and #5291.