### PR TITLE
Message key for constraint.pattern

### DIFF
--- a/framework/src/play/src/main/resources/messages.default
+++ b/framework/src/play/src/main/resources/messages.default
@@ -11,6 +11,7 @@ constraint.max=Maximum value: {0}
 constraint.minLength=Minimum length: {0}
 constraint.maxLength=Maximum length: {0}
 constraint.email=Email
+constraint.pattern=Required pattern: {0}
 
 # --- Formats
 format.date=Date (''{0}'')


### PR DESCRIPTION
Seems it was forgotten. It's defined [here](https://github.com/playframework/playframework/blob/2.5.0-M2/framework/src/play-java/src/main/java/play/data/validation/Constraints.java#L401).