### PR TITLE
Mockito is not included in build by default

### DIFF
--- a/documentation/manual/working/javaGuide/main/tests/JavaTest.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTest.md
@@ -47,7 +47,9 @@ Hamcrest matchers:
 
 Mocks are used to isolate unit tests against external dependencies. For example, if your class under test depends on an external data access class, you can mock this to provide controlled data and eliminate the need for an external data resource.
 
-The [Mockito](https://github.com/mockito/mockito) library is included in your project build to assist you in using mocks.
+Include [Mockito](https://github.com/mockito/mockito) library in your project build to assist you in using mocks.
+
+```libraryDependencies += "org.mockito" % "mockito-all" % "1.10.19"```
 
 Using Mockito, you can mock classes or interfaces like so:
 


### PR DESCRIPTION
Mockito is not included in build by default, but the documentation was saying that.