### PR TITLE
Action of request handler can now be executed before action composition

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/http/JavaHttpRequestHandlers.md
+++ b/documentation/manual/working/javaGuide/advanced/http/JavaHttpRequestHandlers.md
@@ -12,7 +12,7 @@ The [`HttpRequestHandler`](api/java/play/http/HttpRequestHandler.html) interface
 
 There is also a [`DefaultHttpRequestHandler`](api/java/play/http/DefaultHttpRequestHandler.html) class that can be used if you don't want to implement both methods.
 
->> Note: If you are providing an implementation of `wrapAction` because you need to apply a cross cutting concern to an action before is executed, creating a [[filter|JavaHttpFilters]] is a more idiomatic way of achieving the same.
+> **Note:** If you are providing an implementation of `wrapAction` because you need to apply a cross cutting concern to an action before is executed, creating a [[filter|JavaHttpFilters]] is a more idiomatic way of achieving the same.
 
 ## Configuring the http request handler
 
@@ -29,3 +29,5 @@ If you don’t want to place your request handler in the root package, or if you
 The http request handler that Play uses if none is configured is one that delegates to the legacy `GlobalSettings` methods.  This may have a performance impact as it will mean your application has to do many lookups out of Guice to handle a single request.  If you are not using a `Global` object, then you don't need this, instead you can configure Play to use the default http request handler:
 
     play.http.requestHandler = "play.http.DefaultHttpRequestHandler"
+
+> **Note:** If you are also using [[action composition|JavaActionsComposition]] then the action returned by the ```createAction``` method of the request handler is executed **after** the action composition ones by default. If you want to change this order set ```play.http.actionComposition.executeRequestHandlerActionFirst = true``` in ```application.conf```.

--- a/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionRequestHandler.java
+++ b/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionRequestHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.it.http;
+
+import play.http.HttpRequestHandler;
+import play.mvc.*;
+import play.test.Helpers;
+
+import java.lang.reflect.Method;
+
+import java.util.concurrent.CompletionStage;
+
+public class ActionCompositionRequestHandler implements HttpRequestHandler {
+
+    @Override
+    public Action createAction(Http.Request request, Method actionMethod) {
+        return new Action.Simple() {
+            @Override
+            public CompletionStage<Result> call(Http.Context ctx) {
+                return delegate.call(ctx).thenApply(result -> {
+                    String newContent = "requesthandler" + Helpers.contentAsString(result);
+                    return Results.ok(newContent);
+                });
+            }
+        };
+    }
+
+    @Override
+    public Action wrapAction(Action action) {
+        return action;
+    }
+}

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -70,6 +70,108 @@ object JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     }
   }
 
