### PR TITLE
Documentation on managing circular dependencies

### DIFF
--- a/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
@@ -145,6 +145,20 @@ If there is a module that you don't want to be loaded, you can exclude it by app
 
     play.modules.disabled += "play.api.db.evolutions.EvolutionsModule"
 
+## Managing circular dependencies
+
+Circular dependencies happen when one of your components depends on another component that depends on the original component (either directly or indirectly). For example:
+
+@[circular](code/javaguide/di/guice/CircularDependencies.java)
+
+In this case, `Foo` depends on `Bar`, which depends on `Baz`, which depends on `Foo`. So you won't be able to instantate any of these classes. You can work around this problem by using a `Provider`:
+
+@[circular-provider](code/javaguide/di/guice/CircularDependencies.java)
+
+Note that if you're using constructor injection it will be much more clear when you have a circular dependency, since it will be impossible to instantiate the component manually.
+
+Generally, circular dependencies can be resolved by breaking up your components in a more atomic way, or finding a more specific component to depend on. A common problem is a dependency on `Application`. When your component depends on `Application` it's saying that it needs a complete application to do its job; typically that's not the case. Your dependencies should be on more specific components (e.g. `Environment`) that have the specific functionality you need. As a last resort you can work around the problem by injecting a `Provider<Application>`.
+
 ## Advanced: Extending the GuiceApplicationLoader
 
 Play's runtime dependency injection is bootstrapped by the [`GuiceApplicationLoader`](api/java/play/inject/guice/GuiceApplicationLoader.html) class. This class loads all the modules, feeds the modules into Guice, then uses Guice to create the application. If you want to control how Guice initializes the application then you can extend the `GuiceApplicationLoader` class.

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/guice/CircularDependencies.java
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/guice/CircularDependencies.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package javaguide.di.guice;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+class CircularDependencies {
+
+class NoProvider {
+//#circular
+public class Foo {
+  @Inject Bar bar;
+}
+public class Bar {
+  @Inject Baz baz;
+}
+public class Baz {
+  @Inject Foo foo;
+}
+//#circular
+}
+
+class WithProvider {
+//#circular-provider
+public class Foo {
+  @Inject Bar bar;
+}
+public class Bar {
+  @Inject Baz baz;
+}
+public class Baz {
+  @Inject Provider<Foo> fooProvider;
+}
+//#circular-provider
+}
+
+}

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaDependencyInjection.md
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaDependencyInjection.md
@@ -144,6 +144,18 @@ If there is a module that you don't want to be loaded, you can exclude it by app
 
     play.modules.disabled += "play.api.db.evolutions.EvolutionsModule"
 
+## Managing circular dependencies
+
+Circular dependencies happen when one of your components depends on another component that depends on the original component (either directly or indirectly). For example:
+
+@[circular](code/RuntimeDependencyInjection.scala)
+
+In this case, `Foo` depends on `Bar`, which depends on `Baz`, which depends on `Foo`. So you won't be able to instantate any of these classes. You can work around this problem by using a `Provider`:
+
+@[circular-provider](code/RuntimeDependencyInjection.scala)
+
+Generally, circular dependencies can be resolved by breaking up your components in a more atomic way, or finding a more specific component to depend on. A common problem is a dependency on `Application`. When your component depends on `Application` it's saying that it needs a complete application to do its job; typically that's not the case. Your dependencies should be on more specific components (e.g. `Environment`) that have the specific functionality you need. As a last resort you can work around the problem by injecting a `Provider[Application]`.
+
 ## Advanced: Extending the GuiceApplicationLoader
 
 Play's runtime dependency injection is bootstrapped by the [`GuiceApplicationLoader`](api/scala/play/api/inject/guice/GuiceApplicationLoader.html) class. This class loads all the modules, feeds the modules into Guice, then uses Guice to create the application. If you want to control how Guice initializes the application then you can extend the `GuiceApplicationLoader` class.

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
@@ -104,7 +104,7 @@ import implemented._
 //#guice-module
 import com.google.inject.AbstractModule
 import com.google.inject.name.Names
-  
+
 class Module extends AbstractModule {
   def configure() = {
 
@@ -128,7 +128,7 @@ import implemented._
 import com.google.inject.AbstractModule
 import com.google.inject.name.Names
 import play.api.{ Configuration, Environment }
-  
+
 class Module(
   environment: Environment,
   configuration: Configuration) extends AbstractModule {
@@ -163,7 +163,7 @@ import implemented._
 //#eager-guice-module
 import com.google.inject.AbstractModule
 import com.google.inject.name.Names
-  
+
 class Module extends AbstractModule {
   def configure() = {
 
@@ -245,4 +245,28 @@ class CustomApplicationLoader extends GuiceApplicationLoader() {
   }
 }
 //#custom-application-loader
+}
+
+package circular {
+
+//#circular
+import javax.inject.Inject
+
+class Foo @Inject() (bar: Bar)
+class Bar @Inject() (baz: Baz)
+class Baz @Inject() (foo: Foo)
+//#circular
+
+}
+
+package circularProvider {
+
+//#circular-provider
+import javax.inject.{ Inject, Provider }
+
+class Foo @Inject() (bar: Bar)
+class Bar @Inject() (baz: Baz)
+class Baz @Inject() (foo: Provider[Foo])
+//#circular-provider
+
 }


### PR DESCRIPTION
## Purpose

Documents how to handle circular dependencies in a Play app.

## Background Context

#5695 turns off Guice's automatic proxying to resolve circular dependencies, and there have been a few questions in the past about handling circular dependencies, especially when dealing with dependencies on Application.

## References

https://groups.google.com/forum/#!topic/play-framework-dev/RqSoXt0FJT0
#5695
