### PR TITLE
Key formats.date is shorter and more clear

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/format/Formats.java
+++ b/framework/src/play-java/src/main/java/play/data/format/Formats.java
@@ -34,12 +34,12 @@ public class Formats {
 
         /**
          * Creates a date formatter.
-         * The value defined for the message file key "formats.dateFormat" will be used as the default pattern.
+         * The value defined for the message file key "formats.date" will be used as the default pattern.
          *
          * @param messagesApi messages to look up the pattern
          */
         public DateFormatter(MessagesApi messagesApi) {
-            this(messagesApi, "formats.dateFormat");
+            this(messagesApi, "formats.date");
         }
 
         /**

--- a/framework/src/play-java/src/test/resources/messages.en-US
+++ b/framework/src/play-java/src/test/resources/messages.en-US
@@ -1,2 +1,2 @@
 customFormats.date=MM-dd-yyyy
-formats.dateFormat=dd/MM/yyyy
+formats.date=dd/MM/yyyy

--- a/framework/src/play-java/src/test/resources/messages.fr
+++ b/framework/src/play-java/src/test/resources/messages.fr
@@ -1,2 +1,2 @@
 customFormats.date=dd.MM.yyyy
-formats.dateFormat=MM_dd_yyyy
+formats.date=MM_dd_yyyy

--- a/framework/src/play/src/main/resources/messages.default
+++ b/framework/src/play/src/main/resources/messages.default
@@ -20,7 +20,7 @@ format.real=Real
 format.uuid=UUID
 
 # --- Patterns for Formats
-formats.dateFormat=yyyy-MM-dd
+formats.date=yyyy-MM-dd
 
 # --- Errors
 error.invalid=Invalid value


### PR DESCRIPTION
Not to be confused with `format.date`  (without the `s`).
If you think it is to similiar just close this PR.