### PR TITLE
Deprecate static i18n Java API

### DIFF
--- a/framework/src/play/src/main/java/play/Play.java
+++ b/framework/src/play/src/main/java/play/Play.java
@@ -7,7 +7,10 @@ import play.core.j.JavaModeConverter$;
 
 /**
  * High-level API to access Play global features.
+ *
+ * @deprecated Please use dependency injection.  Deprecated since 2.5.0.
  */
+@Deprecated
 public class Play {
 
     /**
@@ -16,7 +19,7 @@ public class Play {
      */
     @Deprecated
     public static Application application() {
-        return play.api.Play.current().injector().instanceOf(Application.class);
+        return privateCurrent().injector().instanceOf(Application.class);
     }
 
     /**
@@ -25,7 +28,7 @@ public class Play {
      */
     @Deprecated
     public static Mode mode() {
-        return JavaModeConverter$.MODULE$.asJavaMode(play.api.Play.mode(play.api.Play.current()));
+        return JavaModeConverter$.MODULE$.asJavaMode(play.api.Play.mode(privateCurrent()));
     }
 
     /**
@@ -34,7 +37,7 @@ public class Play {
      */
     @Deprecated
     public static boolean isDev() {
-        return play.api.Play.isDev(play.api.Play.current());
+        return play.api.Play.isDev(privateCurrent());
     }
 
     /**
@@ -43,7 +46,7 @@ public class Play {
      */
     @Deprecated
     public static boolean isProd() {
-        return play.api.Play.isProd(play.api.Play.current());
+        return play.api.Play.isProd(privateCurrent());
     }
 
     /**
@@ -52,18 +55,38 @@ public class Play {
      */
     @Deprecated
     public static boolean isTest() {
-        return play.api.Play.isTest(play.api.Play.current());
+        return play.api.Play.isTest(privateCurrent());
     }
 
+    /**
+     * @deprecated Deprecated since 2.5.0.
+     * @return Deprecated
+     */
+    @Deprecated
     public static String langCookieName() {
-        return play.api.i18n.Messages.Implicits$.MODULE$.applicationMessagesApi(play.api.Play.current()).langCookieName();
+        return play.api.i18n.Messages.Implicits$.MODULE$.applicationMessagesApi(privateCurrent()).langCookieName();
     }
 
+    /**
+     * @deprecated Deprecated since 2.5.0.
+     * @return Deprecated
+     */
+    @Deprecated
     public static boolean langCookieSecure() {
-        return play.api.i18n.Messages.Implicits$.MODULE$.applicationMessagesApi(play.api.Play.current()).langCookieSecure();
+        return play.api.i18n.Messages.Implicits$.MODULE$.applicationMessagesApi(privateCurrent()).langCookieSecure();
     }
 
+    /**
+     * @deprecated Deprecated since 2.5.0.
+     * @return Deprecated
+     */
+    @Deprecated
     public static boolean langCookieHttpOnly() {
-        return play.api.i18n.Messages.Implicits$.MODULE$.applicationMessagesApi(play.api.Play.current()).langCookieHttpOnly();
+        return play.api.i18n.Messages.Implicits$.MODULE$.applicationMessagesApi(privateCurrent()).langCookieHttpOnly();
     }
+
+    private static play.api.Application privateCurrent() {
+        return play.api.Play.current();
+    }
+
 }

--- a/framework/src/play/src/main/java/play/i18n/Lang.java
+++ b/framework/src/play/src/main/java/play/i18n/Lang.java
@@ -4,6 +4,9 @@
 package play.i18n;
 
 import java.util.*;
+
+import play.Application;
+import play.api.Play;
 import play.libs.*;
 
 /**
@@ -74,9 +77,19 @@ public class Lang extends play.api.i18n.Lang {
      * Retrieve Lang availables from the application configuration.
      *
      * @return the available languages
+     * @deprecated Please use Lang.availables(app), since 2.5.0
      */
