### PR TITLE
allow i18n usage on weblogic (play 2.4)

### DIFF
--- a/framework/src/play/src/main/scala/play/utils/Resources.scala
+++ b/framework/src/play/src/main/scala/play/utils/Resources.scala
@@ -16,7 +16,8 @@ object Resources {
 
   def isDirectory(classLoader: ClassLoader, url: URL) = url.getProtocol match {
     case "file" => new File(url.toURI).isDirectory
-    case "jar" => isJarResourceDirectory(url)
+    case "jar" => isZipResourceDirectory(url)
+    case "zip" => isZipResourceDirectory(url)
     case "bundle" => isBundleResourceDirectory(classLoader, url)
     case _ => throw new IllegalArgumentException(s"Cannot check isDirectory for a URL with protocol='${url.getProtocol}'")
   }
@@ -75,13 +76,18 @@ object Resources {
     classLoader.getResource(path) != null && classLoader.getResource(pathSlash) != null
   }
 
-  private def isJarResourceDirectory(url: URL): Boolean = {
+  private def isZipResourceDirectory(url: URL): Boolean = {
     val path = url.getPath
     val bangIndex = url.getFile.indexOf("!")
 
-    val jarFile: File = new File(URI.create(path.substring(0, bangIndex)))
+    val startIndex = if (path.startsWith("zip:")) 4 else 0
+    val fileUri = path.substring(startIndex, bangIndex)
+    val fileProtocol = if (fileUri.startsWith("/")) "file://" else ""
+    val absoluteFileUri = fileProtocol + fileUri
+
+    val zipFile: File = new File(URI.create(absoluteFileUri))
     val resourcePath = URI.create(path.substring(bangIndex + 1)).getPath.drop(1)
-    val zip = new ZipFile(jarFile)
+    val zip = new ZipFile(zipFile)
 
     try {
       val entry = zip.getEntry(resourcePath)

--- a/framework/src/play/src/test/scala/play/utils/ResourcesSpec.scala
+++ b/framework/src/play/src/test/scala/play/utils/ResourcesSpec.scala
@@ -114,7 +114,27 @@ object ResourcesSpec extends Specification {
       isDirectory(osgiClassloader, url) must beFalse
     }
 
-    "throw an exception for a URL with a protocol other than 'file'/'jar'/'bundle'" in {
+    "return true for a directory resource URL with the 'zip' protocol" in {
+      val url = new URL("zip", "", 0, createZipUrl(jar, dirRes), EmptyURLStreamHandler)
+      isDirectory(classloader, url) must beTrue
+    }
+
+    "return true for a directory resource URL that contains spaces in the zip path with the 'zip' protocol" in {
+      val url = new URL("zip", "", 0, createZipUrl(spacesJar, dirRes), EmptyURLStreamHandler)
+      isDirectory(classloader, url) must beTrue
+    }
+
+    "return true for a directory resource URL that contains spaces in the file path with the 'zip' protocol" in {
+      val url = new URL("zip", "", 0, createZipUrl(jar, dirSpacesRes), EmptyURLStreamHandler)
+      isDirectory(classloader, url) must beTrue
+    }
+
+    "return false for a file resource URL with the 'zip' protocol" in {
+      val url = new URL("zip", "", 0, createZipUrl(jar, fileRes), EmptyURLStreamHandler)
+      isDirectory(classloader, url) must beFalse
+    }
+
+    "throw an exception for a URL with a protocol other than 'file'/'jar'/'zip'/'bundle'" in {
       val url = new URL("ftp", "", "/some/path")
       isDirectory(classloader, url) must throwAn[IllegalArgumentException]
     }
@@ -129,8 +149,18 @@ object ResourcesSpec extends Specification {
     }
   }
 
+  object EmptyURLStreamHandler extends URLStreamHandler {
+    def openConnection(u: URL) = new URLConnection(u) {
+      def connect() {}
+    }
+  }
+
   private def createJarUrl(jarFile: File, file: File) = {
     s"${jarFile.toURI.toURL}!/${UriEncoding.encodePathSegment(file.getName, "utf-8")}"
+  }
+
+  private def createZipUrl(zipFile: File, file: File) = {
+    s"zip:${zipFile.toURI.toURL}!/${UriEncoding.encodePathSegment(file.getName, "utf-8")}"
   }
 
   private def createTempDir(prefix: String, suffix: String, parent: File = null) = {


### PR DESCRIPTION
# Pull Request Checklist

- [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
- [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
- [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
- [ ]  (N/A) Have you added copyright headers to new files?
- [ ] (N/A) Have you checked that both Scala and Java APIs are updated?
- [ ] (N/A) Have you updated the documentation?
- [x] Have you added tests?

## Purpose

Allow I18n usage of play 2.4 apps on weblogic.

## Background Context

Loading of I18n messages checks if items on the classpath are directories and breaks the application on unknown protocol e.g. "zip", which exists on weblogic installations.


## References

Original commit introducing the breakage - https://github.com/playframework/playframework/commit/686a9b4535815d24381cea9acd901461fd28a4fa

Fix for 2.3 branch - https://github.com/playframework/playframework/commit/422ca97c54a7ab84cb965df1474f2cd0d11e5fc6 (PR #5728)