### PR TITLE
play.data.Form uses DI now via FormFactory

### DIFF
--- a/documentation/manual/working/javaGuide/main/forms/JavaForms.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaForms.md
@@ -9,6 +9,8 @@ The `play.data` package contains several helpers to handle HTTP form data submis
 
 @[user](code/javaguide/forms/u1/User.java)
 
+To wrap a class you have to inject a `play.data.FormFactory` into your Controller which then allows you to create the form:
+
 @[create](code/javaguide/forms/JavaForms.java)
 
 > **Note:** The underlying binding is done using [Spring data binder](https://docs.spring.io/spring/docs/3.0.x/reference/validation.html).

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaFormHelpers.scala
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaFormHelpers.scala
@@ -3,6 +3,7 @@
  */
 package javaguide.forms
 
+import play.api.Application
 import play.api.test.{WithApplication, PlaySpecification}
 import play.data.Form
 import javaguide.forms.html.{UserForm, User}
@@ -12,12 +13,13 @@ object JavaFormHelpers extends PlaySpecification {
 
   "java form helpers" should {
     {
-      val form = Form.form(classOf[User])
-      val u = new UserForm
-      u.setName("foo")
-      u.setEmails(util.Arrays.asList("a@a", "b@b"))
-      val userForm = Form.form(classOf[UserForm]).fill(u)
-      def segment(name: String) = {
+      def segment(name: String)(implicit app: Application) = {
+        val formFactory = app.injector.instanceOf[play.data.FormFactory]
+        val form = formFactory.form(classOf[User])
+        val u = new UserForm
+        u.setName("foo")
+        u.setEmails(util.Arrays.asList("a@a", "b@b"))
+        val userForm = formFactory.form(classOf[UserForm]).fill(u)
         val body = html.helpers(form, userForm).body
         body.lines.dropWhile(_ != "<span class=\"" + name + "\">").drop(1).takeWhile(_ != "</span>").mkString("\n")
       }
@@ -49,7 +51,8 @@ object JavaFormHelpers extends PlaySpecification {
 
     {
       "allow rendering input fields" in new WithApplication() {
-        val form = Form.form(classOf[User])
+        val formFactory = app.injector.instanceOf[play.data.FormFactory]
+        val form = formFactory.form(classOf[User])
         val body = html.fullform(form).body
         body must contain("""type="text"""")
         body must contain("""type="password"""")
@@ -58,7 +61,8 @@ object JavaFormHelpers extends PlaySpecification {
       }
 
       "allow custom field constructors" in new WithApplication() {
-        val form = Form.form(classOf[User])
+        val formFactory = app.injector.instanceOf[play.data.FormFactory]
+        val form = formFactory.form(classOf[User])
         val body = html.withFieldConstructor(form).body
         body must contain("foobar")
       }

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/controllers/OpenIDController.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/controllers/OpenIDController.java
@@ -20,6 +20,9 @@ public class OpenIDController extends Controller {
     @Inject
     OpenIdClient openIdClient;
 
+    @Inject
+    FormFactory formFactory;
+
     public Result login() {
         return ok(views.html.login.render(""));
     }
@@ -27,7 +30,7 @@ public class OpenIDController extends Controller {
     public CompletionStage<Result> loginPost() {
 
         // Form data
-        DynamicForm requestData = Form.form().bindFromRequest();
+        DynamicForm requestData = formFactory.form().bindFromRequest();
         String openID = requestData.get("openID");
 
         CompletionStage<String> redirectUrlPromise =

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/JavaFormSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/JavaFormSpec.scala
@@ -17,7 +17,8 @@ object JavaFormSpec extends PlaySpecification {
 
     "throw a meaningful exception when get is called on an invalid form" in new WithApplication() {
       JavaHelpers.withContext(FakeRequest()) { _ =>
-        val myForm = Form.form(classOf[FooForm]).bind(Map("id" -> "1234567891").asJava)
+        val formFactory = app.injector.instanceOf[play.data.FormFactory]
+        val myForm = formFactory.form(classOf[FooForm]).bind(Map("id" -> "1234567891").asJava)
         myForm.hasErrors must beEqualTo(true)
         myForm.get must throwAn[IllegalStateException].like {
           case e => e.getMessage must contain("fooName")

--- a/framework/src/play-java/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java/src/main/java/play/data/DynamicForm.java
@@ -6,6 +6,7 @@ package play.data;
 import java.util.*;
 
 import play.data.validation.*;
+import play.i18n.MessagesApi;
 
 /**
  * A dynamic form. This form is backed by a simple <code>HashMap&lt;String,String&gt;</code>
@@ -17,8 +18,8 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     /**
      * Creates a new empty dynamic form.
      */
-    public DynamicForm() {
-        super(DynamicForm.Dynamic.class);
+    public DynamicForm(MessagesApi messagesApi) {
+        super(DynamicForm.Dynamic.class, messagesApi);
         rawData = new HashMap<>();
     }
     
@@ -29,8 +30,8 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      * @param errors the collection of errors associated with this form
      * @param value optional concrete value if the form submission was successful
      */
-    public DynamicForm(Map<String,String> data, Map<String,List<ValidationError>> errors, Optional<Dynamic> value) {
-        super(null, DynamicForm.Dynamic.class, data, errors, value);
+    public DynamicForm(Map<String,String> data, Map<String,List<ValidationError>> errors, Optional<Dynamic> value, MessagesApi messagesApi) {
+        super(null, DynamicForm.Dynamic.class, data, errors, value, messagesApi);
         rawData = new HashMap<>();
         for (Map.Entry<String, String> e : data.entrySet()) {
             rawData.put(asNormalKey(e.getKey()), e.getValue());
@@ -59,7 +60,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      */
     public DynamicForm fill(Map value) {
         Form<Dynamic> form = super.fill(new Dynamic(value));
-        return new DynamicForm(form.data(), form.errors(), form.value());
+        return new DynamicForm(form.data(), form.errors(), form.value(), messagesApi);
     }
 
     /**
@@ -99,7 +100,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         }
         
         Form<Dynamic> form = super.bind(data, allowedFields);
-        return new DynamicForm(form.data(), form.errors(), form.value());
+        return new DynamicForm(form.data(), form.errors(), form.value(), messagesApi);
     }
     
     /**

--- a/framework/src/play-java/src/main/java/play/data/FormFactory.java
+++ b/framework/src/play-java/src/main/java/play/data/FormFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.data;
+
+import javax.inject.Inject;
+import play.i18n.MessagesApi;
+
+/**
+ * Helper to create HTML forms.
+ */
+public class FormFactory {
+
+    private final MessagesApi messagesApi;
+
+    @Inject
+    public FormFactory(MessagesApi messagesApi) {
+        this.messagesApi = messagesApi;
+    }
+    
+    /**
+     * Instantiates a dynamic form.
+     */
+    public DynamicForm form() {
+        return new DynamicForm(messagesApi);
+    }
+    
+    /**
+     * Instantiates a new form that wraps the specified class.
+     */
+    public <T> Form<T> form(Class<T> clazz) {
+        return new Form<>(clazz, messagesApi);
+    }
+    
+    /**
+     * Instantiates a new form that wraps the specified class.
+     */
+    public <T> Form<T> form(String name, Class<T> clazz) {
+        return new Form<>(name, clazz, messagesApi);
+    }
+    
+    /**
+     * Instantiates a new form that wraps the specified class.
+     */
+    public <T> Form<T> form(String name, Class<T> clazz, Class<?> group) {
+        return new Form<>(name, clazz, group, messagesApi);
+    }
+
+    /**
+     * Instantiates a new form that wraps the specified class.
+     */
+    public <T> Form<T> form(Class<T> clazz, Class<?> group) {
+        return new Form<>(null, clazz, group, messagesApi);
+    }
+
+}

--- a/framework/src/play-java/src/main/java/play/data/FormFactoryModule.java
+++ b/framework/src/play-java/src/main/java/play/data/FormFactoryModule.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package play.data;
+
+import play.api.Configuration;
+import play.api.Environment;
+import play.api.inject.Binding;
+import play.api.inject.Module;
+import scala.collection.Seq;
+
+public class FormFactoryModule extends Module {
+
+    @Override
+    public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
+        return seq(
+            bind(FormFactory.class).toSelf()
+        );
+    }
+
+}

--- a/framework/src/play-java/src/main/resources/reference.conf
+++ b/framework/src/play-java/src/main/resources/reference.conf
@@ -1,6 +1,7 @@
 play {
   modules {
     enabled += "play.inject.BuiltInModule"
+    enabled += "play.data.FormFactoryModule"
     enabled += "play.core.ObjectMapperModule"
   }
 }

--- a/framework/src/play-java/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
+++ b/framework/src/play-java/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
@@ -71,6 +71,7 @@ public class GuiceApplicationBuilderTest {
     public void disableLoadedModules() {
         Injector injector = new GuiceApplicationBuilder()
             .disable(play.api.i18n.I18nModule.class)
+            .disable(play.data.FormFactoryModule.class)
             .injector();
 
         exception.expect(com.google.inject.ConfigurationException.class);

--- a/framework/src/play-java/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/DynamicFormSpec.scala
@@ -22,50 +22,50 @@ object DynamicFormSpec extends Specification {
   "a dynamic form" should {
 
     "bind values from a request" in {
-      val form = new DynamicForm().bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
+      val form = new DynamicForm(new play.i18n.MessagesApi(messagesApi)).bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       form.get("foo") must_== "bar"
     }
 
     "allow access to raw data values from request" in {
-      val form = new DynamicForm().bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
+      val form = new DynamicForm(new play.i18n.MessagesApi(messagesApi)).bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       form.data().get("foo") must_== "bar"
     }
 
     "display submitted values in template helpers" in {
-      val form = new DynamicForm().bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
+      val form = new DynamicForm(new play.i18n.MessagesApi(messagesApi)).bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       val html = inputText(form("foo")).body
       html must contain("value=\"bar\"")
       html must contain("name=\"foo\"")
     }
 
     "render correctly when no value is submitted in template helpers" in {
-      val form = new DynamicForm().bindFromRequest(FormSpec.dummyRequest(Map()))
+      val form = new DynamicForm(new play.i18n.MessagesApi(messagesApi)).bindFromRequest(FormSpec.dummyRequest(Map()))
       val html = inputText(form("foo")).body
       html must contain("value=\"\"")
       html must contain("name=\"foo\"")
     }
 
     "display errors in template helpers" in {
-      val form = new DynamicForm().bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
+      val form = new DynamicForm(new play.i18n.MessagesApi(messagesApi)).bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       form.reject("foo", "There was an error")
       val html = inputText(form("foo")).body
       html must contain("There was an error")
     }
 
     "display errors when a field is not present" in {
-      val form = new DynamicForm().bindFromRequest(FormSpec.dummyRequest(Map()))
+      val form = new DynamicForm(new play.i18n.MessagesApi(messagesApi)).bindFromRequest(FormSpec.dummyRequest(Map()))
       form.reject("foo", "Foo is required")
       val html = inputText(form("foo")).body
       html must contain("Foo is required")
     }
 
     "allow access to the property when filled" in {
-      val form = new DynamicForm().fill(Map("foo" -> "bar"))
+      val form = new DynamicForm(new play.i18n.MessagesApi(messagesApi)).fill(Map("foo" -> "bar"))
       form.get("foo") must_== "bar"
     }
 
     "allow access to the equivalent of the raw data when filled" in {
-      val form = new DynamicForm().fill(Map("foo" -> "bar"))
+      val form = new DynamicForm(new play.i18n.MessagesApi(messagesApi)).fill(Map("foo" -> "bar"))
       form("foo").value() must_== "bar"
     }
 

--- a/framework/src/play-java/src/test/scala/play/data/PartialValidationSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/PartialValidationSpec.scala
@@ -7,23 +7,30 @@ import validation.Constraints.{ MaxLength, Required }
 import beans.BeanProperty
 import org.specs2.mutable.Specification
 import scala.collection.JavaConverters._
+import play.api.{ Configuration, Environment }
+import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
+import play.data.FormFactory
 
 class PartialValidationSpec extends Specification {
+
+  val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
+  val formFactory = new FormFactory(new play.i18n.MessagesApi(messagesApi))
+
   "partial validation" should {
     "not fail when fields not in the same group fail validation" in {
-      val form = Form.form(classOf[SomeForm], classOf[Partial]).bind(Map("prop2" -> "Hello", "prop3" -> "abc").asJava)
+      val form = formFactory.form(classOf[SomeForm], classOf[Partial]).bind(Map("prop2" -> "Hello", "prop3" -> "abc").asJava)
       form.errors().asScala must beEmpty
     }
 
     "fail when a field in the group fails validation" in {
-      val form = Form.form(classOf[SomeForm], classOf[Partial]).bind(Map("prop3" -> "abc").asJava)
+      val form = formFactory.form(classOf[SomeForm], classOf[Partial]).bind(Map("prop3" -> "abc").asJava)
       form.hasErrors must_== true
     }
 
     "support multiple validations for the same group" in {
-      val form1 = Form.form(classOf[SomeForm]).bind(Map("prop2" -> "Hello").asJava)
+      val form1 = formFactory.form(classOf[SomeForm]).bind(Map("prop2" -> "Hello").asJava)
       form1.hasErrors must_== true
-      val form2 = Form.form(classOf[SomeForm]).bind(Map("prop2" -> "Hello", "prop3" -> "abcd").asJava)
+      val form2 = formFactory.form(classOf[SomeForm]).bind(Map("prop2" -> "Hello", "prop3" -> "abcd").asJava)
       form2.hasErrors must_== true
     }
   }

--- a/templates/play-java-intro/app/controllers/Application.java
+++ b/templates/play-java-intro/app/controllers/Application.java
@@ -5,12 +5,16 @@ import play.mvc.*;
 import play.db.jpa.*;
 import views.html.*;
 import models.Person;
-import play.data.Form;
+import play.data.FormFactory;
+import javax.inject.Inject;
 import java.util.List;
 
 import static play.libs.Json.*;
 
 public class Application extends Controller {
+
+    @Inject
+    FormFactory formFactory;
 
     public Result index() {
         return ok(index.render());
@@ -18,7 +22,7 @@ public class Application extends Controller {
 
     @Transactional
     public Result addPerson() {
-        Person person = Form.form(Person.class).bindFromRequest().get();
+        Person person = formFactory.form(Person.class).bindFromRequest().get();
         JPA.em().persist(person);
         return redirect(routes.Application.index());
     }


### PR DESCRIPTION
Fixes #5678

Introduces a `FormBuilder` which can be injected to create a `Form` with all the dependency it needs.
I completely got rid of any static `Form.form` reference in the codebase.
@gmethvin Is that the solution that you have in mind?

If this PR makes it in it makes it **much** more easier to fix/implement #5666/#5670 and #5619 and #5620.