### PR TITLE
Update controller to be class based assuming DI

### DIFF
--- a/documentation/manual/working/commonGuide/build/SBTSubProjects.md
+++ b/documentation/manual/working/commonGuide/build/SBTSubProjects.md
@@ -97,7 +97,7 @@ One thing to note is that if you have a mix of Play and non-Play projects, you m
 
 ```scala
 object Common {
- 
+
   val playSettings = settings ++ Seq(
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies += specs2 % Test,
@@ -177,7 +177,7 @@ project
 `conf/routes`:
 
 ```
-GET /index                  controllers.Application.index()
+GET /index                  controllers.HomeController.index()
 
 ->  /admin admin.Routes
 
@@ -213,7 +213,7 @@ public class Assets {
 
 and a controller:
 
-`modules/admin/controllers/Application.scala`:
+`modules/admin/controllers/HomeController.scala`:
 
 ```scala
 package controllers.admin
@@ -222,7 +222,7 @@ import play.api._
 import play.api.mvc._
 import views.html._
 
-object Application extends Controller {
+class HomeController extends Controller {
 
   def index = Action { implicit request =>
     Ok("admin")
@@ -236,7 +236,7 @@ in case of a regular controller call:
 
 
 ```
-controllers.admin.routes.Application.index
+controllers.admin.routes.HomeController.index
 ```
 
 and for `Assets`:
@@ -254,7 +254,7 @@ http://localhost:9000/index
 triggers
 
 ```
-controllers.Application.index
+controllers.HomeController.index
 ```
 
 and
@@ -266,5 +266,5 @@ http://localhost:9000/admin/index
 triggers
 
 ```
-controllers.admin.Application.index
+controllers.admin.HomeController.index
 ```

--- a/documentation/manual/working/commonGuide/build/code/SubProjectsAssetsBuilder.scala
+++ b/documentation/manual/working/commonGuide/build/code/SubProjectsAssetsBuilder.scala
@@ -14,6 +14,6 @@ class Assets @Inject() (errorHandler: HttpErrorHandler) extends controllers.Asse
 
 import play.api.mvc._
 
-class Application extends Controller {
+class HomeController extends Controller {
   def index = Action(Ok)
 }

--- a/documentation/manual/working/commonGuide/build/code/common.build.routes
+++ b/documentation/manual/working/commonGuide/build/code/common.build.routes
@@ -1,5 +1,5 @@
 #assets-routes
-GET /index                  controllers.admin.Application.index()
+GET /index                  controllers.admin.HomeController.index()
 
 GET /assets/*file           controllers.Assets.at(path="/public/lib/myadmin", file)
 #assets-routes


### PR DESCRIPTION
## Fixes

Fixes https://github.com/playframework/playframework/issues/5718

## Purpose

Changes instances of `Application` to `HomeController` and uses `class HomeController` instead of `object HomeController` to make the code more DI aware.

## Background Context

The new Play templates use `HomeController` as a name instead of `controllers.Application` to avoid confusion with `play.api.Application`.  Since 2.5.x uses InjectedRoutesGenerator by default, use of `object Application` should be a deprecated usage and there are multiple bugs based on outdated docs.

## References

* https://stackoverflow.com/questions/33985108/play-framework-2-4-x-module-route-specific-name-fails-with-assets-is-not-a
* https://github.com/playframework/playframework/issues/4812
