### PR TITLE
Improve and update SBT Dependencies docs

### DIFF
--- a/documentation/manual/working/commonGuide/build/SBTDependencies.md
+++ b/documentation/manual/working/commonGuide/build/SBTDependencies.md
@@ -1,17 +1,19 @@
 <!--- Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com> -->
 # Managing library dependencies
 
+> **Note**: Some sections of this page were copied from sbt manual, specifically from the [Library Dependencies](http://www.scala-sbt.org/0.13/docs/Library-Dependencies.html) page. Please, for a most updated version.
+
 ## Unmanaged dependencies
 
 Most people end up using managed dependencies - which allows for fine-grained control, but unmanaged dependencies can be simpler when starting out.
 
-Unmanaged dependencies work like this: create a `lib/` directory in the root of your project and then add jar files to that directory. They will automatically be added to the application classpath. There’s not much else to it!
+Unmanaged dependencies work like this: create a `lib/` directory in the root of your project and then add jar files to that directory. They will automatically be added to the application classpath. There's not much else to it.
 
-There’s nothing to add to `build.sbt` to use unmanaged dependencies, although you could change a configuration key if you’d like to use a directory different to `lib`.
+There's nothing to add to `build.sbt` to use unmanaged dependencies, although you could change a configuration key if you'd like to use a directory different than `lib`.
 
 ## Managed dependencies
 
-Play uses Apache Ivy (via sbt) to implement managed dependencies, so if you’re familiar with Maven or Ivy, you won’t have much trouble.
+Play uses [Apache Ivy](http://ant.apache.org/ivy/) (via sbt) to implement managed dependencies, so if you're familiar with Maven or Ivy, you are already used to managed dependencies.
 
 Most of the time you can simply list your dependencies in the `build.sbt` file. 
 
@@ -21,7 +23,7 @@ Declaring a dependency looks like this (defining `group`, `artifact` and `revisi
 libraryDependencies += "org.apache.derby" % "derby" % "10.11.1.1"
 ```
 
-or like this, with an optional `configuration`:
+Or like this, with an optional `configuration`:
 
 ```scala
 libraryDependencies += "org.apache.derby" % "derby" % "10.11.1.1" % "test"
@@ -40,23 +42,23 @@ Of course, sbt (via Ivy) has to know where to download the module. If your modul
 
 ### Getting the right Scala version with `%%`
 
-If you use `groupID %% artifactID % revision` instead of `groupID % artifactID % revision` (the difference is the double `%%` after the `groupID`), sbt will add your project’s Scala version to the artifact name. This is just a shortcut. 
-
-You could write this without the `%%`:
+If you use `groupID %% artifactID % revision` rather than `groupID % artifactID % revision` (the difference is the double `%%` after the `groupID`), sbt will add your project's Scala version to the artifact name. This is just a shortcut. You could write this without the `%%`:
 
 ```scala
-libraryDependencies += "org.scala-tools" % "scala-stm_2.9.1" % "0.3"
+libraryDependencies += "org.scala-tools" % "scala-stm_2.11.1" % "0.3"
 ```
 
-Assuming the `scalaVersion` for your build is `2.9.1`, the following is identical:
+Assuming the `scalaVersion` for your build is `2.11.1`, the following is identical (note the double `%%` after `"org.scala-tools"`):
 
 ```scala
 libraryDependencies += "org.scala-tools" %% "scala-stm" % "0.3"
 ```
 
+The idea is that many dependencies are compiled for multiple Scala versions, and you'd like to get the one that matches your project to ensure binary compatibility.
+
 ### Resolvers
 
-sbt uses the standard Maven2 repository and the Typesafe Releases (<https://repo.typesafe.com/typesafe/releases>) repositories by default. If your dependency isn’t on one of the default repositories, you’ll have to add a resolver to help Ivy find it.
+sbt uses the standard Maven2 repository and the Typesafe Releases (<https://repo.typesafe.com/typesafe/releases>) repositories by default. If your dependency isn't on one of the default repositories, you'll have to add a resolver to help Ivy find it.
 
 Use the `resolvers` setting key to add your own resolver.
 
@@ -78,3 +80,10 @@ resolvers += (
 )
 ```
 
+## Handling conflicts between dependencies
+
+sbt has extensive documentation about how to manage conflict between your dependencies:
+
+[SBT: Dependencies Conflict Management](http://www.scala-sbt.org/0.13/docs/Library-Management.html#Conflict+Management)
+
+You can also use [sbt-dependency-graph](https://github.com/jrudolph/sbt-dependency-graph) to have a better visualization of your dependency tree. See also our page about [[debugging sbt|SBTDebugging]] common problems.


### PR DESCRIPTION
## Fixes

Fixes #2441

## Purpose

Point users to the right page at sbt docs when they have problems with dependency management.

## Background Context

Most of the SBTDependencies page is just copy and paste from sbt docs. I've just give the page some update and add a section about conflict management.

## References

See issue #2441.
