### PR TITLE
Minor improvements to Java documentation

### DIFF
--- a/documentation/manual/releases/release24/migration24/PluginsToModules.md
+++ b/documentation/manual/releases/release24/migration24/PluginsToModules.md
@@ -1,6 +1,8 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
 # Migrating Plugin to Module
 
+> **Note:** The deprecated `play.Plugin` system is removed as of 2.5.x.
+
 If you have implemented a Play plugin, please consider migrating your implementation to use [`play.api.inject.Module`](api/scala/play/api/inject/Module.html), instead of the deprecated Java `play.Plugin` or Scala `play.api.Plugin` types.
 
 The main difference between the old `Plugin` API, and the new one using `Module`, is that with the latter we are going to fully embrace Dependency Injection (DI) - you can read [[here|Highlights24#Dependency-Injection]] to understand why Play became opinionated about DI.
@@ -13,26 +15,25 @@ With the old `Plugin` API, you were required to provide a `play.plugins` file co
 
 Start by creating a class that inherits from `play.api.inject.Module`, and provide an implementation for the `bindings` method. In this method you should wire types to concrete implementation so that components provided by your module can be injected in users' code, or in other modules. Next follows an example.
 
-In Java
+In Java:
 
 @[module-decl](code24/MyModule.java)
 
-In Scala
+In Scala:
 
 @[module-decl](code24/MyModule.scala)
 
-
 Note that if a component you are defining requires another component, you should simply add the required component as a constructor's dependency, prepending the constructor with the `@javax.inject.Inject` annotation. The DI framework will then take care of the rest.
 
-> Note that if a component B requires A, then B will be initialized only after A is initialized.
+> **Note:** if a component B requires A, then B will be initialized only after A is initialized.
 
 Next follows an example of a component named `MyComponentImpl` requiring the `ApplicationLifecycle` component.
 
-In Java
+In Java:
 
 @[components-decl](code24/MyComponent.java)
 
-In Scala
+In Scala:
 
 @[components-decl](code24/MyComponent.scala)
 
@@ -46,7 +47,7 @@ play.modules.enabled  += "my.module.MyModule"
 
 If you are working on a library that will be used by other projects (including sub projects), add the above line in your `reference.conf` file (if you don't have a `reference.conf` yet, create one and place it under `src/main/resources`). Otherwise, if it's in an end Play project, it should be in `application.conf`.
 
-> Note: If you are working on a library, it is highly discouraged to use `play.modules.disabled` to disable modules, as it can lead to undetermistic results when modules are loaded by the application (see [this issue](https://github.com/playframework/play-slick/issues/245) for reasons on why you should not touch `play.modules.disabled`). In fact, `play.modules.disabled` is intended for end users to be able to override what modules are enabled by default.
+> **Note:** If you are working on a library, it is highly discouraged to use `play.modules.disabled` to disable modules, as it can lead to nondeterministic results when modules are loaded by the application (see [this issue](https://github.com/playframework/play-slick/issues/245) for reasons on why you should not touch `play.modules.disabled`). In fact, `play.modules.disabled` is intended for end users to be able to override what modules are enabled by default.
 
 ### Compile-time DI
 

--- a/documentation/manual/working/commonGuide/build/SBTDependencies.md
+++ b/documentation/manual/working/commonGuide/build/SBTDependencies.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
 # Managing library dependencies
 
-> **Note**: Some sections of this page were copied from sbt manual, specifically from the [Library Dependencies](http://www.scala-sbt.org/0.13/docs/Library-Dependencies.html) page. Please, for a most updated version.
+> **Note:** Some sections of this page were copied from sbt manual, specifically from the [Library Dependencies](http://www.scala-sbt.org/0.13/docs/Library-Dependencies.html) page. Please, for a most updated version.
 
 ## Unmanaged dependencies
 

--- a/documentation/manual/working/javaGuide/advanced/routing/RequestBinders.md
+++ b/documentation/manual/working/javaGuide/advanced/routing/RequestBinders.md
@@ -5,19 +5,19 @@ Play provides a mechanism to bind types from path or query string parameters.
 
 ## PathBindable
 
-PathBindable allows to bind business objects from the URL path; this means we’ll be able to define routes like `/user/3` to call an action such as the following:
+[PathBindable](api/java/play/mvc/PathBindable.html) allows to bind business objects from the URL path; this means we’ll be able to define routes like `/user/3` to call an action such as the following:
 
-- `controller`
+### `controller`
 
 @[path](code/javaguide/binder/controllers/BinderApplication.java)
 
 The `user` parameter will automatically be retrieved using the id extracted from the URL path, e.g. with the following route definition:
 
-- `/conf/routes`
+### `/conf/routes`
 
 @[user](code/javaguide.binder.routes)
 
-Any type T that implements [`PathBindable`](api/java/play/mvc/PathBindable.html) can be bound to/from a path parameter.
+Any type `T` that implements [`PathBindable`](api/java/play/mvc/PathBindable.html) can be bound to/from a path parameter.
 It defines abstract methods `bind` (build a value from the path) and `unbind` (build a path fragment from a value).
 
 For a class like:
@@ -28,22 +28,21 @@ A simple example of the binder's use binding the `:id` path parameter:
 
 @[bind](code/javaguide/binder/models/User.java)
 
+In this example `findById` method is invoked to retrieve `User` instance.
 
-In this example findById method is invoked to retrieve `User` instance; note that in real world such method should be lightweight and not involve e.g. DB access, because the code is called on the server IO thread and must be totally non-blocking.
-
-You would therefore for example use simple objects identifier as path bindable, and retrieve the real values using action composition.
+> **Note:** in a real application such method should be lightweight and not involve e.g. DB access, because the code is called on the server IO thread and must be totally non-blocking. You would therefore for example use simple objects identifier as path bindable, and retrieve the real values using action composition.
 
 ## QueryStringBindable
 
 A similar mechanism is used for query string parameters; a route like `/age` can be defined to call an action such as:
 
-- `controller`
+### `controller`
 
 @[query](code/javaguide/binder/controllers/BinderApplication.java)
 
 The `age` parameter will automatically be retrieved using parameters extracted from the query string e.g. `/age?from=1&to=10`
 
-Any type T that implements [`QueryStringBindable`](api/java/play/mvc/QueryStringBindable.html) can be bound to/from query one or more query string parameters. Similar to [`PathBindable`](api/java/play/mvc/PathBindable.html), it defines abstract methods `bind` and `unbind`.
+Any type `T` that implements [`QueryStringBindable`](api/java/play/mvc/QueryStringBindable.html) can be bound to/from query one or more query string parameters. Similar to [`PathBindable`](api/java/play/mvc/PathBindable.html), it defines abstract methods `bind` and `unbind`.
 
 For a class like:
 

--- a/documentation/manual/working/javaGuide/main/JavaHome.md
+++ b/documentation/manual/working/javaGuide/main/JavaHome.md
@@ -3,6 +3,6 @@
 
 This section introduces you to the most common aspects of writing a Play application in Java. You'll learn about handling HTTP requests, sending HTTP responses, working with different types of data, using databases and much more.
 
-> Note: The Play APIs for Java and Scala are separated into different packages. All the Java APIs are under the `play` package; all the Scala APIs are under `play.api`. For example, the Java MVC API is under `play.mvc` and the Scala MVC API is under `play.api.mvc`.
+> **Note:** The Play APIs for Java and Scala are separated into different packages. All the Java APIs are under the `play` package; all the Scala APIs are under `play.api`. For example, the Java MVC API is under `play.mvc` and the Scala MVC API is under `play.api.mvc`.
 
 @toc@

--- a/documentation/manual/working/javaGuide/main/akka/JavaAkka.md
+++ b/documentation/manual/working/javaGuide/main/akka/JavaAkka.md
@@ -117,7 +117,7 @@ By default the name of the Play actor system is `application`. You can change th
 play.akka.actor-system = "custom-name"
 ```
 
-> **Note:** This feature is useful if you want to put your play application ActorSystem in an akka cluster.
+> **Note:** This feature is useful if you want to put your play application `ActorSystem` in an akka cluster.
 
 ## Executing a block of code asynchronously
 

--- a/documentation/manual/working/javaGuide/main/application/JavaEssentialAction.md
+++ b/documentation/manual/working/javaGuide/main/application/JavaEssentialAction.md
@@ -3,9 +3,9 @@
 
 ## What is EssentialAction?
 
-EssentialAction is the underlying functional type used by Play's HTTP APIs. This differs from the `Action` type in Java, a higher-level type that accepts a `Context` and returns a `CompletionStage<Result>`. Most of the time you will not need to use `EssentialAction` directly in a Java application, but it can be useful when writing filters or interacting with other low-level Play APIs.
+[`EssentialAction`](api/java/play/mvc/EssentialAction.html) is the underlying functional type used by Play's HTTP APIs. This differs from the `Action` type in Java, a higher-level type that accepts a `Context` and returns a `CompletionStage<Result>`. Most of the time you will not need to use `EssentialAction` directly in a Java application, but it can be useful when writing filters or interacting with other low-level Play APIs.
 
-To understand EssentialAction we need to understand the Play architecture.
+To understand `EssentialAction` we need to understand the Play architecture.
 
 The core of Play is really small, surrounded by a fair amount of useful APIs, services and structure to make Web Programming tasks easier.
 
@@ -29,13 +29,13 @@ What we need to change is the second arrow to make it receive its input in chunk
 RequestHeader -> Accumulator<ByteString, Result>
 ```
 
-Ultimately, our Java type looks like 
+Ultimately, our Java type looks like:
 
 ```java
 Function<RequestHeader, Accumulator<ByteString, Result>>
 ```
 
-And this should read as: Take the request headers, take chunks of `ByteString` which represent the request body and eventually return a `Result`. This exactly how the `EssentialAction`'s apply method is defined
+And this should read as: Take the request headers, take chunks of `ByteString` which represent the request body and eventually return a `Result`. This exactly how the `EssentialAction`'s apply method is defined:
 
 ```java
 public abstract Accumulator<ByteString, Result> apply(RequestHeader requestHeader);

--- a/documentation/manual/working/javaGuide/main/application/JavaHttpFilters.md
+++ b/documentation/manual/working/javaGuide/main/application/JavaHttpFilters.md
@@ -37,13 +37,13 @@ If you want to have different filters in different environments, or would prefer
 
 ## Where do filters fit in?
 
-Filters wrap the action after the action has been looked up by the router.  This means you cannot use a filter to transform a path, method or query parameter to impact the router. However you can direct the request to a different action by invoking that action directly from the filter, though be aware that this will bypass the rest of the filter chain. If you do need to modify the request before the router is invoked, a better way to do this would be to place your logic in `Global.onRouteRequest` instead.
+Filters wrap the action after the action has been looked up by the router.  This means you cannot use a filter to transform a path, method or query parameter to impact the router. However you can direct the request to a different action by invoking that action directly from the filter, though be aware that this will bypass the rest of the filter chain. If you do need to modify the request before the router is invoked, a better way to do this would be to place your logic in [[ a `HttpRequestHandler`|JavaActionCreator#HTTP-request-handlers]] instead.
 
 Since filters are applied after routing is done, it is possible to access routing information from the request, via the `tags` map on the `RequestHeader`. For example, you might want to log the time against the action method. In that case, you might update the filter to look like this:
 
 @[routing-info-access](code/javaguide/application/httpfilters/RoutedLoggingFilter.java)
 
-> Routing tags are a feature of the Play router.  If you use a custom router, or return a custom action in `Global.onRouteRequest`, these parameters may not be available.
+> **Note:** Routing tags are a feature of the Play router. If you use a custom router these parameters may not be available.
 
 ## More powerful filters
 
@@ -55,4 +55,4 @@ Here is the above filter example rewritten as an `EssentialFilter`:
 
 The key difference here, apart from creating a new `EssentialAction` to wrap the passed in `next` action, is when we invoke next, we get back an [`Accumulator`](api/java/play/libs/streams/Accumulator.html).  You could compose this with an Akka streams Flow using the `through` method some transformations to the stream if you wished.  We then `map` the result of the iteratee and thus handle it.
 
-> Although it may seem that there are two different filter APIs, there is only one, `EssentialFilter`.  The simpler `Filter` API in the earlier examples extends `EssentialFilter`, and implements it by creating a new `EssentialAction`.  The passed in callback makes it appear to skip the body parsing by creating a promise for the `Result`, while the body parsing and the rest of the action are executed asynchronously.
+> **Note:** Although it may seem that there are two different filter APIs, there is only one, `EssentialFilter`.  The simpler `Filter` API in the earlier examples extends `EssentialFilter`, and implements it by creating a new `EssentialAction`.  The passed in callback makes it appear to skip the body parsing by creating a promise for the `Result`, while the body parsing and the rest of the action are executed asynchronously.

--- a/documentation/manual/working/javaGuide/main/async/JavaComet.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaComet.md
@@ -47,7 +47,7 @@ For an example of a Comet helper, see the [Play 2.5 Clock Template](https://gith
 
 ## Debugging Comet
 
-The easiest way to debug a Comet stream that is not working is to use the [`log()`](http://doc.akka.io/docs/akka-stream-and-http-experimental/2.0.3/java/stream-cookbook.html#Logging_elements_of_a_stream) operation to show any errors involved in mapping data through the stream.
+The easiest way to debug a Comet stream that is not working is to use the [`log()`](http://doc.akka.io/docs/akka/2.4.2/java/stream/stream-cookbook.html#Logging_elements_of_a_stream) operation to show any errors involved in mapping data through the stream.
 
 ## Legacy Comet Functionality
 

--- a/documentation/manual/working/javaGuide/main/async/JavaStream.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaStream.md
@@ -11,7 +11,7 @@ By default, when you send a simple result, such as:
 
 You are not specifying a `Content-Length` header. Of course, because the content you are sending is well known, Play is able to compute the content size for you and to generate the appropriate header.
 
-> **Note** that for text-based content this is not as simple as it looks, since the `Content-Length` header must be computed according the encoding used to translate characters to bytes.
+> **Note:** for text-based content this is not as simple as it looks, since the `Content-Length` header must be computed according the encoding used to translate characters to bytes.
 
 To be able to compute the `Content-Length` header properly, Play must consume the whole response data and load its content into memory.
 

--- a/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
@@ -5,6 +5,8 @@
 
 Modern HTML5 compliant web browsers natively support WebSockets via a JavaScript WebSocket API.  However WebSockets are not limited in just being used by WebBrowsers, there are many WebSocket client libraries available, allowing for example servers to talk to each other, and also native mobile apps to use WebSockets.  Using WebSockets in these contexts has the advantage of being able to reuse the existing TCP port that a Play server uses.
 
+> **Tip:** Check [caniuse.com](http://caniuse.com/#feat=websockets) to see more about which browsers supports WebSockets, known issues and more information.
+
 ## Handling WebSockets
 
 Until now, we've been writing methods that return `Result` to handle standard HTTP requests.  WebSockets are quite different and can’t be handled via standard Play actions.

--- a/documentation/manual/working/javaGuide/main/cache/JavaCache.md
+++ b/documentation/manual/working/javaGuide/main/cache/JavaCache.md
@@ -11,12 +11,7 @@ The default implementation of the cache API uses [EHCache](http://www.ehcache.or
 
 Add `cache` into your dependencies list. For example, in `build.sbt`:
 
-```scala
-libraryDependencies ++= Seq(
-  cache,
-  ...
-)
-```
+@[cache-sbt-dependencies](code/cache.sbt)
 
 ## Accessing the Cache API
 
@@ -78,6 +73,6 @@ To replace the default implementation, you'll need to disable the default implem
 play.modules.disabled += "play.api.cache.EhCacheModule"
 ```
 
-Then simply implement CacheApi and bind it in the DI container.
+Then simply implement [CacheApi](api/java/play/cache/CacheApi.html) and bind it in the DI container.
 
 To provide an implementation of the cache API in addition to the default implementation, you can either create a custom qualifier, or reuse the `NamedCache` qualifier to bind the implementation.

--- a/documentation/manual/working/javaGuide/main/cache/code/cache.sbt
+++ b/documentation/manual/working/javaGuide/main/cache/code/cache.sbt
@@ -1,0 +1,9 @@
+//
+// Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+//
+
+//#cache-sbt-dependencies
+libraryDependencies ++= Seq(
+  cache
+)
+//#cache-sbt-dependencies

--- a/documentation/manual/working/javaGuide/main/forms/JavaCsrf.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaCsrf.md
@@ -31,7 +31,7 @@ play.filters.csrf.headers.bypassHeaders {
   X-Requested-With = "*"
   Csrf-Token = "nocheck"
 }
-``
+```
 
 Caution should be taken when using this configuration option, as historically browser plugins have undermined this type of CSRF defence.
 

--- a/documentation/manual/working/javaGuide/main/forms/JavaForms.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaForms.md
@@ -13,7 +13,7 @@ To wrap a class you have to inject a `play.data.FormFactory` into your Controlle
 
 @[create](code/javaguide/forms/JavaForms.java)
 
-> **Note:** The underlying binding is done using [Spring data binder](https://docs.spring.io/spring/docs/3.0.x/reference/validation.html).
+> **Note:** The underlying binding is done using [Spring data binder](https://docs.spring.io/spring/docs/4.2.4.RELEASE/spring-framework-reference/html/validation.html).
 
 This form can generate a `User` result value from `HashMap<String,String>` data:
 
@@ -97,4 +97,4 @@ When the binding fails an array of errors keys is created, the first one defined
 
     ["error.invalid.<fieldName>", "error.invalid.<type>", "error.invalid"]
 
-The errors keys are created by [Spring DefaultMessageCodesResolver](http://static.springsource.org/spring/docs/3.0.7.RELEASE/javadoc-api/org/springframework/validation/DefaultMessageCodesResolver.html), the root "typeMismatch" is replaced by "error.invalid".
+The errors keys are created by [Spring DefaultMessageCodesResolver](https://docs.spring.io/spring/docs/4.2.4.RELEASE/javadoc-api/org/springframework/validation/DefaultMessageCodesResolver.html), the root "typeMismatch" is replaced by "error.invalid".

--- a/documentation/manual/working/javaGuide/main/http/JavaActionsComposition.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaActionsComposition.md
@@ -53,14 +53,7 @@ You can then use your new annotation with an action method:
 
 You can also put any action composition annotation directly on the `Controller` class. In this case it will be applied to all action methods defined by this controller.
 
-```java
-@Authenticated
-public class Admin extends Controller {
-    
-  …
-    
-}
-```
+@[annotated-controller](code/javaguide/http/JavaActionsComposition.java)
 
 > **Note:** If you want the action composition annotation(s) put on a ```Controller``` class to be executed before the one(s) put on action methods set ```play.http.actionComposition.controllerAnnotationsFirst = true``` in ```application.conf```. However, be aware that if you use a third party module in your project it may rely on a certain execution order of its annotations.
 

--- a/documentation/manual/working/javaGuide/main/http/JavaBodyParsers.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaBodyParsers.md
@@ -5,7 +5,7 @@
 
 An HTTP request is a header followed by a body.  The header is typically small - it can be safely buffered in memory, hence in Play it is modelled using the [`RequestHeader`](api/java/play/mvc/Http.RequestHeader.html) class.  The body however can be potentially very long, and so is not buffered in memory, but rather is modelled as a stream.  However, many request body payloads are small and can be modelled in memory, and so to map the body stream to an object in memory, Play provides a [`BodyParser`](api/java/play/mvc/BodyParser.html) abstraction.
 
-Since Play is an asynchronous framework, the traditional `InputStream` can't be used to read the request body - input streams are blocking, when you invoke `read`, the thread invoking it must wait for data to be available.  Instead, Play uses an asynchronous streaming library called [Akka streams](http://doc.akka.io/docs/akka-stream-and-http-experimental/1.0/java.html).  Akka streams is an implementation of [Reactive Streams](http://www.reactive-streams.org/), a SPI that allows many asynchronous streaming APIs to seamlessly work together, so though traditional `InputStream` based technologies are not suitable for use with Play, Akka streams and the entire ecosystem of asynchronous libraries around Reactive Streams will provide you with everything you need.
+Since Play is an asynchronous framework, the traditional `InputStream` can't be used to read the request body - input streams are blocking, when you invoke `read`, the thread invoking it must wait for data to be available.  Instead, Play uses an asynchronous streaming library called [Akka streams](http://doc.akka.io/docs/akka/2.4.2/java/stream/index.html).  Akka streams is an implementation of [Reactive Streams](http://www.reactive-streams.org/), a SPI that allows many asynchronous streaming APIs to seamlessly work together, so though traditional `InputStream` based technologies are not suitable for use with Play, Akka streams and the entire ecosystem of asynchronous libraries around Reactive Streams will provide you with everything you need.
 
 ## Using the built in body parsers
 
@@ -21,11 +21,11 @@ The request body can be accessed through the `body()` method on [`Request`](api/
 
 The following is a mapping of types supported by the default body parser:
 
-- **text/plain**: `String`, accessible via `asText()`.
-- **application/json**: `com.fasterxml.jackson.databind.JsonNode`, accessible via `asJson()`.
-- **application/xml**, **text/xml** or **application/XXX+xml**: `org.w3c.Document`, accessible via `asXml()`.
-- **application/form-url-encoded**: `Map<String, String[]>`, accessible via `asFormUrlEncoded()`.
-- **multipart/form-data**: [`MultipartFormData`](api/java/play/mvc/Http.MultipartFormData.html), accessible via `asMultipartFormData()`.
+- **`text/plain`**: `String`, accessible via `asText()`.
+- **`application/json`**: `com.fasterxml.jackson.databind.JsonNode`, accessible via `asJson()`.
+- **`application/xml`**, **`text/xml`** or **`application/XXX+xml`**: `org.w3c.Document`, accessible via `asXml()`.
+- **`application/form-url-encoded`**: `Map<String, String[]>`, accessible via `asFormUrlEncoded()`.
+- **`multipart/form-data`**: [`MultipartFormData`](api/java/play/mvc/Http.MultipartFormData.html), accessible via `asMultipartFormData()`.
 - Any other content type: [`RawBuffer`](api/java/play/mvc/Http.RawBuffer.html), accessible via `asRaw()`.
 
 The default body parser, for performance reasons, won't attempt to parse the body if the request method is not defined to have a meaningful body, as defined by the HTTP spec.  This means it only parses bodies of `POST`, `PUT` and `PATCH` requests, but not `GET`, `HEAD` or `DELETE`.  If you would like to parse request bodies for these methods, you can use the `AnyContent` body parser, described [below](#Choosing-an-explicit-body-parser).
@@ -72,9 +72,9 @@ The signature of this method may be a bit daunting at first, so let's break it d
 
 The method takes a [`RequestHeader`](api/java/play/mvc/Http.RequestHeader.html).  This can be used to check information about the request - most commonly, it is used to get the `Content-Type`, so that the body can be correctly parsed.
 
-The return type of the method is an [`Accumulator`](api/java/play/libs/streams/Accumulator.html).  An accumulator is a thin layer around an [Akka streams](http://doc.akka.io/docs/akka-stream-and-http-experimental/1.0/java.html) [`Sink`](http://doc.akka.io/japi/akka-stream-and-http-experimental/1.0/akka/stream/javadsl/Sink.html).  An accumulator asynchronously accumulates streams of elements into a result, it can be run by passing in an Akka streams [`Source`](http://doc.akka.io/japi/akka-stream-and-http-experimental/1.0/akka/stream/javadsl/Source.html), this will return a `CompletionStage` that will be redeemed when the accumulator is complete.  It is essentially the same thing as a `Sink<E, CompletionStage<A>>`, in fact it is nothing more than a wrapper around this type, but the big difference is that `Accumulator` provides convenient methods such as `map`, `mapFuture`, `recover` etc. for working with the result as if it were a promise, where `Sink` requires all such operations to be wrapped in a `mapMaterializedValue` call.
+The return type of the method is an [`Accumulator`](api/java/play/libs/streams/Accumulator.html).  An accumulator is a thin layer around an [Akka streams](http://doc.akka.io/docs/akka/2.4.2/java/stream/index.html) [`Sink`](http://doc.akka.io/japi/akka/2.4.2/akka/stream/javadsl/Sink.html).  An accumulator asynchronously accumulates streams of elements into a result, it can be run by passing in an Akka streams [`Source`](http://doc.akka.io/japi/akka/2.4.2/akka/stream/javadsl/Source.html), this will return a `CompletionStage` that will be redeemed when the accumulator is complete.  It is essentially the same thing as a `Sink<E, CompletionStage<A>>`, in fact it is nothing more than a wrapper around this type, but the big difference is that `Accumulator` provides convenient methods such as `map`, `mapFuture`, `recover` etc. for working with the result as if it were a promise, where `Sink` requires all such operations to be wrapped in a `mapMaterializedValue` call.
 
-The accumulator that the `apply` method returns consumes elements of type [`ByteString`](http://doc.akka.io/japi/akka/2.3.10/akka/util/ByteString.html) - these are essentially arrays of bytes, but differ from `byte[]` in that `ByteString` is immutable, and many operations such as slicing and appending happen in constant time.
+The accumulator that the `apply` method returns consumes elements of type [`ByteString`](http://doc.akka.io/japi/akka/2.4.2/akka/util/ByteString.html) - these are essentially arrays of bytes, but differ from `byte[]` in that `ByteString` is immutable, and many operations such as slicing and appending happen in constant time.
 
 The return type of the accumulator is `F.Either<Result, A>`.  This says it will either return a `Result`, or it will return a body of type `A`.  A result is generally returned in the case of an error, for example, if the body failed to be parsed, if the `Content-Type` didn't match the type that the body parser accepts, or if an in memory buffer was exceeded.  When the body parser returns a result, this will short circuit the processing of the action - the body parsers result will be returned immediately, and the action will never be invoked.
 
@@ -112,6 +112,6 @@ In rare circumstances, it may be necessary to write a custom parser using Akka s
 
 However, when that's not feasible, for example when the body you need to parse is too long to fit in memory, then you may need to write a custom body parser.
 
-A full description of how to use Akka streams is beyond the scope of this documentation - the best place to start is to read the [Akka streams documentation](http://doc.akka.io/docs/akka-stream-and-http-experimental/1.0/java.html).  However, the following shows a CSV parser, which builds on the [Parsing lines from a stream of ByteStrings](http://doc.akka.io/docs/akka-stream-and-http-experimental/1.0/java/stream-cookbook.html#Parsing_lines_from_a_stream_of_ByteStrings) documentation from the Akka streams cookbook:
+A full description of how to use Akka streams is beyond the scope of this documentation - the best place to start is to read the [Akka streams documentation](http://doc.akka.io/docs/akka/2.4.2/java/stream/index.html).  However, the following shows a CSV parser, which builds on the [Parsing lines from a stream of ByteStrings](http://doc.akka.io/docs/akka/2.4.2/java/stream/stream-cookbook.html#Parsing_lines_from_a_stream_of_ByteStrings) documentation from the Akka streams cookbook:
 
 @[csv](code/javaguide/http/JavaBodyParsers.java)

--- a/documentation/manual/working/javaGuide/main/http/JavaContentNegotiation.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaContentNegotiation.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
 # Content negotiation
 
-Content negotiation is a mechanism that makes it possible to serve different representation of a same resource (URI). It is useful *e.g.* for writing Web Services supporting several output formats (XML, JSON, etc.). Server-driven negotiation is essentially performed using the `Accept*` requests headers. You can find more information on content negotiation in the [HTTP specification](http://www.w3.org/Protocols/rfc2616/rfc2616-sec12.html).
+[Content negotiation](https://en.wikipedia.org/wiki/Content_negotiation) is a mechanism that makes it possible to serve different representation of a same resource (URI). It is useful *e.g.* for writing Web Services supporting several output formats (XML, JSON, etc.). Server-driven negotiation is essentially performed using the `Accept*` requests headers. You can find more information on content negotiation in the [HTTP specification](http://www.w3.org/Protocols/rfc2616/rfc2616-sec12.html).
 
 ## Language
 

--- a/documentation/manual/working/javaGuide/main/http/JavaRouting.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaRouting.md
@@ -32,7 +32,7 @@ Let’s see what a route definition looks like:
 
 @[clients-show](code/javaguide.http.routing.routes)
 
-> Note that in the action call, the parameter type comes after the parameter name, like in Scala.
+> **Note:** in the action call, the parameter type comes after the parameter name, like in Scala.
 
 Each route starts with the HTTP method, followed by the URI pattern. The last element of a route is the call definition.
 
@@ -42,7 +42,7 @@ You can also add comments to the route file, with the `#` character:
 
 ## The HTTP method
 
-The HTTP method can be any of the valid methods supported by HTTP (`GET`, `PATCH`, `POST`, `PUT`, `DELETE`, `HEAD`).
+The HTTP method can be any of the valid methods supported by HTTP (`GET`, `PATCH`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`).
 
 ## The URI pattern
 
@@ -60,7 +60,7 @@ If you want to define a route that, say, retrieves a client by id, you need to a
 
 @[clients-show](code/javaguide.http.routing.routes)
 
-> Note that a URI pattern may have more than one dynamic part.
+> **Note:** A URI pattern may have more than one dynamic part.
 
 The default matching strategy for a dynamic part is defined by the regular expression `[^/]+`, meaning that any dynamic part defined as `:id` will match exactly one URI path segment.
 
@@ -156,4 +156,4 @@ You can then reverse the URL to the `hello` action method, by using the `control
 
 ## Advanced Routing
 
-See [[Routing DSL|JavaRoutingDsl]]
+See [[Routing DSL|JavaRoutingDsl]].

--- a/documentation/manual/working/javaGuide/main/http/JavaSessionFlash.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaSessionFlash.md
@@ -9,7 +9,7 @@ It’s important to understand that Session and Flash data are not stored in the
 
 Cookies are signed with a secret key so the client can’t modify the cookie data (or it will be invalidated). The Play session is not intended to be used as a cache. If you need to cache some data related to a specific session, you can use the Play built-in cache mechanism and use the session to store a unique ID to associate the cached data with a specific user.
 
-> There is no technical timeout for the session, which expires when the user closes the web browser. If you need a functional timeout for a specific application, just store a timestamp into the user Session and use it however your application needs (e.g. for a maximum session duration, maximum inactivity duration, etc.).
+> **Note:** There is no technical timeout for the session, which expires when the user closes the web browser. If you need a functional timeout for a specific application, just store a timestamp into the user Session and use it however your application needs (e.g. for a maximum session duration, maximum inactivity duration, etc.).
 
 ## Storing data into the Session
 

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActionsComposition.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActionsComposition.java
@@ -15,9 +15,6 @@ import java.lang.annotation.Target;
 
 import java.util.concurrent.CompletionStage;
 
-/**
- *
- */
 public class JavaActionsComposition extends Controller {
 
     // #verbose-action
@@ -92,4 +89,11 @@ public class JavaActionsComposition extends Controller {
     }
     // #pass-arg-action-index
 
+    // #annotated-controller
+    @Security.Authenticated
+    public class Admin extends Controller {
+        /// ###insert: ...
+
+    }
+    // #annotated-controller
 }

--- a/documentation/manual/working/javaGuide/main/i18n/JavaI18N.md
+++ b/documentation/manual/working/javaGuide/main/i18n/JavaI18N.md
@@ -19,9 +19,7 @@ The default `conf/messages` file matches all languages. You can specify addition
 
 You can retrieve messages for the _current language_ using the `play.i18n.Messages` object:
 
-```
-String title = Messages.get("home.title")
-```
+@[current-lang-render](code/javaguide/i18n/JavaI18N.java)
 
 The _current language_ is found by looking at the `lang` field in the current [`Context`](api/java/play/mvc/Http.Context.html). If there's no current `Context` then the default language is used. The `Context`'s `lang` value is determined by:
 

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/JavaI18N.java
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/JavaI18N.java
@@ -36,6 +36,9 @@ public class JavaI18N extends WithApplication {
 
     @Test
     public void checkSpecifyLangHello() {
+        //#current-lang-render
+        String message = Messages.get("home.title");
+        //#current-lang-render
         //#specify-lang-render
         String title = Messages.get(Lang.forCode("fr"), "hello");
         //#specify-lang-render

--- a/documentation/manual/working/javaGuide/main/json/JavaJsonActions.md
+++ b/documentation/manual/working/javaGuide/main/json/JavaJsonActions.md
@@ -31,7 +31,7 @@ Of course it’s way better (and simpler) to specify our own `BodyParser` to ask
 
 > **Note:** This way, a 400 HTTP response will be automatically returned for non JSON requests with Content-type set to application/json.
 
-You can test it with **cURL** from a command line:
+You can test it with **`curl`** from a command line:
 
 ```bash
 curl
@@ -74,6 +74,6 @@ You can also return a Java object and have it automatically serialized to JSON b
 
 Because Play uses Jackson, you can use your own `ObjectMapper` to create `JsonNode`s. The [documentation for jackson-databind](https://github.com/FasterXML/jackson-databind/blob/master/README.md) explains how you can further customize JSON conversion process.
 
-If you would like to use Play's `Json` APIs (`toJson`/`fromJson`) with a customized `ObjectMapper`, you can add something like this in your `GlobalSettings#onStart`:
+If you would like to use Play's `Json` APIs (`toJson`/`fromJson`) with a customized `ObjectMapper`, you can create a custom [[`ApplicationLoader`|JavaApplication]]:
 
-@[custom-object-mapper](code/javaguide/json/JavaJsonActions.java)
+@[custom-apploader-object-mapper](code/javaguide/json/JavaJsonCustomObjectMapper.java)

--- a/documentation/manual/working/javaGuide/main/json/code/javaguide/json/JavaJsonActions.java
+++ b/documentation/manual/working/javaGuide/main/json/code/javaguide/json/JavaJsonActions.java
@@ -1,7 +1,7 @@
-package javaguide.json;
 /*
  * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
  */
+package javaguide.json;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +29,7 @@ public class JavaJsonActions extends WithApplication {
 
     //#person-class
     // Note: can use getters/setters as well; here we just use public fields directly.
-    // if using getters/setters, you can keep keep the fields `protected` or `private`
+    // if using getters/setters, you can keep the fields `protected` or `private`
     public static class Person {
         public String firstName;
         public String lastName;
@@ -62,19 +62,6 @@ public class JavaJsonActions extends WithApplication {
         assertThat(personJson.get("firstName").asText(), equalTo("Foo"));
         assertThat(personJson.get("lastName").asText(), equalTo("Bar"));
         assertThat(personJson.get("age").asInt(), equalTo(30));
-    }
-
-    @Test
-    public void customObjectMapper() {
-        //#custom-object-mapper
-        ObjectMapper mapper = new ObjectMapper()
-            // enable features and customize the object mapper here ...
-            .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
-            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-            // etc.
-        Json.setObjectMapper(mapper);
-        //#custom-object-mapper
-        assertThat(Json.mapper(), equalTo(mapper));
     }
 
     @Test

--- a/documentation/manual/working/javaGuide/main/json/code/javaguide/json/JavaJsonCustomObjectMapper.java
+++ b/documentation/manual/working/javaGuide/main/json/code/javaguide/json/JavaJsonCustomObjectMapper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package javaguide.json;
+
+import play.Application;
+import play.ApplicationLoader;
+import play.inject.guice.GuiceApplicationBuilder;
+import play.inject.guice.GuiceApplicationLoader;
+
+import play.libs.Json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+
+public class JavaJsonCustomObjectMapper {
+
+    //#custom-apploader-object-mapper
+    public class ObjectMapperApplicationLoader extends GuiceApplicationLoader {
+        @Override
+        public GuiceApplicationBuilder builder(Context context) {
+            ObjectMapper mapper = Json.newDefaultMapper()
+                    // enable features and customize the object mapper here ...
+                    .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+                    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+                    // etc.
+            Json.setObjectMapper(mapper);
+            return super.builder(context);
+        }
+    }
+    //#custom-apploader-object-mapper
+}

--- a/documentation/manual/working/javaGuide/main/logging/JavaLogging.md
+++ b/documentation/manual/working/javaGuide/main/logging/JavaLogging.md
@@ -8,6 +8,7 @@ Using logging in your application can be useful for monitoring, debugging, error
 The logging API uses a set of components that help you to implement an effective logging strategy.
 
 #### Logger
+
 Your application can define loggers to send log message requests. Each logger has a name which will appear in log messages and is used for configuration.  
 
 Loggers follow a hierarchical inheritance structure based on their naming. A logger is said to be an ancestor of another logger if its name followed by a dot is the prefix of descendant logger name. For example, a logger named "com.foo" is the ancestor of a logger named "com.foo.bar.Baz." All loggers inherit from a root logger. Logger inheritance allows you to configure a set of loggers by configuring a common ancestor.
@@ -15,6 +16,7 @@ Loggers follow a hierarchical inheritance structure based on their naming. A log
 Play applications are provided a default logger named "application" or you can create your own loggers. The Play libraries use a logger named "play", and some third party libraries will have loggers with their own names.
 
 #### Log levels
+
 Log levels are used to classify the severity of log messages. When you write a log request statement you will specify the severity and this will appear in generated log messages.
 
 This is the set of available log levels, in decreasing order of severity.
@@ -29,18 +31,21 @@ This is the set of available log levels, in decreasing order of severity.
 In addition to classifying messages, log levels are used to configure severity thresholds on loggers and appenders. For example, a logger set to level `INFO` will log any request of level `INFO` or higher (`INFO`, `WARN`, `ERROR`) but will ignore requests of lower severities (`DEBUG`, `TRACE`). Using `OFF` will ignore all log requests.
 
 #### Appenders
+
 The logging API allows logging requests to print to one or many output destinations called "appenders." Appenders are specified in configuration and options exist for the console, files, databases, and other outputs.
 
 Appenders combined with loggers can help you route and filter log messages. For example, you could use one appender for a logger that logs useful data for analytics and another appender for errors that is monitored by an operations team.
 
-> Note: For further information on architecture, see the [Logback documentation](http://logback.qos.ch/manual/architecture.html).
+> **Note:** For further information on architecture, see the [Logback documentation](http://logback.qos.ch/manual/architecture.html).
 
 ## Using Loggers
+
 First import the `Logger` class:
 
 @[logging-import](code/javaguide/logging/JavaLogging.java)
 
-#### The default Logger
+### The default Logger
+
 The `Logger` class serves as the default logger using the name "application." You can use it to write log request statements:
 
 @[logging-default-logger](code/javaguide/logging/JavaLogging.java)
@@ -60,7 +65,7 @@ java.lang.ArithmeticException: / by zero
 
 Note that the messages have the log level, logger name, message, and stack trace if a Throwable was used in the log request.
 
-#### Creating your own loggers
+### Creating your own loggers
 
 Although it may be tempting to use the default logger everywhere, it's generally a bad design practice. Creating your own loggers with distinct names allows for flexible configuration, filtering of log output, and pinpointing the source of log messages.
 
@@ -72,7 +77,7 @@ A common strategy for logging application events is to use a distinct logger per
 
 @[logging-create-logger-class](code/javaguide/logging/JavaLogging.java)
 
-#### Logging patterns
+### Logging patterns
 
 Effective use of loggers can help you achieve many goals with the same tool:
 

--- a/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
@@ -54,7 +54,7 @@ Running Play in development mode while using JPA will work fine, but in order to
 
 @[jpa-externalize-resources](code/jpa.sbt)
 
-Since Play 2.4 the contents of the `conf` directory are added to the classpath by default. This option will disable that behavior and allow a JPA application to be deployed. Note that the content of conf directory will still be available in the classpath due to it being included in the application's jar file.
+> **Note:** Since Play 2.4 the contents of the `conf` directory are added to the classpath by default. This option will disable that behavior and allow a JPA application to be deployed. The content of conf directory will still be available in the classpath due to it being included in the application's jar file.
 
 ## Annotating JPA actions with `@Transactional`
 

--- a/documentation/manual/working/javaGuide/main/tests/JavaFunctionalTest.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaFunctionalTest.md
@@ -5,10 +5,7 @@ Play provides a number of classes and convenience methods that assist with funct
 
 You can add these methods and classes by importing the following:
 
-```java
-import play.test.*;
-import static play.test.Helpers.*;
-```
+@[test-imports](code/javaguide/tests/FakeApplicationTest.java)
 
 ## Creating `Application` instances for testing
 

--- a/documentation/manual/working/javaGuide/main/tests/JavaTest.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTest.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
 # Testing your application
 
-Writing tests for your application can be an involved process. Play supports JUnit and provides helpers and application stubs to make testing your application as easy as possible.
+Writing tests for your application can be an involved process. Play supports [JUnit](http://junit.org/) and provides helpers and application stubs to make testing your application as easy as possible.
 
 ## Overview
 
@@ -15,11 +15,11 @@ You can run tests from the Activator console.
 * To run tests continually, run a command with a tilde in front, i.e. `~testQuick`.
 * To access test helpers such as `FakeApplication` in console, run `test:console`.
 
-Testing in Play is based on [sbt](http://www.scala-sbt.org/), and a full description is available in the [testing documentation](http://www.scala-sbt.org/release/docs/Detailed-Topics/Testing.html).
+Testing in Play is based on [sbt](http://www.scala-sbt.org/), and a full description is available in the [testing documentation](http://www.scala-sbt.org/release/docs/Testing.html).
 
 ## Using JUnit
 
-The default way to test a Play application is with [JUnit](http://www.junit.org/).
+The default way to test a Play application is with [JUnit](http://junit.org/).
 
 @[test-simple](code/javaguide/tests/SimpleTest.java)
 
@@ -39,7 +39,7 @@ The default way to test a Play application is with [JUnit](http://www.junit.org/
 
 Some developers prefer to write their assertions in a more fluent style than JUnit asserts. Popular libraries for other assertion styles are included for convenience.
 
-Hamcrest matchers:
+[Hamcrest](http://hamcrest.org/JavaHamcrest/) matchers:
 
 @[test-hamcrest](code/javaguide/tests/HamcrestTest.java)
 
@@ -75,17 +75,7 @@ In this way, the `UserService.isAdmin` method can be tested by mocking the `User
 
 @[test-model-test](code/javaguide/tests/ModelTest.java)
 
-> **Note:** Applications using Ebean ORM may be written to rely on Play's automatic getter/setter generation.  Play also rewrites field accesses to use the generated getters/setters.  Ebean relies on calls to the setters to do dirty checking.  In order to use these patterns in JUnit tests, you will need to enable Play's field access rewriting in test by adding the following to `build.sbt`:
-
-> ```scala
-> compile in Test <<= PostCompile(Test)
-> ```
->
-> You may also need the following import at the top of your `build.sbt`:
->
-> ```scala
-> import play.Play._
-> ```
+> **Note:** Applications using Ebean ORM may be written to rely on Play's automatic getter/setter generation. If this is your case, check how [[Play enhancer sbt plugin|PlayEnhancer]] works.
 
 ## Unit testing controllers
 
@@ -93,7 +83,7 @@ You can test your controllers using Play's [test helpers](api/java/play/test/Hel
 
 @[test-controller-test](code/javaguide/tests/ApplicationTest.java)
 
-You can also retrieve an action reference from the reverse router and invoke it. This also allows you to use `FakeRequest` which is a mock for request data:
+You can also retrieve an action reference from the reverse router and invoke it. This also allows you to use [`FakeRequest`](api/java/play/test/FakeRequest.html) which is a mock for request data:
 
 @[test-controller-routes](code/javaguide/tests/ApplicationTest.java)
 

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ApplicationTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ApplicationTest.java
@@ -58,6 +58,7 @@ public class ApplicationTest extends WithApplication {
   //#test-template
   @Test
   public void renderTemplate() {
+    //###replace:     Content html = views.html.index.render("Welcome to Play!");
     Content html = javaguide.tests.html.index.render("Welcome to Play!");
     assertEquals("text/html", html.contentType());
     assertTrue(contentAsString(html).contains("Welcome to Play!"));

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/FakeApplicationTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/FakeApplicationTest.java
@@ -3,10 +3,13 @@
  */
 package javaguide.tests;
 
+//#test-imports
+import play.test.*;
 import static play.test.Helpers.*;
-import static org.junit.Assert.*;
+//#test-imports
 
 import org.junit.Test;
+import static org.junit.Assert.*;
 
 import play.Application;
 import play.GlobalSettings;

--- a/documentation/manual/working/javaGuide/main/ws/JavaOAuth.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaOAuth.md
@@ -9,11 +9,7 @@ There are two very different versions of OAuth: [OAuth 1.0](https://tools.ietf.o
 
 To use OAuth, first add `javaWs`  to your `build.sbt` file:
 
-```scala
-libraryDependencies ++= Seq(
-  javaWs
-)
-```
+@[javaws-sbt-dependencies](code/javaws.sbt)
 
 ## Required Information
 

--- a/documentation/manual/working/javaGuide/main/ws/JavaOpenID.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaOpenID.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
 # OpenID Support in Play
 
-OpenID is a protocol for users to access several services with a single account. As a web developer, you can use OpenID to offer users a way to log in using an account they already have, such as their [Google account](https://developers.google.com/accounts/docs/OpenID). In the enterprise, you may be able to use OpenID to connect to a company’s SSO server.
+[OpenID](http://openid.net/get-an-openid/what-is-openid/) is a protocol for users to access several services with a single account. As a web developer, you can use OpenID to offer users a way to log in using an account they already have, such as their [Google account](https://developers.google.com/accounts/docs/OpenID). In the enterprise, you may be able to use OpenID to connect to a company’s SSO server.
 
 ## The OpenID flow in a nutshell
 
@@ -16,11 +16,7 @@ Step 1 may be omitted if all your users are using the same OpenID provider (for 
 
 To use OpenID, first add `javaWs`  to your `build.sbt` file:
 
-```scala
-libraryDependencies ++= Seq(
-  javaWs
-)
-```
+@[javaws-sbt-dependencies](code/javaws.sbt)
 
 Now any controller or component that wants to use OpenID will have to declare a dependency on the [OpenIdClient](api/java/play/libs/openid/OpenIdClient.html).
 
@@ -38,7 +34,7 @@ If the `CompletionStage` fails, you can define a fallback, which redirects back 
 
 @[ws-openid-routes](code/javaguide.ws.routes)
 
-controller:
+Controller:
 
 @[ws-openid-controller](code/javaguide/ws/controllers/OpenIDController.java)
 

--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -3,19 +3,15 @@
 
 Sometimes we would like to call other HTTP services from within a Play application. Play supports this via its [WS library](api/java/play/libs/ws/package-summary.html), which provides a way to make asynchronous HTTP calls.
 
-There are two important parts to using the WS API: making a request, and processing the response. We'll discuss how to make both GET and POST HTTP requests first, and then show how to process the response from the WS. Finally, we'll discuss some common use cases.
+There are two important parts to using the WS API: making a request, and processing the response. We'll discuss how to make both GET and POST HTTP requests first, and then show how to process the response from the WS library. Finally, we'll discuss some common use cases.
 
 ## Making a Request
 
 To use WS, first add `javaWs` to your `build.sbt` file:
 
-```scala
-libraryDependencies ++= Seq(
-  javaWs
-)
-```
+@[javaws-sbt-dependencies](code/javaws.sbt)
 
-Now any controller or component that wants to use WS will have to add the following imports and then declare a dependency on the `WSClient` type to use dependency injection:
+Now any controller or component that wants to use WS will have to add the following imports and then declare a dependency on the [`WSClient`](api/java/play/libs/ws/WSClient.html) type to use dependency injection:
 
 @[ws-controller](code/javaguide/ws/Application.java)
 
@@ -160,9 +156,13 @@ You can map a `CompletionStage<WSResponse>` to a `CompletionStage<Result>` that 
 
 ## Using WSClient
 
-We recommend that you get your `WSClient` instances using dependency injection as described above. `WSClient` instances created through dependency injection are simpler to use because they are automatically created when the application starts and cleaned up when the application stops.
+We recommend that you get your `WSClient` instances using [[dependency injection|JavaDependencyInjection]] as described above. `WSClient` instances created through dependency injection are simpler to use because they are automatically created when the application starts and cleaned up when the application stops.
 
-However, if you choose, you can instantiate a `WSClient` directly from code and use this for making requests or for configuring underlying `AsyncHttpClient` options. **If you create a WSClient manually then you _must_ call `client.close()` to clean it up when you've finished with it.** Each client creates its own thread pool. If you fail to close the client or if you create too many clients then you will run out of threads or file handles -— you'll get errors like "Unable to create new native thread" or "too many open files" as the underlying resources are consumed.
+However, if you choose, you can instantiate a `WSClient` directly from code and use this for making requests or for configuring underlying `AsyncHttpClient` options.
+
+> **Note:** If you create a `WSClient` manually then you **must** call `client.close()` to clean it up when you've finished with it. Each client creates its own thread pool. If you fail to close the client or if you create too many clients then you will run out of threads or file handles -— you'll get errors like "Unable to create new native thread" or "too many open files" as the underlying resources are consumed.
+
+Here is an example of how to create a `WSClient` instance by yourself:
 
 @[ws-custom-client-imports](code/javaguide/ws/JavaWS.java)
 
@@ -174,18 +174,18 @@ Once you are done with your custom client work, you **must** close the client:
 
 @[ws-close-client](code/javaguide/ws/JavaWS.java)
 
-Ideally, you should only close a client after you know all requests have been completed.  You should not use try-with-resources to automatically close a WSClient instance, because WSClient logic is asynchronous and try-with-resources only supports synchronous code in its body.
+Ideally, you should only close a client after you know all requests have been completed.  You should not use [`try-with-resources`](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) to automatically close a WSClient instance, because WSClient logic is asynchronous and `try-with-resources` only supports synchronous code in its body.
 
 ## Accessing AsyncHttpClient
 
-You can get access to the underlying [AsyncHttpClient](http://static.javadoc.io/org.asynchttpclient/async-http-client/2.0.0-RC7/org/asynchttpclient/AsyncHttpClient.html) from a `WSClient`.
+You can get access to the underlying [AsyncHttpClient](http://static.javadoc.io/org.asynchttpclient/async-http-client/2.0.0-RC9/org/asynchttpclient/AsyncHttpClient.html) from a `WSClient`.
 
 @[ws-underlying-client](code/javaguide/ws/JavaWS.java)
 
-This is important in a couple of cases.  WS has a couple of limitations that require access to the underlying client:
+This is important in a couple of cases. The WS library has a couple of limitations that require access to the underlying client:
 
-* `WS` does not support multi part form upload directly.  You can use the underlying client with [RequestBuilder.addBodyPart](http://static.javadoc.io/org.asynchttpclient/async-http-client/2.0.0-RC7/org/asynchttpclient/RequestBuilderBase.html#addBodyPart-org.asynchttpclient.request.body.multipart.Part-).
-* `WS` does not support streaming body upload.  In this case, you should use the `FeedableBodyGenerator` provided by AsyncHttpClient.
+* `WS` does not support multi part form upload directly.  You can use the underlying client with [RequestBuilder.addBodyPart](http://static.javadoc.io/org.asynchttpclient/async-http-client/2.0.0-RC9/org/asynchttpclient/RequestBuilderBase.html#addBodyPart-org.asynchttpclient.request.body.multipart.Part-).
+* `WS` does not support streaming body upload.  In this case, you should use the [`FeedableBodyGenerator`](http://static.javadoc.io/org.asynchttpclient/async-http-client/2.0.0-RC9/org/asynchttpclient/request/body/generator/FeedableBodyGenerator.html) provided by AsyncHttpClient.
 
 ## Configuring WS
 
@@ -214,7 +214,7 @@ To configure WS for use with HTTP over SSL/TLS (HTTPS), please see [[Configuring
 
 The following advanced settings can be configured on the underlying AsyncHttpClientConfig.
 
-Please refer to the [AsyncHttpClientConfig Documentation](http://static.javadoc.io/org.asynchttpclient/async-http-client/2.0.0-RC7/org/asynchttpclient/DefaultAsyncHttpClientConfig.Builder.html) for more information.
+Please refer to the [AsyncHttpClientConfig Documentation](http://static.javadoc.io/org.asynchttpclient/async-http-client/2.0.0-RC9/org/asynchttpclient/DefaultAsyncHttpClientConfig.Builder.html) for more information.
 
 > **Note:** `allowPoolingConnection` and `allowSslConnectionPool` are combined in AsyncHttpClient 2.0 into a single `keepAlive` variable.  As such, `play.ws.ning.allowPoolingConnection` and `play.ws.ning.allowSslConnectionPool` are not valid and will throw an exception if configured.
 

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -204,8 +204,8 @@ public class JavaWS {
                     // Get the content type
                     String contentType =
                             Optional.ofNullable(responseHeaders.getHeaders().get("Content-Type"))
-                                    .map(contentTypes -> contentTypes.get(0)).
-                                    orElse("application/octet-stream");
+                                    .map(contentTypes -> contentTypes.get(0))
+                                    .orElse("application/octet-stream");
 
                     // If there's a content length, send that, otherwise return the body chunked
                     Optional<String> contentLength = Optional.ofNullable(responseHeaders.getHeaders()

--- a/documentation/manual/working/javaGuide/main/ws/code/javaws.sbt
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaws.sbt
@@ -1,0 +1,9 @@
+//
+// Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+//
+
+//#javaws-sbt-dependencies
+libraryDependencies ++= Seq(
+  javaWs
+)
+//#javaws-sbt-dependencies

--- a/documentation/manual/working/javaGuide/main/xml/JavaXmlRequests.md
+++ b/documentation/manual/working/javaGuide/main/xml/JavaXmlRequests.md
@@ -15,9 +15,9 @@ Of course it’s way better (and simpler) to specify our own `BodyParser` to ask
 
 > **Note:** This way, a 400 HTTP response will be automatically returned for non-XML requests.
 
-You can test it with **cURL** on the command line:
+You can test it with **`curl`** on the command line:
 
-```
+```bash
 curl 
   --header "Content-type: application/xml" 
   --request POST 

--- a/documentation/manual/working/javaGuide/main/xml/code/javaguide/xml/JavaXmlRequests.java
+++ b/documentation/manual/working/javaGuide/main/xml/code/javaguide/xml/JavaXmlRequests.java
@@ -5,59 +5,58 @@ package javaguide.xml;
 
 import org.w3c.dom.Document;
 import play.libs.XPath;
-
 import play.mvc.BodyParser;
 import play.mvc.Controller;
 import play.mvc.Result;
 
 public class JavaXmlRequests extends Controller {
-	//#xml-hello
-	public static Result sayHello() {
-	  Document dom = request().body().asXml();
-	  if(dom == null) {
-		return badRequest("Expecting Xml data");
-	  } else {
-		String name = XPath.selectText("//name", dom);
-		if(name == null) {
-		  return badRequest("Missing parameter [name]");
-		} else {
-		  return ok("Hello " + name);
-		}
-	  }
-	}
-	//#xml-hello
-	
-	//#xml-hello-bodyparser
-	@BodyParser.Of(BodyParser.Xml.class)
-	public static Result sayHelloBP() {
-	  Document dom = request().body().asXml();
-	  if(dom == null) {
-		return badRequest("Expecting Xml data");
-	  } else {
-		String name = XPath.selectText("//name", dom);
-		if(name == null) {
-		  return badRequest("Missing parameter [name]");
-		} else {
-		  return ok("Hello " + name);
-		}
-	  }
-	}
-	//#xml-hello-bodyparser
-	
-	//#xml-reply
-	@BodyParser.Of(BodyParser.Xml.class)
-	public static Result replyHello() {
-	  Document dom = request().body().asXml();
-	  if(dom == null) {
-		return badRequest("Expecting Xml data");
-	  } else {
-		String name = XPath.selectText("//name", dom);
-		if(name == null) {
-		  return badRequest("<message \"status\"=\"KO\">Missing parameter [name]</message>");
-		} else {
-		  return ok("<message \"status\"=\"OK\">Hello " + name + "</message>");
-		}
-	  }
-	}
-	//#xml-reply
+    //#xml-hello
+    public Result sayHello() {
+        Document dom = request().body().asXml();
+        if (dom == null) {
+            return badRequest("Expecting Xml data");
+        } else {
+            String name = XPath.selectText("//name", dom);
+            if (name == null) {
+                return badRequest("Missing parameter [name]");
+            } else {
+                return ok("Hello " + name);
+            }
+        }
+    }
+    //#xml-hello
+
+    //#xml-hello-bodyparser
+    @BodyParser.Of(BodyParser.Xml.class)
+    public Result sayHelloBP() {
+        Document dom = request().body().asXml();
+        if (dom == null) {
+            return badRequest("Expecting Xml data");
+        } else {
+            String name = XPath.selectText("//name", dom);
+            if (name == null) {
+                return badRequest("Missing parameter [name]");
+            } else {
+                return ok("Hello " + name);
+            }
+        }
+    }
+    //#xml-hello-bodyparser
+
+    //#xml-reply
+    @BodyParser.Of(BodyParser.Xml.class)
+    public Result replyHello() {
+        Document dom = request().body().asXml();
+        if (dom == null) {
+            return badRequest("Expecting Xml data");
+        } else {
+            String name = XPath.selectText("//name", dom);
+            if (name == null) {
+                return badRequest("<message \"status\"=\"KO\">Missing parameter [name]</message>").as("application/xml");
+            } else {
+                return ok("<message \"status\"=\"OK\">Hello " + name + "</message>").as("application/xml");
+            }
+        }
+    }
+    //#xml-reply
 }

--- a/documentation/manual/working/scalaGuide/main/async/ScalaStream.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaStream.md
@@ -15,7 +15,7 @@ def index = Action {
 
 Of course, because the content you are sending is well-known, Play is able to compute the content size for you and to generate the appropriate header.
 
-> **Note** that for text-based content it is not as simple as it looks, since the `Content-Length` header must be computed according the character encoding used to translate characters to bytes.
+> **Note**: for text-based content it is not as simple as it looks, since the `Content-Length` header must be computed according the character encoding used to translate characters to bytes.
 
 Actually, we previously saw that the response body is specified using a `play.api.libs.iteratee.Enumerator`:
 

--- a/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
@@ -5,6 +5,8 @@
 
 Modern HTML5 compliant web browsers natively support WebSockets via a JavaScript WebSocket API.  However WebSockets are not limited in just being used by WebBrowsers, there are many WebSocket client libraries available, allowing for example servers to talk to each other, and also native mobile apps to use WebSockets.  Using WebSockets in these contexts has the advantage of being able to reuse the existing TCP port that a Play server uses.
 
+> **Tip:** Check [caniuse.com](http://caniuse.com/#feat=websockets) to see more about which browsers supports WebSockets, known issues and more information.
+
 ## Handling WebSockets
 
 Until now, we were using `Action` instances to handle standard HTTP requests and send back standard HTTP responses. WebSockets are a totally different beast and can’t be handled via standard `Action`.

--- a/documentation/manual/working/scalaGuide/main/upload/ScalaFileUpload.md
+++ b/documentation/manual/working/scalaGuide/main/upload/ScalaFileUpload.md
@@ -5,7 +5,7 @@
 
 The standard way to upload files in a web application is to use a form with a special `multipart/form-data` encoding, which lets you mix standard form data with file attachment data. 
 
-> **Note**: The HTTP method used to submit the form must be `POST` (not `GET`). 
+> **Note:** The HTTP method used to submit the form must be `POST` (not `GET`).
 
 Start by writing an HTML form:
 


### PR DESCRIPTION
## Fixes

Possible #4864.

## Purpose

A lot of minor improvements to Java documentation. 

1. Correct some small markdown format issues and punctuations
2. Correct some links to external docs to match dependencies versions
3. Remove some deprecated examples
4. Extract embedded code to snippet files
5. Remove/update outdated information

This also possible fixes #4864.

## Background Context

While this PR changes a lot of things, it is pretty simple and straightforward. It is focused in improve the documentation and it can backported safety to branch 2.5.x. I will probably submit another PR doing the same kind of revision for Scala version of the docs.

