### PR TITLE
#4574: Improve the case of when to display the logger configuration deprecation message

### DIFF
--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
@@ -8,8 +8,10 @@ import javax.inject.{ Provider, Inject }
 import com.google.inject.{ Module => GuiceModule }
 import play.api.routing.Router
 import play.api._
-import play.api.inject.{ Injector => PlayInjector, RoutesProvider, bind }
+import play.api.inject.{ RoutesProvider, bind }
 import play.core.{ DefaultWebCommands, WebCommands }
+
+import scala.collection.mutable
 
 /**
  * A builder for creating Applications using Guice.
@@ -89,7 +91,7 @@ final class GuiceApplicationBuilder(
       _.configure(environment)
     }
 
-    if (appConfiguration.underlying.hasPath("logger")) {
+    if (shouldDisplayLoggerDeprecationMessage(appConfiguration)) {
       Logger.warn("Logger configuration in conf files is deprecated and has no effect. Use a logback configuration file instead.")
     }
 
@@ -101,13 +103,13 @@ final class GuiceApplicationBuilder(
         bind[GlobalSettings.Deprecated] to globalSettings,
         bind[OptionalSourceMapper] to new OptionalSourceMapper(None),
         bind[WebCommands] to new DefaultWebCommands
-      ).createModule
+      ).createModule()
   }
 
   /**
    * Create a new Play Application using this configured builder.
    */
-  def build(): Application = injector.instanceOf[Application]
+  def build(): Application = injector().instanceOf[Application]
 
   /**
    * Internal copy method with defaults.
@@ -135,6 +137,45 @@ final class GuiceApplicationBuilder(
     disabled: Seq[Class[_]],
     eagerly: Boolean): GuiceApplicationBuilder =
     copy(environment, configuration, modules, overrides, disabled, eagerly)
+
+  /**
+   * Checks if the path contains the logger path
+   * and whether or not one of the keys contains a deprecated value
+   *
+   * @param appConfiguration The app configuration
+   * @return Returns true if one of the keys contains a deprecated value, otherwise false
+   */
+  def shouldDisplayLoggerDeprecationMessage(appConfiguration: Configuration): Boolean = {
+    import scala.collection.JavaConverters._
+    import scala.collection.mutable
+
+    val deprecatedValues = List("DEBUG", "WARN", "ERROR", "INFO", "TRACE", "OFF")
+
+    // Recursively checks each key to see if it contains a deprecated value
+    def hasDeprecatedValue(values: mutable.Map[String, AnyRef]): Boolean = {
+      values.exists {
+        case (_, value: String) if deprecatedValues.contains(value) =>
+          true
+        case (_, value: java.util.Map[String, AnyRef]) =>
+          hasDeprecatedValue(value.asScala)
+        case _ =>
+          false
+      }
+    }
+
+    if (appConfiguration.underlying.hasPath("logger")) {
+      appConfiguration.underlying.getAnyRef("logger") match {
+        case value: String =>
+          hasDeprecatedValue(mutable.Map("logger" -> value))
+        case value: java.util.Map[String, AnyRef] =>
+          hasDeprecatedValue(value.asScala)
+        case _ =>
+          false
+      }
+    } else {
+      false
+    }
+  }
 }
 
 private class AdditionalRouterProvider(additional: Router) extends Provider[Router] {

--- a/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
@@ -88,6 +88,23 @@ object GuiceApplicationBuilderSpec extends Specification {
       builder.injector().instanceOf[C] must throwAn[ProvisionException]
     }
 
+    "display logger deprecation message" in {
+      List("logger", "logger.resource", "logger.resource.test").forall { path =>
+        List("DEBUG", "WARN", "INFO", "ERROR", "TRACE", "OFF").forall { value =>
+          val data = Map(path -> value)
+          val builder = new GuiceApplicationBuilder()
+          builder.shouldDisplayLoggerDeprecationMessage(Configuration.from(data)) must_=== true
+        }
+      }
+    }
+
+    "not display logger deprecation message" in {
+      List("logger", "logger.resource", "logger.resource.test").forall { path =>
+        val data = Map(path -> "NOT_A_DEPRECATED_VALUE")
+        val builder = new GuiceApplicationBuilder()
+        builder.shouldDisplayLoggerDeprecationMessage(Configuration.from(data)) must_=== false
+      }
+    }
   }
 
   trait A


### PR DESCRIPTION
Introduced a new method in GuiceApplicationBuilder named shouldDisplayLoggerDeprecationMessage that checks the logger path for any of the deprecated values DEBUG/WARN/INFO/ERROR and in case of a deprecated value it returns true. This is then used instead of the old call that checked if the path contained the logger key. 

