### PR TITLE
Changed to the correct logger object

### DIFF
--- a/templates/play-scala/conf/logback.xml
+++ b/templates/play-scala/conf/logback.xml
@@ -1,6 +1,6 @@
 <configuration>
 
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>


### PR DESCRIPTION
The original file had `""play.api.libs.logback.ColoredLevel""`which generated an error when the project was run.  `""play.api.Logger$ColoredLevel""` works ok.