### PR TITLE
Allow configuring binder options on Guice injector

### DIFF
--- a/documentation/manual/releases/release25/migration25/Migration25.md
+++ b/documentation/manual/releases/release25/migration25/Migration25.md
@@ -5,7 +5,7 @@ This is a guide for migrating from Play 2.4 to Play 2.5. If you need to migrate 
 
 As well as the information contained on this page, there is more detailed migration information for some topics:
 
-- [[Streams Migration Guide|StreamsMigration25]] – Migrating to Akka streams, now used in place of iteratees in many Play APIs 
+- [[Streams Migration Guide|StreamsMigration25]] – Migrating to Akka streams, now used in place of iteratees in many Play APIs
 - [[Java Migration Guide|JavaMigration25]] - Migrating Java applications. Play now uses native Java types for functional types and offers several new customizable components in Java.
 
 ## sbt upgrade to 0.13.9
@@ -76,7 +76,7 @@ You can find more details on how to set up Play with different logging framework
 Play WS has been upgraded to use [AsyncHttpClient](https://github.com/AsyncHttpClient/async-http-client) 2.  This is a major upgrade that uses Netty 4.0. Most of the changes in AHC 2.0 are under the hood, but AHC has some significant refactorings which require breaking changes to the WS API:
 
 * `AsyncHttpClientConfig` replaced by [`DefaultAsyncHttpClientConfig`](https://static.javadoc.io/org.asynchttpclient/async-http-client/2.0.0-RC7/org/asynchttpclient/DefaultAsyncHttpClientConfig.html).
-* [`allowPoolingConnection`](https://static.javadoc.io/com.ning/async-http-client/1.9.32/com/ning/http/client/AsyncHttpClientConfig.html#allowPoolingConnections) and `allowSslConnectionPool` are combined in AsyncHttpClient into a single `keepAlive` variable.  As such, `play.ws.ning.allowPoolingConnection` and `play.ws.ning.allowSslConnectionPool` are not valid and will throw an exception if configured.  
+* [`allowPoolingConnection`](https://static.javadoc.io/com.ning/async-http-client/1.9.32/com/ning/http/client/AsyncHttpClientConfig.html#allowPoolingConnections) and `allowSslConnectionPool` are combined in AsyncHttpClient into a single `keepAlive` variable.  As such, `play.ws.ning.allowPoolingConnection` and `play.ws.ning.allowSslConnectionPool` are not valid and will throw an exception if configured.
 * [`webSocketIdleTimeout`](https://static.javadoc.io/com.ning/async-http-client/1.9.32/com/ning/http/client/AsyncHttpClientConfig.html#webSocketTimeout) has been removed, so is no longer available in `AhcWSClientConfig`.
 * [`ioThreadMultiplier`](https://static.javadoc.io/com.ning/async-http-client/1.9.32/com/ning/http/client/AsyncHttpClientConfig.html#ioThreadMultiplier) has been removed, so is no longer available in `AhcWSClientConfig`.
 * [`FluentCaseInsensitiveStringsMap`](https://static.javadoc.io/com.ning/async-http-client/1.9.32/com/ning/http/client/FluentCaseInsensitiveStringsMap.html) class is removed and replaced by Netty's `HttpHeader` class.
@@ -99,7 +99,7 @@ The Plugins API was deprecated in Play 2.4 and has been removed in Play 2.5. The
 
 ## Routes generated with InjectedRoutesGenerator
 
-Routes are now generated using the dependency injection aware `InjectedRoutesGenerator`, rather than the previous `StaticRoutesGenerator` which assumed controllers were singleton objects.  
+Routes are now generated using the dependency injection aware `InjectedRoutesGenerator`, rather than the previous `StaticRoutesGenerator` which assumed controllers were singleton objects.
 
 To revert back to the earlier behavior (if you have "object MyController" in your code, for example), please add:
 
@@ -168,23 +168,37 @@ class HomeController @Inject() (environment: play.api.Environment, configuration
 Generally the components you use should not need to depend on the entire application, but sometimes you have to deal with legacy components that require one. You can handle this by injecting the application into one of your components:
 
 ```
-class FooController @Inject() (implicit app: Application) extends Controller {
+class FooController @Inject() (appProvider: Provider[Application]) extends Controller {
+  implicit lazy val app = appProvider.get()
   def bar = Action {
     Ok(Foo.bar(app))
   }
 }
 ```
 
+Note that you usually want to use a `Provider[Application]` in this case to avoid circular dependencies.
+
 Even better, you can make your own `*Api` class that turns the static methods into instance methods:
 
 ```
-class FooApi @Inject() (implicit app: Application) {
+class FooApi @Inject() (appProvider: Provider[Application]) {
+  implicit lazy val app = appProvider.get()
   def bar = Foo.bar(app)
   def baz = Foo.baz(app)
 }
 ```
 
 This allows you to benefit from the testability you get with DI and still use your library that uses global state.
+
+## Guice injector and Guice builder changes
+
+By default, Guice can resolve your circular dependency by proxying an interface in the cycle. Since circular dependencies are generally a code smell, and you can also inject Providers to break the cycle, we have chosen to disable this feature on the default Guice injector. Other DI frameworks also are not likely to have this feature, so it can lead to problems when writing Play modules.
+
+Now there are four new methods on the Guice builders (`GuiceInjectorBuilder` and `GuiceApplicationBuilder`) for customizing how Guice injects your classes:
+* `disableCircularProxies`: disables the above-mentioned behaviour of proxying interfaces to resolve circular dependencies. To allow proxying use `disableCircularProxies(false)`.
+* `requireExplicitBindings`: instructs the injector to only inject classes that are explicitly bound in a module. Can be useful in testing for verifying bindings.
+* `requireAtInjectOnConstructors`: requires a constructor annotated with @Inject to instantiate a class.
+* `requireExactBindingAnnotations`: disables the error-prone feature in Guice where it can substitute a binding for @Named Foo when injecting @Named("foo") Foo.
 
 ## CSRF changes
 

--- a/framework/src/play-java/src/main/java/play/inject/guice/GuiceBuilder.java
+++ b/framework/src/play-java/src/main/java/play/inject/guice/GuiceBuilder.java
@@ -5,15 +5,15 @@ package play.inject.guice;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Module;
-import java.io.File;
-import java.util.Map;
-import play.api.inject.guice.GuiceableModule;
 import play.Configuration;
 import play.Environment;
-import play.inject.DelegateInjector;
+import play.Mode;
+import play.api.inject.guice.GuiceableModule;
 import play.inject.Injector;
 import play.libs.Scala;
-import play.Mode;
+
+import java.io.File;
+import java.util.Map;
 
 /**
  * A builder for creating Guice-backed Play Injectors.

--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
@@ -5,7 +5,7 @@ package play.api.inject.guice
 
 import javax.inject.{ Provider, Inject }
 
-import com.google.inject.{ Module => GuiceModule }
+import com.google.inject.{Module => GuiceModule, Binder}
 import play.api.mvc.{RequestHeader, Handler}
 import play.api.routing.Router
 import play.api._
@@ -23,12 +23,13 @@ final case class GuiceApplicationBuilder(
   modules: Seq[GuiceableModule] = Seq.empty,
   overrides: Seq[GuiceableModule] = Seq.empty,
   disabled: Seq[Class[_]] = Seq.empty,
+  binderOptions: Set[BinderOption] = BinderOption.defaults,
   eagerly: Boolean = false,
   loadConfiguration: Environment => Configuration = Configuration.load,
   global: Option[GlobalSettings.Deprecated] = None,
   loadModules: (Environment, Configuration) => Seq[GuiceableModule] = GuiceableModule.loadModules) extends GuiceBuilder[GuiceApplicationBuilder](
-  environment, configuration, modules, overrides, disabled, eagerly
-) {
+    environment, configuration, modules, overrides, disabled, binderOptions, eagerly
+  ) {
 
   // extra constructor for creating from Java
   def this() = this(environment = Environment.simple())
@@ -130,11 +131,12 @@ final case class GuiceApplicationBuilder(
     modules: Seq[GuiceableModule] = modules,
     overrides: Seq[GuiceableModule] = overrides,
     disabled: Seq[Class[_]] = disabled,
+    binderOptions: Set[BinderOption] = binderOptions,
     eagerly: Boolean = eagerly,
     loadConfiguration: Environment => Configuration = loadConfiguration,
     global: Option[GlobalSettings] = global,
     loadModules: (Environment, Configuration) => Seq[GuiceableModule] = loadModules): GuiceApplicationBuilder =
-    new GuiceApplicationBuilder(environment, configuration, modules, overrides, disabled, eagerly, loadConfiguration, global, loadModules)
+    new GuiceApplicationBuilder(environment, configuration, modules, overrides, disabled, binderOptions, eagerly, loadConfiguration, global, loadModules)
 
   /**
    * Implementation of Self creation for GuiceBuilder.
@@ -145,8 +147,9 @@ final case class GuiceApplicationBuilder(
     modules: Seq[GuiceableModule],
     overrides: Seq[GuiceableModule],
     disabled: Seq[Class[_]],
+    binderOptions: Set[BinderOption] = binderOptions,
     eagerly: Boolean): GuiceApplicationBuilder =
-    copy(environment, configuration, modules, overrides, disabled, eagerly)
+    copy(environment, configuration, modules, overrides, disabled, binderOptions, eagerly)
 
   /**
    * Checks if the path contains the logger path

--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
@@ -26,6 +26,7 @@ class GuiceApplicationLoader(protected val initialBuilder: GuiceApplicationBuild
    */
   protected def builder(context: ApplicationLoader.Context): GuiceApplicationBuilder = {
     initialBuilder
+      .disableCircularProxies()
       .in(context.environment)
       .loadConfig(context.initialConfiguration)
       .overrides(overrides(context): _*)

--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
@@ -5,7 +5,7 @@ package play.api.inject
 package guice
 
 import com.google.inject.util.{ Modules => GuiceModules, Providers => GuiceProviders }
-import com.google.inject.{ Module => GuiceModule, Stage, CreationException, Guice }
+import com.google.inject.{ Module => GuiceModule, Binder, Stage, CreationException, Guice }
 import java.io.File
 import javax.inject.Inject
 import play.api.inject.{ Binding => PlayBinding, Injector => PlayInjector, Module => PlayModule }
@@ -24,7 +24,10 @@ abstract class GuiceBuilder[Self] protected (
     modules: Seq[GuiceableModule],
     overrides: Seq[GuiceableModule],
     disabled: Seq[Class[_]],
+    binderOptions: Set[BinderOption],
     eagerly: Boolean) {
+
+  import BinderOption._
 
   /**
    * Set the environment.
@@ -74,6 +77,45 @@ abstract class GuiceBuilder[Self] protected (
   final def configure(conf: (String, Any)*): Self =
     configure(conf.toMap)
 
+  private def withBinderOption(opt: BinderOption, enabled: Boolean = false): Self = {
+    copyBuilder(binderOptions = if (enabled) binderOptions + opt else binderOptions - opt)
+  }
+
+  /**
+   * Disable circular proxies on the Guice Binder. Without this option, Guice will try to proxy interfaces/traits to
+   * break a circular dependency.
+   *
+   * Circular proxies are disabled by default.  Use disableCircularProxies(false) to allow circular proxies.
+   */
+  final def disableCircularProxies(disable: Boolean = true): Self =
+    withBinderOption(DisableCircularProxies, disable)
+
+  /**
+   * Requires that Guice finds an exactly matching binding annotation.
+   *
+   * Disables the error-prone feature in Guice where it can substitute a binding for @Named Foo when injecting @Named("foo") Foo.
+   *
+   * This option is disabled by default.``
+   */
+  final def requireExactBindingAnnotations(require: Boolean = true): Self =
+    withBinderOption(RequireExactBindingAnnotations, require)
+
+  /**
+   * Require @Inject on constructors (even default constructors).
+   *
+   * This option is disabled by default.
+   */
+  final def requireAtInjectOnConstructors(require: Boolean = true): Self =
+    withBinderOption(RequireAtInjectOnConstructors, require)
+
+  /**
+   * Instructs the injector to only inject classes that are explicitly bound in a module.
+   *
+   * This option is disabled by default.
+   */
+  final def requireExplicitBindings(require: Boolean = true): Self =
+    withBinderOption(RequireExplicitBindings, require)
+
   /**
    * Add Guice modules, Play modules, or Play bindings.
    *
@@ -106,7 +148,7 @@ abstract class GuiceBuilder[Self] protected (
   /**
    * Create a Play Injector backed by Guice using this configured builder.
    */
-  def applicationModule(): GuiceModule = createModule
+  def applicationModule(): GuiceModule = createModule()
 
   /**
    * Creation of the Guice Module used by the injector.
@@ -119,10 +161,10 @@ abstract class GuiceBuilder[Self] protected (
       // Java API injector is bound here so that it's available in both
       // the default application loader and the Java Guice builders
       bind[play.inject.Injector].to[play.inject.DelegateInjector]
-    ))
+    ), binderOptions)
     val enabledModules = modules.map(_.disable(disabled))
-    val bindingModules = GuiceableModule.guiced(environment, configuration)(enabledModules) :+ injectorModule
-    val overrideModules = GuiceableModule.guiced(environment, configuration)(overrides)
+    val bindingModules = GuiceableModule.guiced(environment, configuration, binderOptions)(enabledModules) :+ injectorModule
+    val overrideModules = GuiceableModule.guiced(environment, configuration, binderOptions)(overrides)
     GuiceModules.`override`(bindingModules.asJava).`with`(overrideModules.asJava)
   }
 
@@ -161,8 +203,9 @@ abstract class GuiceBuilder[Self] protected (
     modules: Seq[GuiceableModule] = modules,
     overrides: Seq[GuiceableModule] = overrides,
     disabled: Seq[Class[_]] = disabled,
+    binderOptions: Set[BinderOption] = binderOptions,
     eagerly: Boolean = eagerly): Self =
-    newBuilder(environment, configuration, modules, overrides, disabled, eagerly)
+    newBuilder(environment, configuration, modules, overrides, disabled, binderOptions, eagerly)
 
   /**
    * Create a new Self for this immutable builder.
@@ -174,6 +217,7 @@ abstract class GuiceBuilder[Self] protected (
     modules: Seq[GuiceableModule],
     overrides: Seq[GuiceableModule],
     disabled: Seq[Class[_]],
+    binderOptions: Set[BinderOption],
     eagerly: Boolean): Self
 
 }
@@ -187,8 +231,9 @@ final class GuiceInjectorBuilder(
   modules: Seq[GuiceableModule] = Seq.empty,
   overrides: Seq[GuiceableModule] = Seq.empty,
   disabled: Seq[Class[_]] = Seq.empty,
+  binderOptions: Set[BinderOption] = BinderOption.defaults,
   eagerly: Boolean = false) extends GuiceBuilder[GuiceInjectorBuilder](
-  environment, configuration, modules, overrides, disabled, eagerly
+  environment, configuration, modules, overrides, disabled, binderOptions, eagerly
 ) {
 
   // extra constructor for creating from Java
@@ -205,15 +250,16 @@ final class GuiceInjectorBuilder(
     modules: Seq[GuiceableModule],
     overrides: Seq[GuiceableModule],
     disabled: Seq[Class[_]],
+    binderOptions: Set[BinderOption],
     eagerly: Boolean): GuiceInjectorBuilder =
-    new GuiceInjectorBuilder(environment, configuration, modules, overrides, disabled, eagerly)
+    new GuiceInjectorBuilder(environment, configuration, modules, overrides, disabled, binderOptions, eagerly)
 }
 
 /**
  * Magnet pattern for creating Guice modules from Play modules or bindings.
  */
 trait GuiceableModule {
-  def guiced(env: Environment, conf: Configuration): Seq[GuiceModule]
+  def guiced(env: Environment, conf: Configuration, binderOptions: Set[BinderOption]): Seq[GuiceModule]
   def disable(classes: Seq[Class[_]]): GuiceableModule
 }
 
@@ -241,8 +287,8 @@ object GuiceableModule extends GuiceableModuleConversions {
   /**
    * Apply GuiceableModules to create Guice modules.
    */
-  def guiced(env: Environment, conf: Configuration)(builders: Seq[GuiceableModule]): Seq[GuiceModule] =
-    builders flatMap { module => module.guiced(env, conf) }
+  def guiced(env: Environment, conf: Configuration, binderOptions: Set[BinderOption])(builders: Seq[GuiceableModule]): Seq[GuiceModule] =
+    builders flatMap { module => module.guiced(env, conf, binderOptions) }
 
 }
 
@@ -256,7 +302,7 @@ trait GuiceableModuleConversions {
   implicit def fromGuiceModule(guiceModule: GuiceModule): GuiceableModule = fromGuiceModules(Seq(guiceModule))
 
   implicit def fromGuiceModules(guiceModules: Seq[GuiceModule]): GuiceableModule = new GuiceableModule {
-    def guiced(env: Environment, conf: Configuration): Seq[GuiceModule] = guiceModules
+    def guiced(env: Environment, conf: Configuration, binderOptions: Set[BinderOption]): Seq[GuiceModule] = guiceModules
     def disable(classes: Seq[Class[_]]): GuiceableModule = fromGuiceModules(filterOut(classes, guiceModules))
     override def toString = s"GuiceableModule(${guiceModules.mkString(", ")})"
   }
@@ -264,7 +310,8 @@ trait GuiceableModuleConversions {
   implicit def fromPlayModule(playModule: PlayModule): GuiceableModule = fromPlayModules(Seq(playModule))
 
   implicit def fromPlayModules(playModules: Seq[PlayModule]): GuiceableModule = new GuiceableModule {
-    def guiced(env: Environment, conf: Configuration): Seq[GuiceModule] = playModules.map(guice(env, conf))
+    def guiced(env: Environment, conf: Configuration, binderOptions: Set[BinderOption]): Seq[GuiceModule] =
+      playModules.map(guice(env, conf, binderOptions))
     def disable(classes: Seq[Class[_]]): GuiceableModule = fromPlayModules(filterOut(classes, playModules))
     override def toString = s"GuiceableModule(${playModules.mkString(", ")})"
   }
@@ -272,7 +319,8 @@ trait GuiceableModuleConversions {
   implicit def fromPlayBinding(binding: PlayBinding[_]): GuiceableModule = fromPlayBindings(Seq(binding))
 
   implicit def fromPlayBindings(bindings: Seq[PlayBinding[_]]): GuiceableModule = new GuiceableModule {
-    def guiced(env: Environment, conf: Configuration): Seq[GuiceModule] = Seq(guice(bindings))
+    def guiced(env: Environment, conf: Configuration, binderOptions: Set[BinderOption]): Seq[GuiceModule] =
+      Seq(guice(bindings, binderOptions))
     def disable(classes: Seq[Class[_]]): GuiceableModule = this // no filtering
     override def toString = s"GuiceableModule(${bindings.mkString(", ")})"
   }
@@ -283,15 +331,16 @@ trait GuiceableModuleConversions {
   /**
    * Convert the given Play module to a Guice module.
    */
-  def guice(env: Environment, conf: Configuration)(module: PlayModule): GuiceModule =
-    guice(module.bindings(env, conf))
+  def guice(env: Environment, conf: Configuration, binderOptions: Set[BinderOption])(module: PlayModule): GuiceModule =
+    guice(module.bindings(env, conf), binderOptions)
 
   /**
    * Convert the given Play bindings to a Guice module.
    */
-  def guice(bindings: Seq[PlayBinding[_]]): GuiceModule = {
+  def guice(bindings: Seq[PlayBinding[_]], binderOptions: Set[BinderOption]): GuiceModule = {
     new com.google.inject.AbstractModule {
       def configure(): Unit = {
+        binderOptions.foreach(_(binder))
         for (b <- bindings) {
           val binding = b.asInstanceOf[PlayBinding[Any]]
           val builder = binder().withSource(binding).bind(GuiceKey(binding.key))
@@ -312,6 +361,18 @@ trait GuiceableModuleConversions {
     }
   }
 
+}
+
+sealed abstract class BinderOption(configureBinder: Binder => Unit) extends (Binder => Unit) {
+  def apply(b: Binder) = configureBinder(b)
+}
+object BinderOption {
+  val defaults: Set[BinderOption] = Set(DisableCircularProxies)
+
+  case object DisableCircularProxies extends BinderOption(_.disableCircularProxies)
+  case object RequireAtInjectOnConstructors extends BinderOption(_.requireAtInjectOnConstructors)
+  case object RequireExactBindingAnnotations extends BinderOption(_.requireExactBindingAnnotations)
+  case object RequireExplicitBindings extends BinderOption(_.requireExplicitBindings)
 }
 
 /**

--- a/framework/src/play/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
@@ -115,6 +115,20 @@ object GuiceInjectorBuilderSpec extends Specification {
       injector.instanceOf[D] must beAnInstanceOf[D1]
     }
 
+    "configure binder" in {
+      val injector = new GuiceInjectorBuilder()
+        .requireExplicitBindings()
+        .bindings(
+          bind[A].to[A1],
+          bind[B].to[B1]
+        )
+        .injector
+      injector.instanceOf[A] must beAnInstanceOf[A1]
+      injector.instanceOf[B] must beAnInstanceOf[B1]
+      injector.instanceOf[B1] must throwA[com.google.inject.ConfigurationException]
+      injector.instanceOf[C1] must throwA[com.google.inject.ConfigurationException]
+    }
+
   }
 
   class EnvironmentModule extends Module {

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/controllers/Application.scala
@@ -9,7 +9,7 @@ import scala.collection.JavaConverters._
 
 import javax.inject.Inject
 
-class Application @Inject() (app: play.api.Application, configuration: Configuration) extends Controller {
+class Application @Inject() (env: Environment, configuration: Configuration) extends Controller {
 
   def index = Action {
     Ok(views.html.index("Your new application is ready."))
@@ -20,7 +20,7 @@ class Application @Inject() (app: play.api.Application, configuration: Configura
   }
 
   def count = Action {
-    val num = app.resource("application.conf").toSeq.size
+    val num = env.resource("application.conf").toSeq.size
     Ok(num.toString)
   }
 }


### PR DESCRIPTION
Guice offers several configuration options on the binder that advanced users might want to enable for testing purposes or for their entire application:
- `disableCircularProxies`: Disable proxying interfaces to break circular dependencies. By default, if Guice finds a circular dependency, it can break it by creating a proxy interface.
- `requireExplicitBindings`: Only inject classes that are explicitly bound in a module.
- `requireExactBindingAnnotations`: Disables the error-prone feature in Guice where it can substitute a binding for @Named Foo when injecting @Named("foo") Foo.
- `requireAtInjectOnConstructors`: Only inject classes that have a constructor explicitly annotated with @Inject

This also enables `disableCircularProxies` by default and fixes the classes that have circular dependencies