### PR TITLE
Refactor several Enumeratee implementations.

### DIFF
--- a/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
+++ b/framework/src/iteratees/src/main/scala/play/api/libs/iteratee/Enumeratee.scala
@@ -415,7 +415,7 @@ object Enumeratee {
       case in => Done(Cont(k), in)
     }
 
-    def continue[A](k: K[E, A]) = if (count <= 0) Done(Cont(k), Input.EOF) else Cont(step(count)(k))
+    def continue[A](k: K[E, A]) = if (count <= 0) Done(Cont(k)) else Cont(step(count)(k))
 
   }
 

--- a/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumerateesSpec.scala
+++ b/framework/src/iteratees/src/test/scala/play/api/libs/iteratee/EnumerateesSpec.scala
@@ -139,6 +139,14 @@ object EnumerateesSpec extends Specification
 
     }
 
+    "passes along what's left of chunks after taking 0" in {
+      mustExecute(1) { flatMapEC =>
+        val take0AndConsume = (Enumeratee.take[String](0) &>> Iteratee.consume()).flatMap(_ => Iteratee.consume())(flatMapEC)
+        val enumerator = Enumerator(Range(1, 20).map(_.toString): _*)
+        Await.result(enumerator |>>> take0AndConsume, Duration.Inf) must equalTo(Range(1, 20).map(_.toString).mkString)
+      }
+    }
+
     "passes along what's left of chunks after taking 3" in {
       mustExecute(1) { flatMapEC =>
         val take3AndConsume = (Enumeratee.take[String](3) &>> Iteratee.consume()).flatMap(_ => Iteratee.consume())(flatMapEC)


### PR DESCRIPTION
The first commit fixes a bug with `Enumeratee.take(0)` (test included), where the chunks are not passed along. (I can make this a separate pull request, but there is a dependency.)

---

The other commits simplify many of the `Enumeratee` implementations. Many do odd things. For example:

```
def filter[E](predicate: E => Boolean)(implicit ec: ExecutionContext): Enumeratee[E, E] = new CheckDone[E, E] {
  val pec = ec.prepare()

  def step[A](k: K[E, A]): K[E, Iteratee[E, A]] = {

    case in @ Input.El(e) => Iteratee.flatten(Future(predicate(e))(pec).map { b =>
      if (b) (new CheckDone[E, E] { def continue[A](k: K[E, A]) = Cont(step(k)) } &> k(in)) else Cont(step(k))
    }(dec))

    case Input.Empty =>
      new CheckDone[E, E] { def continue[A](k: K[E, A]) = Cont(step(k)) } &> k(Input.Empty)

    case Input.EOF => Done(Cont(k), Input.EOF)

  }

  def continue[A](k: K[E, A]) = Cont(step(k))

}
```

Even to someone who knows iteratees, there is a lot of noise. It can be written more clearly as

```
def filter[E](predicate: E => Boolean)(implicit ec: ExecutionContext): Enumeratee[E, E] = new CheckDone[E, E] {
  val pec = ec.prepare()

  def continue[A](k: K[E, A]) = Cont {
    case in @ Input.El(e) => Iteratee.flatten(Future(predicate(e))(pec).map(
      if (_) this &> k(in) else Cont(step(k)))(dec)
    )

    case Input.Empty => this &> k(Input.Empty)

    case Input.EOF => Done(Cont(k), Input.EOF)
  }
}
```

It's nice to have excellent examples for creating your own Enumeratees.

In total, this drops about 200 lines from Enumeratee.scala.