### PR TITLE
add evolutions parameter `skipApplyDownsOnly`

### DIFF
--- a/framework/src/play-jdbc-evolutions/src/main/resources/reference.conf
+++ b/framework/src/play-jdbc-evolutions/src/main/resources/reference.conf
@@ -29,6 +29,9 @@ play {
     # to prod mode.
     autoApplyDowns = false
 
+    # Whether evolutions should be skipped, if the scripts are all down.
+    skipApplyDownsOnly = false
+
     # Db specific configuration. Should be a map of db names to configuration in the same format as this.
     db {
 

--- a/framework/src/play-jdbc/src/main/resources/reference.conf
+++ b/framework/src/play-jdbc/src/main/resources/reference.conf
@@ -225,6 +225,9 @@ play {
     # to prod mode.
     autoApplyDowns = false
 
+    # Whether evolutions should be skipped, if the scripts are all down.
+    skipApplyDownsOnly = false
+
     # Db specific configuration. Should be a map of db names to configuration in the same format as this.
     db {
 


### PR DESCRIPTION
I have been operating the service in a micro- service architecture.
In a particular service instance,
sometimes evolution script is not up-to-date.

so, I wish to skip the evolution scripts if downs only.
