### PR TITLE
(WIP) Fixes #902 added a way to sent multipart/form-data requests via play-ws

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -75,6 +75,12 @@ The easiest way to post JSON data is to use the [[JSON library|JavaJsonActions]]
 
 @[ws-post-json](code/javaguide/ws/JavaWS.java)
 
+### Submitting multipart/form data
+
+The easiest way to post multipart/form data is to use a `Source<Http.MultipartFormData<Source<ByteString>, ?>, ?>`
+
+@[ws-post-multipart](code/javaguide/ws/JavaWS.java)
+
 ### Streaming data
 
 It's also possible to stream data.
@@ -100,6 +106,7 @@ Working with the [`WSResponse`](api/java/play/libs/ws/WSResponse.html) is done b
 You can process the response as a `JsonNode` by calling `response.asJson()`.
 
 @[ws-response-json](code/javaguide/ws/JavaWS.java)
+
 
 ### Processing a response as XML
 
@@ -184,7 +191,6 @@ You can get access to the underlying [AsyncHttpClient](http://static.javadoc.io/
 
 This is important in a couple of cases. The WS library has a couple of limitations that require access to the underlying client:
 
-* `WS` does not support multi part form upload directly.  You can use the underlying client with [RequestBuilder.addBodyPart](http://static.javadoc.io/org.asynchttpclient/async-http-client/2.0.0-RC12/org/asynchttpclient/RequestBuilderBase.html#addBodyPart-org.asynchttpclient.request.body.multipart.Part-).
 * `WS` does not support streaming body upload.  In this case, you should use the [`FeedableBodyGenerator`](http://static.javadoc.io/org.asynchttpclient/async-http-client/2.0.0-RC12/org/asynchttpclient/request/body/generator/FeedableBodyGenerator.html) provided by AsyncHttpClient.
 
 ## Configuring WS

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -9,6 +9,7 @@ import javaguide.testhelpers.MockJavaAction;
 import org.slf4j.Logger;
 import play.api.libs.ws.ahc.AhcCurlRequestLogger;
 import play.libs.ws.*;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 // #ws-imports
@@ -19,6 +20,7 @@ import play.libs.Json;
 // #json-imports
 
 import play.libs.ws.ahc.AhcWSClient;
+import play.mvc.Http;
 import scala.compat.java8.FutureConverters;
 
 import java.io.*;
@@ -113,6 +115,10 @@ public class JavaWS {
 
             ws.url(url).post(json);
             // #ws-post-json
+
+            // #ws-post-multipart
+            ws.url(url).post(Source.single(new Http.MultipartFormData.DataPart("hello", "world")));
+            // #ws-post-multipart
 
             String value = IntStream.range(0,100).boxed().
                 map(i -> "abcdefghij").reduce("", (a,b) -> a + b);

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -81,6 +81,12 @@ To post url-form-encoded data a `Map[String, Seq[String]]` needs to be passed in
 
 @[url-encoded](code/ScalaWSSpec.scala)
 
+### Submitting multipart/form data
+
+To post multipart-form-encoded data a `Seq[org.asynchttpclient.request.body.multipart.Part]` needs to be passed into `post`.
+
+@[multipart-encoded](code/ScalaWSSpec.scala)
+
 ### Submitting JSON data
 
 The easiest way to post JSON data is to use the [[JSON|ScalaJson]] library.
@@ -216,7 +222,6 @@ You can get access to the underlying [AsyncHttpClient](http://static.javadoc.io/
 
 This is important in a couple of cases.  WS has a couple of limitations that require access to the underlying client:
 
-* `WS` does not support multi part form upload directly.  You can use the underlying client with [RequestBuilder.addBodyPart](http://static.javadoc.io/org.asynchttpclient/async-http-client/2.0.0-RC12/org/asynchttpclient/RequestBuilderBase.html#addBodyPart-org.asynchttpclient.request.body.multipart.Part-).
 * `WS` does not support streaming body upload.  In this case, you should use the `FeedableBodyGenerator` provided by AsyncHttpClient.
 
 ## Configuring WS

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -190,6 +190,18 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
         await(response).body must_== "value"
       }
 
+      "post with multipart/form encoded body" in withServer{
+          case("POST", "/") => Action(BodyParsers.parse.multipartFormData)(r => Ok(r.body.asFormUrlEncoded("key").head))
+        } { ws =>
+        import play.api.mvc.MultipartFormData._
+        val response =
+        //#multipart-encoded
+        ws.url(url).post(Source.single(DataPart("key", "value")))
+        //#multipart-encoded
+
+        await(response).body must_== "value"
+      }
+
       "post with JSON body" in  withServer {
         case ("POST", "/") => Action(BodyParsers.parse.json)(r => Ok(r.body))
       } { ws =>

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
+import play.mvc.Http;
 
 
 import java.io.File;
@@ -72,6 +73,14 @@ public interface WSRequest {
      */
     CompletionStage<WSResponse> patch(File body);
 
+    /**
+     * Perform a PATCH on the request asynchronously.
+     *
+     * @param body represented as a MultipartFormData.Part
+     * @return a promise to the response
+     */
+    CompletionStage<WSResponse> patch(Source<? super Http.MultipartFormData.Part<Source<ByteString, ?>>, ?> body);
+
     //-------------------------------------------------------------------------
     // "POST"
     //-------------------------------------------------------------------------
@@ -108,6 +117,14 @@ public interface WSRequest {
      */
     CompletionStage<WSResponse> post(File body);
 
+    /**
+     * Perform a POST on the request asynchronously.
+     *
+     * @param body represented as a MultipartFormData.Part
+     * @return a promise to the response
+     */
+    CompletionStage<WSResponse> post(Source<? super Http.MultipartFormData.Part<Source<ByteString, ?>>, ?> body);
+
     //-------------------------------------------------------------------------
     // "PUT"
     //-------------------------------------------------------------------------
@@ -143,6 +160,14 @@ public interface WSRequest {
      * @return a promise to the response
      */
     CompletionStage<WSResponse> put(File body);
+
+    /**
+     * Perform a PUT on the request asynchronously.
+     *
+     * @param body represented as a MultipartFormData.Part
+     * @return a promise to the response
+     */
+    CompletionStage<WSResponse> put(Source<? super Http.MultipartFormData.Part<Source<ByteString, ?>>, ?> body);
 
     //-------------------------------------------------------------------------
     // Miscellaneous execution methods

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -16,6 +16,8 @@ import play.api.Application
 import play.api.http.Writeable
 import play.api.libs.json.JsValue
 import play.api.libs.iteratee._
+import play.core.formatters.Multipart
+import play.api.mvc.MultipartFormData
 import java.io.IOException
 
 /**
@@ -432,6 +434,15 @@ trait WSRequest {
   }
 
   /**
+   * Helper method for multipart body
+   */
+  private[libs] def withMultipartBody(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): WSRequest = {
+    val boundary = Multipart.randomBoundary()
+    val contentType = s"multipart/form-data; boundary=$boundary"
+    withBody(StreamedBody(Multipart.transform(body, boundary))).withHeaders("Content-Type" -> contentType)
+  }
+
+  /**
    * Sets the method for this request
    */
   def withMethod(method: String): WSRequest
@@ -474,6 +485,13 @@ trait WSRequest {
   def patch(body: File): Future[WSResponse] = withMethod("PATCH").withBody(FileBody(body)).execute()
 
   /**
+   * Perform a PATCH on the request asynchronously.
+   */
+  def patch(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): Future[WSResponse] = {
+    withMethod("PATCH").withMultipartBody(body).execute()
+  }
+
+  /**
    * performs a POST with supplied body
    * @param consumer that's handling the response
    */
@@ -498,6 +516,13 @@ trait WSRequest {
   def post(body: File): Future[WSResponse] = withMethod("POST").withBody(FileBody(body)).execute()
 
   /**
+   * Perform a POST on the request asynchronously.
+   */
+  def post(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): Future[WSResponse] = {
+    withMethod("POST").withMultipartBody(body).execute()
+  }
+
+  /**
    * performs a POST with supplied body
    * @param consumer that's handling the response
    */
@@ -520,6 +545,13 @@ trait WSRequest {
    * Request body won't be chunked
    */
   def put(body: File): Future[WSResponse] = withMethod("PUT").withBody(FileBody(body)).execute()
+
+  /**
+   * Perform a PUT on the request asynchronously.
+   */
+  def put(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): Future[WSResponse] = {
+    withMethod("PUT").withMultipartBody(body).execute()
+  }
 
   /**
    * performs a PUT with supplied body

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -3,6 +3,7 @@
  */
 package play.mvc;
 
+import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.w3c.dom.Document;
@@ -1395,10 +1396,14 @@ public class Http {
             }
         }
 
+        public static interface Part<A> {
+
+        }
+
         /**
          * A file part.
          */
-        public static class FilePart<A> {
+        public static class FilePart<A> implements Part<A> {
 
             final String key;
             final String filename;
@@ -1446,6 +1451,35 @@ public class Http {
              */
             public A getFile() {
                 return file;
+            }
+
+        }
+
+        public static class DataPart implements Part<Source<ByteString, ?>> {
+            private final String key;
+            private final String value;
+
+            public DataPart(String key, String value) {
+                this.key = key;
+                this.value = value;
+            }
+
+            /**
+             * The part name.
+             *
+             * @return the part name
+             */
+            public String getKey() {
+                return key;
+            }
+
+            /**
+             * The part value.
+             *
+             * @return the part value
+             */
+            public String getValue() {
+                return value;
             }
 
         }

--- a/framework/src/play/src/main/java/play/mvc/MultipartFormatter.java
+++ b/framework/src/play/src/main/java/play/mvc/MultipartFormatter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.mvc;
+
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+import play.api.mvc.MultipartFormData;
+import play.core.formatters.Multipart;
+import scala.Option;
+
+import java.nio.charset.Charset;
+import java.util.concurrent.ThreadLocalRandom;
+
+
+public class MultipartFormatter {
+
+    public static String randomBoundary() {
+        return Multipart.randomBoundary(18, ThreadLocalRandom.current());
+    }
+
+    public static String boundaryToContentType(String boundary) {
+        return "multipart/form-data; boundary=" + boundary;
+    }
+
+    public static Source<ByteString, ?> transform(Source<? super Http.MultipartFormData.Part<Source<ByteString, ?>>, ?> parts, String boundary) {
+        Source<MultipartFormData.Part<akka.stream.scaladsl.Source<ByteString, ?>>, ?> source = parts.map((part) -> {
+            if (part instanceof Http.MultipartFormData.DataPart) {
+                Http.MultipartFormData.DataPart dp = (Http.MultipartFormData.DataPart) part;
+                return (MultipartFormData.Part) new MultipartFormData.DataPart(dp.getKey(), dp.getValue());
+            } else if (part instanceof Http.MultipartFormData.FilePart) {
+                Http.MultipartFormData.FilePart fp = (Http.MultipartFormData.FilePart) part;
+                if (fp.file instanceof Source) {
+                    Source ref = (Source) fp.file;
+                    Option<String> ct = Option.apply(fp.getContentType());
+                    return (MultipartFormData.Part)new MultipartFormData.FilePart<akka.stream.scaladsl.Source<ByteString, ?>>(fp.getKey(), fp.getFilename(), ct, ref.asScala());
+                }
+            }
+            throw new UnsupportedOperationException("Unsupported Part Class");
+        });
+
+        return source.via(Multipart.format(boundary, Charset.defaultCharset(), 4096));
+    }
+
+
+}

--- a/framework/src/play/src/main/scala/play/core/formatters/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/formatters/Multipart.scala
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.formatters
+
+import java.nio.CharBuffer
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets._
+import java.util.concurrent.ThreadLocalRandom
+
+import akka.NotUsed
+import akka.stream.scaladsl.{ Flow, Source }
+import akka.stream.stage.{ Context, PushPullStage, SyncDirective, TerminationDirective }
+import akka.util.{ ByteString, ByteStringBuilder }
+import play.api.mvc.MultipartFormData
+import play.api.mvc.MultipartFormData.Part
+
+import scala.annotation.tailrec
+
+object Multipart {
+  private[this] def CrLf = "\r\n"
+
+  private[this] val alphabet = "-_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes(US_ASCII)
+
+  /**
+   * Transforms a `Source[MultipartFormData.Part]` to a `Source[ByteString]`
+   */
+  def transform(body: Source[MultipartFormData.Part[Source[ByteString, _]], _], boundary: String): Source[ByteString, _] = {
+    body.via(format(boundary, Charset.defaultCharset(), 4096))
+  }
+
+  /**
+   * Provides a Formatting Flow which could be used to format a MultipartFormData.Part source to a multipart/form data body
+   */
+  def format(boundary: String, nioCharset: Charset, chunkSize: Int): Flow[MultipartFormData.Part[Source[ByteString, _]], ByteString, NotUsed] = {
+    Flow[MultipartFormData.Part[Source[ByteString, _]]].transform(() => streamed(boundary, nioCharset, chunkSize))
+      .flatMapConcat(identity)
+  }
+
+  /**
+   * Creates a new random number of the given length and base64 encodes it (using a custom "safe" alphabet).
+   *
+   * @throws IllegalArgumentException if the length is greater than 70 or less than 1 as specified in
+   *                                  <a href="https://tools.ietf.org/html/rfc2046#section-5.1.1">rfc2046</a>
+   */
+  def randomBoundary(length: Int = 18, random: java.util.Random = ThreadLocalRandom.current()): String = {
+    if (length < 1 && length > 70) throw new IllegalArgumentException("length can't be greater than 70 or less than 1")
+    val bytes: Seq[Byte] = for (byte <- 1 to length) yield {
+      alphabet(random.nextInt(alphabet.length))
+    }
+    new String(bytes.toArray, US_ASCII)
+  }
+
+  private sealed trait Formatter {
+    def ~~(ch: Char): this.type
+
+    def ~~(string: String): this.type = {
+      @tailrec def rec(ix: Int = 0): this.type =
+        if (ix < string.length) {
+          this ~~ string.charAt(ix)
+          rec(ix + 1)
+        } else this
+      rec()
+    }
+
+  }
+
+  private class CustomCharsetByteStringFormatter(nioCharset: Charset, sizeHint: Int) extends Formatter {
+    private[this] val charBuffer = CharBuffer.allocate(64)
+    private[this] val builder = new ByteStringBuilder
+    builder.sizeHint(sizeHint)
+
+    def get: ByteString = {
+      flushCharBuffer()
+      builder.result()
+    }
+
+    def ~~(char: Char): this.type = {
+      if (!charBuffer.hasRemaining) flushCharBuffer()
+      charBuffer.put(char)
+      this
+    }
+
+    def ~~(bytes: ByteString): this.type = {
+      if (bytes.nonEmpty) {
+        flushCharBuffer()
+        builder ++= bytes
+      }
+      this
+    }
+
+    private def flushCharBuffer(): Unit = {
+      charBuffer.flip()
+      if (charBuffer.hasRemaining) {
+        val byteBuffer = nioCharset.encode(charBuffer)
+        val bytes = new Array[Byte](byteBuffer.remaining())
+        byteBuffer.get(bytes)
+        builder.putBytes(bytes)
+      }
+      charBuffer.clear()
+    }
+
+  }
+
+  private class ByteStringFormatter(sizeHint: Int) extends Formatter {
+    private[this] val builder = new ByteStringBuilder
+    builder.sizeHint(sizeHint)
+
+    def get: ByteString = builder.result
+
+    def ~~(char: Char): this.type = {
+      builder += char.toByte
+      this
+    }
+
+  }
+
+  private def streamed(boundary: String,
+    nioCharset: Charset,
+    chunkSize: Int): PushPullStage[MultipartFormData.Part[Source[ByteString, _]], Source[ByteString, Any]] =
+    new PushPullStage[MultipartFormData.Part[Source[ByteString, _]], Source[ByteString, Any]] {
+      var firstBoundaryRendered = false
+
+      override def onPush(bodyPart: Part[Source[ByteString, _]], ctx: Context[Source[ByteString, Any]]): SyncDirective = {
+        val f = new CustomCharsetByteStringFormatter(nioCharset, chunkSize)
+
+        def bodyPartChunks(data: Source[ByteString, Any]): Source[ByteString, Any] = {
+          (Source.single(f.get) ++ data).mapMaterializedValue((_) => ())
+        }
+
+        def completePartFormatting(): Source[ByteString, Any] = bodyPart match {
+          case MultipartFormData.DataPart(_, data) => Source.single((f ~~ ByteString(data)).get)
+          case MultipartFormData.FilePart(_, _, _, ref) => bodyPartChunks(ref)
+          case _ => throw new UnsupportedOperationException()
+        }
+
+        renderBoundary(f, boundary, suppressInitialCrLf = !firstBoundaryRendered)
+        firstBoundaryRendered = true
+
+        val (key, filename, contentType) = bodyPart match {
+          case MultipartFormData.DataPart(innerKey, _) => (innerKey, None, Option("text/plain"))
+          case MultipartFormData.FilePart(innerKey, innerFilename, innerContentType, _) => (innerKey, Option(innerFilename), innerContentType)
+          case _ => throw new UnsupportedOperationException()
+        }
+        renderDisposition(f, key, filename)
+        contentType.foreach { ct => renderContentType(f, ct) }
+        renderBuffer(f)
+        ctx.push(completePartFormatting())
+      }
+
+      override def onPull(ctx: Context[Source[ByteString, Any]]): SyncDirective = {
+        val finishing = ctx.isFinishing
+        if (finishing && firstBoundaryRendered) {
+          val f = new ByteStringFormatter(boundary.length + 4)
+          renderFinalBoundary(f, boundary)
+          ctx.pushAndFinish(Source.single(f.get))
+        } else if (finishing) {
+          ctx.finish()
+        } else {
+          ctx.pull()
+        }
+      }
+
+      override def onUpstreamFinish(ctx: Context[Source[ByteString, Any]]): TerminationDirective = ctx.absorbTermination()
+
+    }
+
+  private def renderBoundary(f: Formatter, boundary: String, suppressInitialCrLf: Boolean = false): Unit = {
+    if (!suppressInitialCrLf) f ~~ CrLf
+    f ~~ '-' ~~ '-' ~~ boundary ~~ CrLf
+  }
+
+  private def renderFinalBoundary(f: Formatter, boundary: String): Unit =
+    f ~~ CrLf ~~ '-' ~~ '-' ~~ boundary ~~ '-' ~~ '-'
+
+  private def renderDisposition(f: Formatter, contentDisposition: String, filename: Option[String]): Unit = {
+    f ~~ "Content-Disposition: form-data; name=" ~~ '"' ~~ contentDisposition ~~ '"'
+    filename.foreach { name => f ~~ "; filename=" ~~ '"' ~~ name ~~ '"' }
+    f ~~ CrLf
+  }
+
+  private def renderContentType(f: Formatter, contentType: String): Unit = {
+    f ~~ "Content-Type: " ~~ contentType ~~ CrLf
+  }
+
+  private def renderBuffer(f: Formatter): Unit = {
+    f ~~ CrLf
+  }
+
+}


### PR DESCRIPTION
Hello here is a PR for #902, actually it misses the following things:

- [x] Tests
- [x] Squashed Commits
- [x] Java Code

Actually before providing a Documentation I wanted to grab some feedback if that is clever enough.
Also I'm not sure where to put tests for that behavior since there aren't many tests for WS yet.

**Edit:** 
Actually what I thought is if I should provide custom interfaces for Part, however then I thought that actually implementing them on top would actually double the work here, however It could be good to add them later, so that we could send JsValue and XML without additional work. However for the moment I found that satisfying, since there aren't many frameworks that actually parse anything else than StringParts and FileParts, actually even Play only knows how to handle Content-Disposition=form-data. 

**Edit2:** I added documentation, I'm still unsure about additional tests, are they required? And when, where could I put them? Would've put them into ``play.libs.ws.WSSpec`` and ``play.api.libs.ws.WSRequestSpec``