### PR TITLE
Deprecate WS static methods that use Play.current under the hood.

### DIFF
--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WS.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WS.java
@@ -23,7 +23,9 @@ public class WS {
      * Returns the default WSClient object managed by the Play application.
      *
      * @return a configured WSClient
+     * @deprecated Please use a WSClient instance using DI (since 2.5)
      */
+    @Deprecated
     public static WSClient client() {
         Application app = play.Play.application();
         return app.injector().instanceOf(WSClient.class);
@@ -35,7 +37,9 @@ public class WS {
      * return an asynchronous {@code Promise<WSResponse>}.
      *
      * @param url the URL to request
+     * @deprecated Please use a WSClient instance using DI (since 2.5)
      */
+    @Deprecated
     public static WSRequest url(String url) {
         return client().url(url);
     }

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -58,15 +58,21 @@ trait WSRequestMagnet {
  *
  * Usage example:
  * {{{
- * WS.url("http://example.com/feed").get()
- * WS.url("http://example.com/item").post("content")
+ * class MyService @Inject() (ws: WSClient) {
+ *   ws.url("http://example.com/feed").get()
+ *   ws.url("http://example.com/item").post("content")
+ * }
  * }}}
  *
  * When greater flexibility is needed, you can also create clients explicitly and pass them into WS:
  *
  * {{{
- * implicit val client = new AhcWSClient(builder.build())
- * WS.url("http://example.com/feed").get()
+ * import play.api.libs.ws._
+ * import play.api.libs.ws.ahc._
+ *
+ * val client = new AhcWSClient(new AhcConfigBuilder())
+ * client.url("http://example.com/feed").get()
+ * client.close() // must explicitly manage lifecycle
  * }}}
  *
  * Or call the client directly:
@@ -78,16 +84,14 @@ trait WSRequestMagnet {
  *
  * val configuration = play.api.Configuration(ConfigFactory.parseString(
  * """
- *   |ws.ssl.trustManager = ...
+ *   |play.ws.ssl.trustManager = ...
  * """.stripMargin))
  * val parser = new DefaultWSConfigParser(configuration, Play.current.classloader)
  * val builder = new AhcConfigBuilder(parser.parse())
  * val secureClient: WSClient = new AhcWSClient(builder.build())
  * val response = secureClient.url("https://secure.com").get()
+ * secureClient.close() // must explicitly manage lifecycle
  * }}}
- *
- * Note that the resolution of URL is done through the magnet pattern defined in
- * `WSRequestMagnet`.
  *
  * The value returned is a {@code Future[WSResponse]}, and you should use Play's asynchronous mechanisms to
  * use this response.


### PR DESCRIPTION
Deprecates some WS.client methods that assume use of Play.current.

Update some scaladoc in WS that is no longer accurate with the codebase.