### PR TITLE
JPAApi improvements

### DIFF
--- a/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
@@ -3,34 +3,29 @@
 
 ## Adding dependencies to your project
 
-First you need to tell play that your project need javaJpa plugin which provide JDBC and JPA api dependencies.
+First you need to tell Play that your project depends on `javaJpa` which will provide JDBC and JPA api dependencies.
 
-There is no built-in JPA implementation in Play; you can choose any available implementation. For example, to use Hibernate, just add the dependency to your project:
+There is no built-in JPA implementation in Play; you can choose any available implementation. For example, to use [Hibernate](http://hibernate.org/), just add the following dependency to your project:
 
-```
-libraryDependencies ++= Seq(
-  javaJpa,
-  "org.hibernate" % "hibernate-entitymanager" % "4.3.9.Final" // replace by your jpa implementation
-)
-```
+@[jpa-sbt-dependencies](code/jpa.sbt)
 
 ## Exposing the datasource through JNDI
 
-JPA requires the datasource to be accessible via JNDI. You can expose any Play-managed datasource via JNDI by adding this configuration in `conf/application.conf`:
+JPA requires the datasource to be accessible via [JNDI](http://www.oracle.com/technetwork/java/jndi/index.html). You can expose any Play-managed datasource via JNDI by adding this configuration in `conf/application.conf`:
 
 ```
-db.default.driver=org.h2.Driver
-db.default.url="jdbc:h2:mem:play"
 db.default.jndiName=DefaultDS
 ```
 
-## Creating a persistence unit
+See the [[Java Database docs|JavaDatabase]] for more information about how to configure your datasource.
+
+## Creating a Persistence Unit
 
 Next you have to create a proper `persistence.xml` JPA configuration file. Put it into the `conf/META-INF` directory, so it will be properly added to your classpath.
 
 Here is a sample configuration file to use with Hibernate:
 
-```
+```xml
 <persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
@@ -47,7 +42,7 @@ Here is a sample configuration file to use with Hibernate:
 </persistence>
 ```
 
-Finally you have to tell Play, which persistent unit should be used by your JPA provider. This is done by the `jpa.default` property in your `application.conf`.
+Finally you have to tell Play, which persistent unit should be used by your JPA provider. This is done by the `jpa.default` property in your `conf/application.conf`.
 
 ```
 jpa.default=defaultPersistenceUnit
@@ -59,38 +54,56 @@ Running Play in development mode while using JPA will work fine, but in order to
 
 @[jpa-externalize-resources](code/jpa.sbt)
 
-Since Play 2.4 the contents of the `conf` directory are added to the classpath by default. This option will disable that behavior and allow a JPA application to be deployed. Note that the content of conf directory will still be available in the classpath due to it being included in the applications jar file.
-
+Since Play 2.4 the contents of the `conf` directory are added to the classpath by default. This option will disable that behavior and allow a JPA application to be deployed. Note that the content of conf directory will still be available in the classpath due to it being included in the application's jar file.
 
 ## Annotating JPA actions with `@Transactional`
 
 Every JPA call must be done in a transaction so, to enable JPA for a particular action, annotate it with `@play.db.jpa.Transactional`. This will compose your action method with a JPA `Action` that manages the transaction for you:
 
-```
-@Transactional
-public static Result index() {
-  ...
-}
-```
+@[jpa-controller-transactional-imports](code/controllers/JPAController.java)
+
+@[jpa-controller-transactional-action](code/controllers/JPAController.java)
 
 If your action runs only queries, you can set the `readOnly` attribute to `true`:
 
+@[jpa-controller-transactional-readonly](code/controllers/JPAController.java)
+
+## Using `play.db.jpa.JPAApi`
+
+Play offers you a convenient API to work with [Entity Manager](https://docs.oracle.com/javaee/7/api/javax/persistence/EntityManager.html) and Transactions. This API is defined by `play.db.jpa.JPAApi`, which can be injected at other objects like the code below:
+
+@[jpa-controller-api-inject](code/controllers/JPAController.java)
+
+If you already are in a transactional context (because you have annotated your action with `@Transactional`),
+
+@[jpa-access-entity-manager](code/controllers/JPAController.java)
+
+But if you do not annotate your action with `@Transactional` and are trying to access a Entity Manager using `jpaApi.em()`, you will get the following error:
+
 ```
-@Transactional(readOnly=true)
-public static Result index() {
-  ...
-}
+java.lang.RuntimeException: No EntityManager found in the context. Try to annotate your action method with @play.db.jpa.Transactional
 ```
 
-## Using the `play.db.jpa.JPA` helper
+### Running transactions decoupled from requests
 
-At any time you can retrieve the current entity manager from the `play.db.jpa.JPA` helper class:
+It is likely that you need to run transactions that are not coupled with requests, for instance, transactions executed inside a scheduled job. JPAApi has some methods that enable you to do so. The following methods are available to execute arbitrary code inside a JPA transaction:
 
-```
-public static Company findById(Long id) {
-  return JPA.em().find(Company.class, id);
-}
-```
+* `JPAApi.withTransaction(Function<EntityManager, T>)`
+* `JPAApi.withTransaction(String, Function<EntityManager, T>)`
+* `JPAApi.withTransaction(String, boolean, Function<EntityManager, T>)`
+* `JPAApi.withTransaction(Supplier<T>)`
+* `JPAApi.withTransaction(Runnable)`
+* `JPAApi.withTransaction(String, boolean, Supplier<T>)`
+
+### Examples:
+
+Using `JPAApi.withTransaction(Function<EntityManager, T>)`:
+
+@[jpa-withTransaction-function](code/controllers/JPAController.java)
+
+Using `JPAApi.withTransaction(Runnable)` to run a batch update:
+
+@[jpa-withTransaction-runnable](code/controllers/JPAController.java)
 
 ## Enabling Play database evolutions
 

--- a/documentation/manual/working/javaGuide/main/sql/code/JavaApplicationDatabase.java
+++ b/documentation/manual/working/javaGuide/main/sql/code/JavaApplicationDatabase.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
 package javaguide.sql;
 
 import javax.inject.Inject;

--- a/documentation/manual/working/javaGuide/main/sql/code/JavaNamedDatabase.java
+++ b/documentation/manual/working/javaGuide/main/sql/code/JavaNamedDatabase.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
 package javaguide.sql;
 
 import javax.inject.Inject;

--- a/documentation/manual/working/javaGuide/main/sql/code/controllers/JPAController.java
+++ b/documentation/manual/working/javaGuide/main/sql/code/controllers/JPAController.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package controllers;
+
+import javax.inject.Inject;
+import javax.persistence.Query;
+import javax.persistence.EntityManager;
+
+import play.mvc.*;
+//#jpa-controller-transactional-imports
+import play.db.jpa.Transactional;
+//#jpa-controller-transactional-imports
+
+//#jpa-controller-api-imports
+import play.db.jpa.JPAApi;
+//#jpa-controller-api-imports
+
+public class JPAController extends Controller {
+
+    private JPAApi jpaApi;
+
+    //#jpa-controller-api-inject
+    @Inject
+    public JPAController(JPAApi api) {
+        this.jpaApi = api;
+    }
+    //#jpa-controller-api-inject
+
+    //#jpa-controller-transactional-action
+    @Transactional
+    public Result index() {
+        return ok("A Transactional action");
+    }
+    //#jpa-controller-transactional-action
+
+    //#jpa-controller-transactional-readonly
+    @Transactional(readOnly = true)
+    public Result list() {
+        return ok("A Transactional action");
+    }
+    //#jpa-controller-transactional-readonly
+
+    //#jpa-access-entity-manager
+    public void upadateSomething() {
+        EntityManager em = jpaApi.em();
+        // do something with the entity manager, per instance
+        // save, update or query model objects.
+    }
+    //#jpa-access-entity-manager
+
+    public void runningWithTransaction() {
+        //#jpa-withTransaction-function
+        // lambda is an instance of Function<EntityManager, Long>
+        jpaApi.withTransaction(entityManager -> {
+            Query query = entityManager.createNativeQuery("select max(age) from people");
+            return (Long) query.getSingleResult();
+        });
+        //#jpa-withTransaction-function
+
+        //#jpa-withTransaction-runnable
+        // lambda is an instance of Runnable
+        jpaApi.withTransaction(() -> {
+            EntityManager em = jpaApi.em();
+            Query query = em.createNativeQuery("update people set active = 1 where age > 18");
+            query.executeUpdate();
+        });
+        //#jpa-withTransaction-runnable
+    }
+}

--- a/documentation/manual/working/javaGuide/main/sql/code/jpa.sbt
+++ b/documentation/manual/working/javaGuide/main/sql/code/jpa.sbt
@@ -2,6 +2,13 @@
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
 
+//#jpa-sbt-dependencies
+libraryDependencies ++= Seq(
+  javaJpa,
+  "org.hibernate" % "hibernate-entitymanager" % "5.1.0.Final" // replace by your jpa implementation
+)
+//#jpa-sbt-dependencies
+
 //#jpa-externalize-resources
 PlayKeys.externalizeResources := false
 //#jpa-externalize-resources

--- a/documentation/project/Build.scala
+++ b/documentation/project/Build.scala
@@ -50,6 +50,7 @@ object ApplicationBuild extends Build {
       playProject("Play") % "test",
       playProject("Play-Specs2") % "test",
       playProject("Play-Java") % "test",
+      playProject("Play-Java-JPA") % "test",
       playProject("Play-Cache") % "test",
       playProject("Play-Java-WS") % "test",
       playProject("Filters-Helpers") % "test",

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -3,12 +3,11 @@
  */
 package play.db.jpa;
 
-import play.db.DBApi;
 import play.inject.ApplicationLifecycle;
-import play.libs.F;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.inject.Inject;
@@ -23,10 +22,13 @@ public class DefaultJPAApi implements JPAApi {
 
     private final JPAConfig jpaConfig;
 
-    private final Map<String, EntityManagerFactory> emfs = new HashMap<String, EntityManagerFactory>();
+    private final Map<String, EntityManagerFactory> emfs = new HashMap<>();
 
-    public DefaultJPAApi(JPAConfig jpaConfig) {
+    private final JPAEntityManagerContext entityManagerContext;
+
+    public DefaultJPAApi(JPAConfig jpaConfig, JPAEntityManagerContext entityManagerContext) {
         this.jpaConfig = jpaConfig;
+        this.entityManagerContext = entityManagerContext;
     }
 
     @Singleton
@@ -34,9 +36,9 @@ public class DefaultJPAApi implements JPAApi {
         private final JPAApi jpaApi;
 
         @Inject
-        public JPAApiProvider(JPAConfig jpaConfig, DBApi dbApi, ApplicationLifecycle lifecycle) {
+        public JPAApiProvider(JPAConfig jpaConfig, JPAEntityManagerContext context, ApplicationLifecycle lifecycle) {
             // dependency on db api ensures that the databases are initialised
-            jpaApi = new DefaultJPAApi(jpaConfig);
+            jpaApi = new DefaultJPAApi(jpaConfig, context);
             lifecycle.addStopHook(() -> {
                 jpaApi.shutdown();
                 return CompletableFuture.completedFuture(null);
@@ -54,9 +56,9 @@ public class DefaultJPAApi implements JPAApi {
      * Initialise JPA entity manager factories.
      */
     public JPAApi start() {
-        for (JPAConfig.PersistenceUnit persistenceUnit : jpaConfig.persistenceUnits()) {
-            emfs.put(persistenceUnit.name, Persistence.createEntityManagerFactory(persistenceUnit.unitName));
-        }
+        jpaConfig.persistenceUnits().forEach(persistenceUnit ->
+                emfs.put(persistenceUnit.name, Persistence.createEntityManagerFactory(persistenceUnit.unitName))
+        );
         return this;
     }
 
@@ -74,24 +76,96 @@ public class DefaultJPAApi implements JPAApi {
     }
 
     /**
+     * Get the EntityManager for a particular persistence unit for this thread.
+     *
+     * @return EntityManager for the specified persistence unit name
+     */
+    public EntityManager em() {
+        return entityManagerContext.em();
+    }
+
+    /**
+     * Run a block of code with the EntityManager for the named Persistence Unit.
+     *
+     * @param block Block of code to execute
+     * @param <T> type of result
+     * @return code execution result
+     */
+    public <T> T withTransaction(Function<EntityManager, T> block) {
+        return withTransaction("default", false, block);
+    }
+
+    /**
+     * Run a block of code with the EntityManager for the named Persistence Unit.
+     *
+     * @param name The persistence unit name
+     * @param block Block of code to execute
+     * @param <T> type of result
+     * @return code execution result
+     */
+    public <T> T withTransaction(String name, Function<EntityManager, T> block) {
+        return withTransaction("default", false, block);
+    }
+
+    /**
+     * Run a block of code with the EntityManager for the named Persistence Unit.
+     *
+     * @param name The persistence unit name
+     * @param readOnly Is the transaction read-only?
+     * @param block Block of code to execute
+     * @param <T> type of result
+     * @return code execution result
+     */
+    public <T> T withTransaction(String name, boolean readOnly, Function<EntityManager, T> block) {
+        EntityManager entityManager = null;
+        EntityTransaction tx = null;
+
+        try {
+            entityManager = em(name);
+
+            if (entityManager == null) {
+                throw new RuntimeException("No JPA entity manager defined for '" + name + "'");
+            }
+
+            entityManagerContext.push(entityManager, true);
+
+            if (!readOnly) {
+                tx = entityManager.getTransaction();
+                tx.begin();
+            }
+
+            T result = block.apply(entityManager);
+
+            if (tx != null) {
+                if(tx.getRollbackOnly()) {
+                    tx.rollback();
+                } else {
+                    tx.commit();
+                }
+            }
+
+            return result;
+
+        } catch (Throwable t) {
+            if (tx != null) {
+                try { tx.rollback(); } catch (Throwable e) {}
+            }
+            throw t;
+        } finally {
+            entityManagerContext.pop(true);
+            if (entityManager != null) {
+                entityManager.close();
+            }
+        }
+    }
+
+    /**
      * Run a block of code in a JPA transaction.
      *
      * @param block Block of code to execute
      */
     public <T> T withTransaction(Supplier<T> block) {
         return withTransaction("default", false, block);
-    }
-
-    /**
-     * Run a block of asynchronous code in a JPA transaction.
-     *
-     * @param block Block of code to execute
-     *
-     * @deprecated This may cause deadlocks
-     */
-    @Deprecated
-    public <T> F.Promise<T> withTransactionAsync(Supplier<F.Promise<T>> block) {
-        return withTransactionAsync("default", false, block);
     }
 
     /**
@@ -118,132 +192,16 @@ public class DefaultJPAApi implements JPAApi {
      * @param block Block of code to execute
      */
     public <T> T withTransaction(String name, boolean readOnly, Supplier<T> block) {
-        EntityManager entityManager = null;
-        EntityTransaction tx = null;
-
-        try {
-            entityManager = em(name);
-
-            if (entityManager == null) {
-                throw new RuntimeException("No JPA entity manager defined for '" + name + "'");
-            }
-
-            JPA.bindForSync(entityManager);
-
-            if (!readOnly) {
-                tx = entityManager.getTransaction();
-                tx.begin();
-            }
-
-            T result = block.get();
-
-            if (tx != null) {
-                if(tx.getRollbackOnly()) {
-                    tx.rollback();
-                } else {
-                    tx.commit();
-                }
-            }
-
-            return result;
-
-        } catch (Throwable t) {
-            if (tx != null) {
-                try { tx.rollback(); } catch (Throwable e) {}
-            }
-            throw t;
-        } finally {
-            JPA.bindForSync(null);
-            if (entityManager != null) {
-                entityManager.close();
-            }
-        }
-    }
-
-    /**
-     * Run a block of asynchronous code in a JPA transaction.
-     *
-     * @param name The persistence unit name
-     * @param readOnly Is the transaction read-only?
-     * @param block Block of code to execute.
-     *
-     * @deprecated This may cause deadlocks
-     */
-    @Deprecated
-    public <T> F.Promise<T> withTransactionAsync(String name, boolean readOnly, Supplier<F.Promise<T>> block) {
-        EntityManager entityManager = null;
-        EntityTransaction tx = null;
-
-        try {
-            entityManager = em(name);
-
-            if (entityManager == null) {
-                throw new RuntimeException("No JPA entity manager defined for '" + name + "'");
-            }
-
-            JPA.bindForAsync(entityManager);
-
-            if (!readOnly) {
-                tx = entityManager.getTransaction();
-                tx.begin();
-            }
-
-            F.Promise<T> result = block.get();
-
-            final EntityManager fem = entityManager;
-            final EntityTransaction ftx = tx;
-
-            F.Promise<T> committedResult = (ftx == null) ? result : result.map(t -> {
-                if (ftx.getRollbackOnly()) {
-                    ftx.rollback();
-                } else {
-                    ftx.commit();
-                }
-                return t;
-            });
-
-            committedResult.onFailure(t -> {
-                if (ftx != null) {
-                    try { if (ftx.isActive()) { ftx.rollback(); } } catch (Throwable e) {}
-                }
-                try {
-                    fem.close();
-                } finally {
-                    JPA.bindForAsync(null);
-                }
-            });
-            committedResult.onRedeem(t -> {
-                try {
-                    fem.close();
-                } finally {
-                    JPA.bindForAsync(null);
-                }
-            });
-
-            return committedResult;
-
-        } catch (Throwable t) {
-            if (tx != null) {
-                try { tx.rollback(); } catch (Throwable e) {}
-            }
-            if (entityManager != null) {
-                try {
-                    entityManager.close();
-                } finally {
-                    JPA.bindForAsync(null);
-                }
-            }
-            throw t;
-        }
+        return withTransaction(name, readOnly, entityManager -> {
+            return block.get();
+        });
     }
 
     /**
      * Close all entity manager factories.
      */
     public void shutdown() {
-        for (EntityManagerFactory emf : emfs.values()) {
-            emf.close();
-        }
+        emfs.values().forEach(EntityManagerFactory::close);
     }
 
 }

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
@@ -3,10 +3,10 @@
  */
 package play.db.jpa;
 
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.persistence.EntityManager;
-import play.libs.F;
 
 /**
  * JPA API.
@@ -29,6 +29,43 @@ public interface JPAApi {
     public EntityManager em(String name);
 
     /**
+     * Get the EntityManager for a particular persistence unit for this thread.
+     *
+     * @return EntityManager for the specified persistence unit name
+     */
+    public EntityManager em();
+
+    /**
+     * Run a block of code with a given EntityManager.
+     *
+     * @param block Block of code to execute
+     * @param <T> type of result
+     * @return code execution result
+     */
+    public <T> T withTransaction(Function<EntityManager, T> block);
+
+    /**
+     * Run a block of code with a given EntityManager.
+     *
+     * @param name The persistence unit name
+     * @param block Block of code to execute
+     * @param <T> type of result
+     * @return code execution result
+     */
+    public <T> T withTransaction(String name, Function<EntityManager, T> block);
+
+    /**
+     * Run a block of code with a given EntityManager.
+     *
+     * @param name The persistence unit name
+     * @param readOnly Is the transaction read-only?
+     * @param block Block of code to execute
+     * @param <T> type of result
+     * @return code execution result
+     */
+    public <T> T withTransaction(String name, boolean readOnly, Function<EntityManager, T> block);
+
+    /**
      * Run a block of code in a JPA transaction.
      *
      * @param block Block of code to execute
@@ -38,23 +75,11 @@ public interface JPAApi {
     public <T> T withTransaction(Supplier<T> block);
 
     /**
-     * Run a block of asynchronous code in a JPA transaction.
-     *
-     * @param block Block of code to execute
-     * @param <T> type of result
-     * @return code execution result
-     *
-     * @deprecated This may cause deadlocks
-     */
-    @Deprecated
-    public <T> F.Promise<T> withTransactionAsync(Supplier<F.Promise<T>> block);
-
-    /**
      * Run a block of code in a JPA transaction.
      *
      * @param block Block of code to execute
      */
-    public void withTransaction(final Runnable block);
+    public void withTransaction(Runnable block);
 
     /**
      * Run a block of code in a JPA transaction.
@@ -66,20 +91,6 @@ public interface JPAApi {
      * @return code execution result
      */
     public <T> T withTransaction(String name, boolean readOnly, Supplier<T> block);
-
-    /**
-     * Run a block of asynchronous code in a JPA transaction.
-     *
-     * @param name The persistence unit name
-     * @param readOnly Is the transaction read-only?
-     * @param block Block of code to execute.
-     * @param <T> type of result
-     * @return code execution result
-     *
-     * @deprecated This may cause deadlocks
-     */
-    @Deprecated
-    public <T> F.Promise<T> withTransactionAsync(String name, boolean readOnly, Supplier<F.Promise<T>> block);
 
     /**
      * Close all entity manager factories.

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAEntityManagerContext.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAEntityManagerContext.java
@@ -1,0 +1,98 @@
+package play.db.jpa;
+
+import play.mvc.Http;
+
+import javax.persistence.EntityManager;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public class JPAEntityManagerContext extends ThreadLocal<Deque<EntityManager>> {
+
+    private static final String CURRENT_ENTITY_MANAGER = "entityManagerContext";
+
+    @Override
+    public Deque<EntityManager> initialValue() {
+        return new ArrayDeque<>();
+    }
+
+    /**
+     * Get the default EntityManager for this thread.
+     *
+     * @throws RuntimeException if no EntityManager is bound to the current Http.Context or the current Thread.
+     * @return the EntityManager
+     */
+    public EntityManager em() {
+        Http.Context context = Http.Context.current.get();
+        Deque<EntityManager> ems = this.emStack(true);
+
+        if (ems.isEmpty()) {
+            if (context != null) {
+                throw new RuntimeException("No EntityManager found in the context. Try to annotate your action method with @play.db.jpa.Transactional");
+            } else {
+                throw new RuntimeException("No EntityManager bound to this thread. Try wrapping this call in JPAApi.withTransaction, or ensure that the HTTP context is setup on this thread.");
+            }
+        }
+
+        return ems.peekFirst();
+    }
+
+    /**
+     * Get the EntityManager stack.
+     */
+    @SuppressWarnings("unchecked")
+    public Deque<EntityManager> emStack(boolean threadLocalFallback) {
+        Http.Context context = Http.Context.current.get();
+        if (context != null) {
+            Object emsObject = context.args.get(CURRENT_ENTITY_MANAGER);
+            if (emsObject != null) {
+                return (Deque<EntityManager>) emsObject;
+            } else {
+                Deque<EntityManager> ems = new ArrayDeque<>();
+                context.args.put(CURRENT_ENTITY_MANAGER, ems);
+                return ems;
+            }
+        } else {
+            // Not a web request
+            if (threadLocalFallback) {
+                return this.get();
+            } else {
+                throw new RuntimeException("No Http.Context is present. If you want to invoke this method outside of a HTTP request, you need to wrap the call with JPA.withTransaction instead.");
+            }
+        }
+    }
+
+    public void push(EntityManager em, boolean threadLocalFallback) {
+        Deque<EntityManager> ems = this.emStack(threadLocalFallback);
+        if (em != null) {
+            ems.push(em);
+        }
+    }
+
+    public void pop(boolean threadLocalFallback) {
+        Deque<EntityManager> ems = this.emStack(threadLocalFallback);
+        if (ems.isEmpty()) {
+            throw new IllegalStateException("Tried to remove the EntityManager, but none was set.");
+        }
+        ems.pop();
+    }
+
+    /**
+     * Pushes or pops the EntityManager stack depending on the value of the
+     * em argument. If em is null, then the current EntityManager is popped. If em
+     * is non-null, then em is pushed onto the stack and becomes the current EntityManager.
+     *
+     * @deprecated use push or pop methods
+     */
+    @Deprecated
+    public void pushOrPopEm(EntityManager em, boolean threadLocalFallback) {
+        Deque<EntityManager> ems = this.emStack(threadLocalFallback);
+        if (em != null) {
+            ems.push(em);
+        } else {
+            if (ems.isEmpty()) {
+                throw new IllegalStateException("Tried to remove the EntityManager, but none was set.");
+            }
+            ems.pop();
+        }
+    }
+}

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/TransactionalAction.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/TransactionalAction.java
@@ -6,6 +6,7 @@ package play.db.jpa;
 import play.mvc.*;
 import play.mvc.Http.*;
 
+import javax.inject.Inject;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -13,8 +14,15 @@ import java.util.concurrent.CompletionStage;
  */
 public class TransactionalAction extends Action<Transactional> {
 
+    private JPAApi jpaApi;
+
+    @Inject
+    public TransactionalAction(JPAApi jpaApi) {
+        this.jpaApi = jpaApi;
+    }
+
     public CompletionStage<Result> call(final Context ctx) {
-        return JPA.withTransaction(
+        return jpaApi.withTransaction(
             configuration.value(),
             configuration.readOnly(),
             () -> delegate.call(ctx)

--- a/framework/src/play-java-jpa/src/test/java/play/db/jpa/JPAApiTest.java
+++ b/framework/src/play-java-jpa/src/test/java/play/db/jpa/JPAApiTest.java
@@ -3,24 +3,97 @@
  */
 package play.db.jpa;
 
+import org.junit.Rule;
+import org.junit.rules.ExternalResource;
 import play.db.Database;
 import play.db.Databases;
 
 import org.junit.Test;
+
+import javax.persistence.EntityManager;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 public class JPAApiTest {
 
+    @Rule
+    public TestDatabase db = new TestDatabase();
+
     @Test
-    public void insertAndFindEntities() throws Exception {
-        TestDatabase db = new TestDatabase();
+    public void shouldBeAbleToGetAnEntityManagerWithAGivenName() {
+        EntityManager em = db.jpa.em("default");
+        assertThat(em, notNullValue());
+    }
+
+    @Test
+    public void shouldExecuteAFunctionBlockUsingAEntityManager() {
+        db.jpa.withTransaction(entityManager -> {
+            TestEntity entity = createTestEntity();
+            entityManager.persist(entity);
+            return entity;
+        });
 
         db.jpa.withTransaction(() -> {
-            TestEntity entity = new TestEntity();
-            entity.id = 1L;
-            entity.name = "alice";
+            TestEntity entity = TestEntity.find(1L);
+            assertThat(entity.name, equalTo("alice"));
+        });
+    }
+
+    @Test
+    public void shouldReuseEntityManagerWhenExecutingTransaction() {
+        JPAApi api = db.jpa;
+        boolean reused = api.withTransaction(entityManager -> {
+            EntityManager fromContext = api.em();
+            return fromContext == entityManager;
+        });
+
+        assertThat(reused, is(true));
+    }
+
+    @Test
+    public void shouldExecuteAFunctionBlockUsingASpecificNamedEntityManager() {
+        db.jpa.withTransaction("default", entityManager -> {
+            TestEntity entity = createTestEntity();
+            entityManager.persist(entity);
+            return entity;
+        });
+
+        db.jpa.withTransaction(() -> {
+            TestEntity entity = TestEntity.find(1L);
+            assertThat(entity.name, equalTo("alice"));
+        });
+    }
+
+    @Test
+    public void shouldExecuteAFunctionBlockAsAReadOnlyTransaction() {
+        db.jpa.withTransaction("default", true, entityManager -> {
+            TestEntity entity = createTestEntity();
+            entityManager.persist(entity);
+            return entity;
+        });
+
+        db.jpa.withTransaction(() -> {
+            TestEntity entity = TestEntity.find(1L);
+            assertThat(entity, nullValue());
+        });
+    }
+
+    private TestEntity createTestEntity() {
+        return createTestEntity(1L);
+    }
+
+    private TestEntity createTestEntity(Long id) {
+        TestEntity entity = new TestEntity();
+        entity.id = id;
+        entity.name = "alice";
+        return entity;
+    }
+
+    @Test
+    public void shouldExecuteASupplierBlockInsideATransaction() throws Exception {
+        db.jpa.withTransaction(() -> {
+            TestEntity entity = createTestEntity();
             entity.save();
         });
 
@@ -28,19 +101,88 @@ public class JPAApiTest {
             TestEntity entity = TestEntity.find(1L);
             assertThat(entity.name, equalTo("alice"));
         });
-
-        db.shutdown();
     }
 
-    public static class TestDatabase {
-        final Database database;
-        final JPAApi jpa;
+    @Test
+    public void shouldNestTransactions() {
+        db.jpa.withTransaction(() -> {
+            TestEntity entity = new TestEntity();
+            entity.id = 2L;
+            entity.name = "test2";
+            entity.save();
 
-        public TestDatabase() {
-            database = Databases.inMemoryWith("jndiName", "DefaultDS");
-            execute("create table TestEntity (id bigint not null, name varchar(255));");
-            jpa = JPA.createFor("defaultPersistenceUnit");
-        }
+            db.jpa.withTransaction(() -> {
+                TestEntity entity2 = TestEntity.find(2L);
+                assertThat(entity2, nullValue());
+            });
+
+            // Verify that we can still access the EntityManager
+            TestEntity entity3 = TestEntity.find(2L);
+            assertThat(entity3, equalTo(entity));
+        });
+    }
+
+    @Test
+    public void shouldRollbackInnerTransactionOnly() {
+        db.jpa.withTransaction(() -> {
+            // Parent transaction creates entity 2
+            TestEntity entity = createTestEntity(2L);
+            entity.save();
+
+            db.jpa.withTransaction(() -> {
+                // Nested transaction creates entity 3, but rolls back
+                TestEntity entity2 = createTestEntity(3L);
+                entity2.save();
+
+                JPA.em().getTransaction().setRollbackOnly();
+            });
+
+            // Verify that we can still access the EntityManager
+            TestEntity entity3 = TestEntity.find(2L);
+            assertThat(entity3, equalTo(entity));
+        });
+
+        db.jpa.withTransaction(() -> {
+            TestEntity entity = TestEntity.find(3L);
+            assertThat(entity, nullValue());
+
+            TestEntity entity2 = TestEntity.find(2L);
+            assertThat(entity2.name, equalTo("alice"));
+        });
+    }
+
+    @Test
+    public void shouldRollbackOuterTransactionOnly() {
+        db.jpa.withTransaction(() -> {
+            // Parent transaction creates entity 2, but rolls back
+            TestEntity entity = createTestEntity(2L);
+            entity.save();
+
+            db.jpa.withTransaction(() -> {
+                // Nested transaction creates entity 3
+                TestEntity entity2 = createTestEntity(3L);
+                entity2.save();
+            });
+
+            // Verify that we can still access the EntityManager
+            TestEntity entity3 = TestEntity.find(2L);
+            assertThat(entity3, equalTo(entity));
+
+            db.jpa.em().getTransaction().setRollbackOnly();
+        });
+
+        db.jpa.withTransaction(() -> {
+            TestEntity entity = TestEntity.find(3L);
+            assertThat(entity.name, equalTo("alice"));
+
+            TestEntity entity2 = TestEntity.find(2L);
+            assertThat(entity2, nullValue());
+        });
+    }
+
+    public static class TestDatabase extends ExternalResource {
+        Database database;
+        JPAApi jpa;
 
         public void execute(final String sql) {
             database.withConnection(connection -> {
@@ -48,7 +190,15 @@ public class JPAApiTest {
             });
         }
 
-        public void shutdown() {
+        @Override
+        public void before() {
+            database = Databases.inMemoryWith("jndiName", "DefaultDS");
+            execute("create table TestEntity (id bigint not null, name varchar(255));");
+            jpa = JPA.createFor("defaultPersistenceUnit");
+        }
+
+        @Override
+        public void after() {
             jpa.shutdown();
             database.shutdown();
         }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -44,7 +44,7 @@ public class Http {
      */
     public static class Context {
 
-        public static ThreadLocal<Context> current = new ThreadLocal<Context>();
+        public static ThreadLocal<Context> current = new ThreadLocal<>();
 
         /**
          * Retrieves the current HTTP context, for the current thread.


### PR DESCRIPTION
## Fixes

Fixes #4890

## Purpose

Improves the JPAApi to be more consistent and also to have better ways to handle EntityManager lifecycle.

## Background Context

See this comment: https://github.com/playframework/playframework/issues/4890#issuecomment-127368670

## References

Please see discussion and suggestions made at #4890.

## Details

This changes both JPAApi and JPA helper to work more consistently.

1. Both JPAApi.em(String) and JPA.em(String) should always return a new EntityManager for the given name. This was already working this way and only tests were added to avoid regressions
2. Now both JPA and JPAApi  have an em() method which returns the EntityManager from Http.Context or ThreadLocal if available. A new class was created to "hold" the current EntityManager instead of duplicate/split this logic between JPAApi and JPA.
3. JPAApi now overloads method withTransaction to have options receiving a Function<EntityManager, T> so users can avoid JPAApi.em() calls. The support for Function<EntityManager, T> is on par with what is offered to Supplier<T>.
4. Deprecated methods were removed and additional deprecation tags were added beyond what was already deprecated by #5697.
5. Docs were improved to add more examples and also to extract code to external snippets.