+    @Deprecated
     public static List<Lang> availables() {
-        List<play.api.i18n.Lang> langs = Scala.asJava(play.api.i18n.Lang.availables(play.api.Play.current()));
+        Application current = play.Play.application();
+        return availables(current);
+    }
+
+    /**
+     * Retrieve Lang availables from the application configuration.
+     */
+    public static List<Lang> availables(Application app) {
+        List<play.api.i18n.Lang> langs = Scala.asJava(play.api.i18n.Lang.availables(app.getWrappedApplication()));
         List<play.i18n.Lang> result = new ArrayList<play.i18n.Lang>();
         for(play.api.i18n.Lang lang: langs) {
             result.add(new Lang(lang));
@@ -90,13 +103,30 @@ public class Lang extends play.api.i18n.Lang {
      *
      * @param langs the set of langs from which to guess the preferred
      * @return the preferred lang.
+     * @deprecated Please use preferred(app, langs).  Deprecated since 2.5.0.
      */
+    @Deprecated
     public static Lang preferred(List<Lang> langs) {
+        play.api.Application app = Play.current();
         List<play.api.i18n.Lang> result = new ArrayList<play.api.i18n.Lang>();
         for(play.i18n.Lang lang: langs) {
             result.add(lang.underlyingLang);
         }
-        return new Lang(play.api.i18n.Lang.preferred(Scala.toSeq(result), play.api.Play.current()));
+        return new Lang(play.api.i18n.Lang.preferred(Scala.toSeq(result), app));
     }
 
+    /**
+     * Guess the preferred lang in the langs set passed as argument.
+     * The first Lang that matches an available Lang wins, otherwise returns the first Lang available in this application.
+     *
+     * @param langs the set of langs from which to guess the preferred
+     * @return the preferred lang.
+     */
+    public static Lang preferred(Application app, List<Lang> langs) {
+        List<play.api.i18n.Lang> result = new ArrayList<play.api.i18n.Lang>();
+        for(play.i18n.Lang lang: langs) {
+            result.add(lang.underlyingLang);
+        }
+        return new Lang(play.api.i18n.Lang.preferred(Scala.toSeq(result), app.getWrappedApplication()));
+    }
 }

--- a/framework/src/play/src/main/java/play/i18n/Messages.java
+++ b/framework/src/play/src/main/java/play/i18n/Messages.java
@@ -4,9 +4,7 @@
 package play.i18n;
 
 import org.apache.commons.lang3.ArrayUtils;
-import play.Application;
-import play.api.Play;
-import play.api.i18n.Messages$;
+import play.api.Application;
 import scala.collection.mutable.Buffer;
 
 import java.util.Arrays;
@@ -36,8 +34,10 @@ public class Messages {
         return lang;
     }
 
-    private static MessagesApi getMessagesApi() {
-        return Play.current().injector().instanceOf(MessagesApi.class);
+    private static Messages getMessages(Lang lang) {
+        Application app = play.api.Play.current();
+        MessagesApi scalaApi = app.injector().instanceOf(MessagesApi.class);
+        return new Messages(lang, scalaApi);
     }
 
     /**
@@ -79,9 +79,11 @@ public class Messages {
     * @param key the message key
     * @param args the message arguments
     * @return the formatted message or a default rendering if the key wasn't defined
+     * @deprecated Please use messages.at(key, args). since 2.5.0
     */
+    @Deprecated
     public static String get(Lang lang, String key, Object... args) {
-        return getMessagesApi().get(lang, key, args);
+        return getMessages(lang).at(key, args);
     }
 
     /**
@@ -93,9 +95,11 @@ public class Messages {
     * @param keys the messages keys
     * @param args the message arguments
     * @return the formatted message or a default rendering if the key wasn't defined
+     * @deprecated Please use messages.at(keys, args)
     */
+    @Deprecated
     public static String get(Lang lang, List<String> keys, Object... args) {
-        return getMessagesApi().get(lang, keys, args);
+        return getMessages(lang).at(keys, args);
     }
 
     /**
@@ -106,9 +110,11 @@ public class Messages {
     * @param key the message key
     * @param args the message arguments
     * @return the formatted message or a default rendering if the key wasn't defined
+     * @deprecated use messages.at(key, args).  Deprecated since 2.5.0
     */
+    @Deprecated
     public static String get(String key, Object... args) {
-        return getMessagesApi().get(getLang(), key, args);
+        return getMessages(getLang()).at(key, args);
     }
 
     /**
@@ -119,9 +125,11 @@ public class Messages {
     * @param keys the messages keys
     * @param args the message arguments
     * @return the formatted message or a default rendering if the key wasn't defined
+     * @deprecated use messages.at(keys, args).  Deprecated since 2.5.0
     */
+    @Deprecated
     public static String get(List<String> keys, Object... args) {
-        return getMessagesApi().get(getLang(), keys, args);
+        return getMessages(getLang()).at(keys, args);
     }
 
     /**
@@ -129,18 +137,22 @@ public class Messages {
     * @param lang the message lang
     * @param key the message key
     * @return a Boolean
+     * @deprecated Use messages.isDefinedAt(key).  Deprecated since 2.5.0
     */
+    @Deprecated
     public static Boolean isDefined(Lang lang, String key) {
-        return getMessagesApi().isDefinedAt(lang, key);
+        return getMessages(lang).isDefinedAt(key);
     }
 
     /**
     * Check if a message key is defined.
     * @param key the message key
     * @return a Boolean
+     * @deprecated Use messages.isDefinedAt(key).  Deprecated since 2.5.0
     */
+    @Deprecated
     public static Boolean isDefined(String key) {
-        return getMessagesApi().isDefinedAt(getLang(), key);
+        return getMessages(getLang()).isDefinedAt(key);
     }
 
     // All these methods are the new API

--- a/framework/src/play/src/main/java/play/i18n/MessagesApi.java
+++ b/framework/src/play/src/main/java/play/i18n/MessagesApi.java
@@ -135,4 +135,16 @@ public class MessagesApi {
         return new Messages(new Lang(msgs.lang()), this);
     }
 
+    public String langCookieName() {
+        return messages.langCookieName();
+    }
+
+    public boolean langCookieSecure() {
+        return messages.langCookieSecure();
+    }
+
+    public boolean langCookieHttpOnly() {
+        return messages.langCookieHttpOnly();
+    }
+
 }


### PR DESCRIPTION
Fixes https://github.com/playframework/playframework/issues/5596

Move to instance `play.i18n.Messages` methods.

Deprecate `play.Play`, since every single method in it is deprecated.  Also some clean up.