### PR TITLE
fix external link to Scalatest

### DIFF
--- a/documentation/manual/releases/release25/Highlights25.md
+++ b/documentation/manual/releases/release25/Highlights25.md
@@ -94,5 +94,5 @@ Play WS has been upgraded to AsyncHttpClient 2.0, and now includes a request pip
 
 ## ScalaTest Improvements
 
-Play has upgraded to [Scalatest 3.0](http://scalatest.org/release_notes/3.0.0) as the default Scala testing framework and example ScalaTests included with the seed templates.  For more information, please see [[Testing your Application with ScalaTest|ScalaTestingWithScalaTest]].
+Play has upgraded to [Scalatest 3.0](http://www.scalatest.org/release_notes/3.0.0) as the default Scala testing framework and example ScalaTests included with the seed templates.  For more information, please see [[Testing your Application with ScalaTest|ScalaTestingWithScalaTest]].
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fix external URL in documentation.

## Purpose

Fix external URL in documentation.

---

Current external link http://scalatest.org/release_notes/3.0.0 seems to
go to some Spotify-styled error page.

Updated link http://www.scalatest.org/release_notes/3.0.0 seems to
be the right one.