### PR TITLE
Potential NPE in Cookies#decodeSetCookieHeader.

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -898,21 +898,21 @@ package play.api.mvc {
     def decodeSetCookieHeader(cookieHeader: String): Seq[Cookie] = {
       Try {
         val decoder = config.clientDecoder
-        SetCookieHeaderSeparatorRegex.split(cookieHeader).toSeq.map { cookieString =>
-          val cookie = decoder.decode(cookieString.trim)
-          Cookie(
-            cookie.name,
-            cookie.value,
-            if (cookie.maxAge == Integer.MIN_VALUE) None else Some(cookie.maxAge),
-            Option(cookie.path).getOrElse("/"),
-            Option(cookie.domain),
-            cookie.isSecure,
-            cookie.isHttpOnly
-          )
+        SetCookieHeaderSeparatorRegex.split(cookieHeader).toSeq.flatMap { cookieString =>
+          Option(decoder.decode(cookieString.trim)).map(cookie =>
+            Cookie(
+              cookie.name,
+              cookie.value,
+              if (cookie.maxAge == Integer.MIN_VALUE) None else Some(cookie.maxAge),
+              Option(cookie.path).getOrElse("/"),
+              Option(cookie.domain),
+              cookie.isSecure,
+              cookie.isHttpOnly
+            ))
         }
       }.getOrElse {
         logger.debug(s"Couldn't decode the Cookie header containing: $cookieHeader")
-        Nil
+        Seq.empty
       }
     }
 

--- a/framework/src/play/src/test/scala/play/api/mvc/CookiesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/CookiesSpec.scala
@@ -86,6 +86,13 @@ object CookiesSpec extends Specification {
     }
   }
 
+  "object Cookies#decodeSetCookieHeader" should {
+    "parse empty string without exception " in {
+      val decoded = Cookies.decodeSetCookieHeader("")
+      decoded must beEqualTo(Seq.empty)
+    }
+  }
+
   "merging cookies" should {
     "replace old cookies with new cookies of the same name" in {
       val originalRequest = FakeRequest().withCookies(Cookie("foo", "fooValue1"), Cookie("bar", "barValue2"))

--- a/framework/src/play/src/test/scala/play/api/mvc/CookiesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/CookiesSpec.scala
@@ -89,7 +89,7 @@ object CookiesSpec extends Specification {
   "object Cookies#decodeSetCookieHeader" should {
     "parse empty string without exception " in {
       val decoded = Cookies.decodeSetCookieHeader("")
-      decoded must beEqualTo(Seq.empty)
+      decoded must be empty
     }
   }
 


### PR DESCRIPTION
When the `cookieHeader` is empty: `Cookies.decodeSetCookieHeader("")` the variable `cookie` is set to null.
The message `Couldn't decode the Cookie header containing: ` occurs in production logs many, many times for each user trying to connect with application without cookies in session.

See #5591 for more details.
PR solves #5591