### PR TITLE
Catch and re-throw PlayException which is enclosed in CreationException

### DIFF
--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
@@ -10,6 +10,7 @@ import java.io.File
 import javax.inject.Inject
 import play.api.inject.{ Binding => PlayBinding, BindingKey, Injector => PlayInjector, Module => PlayModule }
 import play.api.{ Configuration, Environment, Mode, PlayException }
+import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
 class GuiceLoadException(message: String) extends RuntimeException(message)
@@ -140,7 +141,13 @@ abstract class GuiceBuilder[Self] protected (
     } catch {
       case e: CreationException => e.getCause match {
         case p: PlayException => throw p
-        case _ => throw e
+        case _ => {
+          e.getErrorMessages.asScala.foreach(_.getCause match {
+            case p: PlayException => throw p
+            case _ => // do nothing
+          })
+          throw e
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #4808 - see it's comments.

When we fail to [create an injector](https://github.com/playframework/playframework/blob/2.5.0-M2/framework/src/play/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala#L138) an exception gets thrown which we catch and [look for](https://github.com/playframework/playframework/blob/2.5.0-M2/framework/src/play/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala#L140-L144) a `PlayException` via `getCause`.
The problem here is that a `CreationException` does **not** return a cause when you call `getCause` on it (it's `null`). That's because of how the `CreationException` gets [created](https://github.com/google/guice/blob/4.0/core/src/com/google/inject/internal/Errors.java#L466).
Instead, we are able to access errors via [`CreationException.getErrorMessages()`](https://github.com/google/guice/blob/4.0/core/src/com/google/inject/CreationException.java#L44-L47).
So the fix is to also look there for possible `PlayException`s :smile: 