### PR TITLE
Corrections and updates to Specs2 docs

### DIFF
--- a/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
@@ -5,22 +5,19 @@ Play provides a number of classes and convenience methods that assist with funct
 
 You can add these methods and classes by importing the following:
 
-```scala
-import play.api.test._
-import play.api.test.Helpers._
-```
+@[scalafunctionaltest-imports](code/specs2/ScalaFunctionalTestSpec.scala)
 
 ## Creating `Application` instances for testing
 
 Play frequently requires a running [`Application`](api/scala/play/api/Application.html) as context. If you're using the default Guice dependency injection, you can use the [`GuiceApplicationBuilder`](api/scala/play/api/inject/guice/GuiceApplicationBuilder.html) class which can be configured with different configuration, routes, or even additional modules.
 
-@[scalafunctionaltest-fakeApplication](code/specs2/ScalaFunctionalTestSpec.scala)
+@[scalafunctionaltest-application](code/specs2/ScalaFunctionalTestSpec.scala)
 
 ## WithApplication
 
 To pass in an application to an example, use [`WithApplication`](api/scala/play/api/test/WithApplication.html).  An explicit [`Application`](api/scala/play/api/Application.html) can be passed in, but a default application (created from the default `GuiceApplicationBuilder`) is provided for convenience.
 
