### PR TITLE
Remove -mem from 2.4.x production configuration documentation as it doesn't work

### DIFF
--- a/documentation/manual/detailedTopics/production/ProductionConfiguration.md
+++ b/documentation/manual/detailedTopics/production/ProductionConfiguration.md
@@ -269,10 +269,3 @@ You can specify any JVM arguments to the application startup script. Otherwise t
 ```
 $ /path/to/bin/<project-name> -J-Xms128M -J-Xmx512m -J-server
 ```
-
-As a convenience you can also set memory min, max, permgen and the reserved code cache size in one go; a formula is used to
-determine these values given the supplied parameter (which represents maximum memory):
-
-```
-$ /path/to/bin/<project-name> -mem 512 -J-server
-```


### PR DESCRIPTION
update the 2.4.x jvm options documentation

related to: #5579 