### PR TITLE
Enable prefixed SimpleRouter to handle / request with prefix only

### DIFF
--- a/framework/src/play/src/main/scala/play/api/routing/Router.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/Router.scala
@@ -3,8 +3,8 @@
  */
 package play.api.routing
 
-import play.api.{ PlayConfig, Configuration, Environment }
-import play.api.mvc.{ RequestHeader, Handler }
+import play.api.mvc.{Handler, RequestHeader}
+import play.api.{Configuration, Environment, PlayConfig}
 import play.core.j.JavaRouterAdapter
 import play.utils.Reflect
 
@@ -119,6 +119,7 @@ trait SimpleRouter extends Router { self =>
         def routes = {
           val p = if (prefix.endsWith("/")) prefix else prefix + "/"
           val prefixed: PartialFunction[RequestHeader, RequestHeader] = {
+            case rh: RequestHeader if rh.path == prefix => rh.copy(path = "/")
             case rh: RequestHeader if rh.path.startsWith(p) => rh.copy(path = rh.path.drop(p.length - 1))
           }
           Function.unlift(prefixed.lift.andThen(_.flatMap(self.routes.lift)))

--- a/framework/src/play/src/test/scala/play/api/routing/SimpleRouterSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/routing/SimpleRouterSpec.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
 package play.api.routing
 
 import org.specs2.mutable.Specification

--- a/framework/src/play/src/test/scala/play/api/routing/SimpleRouterSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/routing/SimpleRouterSpec.scala
@@ -1,0 +1,42 @@
+package play.api.routing
+
+import org.specs2.mutable.Specification
+import play.api.mvc.Action
+import play.api.mvc.Results._
+import play.api.routing.sird._
+import play.core.test.FakeRequest
+
+object SimpleRouterSpec extends Specification {
+
+  "SimpleRouter" should {
+
+    val RootAction = Action(Ok)
+
+    val router = SimpleRouter {
+      case GET(p"/") => RootAction
+    }
+
+    "support root requests" in {
+
+      "without prefix" in {
+        router.handlerFor(FakeRequest("GET", "/")) must beLike {
+          case Some(RootAction) => ok
+        }
+      }
+
+      "with prefix" in {
+        val prefixedRouter = router.withPrefix("/prefix")
+
+        prefixedRouter.handlerFor(FakeRequest("GET", "/prefix")) must beLike {
+          case Some(RootAction) => ok
+        }
+
+        prefixedRouter.handlerFor(FakeRequest("GET", "/prefix/")) must beLike {
+          case Some(RootAction) => ok
+        }
+      }
+
+    }
+  }
+
+}


### PR DESCRIPTION
Hi,

My problem was, I had to define a router with SIRD like 
```
val myRouter = Router.from {
  case GET(p"/") => // an action
  case GET(p"/$id") => // another action with the path extracted id
}
```
and use it in the `routes` file like
```
->          /myPrefix           foo.Bar.myRouter
```
Therefore, I was expecting the application to handle `GET /myPrefix` requests which were not.
Instead `GET /myPrefix/` was handled.
The problem is from the `withPrefix` implementation of the `SimpleRouter`.

I hope it helps.
By the way, I added a test that covers the use case above.