### PR TITLE
Improve GzipFilter configuration from Java

### DIFF
--- a/documentation/manual/working/commonGuide/filters/GzipEncoding.md
+++ b/documentation/manual/working/commonGuide/filters/GzipEncoding.md
@@ -33,4 +33,8 @@ To control which responses are and aren't implemented, use the `shouldGzip` para
 
 For example, the code below only gzips HTML responses:
 
-@[should-gzip](code/GzipEncoding.scala)
+Scala
+: @[should-gzip](code/GzipEncoding.scala)
+
+Java
+: @[gzip-filter](code/detailedtopics/configuration/gzipencoding/CustomFilters.java)

--- a/documentation/manual/working/commonGuide/filters/code/GzipEncoding.scala
+++ b/documentation/manual/working/commonGuide/filters/code/GzipEncoding.scala
@@ -5,6 +5,7 @@ package detailedtopics.configuration.gzipencoding
 
 import akka.stream.ActorMaterializer
 import play.api.test._
+import detailedtopics.configuration.gzipencoding.CustomFilters
 
 object GzipEncoding extends PlaySpecification {
 
@@ -21,7 +22,7 @@ object GzipEncoding extends PlaySpecification {
 
   "gzip filter" should {
 
-    "allow custom strategies for when to gzip" in {
+    "allow custom strategies for when to gzip (Scala)" in {
 
       import play.api.mvc._
       val app = FakeApplication()
@@ -33,6 +34,21 @@ object GzipEncoding extends PlaySpecification {
           new GzipFilter(shouldGzip = (request, response) =>
             response.body.contentType.exists(_.startsWith("text/html")))
         //#should-gzip
+
+        header(CONTENT_ENCODING,
+          filter(Action(Results.Ok("foo")))(gzipRequest).run()
+        ) must beNone
+      }
+    }
+
+    "allow custom strategies for when to gzip (Java)" in {
+
+      import play.api.mvc._
+      val app = FakeApplication()
+      running(app) {
+        implicit val mat = ActorMaterializer()(app.actorSystem)
+
+        val filter = (new CustomFilters).gzipFilter
 
         header(CONTENT_ENCODING,
           filter(Action(Results.Ok("foo")))(gzipRequest).run()

--- a/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/gzipencoding/CustomFilters.java
+++ b/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/gzipencoding/CustomFilters.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package detailedtopics.configuration.gzipencoding;
+
+import play.api.mvc.EssentialFilter;
+import play.filters.gzip.GzipFilter;
+import play.filters.gzip.GzipFilterConfig;
+import play.http.HttpFilters;
+
+import javax.inject.Inject;
+
+public class CustomFilters implements HttpFilters {
+
+    //#gzip-filter
+    GzipFilter gzipFilter = new GzipFilter(
+      new GzipFilterConfig().withShouldGzip((req, res) ->
+        res.body().contentType().orElse("").startsWith("text/html")
+      )
+    );
+    //#gzip-filter
+
+    public EssentialFilter[] filters() {
+        return new EssentialFilter[] { gzipFilter };
+    }
+}


### PR DESCRIPTION
In general, I think our built in filters can accept `Config` classes that that use the builder pattern. 

/cc @mkurz 