### PR TITLE
Update ModuleDirectory.md with info on Typescript integration

### DIFF
--- a/documentation/manual/ModuleDirectory.md
+++ b/documentation/manual/ModuleDirectory.md
@@ -26,6 +26,9 @@
 * **Website:** <https://github.com/jlitola/play-sass>
 * **Short description:** Asset handling for [Sass](http://sass-lang.com/) files
 
+### Typescript Plugin
+* **Website:** <https://github.com/ArpNetworking/sbt-typescript>
+* **Short description:** A plugin for SBT that uses sbt-web to compile typescript resources
 
 
 ## Auth


### PR DESCRIPTION
Adding info on integration a Typescript compiler in sbt. The one mentioned in the 2.4 docs (https://github.com/mumoshu/play2-typescript) does not work.
I have personally tested the plugin sucessfully with Play 2.4.4 and 2.4.6 but should support 2.5 as well according to the site.