### PR TITLE
[doc] Add a test for single static file

### DIFF
--- a/documentation/manual/working/commonGuide/assets/AssetsOverview.md
+++ b/documentation/manual/working/commonGuide/assets/AssetsOverview.md
@@ -52,9 +52,7 @@ The `path` parameter must be fixed and defines the directory managed by the acti
 
 Here is the typical mapping of the `Assets` controller in your `conf/routes` file:
 
-```
-GET  /assets/*file        controllers.Assets.at(path="/public", file)
-```
+@[assets-wildcard](code/routes)
 
 Note that we define the `*file` dynamic part that will match the `.*` regular expression. So for example, if you send this request to the server:
 
@@ -68,7 +66,9 @@ The router will invoke the `Assets.at` action with the following parameters:
 controllers.Assets.at("/public", "javascripts/jquery.js")
 ```
 
-This action will look-up and serve the file and if it exists.
+To route to a single static file, both the path and file has to be specified:
+
+@[assets-single-static-file](code/routes)
 
 ## Reverse routing for public assets
 
@@ -88,10 +88,7 @@ Note that we don’t specify the first `folder` parameter when we reverse the ro
 
 However, if you define two mappings for the `Assets.at` action, like this:
 
-```
-GET  /javascripts/*file        controllers.Assets.at(path="/public/javascripts", file)
-GET  /images/*file             controllers.Assets.at(path="/public/images", file)
-```
+@[assets-two-mappings](code/routes)
 
 You will then need to specify both parameters when using the reverse router:
 

--- a/documentation/manual/working/commonGuide/assets/code/routes
+++ b/documentation/manual/working/commonGuide/assets/code/routes
@@ -1,0 +1,12 @@
+#assets-wildcard
+GET  /assets/*file        controllers.Assets.at(path="/public", file)
+#assets-wildcard
+
+#assets-single-static-file
+GET  /favicon.ico        controllers.Assets.at(path="/public", file="favicon.ico")
+#assets-single-static-file
+
+#assets-two-mappings
+GET  /javascripts/*file        controllers.Assets.at(path="/public/javascripts", file)
+GET  /images/*file             controllers.Assets.at(path="/public/images", file)
+#assets-two-mappings

--- a/documentation/manual/working/commonGuide/build/SBTSubProjects.md
+++ b/documentation/manual/working/commonGuide/build/SBTSubProjects.md
@@ -186,7 +186,7 @@ GET     /assets/*file       controllers.Assets.at(path="/public", file)
 
 `modules/admin/conf/admin.routes`:
 
-@[assets-routes](code/detailedtopics.build.subprojects.assets.routes)
+@[assets-routes](code/routes)
 
 > **Note:** Resources are served from a unique classloader, and thus resource path must be relative from project classpath root.
 > Subprojects resources are generated in `target/web/public/main/lib/{module-name}`, so the resources are accessible from `/public/lib/{module-name}` when using `play.api.Application#resources(uri)` method, which is what the `Assets.at` method does.

--- a/documentation/manual/working/commonGuide/build/code/routes
+++ b/documentation/manual/working/commonGuide/build/code/routes
@@ -1,5 +1,5 @@
 #assets-routes
 GET /index                  controllers.admin.Application.index()
 
-GET /assets/*file           controllers.admin.Assets.at(path="/public/lib/myadmin", file)
+GET /assets/*file           controllers.Assets.at(path="/public/lib/myadmin", file)
 #assets-routes

--- a/documentation/project/Build.scala
+++ b/documentation/project/Build.scala
@@ -31,6 +31,7 @@ object ApplicationBuild extends Build {
 
     PlayDocsKeys.javaManualSourceDirectories := (baseDirectory.value / "manual" / "working" / "javaGuide" ** "code").get,
     PlayDocsKeys.scalaManualSourceDirectories := (baseDirectory.value / "manual" / "working" / "scalaGuide" ** "code").get,
+    PlayDocsKeys.commonManualSourceDirectories := (baseDirectory.value / "manual" / "working" / "commonGuide" ** "code").get,
 
     unmanagedSourceDirectories in Test ++= (baseDirectory.value / "manual" / "detailedTopics" ** "code").get,
     unmanagedResourceDirectories in Test ++= (baseDirectory.value / "manual" / "detailedTopics" ** "code").get,

--- a/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
+++ b/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
@@ -41,6 +41,7 @@ object Imports {
 
     val javaManualSourceDirectories = SettingKey[Seq[File]]("javaManualSourceDirectories")
     val scalaManualSourceDirectories = SettingKey[Seq[File]]("scalaManualSourceDirectories")
+    val commonManualSourceDirectories = SettingKey[Seq[File]]("commonManualSourceDirectories")
     val javaTwirlSourceManaged = SettingKey[File]("javaRoutesSourceManaged")
     val scalaTwirlSourceManaged = SettingKey[File]("scalaRoutesSourceManaged")
 
@@ -128,7 +129,8 @@ object PlayDocsPlugin extends AutoPlugin {
     routesCompilerTasks in Test := {
       val javaRoutes = (javaManualSourceDirectories.value * "*.routes").get
       val scalaRoutes = (scalaManualSourceDirectories.value * "*.routes").get
-      (javaRoutes.map(_ -> Seq("play.libs.F")) ++ scalaRoutes.map(_ -> Nil)).map {
+      val commonRoutes = (commonManualSourceDirectories.value * "*.routes").get
+      (javaRoutes.map(_ -> Seq("play.libs.F")) ++ scalaRoutes.map(_ -> Nil) ++ commonRoutes.map(_ -> Nil)).map {
         case (file, imports) => RoutesCompilerTask(file, imports, true, true, true)
       }
     },


### PR DESCRIPTION
Pulls in the logic from https://github.com/playframework/playframework/pull/4922 and adds a test to make sure at least the routes file will parse okay, as per 4922 review.

This turns out to be a bit more complex because all the routes file are in commonGuide, so needed to change up the build file to add commonGuide to the build.  This in tern required that the routes files be changed so they weren't under the package mapping scheme (which now caused compilation errors).

Also moves some other routes into code snippets as well, although I did not attempt a full sweep.