### PR TITLE
Conversions for Java filters

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -226,7 +226,7 @@ trait FiltersSpec extends Specification with ServerIntegrationSpecification {
 
     private def getResult(t: Throwable): Result = {
       // Get the cause of the CompletionException
-      Results.internalServerError(t.getCause.getMessage)
+      Results.internalServerError(Option(t.getCause).getOrElse(t).getMessage)
     }
 
     def apply(next: EssentialAction) = new EssentialAction {

--- a/framework/src/play/src/main/java/play/mvc/EssentialAction.java
+++ b/framework/src/play/src/main/java/play/mvc/EssentialAction.java
@@ -30,22 +30,6 @@ public abstract class EssentialAction
           }
         };
     }
-  
-    public static EssentialAction fromScala(play.api.mvc.EssentialAction action) {
-        return new EssentialAction() {
-            @Override
-            public Accumulator<ByteString, Result> apply(RequestHeader rh) {
-                return action.apply(rh._underlyingHeader())
-                    .asJava()
-                    .map(r -> r.asJava(), Execution.internalContext());
-            }
-
-            @Override
-            public play.api.libs.streams.Accumulator<ByteString, play.api.mvc.Result> apply(play.api.mvc.RequestHeader rh) {
-                return action.apply(rh);
-            }
-        };
-    }
 
     public abstract Accumulator<ByteString, Result> apply(RequestHeader requestHeader);
 
@@ -61,5 +45,8 @@ public abstract class EssentialAction
         return this;
     }
 
-
+    @Override
+    public EssentialAction asJava() {
+        return this;
+    }
 }

--- a/framework/src/play/src/main/java/play/mvc/EssentialFilter.java
+++ b/framework/src/play/src/main/java/play/mvc/EssentialFilter.java
@@ -5,6 +5,11 @@ public abstract class EssentialFilter implements play.api.mvc.EssentialFilter {
 
     @Override
     public play.mvc.EssentialAction apply(play.api.mvc.EssentialAction next) {
-        return apply(EssentialAction.fromScala(next));
+        return apply(next.asJava());
+    }
+
+    @Override
+    public EssentialFilter asJava() {
+        return this;
     }
 }

--- a/framework/src/play/src/main/java/play/mvc/Filter.java
+++ b/framework/src/play/src/main/java/play/mvc/Filter.java
@@ -22,7 +22,7 @@ public abstract class Filter extends EssentialFilter {
 
     @Override
     public EssentialAction apply(EssentialAction next) {
-        return EssentialAction.fromScala(asScala().apply(next));
+        return asScala().apply(next).asJava();
     }
 
     public play.api.mvc.Filter asScala() {
@@ -49,7 +49,11 @@ public abstract class Filter extends EssentialFilter {
                     ).thenApply(r -> r.asScala())
                 );
             }
+
+            @Override
+            public EssentialFilter asJava() {
+                return Filter.this;
+            }
         };
     }
-
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -36,7 +36,7 @@ trait RequestTaggingHandler extends Handler {
  * An `EssentialAction` is a `Handler`, which means it is one of the objects
  * that Play uses to handle requests.
  */
-trait EssentialAction extends (RequestHeader => Accumulator[ByteString, Result]) with Handler {
+trait EssentialAction extends (RequestHeader => Accumulator[ByteString, Result]) with Handler { self =>
 
   /**
    * Returns itself, for better support in the routes file.
@@ -44,6 +44,12 @@ trait EssentialAction extends (RequestHeader => Accumulator[ByteString, Result])
    * @return itself
    */
   def apply() = this
+
+  def asJava: play.mvc.EssentialAction = new play.mvc.EssentialAction() {
+    import play.api.libs.concurrent.Execution.Implicits.defaultContext
+    def apply(rh: play.mvc.Http.RequestHeader) = self(rh._underlyingHeader).map(_.asJava).asJava
+    override def apply(rh: RequestHeader) = self(rh)
+  }
 
 }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
@@ -12,6 +12,10 @@ import scala.concurrent.{ Promise, Future }
 
 trait EssentialFilter {
   def apply(next: EssentialAction): EssentialAction
+
+  def asJava: play.mvc.EssentialFilter = new play.mvc.EssentialFilter {
+    override def apply(next: play.mvc.EssentialAction) = EssentialFilter.this(next).asJava
+  }
 }
 
 /**
@@ -60,8 +64,8 @@ trait Filter extends EssentialFilter {
         })(rh)
 
         result.onComplete({ resultTry =>
-          // It is possible that the delegate function (the next filter in the chain) was never invoked by this Filter. 
-          // Therefore, as a fallback, we try to redeem the bodyIteratee Promise here with an iteratee that consumes 
+          // It is possible that the delegate function (the next filter in the chain) was never invoked by this Filter.
+          // Therefore, as a fallback, we try to redeem the bodyIteratee Promise here with an iteratee that consumes
           // the request body.
           bodyAccumulator.tryComplete(resultTry.map(simpleResult => Accumulator.done(simpleResult)))
         })
@@ -73,9 +77,9 @@ trait Filter extends EssentialFilter {
             result
           }.recoverWith {
             case t: Throwable =>
-              // If the iteratee finishes with an error, fail the promised result that was returned to the 
-              // filter with the same error. Note, we MUST use tryFailure here as it's possible that a) 
-              // promisedResult was already completed successfully in the mapM method above but b) calculating 
+              // If the iteratee finishes with an error, fail the promised result that was returned to the
+              // filter with the same error. Note, we MUST use tryFailure here as it's possible that a)
+              // promisedResult was already completed successfully in the mapM method above but b) calculating
               // the result in that method caused an error, so we ended up in this recover block anyway.
               promisedResult.tryFailure(t)
               result


### PR DESCRIPTION
With the `asJava` method on `EssentialFilter`, now Java users can extend (by composition) existing Scala filters using the Java API.