### PR TITLE
Add missing HTTP statuses in play.mvc.Http

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -2142,9 +2142,9 @@ public class Http {
      * Defines all standard HTTP status codes.
      */
     public static interface Status {
-
         int CONTINUE = 100;
         int SWITCHING_PROTOCOLS = 101;
+
         int OK = 200;
         int CREATED = 201;
         int ACCEPTED = 202;
@@ -2152,6 +2152,8 @@ public class Http {
         int NO_CONTENT = 204;
         int RESET_CONTENT = 205;
         int PARTIAL_CONTENT = 206;
+        int MULTI_STATUS = 207;
+
         int MULTIPLE_CHOICES = 300;
         int MOVED_PERMANENTLY = 301;
         int FOUND = 302;
@@ -2160,6 +2162,7 @@ public class Http {
         int USE_PROXY = 305;
         int TEMPORARY_REDIRECT = 307;
         int PERMANENT_REDIRECT = 308;
+
         int BAD_REQUEST = 400;
         int UNAUTHORIZED = 401;
         int PAYMENT_REQUIRED = 402;
@@ -2181,13 +2184,16 @@ public class Http {
         int UNPROCESSABLE_ENTITY = 422;
         int LOCKED = 423;
         int FAILED_DEPENDENCY = 424;
+        int UPGRADE_REQUIRED = 426;
         int TOO_MANY_REQUESTS = 429;
+
         int INTERNAL_SERVER_ERROR = 500;
         int NOT_IMPLEMENTED = 501;
         int BAD_GATEWAY = 502;
         int SERVICE_UNAVAILABLE = 503;
         int GATEWAY_TIMEOUT = 504;
         int HTTP_VERSION_NOT_SUPPORTED = 505;
+        int INSUFFICIENT_STORAGE = 507;
     }
 
     /** Common HTTP MIME types */


### PR DESCRIPTION
## Purpose

`play.mvc.HTTP` is missing few HTTP statuses comparing to `play.api.http.StandardValues`
