### PR TITLE
Deprecation Warning Fix for play-scala Template's Tests

### DIFF
--- a/templates/play-scala/test/ApplicationSpec.scala
+++ b/templates/play-scala/test/ApplicationSpec.scala
@@ -12,7 +12,7 @@ class ApplicationSpec extends PlaySpec with OneAppPerTest {
   "Routes" should {
 
     "send 404 on a bad request" in  {
-      route(FakeRequest(GET, "/boum")).map(status(_)) mustBe Some(NOT_FOUND)
+      route(app, FakeRequest(GET, "/boum")).map(status(_)) mustBe Some(NOT_FOUND)
     }
 
   }
@@ -20,7 +20,7 @@ class ApplicationSpec extends PlaySpec with OneAppPerTest {
   "HomeController" should {
 
     "render the index page" in {
-      val home = route(FakeRequest(GET, "/")).get
+      val home = route(app, FakeRequest(GET, "/")).get
 
       status(home) mustBe OK
       contentType(home) mustBe Some("text/html")
@@ -32,9 +32,9 @@ class ApplicationSpec extends PlaySpec with OneAppPerTest {
   "CountController" should {
 
     "return an increasing count" in {
-      contentAsString(route(FakeRequest(GET, "/count")).get) mustBe "0"
-      contentAsString(route(FakeRequest(GET, "/count")).get) mustBe "1"
-      contentAsString(route(FakeRequest(GET, "/count")).get) mustBe "2"
+      contentAsString(route(app, FakeRequest(GET, "/count")).get) mustBe "0"
+      contentAsString(route(app, FakeRequest(GET, "/count")).get) mustBe "1"
+      contentAsString(route(app, FakeRequest(GET, "/count")).get) mustBe "2"
     }
 
   }


### PR DESCRIPTION
Fixed deprecation warnings in ApplicationSpec.scala in templates/play-scala template project.