### PR TITLE
Fix typos and make docs notes consistent

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -40,7 +40,7 @@ Any directory under /manual called "code" is treated as a root of a test directo
 
 There is no out of the box integration, but you can use the [sbt-idea](https://github.com/mpeltonen/sbt-idea) plugin or the [Eclipse](https://github.com/typesafehub/sbteclipse) plugin to generate a project for you.
 
-NOTE: if you use sbt-idea, the generated project defines "com.typesafe.play" and other libraries as "runtime" and so does not expose the included libraries to the IDE.  Setting them to "test" manually makes everything work.
+> **Note:** if you use sbt-idea, the generated project defines "com.typesafe.play" and other libraries as "runtime" and so does not expose the included libraries to the IDE.  Setting them to "test" manually makes everything work.
 
 ## Testing
 

--- a/documentation/manual/ModuleDirectory.md
+++ b/documentation/manual/ModuleDirectory.md
@@ -156,7 +156,7 @@ To create your own public module or to migrate from a `play.api.Plugin`, please 
 ### HTML5 Tags module (Java and Scala)
 * **Website:** <https://github.com/loicdescotte/Play2-HTML5Tags>
 * **Documentation:** <https://github.com/loicdescotte/Play2-HTML5Tags/blob/master/README.md>
-* **Short description:** These tags add client side validation capabilities, based on model constraints (e.g required, email pattern, max|min lentgh...) and specific input fields (date, telephone number, url...) to Play templates
+* **Short description:** These tags add client side validation capabilities, based on model constraints (e.g required, email pattern, max|min length...) and specific input fields (date, telephone number, url...) to Play templates
 
 ### PDF module (Java)
 

--- a/documentation/manual/gettingStarted/Installing.md
+++ b/documentation/manual/gettingStarted/Installing.md
@@ -71,7 +71,7 @@ Activator comes with a couple of different "seeds" that can be used to start off
 
 Open a command prompt, and type `activator ui` to bring up the GUI interface.  A browser window will open with the Web UI at [http://localhost:8888](http://localhost:8888).
 
-> *NOTE*: If you're behind a proxy, make sure to define it with `set HTTP_PROXY=http://<host>:<port>` on Windows or `export  HTTP_PROXY=http://<host>:<port>` on UNIX.
+> **Note:** If you're behind a proxy, make sure to define it with `set HTTP_PROXY=http://<host>:<port>` on Windows or `export  HTTP_PROXY=http://<host>:<port>` on UNIX.
 
 Follow the arrows to create a new project:
 

--- a/documentation/manual/hacking/Documentation.md
+++ b/documentation/manual/hacking/Documentation.md
@@ -110,4 +110,4 @@ To ensure that the docs render correctly, run `sbt run` from within the `documen
 
 To ensure that the code samples compile, run and tests pass, run `sbt test`.
 
-To validate that the documentation is structurely sound, run `sbt validateDocs`.  This checks that there are no broken wiki links, code references or resource links, ensures that all documentation markdown filenames are unique, and ensures that there are no orphaned pages.
+To validate that the documentation is structurally sound, run `sbt validateDocs`.  This checks that there are no broken wiki links, code references or resource links, ensures that all documentation markdown filenames are unique, and ensures that there are no orphaned pages.

--- a/documentation/manual/releases/release25/Highlights25.md
+++ b/documentation/manual/releases/release25/Highlights25.md
@@ -74,12 +74,12 @@ Play applications will need to make a small change to their configuration becaus
 
 ## Logging SQL statements
 
-Play now has an easy way to log SQL statements, built on [jdbcdslog](https://github.com/jdbcdslog/jdbcdslog), that works across all JDBC databases, connection pool implementations and persisence frameworks (Anorm, Ebean, JPA, Slick, etc). When you enable logging you will see each SQL statement sent to your database as well as performance information about how long the statement takes to run.
+Play now has an easy way to log SQL statements, built on [jdbcdslog](https://github.com/jdbcdslog/jdbcdslog), that works across all JDBC databases, connection pool implementations and persistence frameworks (Anorm, Ebean, JPA, Slick, etc). When you enable logging you will see each SQL statement sent to your database as well as performance information about how long the statement takes to run.
 
 For more information about how to use SQL logging, see the Play [[Java|JavaDatabase#How-to-configure-SQL-log-statement]] and [[Scala|ScalaDatabase#How-to-configure-SQL-log-statement]] database documentation.
 
 ## Netty native socket transport
 
-If you run Play server on Linux you can now get a performance boost by using the [native socket feature](http://netty.io/wiki/native-transports.html) that was introdued in Netty 4.0.
+If you run Play server on Linux you can now get a performance boost by using the [native socket feature](http://netty.io/wiki/native-transports.html) that was introduced in Netty 4.0.
 
 You can learn how to use native sockets in Play documentation on [[configuring Netty|SettingsNetty#Configuring-transport-socket]].

--- a/documentation/manual/releases/release25/migration25/JavaMigration25.md
+++ b/documentation/manual/releases/release25/migration25/JavaMigration25.md
@@ -4,7 +4,7 @@ In order to better fit in to the Java 8 ecosystem, and to allow Play Java users 
 
 ## New Java APIs
 
-There are several API changes to accomodate writing filters and HTTP request handlers in Java, in particular with the `HttpRequestHandler` interface. If you are using Scala for these components you are still free to use the Scala API if you wish.
+There are several API changes to accommodate writing filters and HTTP request handlers in Java, in particular with the `HttpRequestHandler` interface. If you are using Scala for these components you are still free to use the Scala API if you wish.
 
 ### Filter API
 

--- a/documentation/manual/releases/release25/migration25/Migration25.md
+++ b/documentation/manual/releases/release25/migration25/Migration25.md
@@ -95,7 +95,7 @@ As part of the on going efforts to move away from global state in Play, `GlobalS
 
 ## Removed Plugins API
 
-The Plugins API was deprecated in Play 2.4 and has been removed in Play 2.5. The Plugins API has been superceded by Play's dependency injection and module system which provides a cleaner and more flexible way to build reusable components.  For details on how to migrate from plugins to dependency injection see the [[Play 2.4 migration guide|PluginsToModules]].
+The Plugins API was deprecated in Play 2.4 and has been removed in Play 2.5. The Plugins API has been superseded by Play's dependency injection and module system which provides a cleaner and more flexible way to build reusable components.  For details on how to migrate from plugins to dependency injection see the [[Play 2.4 migration guide|PluginsToModules]].
 
 ## Routes generated with InjectedRoutesGenerator
 

--- a/documentation/manual/working/commonGuide/configuration/ThreadPools.md
+++ b/documentation/manual/working/commonGuide/configuration/ThreadPools.md
@@ -111,7 +111,7 @@ If you have a custom executor, you can wrap it in an `HttpExecutionContext` simp
 
 How you should best divide work in your application between different thread pools greatly depends on the types of work that your application is doing, and the control you want to have over how much of which work can be done in parallel.  There is no one size fits all solution to the problem, and the best decision for you will come from understanding the blocking-IO requirements of your application and the implications they have on your thread pools. It may help to do load testing on your application to tune and verify your configuration.
 
-> **NOTE**: In a blocking environment, `thread-pool-executor` is better than `fork-join` because no work-stealing is possible, and a `fixed-pool-size` size should be used and set to the maximum size of the underlying resource.
+> **Note:** In a blocking environment, `thread-pool-executor` is better than `fork-join` because no work-stealing is possible, and a `fixed-pool-size` size should be used and set to the maximum size of the underlying resource.
 >
 > Given the fact that JDBC is blocking, thread pools can be sized to the number of connections available to a database pool, assuming that the thread pool is used exclusively for database access.  Fewer threads will not consume the number of connections available.  Any more threads than the number of connections available could be wasteful given contention for the connections.
 

--- a/documentation/manual/working/commonGuide/configuration/ws/CertificateGeneration.md
+++ b/documentation/manual/working/commonGuide/configuration/ws/CertificateGeneration.md
@@ -49,7 +49,7 @@ Owner: CN=example.com, OU=Example Org, O=Example Company, L=San Francisco, ST=Ca
 Issuer: CN=exampleCA, OU=Example Org, O=Example Company, L=San Francisco, ST=California, C=US
 ```
 
-> **NOTE**: Also see the [[Configuring HTTPS|ConfiguringHttps]] section for more information.
+> **Note:** Also see the [[Configuring HTTPS|ConfiguringHttps]] section for more information.
 
 ### Configuring example.com certificates in Nginx
 
@@ -81,7 +81,7 @@ You can check the certificate is what you expect by checking the server:
 keytool -printcert -sslserver example.com
 ```
 
-> **NOTE**: Also see the [[Setting up a front end HTTP server|HTTPServer]] section for more information.
+> **Note:** Also see the [[Setting up a front end HTTP server|HTTPServer]] section for more information.
 
 ## Client Configuration
 
@@ -116,7 +116,7 @@ play.ws.ssl {
 }
 ```
 
-> **NOTE**: Also see the [[Configuring Key Stores and Trust Stores|KeyStores]] section for more information.
+> **Note:** Also see the [[Configuring Key Stores and Trust Stores|KeyStores]] section for more information.
 
 ### Configure Client Authentication
 
@@ -157,7 +157,7 @@ play.ws.ssl {
 }
 ```
 
-> **NOTE**: Also see the [[Configuring Key Stores and Trust Stores|KeyStores]] section for more information.
+> **Note:** Also see the [[Configuring Key Stores and Trust Stores|KeyStores]] section for more information.
 
 ## Certificate Management Tools
 

--- a/documentation/manual/working/commonGuide/configuration/ws/CertificateRevocation.md
+++ b/documentation/manual/working/commonGuide/configuration/ws/CertificateRevocation.md
@@ -30,7 +30,7 @@ java.security.Security.setProperty("ocsp.enable", "true")
 
 And this will set OCSP checking when making HTTPS requests.
 
-> NOTE: Enabling OCSP requires a round trip to the OCSP responder.  This adds a notable overhead on HTTPS calls, and can make calls up to [33% slower](https://blog.cloudflare.com/ocsp-stapling-how-cloudflare-just-made-ssl-30).  The mitigation technique, OCSP stapling, is not supported in JSSE.
+> **Note:** Enabling OCSP requires a round trip to the OCSP responder.  This adds a notable overhead on HTTPS calls, and can make calls up to [33% slower](https://blog.cloudflare.com/ocsp-stapling-how-cloudflare-just-made-ssl-30).  The mitigation technique, OCSP stapling, is not supported in JSSE.
 
 Or, if you wish to use a static CRL list, you can define a list of URLs:
 

--- a/documentation/manual/working/commonGuide/configuration/ws/CertificateValidation.md
+++ b/documentation/manual/working/commonGuide/configuration/ws/CertificateValidation.md
@@ -43,7 +43,7 @@ These settings are based in part on [keylength.com](https://www.keylength.com/),
 >
 > The date for disabling/removing 1024-bit root certificates will be dependent on the state of the art in public key cryptography, but under no circumstances should any party expect continued support for this modulus size past December 31, 2013. As mentioned above, this date could get moved up substantially if new attacks are discovered. We recommend all parties involved in secure transactions on the web move away from 1024-bit moduli as soon as possible.
 
-**NOTE:** because weak key sizes also apply to root certificates (which is not included in the certificate chain available to the PKIX certpath checker included in JSSE), setting this option will check the accepted issuers in any configured trustmanagers and keymanagers, including the default.
+> **Note:** because weak key sizes also apply to root certificates (which is not included in the certificate chain available to the PKIX certpath checker included in JSSE), setting this option will check the accepted issuers in any configured trustmanagers and keymanagers, including the default.
 
 Over 95% of trusted leaf certificates and 95% of trusted signing certificates use [NIST recommended key sizes](http://csrc.nist.gov/publications/nistpubs/800-131A/sp800-131A.pdf), so this is considered a safe default.
 
@@ -51,7 +51,7 @@ Over 95% of trusted leaf certificates and 95% of trusted signing certificates us
 
 To disable signature algorithms and weak key sizes globally across the JVM, use the `jdk.certpath.disabledAlgorithms` [security property](http://simsmi.blogspot.com/2011/07/java-se-7-release-security-enhancements.html).  Setting security properties is covered in more depth in [[Configuring Cipher Suites|CipherSuites]] section.
 
-> **NOTE** if configured, the `jdk.certpath.disabledAlgorithms` property should contain the settings from both `disabledKeyAlgorithms` and `disabledSignatureAlgorithms`.
+> **Note:** if configured, the `jdk.certpath.disabledAlgorithms` property should contain the settings from both `disabledKeyAlgorithms` and `disabledSignatureAlgorithms`.
 
 ## Debugging Certificate Validation
 

--- a/documentation/manual/working/commonGuide/configuration/ws/DebuggingSSL.md
+++ b/documentation/manual/working/commonGuide/configuration/ws/DebuggingSSL.md
@@ -48,7 +48,7 @@ play.ws.ssl.debug = {
 }
 ```
 
-> NOTE: This feature changes the setting of the `java.net.debug` system property which is global on the JVM.  In addition, this feature [changes static properties at runtime](https://tersesystems.com/2014/03/02/monkeypatching-java-classes/), and is only intended for use in development environments.
+> **Note:** This feature changes the setting of the `java.net.debug` system property which is global on the JVM.  In addition, this feature [changes static properties at runtime](https://tersesystems.com/2014/03/02/monkeypatching-java-classes/), and is only intended for use in development environments.
 
 ## Verbose Debugging
 

--- a/documentation/manual/working/commonGuide/configuration/ws/KeyStores.md
+++ b/documentation/manual/working/commonGuide/configuration/ws/KeyStores.md
@@ -25,7 +25,7 @@ play.ws.ssl {
 ```
 
 
-> **NOTE**: Trust stores should only contain CA certificates with public keys, usually JKS or PEM.  PKCS12 format is supported, but PKCS12 should not contain private keys in a trust store, as noted in the [reference guide](https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#SunJSSE).
+> **Note:** Trust stores should only contain CA certificates with public keys, usually JKS or PEM.  PKCS12 format is supported, but PKCS12 should not contain private keys in a trust store, as noted in the [reference guide](https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#SunJSSE).
 
 ## Configuring a Key Manager
 
@@ -47,7 +47,7 @@ play.ws.ssl {
 }
 ```
 
-> **NOTE**: A key store that holds private keys should use PKCS12 format, as indicated in the [reference guide](https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#SunJSSE).
+> **Note:** A key store that holds private keys should use PKCS12 format, as indicated in the [reference guide](https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#SunJSSE).
 
 ## Configuring a Store
 

--- a/documentation/manual/working/commonGuide/configuration/ws/LooseSSL.md
+++ b/documentation/manual/working/commonGuide/configuration/ws/LooseSSL.md
@@ -55,7 +55,7 @@ Finally, here are the options themselves.
 
 ### Disabling Certificate Verification
 
-> **NOTE**: In most cases, people turn off certificate verification because they haven't generated certificates.  **There are other options besides disabling certificate verification.**
+> **Note:** In most cases, people turn off certificate verification because they haven't generated certificates.  **There are other options besides disabling certificate verification.**
 >
 > * [[Quick Start to WS SSL|WSQuickStart]] shows how to connect directly to a server using a self signed certificate.
 > * [[Generating X.509 Certificates|CertificateGeneration]] lists a number of GUI applications that will generate certificates for you.

--- a/documentation/manual/working/commonGuide/configuration/ws/TestingSSL.md
+++ b/documentation/manual/working/commonGuide/configuration/ws/TestingSSL.md
@@ -21,7 +21,7 @@ wsUrl("https://example.com").get()
 
 There are several points of where a connection can be attacked.  Writing these tests is fairly easy, and running these adversarial tests against unsuspecting programmers can be extremely satisfying.  
 
-> **NOTE**:This should not be taken as a complete list, but as a guide.  In situations where security is paramount, a review should be done by professional info-sec consultants.
+> **Note:**This should not be taken as a complete list, but as a guide.  In situations where security is paramount, a review should be done by professional info-sec consultants.
 
 ### Testing Certificate Verification
 
@@ -33,7 +33,7 @@ This is a very common failure.  There are a number of proxies like [mitmproxy](h
 
 The server should send a cipher suite that includes NULL or ANON cipher suites in the handshake.  If the client accepts it, it is sending unencrypted data.
 
-> **NOTE**: For a more in depth test of a server's cipher suites, see [sslyze](https://github.com/iSECPartners/sslyze).
+> **Note:** For a more in depth test of a server's cipher suites, see [sslyze](https://github.com/iSECPartners/sslyze).
 
 ### Testing Certificate Validation
 
@@ -41,11 +41,11 @@ To test for weak signatures, the server should send the client a certificate whi
 
 To test for weak certificate, The server should send the client a certificate which contains a public key with a key size under 1024 bits.  The client should reject it as being too weak.
 
-> **NOTE**: For a more in depth test of certification validation, see [tlspretense](https://github.com/iSECPartners/tlspretense) and [frankencert](https://github.com/sumanj/frankencert).
+> **Note:** For a more in depth test of certification validation, see [tlspretense](https://github.com/iSECPartners/tlspretense) and [frankencert](https://github.com/sumanj/frankencert).
 
 ### Testing Hostname Verification
 
 Write a test to "https://example.com".  If the server presents a certificate where the subjectAltName's dnsName is not example.com, the connection should terminate.
 
-> **NOTE**: For a more in depth test, see [dnschef](https://tersesystems.com/2014/03/31/testing-hostname-verification/). 
+> **Note:** For a more in depth test, see [dnschef](https://tersesystems.com/2014/03/31/testing-hostname-verification/).
 

--- a/documentation/manual/working/commonGuide/configuration/ws/WSQuickStart.md
+++ b/documentation/manual/working/commonGuide/configuration/ws/WSQuickStart.md
@@ -68,7 +68,7 @@ which will return a series of certificates in PEM format:
 
 which can be copied and pasted into a file.  The very last certificate in the chain will be the root CA certificate.
 
-> **NOTE**: Not all websites will include the root CA certificate.  You should decode the certificate with keytool or with [certificate decoder](https://www.sslshopper.com/certificate-decoder.html) to ensure you have the right certificate.
+> **Note:** Not all websites will include the root CA certificate.  You should decode the certificate with keytool or with [certificate decoder](https://www.sslshopper.com/certificate-decoder.html) to ensure you have the right certificate.
 
 ## Point the trust manager at the PEM file
 

--- a/documentation/manual/working/javaGuide/advanced/extending/JavaPlayModules.md
+++ b/documentation/manual/working/javaGuide/advanced/extending/JavaPlayModules.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com> -->
 # Writing Play Modules
 
-> **NOTE**: This page covers the new [[module system|JavaDependencyInjection#Play-libraries]] to add new functionality to Play.   
+> **Note:** This page covers the new [[module system|JavaDependencyInjection#Play-libraries]] to add new functionality to Play.
 >
 > The deprecated `play.Plugin` system is removed as of 2.5.x.  
 

--- a/documentation/manual/working/javaGuide/advanced/extending/JavaPlugins.md
+++ b/documentation/manual/working/javaGuide/advanced/extending/JavaPlugins.md
@@ -1,6 +1,6 @@
 <!--- Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com> -->
 # Writing Plugins
 
-> **NOTE**:  The `play.Plugin` API was deprecated in 2.4.x and is removed as of 2.5.x.  
+> **Note:**  The `play.Plugin` API was deprecated in 2.4.x and is removed as of 2.5.x.
 >
 > Please use [[Play Modules|JavaPlayModules]], and see the [[Plugins to Modules|PluginsToModules]] page for migration details.

--- a/documentation/manual/working/javaGuide/main/application/JavaApplication.md
+++ b/documentation/manual/working/javaGuide/main/application/JavaApplication.md
@@ -1,9 +1,9 @@
 <!--- Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com> -->
 # Application Settings
 
-A running instance of Play is built around the `Application` class, the starting point for most of the application state for Play.  The Application is loaded through an `ApplicationLoader` and is configured with a disposible classloader so that changing a setting in development mode will reload the Application.  Most of the `Application` settings are configurable, but more complex behavior can be hooked into Play by binding the various handlers to a specific instance through dependency injection.
+A running instance of Play is built around the `Application` class, the starting point for most of the application state for Play.  The Application is loaded through an `ApplicationLoader` and is configured with a disposable classloader so that changing a setting in development mode will reload the Application.  Most of the `Application` settings are configurable, but more complex behavior can be hooked into Play by binding the various handlers to a specific instance through dependency injection.
 
-> **NOTE**: Application configuration has changed in Play 2.5.x so that [[dependency injection|JavaDependencyInjection]] is the primary method of configuration.  
+> **Note:** Application configuration has changed in Play 2.5.x so that [[dependency injection|JavaDependencyInjection]] is the primary method of configuration.
 >
 > Configuring the application through `GlobalSettings` class is still available through [[Global Settings|JavaGlobal]], but is deprecated and may be removed in future versions.  Please see the [[Removing `GlobalSettings`|GlobalSettings]] page for how to migrate away from GlobalSettings.
 

--- a/documentation/manual/working/javaGuide/main/application/JavaGlobal.md
+++ b/documentation/manual/working/javaGuide/main/application/JavaGlobal.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com> -->
 # Global Settings
 
-> **NOTE**: The `GlobalSettings` class is deprecated in 2.5.x.  Please see the [[Removing `GlobalSettings`|GlobalSettings]] page for how to migrate away from GlobalSettings. 
+> **Note:** The `GlobalSettings` class is deprecated in 2.5.x.  Please see the [[Removing `GlobalSettings`|GlobalSettings]] page for how to migrate away from GlobalSettings.
 
 ## The Global object
 

--- a/documentation/manual/working/javaGuide/main/forms/JavaCsrf.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaCsrf.md
@@ -11,7 +11,7 @@ There is no simple answer to what requests are safe and what are vulnerable to C
 * The request has one or more `Cookie` or `Authorization` headers.
 * The CORS filter is not configured to trust the request's origin.
 
-> **Note:** If you use browser-based authentication other than using cookies or HTTP authenticaton, such as NTLM or client certificate based authentication, then you **must** set `play.filters.csrf.header.protectHeaders = null`, or include the headers used in authentication in `protectHeaders`.
+> **Note:** If you use browser-based authentication other than using cookies or HTTP authentication, such as NTLM or client certificate based authentication, then you **must** set `play.filters.csrf.header.protectHeaders = null`, or include the headers used in authentication in `protectHeaders`.
 
 ### Play's CSRF protection
 
@@ -35,7 +35,7 @@ play.filters.csrf.headers.bypassHeaders {
 
 Caution should be taken when using this configuration option, as historically browser plugins have undermined this type of CSRF defence.
 
-### Trusting CORS requsets
+### Trusting CORS requests
 
 By default, if you have a CORS filter before your CSRF filter, the CSRF filter will let through CORS requests from trusted origins. To disable this check, set the config option `play.filters.csrf.bypassCorsTrustedOrigins = false`.
 

--- a/documentation/manual/working/javaGuide/main/logging/JavaLogging.md
+++ b/documentation/manual/working/javaGuide/main/logging/JavaLogging.md
@@ -62,7 +62,7 @@ Note that the messages have the log level, logger name, message, and stack trace
 
 #### Creating your own loggers
 
-Although it may be tempting to use the default logger everywhere, it's generally a bad design practice. Creating your own loggers with distinct names allows for flexibile configuration, filtering of log output, and pinpointing the source of log messages.
+Although it may be tempting to use the default logger everywhere, it's generally a bad design practice. Creating your own loggers with distinct names allows for flexible configuration, filtering of log output, and pinpointing the source of log messages.
 
 You can create a new logger using the `Logger.of` factory method with a name argument:
 

--- a/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
@@ -59,7 +59,7 @@ Running Play in development mode while using JPA will work fine, but in order to
 
 @[jpa-externalize-resources](code/jpa.sbt)
 
-Since Play 2.4 the contents of the `conf` directory are added to the classpath by default. This option will disable that behavior and allow a JPA application to be deployed. Note that the content of conf directory will still be available in the classpath due to it being inclued in the applications jar file.
+Since Play 2.4 the contents of the `conf` directory are added to the classpath by default. This option will disable that behavior and allow a JPA application to be deployed. Note that the content of conf directory will still be available in the classpath due to it being included in the applications jar file.
 
 
 ## Annotating JPA actions with `@Transactional`

--- a/documentation/manual/working/javaGuide/main/tests/JavaTestingWebServiceClients.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTestingWebServiceClients.md
@@ -17,7 +17,7 @@ This approach gives the least confidence in the test code - often this kind of t
 
 ### Mock the web service
 
-This approach is a good compromise between testing against the actual web service and mocking the http client.  Your tests will show that all the requests it makes are valid HTTP requests, that serialisation/deserialisation of bodies work, etc, but they will be entirely self contained, not depending on any third party services.
+This approach is a good compromise between testing against the actual web service and mocking the http client.  Your tests will show that all the requests it makes are valid HTTP requests, that serialization/deserialization of bodies work, etc, but they will be entirely self contained, not depending on any third party services.
 
 Play provides some helper utilities for mocking a web service in tests, making this approach to testing a very viable and attractive option.
 

--- a/documentation/manual/working/javaGuide/main/ws/JavaOAuth.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaOAuth.md
@@ -50,4 +50,4 @@ controller:
 
 @[ws-oauth-controller](code/javaguide/ws/controllers/Twitter.java)
 
-> **NOTE**: OAuth does not provide any protection against [MITM attacks](https://en.wikipedia.org/wiki/Man-in-the-middle_attack).  This example shows the OAuth token and secret stored in a session cookie -- for the best security, always use HTTPS with `play.http.session.secure=true` defined.
+> **Note:** OAuth does not provide any protection against [MITM attacks](https://en.wikipedia.org/wiki/Man-in-the-middle_attack).  This example shows the OAuth token and secret stored in a session cookie -- for the best security, always use HTTPS with `play.http.session.secure=true` defined.

--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -111,7 +111,7 @@ Calling `get()`, `post()` or `execute()` will cause the body of the response to 
 
 `WS` lets you consume the response's body incrementally by using an Akka Streams `Sink`.  The `stream()` method on `WSRequest` returns a `CompletionStage<StreamedResponse>`. A `StreamedResponse` is a simple container holding together the response's headers and body.
 
-Any controller or component that wants to levearge the WS streaming functionality will have to add the following imports and dependencies:
+Any controller or component that wants to leverage the WS streaming functionality will have to add the following imports and dependencies:
 
 @[ws-streams-controller](code/javaguide/ws/MyController.java)
 
@@ -210,7 +210,7 @@ The following advanced settings can be configured on the underlying AsyncHttpCli
 
 Please refer to the [AsyncHttpClientConfig Documentation](http://static.javadoc.io/org.asynchttpclient/async-http-client/2.0.0-RC7/org/asynchttpclient/DefaultAsyncHttpClientConfig.Builder.html) for more information.
 
-> *NOTE*: `allowPoolingConnection` and `allowSslConnectionPool` are combined in AsyncHttpClient 2.0 into a single `keepAlive` variable.  As such, `play.ws.ning.allowPoolingConnection` and `play.ws.ning.allowSslConnectionPool` are not valid and will throw an exception if configured.
+> **Note:** `allowPoolingConnection` and `allowSslConnectionPool` are combined in AsyncHttpClient 2.0 into a single `keepAlive` variable.  As such, `play.ws.ning.allowPoolingConnection` and `play.ws.ning.allowSslConnectionPool` are not valid and will throw an exception if configured.
 
 * `play.ws.ahc.keepAlive`
 * `play.ws.ahc.maxConnectionsPerHost`

--- a/documentation/manual/working/scalaGuide/advanced/extending/ScalaPlayModules.md
+++ b/documentation/manual/working/scalaGuide/advanced/extending/ScalaPlayModules.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com> -->
 # Writing Play Modules
 
-> **NOTE**: This page covers the new [[module system|ScalaDependencyInjection#Play-libraries]] to add functionality to Play.   
+> **Note:** This page covers the new [[module system|ScalaDependencyInjection#Play-libraries]] to add functionality to Play.
 >
 > The deprecated `play.api.Plugin` system is removed as of 2.5.x.  
 

--- a/documentation/manual/working/scalaGuide/advanced/extending/ScalaPlugins.md
+++ b/documentation/manual/working/scalaGuide/advanced/extending/ScalaPlugins.md
@@ -1,6 +1,6 @@
 <!--- Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com> -->
 # Writing Plugins
 
-> **NOTE**:  The `play.api.Plugin` API was deprecated in 2.4.x and is removed as of 2.5.x.  
+> **Note:**  The `play.api.Plugin` API was deprecated in 2.4.x and is removed as of 2.5.x.
 >
 > Please use [[Play Modules|ScalaPlayModules]], and see the [[Plugins to Modules|PluginsToModules]] page for migration details.

--- a/documentation/manual/working/scalaGuide/advanced/iteratees/Enumerators.md
+++ b/documentation/manual/working/scalaGuide/advanced/iteratees/Enumerators.md
@@ -46,7 +46,7 @@ eventuallyResult.onSuccess { case x => println(x) }
 // Prints "GuillaumeSadekPeterErwan"
 ```
 
-You might notice here that an `Iteratee` will eventually produce a result (returning a promise when calling fold and passing appropriate calbacks), and a `Future` eventually produces a result. Then a `Future[Iteratee[E,A]]` can be viewed as `Iteratee[E,A]`. Indeed this is what `Iteratee.flatten` does, Let’s apply it to the previous example:
+You might notice here that an `Iteratee` will eventually produce a result (returning a promise when calling fold and passing appropriate callbacks), and a `Future` eventually produces a result. Then a `Future[Iteratee[E,A]]` can be viewed as `Iteratee[E,A]`. Indeed this is what `Iteratee.flatten` does, Let’s apply it to the previous example:
 
 ```scala
 //Apply the enumerator and flatten then run the resulting iteratee
@@ -146,7 +146,7 @@ enumerator |>> Iteratee.foreach(println)
 
 The `onStart` function will be called each time the `Enumerator` is applied to an `Iteratee`. In some applications, a chatroom for instance, it makes sense to assign the `enumerator` to a synchronized global value (using STMs for example) that will contain a list of listeners. `Concurrent.unicast` accepts two other functions, `onComplete` and `onError`.
 
-One more interesting method is the `interleave` or `>-` method which as the name says, itrerleaves two Enumerators. For reactive `Enumerator`s Input will be passed as it happens from any of the interleaved `Enumerator`s
+One more interesting method is the `interleave` or `>-` method which as the name says, interleaves two Enumerators. For reactive `Enumerator`s Input will be passed as it happens from any of the interleaved `Enumerator`s
 
 ## Enumerators à la carte
 

--- a/documentation/manual/working/scalaGuide/main/application/ScalaApplication.md
+++ b/documentation/manual/working/scalaGuide/main/application/ScalaApplication.md
@@ -1,9 +1,9 @@
 <!--- Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com> -->
 # Application Settings
 
-A running instance of Play is built around the `Application` class, the starting point for most of the application state for Play.  The Application is loaded through an `ApplicationLoader` and is configured with a disposible classloader so that changing a setting in development mode will reload the Application.  Most of the `Application` settings are configurable, but more complex behavior can be hooked into Play by binding the various handlers to a specific instance through dependency injection.
+A running instance of Play is built around the `Application` class, the starting point for most of the application state for Play.  The Application is loaded through an `ApplicationLoader` and is configured with a disposable classloader so that changing a setting in development mode will reload the Application.  Most of the `Application` settings are configurable, but more complex behavior can be hooked into Play by binding the various handlers to a specific instance through dependency injection.
 
-> **NOTE**: Application configuration has changed in Play 2.5.x so that [[dependency injection|ScalaDependencyInjection]] is the primary method of configuration.  
+> **Note:** Application configuration has changed in Play 2.5.x so that [[dependency injection|ScalaDependencyInjection]] is the primary method of configuration.
 > 
 > Configuring the application through `GlobalSettings` class is still available, but is deprecated and may be removed in future versions.  Please see the [[Removing `GlobalSettings`|GlobalSettings]] page for how to migrate away from GlobalSettings. 
 

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaCsrf.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaCsrf.md
@@ -11,7 +11,7 @@ There is no simple answer to what requests are safe and what are vulnerable to C
 * The request has one or more `Cookie` or `Authorization` headers.
 * The CORS filter is not configured to trust the request's origin.
 
-> **Note:** If you use browser-based authentication other than using cookies or HTTP authenticaton, such as NTLM or client certificate based authentication, then you **must** set `play.filters.csrf.header.protectHeaders = null`, or include the headers used in authentication in `protectHeaders`.
+> **Note:** If you use browser-based authentication other than using cookies or HTTP authentication, such as NTLM or client certificate based authentication, then you **must** set `play.filters.csrf.header.protectHeaders = null`, or include the headers used in authentication in `protectHeaders`.
 
 ### Play's CSRF protection
 
@@ -35,7 +35,7 @@ play.filters.csrf.headers.bypassHeaders {
 
 Caution should be taken when using this configuration option, as historically browser plugins have undermined this type of CSRF defence.
 
-### Trusting CORS requsets
+### Trusting CORS requests
 
 By default, if you have a CORS filter before your CSRF filter, the CSRF filter will let through CORS requests from trusted origins. To disable this check, set the config option `play.filters.csrf.bypassCorsTrustedOrigins = false`.
 

--- a/documentation/manual/working/scalaGuide/main/http/ScalaActionsComposition.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaActionsComposition.md
@@ -25,7 +25,7 @@ Since `ActionBuilder` provides all the different methods of building actions, th
 
 ### Composing actions
 
-In most applications, we will want to have multiple action builders, some that do different types of authentication, some that provide different types of generic functionality, etc.  In which case, we won't want to rewrite our logging action code for each type of action builder, we will want to define it in a reuseable way.
+In most applications, we will want to have multiple action builders, some that do different types of authentication, some that provide different types of generic functionality, etc.  In which case, we won't want to rewrite our logging action code for each type of action builder, we will want to define it in a reusable way.
 
 Reusable action code can be implemented by wrapping actions:
 

--- a/documentation/manual/working/scalaGuide/main/logging/ScalaLogging.md
+++ b/documentation/manual/working/scalaGuide/main/logging/ScalaLogging.md
@@ -61,7 +61,7 @@ java.lang.ArithmeticException: / by zero
 Note that the messages have the log level, logger name, message, and stack trace if a Throwable was used in the log request.
 
 #### Creating your own loggers
-Although it may be tempting to use the default logger everywhere, it's generally a bad design practice. Creating your own loggers with distinct names allows for flexibile configuration, filtering of log output, and pinpointing the source of log messages.
+Although it may be tempting to use the default logger everywhere, it's generally a bad design practice. Creating your own loggers with distinct names allows for flexible configuration, filtering of log output, and pinpointing the source of log messages.
 
 You can create a new logger using the `Logger.apply` factory method with a name argument:
 

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
@@ -18,7 +18,7 @@ Play frequently requires a running [`Application`](api/scala/play/api/Applicatio
 
 ## WithApplication
 
-To pass in an application to an example, use [`WithApplication`](api/scala/play/api/test/WithApplication.html).  An explicit [`Application`](api/scala/play/api/Application.html) can be passed in, but a default application (created from the default `GuiceApplicationBulider`) is provided for convenience.
+To pass in an application to an example, use [`WithApplication`](api/scala/play/api/test/WithApplication.html).  An explicit [`Application`](api/scala/play/api/Application.html) can be passed in, but a default application (created from the default `GuiceApplicationBuilder`) is provided for convenience.
 
 Because [`WithApplication`](api/scala/play/api/test/WithApplication.html) is a built in [`Around`](https://etorreborre.github.io/specs2/guide/SPECS2-3.4/org.specs2.guide.Contexts.html#aroundeach) block, you can override it to provide your own data population:
 

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWebServiceClients.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWebServiceClients.md
@@ -17,7 +17,7 @@ This approach gives the least confidence in the test code - often this kind of t
 
 ### Mock the web service
 
-This approach is a good compromise between testing against the actual web service and mocking the http client.  Your tests will show that all the requests it makes are valid HTTP requests, that serialisation/deserialisation of bodies work, etc, but they will be entirely self contained, not depending on any third party services.
+This approach is a good compromise between testing against the actual web service and mocking the http client.  Your tests will show that all the requests it makes are valid HTTP requests, that serialization/deserialization of bodies work, etc, but they will be entirely self contained, not depending on any third party services.
 
 Play provides some helper utilities for mocking a web service in tests, making this approach to testing a very viable and attractive option.
 

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
@@ -33,7 +33,7 @@ Specifications extend the [`Specification`](https://etorreborre.github.io/specs2
 
 Specifications can be run in either IntelliJ IDEA (using the [Scala plugin](https://blog.jetbrains.com/scala/)) or in Eclipse (using the [Scala IDE](http://scala-ide.org/)).  Please see the [[IDE page|IDE]] for more details.
 
-NOTE: Due to a bug in the [presentation compiler](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/support/tickets/1001843-specs2-tests-with-junit-runner-are-not-recognized-if-there-is-package-directory-mismatch#/activity/ticket:), tests must be defined in a specific format to work with Eclipse:
+> **Note:** Due to a bug in the [presentation compiler](https://scala-ide-portfolio.assembla.com/spaces/scala-ide/support/tickets/1001843-specs2-tests-with-junit-runner-are-not-recognized-if-there-is-package-directory-mismatch#/activity/ticket:), tests must be defined in a specific format to work with Eclipse:
 
 * The package must be exactly the same as the directory path.
 * The specification must be annotated with `@RunWith(classOf[JUnitRunner])`.

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaOAuth.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaOAuth.md
@@ -50,4 +50,4 @@ After implementing the flow, the timeline is available by signing requests throu
 
 @[extended](code/ScalaOAuthSpec.scala)
 
-> **NOTE**: OAuth does not provide any protection against MITM attacks.  This example shows the OAuth token and secret stored in a session cookie -- for the best security, always use HTTPS with `play.http.session.cookie.secure=true` defined.
+> **Note:** OAuth does not provide any protection against MITM attacks.  This example shows the OAuth token and secret stored in a session cookie -- for the best security, always use HTTPS with `play.http.session.cookie.secure=true` defined.

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -117,7 +117,7 @@ If you are not using DI, you can still access the default Play execution context
 
 @[scalaws-context](code/ScalaWSSpec.scala)
 
-The examples also use the folowing case class for serialization / deserialization:
+The examples also use the following case class for serialization/deserialization:
 
 @[scalaws-person](code/ScalaWSSpec.scala)
 
@@ -229,7 +229,7 @@ The following advanced settings can be configured on the underlying AsyncHttpCli
 
 Please refer to the [AsyncHttpClientConfig Documentation](http://static.javadoc.io/org.asynchttpclient/async-http-client/2.0.0-RC7/org/asynchttpclient/DefaultAsyncHttpClientConfig.Builder.html) for more information.
 
-> *NOTE*: `allowPoolingConnection` and `allowSslConnectionPool` are combined in AsyncHttpClient 2.0 into a single `keepAlive` variable.  As such, `play.ws.ning.allowPoolingConnection` and `play.ws.ning.allowSslConnectionPool` are not valid and will throw an exception if configured.
+> **Note:** `allowPoolingConnection` and `allowSslConnectionPool` are combined in AsyncHttpClient 2.0 into a single `keepAlive` variable.  As such, `play.ws.ning.allowPoolingConnection` and `play.ws.ning.allowSslConnectionPool` are not valid and will throw an exception if configured.
 
 * `play.ws.ahc.keepAlive`
 * `play.ws.ahc.maxConnectionsPerHost`


### PR DESCRIPTION
## Purpose

Fix some docs typos/spelling and also use the same "markup" to notes in the docs.