### PR TITLE
Moved forwarded header configuration to reference.conf

### DIFF
--- a/framework/src/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -368,7 +368,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
     new ForwardedHeaderHandler(ForwardedHeaderHandlerConfig(None))
 
   def handler(config: Map[String, Any]) =
-    new ForwardedHeaderHandler(ForwardedHeaderHandlerConfig(Some(Configuration.from(config))))
+    new ForwardedHeaderHandler(ForwardedHeaderHandlerConfig(Some(Configuration.reference ++ Configuration.from(config))))
 
   def version(s: String) = {
     Map("play.http.forwarded.version" -> s)

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -59,6 +59,36 @@ play {
     # default to play.api.http.NoHttpFilters, which provides no filters.
     filters = null
 
+    # Forwarded header configuration
+    # Play supports various forwarded headers used by proxies to indicate the incoming IP address and protocol of
+    # requests. Play uses this in the implementation of the RequestHeader.remoteAddress and RequestHeader.secure
+    # fields.
+    forwarded = {
+
+      # The version of forwarded headers to use.
+      # Valid values are x-forwarded and rfc7239.
+      # x-forwarded uses the de facto standard X-Forwarded-For and X-Forwarded-Proto headers to determine the correct
+      # remote address and protocol for the request. These headers are widely used, however, they have some serious
+      # limitations, for example, if you have multiple proxies, and only one of them adds the X-Forwarded-Proto header,
+      # it's impossible to reliably determine which proxy added it and therefore whether the request from the client
+      # was made using https or http. rfc7239 uses the new Forwarded header standard, and solves many of the
+      # limitations of the X-Forwarded-* headers.
+      version = "x-forwarded"
+
+      # The trusted proxies.
+      # Trusted proxies may either be individual IPv4 or IPv6 addresses, or be IPv4 or IPv6 CIDR address ranges.
+      # This is used to prevent IP address spoofing. Multiple proxies can add and append to the forwarded headers,
+      # including the client, which could masquerade as a proxy proxying requests on behalf of another client.  Play
+      # will validate that the incoming request IP, and all forwarded headers match the addresses in this list, and will
+      # present the first untrusted IP address that it finds (or if all addresses are trusted, the last address) to the
+      # application.
+      # Note that a number of cloud hosting platforms, most notably AWS, make no guarantees as to what IP addresses
+      # their proxies will make requests from. If this is the case, in order for Play to respect the forwarded headers,
+      # you need to trust all IP addresses, therefore making it possible for clients to spoof the incoming address.
+      # To trust all IP addresses, set this to ["0.0.0.0/0", "::/0"].
+      trustedProxies = ["127.0.0.1", "::1"]
+    }
+
     # Parsing configuration
     parser = {
 


### PR DESCRIPTION
In addition, I improved the docs to be more detailed and clearer, including information about getting forwarded headers working on platforms that require trusting all proxies.