### PR TITLE
Hardened CSRF filter

### DIFF
--- a/documentation/manual/working/javaGuide/main/forms/JavaCsrf.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaCsrf.md
@@ -5,28 +5,25 @@ Cross Site Request Forgery (CSRF) is a security exploit where an attacker tricks
 
 It is recommended that you familiarise yourself with CSRF, what the attack vectors are, and what the attack vectors are not.  We recommend starting with [this information from OWASP](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_%28CSRF%29).
 
-Simply put, an attacker can coerce a victim's browser to make the following types of requests:
+There is no simple answer to what requests are safe and what are vulnerable to CSRF requests, the reason for this is that there is no clear specification as to what is allowable from plugins and future extensions to specifications.  Historically, browser plugins and extensions have relaxed the rules that frameworks previously thought could be trusted, introducing CSRF vulnerabilities to many applications, and the onus has been on the frameworks to fix them.  For this reason, Play takes a conservative approach in its defaults, but allows you to configure exactly when a check is done.  By default, Play will require a CSRF check when all of the following are true:
 
-* All `GET` requests
-* `POST` requests with bodies of type `application/x-www-form-urlencoded`, `multipart/form-data` and `text/plain`
+* The request method is not `GET`, `HEAD` or `OPTIONS`.
+* The request has one or more `Cookie` headers.
 
-An attacker can not:
-
-* Coerce the browser to use other request methods such as `PUT` and `DELETE`
-* Coerce the browser to post other content types, such as `application/json`
-* Coerce the browser to send new cookies, other than those that the server has already set
-* Coerce the browser to set arbitrary headers, other than the normal headers the browser adds to requests
-
-Since `GET` requests are not meant to be mutative, there is no danger to an application that follows this best practice.  So the only requests that need CSRF protection are `POST` requests with the above mentioned content types.
+> **Note:** If you use non `Cookie` browser based authentication, such as HTTP Basic, NTLM, or client certificate based authentication, then requests without `Cookie` headers may also be vulnerable to CSRF attacks.  In this case, you **must** set `play.filters.csrf.header.bypassNoCookies` to `false`.
 
 ### Play's CSRF protection
 
-Play supports multiple methods for verifying that a request is not a CSRF request.  The primary mechanism is a CSRF token.  This token gets placed either in the query string or body of every form submitted, and also gets placed in the user's session.  Play then verifies that both tokens are present and match.
+Play supports multiple methods for verifying that a request is not a CSRF request.  The primary mechanism is a CSRF token.  This token gets placed either in the query string or body of every form submitted, and also gets placed in the users session.  Play then verifies that both tokens are present and match.
 
-To allow simple protection for non browser requests, such as requests made through AJAX, Play also supports the following:
+To allow simple protection for non browser requests, Play does not check requests with no cookies in the header.  If you are making requests with AJAX, you can place the CSRF token in the HTML page, and then add it to the request using the `Csrf-Token` header.
+
+Alternatively, you can set `play.filters.csrf.header.bypass` to `true`, and this will disable the check under the following conditions:
 
 * If an `X-Requested-With` header is present, Play will consider the request safe.  `X-Requested-With` is added to requests by many popular Javascript libraries, such as jQuery.
 * If a `Csrf-Token` header with value `nocheck` is present, or with a valid CSRF token, Play will consider the request safe.
+
+Caution should be taken when using this configuration option, as historically browser plugins have undermined this type of CSRF defence.
 
 ## Applying a global CSRF filter
 

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaCsrf.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaCsrf.java
@@ -15,6 +15,7 @@ import play.filters.csrf.CSRFFilter;
 import play.filters.csrf.RequireCSRFCheck;
 import play.filters.csrf.CSRF;
 import play.libs.Crypto;
+import play.mvc.Http;
 import play.mvc.Result;
 import play.test.WithApplication;
 
@@ -73,6 +74,7 @@ public class JavaCsrf extends WithApplication {
     @Test
     public void csrfCheck() {
         assertThat(MockJavaActionHelper.call(new Controller1(), fakeRequest("POST", "/")
+            .cookie(Http.Cookie.builder("foo", "bar").build())
             .bodyForm(Collections.singletonMap("foo", "bar")), mat).status(), equalTo(FORBIDDEN));
     }
 

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaCsrf.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaCsrf.scala
@@ -64,7 +64,8 @@ object ScalaCsrf extends PlaySpecification {
       }
       //#csrf-check
 
-      await(save(FakeRequest("POST", "/").withHeaders(CONTENT_TYPE -> "application/x-www-form-urlencoded")))
+      await(save(FakeRequest("POST", "/").withCookies(Cookie("foo", "bar"))
+        .withHeaders(CONTENT_TYPE -> "application/x-www-form-urlencoded")))
         .header.status must_== FORBIDDEN
     }
 
@@ -121,7 +122,8 @@ object ScalaCsrf extends PlaySpecification {
       }
       //#csrf-actions
 
-      await(save(FakeRequest("POST", "/").withHeaders(CONTENT_TYPE -> "application/x-www-form-urlencoded")))
+      await(save(FakeRequest("POST", "/").withCookies(Cookie("foo", "bar"))
+        .withHeaders(CONTENT_TYPE -> "application/x-www-form-urlencoded")))
         .header.status must_== FORBIDDEN
       val body = await(form(FakeRequest("GET", "/")).flatMap(_.body.consumeData))
       Crypto.extractSignedToken(body.utf8String) must beSome

