### PR TITLE
ctx().messages() takes current lang into account now

### DIFF
--- a/documentation/manual/working/scalaGuide/advanced/extending/code/ScalaExtendingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/extending/code/ScalaExtendingPlay.scala
@@ -17,7 +17,9 @@ object ScalaExtendingPlay extends Specification {
     override def messages: Map[String, Map[String, String]] = ???
     override def preferred(candidates: Seq[Lang]): Messages = ???
     override def preferred(request: mvc.RequestHeader): Messages = ???
+    override def preferred(request: mvc.RequestHeader, ctxLang: Lang): Messages = ???
     override def preferred(request: RequestHeader): Messages = ???
+    override def preferred(request: RequestHeader, ctxLang: Lang): Messages = ???
     override def langCookieHttpOnly: Boolean = ???
     override def clearLang(result: Result): Result = ???
     override def langCookieSecure: Boolean = ???

--- a/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
@@ -84,6 +84,8 @@ public class HttpTest {
             // The language and cookie should now be 'en-US'
             assertThat(ctx.lang().code()).isEqualTo("en-US");
             assertThat(responseLangCookie(ctx)).isEqualTo("en-US");
+            // ctx.messages() takes the language which is set now into account
+            assertThat(ctx.messages().at("hello")).isEqualTo("Aloha");
         });
     }
 
@@ -130,6 +132,8 @@ public class HttpTest {
             // The language should now be 'en-US', but the cookie mustn't be set
             assertThat(ctx.lang().code()).isEqualTo("en-US");
             assertThat(responseLangCookie(ctx)).isNull();
+            // ctx.messages() takes the language which is set now into account
+            assertThat(ctx.messages().at("hello")).isEqualTo("Aloha");
         });
     }
 

--- a/framework/src/play-java/src/test/resources/messages.en-US
+++ b/framework/src/play-java/src/test/resources/messages.en-US
@@ -1,2 +1,3 @@
 customFormats.date=MM-dd-yyyy
 formats.date=dd/MM/yyyy
+hello=Aloha

--- a/framework/src/play/src/main/java/play/i18n/MessagesApi.java
+++ b/framework/src/play/src/main/java/play/i18n/MessagesApi.java
@@ -122,16 +122,30 @@ public class MessagesApi {
 
 
     /**
-     * Get a messages context appropriate for the given candidates.
+     * Get a messages context appropriate for the given request.
      *
-     * Will select a language from the candidates, based on the languages available, and fallback to the default language
+     * Will select a language from the request, based on the languages available, and fallback to the default language
      * if none of the candidates are available.
      *
      * @param request the incoming request
      * @return the preferred messages context for the request
      */
     public Messages preferred(Http.RequestHeader request) {
-        play.api.i18n.Messages msgs = messages.preferred(request);
+        return preferred(request, null);
+    }
+
+    /**
+     * Get a messages context appropriate for the given request.
+     *
+     * Will select a language from the request and the current context lang, based on the languages available, and fallback to the default language
+     * if none of the candidates are available.
+     *
+     * @param request the incoming request
+     * @param ctxLang the language of the current context
+     * @return the preferred messages context for the request
+     */
+    public Messages preferred(Http.RequestHeader request, Lang ctxLang) {
+        play.api.i18n.Messages msgs = messages.preferred(request, ctxLang);
         return new Messages(new Lang(msgs.lang()), this);
     }
 

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -188,7 +188,7 @@ public class Http {
          * @return the messages for the current lang
          */
         public Messages messages() {
-            return messagesApi().preferred(request());
+            return messagesApi().preferred(request(), lang);
         }
 
         /**

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -408,9 +408,19 @@ trait MessagesApi {
   def preferred(request: RequestHeader): Messages
 
   /**
+   * Get the preferred messages for the given request and the current context lang
+   */
+  def preferred(request: RequestHeader, ctxLang: Lang): Messages
+
+  /**
    * Get the preferred messages for the given Java request
    */
   def preferred(request: play.mvc.Http.RequestHeader): Messages
+
+  /**
+   * Get the preferred messages for the given Java request and the current context lang
+   */
+  def preferred(request: play.mvc.Http.RequestHeader, ctxLang: Lang): Messages
 
   /**
    * Set the language on the result
@@ -483,14 +493,19 @@ class DefaultMessagesApi @Inject() (environment: Environment, configuration: Con
 
   def preferred(candidates: Seq[Lang]) = Messages(langs.preferred(candidates), this)
 
-  def preferred(request: RequestHeader) = {
+  def preferred(request: RequestHeader) = preferred(request, null)
+
+  def preferred(request: RequestHeader, ctxLang: Lang) = {
+    val maybeLangFromContext = Option(ctxLang)
     val maybeLangFromCookie = request.cookies.get(langCookieName)
       .flatMap(c => Lang.get(c.value))
-    val lang = langs.preferred(maybeLangFromCookie.toSeq ++ request.acceptLanguages)
+    val lang = langs.preferred(maybeLangFromContext.toSeq ++ maybeLangFromCookie.toSeq ++ request.acceptLanguages)
     Messages(lang, this)
   }
 
-  def preferred(request: Http.RequestHeader) = preferred(request._underlyingHeader())
+  def preferred(request: Http.RequestHeader) = preferred(request, null)
+
+  def preferred(request: Http.RequestHeader, ctxLang: Lang) = preferred(request._underlyingHeader(), ctxLang)
 
   def setLang(result: Result, lang: Lang) = result.withCookies(Cookie(langCookieName, lang.code, path = Session.path, domain = Session.domain,
     secure = langCookieSecure, httpOnly = langCookieHttpOnly))


### PR DESCRIPTION
Fixes #5875 

`ctx().messages()` [says](https://github.com/playframework/playframework/blob/2.5.0/framework/src/play/src/main/java/play/mvc/Http.java#L187) it `returns the messages for the current lang` but that isn't true. It just uses the request, but doesn't care about the `lang` variable, which could be altered be `changeLang()` or `setTransientLang()`.

A more detailed explanation can be found here: https://github.com/playframework/playframework/issues/5875#issuecomment-196322682