### PR TITLE
Expose client X509Certificates for a request

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -69,6 +69,7 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
       }
       override def remoteAddress = remoteConnection.address.getHostAddress
       override def secure = remoteConnection.secure
+      override def clientCertificateChain = None // TODO - Akka does not yet expose the SSLEngine used for the request
     }
   }
 

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -156,6 +156,12 @@ class NettyServer(
         sslEngineProvider.map { sslEngineProvider =>
           val sslEngine = sslEngineProvider.createSSLEngine()
           sslEngine.setUseClientMode(false)
+          if (config.configuration.getBoolean("play.server.https.wantClientAuth").getOrElse(false)) {
+            sslEngine.setWantClientAuth(true)
+          }
+          if (config.configuration.getBoolean("play.server.https.needClientAuth").getOrElse(false)) {
+            sslEngine.setNeedClientAuth(true)
+          }
           pipeline.addLast("ssl", new SslHandler(sslEngine))
         }
       }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -61,12 +61,12 @@ private[play] class PlayRequestHandler(val server: NettyServer) extends ChannelI
 
     val requestId = RequestIdProvider.requestIDs.incrementAndGet()
     val tryRequest = modelConversion.convertRequest(requestId,
-      channel.remoteAddress().asInstanceOf[InetSocketAddress], channel.pipeline().get(classOf[SslHandler]) != null,
+      channel.remoteAddress().asInstanceOf[InetSocketAddress], Option(channel.pipeline().get(classOf[SslHandler])),
       request)
 
     def clientError(statusCode: Int, message: String) = {
       val requestHeader = modelConversion.createUnparsedRequestHeader(requestId, request,
-        channel.remoteAddress().asInstanceOf[InetSocketAddress], channel.pipeline().get(classOf[SslHandler]) != null)
+        channel.remoteAddress().asInstanceOf[InetSocketAddress], Option(channel.pipeline().get(classOf[SslHandler])))
       val result = errorHandler(server.applicationProvider.current).onClientError(requestHeader, statusCode,
         if (message == null) "" else message)
       // If there's a problem in parsing the request, then we should close the connection, once done with it

--- a/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -23,6 +23,7 @@ object ServerResultUtilsSpec extends Specification with IterateeSpecification {
     def queryString = Map()
     def remoteAddress = ""
     def secure = false
+    override def clientCertificateChain = None
     val headers = new Headers(cookie.map { case (name, value) => "Cookie" -> s"$name=$value" }.toSeq)
   }
 

--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -3,6 +3,8 @@
  */
 package play.api.test
 
