### PR TITLE
Update 2.4.x to AHC 1.9.33

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -270,7 +270,7 @@ object Dependencies {
 
   val playWsDeps = Seq(
     guava,
-    "com.ning" % "async-http-client" % "1.9.21"
+    "com.ning" % "async-http-client" % "1.9.33"
   ) ++ Seq("signpost-core", "signpost-commonshttp4").map("oauth.signpost" % _  % "1.2.1.2") ++
   (specsBuild :+ specsMatcherExtra).map(_ % Test) :+
   mockitoAll % Test

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
@@ -59,9 +59,6 @@ trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecificat
       flashCookie must beSome.like {
         case cookie =>
           cookie.value must beNone
-          cookie.expires must beSome.like {
-            case expires => expires must be lessThan System.currentTimeMillis()
-          }
           cookie.maxAge must beSome(0)
       }
     }

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSCookie.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSCookie.java
@@ -22,6 +22,10 @@ public interface WSCookie {
 
     public String getPath();
 
+    /**
+     * @deprecated "AHC 1.9.33 no longer supports expires, please use maxAge.
+     */
+    @Deprecated
     public Long getExpires();
 
     public Integer getMaxAge();

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSCookie.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ning/NingWSCookie.java
@@ -45,7 +45,7 @@ public class NingWSCookie implements WSCookie {
     }
 
     public Integer getMaxAge() {
-        return ahcCookie.getMaxAge();
+        return ((int) ahcCookie.getMaxAge());
     }
 
     public Boolean isSecure() {

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -578,6 +578,7 @@ trait WSCookie {
   /**
    * The expiry date.
    */
+  @deprecated("AHC 1.9.33 no longer supports expires, please use maxAge", "2.4.7")
   def expires: Option[Long]
 
   /**

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
@@ -531,7 +531,7 @@ private class NingWSCookie(ahcCookie: AHCCookie) extends WSCookie {
   /**
    * The maximum age.
    */
-  def maxAge: Option[Int] = if (ahcCookie.getMaxAge <= -1) None else Some(ahcCookie.getMaxAge)
+  def maxAge: Option[Int] = if (ahcCookie.getMaxAge <= -1) None else Some(ahcCookie.getMaxAge.toInt)
 
   /**
    * If the cookie is secure.

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ning/NingWSSpec.scala
@@ -270,7 +270,7 @@ object NingWSSpec extends PlaySpecification with Mockito {
       val (name, value, wrap, domain, path, expires, maxAge, secure, httpOnly) =
         ("someName", "someValue", true, "example.com", "/", 2000L, 1000, false, false)
 
-      val ahcCookie: AHCCookie = new AHCCookie(name, value, wrap, domain, path, expires, maxAge, secure, httpOnly)
+      val ahcCookie: AHCCookie = new AHCCookie(name, value, wrap, domain, path, maxAge, secure, httpOnly)
       ahcResponse.getCookies returns util.Arrays.asList(ahcCookie)
 
       val response = NingWSResponse(ahcResponse)
@@ -282,7 +282,6 @@ object NingWSSpec extends PlaySpecification with Mockito {
       cookie.name must beSome(name)
       cookie.value must beSome(value)
       cookie.path must ===(path)
-      cookie.expires must beSome(expires)
       cookie.maxAge must beSome(maxAge)
       cookie.secure must beFalse
     }
@@ -292,7 +291,7 @@ object NingWSSpec extends PlaySpecification with Mockito {
       val (name, value, wrap, domain, path, expires, maxAge, secure, httpOnly) =
         ("someName", "someValue", true, "example.com", "/", 2000L, 1000, false, false)
 
-      val ahcCookie: AHCCookie = new AHCCookie(name, value, wrap, domain, path, expires, maxAge, secure, httpOnly)
+      val ahcCookie: AHCCookie = new AHCCookie(name, value, wrap, domain, path, maxAge, secure, httpOnly)
       ahcResponse.getCookies returns util.Arrays.asList(ahcCookie)
 
       val response = NingWSResponse(ahcResponse)
@@ -304,7 +303,6 @@ object NingWSSpec extends PlaySpecification with Mockito {
           cookie.value must beSome(value)
           cookie.domain must ===(domain)
           cookie.path must ===(path)
-          cookie.expires must beSome(expires)
           cookie.maxAge must beSome(maxAge)
           cookie.secure must beFalse
       }
@@ -313,14 +311,13 @@ object NingWSSpec extends PlaySpecification with Mockito {
     "return -1 values of expires and maxAge as None" in {
       val ahcResponse: AHCResponse = mock[AHCResponse]
 
-      val ahcCookie: AHCCookie = new AHCCookie("someName", "value", true, "domain", "path", -1L, -1, false, false)
+      val ahcCookie: AHCCookie = new AHCCookie("someName", "value", true, "domain", "path", -1, false, false)
       ahcResponse.getCookies returns util.Arrays.asList(ahcCookie)
 
       val response = NingWSResponse(ahcResponse)
 
       val optionCookie = response.cookie("someName")
       optionCookie must beSome[WSCookie].which { cookie =>
-        cookie.expires must beNone
         cookie.maxAge must beNone
       }
     }


### PR DESCRIPTION
Should fix https://github.com/playframework/playframework/issues/5626

Note that AHC 1.9.33 has binary incompatible changes with 1.9.21, because the expires field is no longer used in an AHC cookie.