### PR TITLE
Add a test and a note for bonecp settings

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/SettingsJDBC.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsJDBC.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com> -->
 # Configuring the JDBC pool.
 
-The Play JDBC datasource is managed by [HikariCP](https://brettwooldridge.github.io/HikariCP/). 
+The Play JDBC datasource is managed by [HikariCP](https://brettwooldridge.github.io/HikariCP/).
 
 ## Special URLs
 
@@ -25,9 +25,15 @@ db.default.url="mysql://user:password@localhost:port/database"
 db.default.url="postgres://user:password@localhost:port/database"
 ```
 
-
 ## Reference
 
 In addition to the classical `driver`, `url`, `username`, `password` configuration properties, it also supports additional tuning parameters if you need them.  The `play.db.prototype` configuration from the Play JDBC `reference.conf` is used as the prototype for the configuration for all database connections.  The defaults for all the available configuration options can be seen here:
 
 @[](/confs/play-jdbc/reference.conf)
+
+When you need to specify some settings for a connection pool, you can override the prototype settings.  For example, to set the default connection pool for BoneCP and set maxConnectionsPerPartition for the default pool, you would set the following in your `application.conf` file:
+
+```
+play.db.pool=bonecp
+play.db.prototype.bonecp.maxConnectionsPerPartition = 50
+```

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/ConnectionPoolConfigSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/ConnectionPoolConfigSpec.scala
@@ -51,6 +51,22 @@ class ConnectionPoolConfigSpec extends PlaySpecification {
       }
     }
 
+    "use BoneCP with 'bonecp' specific settings" in new WithApplication(FakeApplication(
+      additionalConfiguration = Map(
+        "play.db.pool" -> "bonecp",
+        "db.default.url" -> "jdbc:h2:mem:default",
+        "db.other.driver" -> "org.h2.Driver",
+        "db.other.url" -> "jdbc:h2:mem:other",
+        "play.db.prototype.bonecp.maxConnectionsPerPartition" -> "50"
+      )
+    )) {
+      import com.jolbox.bonecp.BoneCPDataSource
+      val db = app.injector.instanceOf[DBApi]
+      val bonecpDataSource: BoneCPDataSource = db.database("default").dataSource.asInstanceOf[BoneCPDataSource]
+      val bonecpConfig = bonecpDataSource.getConfig
+      bonecpConfig.getMaxConnectionsPerPartition must be_==(50)
+    }
+
     "use BoneCP when database-specific pool is 'bonecp'" in new WithApplication(FakeApplication(
       additionalConfiguration = Map(
         "db.default.pool" -> "bonecp",


### PR DESCRIPTION
The JDBC settings page is missing an example of how to override the connection pool settings.  Added a test and some notes.