### PR TITLE
Make CORS filter treat http and https as different origins

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
@@ -3,6 +3,8 @@
  */
 package play.filters.cors
 
+import java.util.Locale
+
 import scala.collection.immutable
 import scala.concurrent.Future
 
@@ -27,53 +29,45 @@ private[cors] trait AbstractCORSPolicy {
   protected def errorHandler: HttpErrorHandler
 
   /**
-   * HTTP Methods support by Play
+   * HTTP Methods supported by Play
    */
-  private val HttpMethods = {
+  private val SupportedHttpMethods: Set[String] = {
     import HttpVerbs._
     immutable.HashSet(GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS)
   }
 
   protected def filterRequest(next: RequestHeader => Future[Result], request: RequestHeader): Future[Result] = {
-    request.headers.get(HeaderNames.ORIGIN) match {
-      case None =>
+    (request.headers.get(HeaderNames.ORIGIN), request.method) match {
+      case (None, _) =>
         /* http://www.w3.org/TR/cors/#resource-requests
          * § 6.1.1
          * If the Origin header is not present terminate this set of steps.
          */
         next(request)
-      case Some(originHeader) =>
-        if (originHeader.isEmpty || !isValidOrigin(originHeader)) {
-          handleInvalidCORSRequest(request)
-        } else if ({
-          val originUri = new URI(originHeader)
-          val hostUri = new URI("//" + request.host)
-          originUri.getHost == hostUri.getHost && originUri.getPort == hostUri.getPort
-        }) {
-          // HOST and ORIGIN match, so this is a same-origin request, pass through.
-          next(request)
-        } else {
-          val method = request.method
-          if (HttpMethods.contains(method)) {
-            if (method == HttpVerbs.OPTIONS) {
-              request.headers.get(HeaderNames.ACCESS_CONTROL_REQUEST_METHOD) match {
-                case None =>
-                  handleCORSRequest(next, request)
-                case Some(requestMethod) =>
-                  if (requestMethod.isEmpty) {
-                    handleInvalidCORSRequest(request)
-                  } else {
-                    handlePreFlightCORSRequest(request)
-                  }
-              }
-            } else {
-              handleCORSRequest(next, request)
-            }
-          } else {
-            // unrecognized method so invalid request
+      case (Some(originHeader), _) if originHeader.isEmpty || !isValidOrigin(originHeader) =>
+        /*
+         * If the value of the Origin header is not a case-sensitive match for any of the values in list of origins, do
+         * not set any additional headers and terminate this set of steps.
+         */
+        handleInvalidCORSRequest(request)
+      case (Some(originHeader), _) if isSameOrigin(originHeader, request) =>
+        // Same-origin request
+        next(request)
+      case (_, HttpVerbs.OPTIONS) =>
+        // Check for preflight request
+        request.headers.get(HeaderNames.ACCESS_CONTROL_REQUEST_METHOD) match {
+          case None =>
+            handleCORSRequest(next, request)
+          case Some("") =>
             handleInvalidCORSRequest(request)
-          }
+          case _ =>
+            handlePreFlightCORSRequest(request)
         }
+      case (_, method) if SupportedHttpMethods.contains(method) =>
+        handleCORSRequest(next, request)
+      case _ =>
+        // unrecognized method so invalid request
+        handleInvalidCORSRequest(request)
     }
   }
 
@@ -192,7 +186,7 @@ private[cors] trait AbstractCORSPolicy {
            * values in list of methods do not set any additional
            * headers and terminate this set of steps.
            */
-          if (!HttpMethods.contains(accessControlRequestMethod) ||
+          if (!SupportedHttpMethods.contains(accessControlRequestMethod) ||
             !methodPredicate(accessControlRequestMethod)) {
             handleInvalidCORSRequest(request)
           } else {
@@ -321,5 +315,11 @@ private[cors] trait AbstractCORSPolicy {
         case _: URISyntaxException => false
       }
     }
+  }
+
+  private def isSameOrigin(origin: String, request: RequestHeader): Boolean = {
+    val hostUri = new URI(origin.toLowerCase(Locale.ENGLISH))
+    val originUri = new URI((if (request.secure) "https://" else "http://") + request.host.toLowerCase(Locale.ENGLISH))
+    (hostUri.getScheme, hostUri.getHost, hostUri.getPort) == (originUri.getScheme, originUri.getHost, originUri.getPort)
   }
 }

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSSpec.scala
@@ -6,16 +6,15 @@ package play.filters.cors
 import javax.inject.Inject
 
 import play.api.http.{ContentTypes, HttpFilters}
+import play.api.inject.bind
+import play.api.mvc.{Action, Result, Results}
 import play.api.routing.Router
 import play.api.routing.sird._
+import play.api.test.{FakeRequest, PlaySpecification}
+import play.api.{Application, Configuration}
 import play.filters.csrf.{CSRFCheck, CSRFFilter}
 
 import scala.concurrent.Future
-
-import play.api.{Application, Configuration}
-import play.api.mvc.{ Action, Result, Results }
-import play.api.test.{ FakeRequest, PlaySpecification }
-import play.api.inject.bind
 
 object CORSFilterSpec extends CORSCommonSpec {
 
@@ -205,6 +204,16 @@ trait CORSCommonSpec extends PlaySpecification {
 
       status(result) must_== OK
       header(ACCESS_CONTROL_ALLOW_ORIGIN, result) must beSome("http://www.example.com:9000")
+    }
+
+    "not consider different protocols to be the same origin" in withApplication() {
+      val result = route(fakeRequest().withHeaders(
+        ORIGIN -> "https://www.example.com:9000",
+        HOST -> "www.example.com:9000"
+      )).get
+
+      status(result) must_== OK
+      header(ACCESS_CONTROL_ALLOW_ORIGIN, result) must beSome("https://www.example.com:9000")
     }
 
     "forbid an empty origin header" in withApplication() {


### PR DESCRIPTION
Fixes #5687

Change the CORS filter to treat HTTP and HTTPS requests as different origins. Previously, we would let the request pass through without adding CORS headers if the host and port matched. Now we check the `request.secure` attribute so requests to `https://example.com` are treated differently from `http://example.com`.

Another possible approach might be to check all requests with an origin, but since some browsers send the `Origin` header with same-origin requests, it would mean we'd have to whitelist the origin of the server as well, so it could break things for existing users.