### PR TITLE
h2 dpendency fix for datetime2

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   val findBugs = "com.google.code.findbugs" % "jsr305" % "2.0.3" // Needed by guava
   val mockitoAll = "org.mockito" % "mockito-all" % "1.9.5"
 
-  val h2database = "com.h2database" % "h2" % "1.3.175"
+  val h2database = "com.h2database" % "h2" % "1.4.181"
 
   val jdbcDeps = Seq(
     "com.jolbox" % "bonecp" % "0.8.0.RELEASE",


### PR DESCRIPTION
There was a bug in H2 witch fixed on the 1.4.181.
This is prevented to use inmemory database in some cases.

The fix in the H2 repo:
https://github.com/h2database/h2database/commit/93430bf7bc087a1d074695ce3ac83fc9778036ba

The error:
http://stackoverflow.com/questions/22905280/h2-db-with-datetime2