### PR TITLE
Optimised accumulators

### DIFF
--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -238,7 +238,12 @@ private[play] class PlayRequestHandler(val server: NettyServer) extends ChannelI
 
     val body = modelConversion.convertRequestBody(request)
     val bodyParser = action(requestHeader)
-    val resultFuture = bodyParser.run(body)
+    val resultFuture = body match {
+      case None =>
+        bodyParser.run()
+      case Some(source) =>
+        bodyParser.run(source)
+    }
 
     resultFuture.recoverWith {
       case error =>

--- a/framework/src/play-streams/src/main/java/play/libs/streams/Accumulator.java
+++ b/framework/src/play-streams/src/main/java/play/libs/streams/Accumulator.java
@@ -5,6 +5,7 @@ import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
+import play.api.libs.streams.Accumulator$;
 import scala.compat.java8.FutureConverters;
 import scala.concurrent.Future;
 
@@ -27,18 +28,9 @@ import java.util.function.Function;
  * materialise a scala.concurrent.Future, hence the <code>fromSink</code> method is provided to create an accumulator
  * from a typical Akka streams <code>Sink</code>.
  */
-public final class Accumulator<E, A> {
+public abstract class Accumulator<E, A> {
 
-    private final Sink<E, CompletionStage<A>> sink;
-
-    /**
-     * Create an accumulator for the given sink.
-     *
-     * @param sink The sink to wrap.
-     */
-    public Accumulator(Sink<E, CompletionStage<A>> sink) {
-        this.sink = sink;
-    }
+    private Accumulator() {}
 
     /**
      * Map the accumulated value.
@@ -47,9 +39,7 @@ public final class Accumulator<E, A> {
      * @param executor The executor to run the function in.
      * @return A new accumulator with the mapped value.
      */
-    public <B> Accumulator<E, B> map(Function<? super A, ? extends B> f, Executor executor) {
-        return new Accumulator<>(sink.mapMaterializedValue(cs -> cs.thenApplyAsync(f, executor)));
-    }
+    public abstract <B> Accumulator<E, B> map(Function<? super A, ? extends B> f, Executor executor);
 
     /**
      * Map the accumulated value with a function that returns a future.
@@ -58,9 +48,7 @@ public final class Accumulator<E, A> {
      * @param executor The executor to run the function in.
      * @return A new accumulator with the mapped value.
      */
-    public <B> Accumulator<E, B> mapFuture(Function<? super A, ? extends CompletionStage<B>> f, Executor executor) {
-        return new Accumulator<>(sink.mapMaterializedValue(cs -> cs.thenComposeAsync(f, executor)));
-    }
+    public abstract <B> Accumulator<E, B> mapFuture(Function<? super A, ? extends CompletionStage<B>> f, Executor executor);
 
     /**
      * Recover from any errors encountered by the accumulator.
@@ -69,18 +57,7 @@ public final class Accumulator<E, A> {
      * @param executor The executor to run the function in.
      * @return A new accumulator that has recovered from errors.
      */
-    public Accumulator<E, A> recover(Function<? super Throwable, ? extends A> f, Executor executor) {
-        return new Accumulator<>(
-                sink.mapMaterializedValue(cs ->
-                        cs.handleAsync((a, error) -> {
-                            if (a != null) {
-                                return a;
-                            } else {
-                                return f.apply(error);
-                            }
-                        }, executor))
-        );
-    }
+    public abstract Accumulator<E, A> recover(Function<? super Throwable, ? extends A> f, Executor executor);
 
     /**
      * Recover from any errors encountered by the accumulator.
@@ -89,22 +66,7 @@ public final class Accumulator<E, A> {
      * @param executor The executor to run the function in.
      * @return A new accumulator that has recovered from errors.
      */
-    public Accumulator<E, A> recoverWith(Function<? super Throwable, ? extends CompletionStage<A>> f, Executor executor) {
-        return new Accumulator<>(
-                sink.mapMaterializedValue(cs ->
-                        cs.handleAsync((a, error) -> {
-                            if (a != null) {
-                                return CompletableFuture.completedFuture(a);
-                            } else {
-                                if (error instanceof CompletionException) {
-                                    return f.apply(error.getCause());
-                                } else {
-                                    return f.apply(error);
-                                }
-                            }
-                        }, executor).thenCompose(Function.identity()))
-        );
-    }
+    public abstract Accumulator<E, A> recoverWith(Function<? super Throwable, ? extends CompletionStage<A>> f, Executor executor);
 
     /**
      * Pass the stream through the given flow before forwarding it to the accumulator.
@@ -112,9 +74,7 @@ public final class Accumulator<E, A> {
      * @param flow The flow to send the stream through first.
      * @return A new accumulator with the given flow in its graph.
      */
-    public <D> Accumulator<D, A> through(Flow<D, E, ?> flow) {
-        return new Accumulator<>(flow.toMat(sink, Keep.right()));
-    }
+    public abstract <D> Accumulator<D, A> through(Flow<D, E, ?> flow);
 
     /**
      * Run the accumulator with an empty source.
@@ -122,38 +82,30 @@ public final class Accumulator<E, A> {
      * @param mat The flow materializer.
      * @return A future that will be redeemed when the accumulator is done.
      */
-    public CompletionStage<A> run(Materializer mat) {
-        return Source.<E>empty().runWith(sink, mat);
-    }
+    public abstract CompletionStage<A> run(Materializer mat);
 
     /**
      * Run the accumulator with the given source.
      *
      * @param source The source to feed into the accumulator.
      * @param mat The flow materializer.
-     * @return A fuwure that will be redeemed when the accumulator is done.
+     * @return A future that will be redeemed when the accumulator is done.
      */
-    public CompletionStage<A> run(Source<E, ?> source, Materializer mat) {
-        return source.runWith(sink, mat);
-    }
+    public abstract CompletionStage<A> run(Source<E, ?> source, Materializer mat);
 
     /**
      * Convert this accumulator to a sink.
      *
      * @return The sink.
      */
-    public Sink<E, CompletionStage<A>> toSink() {
-        return sink;
-    }
+    public abstract Sink<E, CompletionStage<A>> toSink();
 
     /**
      * Convert this accumulator to a Scala accumulator.
      *
      * @return The Scala Accumulator.
      */
-    public play.api.libs.streams.Accumulator<E, A> asScala() {
-        return new play.api.libs.streams.Accumulator<>(sink.mapMaterializedValue(FutureConverters::toScala).asScala());
-    }
+    public abstract play.api.libs.streams.Accumulator<E, A> asScala();
 
     /**
      * Create an accumulator from an Akka streams sink.
@@ -165,8 +117,9 @@ public final class Accumulator<E, A> {
      * @return An accumulator created from the sink.
      */
     public static <E, A> Accumulator<E, A> fromSink(Sink<E, Future<A>> sink) {
-        return new Accumulator<>(sink.mapMaterializedValue(FutureConverters::toJava));
+        return new SinkAccumulator<>(sink.mapMaterializedValue(FutureConverters::toJava));
     }
+
 
     /**
      * Create an accumulator that forwards the stream fed into it to the source it produces.
@@ -181,7 +134,7 @@ public final class Accumulator<E, A> {
     public static <E> Accumulator<E, Source<E, ?>> source() {
         // If Akka streams ever provides Sink.source(), we should use that instead.
         // https://github.com/akka/akka/issues/18406
-        return new Accumulator<>(Sink.<E>asPublisher(false).mapMaterializedValue(publisher ->
+        return new SinkAccumulator<>(Sink.<E>asPublisher(false).mapMaterializedValue(publisher ->
                         CompletableFuture.completedFuture(Source.fromPublisher(publisher))
         ));
     }
@@ -203,7 +156,132 @@ public final class Accumulator<E, A> {
      * @return The accumulator.
      */
     public static <E, A> Accumulator<E, A> done(CompletionStage<A> a) {
-        return new Accumulator(Sink.cancelled().mapMaterializedValue((unit) -> a));
+        return new DoneAccumulator<>(a);
+    }
+
+    private static final class SinkAccumulator<E, A> extends Accumulator<E, A> {
+
+        private final Sink<E, CompletionStage<A>> sink;
+
+        private SinkAccumulator(Sink<E, CompletionStage<A>> sink) {
+            this.sink = sink;
+        }
+
+        public <B> Accumulator<E, B> map(Function<? super A, ? extends B> f, Executor executor) {
+            return new SinkAccumulator<>(sink.mapMaterializedValue(cs -> cs.thenApplyAsync(f, executor)));
+        }
+
+        public <B> Accumulator<E, B> mapFuture(Function<? super A, ? extends CompletionStage<B>> f, Executor executor) {
+            return new SinkAccumulator<>(sink.mapMaterializedValue(cs -> cs.thenComposeAsync(f, executor)));
+        }
+
+        public Accumulator<E, A> recover(Function<? super Throwable, ? extends A> f, Executor executor) {
+            return new SinkAccumulator<>(
+                sink.mapMaterializedValue(cs -> completionStageRecover(cs, f, executor))
+            );
+        }
+
+        public Accumulator<E, A> recoverWith(Function<? super Throwable, ? extends CompletionStage<A>> f, Executor executor) {
+            return new SinkAccumulator<>(
+                sink.mapMaterializedValue(cs -> completionStageRecoverWith(cs, f, executor))
+            );
+        }
+
+        public <D> Accumulator<D, A> through(Flow<D, E, ?> flow) {
+            return new SinkAccumulator<>(flow.toMat(sink, Keep.right()));
+        }
+
+        public CompletionStage<A> run(Materializer mat) {
+            return Source.<E>empty().runWith(sink, mat);
+        }
+
+        public CompletionStage<A> run(Source<E, ?> source, Materializer mat) {
+            return source.runWith(sink, mat);
+        }
+
+        public Sink<E, CompletionStage<A>> toSink() {
+            return sink;
+        }
+
+        public play.api.libs.streams.Accumulator<E, A> asScala() {
+            return Accumulator$.MODULE$.apply(sink.mapMaterializedValue(FutureConverters::toScala).asScala());
+        }
+
+    }
+
+    private static final class DoneAccumulator<E, A> extends Accumulator<E, A> {
+
+        private final CompletionStage<A> value;
+
+        private DoneAccumulator(CompletionStage<A> value) {
+            this.value = value;
+        }
+
+        public <B> Accumulator<E, B> map(Function<? super A, ? extends B> f, Executor executor) {
+            return new DoneAccumulator<>(value.thenApplyAsync(f, executor));
+        }
+
+        public <B> Accumulator<E, B> mapFuture(Function<? super A, ? extends CompletionStage<B>> f, Executor executor) {
+            return new DoneAccumulator<>(value.thenComposeAsync(f, executor));
+        }
+
+        public Accumulator<E, A> recover(Function<? super Throwable, ? extends A> f, Executor executor) {
+            return new DoneAccumulator<>(completionStageRecover(value, f, executor));
+        }
+
+        public Accumulator<E, A> recoverWith(Function<? super Throwable, ? extends CompletionStage<A>> f, Executor executor) {
+            return new DoneAccumulator<>(completionStageRecoverWith(value, f, executor));
+        }
+
+        @SuppressWarnings("unchecked")
+        public <D> Accumulator<D, A> through(Flow<D, E, ?> flow) {
+            return (Accumulator<D, A>) this;
+        }
+
+        public CompletionStage<A> run(Materializer mat) {
+            return value;
+        }
+
+        public CompletionStage<A> run(Source<E, ?> source, Materializer mat) {
+            source.runWith(Sink.cancelled(), mat);
+            return value;
+        }
+
+        public Sink<E, CompletionStage<A>> toSink() {
+            return Sink.<E>cancelled().mapMaterializedValue(u -> value);
+        }
+
+        @SuppressWarnings("unchecked")
+        public play.api.libs.streams.Accumulator<E, A> asScala() {
+            return (play.api.libs.streams.Accumulator<E, A>) Accumulator$.MODULE$.done(FutureConverters.toScala(value));
+        }
+
+    }
+
+    private static <A> CompletionStage<A> completionStageRecoverWith(CompletionStage<A> cs,
+        Function<? super Throwable, ? extends CompletionStage<A>> f, Executor executor) {
+        return cs.handleAsync((a, error) -> {
+            if (a != null) {
+                return CompletableFuture.completedFuture(a);
+            } else {
+                if (error instanceof CompletionException) {
+                    return f.apply(error.getCause());
+                } else {
+                    return f.apply(error);
+                }
+            }
+        }, executor).thenCompose(Function.identity());
+    }
+
+    private static <A> CompletionStage<A> completionStageRecover(CompletionStage<A> cs,
+        Function<? super Throwable, ? extends A> f, Executor executor) {
+        return cs.handleAsync((a, error) -> {
+            if (a != null) {
+                return a;
+            } else {
+                return f.apply(error);
+            }
+        }, executor);
     }
 
 }

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
@@ -6,6 +6,7 @@ import org.reactivestreams.{ Publisher, Subscription, Subscriber }
 
 import scala.concurrent.{ Promise, ExecutionContext, Future }
 import scala.util.{ Failure, Success }
+import scala.compat.java8.FutureConverters._
 
 /**
  * An accumulator of elements into a future of a result.
@@ -13,37 +14,32 @@ import scala.util.{ Failure, Success }
  * This is essentially a lightweight wrapper around a Sink that gets materialised to a Future, but provides convenient
  * methods for working directly with that future as well as transforming the input.
  */
-final class Accumulator[-E, +A](sink: Sink[E, Future[A]]) {
+sealed trait Accumulator[-E, +A] {
 
   /**
    * Map the result of this accumulator to something else.
    */
-  def map[B](f: A => B)(implicit executor: ExecutionContext): Accumulator[E, B] =
-    new Accumulator(sink.mapMaterializedValue(_.map(f)))
+  def map[B](f: A => B)(implicit executor: ExecutionContext): Accumulator[E, B]
 
   /**
    * Map the result of this accumulator to a future of something else.
    */
-  def mapFuture[B](f: A => Future[B])(implicit executor: ExecutionContext): Accumulator[E, B] =
-    new Accumulator(sink.mapMaterializedValue(_.flatMap(f)))
+  def mapFuture[B](f: A => Future[B])(implicit executor: ExecutionContext): Accumulator[E, B]
 
   /**
    * Recover from errors encountered by this accumulator.
    */
-  def recover[B >: A](pf: PartialFunction[Throwable, B])(implicit executor: ExecutionContext): Accumulator[E, B] =
-    new Accumulator(sink.mapMaterializedValue(_.recover(pf)))
+  def recover[B >: A](pf: PartialFunction[Throwable, B])(implicit executor: ExecutionContext): Accumulator[E, B]
 
   /**
    * Recover from errors encountered by this accumulator.
    */
-  def recoverWith[B >: A](pf: PartialFunction[Throwable, Future[B]])(implicit executor: ExecutionContext): Accumulator[E, B] =
-    new Accumulator(sink.mapMaterializedValue(_.recoverWith(pf)))
+  def recoverWith[B >: A](pf: PartialFunction[Throwable, Future[B]])(implicit executor: ExecutionContext): Accumulator[E, B]
 
   /**
    * Return a new accumulator that first feeds the input through the given flow before it goes through this accumulator.
    */
-  def through[F](flow: Flow[F, E, _]): Accumulator[F, A] =
-    new Accumulator(flow.toMat(sink)(Keep.right))
+  def through[F](flow: Flow[F, E, _]): Accumulator[F, A]
 
   /**
    * Right associative operator alias for through.
@@ -61,16 +57,12 @@ final class Accumulator[-E, +A](sink: Sink[E, Future[A]]) {
   /**
    * Run this accumulator by feeding in the given source.
    */
-  def run(source: Source[E, _])(implicit materializer: Materializer): Future[A] = {
-    source.toMat(sink)(Keep.right).run()
-  }
+  def run(source: Source[E, _])(implicit materializer: Materializer): Future[A]
 
   /**
-   * Run this accumulator by feeding a completed source into it.
+   * Run this accumulator by feeding nothing into it.
    */
-  def run()(implicit materializer: Materializer): Future[A] = {
-    run(Source.empty)
-  }
+  def run()(implicit materializer: Materializer): Future[A]
 
   /**
    * Right associative operator alias for run.
@@ -88,16 +80,89 @@ final class Accumulator[-E, +A](sink: Sink[E, Future[A]]) {
   /**
    * Convert this accumulator to a Sink that gets materialised to a Future.
    */
-  def toSink: Sink[E, Future[A]] = sink
+  def toSink: Sink[E, Future[A]]
 
   import scala.annotation.unchecked.{ uncheckedVariance => uV }
+
   /**
    * Convert this accumulator to a Java Accumulator.
    *
    * @return The Java accumulator.
    */
+  def asJava: play.libs.streams.Accumulator[E @uV, A @uV]
+}
+
+/**
+ * An accumulator backed by a sink.
+ *
+ * This is essentially a lightweight wrapper around a Sink that gets materialised to a Future, but provides convenient
+ * methods for working directly with that future as well as transforming the input.
+ */
+private class SinkAccumulator[-E, +A](sink: Sink[E, Future[A]]) extends Accumulator[E, A] {
+
+  def map[B](f: A => B)(implicit executor: ExecutionContext): Accumulator[E, B] =
+    new SinkAccumulator(sink.mapMaterializedValue(_.map(f)))
+
+  def mapFuture[B](f: A => Future[B])(implicit executor: ExecutionContext): Accumulator[E, B] =
+    new SinkAccumulator(sink.mapMaterializedValue(_.flatMap(f)))
+
+  def recover[B >: A](pf: PartialFunction[Throwable, B])(implicit executor: ExecutionContext): Accumulator[E, B] =
+    new SinkAccumulator(sink.mapMaterializedValue(_.recover(pf)))
+
+  def recoverWith[B >: A](pf: PartialFunction[Throwable, Future[B]])(implicit executor: ExecutionContext): Accumulator[E, B] =
+    new SinkAccumulator(sink.mapMaterializedValue(_.recoverWith(pf)))
+
+  def through[F](flow: Flow[F, E, _]): Accumulator[F, A] =
+    new SinkAccumulator(flow.toMat(sink)(Keep.right))
+
+  def run(source: Source[E, _])(implicit materializer: Materializer): Future[A] = {
+    source.toMat(sink)(Keep.right).run()
+  }
+
+  def run()(implicit materializer: Materializer): Future[A] = {
+    run(Source.empty)
+  }
+
+  def toSink: Sink[E, Future[A]] = sink
+
+  import scala.annotation.unchecked.{ uncheckedVariance => uV }
+
   def asJava: play.libs.streams.Accumulator[E @uV, A @uV] = {
     play.libs.streams.Accumulator.fromSink(sink.asJava)
+  }
+}
+
+/**
+ * An accumulator that ignores the body passed in, and is immediately available.
+ */
+private class DoneAccumulator[+A](future: Future[A]) extends Accumulator[Any, A] {
+
+  def map[B](f: A => B)(implicit executor: ExecutionContext): Accumulator[Any, B] =
+    new DoneAccumulator(future.map(f))
+
+  def mapFuture[B](f: A => Future[B])(implicit executor: ExecutionContext): Accumulator[Any, B] =
+    new DoneAccumulator(future.flatMap(f))
+
+  def recover[B >: A](pf: PartialFunction[Throwable, B])(implicit executor: ExecutionContext): Accumulator[Any, B] =
+    new DoneAccumulator(future.recover(pf))
+
+  def recoverWith[B >: A](pf: PartialFunction[Throwable, Future[B]])(implicit executor: ExecutionContext): Accumulator[Any, B] =
+    new DoneAccumulator(future.recoverWith(pf))
+
+  def through[F](flow: Flow[F, Any, _]): Accumulator[F, A] = this
+
+  def run(source: Source[Any, _])(implicit materializer: Materializer): Future[A] = {
+    source.toMat(Sink.cancelled)((_, _) => future).run()
+  }
+
+  def run()(implicit materializer: Materializer): Future[A] = future
+
+  def toSink: Sink[Any, Future[A]] = Sink.cancelled.mapMaterializedValue(_ => future)
+
+  import scala.annotation.unchecked.{ uncheckedVariance => uV }
+
+  def asJava: play.libs.streams.Accumulator[Any @uV, A @uV] = {
+    play.libs.streams.Accumulator.done(future.toJava)
   }
 }
 
@@ -106,7 +171,7 @@ object Accumulator {
   /**
    * Create a new accumulator from the given Sink.
    */
-  def apply[E, A](sink: Sink[E, Future[A]]): Accumulator[E, A] = new Accumulator(sink)
+  def apply[E, A](sink: Sink[E, Future[A]]): Accumulator[E, A] = new SinkAccumulator(sink)
 
   /**
    * Create a done accumulator.
@@ -114,7 +179,7 @@ object Accumulator {
    * The underlying sink will cancel as soon as its onSubscribe method is called, and the materialized value will be
    * an immediately available future of `a`.
    */
-  def done[A](a: A): Accumulator[Any, A] = new Accumulator(Sink.cancelled[Any].mapMaterializedValue(_ => Future.successful(a)))
+  def done[A](a: A): Accumulator[Any, A] = new DoneAccumulator[A](Future.successful(a))
 
   /**
    * Create a done accumulator.
@@ -122,7 +187,7 @@ object Accumulator {
    * The underlying sink will cancel as soon as its onSubscribe method is called, and the materialized value will be
    * the passed in future.
    */
-  def done[A](a: Future[A]): Accumulator[Any, A] = new Accumulator(Sink.cancelled[Any].mapMaterializedValue(_ => a))
+  def done[A](a: Future[A]): Accumulator[Any, A] = new DoneAccumulator(a)
 
   /**
    * Create an accumulator that forwards the stream fed into it to the source it produces.
@@ -137,7 +202,7 @@ object Accumulator {
   def source[E]: Accumulator[E, Source[E, _]] = {
     // If Akka streams ever provides Sink.source(), we should use that instead.
     // https://github.com/akka/akka/issues/18406
-    Accumulator(Sink.asPublisher[E](fanout = false).mapMaterializedValue(publisher => Future.successful(Source.fromPublisher(publisher))))
+    new SinkAccumulator(Sink.asPublisher[E](fanout = false).mapMaterializedValue(publisher => Future.successful(Source.fromPublisher(publisher))))
   }
 
   /**
@@ -179,7 +244,7 @@ object Accumulator {
       def onNext(t: E) = subscriber.onNext(t)
     })
 
-    new Accumulator(sink.mapMaterializedValue(_ => result.future))
+    new SinkAccumulator(sink.mapMaterializedValue(_ => result.future))
   }
 
 }


### PR DESCRIPTION
The optimisation here is that when there is no body, *and* the accumulator was created using Accumulator.done (ie, the Accumulator isn't interested in the body), rather than feeding an empty source into a cancelled sink to get the result of the accumulator, the result is passed directly.  This avoids needing to materialize an Akka streams flow.

Testing this with prune on vegimite, I've seen the scala-di-simple tests run at 70K req/s, almost twice as fast as the current master speed (which was down at 36K req/s due to a regression introduced in the Akka streams 2 upgrade), 18K req/s faster than the pre Akka streams 2 speeds, and 12K req/s faster than Play 2.4.