### PR TITLE
Suppress spurious logback warnings

### DIFF
--- a/framework/src/iteratees/src/test/resources/logback-test.xml
+++ b/framework/src/iteratees/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/play-cache/src/test/resources/logback-test.xml
+++ b/framework/src/play-cache/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/play-filters-helpers/src/test/resources/logback-test.xml
+++ b/framework/src/play-filters-helpers/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/play-java-jdbc/src/test/resources/logback-test.xml
+++ b/framework/src/play-java-jdbc/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/play-java-jpa/src/test/resources/logback-test.xml
+++ b/framework/src/play-java-jpa/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/play-java-ws/src/test/resources/logback-test.xml
+++ b/framework/src/play-java-ws/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/play-java/src/test/resources/logback-test.xml
+++ b/framework/src/play-java/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/play-jdbc-evolutions/src/test/resources/logback-test.xml
+++ b/framework/src/play-jdbc-evolutions/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/play-jdbc/src/test/resources/logback-test.xml
+++ b/framework/src/play-jdbc/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/play-json/src/test/resources/logback-test.xml
+++ b/framework/src/play-json/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/play-server/src/test/resources/logback-test.xml
+++ b/framework/src/play-server/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/play-specs2/src/test/resources/logback-test.xml
+++ b/framework/src/play-specs2/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/play-streams/src/test/resources/logback-test.xml
+++ b/framework/src/play-streams/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/play-test/src/test/resources/logback-test.xml
+++ b/framework/src/play-test/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/play-ws/src/test/resources/logback-test.xml
+++ b/framework/src/play-ws/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/routes-compiler/src/test/resources/logback-test.xml
+++ b/framework/src/routes-compiler/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/run-support/src/test/resources/logback-test.xml
+++ b/framework/src/run-support/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/framework/src/sbt-plugin/src/test/resources/logback-test.xml
+++ b/framework/src/sbt-plugin/src/test/resources/logback-test.xml
@@ -2,6 +2,8 @@
   ~ Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
   -->
 <configuration>
+    <!-- Suppress logback complaining about multiple logback-test.xml files -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
Suppress spurious logback warnings

This is needed because multi-module projects are very hard to segment correctly so there is only one logback-test.xml.  In addition, we're also getting `No appenders present in context [default] for logger [play.api.mvc.Cookies]` when the test seems to run before logback has initialized correctly.

If we need to do slf4j testing specifically, worth looking at https://github.com/portingle/slf4jtesting
