### PR TITLE
Remove deprecated NotNull trait

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala
@@ -140,11 +140,8 @@ object Json {
    *
    * There is an implicit conversion from any Type with a Json Writes to JsValueWrapper
    * which is an empty trait that shouldn't end into unexpected implicit conversions.
-   *
-   * Something to note due to `JsValueWrapper` extending `NotNull` :
-   * `null` or `None` will end into compiling error : use JsNull instead.
    */
-  sealed trait JsValueWrapper extends NotNull
+  sealed trait JsValueWrapper
 
   private case class JsValueWrapperImpl(field: JsValue) extends JsValueWrapper
 

--- a/framework/src/play/src/main/scala/views/helper/Helpers.scala
+++ b/framework/src/play/src/main/scala/views/helper/Helpers.scala
@@ -53,7 +53,7 @@ package views.html.helper {
 
   }
 
-  trait FieldConstructor extends NotNull {
+  trait FieldConstructor {
     def apply(elts: FieldElements): Html
   }
 


### PR DESCRIPTION
Fixes following compiler warning:

```
[warn] /home/wsargent/work/playframework/master/framework/src/play-json/src/main/scala/play/api/libs/json/Json.scala:147: trait NotNull in package scala is deprecated: This trait will be removed
[warn]   sealed trait JsValueWrapper extends NotNull
```

See https://issues.scala-lang.org/browse/SI-7247.  

I think removing this is fine, as no-one is going to be referring to `val foo:NotNull` as the base type.