### PR TITLE
Fixes #4614 Make Akka.system point to app.actorSystem

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -24,8 +24,6 @@ import scala.reflect.ClassTag
  */
 object Akka {
 
-  private val actorSystemCache = Application.instanceCache[ActorSystem]
-
   /**
    * Retrieve the application Akka Actor system, using an implicit application.
    *
@@ -37,7 +35,7 @@ object Akka {
    * }}}
    */
   @deprecated("Please use a dependency injected ActorSystem", "2.5.0")
-  def system(implicit app: Application): ActorSystem = actorSystemCache(app)
+  def system(implicit app: Application): ActorSystem = app.actorSystem
 
   /**
    * Create a provider for an actor implemented by the given class, with the given name.


### PR DESCRIPTION
Fixes #4614 

[As recommended](https://github.com/playframework/playframework/issues/4614#issuecomment-121089467) by @richdougherty, instead of using a cache, just use the field that is already on Application.

This should probably be backported to 2.4.x, let me know if there's anything I need to do to make that happen.