### PR TITLE
Make CORS filter treat http and https as different origins (2.4.x)

### DIFF
--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSSpec.scala
@@ -5,17 +5,16 @@ package play.filters.cors
 
 import javax.inject.Inject
 
+import play.api.Configuration
 import play.api.http.HttpFilters
+import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc.{ Action, Result, Results }
 import play.api.routing.Router
 import play.api.routing.sird._
+import play.api.test.{ FakeApplication, FakeRequest, PlaySpecification }
 
 import scala.concurrent.Future
-
-import play.api.Configuration
-import play.api.mvc.{ Action, Result, Results }
-import play.api.test.{ FakeRequest, FakeApplication, PlaySpecification }
-import play.api.inject.bind
 
 object CORSFilterSpec extends CORSCommonSpec {
 
@@ -161,6 +160,16 @@ trait CORSCommonSpec extends PlaySpecification {
 
       status(result) must_== OK
       header(ACCESS_CONTROL_ALLOW_ORIGIN, result) must beSome("http://www.example.com:9000")
+    }
+
+    "not consider different protocols to be the same origin" in withApplication() {
+      val result = route(fakeRequest().withHeaders(
+        ORIGIN -> "https://www.example.com:9000",
+        HOST -> "www.example.com:9000"
+      )).get
+
+      status(result) must_== OK
+      header(ACCESS_CONTROL_ALLOW_ORIGIN, result) must beSome("https://www.example.com:9000")
     }
 
     "forbid an empty origin header" in withApplication() {

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
@@ -388,7 +388,7 @@ trait DefaultReads extends LowPriorityDefaultReads {
     implicit def InstantFormatterParser(formatter: DateTimeFormatter): TemporalParser[Instant] = new TemporalParser[Instant] {
       def parse(input: String): Option[Instant] = try {
         val time = LocalDateTime.parse(input, formatter).atZone(ZoneId.of("Z"))
-        
+
         Some(time.toInstant)
       } catch {
         case _: DateTimeParseException => None


### PR DESCRIPTION
Backport of #5703
