### PR TITLE
"db.default.driver" is missing from Procfile

### DIFF
--- a/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
+++ b/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
@@ -208,7 +208,7 @@ libraryDependencies += "org.postgresql" % "postgresql" % "9.4-1201-jdbc41"
 Then create a new file in your project's root directory named `Procfile` (with a capital "P") that contains the following (substituting the `myapp` with your project's name):
 
 ```txt
-web: target/universal/stage/bin/myapp -Dhttp.port=${PORT} -Dplay.evolutions.db.default.autoApply=true -Ddb.default.url=${DATABASE_URL}
+web: target/universal/stage/bin/myapp -Dhttp.port=${PORT} -Dplay.evolutions.db.default.autoApply=true -Ddb.default.driver=org.postgresql.Driver -Ddb.default.url=${DATABASE_URL}
 ```
 
 This instructs Heroku that for the process named `web` it will run Play and override the `play.evolutions.db.default.autoApply`, `db.default.driver`, and `db.default.url` configuration parameters.  Note that the `Procfile` command can be maximum 255 characters long.  Alternatively, use the `-Dconfig.resource=` or `-Dconfig.file=` mentioned in [[production configuration|ProductionConfiguration]] page.


### PR DESCRIPTION
"db.default.driver" is missing from Procfile.
If Procfile dose not have "db.default.driver", an error occurs.

I found the same problem in 2.4.3/2.4.4/2.4.x/2.5.0-M2/2.5.x of the document