### PR TITLE
Prevent mapWrites from losing ordering on ordered maps

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
@@ -3,28 +3,18 @@
  */
 package play.api.libs.json
 
-import java.time.{
-  Instant,
-  LocalDate,
-  LocalDateTime,
-  OffsetDateTime,
-  ZoneId,
-  ZoneOffset,
-  ZonedDateTime
-}
-import java.time.temporal.Temporal
 import java.time.format.DateTimeFormatter
+import java.time.temporal.Temporal
+import java.time.{ Instant, LocalDate, LocalDateTime, OffsetDateTime, ZoneOffset, ZonedDateTime }
 
+import com.fasterxml.jackson.databind.JsonNode
 import play.api.libs.functional.ContravariantFunctor
+import play.api.libs.json.Json._
 import play.api.libs.json.jackson.JacksonJson
 
 import scala.annotation.implicitNotFound
 import scala.collection._
 import scala.reflect.ClassTag
-
-import com.fasterxml.jackson.databind.JsonNode
-
-import Json._
 
 /**
  * Json serializer: write an implicit to define a serializer for any type
@@ -188,22 +178,22 @@ trait DefaultWrites {
   /**
    * Serializer for Array[T] types.
    */
-  implicit def arrayWrites[T: ClassTag](implicit fmt: Writes[T]): Writes[Array[T]] = new Writes[Array[T]] {
-    def writes(ts: Array[T]) = JsArray(ts.map(t => toJson(t)(fmt)).toList)
+  implicit def arrayWrites[T: ClassTag: Writes]: Writes[Array[T]] = Writes[Array[T]] { ts =>
+    JsArray(ts.map(toJson(_)).toSeq)
   }
 
   /**
    * Serializer for Map[String,V] types.
    */
-  implicit def mapWrites[V](implicit fmtv: Writes[V]): OWrites[collection.immutable.Map[String, V]] = OWrites[collection.immutable.Map[String, V]] { ts =>
-    JsObject(ts.map { case (k, v) => (k, toJson(v)(fmtv)) }.toList)
+  implicit def mapWrites[V: Writes]: OWrites[Map[String, V]] = OWrites[Map[String, V]] { ts =>
+    JsObject(ts.mapValues(toJson(_)).toSeq)
   }
 
   /**
    * Serializer for Traversables types.
    */
-  implicit def traversableWrites[A: Writes] = new Writes[Traversable[A]] {
-    def writes(as: Traversable[A]) = JsArray(as.map(toJson(_)).toSeq)
+  implicit def traversableWrites[A: Writes] = Writes[Traversable[A]] { as =>
+    JsArray(as.map(toJson(_)).toSeq)
   }
 
   /**

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -5,10 +5,11 @@ package play.api.libs.json
 
 import java.util.{ Calendar, Date, TimeZone }
 
-import com.fasterxml.jackson.databind.{ ObjectMapper, JsonMappingException, JsonNode }
-
+import com.fasterxml.jackson.databind.{ JsonNode, ObjectMapper }
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Json._
+
+import scala.collection.immutable.ListMap
 
 object JsonSpec extends org.specs2.mutable.Specification {
 
@@ -469,6 +470,37 @@ object JsonSpec extends org.specs2.mutable.Specification {
       )(unlift(TestCase.unapply))
 
       Json.toJson(TestCase("my-id", "foo", "bar")) must beEqualTo(js)
+    }
+
+    "keep the insertion order on ListMap" in {
+      val test = Json.toJson(
+        ListMap(
+          "name" -> "foo",
+          "zip" -> "foo",
+          "city" -> "foo"
+        ))
+      val req = """{"name":"foo", "zip":"foo", "city":"foo"}"""
+      test.toString must beEqualTo(Json.parse(req).toString).ignoreSpace
+    }
+    "keep insertion order on large ListMap" in {
+      val test = Json.toJson(
+        ListMap(
+          "name" -> "a", "zip" -> "foo", "city" -> "foo",
+          "address" -> "foo", "phone" -> "foo", "latitude" -> "foo",
+          "longitude" -> "foo", "hny" -> "foo", "hz" -> "foo",
+          "hek" -> "foo", "hev" -> "foo", "kny" -> "foo",
+          "kz" -> "foo", "kek" -> "foo", "kev" -> "foo",
+          "szeny" -> "foo", "szez" -> "foo", "szeek" -> "foo",
+          "szeev" -> "foo", "csny" -> "foo", "csz" -> "foo",
+          "csek" -> "foo", "csev" -> "foo", "pny" -> "foo",
+          "pz" -> "foo", "pek" -> "foo", "pev" -> "foo",
+          "szony" -> "foo", "szoz" -> "foo", "szoek" -> "foo",
+          "szoev" -> "foo", "vny" -> "foo", "vz" -> "foo",
+          "vek" -> "foo", "vev" -> "foo"
+        )
+      )
+      val req = """{"name": "a", "zip": "foo", "city": "foo", "address": "foo", "phone": "foo", "latitude": "foo", "longitude": "foo", "hny": "foo", "hz": "foo", "hek": "foo", "hev": "foo", "kny": "foo", "kz": "foo", "kek": "foo", "kev": "foo", "szeny": "foo", "szez": "foo", "szeek": "foo", "szeev": "foo", "csny": "foo", "csz": "foo", "csek": "foo", "csev": "foo", "pny": "foo", "pz": "foo", "pek": "foo", "pev": "foo", "szony": "foo", "szoz": "foo", "szoek": "foo", "szoev": "foo", "vny": "foo", "vz": "foo", "vek": "foo", "vev": "foo"}"""
+      test.toString must beEqualTo(Json.parse(req).toString).ignoreSpace
     }
   }
 }


### PR DESCRIPTION
Fixes #5711

The current implementation calls `map` on the `Map` but it would be sufficient to call `mapValues`. If called on an ordered map like a `ListMap`, the `map` method will produce an unordered map, but `mapValues` does not have this problem.