### PR TITLE
Explicitly depend on htmlunit 2.20 to support jQuery 2.20

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -264,6 +264,7 @@ object Dependencies {
     junitInterface,
     guava,
     findBugs,
+    "net.sourceforge.htmlunit" % "htmlunit" % "2.20", // adds support for jQuery 2.20; can be removed as soon as fluentlenium has it in it's own dependencies
     ("org.fluentlenium" % "fluentlenium-core" % "0.10.9")
       .exclude("org.jboss.netty", "netty")
   )

--- a/templates/play-java-intro/test/IntegrationTest.java
+++ b/templates/play-java-intro/test/IntegrationTest.java
@@ -20,7 +20,6 @@ public class IntegrationTest {
     @Test
     public void test() {
         running(testServer(3333, fakeApplication(inMemoryDatabase())), HTMLUNIT, browser -> {
-            ((HtmlUnitDriver) browser.getDriver()).setJavascriptEnabled(false);
             browser.goTo("http://localhost:3333");
             assertThat(browser.pageSource(), containsString("Add Person"));
         });

--- a/templates/play-scala-intro/test/IntegrationSpec.scala
+++ b/templates/play-scala-intro/test/IntegrationSpec.scala
@@ -16,7 +16,7 @@ class IntegrationSpec extends Specification {
 
   "Application" should {
 
-    "work from within a browser" in new WithBrowser(webDriver = new HtmlUnitDriver(false)) {
+    "work from within a browser" in new WithBrowser {
 
       browser.goTo("http://localhost:" + port)
 


### PR DESCRIPTION
Fixes #5050

Allows us to enable javascript again in the integration tests (Originally I disabled javascript in #5613).