### PR TITLE
[FAIL] Ok.sendFile in tests missing ContentLength

### DIFF
--- a/framework/src/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
+++ b/framework/src/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
@@ -46,7 +46,16 @@ object FakesSpec extends PlaySpecification {
       case (PUT, "/process") => Action { req =>
         Results.Ok(req.headers.get(CONTENT_TYPE) getOrElse "")
       }
+      case (GET, "/") ⇒ Action { req ⇒
+        Ok.sendFile(new java.io.File(""))
+      }
     }.build()
+
+    "Have Content-Length for Ok.sendFile" in new WithApplication(app) {
+      route(app, FakeRequest(GET, "/")) aka "response" must beSome.which { resp ⇒
+        headers(resp) aka "headers" must contain(CONTENT_LENGTH)
+      }
+    }
 
     "Define Content-Type header based on body" in new WithApplication(app) {
       val xml =


### PR DESCRIPTION
## Purpose

This PR includes a failing test case for missing headers using `Ok.sendFile`.

## References

https://groups.google.com/d/msg/play-framework/Ol8bZVqEDrQ/Hx9Z_FaxFgAJ
