### PR TITLE
[WIP] Adds OPTIONS as an HTTP verb that may contain a body by default.

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
@@ -30,8 +30,8 @@ object DefaultBodyParserSpec extends PlaySpecification {
       parse("HEAD", None, ByteString("bar")) must beRight(AnyContentAsEmpty)
     }
 
-    "ignore text bodies for OPTIONS requests" in new WithApplication() {
-      parse("GET", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsEmpty)
+    "parse text bodies for OPTIONS requests" in new WithApplication() {
+      parse("OPTIONS", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
     }
 
     "parse XML bodies for PATCH requests" in new WithApplication() {

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -579,15 +579,18 @@ trait BodyParsers {
     // -- Magic any content
 
     /**
-     * If the request is a PATCH, POST, or PUT, parse the body content by checking the Content-Type header.
+     * If the request is a PATCH, POST, PUT, or OPTIONS, parse the body content by checking the Content-Type header.
      */
     def default: BodyParser[AnyContent] = default(None)
 
     /**
-     * If the request is a PATCH, POST, or PUT, parse the body content by checking the Content-Type header.
+     * If the request is a PATCH, POST, PUT, or OPTIONS, parse the body content by checking the Content-Type header.
      */
     def default(maxLength: Option[Long]): BodyParser[AnyContent] = using { request =>
-      if (request.method == HttpVerbs.PATCH || request.method == HttpVerbs.POST || request.method == HttpVerbs.PUT) {
+      if (request.method == HttpVerbs.PATCH
+        || request.method == HttpVerbs.POST
+        || request.method == HttpVerbs.PUT
+        || request.method == HttpVerbs.OPTIONS) {
         anyContent(maxLength)
       } else {
         ignore(AnyContentAsEmpty)


### PR DESCRIPTION
Still a work in progress.

## Fixes

Fixes https://github.com/playframework/playframework/issues/5503 -- note there is some confusion in the initial bug reporting, and https://github.com/playframework/playframework/issues/5503#issuecomment-175846025 is the real problem here.

## Purpose

Adds OPTIONS as an HTTP verb that may contain a body by default.

## Background Context

Adding a specific verb for OPTIONS is the lightest touch approach here.  BodyParsers.parse is a singleton object, and so it might be better to use an "application.bodyParsers" approach to help avoid global scope (especially if custom HTTP verbs are used).

## References

Per https://tools.ietf.org/html/rfc7231#section-4.3.7 a client may send OPTIONS with a payload body:

```
 A client that generates an OPTIONS request containing a payload body
   MUST send a valid Content-Type header field describing the
   representation media type.  Although this specification does not
   define any use for such a payload, future extensions to HTTP might
   use the OPTIONS body to make more detailed queries about the target
   resource.
```