### PR TITLE
Option against String will always yield false

### DIFF
--- a/framework/src/play-cache/src/main/scala/play/api/cache/Cached.scala
+++ b/framework/src/play-cache/src/main/scala/play/api/cache/Cached.scala
@@ -189,7 +189,7 @@ final class CachedBuilder(
     val notModified = for {
       requestEtag <- request.headers.get(IF_NONE_MATCH)
       etag <- cache.get[String](etagKey)
-      if requestEtag == "*" || etag == requestEtag
+      if requestEtag.contains("*") || etag == requestEtag
     } yield Accumulator.done(NotModified)
 
     notModified.orElse {


### PR DESCRIPTION
In Line 192 of Cached.scala, requestETag, Option[String], is using "==" with "*"