### PR TITLE
Rename CSRFComponents.csrfTokenSigner to be consistent with BuiltInComponents

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -281,13 +281,13 @@ class CSRFModule extends Module {
  */
 trait CSRFComponents {
   def configuration: Configuration
-  def tokenSigner: CSRFTokenSigner
+  def csrfTokenSigner: CSRFTokenSigner
   def httpErrorHandler: HttpErrorHandler
   implicit def materializer: Materializer
 
   lazy val csrfConfig: CSRFConfig = CSRFConfig.fromConfiguration(configuration)
-  lazy val csrfTokenProvider: CSRF.TokenProvider = new CSRF.TokenProviderProvider(csrfConfig, tokenSigner).get
+  lazy val csrfTokenProvider: CSRF.TokenProvider = new CSRF.TokenProviderProvider(csrfConfig, csrfTokenSigner).get
   lazy val csrfErrorHandler: CSRF.ErrorHandler = new CSRFHttpErrorHandler(httpErrorHandler)
-  lazy val csrfFilter: CSRFFilter = new CSRFFilter(csrfConfig, tokenSigner, csrfTokenProvider, csrfErrorHandler)
+  lazy val csrfFilter: CSRFFilter = new CSRFFilter(csrfConfig, csrfTokenSigner, csrfTokenProvider, csrfErrorHandler)
 
 }


### PR DESCRIPTION
Before the PR: the `CSRFTokenSigner` provided by `BuiltInComponents` was not automatically used by `CSRFComponents`: one had to explicitly alias it (`val tokenSigner = csrfTokenSigner`).