+import java.security.cert.X509Certificate
+
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.util.ByteString
@@ -33,7 +35,7 @@ case class FakeHeaders(data: Seq[(String, String)] = Seq.empty) extends Headers(
  * @param body The request body.
  * @param remoteAddress The client IP.
  */
-case class FakeRequest[A](method: String, uri: String, headers: Headers, body: A, remoteAddress: String = "127.0.0.1", version: String = "HTTP/1.1", id: Long = 666, tags: Map[String, String] = Map.empty[String, String], secure: Boolean = false) extends Request[A] {
+case class FakeRequest[A](method: String, uri: String, headers: Headers, body: A, remoteAddress: String = "127.0.0.1", version: String = "HTTP/1.1", id: Long = 666, tags: Map[String, String] = Map.empty[String, String], secure: Boolean = false, clientCertificateChain: Option[Seq[X509Certificate]] = None) extends Request[A] {
 
   def copyFakeRequest[B](
     id: Long = this.id,
@@ -45,9 +47,10 @@ case class FakeRequest[A](method: String, uri: String, headers: Headers, body: A
     headers: Headers = this.headers,
     remoteAddress: String = this.remoteAddress,
     secure: Boolean = this.secure,
+    clientCertificateChain: Option[Seq[X509Certificate]] = this.clientCertificateChain,
     body: B = this.body): FakeRequest[B] = {
     new FakeRequest[B](
-      method, uri, headers, body, remoteAddress, version, id, tags, secure
+      method, uri, headers, body, remoteAddress, version, id, tags, secure, clientCertificateChain
     )
   }
 

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -19,6 +19,7 @@ import play.libs.XML;
 import scala.Tuple2;
 import scala.collection.JavaConversions;
 import scala.collection.Seq;
+import scala.compat.java8.OptionConverters;
 
 import java.io.File;
 import java.io.UnsupportedEncodingException;
@@ -26,6 +27,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.security.cert.X509Certificate;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -582,6 +584,13 @@ public class Http {
         Optional<String> charset();
 
         /**
+         * The X509 certificate chain presented by a client during SSL requests.
+         *
+         * @return The chain of X509Certificates used for the request if the request is secure and the server supports it.
+         */
+        Optional<List<X509Certificate>> clientCertificateChain();
+
+        /**
          * @return the tags for the request
          */
         Map<String, String> tags();
@@ -905,7 +914,8 @@ public class Http {
                 mapListToScala(splitQuery()),
                 buildHeaders(),
                 remoteAddress,
-                secure));
+                secure,
+                OptionConverters.toScala(clientCertificateChain.map(lst -> scala.collection.JavaConversions.asScalaBuffer(lst).toSeq()))));
         }
 
         // -------------------
@@ -919,6 +929,7 @@ public class Http {
         protected String version;
         protected Map<String, String[]> headers = new HashMap<>();
         protected String remoteAddress;
+        protected Optional<List<X509Certificate>> clientCertificateChain = Optional.empty();
 
         /**
          * @return the id of the request
@@ -1253,6 +1264,23 @@ public class Http {
          */
         public RequestBuilder remoteAddress(String remoteAddress) {
             this.remoteAddress = remoteAddress;
+            return this;
+        }
+
+        /**
+         * @return the client X509Certificates if they have been set
+         */
+        public Optional<List<X509Certificate>> clientCertificateChain() {
+            return clientCertificateChain;
+        }
+
+        /**
+         *
+         * @param clientCertificateChain sets the X509Certificates to use
+         * @return the builder instance
+         */
+        public RequestBuilder clientCertificateChain(List<X509Certificate> clientCertificateChain) {
+            this.clientCertificateChain = Optional.ofNullable(clientCertificateChain);
             return this;
         }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -3,6 +3,7 @@
  */
 package play.api.mvc {
 
+  import java.security.cert.X509Certificate
   import java.util.Locale
 
   import play.api._
@@ -86,6 +87,11 @@ package play.api.mvc {
      * Is the client using SSL?
      */
     def secure: Boolean
+
+    /**
+     * The X509 certificate chain presented by a client during SSL requests.
+     */
+    def clientCertificateChain: Option[Seq[X509Certificate]]
 
     // -- Computed
 
@@ -176,6 +182,7 @@ package play.api.mvc {
 
     /**
       * Convenience method for adding a single tag to this request
+      *
       * @return the tagged request
       */
     def withTag(tagName: String, tagValue: String): RequestHeader = {
@@ -195,8 +202,9 @@ package play.api.mvc {
       queryString: Map[String, Seq[String]] = this.queryString,
       headers: Headers = this.headers,
       remoteAddress: => String = this.remoteAddress,
-      secure: => Boolean = this.secure): RequestHeader = {
-      val (_id, _tags, _uri, _path, _method, _version, _queryString, _headers, _remoteAddress, _secure) = (id, tags, uri, path, method, version, queryString, headers, () => remoteAddress, () => secure)
+      secure: => Boolean = this.secure,
+      clientCertificateChain: Option[Seq[X509Certificate]] = this.clientCertificateChain): RequestHeader = {
+      val (_id, _tags, _uri, _path, _method, _version, _queryString, _headers, _remoteAddress, _secure, _clientCertificateChain) = (id, tags, uri, path, method, version, queryString, headers, () => remoteAddress, () => secure, clientCertificateChain)
       new RequestHeader {
         override val id = _id
         override val tags = _tags
@@ -208,6 +216,7 @@ package play.api.mvc {
         override val headers = _headers
         override lazy val remoteAddress = _remoteAddress()
         override lazy val secure = _secure()
+        override val clientCertificateChain = _clientCertificateChain
       }
     }
 
@@ -248,7 +257,8 @@ package play.api.mvc {
       override val queryString: Map[String, Seq[String]],
       override val headers: Headers,
       override val remoteAddress: String,
-      override val secure: Boolean) extends RequestHeader {
+      override val secure: Boolean,
+      override val clientCertificateChain: Option[Seq[X509Certificate]]) extends RequestHeader {
   }
 
   /**
@@ -279,6 +289,8 @@ package play.api.mvc {
       override def headers = self.headers
       override def remoteAddress = self.remoteAddress
       override def secure = self.secure
+      override def clientCertificateChain = self.clientCertificateChain
+
       override lazy val body = f(self.body)
     }
 
@@ -296,7 +308,8 @@ package play.api.mvc {
       override val queryString: Map[String, Seq[String]],
       override val headers: Headers,
       override val remoteAddress: String,
-      override val secure: Boolean) extends Request[A] {
+      override val secure: Boolean,
+      override val clientCertificateChain: Option[Seq[X509Certificate]]) extends Request[A] {
   }
 
   object Request {
@@ -312,6 +325,7 @@ package play.api.mvc {
       override def headers = rh.headers
       override lazy val remoteAddress = rh.remoteAddress
       override lazy val secure = rh.secure
+      override val clientCertificateChain = rh.clientCertificateChain
       override val body = a
     }
   }
@@ -331,6 +345,7 @@ package play.api.mvc {
     override def version = request.version
     override def remoteAddress = request.remoteAddress
     override def secure = request.secure
+    override def clientCertificateChain = request.clientCertificateChain
   }
 
   /**

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -193,6 +193,8 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
 
   def cookies = JavaHelpers.cookiesToJavaCookies(header.cookies)
 
+  override def clientCertificateChain() = OptionConverters.toJava(header.clientCertificateChain.map(_.asJava))
+
   def getQueryString(key: String): String = {
     if (queryString().containsKey(key) && queryString().get(key).length > 0) queryString().get(key)(0) else null
   }

--- a/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -77,5 +77,6 @@ class RequestHeaderSpec extends Specification {
     def queryString = Map()
     def remoteAddress = ""
     def secure = false
+    override def clientCertificateChain = None
   }
 }

--- a/framework/src/play/src/test/scala/play/core/test/Fakes.scala
+++ b/framework/src/play/src/test/scala/play/core/test/Fakes.scala
@@ -3,6 +3,8 @@
  */
 package play.core.test
 
+import java.security.cert.X509Certificate
+
 import akka.util.ByteString
 import play.api.inject.guice.GuiceInjectorBuilder
 import play.api.inject.{ BindingKey, Binding, Injector }
@@ -37,7 +39,7 @@ object Fakes {
  */
 case class FakeHeaders(data: Seq[(String, String)] = Seq.empty) extends Headers(data)
 
-case class FakeRequest[A](method: String, uri: String, headers: Headers, body: A, remoteAddress: String = "127.0.0.1", version: String = "HTTP/1.1", id: Long = 666, tags: Map[String, String] = Map.empty[String, String], secure: Boolean = false) extends Request[A] {
+case class FakeRequest[A](method: String, uri: String, headers: Headers, body: A, remoteAddress: String = "127.0.0.1", version: String = "HTTP/1.1", id: Long = 666, tags: Map[String, String] = Map.empty[String, String], secure: Boolean = false, clientCertificateChain: Option[Seq[X509Certificate]] = None) extends Request[A] {
 
   private def _copy[B](
     id: Long = this.id,
@@ -49,9 +51,10 @@ case class FakeRequest[A](method: String, uri: String, headers: Headers, body: A
     headers: Headers = this.headers,
     remoteAddress: String = this.remoteAddress,
     secure: Boolean = this.secure,
+    clientCertificateChain: Option[Seq[X509Certificate]] = this.clientCertificateChain,
     body: B = this.body): FakeRequest[B] = {
     new FakeRequest[B](
-      method, uri, headers, body, remoteAddress, version, id, tags, secure
+      method, uri, headers, body, remoteAddress, version, id, tags, secure, clientCertificateChain
     )
   }
 


### PR DESCRIPTION
## Purpose

Exposes the SSLSession for requests over SSL. This allows access to the X509 Certificate that a client may present.

## Background Context

Rather than exposing the certificate directly I thought it would be more useful to expose the SSLSession since it provides access to the full certificate chain as well as both the (java|javax).security.cert.X509Certificate APIs. The certificates won't be available unless wantClientAuth or needClientAuth is enabled through config.

I've tested this locally using a self signed client certificate and setting noCaVerification to true. I'm not sure of the best way to write automated tests for this - suggestions for testing strategies are welcome.

I didn't find a way to implement this for the Akka server. The SSLEngine seems to only be available in TLSActor and not through the Akka HttpRequest.