+  "When action composition is configured to invoke request handler action first" should {
+    "execute request handler action first and action composition before controller composition" in makeRequest(new ComposedController {
+      @ActionAnnotation
+      override def action: Result = Results.ok()
+    }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false",
+           "play.http.actionComposition.executeRequestHandlerActionFirst" -> "true",
+           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
+      response.body must beEqualTo("requesthandleractioncontroller")
+    }
+
+    "execute request handler action first and controller composition before action composition" in makeRequest(new ComposedController {
+      @ActionAnnotation
+      override def action: Result = Results.ok()
+    }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "true",
+           "play.http.actionComposition.executeRequestHandlerActionFirst" -> "true",
+           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
+      response.body must beEqualTo("requesthandlercontrolleraction")
+    }
+
+    "execute request handler action first with only controller composition" in makeRequest(new ComposedController {
+      override def action: Result = Results.ok()
+    }, Map("play.http.actionComposition.executeRequestHandlerActionFirst" -> "true",
+           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
+      response.body must beEqualTo("requesthandlercontroller")
+    }
+
+    "execute request handler action first with only action composition" in makeRequest(new MockController {
+      @ActionAnnotation
+      override def action: Result = Results.ok()
+    }, Map("play.http.actionComposition.executeRequestHandlerActionFirst" -> "true",
+           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
+      response.body must beEqualTo("requesthandleraction")
+    }
+  }
+
+  "When action composition is configured to invoke request handler action last" should {
+    "execute request handler action last and action composition before controller composition" in makeRequest(new ComposedController {
+      @ActionAnnotation
+      override def action: Result = Results.ok()
+    }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false",
+           "play.http.actionComposition.executeRequestHandlerActionFirst" -> "false",
+           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
+      response.body must beEqualTo("actioncontrollerrequesthandler")
+    }
+
+    "execute request handler action last and controller composition before action composition" in makeRequest(new ComposedController {
+      @ActionAnnotation
+      override def action: Result = Results.ok()
+    }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "true",
+           "play.http.actionComposition.executeRequestHandlerActionFirst" -> "false",
+           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
+      response.body must beEqualTo("controlleractionrequesthandler")
+    }
+
+    "execute request handler action last with only controller composition" in makeRequest(new ComposedController {
+      override def action: Result = Results.ok()
+    }, Map("play.http.actionComposition.executeRequestHandlerActionFirst" -> "false",
+           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
+      response.body must beEqualTo("controllerrequesthandler")
+    }
+
+    "execute request handler action last with only action composition" in makeRequest(new MockController {
+      @ActionAnnotation
+      override def action: Result = Results.ok()
+    }, Map("play.http.actionComposition.executeRequestHandlerActionFirst" -> "false",
+           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
+      response.body must beEqualTo("actionrequesthandler")
+    }
+
+    "execute request handler action last is the default and controller composition before action composition" in makeRequest(new ComposedController {
+      @ActionAnnotation
+      override def action: Result = Results.ok()
+    }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "true",
+           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
+      response.body must beEqualTo("controlleractionrequesthandler")
+    }
+
+    "execute request handler action last is the default and action composition before controller composition" in makeRequest(new ComposedController {
+      @ActionAnnotation
+      override def action: Result = Results.ok()
+    }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false",
+           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
+      response.body must beEqualTo("actioncontrollerrequesthandler")
+    }
+  }
+
+  "When request handler is configured without action composition" should {
+    "execute request handler action last without action composition" in makeRequest(new MockController {
+      override def action: Result = Results.ok()
+    }, Map("play.http.actionComposition.executeRequestHandlerActionFirst" -> "false",
+           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
+      response.body must beEqualTo("requesthandler")
+    }
+
+    "execute request handler action first without action composition" in makeRequest(new MockController {
+      override def action: Result = Results.ok()
+    }, Map("play.http.actionComposition.executeRequestHandlerActionFirst" -> "true",
+           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
+      response.body must beEqualTo("requesthandler")
+    }
+  }
+
 }
 
 @ControllerAnnotation

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -68,6 +68,9 @@ play {
 
       # If annotations put directly on Controller classes should be executed before the ones put on action methods
       controllerAnnotationsFirst = false
+
+      # If the action returned by the createAction method of the request handler should be executed before the action composition ones
+      executeRequestHandlerActionFirst = false
     }
 
     # Cookies configuration

--- a/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -89,9 +89,12 @@ case class ParserConfiguration(
  * Configuration for action composition.
  *
  * @param controllerAnnotationsFirst If annotations put on controllers should be executed before the ones put on actions.
+ * @param executeRequestHandlerActionFirst If the action returned by the createAction method of the request handler should be
+ *                                         executed before the action composition ones.
  */
 case class ActionCompositionConfiguration(
-  controllerAnnotationsFirst: Boolean = false)
+  controllerAnnotationsFirst: Boolean = false,
+  executeRequestHandlerActionFirst: Boolean = false)
 
 object HttpConfiguration {
 
@@ -118,7 +121,8 @@ object HttpConfiguration {
         maxDiskBuffer = config.get[ConfigMemorySize]("play.http.parser.maxDiskBuffer").toBytes
       ),
       actionComposition = ActionCompositionConfiguration(
-        controllerAnnotationsFirst = config.get[Boolean]("play.http.actionComposition.controllerAnnotationsFirst")
+        controllerAnnotationsFirst = config.get[Boolean]("play.http.actionComposition.controllerAnnotationsFirst"),
+        executeRequestHandlerActionFirst = config.get[Boolean]("play.http.actionComposition.executeRequestHandlerActionFirst")
       ),
       cookies = CookiesConfiguration(
         strict = config.get[Boolean]("play.http.cookies.strict")

--- a/framework/src/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
@@ -20,6 +20,7 @@ object HttpConfigurationSpec extends Specification {
         "play.http.parser.maxMemoryBuffer" -> "10k",
         "play.http.parser.maxDiskBuffer" -> "20k",
         "play.http.actionComposition.controllerAnnotationsFirst" -> "true",
+        "play.http.actionComposition.executeRequestHandlerActionFirst" -> "true",
         "play.http.cookies.strict" -> "true",
         "play.http.session.cookieName" -> "PLAY_SESSION",
         "play.http.session.secure" -> "true",
@@ -103,6 +104,19 @@ object HttpConfigurationSpec extends Specification {
       "cookie httpOnly" in {
         val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
         httpConfiguration.flash.httpOnly must beTrue
+      }
+    }
+
+    "configure action composition" in {
+
+      "controller annotations first" in {
+        val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
+        httpConfiguration.actionComposition.controllerAnnotationsFirst must beTrue
+      }
+
+      "execute request handler action first" in {
+        val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
+        httpConfiguration.actionComposition.executeRequestHandlerActionFirst must beTrue
       }
     }
   }


### PR DESCRIPTION
Finally fixes #1088

To keep backward compatibility I choose to add a config setting - the default stays like it is right now.
But you can now set `play.http.actionComposition.executeRequestHandlerActionFirst=true`.

The fix was quite easy: In `JavaAction.scala` we just need to change the order of how the actions are delegated.