### PR TITLE
Don't send charset if we don't need to

### DIFF
--- a/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
@@ -24,11 +24,6 @@ trait ContentTypes {
   def HTML(implicit codec: Codec) = withCharset(MimeTypes.HTML)
 
   /**
-   * Content-Type of json.
-   */
-  def JSON(implicit codec: Codec) = withCharset(MimeTypes.JSON)
-
-  /**
    * Content-Type of xml.
    */
   def XML(implicit codec: Codec) = withCharset(MimeTypes.XML)
@@ -44,11 +39,6 @@ trait ContentTypes {
   def JAVASCRIPT(implicit codec: Codec) = withCharset(MimeTypes.JAVASCRIPT)
 
   /**
-   * Content-Type of form-urlencoded.
-   */
-  def FORM(implicit codec: Codec) = withCharset(MimeTypes.FORM)
-
-  /**
    * Content-Type of server sent events.
    */
   def EVENT_STREAM(implicit codec: Codec) = withCharset(MimeTypes.EVENT_STREAM)
@@ -59,6 +49,16 @@ trait ContentTypes {
   val CACHE_MANIFEST = withCharset(MimeTypes.CACHE_MANIFEST)(Codec.utf_8)
 
   /**
+   * Content-Type of json. This content type does not define a charset parameter.
+   */
+  val JSON = MimeTypes.JSON
+
+  /**
+   * Content-Type of form-urlencoded. This content type does not define a charset parameter.
+   */
+  val FORM = MimeTypes.FORM
+
+  /**
    * Content-Type of binary data.
    */
   val BINARY = MimeTypes.BINARY
@@ -66,7 +66,7 @@ trait ContentTypes {
   /**
    * @return the `codec` charset appended to `mimeType`
    */
-  def withCharset(mimeType: String)(implicit codec: Codec) = mimeType + "; charset=" + codec.charset
+  def withCharset(mimeType: String)(implicit codec: Codec) = s"$mimeType; charset=${codec.charset}"
 
 }
 


### PR DESCRIPTION
Related ML discussion: https://groups.google.com/forum/#!topic/play-framework/oiMC43aZP8c

The charset parameter is meaningless for the [application/json](https://www.iana.org/assignments/media-types/application/json) media type, and apparently some servers error if you send it.

The same is also true for [application/x-www-form-urlencoded](https://www.iana.org/assignments/media-types/application/x-www-form-urlencoded).

