### PR TITLE
Fix play-scala-intro Project Template

### DIFF
--- a/templates/play-scala-intro/build.sbt
+++ b/templates/play-scala-intro/build.sbt
@@ -6,6 +6,8 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 scalaVersion := "%SCALA_VERSION%"
 
+routesGenerator := InjectedRoutesGenerator
+
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-slick" % "%PLAY_SLICK_VERSION%",
   "com.typesafe.play" %% "play-slick-evolutions" % "%PLAY_SLICK_VERSION%",


### PR DESCRIPTION
Fixed the broken play-scala-intro template build by adding routesGenerator := InjectedRoutesGenerator in build.sbt.