### PR TITLE
Deprecate Play.current and Play.maybeApplication

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -62,7 +62,7 @@ object CSRFConfig {
 
   private[play] val HeaderNoCheck = "nocheck"
 
-  def global = Play.maybeApplication.map(_.injector.instanceOf[CSRFConfig]).getOrElse(CSRFConfig())
+  def global = Play.privateMaybeApplication.map(_.injector.instanceOf[CSRFConfig]).getOrElse(CSRFConfig())
 
   def fromConfiguration(conf: Configuration): CSRFConfig = {
     val config = PlayConfig(conf).getDeprecatedWithFallback("play.filters.csrf", "csrf")

--- a/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
+++ b/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
@@ -62,7 +62,11 @@ object PlayMagicForJava {
       val jmessages = play.mvc.Http.Context.current().messages()
       play.api.i18n.Messages(jmessages.lang(), jmessages.messagesApi().scalaApi())
     } catch {
-      case NonFatal(_) => play.api.i18n.Messages(play.api.i18n.Lang.defaultLang, play.api.i18n.Messages.messagesApiCache(play.api.Play.current))
+      case NonFatal(_) =>
+        val app = play.api.Play.privateMaybeApplication.get
+        val api = play.api.i18n.Messages.messagesApiCache(app)
+        val lang = play.api.i18n.Lang.defaultLang
+        play.api.i18n.Messages(lang, api)
     }
 
 }

--- a/framework/src/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
+++ b/framework/src/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
@@ -65,12 +65,13 @@ private[routing] object RouterBuilderHelper {
               case Right(params) =>
 
                 // Convert to a Scala action
-                val parser = HandlerInvokerFactory.javaBodyParserToScala(
+                val parser = HandlerInvokerFactory.javaBodyParserToScala {
                   // If testing an embedded application we may not have a Guice injector, therefore we can't rely on
                   // it to instantiate the default body parser, we have to instantiate it ourselves.
-                  new play.mvc.BodyParser.Default(new JavaHttpErrorHandlerDelegate(Play.current.errorHandler),
-                    Play.current.injector.instanceOf[HttpConfiguration])
-                )
+                  val app = Play.privateMaybeApplication.get // throw exception if no current app
+                  new play.mvc.BodyParser.Default(new JavaHttpErrorHandlerDelegate(app.errorHandler),
+                    app.injector.instanceOf[HttpConfiguration])
+                }
                 Action.async(parser) { request =>
                   val ctx = JavaHelpers.createJavaContext(request)
                   try {

--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -239,7 +239,7 @@ object OfflineEvolutions {
 
   private val logger = Logger(this.getClass)
 
-  private def isTest: Boolean = Play.maybeApplication.exists(_.mode == Mode.Test)
+  private def isTest: Boolean = Play.privateMaybeApplication.exists(_.mode == Mode.Test)
 
   private def getEvolutions(appPath: File, classloader: ClassLoader, dbApi: DBApi): EvolutionsComponents = {
     val _dbApi = dbApi

--- a/framework/src/play-specs2/src/test/scala/play/api/test/SpecsSpec.scala
+++ b/framework/src/play-specs2/src/test/scala/play/api/test/SpecsSpec.scala
@@ -21,6 +21,7 @@ object SpecsSpec extends Specification {
       getConfig("foo") must beSome("bar")
     }
     "start the application" in new WithApplication(fakeApp("foo" -> "bar", "ehcacheplugin" -> "disabled")) {
+      //noinspection ScalaDeprecation
       Play.maybeApplication must beSome(app)
     }
   }

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -237,7 +237,10 @@ trait RouteInvokers extends EssentialActionCaller {
    * Use the HttpRequestHandler to determine the Action to call for this request and execute it.
    *
    * The body is serialised using the implicit writable, so that the action body parser can deserialise it.
+   *
+   * @deprecated Use the version that takes an application, since 2.5.0
    */
+  @deprecated("Use the version that takes an application", "2.5.0")
   def route[T](rh: RequestHeader, body: T)(implicit w: Writeable[T]): Option[Future[Result]] = route(Play.current, rh, body)
 
   /**
@@ -251,7 +254,10 @@ trait RouteInvokers extends EssentialActionCaller {
    * Use the HttpRequestHandler to determine the Action to call for this request and execute it.
    *
    * The body is serialised using the implicit writable, so that the action body parser can deserialise it.
+   *
+   * @deprecated Use the version that takes an application, since 2.5.0
    */
+  @deprecated("Use the version that takes an application", "2.5.0")
   def route[T](req: Request[T])(implicit w: Writeable[T]): Option[Future[Result]] = route(Play.current, req)
 }
 

--- a/framework/src/play-test/src/test/java/play/test/WithApplicationTest.java
+++ b/framework/src/play-test/src/test/java/play/test/WithApplicationTest.java
@@ -15,6 +15,7 @@ public class WithApplicationTest extends WithApplication {
     @Test
     public void withApplicationShouldProvideAnApplication() {
         assertNotNull(app);
+        //noinspection deprecation
         assertNotNull(Play.application());
     }
 

--- a/framework/src/play-ws/src/main/scala/play/api/test/WSTestClient.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/test/WSTestClient.scala
@@ -22,13 +22,13 @@ trait WsTestClient {
    * }
    * }}}
    */
-  def wsCall(call: Call)(implicit port: Port, client: WSClient = WS.client(play.api.Play.current)): WSRequest = wsUrl(call.url)
+  def wsCall(call: Call)(implicit port: Port, client: WSClient = WS.client(play.api.Play.privateMaybeApplication.get)): WSRequest = wsUrl(call.url)
 
   /**
    * Constructs a WS request holder for the given relative URL.  Optionally takes a port and WSClient.  Note that the WS client used
    * by default requires a running Play application (use WithApplication for tests).
    */
-  def wsUrl(url: String)(implicit port: Port, client: WSClient = WS.client(play.api.Play.current)) = {
+  def wsUrl(url: String)(implicit port: Port, client: WSClient = WS.client(play.api.Play.privateMaybeApplication.get)) = {
     WS.clientUrl("http://localhost:" + port + url)
   }
 

--- a/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
+++ b/framework/src/play/src/main/scala/play/api/GlobalSettings.scala
@@ -37,24 +37,24 @@ trait GlobalSettings {
    * Note, this should only be used for the default implementations of onError, onHandlerNotFound and onBadRequest.
    */
   private def defaultErrorHandler: HttpErrorHandler = {
-    Play.maybeApplication.fold[HttpErrorHandler](DefaultHttpErrorHandler)(dhehCache)
+    Play.privateMaybeApplication.fold[HttpErrorHandler](DefaultHttpErrorHandler)(dhehCache)
   }
 
   /**
    * This should be used for all invocations of error handling in Global.
    */
   private def configuredErrorHandler: HttpErrorHandler = {
-    Play.maybeApplication.fold[HttpErrorHandler](DefaultHttpErrorHandler)(_.errorHandler)
+    Play.privateMaybeApplication.fold[HttpErrorHandler](DefaultHttpErrorHandler)(_.errorHandler)
   }
 
   private val jchrhCache = Application.instanceCache[JavaCompatibleHttpRequestHandler]
   private def defaultRequestHandler: Option[DefaultHttpRequestHandler] = {
-    Play.maybeApplication.map(jchrhCache)
+    Play.privateMaybeApplication.map(jchrhCache)
   }
 
   private val httpFiltersCache = Application.instanceCache[HttpFilters]
   private def filters: HttpFilters = {
-    Play.maybeApplication.fold[HttpFilters](NoHttpFilters)(httpFiltersCache)
+    Play.privateMaybeApplication.fold[HttpFilters](NoHttpFilters)(httpFiltersCache)
   }
 
   /**
@@ -122,7 +122,7 @@ trait GlobalSettings {
    */
   def doFilter(next: RequestHeader => Handler): (RequestHeader => Handler) = {
     (request: RequestHeader) =>
-      val context = Play.maybeApplication.fold("") { app =>
+      val context = Play.privateMaybeApplication.fold("") { app =>
         httpConfigurationCache(app).context.stripSuffix("/")
       }
       val inContext = context.isEmpty || request.path == context || request.path.startsWith(context + "/")

--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -55,21 +55,35 @@ object Play {
 
   /**
    * Returns the currently running application, or `null` if not defined.
+   *
+   * @deprecated This is a static reference to application, use DI, since 2.5.0
    */
+  @deprecated("This is a static reference to application, use DI", "2.5.0")
   def unsafeApplication: Application = _currentApp
 
   /**
    * Optionally returns the current running application.
+   *
+   * @deprecated This is a static reference to application, use DI, since 2.5.0
    */
+  @deprecated("This is a static reference to application, use DI instead", "2.5.0")
   def maybeApplication: Option[Application] = Option(_currentApp)
+
+  private[play] def privateMaybeApplication: Option[Application] = Option(_currentApp)
+
+  /* Used by the routes compiler to resolve an application for the injector.  Treat as private. */
+  def routesCompilerMaybeApplication: Option[Application] = Option(_currentApp)
 
   /**
    * Implicitly import the current running application in the context.
    *
    * Note that by relying on this, your code will only work properly in
    * the context of a running application.
+   *
+   * @deprecated This is a static reference to application, use DI, since 2.5.0
    */
-  implicit def current: Application = maybeApplication.getOrElse(sys.error("There is no started application"))
+  @deprecated("This is a static reference to application, use DI instead", "2.5.0")
+  implicit def current: Application = privateMaybeApplication.getOrElse(sys.error("There is no started application"))
 
   @volatile private[play] var _currentApp: Application = _
 

--- a/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -146,5 +146,5 @@ object HttpConfiguration {
   /**
    * Don't use this - only exists for transition from global state
    */
-  private[play] def current = Play.maybeApplication.fold(HttpConfiguration())(httpConfigurationCache)
+  private[play] def current = Play.privateMaybeApplication.fold(HttpConfiguration())(httpConfigurationCache)
 }

--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -287,7 +287,7 @@ object DefaultHttpErrorHandler extends DefaultHttpErrorHandler(Environment.simpl
  */
 object LazyHttpErrorHandler extends HttpErrorHandler {
 
-  private def errorHandler = Play.maybeApplication.fold[HttpErrorHandler](DefaultHttpErrorHandler)(_.errorHandler)
+  private def errorHandler = Play.privateMaybeApplication.fold[HttpErrorHandler](DefaultHttpErrorHandler)(_.errorHandler)
 
   def onClientError(request: RequestHeader, statusCode: Int, message: String) =
     errorHandler.onClientError(request, statusCode, message)

--- a/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
@@ -36,7 +36,7 @@ object Crypto {
 
   private val cryptoCache = Application.instanceCache[Crypto]
   private def crypto = {
-    Play.maybeApplication.fold(
+    Play.privateMaybeApplication.fold(
       new Crypto(new CryptoConfigParser(
         Environment.simple(), Configuration.from(Map("play.crypto.aes.transformation" -> "AES/CTR/NoPadding"))
       ).get)

--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -122,7 +122,7 @@ object Files {
      * instance or the SingletonTemporaryFileCreator if no application
      * is currently running.
      */
-    private def currentCreator: TemporaryFileCreator = Play.maybeApplication.fold[TemporaryFileCreator](SingletonTemporaryFileCreator)(creatorCache)
+    private def currentCreator: TemporaryFileCreator = Play.privateMaybeApplication.fold[TemporaryFileCreator](SingletonTemporaryFileCreator)(creatorCache)
 
     /**
      * Create a new temporary file.

--- a/framework/src/play/src/main/scala/play/api/libs/JNDI.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/JNDI.scala
@@ -24,14 +24,14 @@ object JNDI {
     val env = new java.util.Hashtable[String, String]
 
     env.put(INITIAL_CONTEXT_FACTORY, {
-      Play.maybeApplication.flatMap(_.configuration.getString(INITIAL_CONTEXT_FACTORY)).getOrElse {
+      Play.privateMaybeApplication.flatMap(_.configuration.getString(INITIAL_CONTEXT_FACTORY)).getOrElse {
         System.setProperty(INITIAL_CONTEXT_FACTORY, IN_MEMORY_JNDI)
         IN_MEMORY_JNDI
       }
     })
 
     env.put(PROVIDER_URL, {
-      Play.maybeApplication.flatMap(_.configuration.getString(PROVIDER_URL)).getOrElse {
+      Play.privateMaybeApplication.flatMap(_.configuration.getString(PROVIDER_URL)).getOrElse {
         System.setProperty(PROVIDER_URL, IN_MEMORY_URL)
         IN_MEMORY_URL
       }

--- a/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
@@ -31,7 +31,7 @@ object MimeTypes {
   /**
    * Mimetypes defined in the current application, as declared in application.conf
    */
-  def applicationTypes: Map[String, String] = play.api.Play.maybeApplication.flatMap { application =>
+  def applicationTypes: Map[String, String] = play.api.Play.privateMaybeApplication.flatMap { application =>
     application.configuration.getConfig("mimetype").map { config =>
       config.subKeys.map { key =>
         (key, config.getString(key))

--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -101,7 +101,7 @@ trait Action[A] extends EssentialAction {
     case Right(a) =>
       val request = Request(rh, a)
       logger.trace("Invoking action with request: " + request)
-      Play.maybeApplication.map { app =>
+      Play.privateMaybeApplication.map { app =>
         play.utils.Threads.withContextClassLoader(app.classloader) {
           apply(request)
         }

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -278,7 +278,7 @@ trait BodyParsers {
 
     private[play] val ApplicationXmlMatcher = """application/.*\+xml.*""".r
 
-    private def config = Play.maybeApplication.map(app => hcCache(app).parser)
+    private def config = Play.privateMaybeApplication.map(app => hcCache(app).parser)
       .getOrElse(ParserConfiguration())
 
     /**
@@ -651,7 +651,8 @@ trait BodyParsers {
      */
     def multipartFormData[A](filePartHandler: Multipart.FilePartHandler[A], maxLength: Long = DefaultMaxDiskLength): BodyParser[MultipartFormData[A]] = {
       BodyParser("multipartFormData") { request =>
-        implicit val mat = Play.current.materializer
+        val app = Play.privateMaybeApplication.get // throw exception
+        implicit val mat = app.materializer
         val bodyAccumulator = Multipart.multipartParser(DefaultMaxTextLength, filePartHandler).apply(request)
         enforceMaxLength(request, maxLength, bodyAccumulator)
       }

--- a/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
@@ -72,7 +72,7 @@ trait Controller extends Results with BodyParsers with HttpProtocol with Status 
    * }}}
    */
   implicit def request2lang(implicit request: RequestHeader): Lang = {
-    play.api.Play.maybeApplication.map(app => play.api.i18n.Messages.messagesApiCache(app).preferred(request).lang)
+    play.api.Play.privateMaybeApplication.map(app => play.api.i18n.Messages.messagesApiCache(app).preferred(request).lang)
       .getOrElse(request.acceptLanguages.headOption.getOrElse(play.api.i18n.Lang.defaultLang))
   }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -250,7 +250,7 @@ case class Result(header: ResponseHeader, body: HttpEntity) {
    * Returns true if the status code is not 3xx and the application is in Dev mode.
    */
   private def shouldWarnIfNotRedirect(flash: Flash): Boolean = {
-    play.api.Play.maybeApplication.exists(app =>
+    play.api.Play.privateMaybeApplication.exists(app =>
       (app.mode == play.api.Mode.Dev) && (!flash.isEmpty) && (header.status < 300 || header.status > 399))
   }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Security.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Security.scala
@@ -57,7 +57,7 @@ object Security {
   /**
    * Key of the username attribute stored in session.
    */
-  lazy val username: String = Play.maybeApplication.flatMap(_.configuration.getString("session.username")) getOrElse ("username")
+  lazy val username: String = Play.privateMaybeApplication.flatMap(_.configuration.getString("session.username")) getOrElse ("username")
 
   /**
    * Wraps another action, allowing only authenticated HTTP requests.

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -208,7 +208,7 @@ object Multipart {
   }
 
   private def createBadResult[A](msg: String, status: Int = BAD_REQUEST): RequestHeader => Future[Either[Result, A]] = { request =>
-    Play.maybeApplication.fold(Future.successful(Left(Results.Status(status): Result)))(
+    Play.privateMaybeApplication.fold(Future.successful(Left(Results.Status(status): Result)))(
       _.errorHandler.onClientError(request, status, msg).map(Left(_)))
   }
 

--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
@@ -125,7 +125,7 @@ package object templates {
   /**
    * The code to statically get the Play injector
    */
-  val Injector = "play.api.Play.maybeApplication.map(_.injector).getOrElse(play.api.inject.NewInstanceInjector)"
+  val Injector = "play.api.Play.routesCompilerMaybeApplication.map(_.injector).getOrElse(play.api.inject.NewInstanceInjector)"
 
   val scalaReservedWords = List(
     "abstract", "case", "catch", "class",

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/tests/RouterSpec.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/tests/RouterSpec.scala
@@ -20,59 +20,59 @@ object RouterSpec extends PlaySpecification {
   }
 
   "bind boolean parameters" in {
-    "from the query string" in new WithApplication() {
-      val Some(result) = route(FakeRequest(GET, "/take-bool?b=true"))
+    "from the query string" in new WithApplication() { 
+      val Some(result) = route(implicitApp, FakeRequest(GET, "/take-bool?b=true"))
       contentAsString(result) must equalTo ("true")
-      val Some(result2) = route(FakeRequest(GET, "/take-bool?b=false"))
+      val Some(result2) = route(implicitApp, FakeRequest(GET, "/take-bool?b=false"))
       contentAsString(result2) must equalTo ("false")
       // Bind boolean values from 1 and 0 integers too
-      contentAsString(route(FakeRequest(GET, "/take-bool?b=1")).get) must equalTo ("true")
-      contentAsString(route(FakeRequest(GET, "/take-bool?b=0")).get) must equalTo ("false")
+      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=1")).get) must equalTo ("true")
+      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=0")).get) must equalTo ("false")
     }
     "from the path" in new WithApplication() {
-      val Some(result) = route(FakeRequest(GET, "/take-bool-2/true"))
+      val Some(result) = route(implicitApp, FakeRequest(GET, "/take-bool-2/true"))
       contentAsString(result) must equalTo ("true")
-      val Some(result2) = route(FakeRequest(GET, "/take-bool-2/false"))
+      val Some(result2) = route(implicitApp, FakeRequest(GET, "/take-bool-2/false"))
       contentAsString(result2) must equalTo ("false")
       // Bind boolean values from 1 and 0 integers too
-      contentAsString(route(FakeRequest(GET, "/take-bool-2/1")).get) must equalTo ("true")
-      contentAsString(route(FakeRequest(GET, "/take-bool-2/0")).get) must equalTo ("false")
+      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/1")).get) must equalTo ("true")
+      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/0")).get) must equalTo ("false")
     }
   }
 
   "bind int parameters from the query string as a list" in {
 
     "from a list of numbers" in new WithApplication() {
-      val Some(result) = route(FakeRequest(GET, controllers.routes.Application.takeList(List(1, 2, 3)).url))
+      val Some(result) = route(implicitApp, FakeRequest(GET, controllers.routes.Application.takeList(List(1, 2, 3)).url))
       contentAsString(result) must equalTo("1,2,3")
     }
     "from a list of numbers and letters" in new WithApplication() {
-      val Some(result) = route(FakeRequest(GET, "/take-list?x=1&x=a&x=2"))
+      val Some(result) = route(implicitApp, FakeRequest(GET, "/take-list?x=1&x=a&x=2"))
       status(result) must equalTo(BAD_REQUEST)
     }
     "when there is no parameter at all" in new WithApplication() {
-      val Some(result) = route(FakeRequest(GET, "/take-list"))
+      val Some(result) = route(implicitApp, FakeRequest(GET, "/take-list"))
       contentAsString(result) must equalTo("")
     }
     "using the Java API" in new WithApplication() {
-      val Some(result) = route(FakeRequest(GET, "/take-java-list?x=1&x=2&x=3"))
+      val Some(result) = route(implicitApp, FakeRequest(GET, "/take-java-list?x=1&x=2&x=3"))
       contentAsString(result) must equalTo("1,2,3")
     }
     "using backticked names on route params" in new WithApplication() {
-      val Some(result) = route(FakeRequest(GET, "/take-list-tick-param?b[]=4&b[]=5&b[]=6"))
+      val Some(result) = route(implicitApp, FakeRequest(GET, "/take-list-tick-param?b[]=4&b[]=5&b[]=6"))
       contentAsString(result) must equalTo("4,5,6")
     }
     "using backticked names urlencoded on route params" in new WithApplication() {
-      val Some(result) = route(FakeRequest(GET, "/take-list-tick-param?b%5B%5D=4&b%5B%5D=5&b%5B%5D=6"))
+      val Some(result) = route(implicitApp, FakeRequest(GET, "/take-list-tick-param?b%5B%5D=4&b%5B%5D=5&b%5B%5D=6"))
       contentAsString(result) must equalTo("4,5,6")
     }
   }
 
   "use a new instance for each instantiated controller" in new WithApplication() {
-    route(FakeRequest(GET, "/instance")) must beSome.like {
+    route(implicitApp, FakeRequest(GET, "/instance")) must beSome.like {
       case result => contentAsString(result) must_== "1"
     }
-    route(FakeRequest(GET, "/instance")) must beSome.like {
+    route(implicitApp, FakeRequest(GET, "/instance")) must beSome.like {
       case result => contentAsString(result) must_== "1"
     }
   }
@@ -83,7 +83,7 @@ object RouterSpec extends PlaySpecification {
                        dynamicDecoded: String, staticDecoded: String, queryDecoded: String) = {
       val path = s"/urlcoding/$dynamicEncoded/$staticEncoded?q=$queryEncoded"
       val expected = s"dynamic=$dynamicDecoded static=$staticDecoded query=$queryDecoded"
-      val Some(result) = route(FakeRequest(GET, path))
+      val Some(result) = route(implicitApp, FakeRequest(GET, path))
       val actual = contentAsString(result)
       actual must equalTo(expected)
     }
@@ -121,14 +121,14 @@ object RouterSpec extends PlaySpecification {
 
   "allow reverse routing of routes includes" in new WithApplication() {
     // Force the router to bootstrap the prefix
-    app.injector.instanceOf[play.api.routing.Router]
+    implicitApp.injector.instanceOf[play.api.routing.Router]
     controllers.module.routes.ModuleController.index().url must_== "/module/index"
   }
 
   "document the router" in new WithApplication() {
     // The purpose of this test is to alert anyone that changes the format of the router documentation that
     // it is being used by Swagger. So if you do change it, please let Tony Tam know at tony at wordnik dot com.
-    val someRoute = app.injector.instanceOf[play.api.routing.Router].documentation.find(r => r._1 == "GET" && r._2.startsWith("/with/"))
+    val someRoute = implicitApp.injector.instanceOf[play.api.routing.Router].documentation.find(r => r._1 == "GET" && r._2.startsWith("/with/"))
     someRoute must beSome[(String, String, String)]
     val route = someRoute.get
     route._2 must_== "/with/$param<[^/]+>"

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/tests/RouterSpec.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/tests/RouterSpec.scala
@@ -17,53 +17,53 @@ object RouterSpec extends PlaySpecification {
   }
 
   "bind boolean parameters" in {
-    "from the query string" in new WithApplication() {
-      val Some(result) = route(FakeRequest(GET, "/take-bool?b=true"))
+    "from the query string" in new WithApplication() { 
+      val Some(result) = route(implicitApp, FakeRequest(GET, "/take-bool?b=true"))
       contentAsString(result) must equalTo ("true")
-      val Some(result2) = route(FakeRequest(GET, "/take-bool?b=false"))
+      val Some(result2) = route(implicitApp, FakeRequest(GET, "/take-bool?b=false"))
       contentAsString(result2) must equalTo ("false")
       // Bind boolean values from 1 and 0 integers too
-      contentAsString(route(FakeRequest(GET, "/take-bool?b=1")).get) must equalTo ("true")
-      contentAsString(route(FakeRequest(GET, "/take-bool?b=0")).get) must equalTo ("false")
+      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=1")).get) must equalTo ("true")
+      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=0")).get) must equalTo ("false")
     }
-    "from the path" in new WithApplication() {
-      val Some(result) = route(FakeRequest(GET, "/take-bool-2/true"))
+    "from the path" in new WithApplication() { 
+      val Some(result) = route(implicitApp, FakeRequest(GET, "/take-bool-2/true"))
       contentAsString(result) must equalTo ("true")
-      val Some(result2) = route(FakeRequest(GET, "/take-bool-2/false"))
+      val Some(result2) = route(implicitApp, FakeRequest(GET, "/take-bool-2/false"))
       contentAsString(result2) must equalTo ("false")
       // Bind boolean values from 1 and 0 integers too
-      contentAsString(route(FakeRequest(GET, "/take-bool-2/1")).get) must equalTo ("true")
-      contentAsString(route(FakeRequest(GET, "/take-bool-2/0")).get) must equalTo ("false")
+      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/1")).get) must equalTo ("true")
+      contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool-2/0")).get) must equalTo ("false")
     }
   }
 
   "bind int parameters from the query string as a list" in {
 
-    "from a list of numbers" in new WithApplication() {
-      val Some(result) = route(FakeRequest(GET, controllers.routes.Application.takeList(List(1, 2, 3)).url))
+    "from a list of numbers" in new WithApplication() { 
+      val Some(result) = route(implicitApp, FakeRequest(GET, controllers.routes.Application.takeList(List(1, 2, 3)).url))
       contentAsString(result) must equalTo("1,2,3")
     }
-    "from a list of numbers and letters" in new WithApplication() {
-      val Some(result) = route(FakeRequest(GET, "/take-list?x=1&x=a&x=2"))
+    "from a list of numbers and letters" in new WithApplication() { 
+      val Some(result) = route(implicitApp, FakeRequest(GET, "/take-list?x=1&x=a&x=2"))
       status(result) must equalTo(BAD_REQUEST)
     }
-    "when there is no parameter at all" in new WithApplication() {
-      val Some(result) = route(FakeRequest(GET, "/take-list"))
+    "when there is no parameter at all" in new WithApplication() { 
+      val Some(result) = route(implicitApp, FakeRequest(GET, "/take-list"))
       contentAsString(result) must equalTo("")
     }
-    "using the Java API" in new WithApplication() {
-      val Some(result) = route(FakeRequest(GET, "/take-java-list?x=1&x=2&x=3"))
+    "using the Java API" in new WithApplication() { 
+      val Some(result) = route(implicitApp, FakeRequest(GET, "/take-java-list?x=1&x=2&x=3"))
       contentAsString(result) must equalTo("1,2,3")
     }
   }
 
-  "URL encoding and decoding works correctly" in new WithApplication() {
+  "URL encoding and decoding works correctly" in new WithApplication() { 
     def checkDecoding(
                        dynamicEncoded: String, staticEncoded: String, queryEncoded: String,
                        dynamicDecoded: String, staticDecoded: String, queryDecoded: String) = {
       val path = s"/urlcoding/$dynamicEncoded/$staticEncoded?q=$queryEncoded"
       val expected = s"dynamic=$dynamicDecoded static=$staticDecoded query=$queryDecoded"
-      val Some(result) = route(FakeRequest(GET, path))
+      val Some(result) = route(implicitApp, FakeRequest(GET, path))
       val actual = contentAsString(result)
       actual must equalTo(expected)
     }
@@ -99,16 +99,16 @@ object RouterSpec extends PlaySpecification {
     checkEncoding("123", "456", "789", "123", "456", "789")
   }
 
-  "allow reverse routing of routes includes" in new WithApplication() {
+  "allow reverse routing of routes includes" in new WithApplication() { 
     // Force the router to bootstrap the prefix
-    app.injector.instanceOf[play.api.routing.Router]
+    implicitApp.injector.instanceOf[play.api.routing.Router]
     controllers.module.routes.ModuleController.index().url must_== "/module/index"
   }
 
   "document the router" in new WithApplication() {
     // The purpose of this test is to alert anyone that changes the format of the router documentation that
     // it is being used by Swagger. So if you do change it, please let Tony Tam know at tony at wordnik dot com.
-    val someRoute = app.injector.instanceOf[play.api.routing.Router].documentation.find(r => r._1 == "GET" && r._2.startsWith("/with/"))
+    val someRoute = implicitApp.injector.instanceOf[play.api.routing.Router].documentation.find(r => r._1 == "GET" && r._2.startsWith("/with/"))
     someRoute must beSome[(String, String, String)]
     val route = someRoute.get
     route._2 must_== "/with/$param<[^/]+>"


### PR DESCRIPTION
Deprecate the static `Play.current` and `Play.maybeApplication` methods.

Note that this is less dramatic than it seems, since there's new `private[play] privateMaybeApplication` method call and most of the internal applications are still using it.  There's also a route compiler which isn't under the play package which I had to account for.

I have not attempted to refactor any of the major offenders, such as Assets or CSRF.  Searching for `privateMaybeApplication` should show where we have internal dependencies.  