### PR TITLE
Possible fix for rendering issue on web site

### DIFF
--- a/documentation/manual/releases/release25/migration25/StreamsMigration25.md
+++ b/documentation/manual/releases/release25/migration25/StreamsMigration25.md
@@ -317,6 +317,7 @@ You can replace your `*.Out` class with any `Source` that produces a stream. The
 If you want to replace your `*.Out` with a simple object that you can write messages to and then close, without worrying about back pressure, then you can use the `Source.actorRef` method:
 
 Java:
+
 ```java
 Source<ByteString, ?> source = Source.<ByteString>actorRef(256, OverflowStrategy.dropNew)
   .mapMaterializerValue(sourceActor -> {
@@ -327,6 +328,7 @@ Source<ByteString, ?> source = Source.<ByteString>actorRef(256, OverflowStrategy
 ```
 
 Scala:
+
 ```scala
 val source = Source.actorRef[ByteString](256, OverflowStrategy.dropNew).mapMaterializedValue { sourceActor =>
   sourceActor ! ByteString("hello")


### PR DESCRIPTION
Maybe need a newline before the start of these two code blocks? The HTML rendering on the project website isn't doing code highlighting correctly and showing the lowercase word "java" for the first and "scala" for the second in the visible content, too.