### PR TITLE
Remove references to build script

### DIFF
--- a/framework/bin/checkCodeStyle
+++ b/framework/bin/checkCodeStyle
@@ -9,7 +9,7 @@ cd $FRAMEWORK
 build clean scalariformFormat test:scalariformFormat
 git diff --exit-code || (
   echo "ERROR: Scalariform check failed, see differences above."
-  echo "To fix, format your sources using ./build scalariformFormat test:scalariformFormat before submitting a pull request."
+  echo "To fix, format your sources using sbt scalariformFormat test:scalariformFormat before submitting a pull request."
   echo "Additionally, please squash your commits (eg, use git commit --amend) if you're going to update this pull request."
   false
 )

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/debug/DebugConfigurationSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/debug/DebugConfigurationSpec.scala
@@ -19,7 +19,7 @@ object DebugConfigurationSpec extends Specification with After {
   sequential // global settings, must be sequential
 
   // Loggers not needed, but useful to doublecheck that the code is doing what it should.
-  // ./build test-only play.api.libs.ws.ssl.debug.DebugConfigurationSpec
+  // sbt 'test-only play.api.libs.ws.ssl.debug.DebugConfigurationSpec'
   val internalDebugLogger = org.slf4j.LoggerFactory.getLogger("play.api.libs.ws.ssl.debug.FixInternalDebugLogging")
   val certpathDebugLogger = org.slf4j.LoggerFactory.getLogger("play.api.libs.ws.ssl.debug.FixCertpathDebugLogging")
 


### PR DESCRIPTION
The `./build` script was removed in #5648 but we still refer to it in a couple places.