### PR TITLE
Deprecate static play.libs.Akka.system method.

### DIFF
--- a/framework/src/play/src/main/java/play/libs/Akka.java
+++ b/framework/src/play/src/main/java/play/libs/Akka.java
@@ -6,15 +6,12 @@ package play.libs;
 import akka.actor.Actor;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
-
 import akka.actor.Props;
-import play.api.*;
-import play.api.inject.Binding;
+import play.api.Play;
 import play.api.libs.concurrent.ActorRefProvider;
 import scala.reflect.ClassTag$;
 import scala.runtime.AbstractFunction1;
 
-import javax.inject.Inject;
 import javax.inject.Provider;
 import java.util.function.Function;
 
@@ -25,7 +22,10 @@ public class Akka {
 
     /**
      * Retrieve the application Akka Actor system.
+     *
+     * @deprecated Please use "@Inject ActorSystem actorSystem", since 2.5.0
      */
+    @Deprecated
     public static ActorSystem system() {
         return play.api.libs.concurrent.Akka.system(Play.current());
     }

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -27,7 +27,7 @@ object Akka {
   private val actorSystemCache = Application.instanceCache[ActorSystem]
 
   /**
-   * Retrieve the application Akka Actor system.
+   * Retrieve the application Akka Actor system, using an implicit application.
    *
    * Example:
    * {{{


### PR DESCRIPTION
This method is not referenced anywhere in the code, and the documentation correctly uses dependency injection: https://github.com/playframework/playframework/blob/master/documentation/manual/working/javaGuide/main/akka/JavaAkka.md

I did add a note in scaladoc to say that the Scala version of Akka.system takes an implicit application.