### PR TITLE
Correctly exclude child options

### DIFF
--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -99,7 +99,7 @@ class NettyServer(
       case number: Number => number.intValue().asInstanceOf[Integer]
       case other => other
     }
-    config.entrySet().asScala.filterNot(_.getKey == "child").foreach { option =>
+    config.entrySet().asScala.filterNot(_.getKey.startsWith("child.")).foreach { option =>
       if (ChannelOption.exists(option.getKey)) {
         setOption(ChannelOption.valueOf(option.getKey), unwrap(option.getValue))
       } else {


### PR DESCRIPTION
This fixes the following warnings in the logs when Netty binds the server channel:

```
Ignoring unknown Netty channel option: child.SO_KEEPALIVE
Valid values can be found at http://netty.io/4.0/api/io/netty/channel/ChannelOption.html
```