### PR TITLE
Flatten operation on Java Accumulator

### DIFF
--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
@@ -6,6 +6,7 @@ package play.api.libs.streams
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{ Flow, Source, Sink }
 import akka.stream.{ ActorMaterializer, Materializer }
+
 import org.reactivestreams.{ Subscription, Subscriber, Publisher }
 import org.specs2.mutable.Specification
 
@@ -26,7 +27,7 @@ object AccumulatorSpec extends Specification {
     }
   }
 
-  def sum = Accumulator(Sink.fold[Int, Int](0)(_ + _))
+  def sum: Accumulator[Int, Int] = Accumulator(Sink.fold[Int, Int](0)(_ + _))
   def source = Source(1 to 3)
   def await[T](f: Future[T]) = Await.result(f, 10.seconds)
   def error[T](any: Any): T = throw sys.error("error")
@@ -40,7 +41,6 @@ object AccumulatorSpec extends Specification {
   })
 
   "an accumulator" should {
-
     "provide map" in withMaterializer { implicit m =>
       await(sum.map(_ + 10).run(source)) must_== 16
     }
@@ -112,7 +112,5 @@ object AccumulatorSpec extends Specification {
         await(FutureConverters.toScala(sum.asJava.run(source.asJava, m))) must_== 6
       }
     }
-
   }
-
 }

--- a/framework/src/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
@@ -1,0 +1,107 @@
+package play.libs.streams
+
+import java.util.concurrent.{
+  CompletableFuture,
+  CompletionStage,
+  ExecutionException,
+  TimeUnit
+}
+
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import scala.compat.java8.FutureConverters
+
+import akka.actor.ActorSystem
+import akka.stream.javadsl.{ Flow, Source, Sink }
+import akka.stream.{ ActorMaterializer, Materializer }
+import akka.japi.function.{ Function => JFn, Function2 => JFn2 }
+
+import org.reactivestreams.{ Subscription, Subscriber, Publisher }
+
+object AccumulatorSpec extends org.specs2.mutable.Specification {
+  import scala.collection.JavaConversions.asJavaIterable
+
+  def withMaterializer[T](block: Materializer => T) = {
+    val system = ActorSystem("test")
+    try {
+      block(ActorMaterializer()(system))
+    } finally {
+      system.terminate()
+      Await.result(system.whenTerminated, Duration.Inf)
+    }
+  }
+
+  def sum: Accumulator[Int, Int] =
+    Accumulator.fromSink(Sink.fold[Int, Int](0,
+      new JFn2[Int, Int, Int] { def apply(a: Int, b: Int) = a + b }))
+
+  def source = Source from asJavaIterable(1 to 3)
+  def sawait[T](f: Future[T]) = Await.result(f, 10.seconds)
+  def await[T](f: CompletionStage[T]) =
+    f.toCompletableFuture.get(10, TimeUnit.SECONDS)
+
+  def errorSource[T] = Source.fromPublisher(new Publisher[T] {
+    def subscribe(s: Subscriber[_ >: T]) = {
+      s.onSubscribe(new Subscription {
+        def cancel() = s.onComplete()
+        def request(n: Long) = s.onError(new RuntimeException("error"))
+      })
+    }
+  })
+
+  "an accumulator" should {
+    "be flattenable from a future of itself" in {
+      "for a successful future" in withMaterializer { m =>
+        val completable = new CompletableFuture[Accumulator[Int, Int]]()
+
+        val fAcc = Accumulator.flatten[Int, Int](completable, m)
+        completable complete sum
+
+        await(fAcc.run(source, m)) must_== 6
+      }
+
+      "for a failed future" in withMaterializer { implicit m =>
+        val completable = new CompletableFuture[Accumulator[Int, Int]]()
+
+        val fAcc = Accumulator.flatten[Int, Int](completable, m)
+        completable.completeExceptionally(new RuntimeException("failed"))
+
+        await(fAcc.run(source, m)) must throwA[ExecutionException].like {
+          case ex =>
+            val cause = ex.getCause
+            cause.isInstanceOf[RuntimeException] must beTrue and (
+              cause.getMessage must_== "failed")
+        }
+      }
+
+      "for a failed stream" in withMaterializer { implicit m =>
+        val completable = new CompletableFuture[Accumulator[Int, Int]]()
+
+        val fAcc = Accumulator.flatten[Int, Int](completable, m)
+        completable complete sum
+
+        await(fAcc.run(errorSource, m)) must throwA[ExecutionException].like {
+          case ex =>
+            val cause = ex.getCause
+            cause.isInstanceOf[RuntimeException] must beTrue and (
+              cause.getMessage must_== "error")
+        }
+      }
+    }
+
+    "be compatible with Java accumulator" in {
+      "Java asScala" in withMaterializer { implicit m =>
+        val sink = sum.toSink.mapMaterializedValue(
+          new JFn[CompletionStage[Int], Future[Int]] {
+            def apply(f: CompletionStage[Int]): Future[Int] =
+              FutureConverters.toScala(f)
+          })
+
+        sawait(play.api.libs.streams.Accumulator(sink.asScala).
+          run(source.asScala)) must_== 6
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Generally, allows to flatten Java `Accumulator` from `CompletionStage` (as from `Future` with the Scala equivalent).
- More specifically, will allow to restore the possibility to flatten `Future[BodyParser]` (as previously using `BodyParsers.parse.empty.flatMapM(_ => futureBodyParser)`).