### PR TITLE
Provide a conventional way to provide a module

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/dependencyinjection/JavaDependencyInjection.md
+++ b/documentation/manual/working/javaGuide/advanced/dependencyinjection/JavaDependencyInjection.md
@@ -87,11 +87,15 @@ The simplest way to bind an implementation to an interface is to use the Guice [
 
 In some more complex situations, you may want to provide more complex bindings, such as when you have multiple implementations of the one trait, which are qualified by [@Named](https://docs.oracle.com/javaee/7/api/javax/inject/Named.html) annotations.  In these cases, you can implement a custom Guice [Module](https://google.github.io/guice/api-docs/latest/javadoc/index.html?com/google/inject/Module.html):
 
-@[guice-module](code/javaguide/advanced/di/guice/HelloModule.java)
+@[guice-module](code/javaguide/advanced/di/guice/Module.java)
 
-To register this module with Play, append it's fully qualified class name to the `play.modules.enabled` list in `application.conf`:
+If you call this module `Module` and place it in the root package, it will automatically be registered with Play.  Alternatively, if you want to give it a different name or put it in a different package, you can register it with Play by appending its fully qualified class name to the `play.modules.enabled` list in `application.conf`:
 
     play.modules.enabled += "modules.HelloModule"
+
+You can also disable the automatic registration of a module named `Module` in the root package by adding it to the disabled modules:
+
+    play.modules.disabled += "Module"
 
 #### Configurable bindings
 
@@ -99,7 +103,7 @@ Sometimes you might want to read the Play `Configuration` or use a `ClassLoader`
 
 In the example below, the `Hello` binding for each language is read from a configuration file. This allows new `Hello` bindings to be added by adding new settings in your `application.conf` file.
 
-@[dynamic-guice-module](code/javaguide/advanced/di/guice/dynamic/HelloModule.java)
+@[dynamic-guice-module](code/javaguide/advanced/di/guice/dynamic/Module.java)
 
 > **Note:** In most cases, if you need to access `Configuration` when you create a component, you should inject the `Configuration` object into the component itself or into the component's `Provider`. Then you can read the `Configuration` when you create the component. You usually don't need to read `Configuration` when you create the bindings for the component.
 
@@ -107,7 +111,7 @@ In the example below, the `Hello` binding for each language is read from a confi
 
 In the code above, new `EnglishHello` and `GermanHello` objects will be created each time they are used. If you only want to create these objects once, perhaps because they're expensive to create, then you should use the `@Singleton` annotation as [described above](#Singletons). If you want to create them once and also create them _eagerly_ when the application starts up, rather than lazily when they are needed, then you can use [Guice's eager singleton binding](https://github.com/google/guice/wiki/Scopes#eager-singletons).
 
-@[eager-guice-module](code/javaguide/advanced/di/guice/eager/HelloModule.java)
+@[eager-guice-module](code/javaguide/advanced/di/guice/eager/Module.java)
 
 ### Play libraries
 

--- a/documentation/manual/working/javaGuide/advanced/dependencyinjection/code/javaguide/advanced/di/guice/Module.java
+++ b/documentation/manual/working/javaGuide/advanced/dependencyinjection/code/javaguide/advanced/di/guice/Module.java
@@ -9,7 +9,7 @@ import javaguide.advanced.di.*;
 import com.google.inject.AbstractModule;
 import com.google.inject.name.Names;
 
-public class HelloModule extends AbstractModule {
+public class Module extends AbstractModule {
     protected void configure() {
 
         bind(Hello.class)

--- a/documentation/manual/working/javaGuide/advanced/dependencyinjection/code/javaguide/advanced/di/guice/dynamic/Module.java
+++ b/documentation/manual/working/javaGuide/advanced/dependencyinjection/code/javaguide/advanced/di/guice/dynamic/Module.java
@@ -12,12 +12,12 @@ import com.google.inject.name.Names;
 import play.Configuration;
 import play.Environment;
 
-public class HelloModule extends AbstractModule {
+public class Module extends AbstractModule {
 
     private final Environment environment;
     private final Configuration configuration;
 
-    public HelloModule(
+    public Module(
           Environment environment,
           Configuration configuration) {
         this.environment = environment;

--- a/documentation/manual/working/javaGuide/advanced/dependencyinjection/code/javaguide/advanced/di/guice/eager/Module.java
+++ b/documentation/manual/working/javaGuide/advanced/dependencyinjection/code/javaguide/advanced/di/guice/eager/Module.java
@@ -9,7 +9,7 @@ import javaguide.advanced.di.*;
 import com.google.inject.AbstractModule;
 import com.google.inject.name.Names;
 
-public class HelloModule extends AbstractModule {
+public class Module extends AbstractModule {
     protected void configure() {
 
         bind(Hello.class)

--- a/documentation/manual/working/scalaGuide/advanced/dependencyinjection/ScalaDependencyInjection.md
+++ b/documentation/manual/working/scalaGuide/advanced/dependencyinjection/ScalaDependencyInjection.md
@@ -85,9 +85,13 @@ In some more complex situations, you may want to provide more complex bindings, 
 
 @[guice-module](code/RuntimeDependencyInjection.scala)
 
-To register this module with Play, append it's fully qualified class name to the `play.modules.enabled` list in `application.conf`:
+If you call this module `Module` and place it in the root package, it will automatically be registered with Play.  Alternatively, if you want to give it a different name or put it in a different package, you can register it with Play by appending its fully qualified class name to the `play.modules.enabled` list in `application.conf`:
 
     play.modules.enabled += "modules.HelloModule"
+
+You can also disable the automatic registration of a module named `Module` in the root package by adding it to the disabled modules:
+
+    play.modules.disabled += "Module"
 
 #### Configurable bindings
 

--- a/documentation/manual/working/scalaGuide/advanced/dependencyinjection/code/RuntimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/advanced/dependencyinjection/code/RuntimeDependencyInjection.scala
@@ -105,7 +105,7 @@ import implemented._
 import com.google.inject.AbstractModule
 import com.google.inject.name.Names
   
-class HelloModule extends AbstractModule {
+class Module extends AbstractModule {
   def configure() = {
 
     bind(classOf[Hello])
@@ -129,7 +129,7 @@ import com.google.inject.AbstractModule
 import com.google.inject.name.Names
 import play.api.{ Configuration, Environment }
   
-class HelloModule(
+class Module(
   environment: Environment,
   configuration: Configuration) extends AbstractModule {
   def configure() = {
@@ -164,7 +164,7 @@ import implemented._
 import com.google.inject.AbstractModule
 import com.google.inject.name.Names
   
-class HelloModule extends AbstractModule {
+class Module extends AbstractModule {
   def configure() = {
 
     bind(classOf[Hello])

--- a/framework/src/play/src/main/scala/play/api/inject/Module.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Module.scala
@@ -81,6 +81,8 @@ abstract class Module {
  */
 object Modules {
 
+  private val DefaultModuleName = "Module"
+
   /**
    * Locate the modules from the environment.
    *
@@ -100,39 +102,53 @@ object Modules {
 
     val moduleClassNames = includes.toSet -- excludes
 
+    // Construct the default module if it exists
+    // Allow users to add "Module" to the excludes to exclude even attempting to look it up
+    val defaultModule = if (excludes.contains(DefaultModuleName)) None else try {
+      val defaultModuleClass = environment.classLoader.loadClass(DefaultModuleName).asInstanceOf[Class[Any]]
+      Some(constructModule(environment, configuration, DefaultModuleName, () => defaultModuleClass))
+    } catch {
+      case e: ClassNotFoundException => None
+    }
+
     moduleClassNames.map { className =>
-      try {
-        val clazz = environment.classLoader.loadClass(className)
+      constructModule(environment, configuration, className,
+        () => environment.classLoader.loadClass(className).asInstanceOf[Class[Any]])
+    }.toSeq ++ defaultModule
+  }
 
-        def tryConstruct(args: AnyRef*): Option[Any] = {
-          val ctor: Option[Constructor[_]] = try {
-            val argTypes = args.map(_.getClass)
-            Some(clazz.getConstructor(argTypes: _*))
-          } catch {
-            case _: NoSuchMethodException => None
-            case _: SecurityException => None
-          }
-          ctor.map(_.newInstance(args: _*))
-        }
+  private def constructModule[T](environment: Environment, configuration: Configuration, className: String, loadModuleClass: () => Class[T]): T = {
+    try {
+      val moduleClass = loadModuleClass()
 
-        {
-          tryConstruct(environment, configuration)
-        } orElse {
-          tryConstruct(new JavaEnvironment(environment), new JavaConfiguration(configuration))
-        } orElse {
-          tryConstruct()
-        } getOrElse {
-          throw new PlayException("No valid constructors", "Module [" + className + "] cannot be instantiated.")
+      def tryConstruct(args: AnyRef*): Option[T] = {
+        val ctor: Option[Constructor[T]] = try {
+          val argTypes = args.map(_.getClass)
+          Some(moduleClass.getConstructor(argTypes: _*))
+        } catch {
+          case _: NoSuchMethodException => None
+          case _: SecurityException => None
         }
-      } catch {
-        case e: PlayException => throw e
-        case e: VirtualMachineError => throw e
-        case e: ThreadDeath => throw e
-        case e: Throwable => throw new PlayException(
-          "Cannot load module",
-          "Module [" + className + "] cannot be instantiated.",
-          e)
+        ctor.map(_.newInstance(args: _*))
       }
-    }.toSeq
+
+      {
+        tryConstruct(environment, configuration)
+      } orElse {
+        tryConstruct(new JavaEnvironment(environment), new JavaConfiguration(configuration))
+      } orElse {
+        tryConstruct()
+      } getOrElse {
+        throw new PlayException("No valid constructors", "Module [" + className + "] cannot be instantiated.")
+      }
+    } catch {
+      case e: PlayException => throw e
+      case e: VirtualMachineError => throw e
+      case e: ThreadDeath => throw e
+      case e: Throwable => throw new PlayException(
+        "Cannot load module",
+        "Module [" + className + "] cannot be instantiated.",
+        e)
+    }
   }
 }


### PR DESCRIPTION
With many things in Play, a conventional, zero config way of providing a component is allowed by creating a particular class in the root package that implements that component.  For example, filters can be provided by putting an implementation of the `HttpFilters` class in a class called `Filters` in the root package.

The same should be done for modules - there should be a conventional location to put a module in the root package that allows the inclusion of that module with zero configuration.

Given that we usually encourage users to implement Guice's `AbstractModule` rather than Plays `Module`, I don't think we need to worry about the naming collision of `Module`, so I think `Module` would be a good name for it, and this is in keeping with the naming conventions for other conventional components, `HttpErrorHandler` is named `ErrorHandler`, `HttpFilters` is `Filters`, `HttpRequestHandler` is `RequestHandler`, etc.