### PR TITLE
Fix deprecation warnings in play-scala-intro

### DIFF
--- a/templates/play-scala-intro/test/ApplicationSpec.scala
+++ b/templates/play-scala-intro/test/ApplicationSpec.scala
@@ -16,11 +16,11 @@ class ApplicationSpec extends Specification {
   "Application" should {
 
     "send 404 on a bad request" in new WithApplication {
-      route(FakeRequest(GET, "/boum")) must beSome.which (status(_) == NOT_FOUND)
+      route(app, FakeRequest(GET, "/boum")) must beSome.which (status(_) == NOT_FOUND)
     }
 
     "render the index page" in new WithApplication {
-      val home = route(FakeRequest(GET, "/")).get
+      val home = route(app, FakeRequest(GET, "/")).get
 
       status(home) must equalTo(OK)
       contentType(home) must beSome.which(_ == "text/html")


### PR DESCRIPTION
## Purpose

In line with commit a2e4c7ff6b125638b8d9d511e27a7c338c6e9c69 this change also fixes the deprecation warnings in the play-scala-intro template:

```
test/ApplicationSpec.scala:23:

    method route in trait RouteInvokers is
    deprecated: Use the version that takes an application
```