### PR TITLE
Deprecate FakeApplication and use GuiceApplicationBuilder instead

### DIFF
--- a/documentation/manual/releases/release23/Migration23.md
+++ b/documentation/manual/releases/release23/Migration23.md
@@ -580,7 +580,7 @@ The session timeout configuration item, `session.maxAge`, used to be an integer,
 
 ## Java JUnit superclasses
 
-The Java `WithApplication`, `WithServer` and `WithBrowser` JUnit test superclasses have been modified to define an `@Before` annotated method.  This means, previously where you had to explicitly start a fake application by defining:
+The Java `WithApplication`, `WithServer` and `WithBrowser` JUnit test superclasses have been modified to define an `@Before` annotated method.  This means, previously where you had to explicitly start an application by defining:
 
 ```java
 @Before
@@ -589,11 +589,11 @@ public void setUp() {
 }
 ```
 
-Now you don't need to. If you need to provide a custom fake application, you can do so by overriding the `provideFakeApplication` method:
+Now you don't need to. If you need to provide a custom application, you can do so by overriding the `provideFakeApplication` method:
 
 ```java
 @Override
-protected FakeApplication provideFakeApplication() {
+protected Application provideFakeApplication() {
     return Helpers.fakeApplication(Helpers.inMemoryDatabase());
 }
 ```

--- a/documentation/manual/working/commonGuide/configuration/code/ThreadPools.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/ThreadPools.scala
@@ -12,6 +12,7 @@ import akka.actor.ActorSystem
 import play.api.libs.concurrent.Akka
 import scala.concurrent.{Future, ExecutionContext}
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.collection.convert.JavaConversions._
 import java.io.File
 import org.specs2.execute.AsResult
 
@@ -179,8 +180,7 @@ object ThreadPoolsSpec extends PlaySpecification {
 
   def runningWithConfig[T: AsResult](config: String )(block: Application => T) = {
     val parsed: java.util.Map[String,Object] = ConfigFactory.parseString(config).root.unwrapped
-    val app = FakeApplication(additionalConfiguration = collection.JavaConversions.mapAsScalaMap(parsed).toMap)
-    running(app)(block(app))
+    running(_.configure(parsed.asScala))(block)
   }
 }
 

--- a/documentation/manual/working/commonGuide/configuration/code/detailedtopics/ThreadPoolsJava.java
+++ b/documentation/manual/working/commonGuide/configuration/code/detailedtopics/ThreadPoolsJava.java
@@ -5,7 +5,6 @@ package detailedtopics;
 
 import org.junit.Test;
 import play.Play;
-import play.test.FakeApplication;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;

