### PR TITLE
Replace the connection handler in netty core.

### DIFF
--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -4,6 +4,7 @@
 package play.core.server
 
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicLong
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
@@ -116,6 +117,7 @@ class NettyServer(
   private def bind(address: InetSocketAddress): (Channel, Source[Channel, _]) = {
     val serverChannelEventLoop = eventLoop.next
 
+    // Watches for channel events, and pushes them through a reactive streams publisher.
     val channelPublisher = new HandlerPublisher(serverChannelEventLoop, classOf[Channel])
 
     val channelClass = transport match {
@@ -126,7 +128,7 @@ class NettyServer(
     val bootstrap = new Bootstrap()
       .channel(channelClass)
       .group(serverChannelEventLoop)
-      .option(ChannelOption.AUTO_READ, java.lang.Boolean.FALSE)
+      .option(ChannelOption.AUTO_READ, java.lang.Boolean.FALSE) // publisher does ctx.read()
       .handler(channelPublisher)
       .localAddress(address)
 
@@ -139,22 +141,17 @@ class NettyServer(
   }
 
   /**
-   * Create a sink for the incoming connection channels, using the given handler function to handle the
-   * requests/responses.
+   * Create a sink for the incoming connection channels.
    */
-  private def channelSink(secure: Boolean, handler: Channel => Flow[HttpRequest, HttpResponse, _]): Sink[Channel, Future[Unit]] = {
+  private def channelSink(secure: Boolean): Sink[Channel, Future[Unit]] = {
+    Sink.foreach[Channel] { (connChannel: Channel) =>
 
-    Sink.foreach[Channel] { (channel: Channel) =>
+      // Setup the channel for explicit reads
+      connChannel.config().setOption(ChannelOption.AUTO_READ, java.lang.Boolean.FALSE)
 
-      // Select an event loop for this channel
-      val childChannelEventLoop = eventLoop.next()
+      setOptions(connChannel.config().setOption, nettyConfig.getConfig("option.child"))
 
-      // Setup the channel
-      channel.config().setOption(ChannelOption.AUTO_READ, java.lang.Boolean.FALSE)
-
-      setOptions(channel.config().setOption, nettyConfig.getConfig("option.child"))
-
-      val pipeline = channel.pipeline()
+      val pipeline = connChannel.pipeline()
       if (secure) {
         sslEngineProvider.map { sslEngineProvider =>
           val sslEngine = sslEngineProvider.createSSLEngine()
@@ -171,31 +168,17 @@ class NettyServer(
         pipeline.addLast("logging", new LoggingHandler(LogLevel.DEBUG))
       }
 
-      // Reactive streams publisher/subscribers
-      val requestPublisher = new HandlerPublisher(childChannelEventLoop, classOf[HttpRequest])
-      val responseSubscriber = new HandlerSubscriber[HttpResponse](childChannelEventLoop) {
-        override def error(error: Throwable) = {
-          handleSubscriberError(error)
-          super.error(error)
-        }
-      }
+      val requestHandler = new PlayRequestHandler(this)
 
-      // HttpStreamsServerHandler adapts the request/response bodies to/from reactive streams
-      pipeline.addLast("http-handler", new HttpStreamsServerHandler(Seq[ChannelHandler](requestPublisher, responseSubscriber).asJava))
+      // Use the streams handler to close off the connection.
+      pipeline.addLast("http-handler", new HttpStreamsServerHandler(Seq[ChannelHandler](requestHandler).asJava))
 
-      pipeline.addLast("request-publisher", requestPublisher)
-      pipeline.addLast("response-subscriber", responseSubscriber)
-
-      // Get the processor to handle this channel
-      val channelProcessor = handler(channel).toProcessor.run()
-
-      // Attach the publisher/subscriber
-      channelProcessor.subscribe(responseSubscriber)
-      requestPublisher.subscribe(channelProcessor)
+      pipeline.addLast("request-handler", requestHandler)
 
       // And finally, register the channel with the event loop
-      childChannelEventLoop.register(channel)
-      allChannels.add(channel)
+      val childChannelEventLoop = eventLoop.next()
+      childChannelEventLoop.register(connChannel)
+      allChannels.add(connChannel)
     }
   }
 
@@ -210,19 +193,17 @@ class NettyServer(
     }
   }
 
-  private val nettyServerFlow = new NettyServerFlow(this)
-
   // Maybe the HTTP server channel
   private val httpChannel = config.port.map { port =>
     val (serverChannel, channelSource) = bind(new InetSocketAddress(config.address, port))
-    channelSource.runWith(channelSink(secure = false, nettyServerFlow.createFlow))
+    channelSource.runWith(channelSink(secure = false))
     serverChannel
   }
 
   // Maybe the HTTPS server channel
   private val httpsChannel = config.sslPort.map { port =>
     val (serverChannel, channelSource) = bind(new InetSocketAddress(config.address, port))
-    channelSource.runWith(channelSink(secure = true, nettyServerFlow.createFlow))
+    channelSource.runWith(channelSink(secure = true))
     serverChannel
   }
 

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -1,20 +1,21 @@
 package play.core.server.netty
 
+import java.io.IOException
 import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicLong
 
 import akka.stream.Materializer
-import akka.stream.scaladsl.Flow
 import com.typesafe.netty.http.DefaultWebSocketHttpResponse
-import io.netty.channel.Channel
+import io.netty.channel._
 import io.netty.handler.codec.TooLongFrameException
-import io.netty.handler.codec.http._
+import io.netty.handler.codec.http.HttpHeaders.Names
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory
+import io.netty.handler.codec.http._
 import io.netty.handler.ssl.SslHandler
-import play.api.Application
-import play.api.Logger
-import play.api.http._
+import play.api.{ Application, Logger }
+import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler, Status, HeaderNames }
 import play.api.libs.streams.Accumulator
-import play.api.mvc._
+import play.api.mvc.{ RequestHeader, Results, WebSocket, EssentialAction }
 import play.core.server.NettyServer
 import play.core.server.common.{ ServerResultUtils, ForwardedHeaderHandler }
 import play.core.system.RequestIdProvider
@@ -22,9 +23,23 @@ import play.core.system.RequestIdProvider
 import scala.concurrent.Future
 import scala.util.{ Success, Failure }
 
-private[server] class NettyServerFlow(server: NettyServer) {
+private object PlayRequestHandler {
+  private val logger: Logger = Logger(classOf[PlayRequestHandler])
+}
 
-  private val logger = Logger(classOf[NettyServerFlow])
+private[play] class PlayRequestHandler(val server: NettyServer) extends ChannelInboundHandlerAdapter {
+
+  import PlayRequestHandler._
+
+  // We keep track of whether there are requests in flight.  If there are, we don't respond to read
+  // complete, since back pressure is the responsibility of the streams.
+  private val requestsInFlight = new AtomicLong()
+
+  // This is used essentially as a queue, each incoming request attaches callbacks to this
+  // and replaces it to ensure that responses are written out in the same order that they came
+  // in.
+  private var lastResponseSent: Future[Unit] = Future.successful(())
+
   // todo: make forwarded header handling a filter
   private lazy val modelConversion = new NettyModelConversion(
     new ForwardedHeaderHandler(
@@ -33,18 +48,9 @@ private[server] class NettyServerFlow(server: NettyServer) {
   )
 
   /**
-   * Create a flow to handle the given channel.
-   */
-  def createFlow(channel: Channel): Flow[HttpRequest, HttpResponse, _] = {
-    Flow[HttpRequest].mapAsync(2) { request =>
-      handle(channel, request)
-    }
-  }
-
-  /**
    * Handle the given request.
    */
-  private def handle(channel: Channel, request: HttpRequest): Future[HttpResponse] = {
+  def handle(channel: Channel, request: HttpRequest): Future[HttpResponse] = {
 
     logger.trace("Http request received by netty: " + request)
 
@@ -142,12 +148,92 @@ private[server] class NettyServerFlow(server: NettyServer) {
     }
   }
 
+  //----------------------------------------------------------------
+  // Netty overrides
+
+  override def channelRead(ctx: ChannelHandlerContext, msg: Object): Unit = {
+    logger.trace(s"channelRead: ctx = ${ctx}, msg = ${msg}")
+    msg match {
+      case req: HttpRequest =>
+        requestsInFlight.incrementAndGet()
+        // Do essentially the same thing that the mapAsync call in NettyFlowHandler is doing
+        val future: Future[HttpResponse] = handle(ctx.channel(), req)
+
+        import play.api.libs.iteratee.Execution.Implicits.trampoline
+        lastResponseSent = lastResponseSent.flatMap { _ =>
+          // Need an explicit cast to Future[Unit] to help scalac out.
+          val f: Future[Unit] = future.map { httpResponse =>
+            if (requestsInFlight.decrementAndGet() == 0) {
+              // Since we've now gone down to zero, we need to issue a
+              // read, in case we ignored an earlier read complete
+              ctx.read()
+            }
+            ctx.writeAndFlush(httpResponse)
+          }
+
+          f.recover {
+            case error: Exception =>
+              logger.error("Exception caught in channelRead future", error)
+              sendSimpleErrorResponse(ctx, HttpResponseStatus.SERVICE_UNAVAILABLE)
+          }
+        }
+    }
+  }
+
+  override def channelReadComplete(ctx: ChannelHandlerContext): Unit = {
+    logger.trace(s"channelReadComplete: ctx = ${ctx}")
+
+    // The normal response to read complete is to issue another read,
+    // but we only want to do that if there are no requests in flight,
+    // this will effectively limit the number of in flight requests that
+    // we'll handle by pushing back on the TCP stream, but it also ensures
+    // we don't get in the way of the request body reactive streams,
+    // which will be using channel read complete and read to implement
+    // their own back pressure
+    if (requestsInFlight.get() == 0) {
+      ctx.read()
+    } else {
+      // otherwise forward it, so that any handler publishers downstream
+      // can handle it
+      ctx.fireChannelReadComplete()
+    }
+  }
+
+  override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
+    cause match {
+      // IO exceptions happen all the time, it usually just means that the client has closed the connection before fully
+      // sending/receiving the response.
+      case e: IOException =>
+        logger.trace("Benign IO exception caught in Netty", e)
+        ctx.channel().close()
+      case e: TooLongFrameException =>
+        logger.warn("Handling TooLongFrameException", e)
+        sendSimpleErrorResponse(ctx, HttpResponseStatus.REQUEST_URI_TOO_LONG)
+      case e: IllegalArgumentException if Option(e.getMessage).exists(_.contains("Header value contains a prohibited character")) =>
+        // https://github.com/netty/netty/blob/netty-3.9.3.Final/src/main/java/org/jboss/netty/handler/codec/http/HttpHeaders.java#L1075-L1080
+        logger.debug("Handling Header value error", e)
+        sendSimpleErrorResponse(ctx, HttpResponseStatus.BAD_REQUEST)
+      case e =>
+        logger.error("Exception caught in Netty", e)
+        ctx.channel().close()
+    }
+  }
+
+  override def channelActive(ctx: ChannelHandlerContext): Unit = {
+    // AUTO_READ is off, so need to do the first read explicitly.
+    // this method is called when the channel is registered with the event loop,
+    // so ctx.read is automatically safe here w/o needing an isRegistered().
+    ctx.read()
+  }
+
+  //----------------------------------------------------------------
+  // Private methods
+
   /**
    * Handle an essential action.
    */
   private def handleAction(action: EssentialAction, requestHeader: RequestHeader,
     request: HttpRequest, app: Option[Application]): Future[HttpResponse] = {
-
     implicit val mat: Materializer = app.fold(server.materializer)(_.materializer)
     import play.api.libs.iteratee.Execution.Implicits.trampoline
 
@@ -170,7 +256,18 @@ private[server] class NettyServerFlow(server: NettyServer) {
   /**
    * Get the error handler for the application.
    */
-  private def errorHandler(app: Option[Application]) =
+  private def errorHandler(app: Option[Application]): HttpErrorHandler =
     app.fold[HttpErrorHandler](DefaultHttpErrorHandler)(_.errorHandler)
 
+  /**
+   * Sends a simple response with no body, then closes the connection.
+   */
+  private def sendSimpleErrorResponse(ctx: ChannelHandlerContext, status: HttpResponseStatus): ChannelFuture = {
+    val response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status)
+    response.headers().set(Names.CONNECTION, "close")
+    response.headers().set(Names.CONTENT_LENGTH, "0")
+    val f = ctx.channel().write(response)
+    f.addListener(ChannelFutureListener.CLOSE)
+    f
+  }
 }


### PR DESCRIPTION
Changes the connection handler in the NettyServer from using an Akka Streams approach to using a straight handler.  Modest improvements, but cuts down on context switch.

cc @jroper 