### PR TITLE
Fail to start the server if we can't bind to a port

### DIFF
--- a/framework/src/play-server/src/main/scala/play/core/server/ServerListenException.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ServerListenException.scala
@@ -1,0 +1,10 @@
+package play.core.server
+
+import java.net.SocketAddress
+
+/**
+ * This execption is thrown when the server is unable to listen on a port
+ */
+class ServerListenException(protocol: String, address: SocketAddress) extends Exception {
+  override def getMessage = s"Failed to listen for $protocol on $address!"
+}

--- a/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -10,7 +10,7 @@ import java.util.jar.JarFile
 import play.api.PlayException
 import play.core.{ Build, BuildLink, BuildDocHandler }
 import play.runsupport.classloader.{ ApplicationClassLoaderProvider, DelegatingClassLoader }
-import sbt.{ PathFinder, WatchState, SourceModificationWatch }
+import sbt._
 
 object Reloader {
 
@@ -266,6 +266,11 @@ object Reloader {
           } catch {
             case e: Throwable => // Swallow any exceptions so that all `onError`s get called.
           }
+        }
+        // Convert play-server exceptions to our to our ServerStartException
+        def getRootCause(t: Throwable): Throwable = if (t.getCause == null) t else getRootCause(t.getCause)
+        if (getRootCause(e).getClass.getName == "play.core.server.ServerListenException") {
+          throw new ServerStartException(e)
         }
         throw e
     }

--- a/framework/src/run-support/src/main/scala/play/runsupport/ServerStartException.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/ServerStartException.scala
@@ -1,0 +1,7 @@
+package play.runsupport
+
+import sbt.FeedbackProvidedException
+
+class ServerStartException(underlying: Throwable) extends FeedbackProvidedException {
+  override def getMessage = underlying.getMessage
+}


### PR DESCRIPTION
Fixes #5568

Now when I try `sbt run` when the port is already bound, it looks like this:
```
--- (Running the application, auto-reloading is enabled) ---

[error] p.c.s.NettyServer - Failed to listen for HTTP on /0.0.0.0:9000!
[error] (compile:run) play.runsupport.ServerStartException
[error] Total time: 1 s, completed Feb 23, 2016 5:55:02 AM
```
I extended `FeedbackProvidedException` to suppress the stack trace in SBT.