### PR TITLE
Java HttpRequestHandler, ActionCreator and Router

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/routing/code/AppLoader.scala
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/AppLoader.scala
@@ -19,7 +19,7 @@ class AppLoader extends ApplicationLoader {
 
 class MyComponents(context: Context) extends BuiltInComponentsFromContext(context) {
   lazy val router = Router.from {
-       RoutingDslBuilder.getRouter().routes
+       RoutingDslBuilder.getRouter.asScala.routes
   }
 }
 //#load

--- a/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/advanced/routing/JavaRoutingDsl.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/advanced/routing/JavaRoutingDsl.java
@@ -6,7 +6,7 @@ package javaguide.advanced.routing;
 import org.junit.Test;
 
 //#imports
-import play.api.routing.Router;
+import play.routing.Router;
 import play.routing.RoutingDsl;
 import java.util.concurrent.CompletableFuture;
 

--- a/documentation/manual/working/javaGuide/advanced/routing/code/router/RoutingDslBuilder.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/router/RoutingDslBuilder.java
@@ -1,6 +1,6 @@
 package router;
 
-import play.api.routing.Router;
+import play.routing.Router;
 import play.mvc.Controller;
 import play.routing.RoutingDsl;
 

--- a/documentation/manual/working/javaGuide/code/MockJavaAction.scala
+++ b/documentation/manual/working/javaGuide/code/MockJavaAction.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.{CompletionStage, CompletableFuture}
 import akka.stream.Materializer
 import play.api.mvc.{Action, Request}
 import play.core.j.{JavaHandlerComponents, JavaHelpers, JavaActionAnnotations, JavaAction}
-import play.http.DefaultHttpRequestHandler
+import play.http.DefaultActionCreator
 import play.mvc.{Controller, Http, Result}
 import play.api.test.Helpers
 import java.lang.reflect.Method
@@ -17,7 +17,7 @@ abstract class MockJavaAction extends Controller with Action[Http.RequestBody] {
   self =>
 
   private lazy val components = new JavaHandlerComponents(
-    play.api.Play.current.injector, new DefaultHttpRequestHandler
+    play.api.Play.current.injector, new DefaultActionCreator
   )
 
   private lazy val action = new JavaAction(components) {

--- a/documentation/manual/working/javaGuide/main/application/code/javaguide/application/httpfilters/RoutedLoggingFilter.java
+++ b/documentation/manual/working/javaGuide/main/application/code/javaguide/application/httpfilters/RoutedLoggingFilter.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 import akka.stream.Materializer;
 import play.Logger;
 import play.mvc.*;
+import play.routing.Router.Tags;
 
 public class RoutedLoggingFilter extends Filter {
 
@@ -23,8 +24,8 @@ public class RoutedLoggingFilter extends Filter {
         long startTime = System.currentTimeMillis();
         return nextFilter.apply(requestHeader).thenApply(result -> {
             Map<String, String> tags = requestHeader.tags();
-            String actionMethod = tags.get("ROUTE_CONTROLLER") +
-                "." + tags.get("ROUTE_ACTION_METHOD");
+            String actionMethod = tags.get(Tags.ROUTE_CONTROLLER) +
+                "." + tags.get(Tags.ROUTE_ACTION_METHOD);
             long endTime = System.currentTimeMillis();
             long requestTime = endTime - startTime;
 

--- a/documentation/manual/working/javaGuide/main/http/JavaActionCreator.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaActionCreator.md
@@ -1,33 +1,53 @@
 <!--- Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com> -->
-# HTTP Request Handlers
+# Intercepting HTTP requests
 
-Play abstraction for handling requests is less sophisticated in the Play Java API, when compared to its Scala counterpart. However, it may still be enough if you only need to execute some code before the controller's action method associated to the passed request is executed. If that's not enough, then you should fall back to the [[Scala API|ScalaHttpRequestHandlers]] for creating a HTTP request handler.
+Play's Java APIs provide two ways of intercepting action calls. The first is called `ActionCreator`, which provides a `createAction` method that is used to create the initial action used in action composition. It handles calling the actual method for your action, which allows you to intercept requests.
 
-## Implementing a custom request handler
+The second way is to implement your own `HttpRequestHandler`, which is the primary entry point for all HTTP requests in Play. This includes requests from both Java and Scala actions.
 
-The [`HttpRequestHandler`](api/java/play/http/HttpRequestHandler.html) interface has two methods that needs to be implemented: 
+## Action creators
+
+The [`ActionCreator`](api/java/play/http/ActionCreator.html) interface has two methods that can be implemented: 
 
 * `createAction`: Takes the request and the controller's action method associated with the passed request.
 *  `wrapAction`: Takes the action to be run and allows for a final global interceptor to be added to the action.
 
-There is also a [`DefaultHttpRequestHandler`](api/java/play/http/DefaultHttpRequestHandler.html) class that can be used if you don't want to implement both methods.
+There is also a [`DefaultActionCreator`](api/java/play/http/ActionCreator.html) interface you can extend with default implementations.
 
-> **Note:** If you are providing an implementation of `wrapAction` because you need to apply a cross cutting concern to an action before is executed, creating a [[filter|JavaHttpFilters]] is a more idiomatic way of achieving the same.
+> **Note:** If you are providing an implementation of `wrapAction` because you need to apply a cross cutting concern to an action before it is executed, creating a [[filter|JavaHttpFilters]] is a more idiomatic way of achieving the same.
 
-## Configuring the http request handler
+A custom action creator can be supplied by creating a class in the root package called `ActionCreator` that implements `play.http.ActionCreator`, for example:
 
-A custom http handler can be supplied by creating a class in the root package called `RequestHandler` that implements `HttpRequestHandler`, for example:
+@[default](code/javaguide/ActionCreator.java)
 
-@[default](code/javaguide/RequestHandler.java)
+If you don’t want to place this class in the root package, or if you want to be able to configure different action handlers for different environments, you can do this by configuring the `play.http.actionCreator` configuration property in `application.conf`:
+
+    play.http.actionCreator = "com.example.MyActionCreator"
+
+> **Note:** If you are also using [[action composition|JavaActionsComposition]] then the action returned by the ```createAction``` method is executed **after** the action composition ones by default. If you want to change this order set ```play.http.actionComposition.executeActionCreatorActionFirst = true``` in ```application.conf```.
+
+## HTTP request handlers
+
+Sometimes an application will have more advanced needs that aren't met by Play's abstractions. When this is the case, applications can provide custom implementations of Play's lowest level HTTP pipeline API, the [`HttpRequestHandler`](api/java/play/http/HttpRequestHandler.html).
+
+Providing a custom `HttpRequestHandler` should be a last course of action. Most custom needs can be met through implementing a custom router or a [[filter|JavaHttpFilters]].
+
+### Implementing a custom request handler
+
+The `HttpRequestHandler` trait has one method to be implemented, `handlerForRequest`.  This takes the request to get a handler for, and returns a `HandlerForRequest` instance containing a `RequestHeader` and a `Handler`.
+
+The reason why a request header is returned is so that information, such as routing information, can be added to the request. In this way, the router is able to tag requests with routing information, such as which route matched the request, which can be useful for monitoring or even for injecting cross cutting functionality.
+
+A very simple request handler that simply delegates to a router might look like this:
+
+@[simple](code/javaguide/http/SimpleHttpRequestHandler.java)
+
+Note that `HttpRequestHandler` currently has two legacy methods with default implementations that have since been moved to `ActionCreator`.
+
+### Configuring the http request handler
+
+A custom http handler can be supplied by creating a class in the root package called `RequestHandler` that implements `HttpRequestHandler`.
 
 If you don’t want to place your request handler in the root package, or if you want to be able to configure different request handlers for different environments, you can do this by configuring the `play.http.requestHandler` configuration property in `application.conf`:
 
     play.http.requestHandler = "com.example.RequestHandler"
-    
-### Performance notes
-
-The http request handler that Play uses if none is configured is one that delegates to the legacy `GlobalSettings` methods.  This may have a performance impact as it will mean your application has to do many lookups out of Guice to handle a single request.  If you are not using a `Global` object, then you don't need this, instead you can configure Play to use the default http request handler:
-
-    play.http.requestHandler = "play.http.DefaultHttpRequestHandler"
-
-> **Note:** If you are also using [[action composition|JavaActionsComposition]] then the action returned by the ```createAction``` method of the request handler is executed **after** the action composition ones by default. If you want to change this order set ```play.http.actionComposition.executeRequestHandlerActionFirst = true``` in ```application.conf```.

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/ActionCreator.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/ActionCreator.java
@@ -3,7 +3,6 @@
  */
 
 //#default
-import play.http.HttpRequestHandler;
 import play.mvc.Action;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -11,8 +10,7 @@ import java.util.concurrent.CompletionStage;
 
 import java.lang.reflect.Method;
 
-public class RequestHandler implements HttpRequestHandler {
-
+public class ActionCreator implements play.http.ActionCreator {
     @Override
     public Action createAction(Http.Request request, Method actionMethod) {
         return new Action.Simple() {
@@ -21,11 +19,6 @@ public class RequestHandler implements HttpRequestHandler {
                 return delegate.call(ctx);
             }
         };
-    }
-
-    @Override
-    public Action wrapAction(Action action) {
-        return action;
     }
 }
 //#default

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActionCreator.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActionCreator.java
@@ -1,9 +1,9 @@
-package javaguide.http;/*
+package javaguide.http;
+/*
  * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
  */
 
 //#default
-import play.http.HttpRequestHandler;
 import play.mvc.Action;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -11,8 +11,7 @@ import java.util.concurrent.CompletionStage;
 
 import java.lang.reflect.Method;
 
-public class JavaActionCreator implements HttpRequestHandler {
-
+public class JavaActionCreator implements play.http.ActionCreator {
     @Override
     public Action createAction(Http.Request request, Method actionMethod) {
         return new Action.Simple() {
@@ -21,11 +20,6 @@ public class JavaActionCreator implements HttpRequestHandler {
                 return delegate.call(ctx);
             }
         };
-    }
-
-    @Override
-    public Action wrapAction(Action action) {
-        return action;
     }
 }
 //#default

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/SimpleHttpRequestHandler.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/SimpleHttpRequestHandler.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package javaguide.advanced.httprequesthandlers;
+
+//#simple
+import javax.inject.Inject;
+import play.routing.Router;
+import play.api.mvc.Handler;
+import play.http.*;
+import play.mvc.*;
+import play.libs.streams.Accumulator;
+
+public class SimpleHttpRequestHandler implements HttpRequestHandler {
+    private final Router router;
+
+    @Inject
+    public SimpleHttpRequestHandler(Router router) {
+        this.router = router;
+    }
+
+    public HandlerForRequest handlerForRequest(Http.RequestHeader request) {
+        Handler handler = router.route(request).orElseGet(() ->
+            EssentialAction.of(req -> Accumulator.done(Results.notFound()))
+        );
+        return new HandlerForRequest(request, handler);
+    }
+}
+//#simple

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/GitHubClientTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/GitHubClientTest.java
@@ -6,7 +6,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import com.fasterxml.jackson.databind.node.*;
 import org.junit.*;
-import play.api.routing.Router;
+import play.routing.Router;
 import play.libs.Json;
 import play.libs.ws.*;
 import play.routing.RoutingDsl;

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/JavaTestingWebServiceClients.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/JavaTestingWebServiceClients.java
@@ -2,7 +2,7 @@ package javaguide.tests;
 
 import com.fasterxml.jackson.databind.node.*;
 import org.junit.Test;
-import play.api.routing.Router;
+import play.routing.Router;
 import play.libs.Json;
 import play.libs.ws.WS;
 import play.libs.ws.WSClient;

--- a/framework/src/play-integration-test/src/test/java/play/it/JavaServerIntegrationTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/it/JavaServerIntegrationTest.java
@@ -6,8 +6,7 @@ package play.it;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
-import play.api.routing.Router;
-import play.test.Helpers;
+import play.routing.Router;
 import play.server.Server;
 
 import javax.net.ssl.SSLException;
@@ -146,7 +145,7 @@ public class JavaServerIntegrationTest {
     }
 
     private Router _emptyRouter() {
-        return Helpers.fakeApplication().getWrappedApplication().routes();
+        return Router.empty();
     }
 
     private boolean _isPortOccupied(int port) {

--- a/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionActionCreator.java
+++ b/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionActionCreator.java
@@ -3,6 +3,7 @@
  */
 package play.it.http;
 
+import play.http.ActionCreator;
 import play.http.HttpRequestHandler;
 import play.mvc.*;
 import play.test.Helpers;
@@ -11,7 +12,7 @@ import java.lang.reflect.Method;
 
 import java.util.concurrent.CompletionStage;
 
-public class ActionCompositionRequestHandler implements HttpRequestHandler {
+public class ActionCompositionActionCreator implements ActionCreator {
 
     @Override
     public Action createAction(Http.Request request, Method actionMethod) {
@@ -19,15 +20,10 @@ public class ActionCompositionRequestHandler implements HttpRequestHandler {
             @Override
             public CompletionStage<Result> call(Http.Context ctx) {
                 return delegate.call(ctx).thenApply(result -> {
-                    String newContent = "requesthandler" + Helpers.contentAsString(result);
+                    String newContent = "actioncreator" + Helpers.contentAsString(result);
                     return Results.ok(newContent);
                 });
             }
         };
-    }
-
-    @Override
-    public Action wrapAction(Action action) {
-        return action;
     }
 }

--- a/framework/src/play-integration-test/src/test/java/play/routing/RoutingDslTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/routing/RoutingDslTest.java
@@ -4,7 +4,7 @@
 package play.routing;
 
 import org.junit.Test;
-import play.api.routing.Router;
+import play.routing.Router;
 import play.libs.F;
 import play.mvc.PathBindable;
 import play.mvc.Result;

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -75,33 +75,33 @@ object JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       @ActionAnnotation
       override def action: Result = Results.ok()
     }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false",
-           "play.http.actionComposition.executeRequestHandlerActionFirst" -> "true",
-           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
-      response.body must beEqualTo("requesthandleractioncontroller")
+           "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
+           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+      response.body must beEqualTo("actioncreatoractioncontroller")
     }
 
     "execute request handler action first and controller composition before action composition" in makeRequest(new ComposedController {
       @ActionAnnotation
       override def action: Result = Results.ok()
     }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "true",
-           "play.http.actionComposition.executeRequestHandlerActionFirst" -> "true",
-           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
-      response.body must beEqualTo("requesthandlercontrolleraction")
+           "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
+           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+      response.body must beEqualTo("actioncreatorcontrolleraction")
     }
 
     "execute request handler action first with only controller composition" in makeRequest(new ComposedController {
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.executeRequestHandlerActionFirst" -> "true",
-           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
-      response.body must beEqualTo("requesthandlercontroller")
+    }, Map("play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
+           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+      response.body must beEqualTo("actioncreatorcontroller")
     }
 
     "execute request handler action first with only action composition" in makeRequest(new MockController {
       @ActionAnnotation
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.executeRequestHandlerActionFirst" -> "true",
-           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
-      response.body must beEqualTo("requesthandleraction")
+    }, Map("play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
+           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+      response.body must beEqualTo("actioncreatoraction")
     }
   }
 
@@ -110,65 +110,65 @@ object JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       @ActionAnnotation
       override def action: Result = Results.ok()
     }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false",
-           "play.http.actionComposition.executeRequestHandlerActionFirst" -> "false",
-           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
-      response.body must beEqualTo("actioncontrollerrequesthandler")
+           "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
+           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+      response.body must beEqualTo("actioncontrolleractioncreator")
     }
 
     "execute request handler action last and controller composition before action composition" in makeRequest(new ComposedController {
       @ActionAnnotation
       override def action: Result = Results.ok()
     }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "true",
-           "play.http.actionComposition.executeRequestHandlerActionFirst" -> "false",
-           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
-      response.body must beEqualTo("controlleractionrequesthandler")
+           "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
+           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+      response.body must beEqualTo("controlleractionactioncreator")
     }
 
     "execute request handler action last with only controller composition" in makeRequest(new ComposedController {
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.executeRequestHandlerActionFirst" -> "false",
-           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
-      response.body must beEqualTo("controllerrequesthandler")
+    }, Map("play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
+           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+      response.body must beEqualTo("controlleractioncreator")
     }
 
     "execute request handler action last with only action composition" in makeRequest(new MockController {
       @ActionAnnotation
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.executeRequestHandlerActionFirst" -> "false",
-           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
-      response.body must beEqualTo("actionrequesthandler")
+    }, Map("play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
+           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+      response.body must beEqualTo("actionactioncreator")
     }
 
     "execute request handler action last is the default and controller composition before action composition" in makeRequest(new ComposedController {
       @ActionAnnotation
       override def action: Result = Results.ok()
     }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "true",
-           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
-      response.body must beEqualTo("controlleractionrequesthandler")
+           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+      response.body must beEqualTo("controlleractionactioncreator")
     }
 
     "execute request handler action last is the default and action composition before controller composition" in makeRequest(new ComposedController {
       @ActionAnnotation
       override def action: Result = Results.ok()
     }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false",
-           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
-      response.body must beEqualTo("actioncontrollerrequesthandler")
+           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+      response.body must beEqualTo("actioncontrolleractioncreator")
     }
   }
 
   "When request handler is configured without action composition" should {
     "execute request handler action last without action composition" in makeRequest(new MockController {
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.executeRequestHandlerActionFirst" -> "false",
-           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
-      response.body must beEqualTo("requesthandler")
+    }, Map("play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
+           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+      response.body must beEqualTo("actioncreator")
     }
 
     "execute request handler action first without action composition" in makeRequest(new MockController {
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.executeRequestHandlerActionFirst" -> "true",
-           "play.http.requestHandler" -> "play.it.http.ActionCompositionRequestHandler")) { response =>
-      response.body must beEqualTo("requesthandler")
+    }, Map("play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
+           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+      response.body must beEqualTo("actioncreator")
     }
   }
 

--- a/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
+++ b/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
@@ -158,7 +158,7 @@ public class RoutingDsl {
      *
      * @return The built router.
      */
-    public play.api.routing.Router build() {
+    public play.routing.Router build() {
         return RouterBuilderHelper.build(this);
     }
 
@@ -216,12 +216,12 @@ public class RoutingDsl {
         Method actionMethod = null;
         for (Method m : actionFunction.getMethods()) {
         	// Here I assume that we are always passing a `actionFunction` type that:
-        	// 1) defines exactly one abstract method, and 
+        	// 1) defines exactly one abstract method, and
         	// 2) the abstract method is the method that we want to invoke.
-        	// This works fine with the current implementation of `PathPatternMatcher`, but I wouldn't be 
+        	// This works fine with the current implementation of `PathPatternMatcher`, but I wouldn't be
         	// surprised if it breaks in the future, which is why this comment exists.
-        	// Also, the former implementation (which was checking for the first non default method), was 
-        	// not working when using a `java.util.function.Function` type (Function.identity was being 
+        	// Also, the former implementation (which was checking for the first non default method), was
+        	// not working when using a `java.util.function.Function` type (Function.identity was being
         	// returned, instead of Function.apply).
             if (Modifier.isAbstract(m.getModifiers())) {
                 actionMethod = m;

--- a/framework/src/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
+++ b/framework/src/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
@@ -21,7 +21,7 @@ import scala.compat.java8.FutureConverters
 import scala.concurrent.Future
 
 private[routing] object RouterBuilderHelper {
-  def build(router: RoutingDsl): play.api.routing.Router = {
+  def build(router: RoutingDsl): play.routing.Router = {
     val routes = router.routes.toList
 
     // Create the router
@@ -90,6 +90,6 @@ private[routing] object RouterBuilderHelper {
           } else None
         } else None
       ))
-    })
+    }).asJava
   }
 }

--- a/framework/src/play-server/src/main/java/play/server/Server.java
+++ b/framework/src/play-server/src/main/java/play/server/Server.java
@@ -4,7 +4,7 @@
 package play.server;
 
 import play.Mode;
-import play.api.routing.Router;
+import play.routing.Router;
 import play.core.j.JavaModeConverter;
 import play.core.server.JavaServerHelper;
 import scala.Int;
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import scala.compat.java8.OptionConverters;
-        
+
 /**
  * A Play server.
  */
@@ -204,7 +204,7 @@ public class Server {
             Server.Config config = _buildConfig();
             return new Server(
                     JavaServerHelper.forRouter(
-                            router,
+                            router.asScala(),
                             JavaModeConverter.asScalaMode(config.mode()),
                             OptionConverters.toScala(config.maybeHttpPort()),
                             OptionConverters.toScala(config.maybeHttpsPort())

--- a/framework/src/play/src/main/java/play/http/ActionCreator.java
+++ b/framework/src/play/src/main/java/play/http/ActionCreator.java
@@ -1,0 +1,40 @@
+package play.http;
+
+import java.lang.reflect.Method;
+
+import play.mvc.Action;
+import play.mvc.Http.Request;
+
+/**
+ * An interface for creating a Java actions from Java methods.
+ */
+@FunctionalInterface
+public interface ActionCreator {
+    /**
+     * Call to create the root Action of a request for a Java application.
+     *
+     * The request and actionMethod values are passed for information.  Implementations of this method should create
+     * an instance of Action that invokes the injected action delegate.
+     *
+     * @param request The HTTP Request
+     * @param actionMethod The action method containing the user code for this Action.
+     * @return The default implementation returns a raw Action calling the method.
+     */
+    Action createAction(Request request, Method actionMethod);
+
+    /**
+     * Call to wrap the outer action of a Java application.
+     *
+     * This method is passed a fully composed action, allowing a last final global interceptor to be added to the
+     * action if required.
+     *
+     * @deprecated This functionality can be emulated by other means.
+     *
+     * @param action The action to wrap.
+     * @return A wrapped action.
+     */
+    @Deprecated
+    default Action wrapAction(Action action) {
+        return action;
+    }
+}

--- a/framework/src/play/src/main/java/play/http/DefaultActionCreator.java
+++ b/framework/src/play/src/main/java/play/http/DefaultActionCreator.java
@@ -1,0 +1,32 @@
+package play.http;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletionStage;
+
+import play.mvc.Action;
+import play.mvc.Http;
+import play.mvc.Http.Request;
+import play.mvc.Result;
+
+/**
+ * A default implementation of the action creator.
+ *
+ * To create a custom action creator, extend this class or implement the ActionCreator interface directly.
+ */
+public class DefaultActionCreator implements ActionCreator {
+
+  @Override
+  public Action createAction(Request request, Method actionMethod) {
+    return new Action.Simple() {
+      @Override
+      public CompletionStage<Result> call(Http.Context ctx) {
+        return delegate.call(ctx);
+      }
+    };
+  }
+
+  @Override
+  public final Action wrapAction(Action action) {
+    return action;
+  }
+}

--- a/framework/src/play/src/main/java/play/http/DefaultHttpRequestHandler.java
+++ b/framework/src/play/src/main/java/play/http/DefaultHttpRequestHandler.java
@@ -3,27 +3,25 @@
  */
 package play.http;
 
-import play.mvc.Action;
-import play.mvc.Http;
-import play.mvc.Result;
+import javax.inject.Inject;
 
-import java.lang.reflect.Method;
-import java.util.concurrent.CompletionStage;
+import play.api.mvc.Handler;
+import play.core.j.RequestHeaderImpl;
+import play.mvc.Http.RequestHeader;
+import scala.Tuple2;
 
 public class DefaultHttpRequestHandler implements HttpRequestHandler {
 
-    @Override
-    public Action createAction(Http.Request request, Method actionMethod) {
-        return new Action.Simple() {
-            @Override
-            public CompletionStage<Result> call(Http.Context ctx) {
-                return delegate.call(ctx);
-            }
-        };
+    private final play.api.http.HttpRequestHandler underlying;
+
+    @Inject
+    public DefaultHttpRequestHandler(play.api.http.HttpRequestHandler underlying) {
+        this.underlying = underlying;
     }
 
     @Override
-    public Action wrapAction(Action action) {
-        return action;
+    public HandlerForRequest handlerForRequest(RequestHeader request) {
+        Tuple2<play.api.mvc.RequestHeader, Handler> result = underlying.handlerForRequest(request._underlyingHeader());
+        return new HandlerForRequest(new RequestHeaderImpl(result._1()), result._2());
     }
 }

--- a/framework/src/play/src/main/java/play/http/GlobalSettingsHttpRequestHandler.java
+++ b/framework/src/play/src/main/java/play/http/GlobalSettingsHttpRequestHandler.java
@@ -3,14 +3,15 @@
  */
 package play.http;
 
+import java.lang.reflect.Method;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 import play.api.GlobalSettings;
 import play.core.j.JavaGlobalSettingsAdapter;
 import play.mvc.Action;
 import play.mvc.Http;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.lang.reflect.Method;
 
 /**
  * Request handler that delegates to global
@@ -21,7 +22,8 @@ public class GlobalSettingsHttpRequestHandler extends DefaultHttpRequestHandler 
     private final GlobalSettings global;
 
     @Inject
-    public GlobalSettingsHttpRequestHandler(GlobalSettings global) {
+    public GlobalSettingsHttpRequestHandler(GlobalSettings global, play.api.http.HttpRequestHandler underlying) {
+        super(underlying);
         this.global = global;
     }
 

--- a/framework/src/play/src/main/java/play/http/HandlerForRequest.java
+++ b/framework/src/play/src/main/java/play/http/HandlerForRequest.java
@@ -1,0 +1,25 @@
+package play.http;
+
+import play.api.mvc.Handler;
+import play.mvc.Http.RequestHeader;
+
+/**
+ * A request and a handler to handle it.
+ */
+public class HandlerForRequest {
+  private final RequestHeader request;
+  private final Handler handler;
+
+  public HandlerForRequest(RequestHeader request, Handler handler) {
+    this.request = request;
+    this.handler = handler;
+  }
+
+  public RequestHeader getRequest() {
+    return request;
+  }
+
+  public Handler getHandler() {
+    return handler;
+  }
+}

--- a/framework/src/play/src/main/java/play/http/HttpRequestHandler.java
+++ b/framework/src/play/src/main/java/play/http/HttpRequestHandler.java
@@ -3,10 +3,14 @@
  */
 package play.http;
 
-import play.mvc.Action;
-import play.mvc.Http.*;
-
 import java.lang.reflect.Method;
+import java.util.concurrent.CompletionStage;
+
+import play.mvc.Action;
+import play.mvc.Http;
+import play.mvc.Http.Request;
+import play.mvc.Http.RequestHeader;
+import play.mvc.Result;
 
 /**
  * An HTTP request handler
@@ -14,16 +18,42 @@ import java.lang.reflect.Method;
 public interface HttpRequestHandler {
 
     /**
+     * Get a handler for the given request.
+     *
+     * In addition to retrieving a handler for the request, the request itself may be modified - typically it will be
+     * tagged with routing information.  It is also acceptable to simply return the request as is.  Play will switch to
+     * using the returned request from this point in in its request handling.
+     *
+     * The reason why the API allows returning a modified request, rather than just wrapping the Handler in a new Handler
+     * that modifies the request, is so that Play can pass this request to other handlers, such as error handlers, or
+     * filters, and they will get the tagged/modified request.
+     *
+     * @param request The request to handle
+     * @return The possibly modified/tagged request, and a handler to handle it
+     */
+    HandlerForRequest handlerForRequest(RequestHeader request);
+
+    /**
      * Call to create the root Action of a request for a Java application.
      *
      * The request and actionMethod values are passed for information.  Implementations of this method should create
      * an instance of Action that invokes the injected action delegate.
      *
+     * @deprecated Use ActionCreator instead.
+     *
      * @param request The HTTP Request
      * @param actionMethod The action method containing the user code for this Action.
      * @return The default implementation returns a raw Action calling the method.
      */
-    Action createAction(Request request, Method actionMethod);
+    @Deprecated
+    default Action createAction(Request request, Method actionMethod) {
+        return new Action.Simple() {
+            @Override
+            public CompletionStage<Result> call(Http.Context ctx) {
+                return delegate.call(ctx);
+            }
+        };
+    }
 
     /**
      * Call to wrap the outer action of a Java application.
@@ -31,8 +61,13 @@ public interface HttpRequestHandler {
      * This method is passed a fully composed action, allowing a last final global interceptor to be added to the
      * action if required.
      *
+     * @deprecated Use ActionCreator instead.
+     *
      * @param action The action to wrap.
      * @return A wrapped action.
      */
-    Action wrapAction(Action action);
+    @Deprecated
+    default Action wrapAction(Action action) {
+        return action;
+    }
 }

--- a/framework/src/play/src/main/java/play/http/HttpRequestHandlerActionCreator.java
+++ b/framework/src/play/src/main/java/play/http/HttpRequestHandlerActionCreator.java
@@ -1,0 +1,34 @@
+package play.http;
+
+import java.lang.reflect.Method;
+
+import javax.inject.Inject;
+
+import play.mvc.Action;
+import play.mvc.Http.Request;
+
+/**
+ * An action creator that delegates to HttpRequestHandler.
+ *
+ * If you wish to customize these behaviors, you should override the ones here rather than the (deprecated) ones in
+ * HttpRequestHandler.
+ */
+public class HttpRequestHandlerActionCreator implements ActionCreator {
+
+  private final HttpRequestHandler httpRequestHandler;
+
+  @Inject
+  public HttpRequestHandlerActionCreator(HttpRequestHandler httpRequestHandler) {
+    this.httpRequestHandler = httpRequestHandler;
+  }
+
+  @Override
+  public Action createAction(Request request, Method actionMethod) {
+    return httpRequestHandler.createAction(request, actionMethod);
+  }
+
+  @Override
+  public Action wrapAction(Action action) {
+    return httpRequestHandler.wrapAction(action);
+  }
+}

--- a/framework/src/play/src/main/java/play/routing/Router.java
+++ b/framework/src/play/src/main/java/play/routing/Router.java
@@ -1,0 +1,81 @@
+package play.routing;
+
+import java.util.List;
+import java.util.Optional;
+
+import akka.japi.JavaPartialFunction;
+import akka.routing.Router$;
+import play.api.mvc.Handler;
+import play.api.routing.SimpleRouter$;
+import play.core.j.RequestHeaderImpl;
+import play.mvc.Http.RequestHeader;
+
+/**
+ * The Java Router API
+ */
+public interface Router {
+
+    List<RouteDocumentation> documentation();
+
+    Optional<Handler> route(RequestHeader request);
+
+    Router withPrefix(String prefix);
+
+    default play.api.routing.Router asScala() {
+        return SimpleRouter$.MODULE$.apply(new JavaPartialFunction<play.api.mvc.RequestHeader, Handler>() {
+            @Override
+            public Handler apply(play.api.mvc.RequestHeader req, boolean isCheck) throws Exception {
+                Optional<Handler> handler = route(new RequestHeaderImpl(req));
+                if (handler.isPresent()) {
+                    return handler.get();
+                } else if (isCheck) {
+                    return null;
+                } else {
+                    throw noMatch();
+                }
+            }
+        });
+    }
+
+    static Router empty() {
+        return play.api.routing.Router$.MODULE$.empty().asJava();
+    }
+
+    // These should match those in play.api.routing.Router.Tags
+    class Tags {
+        /** The verb that the router matched */
+        public static final String ROUTE_VERB = "ROUTE_VERB";
+        /** The pattern that the router used to match the path */
+        public static final String ROUTE_PATTERN = "ROUTE_PATTERN";
+        /** The controller that was routed to */
+        public static final String ROUTE_CONTROLLER = "ROUTE_CONTROLLER";
+        /** The method on the controller that was invoked */
+        public static final String ROUTE_ACTION_METHOD = "ROUTE_ACTION_METHOD";
+        /** The comments in the routes file that were above the route */
+        public static final String ROUTE_COMMENTS = "ROUTE_COMMENTS";
+    }
+
+    class RouteDocumentation {
+        private final String httpMethod;
+        private final String pathPattern;
+        private final String controllerMethodInvocation;
+
+        public RouteDocumentation(String httpMethod, String pathPattern, String controllerMethodInvocation) {
+            this.httpMethod = httpMethod;
+            this.pathPattern = pathPattern;
+            this.controllerMethodInvocation = controllerMethodInvocation;
+        }
+
+        public String getHttpMethod() {
+            return httpMethod;
+        }
+
+        public String getPathPattern() {
+            return pathPattern;
+        }
+
+        public String getControllerMethodInvocation() {
+            return controllerMethodInvocation;
+        }
+    }
+}

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -32,6 +32,13 @@ play {
     # handling methods on Global.
     requestHandler = null
 
+    # The request handler.
+    # Used by Play's built in DI support to locate and bind a request handler.  Must be one of the following:
+    # - A FQCN that implements play.http.ActionCreator (Java).
+    # If null, will attempt to load a class called ActionCreator in the root package, otherwise if that's
+    # not found, will default to play.http.DefaultActionCreator.
+    actionCreator = null
+
     # The error handler.
     # Used by Play's built in DI support to locate and bind an error handler.  Must be one of the following:
     # - A FQCN that implements play.api.http.HttpErrorHandler (Scala).
@@ -69,8 +76,8 @@ play {
       # If annotations put directly on Controller classes should be executed before the ones put on action methods
       controllerAnnotationsFirst = false
 
-      # If the action returned by the createAction method of the request handler should be executed before the action composition ones
-      executeRequestHandlerActionFirst = false
+      # If the action returned by the action creator should be executed before the action composition ones
+      executeActionCreatorActionFirst = false
     }
 
     # Cookies configuration

--- a/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -89,12 +89,12 @@ case class ParserConfiguration(
  * Configuration for action composition.
  *
  * @param controllerAnnotationsFirst If annotations put on controllers should be executed before the ones put on actions.
- * @param executeRequestHandlerActionFirst If the action returned by the createAction method of the request handler should be
+ * @param executeActionCreatorActionFirst If the action returned by the action creator should be
  *                                         executed before the action composition ones.
  */
 case class ActionCompositionConfiguration(
   controllerAnnotationsFirst: Boolean = false,
-  executeRequestHandlerActionFirst: Boolean = false)
+  executeActionCreatorActionFirst: Boolean = false)
 
 object HttpConfiguration {
 
@@ -122,7 +122,7 @@ object HttpConfiguration {
       ),
       actionComposition = ActionCompositionConfiguration(
         controllerAnnotationsFirst = config.get[Boolean]("play.http.actionComposition.controllerAnnotationsFirst"),
-        executeRequestHandlerActionFirst = config.get[Boolean]("play.http.actionComposition.executeRequestHandlerActionFirst")
+        executeActionCreatorActionFirst = config.get[Boolean]("play.http.actionComposition.executeActionCreatorActionFirst")
       ),
       cookies = CookiesConfiguration(
         strict = config.get[Boolean]("play.http.cookies.strict")

--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -4,16 +4,17 @@
 package play.api.inject
 
 import java.util.concurrent.Executor
+import javax.inject.{ Inject, Provider, Singleton }
 
 import akka.actor.ActorSystem
-import javax.inject.{ Singleton, Inject, Provider }
 import akka.stream.Materializer
 import play.api._
 import play.api.http._
 import play.api.libs.Files.{ DefaultTemporaryFileCreator, TemporaryFileCreator }
-import play.api.libs.{ CryptoConfig, Crypto, CryptoConfigParser }
-import play.api.libs.concurrent.{ MaterializerProvider, ExecutionContextProvider, ActorSystemProvider }
+import play.api.libs.concurrent.{ ActorSystemProvider, ExecutionContextProvider, MaterializerProvider }
+import play.api.libs.{ Crypto, CryptoConfig, CryptoConfigParser }
 import play.api.routing.Router
+import play.core.j.JavaRouterAdapter
 import play.libs.concurrent.HttpExecutionContext
 
 import scala.concurrent.ExecutionContext
@@ -45,6 +46,7 @@ class BuiltinModule extends Module {
       bind[play.Application].to[play.DefaultApplication],
 
       bind[Router].toProvider[RoutesProvider],
+      bind[play.routing.Router].to[JavaRouterAdapter],
       bind[ActorSystem].toProvider[ActorSystemProvider],
       bind[Materializer].toProvider[MaterializerProvider],
       bind[ExecutionContext].toProvider[ExecutionContextProvider],
@@ -57,7 +59,8 @@ class BuiltinModule extends Module {
     ) ++ dynamicBindings(
         HttpErrorHandler.bindingsFromConfiguration,
         HttpFilters.bindingsFromConfiguration,
-        HttpRequestHandler.bindingsFromConfiguration
+        HttpRequestHandler.bindingsFromConfiguration,
+        ActionCreator.bindingsFromConfiguration
       )
   }
 }

--- a/framework/src/play/src/main/scala/play/api/routing/Router.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/Router.scala
@@ -5,6 +5,7 @@ package play.api.routing
 
 import play.api.{ PlayConfig, Configuration, Environment }
 import play.api.mvc.{ RequestHeader, Handler }
+import play.core.j.JavaRouterAdapter
 import play.utils.Reflect
 
 /**
@@ -37,6 +38,8 @@ trait Router {
   def handlerFor(request: RequestHeader): Option[Handler] = {
     routes.lift(request)
   }
+
+  def asJava: play.routing.Router = new JavaRouterAdapter(this)
 }
 
 /**

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -77,9 +77,9 @@ abstract class JavaAction(components: JavaHandlerComponents) extends Action[play
       }
     }
 
-    val baseAction = components.requestHandler.createAction(javaContext.request, annotations.method)
+    val baseAction = components.actionCreator.createAction(javaContext.request, annotations.method)
 
-    val endOfChainAction = if (config.executeRequestHandlerActionFirst) {
+    val endOfChainAction = if (config.executeActionCreatorActionFirst) {
       rootAction
     } else {
       baseAction.delegate = rootAction
@@ -94,7 +94,7 @@ abstract class JavaAction(components: JavaHandlerComponents) extends Action[play
         action
     }
 
-    val finalAction = components.requestHandler.wrapAction(if (config.executeRequestHandlerActionFirst) {
+    val finalAction = components.actionCreator.wrapAction(if (config.executeActionCreatorActionFirst) {
       baseAction.delegate = finalUserDeclaredAction
       baseAction
     } else {
@@ -131,6 +131,5 @@ trait JavaHandler extends Handler {
 /**
  * The components necessary to handle a Java handler.
  */
-class JavaHandlerComponents @Inject() (val injector: Injector,
-  val requestHandler: play.http.HttpRequestHandler)
+class JavaHandlerComponents @Inject() (val injector: Injector, val actionCreator: play.http.ActionCreator)
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaHttpRequestHandlerAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHttpRequestHandlerAdapter.scala
@@ -1,0 +1,17 @@
+package play.core.j
+
+import javax.inject.Inject
+
+import play.api.http.HttpRequestHandler
+import play.api.mvc.RequestHeader
+import play.http.{ HttpRequestHandler => JHttpRequestHandler }
+
+/**
+ * Adapter from a Java HttpRequestHandler to a Scala HttpRequestHandler
+ */
+class JavaHttpRequestHandlerAdapter @Inject() (underlying: JHttpRequestHandler) extends HttpRequestHandler {
+  override def handlerForRequest(request: RequestHeader) = {
+    val handlerForRequest = underlying.handlerForRequest(new RequestHeaderImpl(request))
+    (handlerForRequest.getRequest._underlyingHeader(), handlerForRequest.getHandler)
+  }
+}

--- a/framework/src/play/src/main/scala/play/core/j/JavaRouterAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaRouterAdapter.scala
@@ -1,0 +1,23 @@
+package play.core.j
+
+import javax.inject.Inject
+
+import play.mvc.Http.RequestHeader
+import play.routing.Router.RouteDocumentation
+
+import scala.collection.JavaConverters._
+import scala.compat.java8.FunctionConverters._
+import scala.compat.java8.OptionConverters._
+
+/**
+ * Adapts the Scala router to the Java Router API
+ */
+class JavaRouterAdapter @Inject() (underlying: play.api.routing.Router) extends play.routing.Router {
+  def route(request: RequestHeader) = underlying.handlerFor(request._underlyingHeader).asJava
+  def withPrefix(prefix: String) = new JavaRouterAdapter(asScala.withPrefix(prefix))
+  def documentation() = asScala.documentation.map {
+    case (httpMethod, pathPattern, controllerMethodInvocation) =>
+      new RouteDocumentation(httpMethod, pathPattern, controllerMethodInvocation)
+  }.asJava
+  def asScala = underlying
+}

--- a/framework/src/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
@@ -20,7 +20,7 @@ object HttpConfigurationSpec extends Specification {
         "play.http.parser.maxMemoryBuffer" -> "10k",
         "play.http.parser.maxDiskBuffer" -> "20k",
         "play.http.actionComposition.controllerAnnotationsFirst" -> "true",
-        "play.http.actionComposition.executeRequestHandlerActionFirst" -> "true",
+        "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
         "play.http.cookies.strict" -> "true",
         "play.http.session.cookieName" -> "PLAY_SESSION",
         "play.http.session.secure" -> "true",
@@ -116,7 +116,7 @@ object HttpConfigurationSpec extends Specification {
 
       "execute request handler action first" in {
         val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
-        httpConfiguration.actionComposition.executeRequestHandlerActionFirst must beTrue
+        httpConfiguration.actionComposition.executeActionCreatorActionFirst must beTrue
       }
     }
   }


### PR DESCRIPTION
Make the following changes to make it possible to write a Java `HttpRequestHandler` that works like the Scala one:
 - Create the `ActionCreator` interface to handle the `createAction` and `wrapAction` functionality in the current Java `HttpRequestHandler`. Deprecate those methods in `HttpRequestHandler`.
 - Add configuration for `ActionHandler` and delegation to the deprecated `HttpRequestHandler` methods by default.
 - Add the `handlerForRequest` method to `HttpRequestHandler` (the only non-deprecated method).
 - Create `Router` class for Java.