### PR TITLE
Fix some links to external sites in documentation

### DIFF
--- a/documentation/manual/about/PlayUserGroups.md
+++ b/documentation/manual/about/PlayUserGroups.md
@@ -22,10 +22,6 @@ http://www.meetup.com/Play-Berlin-Brandenburg/
 
 http://www.meetup.com/play-argentina/
 
-## Stockholm
-
-http://www.meetup.com/play-stockholm/
-
 ## Belgium
 
 http://www.play-be.org

--- a/documentation/manual/releases/release24/migration24/Migration24.md
+++ b/documentation/manual/releases/release24/migration24/Migration24.md
@@ -456,9 +456,9 @@ Due to the recent spate of TLS vulnerabilities, there has been more activity to 
 
 ## Crypto APIs
 
-Play 2.4's AES encryption now uses [initialization vectors](http://en.wikipedia.org/wiki/Initialization_vector) to randomize each encryption. The Play encryption format has been changed to add support for initialization vectors.
+Play 2.4's AES encryption now uses [initialization vectors](https://en.wikipedia.org/wiki/Initialization_vector) to randomize each encryption. The Play encryption format has been changed to add support for initialization vectors.
 
-The full name of the new AES transformation used by Play 2.4 is `AES/CTR/NoPadding`. The old transformation was `AES/ECB/PKCS5Padding`. The [`CTR`](http://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Counter_.28CTR.29) mode is much more secure than the `ECB` mode. As before, you can override Play's encryption transformation by setting the `play.crypto.aes.transformation` configuration option. In Play 2.4, any [transformation supported by your JRE](http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#Cipher) can be used, including transformations that use an initialization vector.
+The full name of the new AES transformation used by Play 2.4 is `AES/CTR/NoPadding`. The old transformation was `AES/ECB/PKCS5Padding`. The [`CTR`](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Counter_.28CTR.29) mode is much more secure than the `ECB` mode. As before, you can override Play's encryption transformation by setting the `play.crypto.aes.transformation` configuration option. In Play 2.4, any [transformation supported by your JRE](http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#Cipher) can be used, including transformations that use an initialization vector.
 
 Play 2.4 uses a new encryption format, but it can read data encrypted by earlier versions of Play. However, earlier versions of Play **will not** be able to read data encrypted by Play 2.4. If your Play 2.4 application needs to produce data in the old format then you may want to copy the algorithm from the [Play 2.3 Crypto code](https://github.com/playframework/playframework/blob/2.3.6/framework/src/play/src/main/scala/play/api/libs/Crypto.scala#L187-L277).
 

--- a/documentation/manual/working/commonGuide/configuration/ws/LooseSSL.md
+++ b/documentation/manual/working/commonGuide/configuration/ws/LooseSSL.md
@@ -61,7 +61,7 @@ Finally, here are the options themselves.
 > * [[Generating X.509 Certificates|CertificateGeneration]] lists a number of GUI applications that will generate certificates for you.
 > * [[Example Configurations|ExampleSSLConfig]] shows complete configuration of TLS using self signed certificates.
 > * If you want to view your application through HTTPS, you can use [ngrok](https://ngrok.com/) to proxy your application.
-> * If you need a certificate authority but don't want to pay money, [StartSSL](https://www.startssl.com/?app=1) or [CACert](http://www.cacert.org/) will give you a free certificate.
+> * If you need a certificate authority but don't want to pay money, [StartSSL](https://www.startssl.com/Support?v=1) or [CACert](http://www.cacert.org/) will give you a free certificate.
 * If you want a self signed certificate and private key without typing on the command line, you can use [selfsignedcertificate.com](http://www.selfsignedcertificate.com/).
 
 If you've read the above and you still want to completely disable certificate verification, set the following;

--- a/documentation/manual/working/commonGuide/filters/SecurityHeaders.md
+++ b/documentation/manual/working/commonGuide/filters/SecurityHeaders.md
@@ -30,8 +30,8 @@ Scaladoc is available in the [play.filters.headers](api/scala/play/filters/heade
 The filter will set headers in the HTTP response automatically.  The settings can can be configured through the following settings in `application.conf`
 
 * `play.filters.headers.frameOptions` - sets [X-Frame-Options](https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options), "DENY" by default.
-* `play.filters.headers.xssProtection` - sets [X-XSS-Protection](http://blogs.msdn.com/b/ie/archive/2008/07/02/ie8-security-part-iv-the-xss-filter.aspx), "1; mode=block" by default.
-* `play.filters.headers.contentTypeOptions` - sets [X-Content-Type-Options](http://blogs.msdn.com/b/ie/archive/2008/09/02/ie8-security-part-vi-beta-2-update.aspx), "nosniff" by default.
+* `play.filters.headers.xssProtection` - sets [X-XSS-Protection](https://blogs.msdn.microsoft.com/ie/2008/07/02/ie8-security-part-iv-the-xss-filter/), "1; mode=block" by default.
+* `play.filters.headers.contentTypeOptions` - sets [X-Content-Type-Options](https://blogs.msdn.microsoft.com/ie/2008/09/02/ie8-security-part-vi-beta-2-update/), "nosniff" by default.
 * `play.filters.headers.permittedCrossDomainPolicies` - sets [X-Permitted-Cross-Domain-Policies](https://www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html), "master-only" by default.
 * `play.filters.headers.contentSecurityPolicy` - sets [Content-Security-Policy](http://www.html5rocks.com/en/tutorials/security/content-security-policy/), "default-src 'self'" by default.
 

--- a/documentation/manual/working/commonGuide/production/HTTPServer.md
+++ b/documentation/manual/working/commonGuide/production/HTTPServer.md
@@ -41,7 +41,7 @@ $HTTP["host"] =~ "www.loadbalancedapp.com" {
 
 ## Set up with nginx
 
-This example shows you how to configure [nginx](http://wiki.nginx.org/Main) as a front end web server. Note that you can do the same with Apache, but if you only need virtual hosting or load balancing, nginx is a very good choice and much easier to configure!
+This example shows you how to configure [nginx](https://www.nginx.com/resources/wiki/) as a front end web server. Note that you can do the same with Apache, but if you only need virtual hosting or load balancing, nginx is a very good choice and much easier to configure!
 
 The `/etc/nginx/nginx.conf` file should define things like this:
 

--- a/documentation/manual/working/javaGuide/main/sql/JavaDatabase.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaDatabase.md
@@ -143,7 +143,7 @@ libraryDependencies += "mysql" % "mysql-connector-java" % "5.1.36"
 
 ## Selecting and configuring the connection pool
 
-Out of the box, Play provides two database connection pool implementations, [HikariCP](https://github.com/brettwooldridge/HikariCP) and [BoneCP](http://jolbox.com/).  The default is HikariCP, but this can be changed by setting the `play.db.pool` property:
+Out of the box, Play provides two database connection pool implementations, [HikariCP](https://github.com/brettwooldridge/HikariCP) and [BoneCP](http://www.jolbox.com/).  The default is HikariCP, but this can be changed by setting the `play.db.pool` property:
 
 ```
 play.db.pool=bonecp

--- a/documentation/manual/working/javaGuide/main/ws/JavaOAuth.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaOAuth.md
@@ -50,4 +50,4 @@ controller:
 
 @[ws-oauth-controller](code/javaguide/ws/controllers/Twitter.java)
 
-> **NOTE**: OAuth does not provide any protection against [MITM attacks](http://en.wikipedia.org/wiki/Man-in-the-middle_attack).  This example shows the OAuth token and secret stored in a session cookie -- for the best security, always use HTTPS with `play.http.session.secure=true` defined.
+> **NOTE**: OAuth does not provide any protection against [MITM attacks](https://en.wikipedia.org/wiki/Man-in-the-middle_attack).  This example shows the OAuth token and secret stored in a session cookie -- for the best security, always use HTTPS with `play.http.session.secure=true` defined.

--- a/documentation/manual/working/scalaGuide/main/json/ScalaJsonHttp.md
+++ b/documentation/manual/working/scalaGuide/main/json/ScalaJsonHttp.md
@@ -33,7 +33,7 @@ The last step is to add a route for our `Action` in `conf/routes`:
 GET   /places               controllers.Application.listPlaces
 ```
 
-We can test the action by making a request with a browser or HTTP tool. This example uses the unix command line tool [cURL](http://curl.haxx.se/).
+We can test the action by making a request with a browser or HTTP tool. This example uses the unix command line tool [cURL](https://curl.haxx.se/).
 
 ```
 curl --include http://localhost:9000/places

--- a/documentation/manual/working/scalaGuide/main/sql/ScalaDatabase.md
+++ b/documentation/manual/working/scalaGuide/main/sql/ScalaDatabase.md
@@ -156,7 +156,7 @@ For a database other than the default:
 
 ## Selecting and configuring the connection pool
 
-Out of the box, Play provides two database connection pool implementations, [HikariCP](https://github.com/brettwooldridge/HikariCP) and [BoneCP](http://jolbox.com/). **The default is HikariCP**, but this can be changed by setting the `play.db.pool` property:
+Out of the box, Play provides two database connection pool implementations, [HikariCP](https://github.com/brettwooldridge/HikariCP) and [BoneCP](http://www.jolbox.com/). **The default is HikariCP**, but this can be changed by setting the `play.db.pool` property:
 
 ```
 play.db.pool=bonecp

--- a/documentation/manual/working/scalaGuide/main/xml/ScalaXmlRequests.md
+++ b/documentation/manual/working/scalaGuide/main/xml/ScalaXmlRequests.md
@@ -15,7 +15,7 @@ It’s way better (and simpler) to specify our own `BodyParser` to ask Play to p
 
 > **Note:** When using an XML body parser, the `request.body` value is directly a valid `NodeSeq`. 
 
-You can test it with [cURL](http://curl.haxx.se/) from a command line:
+You can test it with [cURL](https://curl.haxx.se/) from a command line:
 
 ```
 curl 


### PR DESCRIPTION

TODO: 
Correct the 404 status code response for Typesafe snapshots repository URL in 
https://github.com/playframework/playframework/blob/master/documentation/manual/hacking/Repositories.md