### PR TITLE
delpy01Partially restore BodyParsers.parse.maxLength behaviour WRT 2.4.x

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MaxLengthBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MaxLengthBodyParserSpec.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.it.http.parsing
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import play.api.mvc.{ MaxSizeExceeded, BodyParsers }
+import play.api.test._
+
+object MaxLengthBodyParserSpec extends PlaySpecification {
+
+  "The maxSize body parser" should {
+
+    def parse(size: Long, underlyingSize: Long, bytes: ByteString, contentType: Option[String], encoding: String)(implicit mat: Materializer) = {
+      val request = FakeRequest().withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*)
+      val parser = BodyParsers.parse.maxLength(size, BodyParsers.parse.anyContent(Some(underlyingSize)))
+      await(parser(request).run(Source.single(bytes)))
+    }
+
+    "return MaxSizeExceeded with a limit lower than the underlying parser" in new WithApplication() {
+      parse(1, 10, ByteString("foo"), Some("text/plain"), "utf-8") must beRight.like {
+        case Left(MaxSizeExceeded(size)) => size must_== 1
+      }
+    }
+
+    "return EntityTooLarge with a limit equal to the underlying parser" in new WithApplication() {
+      parse(1, 1, ByteString("foo"), Some("text/plain"), "utf-8") must beLeft.like {
+        case r => r.header.status == REQUEST_ENTITY_TOO_LARGE
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request Checklist

* Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* Have you added copyright headers to new files?
* Have you checked that both Scala and Java APIs are updated?
* Have you updated the documentation?
* Have you added tests?

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?

Ensure that when handling a `MaxLengthLimitAttained` error that the
relevant limit is the same as that expected. Otherwise, the limit
given to the `maxLength` body parser is handled erroneously by that
of the underlying parser, resulting in a 413 response being returned.

Note that if the `maxLength` parser and the underlying parser have
the same limit, the underlying one will 'win', returning 413.