### PR TITLE
Make noMatch overridable

### DIFF
--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -506,7 +506,7 @@ class DefaultMessagesApi @Inject() (environment: Environment, configuration: Con
     }.getOrElse(noMatch(keys.last, args))
   }
 
-  private def noMatch(key: String, args: Seq[Any]) = key
+  protected def noMatch(key: String, args: Seq[Any])(implicit lang: Lang) = key
 
   def translate(key: String, args: Seq[Any])(implicit lang: Lang): Option[String] = {
     val langsToTry: List[Lang] =


### PR DESCRIPTION
We'd like to be able to customize the behavior when a localization key is missing.