### PR TITLE
Get raw request URI in AkkaHttpServer

### DIFF
--- a/framework/src/play-akka-http-server/src/main/resources/play/reference-overrides.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/play/reference-overrides.conf
@@ -15,7 +15,12 @@ akka {
   # Turn off dead letters until Akka HTTP server is stable
   log-dead-letters = off
 
-  # Disable Akka-HTTP's transparent HEAD handling. so that play's HEAD handling can take action
-  http.server.transparent-head-requests = false
+  http.server {
+    # Disable Akka-HTTP's transparent HEAD handling. so that play's HEAD handling can take action
+    transparent-head-requests = false
+
+    # Enable Raw-Request-URI header to get actual request URI
+    raw-request-uri-header = true
+  }
 
 }


### PR DESCRIPTION
Fixes #5780

Enables the `Raw-Request-URI` header in akka-http and uses that for `request.uri`.