### PR TITLE
Remove deprecated methods from Configuration

### DIFF
--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -245,7 +245,7 @@ object OfflineEvolutions {
     val _dbApi = dbApi
     new EvolutionsComponents {
       lazy val environment = Environment(appPath, classloader, Mode.Dev)
-      lazy val configuration = Configuration.load(appPath)
+      lazy val configuration = Configuration.load(environment, Map.empty)
       lazy val applicationLifecycle = new DefaultApplicationLifecycle
       lazy val dynamicEvolutions = new DynamicEvolutions
       lazy val dbApi: DBApi = _dbApi

--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -105,28 +105,6 @@ object Configuration {
   }
 
   /**
-   * Loads a new `Configuration` either from the classpath or from
-   * `conf/application.conf` depending on the application's Mode.
-   *
-   * The provided mode is used if the application is not ready
-   * yet, just like when calling this method from `play.api.Application`.
-   *
-   * Defaults to Mode.Dev
-   *
-   * @param mode Application mode.
-   * @return a `Configuration` instance
-   */
-  @deprecated("Use load(Environment, Map[String,AnyRef]) instead", "2.4.0")
-  def load(appPath: File, mode: Mode.Mode = Mode.Dev, devSettings: Map[String, AnyRef] = Map.empty): Configuration = {
-    val currentMode = Play.maybeApplication.map(_.mode).getOrElse(mode)
-    if (currentMode == Mode.Prod) {
-      load(Thread.currentThread.getContextClassLoader, System.getProperties, Map.empty, allowMissingApplicationConf = false)
-    } else {
-      load(Thread.currentThread.getContextClassLoader, System.getProperties, devSettings, allowMissingApplicationConf = true)
-    }
-  }
-
-  /**
    * Load a new Configuration from the Environment.
    */
   def load(environment: Environment, devSettings: Map[String, AnyRef]): Configuration = {


### PR DESCRIPTION
Remove a load method from `play.api.Configuration`, as part of on-going work for #5309.

Lower in priority than #5323