### PR TITLE
Move reference to play.api.Play.current to privateMaybeApplication

### DIFF
--- a/framework/src/play/src/main/scala/play/core/j/JavaWebSocket.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaWebSocket.scala
@@ -19,7 +19,7 @@ import scala.compat.java8.FutureConverters
 import com.fasterxml.jackson.databind.JsonNode
 import play.api.libs.concurrent.Akka
 
-import play.api.Play.current
+
 import play.core.Execution.Implicits.internalContext
 
 /**
@@ -45,8 +45,8 @@ object JavaWebSocket extends JavaHelpers {
         Left(createResult(javaContext, result))
 
       } getOrElse {
-
-        implicit val system = Akka.system
+        val current = play.api.Play.privateMaybeApplication.get
+        implicit val system = current.actorSystem
         implicit val mat = current.materializer
 
         Right(


### PR DESCRIPTION
One less warning.  Since JavaWebSocket.scala is itself a deprecation wrapper, I wasn't sure about deprecating it myself.

@dotta can you review to see if we can refactor this to take implicit application or the like?