### PR TITLE
Avoid formatting generated routes files

### DIFF
--- a/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
+++ b/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
@@ -10,6 +10,7 @@
 
 @for(p <- pkg) {package @p}
 
+// format: OFF
 import play.core.routing._
 import play.core.routing.HandlerInvokerFactory._
 import play.core.j._

--- a/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/forwardsRouter.scala.twirl
+++ b/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/forwardsRouter.scala.twirl
@@ -1,6 +1,7 @@
 @import play.routes.compiler._
 @import play.routes.compiler.templates._
 @(sourceInfo: RoutesSourceInfo, pkg: Option[String], imports: Seq[String], rules: Seq[Rule])
+// format: OFF
 // @@GENERATOR:play-routes-compiler
 // @@SOURCE:@sourceInfo.source
 // @@DATE:@sourceInfo.date

--- a/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/javaWrappers.scala.twirl
+++ b/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/javaWrappers.scala.twirl
@@ -1,6 +1,7 @@
 @import play.routes.compiler._
 @import play.routes.compiler.templates._
 @(sourceInfo: RoutesSourceInfo, pkg: Option[String], packageName: String, controllers: Seq[String])
+// format: OFF
 // @@GENERATOR:play-routes-compiler
 // @@SOURCE:@sourceInfo.source
 // @@DATE:@sourceInfo.date

--- a/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/javascriptReverseRouter.scala.twirl
+++ b/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/javascriptReverseRouter.scala.twirl
@@ -1,6 +1,7 @@
 @import play.routes.compiler._
 @import play.routes.compiler.templates._
 @(sourceInfo: RoutesSourceInfo, pkg: Option[String], imports: Seq[String], packageName: String, routes: Seq[Route], namespaceReverseRouter: Boolean, useInjector: Route => Boolean)
+// format: OFF
 // @@GENERATOR:play-routes-compiler
 // @@SOURCE:@sourceInfo.source
 // @@DATE:@sourceInfo.date

--- a/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/reverseRouter.scala.twirl
+++ b/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/reverseRouter.scala.twirl
@@ -1,6 +1,7 @@
 @import play.routes.compiler._
 @import play.routes.compiler.templates._
 @(sourceInfo: RoutesSourceInfo, pkg: Option[String], imports: Seq[String], packageName: String, routes: Seq[Route], namespaceReverseRouter: Boolean, useInjector: Route => Boolean)
+// format: OFF
 // @@GENERATOR:play-routes-compiler
 // @@SOURCE:@sourceInfo.source
 // @@DATE:@sourceInfo.date

--- a/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/routesPrefix.scala.twirl
+++ b/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/routesPrefix.scala.twirl
@@ -1,6 +1,7 @@
 @import play.routes.compiler._
 @import play.routes.compiler.templates._
 @(sourceInfo: RoutesSourceInfo, pkg: Option[String], useInjector: Route => Boolean)
+// format: OFF
 // @@GENERATOR:play-routes-compiler
 // @@SOURCE:@sourceInfo.source
 // @@DATE:@sourceInfo.date


### PR DESCRIPTION
When using [sbt-scalariform](https://github.com/sbt/sbt-scalariform) with Play >= 2.4 Scalariform finds and reformats the generated routes files all the time which prevents the incremental compiler from working correctly. It's not only annoying but significantly slows down development of larger projects unless we give up automatic code formatting.

This is not something we can easily prevent as users of Play Framework because it requires manually excluding all generated routes files from code formatting. It's not even a one-liner because `playRoutes` is a task which sbt settings can't depend on.

So as a workaround I added [Scalariform directives](https://github.com/scala-ide/scalariform#format-onoff) to the routes templates in order to prevent the generated .scala files from being formatted, which I think is a good compromise to provide compatibility with Scalariform.

I'm not sure if this is the best way to address this problem but it definitely works.

Related sbt-scalariform issue here: https://github.com/sbt/sbt-scalariform/issues/32