### PR TITLE
TolerantText charset handling

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -8,6 +8,7 @@ import akka.stream.javadsl.Sink;
 import akka.util.ByteString;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.w3c.dom.Document;
+import play.Logger;
 import play.api.http.HttpConfiguration;
 import play.api.http.Status$;
 import play.api.libs.Files;
@@ -18,6 +19,9 @@ import play.http.HttpErrorHandler;
 import play.libs.F;
 import play.libs.XML;
 import play.libs.streams.Accumulator;
+import play.mvc.Http.HeaderNames;
+import play.mvc.Http.MimeTypes;
+import play.util.XmlEncodingDetective;
 import scala.compat.java8.FutureConverters;
 
 import javax.inject.Inject;
@@ -248,8 +252,53 @@ public interface BodyParser<A> {
 
         @Override
         protected String parse(Http.RequestHeader request, ByteString bytes) throws Exception {
-            String charset = request.charset().orElse("ISO-8859-1");
+            String charset = request.charset().orElse("");
+            String requestContentType = request.getHeader(HeaderNames.CONTENT_TYPE);
+            if (!"".equals(charset) && !MimeTypes.JSON.equals(requestContentType)){
+                return bytes.decodeString(charset);
+            }
+            charset = "ISO-8859-1";
+            switch (requestContentType){
+                case MimeTypes.JSON:
+                    charset = getJsonCharset(bytes);
+                    break;
+                case MimeTypes.XML: case MimeTypes.XML_DTD: case MimeTypes.XML_EXTERNAL_PARSED_ENTITY:
+                    try {
+                        charset = XmlEncodingDetective.detectEncoding(bytes, request.charset().orElse(null), requestContentType);
+                    } catch (Exception e){
+                        Logger.info("failed to detect encoding: " + e.getMessage());
+                        charset = "UTF-8";
+                    }
+                    break;
+                case MimeTypes.TEXT: case MimeTypes.HTML:
+                    charset = "ISO-8859-1";
+                    break;
+                default:
+                    break;
+            }
             return bytes.decodeString(charset);
+        }
+
+        private String getJsonCharset(ByteString bytes){
+            String charset = "UTF-8";
+            try {
+                Byte[] octetsArray = new Byte[4];
+                bytes.copyToArray(octetsArray, 0, 4);
+                if (octetsArray[0] == 0 && octetsArray[1] == 0 && octetsArray[2] == 0 && octetsArray[3] != 0){
+                    charset = "UTF-32BE";
+                } else if (octetsArray[0] == 0 && octetsArray[1] != 0 && octetsArray[2] == 0 && octetsArray[3] != 0){
+                    charset = "UTF-16BE";
+                } else if (octetsArray[0] != 0 && octetsArray[1] == 0 && octetsArray[2] == 0 && octetsArray[3] == 0){
+                    charset = "UTF-32LE";
+                } else if (octetsArray[0] != 0 && octetsArray[1] == 0 && octetsArray[2] != 0 && octetsArray[3] == 0){
+                    charset = "UTF-16LE";
+                } else if (octetsArray[0] != 0 && octetsArray[1] != 0 && octetsArray[2] != 0 && octetsArray[3] != 0){
+                    charset = "UTF-8";
+                }
+                return charset;
+            } catch (Exception e){
+                return charset;
+            }
         }
     }
 

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -2207,6 +2207,16 @@ public class Http {
         String XML = "application/xml";
 
         /**
+         * Content-Type of xml-external-parsed-entity.
+         */
+        String XML_EXTERNAL_PARSED_ENTITY = "application/xml-external-parsed-entity";
+
+        /**
+         * Content-Type of xml-dtd.
+         */
+        String XML_DTD = "application/xml-dtd";
+
+        /**
          * Content-Type of css.
          */
         String CSS = "text/css";

--- a/framework/src/play/src/main/java/play/util/XmlEncodingDetective.java
+++ b/framework/src/play/src/main/java/play/util/XmlEncodingDetective.java
@@ -1,0 +1,231 @@
+package play.util;
+
+import akka.util.ByteString;
+
+import java.io.*;
+import java.text.MessageFormat;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @implNote    adapted, fixed and enhanced (refs https://tools.ietf.org/html/rfc7303 instead of http://www.ietf.org/rfc/rfc3023.txt)
+ *              from https://rometools.github.io/rome/
+ *
+ */
+public abstract class XmlEncodingDetective {
+
+    private static final String US_ASCII = "US-ASCII";
+    private static final String UTF_8 = "UTF-8";
+    private static final String UTF_16BE = "UTF-16BE";
+    private static final String UTF_16LE = "UTF-16LE";
+    private static final String UTF_16 = "UTF-16";
+    private static final String UTF_32LE = "UTF-32LE";
+    private static final String UTF_32BE = "UTF-32BE";
+    private static final String UTF_32 = "UTF-32";
+
+    private static final int PROLOG_BUFFER_SIZE = 4096;
+
+    private static final Pattern ENCODING_PATTERN = Pattern.compile("<\\?xml.*encoding[\\s]*=[\\s]*((?:\".[^\"]*\")|" +
+            "(?:'.[^']*'))", Pattern.MULTILINE);
+
+    private static final MessageFormat RAW_EX_1 = new MessageFormat("Invalid encoding, BOM [{0}] XML guess [{1}] XML " +
+            "prolog [{2}] encoding mismatch");
+    private static final MessageFormat RAW_EX_2 = new MessageFormat("Invalid encoding, BOM [{0}] XML guess [{1}] XML " +
+            "prolog [{2}] unknown BOM");
+    private static final MessageFormat HTTP_EX_1 = new MessageFormat(
+            "Invalid encoding, CT-MIME [{0}] CT-Enc [{1}] BOM [{2}] XML guess [{3}] XML prolog [{4}], BOM must be " +
+                    "NULL");
+    private static final MessageFormat HTTP_EX_2 = new MessageFormat(
+            "Invalid encoding, CT-MIME [{0}] CT-Enc [{1}] BOM [{2}] XML guess [{3}] XML prolog [{4}], encoding " +
+                    "mismatch");
+
+    /**
+     * @param byteString
+     * @param httpCharset
+     * @param httpContentType
+     * @return best effort encoding
+     * @throws IOException when detecting fails
+     */
+    public static String detectEncoding(final ByteString byteString, final String httpCharset, final String
+            httpContentType) throws IOException {
+
+        final String bomEncoding = getBOMEncoding(byteString);
+        int mark = 0;
+        if (bomEncoding != null) {
+            switch (bomEncoding) {
+                case UTF_16BE:
+                case UTF_16LE:
+                    mark = 2;
+                    break;
+                case UTF_32BE:
+                case UTF_32LE:
+                    mark = 4;
+                    break;
+                default: // UTF-8
+                    mark = 3;
+            }
+        }
+        final String octetEncoding = getOctetEncoding(byteString, mark);
+        if (octetEncoding != null) {
+            if (bomEncoding != null && !octetEncoding.equals(bomEncoding)) {
+                throw new RuntimeException("XML Encoding error: first octets pattern doesn't match existing BOM " +
+                        "encoding");
+            }
+        }
+        final String prologEncoding = getPrologEncoding(byteString, (bomEncoding == null) ? octetEncoding :
+                bomEncoding, mark);
+        String result = calculateHttpEncoding(httpContentType, httpCharset, bomEncoding, octetEncoding, prologEncoding);
+        return result;
+    }
+
+    private static String getBOMEncoding(final ByteString byteString) {
+        String encoding = null;
+        Byte[] bytes = new Byte[4];
+        byteString.copyToArray(bytes, 0, 4);
+
+        if (bytes[0] == 0xFE && bytes[1] == 0xFF) {
+            encoding = UTF_16BE;
+        } else if (bytes[0] == 0xFF && bytes[1] == 0xFE) {
+            if (bytes[2] == 0x00 && bytes[3] == 0x00) {
+                encoding = UTF_32LE;
+            } else {
+                encoding = UTF_16LE;
+            }
+        } else if (bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) {
+            encoding = UTF_8;
+        } else if (bytes[0] == 0x00 && bytes[1] == 0x00 && bytes[2] == 0xFE && bytes[3] == 0xFF) {
+            encoding = UTF_32BE;
+        }
+        return encoding;
+    }
+
+    private static String getOctetEncoding(final ByteString byteString, final int mark) {
+        String encoding = null;
+        Byte[] bytes = new Byte[4];
+        byteString.copyToArray(bytes, mark, 4);
+        if (bytes[0] == 0x00 && bytes[1] == 0x3C && bytes[2] == 0x00 && bytes[3] == 0x3F) {
+            encoding = UTF_16BE;
+        } else if (bytes[0] == 0x3C && bytes[1] == 0x00 && bytes[2] == 0x3F && bytes[3] == 0x00) {
+            encoding = UTF_16LE;
+        } else if (bytes[0] == 0x3C && bytes[1] == 0x3F && bytes[2] == 0x78 && bytes[3] == 0x6D) {
+            encoding = UTF_8;
+        } else if (bytes[0] == 0x00 && bytes[1] == 0x00 && bytes[2] == 0x00 && bytes[3] == 0x3C) {
+            encoding = UTF_32BE;
+        } else if (bytes[0] == 0x3C && bytes[1] == 0x00 && bytes[2] == 0x00 && bytes[3] == 0x00) {
+            encoding = UTF_32LE;
+        } else if (bytes[0] == 0x3C && bytes[1] == 0x00 && bytes[2] == 0x78 && bytes[3] == 0x00) {
+            encoding = UTF_32LE;
+        }
+        return encoding;
+    }
+
+    private static String getPrologEncoding(final ByteString byteString, final String fileEncoding, final int mark)
+            throws IOException {
+        String encoding = null;
+
+        if (fileEncoding != null) {
+            int bytesSize = byteString.size();
+            int bufferSize = (bytesSize > PROLOG_BUFFER_SIZE) ? PROLOG_BUFFER_SIZE : bytesSize;
+            Byte[] bytesAll = new Byte[bufferSize];
+            byteString.copyToArray(bytesAll);
+            Byte[] bytes = new Byte[bufferSize - mark];
+            System.arraycopy(bytesAll,mark,bytes,0,bytes.length);
+            byte[] bytesPrim = toPrimitive(bytes);
+            final String firstChars = new String(bytesPrim, 0, bytes.length);
+            final int firstGT = firstChars.indexOf(">");
+            if (firstGT == -1) {
+                throw new IOException("XML prolog or ROOT element not found on first " + bytesPrim.length + " bytes");
+            }
+            if (bytes.length > 0) {
+                final Reader reader = new InputStreamReader(new ByteArrayInputStream(bytesPrim, 0, firstGT + 1),
+                        fileEncoding);
+                final BufferedReader bReader = new BufferedReader(reader);
+                final StringBuffer prolog = new StringBuffer();
+                String line = bReader.readLine();
+                while (line != null) {
+                    prolog.append(line);
+                    line = bReader.readLine();
+                }
+                final Matcher m = ENCODING_PATTERN.matcher(prolog);
+                if (m.find()) {
+                    encoding = m.group(1).toUpperCase(Locale.ENGLISH);
+                    encoding = encoding.substring(1, encoding.length() - 1);
+                }
+            }
+        }
+
+        return encoding;
+    }
+
+    private static String calculateHttpEncoding(final String httpContentType, final String httpCharset, final String
+            bomEncoding, final String octetsEncoding, final String prologEncoding) throws IOException {
+        String encoding;
+        if (httpCharset == null) {
+            encoding = calculateRawEncoding(bomEncoding, octetsEncoding, prologEncoding);
+        } else if (bomEncoding != null && (httpCharset.equals(UTF_16BE) || httpCharset.equals(UTF_16LE))) {
+            throw new IOException(HTTP_EX_1.format(new Object[]{httpContentType, httpCharset, bomEncoding,
+                    octetsEncoding, prologEncoding}));
+        } else if (httpCharset.equals(UTF_16) || httpCharset.equals(UTF_32)) {
+            if (bomEncoding != null && bomEncoding.startsWith(httpCharset)) {
+                encoding = bomEncoding;
+            } else {
+                throw new IOException(HTTP_EX_2.format(new Object[]{httpContentType, httpCharset, bomEncoding,
+                        octetsEncoding, prologEncoding}));
+            }
+        } else {
+            encoding = httpCharset;
+        }
+
+        return encoding;
+    }
+
+    private static String calculateRawEncoding(final String bomEncoding, final String octetsEncoding, final String
+            prologEncoding) throws IOException {
+        String encoding;
+        if (bomEncoding == null) {
+            if (octetsEncoding == null || prologEncoding == null) {
+                encoding = UTF_8;
+            } else if ((prologEncoding.equals(UTF_16) && (octetsEncoding.equals(UTF_16BE) || octetsEncoding.equals(UTF_16LE))) ||
+                    (prologEncoding.equals(UTF_32) && (octetsEncoding.equals(UTF_32BE) || octetsEncoding.equals (UTF_32LE)))) {
+                encoding = octetsEncoding;
+            } else {
+                encoding = prologEncoding;
+            }
+        } else if (bomEncoding.equals(UTF_8)) {
+            if (octetsEncoding != null && !octetsEncoding.equals(UTF_8)) {
+                throw new IOException(RAW_EX_1.format(new Object[]{bomEncoding, octetsEncoding, prologEncoding}));
+            }
+            if (prologEncoding != null && !prologEncoding.equals(UTF_8)) {
+                throw new IOException(RAW_EX_1.format(new Object[]{bomEncoding, octetsEncoding, prologEncoding}));
+            }
+            encoding = UTF_8;
+        } else if (bomEncoding.equals(UTF_16BE) || bomEncoding.equals(UTF_16LE) || bomEncoding.equals(UTF_32BE) ||
+                bomEncoding.equals(UTF_32LE)) {
+            if (octetsEncoding != null && !octetsEncoding.equals(bomEncoding)) {
+                throw new IOException(RAW_EX_1.format(new Object[]{bomEncoding, octetsEncoding, prologEncoding}));
+            }
+            if (prologEncoding != null && !prologEncoding.equals(UTF_16) && !prologEncoding.equals(UTF_32) &&
+                    !prologEncoding.equals(bomEncoding)) {
+                throw new IOException(RAW_EX_1.format(new Object[]{bomEncoding, octetsEncoding, prologEncoding}));
+            }
+            encoding = bomEncoding;
+        } else {
+            throw new IOException(RAW_EX_2.format(new Object[]{bomEncoding, octetsEncoding, prologEncoding}));
+        }
+        return encoding;
+    }
+
+    public static byte[] toPrimitive(Byte[] array) {
+        if (array == null) {
+            return null;
+        } else if (array.length == 0) {
+            return new byte[0];
+        }
+        final byte[] result = new byte[array.length];
+        for (int i = 0; i < array.length; i++) {
+            result[i] = array[i].byteValue();
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Related to #5334 and #5338;

Adds best effort charset resolution in TolerantText java body parser, inferring from content type and first octets in JSON files (for JSON content type, refs https://tools.ietf.org/html/rfc4627). Defaults to UTF-8 for XML and ISO-8559-1 for text MIME types. 

If agreed upon, will add test case and  XML charset resolution to behave similarly to JSON, based on Appendix F of XML spec (http://www.w3.org/TR/xml/#sec-guessing), with BOM and first octets checking, not parsing declaration.