### PR TITLE
change the default request handler to DefaultHttpRequestHandler

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/bindings/GlobalSettingsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/bindings/GlobalSettingsSpec.scala
@@ -27,7 +27,7 @@ trait GlobalSettingsSpec extends PlaySpecification with WsTestClient with Server
     implicit val port = testServerPort
     val additionalSettings = applicationGlobal.fold(Map.empty[String, String]) { s: String =>
       Map("application.global" -> s"play.it.bindings.$s")
-    }
+    } + ("play.http.requestHandler" -> "play.api.http.GlobalSettingsHttpRequestHandler")
     import play.api.inject._
     import play.api.routing.sird._
     lazy val app: Application = new GuiceApplicationBuilder()

--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -50,7 +50,7 @@ trait GlobalFiltersSpec extends FiltersSpec {
     import play.api.inject.bind
 
     val app = new GuiceApplicationBuilder()
-      .configure(settings)
+      .configure(settings + ("play.http.requestHandler" -> "play.api.http.GlobalSettingsHttpRequestHandler"))
       .overrides(bind[Router].toInstance(testRouter))
       .global(
         new WithFilters(filters: _*) {

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -28,8 +28,7 @@ play {
     # - provided, indicates that the application has bound an instance of play.api.http.HttpRequestHandler through some
     #   other mechanism.
     # If null, will attempt to load a class called RequestHandler in the root package, otherwise if that's
-    # not found, will default to play.api.http.GlobalSettingsHttpRequestHandler, which delegates to legacy request
-    # handling methods on Global.
+    # not found, will default to play.api.http.JavaCompatibleHttpRequestHandler.
     requestHandler = null
 
     # The error handler.


### PR DESCRIPTION
fix #5357

As part of the process to deprecate `GlobalSettings` this commit changes the default implementation of `HttpRequestHandler` from `GlobalSettingsHttpRequestHandler` to `DefaultHttpRequestHandler`.