### PR TITLE
Add updated verbose debugging section

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/ws/DebuggingSSL.md
+++ b/documentation/manual/working/commonGuide/configuration/ws/DebuggingSSL.md
@@ -52,7 +52,7 @@ play.ws.ssl.debug = {
 
 ## Verbose Debugging
 
-To see the behavior of WS SSL, you can configuring the SLF4J logger `play.api.libs.ws.ssl` for debug output.  For example, in Logback you would configure:
+To see the behavior of WS SSL, you can configure the SLF4J logger `play.api.libs.ws.ssl` for debug output.  For example, if you are using Logback, in `conf/logback.xml` you would configure:
 
 ```
 <logger name="play.api.libs.ws.ssl" value="DEBUG"/>

--- a/documentation/manual/working/commonGuide/configuration/ws/DebuggingSSL.md
+++ b/documentation/manual/working/commonGuide/configuration/ws/DebuggingSSL.md
@@ -52,10 +52,10 @@ play.ws.ssl.debug = {
 
 ## Verbose Debugging
 
-To see the behavior of WS, you can configuring the SLF4J logger for debug output:
+To see the behavior of WS SSL, you can configuring the SLF4J logger `play.api.libs.ws.ssl` for debug output.  For example, in Logback you would configure:
 
 ```
-logger.play.api.libs.ws.ssl=DEBUG
+<logger name="play.api.libs.ws.ssl" value="DEBUG"/>
 ```
 
 ## Dynamic Debugging


### PR DESCRIPTION
## Fixes

Verbose logging section used a (very) obsolete example to show debug configuration.

## Purpose

Fix section to use logback style.
