### PR TITLE
Allow to set schema for play_evolutions(_lock) table

### DIFF
--- a/documentation/manual/detailedTopics/evolutions/Evolutions.md
+++ b/documentation/manual/detailedTopics/evolutions/Evolutions.md
@@ -64,6 +64,7 @@ If you agree with the SQL script, you can apply it directly by clicking on the â
 Evolutions can be configured both globally and per datasource.  For global configuration, keys should be prefixed with `play.evolutions`.  For per datasource configuration, keys should be prefixed with `play.evolutions.db.<datasourcename>`, for example `play.evolutions.db.default`.  The following configuration options are supported:
 
 * `enabled` - Whether evolutions are enabled.  If configured globally to be false, it disables the evolutions module altogether.  Defaults to true.
+* `schema` - Database schema in which the generated evolution and lock tables will be saved to. No schema is set by default.
 * `autocommit` - Whether autocommit should be used.  If false, evolutions will be applied in a single transaction.  Defaults to true.
 * `useLocks` - Whether a locks table should be used.  This must be used if you have many Play nodes that may potentially run evolutions, but you want to ensure that only one does.  It will create a table called `play_evolutions_lock`, and use a `SELECT FOR UPDATE NOWAIT` or `SELECT FOR UPDATE` to lock it.  This will only work for Postgres, Oracle, and MySQL InnoDB. It will not work for other databases.  Defaults to false.
 * `autoApply` - Whether evolutions should be automatically applied.  In dev mode, this will cause both ups and downs evolutions to be automatically applied.  In prod mode, it will cause only ups evolutions to be automatically applied.  Defaults to false.

--- a/framework/src/play-jdbc-evolutions/src/main/java/play/db/evolutions/Evolutions.java
+++ b/framework/src/play-jdbc-evolutions/src/main/java/play/db/evolutions/Evolutions.java
@@ -68,10 +68,33 @@ public class Evolutions {
      * @param database The database to apply the evolutions to.
      * @param reader The reader to read the evolutions.
      * @param autocommit Whether autocommit should be used.
+     * @param schema The schema where all the play evolution tables are saved in
+     */
+    public static void applyEvolutions(Database database, play.api.db.evolutions.EvolutionsReader reader, boolean autocommit, String schema) {
+        DatabaseEvolutions evolutions = new DatabaseEvolutions(database.toScala(), schema);
+        evolutions.evolve(evolutions.scripts(reader), autocommit);
+    }
+
+    /**
+     * Apply evolutions for the given database.
+     *
+     * @param database The database to apply the evolutions to.
+     * @param reader The reader to read the evolutions.
+     * @param schema The schema where all the play evolution tables are saved in
+     */
+    public static void applyEvolutions(Database database, play.api.db.evolutions.EvolutionsReader reader, String schema) {
+        applyEvolutions(database, reader, true, schema);
+    }
+
+    /**
+     * Apply evolutions for the given database.
+     *
+     * @param database The database to apply the evolutions to.
+     * @param reader The reader to read the evolutions.
+     * @param autocommit Whether autocommit should be used.
      */
     public static void applyEvolutions(Database database, play.api.db.evolutions.EvolutionsReader reader, boolean autocommit) {
-        DatabaseEvolutions evolutions = new DatabaseEvolutions(database.toScala());
-        evolutions.evolve(evolutions.scripts(reader), autocommit);
+        applyEvolutions(database, reader, autocommit, "");
     }
 
     /**
@@ -88,9 +111,33 @@ public class Evolutions {
      * Apply evolutions for the given database.
      *
      * @param database The database to apply the evolutions to.
+     * @param schema The schema where all the play evolution tables are saved in
+     */
+    public static void applyEvolutions(Database database, String schema) {
+        applyEvolutions(database, fromClassLoader(), schema);
+    }
+
+    /**
+     * Apply evolutions for the given database.
+     *
+     * @param database The database to apply the evolutions to.
      */
     public static void applyEvolutions(Database database) {
-        applyEvolutions(database, fromClassLoader());
+        applyEvolutions(database, "");
+    }
+
+    /**
+     * Cleanup evolutions for the given database.
+     *
+     * This will run the down scripts for all the applied evolutions.
+     *
+     * @param database The database to apply the evolutions to.
+     * @param autocommit Whether autocommit should be used.
+     * @param schema The schema where all the play evolution tables are saved in
+     */
+    public static void cleanupEvolutions(Database database, boolean autocommit, String schema) {
+        DatabaseEvolutions evolutions = new DatabaseEvolutions(database.toScala(), schema);
+        evolutions.evolve(evolutions.resetScripts(), autocommit);
     }
 
     /**
@@ -102,8 +149,19 @@ public class Evolutions {
      * @param autocommit Whether autocommit should be used.
      */
     public static void cleanupEvolutions(Database database, boolean autocommit) {
-        DatabaseEvolutions evolutions = new DatabaseEvolutions(database.toScala());
-        evolutions.evolve(evolutions.resetScripts(), autocommit);
+        cleanupEvolutions(database, autocommit, "");
+    }
+
+    /**
+     * Cleanup evolutions for the given database.
+     *
+     * This will run the down scripts for all the applied evolutions.
+     *
+     * @param database The database to apply the evolutions to.
+     * @param schema The schema where all the play evolution tables are saved in
+     */
+    public static void cleanupEvolutions(Database database, String schema) {
+        cleanupEvolutions(database, true, schema);
     }
 
     /**
@@ -114,6 +172,6 @@ public class Evolutions {
      * @param database The database to apply the evolutions to.
      */
     public static void cleanupEvolutions(Database database) {
-        cleanupEvolutions(database, true);
+        cleanupEvolutions(database, "");
     }
 }

