### PR TITLE
Use actorsystem terminate

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/code/ThreadPools.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/ThreadPools.scala
@@ -42,7 +42,7 @@ object ThreadPoolsSpec extends PlaySpecification {
       #default-config """
       val parsed = ConfigFactory.parseString(config)
       val actorSystem = ActorSystem("test", parsed.getConfig("akka"))
-      actorSystem.shutdown()
+      actorSystem.terminate()
       success
     }
 
@@ -65,7 +65,7 @@ object ThreadPoolsSpec extends PlaySpecification {
       #akka-default-config """
       val parsed = ConfigFactory.parseString(config)
       val actorSystem = ActorSystem("test", parsed.getConfig("akka"))
-      actorSystem.shutdown()
+      actorSystem.terminate()
       success
     }
 
@@ -128,7 +128,7 @@ object ThreadPoolsSpec extends PlaySpecification {
       #highly-synchronous """)
 
       val actorSystem = ActorSystem("test", config.getConfig("akka"))
-      actorSystem.shutdown()
+      actorSystem.terminate()
       success
     }
 

--- a/documentation/manual/working/scalaGuide/main/akka/code/ScalaAkka.scala
+++ b/documentation/manual/working/scalaGuide/main/akka/code/ScalaAkka.scala
@@ -7,7 +7,8 @@ import akka.actor.ActorSystem
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import play.api.inject.guice.GuiceApplicationBuilder
-import scala.concurrent.duration._
+  import scala.concurrent.Await
+  import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 import play.api.test._
@@ -22,8 +23,8 @@ class ScalaAkkaSpec extends PlaySpecification {
     try {
       block(system)
     } finally {
-      system.shutdown()
-      system.awaitTermination()
+      system.terminate()
+      Await.result(system.whenTerminated, Duration.Inf)
     }
   }
   

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -64,7 +64,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
   val system = ActorSystem()
   implicit val materializer = ActorMaterializer()(system)
 
-  def afterAll(): Unit = system.shutdown()
+  def afterAll(): Unit = system.terminate()
 
   def withSimpleServer[T](block: WSClient => T): T = withServer {
     case _ => Action(Ok)

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
@@ -242,7 +242,7 @@ class AkkaHttpServer(
       case NonFatal(e) => logger.error("Error while stopping logger", e)
     }
 
-    system.shutdown()
+    system.terminate()
 
     // Call provided hook
     // Do this last because the hooks were created before the server,

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/BodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/BodyParserSpec.scala
@@ -32,7 +32,7 @@ object BodyParserSpec extends PlaySpecification with ExecutionSpecification with
         }
       }
     } finally {
-      system.shutdown()
+      system.terminate()
     }
   }
 

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WS.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WS.java
@@ -84,7 +84,7 @@ public class WS {
                     client.close();
                 }
                 finally {
-                    system.shutdown();
+                    system.terminate();
                 }
             }
         };

--- a/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -219,8 +219,8 @@ object DevServerStart {
 
         val serverContext = ServerProvider.Context(serverConfig, appProvider, actorSystem,
           ActorMaterializer()(actorSystem), () => {
-            actorSystem.shutdown()
-            actorSystem.awaitTermination()
+            actorSystem.terminate()
+            Await.result(actorSystem.whenTerminated, Duration.Inf)
             Future.successful(())
           })
         val serverProvider = ServerProvider.fromConfiguration(classLoader, serverConfig.configuration)

--- a/framework/src/play-streams/src/test/java/play/libs/streams/AccumulatorTest.java
+++ b/framework/src/play-streams/src/test/java/play/libs/streams/AccumulatorTest.java
@@ -107,6 +107,6 @@ public class AccumulatorTest {
 
     @After
     public void tearDown() {
-        system.shutdown();
+        system.terminate();
     }
 }

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
@@ -18,8 +18,8 @@ object AccumulatorSpec extends Specification {
     try {
       block(ActorMaterializer()(system))
     } finally {
-      system.shutdown()
-      system.awaitTermination()
+      system.terminate()
+      Await.result(system.whenTerminated, Duration.Inf)
     }
   }
 

--- a/framework/src/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/framework/src/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -63,7 +63,7 @@ class HelpersSpec extends Specification {
         implicit val mat = ActorMaterializer()
         contentAsBytes(Future.successful(Ok.chunked(Source(List("a", "b", "c"))))) must_== ByteString(97, 98, 99)
       } finally {
-        system.shutdown()
+        system.terminate()
       }
     }
 

--- a/framework/src/play-ws/src/main/scala/play/api/test/WSTestClient.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/test/WSTestClient.scala
@@ -76,7 +76,7 @@ trait WsTestClient {
       block(wrappedClient)
     } finally {
       client.close()
-      system.shutdown()
+      system.terminate()
     }
   }
 }

--- a/framework/src/play/src/test/scala/play/api/mvc/RawBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RawBodyParserSpec.scala
@@ -27,7 +27,7 @@ object RawBodyParserSpec extends Specification with AfterAll {
 
   def afterAll(): Unit = {
     materializer.shutdown()
-    system.shutdown()
+    system.terminate()
   }
 
   val config = ParserConfiguration()


### PR DESCRIPTION
Fixes deprecated warnings like

```
[warn] /home/wsargent/work/playframework/doc-deprecate-plugin/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala:245: method shutdown in class ActorSystem is deprecated: Use the terminate() method instead
[warn]     system.shutdown()
```