### PR TITLE
Remove internal references to deprecated play.api.Play.* methods

### DIFF
--- a/documentation/manual/releases/release25/Migration25.md
+++ b/documentation/manual/releases/release25/Migration25.md
@@ -240,3 +240,39 @@ routesGenerator := StaticRoutesGenerator
 ```
 
 to your `build.sbt` file.
+
+## Deprecated play.Play and play.api.Play methods
+
+The following methods have been deprecated in `play.Play`:
+
+* `public static Application application()`
+* `public static Mode mode()`
+* `public static boolean isDev()`
+* `public static boolean isProd()`
+* `public static boolean isTest()`
+
+Likewise, methods in `play.api.Play` that take an implicit `Application` and delegate to Application, such as `def classloader(implicit app: Application)` are now deprecated.
+
+### How to migrate
+
+These methods delegate to either `play.Application` or `play.Environment` -- code that uses them should use dependency injection to inject the relevant class.
+
+For example, the following code injects an application into a Controller in Scala:
+
+```
+class HomeController @Inject() (app: play.api.Application, configuration: play.api.Configuration) extends Controller {
+
+  def index = Action {
+    Ok(views.html.index("Your new application is ready."))
+  }
+
+  def config = Action {
+    Ok(configuration.underlying.getString("some.config"))
+  }
+
+  def count = Action {
+    val num = app.resource("application.conf").toSeq.size
+    Ok(num.toString)
+  }
+}
+```

--- a/documentation/manual/working/commonGuide/configuration/code/detailedtopics/ThreadPoolsJava.java
+++ b/documentation/manual/working/commonGuide/configuration/code/detailedtopics/ThreadPoolsJava.java
@@ -15,12 +15,13 @@ public class ThreadPoolsJava {
 
     @Test
     public void usingAppClassLoader() throws Exception {
-        running(fakeApplication(), new Runnable() {
+        final FakeApplication app = fakeApplication();
+        running(app, new Runnable() {
             public void run() {
                 String myClassName = "java.lang.String";
                 try {
                     //#using-app-classloader
-                    Class myClass = Play.application().classloader().loadClass(myClassName);
+                    Class myClass = app.classloader().loadClass(myClassName);
                     //#using-app-classloader
                     assertThat(myClass, notNullValue());
                 } catch (ClassNotFoundException e) {

--- a/framework/src/play-cache/src/main/java/play/cache/Cache.java
+++ b/framework/src/play-cache/src/main/java/play/cache/Cache.java
@@ -11,7 +11,7 @@ import java.util.concurrent.Callable;
 public class Cache {
 
     private static CacheApi cacheApi() {
-        return play.Play.application().injector().instanceOf(CacheApi.class);
+        return play.api.Play.current().injector().instanceOf(CacheApi.class);
     }
 
     /**

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
@@ -4,6 +4,8 @@
 package play.db.jpa;
 
 import play.*;
+import play.api.Application;
+import play.api.Play;
 import play.libs.F;
 import play.mvc.Http;
 
@@ -59,11 +61,7 @@ public class JPA {
      * @return the JPAApi
      */
     public static JPAApi jpaApi() {
-        Application app = Play.application();
-        if (app == null) {
-            throw new RuntimeException("No application running");
-        }
-        return app.injector().instanceOf(JPAApi.class);
+        return Play.current().injector().instanceOf(JPAApi.class);
     }
 
     /**

--- a/framework/src/play-java-ws/src/main/java/play/libs/openid/OpenID.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/openid/OpenID.java
@@ -21,7 +21,7 @@ import play.mvc.Http.Request;
 public class OpenID {
 
     private static OpenIdClient client() {
-        return Play.application().injector().instanceOf(OpenIdClient.class);
+        return play.api.Play.current().injector().instanceOf(OpenIdClient.class);
     }
 
     /**

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WS.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WS.java
@@ -28,8 +28,7 @@ public class WS {
      */
     @Deprecated
     public static WSClient client() {
-        Application app = play.Play.application();
-        return app.injector().instanceOf(WSClient.class);
+        return play.api.Play.current().injector().instanceOf(WSClient.class);
     }
 
     /**

--- a/framework/src/play-java/src/main/java/play/libs/Yaml.java
+++ b/framework/src/play-java/src/main/java/play/libs/Yaml.java
@@ -8,6 +8,8 @@ import java.util.*;
 
 import org.yaml.snakeyaml.*;
 import org.yaml.snakeyaml.constructor.*;
+import play.Application;
+import play.api.Play;
 
 /**
  * Yaml utilities.
@@ -18,9 +20,11 @@ public class Yaml {
      * Load a Yaml file from the classpath.
      */
     public static Object load(String resourceName) {
+        final Application application = Play.current().injector().instanceOf(Application.class);
+
         return load(
-            play.Play.application().resourceAsStream(resourceName),
-            play.Play.application().classloader()
+            application.resourceAsStream(resourceName),
+            application.classloader()
         );
     }
     

--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -55,8 +55,9 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
             play.api.mvc.Action action = (play.api.mvc.Action) handler;
             return wrapScalaResult(action.apply(requestBuilder._underlyingRequest()), timeout);
         } else if (handler instanceof JavaHandler) {
+            final play.api.inject.Injector injector = play.api.Play.current().injector();
             return invokeHandler(
-                ((JavaHandler) handler).withComponents(Play.application().injector().instanceOf(JavaHandlerComponents.class)),
+                ((JavaHandler) handler).withComponents(injector.instanceOf(JavaHandlerComponents.class)),
                 requestBuilder, timeout
             );
         } else {
@@ -350,7 +351,9 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     }
 
     public static Result route(RequestBuilder requestBuilder, long timeout) {
-      return route(play.Play.application(), requestBuilder, timeout);
+        final play.Application application = play.api.Play.current().injector().instanceOf(play.Application.class);
+
+        return route(application, requestBuilder, timeout);
     }
 
     public static Result route(Application app, RequestBuilder requestBuilder) {

--- a/framework/src/play-test/src/test/java/play/test/WithApplicationTest.java
+++ b/framework/src/play-test/src/test/java/play/test/WithApplicationTest.java
@@ -15,14 +15,13 @@ public class WithApplicationTest extends WithApplication {
     @Test
     public void withApplicationShouldProvideAnApplication() {
         assertNotNull(app);
-        //noinspection deprecation
-        assertNotNull(Play.application());
+        assertTrue(play.api.Play.maybeApplication().nonEmpty());
     }
 
     @Test
     public void withApplicationShouldCleanUpApplication() {
         stopPlay();
         assertNull(app);
-        assertTrue(play.api.Play.maybeApplication().isEmpty());
+        assertTrue(play.api.Play.privateMaybeApplication().isEmpty());
     }
 }

--- a/framework/src/play/src/main/java/play/Application.java
+++ b/framework/src/play/src/main/java/play/Application.java
@@ -91,9 +91,7 @@ public interface Application {
      *
      * @return true if the application is in DEV mode
      */
-    default boolean isDev() {
-        return play.api.Play.isDev(getWrappedApplication());
-    }
+    default boolean isDev() { return getWrappedApplication().isDev(); }
 
     /**
      * Check whether the application is in {@link Mode#PROD} mode.
@@ -101,7 +99,7 @@ public interface Application {
      * @return true if the application is in PROD mode
      */
     default boolean isProd() {
-        return play.api.Play.isProd(getWrappedApplication());
+        return getWrappedApplication().isProd();
     }
 
     /**
@@ -110,7 +108,7 @@ public interface Application {
      * @return true if the application is in TEST mode
      */
     default boolean isTest() {
-        return play.api.Play.isTest(getWrappedApplication());
+        return getWrappedApplication().isTest();
     }
 
 }

--- a/framework/src/play/src/main/java/play/Play.java
+++ b/framework/src/play/src/main/java/play/Play.java
@@ -11,7 +11,7 @@ import play.core.j.JavaModeConverter$;
 public class Play {
 
     /**
-     * @deprecated inject the {@link play.Application} instead
+     * @deprecated inject the {@link play.Application} instead.   Deprecated since 2.5.0.
      * @return Deprecated
      */
     @Deprecated
@@ -20,7 +20,7 @@ public class Play {
     }
 
     /**
-     * @deprecated inject the {@link play.Environment} instead
+     * @deprecated inject the {@link play.Environment} instead.   Deprecated since 2.5.0.
      * @return Deprecated
      */
     @Deprecated
@@ -29,7 +29,7 @@ public class Play {
     }
 
     /**
-     * @deprecated inject the {@link play.Environment} instead
+     * @deprecated inject the {@link play.Environment} instead.   Deprecated since 2.5.0.
      * @return Deprecated
      */
     @Deprecated
@@ -38,7 +38,7 @@ public class Play {
     }
 
     /**
-     * @deprecated inject the {@link play.Environment} instead
+     * @deprecated inject the {@link play.Environment} instead.   Deprecated since 2.5.0.
      * @return Deprecated
      */
     @Deprecated
@@ -47,7 +47,7 @@ public class Play {
     }
 
     /**
-     * @deprecated inject the {@link play.Environment} instead
+     * @deprecated inject the {@link play.Environment} instead.   Deprecated since 2.5.0.
      * @return Deprecated
      */
     @Deprecated

--- a/framework/src/play/src/main/java/play/i18n/Messages.java
+++ b/framework/src/play/src/main/java/play/i18n/Messages.java
@@ -4,6 +4,8 @@
 package play.i18n;
 
 import org.apache.commons.lang3.ArrayUtils;
+import play.Application;
+import play.api.Play;
 import play.api.i18n.Messages$;
 import scala.collection.mutable.Buffer;
 
@@ -35,7 +37,7 @@ public class Messages {
     }
 
     private static MessagesApi getMessagesApi() {
-        return play.Play.application().injector().instanceOf(MessagesApi.class);
+        return Play.current().injector().instanceOf(MessagesApi.class);
     }
 
     /**

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -200,7 +200,7 @@ public class Http {
          * @return the messages for the current lang
          */
         public Messages messages() {
-            return Play.application().injector().instanceOf(MessagesApi.class).preferred(request());
+            return play.api.Play.current().injector().instanceOf(MessagesApi.class).preferred(request());
         }
 
         /**

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -57,6 +57,10 @@ trait Application {
    */
   def mode: Mode.Mode
 
+  private[play] def isDev = (mode == Mode.Dev)
+  private[play] def isTest = (mode == Mode.Test)
+  private[play] def isProd = (mode == Mode.Prod)
+
   @deprecated("Use dependency injection", "2.5.0")
   def global: GlobalSettings.Deprecated = injector.instanceOf[GlobalSettings.Deprecated]
 

--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -99,7 +99,7 @@ object Play {
 
     _currentApp = app
 
-    Threads.withContextClassLoader(classloader(app)) {
+    Threads.withContextClassLoader(app.classloader) {
       // Call before start now
       app.global.beforeStart(app)
 
@@ -123,7 +123,7 @@ object Play {
    */
   def stop(app: Application) {
     if (app != null) {
-      Threads.withContextClassLoader(classloader(app)) {
+      Threads.withContextClassLoader(app.classloader) {
         app.global.onStop(app)
         try { Await.ready(app.stop(), Duration.Inf) } catch { case NonFatal(e) => logger.warn("Error stopping application", e) }
       }
@@ -134,7 +134,7 @@ object Play {
   /**
    * @deprecated inject the [[play.api.Environment]] instead
    */
-  @Deprecated
+  @deprecated("inject the play.api.Environment instead", "2.5.0")
   def resourceAsStream(name: String)(implicit app: Application): Option[InputStream] = {
     app.resourceAsStream(name)
   }
@@ -142,7 +142,7 @@ object Play {
   /**
    * @deprecated inject the [[play.api.Environment]] instead
    */
-  @Deprecated
+  @deprecated("inject the play.api.Environment instead", "2.5.0")
   def resource(name: String)(implicit app: Application): Option[java.net.URL] = {
     app.resource(name)
   }
@@ -150,7 +150,7 @@ object Play {
   /**
    * @deprecated inject the [[play.api.Environment]] instead
    */
-  @Deprecated
+  @deprecated("inject the play.api.Environment instead", "2.5.0")
   def getFile(relativePath: String)(implicit app: Application): File = {
     app.getFile(relativePath)
   }
@@ -158,7 +158,7 @@ object Play {
   /**
    * @deprecated inject the [[play.api.Environment]] instead
    */
-  @Deprecated
+  @deprecated("inject the play.api.Environment instead", "2.5.0")
   def getExistingFile(relativePath: String)(implicit app: Application): Option[File] = {
     app.getExistingFile(relativePath)
   }
@@ -166,49 +166,49 @@ object Play {
   /**
    * @deprecated inject the [[play.api.Application]] instead
    */
-  @Deprecated
+  @deprecated("inject the play.api.Environment instead", "2.5.0")
   def application(implicit app: Application): Application = app
 
   /**
    * @deprecated inject the [[play.api.Environment]] instead
    */
-  @Deprecated
+  @deprecated("inject the play.api.Environment instead", "2.5.0")
   def classloader(implicit app: Application): ClassLoader = app.classloader
 
   /**
    * @deprecated inject the [[play.api.Configuration]] instead
    */
-  @Deprecated
+  @deprecated("inject the play.api.Environment instead", "2.5.0")
   def configuration(implicit app: Application): Configuration = app.configuration
 
   /**
    * @deprecated inject the [[play.api.routing.Router]] instead
    */
-  @Deprecated
+  @deprecated("inject the play.api.Environment instead", "2.5.0")
   def routes(implicit app: Application): play.api.routing.Router = app.routes
 
   /**
    * @deprecated inject the [[play.api.Environment]] instead
    */
-  @Deprecated
+  @deprecated("inject the play.api.Environment instead", "2.5.0")
   def mode(implicit app: Application): Mode.Mode = app.mode
 
   /**
    * @deprecated inject the [[play.api.Environment]] instead
    */
-  @Deprecated
+  @deprecated("inject the play.api.Environment instead", "2.5.0")
   def isDev(implicit app: Application): Boolean = (app.mode == Mode.Dev)
 
   /**
    * @deprecated inject the [[play.api.Environment]] instead
    */
-  @Deprecated
+  @deprecated("inject the play.api.Environment instead", "2.5.0")
   def isProd(implicit app: Application): Boolean = (app.mode == Mode.Prod)
 
   /**
    * @deprecated inject the [[play.api.Environment]] instead
    */
-  @Deprecated
+  @deprecated("inject the play.api.Environment instead", "2.5.0")
   def isTest(implicit app: Application): Boolean = (app.mode == Mode.Test)
 
   /**

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/controllers/Application.scala
@@ -5,21 +5,22 @@ package controllers
 
 import play.api._
 import play.api.mvc._
-import play.api.Play.current
 import scala.collection.JavaConverters._
 
-class Application extends Controller {
+import javax.inject.Inject
+
+class Application @Inject() (app: play.api.Application, configuration: Configuration) extends Controller {
 
   def index = Action {
     Ok(views.html.index("Your new application is ready."))
   }
 
   def config = Action {
-    Ok(Play.configuration.underlying.getString("some.config"))
+    Ok(configuration.underlying.getString("some.config"))
   }
 
   def count = Action {
-    val num = Play.classloader.getResources("application.conf").asScala.toSeq.size
+    val num = app.resource("application.conf").toSeq.size
     Ok(num.toString)
   }
 }

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
@@ -6,6 +6,8 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
 
+routesGenerator := InjectedRoutesGenerator
+
 val checkStartScript = InputKey[Unit]("checkStartScript")
 
 checkStartScript := {


### PR DESCRIPTION
Ongoing work for #5309.  This takes out the deprecated methods in play.api.Play (which mostly delegate to application).

There's a fair bit of code that goes straight to Play.current.injector etc, but removing current is out of scope.