--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -42,27 +42,37 @@ play.filters {
       name = "Csrf-Token"
 
       # Whether simple tokens in the header should allow CSRF checks to be bypassed.
-      bypass = true
+      # If true, this will allow the CSRF check to be bypassed if the X-Requested-With header is present, or if
+      # the Csrf-Token header is nocheck.
+      bypass = false
+
+      # Bypass the CSRF check if there are no cookies.
+      # Generally, CSRF attacks use a users browser to submit requests with the users cookies, thus doing requests
+      # on their behalf.  If there are are no cookies, there is no danger of this happening.
+      # This may however by undesirable in cases where non cookie based authentication mechanisms are being used, such
+      # as client certificates, NTLM authentication or other authentication means.
+      bypassNoCookies = true
     }
 
     # Method lists
     method {
       # If non empty, then requests will be checked if the method is not in this list.
-      whiteList = []
+      whiteList = ["GET", "HEAD", "OPTIONS"]
 
       # The black list is only used if the white list is empty.
       # Only check methods in this list.
-      blackList = ["POST"]
+      blackList = []
     }
 
     # Content type lists
+    # If both white lists and black lists are empty, then all content types are checked.
     contentType {
       # If non empty, then requests will be checked if the content type is not in this list.
       whiteList = []
 
       # The black list is only used if the white list is empty.
       # Only check content types in this list.
-      blackList = ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"]
+      blackList = []
     }
 
     # The error handler.

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -10,6 +10,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{ Keep, Source, Sink, Flow }
 import akka.stream.stage.{ DetachedContext, DetachedStage }
 import akka.util.ByteString
+import play.api.http.HeaderNames
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.api.http.HeaderNames._
@@ -388,6 +389,8 @@ object CSRFAction {
       } else {
         false
       }
+    } else if (config.noCookieBypass) {
+      request.headers.get(HeaderNames.COOKIE).isEmpty
     } else {
       false
     }

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -66,15 +66,17 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
         .post(Map("foo" -> "bar"))
       )(_.status must_== OK)
     }
-    "accept requests with nocheck header" in {
-      csrfCheckRequest(_.withHeaders(HeaderName -> "nocheck")
+    "reject requests with nocheck header" in {
+      csrfCheckRequest(_.withCookies("foo" -> "bar")
+        .withHeaders(HeaderName -> "nocheck")
         .post(Map("foo" -> "bar"))
-      )(_.status must_== OK)
+      )(_.status must_== errorStatusCode)
     }
-    "accept requests with ajax header" in {
-      csrfCheckRequest(_.withHeaders("X-Requested-With" -> "a spoon")
+    "reject requests with ajax header" in {
+      csrfCheckRequest(_.withCookies("foo" -> "bar")
+        .withHeaders("X-Requested-With" -> "a spoon")
         .post(Map("foo" -> "bar"))
-      )(_.status must_== OK)
+      )(_.status must_== errorStatusCode)
     }
     "reject requests with different token in body" in {
       csrfCheckRequest(req => addToken(req, generate)
@@ -88,7 +90,8 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
     }
     "reject requests with token in body but not in session" in {
       csrfCheckRequest(
-        _.post(Map("foo" -> "bar", TokenName -> generate))
+        _.withSession("foo" -> "bar")
+          .post(Map("foo" -> "bar", TokenName -> generate))
       )(_.status must_== errorStatusCode)
     }
 
@@ -217,6 +220,23 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
       def compareTokens(a: String, b: String) = Crypto.compareSignedTokens(a, b) must beTrue
 
       sharedTests(csrfCheckRequest, csrfAddToken, generate, addToken, getToken, compareTokens, UNAUTHORIZED)
+    }
+
+    "allow configuring a header bypass" in {
+      def csrfCheckRequest = buildCsrfCheckRequest(false, "play.filters.csrf.header.bypass" -> "true")
+
+      "accept requests with nocheck header" in {
+        csrfCheckRequest(_.withCookies("foo" -> "bar")
+          .withHeaders(HeaderName -> "nocheck")
+          .post(Map("foo" -> "bar"))
+        )(_.status must_== OK)
+      }
+      "accept requests with ajax header" in {
+        csrfCheckRequest(_.withCookies("foo" -> "bar")
+          .withHeaders("X-Requested-With" -> "a spoon")
+          .post(Map("foo" -> "bar"))
+        )(_.status must_== OK)
+      }
     }
   }
 

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -53,12 +53,18 @@ object CSRFFilterSpec extends CSRFCommonSpecs {
       buildCsrfAddToken()(_.withHeaders(ACCEPT -> "text/html").head())(_.status must_== OK)
     }
 
-    // extra conditions for not doing a check
-    "not check non form bodies" in {
-      buildCsrfCheckRequest(false)(_.post(Json.obj("foo" -> "bar")))(_.status must_== OK)
+    // extra conditions for doing a check
+    "check non form bodies" in {
+      buildCsrfCheckRequest(false)(_.withCookies("foo" -> "bar").post(Json.obj("foo" -> "bar")))(_.status must_== FORBIDDEN)
+    }
+    "check all methods" in {
+      buildCsrfCheckRequest(false)(_.withCookies("foo" -> "bar").delete())(_.status must_== FORBIDDEN)
     }
     "not check safe methods" in {
-      buildCsrfCheckRequest(false)(_.put(Map("foo" -> "bar")))(_.status must_== OK)
+      buildCsrfCheckRequest(false)(_.withCookies("foo" -> "bar").options())(_.status must_== OK)
+    }
+    "not check requests with no cookies" in {
+      buildCsrfCheckRequest(false)(_.post(Map("foo" -> "bar")))(_.status must_== OK)
     }
 
     // other


### PR DESCRIPTION
* Disable header bypass by default
* Switch to HTTP method whitelist by default
* Don't trust any content types by default
* Add new mode where check is only done if there are cookies present