### PR TITLE
Java EssentialFilter/EssentialAction API

### DIFF
--- a/documentation/manual/working/javaGuide/main/application/JavaEssentialAction.md
+++ b/documentation/manual/working/javaGuide/main/application/JavaEssentialAction.md
@@ -1,0 +1,68 @@
+<!--- Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com> -->
+# Introduction to Play HTTP API
+
+## What is EssentialAction?
+
+EssentialAction is the underlying functional type used by Play's HTTP APIs. This differs from the `Action` type in Java, a higher-level type that accepts a `Context` and returns a `CompletionStage<Result>`. Most of the time you will not need to use `EssentialAction` directly in a Java application, but it can be useful when writing filters or interacting with other low-level Play APIs.
+
+To understand EssentialAction we need to understand the Play architecture.
+
+The core of Play is really small, surrounded by a fair amount of useful APIs, services and structure to make Web Programming tasks easier.
+
+Basically, Play's action API abstractly has the following type:
+
+```java
+RequestHeader -> byte[] -> Result 
+```
+
+The above takes the request header `RequestHeader`, then takes the request body as `byte[]` and produces a `Result`.
+
+Now this type presumes putting request body entirely into memory (or disk), even if you only want to compute a value out of it, or better forward it to a storage service like Amazon S3.
+
+We rather want to receive request body chunks as a stream and be able to process them progressively if necessary.
+
+What we need to change is the second arrow to make it receive its input in chunks and eventually produce a result. There is a type that does exactly this, it is called `Accumulator` and takes two type parameters.
+
+`Accumulator<E,R>` is a type of [arrow](https://www.haskell.org/arrows/) that will take its input in chunks of type `E` and eventually return `R`. For our API we need an Accumulator that takes chunks of `ByteString` (essentially a more efficient wrapper for a byte array) and eventually return a `Result`. So we slightly modify the type to be:
+
+```java
+RequestHeader -> Accumulator<ByteString, Result>
+```
+
+Ultimately, our Java type looks like 
+
+```java
+Function<RequestHeader, Accumulator<ByteString, Result>>
+```
+
+And this should read as: Take the request headers, take chunks of `ByteString` which represent the request body and eventually return a `Result`. This exactly how the `EssentialAction`'s apply method is defined
+
+```java
+public abstract Accumulator<ByteString, Result> apply(RequestHeader requestHeader);
+```
+
+The `Result` type, on the other hand, can be abstractly thought of as the response headers and the body of the response:
+
+```java
+Result(ResponseHeader header, ByteString body)
+```
+
+But, what if we want to send the response body progressively to the client without filling it entirely into memory? We need to improve our type. We need to replace the body type from a `ByteString` to something that produces chunks of `ByteString`. 
+
+We already have a type for this and is called `Source<E, ?>` which means that it is capable of producing chunks of `E`, in our case `Source<ByteString, ?>`:
+
+```java
+Result(ResponseHeader header, Source<ByteString, ?> body)
+```
+
+If we don't have to send the response progressively we still can send the entire body as a single chunk. In the actual API, Play supports different types of entities using the `HttpEntity` wrapper type, which supports streamed, chunked, and strict entities.
+
+## Bottom Line
+
+The essential Play HTTP API is quite simple:
+
+```java
+RequestHeader -> Accumulator<ByteString, Result>
+```
+
+which reads as the following: Take the `RequestHeader` then take chunks of `ByteString` and return a response. A response consists of `ResponseHeaders` and a body which is chunks of values convertible to `ByteString` to be written to the socket represented in the `Source<E, ?>` type.

--- a/documentation/manual/working/javaGuide/main/application/code/javaguide/application/httpfilters/EssentialLoggingFilter.java
+++ b/documentation/manual/working/javaGuide/main/application/code/javaguide/application/httpfilters/EssentialLoggingFilter.java
@@ -1,0 +1,38 @@
+package javaguide.application.httpfilters;
+
+// #essential-filter-example
+import java.util.concurrent.Executor;
+import javax.inject.Inject;
+import akka.util.ByteString;
+import play.Logger;
+import play.libs.streams.Accumulator;
+import play.mvc.*;
+
+public class EssentialLoggingFilter extends EssentialFilter {
+
+    private final Executor executor;
+
+    @Inject
+    public EssentialLoggingFilter(Executor executor) {
+        super();
+        this.executor = executor;
+    }
+
+    @Override
+    public EssentialAction apply(EssentialAction next) {
+        return EssentialAction.of(request -> {
+            long startTime = System.currentTimeMillis();
+            Accumulator<ByteString, Result> accumulator = next.apply(request);
+            return accumulator.map(result -> {
+                long endTime = System.currentTimeMillis();
+                long requestTime = endTime - startTime;
+
+                Logger.info("{} {} took {}ms and returned {}",
+                    request.method(), request.uri(), requestTime, result.status());
+
+                return result.withHeader("Request-Time", "" + requestTime);
+            }, executor);
+        });
+    }
+}
+// #essential-filter-example

--- a/documentation/manual/working/javaGuide/main/application/code/javaguide/application/httpfilters/Filters.java
+++ b/documentation/manual/working/javaGuide/main/application/code/javaguide/application/httpfilters/Filters.java
@@ -1,7 +1,6 @@
 package javaguide.application.httpfilters;
 
 // #filters
-import play.api.Logger;
 import play.api.mvc.EssentialFilter;
 import play.http.HttpFilters;
 import play.filters.gzip.GzipFilter;
@@ -10,15 +9,17 @@ import javax.inject.Inject;
 public class Filters implements HttpFilters {
 
   private final GzipFilter gzip;
+  private final LoggingFilter logging;
 
   @Inject
-  public Filters(GzipFilter gzip) {
+  public Filters(GzipFilter gzip, LoggingFilter logging) {
     this.gzip = gzip;
+    this.logging = logging;
   }
 
   @Override
   public EssentialFilter[] filters() {
-    return new EssentialFilter[] { gzip };
+    return new EssentialFilter[] { gzip, logging };
   }
 }
 //#filters

--- a/documentation/manual/working/javaGuide/main/application/code/javaguide/application/httpfilters/LoggingFilter.java
+++ b/documentation/manual/working/javaGuide/main/application/code/javaguide/application/httpfilters/LoggingFilter.java
@@ -1,0 +1,34 @@
+package javaguide.application.httpfilters;
+
+// #simple-filter
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import javax.inject.Inject;
+import akka.stream.Materializer;
+import play.Logger;
+import play.mvc.*;
+
+public class LoggingFilter extends Filter {
+
+    @Inject
+    public LoggingFilter(Materializer mat) {
+        super(mat);
+    }
+
+    @Override
+    public CompletionStage<Result> apply(
+            Function<Http.RequestHeader, CompletionStage<Result>> nextFilter,
+            Http.RequestHeader requestHeader) {
+        long startTime = System.currentTimeMillis();
+        return nextFilter.apply(requestHeader).thenApply(result -> {
+            long endTime = System.currentTimeMillis();
+            long requestTime = endTime - startTime;
+
+            Logger.info("{} {} took {}ms and returned {}",
+                requestHeader.method(), requestHeader.uri(), requestTime, result.status());
+
+            return result.withHeader("Request-Time", "" + requestTime);
+        });
+    }
+}
+// #simple-filter

--- a/documentation/manual/working/javaGuide/main/application/code/javaguide/application/httpfilters/RoutedLoggingFilter.java
+++ b/documentation/manual/working/javaGuide/main/application/code/javaguide/application/httpfilters/RoutedLoggingFilter.java
@@ -1,0 +1,38 @@
+package javaguide.application.httpfilters;
+
+// #routing-info-access
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.Map;
+import javax.inject.Inject;
+import akka.stream.Materializer;
+import play.Logger;
+import play.mvc.*;
+
+public class RoutedLoggingFilter extends Filter {
+
+    @Inject
+    public RoutedLoggingFilter(Materializer mat) {
+        super(mat);
+    }
+
+    @Override
+    public CompletionStage<Result> apply(
+            Function<Http.RequestHeader, CompletionStage<Result>> nextFilter,
+            Http.RequestHeader requestHeader) {
+        long startTime = System.currentTimeMillis();
+        return nextFilter.apply(requestHeader).thenApply(result -> {
+            Map<String, String> tags = requestHeader.tags();
+            String actionMethod = tags.get("ROUTE_CONTROLLER") +
+                "." + tags.get("ROUTE_ACTION_METHOD");
+            long endTime = System.currentTimeMillis();
+            long requestTime = endTime - startTime;
+
+            Logger.info("{} took {}ms and returned {}",
+                actionMethod, requestTime, result.status());
+
+            return result.withHeader("Request-Time", "" + requestTime);
+        });
+    }
+}
+// #routing-info-access

--- a/documentation/manual/working/javaGuide/main/application/index.toc
+++ b/documentation/manual/working/javaGuide/main/application/index.toc
@@ -1,4 +1,5 @@
 JavaApplication:Application settings
+JavaEssentialAction:Essential Actions
 JavaHttpFilters:HTTP filters
 JavaErrorHandling:Error handling
 JavaGlobal:Global settings

--- a/documentation/manual/working/scalaGuide/main/application/ScalaEssentialAction.md
+++ b/documentation/manual/working/scalaGuide/main/application/ScalaEssentialAction.md
@@ -3,11 +3,11 @@
 
 ## What is EssentialAction?
 
-The EssentialAction is the new simpler type replacing the old Action[A]. To understand EssentialAction we need to understand the Play architecture.
+The EssentialAction is the simpler type underlying Action[A]. To understand EssentialAction we need to understand the Play architecture.
 
-The core of Play2 is really small, surrounded by a fair amount of useful APIs, services and structure to make Web Programming tasks easier.
+The core of Play is really small, surrounded by a fair amount of useful APIs, services and structure to make Web Programming tasks easier.
 
-Basically, Play2 is an API that abstractly have the following type:
+Basically, Play's action API abstractly has the following type:
 
 ```scala
 RequestHeader -> Array[Byte] -> Result 
@@ -19,67 +19,63 @@ Now this type presumes putting request body entirely into memory (or disk), even
 
 We rather want to receive request body chunks as a stream and be able to process them progressively if necessary.
 
-What we need to change is the second arrow to make it receive its input in chunks and eventually produce a result. There is a type that does exactly this, it is called `Iteratee` and takes two type parameters.
+What we need to change is the second arrow to make it receive its input in chunks and eventually produce a result. There is a type that does exactly this, it is called `Accumulator` and takes two type parameters.
 
-`Iteratee[E,R]` is a type of [arrow](https://www.haskell.org/arrows/) that will take its input in chunks of type `E` and eventually return `R`. For our API we need an Iteratee that takes chunks of `Array[Byte]` and eventually return a `Result`. So we slightly modify the type to be:
+`Accumulator[E,R]` is a type of [arrow](https://www.haskell.org/arrows/) that will take its input in chunks of type `E` and eventually return `R`. For our API we need an Accumulator that takes chunks of `ByteString` (essentially a more efficient wrapper for a byte array) and eventually return a `Result`. So we slightly modify the type to be:
 
 ```scala
-RequestHeader -> Iteratee[Array[Byte],Result]
+RequestHeader -> Accumulator[ByteString, Result]
 ```
 
-For the first arrow, we are simply using the Function[From,To] which could be type aliased with `=>`:
+For the first arrow, we are simply using the Function[From, To] which could be type aliased with `=>`:
 
 ```scala
-RequestHeader => Iteratee[Array[Byte],Result]
+RequestHeader => Accumulator[ByteString, Result]
 ```
 
-Now if I define an infix type alias for `Iteratee[E,R]`:
+Now if I define an infix type alias for `Accumulator[E,R]`:
 
-`type ==>[E,R] = Iteratee[E,R]` then I can write the type in a funnier way:
+`type ==>[E,R] = Accumulator[E,R]` then I can write the type in a funnier way:
 
 ```scala
-RequestHeader => Array[Byte] ==> Result
+RequestHeader => ByteString ==> Result
 ```
 
-And this should read as: Take the request headers, take chunks of `Array[Byte]` which represent the request body and eventually return a `Result`. This exactly how the `EssentialAction` type is defined:
+And this should read as: Take the request headers, take chunks of `ByteString` which represent the request body and eventually return a `Result`. This exactly how the `EssentialAction` type is defined:
 
 ```scala
-trait EssentialAction extends (RequestHeader => Iteratee[Array[Byte], Result])
+trait EssentialAction extends (RequestHeader => Accumulator[ByteString, Result])
 ```
 
 The `Result` type, on the other hand, can be abstractly thought of as the response headers and the body of the response:
 
 ```scala
-case class Result(headers: ResponseHeader, body:Array[Byte])
+case class Result(header: ResponseHeader, body: ByteString)
 ```
 
-But, what if we want to send the response body progressively to the client without filling it entirely into memory. We need to improve our type. We need to replace the body type from an `Array[Byte]` to something that produces chunks of `Array[Byte]`. 
+But, what if we want to send the response body progressively to the client without filling it entirely into memory? We need to improve our type. We need to replace the body type from a `ByteString` to something that produces chunks of `ByteString`. 
 
-We already have a type for this and is called `Enumerator[E]` which means that it is capable of producing chunks of `E`, in our case `Enumerator[Array[Byte]]`: 
+We already have a type for this and is called `Source[E, _]` which means that it is capable of producing chunks of `E`, in our case `Source[ByteString, _]`: 
 
 ```scala
-case class Result(headers:ResponseHeaders, body:Enumerator[Array[Byte]])
+case class Result(header: ResponseHeader, body: Source[ByteString, _])
 ```
 
-If we don't have to send the response progressively we still can send the entire body as a single chunk.
+If we don't have to send the response progressively we still can send the entire body as a single chunk. In the actual API, Play supports different types of entities using the `HttpEntity` wrapper type, which supports streamed, chunked, and strict entities.
 
-We can stream and write any type of data to socket as long as it is convertible to an `Array[Byte]`, that is what `Writeable[E]` insures for a given type 'E':
-
-```scala
-case class Result[E](headers:ResponseHeaders, body:Enumerator[E])(implicit writeable:Writeable[E])
-```
+Note that Play's built-in helpers like `Ok(myObject)` convert `myObject` to an entity using an implicit `Writeable[E]` instance that creates an `HttpEntity` from the entity `E`.
 
 ## Bottom Line
 
-The essential Play2 HTTP API is quite simple:
+The essential Play HTTP API is quite simple:
 
 ```scala
-RequestHeader -> Iteratee[Array[Byte],Result]
+RequestHeader -> Accumulator[ByteString, Result]
 ```
 or the funnier
 
 ```scala
-RequestHeader => Array[Byte] ==> Result
+RequestHeader => ByteString ==> Result
 ```
 
-Which reads as the following: Take the `RequestHeader` then take chunks of `Array[Byte]` and return a response. A response consists of `ResponseHeaders` and a body which is chunks of values convertible to `Array[Byte]` to be written to the socket represented in the `Enumerator[E]` type.
+which reads as the following: Take the `RequestHeader` then take chunks of `ByteString` and return a response. A response consists of `ResponseHeaders` and a body which is chunks of values convertible to `ByteString` to be written to the socket represented in the `Source[E, _]` type.

--- a/documentation/manual/working/scalaGuide/main/application/ScalaHttpFilters.md
+++ b/documentation/manual/working/scalaGuide/main/application/ScalaHttpFilters.md
@@ -37,9 +37,9 @@ If you want to have different filters in different environments, or would prefer
 
 ## Where do filters fit in?
 
-Filters wrap the action after the action has been looked up by the router.  This means you cannot use a filter to transform a path, method or query parameter to impact the router.  However you can direct the request to a different action by invoking that action directly from the filter, though be aware that this will bypass the rest of the filter chain.  If you do need to modify the request before the router is invoked, a better way to do this would be to place your logic in [[`HttpRequestHandler`|ScalaHttpRequestHandlers]] instead.
+Filters wrap the action after the action has been looked up by the router. This means you cannot use a filter to transform a path, method or query parameter to impact the router. However you can direct the request to a different action by invoking that action directly from the filter, though be aware that this will bypass the rest of the filter chain. If you do need to modify the request before the router is invoked, a better way to do this would be to place your logic in [[`HttpRequestHandler`|ScalaHttpRequestHandlers]] instead.
 
-Since filters are applied after routing is done, it is possible to access routing information from the request, via the `tags` map on the `RequestHeader`.  For example, you might want to log the time against the action method.  In that case, you might update the `logTime` method to look like this:
+Since filters are applied after routing is done, it is possible to access routing information from the request, via the `tags` map on the `RequestHeader`. For example, you might want to log the time against the action method. In that case, you might update the filter to look like this:
 
 @[routing-info-access](code/FiltersRouting.scala)
 
@@ -47,7 +47,7 @@ Since filters are applied after routing is done, it is possible to access routin
 
 ## More powerful filters
 
-Play provides a lower level filter API called [`EssentialFilter`](api/scala/play/api/mvc/EssentialFilter.html) which gives you full access to the body of the request.  This API allows you to wrap [[EssentialAction|ScalaEssentialAction]] with another action.
+Play provides a lower level filter API called [`EssentialFilter`](api/scala/play/api/mvc/EssentialFilter.html) which gives you full access to the body of the request. This API allows you to wrap [[EssentialAction|ScalaEssentialAction]] with another action.
 
 Here is the above filter example rewritten as an `EssentialFilter`:
 

--- a/framework/src/play/src/main/java/play/mvc/Action.java
+++ b/framework/src/play/src/main/java/play/mvc/Action.java
@@ -3,9 +3,9 @@
  */
 package play.mvc;
 
-import play.mvc.Http.*;
-
 import java.util.concurrent.CompletionStage;
+
+import play.mvc.Http.Context;
 
 /**
  * An action acts as decorator for the action method call.

--- a/framework/src/play/src/main/java/play/mvc/EssentialAction.java
+++ b/framework/src/play/src/main/java/play/mvc/EssentialAction.java
@@ -1,0 +1,65 @@
+package play.mvc;
+
+import java.util.function.Function;
+
+import akka.util.ByteString;
+import play.api.mvc.Handler;
+import play.core.Execution;
+import play.core.j.RequestHeaderImpl;
+import play.libs.streams.Accumulator;
+import play.mvc.Http.RequestHeader;
+import scala.runtime.AbstractFunction1;
+
+/**
+ * Given a `RequestHeader`, an `EssentialAction` consumes the request body (a `ByteString`) and returns a `Result`.
+ *
+ * An `EssentialAction` is a `Handler`, which means it is one of the objects that Play uses to handle requests. You
+ * can use this to create your action inside a filter, for example.
+ *
+ * Unlike traditional method-based Java actions, EssentialAction does not use a context.
+ */
+public abstract class EssentialAction
+    extends AbstractFunction1<play.api.mvc.RequestHeader, play.api.libs.streams.Accumulator<ByteString, play.api.mvc.Result>>
+    implements play.api.mvc.EssentialAction, Handler {
+
+    public static EssentialAction of(Function<RequestHeader, Accumulator<ByteString, Result>> action) {
+        return new EssentialAction() {
+          @Override
+          public Accumulator<ByteString, Result> apply(RequestHeader requestHeader) {
+              return action.apply(requestHeader);
+          }
+        };
+    }
+  
+    public static EssentialAction fromScala(play.api.mvc.EssentialAction action) {
+        return new EssentialAction() {
+            @Override
+            public Accumulator<ByteString, Result> apply(RequestHeader rh) {
+                return action.apply(rh._underlyingHeader())
+                    .asJava()
+                    .map(r -> r.asJava(), Execution.internalContext());
+            }
+
+            @Override
+            public play.api.libs.streams.Accumulator<ByteString, play.api.mvc.Result> apply(play.api.mvc.RequestHeader rh) {
+                return action.apply(rh);
+            }
+        };
+    }
+
+    public abstract Accumulator<ByteString, Result> apply(RequestHeader requestHeader);
+
+    @Override
+    public play.api.libs.streams.Accumulator<ByteString, play.api.mvc.Result> apply(play.api.mvc.RequestHeader rh) {
+        return apply(new RequestHeaderImpl(rh))
+            .map(r -> r.asScala(), Execution.internalContext())
+            .asScala();
+    }
+
+    @Override
+    public play.api.mvc.EssentialAction apply() {
+        return this;
+    }
+
+
+}

--- a/framework/src/play/src/main/java/play/mvc/EssentialFilter.java
+++ b/framework/src/play/src/main/java/play/mvc/EssentialFilter.java
@@ -1,0 +1,10 @@
+package play.mvc;
+
+public abstract class EssentialFilter implements play.api.mvc.EssentialFilter {
+    public abstract EssentialAction apply(play.mvc.EssentialAction next);
+
+    @Override
+    public play.mvc.EssentialAction apply(play.api.mvc.EssentialAction next) {
+        return apply(EssentialAction.fromScala(next));
+    }
+}

--- a/framework/src/play/src/main/java/play/mvc/Filter.java
+++ b/framework/src/play/src/main/java/play/mvc/Filter.java
@@ -1,0 +1,55 @@
+package play.mvc;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import akka.stream.Materializer;
+import play.core.j.RequestHeaderImpl;
+import play.mvc.Http.RequestHeader;
+import scala.Function1;
+import scala.compat.java8.FutureConverters;
+
+public abstract class Filter extends EssentialFilter {
+
+    protected final Materializer materializer;
+
+    public Filter(Materializer mat) {
+        super();
+        this.materializer = mat;
+    }
+
+    public abstract CompletionStage<Result> apply(Function<RequestHeader, CompletionStage<Result>> next, RequestHeader rh);
+
+    @Override
+    public EssentialAction apply(EssentialAction next) {
+        return EssentialAction.fromScala(asScala().apply(next));
+    }
+
+    public play.api.mvc.Filter asScala() {
+        return new play.api.mvc.Filter() {
+            @Override
+            public Materializer mat() {
+                return materializer;
+            }
+
+            @Override
+            public play.api.mvc.EssentialAction apply(play.api.mvc.EssentialAction next) {
+                return Filter.this.apply(next);
+            }
+
+            @Override
+            public scala.concurrent.Future<play.api.mvc.Result> apply(
+                    Function1<play.api.mvc.RequestHeader,
+                    scala.concurrent.Future<play.api.mvc.Result>> next,
+                    play.api.mvc.RequestHeader requestHeader) {
+                return FutureConverters.toScala(
+                    Filter.this.apply(
+                        (rh) -> FutureConverters.toJava(next.apply(rh._underlyingHeader())).thenApply(r -> r.asJava()),
+                        new RequestHeaderImpl(requestHeader)
+                    ).thenApply(r -> r.asScala())
+                );
+            }
+        };
+    }
+
+}

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -583,6 +583,11 @@ public class Http {
         Optional<String> charset();
 
         /**
+         * @return the tags for the request
+         */
+        Map<String, String> tags();
+
+        /**
          * For internal Play-use only
          *
          * @return the underlying request

--- a/framework/src/play/src/main/scala/play/core/Execution.scala
+++ b/framework/src/play/src/main/scala/play/core/Execution.scala
@@ -5,14 +5,14 @@ package play.core
 
 import java.util.concurrent.ForkJoinPool
 import play.api.{ Application, Play }
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
 
 /**
  * Provides access to Play's internal ExecutionContext.
  */
 private[play] object Execution {
 
-  def internalContext: ExecutionContext = {
+  def internalContext: ExecutionContextExecutor = {
     val appOrNull: Application = Play._currentApp
     appOrNull match {
       case null => common

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -220,6 +220,8 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
 
   def charset() = OptionConverters.toJava(header.charset)
 
+  def tags = header.tags.asJava
+
   override def toString = header.toString
 
 }


### PR DESCRIPTION
Adds the necessary `EssentialAction` and `EssentialFilter` classes required to create filters from Java. Note that `play.mvc.Action` does not extend `EssentialAction`. I think this is okay for now, but I would like to eventually create a functional API for Java so Java users can construct actions similar to how it's done in Scala.

This will also allow us to create a Java API for `play.api.http.HttpRequestHandler` that actually handles requests at a low level.