### PR TITLE
Change routes compiler to InjectedRoutesGenerator

### DIFF
--- a/documentation/manual/releases/Migration25.md
+++ b/documentation/manual/releases/Migration25.md
@@ -96,3 +96,15 @@ Details on how to set up Play with different logging frameworks are in [[Configu
 ## Renamed Ning components into Ahc
 
 In order to reflect the proper AsyncHttpClient library name, package `play.api.libs.ws.ning` was renamed into `play.api.libs.ws.ahc` and `Ning*` classes were renamed into `Ahc*`.
+
+## Routes generated with InjectedRoutesGenerator
+
+Routes are now generated using the dependency injection aware `InjectedRoutesGenerator`, rather than the previous `StaticRoutesGenerator` which assumed controllers were singleton objects.  
+
+To revert back to the earlier behavior (if you have "object MyController" in your code, for example), please add:
+
+```
+routesGenerator := StaticRoutesGenerator
+```
+
+to your `build.sbt` file.

--- a/documentation/manual/working/scalaGuide/advanced/dependencyinjection/code/static.sbt
+++ b/documentation/manual/working/scalaGuide/advanced/dependencyinjection/code/static.sbt
@@ -1,0 +1,3 @@
+//#content
+routesGenerator := StaticRoutesGenerator
+//#content

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaDependencyInjection.md
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaDependencyInjection.md
@@ -21,17 +21,22 @@ There are two ways to make Play use dependency injected controllers.
 
 ### Injected routes generator
 
-By default, Play will generate a static router, that assumes that all actions are static methods.  By configuring Play to use the injected routes generator, you can get Play to generate a router that will declare all the controllers that it routes to as dependencies, allowing your controllers to be dependency injected themselves.
+By default (since 2.5.0), Play will generate a router that will declare all the controllers that it routes to as dependencies, allowing your controllers to be dependency injected themselves.
 
-We recommend always using the injected routes generator, the static routes generator exists primarily as a tool to aid migration so that existing projects don't have to make all their controllers non static at once.
 
-To enable the injected routes generator, add the following to your build settings in `build.sbt`:
+To enable the injected routes generator specifically, add the following to your build settings in `build.sbt`:
 
 @[content](code/injected.sbt)
 
 When using the injected routes generator, prefixing the action with an `@` symbol takes on a special meaning, it means instead of the controller being injected directly, a `Provider` of the controller will be injected.  This allows, for example, prototype controllers, as well as an option for breaking cyclic dependencies.
 
-### Injected actions
+### Static routes generator
+
+You can configure Play to use the legacy (pre 2.5.0) static routes generator, that assumes that all actions are static methods.  To configure the project, add the following to build.sbt:
+
+@[content](code/static.sbt)
+
+We recommend always using the injected routes generator.  The static routes generator exists primarily as a tool to aid migration so that existing projects don't have to make all their controllers non static at once.
 
 If using the static routes generator, you can indicate that an action has an injected controller by prefixing the action with `@`, like so:
 

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/app/controllers/Application.scala
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/app/controllers/Application.scala
@@ -5,7 +5,7 @@ package controllers
 
 import play.api.mvc._
 
-object Application extends Controller {
+class Application extends Controller {
 
   /**
    * This action echoes the value of the HTTP_SERVER tag so that we

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/system-property/app/controllers/Application.scala
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/system-property/app/controllers/Application.scala
@@ -5,7 +5,7 @@ package controllers
 
 import play.api.mvc._
 
-object Application extends Controller {
+class Application extends Controller {
 
   /**
    * This action echoes the value of the HTTP_SERVER tag so that we

--- a/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/app/controllers/Application.scala
+++ b/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/app/controllers/Application.scala
@@ -5,7 +5,7 @@ package controllers
 
 import play.api.mvc._
 
-object Application extends Controller {
+class Application extends Controller {
   def index = Action {
     Ok("original-fork-run")
   }

--- a/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/changes/Application.scala.1
+++ b/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/changes/Application.scala.1
@@ -5,7 +5,7 @@ package controllers
 
 import play.api.mvc._
 
-object Application extends Controller {
+class Application extends Controller {
   def index = Action {
     Ok("first")
   }

--- a/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/changes/Application.scala.2
+++ b/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/changes/Application.scala.2
@@ -5,7 +5,7 @@ package controllers
 
 import play.api.mvc._
 
-object Application extends Controller {
+class Application extends Controller {
   def index = Action {
     Ok("first)
   }

--- a/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/changes/Application.scala.3
+++ b/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/changes/Application.scala.3
@@ -5,7 +5,7 @@ package controllers
 
 import play.api.mvc._
 
-object Application extends Controller {
+class Application extends Controller {
   def index = Action {
     Ok("second")
   }

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
@@ -119,7 +119,7 @@ object RoutesCompiler extends AutoPlugin {
     },
 
     namespaceReverseRouter := false,
-    routesGenerator := StaticRoutesGenerator,
+    routesGenerator := InjectedRoutesGenerator, // changed from StaticRoutesGenerator in 2.5.0
     sourcePositionMappers += routesPositionMapper
   )
 

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/app/controllers/Application.scala
@@ -5,7 +5,7 @@ package controllers
 
 import play.api.mvc._
 
-object Application extends Controller {
+class Application extends Controller {
   def index = Action {
     Ok("original")
   }

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.1
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.1
@@ -5,7 +5,7 @@ package controllers
 
 import play.api.mvc._
 
-object Application extends Controller {
+class Application extends Controller {
   def index = Action {
     Ok("first")
   }

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.2
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.2
@@ -5,7 +5,7 @@ package controllers
 
 import play.api.mvc._
 
-object Application extends Controller {
+class Application extends Controller {
   def index = Action {
     Ok("first)
   }

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.3
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/changes/Application.scala.3
@@ -5,7 +5,7 @@ package controllers
 
 import play.api.mvc._
 
-object Application extends Controller {
+class Application extends Controller {
   def index = Action {
     Ok("second")
   }

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/controllers/Application.scala
@@ -8,7 +8,7 @@ import play.api.mvc._
 import play.api.Play.current
 import scala.collection.JavaConverters._
 
-object Application extends Controller {
+class Application extends Controller {
 
   def index = Action {
     Ok(views.html.index("Your new application is ready."))

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/test
@@ -4,5 +4,5 @@
 # Check that the compile errors are successfully mapped from the generated Scala back to the original source
 > checkLogContains app/views/index.scala.html:3: not found: value foo
 > checkLogContains Foo: @foo.bar
-> checkLogContains conf/routes:3: object Foo is not a member of package controllers
+> checkLogContains conf/routes:3: type Foo is not a member of package controllers
 > checkLogContains GET / controllers.Foo.index

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/controllers/Application.scala
@@ -6,7 +6,7 @@ package controllers
 import play.api.mvc._
 import scala.collection.JavaConversions._
 
-object Application extends Controller {
+class Application extends Controller {
   def index = Action {
     Ok
   }

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/controllers/module/ModuleController.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/controllers/module/ModuleController.scala
@@ -5,7 +5,7 @@ package controllers.module
 
 import play.api.mvc._
 
-object ModuleController extends Controller {
+class ModuleController extends Controller {
   def index = Action {
     Ok
   }

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/controllers/πø$7ß.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/controllers/πø$7ß.scala
@@ -5,7 +5,7 @@ package controllers
 
 import play.api.mvc._
 
-object πø$7ß extends Controller {
+class πø$7ß extends Controller {
   def ôü65$t(i: Int) = Action {
     Ok
   }

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/Application.scala
@@ -5,6 +5,6 @@ package controllers
 
 import play.api.mvc._
 
-object Application extends Controller {
+class Application extends Controller {
   def index = Action(Ok)
 }

--- a/templates/play-java-intro/build.sbt
+++ b/templates/play-java-intro/build.sbt
@@ -13,6 +13,3 @@ libraryDependencies ++= Seq(
   "org.hibernate" % "hibernate-entitymanager" % "4.3.7.Final"
 )
 
-// Play provides two styles of routers, one expects its actions to be injected, the
-// other, legacy style, accesses its actions statically.
-routesGenerator := InjectedRoutesGenerator

--- a/templates/play-java/build.sbt
+++ b/templates/play-java/build.sbt
@@ -11,7 +11,3 @@ libraryDependencies ++= Seq(
   cache,
   javaWs
 )
-
-// Play provides two styles of routers, one expects its actions to be injected, the
-// other, legacy style, accesses its actions statically.
-routesGenerator := InjectedRoutesGenerator

--- a/templates/play-scala-intro/build.sbt
+++ b/templates/play-scala-intro/build.sbt
@@ -13,6 +13,3 @@ libraryDependencies ++= Seq(
   specs2 % Test
 )
 
-// Play provides two styles of routers, one expects its actions to be injected, the
-// other, legacy style, accesses its actions statically.
-routesGenerator := InjectedRoutesGenerator

--- a/templates/play-scala/build.sbt
+++ b/templates/play-scala/build.sbt
@@ -13,6 +13,4 @@ libraryDependencies ++= Seq(
   specs2 % Test
 )
 
-// Play provides two styles of routers, one expects its actions to be injected, the
-// other, legacy style, accesses its actions statically.
-routesGenerator := InjectedRoutesGenerator
+resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"


### PR DESCRIPTION
Makes routesGenerator := InjectedRoutesGenerator the default.

TODO: The reference to "Replaced static methods with dependency injection" in Migration25.md needs to be updated.