### PR TITLE
Rename identifiers named "flowMaterializer" to "materializer"

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
@@ -21,10 +21,10 @@ class CORSConfigProvider @Inject() (configuration: Configuration) extends Provid
  * Provider for CORSFilter.
  */
 class CORSFilterProvider @Inject() (configuration: Configuration, errorHandler: HttpErrorHandler, corsConfig: CORSConfig,
-    flowMaterializer: Materializer) extends Provider[CORSFilter] {
+    materializer: Materializer) extends Provider[CORSFilter] {
   lazy val get = {
     val pathPrefixes = PlayConfig(configuration).get[Seq[String]]("play.filters.cors.pathPrefixes")
-    new CORSFilter(corsConfig, errorHandler, pathPrefixes)(flowMaterializer)
+    new CORSFilter(corsConfig, errorHandler, pathPrefixes)(materializer)
   }
 }
 
@@ -44,7 +44,7 @@ class CORSModule extends Module {
 trait CORSComponents {
   def configuration: Configuration
   def httpErrorHandler: HttpErrorHandler
-  implicit def flowMaterializer: Materializer
+  implicit def materializer: Materializer
 
   lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(configuration)
   lazy val corsFilter: CORSFilter = new CORSFilter(corsConfig, httpErrorHandler, corsPathPrefixes)

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -252,7 +252,7 @@ class CSRFModule extends Module {
 trait CSRFComponents {
   def configuration: Configuration
   def httpErrorHandler: HttpErrorHandler
-  implicit def flowMaterializer: Materializer
+  implicit def materializer: Materializer
 
   lazy val csrfConfig: CSRFConfig = CSRFConfig.fromConfiguration(configuration)
   lazy val csrfTokenProvider: CSRF.TokenProvider = new CSRF.TokenProviderProvider(csrfConfig).get

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/Streams.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/Streams.scala
@@ -198,7 +198,7 @@ object Streams {
    * This is done by creating an Akka streams Subscriber based Source, and
    * adapting that to an Iteratee, before running the Akka streams source.
    *
-   * This method for adaptation requires a FlowMaterializer to materialize
+   * This method for adaptation requires a Materializer to materialize
    * the subscriber, however it does not materialize the subscriber until the
    * iteratees fold method has been invoked.
    */


### PR DESCRIPTION
```FlowMaterializer``` was a trait in early versions of akka-stream that later was renamed to ```Materializer```. In Filters-Helpers code, there are some identifier names derived from ```FlowMaterializer``` name, but some are already named ```materializer```, so naming is inconsistent. 

This naming is quite important when using compile-time DI since in ```BuiltInComponents```  there is a val named ```materializer```, which is not compatible with ```def flowMaterializer``` in ```CORSComponents```.

This is my first PR for Play framework, I hope I didn't break any rules.