### PR TITLE
Add optimized Headers implementation for Netty

### DIFF
--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyHeadersWrapper.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyHeadersWrapper.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.core.server.netty
+
+import io.netty.handler.codec.http._
+import play.api.mvc._
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.JavaConverters._
+
+/**
+ * An implementation of Play `Headers` that wraps the raw Netty headers and
+ * provides faster performance for some common read operations.
+ */
+private[server] class NettyHeadersWrapper(nettyHeaders: HttpHeaders) extends Headers(null) {
+
+  override def headers: Seq[(String, String)] = {
+    // Lazily initialize the header sequence using the Netty headers. It's OK
+    // if we do this operation concurrently because the operation is idempotent.
+    if (_headers == null) {
+      _headers = nettyHeaders.entries.asScala.map(h => h.getKey -> h.getValue)
+    }
+    _headers
+  }
+
+  override def get(key: String): Option[String] = Option(nettyHeaders.get(key))
+  override def apply(key: String): String = {
+    val value = nettyHeaders.get(key)
+    if (value == null) scala.sys.error("Header doesn't exist") else value
+  }
+  override def getAll(key: String): Seq[String] = nettyHeaders.getAll(key).asScala
+}

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
 package play.core.server.netty
 
 import java.net.{ URI, InetSocketAddress }
@@ -66,7 +69,7 @@ private[server] class NettyModelConversion(forwardedHeaderHandler: ForwardedHead
       override def method = request.getMethod.name()
       override def version = request.getProtocolVersion.text()
       override def queryString = parameters
-      override lazy val headers = getHeaders(request)
+      override val headers = new NettyHeadersWrapper(request.headers)
       private lazy val remoteConnection: ConnectionInfo = {
         forwardedHeaderHandler.remoteConnection(_remoteAddress.getAddress, secureProtocol, headers)
       }
@@ -106,16 +109,10 @@ private[server] class NettyModelConversion(forwardedHeaderHandler: ForwardedHead
           Map.empty
         }
       }
-      override lazy val headers = getHeaders(request)
+      override val headers = new NettyHeadersWrapper(request.headers)
       override def remoteAddress = _remoteAddress.getAddress.toString
       override def secure = secureProtocol
     }
-  }
-
-  /** Convert the Netty headers to a Play headers object. */
-  private def getHeaders(request: HttpRequest): Headers = {
-    val pairs = request.headers().entries().asScala.map(h => h.getKey -> h.getValue)
-    new Headers(pairs)
   }
 
   /** Create the source for the request body */

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -375,8 +375,17 @@ package play.api.mvc {
 
   /**
    * The HTTP headers set.
+   *
+   * @param _headers The sequence of values. This value is protected and mutable
+   * since subclasses might initially set it to a `null` value and then initialize
+   * it lazily.
    */
-  class Headers(val headers: Seq[(String, String)]) {
+  class Headers(protected var _headers: Seq[(String, String)]) {
+
+    /**
+     * The headers as a sequence of name-value pairs.
+     */
+    def headers: Seq[(String, String)] = _headers
 
     /**
      * Append the given headers


### PR DESCRIPTION
This change improves performance by about 4000 requests/s on a simple benchmark.

*The comments below no longer apply. I'm using a simpler implementation as suggested by @jroper.*

~~This change improves performance by about 5% on a simple benchmark.~~

~~The standard Play `Headers` implementation is slow. `Headers` are stored as a sequence of string pairs. Accessing a single header value involves converting the pairs into a `Map` of headers and sequences of values then converting the sequence to an `Option`.~~

~~We can improve performance on each request by introducing a new `Headers` implementation that wraps the Netty headers data structure and delegates calls directly to Netty where possible. This saves a lot of work in the common case of reading header values because Netty has a fast implementation for these cases.~~

~~Not all header methods have equivalent Netty header methods. For example, if you try to modify the headers by adding a new header value, the implementation will converting the Netty headers into a sequence of strings and then add the new header, just like the standard implementation. However, for most requests we will now be able to avoid this conversion and use the fast Netty headers instead.~~

~~Unfortunately add a new implementation of `Headers` I wasn't able to just subclass the `Headers` class. That would have been straightforward, but unfortunately the `Headers` class has a public constructor that is commonly used for constructing `Headers`. This public constructor means that the `Headers` class needs to continue to support the current sequence of strings data structure.~~

~~Instead of subclassing `Headers`, I've added a private abstract class called `HeadersImpl` that contains all the same methods as `Headers`. The `Headers` class now delegates to an internal `HeadersImpl` to do all of its work.~~

~~This `HeadersImpl` has two private subclasses: one that handles headers in the normal way, as a sequence of pairs, and another that wraps Netty headers.~~

~~By adding the `HeadersImpl` class and its subclasses we can continue to support the public constructor in `Headers`. When that constructor is called we construct a normal `HeadersImpl`, but we can now also construct other types of `HeadersImpl` too, such as the one that wraps Netty headers.~~

~~I've deprecated the public constructor in `Headers` so we will be able to remove it in in Play 2.6. When the public constructor is removed, we can merge the `HeadersImpl` class back into the Headers class and the two `HeadersImpl` subclasses can become subclasses of Headers.~~