### PR TITLE
Look up arguments of constraint/format/error messages in message file

### DIFF
--- a/framework/src/play-java/src/test/resources/messages
+++ b/framework/src/play-java/src/test/resources/messages
@@ -1,0 +1,2 @@
+error.custom=It looks like something {0}
+error.customarg=was not correct

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -223,16 +223,22 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
   /**
    * Returns the form errors serialized as Json.
    */
-  def errorsAsJson(implicit lang: play.api.i18n.Messages): play.api.libs.json.JsValue = {
+  def errorsAsJson(implicit messages: play.api.i18n.Messages): play.api.libs.json.JsValue = {
 
     import play.api.libs.json._
 
     Json.toJson(
       errors.groupBy(_.key).mapValues { errors =>
-        errors.map(e => play.api.i18n.Messages(e.message, e.args: _*))
+        errors.map(e => messages(e.message, e.args.map(a => translateMsgArg(a)): _*))
       }
     )
 
+  }
+
+  private def translateMsgArg(msgArg: Any)(implicit messages: play.api.i18n.Messages) = msgArg match {
+    case key: String => messages(key)
+    case keys: Seq[String] => keys.map(key => messages(key))
+    case _ => msgArg
   }
 
   /**

--- a/framework/src/play/src/main/scala/views/helper/Helpers.scala
+++ b/framework/src/play/src/main/scala/views/helper/Helpers.scala
@@ -17,22 +17,22 @@ package views.html.helper {
           case Some(false) => false
           case _ => true
         }) {
-          field.constraints.map(c => messages(c._1, c._2: _*)) ++
-            field.format.map(f => messages(f._1, f._2: _*))
+          field.constraints.map(c => messages(c._1, c._2.map(a => translateMsgArg(a)): _*)) ++
+            field.format.map(f => messages(f._1, f._2.map(a => translateMsgArg(a)): _*))
         } else Nil)
       }
     }
 
     def errors: Seq[String] = {
       (args.get('_error) match {
-        case Some(Some(play.api.data.FormError(_, message, args))) => Some(Seq(messages(message, args: _*)))
+        case Some(Some(play.api.data.FormError(_, message, args))) => Some(Seq(messages(message, args.map(a => translateMsgArg(a)): _*)))
         case _ => None
       }).getOrElse {
         (if (args.get('_showErrors) match {
           case Some(false) => false
           case _ => true
         }) {
-          field.errors.map(e => messages(e.message, e.args: _*))
+          field.errors.map(e => messages(e.message, e.args.map(a => translateMsgArg(a)): _*))
         } else Nil)
       }
     }
@@ -49,6 +49,12 @@ package views.html.helper {
 
     def name: Any = {
       args.get('_name).getOrElse(messages(field.label))
+    }
+
+    private def translateMsgArg(msgArg: Any) = msgArg match {
+      case key: String => messages(key)
+      case keys: Seq[String] => keys.map(key => messages(key))
+      case _ => msgArg
     }
 
   }

--- a/framework/src/play/src/test/resources/messages
+++ b/framework/src/play/src/test/resources/messages
@@ -1,0 +1,8 @@
+error.custom=This is a {0}
+error.customarg=custom error
+
+constraint.custom=I am a {0}
+constraint.customarg=custom constraint
+
+format.custom=Look at me! I am a {0}
+format.customarg=custom format pattern

--- a/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
@@ -3,9 +3,11 @@
  */
 package play.api.data
 
+import play.api.{ Configuration, Environment }
 import play.api.data.Forms._
 import play.api.data.validation.Constraints._
 import play.api.data.format.Formats._
+import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
 import play.api.libs.json.Json
 import org.specs2.mutable.Specification
 import org.joda.time.{ DateTime, LocalDate }
@@ -282,6 +284,14 @@ object FormSpec extends Specification {
   "reject boolean binding from an invalid json" in {
     val f = ScalaForms.booleanForm.bind(Json.obj("accepted" -> "foo"))
     f.errors must not be 'empty
+  }
+
+  "correctly lookup error messages when using errorsAsJson" in {
+    val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
+    implicit val messages = messagesApi.preferred(Seq.empty)
+
+    val form = Form(single("foo" -> Forms.text), Map.empty, Seq(FormError("foo", "error.custom", Seq("error.customarg"))), None)
+    (form.errorsAsJson \ "foo")(0).asOpt[String] must beSome("This is a custom error")
   }
 }
 

--- a/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -178,4 +178,23 @@ object HelpersSpec extends Specification {
       body must contain("""label for="bar_0">bar.0""")
     }
   }
+
+  "helpers" should {
+    "correctly lookup constraint, error and format messages" in {
+
+      val field = Field(
+        Form(single("foo" -> Forms.text)),
+        "foo",
+        Seq(("constraint.custom", Seq("constraint.customarg"))),
+        Some("format.custom", Seq("format.customarg")),
+        Seq(FormError("foo", "error.custom", Seq("error.customarg"))),
+        None)
+
+      val body = inputText.apply(field).body
+
+      body must contain("""<dd class="error">This is a custom error</dd>""")
+      body must contain("""<dd class="info">I am a custom constraint</dd>""")
+      body must contain("""<dd class="info">Look at me! I am a custom format pattern</dd>""")
+    }
+  }
 }


### PR DESCRIPTION
Original this was part of #5619.
I don't know if I have enough time fix #5619 until the Play 2.5 release so it would be nice to at least get this PR in.
With this PR people (like us) will be able to implement their **own** DataBinders and Constraints which make use of message keys as arguments so...
-  .. *databinders* like `@MyCurrencyBinder(pattern = "myFormats.currency")` where `myFormats.currency` is defined in the `messages.XX` files like e.g. `#,###.##`, etc. will display `#,###.##` correctly when displaying the field's format in the HTML (instead of displaying `myFormats.currency`).
- ...*constraints* like `@MyPattern(value="myConstraints.zipPattern", message="error.zip")` where `myConstraints.zipPattern` is defined in the `messages.XX` files like e.g. `[1-9][0-9]{3}`, etc. (the zip part of addresses vary by country) will display `[1-9][0-9]{3}` correctly when displaying the field's constraint and error message (in case of validation error) in the HTML (instead of displaying `myConstraints.zipPattern`).