-Because [`WithApplication`](api/scala/play/api/test/WithApplication.html) is a built in [`Around`](https://etorreborre.github.io/specs2/guide/SPECS2-3.4/org.specs2.guide.Contexts.html#aroundeach) block, you can override it to provide your own data population:
+Because [`WithApplication`](api/scala/play/api/test/WithApplication.html) is a built in [`Around`](https://etorreborre.github.io/specs2/guide/SPECS2-3.6.6/org.specs2.guide.Contexts.html#aroundeach) block, you can override it to provide your own data population:
 
 @[scalafunctionaltest-withdbdata](code/specs2/WithDbDataSpec.scala)
 
@@ -44,7 +41,7 @@ If you want to test your application using a browser, you can use [Selenium WebD
 
 ## PlaySpecification
 
-[`PlaySpecification`](api/scala/play/api/test/PlaySpecification.html) is an extension of [`Specification`](https://etorreborre.github.io/specs2/api/SPECS2-3.4/index.html#org.specs2.mutable.Specification) that excludes some of the mixins provided in the default specs2 specification that clash with Play helpers methods.  It also mixes in the Play test helpers and types for convenience.
+[`PlaySpecification`](api/scala/play/api/test/PlaySpecification.html) is an extension of [`Specification`](https://etorreborre.github.io/specs2/api/SPECS2-3.6.6/index.html#org.specs2.mutable.Specification) that excludes some of the mixins provided in the default specs2 specification that clash with Play helpers methods.  It also mixes in the Play test helpers and types for convenience.
 
 @[scalafunctionaltest-playspecification](code/specs2/ExamplePlaySpecificationSpec.scala)
 

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
@@ -13,9 +13,9 @@ You can run tests from the Play console.
 * To run only one test class, run `test-only` followed by the name of the class i.e. `test-only my.namespace.MySpec`.
 * To run only the tests that have failed, run `test-quick`.
 * To run tests continually, run a command with a tilde in front, i.e. `~test-quick`.
-* To access test helpers such as `FakeApplication` in console, run `test:console`.
+* To access test helpers such as `FakeRequest` in console, run `test:console`.
 
-Testing in Play is based on SBT, and a full description is available in the [testing SBT](http://www.scala-sbt.org/0.13.0/docs/Detailed-Topics/Testing) chapter.
+Testing in Play is based on SBT, and a full description is available in the [testing SBT](http://www.scala-sbt.org/0.13/docs/Testing.html) chapter.
 
 ## Using specs2
 
@@ -27,7 +27,7 @@ libraryDependencies += specs2 % Test
 
 In [specs2](https://etorreborre.github.io/specs2/), tests are organized into specifications, which contain examples which run the system under test through various different code paths.
 
-Specifications extend the [`Specification`](https://etorreborre.github.io/specs2/api/SPECS2-3.4/index.html#org.specs2.mutable.Specification) trait and are using the should/in format:
+Specifications extend the [`Specification`](https://etorreborre.github.io/specs2/api/SPECS2-3.6.6/index.html#org.specs2.mutable.Specification) trait and are using the should/in format:
 
 @[scalatest-helloworldspec](code/specs2/HelloWorldSpec.scala)
 
@@ -61,17 +61,17 @@ When you use an example, you must return an example result. Usually, you will se
 "Hello world" must endWith("world")
 ```
 
-The expression that follows the `must` keyword are known as [`matchers`](https://etorreborre.github.io/specs2/guide/SPECS2-3.4/org.specs2.guide.Matchers.html). Matchers return an example result, typically Success or Failure.  The example will not compile if it does not return a result.
+The expression that follows the `must` keyword are known as [`matchers`](https://etorreborre.github.io/specs2/guide/SPECS2-3.6.6/org.specs2.guide.Matchers.html). Matchers return an example result, typically Success or Failure.  The example will not compile if it does not return a result.
 
-The most useful matchers are the [match results](https://etorreborre.github.io/specs2/guide/SPECS2-3.4/org.specs2.guide.Matchers.html#out-of-the-box). These are used to check for equality, determine the result of Option and Either, and even check if exceptions are thrown.
+The most useful matchers are the [match results](https://etorreborre.github.io/specs2/guide/SPECS2-3.6.6/org.specs2.guide.Matchers.html#out-of-the-box). These are used to check for equality, determine the result of Option and Either, and even check if exceptions are thrown.
 
-There are also [optional matchers](https://etorreborre.github.io/specs2/guide/SPECS2-3.4/org.specs2.guide.Matchers.html#optional) that allow for XML and JSON matching in tests.
+There are also [optional matchers](https://etorreborre.github.io/specs2/guide/SPECS2-3.6.6/org.specs2.guide.Matchers.html#optional) that allow for XML and JSON matching in tests.
 
 ### Mockito
 
 Mocks are used to isolate unit tests against external dependencies.  For example, if your class depends on an external `DataService` class, you can feed appropriate data to your class without instantiating a `DataService` object.
 
-[Mockito](https://github.com/mockito/mockito) is integrated into specs2 as the default [mocking library](https://etorreborre.github.io/specs2/guide/SPECS2-3.4/org.specs2.guide.UseMockito.html).
+[Mockito](https://github.com/mockito/mockito) is integrated into specs2 as the default [mocking library](https://etorreborre.github.io/specs2/guide/SPECS2-3.6.6/org.specs2.guide.UseMockito.html).
 
 To use Mockito, add the following import:
 
@@ -131,11 +131,11 @@ In this way, the `isAdmin` method can be tested by mocking out the `UserReposito
 
 ## Unit Testing Controllers
 
-When defining controllers as objects, they can be trickier to unit test. In Play this can be alleviated by [[dependency injection|ScalaDependencyInjection]]. Another way to finesse unit testing with a controller declared as a object is to use a trait with an [explicitly typed self reference](http://www.naildrivin5.com/scalatour/wiki_pages/ExplcitlyTypedSelfReferences) to the controller:
+Since your controllers are just regular classes, you can easily unit test them using Play helpers. If your controllers depends on another classes, using [[dependency injection|ScalaDependencyInjection]] will enable you to mock these dependencies. Per instance, given the following controller:
 
 @[scalatest-examplecontroller](code/specs2/ExampleControllerSpec.scala)
 
-and then test the trait:
+You can test it like:
 
 @[scalatest-examplecontrollerspec](code/specs2/ExampleControllerSpec.scala)
 

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleControllerSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleControllerSpec.scala
@@ -10,11 +10,9 @@ import scala.concurrent.Future
 
 object ExampleControllerSpec extends PlaySpecification with Results {
 
-  class TestController() extends Controller with ExampleController
-
   "Example Page#index" should {
     "should be valid" in {
-      val controller = new TestController()
+      val controller = new ExampleController()
       val result: Future[Result] = controller.index().apply(FakeRequest())
       val bodyText: String = contentAsString(result)
       bodyText must be equalTo "ok"
@@ -24,13 +22,9 @@ object ExampleControllerSpec extends PlaySpecification with Results {
 // #scalatest-examplecontrollerspec
 
 // #scalatest-examplecontroller
-trait ExampleController {
-  this: Controller =>
-
+class ExampleController extends Controller {
   def index() = Action {
     Ok("ok")
   }
 }
-
-object ExampleController extends Controller with ExampleController
 // #scalatest-examplecontroller

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/FunctionalExampleControllerSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/FunctionalExampleControllerSpec.scala
@@ -6,7 +6,6 @@ package scalaguide.tests.specs2
 import scalaguide.tests.controllers
 
 import play.api.test._
-import play.api.test.Helpers._
 
 object FunctionalExampleControllerSpec extends PlaySpecification {
 

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/WithDbDataSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/WithDbDataSpec.scala
@@ -4,13 +4,9 @@
 package scalaguide.tests.specs2
 
 import play.api.test._
-import play.api.test.Helpers._
 
 import org.specs2.execute.{Result, AsResult}
 
-/**
- *
- */
 class WithDbDataSpec extends PlaySpecification {
 
   // #scalafunctionaltest-withdbdata


### PR DESCRIPTION
## Purpose

Small corrections and also updates to testing with specs2. This is related with other corrections made at #5799 (backported at #5807) and also playframework/scalatestplus-play#43. While these changes are pretty independent from each other, they are all related to fix some issues with docs for Play 2.5.0.