### PR TITLE
Read pattern for DateFormatter from messages

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/format/Formats.java
+++ b/framework/src/play-java/src/main/java/play/data/format/Formats.java
@@ -26,15 +26,43 @@ public class Formats {
      */
     public static class DateFormatter extends Formatters.SimpleFormatter<Date> {
 
+        private final MessagesApi messagesApi;
+
         private final String pattern;
+
+        private final String patternNoApp;
+
+        /**
+         * Creates a date formatter.
+         * The value defined for the message file key "formats.dateFormat" will be used as the default pattern.
+         *
+         * @param messagesApi messages to look up the pattern
+         */
+        public DateFormatter(MessagesApi messagesApi) {
+            this(messagesApi, "formats.dateFormat");
+        }
 
         /**
          * Creates a date formatter.
          *
-         * @param pattern date pattern, as specified for {@link SimpleDateFormat}.
+         * @param messagesApi messages to look up the pattern
+         * @param pattern date pattern, as specified for {@link SimpleDateFormat}. Can be a message file key.
          */
-        public DateFormatter(String pattern) {
+        public DateFormatter(MessagesApi messagesApi, String pattern) {
+            this(messagesApi, pattern, "yyyy-MM-dd");
+        }
+
+        /**
+         * Creates a date formatter.
+         *
+         * @param messagesApi messages to look up the pattern
+         * @param pattern date pattern, as specified for {@link SimpleDateFormat}. Can be a message file key.
+         * @param patternNoApp date pattern to use as fallback when no app is started.
+         */
+        public DateFormatter(MessagesApi messagesApi, String pattern, String patternNoApp) {
+            this.messagesApi = messagesApi;
             this.pattern = pattern;
+            this.patternNoApp = patternNoApp;
         }
 
         /**
@@ -48,7 +76,10 @@ public class Formats {
             if(text == null || text.trim().isEmpty()) {
                 return null;
             }
-            SimpleDateFormat sdf = new SimpleDateFormat(pattern, locale);
+            Lang lang = new Lang(new play.api.i18n.Lang(locale.getLanguage(), locale.getCountry()));
+            SimpleDateFormat sdf = new SimpleDateFormat(Optional.ofNullable(this.messagesApi)
+                .map(messages -> messages.get(lang, pattern))
+                .orElse(patternNoApp), locale);
             sdf.setLenient(false);
             return sdf.parse(text);
         }
@@ -64,7 +95,10 @@ public class Formats {
             if(value == null) {
                 return "";
             }
-            return new SimpleDateFormat(pattern, locale).format(value);
+            Lang lang = new Lang(new play.api.i18n.Lang(locale.getLanguage(), locale.getCountry()));
+            return new SimpleDateFormat(Optional.ofNullable(this.messagesApi)
+                .map(messages -> messages.get(lang, pattern))
+                .orElse(patternNoApp), locale).format(value);
         }
 
     }

--- a/framework/src/play-java/src/main/java/play/data/format/Formatters.java
+++ b/framework/src/play-java/src/main/java/play/data/format/Formatters.java
@@ -32,7 +32,7 @@ public class Formatters {
         this.messagesApi = messagesApi;
 
         // By default, we always register some common and useful Formatters
-        register(Date.class, new Formats.DateFormatter("yyyy-MM-dd"));
+        register(Date.class, new Formats.DateFormatter(messagesApi));
         register(Date.class, new Formats.AnnotationDateFormatter(messagesApi));
         register(String.class, new Formats.AnnotationNonEmptyFormatter());
         registerOptional();

--- a/framework/src/play-java/src/test/java/play/data/Birthday.java
+++ b/framework/src/play-java/src/test/java/play/data/Birthday.java
@@ -10,11 +10,22 @@ public class Birthday {
     @play.data.format.Formats.DateTime(pattern = "customFormats.date")
     private Date date;
 
+    // No annotation
+    private Date alternativeDate;
+
     public Date getDate() {
         return this.date;
     }
 
     public void setDate(Date date) {
         this.date = date;
+    }
+
+    public Date getAlternativeDate() {
+        return this.alternativeDate;
+    }
+
+    public void setAlternativeDate(Date date) {
+        this.alternativeDate = date;
     }
 }

--- a/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
@@ -305,4 +305,58 @@ public class HttpTest {
         });
     }
 
+    @Test
+    public void testLangDateDataBinder() {
+        withApplication((app) -> {
+            FormFactory formFactory = app.injector().instanceOf(FormFactory.class);
+
+            // Prepare Request and Context
+            Map<String, String> data = new HashMap<>();
+            data.put("alternativeDate", "1982-5-7");
+            RequestBuilder rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
+            Context ctx = new Context(rb);
+            Context.current.set(ctx);
+            // Parse date input with pattern from Play's default messages file
+            Form<Birthday> myForm = formFactory.form(Birthday.class).bindFromRequest();
+            assertThat(myForm.hasErrors()).isFalse();
+            assertThat(myForm.hasGlobalErrors()).isFalse();
+            myForm.data().clear();
+            Birthday birthday = myForm.get();
+            assertThat(myForm.field("alternativeDate").value()).isEqualTo("1982-05-07");
+            assertThat(birthday.getAlternativeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(1982, 5, 7));
+
+            // Prepare Request and Context
+            data = new HashMap<>();
+            data.put("alternativeDate", "10_4_2005");
+            rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
+            ctx = new Context(rb);
+            Context.current.set(ctx);
+            // Parse french date input with pattern from the french messages file
+            ctx.changeLang("fr");
+            myForm = formFactory.form(Birthday.class).bindFromRequest();
+            assertThat(myForm.hasErrors()).isFalse();
+            assertThat(myForm.hasGlobalErrors()).isFalse();
+            myForm.data().clear();
+            birthday = myForm.get();
+            assertThat(myForm.field("alternativeDate").value()).isEqualTo("10_04_2005");
+            assertThat(birthday.getAlternativeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(2005, 10, 4));
+
+            // Prepare Request and Context
+            data = new HashMap<>();
+            data.put("alternativeDate", "3/12/1962");
+            rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
+            ctx = new Context(rb);
+            Context.current.set(ctx);
+            // Parse english date input with pattern from the en-US messages file
+            ctx.changeLang("en-US");
+            myForm = formFactory.form(Birthday.class).bindFromRequest();
+            assertThat(myForm.hasErrors()).isFalse();
+            assertThat(myForm.hasGlobalErrors()).isFalse();
+            myForm.data().clear();
+            birthday = myForm.get();
+            assertThat(myForm.field("alternativeDate").value()).isEqualTo("03/12/1962");
+            assertThat(birthday.getAlternativeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(1962, 12, 3));
+        });
+    }
+
 }

--- a/framework/src/play-java/src/test/resources/messages.en-US
+++ b/framework/src/play-java/src/test/resources/messages.en-US
@@ -1,1 +1,2 @@
 customFormats.date=MM-dd-yyyy
+formats.dateFormat=dd/MM/yyyy

--- a/framework/src/play-java/src/test/resources/messages.fr
+++ b/framework/src/play-java/src/test/resources/messages.fr
@@ -1,1 +1,2 @@
 customFormats.date=dd.MM.yyyy
+formats.dateFormat=MM_dd_yyyy

--- a/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
@@ -61,6 +61,21 @@ object FormSpec extends Specification {
       myForm hasErrors () must beEqualTo(true)
       myForm.errors.get("id").get(0).messages().asScala must contain("error.invalid")
     }
+    "be valid with default date binder" in {
+      val req = dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009"), "endDate" -> Array("2008-11-21")))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
+
+      val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
+      myForm hasErrors () must beEqualTo(false)
+    }
+    "have an error due to baldy formatted date for default date binder" in {
+      val req = dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009"), "endDate" -> Array("2008-11e-21")))
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
+
+      val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
+      myForm hasErrors () must beEqualTo(true)
+      myForm.errors.get("endDate").get(0).messages().asScala must contain("error.invalid.java.util.Date")
+    }
 
     "support repeated values for Java binding" in {
 

--- a/framework/src/play-java/src/test/scala/play/data/Task.scala
+++ b/framework/src/play-java/src/test/scala/play/data/Task.scala
@@ -29,5 +29,8 @@ class Task {
   @DateTime(pattern = "dd/MM/yyyy")
   var dueDate: Date = _
 
+  @BeanProperty
+  var endDate: Date = _
+
 }
 

--- a/framework/src/play/src/main/resources/messages.default
+++ b/framework/src/play/src/main/resources/messages.default
@@ -19,6 +19,9 @@ format.numeric=Numeric
 format.real=Real
 format.uuid=UUID
 
+# --- Patterns for Formats
+formats.dateFormat=yyyy-MM-dd
+
 # --- Errors
 error.invalid=Invalid value
 error.invalid.java.util.Date=Invalid date value


### PR DESCRIPTION
Right now the default pattern for binding *any* `java.util.Date` from a Form is  `'yyyy-MM-dd'`. Unfortunately this pattern is hardcoded :cry: 

We are writing an app for german users and the default pattern for entering dates in german is `'dd.MM.yyyy'`. That's why I want to be able to change the default pattern of the Date binding.
With this PR you can simply change the pattern by putting
```
formats.dateFormat=dd.MM.yyyy
```
in your `messages` files.

This makes date binding much more flexible.

This PR is fully backwards compatible because `yyyy-MM-dd` stays the default pattern.