### PR TITLE
use localname for javascript reverse routes. fix #5340

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
@@ -298,7 +298,7 @@ package object templates {
     Option(route.call.parameters.getOrElse(Nil).filter { p =>
       localNames.contains(p.name) && p.fixed.isDefined
     }.map { p =>
-      p.name + " == \"\"\" + implicitly[JavascriptLiteral[" + p.typeName + "]].to(" + p.fixed.get + ") + \"\"\""
+      localNames(p.name) + " == \"\"\" + implicitly[JavascriptLiteral[" + p.typeName + "]].to(" + p.fixed.get + ") + \"\"\""
     }).filterNot(_.isEmpty).map(_.mkString(" && "))
   }
 

--- a/framework/src/routes-compiler/src/test/scala/play/routes/compiler/templates/TemplatesSpec.scala
+++ b/framework/src/routes-compiler/src/test/scala/play/routes/compiler/templates/TemplatesSpec.scala
@@ -1,0 +1,47 @@
+package play.routes.compiler.templates
+
+import org.specs2.mutable.Specification
+import play.routes.compiler._
+
+/**
+ * Created by mtrovo on 12/7/15.
+ */
+object TemplatesSpec extends Specification {
+  "javascript reverse routes" should {
+    "collect parameter names with index appended" in {
+      val reverseParams: Seq[(Parameter, Int)] = reverseParametersJavascript(Seq(
+        route("/foobar", Seq(
+          Parameter("foo", "String", Some("FOO"), None),
+          Parameter("bar", "String", Some("BAR"), None))),
+        route("/foobar", Seq(
+          Parameter("foo", "String", None, None),
+          Parameter("bar", "String", None, None)))))
+
+      reverseParams must haveSize(2)
+      reverseParams(0)._1.name must_== ("foo0")
+      reverseParams(1)._1.name must_== ("bar1")
+    }
+
+    "constraints uses indexed parameters" in {
+      val routes = Seq(
+        route("/foobar", Seq(
+          Parameter("foo", "String", Some("FOO"), None),
+          Parameter("bar", "String", Some("BAR"), None))),
+        route("/foobar", Seq(
+          Parameter("foo", "String", None, None),
+          Parameter("bar", "String", None, None))))
+      val localNames = reverseLocalNames(routes.head, reverseParametersJavascript(routes))
+      val constraints = javascriptParameterConstraints(routes.head, localNames)
+
+      constraints.get must startWith("foo0 == ")
+      constraints.get must contain("bar1 == ")
+    }
+  }
+
+  def route(staticPath: String, params: Seq[Parameter] = Nil): Route = {
+    Route(
+      HttpVerb("GET"),
+      PathPattern(Seq(StaticPart(staticPath))),
+      HandlerCall("pkg", "ctrl", true, "method", Some(params)))
+  }
+}


### PR DESCRIPTION
This commit fix a bug introduced by PR #5129 as routes parameters have
different name than those being used locally on the generated reverse
routing code.
The error occured because some javsacript code generated by routes
compiler code were not using localnames map when referencing route
parameters, causing js errors as the local variables on js has a
different name than its route parameter counterpart.