### PR TITLE
Fix references to ActorFlow.actorRef

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/WebSocket.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/WebSocket.scala
@@ -272,7 +272,7 @@ object WebSocket {
    *   }
    * }}}
    */
-  @deprecated("Use accept with a flow that wraps a Sink.actorRef and Source.actorRef, or play.api.libs.Streams.actorFlow", "2.5.0")
+  @deprecated("Use accept with a flow that wraps a Sink.actorRef and Source.actorRef, or play.api.libs.Streams.ActorFlow.actorRef", "2.5.0")
   def acceptWithActor[In, Out](f: RequestHeader => HandlerProps)(implicit transformer: MessageFlowTransformer[In, Out],
     app: Application, mat: Materializer): WebSocket = {
     tryAcceptWithActor { req =>
@@ -301,7 +301,7 @@ object WebSocket {
    *   }
    * }}}
    */
-  @deprecated("Use acceptOrResult with a flow that wraps a Sink.actorRef and Source.actorRef, or play.api.libs.Streams.actorFlow", "2.5.0")
+  @deprecated("Use acceptOrResult with a flow that wraps a Sink.actorRef and Source.actorRef, or play.api.libs.Streams.ActorFlow.actorRef", "2.5.0")
   def tryAcceptWithActor[In, Out](f: RequestHeader => Future[Either[Result, HandlerProps]])(implicit transformer: MessageFlowTransformer[In, Out],
     app: Application, mat: Materializer): WebSocket = {
 


### PR DESCRIPTION
There is no `play.api.libs.Streams.actorFlow` method, so moving this.