### PR TITLE
Dependency injection documentation clarifications

### DIFF
--- a/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
@@ -3,11 +3,11 @@
 
 Dependency injection is a way that you can separate your components so that they are not directly dependent on each other, rather, they get injected into each other.
 
-Out of the box, Play provides dependency injection support based on [JSR 330](https://jcp.org/en/jsr/detail?id=330).  The default JSR 330 implementation that comes with Play is [Guice](https://github.com/google/guice), but other JSR 330 implementations can be plugged in.
+Out of the box, Play provides dependency injection support based on [JSR 330](https://jcp.org/en/jsr/detail?id=330).  The default JSR 330 implementation that comes with Play is [Guice](https://github.com/google/guice), but other JSR 330 implementations can be plugged in. The [Guice wiki](https://github.com/google/guice/wiki/) is a great resource for learning more about the features of Guice and DI design patterns in general.
 
 ## Declaring dependencies
 
-If you have a component, such as a controller, and it requires some other components as dependencies, then this can be declared using the [@Inject](https://docs.oracle.com/javaee/7/api/javax/inject/Inject.html) annotation.  The `@Inject` annotation can be used on fields or on constructors, which you decide to use is up to you.  For example, to use field injection:
+If you have a component, such as a controller, and it requires some other components as dependencies, then this can be declared using the [@Inject](https://docs.oracle.com/javaee/7/api/javax/inject/Inject.html) annotation.  The `@Inject` annotation can be used on fields or on constructors.  For example, to use field injection:
 
 @[field](code/javaguide/di/field/MyComponent.java)
 
@@ -15,7 +15,9 @@ To use constructor injection:
 
 @[constructor](code/javaguide/di/constructor/MyComponent.java)
 
-Each of these have their own benefits, and which is best is a matter of hot debate.  For brevity, in the Play documentation, we use field injection, but in Play itself, we use constructor injection.
+For brevity, in the Play documentation, we use field injection, but in Play itself, we use constructor injection.
+
+Constructor injection is the most testable, since all the dependencies are required up front to construct an instance of the class, but it is also more verbose. Guice also has several other [types of injections](https://github.com/google/guice/wiki/Injections) which may be useful in some cases.
 
 ## Dependency injecting controllers
 

--- a/documentation/manual/working/javaGuide/main/http/JavaRouting.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaRouting.md
@@ -16,13 +16,13 @@ Routes are defined in the `conf/routes` file, which is compiled. This means that
 
 ## Dependency Injection
 
-Play supports generating two types of routers, one is a dependency injected router, the other is a static router.  The default is the static router, but if you created a new Play application using the Play seed Activator templates, your project will include the following configuration in `build.sbt` telling it to use the injected router:
+Play supports generating two types of routers, one is a dependency injected router, the other is a static router. The default is the dependency injected router, and that is also the case in the Play seed Activator templates, since we recommend you use dependency-injected controllers. If you need to use static controllers you can switch to the static routes generator by adding the following configuration to your `build.sbt`:
 
 ```scala
-routesGenerator := InjectedRoutesGenerator
+routesGenerator := StaticRoutesGenerator
 ```
 
-The code samples in Play's documentation assumes that you are using the injected routes generator.  If you are not using this, you can trivially adapt the code samples for the static routes generator, either by prefixing the controller invocation part of the route with an `@` symbol, or by declaring each of your action methods as `static`.
+The code samples in Play's documentation assumes that you are using the injected routes generator. If you are not using this, you can trivially adapt the code samples for the static routes generator, either by prefixing the controller invocation part of the route with an `@` symbol, or by declaring each of your action methods as `static`.
 
 ## The routes file syntax
 
@@ -54,7 +54,7 @@ For example, to exactly match `GET /clients/all` incoming requests, you can defi
 
 @[static-path](code/javaguide.http.routing.routes)
 
-### Dynamic parts 
+### Dynamic parts
 
 If you want to define a route that, say, retrieves a client by id, you need to add a dynamic part:
 
@@ -75,7 +75,7 @@ Here, for a request like `GET /files/images/logo.png`, the `name` dynamic part w
 ### Dynamic parts with custom regular expressions
 
 You can also define your own regular expression for a dynamic part, using the `$id<regex>` syntax:
-    
+
 @[regex-path](code/javaguide.http.routing.routes)
 
 ## Call to action generator method
@@ -136,7 +136,7 @@ Many routes can match the same request. If there is a conflict, the first route 
 
 The router can be used to generate a URL from within a Java call. This makes it possible to centralize all your URI patterns in a single configuration file, so you can be more confident when refactoring your application.
 
-For each controller used in the routes file, the router will generate a ‘reverse controller’ in the `routes` package, having the same action methods, with the same signature, but returning a `play.mvc.Call` instead of a `play.mvc.Result`. 
+For each controller used in the routes file, the router will generate a ‘reverse controller’ in the `routes` package, having the same action methods, with the same signature, but returning a `play.mvc.Call` instead of a `play.mvc.Result`.
 
 The `play.mvc.Call` defines an HTTP call, and provides both the HTTP method and the URI.
 

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaDependencyInjection.md
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaDependencyInjection.md
@@ -5,7 +5,7 @@ Dependency injection is a way that you can separate your components so that they
 
 Out of the box, Play provides runtime dependency injection based on [JSR 330](https://jcp.org/en/jsr/detail?id=330).  Runtime dependency injection is so called because the dependency graph is created, wired and validated at runtime.  If a dependency cannot be found for a particular component, you won't get an error until you run your application.  In contrast, Play also supports [[compile time dependency injection|ScalaCompileTimeDependencyInjection]], where errors in the dependency graph are detected and thrown at compile time.
 
-The default JSR 330 implementation that comes with Play is [Guice](https://github.com/google/guice), but other JSR 330 implementations can be plugged in.
+The default JSR 330 implementation that comes with Play is [Guice](https://github.com/google/guice), but other JSR 330 implementations can be plugged in. The [Guice wiki](https://github.com/google/guice/wiki/) is a great resource for learning more about the features of Guice and DI design patterns in general.
 
 ## Declaring dependencies
 
@@ -13,7 +13,9 @@ If you have a component, such as a controller, and it requires some other compon
 
 @[constructor](code/RuntimeDependencyInjection.scala)
 
-Note that the `@Inject` annotation must come after the class name but before the constructor parameters, and must have parenthesis.
+Note that the `@Inject` annotation must come after the class name but before the constructor parameters, and must have parentheses.
+
+Also, Guice does come with several other [types of injections](https://github.com/google/guice/wiki/Injections), but constructor injection is generally the most clear, concise, and testable in Scala, so we recommend using it.
 
 ## Dependency injecting controllers
 

--- a/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
@@ -16,13 +16,13 @@ Routes are defined in the `conf/routes` file, which is compiled. This means that
 
 ## Dependency Injection
 
-Play supports generating two types of routers, one is a dependency injected router, the other is a static router.  The default is the static router, but if you created a new Play application using the Play seed Activator templates, your project will include the following configuration in `build.sbt` telling it to use the injected router:
+Play supports generating two types of routers, one is a dependency injected router, the other is a static router. The default is the dependency injected router, and that is also the case in the Play seed Activator templates, since we recommend you use dependency-injected controllers. If you need to use static controllers you can switch to the static routes generator by adding the following configuration to your `build.sbt`:
 
 ```scala
-routesGenerator := InjectedRoutesGenerator
+routesGenerator := StaticRoutesGenerator
 ```
 
-The code samples in Play's documentation assumes that you are using the injected routes generator.  If you are not using this, you can trivially adapt the code samples for the static routes generator, either by prefixing the controller invocation part of the route with an `@` symbol, or by declaring each of your controllers as an `object` rather than a `class`.
+The code samples in Play's documentation assumes that you are using the injected routes generator. If you are not using this, you can trivially adapt the code samples for the static routes generator, either by prefixing the controller invocation part of the route with an `@` symbol, or by declaring each of your controllers as an `object` rather than a `class`.
 
 ## The routes file syntax
 


### PR DESCRIPTION
Clarified that the default routes generator is `InjectedRoutesGenerator`. Also added some clarifications about using DI and links to the Guice wiki.

I also made the DI doc a bit more opinionated toward constructor injection. In Scala it seems like the obvious choice, but I guess some people justify field injection in their Java apps for reasons of brevity.