### PR TITLE
Generalized stop hook callback return type

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
@@ -35,7 +35,7 @@ class AkkaHttpServer(
     val applicationProvider: ApplicationProvider,
     actorSystem: ActorSystem,
     materializer: Materializer,
-    stopHook: () => Future[Unit]) extends Server {
+    stopHook: () => Future[_]) extends Server {
 
   import AkkaHttpServer._
 

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -46,7 +46,7 @@ case object Native extends NettyTransport
 class NettyServer(
     config: ServerConfig,
     val applicationProvider: ApplicationProvider,
-    stopHook: () => Future[Unit],
+    stopHook: () => Future[_],
     val actorSystem: ActorSystem)(implicit val materializer: Materializer) extends Server {
 
   private val nettyConfig = config.configuration.underlying.getConfig("play.server.netty")

--- a/framework/src/play-server/src/main/scala/play/core/server/ServerProvider.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ServerProvider.scala
@@ -41,7 +41,7 @@ object ServerProvider {
     appProvider: ApplicationProvider,
     actorSystem: ActorSystem,
     materializer: Materializer,
-    stopHook: () => Future[Unit])
+    stopHook: () => Future[_])
 
   /**
    * Load a server provider from the configuration and classloader.

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -279,7 +279,7 @@ class ExecutionContextProvider @Inject() (actorSystem: ActorSystem) extends Prov
 
 object ActorSystemProvider {
 
-  type StopHook = () => Future[Unit]
+  type StopHook = () => Future[_]
 
   private val logger = Logger(classOf[ActorSystemProvider])
 
@@ -328,8 +328,8 @@ object ActorSystemProvider {
    * A lazy wrapper around `start`. Useful when the `ActorSystem` may
    * not be needed.
    */
-  def lazyStart(classLoader: => ClassLoader, configuration: => Configuration): ClosableLazy[ActorSystem, Future[Unit]] = {
-    new ClosableLazy[ActorSystem, Future[Unit]] {
+  def lazyStart(classLoader: => ClassLoader, configuration: => Configuration): ClosableLazy[ActorSystem, Future[_]] = {
+    new ClosableLazy[ActorSystem, Future[_]] {
       protected def create() = start(classLoader, configuration)
       protected def closeNotNeeded = Future.successful(())
     }


### PR DESCRIPTION
In most places the stop hook callback return type was already generalized to
`Future[_]`, so this commit is only finishing the work and updating the few
places where `Future[Unit]` was still used.

The change is source compatible. Furthermore, it removes the need of having to
map futures when their inner type isn't `Unit`.