### PR TITLE
Update Comet API to use Akka Streams

### DIFF
--- a/documentation/manual/releases/release25/migration25/StreamsMigration25.md
+++ b/documentation/manual/releases/release25/migration25/StreamsMigration25.md
@@ -144,6 +144,20 @@ You can also create your own `MappedWebSocketAcceptor` by defining how to conver
 * To learn how to migrate a `WebSocket.In` to a Sink, see XXXX.
 * To learn how to migrate a `WebSocket.Out` to a Source, see XXXX.
 
+#### Migrating Comet
+
+To use [Comet](https://en.wikipedia.org/wiki/Comet_(programming)) in Play you need to produce a chunked HTTP response with specially formatted chunks. Play has a `Comet` class to help produce events on the server that can be sent to the browser.  In Play 2.4.x, a new Comet instance had to be created and used callbacks for Java, and an Enumeratee was used for Scala.  In Play 2.5, there are new APIs added based on Akka Streams.
+
+##### Migrating Java Comet
+
+Create an Akka Streams source for your objects, and convert them into either `String` or `JsonNode` objects.  From there, you can use `play.libs.Comet.string` or `play.libs.Comet.json` to convert your objects into a format suitable for `Results.ok().chunked()`.  There is additional documentation in [[JavaComet]].
+
+Because the Java Comet helper is based around callbacks, it may be easier to turn the callback based class into a `org.reactivestreams.Publisher` directly and use `Source.fromPublisher` to create a source.
+
+##### Migrating Scala Comet
+
+Create an Akka Streams source for your objects, and convert them into either `String` or `JsValue` objects.  From there, you can use `play.api.libs.Comet.string` or `play.api.libs.Comet.json` to convert your objects into a format suitable for `Ok.chunked()`.  There is additional documentation in [[ScalaComet]].
+
 #### Migrating Server-Sent events (`EventSource`)
 
 To use [Server-Sent Events](http://www.html5rocks.com/en/tutorials/eventsource/basics/) in Play you need to produce a chunked HTTP response with specially formatted chunks. Play has an `EventSource` interface to help produce events on the server that can be sent to the browser. In Play 2.4 Java and Scala each had quite different APIs, but in Play 2.5 they have been changed so they're both based on Akka Streams.
@@ -172,7 +186,7 @@ Source<EventSource.Event, ?> eventSource = myStrings.map(Event::event);
 return ok().chunked(EventSource.chunked(eventSource)).as("text/event-stream");
 ```
 
-* To learn how to migrate `EventSource.onConnected`, `EventSource.send`, etc to a `Source`, see XXXX.
+* To migrate `EventSource.onConnected`, `EventSource.send`, etc to a `Source`, implement `org.reactivestreams.Publisher` on the class and use `Source.fromPublisher` to create a source from the callbacks.
 
 If you still want to use the same API as in Play 2.4 you can use the `LegacyEventSource` class. This class is the same as the Play 2.4 API, but it has been renamed and deprecated. If you want to use the new API, but retain the same feel as the old imperative API, you can try [`GraphStage`](http://doc.akka.io/docs/akka/2.4.2/java/stream/stream-customize.html#custom-processing-with-graphstage).
 

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaComet.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaComet.java
@@ -3,84 +3,56 @@
  */
 package javaguide.async;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import javaguide.testhelpers.MockJavaAction;
 import javaguide.testhelpers.MockJavaActionHelper;
-import org.junit.Before;
 import org.junit.Test;
+
+//#comet-imports
+import akka.stream.javadsl.Source;
 import play.libs.Comet;
+import play.libs.Json;
+import play.mvc.Http;
 import play.mvc.Result;
+//#comet-imports
+
 import play.test.WithApplication;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
-import static play.test.Helpers.*;
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import static play.test.Helpers.contentAsString;
+import static play.test.Helpers.fakeRequest;
 
 public class JavaComet extends WithApplication {
 
-    @Test
-    public void manual() {
-        String content = contentAsString(MockJavaActionHelper.call(new Controller1(), fakeRequest(), mat), mat);
-        assertThat(content, containsString("<script>console.log('kiki')</script>"));
-        assertThat(content, containsString("<script>console.log('foo')</script>"));
-        assertThat(content, containsString("<script>console.log('bar')</script>"));
-    }
-
     public static class Controller1 extends MockJavaAction {
-        //#manual
+        //#comet-string
         public static Result index() {
-            // Prepare a chunked text stream
-            Chunks<String> chunks = StringChunks.whenReady(out -> {
-                out.write("<script>console.log('kiki')</script>");
-                out.write("<script>console.log('foo')</script>");
-                out.write("<script>console.log('bar')</script>");
-                out.close();
-            });
-
-            response().setContentType("text/html");
-            return ok(chunks);
+            final Source source = Source.from(Arrays.asList("kiki", "foo", "bar"));
+            return ok().chunked(source.via(Comet.string("parent.cometMessage"))).as(Http.MimeTypes.HTML);
         }
-        //#manual
-    }
-
-    @Test
-    public void comet() {
-        String content = contentAsString(MockJavaActionHelper.call(new Controller2(), fakeRequest(), mat), mat);
-        assertThat(content, containsString("<script type=\"text/javascript\">console.log('kiki');</script>"));
-        assertThat(content, containsString("<script type=\"text/javascript\">console.log('foo');</script>"));
-        assertThat(content, containsString("<script type=\"text/javascript\">console.log('bar');</script>"));
+        //#comet-string
     }
 
     public static class Controller2 extends MockJavaAction {
-        //#comet
-        public Result index() {
-            return ok(Comet.whenConnected("console.log", comet -> {
-                comet.sendMessage("kiki");
-                comet.sendMessage("foo");
-                comet.sendMessage("bar");
-                comet.close();
-            }));
+        //#comet-json
+        public static Result index() {
+            final ObjectNode objectNode = Json.newObject();
+            objectNode.put("foo", "bar");
+            final Source source = Source.from(Arrays.asList(objectNode));
+            return ok().chunked(source.via(Comet.json("parent.cometMessage"))).as(Http.MimeTypes.HTML);
         }
-        //#comet
+        //#comet-json
     }
 
     @Test
     public void foreverIframe() {
-        String content = contentAsString(MockJavaActionHelper.call(new Controller3(), fakeRequest(), mat), mat);
+        String content = contentAsString(MockJavaActionHelper.call(new Controller1(), fakeRequest(), mat), mat);
         assertThat(content, containsString("<script type=\"text/javascript\">parent.cometMessage('kiki');</script>"));
         assertThat(content, containsString("<script type=\"text/javascript\">parent.cometMessage('foo');</script>"));
         assertThat(content, containsString("<script type=\"text/javascript\">parent.cometMessage('bar');</script>"));
     }
 
-    public static class Controller3 extends MockJavaAction {
-        //#forever-iframe
-        public Result index() {
-            return ok(Comet.whenConnected("parent.cometMessage", comet -> {
-                comet.sendMessage("kiki");
-                comet.sendMessage("foo");
-                comet.sendMessage("bar");
-                comet.close();
-            }));
-        }
-        //#forever-iframe
-    }
 }

--- a/documentation/manual/working/javaGuide/main/async/index.toc
+++ b/documentation/manual/working/javaGuide/main/async/index.toc
@@ -1,4 +1,4 @@
 JavaAsync:Handling asynchronous results
 JavaStream:Streaming HTTP responses
-JavaComet:Comet sockets
+JavaComet:Comet
 JavaWebSockets:WebSockets

--- a/documentation/manual/working/scalaGuide/main/async/ScalaComet.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaComet.md
@@ -1,39 +1,37 @@
-<!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
-# Comet sockets
+<!--- Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com> -->
+# Comet
 
-## Using chunked responses to create Comet sockets
+## Using chunked responses with Comet
 
-A good use for **Chunked responses** is to create Comet sockets. A Comet socket is just a chunked `text/html` response containing only `<script>` elements. At each chunk we write a `<script>` tag that is immediately executed by the web browser. This way we can send events live to the web browser from the server: for each message, wrap it into a `<script>` tag that calls a JavaScript callback function, and writes it to the chunked response.
-    
-Let’s write a first proof-of-concept: an enumerator that generates `<script>` tags that each call the browser `console.log` JavaScript function:
-    
-@[manual](code/ScalaComet.scala)
+A common use of **chunked responses** is to create a Comet socket.
 
-If you run this action from a web browser, you will see the three events logged in the browser console.
+A Comet socket is a chunked `text/html` response containing only `<script>` elements. For each chunk, we write a `<script>` tag containing JavaScript that is immediately executed by the web browser. This way we can send events live to the web browser from the server: for each message, wrap it into a `<script>` tag that calls a JavaScript callback function, and write it to the chunked response.
 
-We can write this in a better way by using `play.api.libs.iteratee.Enumeratee` that is just an adapter to transform an `Enumerator[A]` into another `Enumerator[B]`. Let’s use it to wrap standard messages into the `<script>` tags:
-    
-@[enumeratee](code/ScalaComet.scala)
+Because `Ok.chunked` leverages [Akka Streams](http://doc.akka.io/docs/akka/2.4.2/scala/stream/index.html) to take a `Flow[ByteString]`, we can send a `Flow` of elements and transform it so that each element is escaped and wrapped in the Javascript method. The Comet helper automates Comet sockets, pushing an initial blank buffer data for browser compatibility, and supporting both String and JSON messages.  
 
-> **Tip:** Writing `events &> toCometMessage` is just another way of writing `events.through(toCometMessage)`
+## Comet Imports
 
-## Using the `play.api.libs.Comet` helper
+To use the Comet helper, import the following classes:
 
-We provide a Comet helper to handle these Comet chunked streams that do almost the same stuff that we just wrote.
+@[comet-imports](code/ScalaComet.scala)
 
-> **Note:** Actually it does more, like pushing an initial blank buffer data for browser compatibility, and it supports both String and JSON messages. It can also be extended via type classes to support more message types.
+You will also need a materializer, which is best done by pulling `akka.stream.Materializer` from your [[DI system|ScalaDependencyInjection]].   
 
-Let’s just rewrite the previous example to use it:
+## Using Comet with String Flow
 
-@[helper](code/ScalaComet.scala)
+To push string messages through a Flow, do the following:
 
-## The forever iframe technique
+@[comet-string](code/ScalaComet.scala)
 
-The standard technique to write a Comet socket is to load an infinite chunked comet response in an HTML `iframe` and to specify a callback calling the parent frame:
+## Using Comet with JSON Flow
 
-@[iframe](code/ScalaComet.scala)
+To push JSON messages through a Flow, do the following:
 
-With an HTML page like:
+@[comet-json](code/ScalaComet.scala)
+
+## Using Comet with iframe
+
+The comet helper should typically be used with a `forever-iframe` technique, with an HTML page like:
 
 ```
 <script type="text/javascript">
@@ -44,3 +42,19 @@ With an HTML page like:
 
 <iframe src="/comet"></iframe>
 ```
+
+For an example of a Comet helper, see the [Play 2.5 Clock Template](https://github.com/typesafehub/play-2.5-clock/).
+
+## Debugging Comet
+
+The easiest way to debug a Comet stream that is not working is to use the [`log()`](http://doc.akka.io/docs/akka-stream-and-http-experimental/2.0.3/scala/stream-cookbook.html#Logging_elements_of_a_stream) operation to show any errors involved in mapping data through the stream.
+
+## Legacy Comet with Enumerator
+
+Previously existing Comet functionality is still available through an `Enumeratee` using `Comet.apply`, but it is deprecated and you are encouraged to move to the Akka Streams based version.  
+
+If you have existing code that relies heavily on `Enumerator`, you can use [`play.api.libs.streams.Streams`](api/scala/play/api/libs/streams/Streams$.html) and the interoperability with [Reactive Streams](http://doc.akka.io/docs/akka-stream-and-http-experimental/2.0.3/scala/stream-integrations.html#integrating-with-reactive-streams) to convert an Enumerator to a Stream:
+
+@[comet-enumerator](code/ScalaComet.scala)
+
+Also see the [[Streams Migration Guide|StreamsMigration25#Migrating-Enumerators-to-Sources]].

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaComet.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaComet.scala
@@ -3,85 +3,79 @@
  */
 package scalaguide.async.scalacomet
 
+//#comet-imports
 import akka.stream.Materializer
-import play.api.mvc._
-import play.api.libs.iteratee.{Enumeratee, Enumerator}
-import play.api.test._
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
+import akka.stream.scaladsl.Source
+import play.api.http.ContentTypes
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.Comet
+import play.api.libs.iteratee.Enumerator
+import play.api.libs.json._
+import play.api.libs.streams.Streams
+import play.api.mvc._
+//#comet-imports
 
-object ScalaCometSpec extends PlaySpecification with Controller {
+import play.api.test._
+
+object ScalaCometSpec extends PlaySpecification {
+
+  class MockController(val materializer: Materializer) extends Controller {
+
+    //#comet-string
+    def cometString = Action {
+      implicit val m = materializer
+      def stringSource: Source[String, _] = Source(List("kiki", "foo", "bar"))
+      Ok.chunked(stringSource via Comet.string("parent.cometMessage")).as(ContentTypes.HTML)
+    }
+    //#comet-string
+
+    //#comet-json
+    def cometJson = Action {
+      implicit val m = materializer
+      def jsonSource: Source[JsValue, _] = Source(List(JsString("jsonString")))
+      Ok.chunked(jsonSource via Comet.json("parent.cometMessage")).as(ContentTypes.HTML)
+    }
+    //#comet-json
+
+    //#comet-enumerator
+    def cometFromEnumerator = Action {
+      implicit val m = materializer
+      val enum = Enumerator("one", "two", "three")
+      val publisher = Streams.enumeratorToPublisher(enum)
+      def stringSource: Source[String, _] = Source.fromPublisher(publisher)
+      Ok.chunked(stringSource via Comet.string("parent.cometMessage")).as(ContentTypes.HTML)
+    }
+    //#comet-enumerator
+  }
+
+
 
   "play comet" should {
 
-    "allow manually sending comet messages" in new WithApplication() {
-      //#manual
-      def comet = Action {
-        val events = Enumerator(
-          """<script>console.log('kiki')</script>""",
-          """<script>console.log('foo')</script>""",
-          """<script>console.log('bar')</script>"""
-        )
-        Ok.chunked(events).as(HTML)
+    "work with string" in {
+      val app = new GuiceApplicationBuilder().build()
+      try {
+        implicit val m = app.materializer
+        val controller = new MockController(m)
+        val result = controller.cometString.apply(FakeRequest())
+        contentAsString(result) must contain("<html><body><script type=\"text/javascript\">parent.cometMessage('kiki');</script><script type=\"text/javascript\">parent.cometMessage('foo');</script><script type=\"text/javascript\">parent.cometMessage('bar');</script>")
+      } finally {
+        app.stop()
       }
-      //#manual
-      val msgs = cometMessages(comet(FakeRequest()))
-      msgs must haveLength(3)
-      msgs(0) must_== """<script>console.log('kiki')</script>"""
     }
 
-    "allow a smarter way of manually sending comet messages" in new WithApplication() {
-      //#enumeratee
-      import play.twirl.api.Html
-
-      // Transform a String message into an Html script tag
-      val toCometMessage = Enumeratee.map[String] { data =>
-        Html("""<script>console.log('""" + data + """')</script>""")
+    "work with json" in {
+      val app = new GuiceApplicationBuilder().build()
+      try {
+        implicit val m = app.materializer
+        val controller = new MockController(m)
+        val result = controller.cometJson.apply(FakeRequest())
+        contentAsString(result) must contain("<html><body><script type=\"text/javascript\">parent.cometMessage(\"jsonString\");</script>")
+      } finally {
+        app.stop()
       }
-
-      def comet = Action {
-        val events = Enumerator("kiki", "foo", "bar")
-        Ok.chunked(events &> toCometMessage)
-      }
-      //#enumeratee
-
-      val msgs = cometMessages(comet(FakeRequest()))
-      msgs must haveLength(3)
-      msgs(0) must_== """<script>console.log('kiki')</script>"""
-    }
-
-    "allow using the comet helper" in new WithApplication() {
-      //#helper
-      def comet = Action {
-        val events = Enumerator("kiki", "foo", "bar")
-        Ok.chunked(events &> Comet(callback = "console.log"))
-      }
-      //#helper
-
-      val msgs = cometMessages(comet(FakeRequest()))
-      msgs must haveLength(4)
-      msgs(1) must contain("console.log('kiki')")
-    }
-
-    "allow using a forever iframe" in new WithApplication() {
-      //#iframe
-      def comet = Action {
-        val events = Enumerator("kiki", "foo", "bar")
-        Ok.chunked(events &> Comet(callback = "parent.cometMessage"))
-      }
-      //#iframe
-
-      val msgs = cometMessages(comet(FakeRequest()))
-      msgs must haveLength(4)
-      msgs(1) must contain("parent.cometMessage('kiki')")
     }
 
   }
 
-  def cometMessages(result: Future[Result])(implicit mat: Materializer): Seq[String] = {
-    await(await(result).body.dataStream
-      .runFold(Seq.empty[String])((chunks, chunk) => chunks :+ chunk.utf8String)
-    )
-  }
 }

--- a/documentation/manual/working/scalaGuide/main/async/index.toc
+++ b/documentation/manual/working/scalaGuide/main/async/index.toc
@@ -1,4 +1,4 @@
 ScalaAsync:Asynchronous results
 ScalaStream:Streaming HTTP responses
-ScalaComet:Comet sockets
+ScalaComet:Comet
 ScalaWebSockets:WebSockets

--- a/framework/src/play-java/src/main/java/play/libs/Comet.java
+++ b/framework/src/play-java/src/main/java/play/libs/Comet.java
@@ -3,32 +3,117 @@
  */
 package play.libs;
 
-import play.mvc.Results.*;
-
+import akka.NotUsed;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+import akka.util.ByteStringBuilder;
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.commons.lang3.StringEscapeUtils;
+import play.mvc.Results;
 
-import java.util.*;
+import java.util.Arrays;
 import java.util.function.Consumer;
 
 /**
- * A Chunked stream sending Comet messages.
+ * Provides an easy way to use a Comet formatted output with
+ * <a href="http://doc.akka.io/docs/akka/current/java/stream/index.html">Akka Streams</a>.
+ *
+ * There are two methods that can be used to convert strings and JSON, {@code Comet.string}
+ * and {@code Comet.json}.  These methods build on top of the base method, {@code Comet.flow},
+ * which takes a Flow of {@code akka.util.ByteString} and organizes it into Comet format.
+ *
+ * <pre>{@literal
+ *   public Result liveClock() {
+ *        final DateTimeFormatter df = DateTimeFormatter.ofPattern("HH mm ss");
+ *        final Source tickSource = Source.tick(Duration.Zero(), Duration.create(100, MILLISECONDS), "TICK");
+ *        final Source eventSource = tickSource.map((tick) -> df.format(ZonedDateTime.now()));
+ *
+ *        final Source<ByteString, NotUsed> flow = eventSource.via(Comet.string("parent.clockChanged"));
+ *        return ok().chunked(flow).as(Http.MimeTypes.HTML);
+ *   }
+ * }</pre>
  */
-public abstract class Comet extends Chunks<String> {
+public abstract class Comet extends Results.Chunks<String> {
 
-    private Chunks.Out<String> out;
+    private static ByteString initialChunk;
+
+    static {
+        char[] buffer = new char[1024 * 5];
+        Arrays.fill(buffer, ' ');
+        initialChunk = ByteString.fromString(new String(buffer) + "<html><body>");
+    }
+
+    /**
+     * Produces a Flow of escaped ByteString from a series of String elements.  Calls
+     * out to Comet.flow internally.
+     *
+     * @param callbackName the javascript callback method.
+     * @return a flow of ByteString elements.
+     */
+    public static Flow<String, ByteString, NotUsed> string(String callbackName) {
+        return Flow.of(String.class).map(str -> {
+            return ByteString.fromString("'" + StringEscapeUtils.escapeEcmaScript(str) + "'");
+        }).via(flow(callbackName));
+    }
+
+    /**
+     * Produces a flow of ByteString using `Json.stringify` from a Flow of JsonNode.  Calls
+     * out to Comet.flow internally.
+     *
+     * @param callbackName the javascript callback method.
+     * @return a flow of ByteString elements.
+     */
+    public static Flow<JsonNode, ByteString, NotUsed> json(String callbackName) {
+        return Flow.of(JsonNode.class).map(json -> {
+            return ByteString.fromString(Json.stringify(json));
+        }).via(flow(callbackName));
+    }
+
+    /**
+     * Produces a flow of ByteString with a prepended block and a script wrapper.
+     *
+     * @param callbackName the javascript callback method.
+     * @return a flow of ByteString elements.
+     */
+    public static Flow<ByteString, ByteString, NotUsed> flow(String callbackName) {
+        ByteString cb = ByteString.fromString(callbackName);
+        return Flow.of(ByteString.class).map((msg) -> {
+            return formatted(cb, msg);
+        }).prepend(Source.single(initialChunk));
+    }
+
+    private static ByteString formatted(ByteString callbackName, ByteString javascriptMessage) {
+        ByteStringBuilder b = new ByteStringBuilder();
+        b.append(ByteString.fromString("<script type=\"text/javascript\">"));
+        b.append(callbackName);
+        b.append(ByteString.fromString("("));
+        b.append(javascriptMessage);
+        b.append(ByteString.fromString(");</script>"));
+        return b.result();
+    }
+
+    //--------------------------------------------------------------------------------
+    // Deprecated API follows
+    //--------------------------------------------------------------------------------
+
+    private Results.Chunks.Out<String> out;
     private String callbackMethod;
 
     /**
-     * Create a new Comet socket
+     * Create a new Comet socket.
      *
+     * @deprecated Please use {@code Comet.string} or {@code Comet.json}, since 2.5.x
      * @param callbackMethod The Javascript callback method to call on each message.
      */
+    @Deprecated
     public Comet(String callbackMethod) {
         super(play.core.j.JavaResults.writeString("text/html", play.api.mvc.Codec.javaSupported("utf-8")));
         this.callbackMethod = callbackMethod;
     }
 
-    public void onReady(Chunks.Out<String> out) {
+    @Deprecated
+    public void onReady(Results.Chunks.Out<String> out) {
         this.out = out;
         out.write(initialBuffer());
         onConnected();
@@ -37,6 +122,7 @@ public abstract class Comet extends Chunks<String> {
     /**
      * Initial chunk of data to send for browser compatibility (default to send 5Kb of blank data).
      */
+    @Deprecated
     protected String initialBuffer() {
         char[] buffer = new char[1024 * 5];
         Arrays.fill(buffer, ' ');
@@ -46,6 +132,7 @@ public abstract class Comet extends Chunks<String> {
     /**
      * Send a message on this socket (will be received as String in the Javascript callback method).
      */
+    @Deprecated
     public void sendMessage(String message) {
         out.write("<script type=\"text/javascript\">" + callbackMethod + "('" + org.apache.commons.lang3.StringEscapeUtils.escapeEcmaScript(message) + "');</script>");
     }
@@ -53,6 +140,7 @@ public abstract class Comet extends Chunks<String> {
     /**
      * Send a Json message on this socket (will be received as Json in the Javascript callback method).
      */
+    @Deprecated
     public void sendMessage(JsonNode message) {
         out.write("<script type=\"text/javascript\">" + callbackMethod + "(" + Json.stringify(message) + ");</script>");
     }
@@ -60,11 +148,13 @@ public abstract class Comet extends Chunks<String> {
     /**
      * The socket is ready, you can start sending messages.
      */
+    @Deprecated
     public abstract void onConnected();
 
     /**
      * Add a callback to be notified when the client has disconnected.
      */
+    @Deprecated
     public void onDisconnected(Runnable callback) {
         out.onDisconnected(callback);
     }
@@ -72,6 +162,7 @@ public abstract class Comet extends Chunks<String> {
     /**
      * Close the channel
      */
+    @Deprecated
     public void close() {
         out.close();
     }
@@ -86,6 +177,7 @@ public abstract class Comet extends Chunks<String> {
      * @return a new Comet
      * @throws NullPointerException if the specified callback is null
      */
+    @Deprecated
     public static Comet whenConnected(String jsMethod, Consumer<Comet> callback) {
         return new WhenConnectedComet(jsMethod, callback);
     }

--- a/framework/src/play-java/src/test/java/play/libs/CometTest.java
+++ b/framework/src/play-java/src/test/java/play/libs/CometTest.java
@@ -4,11 +4,12 @@
 package play.libs;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.util.ArrayList;
-import java.util.concurrent.CountDownLatch;
 import org.junit.Test;
 import play.api.libs.iteratee.TestChannel;
 import play.mvc.Results.Chunks;
+
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.fest.assertions.Assertions.assertThat;

--- a/framework/src/play/src/main/scala/play/api/libs/Comet.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Comet.scala
@@ -3,45 +3,38 @@
  */
 package play.api.libs
 
+import akka.NotUsed
+import akka.stream.scaladsl.{ Flow, Source }
+import akka.util.{ ByteString, ByteStringBuilder }
 import org.apache.commons.lang3.StringEscapeUtils
-import play.api.libs.json.Json
 import play.api.libs.iteratee._
+import play.api.libs.json.{ JsValue, Json }
+import play.core.Execution.Implicits.internalContext
 import play.twirl.api._
 
-import play.core.Execution.Implicits.internalContext
-
 /**
- * Helper function to produce a Comet Enumeratee.
+ * Helper function to produce a Comet using <a href="http://doc.akka.io/docs/akka/current/scala/stream/index.html">Akka Streams</a>.
+ *
+ * Please see <a href="https://en.wikipedia.org/wiki/Comet_(programming)">https://en.wikipedia.org/wiki/Comet_(programming)</a>
+ * for details of Comet.
  *
  * Example:
+ *
  * {{{
- * val cometStream = Enumerator("A", "B", "C") &> Comet(callback = "console.log")
+ *   def streamClock() = Action {
+ *     val df: DateTimeFormatter = DateTimeFormatter.ofPattern("HH mm ss")
+ *     val tickSource = Source.tick(0 millis, 100 millis, "TICK")
+ *     val source = tickSource.map((tick) => df.format(ZonedDateTime.now()))
+ *     Ok.chunked(source via Comet.flow("parent.clockChanged"))
+ *   }
  * }}}
  *
  */
 object Comet {
 
-  /**
-   * Typeclass for Comet message. Transform each value to a JavaScript message.
-   */
-  case class CometMessage[A](toJavascriptMessage: A => String)
+  val initialHtmlChunk = Html(Array.fill[Char](5 * 1024)(' ').mkString + "<html><body>")
 
-  /**
-   * Default typeclasses for CometMessage.
-   */
-  object CometMessage {
-
-    /**
-     * String messages.
-     */
-    implicit val stringMessages = CometMessage[String](str => "'" + StringEscapeUtils.escapeEcmaScript(str) + "'")
-
-    /**
-     * Json messages.
-     */
-    implicit val jsonMessages = CometMessage[play.api.libs.json.JsValue](Json.stringify)
-
-  }
+  val initialByteString = ByteString.fromString(initialHtmlChunk.toString())
 
   /**
    * Create a Comet Enumeratee.
@@ -50,13 +43,81 @@ object Comet {
    * @param callback Javascript function to call on the browser for each message.
    * @param initialChunk Initial chunk of data to send for browser compatibility (default to send 5Kb of blank data)
    */
-  def apply[E](callback: String, initialChunk: Html = Html(Array.fill[Char](5 * 1024)(' ').mkString + "<html><body>"))(implicit encoder: CometMessage[E]) = new Enumeratee[E, Html] {
-
+  @deprecated("Please use Comet.flow", "2.5.0")
+  def apply[E](callback: String, initialChunk: Html = initialHtmlChunk): Enumeratee[E, Html] = new Enumeratee[E, Html] {
+    val cb: ByteString = ByteString.fromString(callback)
     def applyOn[A](inner: Iteratee[Html, A]): Iteratee[E, Iteratee[Html, A]] = {
-
       val fedWithInitialChunk = Iteratee.flatten(Enumerator(initialChunk) |>> inner)
-      val eToScript = Enumeratee.map[E](data => Html("""<script type="text/javascript">""" + callback + """(""" + encoder.toJavascriptMessage(data) + """);</script>"""))
+      val eToScript = Enumeratee.map[E](toHtml(callback, _))
       eToScript.applyOn(fedWithInitialChunk)
     }
   }
+
+  /**
+   * Produces a Flow of escaped ByteString from a series of String elements.  Calls
+   * out to Comet.flow internally.
+   *
+   * @param callbackName the javascript callback method.
+   * @return a flow of ByteString elements.
+   */
+  def string(callbackName: String): Flow[String, ByteString, NotUsed] = {
+    Flow[String].map(str =>
+      ByteString.fromString("'" + StringEscapeUtils.escapeEcmaScript(str) + "'")
+    ).via(flow(callbackName))
+  }
+
+  /**
+   * Produces a flow of ByteString using `Json.fromJson(_).get` from a Flow of JsValue.  Calls
+   * out to Comet.flow internally.
+   *
+   * @param callbackName the javascript callback method.
+   * @return a flow of ByteString elements.
+   */
+  def json(callbackName: String): Flow[JsValue, ByteString, NotUsed] = {
+    Flow[JsValue].map { msg =>
+      ByteString.fromString(Json.asciiStringify(msg))
+    }.via(flow(callbackName))
+  }
+
+  /**
+   * Creates a flow of ByteString.  Useful when you have objects that are not JSON or String where
+   * you may have to do your own conversion.
+   *
+   * Usage example:
+   *
+   * {{{
+   *   val htmlStream: Source[ByteString, ByteString, NotUsed] = Flow[Html].map { html =>
+   *     ByteString.fromString(html.toString())
+   *   }
+   *   ...
+   *   Ok.chunked(htmlStream via Comet.flow("parent.clockChanged"))
+   * }}}
+   */
+  def flow(callbackName: String, initialChunk: ByteString = initialByteString): Flow[ByteString, ByteString, NotUsed] = {
+    val cb: ByteString = ByteString.fromString(callbackName)
+    Flow.apply[ByteString].map(msg => formatted(cb, msg)).prepend(Source.single(initialChunk))
+  }
+
+  private def formatted(callbackName: ByteString, javascriptMessage: ByteString): ByteString = {
+    val b: ByteStringBuilder = new ByteStringBuilder
+    b.append(ByteString.fromString("""<script type="text/javascript">"""))
+    b.append(callbackName)
+    b.append(ByteString.fromString("("))
+    b.append(javascriptMessage)
+    b.append(ByteString.fromString(");</script>"))
+    b.result
+  }
+
+  private def toHtml[A](callbackName: String, message: A): Html = {
+    val javascriptMessage = message match {
+      case str: String =>
+        "'" + StringEscapeUtils.escapeEcmaScript(str) + "'"
+      case json: JsValue =>
+        Json.stringify(json)
+      case other =>
+        throw new IllegalStateException("Illegal type found: only String or JsValue elements are valid")
+    }
+    Html(s"""<script type="text/javascript">${callbackName}(${javascriptMessage});</script>""")
+  }
+
 }

--- a/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
@@ -12,8 +12,32 @@ import play.core.Execution.Implicits.internalContext
 import play.api.libs.json.{ Json, JsValue }
 
 /**
- * Helps you format Server-Sent Events
- * @see [[http://www.w3.org/TR/eventsource/]]
+ * This class provides an easy way to use Server Sent Events (SSE) as a chunked encoding, using an Akka Source.
+ *
+ * Please see the <a href="http://dev.w3.org/html5/eventsource/">Server-Sent Events specification</a> for details.
+ *
+ * An example of how to display an event stream:
+ *
+ * {{{
+ *   import java.time.ZonedDateTime
+ *   import java.time.format.DateTimeFormatter
+ *   import javax.inject.Singleton
+ *   import akka.stream.scaladsl.Source
+ *   import play.api.http.ContentTypes
+ *   import play.api.libs.EventSource
+ *   import play.api.mvc._
+ *
+ *   import scala.concurrent.duration._
+ *
+ *   def liveClock() = Action {
+ *     val df: DateTimeFormatter = DateTimeFormatter.ofPattern("HH mm ss")
+ *     val tickSource = Source.tick(0 millis, 100 millis, "TICK")
+ *     val source = tickSource.map { (tick) =&gt;
+ *       df.format(ZonedDateTime.now())
+ *     }
+ *     Ok.chunked(source via EventSource.flow).as(ContentTypes.EVENT_STREAM)
+ *   }
+ * }}}
  */
 object EventSource {
 
@@ -41,7 +65,7 @@ object EventSource {
    *
    * {{{
    *   val jsonStream: Source[JsValue, Unit] = createJsonSource()
-   *   Ok.chunked(jsonStream via EventSource.flow).as("text/event-stream")
+   *   Ok.chunked(jsonStream via EventSource.flow).as(ContentTypes.EVENT_STREAM)
    * }}}
    */
   def flow[E: EventDataExtractor: EventNameExtractor: EventIdExtractor]: Flow[E, Event, _] = {

--- a/framework/src/play/src/test/scala/play/api/libs/CometSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/CometSpec.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.api.libs
+
+import akka.stream.Materializer
+import akka.stream.scaladsl._
+import akka.util.{ ByteString, Timeout }
+import org.specs2.mutable._
+import play.api.http.ContentTypes
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.iteratee.Enumerator
+import play.api.libs.json.{ JsString, JsValue }
+import play.api.mvc.{ Action, Controller, Result, Results }
+import play.core.test.FakeRequest
+
+import scala.concurrent.{ Await, Future }
+
+class CometSpec extends Specification {
+
+  class MockController(val materializer: Materializer) extends Controller {
+
+    //#comet-string
+    def cometString = Action {
+      implicit val m = materializer
+      def stringSource: Source[String, _] = Source(List("kiki", "foo", "bar"))
+      Ok.chunked(stringSource via Comet.string("parent.cometMessage")).as(ContentTypes.HTML)
+    }
+    //#comet-string
+
+    //#comet-json
+    def cometJson = Action {
+      implicit val m = materializer
+      def stringSource: Source[JsValue, _] = Source(List(JsString("jsonString")))
+      Ok.chunked(stringSource via Comet.json("parent.cometMessage")).as(ContentTypes.HTML)
+    }
+    //#comet-json
+  }
+
+  "play comet" should {
+
+    "work with enumerator" in {
+      val result = Results.Ok.chunked(Enumerator("foo", "bar", "baz") &> Comet("callback.method"))
+      result.body.contentType must beSome(ContentTypes.HTML)
+    }
+
+    "work with string" in {
+      val app = new GuiceApplicationBuilder().build()
+      try {
+        implicit val m = app.materializer
+        val controller = new MockController(m)
+        val result = controller.cometString.apply(FakeRequest())
+        contentAsString(result) must contain("<html><body><script type=\"text/javascript\">parent.cometMessage('kiki');</script><script type=\"text/javascript\">parent.cometMessage('foo');</script><script type=\"text/javascript\">parent.cometMessage('bar');</script>")
+      } finally {
+        app.stop()
+      }
+    }
+
+    "work with json" in {
+      val app = new GuiceApplicationBuilder().build()
+      try {
+        implicit val m = app.materializer
+        val controller = new MockController(m)
+        val result = controller.cometJson.apply(FakeRequest())
+        contentAsString(result) must contain("<html><body><script type=\"text/javascript\">parent.cometMessage(\"jsonString\");</script>")
+      } finally {
+        app.stop()
+      }
+    }
+
+  }
+
+  //---------------------------------------------------------------------------
+  // Can't use play.api.test.ResultsExtractor here as it is not imported
+  // So, copy the methods necessary to extract string.
+
+  import scala.concurrent.duration._
+
+  implicit def timeout: Timeout = 20.seconds
+
+  def charset(of: Future[Result]): Option[String] = {
+    Await.result(of, timeout.duration).body.contentType match {
+      case Some(s) if s.contains("charset=") => Some(s.split("; *charset=").drop(1).mkString.trim)
+      case _ => None
+    }
+  }
+
+  /**
+   * Extracts the content as String.
+   */
+  def contentAsString(of: Future[Result])(implicit mat: Materializer): String =
+    contentAsBytes(of).decodeString(charset(of).getOrElse("utf-8"))
+
+  /**
+   * Extracts the content as bytes.
+   */
+  def contentAsBytes(of: Future[Result])(implicit mat: Materializer): ByteString = {
+    val result = Await.result(of, timeout.duration)
+    Await.result(result.body.consumeData, timeout.duration)
+  }
+
+}


### PR DESCRIPTION
## Fixes

Fixes https://github.com/playframework/playframework/issues/5602

## Purpose

Add `Comet.flow()` method for both Scala and Java APIs.  Add documentation and migration guide.

## Background Context

Comet needs updating to use Akka Streams.

## References

EventSource Streams API https://github.com/playframework/playframework/pull/5300
