### PR TITLE
Use CSRF config rather than the global one which is not available with compile time dependency injection

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -425,7 +425,7 @@ object CSRFAction {
     import play.api.libs.iteratee.Execution.Implicits.trampoline
 
     errorHandler.handle(request, msg) map { result =>
-      CSRF.getToken(request).fold(
+      CSRF.getToken(request, config).fold(
         config.cookieName.flatMap { cookie =>
           request.cookies.get(cookie).map { token =>
             result.discardingCookies(DiscardingCookie(cookie, domain = Session.domain, path = Session.path,

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -123,17 +123,24 @@ object CSRF {
   }
 
   /**
-   * Extract token from current request
+   * Extract token from current request using global config (required runtime DI)
    */
   def getToken(request: RequestHeader): Option[Token] = {
-    val global = CSRFConfig.global
+    getToken(request, CSRFConfig.global)
+  }
+
+  /**
+   * Extract token from current request using config.
+   * If config is not provided, the global one will be used (required runtime DI)
+   */
+  def getToken(request: RequestHeader, config: CSRFConfig): Option[Token] = {
     // First check the tags, this is where tokens are added if it's added to the current request
     val token = request.tags.get(Token.RequestTag)
       // Check cookie if cookie name is defined
-      .orElse(global.cookieName.flatMap(n => request.cookies.get(n).map(_.value)))
+      .orElse(config.cookieName.flatMap(n => request.cookies.get(n).map(_.value)))
       // Check session
-      .orElse(request.session.get(global.tokenName))
-    if (global.signTokens) {
+      .orElse(request.session.get(config.tokenName))
+    if (config.signTokens) {
       // Extract the signed token, and then resign it. This makes the token random per request, preventing the BREACH
       // vulnerability
       token.flatMap(Crypto.extractSignedToken)


### PR DESCRIPTION
`CSRF.global` is defined as 
```scala
 def global = Play.maybeApplication.map(_.injector.instanceOf[CSRFConfig]).getOrElse(CSRFConfig())
```

There is no `apply` method defines on `CSRFConfig` object, so when using compile time dependency injection, calling global will result in `MethodNotFoundError` at runtime.

The associated changes add a new method to `CSRF ` to retrieve a token accepting a `CSRFConfig` as an argument so that `CSRFAction` is usable with runtime dependency injection.

@richdougherty I would like to backport this fix for `2.4.x` and include it in `2.4.5` if you are fine with the changes. 