### PR TITLE
Upgrade to Akka 2.4.2-RC1

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaBodyParsers.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaBodyParsers.java
@@ -23,6 +23,7 @@ import akka.stream.javadsl.*;
 import play.mvc.*;
 import play.mvc.Http.*;
 import java.util.concurrent.Executor;
+import java.util.concurrent.CompletionStage;
 
 import scala.compat.java8.FutureConverters;
 
@@ -173,7 +174,7 @@ public class JavaBodyParsers extends WithApplication {
         @Override
         public Accumulator<ByteString, F.Either<Result, List<List<String>>>> apply(RequestHeader request) {
             // A flow that splits the stream into CSV lines
-            Sink<ByteString, scala.concurrent.Future<List<List<String>>>> sink = Flow.<ByteString>create()
+            Sink<ByteString, CompletionStage<List<List<String>>>> sink = Flow.<ByteString>create()
                 // We split by the new line character, allowing a maximum of 1000 characters per line
                 .via(Framing.delimiter(ByteString.fromString("\n"), 1000, true))
                 // Turn each line to a String and split it by commas

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -3,6 +3,7 @@
  */
 package scalaguide.ws.scalaws
 
+import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import play.api.libs.ws.ahc._
@@ -81,7 +82,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
    */
   val largeSource: Source[ByteString, _] = {
     val source = Source.single(ByteString("abcdefghij" * 100))
-    (1 to 9).foldLeft(source){(acc, _) => (acc ++ source).mapMaterializedValue(_=> ())}
+    (1 to 9).foldLeft(source){(acc, _) => (acc ++ source)}
   }
 
   "WS" should {

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -6,6 +6,8 @@ import buildinfo.BuildInfo
 
 object Dependencies {
 
+  val akkaVersion = "2.4.2-RC1"
+
   val specsVersion = "3.6.6"
   val specsBuild = Seq(
     "specs2-core",
@@ -114,7 +116,7 @@ object Dependencies {
 
   def runtime(scalaVersion: String) =
     slf4j ++
-    Seq("akka-actor", "akka-slf4j").map("com.typesafe.akka" %% _ % "2.4.1") ++
+    Seq("akka-actor", "akka-slf4j").map("com.typesafe.akka" %% _ % akkaVersion) ++
     jacksons ++
     Seq(
       "org.scala-stm" %% "scala-stm" % "0.7",
@@ -150,7 +152,7 @@ object Dependencies {
   val nettyUtilsDependencies = slf4j
 
   val akkaHttp = Seq(
-    "com.typesafe.akka" %% "akka-http-core-experimental" % "2.0.2"
+    "com.typesafe.akka" %% "akka-http-core" % akkaVersion
   )
 
   def routesCompilerDependencies(scalaVersion: String) = Seq(
@@ -247,7 +249,7 @@ object Dependencies {
 
   val streamsDependencies = Seq(
     "org.reactivestreams" % "reactive-streams" % "1.0.0",
-    "com.typesafe.akka" %% "akka-stream-experimental" % "2.0.2",
+    "com.typesafe.akka" %% "akka-stream" % akkaVersion,
     scalaJava8Compat
   ) ++ specsBuild.map(_ % "test") ++ logback.map(_ % Test) ++ javaTestDeps
 

--- a/framework/src/play-akka-http-server/src/main/scala/akka/http/play/WebSocketHandler.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/akka/http/play/WebSocketHandler.scala
@@ -1,7 +1,7 @@
 package akka.http.play
 
 import akka.http.scaladsl.model.HttpResponse
-import akka.http.scaladsl.model.ws.UpgradeToWebsocket
+import akka.http.scaladsl.model.ws.UpgradeToWebSocket
 import akka.http.impl.engine.ws._
 import akka.stream.scaladsl._
 import akka.stream.stage.{ Context, Stage, PushStage }
@@ -16,8 +16,8 @@ object WebSocketHandler {
   /**
    * Handle a WebSocket
    */
-  def handleWebSocket(upgrade: UpgradeToWebsocket, flow: Flow[Message, Message, _], bufferLimit: Int): HttpResponse = upgrade match {
-    case lowLevel: UpgradeToWebsocketLowLevel =>
+  def handleWebSocket(upgrade: UpgradeToWebSocket, flow: Flow[Message, Message, _], bufferLimit: Int): HttpResponse = upgrade match {
+    case lowLevel: UpgradeToWebSocketLowLevel =>
       lowLevel.handleFrames(messageFlowToFrameFlow(flow, bufferLimit))
     case other => throw new IllegalArgumentException("UpgradeToWebsocket is not an Akka HTTP UpgradeToWebsocketLowLevel")
   }
@@ -150,7 +150,7 @@ object WebSocketHandler {
           closing = true
           ctx.push(Right(close))
       }
-    }), Merge(2, eagerClose = true))
+    }), Merge(2, eagerComplete = true))
   }
 
   private case class Frame(header: FrameHeader, data: ByteString) {

--- a/framework/src/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
+++ b/framework/src/play-integration-test/src/test/java/play/it/http/websocket/WebSocketSpecJavaActions.java
@@ -24,7 +24,7 @@ public class WebSocketSpecJavaActions {
         return Sink.<List<A>, A>fold(new ArrayList<A>(), (result, next) -> {
             result.add(next);
             return result;
-        }).mapMaterializedValue(future -> FutureConverters.toJava(future).thenAccept(onDone));
+        }).mapMaterializedValue(future -> future.thenAccept(onDone));
     }
 
     private static <A> Source<A, ?> emptySource() {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
@@ -198,7 +198,7 @@ object WebSocketClient {
         import GraphDSL.Implicits._
 
         val broadcast = b.add(Broadcast[WebSocketFrame](2))
-        val merge = b.add(Merge[WebSocketFrame](2, eagerClose = true))
+        val merge = b.add(Merge[WebSocketFrame](2, eagerComplete = true))
 
         val handleServerClose = Flow[WebSocketFrame].filter { frame =>
           if (frame.isInstanceOf[CloseWebSocketFrame] && !clientInitiatedClose.get()) {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -23,8 +23,7 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.function.{ Consumer, Function }
 
 object NettyWebSocketSpec extends WebSocketSpec with NettyIntegrationSpecification
-// This is disabled while we wait for https://github.com/akka/akka/issues/19467 to be fixed
-// object AkkaHttpWebSocketSpec extends WebSocketSpec with AkkaHttpIntegrationSpecification
+object AkkaHttpWebSocketSpec extends WebSocketSpec with AkkaHttpIntegrationSpecification
 
 trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
@@ -25,7 +25,8 @@ import scala.concurrent.Future
 
 object NettyWSSpec extends WSSpec with NettyIntegrationSpecification
 
-object AkkaHttpWSSpec extends WSSpec with AkkaHttpIntegrationSpecification
+// Disabled while we wait for https://github.com/akka/akka/issues/19623 to be fixed
+// object AkkaHttpWSSpec extends WSSpec with AkkaHttpIntegrationSpecification
 
 trait WSSpec extends PlaySpecification with ServerIntegrationSpecification {
 

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
@@ -5,6 +5,7 @@
 package play.libs.ws.ahc;
 
 import akka.stream.Materializer;
+import akka.stream.javadsl.AsPublisher;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
@@ -494,7 +495,8 @@ public class AhcWSRequest implements WSRequest {
             builder.setBody(bodyGenerator);
         } else if (body instanceof Source) {
             Source<ByteString,?> sourceBody = (Source<ByteString,?>) body;
-            Publisher<ByteBuffer> publisher = sourceBody.map(ByteString::toByteBuffer).runWith(Sink.asPublisher(false), materializer);
+            Publisher<ByteBuffer> publisher = sourceBody.map(ByteString::toByteBuffer)
+                .runWith(Sink.asPublisher(AsPublisher.WITHOUT_FANOUT), materializer);
             builder.setBody(publisher);
         } else {
             throw new IllegalStateException("Impossible body: " + body);

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -6,6 +6,7 @@ package play.core.server
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicLong
 
+import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.{ Flow, Sink, Source }
@@ -143,7 +144,7 @@ class NettyServer(
   /**
    * Create a sink for the incoming connection channels.
    */
-  private def channelSink(secure: Boolean): Sink[Channel, Future[Unit]] = {
+  private def channelSink(secure: Boolean): Sink[Channel, Future[Done]] = {
     Sink.foreach[Channel] { (connChannel: Channel) =>
 
       // Setup the channel for explicit reads

--- a/framework/src/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -1,5 +1,6 @@
 package play.core.server.common
 
+import akka.NotUsed
 import akka.stream._
 import akka.stream.scaladsl._
 import akka.stream.stage._
@@ -13,7 +14,7 @@ object WebSocketFlowHandler {
    * Implements the WebSocket protocol, including correctly handling the closing of the WebSocket, as well as
    * other control frames like ping/pong.
    */
-  def webSocketProtocol(bufferLimit: Int): BidiFlow[RawMessage, Message, Message, Message, Unit] = {
+  def webSocketProtocol(bufferLimit: Int): BidiFlow[RawMessage, Message, Message, Message, NotUsed] = {
     BidiFlow.fromGraph(new GraphStage[BidiShape[RawMessage, Message, Message, Message]] {
       // The stream of incoming messages from the websocket connection
       val remoteIn = Inlet[RawMessage]("WebSocketIn")

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
@@ -4,6 +4,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{ Source, Keep, Flow, Sink }
 import org.reactivestreams.{ Publisher, Subscription, Subscriber }
 
+import scala.compat.java8.FutureConverters
 import scala.concurrent.{ Promise, ExecutionContext, Future }
 import scala.util.{ Failure, Success }
 import scala.compat.java8.FutureConverters._
@@ -128,7 +129,7 @@ private class SinkAccumulator[-E, +A](sink: Sink[E, Future[A]]) extends Accumula
   import scala.annotation.unchecked.{ uncheckedVariance => uV }
 
   def asJava: play.libs.streams.Accumulator[E @uV, A @uV] = {
-    play.libs.streams.Accumulator.fromSink(sink.asJava)
+    play.libs.streams.Accumulator.fromSink(sink.mapMaterializedValue(FutureConverters.toJava).asJava)
   }
 }
 

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
@@ -26,7 +26,7 @@ object ActorFlow {
    * @param bufferSize The maximum number of elements to buffer.
    * @param overflowStrategy The strategy for how to handle a buffer overflow.
    */
-  def actorRef[In, Out](props: ActorRef => Props, bufferSize: Int = 16, overflowStrategy: OverflowStrategy = OverflowStrategy.dropNew)(implicit factory: ActorRefFactory, mat: Materializer): Flow[In, Out, Unit] = {
+  def actorRef[In, Out](props: ActorRef => Props, bufferSize: Int = 16, overflowStrategy: OverflowStrategy = OverflowStrategy.dropNew)(implicit factory: ActorRefFactory, mat: Materializer): Flow[In, Out, _] = {
 
     val (outActor, publisher) = Source.actorRef[Out](bufferSize, overflowStrategy)
       .toMat(Sink.asPublisher(false))(Keep.both).run()

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/AkkaStreams.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/AkkaStreams.scala
@@ -3,6 +3,7 @@ package play.api.libs.streams
 import akka.stream.scaladsl._
 import akka.stream.stage._
 import akka.stream._
+import akka.Done
 
 import scala.concurrent.Future
 
@@ -58,7 +59,7 @@ object AkkaStreams {
   def onlyFirstCanFinishMerge[T](inputPorts: Int) = GraphDSL.create[UniformFanInShape[T, T]]() { implicit builder =>
     import GraphDSL.Implicits._
 
-    val merge = builder.add(Merge[T](inputPorts, eagerClose = true))
+    val merge = builder.add(Merge[T](inputPorts, eagerComplete = true))
 
     val blockFinishes = (1 until inputPorts).map { i =>
       val blockFinish = builder.add(ignoreAfterFinish[T])
@@ -90,7 +91,7 @@ object AkkaStreams {
   /**
    * A flow that will ignore downstream cancellation, and instead will continue receiving and ignoring the stream.
    */
-  def ignoreAfterCancellation[T]: Flow[T, T, Future[Unit]] = {
+  def ignoreAfterCancellation[T]: Flow[T, T, Future[Done]] = {
     Flow.fromGraph(GraphDSL.create(Sink.ignore) { implicit builder =>
       ignore =>
         import GraphDSL.Implicits._

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
@@ -102,7 +102,7 @@ object AccumulatorSpec extends Specification {
 
     "be compatible with Java accumulator" in {
       "Java asScala" in withMaterializer { implicit m =>
-        await(play.libs.streams.Accumulator.fromSink(sum.toSink.asJava).asScala().run(source)) must_== 6
+        await(play.libs.streams.Accumulator.fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava).asScala().run(source)) must_== 6
       }
 
       "Scala asJava" in withMaterializer { implicit m =>

--- a/framework/src/play/src/main/java/play/http/HttpEntity.java
+++ b/framework/src/play/src/main/java/play/http/HttpEntity.java
@@ -7,7 +7,6 @@ import akka.util.ByteString;
 import play.api.http.HttpChunk;
 import play.twirl.api.Content;
 import play.twirl.api.Xml;
-import scala.compat.java8.FutureConverters;
 import scala.compat.java8.OptionConverters;
 
 import java.util.Optional;
@@ -53,9 +52,7 @@ public abstract class HttpEntity {
      * not be usable after this method is invoked.
      */
     public CompletionStage<ByteString> consumeData(Materializer mat) {
-        return FutureConverters.toJava(
-                dataStream().runFold(ByteString.empty(), ByteString::concat, mat)
-        );
+        return dataStream().runFold(ByteString.empty(), ByteString::concat, mat);
     }
 
     public abstract play.api.http.HttpEntity asScala();

--- a/framework/src/play/src/main/java/play/libs/streams/AkkaStreams.java
+++ b/framework/src/play/src/main/java/play/libs/streams/AkkaStreams.java
@@ -1,6 +1,5 @@
 package play.libs.streams;
 
-import akka.japi.Pair;
 import akka.stream.FlowShape;
 import akka.stream.Graph;
 import akka.stream.UniformFanInShape;


### PR DESCRIPTION
In addition, this upgrades to the Akka streams and HTTP libraries that are now part of Akka 2.4.2.

I had to disable one Akka HTTP test due to a regression in Akka HTTP, this has been reported in https://github.com/akka/akka/issues/19623.