### PR TITLE
Deprecate static cached methods

### DIFF
--- a/framework/src/play-cache/src/main/java/play/cache/Cache.java
+++ b/framework/src/play-cache/src/main/java/play/cache/Cache.java
@@ -7,10 +7,13 @@ import java.util.concurrent.Callable;
 
 /**
  * Provides an access point for Play's cache service.
+ *
+ * @deprecated Please use an dependency injected instance of CacheApi.
  */
+@Deprecated
 public class Cache {
 
-    private static CacheApi cacheApi() {
+    static CacheApi cacheApi() {
         return play.api.Play.current().injector().instanceOf(CacheApi.class);
     }
 
@@ -19,7 +22,9 @@ public class Cache {
      *
      * @param key the cache key
      * @return the object or null
+     * @deprecated Please use non-static cacheApi.get(key), deprecated since 2.5.0
      */
+    @Deprecated
     public static Object get(String key) {
         return cacheApi().get(key);
     }
@@ -27,12 +32,15 @@ public class Cache {
     /**
      * Retrieve a value from the cache, or set it from a default Callable function.
      *
+     * @deprecated Please use non-static cacheApi.getOrElse, deprecated since 2.5.0
+     *
      * @param <T>        the type of object being queried
      * @param key        Item key.
      * @param block      block returning value to set if key does not exist
      * @param expiration expiration period in seconds.
      * @return value
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public static <T> T getOrElse(String key, Callable<T> block, int expiration) {
         return cacheApi().getOrElse(key, block, expiration);
@@ -41,10 +49,13 @@ public class Cache {
     /**
      * Sets a value with expiration.
      *
+     * @deprecated Please use non-static cacheApi.set(key,value,expiration), deprecated since 2.5.0
+     *
      * @param key the key to set
      * @param value the value to set
      * @param expiration expiration in seconds
      */
+    @Deprecated
     public static void set(String key, Object value, int expiration) {
         cacheApi().set(key, value, expiration);
     }
@@ -55,6 +66,7 @@ public class Cache {
      * @param key the key to set
      * @param value the value to set
      */
+    @Deprecated
     public static void set(String key, Object value) {
         cacheApi().set(key, value);
     }
@@ -62,8 +74,11 @@ public class Cache {
     /**
      * Removes the entry at a specific key
      *
+     * @deprecated Please use non-static cacheApi.set(key,value,expiration), deprecated since 2.5.0
+     *
      * @param key the key whose entry to remove
      */
+    @Deprecated
     public static void remove(String key) {
         cacheApi().remove(key);
     }

--- a/framework/src/play-cache/src/main/java/play/cache/CachedAction.java
+++ b/framework/src/play-cache/src/main/java/play/cache/CachedAction.java
@@ -10,21 +10,29 @@ import play.mvc.Action;
 import play.mvc.Http.Context;
 import play.mvc.Result;
 
+import javax.inject.Inject;
+
 /**
  * Cache another action.
  */
 public class CachedAction extends Action<Cached> {
 
+    private CacheApi cacheApi;
+
+    @Inject
+    public CachedAction(CacheApi cacheApi) {
+        this.cacheApi = cacheApi;
+    }
+
     public CompletionStage<Result> call(Context ctx) {
         try {
             final String key = configuration.key();
             final Integer duration = configuration.duration();
-
-            Result cacheResult = (Result) Cache.get(key);
+            Result cacheResult = cacheApi.get(key);
 
             if (cacheResult == null) {
                 return delegate.call(ctx).thenApply(result -> {
-                    Cache.set(key, result, duration);
+                    cacheApi.set(key, result, duration);
                     return result;
                 });
             } else {


### PR DESCRIPTION
Deprecate the static `play.cache.Cache` methods as they are static and rely on `Play.current()`.

Also added a test to make sure that the `Cached` annotation is called, but interesting note -- how do you call a Java controller in Play directly?