### PR TITLE
Fixes #5826 disabledKeyAlgorithms and disabledSignatureAlgorithms are…

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/ws/CertificateValidation.md
+++ b/documentation/manual/working/commonGuide/configuration/ws/CertificateValidation.md
@@ -18,7 +18,7 @@ You can override this to your tastes, but it is recommended to be at least as st
 The default list of disabled signature algorithms is defined below:
 
 ```
-play.ws.ssl.disabledSignatureAlgorithms = "MD2, MD4, MD5"
+play.ws.ssl.disabledSignatureAlgorithms = ["MD2", "MD4", "MD5"]
 ```
 
 MD5 is disabled, based on the proven [collision attack](https://www.win.tue.nl/hashclash/rogue-ca/) and the Mozilla recommendations:
@@ -34,7 +34,7 @@ SHA-1 is considered weak, and new certificates should use digest algorithms from
 WS defines the default list of weak key sizes as follows:
 
 ```
-play.ws.ssl.disabledKeyAlgorithms = "DHE keySize < 2048, ECDH keySize < 2048, ECDHE keySize < 2048, RSA keySize < 2048, DSA keySize < 2048, EC keySize < 224"
+play.ws.ssl.disabledKeyAlgorithms = ["DHE keySize < 2048", "ECDH keySize < 2048", "ECDHE keySize < 2048", "RSA keySize < 2048", "DSA keySize < 2048", "EC keySize < 224"]
 ```
 
 These settings are based in part on [keylength.com](https://www.keylength.com/), and in part on the Mozilla recommendations:


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #5826

## Purpose

Changes the documentation slightly so that:

- play.ws.ssl.disabledSignatureAlgorithms
- play.ws.ssl.disabledKeyAlgorithms

could be configured correctly
