### PR TITLE
Fix FakeKeystore being regenerated

### DIFF
--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/CertificateGenerator.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/CertificateGenerator.scala
@@ -3,7 +3,7 @@
  *  * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
  *
  */
-package play.api.libs.ws.ssl
+package play.core.server.ssl
 
 import sun.security.x509._
 import java.security.cert._

--- a/framework/src/play-server/src/test/scala/play/core/server/ssl/FakeKeyStoreSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/ssl/FakeKeyStoreSpec.scala
@@ -1,0 +1,20 @@
+package play.core.server.ssl
+
+import org.specs2.mutable.Specification
+
+class FakeKeyStoreSpec extends Specification {
+
+  "FakeKeyStore construction" should {
+    "return true on MD5 cert" in {
+      val weakCert = CertificateGenerator.generateRSAWithMD5()
+      val actual = FakeKeyStore.certificateTooWeak(weakCert)
+      actual must beTrue
+    }
+
+    "return false on SHA256withRSA" in {
+      val strongCert = CertificateGenerator.generateRSAWithSHA256()
+      val actual = FakeKeyStore.certificateTooWeak(strongCert)
+      actual must beFalse
+    }
+  }
+}

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmCheckerSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmCheckerSpec.scala
@@ -11,6 +11,7 @@ import java.util.Collections._
 import org.joda.time.{ DateTime, Days, Instant }
 import org.specs2.mutable._
 import play.api.libs.ws.ssl.AlgorithmConstraintsParser._
+import play.core.server.ssl.CertificateGenerator
 
 object AlgorithmCheckerSpec extends Specification {
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmsSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmsSpec.scala
@@ -9,6 +9,7 @@ import org.specs2.mutable._
 
 import java.security.{ SecureRandom, KeyPairGenerator }
 import org.joda.time.Instant
+import play.core.server.ssl.CertificateGenerator
 import sun.security.x509.AlgorithmId
 
 object AlgorithmsSpec extends Specification {

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/CompositeX509KeyManagerSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/CompositeX509KeyManagerSpec.scala
@@ -8,6 +8,8 @@ package play.api.libs.ws.ssl
 import java.net.Socket
 import java.security.{ Principal, PrivateKey }
 
+import play.core.server.ssl.CertificateGenerator
+
 import scala.Array
 
 import javax.net.ssl.{ X509ExtendedKeyManager, SSLEngine, X509KeyManager }

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/CompositeX509TrustManagerSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/CompositeX509TrustManagerSpec.scala
@@ -11,6 +11,8 @@ import org.specs2.mock.Mockito
 import javax.net.ssl.X509TrustManager
 import java.security.cert.{ CertificateException, X509Certificate }
 
+import play.core.server.ssl.CertificateGenerator
+
 object CompositeX509TrustManagerSpec extends Specification with Mockito {
 
   "CompositeX509TrustManager" should {

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/ConfigSSLContextBuilderSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/ConfigSSLContextBuilderSpec.scala
@@ -11,7 +11,7 @@ import javax.net.ssl._
 
 import org.specs2.mock._
 import org.specs2.mutable._
-import play.core.server.ssl.FakeKeyStore
+import play.core.server.ssl.{ CertificateGenerator, FakeKeyStore }
 
 class ConfigSSLContextBuilderSpec extends Specification with Mockito {
 


### PR DESCRIPTION
Fixes https://github.com/playframework/playframework/issues/5367

Moves CertificateGenerator into Play-Server, so it can be used in specs in both Play-WS and Play-Server.