### PR TITLE
Use the latest version of specs2 which no longer requires bintray resolver

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -6,7 +6,7 @@ import buildinfo.BuildInfo
 
 object Dependencies {
 
-  val specsVersion = "3.6.2"
+  val specsVersion = "3.6.6"
   val specsBuild = Seq(
     "specs2-core",
     "specs2-junit",

--- a/templates/play-scala-intro/build.sbt
+++ b/templates/play-scala-intro/build.sbt
@@ -6,8 +6,6 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 scalaVersion := "%SCALA_VERSION%"
 
-resolvers += "Scalaz Bintray Repo" at "https://dl.bintray.com/scalaz/releases"
-
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-slick" % "%PLAY_SLICK_VERSION%",
   "com.typesafe.play" %% "play-slick-evolutions" % "%PLAY_SLICK_VERSION%",

--- a/templates/play-scala/build.sbt
+++ b/templates/play-scala/build.sbt
@@ -13,8 +13,6 @@ libraryDependencies ++= Seq(
   specs2 % Test
 )
 
-resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
-
 // Play provides two styles of routers, one expects its actions to be injected, the
 // other, legacy style, accesses its actions statically.
 routesGenerator := InjectedRoutesGenerator


### PR DESCRIPTION
Fix for https://github.com/playframework/playframework/issues/5396