### PR TITLE
Small corrections to migration guide 2.5

### DIFF
--- a/documentation/manual/releases/release25/Highlights25.md
+++ b/documentation/manual/releases/release25/Highlights25.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
 # What's new in Play 2.5
 
-This page highlights the new features of Play 2.5. If you want learn about the changes you need to make to migrate to Play 2.5, check out the [[Play 2.5 Migration Guide|Migration25]].
+This page highlights the new features of Play 2.5. If you want to learn about the changes you need to make to migrate to Play 2.5, check out the [[Play 2.5 Migration Guide|Migration25]].
 
 ## New streaming API based on Akka Streams
 
@@ -35,7 +35,7 @@ The places where you will come across Akka streams in your Play applications inc
 
 ### Reactive Streams
 
-[Reactive Streams](http://reactivestreams.org) is a new specification for asynchronous streaming, which is scheduled for inclusion in JDK9, and available as a standalone library for JDK6 and above.  In general, it is not an end-user library, rather it is an SPI that streaming libraries can implement in order to integrate with each other.  Both Akka streams and iteratees provide a reactive streams SPI implementation.  This means, existing iteratees code can easily be used with Play's new Akka streams support.  It also means any other reactive streams implementations can be used in Play.
+[Reactive Streams](http://reactivestreams.org) is a new specification for asynchronous streaming, which is scheduled for inclusion in JDK9 and available as a standalone library for JDK6 and above.  In general, it is not an end-user library, rather it is an SPI that streaming libraries can implement in order to integrate with each other.  Both Akka streams and iteratees provide a reactive streams SPI implementation.  This means, existing iteratees code can easily be used with Play's new Akka streams support.  It also means any other reactive streams implementations can be used in Play.
 
 ### The future of iteratees
 
@@ -62,9 +62,9 @@ With Play 2.5 that situation has changed. Java 8 now ships with much better supp
 
 Here are the main changes:
 
-* Use Java functional interfaces (`Runnable`, `Consumer`, `Predicate`, etc). [[(See Migration Guide.)|Migration25#Replaced-functional-types-with-Java-8-functional-types]]
-* Use Java 8's [`Optional`](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html) instead of Play's `F.Option`. [[(See Migration Guide.)|Migration25#Replaced-F.Option-with-Java-8s-Optional]]
-* Use Java 8's [`CompletionStage`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html) instead of Play's `F.Promise`. [[(See Migration Guide.)|Migration25#Replaced-F.Promise-with-Java-8s-CompletionStage]]
+* Use Java functional interfaces (`Runnable`, `Consumer`, `Predicate`, etc). [[(See Migration Guide.)|JavaMigration25#Replaced-functional-types-with-Java-8-functional-types]]
+* Use Java 8's [`Optional`](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html) instead of Play's `F.Option`. [[(See Migration Guide.)|JavaMigration25#Replaced-F.Option-with-Java-8s-Optional]]
+* Use Java 8's [`CompletionStage`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html) instead of Play's `F.Promise`. [[(See Migration Guide.)|JavaMigration25#Replaced-F.Promise-with-Java-8s-CompletionStage]]
 
 ## Support for other logging frameworks
 
@@ -86,7 +86,7 @@ You can learn how to use native sockets in Play documentation on [[configuring N
 
 ## Performance Improvements
 
-Thanks to various performance optimizations, Play 2.5's performance testing framework shows roughly 60K requests per second, an almost 20% improvement over Play 2.4.x. 
+Thanks to various performance optimizations, Play 2.5's performance testing framework shows roughly 60K requests per second, an **almost 20% improvement over Play 2.4.x**.
 
 ## WS Improvements
 

--- a/documentation/manual/releases/release25/migration25/CryptoMigration25.md
+++ b/documentation/manual/releases/release25/migration25/CryptoMigration25.md
@@ -17,7 +17,7 @@ Play uses the `Crypto.sign` method to provide message authentication for session
 
 ### MAC Algorithm Independence
 
-Play currently uses HMAC-SHA1 for signing and verifying session cookies.  An [HMAC](https://en.wikipedia.org/wiki/Hash-based_message_authentication_code) is a cryptographic function that authenticates that data has not been tampered with, using a secret key (the [application secret](https://www.playframework.com/documentation/2.4.x/ApplicationSecret) defined as play.crypto.secret) together with a message digest function (in this case [SHA-1](https://en.wikipedia.org/wiki/SHA-1)).  SHA-1 has suffered [some attacks recently](https://sites.google.com/site/itstheshappening/), but it remains secure when used with an HMAC for [message authenticity](https://killring.org/2014/01/05/how-broken-is-sha-1/).
+Play currently uses HMAC-SHA1 for signing and verifying session cookies.  An [HMAC](https://en.wikipedia.org/wiki/Hash-based_message_authentication_code) is a cryptographic function that authenticates that data has not been tampered with, using a secret key (the [[application secret|ApplicationSecret]] defined as play.crypto.secret) together with a message digest function (in this case [SHA-1](https://en.wikipedia.org/wiki/SHA-1)).  SHA-1 has suffered [some attacks recently](https://sites.google.com/site/itstheshappening/), but it remains secure when used with an HMAC for [message authenticity](https://killring.org/2014/01/05/how-broken-is-sha-1/).
 
 Play needs to have the flexibility be able to move to a different HMAC function [as needed](http://valerieaurora.org/hash.html) and so, should not be part of the public API.
 
@@ -35,7 +35,7 @@ Please do not use `Crypto.sign` or any kind of HMAC, as they are not designed fo
 
 Crypto contains two methods for symmetric encryption, `Crypto.encryptAES` and `Crypto.decryptAES`. These methods are not used internally by Play, but [significant](https://github.com/playframework/playframework/issues/4407) [developer](https://groups.google.com/d/msg/play-framework-dev/Rlrt89Ky_Rk/j6Iq6-snDw8J) [effort](https://groups.google.com/forum/#!topic/play-framework/Pao8MnADAqw) [has](https://ipsec.pl/play-framework/2014/session-variables-encryption-play-framework.html) gone into reviewing these methods.  These methods will be deprecated, and may be removed in future versions.
 
-As alluded to in the warning, these methods are not generally "safe" -- there are some common modes of operation that are not secure using these methods.   Here follows a brief description of some cryptographic issues using `Crypto.encryptAES`.
+As alluded to in the warning, these methods are not generally "safe" -- there are some common modes of operation that are not secure using these methods.  Here follows a brief description of some cryptographic issues using `Crypto.encryptAES`.
 
 Again, `Crypto.encryptAES` is never used directly in Play, so this isn’t a security vulnerability in Play itself.   
 
@@ -69,11 +69,11 @@ There are several migration paths from Crypto functionality.  In order of prefer
 
 ### Kalium
 
-If you have control over binaries in your production environment and do not have external requirements for NIST approved algorithms: use [Kalium](https://abstractj.github.io/kalium/), a wrapper over the libsodium library.
+If you have control over binaries in your production environment and do not have external requirements for NIST approved algorithms: use [Kalium](https://abstractj.github.io/kalium/), a wrapper over the [libsodium](https://download.libsodium.org/doc/) library.
 
-If you need a MAC replacement for `Crypto.sign`, use org.abstractj.kalium.keys.AuthenticationKey, which implements HMAC-SHA512/256.
+If you need a MAC replacement for `Crypto.sign`, use `org.abstractj.kalium.keys.AuthenticationKey`, which implements HMAC-SHA512/256.
 
-If you want a symmetric encryption replacement for `Crypto.encryptAES`, then use org.abstractj.kalium.crypto.SecretBox, which implements [secret-key authenticated encryption](https://download.libsodium.org/doc/secret-key_cryptography/authenticated_encryption.html).
+If you want a symmetric encryption replacement for `Crypto.encryptAES`, then use `org.abstractj.kalium.crypto.SecretBox`, which implements [secret-key authenticated encryption](https://download.libsodium.org/doc/secret-key_cryptography/authenticated_encryption.html).
 
 Note that Kalium does require that a libsodium binary be [installed](https://download.libsodium.org/doc/installation/index.html), preferably from source that you have verified.
 

--- a/documentation/manual/releases/release25/migration25/JavaMigration25.md
+++ b/documentation/manual/releases/release25/migration25/JavaMigration25.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
 # Java Migration Guide
 
-In order to better fit in to the Java 8 ecosystem, and to allow Play Java users to make more idiomatic use of Java in their applications, Play has switched to using a number of Java 8 types such as `CompletionStage` and `Function`. Play also has new Java APIs for `EssentialAction`, `EssentialFilter`, `Router`, `BodyParser`, and `HttpRequestHandler`.
+In order to better fit in to the Java 8 ecosystem, and to allow Play Java users to make more idiomatic use of Java in their applications, Play has switched to using a number of Java 8 types such as `CompletionStage` and `Function`. Play also has new Java APIs for `EssentialAction`, `EssentialFilter`, `Router`, `BodyParser` and `HttpRequestHandler`.
 
 ## New Java APIs
 
@@ -33,7 +33,7 @@ You need to change code that explicitly mentions a type like `F.Function1`. For 
 void myMethod(F.Callback0 block) { ... }
 ```
 
-becomes
+Becomes:
 
 ```java
 void myMethod(Runnable block) { ... }

--- a/documentation/manual/releases/release25/migration25/Migration25.md
+++ b/documentation/manual/releases/release25/migration25/Migration25.md
@@ -101,13 +101,11 @@ The Plugins API was deprecated in Play 2.4 and has been removed in Play 2.5. The
 
 Routes are now generated using the dependency injection aware `InjectedRoutesGenerator`, rather than the previous `StaticRoutesGenerator` which assumed controllers were singleton objects.
 
-To revert back to the earlier behavior (if you have "object MyController" in your code, for example), please add:
+To revert back to the earlier behavior (if you have "object MyController" in your code, for example), please add the following line to your `build.sbt` file:
 
-```
+```scala
 routesGenerator := StaticRoutesGenerator
 ```
-
-to your `build.sbt` file.
 
 Using static controllers with the static routes generator is not deprecated, but it is recommended that you migrate to using classes with dependency injection.
 
@@ -145,7 +143,7 @@ You should refer to the list of dependency injected components in the [[Play 2.4
 
 For example, the following code injects an environment and configuration into a Controller in Scala:
 
-```
+```scala
 class HomeController @Inject() (environment: play.api.Environment, configuration: play.api.Configuration) extends Controller {
 
   def index = Action {
@@ -167,7 +165,7 @@ class HomeController @Inject() (environment: play.api.Environment, configuration
 
 Generally the components you use should not need to depend on the entire application, but sometimes you have to deal with legacy components that require one. You can handle this by injecting the application into one of your components:
 
-```
+```scala
 class FooController @Inject() (appProvider: Provider[Application]) extends Controller {
   implicit lazy val app = appProvider.get()
   def bar = Action {
@@ -180,7 +178,7 @@ Note that you usually want to use a `Provider[Application]` in this case to avoi
 
 Even better, you can make your own `*Api` class that turns the static methods into instance methods:
 
-```
+```scala
 class FooApi @Inject() (appProvider: Provider[Application]) {
   implicit lazy val app = appProvider.get()
   def bar = Foo.bar(app)


### PR DESCRIPTION
## Purpose

Fixes some small problems with migration guide for Play 2.5.0. This should be backward ported to branch 2.5.x.