### PR TITLE
Annotate return type of `JsLookupResult.validate` and `JsValue.validate`

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsLookup.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsLookup.scala
@@ -105,7 +105,7 @@ sealed trait JsLookupResult extends Any with JsReadable {
   def get: JsValue = toOption.get
   def getOrElse(v: => JsValue): JsValue = toOption.getOrElse(v)
 
-  def validate[A](implicit rds: Reads[A]) = this match {
+  def validate[A](implicit rds: Reads[A]): JsResult[A] = this match {
     case JsDefined(v) => v.validate[A]
     case undef: JsUndefined => JsError(undef.validationError)
   }

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsValue.scala
@@ -15,7 +15,7 @@ case class JsResultException(errors: Seq[(JsPath, Seq[ValidationError])]) extend
 sealed trait JsValue extends JsReadable {
   override def toString = Json.stringify(this)
 
-  def validate[A](implicit rds: Reads[A]) = rds.reads(this)
+  def validate[A](implicit rds: Reads[A]): JsResult[A] = rds.reads(this)
 
   def validateOpt[A](implicit rds: Reads[A]): JsResult[Option[A]] = JsDefined(this).validateOpt[A]
 }


### PR DESCRIPTION
I found them missing when navigating the code and while not strictly necessary IMHO adding the return type is a good idea in general for public API.

-- 24pullrequests
[![](http://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png)](http://24pullrequests.com/)