### PR TITLE
Java doc fixes

### DIFF
--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -201,7 +201,7 @@ public class F {
         /**
          * Create a Promise which will be redeemed with the result of a given function.
          *
-         * The Function0 will be run in the default ExecutionContext.
+         * The function will be run in the default ExecutionContext.
          *
          * @param function Used to fulfill the Promise.
          * @deprecated Use {@link CompletableFuture#supplyAsync(Supplier, Executor)} instead.
@@ -212,7 +212,7 @@ public class F {
         }
 
         /**
-         * Create a Promise which will be redeemed with the result of a given Function0.
+         * Create a Promise which will be redeemed with the result of a given function.
          *
          * @param function Used to fulfill the Promise.
          * @param ec The ExecutionContext to run the function in.

--- a/framework/src/play/src/main/java/play/mvc/WebSocket.java
+++ b/framework/src/play/src/main/java/play/mvc/WebSocket.java
@@ -239,7 +239,7 @@ public abstract class WebSocket {
 
     /**
      * Creates a WebSocket. The abstract {@code onReady} method is
-     * implemented using the specified {@code Callback2<In<A>, Out<A>>}
+     * implemented using the specified {@code BiConsumer<In<A>, Out<A>>}
      *
      * @param callback the callback used to implement onReady
      * @param <A> the in/out type of the legacy websocket
@@ -304,7 +304,7 @@ public abstract class WebSocket {
 
     /**
      * An extension of WebSocket that obtains its onReady from
-     * the specified {@code Callback2<In<A>, Out<A>>}.
+     * the specified {@code BiConsumer<In<A>, Out<A>>}.
      *
      * @deprecated Use WebSocket.accept* instead.
      */


### PR DESCRIPTION
`Function0` and `Callback2` have been removed but still used in comments. Probably it was overlooked.