### PR TITLE
Created deprecated Logger$ColoredLevel

### DIFF
--- a/framework/src/play-logback/src/main/scala/play/api/Logger$ColoredLevel.scala
+++ b/framework/src/play-logback/src/main/scala/play/api/Logger$ColoredLevel.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api
+
+import ch.qos.logback.core.joran.util.ConfigurationWatchListUtil
+import play.api.libs.logback.ColoredLevel
+
+/**
+ * Provides the old play.api.Logger$ColoredLevel library so that a deprecation message can be logged.
+ */
+@deprecated("Use play.api.libs.logback.ColoredLevel instead", "2.5.0")
+class Logger$ColoredLevel extends ColoredLevel {
+
+  override def start(): Unit = {
+    super.start()
+    val configLocation = Option(ConfigurationWatchListUtil.getMainWatchURL(getContext)).fold("your logback configuration")(_.toString)
+    val migrationDocs = "https://www.playframework.com/documentation/2.5.x/Migration25#Change-to-Logback-configuration"
+    addError(s"You are using the deprecated ${this.getClass.getName} in $configLocation, please use ${classOf[ColoredLevel].getName} instead. See $migrationDocs for more information.")
+  }
+}


### PR DESCRIPTION
This should allow for a smoother migration path, as it tells the user how to solve the problem, rather than simply having logback emit a ClassNotFoundException.

The result of this change is that when the deprecated class is used, along with all the logback debug output, you see this:

```
13:21:22,079 |-ERROR in play.api.Logger$ColoredLevel@57ac5964 - You are using the deprecated play.api.Logger$ColoredLevel in file:/home/jroper/tmp/play-scala/target/scala-2.11/classes/logback.xml, please use play.api.libs.logback.ColoredLevel instead. See https://www.playframework.com/documentation/2.5.x/Migration25#Change-to-Logback-configuration for more information.
```

It has to be logged at error, as warnings don't trigger logback to dump its status messages - the user would never see the warning.