### PR TITLE
Always send Content-Length with files

### DIFF
--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -188,7 +188,12 @@ private[server] class NettyModelConversion(forwardedHeaderHandler: ForwardedHead
       if (mayHaveContentLength(result.header.status)) {
         result.body.contentLength.foreach { contentLength =>
           if (HttpHeaders.isContentLengthSet(response)) {
-            logger.warn("Content-Length header was set manually in the header, ignoring manual header")
+            val manualContentLength = response.headers.get(CONTENT_LENGTH)
+            if (manualContentLength == contentLength.toString) {
+              logger.info(s"Manual Content-Length header, ignoring manual header.")
+            } else {
+              logger.warn(s"Content-Length header was set manually in the header ($manualContentLength) but is not the same as actual content length ($contentLength).")
+            }
           }
           HttpHeaders.setContentLength(response, contentLength)
         }

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -378,7 +378,8 @@ trait Results {
             CONTENT_DISPOSITION -> {
               val dispositionType = if (inline) "inline" else "attachment"
               dispositionType + "; filename=\"" + name + "\""
-            }
+            },
+            CONTENT_LENGTH -> length.toString
           )
         ),
         HttpEntity.Streamed(

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -3,16 +3,17 @@
  */
 package play.api.mvc
 
-import java.nio.file.{ Files, Paths, Path }
 import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, Path, Paths }
 import java.util.concurrent.atomic.AtomicInteger
 
-import org.joda.time.{ DateTimeZone, DateTime }
+import org.joda.time.{ DateTime, DateTimeZone }
 import org.specs2.mutable._
-import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
-import play.api.{ Configuration, Environment, Play }
 import play.api.http.HeaderNames._
 import play.api.http.Status._
+import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
+import play.api.{ Configuration, Environment, Play }
 import play.core.test._
 
 object ResultsSpec extends Specification {
@@ -207,6 +208,14 @@ object ResultsSpec extends Specification {
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
         (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="${fileName}""""))
+    }
+
+    "send Content-Length with file" in withPath { (file, fileName) =>
+      val content = "test"
+      Files.write(file, content.getBytes(StandardCharsets.ISO_8859_1))
+      val rh = Ok.sendPath(file).header
+
+      rh.headers.get(CONTENT_LENGTH) must beSome(content.length.toString)
     }
 
     "support redirects for reverse routed calls" in {


### PR DESCRIPTION
Fixes #5777.

The NettyServer adds `Content-Length` if it's not present, which is why it was happening in dev mode.