### PR TITLE
Fix StackOverflowError in play.http.DefaultHttpRequestHandler

### DIFF
--- a/framework/src/play/src/main/java/play/http/DefaultHttpRequestHandler.java
+++ b/framework/src/play/src/main/java/play/http/DefaultHttpRequestHandler.java
@@ -12,10 +12,10 @@ import scala.Tuple2;
 
 public class DefaultHttpRequestHandler implements HttpRequestHandler {
 
-    private final play.api.http.HttpRequestHandler underlying;
+    private final play.api.http.JavaCompatibleHttpRequestHandler underlying;
 
     @Inject
-    public DefaultHttpRequestHandler(play.api.http.HttpRequestHandler underlying) {
+    public DefaultHttpRequestHandler(play.api.http.JavaCompatibleHttpRequestHandler underlying) {
         this.underlying = underlying;
     }
 


### PR DESCRIPTION
We actually want it to wrap a `JavaCompatibleHttpRequestHandler`.

See https://groups.google.com/d/msg/play-framework/WLKidonv58U/g7t_a3HLFQAJ
