### PR TITLE
Change default HttpRequestHandlers

### DIFF
--- a/documentation/manual/working/javaGuide/code/MockJavaAction.scala
+++ b/documentation/manual/working/javaGuide/code/MockJavaAction.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.{CompletionStage, CompletableFuture}
 
 import akka.stream.Materializer
 import play.api.mvc.{Action, Request}
-import play.core.j.{JavaHandlerComponents, JavaHelpers, JavaActionAnnotations, JavaAction}
+import play.core.j.{DefaultJavaHandlerComponents, JavaHelpers, JavaActionAnnotations, JavaAction}
 import play.http.DefaultActionCreator
 import play.mvc.{Controller, Http, Result}
 import play.api.test.Helpers
@@ -16,7 +16,7 @@ import java.lang.reflect.Method
 abstract class MockJavaAction extends Controller with Action[Http.RequestBody] {
   self =>
 
-  private lazy val components = new JavaHandlerComponents(
+  private lazy val components = new DefaultJavaHandlerComponents(
     play.api.Play.current.injector, new DefaultActionCreator
   )
 
@@ -25,7 +25,7 @@ abstract class MockJavaAction extends Controller with Action[Http.RequestBody] {
 
     def parser = {
       play.HandlerInvokerFactoryAccessor.javaBodyParserToScala(
-        components.injector.instanceOf(annotations.parser)
+        components.getBodyParser(annotations.parser)
       )
     }
 

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
@@ -26,9 +26,7 @@ object JavaCSRFActionSpec extends CSRFCommonSpecs {
 
   def javaAction[T: ClassTag](method: String, inv: => Result) = new JavaAction(javaHandlerComponents) {
     val clazz = implicitly[ClassTag[T]].runtimeClass
-    def parser = HandlerInvokerFactory.javaBodyParserToScala(
-      javaHandlerComponents.injector.instanceOf(annotations.parser)
-    )
+    def parser = HandlerInvokerFactory.javaBodyParserToScala(javaHandlerComponents.getBodyParser(annotations.parser))
     def invocation = CompletableFuture.completedFuture(inv)
     val annotations = new JavaActionAnnotations(clazz, clazz.getMethod(method))
   }

--- a/framework/src/play-integration-test/src/test/scala/play/it/bindings/GlobalSettingsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/bindings/GlobalSettingsSpec.scala
@@ -27,7 +27,7 @@ trait GlobalSettingsSpec extends PlaySpecification with WsTestClient with Server
     implicit val port = testServerPort
     val additionalSettings = applicationGlobal.fold(Map.empty[String, String]) { s: String =>
       Map("application.global" -> s"play.it.bindings.$s")
-    }
+    } + ("play.http.requestHandler" -> "play.http.GlobalSettingsHttpRequestHandler")
     import play.api.inject._
     import play.api.routing.sird._
     lazy val app: Application = new GuiceApplicationBuilder()

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JAction.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JAction.scala
@@ -30,7 +30,7 @@ object JAction {
     val components = app.injector.instanceOf[JavaHandlerComponents]
     new JavaAction(components) {
       val annotations = new JavaActionAnnotations(c.getClass, c.getClass.getMethod("action"))
-      val parser = HandlerInvokerFactory.javaBodyParserToScala(components.injector.instanceOf(annotations.parser))
+      val parser = HandlerInvokerFactory.javaBodyParserToScala(components.getBodyParser(annotations.parser))
       def invocation = c.invocation
     }
   }

--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -7,7 +7,7 @@ import akka.stream.Materializer
 import java.util.concurrent.CompletionStage
 import java.util.function.{ Function => JFunction }
 import org.specs2.mutable.Specification
-import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
+import play.api.http.{ GlobalSettingsHttpRequestHandler, HttpRequestHandler, DefaultHttpErrorHandler, HttpErrorHandler }
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.streams.Accumulator
 import play.api.libs.ws.WSClient
@@ -89,7 +89,10 @@ trait GlobalFiltersSpec extends FiltersSpec {
 
     val app = new GuiceApplicationBuilder()
       .configure(settings)
-      .overrides(bind[Router].toInstance(testRouter))
+      .overrides(
+        bind[Router].toInstance(testRouter),
+        bind[HttpRequestHandler].to[GlobalSettingsHttpRequestHandler]
+      )
       .global(
         new WithFilters(filters: _*) {
           override def onHandlerNotFound(request: RequestHeader) = {

--- a/framework/src/play/src/main/java/play/http/GlobalSettingsHttpRequestHandler.java
+++ b/framework/src/play/src/main/java/play/http/GlobalSettingsHttpRequestHandler.java
@@ -3,28 +3,42 @@
  */
 package play.http;
 
-import java.lang.reflect.Method;
+import play.api.GlobalSettings;
+import play.api.mvc.Handler;
+import play.api.mvc.RequestHeader;
+import play.core.j.JavaGlobalSettingsAdapter;
+import play.core.j.RequestHeaderImpl;
+import play.mvc.Action;
+import play.mvc.Http;
+import play.mvc.Result;
+import scala.Tuple2;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
-import play.api.GlobalSettings;
-import play.core.j.JavaGlobalSettingsAdapter;
-import play.mvc.Action;
-import play.mvc.Http;
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletionStage;
 
 /**
- * Request handler that delegates to global
+ * Request handler that delegates to GlobalSettings.
+ *
+ * @deprecated GlobalSettings is deprecated. Extend DefaultHttpRequestHandler instead.
  */
+@Deprecated
 @Singleton
-public class GlobalSettingsHttpRequestHandler extends DefaultHttpRequestHandler {
+public class GlobalSettingsHttpRequestHandler implements HttpRequestHandler {
 
     private final GlobalSettings global;
 
     @Inject
-    public GlobalSettingsHttpRequestHandler(GlobalSettings global, play.api.http.HttpRequestHandler underlying) {
-        super(underlying);
+    public GlobalSettingsHttpRequestHandler(GlobalSettings global) {
+        super();
         this.global = global;
+    }
+
+    @Override
+    public HandlerForRequest handlerForRequest(Http.RequestHeader request) {
+        Tuple2<RequestHeader, Handler> result = global.onRequestReceived(request._underlyingHeader());
+        return new HandlerForRequest(new RequestHeaderImpl(result._1()), result._2());
     }
 
     @Override
@@ -32,7 +46,12 @@ public class GlobalSettingsHttpRequestHandler extends DefaultHttpRequestHandler 
         if (global instanceof JavaGlobalSettingsAdapter) {
             return ((JavaGlobalSettingsAdapter) global).underlying().onRequest(request, actionMethod);
         } else {
-            return super.createAction(request, actionMethod);
+            return new Action.Simple() {
+                @Override
+                public CompletionStage<Result> call(Http.Context ctx) {
+                    return delegate.call(ctx);
+                }
+            };
         }
     }
 }

--- a/framework/src/play/src/main/java/play/http/HttpRequestHandler.java
+++ b/framework/src/play/src/main/java/play/http/HttpRequestHandler.java
@@ -6,6 +6,7 @@ package play.http;
 import java.lang.reflect.Method;
 import java.util.concurrent.CompletionStage;
 
+import play.core.j.JavaHttpRequestHandlerAdapter;
 import play.mvc.Action;
 import play.mvc.Http;
 import play.mvc.Http.Request;
@@ -69,5 +70,12 @@ public interface HttpRequestHandler {
     @Deprecated
     default Action wrapAction(Action action) {
         return action;
+    }
+
+    /**
+     * Adapt this to a Scala HttpRequestHandler
+     */
+    default play.api.http.HttpRequestHandler asScala() {
+        return new JavaHttpRequestHandlerAdapter(this);
     }
 }

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -28,8 +28,7 @@ play {
     # - provided, indicates that the application has bound an instance of play.api.http.HttpRequestHandler through some
     #   other mechanism.
     # If null, will attempt to load a class called RequestHandler in the root package, otherwise if that's
-    # not found, will default to play.api.http.GlobalSettingsHttpRequestHandler, which delegates to legacy request
-    # handling methods on Global.
+    # not found, will default to play.api.http.JavaCompatibleHttpRequestHandler.
     requestHandler = null
 
     # The request handler.

--- a/framework/src/play/src/main/scala/play/core/j/JavaHttpRequestHandlerAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHttpRequestHandlerAdapter.scala
@@ -7,7 +7,8 @@ import javax.inject.Inject
 
 import play.api.http.HttpRequestHandler
 import play.api.mvc.RequestHeader
-import play.http.{ HttpRequestHandler => JHttpRequestHandler }
+import play.http.{ HttpRequestHandler => JHttpRequestHandler, HandlerForRequest }
+import play.mvc.Http.{ RequestHeader => JRequestHeader }
 
 /**
  * Adapter from a Java HttpRequestHandler to a Scala HttpRequestHandler
@@ -16,5 +17,15 @@ class JavaHttpRequestHandlerAdapter @Inject() (underlying: JHttpRequestHandler) 
   override def handlerForRequest(request: RequestHeader) = {
     val handlerForRequest = underlying.handlerForRequest(new RequestHeaderImpl(request))
     (handlerForRequest.getRequest._underlyingHeader(), handlerForRequest.getHandler)
+  }
+}
+
+/**
+ * Adapter from a Java HttpRequestHandler to a Scala HttpRequestHandler
+ */
+class JavaHttpRequestHandlerDelegate @Inject() (underlying: HttpRequestHandler) extends JHttpRequestHandler {
+  override def handlerForRequest(request: JRequestHeader) = {
+    val (newRequest, handler) = underlying.handlerForRequest(request._underlyingHeader())
+    new HandlerForRequest(new RequestHeaderImpl(newRequest), handler)
   }
 }

--- a/framework/src/play/src/main/scala/play/core/routing/HandlerInvoker.scala
+++ b/framework/src/play/src/main/scala/play/core/routing/HandlerInvoker.scala
@@ -130,7 +130,7 @@ object HandlerInvokerFactory {
         def withComponents(components: JavaHandlerComponents) = new play.core.j.JavaAction(components) with RequestTaggingHandler {
           val annotations = cachedAnnotations
           val parser = {
-            val javaParser = components.injector.instanceOf(cachedAnnotations.parser)
+            val javaParser = components.getBodyParser(cachedAnnotations.parser)
             javaBodyParserToScala(javaParser)
           }
           def invocation: CompletionStage[JResult] = resultCall(call)


### PR DESCRIPTION
Use `DefaultHttpRequestHandler` in both Java and Scala.

I also did some refactoring of the Java `HttpRequestHandler`-related code.

Fixes #5357, closes #5369.