### PR TITLE
Even more 2.5 migration guide improvements

### DIFF
--- a/documentation/manual/releases/release24/migration24/Migration24.md
+++ b/documentation/manual/releases/release24/migration24/Migration24.md
@@ -569,7 +569,7 @@ serverLoading in Debian := SystemV
 
 The mysterious `OrderedExecutionContext` had [[been retained|Migration22#Concurrent-F.Promise-execution]] in Play for several versions in order to support legacy applications. It was rarely used and has now been removed. If you still need the `OrderedExecutionContext` for some reason, you can create your own implementation based on the [Play 2.3 source](https://github.com/playframework/playframework/blob/2.3.x/framework/src/play/src/main/scala/play/core/j/OrderedExecutionContext.scala). If you haven't heard of this class, then there's nothing you need to do.
 
-### SubProject Assets
+### Subproject Assets
 
 Any assets in sub projects are now by default placed into /lib/[subproject] to allow files with the same name in the root project / different subprojects without causing them to interfere with each other.
 

--- a/documentation/manual/releases/release25/Highlights25.md
+++ b/documentation/manual/releases/release25/Highlights25.md
@@ -5,15 +5,15 @@ This page highlights the new features of Play 2.5. If you want learn about the c
 
 ## New streaming API based on Akka Streams
 
-The main theme of Play 2.5 has been moving from Play's iteratee based asynchronous IO API to [Akka streams](http://doc.akka.io/docs/akka/2.4.2/scala/stream/stream-introduction.html).
+The main theme of Play 2.5 has been moving from Play's iteratee-based asynchronous IO API to [Akka streams](http://doc.akka.io/docs/akka/2.4.2/scala/stream/stream-introduction.html).
 
-At its heart, any time you communicate over the network, or write/read some data to the filesystem, some streaming is involved.  In many cases, this streaming is done at a low level, while at the application level, the framework exposes communications as in memory messages.  This is the case for many Play actions, a body parser converts the request body stream into an object such as a parsed JSON object, which the application consumes, and the returned result body is a JSON object that Play then turns back into a stream.
+At its heart, any time you communicate over the network, or write/read some data to the filesystem, some streaming is involved.  In many cases, this streaming is done at a low level, and the framework exposes the materialized values to your application as in-memory messages.  This is the case for many Play actions, a body parser converts the request body stream into an object such as a parsed JSON object, which the application consumes, and the returned result body is a JSON object that Play then turns back into a stream.
 
 Traditionally, on the JVM, streaming is done using the blocking `InputStream` and `OutputStream` APIs.  These APIs require a dedicated thread to use them - when reading, that thread must block and wait for data, when writing, that thread must block and wait for the data to be flushed.  An asynchronous framework, such as Play, offers many advantages because it limits the resources it requires by not using blocking APIs such as these.  Instead, for streaming, an asynchronous API needs to be used, where the framework is notified that there's data to read or that data has been written, rather than having to have a thread block and wait for it.
 
 Prior to Play 2.5, Play used Iteratees as this asynchronous streaming mechanism, but now it uses Akka Streams.
 
-### Why not iteratees
+### Why not iteratees?
 
 Iteratees are a functional approach to handling asynchronous streaming.  They are incredibly powerful, while also offering an incredibly small API surface area - the Iteratee API consists of one method, `fold`, the rest is just helpers built on top of this method.  Iteratees also provide a very high degree of safety, as long as your code compiles, it's very unlikely that you would have any bugs related to the implementation of an iteratee itself, such as concurrency or error handling, most bugs would be in the "business" logic of the iteratee.
 
@@ -23,7 +23,7 @@ While this safety and simplicity is great, the consequence of it was that it has
 
 Akka streams provides a good balance between safety, simplicity and familiarity.  Akka streams intentionally constrains you in what you can do so that you can only do things correctly, but not as much as iteratees do.  Conceptually they are much more familiar to most developers, offering both functional and imperative ways of working with them.  Akka streams also has a first class Java API, making it simple to implement any streaming requirements in Java that are needed.
 
-### Where is Akka streams used
+### Where are Akka streams used?
 
 The places where you will come across Akka streams in your Play applications include:
 
@@ -35,28 +35,28 @@ The places where you will come across Akka streams in your Play applications inc
 
 ### Reactive Streams
 
-[Reactive Streams](http://reactivestreams.org) is a new specification for asynchronous streaming, which is scheduled for inclusion in JDK9, and available as a stand alone library for JDK6 and above.  In general, it is not an end user library, rather it is an SPI that streaming libraries can implement in order to integrate with each other.  Both Akka streams and iteratees provide a reactive streams SPI implementation.  This means, existing iteratees code can easily be used with Play's new Akka streams support.  It also means any other reactive streams implementations can be used in Play.
+[Reactive Streams](http://reactivestreams.org) is a new specification for asynchronous streaming, which is scheduled for inclusion in JDK9, and available as a standalone library for JDK6 and above.  In general, it is not an end-user library, rather it is an SPI that streaming libraries can implement in order to integrate with each other.  Both Akka streams and iteratees provide a reactive streams SPI implementation.  This means, existing iteratees code can easily be used with Play's new Akka streams support.  It also means any other reactive streams implementations can be used in Play.
 
 ### The future of iteratees
 
-Iteratees still have some use cases where they shine.  At current, there is no plan to deprecate or remove them from Play, though they may be moved to a stand alone library. Since iteratees provide a reactive streams implementation, they will always be usable in Play.
+Iteratees still have some use cases where they shine.  At current, there is no plan to deprecate or remove them from Play, though they may be moved to a standalone library. Since iteratees provide a reactive streams implementation, they will always be usable in Play.
 
 ## Better control over WebSocket frames
 
-The Play 2.5 WebSocket API gives you direct control over WebSocket frames. You can now send and receives binary, text, ping, pong and close frames. If you don't want to worry about this level of detail, Play will still automatically convert your JSON or XML data into the right kind of frame.
+The Play 2.5 WebSocket API gives you direct control over WebSocket frames. You can now send and receive binary, text, ping, pong and close frames. If you don't want to worry about this level of detail, Play will still automatically convert your JSON or XML data into the right kind of frame.
 
 ## New Java APIs
 
-Play 2.5's Java APIs provide feature-parity with the Scala APIs. We have introduced several new Java APIs to do this:
+Play 2.5's Java APIs provide feature parity with the Scala APIs. We have introduced several new Java APIs to do this:
 
 * [`HttpRequestHandler`](api/java/play/http/HttpRequestHandler.html), which allows interception of requests as they come in, before they are sent to the router.
 * [`EssentialAction`](api/java/play/mvc/EssentialAction.html), a low level action used in `EssentialFilter` and `HttpRequestHandler`s.
 * [`EssentialFilter`](api/java/play/mvc/EssentialFilter.html)/[`Filter`](api/java/play/mvc/Filter.html) for writing filters in Java.
-* [`BodyParser`](api/java/play/mvc/EssentialFilter.html), which allows writing custom body parsers in Java.
+* [`BodyParser`](api/java/play/mvc/BodyParser.html), which allows writing custom body parsers in Java.
 
 ## Java API updated to use Java 8 classes
 
-When Play 2.0 was released in 2012 Java had little support for Play's style of asynchronous functional programming. There were no lambdas, futures only had a blocking interface and common functional classes didn't exist. Play provided its own classes to fill the gap.
+When Play 2.0 was released in 2012, Java had little support for Play's style of asynchronous functional programming. There were no lambdas, futures only had a blocking interface and common functional classes didn't exist. Play provided its own classes to fill the gap.
 
 With Play 2.5 that situation has changed. Java 8 now ships with much better support for Play's style of programming. In Play 2.5 the Java APIs have been revamped to use standard Java 8 classes. This means that Play applications will integrate better with other Java libraries and look more like idiomatic Java.
 

--- a/documentation/manual/releases/release25/migration25/JavaMigration25.md
+++ b/documentation/manual/releases/release25/migration25/JavaMigration25.md
@@ -1,6 +1,6 @@
 # Java Migration Guide
 
-In order to better fit in to the Java 8 ecosystem, and to allow Play Java users to make more idiomatic use of Java in their applications, Play has switched to using a number of Java 8 types. Play also has new Java APIs for `EssentialAction`, `EssentialFilter`, `Router` and `HttpRequestHandler`.
+In order to better fit in to the Java 8 ecosystem, and to allow Play Java users to make more idiomatic use of Java in their applications, Play has switched to using a number of Java 8 types such as `CompletionStage` and `Function`. Play also has new Java APIs for `EssentialAction`, `EssentialFilter`, `Router`, `BodyParser`, and `HttpRequestHandler`.
 
 ## New Java APIs
 
@@ -40,14 +40,16 @@ void myMethod(Runnable block) { ... }
 
 The table below shows all the changes:
 
-* `F.Callback0`        -> `java.lang.Runnable`
-* `F.Callback<A>`      -> `java.util.function.Consumer<A>`
-* `F.Callback2<A,B>`   -> `java.util.function.BiConsumer<A,B>`
-* `F.Callback3<A,B,C>` -> No counterpart in Java 8, consider using `akka.japi.function.Function3`
-* `F.Predicate<A>`     -> `java.util.function.Predicate<A>`
-* `F.Function0<A>`     -> `java.util.function.Supplier<A>`
-* `F.Function1<A,R>`   -> `java.util.function.Function<A,R>`
-* `F.Function2<A,B,R>` -> `java.util.function.BiFunction<A,B,R>`
+| **old interface**    | **new interface**
+| --------------------------------------
+| `F.Callback0`        | `java.lang.Runnable`
+| `F.Callback<A>`      | `java.util.function.Consumer<A>`
+| `F.Callback2<A,B>`   | `java.util.function.BiConsumer<A,B>`
+| `F.Callback3<A,B,C>` | No counterpart in Java 8, consider using `akka.japi.function.Function3`
+| `F.Predicate<A>`     | `java.util.function.Predicate<A>`
+| `F.Function0<A>`     | `java.util.function.Supplier<A>`
+| `F.Function1<A,R>`   | `java.util.function.Function<A,R>`
+| `F.Function2<A,B,R>` | `java.util.function.BiFunction<A,B,R>`
 
 **Step 2:** Fix any errors caused by checked exceptions that are thrown inside your lambdas.
 
@@ -61,7 +63,7 @@ onClose(() -> {
 })
 ```
 
-In Play 2.5 the `onClose` method maybe have been changed to take a `java.lang.Runnable` argument instead of `F.Callback0`. Because `Runnable`s can't throw checked exceptions the code above won't compile in Play 2.5.
+In Play 2.5 the `onClose` method has been changed to take a `java.lang.Runnable` argument instead of `F.Callback0`. Because `Runnable`s can't throw checked exceptions the code above won't compile in Play 2.5.
 
 To get the code to compile you can change your lambda code to catch the checked exception (`IOException`) and wrap it in an unchecked exception (`RuntimeException`). It's OK for a `Runnable` to throw an unchecked exception so the code will now compile.
 
@@ -93,29 +95,33 @@ APIs that use `F.Promise` now use the standard Java 8 [`CompletionStage`](https:
 
 **Step 1:** Change all code that returns `F.Promise` to return `CompletionStage` instead. To aid with migration, `F.Promise` also implements the `CompletionStage` interface, which means any existing code that returns `Promise` can still be invoked from code that has been migrated to use `CompletionStage`.
 
-**Step 2** Replace relevant static methods in `F.Promise` with an equivalent method (many of these use the `play.libs.concurrent.Futures` helpers, or the statics on [`CompletableFuture`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html)):
+**Step 2:** Replace relevant static methods in `F.Promise` with an equivalent method (many of these use the [`play.libs.concurrent.Futures`](api/java/play/libs/concurrent/Futures.html) helpers, or the statics on [`CompletableFuture`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html)):
 
-* `Promise.wrap`       -> `scala.compat.java8.FutureConverters.toJava`
-* `Promise.sequence    -> `Futures.sequence`
-* `Promise.timeout`    -> `Futures.timeout`
-* `Promise.pure`       -> `CompletableFuture.completedFuture`
-* `Promise.throwing`   -> Construct `CompletableFuture` and use `completeExceptionally`
-* `Promise.promise`    -> `CompletableFuture.supplyAsync`
-* `Promise.delayed`    -> `Futures.delayed`
+| `F.Promise` method  | alternative |
+| --------------------------------------------|
+| `Promise.wrap`      | `scala.compat.java8.FutureConverters.toJava` |
+| `Promise.sequence`  | `Futures.sequence` |
+| `Promise.timeout`   | `Futures.timeout` |
+| `Promise.pure`      | `CompletableFuture.completedFuture` |
+| `Promise.throwing`  | Construct `CompletableFuture` and use `completeExceptionally` |
+| `Promise.promise`   | `CompletableFuture.supplyAsync` |
+| `Promise.delayed`   | `Futures.delayed` |
 
-**Step 3** Replace existing instance methods with their equivalent on `CompletionStage`:
+**Step 3:** Replace existing instance methods with their equivalent on `CompletionStage`:
 
-* `promise.or`          -> `future.applyToEither`
-* `promise.onRedeem`    -> `future.thenAcceptAsync`
-* `promise.map`         -> `future.thenApplyAsync`
-* `promise.transform`   -> `future.handleAsync`
-* `promise.zip`         -> `future.thenCombine` (and manually construct a tuple)
-* `promise.fallbackTo`  -> `future.handleAsync` followed by `thenCompose(Function.identity())`
-* `promise.recover`     -> `future.exceptionally` (or `future.handleAsync` with `HttpExecution#defaultContext()` if you want `Http.Context` captured).
-* `promise.recoverWith` -> same as `recover`, then use `.thenCompose(Function.identity())`
-* `promise.onFailure`   -> `future.whenCompleteAsync` (use `HttpExecution#defaultContext()` if needed)
-* `promise.flatMap`     -> `future.thenComposeAsync` (use `HttpExecution#defaultContext()` if needed)
-* `promise.filter`      -> `future.thenApplyAsync` and implement the filter manually (use `HttpExecution#defaultContext()` if needed)
+| `F.Promise`         | `CompletionStage` |
+| -----------------------------------------------|
+| `or`                | `applyToEither` |
+| `onRedeem`          | `thenAcceptAsync` |
+| `map`               | `thenApplyAsync` |
+| `transform`         | `handleAsync` |
+| `zip`               | `thenCombine` (and manually construct a tuple) |
+| `fallbackTo`        | `handleAsync` followed by `thenCompose(Function.identity())` |
+| `recover`           | `exceptionally` (or `handleAsync` with `HttpExecution#defaultContext()` if you want `Http.Context` captured). |
+| `recoverWith`       | same as `recover`, then use `.thenCompose(Function.identity())` |
+| `onFailure`         | `whenCompleteAsync` (use `HttpExecution#defaultContext()` if needed) |
+| `flatMap`           | `thenComposeAsync` (use `HttpExecution#defaultContext()` if needed) |
+| `filter`            | `thenApplyAsync` and implement the filter manually (use `HttpExecution#defaultContext()` if needed) |
 
 These migrations are explained in more detail in the [Javadoc for `F.Promise`](api/java/play/libs/F.Promise.html).
 
@@ -140,3 +146,7 @@ Here follows a short table that should ease the migration:
 | `o.map(f)`         | `o.map(f)`                        |
 
 `Optional` has a lot more combinators, so we highly encourage you to [learn its API](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html) if you are not familiar with it already.
+
+## Deprecated static APIs
+
+Several static APIs were deprecated in Play 2.5, in favour of using dependency injected components. Using static global state is bad for testability and modularity, and it is recommended that you move to dependency injection for accessing these APIs. You should refer to the list in the [[Play 2.4 Migration Guide|Migration24#Dependency-Injected-Components]] to find the equivalent dependency injected component for your static API.

--- a/documentation/manual/releases/release25/migration25/Migration25.md
+++ b/documentation/manual/releases/release25/migration25/Migration25.md
@@ -3,10 +3,10 @@
 
 This is a guide for migrating from Play 2.4 to Play 2.5. If you need to migrate from an earlier version of Play then you must first follow the [[Play 2.4 Migration Guide|Migration24]].
 
-As well as the information contained on this page, there are is more detailed migration information for some topics:
+As well as the information contained on this page, there is more detailed migration information for some topics:
 
-- [[Streams Migration Guide|StreamsMigration25]] – Migrating to Play's new streaming library.
-- [[Java Migration Guide|JavaMigration25]] - Migrating Java applications.
+- [[Streams Migration Guide|StreamsMigration25]] – Migrating to Akka streams, now used in place of iteratees in many Play APIs 
+- [[Java Migration Guide|JavaMigration25]] - Migrating Java applications. Play now uses native Java types for functional types and offers several new customizable components in Java.
 
 ## sbt upgrade to 0.13.9
 
@@ -109,6 +109,8 @@ routesGenerator := StaticRoutesGenerator
 
 to your `build.sbt` file.
 
+Using static controllers with the static routes generator is not deprecated, but it is recommended that you migrate to using classes with dependency injection.
+
 ## Replaced static controllers with dependency injection
 
 `controllers.ExternalAssets` is now a class, and has no static equivalent. `controllers.Assets` and `controllers.Default` are also classes, and while static equivalents exist, it is recommended that you use the class version.
@@ -139,7 +141,7 @@ Likewise, methods in `play.api.Play` that take an implicit `Application` and del
 
 These methods delegate to either `play.Application` or `play.Environment` -- code that uses them should use dependency injection to inject the relevant class.
 
-You should refer to the list of dependency injected components in the [[Play 2.4 Migration Guide|Migration24#Dependency-Injected-Components]] to migrate built-in play components.
+You should refer to the list of dependency injected components in the [[Play 2.4 Migration Guide|Migration24#Dependency-Injected-Components]] to migrate built-in Play components.
 
 For example, the following code injects an environment and configuration into a Controller in Scala:
 
@@ -222,6 +224,6 @@ play.filters.csrf {
 
 Previously, a CSRF token could be retrieved from the HTTP request in any action. Now you must have either a CSRF filter or a CSRF action for `CRSF.getToken` to work. If you're not using a filter, you can use the `CSRFAddToken` action in Scala or `AddCSRFToken` Java annotation to ensure a token is in the session.
 
-We also fixed a minor bug in this release in which the CSRF token would be empty (throwing an exception in the template helper) if its signature was invalid. Now it will be regenerated on the same request.
+Also, a minor bug was fixed in this release in which the CSRF token would be empty (throwing an exception in the template helper) if its signature was invalid. Now it will be regenerated on the same request so a token is still available from the template helpers and `CSRF.getToken`.
 
 For more details, please read the CSRF documentation for [[Java|JavaCsrf]] and [[Scala|ScalaCsrf]].

--- a/documentation/manual/releases/release25/migration25/StreamsMigration25.md
+++ b/documentation/manual/releases/release25/migration25/StreamsMigration25.md
@@ -4,9 +4,9 @@ Play 2.5 has made several major changes to how it streams data and response bodi
 
 1. Play 2.5 uses **Akka Streams for streaming**. Previous versions of Play used iteratees for streaming as well as several other ad-hoc types of streaming, such as `WebSocket`, `Chunks`, etc.
 
-    There are two main benefits of the change to use Akka Streams. First, Java users can now access the full features of Play, e.g. writing body parsers and filters. Second, the streaming library is now more consistent across Play.
+    There are two main benefits of the change to use Akka Streams. First, Java users can now access the full feature set of Play, e.g. writing body parsers and filters. Second, the streaming library is now more consistent across Play.
 
-2. Play 2.5 uses **`ByteString` to hold packets of bytes**. Previously, Play usied byte arrays (`byte[]`/`ArrayByte`) to hold bytes.
+2. Play 2.5 uses **`ByteString` to hold packets of bytes**. Previously, Play used byte arrays (`byte[]`/`ArrayByte`) to hold bytes.
 
     The `ByteString` class is immutable like Java's `String`, so it's safer and easier to use. Like `String` it does have a small performance cost, because it copies its data when it is constructed, but this is balanced by its cheap concatenation and substring operations.
 
@@ -57,7 +57,7 @@ In Play 2.5, the `stream` method has been removed and the `feed` method has been
 
 The new API is to create a `Result` object directly and choose an `HttpEntity` to represent its body. For streamed results, you can use the `HttpEntity.Streamed` class. The `Streamed` class takes a `Source` as a body and an optional `Content-Length` header value. The `Source`'s content will be sent to the client. If the entity has a `Content-Length` header then the connection will be left open, otherwise it will be closed to signal the end of the stream.
 
-* To learn how to migrate an Enumerator to a Source, see  [Migrating Enumerators to Sources](#Migrating-Enumerators-to-Sources).
+* To learn how to migrate an Enumerator to a Source, see [Migrating Enumerators to Sources](#Migrating-Enumerators-to-Sources).
 
 #### Migrating WebSockets (`WebSocket`)
 
@@ -83,7 +83,7 @@ trait FrameFormatter[A] {
 }
 ```
 
-The Play 2.5's Scala WebSocket API is built around a `Flow` of `Message`s. A [`Message`](api/scala/play/api/http/websocket/Message.html) represents an [WebSocket frame](https://tools.ietf.org/html/rfc6455#section-5). The `MessageFlowTransformer` type handles transforming high-level objects, like JSON, XML and bytes into `Message` frames. A set of built-in implicit `MessageFlowTransformer`s are provided, and you can also write your own.
+The Play 2.5 Scala WebSocket API is built around a `Flow` of `Message`s. A [`Message`](api/scala/play/api/http/websocket/Message.html) represents a [WebSocket frame](https://tools.ietf.org/html/rfc6455#section-5). The `MessageFlowTransformer` type handles transforming high-level objects, like JSON, XML and bytes into `Message` frames. A set of built-in implicit `MessageFlowTransformer`s are provided, and you can also write your own.
 
 ```scala
 trait WebSocket extends Handler {
@@ -276,7 +276,7 @@ When you're first getting started with Akka Streams, the *Basics and working wit
 * [Basics for Java](http://doc.akka.io/docs/akka/2.4.2/java/stream/stream-flows-and-basics.html)
 * [Basics for Scala](http://doc.akka.io/docs/akka/2.4.2/scala/stream/stream-flows-and-basics.html)
 
-You don't need to convert your whole application in one go. Parts of your application can keep using iteratees while other parts use Akka streams.  Akka streams provides a [reactive streams](http://reactivestreams.org) implementation, and Play's iteratees library also provides a reactive streams implementation, consequently, Play's iteratees can easily be wrapped in Akka streams and vice versa.
+You don't need to convert your whole application in one go. Parts of your application can keep using iteratees while other parts use Akka streams.  Akka streams provides a [reactive streams](http://reactive-streams.org) implementation, and Play's iteratees library also provides a reactive streams implementation, consequently, Play's iteratees can easily be wrapped in Akka streams and vice versa.
 
 #### Migrating byte arrays (`byte[]`/`Array[Byte]`) to `ByteString`s
 


### PR DESCRIPTION
- Made some clarifications about the deprecated static APIs
- Fixed incorrect links
- Improved wording and fixed several minor typographical/spelling/grammar errors
- Changed to tables instead of lists