### PR TITLE
Look up pattern for AnnotationDateFormatter in messages

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/format/Formats.java
+++ b/framework/src/play-java/src/main/java/play/data/format/Formats.java
@@ -11,6 +11,9 @@ import static java.lang.annotation.RetentionPolicy.*;
 
 import java.lang.annotation.*;
 
+import play.i18n.Lang;
+import play.i18n.MessagesApi;
+
 /**
  * Defines several default formatters.
  */
@@ -87,6 +90,17 @@ public class Formats {
      */
     public static class AnnotationDateFormatter extends Formatters.AnnotationFormatter<DateTime,Date> {
 
+        private final MessagesApi messagesApi;
+
+        /**
+         * Creates an annotation date formatter.
+         *
+         * @param messagesApi messages to look up the pattern
+         */
+        public AnnotationDateFormatter(MessagesApi messagesApi) {
+            this.messagesApi = messagesApi;
+        }
+
         /**
          * Binds the field - constructs a concrete value from submitted data.
          *
@@ -99,7 +113,10 @@ public class Formats {
             if(text == null || text.trim().isEmpty()) {
                 return null;
             }
-            SimpleDateFormat sdf = new SimpleDateFormat(annotation.pattern(), locale);
+            Lang lang = new Lang(new play.api.i18n.Lang(locale.getLanguage(), locale.getCountry()));
+            SimpleDateFormat sdf = new SimpleDateFormat(Optional.ofNullable(this.messagesApi)
+                .map(messages -> messages.get(lang, annotation.pattern()))
+                .orElse(annotation.pattern()), locale);
             sdf.setLenient(false);
             return sdf.parse(text);
         }
@@ -116,7 +133,10 @@ public class Formats {
             if(value == null) {
                 return "";
             }
-            return new SimpleDateFormat(annotation.pattern(), locale).format(value);
+            Lang lang = new Lang(new play.api.i18n.Lang(locale.getLanguage(), locale.getCountry()));
+            return new SimpleDateFormat(Optional.ofNullable(this.messagesApi)
+                .map(messages -> messages.get(lang, annotation.pattern()))
+                .orElse(annotation.pattern()), locale).format(value);
         }
 
     }

--- a/framework/src/play-java/src/main/java/play/data/format/Formatters.java
+++ b/framework/src/play-java/src/main/java/play/data/format/Formatters.java
@@ -33,7 +33,7 @@ public class Formatters {
 
         // By default, we always register some common and useful Formatters
         register(Date.class, new Formats.DateFormatter("yyyy-MM-dd"));
-        register(Date.class, new Formats.AnnotationDateFormatter());
+        register(Date.class, new Formats.AnnotationDateFormatter(messagesApi));
         register(String.class, new Formats.AnnotationNonEmptyFormatter());
         registerOptional();
     }

--- a/framework/src/play-java/src/test/java/play/data/Birthday.java
+++ b/framework/src/play-java/src/test/java/play/data/Birthday.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.data;
+
+import java.util.Date;
+
+public class Birthday {
+
+    @play.data.format.Formats.DateTime(pattern = "customFormats.date")
+    private Date date;
+
+    public Date getDate() {
+        return this.date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+}

--- a/framework/src/play-java/src/test/resources/messages
+++ b/framework/src/play-java/src/test/resources/messages
@@ -1,2 +1,3 @@
 error.custom=It looks like something {0}
 error.customarg=was not correct
+customFormats.date=dd/MM/yyyy

--- a/framework/src/play-java/src/test/resources/messages.en-US
+++ b/framework/src/play-java/src/test/resources/messages.en-US
@@ -1,0 +1,1 @@
+customFormats.date=MM-dd-yyyy

--- a/framework/src/play-java/src/test/resources/messages.fr
+++ b/framework/src/play-java/src/test/resources/messages.fr
@@ -1,0 +1,1 @@
+customFormats.date=dd.MM.yyyy


### PR DESCRIPTION
That's how `AnnotationDateFormatter` works right now:
```java
@DateTime(pattern = "dd/MM/YYYY")
private java.util.Date birthDate;
```
The `pattern` for a field is "hardcoded".

Depending on the locale of the request we want to use different patterns. E.g. "dd.MM.YYYY" for german, "dd-MM-YYYY" for english, etc.
Problem: That's not possible right now.

With this PR the pattern string will now also be looked up in the message files so you could define e.g.: `customFormats.date=dd.MM.YYYY` in `messages.de`, `customFormats.date=dd-MM-YYYY` in `messages.en`, etc. and the just use the key:

```java
@DateTime(pattern = "customFormats.date")
```

Actually I am wondering why this was not working before.