### PR TITLE
Fix the code in the documentation for defining custom `Assets' for sub projects.

### DIFF
--- a/documentation/manual/detailedTopics/build/code/SubProjectsAssetsBuilder.scala
+++ b/documentation/manual/detailedTopics/build/code/SubProjectsAssetsBuilder.scala
@@ -1,5 +1,8 @@
 //#assets-builder
 package controllers.admin
-import play.api.http.LazyHttpErrorHandler
-object Assets extends controllers.AssetsBuilder(LazyHttpErrorHandler)
+
+import play.api.http.HttpErrorHandler
+import javax.inject._
+
+class Assets @Inject() (errorHandler: HttpErrorHandler) extends controllers.AssetsBuilder(errorHandler)
 //#assets-builder


### PR DESCRIPTION
Hi. I found the problem in the documentation(https://www.playframework.com/documentation/2.4.x/SBTSubProjects#Assets-and-controller-classes-should-be-all-defined-in-the-controllers.admin-package), so fixed the description. Please review my change.

## Problem
Defining a custom `Assets` by the way described in the doc causes the following errors:

```
--- (Running the application, auto-reloading is enabled) ---

[info] p.c.s.NettyServer - Listening for HTTP on /0:0:0:0:0:0:0:0:9401

(Server started, use Ctrl+D to stop and go back to the console...)

[info] Compiling 10 Scala sources and 2 Java sources to /Users/shinnya/tmp/sample/target/scala-2.11/classes...
[error] /Users/shinnya/tmp/sample/conf/routes:9: type Assets is not a member of package controllers.admin
[error] GET     /assets/*file               controllers.admin.Assets.versioned(path="/public", file: Asset)
[error] /Users/shinnya/tmp/sample/conf/routes:9: type Assets is not a member of package controllers.admin
[error] GET     /assets/*file               controllers.admin.Assets.versioned(path="/public", file: Asset)
[error] /Users/shinnya/tmp/sample/conf/routes:9: type Assets is not a member of package controllers.admin
[error] GET     /assets/*file               controllers.admin.Assets.versioned(path="/public", file: Asset)
[error] /Users/shinnya/tmp/sample/app/views/main.scala.html:8: value Assets is not a member of object controllers.routes
[error]         <link rel="stylesheet" media="screen" href="@routes.Assets.versioned("stylesheets/main.css")">
[error]                                                             ^
[error] /Users//tmp/sample/app/views/main.scala.html:9: value Assets is not a member of object controllers.routes
[error]         <link rel="shortcut icon" type="image/png" href="@routes.Assets.versioned("images/favicon.png")">
[error]                                                                  ^
[error] /Users/shinnya/tmp/sample/app/views/main.scala.html:10: value Assets is not a member of object controllers.routes
[error]         <script src="@routes.Assets.versioned("javascripts/hello.js")" type="text/javascript"></script>
[error]                              ^
[error] 6 errors found
[error] (compile:compileIncremental) Compilation failed
[error] application -

! @6ol8jh5ak - Internal server error, for (GET) [/] ->

play.sbt.PlayExceptions$CompilationException: Compilation error[type Assets is not a member of package controllers.admin]
        at play.sbt.PlayExceptions$CompilationException$.apply(PlayExceptions.scala:27) ~[na:na]
        at play.sbt.PlayExceptions$CompilationException$.apply(PlayExceptions.scala:27) ~[na:na]
        at scala.Option.map(Option.scala:145) ~[scala-library-2.11.6.jar:na]
        at play.sbt.run.PlayReload$$anonfun$taskFailureHandler$1.apply(PlayReload.scala:49) ~[na:na]
        at play.sbt.run.PlayReload$$anonfun$taskFailureHandler$1.apply(PlayReload.scala:44) ~[na:na]
        at scala.Option.map(Option.scala:145) ~[scala-library-2.11.6.jar:na]
        at play.sbt.run.PlayReload$.taskFailureHandler(PlayReload.scala:44) ~[na:na]
        at play.sbt.run.PlayReload$.compileFailure(PlayReload.scala:40) ~[na:na]
        at play.sbt.run.PlayReload$$anonfun$compile$1.apply(PlayReload.scala:17) ~[na:na]
        at play.sbt.run.PlayReload$$anonfun$compile$1.apply(PlayReload.scala:17) ~[na:na]
```

## What I did
I created a new play-scala application and added my custom `Assets` into `app/controllers/Assets.scala`.

The content of `Assets.scala` is here:

```scala
package controllers.admin
import play.api.http.LazyHttpErrorHandler
object Assets extends controllers.AssetsBuilder(LazyHttpErrorHandler)
```

Next, I edited `conf/routes` and replaced `Assets` with my `Assets` like below:

```scala
# Map static resources from the /public folder to the /assets URL path
GET     /assets/*file               controllers.admin.Assets.versioned(path="/public", file: Asset)
```

## How to solve
Defining `class Assets` instead of `object Assets` fixes this issue.

## How to reproduce
Execute shell commands below and access to 127.0.0.1:9000:

```bash
$ activator new sample play-scala
$ cd sample
$ cat <<EOF > app/controllers/Assets.scala
package controllers.admin
import play.api.http.LazyHttpErrorHandler
object Assets extends controllers.AssetsBuilder(LazyHttpErrorHandler)
EOF
$ cat <<EOF > conf/routes
# Routes
# This file defines all application routes (Higher priority routes first)
# ~~~~

# Home page
GET     /                           controllers.Application.index

# Map static resources from the /public folder to the /assets URL path
GET     /assets/*file               controllers.admin.Assets.versioned(path="/public", file: Asset)
EOF
$ activator run -Dhttp.port=9000
```