--- a/documentation/manual/working/commonGuide/filters/code/GzipEncoding.scala
+++ b/documentation/manual/working/commonGuide/filters/code/GzipEncoding.scala
@@ -24,8 +24,7 @@ object GzipEncoding extends PlaySpecification {
     "allow custom strategies for when to gzip" in {
 
       import play.api.mvc._
-      val app = FakeApplication()
-      running(app) {
+      running() { app =>
         implicit val mat = ActorMaterializer()(app.actorSystem)
 
         val filter =

--- a/documentation/manual/working/javaGuide/advanced/routing/code/AppLoader.scala
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/AppLoader.scala
@@ -6,7 +6,6 @@ import play.api.mvc._
 import play.api.routing.Router
 import play.api.routing.sird._
 import scala.concurrent.Future
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.inject.bind
 import router.RoutingDslBuilder
 

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaErrorHandling.scala
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaErrorHandling.scala
@@ -5,6 +5,7 @@ package javaguide.http
 
 import javaguide.application.`def`.ErrorHandler
 
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.Action
 import play.api.test._
 
@@ -13,12 +14,12 @@ import scala.reflect.ClassTag
 object JavaErrorHandling extends PlaySpecification with WsTestClient {
 
   def fakeApp[A](implicit ct: ClassTag[A]) = {
-    FakeApplication(
-      additionalConfiguration = Map("play.http.errorHandler" -> ct.runtimeClass.getName),
-      withRoutes = {
+    GuiceApplicationBuilder()
+      .configure("play.http.errorHandler" -> ct.runtimeClass.getName)
+      .routes {
         case (_, "/error") => Action(_ => throw new RuntimeException("foo"))
       }
-    )
+      .build()
   }
 
   "java error handling" should {

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaRouting.scala
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaRouting.scala
@@ -3,13 +3,14 @@
  */
 package javaguide.http
 
+import play.api.Application
 import akka.stream.ActorMaterializer
 import org.specs2.mutable.Specification
 import play.api.mvc.{EssentialAction, RequestHeader}
 import play.api.routing.Router
 import javaguide.http.routing._
 import play.api.test.Helpers._
-import play.api.test.{FakeRequest, FakeApplication}
+import play.api.test.FakeRequest
 import javaguide.testhelpers.MockJavaAction
 import play.libs.F
 
@@ -50,8 +51,7 @@ object JavaRouting extends Specification {
       contentOf(FakeRequest("GET", "/api/list-all?version=3.0")) must_== "version 3.0"
     }
     "support reverse routing" in {
-      val app = FakeApplication()
-      running(app) {
+      running() { app =>
         implicit val mat = ActorMaterializer()(app.actorSystem)
         header("Location", call(new MockJavaAction {
           override def invocation = F.Promise.pure(new javaguide.http.routing.controllers.Application().index())
@@ -62,8 +62,7 @@ object JavaRouting extends Specification {
   }
 
   def contentOf(rh: RequestHeader, router: Class[_ <: Router] = classOf[Routes]) = {
-    val app = FakeApplication(additionalConfiguration = Map("play.http.router" -> router.getName))
-    running(app) {
+    running(_.configure("play.http.router" -> router.getName)) { app =>
       implicit val mat = ActorMaterializer()(app.actorSystem)
       contentAsString(app.requestHandler.handlerForRequest(rh)._2 match {
         case e: EssentialAction => e(rh).run()

--- a/documentation/manual/working/javaGuide/main/tests/JavaFunctionalTest.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaFunctionalTest.md
@@ -10,17 +10,15 @@ import play.test.*;
 import static play.test.Helpers.*;
 ```
 
-## FakeApplication
+## Creating `Application` instances for testing
 
-Play frequently requires a running [`Application`](api/java/play/Application.html) as context: it is usually provided from [`play.Play.application()`](api/java/play/Play.html).
-
-To provide an environment for tests, Play provides a [`FakeApplication`](api/java/play/test/FakeApplication.html) class which can be configured with a different Global object, additional configuration, or even additional plugins.
+Play frequently requires a running [`Application`](api/java/play/Application.html) as context. To provide an environment for tests, Play provides helpers that produce new application instances for testing:
 
 @[test-fakeapp](code/javaguide/tests/FakeApplicationTest.java)
 
 ## Injecting tests
 
-If you're using Guice for [[dependency injection|JavaDependencyInjection]] then an `Application` for testing can be [[built directly|JavaTestingWithGuice]], instead of using FakeApplication. You can also inject any members of a test class that you might need. It's generally best practice to inject members only in functional tests and to manually create instances in unit tests.
+If you're using Guice for [[dependency injection|JavaDependencyInjection]] then an `Application` for testing can be [[built directly|JavaTestingWithGuice]]. You can also inject any members of a test class that you might need. It's generally best practice to inject members only in functional tests and to manually create instances in unit tests.
 
 @[test-injection](code/javaguide/tests/InjectionTest.java)
 
@@ -30,11 +28,9 @@ To run tests with an `Application`, you can do the following:
 
 @[test-running-fakeapp](code/javaguide/tests/FakeApplicationTest.java)
 
-You can also extend [`WithApplication`](api/java/play/test/WithApplication.html), this will automatically ensure that an application is started and stopped for you:
+You can also extend [`WithApplication`](api/java/play/test/WithApplication.html), this will automatically ensure that an application is started and stopped for each test method:
 
 @[test-withapp](code/javaguide/tests/FunctionalTest.java)
-
-This will ensure that a [`FakeApplication`](api/java/play/test/FakeApplication.html) will be started and stopped for each test method.
 
 ## Testing with a Guice application
 

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide.tests.routes
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide.tests.routes
@@ -1,1 +1,1 @@
-GET  /          controllers.Application.index()
+GET  /          controllers.HomeController.index()

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ApplicationTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ApplicationTest.java
@@ -6,15 +6,16 @@ import static org.junit.Assert.assertTrue;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.*;
 
-import javaguide.tests.controllers.Application;
+import javaguide.tests.controllers.HomeController;
 
 import java.util.ArrayList;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
+import play.Application;
+import play.inject.guice.GuiceApplicationBuilder;
 import play.mvc.Result;
-import play.test.FakeApplication;
 import play.test.Helpers;
 import play.test.WithApplication;
 import play.twirl.api.Content;
@@ -22,16 +23,15 @@ import play.twirl.api.Content;
 public class ApplicationTest extends WithApplication {
   
   @Override
-  protected FakeApplication provideFakeApplication() {
-    return new FakeApplication(new java.io.File("."),
-                               Helpers.class.getClassLoader(),
-                               ImmutableMap.of("play.http.router", "javaguide.tests.Routes"),
-                               fakeGlobal());
+  protected Application provideApplication() {
+    return new GuiceApplicationBuilder()
+      .configure("play.http.router", "javaguide.tests.Routes")
+      .build();
   }
 
   @Test
   public void testIndex() {
-    Result result = new Application().index();
+    Result result = new HomeController().index();
     assertEquals(OK, result.status());
     assertEquals("text/html", result.contentType().get());
     assertEquals("utf-8", result.charset().get());
@@ -45,8 +45,8 @@ public class ApplicationTest extends WithApplication {
   @Test
   public void testCallIndex() {
     Result result = route(
-      //###replace:     controllers.routes.Application.index(),
-      javaguide.tests.controllers.routes.Application.index()
+      //###replace:     controllers.routes.HomeController.index(),
+      javaguide.tests.controllers.routes.HomeController.index()
     );
     assertEquals(OK, result.status());
   }

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/FakeApplicationTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/FakeApplicationTest.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 
 import play.Application;
 import play.GlobalSettings;
-import play.test.FakeApplication;
 import play.test.Helpers;
 
 public class FakeApplicationTest {

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/controllers/HomeController.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/controllers/HomeController.java
@@ -5,7 +5,7 @@ package javaguide.tests.controllers;
 
 import play.mvc.*;
 
-public class Application extends Controller {
+public class HomeController extends Controller {
 
   public Result index() {
     return ok(javaguide.tests.html.index.render("Welcome to Play!"));

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWSSpec.scala
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWSSpec.scala
@@ -11,7 +11,7 @@ import play.api.libs.json._
 
 import play.test.Helpers._
 
-import play.api.test.FakeApplication
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsObject
 import javaguide.testhelpers.MockJavaActionHelper
 import play.api.http.Status
@@ -20,7 +20,7 @@ object JavaWSSpec extends Specification with Results with Status {
   // It's much easier to test this in Scala because we need to set up a
   // fake application with routes.
 
-  def fakeApplication = FakeApplication(withRoutes = {
+  def fakeApplication = GuiceApplicationBuilder().routes {
     case ("GET", "/feed") =>
       Action {
         val obj: JsObject = Json.obj(
@@ -40,7 +40,7 @@ object JavaWSSpec extends Specification with Results with Status {
       Action {
         BadRequest("no binding found")
       }
-  })
+  }.build()
 
   "The Java WS class" should {
     "call WS correctly" in new WithServer(app = fakeApplication, port = 3333) {

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/SirdAppLoader.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/SirdAppLoader.scala
@@ -6,7 +6,6 @@ import play.api.mvc._
 import play.api.routing.Router
 import play.api.routing.sird._
 import scala.concurrent.Future
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.inject.bind
 
 //#load

--- a/documentation/manual/working/scalaGuide/main/akka/code/ScalaAkka.scala
+++ b/documentation/manual/working/scalaGuide/main/akka/code/ScalaAkka.scala
@@ -6,9 +6,8 @@ package scalaguide.akka {
 import akka.actor.ActorSystem
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
-import play.api.inject.guice.GuiceApplicationBuilder
-  import scala.concurrent.Await
-  import scala.concurrent.duration._
+import scala.concurrent.Await
+import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 import play.api.test._
@@ -55,21 +54,19 @@ class ScalaAkkaSpec extends PlaySpecification {
       contentAsString(sayHello("world")(FakeRequest())) must_== "Hello, world"
     }
 
-    "allow binding actors" in new WithApplication(new GuiceApplicationBuilder()
+    "allow binding actors" in new WithApplication(_
       .bindings(new modules.MyModule)
       .configure("my.config" -> "foo")
-      .build()
-    ) {
+    ) { _ =>
       import injection._
       val controller = app.injector.instanceOf[Application]
       contentAsString(controller.getConfig(FakeRequest())) must_== "foo"
     }
 
-    "allow binding actor factories" in new WithApplication(new GuiceApplicationBuilder()
+    "allow binding actor factories" in new WithApplication(_
       .bindings(new factorymodules.MyModule)
       .configure("my.config" -> "foo")
-      .build()
-    ) {
+    ) { _ =>
       import play.api.inject.bind
       import akka.actor._
       import play.api.libs.concurrent.Execution.Implicits.defaultContext

--- a/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
+++ b/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
@@ -23,15 +23,13 @@ class ScalaCacheSpec extends PlaySpecification with Controller {
   import play.api.cache.Cached
 
   def withCache[T](block: CacheApi => T) = {
-    val app = FakeApplication()
-    running(app)(block(app.injector.instanceOf[CacheApi]))
+    running()(app => block(app.injector.instanceOf[CacheApi]))
   }
 
   "A scala Cache" should {
 
     "be injectable" in {
-      val app = FakeApplication()
-      running(app) {
+      running() { app =>
         app.injector.instanceOf[inject.Application]
         ok
       }
@@ -77,16 +75,14 @@ class ScalaCacheSpec extends PlaySpecification with Controller {
     }
 
     "bind multiple" in {
-      val app = FakeApplication(additionalConfiguration = Map("play.cache.bindCaches" -> Seq("session-cache")))
-      running(app) {
+      running(_.configure("play.cache.bindCaches" -> Seq("session-cache"))) { app =>
         app.injector.instanceOf[qualified.Application]
         ok
       }
     }
 
     "cached page" in {
-      val app = FakeApplication()
-      running(app) {
+      running() { app =>
         implicit val mat = ActorMaterializer()(app.actorSystem)
         val cachedApp = app.injector.instanceOf[cachedaction.Application1]
         val result = cachedApp.index(FakeRequest()).run()
@@ -95,16 +91,14 @@ class ScalaCacheSpec extends PlaySpecification with Controller {
     }
 
     "composition cached page" in {
-      val app = FakeApplication()
-      running(app) {
+      running() { app =>
         val cachedApp = app.injector.instanceOf[cachedaction.Application1]
         testAction(action=cachedApp.userProfile,expectedResponse=UNAUTHORIZED)
       }
     }
 
     "control cache" in {
-      val app = FakeApplication()
-      running(app) {
+      running() { app =>
         implicit val mat = ActorMaterializer()(app.actorSystem)
         val cachedApp = app.injector.instanceOf[cachedaction.Application1]
         val result0 = cachedApp.get(1)(FakeRequest("GET", "/resource/1")).run()
@@ -116,8 +110,7 @@ class ScalaCacheSpec extends PlaySpecification with Controller {
     }
 
     "control cache" in {
-      val app = FakeApplication()
-      running(app) {
+      running() { app =>
         implicit val mat = ActorMaterializer()(app.actorSystem)
         val cachedApp = app.injector.instanceOf[cachedaction.Application2]
         val result0 = cachedApp.get(1)(FakeRequest("GET", "/resource/1")).run()
@@ -137,8 +130,7 @@ class ScalaCacheSpec extends PlaySpecification with Controller {
   }
 
   def assertAction[A, T: AsResult](action: EssentialAction, request: => Request[A] = FakeRequest(), expectedResponse: Int = OK)(assertions: Future[Result] => T) = {
-    val app = FakeApplication()
-    running(app) {
+    running() { app =>
       implicit val mat = ActorMaterializer()(app.actorSystem)
       val result = action(request).run()
       status(result) must_== expectedResponse

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
@@ -3,6 +3,7 @@
  */
 package scalaguide.dependencyinjection
 
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test._
 
 object RuntimeDependencyInjection extends PlaySpecification {
@@ -16,8 +17,7 @@ object RuntimeDependencyInjection extends PlaySpecification {
       app.injector.instanceOf[singleton.CurrentSharePrice].get must_== 10
     }
     "support stopping" in {
-      val app = FakeApplication()
-      running(app) {
+      running() { app =>
         app.injector.instanceOf[cleanup.MessageQueueConnection]
       }
       cleanup.MessageQueue.stopped must_== true

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActions.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActions.scala
@@ -157,7 +157,7 @@ object ScalaActionsSpec extends Specification with Controller {
   }
 
   def assertAction[A, T: AsResult](action: Action[A], expectedResponse: Int = OK, request: Request[A] = FakeRequest())(assertions: Future[Result] => T) = {
-    running(FakeApplication()) {
+    running() { _ =>
       val result = action(request)
       status(result) must_== expectedResponse
       assertions(result)

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -6,259 +6,257 @@ package scalaguide.http.scalaactionscomposition {
 
 import akka.stream.ActorMaterializer
 import play.api.test._
-  import play.api.test.Helpers._
-  import org.specs2.mutable.Specification
-  import org.junit.runner.RunWith
-  import org.specs2.runner.JUnitRunner
-  import play.api.Logger
-  import play.api.mvc.Controller
-  import scala.concurrent.Future
-  import org.specs2.execute.AsResult
+import play.api.test.Helpers._
+import org.specs2.mutable.Specification
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+import play.api.Logger
+import play.api.mvc.Controller
+import scala.concurrent.Future
+import org.specs2.execute.AsResult
 
-  case class User(name: String)
-  object User {
-    def find(u: String) = Some(User("player"))
-  }
+case class User(name: String)
+object User {
+  def find(u: String) = Some(User("player"))
+}
 
-  @RunWith(classOf[JUnitRunner])
-  class ScalaActionsCompositionSpec extends Specification with Controller {
+@RunWith(classOf[JUnitRunner])
+class ScalaActionsCompositionSpec extends Specification with Controller {
 
-    "an action composition" should {
+  "an action composition" should {
 
-      "Basic action composition" in {
-        //#basic-logging
-        import play.api.mvc._
+    "Basic action composition" in {
+      //#basic-logging
+      import play.api.mvc._
 
-        object LoggingAction extends ActionBuilder[Request] {
-          def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
-            Logger.info("Calling action")
-            block(request)
-          }
-        }
-        //#basic-logging
-
-        //#basic-logging-index
-        def index = LoggingAction {
-          Ok("Hello World")
-        }
-        //#basic-logging-index
-
-        testAction(index)
-
-        //#basic-logging-parse
-        def submit = LoggingAction(parse.text) { request =>
-          Ok("Got a body " + request.body.length + " bytes long")
-        }
-        //#basic-logging-parse
-
-        val request = FakeRequest().withTextBody("hello with the parse")
-        testAction(index, request)
-      }
-
-      "Wrapping existing actions" in {
-
-        //#actions-class-wrapping
-        import play.api.mvc._
-
-        case class Logging[A](action: Action[A]) extends Action[A] {
-
-          def apply(request: Request[A]): Future[Result] = {
-            Logger.info("Calling action")
-            action(request)
-          }
-
-          lazy val parser = action.parser
-        }
-        //#actions-class-wrapping
-
-        //#actions-wrapping-builder
-        object LoggingAction extends ActionBuilder[Request] {
-          def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
-            block(request)
-          }
-          override def composeAction[A](action: Action[A]) = new Logging(action)
-        }
-        //#actions-wrapping-builder
-
-        {
-          //#actions-wrapping-index
-          def index = LoggingAction {
-            Ok("Hello World")
-          }
-          //#actions-wrapping-index
-
-          testAction(index)
-        }
-
-        {
-          //#actions-wrapping-direct
-          def index = Logging {
-            Action {
-              Ok("Hello World")
-            }
-          }
-          //#actions-wrapping-direct
-
-          testAction(index)
+      object LoggingAction extends ActionBuilder[Request] {
+        def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
+          Logger.info("Calling action")
+          block(request)
         }
       }
+      //#basic-logging
 
-      "Wrapping existing actions without defining the Logging class" in {
+      //#basic-logging-index
+      def index = LoggingAction {
+        Ok("Hello World")
+      }
+      //#basic-logging-index
 
-        //#actions-def-wrapping
-        import play.api.mvc._
+      testAction(index)
 
-        def logging[A](action: Action[A])= Action.async(action.parser) { request =>
+      //#basic-logging-parse
+      def submit = LoggingAction(parse.text) { request =>
+        Ok("Got a body " + request.body.length + " bytes long")
+      }
+      //#basic-logging-parse
+
+      val request = FakeRequest().withTextBody("hello with the parse")
+      testAction(index, request)
+    }
+
+    "Wrapping existing actions" in {
+
+      //#actions-class-wrapping
+      import play.api.mvc._
+
+      case class Logging[A](action: Action[A]) extends Action[A] {
+
+        def apply(request: Request[A]): Future[Result] = {
           Logger.info("Calling action")
           action(request)
         }
-        //#actions-def-wrapping
 
-        val request = FakeRequest().withTextBody("hello with the parse")
-        testAction(logging {
+        lazy val parser = action.parser
+      }
+      //#actions-class-wrapping
+
+      //#actions-wrapping-builder
+      object LoggingAction extends ActionBuilder[Request] {
+        def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
+          block(request)
+        }
+        override def composeAction[A](action: Action[A]) = new Logging(action)
+      }
+      //#actions-wrapping-builder
+
+      {
+        //#actions-wrapping-index
+        def index = LoggingAction {
+          Ok("Hello World")
+        }
+        //#actions-wrapping-index
+
+        testAction(index)
+      }
+
+      {
+        //#actions-wrapping-direct
+        def index = Logging {
           Action {
             Ok("Hello World")
           }
-        }, request)
+        }
+        //#actions-wrapping-direct
+
+        testAction(index)
       }
-
-      "allow modifying the request object" in {
-        //#modify-request
-        import play.api.mvc._
-
-        def xForwardedFor[A](action: Action[A]) = Action.async(action.parser) { request =>
-          val newRequest = request.headers.get("X-Forwarded-For").map { xff =>
-            new WrappedRequest[A](request) {
-              override def remoteAddress = xff
-            }
-          } getOrElse request
-          action(newRequest)
-        }
-        //#modify-request
-
-        testAction(xForwardedFor(Action(Ok)))
-      }
-
-      "allow blocking the request" in {
-        //#block-request
-        import play.api.mvc._
-
-        def onlyHttps[A](action: Action[A]) = Action.async(action.parser) { request =>
-          request.headers.get("X-Forwarded-Proto").collect {
-            case "https" => action(request)
-          } getOrElse {
-            Future.successful(Forbidden("Only HTTPS requests allowed"))
-          }
-        }
-        //#block-request
-
-        testAction(action = onlyHttps(Action(Ok)), expectedResponse = FORBIDDEN)
-      }
-
-      "allow modifying the result" in {
-        implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
-
-        //#modify-result
-        import play.api.mvc._
-        import play.api.libs.concurrent.Execution.Implicits._
-
-        def addUaHeader[A](action: Action[A]) = Action.async(action.parser) { request =>
-          action(request).map(_.withHeaders("X-UA-Compatible" -> "Chrome=1"))
-        }
-        //#modify-result
-
-        assertAction(addUaHeader(Action(Ok))) { result =>
-          header("X-UA-Compatible", result) must beSome("Chrome=1")
-        }
-      }
-
-      "allow action builders with different request types" in {
-
-        //#authenticated-action-builder
-        import play.api.mvc._
-
-        class UserRequest[A](val username: Option[String], request: Request[A]) extends WrappedRequest[A](request)
-
-        object UserAction extends
-            ActionBuilder[UserRequest] with ActionTransformer[Request, UserRequest] {
-          def transform[A](request: Request[A]) = Future.successful {
-            new UserRequest(request.session.get("username"), request)
-          }
-        }
-        //#authenticated-action-builder
-
-        def currentUser = UserAction { request =>
-          Ok("The current user is " + request.username.getOrElse("anonymous"))
-        }
-
-        testAction(currentUser)
-
-        case class Item(id: String) {
-          def addTag(tag: String) = ()
-          def accessibleByUser(user: Option[String]) = user.isDefined
-        }
-        object ItemDao {
-          def findById(id: String) = Some(Item(id))
-        }
-
-        //#request-with-item
-        import play.api.mvc._
-
-        class ItemRequest[A](val item: Item, request: UserRequest[A]) extends WrappedRequest[A](request) {
-          def username = request.username
-        }
-        //#request-with-item
-
-        //#item-action-builder
-        def ItemAction(itemId: String) = new ActionRefiner[UserRequest, ItemRequest] {
-          def refine[A](input: UserRequest[A]) = Future.successful {
-            ItemDao.findById(itemId)
-              .map(new ItemRequest(_, input))
-              .toRight(NotFound)
-          }
-        }
-        //#item-action-builder
-
-        //#permission-check-action
-        object PermissionCheckAction extends ActionFilter[ItemRequest] {
-          def filter[A](input: ItemRequest[A]) = Future.successful {
-            if (!input.item.accessibleByUser(input.username))
-              Some(Forbidden)
-            else
-              None
-          }
-        }
-        //#permission-check-action
-
-        //#item-action-use
-        def tagItem(itemId: String, tag: String) =
-          (UserAction andThen ItemAction(itemId) andThen PermissionCheckAction) { request =>
-            request.item.addTag(tag)
-            Ok("User " + request.username + " tagged " + request.item.id)
-          }
-        //#item-action-use
-
-        testAction(tagItem("foo", "bar"), expectedResponse = FORBIDDEN)
-      }
-
     }
 
-    import play.api.mvc._
-    def testAction[A](action: EssentialAction, request: => Request[A] = FakeRequest(), expectedResponse: Int = OK) = {
-      assertAction(action, request, expectedResponse) { result => success }
+    "Wrapping existing actions without defining the Logging class" in {
+
+      //#actions-def-wrapping
+      import play.api.mvc._
+
+      def logging[A](action: Action[A])= Action.async(action.parser) { request =>
+        Logger.info("Calling action")
+        action(request)
+      }
+      //#actions-def-wrapping
+
+      val request = FakeRequest().withTextBody("hello with the parse")
+      testAction(logging {
+        Action {
+          Ok("Hello World")
+        }
+      }, request)
     }
 
-    def assertAction[A, T: AsResult](action: EssentialAction, request: => Request[A] = FakeRequest(), expectedResponse: Int = OK)(assertions: Future[Result] => T) = {
-      val app = FakeApplication()
-      running(app) {
-        implicit val mat = ActorMaterializer()(app.actorSystem)
-        val result = action(request).run()
-        status(result) must_== expectedResponse
-        assertions(result)
+    "allow modifying the request object" in {
+      //#modify-request
+      import play.api.mvc._
+
+      def xForwardedFor[A](action: Action[A]) = Action.async(action.parser) { request =>
+        val newRequest = request.headers.get("X-Forwarded-For").map { xff =>
+          new WrappedRequest[A](request) {
+            override def remoteAddress = xff
+          }
+        } getOrElse request
+        action(newRequest)
       }
+      //#modify-request
+
+      testAction(xForwardedFor(Action(Ok)))
+    }
+
+    "allow blocking the request" in {
+      //#block-request
+      import play.api.mvc._
+
+      def onlyHttps[A](action: Action[A]) = Action.async(action.parser) { request =>
+        request.headers.get("X-Forwarded-Proto").collect {
+          case "https" => action(request)
+        } getOrElse {
+          Future.successful(Forbidden("Only HTTPS requests allowed"))
+        }
+      }
+      //#block-request
+
+      testAction(action = onlyHttps(Action(Ok)), expectedResponse = FORBIDDEN)
+    }
+
+    "allow modifying the result" in {
+      implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
+
+      //#modify-result
+      import play.api.mvc._
+      import play.api.libs.concurrent.Execution.Implicits._
+
+      def addUaHeader[A](action: Action[A]) = Action.async(action.parser) { request =>
+        action(request).map(_.withHeaders("X-UA-Compatible" -> "Chrome=1"))
+      }
+      //#modify-result
+
+      assertAction(addUaHeader(Action(Ok))) { result =>
+        header("X-UA-Compatible", result) must beSome("Chrome=1")
+      }
+    }
+
+    "allow action builders with different request types" in {
+
+      //#authenticated-action-builder
+      import play.api.mvc._
+
+      class UserRequest[A](val username: Option[String], request: Request[A]) extends WrappedRequest[A](request)
+
+      object UserAction extends
+          ActionBuilder[UserRequest] with ActionTransformer[Request, UserRequest] {
+        def transform[A](request: Request[A]) = Future.successful {
+          new UserRequest(request.session.get("username"), request)
+        }
+      }
+      //#authenticated-action-builder
+
+      def currentUser = UserAction { request =>
+        Ok("The current user is " + request.username.getOrElse("anonymous"))
+      }
+
+      testAction(currentUser)
+
+      case class Item(id: String) {
+        def addTag(tag: String) = ()
+        def accessibleByUser(user: Option[String]) = user.isDefined
+      }
+      object ItemDao {
+        def findById(id: String) = Some(Item(id))
+      }
+
+      //#request-with-item
+      import play.api.mvc._
+
+      class ItemRequest[A](val item: Item, request: UserRequest[A]) extends WrappedRequest[A](request) {
+        def username = request.username
+      }
+      //#request-with-item
+
+      //#item-action-builder
+      def ItemAction(itemId: String) = new ActionRefiner[UserRequest, ItemRequest] {
+        def refine[A](input: UserRequest[A]) = Future.successful {
+          ItemDao.findById(itemId)
+            .map(new ItemRequest(_, input))
+            .toRight(NotFound)
+        }
+      }
+      //#item-action-builder
+
+      //#permission-check-action
+      object PermissionCheckAction extends ActionFilter[ItemRequest] {
+        def filter[A](input: ItemRequest[A]) = Future.successful {
+          if (!input.item.accessibleByUser(input.username))
+            Some(Forbidden)
+          else
+            None
+        }
+      }
+      //#permission-check-action
+
+      //#item-action-use
+      def tagItem(itemId: String, tag: String) =
+        (UserAction andThen ItemAction(itemId) andThen PermissionCheckAction) { request =>
+          request.item.addTag(tag)
+          Ok("User " + request.username + " tagged " + request.item.id)
+        }
+      //#item-action-use
+
+      testAction(tagItem("foo", "bar"), expectedResponse = FORBIDDEN)
     }
 
   }
+
+  import play.api.mvc._
+  def testAction[A](action: EssentialAction, request: => Request[A] = FakeRequest(), expectedResponse: Int = OK) = {
+    assertAction(action, request, expectedResponse) { result => success }
+  }
+
+  def assertAction[A, T: AsResult](action: EssentialAction, request: => Request[A] = FakeRequest(), expectedResponse: Int = OK)(assertions: Future[Result] => T) = {
+    running() { app =>
+      implicit val mat = ActorMaterializer()(app.actorSystem)
+      val result = action(request).run()
+      status(result) must_== expectedResponse
+      assertions(result)
+    }
+  }
+
 }
 
- 
+}

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
@@ -84,8 +84,7 @@ import org.specs2.execute.AsResult
       }
 
       "body parser limit file" in {
-        val app = FakeApplication()
-        running(app) {
+        running() { app =>
           implicit val mat = ActorMaterializer()(app.actorSystem)
           val storeInUserFile = scalaguide.http.scalabodyparsers.full.Application.storeInUserFile
           //#body-parser-limit-file
@@ -166,8 +165,7 @@ import org.specs2.execute.AsResult
     }
 
     def assertAction[A: Writeable, T: AsResult](action: EssentialAction, request: => FakeRequest[A], expectedResponse: Int = OK)(assertions: Future[Result] => T) = {
-      val app = FakeApplication()
-      running(app) {
+      running() { app =>
         implicit val mat = ActorMaterializer()(app.actorSystem)
         val result = call(action, request)
         status(result) must_== expectedResponse

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaContentNegotiation.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaContentNegotiation.scala
@@ -8,6 +8,7 @@ package scalaguide.http.scalacontentnegotiation {
   import play.api.test.Helpers._
   import org.specs2.mutable.Specification
   import play.api.libs.json._
+
   import org.junit.runner.RunWith
   import org.specs2.runner.JUnitRunner
   import scala.concurrent.Future
@@ -56,7 +57,7 @@ package scalaguide.http.scalacontentnegotiation {
     }
 
     def assertAction[A, T: AsResult](action: Action[A], expectedResponse: Int = OK, request: Request[A] = FakeRequest())(assertions: Future[Result] => T) = {
-      running(FakeApplication()) {
+      running() { app =>
         val result = action(request)
         status(result) must_== expectedResponse
         assertions(result)

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
@@ -3,6 +3,7 @@
  */
 package scalaguide.http.errorhandling
 
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.Action
 import play.api.test._
 
@@ -11,12 +12,12 @@ import scala.reflect.ClassTag
 object ScalaErrorHandling extends PlaySpecification with WsTestClient {
 
   def fakeApp[A](implicit ct: ClassTag[A]) = {
-    FakeApplication(
-      additionalConfiguration = Map("play.http.errorHandler" -> ct.runtimeClass.getName),
-      withRoutes = {
+    GuiceApplicationBuilder()
+      .configure("play.http.errorHandler" -> ct.runtimeClass.getName)
+      .routes {
         case (_, "/error") => Action(_ => throw new RuntimeException("foo"))
       }
-    )
+      .build()
   }
 
   "scala error handling" should {

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaResults.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaResults.scala
@@ -94,7 +94,7 @@ package scalaguide.http.scalaresults {
     }
 
     def assertAction[A, T: AsResult](action: Action[A], expectedResponse: Int = OK, request: Request[A] = FakeRequest())(assertions: Future[Result] => T) = {
-      running(FakeApplication()) {
+      running() { app =>
         val result = action(request)
         status(result) must_== expectedResponse
         assertions(result)

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
@@ -140,8 +140,7 @@ object ScalaRoutingSpec extends Specification {
   }
 
   def contentOf(rh: RequestHeader, router: Class[_ <: Router] = classOf[Routes]) = {
-    val app = FakeApplication()
-    running(app) {
+    running() { app =>
       implicit val mat = ActorMaterializer()(app.actorSystem)
       contentAsString(app.injector.instanceOf(router).routes(rh) match {
         case e: EssentialAction => e(rh).run()

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
@@ -113,8 +113,7 @@ package scalaguide.http.scalasessionflash {
     }
 
     def assertAction[A, T: AsResult](action: Action[A], expectedResponse: Int = OK, request: => Request[A] = FakeRequest())(assertions: Future[Result] => T) = {
-      val fakeApp = FakeApplication()
-      running(fakeApp) {
+      running() { _ =>
         val result = action(request)
         status(result) must_== expectedResponse
         assertions(result)

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
@@ -10,17 +10,15 @@ import play.api.test._
 import play.api.test.Helpers._
 ```
 
-## FakeApplication
+## Creating `Application` instances for testing
 
-Play frequently requires a running [`Application`](api/scala/play/api/Application.html) as context: it is usually provided from [`play.api.Play.current`](api/scala/play/api/Play$.html).
-
-To provide an environment for tests, Play provides a [`FakeApplication`](api/scala/play/api/test/FakeApplication.html) class which can be configured with a different Global object, additional configuration, or even additional plugins.
+Play frequently requires a running [`Application`](api/scala/play/api/Application.html) as context. If you're using the default Guice dependency injection, you can use the [`GuiceApplicationBuilder`](api/scala/play/api/inject/guice/GuiceApplicationBuilder.html) class which can be configured with different configuration, routes, or even additional modules.
 
 @[scalafunctionaltest-fakeApplication](code/specs2/ScalaFunctionalTestSpec.scala)
 
 ## WithApplication
 
-To pass in an application to an example, use [`WithApplication`](api/scala/play/api/test/WithApplication.html).  An explicit [`Application`](api/scala/play/api/Application.html) can be passed in, but a default [`FakeApplication`](api/scala/play/api/test/FakeApplication.html) is provided for convenience.
+To pass in an application to an example, use [`WithApplication`](api/scala/play/api/test/WithApplication.html).  An explicit [`Application`](api/scala/play/api/Application.html) can be passed in, but a default application (created from the default `GuiceApplicationBulider`) is provided for convenience.
 
 Because [`WithApplication`](api/scala/play/api/test/WithApplication.html) is a built in [`Around`](https://etorreborre.github.io/specs2/guide/SPECS2-3.4/org.specs2.guide.Contexts.html#aroundeach) block, you can override it to provide your own data population:
 
@@ -34,7 +32,7 @@ Sometimes you want to test the real HTTP stack from within your test, in which c
 
 The `port` value contains the port number the server is running on.  By default this is 19001, however you can change this either by passing the port into [`WithServer`](api/scala/play/api/test/WithServer.html), or by setting the system property `testserver.port`.  This can be useful for integrating with continuous integration servers, so that ports can be dynamically reserved for each build.
 
-A [`FakeApplication`](api/scala/play/api/test/FakeApplication.html) can also be passed to the test server, which is useful for setting up custom routes and testing WS calls:
+An application can also be passed to the test server, which is useful for setting up custom routes and testing WS calls:
 
 @[scalafunctionaltest-testws](code/specs2/ScalaFunctionalTestSpec.scala)
 

--- a/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
+++ b/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
@@ -3,6 +3,7 @@
  */
 package scalaguide.upload.fileupload {
 
+  import play.api.inject.guice.GuiceApplicationBuilder
   import play.api.mvc._
   import play.api.test._
   import org.junit.runner.RunWith
@@ -67,7 +68,7 @@ package scalaguide.upload.fileupload {
     }
 
     def testAction[A](action: Action[A], request: => Request[A] = FakeRequest(), expectedResponse: Int = OK) = {
-      running(FakeApplication()) {
+      running(GuiceApplicationBuilder().build()) {
 
         val result = action(request)
 

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -7,7 +7,9 @@ import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import org.asynchttpclient.AsyncHttpClientConfig
+
 import play.api.{Mode, Environment}
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.ahc._
 import play.api.test._
 
@@ -44,7 +46,7 @@ case class Person(name: String, age: Int)
 // #scalaws-person
 
 /**
- * NOTE: the format here is because we cannot define FakeApplication in a new WithServer at once, as we run into a
+ * NOTE: the format here is because we cannot define a fake application in a new WithServer at once, as we run into a
  * JVM implementation issue.
  */
 @RunWith(classOf[JUnitRunner])
@@ -71,9 +73,9 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
   }(block)
 
   def withServer[T](routes: (String, String) => Handler)(block: WSClient => T): T = {
-    val app = FakeApplication(withRoutes = {
+    val app = GuiceApplicationBuilder().routes({
       case (method, path) => routes(method, path)
-    })
+    }).build()
     running(TestServer(testServerPort, app))(block(app.injector.instanceOf[WSClient]))
   }
 

--- a/documentation/manual/working/scalaGuide/main/xml/code/ScalaXmlRequests.scala
+++ b/documentation/manual/working/scalaGuide/main/xml/code/ScalaXmlRequests.scala
@@ -3,11 +3,11 @@
  */
 package scalaguide.xml.scalaxmlrequests {
 
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
 import play.api.test._
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
-
 
 @RunWith(classOf[JUnitRunner])
 class ScalaXmlRequestsSpec extends PlaySpecification with Controller {
@@ -69,7 +69,7 @@ class ScalaXmlRequestsSpec extends PlaySpecification with Controller {
 
   def testAction[T](action: Action[T], req: Request[T]) = {
 
-    running(FakeApplication()) {
+    running(GuiceApplicationBuilder().build()) {
       val result = action(req)
       status(result) must_== OK
     }

--- a/framework/src/play-cache/src/test/scala/play/api/cache/CachedSpec.scala
+++ b/framework/src/play-cache/src/test/scala/play/api/cache/CachedSpec.scala
@@ -34,9 +34,9 @@ class CachedSpec extends PlaySpecification {
       header(EXPIRES, result2) must_== header(EXPIRES, result1)
     }
 
-    "cache values using named injected CachedApi" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("play.cache.bindCaches" -> Seq("custom"))
-    )) {
+    "cache values using named injected CachedApi" in new WithApplication(
+      _.configure("play.cache.bindCaches" -> Seq("custom"))
+    ) {
       val controller = app.injector.instanceOf[NamedCachedController]
       val result1 = controller.action(FakeRequest()).run()
       contentAsString(result1) must_== "1"
@@ -280,9 +280,9 @@ class CachedSpec extends PlaySpecification {
   }
 
   "EhCacheModule" should {
-    "support binding multiple different caches" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("play.cache.bindCaches" -> Seq("custom"))
-    )) {
+    "support binding multiple different caches" in new WithApplication(
+      _.configure("play.cache.bindCaches" -> Seq("custom"))
+    ) {
       val component = app.injector.instanceOf[SomeComponent]
       val defaultCache = app.injector.instanceOf[CacheApi]
       component.set("foo", "bar")

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -4,6 +4,7 @@
 package play.filters.csrf
 
 import org.specs2.mutable.Specification
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws._
 import scala.concurrent.Future
 import play.api.mvc.{ Handler, Session }
@@ -247,8 +248,11 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
   implicit def simpleFormWriteable: Writeable[Map[String, String]] = Writeable.writeableOf_urlEncodedForm.map[Map[String, String]](_.mapValues(v => Seq(v)))
   implicit def simpleFormContentType: ContentTypeOf[Map[String, String]] = ContentTypeOf[Map[String, String]](Some(ContentTypes.FORM))
 
-  def withServer[T](config: Seq[(String, String)])(router: PartialFunction[(String, String), Handler])(block: => T) = running(TestServer(testServerPort, FakeApplication(
-    additionalConfiguration = Map(config: _*) ++ Map("play.crypto.secret" -> "foobar"),
-    withRoutes = router
-  )))(block)
+  def withServer[T](config: Seq[(String, String)])(router: PartialFunction[(String, String), Handler])(block: => T) = {
+    running(TestServer(testServerPort, GuiceApplicationBuilder()
+      .configure(Map(config: _*) ++ Map("play.crypto.secret" -> "foobar"))
+      .routes(router)
+      .build()
+    ))(block)
+  }
 }

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -16,7 +16,7 @@ import play.api.libs.json.Json
 import play.api.test._
 import scala.util.Random
 import play.api.libs.Crypto
-import play.api.inject.guice.GuiceApplicationLoader
+import play.api.inject.guice.{ GuiceApplicationBuilder, GuiceApplicationLoader }
 import play.api.{ Mode, Configuration, Environment }
 import play.api.ApplicationLoader.Context
 import play.core.DefaultWebCommands
@@ -80,13 +80,13 @@ object CSRFFilterSpec extends CSRFCommonSpecs {
       }
     }
 
-    val notBufferedFakeApp = FakeApplication(
-      additionalConfiguration = Map(
+    val notBufferedFakeApp = GuiceApplicationBuilder()
+      .configure(
         "play.crypto.secret" -> "foobar",
         "play.filters.csrf.body.bufferSize" -> "200",
         "play.http.filters" -> classOf[CsrfFilters].getName
-      ),
-      withRoutes = {
+      )
+      .routes {
         case _ => Action { req =>
           (for {
             body <- req.body.asFormUrlEncoded
@@ -99,7 +99,7 @@ object CSRFFilterSpec extends CSRFCommonSpecs {
           }).getOrElse(Results.NotFound)
         }
       }
-    )
+      .build()
 
     "feed a not fully buffered body once a check has been done and passes" in new WithServer(notBufferedFakeApp, testServerPort) {
       val token = Crypto.generateSignedToken

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
@@ -9,7 +9,6 @@ import javax.inject.Inject
 
 import com.typesafe.config.ConfigFactory
 import play.api.http.HttpFilters
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.routing.Router
 import play.api.test.{ WithApplication, FakeRequest, PlaySpecification }
 import play.api.mvc.{ Action, Result }
@@ -33,15 +32,15 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
   }
 
   def withApplication[T](result: Result, config: String)(block: => T): T = {
-    running(new GuiceApplicationBuilder()
+    running(_
       .configure(configure(config))
       .overrides(
         bind[Router].to(Router.from {
           case _ => Action(result)
         }),
         bind[HttpFilters].to[Filters]
-      ).build
-    )(block)
+      )
+    )(_ => block)
   }
 
   "security headers" should {

--- a/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
@@ -44,7 +44,7 @@ trait ServerIntegrationSpecification extends PendingUntilFixed with AroundEach {
    */
   def TestServer(
     port: Int,
-    application: Application = play.api.FakeApplication(),
+    application: Application = play.api.PlayCoreTestApplication(),
     sslPort: Option[Int] = None): play.api.test.TestServer = {
     play.api.test.TestServer(port, application, sslPort, Some(integrationServerProvider))
   }

--- a/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecificationSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecificationSpec.scala
@@ -1,5 +1,6 @@
 package play.it
 
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
 import play.api.mvc.Results._
 import play.api.test._
@@ -34,7 +35,7 @@ trait ServerIntegrationSpecificationSpec extends PlaySpecification
     }
 
     "run the right HTTP server when using TestServer constructor" in {
-      running(TestServer(testServerPort, FakeApplication(withRoutes = httpServerTagRoutes))) {
+      running(TestServer(testServerPort, GuiceApplicationBuilder().routes(httpServerTagRoutes).build())) {
         val plainRequest = wsUrl("/httpServerTag")(testServerPort)
         val responseFuture = plainRequest.get()
         val response = await(responseFuture)
@@ -44,7 +45,7 @@ trait ServerIntegrationSpecificationSpec extends PlaySpecification
     }
 
     "run the right server when using WithServer trait" in new WithServer(
-      app = FakeApplication(withRoutes = httpServerTagRoutes)) {
+      app = GuiceApplicationBuilder().routes(httpServerTagRoutes).build()) {
       val response = await(wsUrl("/httpServerTag").get())
       response.status must equalTo(OK)
       response.body must_== expectedServerTag.toString

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/EssentialActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/EssentialActionSpec.scala
@@ -3,9 +3,12 @@
  */
 package play.it.action
 
-import play.api.mvc.{ Action, EssentialAction }
+import play.api.Environment
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.Results._
-import play.api.test.{ FakeApplication, PlaySpecification, FakeRequest }
+import play.api.mvc.{ Action, EssentialAction }
+import play.api.test.{ FakeRequest, PlaySpecification }
+
 import scala.concurrent.Promise
 
 object EssentialActionSpec extends PlaySpecification {
@@ -22,10 +25,9 @@ object EssentialActionSpec extends PlaySpecification {
 
       // start fake application with its own classloader
       val applicationClassLoader = new ClassLoader() {}
-      val fakeApplication = FakeApplication(classloader = applicationClassLoader)
-      import fakeApplication.materializer
 
-      running(fakeApplication) {
+      running(_.in(Environment.simple().copy(classLoader = applicationClassLoader))) { app =>
+        import app.materializer
         // run the test with the classloader of the current thread
         Thread.currentThread.getContextClassLoader must not be applicationClassLoader
         call(action, FakeRequest())

--- a/framework/src/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
@@ -3,6 +3,7 @@
  */
 package play.it.auth
 
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test._
 import play.api.mvc.Security.{ AuthenticatedRequest, AuthenticatedBuilder }
 import play.api.mvc._
@@ -59,6 +60,7 @@ object SecuritySpec extends PlaySpecification {
   object FakeConnection extends Connection("fake")
   case class Connection(name: String)
 
-  def withApplication[T](block: => T) =
-    running(FakeApplication(additionalConfiguration = Map("play.crypto.secret" -> "foobar")))(block)
+  def withApplication[T](block: => T) = {
+    running(_.configure("play.crypto.secret" -> "foobar"))(_ => block)
+  }
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/Expect100ContinueSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/Expect100ContinueSpec.scala
@@ -3,6 +3,7 @@
  */
 package play.it.http
 
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.streams.Accumulator
 import play.it._
 import play.api.mvc._
@@ -17,11 +18,7 @@ trait Expect100ContinueSpec extends PlaySpecification with ServerIntegrationSpec
 
     def withServer[T](action: EssentialAction)(block: Port => T) = {
       val port = testServerPort
-      running(TestServer(port, FakeApplication(
-        withRoutes = {
-          case _ => action
-        }
-      ))) {
+      running(TestServer(port, GuiceApplicationBuilder().routes { case _ => action }.build())) {
         block(port)
       }
     }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
@@ -1,5 +1,6 @@
 package play.it.http
 
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test._
 import play.api.mvc.{ Cookie, Flash, Action }
 import play.api.mvc.Results._
@@ -14,7 +15,7 @@ trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecificat
 
   sequential
 
-  def appWithRedirect = FakeApplication(withRoutes = {
+  def appWithRedirect = GuiceApplicationBuilder().routes {
     case ("GET", "/flash") =>
       Action {
         Redirect("/landing").flashing(
@@ -29,7 +30,7 @@ trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecificat
       Action {
         Ok("ok")
       }
-  })
+  }.build()
 
   def withClientAndServer[T](block: WSClient => T) = {
     val app = appWithRedirect
@@ -81,11 +82,9 @@ trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecificat
 
     }
 
-    "honor configuration for flash.secure" in Helpers.running(
-      FakeApplication(additionalConfiguration = Map("play.http.flash.secure" -> true))
-    ) {
-        Flash.encodeAsCookie(Flash()).secure must beTrue
-      }
+    "honor configuration for flash.secure" in Helpers.running(_.configure("play.http.flash.secure" -> true)) { _ =>
+      Flash.encodeAsCookie(Flash()).secure must beTrue
+    }
   }
 
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FormFieldOrderSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FormFieldOrderSpec.scala
@@ -3,12 +3,13 @@
  */
 package play.it.http
 
+import play.api.inject.guice.GuiceApplicationBuilder
+
 import scala.concurrent.duration._
 
 import play.api.mvc._
 import play.api.test._
 import play.api.libs.ws._
-import play.api.test.FakeApplication
 import play.it._
 
 object NettyFormFieldOrderSpec extends FormFieldOrderSpec with NettyIntegrationSpecification
@@ -21,7 +22,7 @@ trait FormFieldOrderSpec extends PlaySpecification with ServerIntegrationSpecifi
     val urlEncoded = "One=one&Two=two&Three=three&Four=four&Five=five&Six=six&Seven=seven"
     val contentType = "application/x-www-form-urlencoded"
 
-    val fakeApp = FakeApplication(withRoutes = {
+    val fakeApp = GuiceApplicationBuilder().routes {
       case ("POST", "/") => Action {
         request: Request[AnyContent] =>
           // Check precondition. This needs to be an x-www-form-urlencoded request body
@@ -41,7 +42,7 @@ trait FormFieldOrderSpec extends PlaySpecification with ServerIntegrationSpecifi
           // Return the re-encoded body as the result body for comparison below
           Results.Ok(reencoded)
       }
-    })
+    }.build()
 
     "preserve form field order" in new WithServer(fakeApp) {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/HttpPipeliningSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/HttpPipeliningSpec.scala
@@ -4,6 +4,7 @@
 package play.it.http
 
 import akka.stream.scaladsl.Source
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.streams.Accumulator
 import play.api.mvc.{ Results, EssentialAction }
 import play.api.test._
@@ -25,11 +26,7 @@ trait HttpPipeliningSpec extends PlaySpecification with ServerIntegrationSpecifi
 
     def withServer[T](action: EssentialAction)(block: Port => T) = {
       val port = testServerPort
-      running(TestServer(port, FakeApplication(
-        withRoutes = {
-          case _ => action
-        }
-      ))) {
+      running(TestServer(port, GuiceApplicationBuilder().routes { case _ => action }.build())) {
         block(port)
       }
     }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -1,21 +1,19 @@
 package play.it.http
 
 import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.WSResponse
-import play.api.test.{ WsTestClient, TestServer, FakeApplication, PlaySpecification }
-import play.it.http.ActionCompositionOrderTest.{ WithUsername, ActionAnnotation, ControllerAnnotation }
-import play.mvc.{ Results, Result }
+import play.api.test.{PlaySpecification, TestServer, WsTestClient}
+import play.it.http.ActionCompositionOrderTest.{ActionAnnotation, ControllerAnnotation, WithUsername}
+import play.mvc.{Result, Results}
 
 object JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
 
   def makeRequest[T](controller: MockController, configuration: Map[String, _ <: Any] = Map.empty)(block: WSResponse => T) = {
     implicit val port = testServerPort
-    lazy val app: Application = FakeApplication(
-      withRoutes = {
-        case _ => JAction(app, controller)
-      },
-      additionalConfiguration = configuration
-    )
+    lazy val app: Application = GuiceApplicationBuilder().configure(configuration).routes {
+      case _ => JAction(app, controller)
+    }.build()
 
     running(TestServer(port, app)) {
       val response = await(wsUrl("/").get())

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -5,6 +5,7 @@ package play.it.http
 
 import java.io.ByteArrayInputStream
 import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test._
 import play.api.libs.ws.WSResponse
 import play.it._
@@ -23,11 +24,9 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
   "Java results handling" should {
     def makeRequest[T](controller: MockController)(block: WSResponse => T) = {
       implicit val port = testServerPort
-      lazy val app: Application = FakeApplication(
-        withRoutes = {
-          case _ => JAction(app, controller)
-        }
-      )
+      lazy val app: Application = GuiceApplicationBuilder().routes {
+        case _ => JAction(app, controller)
+      }.build()
 
       running(TestServer(port, app)) {
         val response = await(wsUrl("/").get())

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
@@ -5,6 +5,7 @@ package play.it.http
 
 import akka.stream.scaladsl.{ Flow, Sink }
 import akka.util.ByteString
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.api.test._
@@ -24,11 +25,7 @@ trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSp
 
     def withServer[T](action: EssentialAction)(block: Port => T) = {
       val port = testServerPort
-      running(TestServer(port, FakeApplication(
-        withRoutes = {
-          case _ => action
-        }
-      ))) {
+      running(TestServer(port, GuiceApplicationBuilder().routes { case _ => action }.build())) {
         block(port)
       }
     }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -6,6 +6,7 @@ package play.it.http
 import java.util.Locale.ENGLISH
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
 import play.api.test._
 import play.api.libs.ws._
@@ -33,11 +34,7 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
 
     def withServer[T](result: Result)(block: Port => T) = {
       val port = testServerPort
-      running(TestServer(port, FakeApplication(
-        withRoutes = {
-          case _ => Action(result)
-        }
-      ))) {
+      running(TestServer(port, GuiceApplicationBuilder().routes { case _ => Action(result) }.build())) {
         block(port)
       }
     }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
@@ -3,6 +3,7 @@
  */
 package play.it.http
 
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test._
 import play.api.mvc._
 import play.api.mvc.Results._
@@ -83,8 +84,8 @@ object ScalaResultsSpec extends PlaySpecification {
   }
 
   def withApplication[T](config: (String, Any)*)(block: => T): T = running(
-    FakeApplication(additionalConfiguration = Map(config: _*) + ("play.crypto.secret" -> "foo"))
-  )(block)
+    _.configure(Map(config: _*) + ("play.crypto.secret" -> "foo"))
+  )(_ => block)
 
   def withFooPath[T](block: => T) = withApplication("application.context" -> "/foo")(block)
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/SecureFlagSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/SecureFlagSpec.scala
@@ -3,6 +3,7 @@
  */
 package play.it.http
 
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
 import play.api.test._
 import play.api.test.TestServer
@@ -33,11 +34,10 @@ trait SecureFlagSpec extends PlaySpecification with ServerIntegrationSpecificati
 
   def withServer[T](action: EssentialAction, sslPort: Option[Int] = None)(block: Port => T) = {
     val port = testServerPort
-    running(TestServer(port, sslPort = sslPort, application = FakeApplication(
-      withRoutes = {
-        case _ => action
-      }
-    ))) {
+    running(TestServer(port, sslPort = sslPort, application = GuiceApplicationBuilder()
+      .routes { case _ => action }
+      .build()
+    )) {
       block(port)
     }
   }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -89,9 +89,9 @@ object MultipartFormDataParserSpec extends PlaySpecification {
       }
     }
 
-    "validate the full length of the body" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("play.http.parser.maxDiskBuffer" -> "100")
-    )) {
+    "validate the full length of the body" in new WithApplication(
+      _.configure("play.http.parser.maxDiskBuffer" -> "100")
+    ) {
       val parser = parse.multipartFormData.apply(FakeRequest().withHeaders(
         CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
       ))
@@ -103,9 +103,9 @@ object MultipartFormDataParserSpec extends PlaySpecification {
       }
     }
 
-    "not parse more than the max data length" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("play.http.parser.maxMemoryBuffer" -> "30")
-    )) {
+    "not parse more than the max data length" in new WithApplication(
+      _.configure("play.http.parser.maxMemoryBuffer" -> "30")
+    ) {
       val parser = parse.multipartFormData.apply(FakeRequest().withHeaders(
         CONTENT_TYPE -> "multipart/form-data; boundary=aabbccddee"
       ))

--- a/framework/src/play-integration-test/src/test/scala/play/it/i18n/LangSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/i18n/LangSpec.scala
@@ -4,12 +4,13 @@
 package play.it.i18n
 
 import play.api.i18n.Lang
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test._
 
 class LangSpec extends PlaySpecification {
   "lang spec" should {
     "allow selecting preferred language" in {
-      implicit val app = FakeApplication(additionalConfiguration = Map("play.i18n.langs" -> Seq("en-US", "es-ES", "de")))
+      implicit val app = GuiceApplicationBuilder().configure("play.i18n.langs" -> Seq("en-US", "es-ES", "de")).build()
       val esEs = Lang("es", "ES")
       val es = Lang("es")
       val deDe = Lang("de", "DE")
@@ -77,7 +78,7 @@ class LangSpec extends PlaySpecification {
       }
 
       "preferred language" in {
-        implicit val app = FakeApplication(additionalConfiguration = Map("application.langs" -> "crh-UA,ber,ast-ES"))
+        implicit val app = GuiceApplicationBuilder().configure("application.langs" -> "crh-UA,ber,ast-ES").build()
 
         val crhUA = Lang("crh", "UA")
         val crh = Lang("crh")

--- a/framework/src/play-integration-test/src/test/scala/play/it/views/DevErrorPageSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/views/DevErrorPageSpec.scala
@@ -15,9 +15,9 @@ object DevErrorPageSpec extends PlaySpecification {
       def sourceName = "someSourceFile"
     }
 
-    "link the error line if play.editor is configured" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("play.editor" -> "someEditorLinkWith %s:%s")
-    )) {
+    "link the error line if play.editor is configured" in new WithApplication(
+      _.configure("play.editor" -> "someEditorLinkWith %s:%s")
+    ) {
       val result = app.errorHandler.onServerError(FakeRequest(), testExceptionSource)
       contentAsString(result) must contain("""href="someEditorLinkWith someSourceFile:100" """)
     }

--- a/framework/src/play-java-jdbc/src/test/scala/play/db/DBSpec.scala
+++ b/framework/src/play-java-jdbc/src/test/scala/play/db/DBSpec.scala
@@ -1,5 +1,6 @@
 package play.db
 
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeApplication
 
 object DBSpec extends org.specs2.mutable.Specification {
@@ -48,9 +49,9 @@ object DBSpec extends org.specs2.mutable.Specification {
 
   lazy val fakeApp = {
     acolyte.jdbc.Driver.register("test", acolyte.jdbc.CompositeHandler.empty())
-    FakeApplication(additionalConfiguration = Map(
+    GuiceApplicationBuilder().configure(
       "db.default.driver" -> "acolyte.jdbc.Driver",
-      "db.default.url" -> "jdbc:acolyte:test?handler=test"))
-
+      "db.default.url" -> "jdbc:acolyte:test?handler=test"
+    ).build()
   }
 }

--- a/framework/src/play-java-ws/src/test/scala/play/libs/ws/WSSpec.scala
+++ b/framework/src/play-java-ws/src/test/scala/play/libs/ws/WSSpec.scala
@@ -1,5 +1,6 @@
 package play.libs.ws
 
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.{ Result, Action }
 import play.api.mvc.Results._
 import play.api.test._
@@ -8,7 +9,7 @@ object WSSpec extends PlaySpecification {
 
   sequential
 
-  val uploadApp = FakeApplication(withRoutes = {
+  val uploadApp = GuiceApplicationBuilder().routes {
     case ("POST", "/") =>
       Action { request =>
         request.body.asRaw.fold[Result](BadRequest) { raw =>
@@ -16,7 +17,7 @@ object WSSpec extends PlaySpecification {
           Ok(s"size=$size")
         }
       }
-  })
+  }.build()
 
   "post(InputStream)" should {
     "upload the stream" in new WithServer(app = uploadApp, port = 3333) {

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/ConnectionPoolConfigSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/ConnectionPoolConfigSpec.scala
@@ -3,19 +3,16 @@
  */
 package play.api.db
 
-import javax.inject.Inject
 import play.api.test._
 
 class ConnectionPoolConfigSpec extends PlaySpecification {
 
   "DBModule bindings" should {
 
-    "use HikariCP when default pool is default" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map(
-        "db.default.url" -> "jdbc:h2:mem:default",
-        "db.other.driver" -> "org.h2.Driver",
-        "db.other.url" -> "jdbc:h2:mem:other"
-      )
+    "use HikariCP when default pool is default" in new WithApplication(_.configure(
+      "db.default.url" -> "jdbc:h2:mem:default",
+      "db.other.driver" -> "org.h2.Driver",
+      "db.other.url" -> "jdbc:h2:mem:other"
     )) {
       val db = app.injector.instanceOf[DBApi]
       db.database("default").withConnection { c =>
@@ -23,13 +20,11 @@ class ConnectionPoolConfigSpec extends PlaySpecification {
       }
     }
 
-    "use HikariCP when default pool is 'hikaricp'" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map(
-        "play.db.pool" -> "hikaricp",
-        "db.default.url" -> "jdbc:h2:mem:default",
-        "db.other.driver" -> "org.h2.Driver",
-        "db.other.url" -> "jdbc:h2:mem:other"
-      )
+    "use HikariCP when default pool is 'hikaricp'" in new WithApplication(_.configure(
+      "play.db.pool" -> "hikaricp",
+      "db.default.url" -> "jdbc:h2:mem:default",
+      "db.other.driver" -> "org.h2.Driver",
+      "db.other.url" -> "jdbc:h2:mem:other"
     )) {
       val db = app.injector.instanceOf[DBApi]
       db.database("default").withConnection { c =>
@@ -37,13 +32,11 @@ class ConnectionPoolConfigSpec extends PlaySpecification {
       }
     }
 
-    "use BoneCP when default pool is 'bonecp'" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map(
-        "play.db.pool" -> "bonecp",
-        "db.default.url" -> "jdbc:h2:mem:default",
-        "db.other.driver" -> "org.h2.Driver",
-        "db.other.url" -> "jdbc:h2:mem:other"
-      )
+    "use BoneCP when default pool is 'bonecp'" in new WithApplication(_.configure(
+      "play.db.pool" -> "bonecp",
+      "db.default.url" -> "jdbc:h2:mem:default",
+      "db.other.driver" -> "org.h2.Driver",
+      "db.other.url" -> "jdbc:h2:mem:other"
     )) {
       val db = app.injector.instanceOf[DBApi]
       db.database("default").withConnection { c =>
@@ -51,14 +44,12 @@ class ConnectionPoolConfigSpec extends PlaySpecification {
       }
     }
 
-    "use BoneCP with 'bonecp' specific settings" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map(
-        "play.db.pool" -> "bonecp",
-        "db.default.url" -> "jdbc:h2:mem:default",
-        "db.other.driver" -> "org.h2.Driver",
-        "db.other.url" -> "jdbc:h2:mem:other",
-        "play.db.prototype.bonecp.maxConnectionsPerPartition" -> "50"
-      )
+    "use BoneCP with 'bonecp' specific settings" in new WithApplication(_.configure(
+      "play.db.pool" -> "bonecp",
+      "db.default.url" -> "jdbc:h2:mem:default",
+      "db.other.driver" -> "org.h2.Driver",
+      "db.other.url" -> "jdbc:h2:mem:other",
+      "play.db.prototype.bonecp.maxConnectionsPerPartition" -> "50"
     )) {
       import com.jolbox.bonecp.BoneCPDataSource
       val db = app.injector.instanceOf[DBApi]

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/NamedDatabaseSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/NamedDatabaseSpec.scala
@@ -10,13 +10,11 @@ class NamedDatabaseSpec extends PlaySpecification {
 
   "DBModule" should {
 
-    "bind databases by name" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map(
-        "db.default.driver" -> "org.h2.Driver",
-        "db.default.url" -> "jdbc:h2:mem:default",
-        "db.other.driver" -> "org.h2.Driver",
-        "db.other.url" -> "jdbc:h2:mem:other"
-      )
+    "bind databases by name" in new WithApplication(_.configure(
+      "db.default.driver" -> "org.h2.Driver",
+      "db.default.url" -> "jdbc:h2:mem:default",
+      "db.other.driver" -> "org.h2.Driver",
+      "db.other.url" -> "jdbc:h2:mem:other"
     )) {
       app.injector.instanceOf[DBApi].databases must have size (2)
       app.injector.instanceOf[DefaultComponent].db.url must_== "jdbc:h2:mem:default"
@@ -24,11 +22,9 @@ class NamedDatabaseSpec extends PlaySpecification {
       app.injector.instanceOf[NamedOtherComponent].db.url must_== "jdbc:h2:mem:other"
     }
 
-    "not bind default databases without configuration" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map(
-        "db.other.driver" -> "org.h2.Driver",
-        "db.other.url" -> "jdbc:h2:mem:other"
-      )
+    "not bind default databases without configuration" in new WithApplication(_.configure(
+      "db.other.driver" -> "org.h2.Driver",
+      "db.other.url" -> "jdbc:h2:mem:other"
     )) {
       app.injector.instanceOf[DBApi].databases must have size (1)
       app.injector.instanceOf[DefaultComponent] must throwA[com.google.inject.ConfigurationException]
@@ -36,34 +32,30 @@ class NamedDatabaseSpec extends PlaySpecification {
       app.injector.instanceOf[NamedOtherComponent].db.url must_== "jdbc:h2:mem:other"
     }
 
-    "not bind databases without configuration" in new WithApplication(FakeApplication()) {
+    "not bind databases without configuration" in new WithApplication() {
       app.injector.instanceOf[DBApi].databases must beEmpty
       app.injector.instanceOf[DefaultComponent] must throwA[com.google.inject.ConfigurationException]
       app.injector.instanceOf[NamedDefaultComponent] must throwA[com.google.inject.ConfigurationException]
       app.injector.instanceOf[NamedOtherComponent] must throwA[com.google.inject.ConfigurationException]
     }
 
-    "allow default database name to be configured" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map(
-        "play.db.default" -> "other",
-        "db.other.driver" -> "org.h2.Driver",
-        "db.other.url" -> "jdbc:h2:mem:other"
-      )
+    "allow default database name to be configured" in new WithApplication(_.configure(
+      "play.db.default" -> "other",
+      "db.other.driver" -> "org.h2.Driver",
+      "db.other.url" -> "jdbc:h2:mem:other"
     )) {
-      app.injector.instanceOf[DBApi].databases must have size (1)
+      app.injector.instanceOf[DBApi].databases must have size 1
       app.injector.instanceOf[DefaultComponent].db.url must_== "jdbc:h2:mem:other"
       app.injector.instanceOf[NamedOtherComponent].db.url must_== "jdbc:h2:mem:other"
       app.injector.instanceOf[NamedDefaultComponent] must throwA[com.google.inject.ConfigurationException]
     }
 
-    "allow db config key to be configured" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map(
-        "play.db.config" -> "databases",
-        "databases.default.driver" -> "org.h2.Driver",
-        "databases.default.url" -> "jdbc:h2:mem:default"
-      )
+    "allow db config key to be configured" in new WithApplication(_.configure(
+      "play.db.config" -> "databases",
+      "databases.default.driver" -> "org.h2.Driver",
+      "databases.default.url" -> "jdbc:h2:mem:default"
     )) {
-      app.injector.instanceOf[DBApi].databases must have size (1)
+      app.injector.instanceOf[DBApi].databases must have size 1
       app.injector.instanceOf[DefaultComponent].db.url must_== "jdbc:h2:mem:default"
       app.injector.instanceOf[NamedDefaultComponent].db.url must_== "jdbc:h2:mem:default"
     }

--- a/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala
+++ b/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala
@@ -7,9 +7,9 @@ import org.openqa.selenium.WebDriver
 import org.specs2.execute.{ AsResult, Result }
 import org.specs2.mutable.Around
 import org.specs2.specification.Scope
-import play.api.inject.guice.GuiceApplicationLoader
+import play.api.inject.guice.{GuiceApplicationBuilder, GuiceApplicationLoader}
 import play.api.{ Application, ApplicationLoader, Environment, Mode }
-import play.core.server.{ NettyServer, ServerProvider }
+import play.core.server.{ ServerProvider }
 
 // NOTE: Do *not* put any initialisation code in the below classes, otherwise delayedInit() gets invoked twice
 // which means around() gets invoked twice and everything is not happy.  Only lazy vals and defs are allowed, no vals
@@ -33,7 +33,12 @@ abstract class WithApplicationLoader(applicationLoader: ApplicationLoader = new 
  *
  * @param app The fake application
  */
-abstract class WithApplication(val app: Application = FakeApplication()) extends Around with Scope {
+abstract class WithApplication(val app: Application = GuiceApplicationBuilder().build()) extends Around with Scope {
+
+  def this(builder: GuiceApplicationBuilder => GuiceApplicationBuilder) {
+    this(builder(GuiceApplicationBuilder()).build())
+  }
+
   implicit def implicitApp = app
   implicit def implicitMaterializer = app.materializer
   override def around[T: AsResult](t: => T): Result = {
@@ -50,7 +55,7 @@ abstract class WithApplication(val app: Application = FakeApplication()) extends
  * server to use. Defaults to providing a Netty server.
  */
 abstract class WithServer(
-    val app: Application = FakeApplication(),
+    val app: Application = GuiceApplicationBuilder().build(),
     val port: Int = Helpers.testServerPort,
     val serverProvider: Option[ServerProvider] = None) extends Around with Scope {
   implicit def implicitMaterializer = app.materializer
@@ -73,7 +78,7 @@ abstract class WithServer(
  */
 abstract class WithBrowser[WEBDRIVER <: WebDriver](
     val webDriver: WebDriver = WebDriverFactory(Helpers.HTMLUNIT),
-    val app: Application = FakeApplication(),
+    val app: Application = GuiceApplicationBuilder().build(),
     val port: Int = Helpers.testServerPort) extends Around with Scope {
 
   def this(

--- a/framework/src/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
+++ b/framework/src/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeUnit
 
 import akka.stream.Materializer
 import akka.util.ByteString
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
 
 import play.api.test.Helpers._
@@ -24,14 +25,11 @@ object FakesSpec extends PlaySpecification {
   "FakeApplication" should {
 
     "allow adding routes inline" in {
-      val app = new FakeApplication(
-        withRoutes = {
-          case ("GET", "/inline") => Action {
-            Results.Ok("inline route")
-          }
+      running(_.routes {
+        case ("GET", "/inline") => Action {
+          Results.Ok("inline route")
         }
-      )
-      running(app) {
+      }) { app =>
         route(app, FakeRequest("GET", "/inline")) must beSome.which { result =>
           status(result) must equalTo(OK)
           contentAsString(result) must equalTo("inline route")
@@ -44,13 +42,11 @@ object FakesSpec extends PlaySpecification {
   }
 
   "FakeRequest" should {
-    def app = new FakeApplication(
-      withRoutes = {
-        case (PUT, "/process") => Action { req =>
-          Results.Ok(req.headers.get(CONTENT_TYPE) getOrElse "")
-        }
+    def app = GuiceApplicationBuilder().routes {
+      case (PUT, "/process") => Action { req =>
+        Results.Ok(req.headers.get(CONTENT_TYPE) getOrElse "")
       }
-    )
+    }.build()
 
     "Define Content-Type header based on body" in new WithApplication(app) {
       val xml =

--- a/framework/src/play-specs2/src/test/scala/play/api/test/SpecsSpec.scala
+++ b/framework/src/play-specs2/src/test/scala/play/api/test/SpecsSpec.scala
@@ -10,17 +10,16 @@ import play.api.{ Play, Application }
 
 object SpecsSpec extends Specification {
 
-  def fakeApp[A](elems: (String, String)*) = FakeApplication(additionalConfiguration = Map(elems: _*))
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 
   "WithApplication context" should {
-    "provide an app" in new WithApplication(fakeApp("foo" -> "bar", "ehcacheplugin" -> "disabled")) {
+    "provide an app" in new WithApplication(_.configure("foo" -> "bar", "ehcacheplugin" -> "disabled")) {
       app.configuration.getString("foo") must beSome("bar")
     }
-    "make the app available implicitly" in new WithApplication(fakeApp("foo" -> "bar", "ehcacheplugin" -> "disabled")) {
+    "make the app available implicitly" in new WithApplication(_.configure("foo" -> "bar", "ehcacheplugin" -> "disabled")) {
       getConfig("foo") must beSome("bar")
     }
-    "start the application" in new WithApplication(fakeApp("foo" -> "bar", "ehcacheplugin" -> "disabled")) {
+    "start the application" in new WithApplication(_.configure("foo" -> "bar", "ehcacheplugin" -> "disabled")) {
       //noinspection ScalaDeprecation
       Play.maybeApplication must beSome(app)
     }

--- a/framework/src/play-test/src/main/java/play/test/FakeApplication.java
+++ b/framework/src/play-test/src/main/java/play/test/FakeApplication.java
@@ -4,8 +4,6 @@
 package play.test;
 
 import java.io.File;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import play.api.mvc.Handler;
@@ -15,7 +13,10 @@ import play.libs.Scala;
 
 /**
  * A fake application for testing.
+ *
+ * @deprecated as of 2.5.0. Use GuiceApplicationBuilder to build your application instance.
  */
+@Deprecated
 public class FakeApplication implements play.Application {
 
     private final play.api.test.FakeApplication application;

--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -12,7 +12,6 @@ import play.routing.Router;
 import play.api.test.PlayRunners$;
 import play.core.j.JavaHandler;
 import play.core.j.JavaHandlerComponents;
-import play.core.j.JavaResultExtractor;
 import play.http.HttpEntity;
 import play.mvc.*;
 import play.api.test.Helpers$;
@@ -121,7 +120,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Build a new fake application.
      */
-    public static FakeApplication fakeApplication() {
+    public static Application fakeApplication() {
         return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(), new HashMap<String,Object>(), null);
     }
 
@@ -131,7 +130,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * @deprecated Use dependency injection (since 2.5.0)
      */
     @Deprecated
-    public static FakeApplication fakeApplication(GlobalSettings global) {
+    public static Application fakeApplication(GlobalSettings global) {
         return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(), new HashMap<String,Object>(), global);
     }
 
@@ -146,21 +145,21 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     }
 
     /**
-     * Constructs a in-memory (h2) database configuration to add to a FakeApplication.
+     * Constructs a in-memory (h2) database configuration to add to a fake application.
      */
     public static Map<String,String> inMemoryDatabase() {
         return inMemoryDatabase("default");
     }
 
     /**
-     * Constructs a in-memory (h2) database configuration to add to a FakeApplication.
+     * Constructs a in-memory (h2) database configuration to add to a fake application.
      */
     public static Map<String,String> inMemoryDatabase(String name) {
         return inMemoryDatabase(name, Collections.<String, String>emptyMap());
     }
 
     /**
-     * Constructs a in-memory (h2) database configuration to add to a FakeApplication.
+     * Constructs a in-memory (h2) database configuration to add to a fake application.
      */
     public static Map<String,String> inMemoryDatabase(String name, Map<String, String> options) {
         return Scala.asJava(play.api.test.Helpers.inMemoryDatabase(name, Scala.asScala(options)));
@@ -169,7 +168,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Build a new fake application.
      */
-    public static FakeApplication fakeApplication(Map<String, ? extends Object> additionalConfiguration) {
+    public static Application fakeApplication(Map<String, ? extends Object> additionalConfiguration) {
         return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(), additionalConfiguration);
     }
 
@@ -179,7 +178,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * @deprecated Use the version without GlobalSettings (since 2.5.0)
      */
     @Deprecated
-    public static FakeApplication fakeApplication(Map<String, ? extends Object> additionalConfiguration, GlobalSettings global) {
+    public static Application fakeApplication(Map<String, ? extends Object> additionalConfiguration, GlobalSettings global) {
         return new FakeApplication(new java.io.File("."), Helpers.class.getClassLoader(), additionalConfiguration, global);
     }
 
@@ -400,7 +399,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     }
 
     /**
-     * Creates a new Test server listening on port defined by configuration setting "testserver.port" (defaults to 19001) and using the given FakeApplication.
+     * Creates a new Test server listening on port defined by configuration setting "testserver.port" (defaults to 19001) and using the given Application.
      */
     public static TestServer testServer(Application app) {
         return testServer(play.api.test.Helpers.testServerPort(), app);

--- a/framework/src/play-test/src/main/java/play/test/WithApplication.java
+++ b/framework/src/play-test/src/main/java/play/test/WithApplication.java
@@ -34,13 +34,15 @@ public class WithApplication {
     }
 
     /**
-     * Old method - use the new {@link #provideApplication() provideApplication} method instead.
      *
      * Override this method to setup the fake application to use.
      *
+     * @deprecated use the new {@link #provideApplication() provideApplication} method instead.
+     *
      * @return The fake application to use
      */
-    protected FakeApplication provideFakeApplication() {
+    @Deprecated
+    protected Application provideFakeApplication() {
         return Helpers.fakeApplication();
     }
 

--- a/framework/src/play-test/src/main/java/play/test/WithServer.java
+++ b/framework/src/play-test/src/main/java/play/test/WithServer.java
@@ -30,13 +30,14 @@ public class WithServer {
     }
 
     /**
-     * Old method - use the new {@link #provideApplication() provideApplication} method instead.
-     *
      * Override this method to setup the fake application to use.
+     *
+     * @deprecated use the new {@link #provideApplication() provideApplication} method instead.
      *
      * @return The fake application used by the server
      */
-    protected FakeApplication provideFakeApplication() {
+    @Deprecated
+    protected Application provideFakeApplication() {
         return Helpers.fakeApplication();
     }
 

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -6,6 +6,7 @@ package play.api.test
 import akka.actor.Cancellable
 import akka.stream.{ ClosedShape, Graph, Materializer }
 import akka.stream.scaladsl.Source
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.mvc.Http.RequestBody
 
 import scala.language.reflectiveCalls
@@ -37,6 +38,16 @@ trait PlayRunners extends HttpVerbs {
   val FIREFOX = classOf[FirefoxDriver]
 
   /**
+    * The base builder used in the running method.
+    */
+  lazy val baseApplicationBuilder = new GuiceApplicationBuilder()
+
+  def running[T]()(block: Application => T): T = {
+    val app = baseApplicationBuilder.build()
+    running(app)(block(app))
+  }
+
+  /**
    * Executes a block of code in a running application.
    */
   def running[T](app: Application)(block: => T): T = {
@@ -48,6 +59,11 @@ trait PlayRunners extends HttpVerbs {
         Play.stop(app)
       }
     }
+  }
+
+  def running[T](builder: GuiceApplicationBuilder => GuiceApplicationBuilder)(block: Application => T): T = {
+    val app = builder(baseApplicationBuilder).build()
+    running(app)(block(app))
   }
 
   /**

--- a/framework/src/play-test/src/main/scala/play/api/test/TestServer.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/TestServer.scala
@@ -4,7 +4,7 @@
 package play.api.test
 
 import play.api._
-import play.core.ApplicationProvider
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.core.server._
 import scala.util.control.NonFatal
 
@@ -19,7 +19,7 @@ import scala.util.control.NonFatal
  */
 case class TestServer(
     port: Int,
-    application: Application = FakeApplication(),
+    application: Application = GuiceApplicationBuilder().build(),
     sslPort: Option[Int] = None,
     serverProvider: Option[ServerProvider] = None) {
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/oauth/OAuthSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/oauth/OAuthSpec.scala
@@ -5,6 +5,7 @@ package play.api.libs.oauth
 
 import akka.util.ByteString
 import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.WS
 import play.api.mvc._
 import play.api.test._
@@ -49,12 +50,12 @@ class OAuthSpec extends PlaySpecification {
   def receiveRequest(makeRequest: Application => String => Future[_]): (RequestHeader, ByteString, String) = {
     val hostUrl = "http://localhost:" + testServerPort
     val promise = Promise[(RequestHeader, ByteString)]()
-    val app = FakeApplication(withRoutes = {
+    val app = GuiceApplicationBuilder().routes {
       case _ => Action(BodyParsers.parse.raw) { request =>
         promise.success((request, request.body.asBytes().getOrElse(ByteString.empty)))
         Results.Ok
       }
-    })
+    }.build()
     running(TestServer(testServerPort, app)) {
       await(makeRequest(app)(hostUrl))
     }

--- a/framework/src/play/src/test/scala/play/api/PlayCoreTestApplication.scala
+++ b/framework/src/play/src/test/scala/play/api/PlayCoreTestApplication.scala
@@ -12,10 +12,9 @@ import java.io.File
  * Fake application as used by Play core tests.  This is needed since Play core can't depend on the Play test API.
  * It's also a lot simpler, doesn't load default config files etc.
  */
-case class FakeApplication(config: Map[String, Any] = Map(),
+private[play] case class PlayCoreTestApplication(config: Map[String, Any] = Map(),
     path: File = new File("."),
-    mode: Mode.Mode = Mode.Test,
-    override val global: GlobalSettings.Deprecated = DefaultGlobal) extends Application {
+    mode: Mode.Mode = Mode.Test) extends Application {
   val classloader = Thread.currentThread.getContextClassLoader
   lazy val configuration = Configuration.from(config)
   private val lazyActorSystem = ActorSystemProvider.lazyStart(classloader, configuration)

--- a/framework/src/play/src/test/scala/play/utils/ResourcesSpec.scala
+++ b/framework/src/play/src/test/scala/play/utils/ResourcesSpec.scala
@@ -1,11 +1,11 @@
 package play.utils
 
 import java.io.{ FileInputStream, BufferedInputStream, File, FileOutputStream }
-import java.net.{ URI, URLEncoder, URL, URLConnection, URLStreamHandler }
+import java.net.{ URL, URLConnection, URLStreamHandler }
 import java.util.zip.{ ZipEntry, ZipOutputStream }
 import org.specs2.mutable.Specification
 
-import play.api.FakeApplication
+import play.api.PlayCoreTestApplication
 
 /**
  * Tests for Resources object
@@ -13,7 +13,7 @@ import play.api.FakeApplication
 object ResourcesSpec extends Specification {
   import Resources._
 
-  lazy val app = FakeApplication()
+  lazy val app = PlayCoreTestApplication()
   lazy val tmpDir = createTempDir("resources-", ".tmp")
   lazy val jar = File.createTempFile("jar-", ".tmp", tmpDir)
   lazy val fileRes = File.createTempFile("file-", ".tmp", tmpDir)


### PR DESCRIPTION
I changed the documentation and most of the tests to use `GuiceApplicationBuilder` to create applications instead of `FakeApplication`.

I also renamed `play.api.FakeApplication` to `play.api.PlayCoreTestApplication`.

The Java test helpers have been changed to return `Application`. This shouldn't really be a breaking change for most people since most of our test APIs were already changed to accept all types of `Application`.

Fixes #5549