--- a/framework/src/play-jdbc-evolutions/src/main/resources/reference.conf
+++ b/framework/src/play-jdbc-evolutions/src/main/resources/reference.conf
@@ -10,6 +10,9 @@ play {
     # Whether evolutions are enabled
     enabled = true
 
+    # Database schema in which the generated evolution and lock tables will be saved to
+    schema = ""
+
     # Whether evolution updates should be performed with autocommit or in a manually managed transaction
     autocommit = true
 

--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
@@ -47,20 +47,21 @@ class ApplicationEvolutions @Inject() (
     val dbConfig = config.forDatasource(db)
     if (dbConfig.enabled) {
       withLock(database, dbConfig) {
-        val scripts = evolutions.scripts(db, reader)
-        val hasDown = scripts.exists(_.isInstanceOf[DownScript])
-
+        val schema = dbConfig.schema
         val autocommit = dbConfig.autocommit
+
+        val scripts = evolutions.scripts(db, reader, schema)
+        val hasDown = scripts.exists(_.isInstanceOf[DownScript])
 
         if (scripts.nonEmpty) {
 
           import Evolutions.toHumanReadableScript
 
           environment.mode match {
-            case Mode.Test => evolutions.evolve(db, scripts, autocommit)
-            case Mode.Dev if dbConfig.autoApply => evolutions.evolve(db, scripts, autocommit)
-            case Mode.Prod if !hasDown && dbConfig.autoApply => evolutions.evolve(db, scripts, autocommit)
-            case Mode.Prod if hasDown && dbConfig.autoApply && dbConfig.autoApplyDowns => evolutions.evolve(db, scripts, autocommit)
+            case Mode.Test => evolutions.evolve(db, scripts, autocommit, schema)
+            case Mode.Dev if dbConfig.autoApply => evolutions.evolve(db, scripts, autocommit, schema)
+            case Mode.Prod if !hasDown && dbConfig.autoApply => evolutions.evolve(db, scripts, autocommit, schema)
+            case Mode.Prod if hasDown && dbConfig.autoApply && dbConfig.autoApplyDowns => evolutions.evolve(db, scripts, autocommit, schema)
             case Mode.Prod if hasDown =>
               logger.warn(s"Your production database [$db] needs evolutions, including downs! \n\n${toHumanReadableScript(scripts)}")
               logger.warn(s"Run with -Dplay.evolutions.db.$db.autoApply=true and -Dplay.evolutions.db.$db.autoApplyDowns=true if you want to run them automatically, including downs (be careful, especially if your down evolutions drop existing data)")
@@ -87,8 +88,8 @@ class ApplicationEvolutions @Inject() (
       val c = ds.getConnection
       c.setAutoCommit(false)
       val s = c.createStatement()
-      createLockTableIfNecessary(url, c, s)
-      lock(url, c, s)
+      createLockTableIfNecessary(url, c, s, dbConfig)
+      lock(url, c, s, dbConfig)
       try {
         block
       } finally {
@@ -99,7 +100,7 @@ class ApplicationEvolutions @Inject() (
     }
   }
 
-  private def createLockTableIfNecessary(url: String, c: Connection, s: Statement): Unit = {
+  private def createLockTableIfNecessary(url: String, c: Connection, s: Statement, dbConfig: EvolutionsDatasourceConfig): Unit = {
     import ApplicationEvolutions._
     val (selectScript, createScript, insertScript) = url match {
       case OracleJdbcUrl() =>
@@ -110,24 +111,24 @@ class ApplicationEvolutions @Inject() (
         (SelectPlayEvolutionsLockSql, CreatePlayEvolutionsLockSql, InsertIntoPlayEvolutionsLockSql)
     }
     try {
-      val r = s.executeQuery(selectScript)
+      val r = s.executeQuery(applySchema(selectScript, dbConfig.schema))
       r.close()
     } catch {
       case e: SQLException =>
         c.rollback()
-        s.execute(createScript)
-        s.executeUpdate(insertScript)
+        s.execute(applySchema(createScript, dbConfig.schema))
+        s.executeUpdate(applySchema(insertScript, dbConfig.schema))
     }
   }
 
-  private def lock(url: String, c: Connection, s: Statement, attempts: Int = 5): Unit = {
+  private def lock(url: String, c: Connection, s: Statement, dbConfig: EvolutionsDatasourceConfig, attempts: Int = 5): Unit = {
     import ApplicationEvolutions._
     val lockScripts = url match {
       case MysqlJdbcUrl(_) => lockPlayEvolutionsLockMysqlSqls
       case _ => lockPlayEvolutionsLockSqls
     }
     try {
-      for (script <- lockScripts) s.executeQuery(script)
+      for (script <- lockScripts) s.executeQuery(applySchema(script, dbConfig.schema))
     } catch {
       case e: SQLException =>
         if (attempts == 0) throw e
@@ -135,7 +136,7 @@ class ApplicationEvolutions @Inject() (
           logger.warn("Exception while attempting to lock evolutions (other node probably has lock), sleeping for 1 sec")
           c.rollback()
           Thread.sleep(1000)
-          lock(url, c, s, attempts - 1)
+          lock(url, c, s, dbConfig, attempts - 1)
         }
     }
   }
@@ -147,37 +148,43 @@ class ApplicationEvolutions @Inject() (
   }
 
   start() // on construction
+
+  // SQL helpers
+
+  private def applySchema(sql: String, schema: String): String = {
+    sql.replaceAll("\\$\\{schema}", Option(schema).filter(_.trim.nonEmpty).map(_.trim + ".").getOrElse(""))
+  }
 }
 
 private object ApplicationEvolutions {
 
   val SelectPlayEvolutionsLockSql =
     """
-      select lock from play_evolutions_lock
+      select lock from ${schema}play_evolutions_lock
     """
 
   val SelectPlayEvolutionsLockMysqlSql =
     """
-      select `lock` from play_evolutions_lock
+      select `lock` from ${schema}play_evolutions_lock
     """
 
   val CreatePlayEvolutionsLockSql =
     """
-      create table play_evolutions_lock (
+      create table ${schema}play_evolutions_lock (
         lock int not null primary key
       )
     """
 
   val CreatePlayEvolutionsLockMysqlSql =
     """
-      create table play_evolutions_lock (
+      create table ${schema}play_evolutions_lock (
         `lock` int not null primary key
       )
     """
 
   val CreatePlayEvolutionsLockOracleSql =
     """
-      CREATE TABLE play_evolutions_lock (
+      CREATE TABLE ${schema}play_evolutions_lock (
         lock Number(10,0) Not Null Enable,
         CONSTRAINT play_evolutions_lock_pk PRIMARY KEY (lock)
       )
@@ -185,18 +192,18 @@ private object ApplicationEvolutions {
 
   val InsertIntoPlayEvolutionsLockSql =
     """
-      insert into play_evolutions_lock (lock) values (1)
+      insert into ${schema}play_evolutions_lock (lock) values (1)
     """
 
   val InsertIntoPlayEvolutionsLockMysqlSql =
     """
-      insert into play_evolutions_lock (`lock`) values (1)
+      insert into ${schema}play_evolutions_lock (`lock`) values (1)
     """
 
   val lockPlayEvolutionsLockSqls =
     List(
       """
-        select lock from play_evolutions_lock where lock = 1 for update nowait
+        select lock from ${schema}play_evolutions_lock where lock = 1 for update nowait
       """
     )
 
@@ -206,7 +213,7 @@ private object ApplicationEvolutions {
         set innodb_lock_wait_timeout = 1
       """,
       """
-        select `lock` from play_evolutions_lock where `lock` = 1 for update
+        select `lock` from ${schema}play_evolutions_lock where `lock` = 1 for update
       """
     )
 }
@@ -216,6 +223,7 @@ private object ApplicationEvolutions {
  */
 trait EvolutionsDatasourceConfig {
   def enabled: Boolean
+  def schema: String
   def autocommit: Boolean
   def useLocks: Boolean
   def autoApply: Boolean
@@ -234,6 +242,7 @@ trait EvolutionsConfig {
  */
 case class DefaultEvolutionsDatasourceConfig(
   enabled: Boolean,
+  schema: String,
   autocommit: Boolean,
   useLocks: Boolean,
   autoApply: Boolean,
@@ -286,12 +295,13 @@ class DefaultEvolutionsConfigParser @Inject() (configuration: Configuration) ext
 
     // Load defaults
     val enabled = config.get[Boolean]("enabled")
+    val schema = config.get[String]("schema")
     val autocommit = getDeprecated[Boolean](config, "play.evolutions", "autocommit", "evolutions.autocommit")
     val useLocks = getDeprecated[Boolean](config, "play.evolutions", "useLocks", "evolutions.use.locks")
     val autoApply = config.get[Boolean]("autoApply")
     val autoApplyDowns = config.get[Boolean]("autoApplyDowns")
 
-    val defaultConfig = new DefaultEvolutionsDatasourceConfig(enabled, autocommit, useLocks, autoApply,
+    val defaultConfig = new DefaultEvolutionsDatasourceConfig(enabled, schema, autocommit, useLocks, autoApply,
       autoApplyDowns)
 
     // Load config specific to datasources
@@ -302,11 +312,12 @@ class DefaultEvolutionsConfigParser @Inject() (configuration: Configuration) ext
     val datasourceConfig = datasourceConfigMap.map {
       case (datasource, dsConfig) =>
         val enabled = dsConfig.get[Boolean]("enabled")
+        val schema = dsConfig.get[String]("schema")
         val autocommit = dsConfig.get[Boolean]("autocommit")
         val useLocks = dsConfig.get[Boolean]("useLocks")
         val autoApply = getDeprecated[Boolean](dsConfig, s"play.evolutions.db.$datasource", "autoApply", s"applyEvolutions.$datasource")
         val autoApplyDowns = getDeprecated[Boolean](dsConfig, s"play.evolutions.db.$datasource", "autoApplyDowns", s"applyDownEvolutions.$datasource")
-        datasource -> new DefaultEvolutionsDatasourceConfig(enabled, autocommit, useLocks, autoApply, autoApplyDowns)
+        datasource -> new DefaultEvolutionsDatasourceConfig(enabled, schema, autocommit, useLocks, autoApply, autoApplyDowns)
     }.toMap
 
     new DefaultEvolutionsConfig(defaultConfig, datasourceConfig)
@@ -345,8 +356,8 @@ class EvolutionsWebCommands @Inject() (evolutions: EvolutionsApi, reader: Evolut
 
       case applyEvolutions(db) => {
         Some {
-          val scripts = evolutions.scripts(db, reader)
-          evolutions.evolve(db, scripts, config.forDatasource(db).autocommit)
+          val scripts = evolutions.scripts(db, reader, config.forDatasource(db).schema)
+          evolutions.evolve(db, scripts, config.forDatasource(db).autocommit, config.forDatasource(db).schema)
           buildLink.forceReload()
           play.api.mvc.Results.Redirect(redirectUrl)
         }
@@ -354,7 +365,7 @@ class EvolutionsWebCommands @Inject() (evolutions: EvolutionsApi, reader: Evolut
 
       case resolveEvolutions(db, rev) => {
         Some {
-          evolutions.resolve(db, rev.toInt)
+          evolutions.resolve(db, rev.toInt, config.forDatasource(db).schema)
           buildLink.forceReload()
           play.api.mvc.Results.Redirect(redirectUrl)
         }

--- a/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/DefaultEvolutionsConfigParserSpec.scala
+++ b/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/DefaultEvolutionsConfigParserSpec.scala
@@ -24,6 +24,13 @@ object DefaultEvolutionsConfigParserSpec extends Specification {
     read(parse(s"play.evolutions.$key" -> false, fooConfig).forDatasource("default")) must_== false
   }
 
+  def testNString(key: String)(read: EvolutionsDatasourceConfig => String) = {
+    // This ensures that the config for default is detected, ensuring that a configuration based fallback is used
+    val fooConfig = "play.evolutions.db.default.foo" -> "foo"
+    read(parse(s"play.evolutions.$key" -> "", fooConfig).forDatasource("default")) must_== ""
+    read(parse(s"play.evolutions.$key" -> "something", fooConfig).forDatasource("default")) must_== "something"
+  }
+
   val default = parse().forDatasource("default")
 
   "The evolutions config parser" should {
@@ -45,6 +52,9 @@ object DefaultEvolutionsConfigParserSpec extends Specification {
       "enabled" in {
         testN("enabled")(_.enabled)
       }
+      "schema" in {
+        testNString("schema")(_.schema)
+      }
       "autocommit" in {
         testN("autocommit")(_.autocommit)
       }
@@ -62,6 +72,9 @@ object DefaultEvolutionsConfigParserSpec extends Specification {
       "enabled" in {
         testN("db.default.enabled")(_.enabled)
       }
+      "schema" in {
+        testNString("db.default.schema")(_.schema)
+      }
       "autocommit" in {
         testN("db.default.autocommit")(_.autocommit)
       }
@@ -78,6 +91,9 @@ object DefaultEvolutionsConfigParserSpec extends Specification {
     "parse defaults" in {
       "enabled" in {
         default.enabled must_== true
+      }
+      "schema" in {
+        default.schema must_== ""
       }
       "autocommit" in {
         default.autocommit must_== true

--- a/framework/src/play-jdbc/src/main/resources/reference.conf
+++ b/framework/src/play-jdbc/src/main/resources/reference.conf
@@ -206,6 +206,9 @@ play {
     # Whether evolutions are enabled
     enabled = true
 
+    # Database schema in which the generated evolution and lock tables will be saved to
+    schema = ""
+
     # Whether evolution updates should be performed with autocommit or in a manually managed transaction
     autocommit = true
 


### PR DESCRIPTION
Fixes #2286

You can now set `play.evolutions.schema` (or `play.evolutions.db.default.schema`) to define the schema in which the `play_evolutions` and `play_evolutions_lock` tables will be stored in.