### PR TITLE
Remove locale param from Annotation- and SimpleFormatter

### DIFF
--- a/documentation/manual/working/javaGuide/main/forms/JavaForms.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaForms.md
@@ -81,6 +81,8 @@ For an object like JodaTime's `LocalTime` it could look like this:
 
 @[register-formatter](code/javaguide/forms/JavaForms.java)
 
+> **Tip:** If you need the current `Locale` (of the current request) to parse or format dates, numbers, etc. within the `parse` or `print` methods you can access it via `play.mvc.Http.Context.current().lang().toLocale()`.
+
 When the binding fails an array of errors keys is created, the first one defined in the messages file will be used. This array will generally contain:
 
     ["error.invalid.<fieldName>", "error.invalid.<type>", "error.invalid"]

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaForms.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaForms.java
@@ -204,7 +204,7 @@ public class JavaForms extends WithApplication {
             );
 
             @Override
-            public LocalTime parse(String input, Locale l) throws ParseException {
+            public LocalTime parse(String input) throws ParseException {
                 Matcher m = timePattern.matcher(input);
                 if (!m.find()) throw new ParseException("No valid Input", 0);
                 int hour = Integer.valueOf(m.group(1));
@@ -213,7 +213,7 @@ public class JavaForms extends WithApplication {
             }
 
             @Override
-            public String print(LocalTime localTime, Locale l) {
+            public String print(LocalTime localTime) {
                 return localTime.toString("HH:mm");
             }
 

--- a/framework/src/play-java/src/main/java/play/data/format/Formats.java
+++ b/framework/src/play-java/src/main/java/play/data/format/Formats.java
@@ -38,14 +38,14 @@ public class Formats {
          * Binds the field - constructs a concrete value from submitted data.
          *
          * @param text the field text
-         * @param locale the current <code>Locale</code>
          * @return a new value
          */
-        public Date parse(String text, Locale locale) throws java.text.ParseException {
+        @Override
+        public Date parse(String text) throws java.text.ParseException {
             if(text == null || text.trim().isEmpty()) {
                 return null;
             }
-            SimpleDateFormat sdf = new SimpleDateFormat(pattern, locale);
+            SimpleDateFormat sdf = new SimpleDateFormat(pattern);
             sdf.setLenient(false);
             return sdf.parse(text);
         }
@@ -54,14 +54,14 @@ public class Formats {
          * Unbinds this fields - converts a concrete value to a plain string.
          *
          * @param value the value to unbind
-         * @param locale the current <code>Locale</code>
          * @return printable version of the value
          */
-        public String print(Date value, Locale locale) {
+        @Override
+        public String print(Date value) {
             if(value == null) {
                 return "";
             }
-            return new SimpleDateFormat(pattern, locale).format(value);
+            return new SimpleDateFormat(pattern).format(value);
         }
 
     }
@@ -92,14 +92,14 @@ public class Formats {
          *
          * @param annotation the annotation that trigerred this formatter
          * @param text the field text
-         * @param locale the current <code>Locale</code>
          * @return a new value
          */
-        public Date parse(DateTime annotation, String text, Locale locale) throws java.text.ParseException {
+        @Override
+        public Date parse(DateTime annotation, String text) throws java.text.ParseException {
             if(text == null || text.trim().isEmpty()) {
                 return null;
             }
-            SimpleDateFormat sdf = new SimpleDateFormat(annotation.pattern(), locale);
+            SimpleDateFormat sdf = new SimpleDateFormat(annotation.pattern());
             sdf.setLenient(false);
             return sdf.parse(text);
         }
@@ -109,14 +109,14 @@ public class Formats {
          *
          * @param annotation the annotation that trigerred this formatter
          * @param value the value to unbind
-         * @param locale the current <code>Locale</code>
          * @return printable version of the value
          */
-        public String print(DateTime annotation, Date value, Locale locale) {
+        @Override
+        public String print(DateTime annotation, Date value) {
             if(value == null) {
                 return "";
             }
-            return new SimpleDateFormat(annotation.pattern(), locale).format(value);
+            return new SimpleDateFormat(annotation.pattern()).format(value);
         }
 
     }
@@ -140,10 +140,10 @@ public class Formats {
          *
          * @param annotation the annotation that trigerred this formatter
          * @param text the field text
-         * @param locale the current <code>Locale</code>
          * @return a new value
          */
-        public String parse(NonEmpty annotation, String text, Locale locale) throws java.text.ParseException {
+        @Override
+        public String parse(NonEmpty annotation, String text) throws java.text.ParseException {
             if(text == null || text.trim().isEmpty()) {
                 return null;
             }
@@ -155,10 +155,10 @@ public class Formats {
          *
          * @param annotation the annotation that trigerred this formatter
          * @param value the value to unbind
-         * @param locale the current <code>Locale</code>
          * @return printable version of the value
          */
-        public String print(NonEmpty annotation, String value, Locale locale) {
+        @Override
+        public String print(NonEmpty annotation, String value) {
             if(value == null) {
                 return "";
             }

--- a/framework/src/play-java/src/main/java/play/data/format/Formatters.java
+++ b/framework/src/play-java/src/main/java/play/data/format/Formatters.java
@@ -121,20 +121,18 @@ public class Formatters {
          * Binds the field - constructs a concrete value from submitted data.
          *
          * @param text the field text
-         * @param locale the current Locale
          * @throws java.text.ParseException if the text could not be parsed into T
          * @return a new value
          */
-        public abstract T parse(String text, Locale locale) throws java.text.ParseException;
+        public abstract T parse(String text) throws java.text.ParseException;
 
         /**
          * Unbinds this field - transforms a concrete value to plain string.
          *
          * @param t the value to unbind
-         * @param locale the current <code>Locale</code>
          * @return printable version of the value
          */
-        public abstract String print(T t, Locale locale);
+        public abstract String print(T t);
 
     }
 
@@ -151,21 +149,19 @@ public class Formatters {
          *
          * @param annotation the annotation that trigerred this formatter
          * @param text the field text
-         * @param locale the current <code>Locale</code>
          * @throws java.text.ParseException when the text could not be parsed
          * @return a new value
          */
-        public abstract T parse(A annotation, String text, Locale locale) throws java.text.ParseException;
+        public abstract T parse(A annotation, String text) throws java.text.ParseException;
 
         /**
          * Unbind this field (ie. transform a concrete value to plain string)
          *
          * @param annotation the annotation that trigerred this formatter.
          * @param value the value to unbind
-         * @param locale the current <code>Locale</code>
          * @return printable version of the value
          */
-        public abstract String print(A annotation, T value, Locale locale);
+        public abstract String print(A annotation, T value);
     }
 
     /**
@@ -174,6 +170,7 @@ public class Formatters {
     private static void registerOptional() {
         conversion.addConverter(new GenericConverter() {
 
+            @Override
             public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
                 if (sourceType.getObjectType().equals(String.class)) {
                     // From String to Optional
@@ -190,6 +187,7 @@ public class Formatters {
                 return null;
             }
 
+            @Override
             public Set<GenericConverter.ConvertiblePair> getConvertibleTypes() {
                 Set<ConvertiblePair> result = new HashSet<>();
                 result.add(new ConvertiblePair(Optional.class, String.class));
@@ -209,14 +207,17 @@ public class Formatters {
     public static <T> void register(final Class<T> clazz, final SimpleFormatter<T> formatter) {
         conversion.addFormatterForFieldType(clazz, new org.springframework.format.Formatter<T>() {
 
+            @Override
             public T parse(String text, Locale locale) throws java.text.ParseException {
-                return formatter.parse(text, locale);
+                return formatter.parse(text);
             }
 
+            @Override
             public String print(T t, Locale locale) {
-                return formatter.print(t, locale);
+                return formatter.print(t);
             }
 
+            @Override
             public String toString() {
                 return formatter.toString();
             }
@@ -239,26 +240,29 @@ public class Formatters {
         )[0];
 
         conversion.addConverter(new ConditionalGenericConverter() {
+            @Override
             public Set<GenericConverter.ConvertiblePair> getConvertibleTypes() {
                 Set<GenericConverter.ConvertiblePair> types = new HashSet<>();
                 types.add(new GenericConverter.ConvertiblePair(clazz, String.class));
                 return types;
             }
 
+            @Override
             public boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType) {
                 return (sourceType.getAnnotation(annotationType) != null);
             }
 
+            @Override
             public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
                 final A a = (A)sourceType.getAnnotation(annotationType);
-                Locale locale = LocaleContextHolder.getLocale();
                 try {
-                    return formatter.print(a, (T)source, locale);
+                    return formatter.print(a, (T)source);
                 } catch (Exception ex) {
                     throw new ConversionFailedException(sourceType, targetType, source, ex);
                 }
             }
 
+            @Override
             public String toString() {
                 return "@" + annotationType.getName() + " "
                     + clazz.getName() + " -> "
@@ -269,26 +273,29 @@ public class Formatters {
         });
 
         conversion.addConverter(new ConditionalGenericConverter() {
+            @Override
             public Set<GenericConverter.ConvertiblePair> getConvertibleTypes() {
                 Set<GenericConverter.ConvertiblePair> types = new HashSet<>();
                 types.add(new GenericConverter.ConvertiblePair(String.class, clazz));
                 return types;
             }
 
+            @Override
             public boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType) {
                 return (targetType.getAnnotation(annotationType) != null);
             }
 
+            @Override
             public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
                 final A a = (A)targetType.getAnnotation(annotationType);
-                Locale locale = LocaleContextHolder.getLocale();
                 try {
-                    return formatter.parse(a, (String)source, locale);
+                    return formatter.parse(a, (String)source);
                 } catch (Exception ex) {
                     throw new ConversionFailedException(sourceType, targetType, source, ex);
                 }
             }
 
+            @Override
             public String toString() {
                 return String.class.getName() + " -> @"
                     + annotationType.getName() + " "


### PR DESCRIPTION
Fixes #2065 
More explanation can also be found here: #4945

People would think the locale passed into the `parse` and `print` method would be the locale of the current request but it isn't. Instead it always is and always was the system's default locale because the locale retrieved from `LocaleContextHolder.getLocale()` has never been set. So this is quite confusing and people did report this behaviour as a bug (which IMHO is).
Actually `git blame` told me that the `LocaleContextHolder...` line was from 20th Sept. 2011, just one week after the first commit to Play 2 - so this has never worked as expected.

Instead of setting the correct Locale I decided to just remove the Locale param and add a note in the documentation of how to retrieve the current locale - because it is the easiest solution:
`Http.Context.current()` already does all we need - it manages/propagate the locale with a thread-local and I think for users it is also more obvious which Locale they are accessing now.