### PR TITLE
CSRF filter API changes

### DIFF
--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/csrf.scala.html
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/csrf.scala.html
@@ -1,4 +1,3 @@
-@()
 
 @import scalaguide.forms.csrf.routes
 

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/form.scala.html
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/form.scala.html
@@ -1,2 +1,0 @@
-
-@play.filters.csrf.CSRF.Token.getToken.value

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaCsrf.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaCsrf.md
@@ -59,9 +59,13 @@ play.http.filters = "filters.MyFilters"
 
 ### Getting the current token
 
-The current CSRF token can be accessed using the `getToken` method.  It takes an implicit `RequestHeader`, so ensure that one is in scope.
+The current CSRF token can be accessed using the `CSRF.getToken` method.  It takes an implicit `RequestHeader`, so ensure that one is in scope.
 
 @[get-token](code/ScalaCsrf.scala)
+
+If you are not using the CSRF filter, you also should inject the `CSRFAddToken` and `CSRFCheck` action wrappers to force adding a token or a CSRF check on a specific action. Otherwise the token will not be available.
+
+@[csrf-controller](code/ScalaCsrf.scala)
 
 To help in adding CSRF tokens to forms, Play provides some template helpers.  The first one adds it to the query string of the action URL:
 
@@ -88,7 +92,7 @@ This might render a form that looks like this:
 </form>
 ```
 
-The form helper methods all require an implicit token or request to be available in scope.  This will typically be provided by adding an implicit `RequestHeader` parameter to your template, if it doesn't have one already.
+The form helper methods all require an implicit `RequestHeader` to be available in scope. This will typically be provided by adding an implicit `RequestHeader` parameter to your template, if it doesn't have one already.
 
 ### Adding a CSRF token to the session
 

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/csrf.scala.html
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/csrf.scala.html
@@ -1,4 +1,4 @@
-@(implicit req: RequestHeader)
+@()(implicit request: play.api.mvc.RequestHeader)
 
 @import scalaguide.forms.csrf.routes
 

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
@@ -3,6 +3,7 @@
  */
 package play.filters.csrf;
 
+import play.api.libs.Crypto;
 import play.api.mvc.RequestHeader;
 import play.api.mvc.Session;
 import play.inject.Injector;
@@ -19,12 +20,14 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
 
     private final CSRFConfig config;
     private final CSRF.TokenProvider tokenProvider;
+    private final Crypto crypto;
     private final Injector injector;
 
     @Inject
-    public RequireCSRFCheckAction(CSRFConfig config, CSRF.TokenProvider tokenProvider, Injector injector) {
+    public RequireCSRFCheckAction(CSRFConfig config, CSRF.TokenProvider tokenProvider, Crypto crypto, Injector injector) {
         this.config = config;
         this.tokenProvider = tokenProvider;
+        this.crypto = crypto;
         this.injector = injector;
     }
 
@@ -32,18 +35,18 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
 
     @Override
     public CompletionStage<Result> call(Http.Context ctx) {
-        RequestHeader request = ctx._requestHeader();
+        RequestHeader request = CSRFAction.tagRequestFromHeader(ctx._requestHeader(), config, crypto);
         // Check for bypass
         if (!CSRFAction.requiresCsrfCheck(request, config)) {
             return delegate.call(ctx);
         } else {
             // Get token from cookie/session
-            Option<String> headerToken = CSRFAction.getTokenFromHeader(request, config);
+            Option<String> headerToken = CSRFAction.getTokenToValidate(request, config, crypto);
             if (headerToken.isDefined()) {
                 String tokenToCheck = null;
 
                 // Get token from query string
-                Option<String> queryStringToken = CSRFAction.getTokenFromQueryString(request, config);
+                Option<String> queryStringToken = CSRFAction.getHeaderToken(request, config);
                 if (queryStringToken.isDefined()) {
                     tokenToCheck = queryStringToken.get();
                 } else {

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -5,18 +5,20 @@ package play.filters.csrf
 
 import java.net.{ URLDecoder, URLEncoder }
 import java.util.Locale
+import javax.inject.Inject
 
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Keep, Source, Sink, Flow }
+import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import akka.stream.stage.{ DetachedContext, DetachedStage }
 import akka.util.ByteString
-import play.api.http.HeaderNames
+import play.api.http.HeaderNames._
+import play.api.libs.Crypto
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
-import play.api.http.HeaderNames._
 import play.core.parsers.Multipart
 import play.filters.cors.CORSFilter
 import play.filters.csrf.CSRF._
+
 import scala.concurrent.Future
 
 /**
@@ -29,6 +31,7 @@ import scala.concurrent.Future
  */
 class CSRFAction(next: EssentialAction,
     config: CSRFConfig = CSRFConfig(),
+    crypto: Crypto = Crypto.crypto,
     tokenProvider: TokenProvider = SignedTokenProvider,
     errorHandler: => ErrorHandler = CSRF.DefaultErrorHandler)(implicit mat: Materializer) extends EssentialAction {
 
@@ -38,7 +41,8 @@ class CSRFAction(next: EssentialAction,
   private def checkFailed(req: RequestHeader, msg: String): Accumulator[ByteString, Result] =
     Accumulator.done(clearTokenIfInvalid(req, config, errorHandler, msg))
 
-  def apply(request: RequestHeader) = {
+  def apply(untaggedRequest: RequestHeader) = {
+    val request = tagRequestFromHeader(untaggedRequest, config, crypto)
 
     // this function exists purely to aid readability
     def continue = next(request)
@@ -51,10 +55,10 @@ class CSRFAction(next: EssentialAction,
       } else {
 
         // Only proceed with checks if there is an incoming token in the header, otherwise there's no point
-        getTokenFromHeader(request, config).map { headerToken =>
+        getTokenToValidate(request, config, crypto).map { headerToken =>
 
           // First check if there's a token in the query string or header, if we find one, don't bother handling the body
-          getTokenFromQueryString(request, config).map { queryStringToken =>
+          getHeaderToken(request, config).map { queryStringToken =>
 
             if (tokenProvider.compareTokens(headerToken, queryStringToken)) {
               filterLogger.trace("[CSRF] Valid token found in query string")
@@ -89,13 +93,13 @@ class CSRFAction(next: EssentialAction,
 
         }
       }
-    } else if (getTokenFromHeader(request, config).isEmpty && config.createIfNotFound(request)) {
+    } else if (getTokenToValidate(request, config, crypto).isEmpty && config.createIfNotFound(request)) {
 
       // No token in header and we have to create one if not found, so create a new token
       val newToken = tokenProvider.generateToken
 
       // The request
-      val requestWithNewToken = request.copy(tags = request.tags + (Token.RequestTag -> newToken))
+      val requestWithNewToken = tagRequest(request, Token(config.tokenName, newToken))
 
       // Once done, add it to the result
       next(requestWithNewToken).map(result =>
@@ -360,13 +364,50 @@ object CSRFAction {
   /**
    * Get the header token, that is, the token that should be validated.
    */
-  private[csrf] def getTokenFromHeader(request: RequestHeader, config: CSRFConfig) = {
+  private[csrf] def getTokenToValidate(request: RequestHeader, config: CSRFConfig, crypto: Crypto) = {
+    val tagToken = request.tags.get(Token.RequestTag)
     val cookieToken = config.cookieName.flatMap(cookie => request.cookies.get(cookie).map(_.value))
     val sessionToken = request.session.get(config.tokenName)
-    cookieToken orElse sessionToken
+    cookieToken orElse sessionToken orElse tagToken filter { token =>
+      // return None if the token is invalid
+      !config.signTokens || crypto.extractSignedToken(token).isDefined
+    }
   }
 
-  private[csrf] def getTokenFromQueryString(request: RequestHeader, config: CSRFConfig) = {
+  /**
+   * Tag incoming requests with the token in the header
+   */
+  private[csrf] def tagRequestFromHeader(request: RequestHeader, config: CSRFConfig, crypto: Crypto): RequestHeader = {
+    getTokenToValidate(request, config, crypto).fold(request) { tokenValue =>
+      val token = Token(config.tokenName, tokenValue)
+      val newReq = tagRequest(request, token)
+      if (config.signTokens) {
+        // Extract the signed token, and then resign it. This makes the token random per request, preventing the BREACH
+        // vulnerability
+        val newTokenValue = crypto.extractSignedToken(token.value).map(crypto.signToken)
+        newTokenValue.fold(newReq)(newReq.withTag(Token.ReSignedRequestTag, _))
+      } else {
+        newReq
+      }
+    }
+  }
+
+  private[csrf] def tagRequestFromHeader[A](request: Request[A], config: CSRFConfig, crypto: Crypto): Request[A] = {
+    Request(tagRequestFromHeader(request: RequestHeader, config, crypto), request.body)
+  }
+
+  private[csrf] def tagRequest(request: RequestHeader, token: Token): RequestHeader = {
+    request.copy(tags = request.tags ++ Map(
+      Token.NameRequestTag -> token.name,
+      Token.RequestTag -> token.value
+    ))
+  }
+
+  private[csrf] def tagRequest[A](request: Request[A], token: Token): Request[A] = {
+    Request(tagRequest(request: RequestHeader, token), request.body)
+  }
+
+  private[csrf] def getHeaderToken(request: RequestHeader, config: CSRFConfig) = {
     val queryStringToken = request.getQueryString(config.tokenName)
     val headerToken = request.headers.get(config.headerName)
 
@@ -383,7 +424,6 @@ object CSRFAction {
   }
 
   private[csrf] def addTokenToResponse(config: CSRFConfig, newToken: String, request: RequestHeader, result: Result) = {
-
     if (isCached(result)) {
       filterLogger.trace("[CSRF] Not adding token to cached response")
       result
@@ -411,7 +451,7 @@ object CSRFAction {
     import play.api.libs.iteratee.Execution.Implicits.trampoline
 
     errorHandler.handle(request, msg) map { result =>
-      CSRF.getToken(request, config).fold(
+      CSRF.getToken(request).fold(
         config.cookieName.flatMap { cookie =>
           request.cookies.get(cookie).map { token =>
             result.discardingCookies(DiscardingCookie(cookie, domain = Session.domain, path = Session.path,
@@ -430,21 +470,21 @@ object CSRFAction {
  *
  * Apply this to all actions that require a CSRF check.
  */
-object CSRFCheck {
+case class CSRFCheck @Inject() (config: CSRFConfig, crypto: Crypto) {
 
-  private class CSRFCheckAction[A](config: CSRFConfig, tokenProvider: TokenProvider, errorHandler: ErrorHandler,
-      wrapped: Action[A]) extends Action[A] {
+  private class CSRFCheckAction[A](tokenProvider: TokenProvider, errorHandler: ErrorHandler, wrapped: Action[A]) extends Action[A] {
     def parser = wrapped.parser
-    def apply(request: Request[A]) = {
+    def apply(untaggedRequest: Request[A]) = {
+      val request = CSRFAction.tagRequestFromHeader(untaggedRequest, config, crypto)
 
       // Maybe bypass
       if (!CSRFAction.requiresCsrfCheck(request, config) || !config.checkContentType(request.contentType)) {
         wrapped(request)
       } else {
         // Get token from header
-        CSRFAction.getTokenFromHeader(request, config).flatMap { headerToken =>
+        CSRFAction.getTokenToValidate(request, config, crypto).flatMap { headerToken =>
           // Get token from query string
-          CSRFAction.getTokenFromQueryString(request, config)
+          CSRFAction.getHeaderToken(request, config)
             // Or from body if not found
             .orElse({
               val form = request.body match {
@@ -470,8 +510,21 @@ object CSRFCheck {
   /**
    * Wrap an action in a CSRF check.
    */
-  def apply[A](action: Action[A], errorHandler: ErrorHandler = CSRF.DefaultErrorHandler, config: CSRFConfig = CSRFConfig.global): Action[A] =
-    new CSRFCheckAction(config, new TokenProviderProvider(config).get, errorHandler, action)
+  def apply[A](action: Action[A], errorHandler: ErrorHandler): Action[A] =
+    new CSRFCheckAction(new TokenProviderProvider(config).get, errorHandler, action)
+
+  /**
+   * Wrap an action in a CSRF check.
+   */
+  def apply[A](action: Action[A]): Action[A] =
+    new CSRFCheckAction(new TokenProviderProvider(config).get, CSRF.DefaultErrorHandler, action)
+}
+
+object CSRFCheck {
+  @deprecated("Use CSRFCheck class with dependency injection instead", "2.5.0")
+  def apply[A](action: Action[A], errorHandler: ErrorHandler = CSRF.DefaultErrorHandler, config: CSRFConfig = CSRFConfig.global, crypto: Crypto = Crypto.crypto): Action[A] = {
+    CSRFCheck(config, crypto)(action, errorHandler)
+  }
 }
 
 /**
@@ -479,19 +532,19 @@ object CSRFCheck {
  *
  * Apply this to all actions that render a form that contains a CSRF token.
  */
-object CSRFAddToken {
+case class CSRFAddToken @Inject() (config: CSRFConfig, crypto: Crypto) {
 
   private class CSRFAddTokenAction[A](config: CSRFConfig, tokenProvider: TokenProvider, wrapped: Action[A]) extends Action[A] {
     def parser = wrapped.parser
-    def apply(request: Request[A]) = {
-      if (CSRFAction.getTokenFromHeader(request, config).isEmpty) {
+    def apply(untaggedRequest: Request[A]) = {
+      val request = CSRFAction.tagRequestFromHeader(untaggedRequest, config, crypto)
+
+      if (CSRFAction.getTokenToValidate(request, config, crypto).isEmpty) {
         // No token in header and we have to create one if not found, so create a new token
         val newToken = tokenProvider.generateToken
 
         // The request
-        val requestWithNewToken = new WrappedRequest(request) {
-          override val tags = request.tags + (Token.RequestTag -> newToken)
-        }
+        val requestWithNewToken = CSRFAction.tagRequest(request, Token(config.tokenName, newToken))
 
         // Once done, add it to the result
         import play.api.libs.iteratee.Execution.Implicits.trampoline
@@ -506,6 +559,11 @@ object CSRFAddToken {
   /**
    * Wrap an action in an action that ensures there is a CSRF token.
    */
-  def apply[A](action: Action[A], config: CSRFConfig = CSRFConfig.global): Action[A] =
+  def apply[A](action: Action[A]): Action[A] =
     new CSRFAddTokenAction(config, new TokenProviderProvider(config).get, action)
+}
+object CSRFAddToken {
+  @deprecated("Use CSRFAddToken class with dependency injection instead", "2.5.0")
+  def apply[A](action: Action[A], config: CSRFConfig = CSRFConfig.global, crypto: Crypto = Crypto.crypto): Action[A] =
+    CSRFAddToken(config, crypto)(action)
 }

--- a/framework/src/play-filters-helpers/src/main/scala/views/html/helper/CSRF.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/views/html/helper/CSRF.scala
@@ -14,21 +14,21 @@ object CSRF {
   /**
    * Add the CSRF token as a query String parameter to this reverse router request
    */
-  def apply(call: Call)(implicit token: play.filters.csrf.CSRF.Token): Call = {
+  def apply(call: Call)(implicit request: RequestHeader): Call = {
+    val token = play.filters.csrf.CSRF.getToken.getOrElse(sys.error("No CSRF token present!"))
     new Call(
       call.method,
-      call.url + {
-        if (call.url.contains("?")) "&" else "?"
-      } + play.filters.csrf.CSRFConfig.global.tokenName + "=" + token.value
+      s"${call.url}${if (call.url.contains("?")) "&" else "?"}${token.name}=${token.value}"
     )
   }
 
   /**
    * Render a CSRF form field token
    */
-  def formField(implicit token: play.filters.csrf.CSRF.Token): Html = {
+  def formField(implicit request: RequestHeader): Html = {
+    val token = play.filters.csrf.CSRF.getToken.getOrElse(sys.error("No CSRF token present!"))
     // probably not possible for an attacker to XSS with a CSRF token, but just to be on the safe side...
-    Html(s"""<input type="hidden" name="${play.filters.csrf.CSRFConfig.global.tokenName}" value="${HtmlFormat.escape(token.value)}"/>""")
+    Html(s"""<input type="hidden" name="${token.name}" value="${HtmlFormat.escape(token.value)}"/>""")
   }
 
 }

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletableFuture
 import javax.inject.Inject
 
 import play.api.http.HttpFilters
+import play.filters.csrf.CSRFConfig
 import play.mvc.Http
 
 import scala.concurrent.Future

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/ScalaCSRFActionSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/ScalaCSRFActionSpec.scala
@@ -15,9 +15,9 @@ object ScalaCSRFActionSpec extends CSRFCommonSpecs {
   def buildCsrfCheckRequest(sendUnauthorizedResult: Boolean, configuration: (String, String)*) = new CsrfTester {
     def apply[T](makeRequest: (WSRequest) => Future[WSResponse])(handleResponse: (WSResponse) => T) = withServer(configuration) {
       case _ => if (sendUnauthorizedResult) {
-        CSRFCheck(Action(req => Results.Ok), new CustomErrorHandler())
+        csrfCheck(Action(req => Results.Ok), new CustomErrorHandler())
       } else {
-        CSRFCheck(Action(req => Results.Ok))
+        csrfCheck(Action(req => Results.Ok))
       }
     } {
       import play.api.Play.current
@@ -27,9 +27,9 @@ object ScalaCSRFActionSpec extends CSRFCommonSpecs {
 
   def buildCsrfAddToken(configuration: (String, String)*) = new CsrfTester {
     def apply[T](makeRequest: (WSRequest) => Future[WSResponse])(handleResponse: (WSResponse) => T) = withServer(configuration) {
-      case _ => CSRFAddToken(Action {
+      case _ => csrfAddToken(Action {
         implicit req =>
-          CSRF.getToken(req).map {
+          CSRF.getToken.map {
             token =>
               Results.Ok(token.value)
           } getOrElse Results.NotFound

--- a/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
@@ -35,7 +35,7 @@ object Crypto {
   class CryptoException(val message: String = null, val throwable: Throwable = null) extends RuntimeException(message, throwable)
 
   private val cryptoCache = Application.instanceCache[Crypto]
-  private def crypto = {
+  private[play] def crypto = {
     Play.privateMaybeApplication.fold(
       new Crypto(new CryptoConfigParser(
         Environment.simple(), Configuration.from(Map("play.crypto.aes.transformation" -> "AES/CTR/NoPadding"))

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -175,6 +175,14 @@ package play.api.mvc {
     } yield charset
 
     /**
+      * Convenience method for adding a single tag to this request
+      * @return the tagged request
+      */
+    def withTag(tagName: String, tagValue: String): RequestHeader = {
+      copy(tags = tags + (tagName -> tagValue))
+    }
+
+    /**
      * Copy the request.
      */
     def copy(

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -222,6 +222,8 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
 
   def tags = header.tags.asJava
 
+  def withTag(name: String, value: String) = header.withTag(name, value)
+
   override def toString = header.toString
 
 }


### PR DESCRIPTION
The form helpers and `CSRF.getToken` now take an `implicit RequestHeader` and will pull the token name and value off of tags on the request. No global state is required to do this, since the token is placed on the request by the `CSRFFilter`.

Unfortunately because of the limitations of tags this solution ended up being a little bit ugly. Ideally we should have a way to attach arbitrary data onto the request, e.g. a `CSRFContext` that has the token name, value, and possibly other functionality (re-signing tokens), but I thought it might be out of the scope of this PR.