### PR TITLE
Fix broken test compilation on Play.privateMaybeApplication

### DIFF
--- a/framework/src/play-test/src/test/java/play/test/WithApplicationTest.java
+++ b/framework/src/play-test/src/test/java/play/test/WithApplicationTest.java
@@ -22,6 +22,6 @@ public class WithApplicationTest extends WithApplication {
     public void withApplicationShouldCleanUpApplication() {
         stopPlay();
         assertNull(app);
-        assertTrue(play.api.Play.privateMaybeApplication().isEmpty());
+        assertTrue(play.api.Play.maybeApplication().isEmpty());
     }
 }


### PR DESCRIPTION
This happens on a clean master:

```
[error] /home/travis/build/playframework/playframework/framework/src/play-test/src/test/java/play/test/WithApplicationTest.java:25: cannot find symbol
[error]   symbol:   method privateMaybeApplication()
[error]   location: class play.api.Play
[error] play.api.Play.privateMaybeApplication
```