### PR TITLE
[Backport] Allow all language tags supported by java.util.Locale

### DIFF
--- a/documentation/manual/working/javaGuide/main/i18n/JavaI18N.md
+++ b/documentation/manual/working/javaGuide/main/i18n/JavaI18N.md
@@ -3,17 +3,19 @@
 
 ## Specifying languages supported by your application
 
-To specify your application’s languages, you need a valid language code, specified by a valid **ISO Language Code**, optionally followed by a valid **ISO Country Code**. For example, `fr` or `en-US`.
+You specify languages for your application using language tags, specially formatted strings that identify a specific language. Language tags can specify simple languages, such as "en" for English, a specific regional dialect of a language (such as "en-AU" for English as used in Australia), a language and a script (such as "az-Latn" for Azerbaijani written in Latin script), or a combination of several of these (such as "zh-cmn-Hans-CN" for Chinese, Mandarin, Simplified script, as used in China).
 
-To start, you need to specify the languages that your application supports in its `conf/application.conf` file:
+To start you need to specify the languages supported by your application in the `conf/application.conf` file:
 
 ```
 play.i18n.langs = [ "en", "en-US", "fr" ]
 ```
 
+These language tags will be validated used to create `Lang` instances. To access the languages supported by your application, you can inject a `Langs` instance into your component.
+
 ## Externalizing messages
 
-You can externalize messages in the `conf/messages.xxx` files. 
+You can externalize messages in the `conf/messages.xxx` files.
 
 The default `conf/messages` file matches all languages. You can specify additional language messages files, such as `conf/messages.fr` or `conf/messages.en-US`.
 

--- a/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
+++ b/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
@@ -3,13 +3,15 @@
 
 ## Specifying languages supported by your application
 
-A valid language code is specified by a valid **ISO 639-2 language code**, optionally followed by a valid **ISO 3166-1 alpha-2 country code**, such as `fr` or `en-US`.
+You specify languages for your application using language tags, specially formatted strings that identify a specific language. Language tags can specify simple languages, such as "en" for English, a specific regional dialect of a language (such as "en-AU" for English as used in Australia), a language and a script (such as "az-Latn" for Azerbaijani written in Latin script), or a combination of several of these (such as "zh-cmn-Hans-CN" for Chinese, Mandarin, Simplified script, as used in China).
 
 To start you need to specify the languages supported by your application in the `conf/application.conf` file:
 
 ```
 play.i18n.langs = [ "en", "en-US", "fr" ]
 ```
+
+These language tags will be validated used to create `Lang` instances. To access the languages supported by your application, you can inject a `Langs` instance into your component.
 
 ## Externalizing messages
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/i18n/LangSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/i18n/LangSpec.scala
@@ -3,42 +3,44 @@
  */
 package play.it.i18n
 
-import play.api.i18n.Lang
+import play.api.i18n.{ Lang, Langs }
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test._
 
 class LangSpec extends PlaySpecification {
   "lang spec" should {
     "allow selecting preferred language" in {
-      implicit val app = GuiceApplicationBuilder().configure("play.i18n.langs" -> Seq("en-US", "es-ES", "de")).build()
-      val esEs = Lang("es", "ES")
+      val esEs = Lang("es-ES")
       val es = Lang("es")
-      val deDe = Lang("de", "DE")
+      val deDe = Lang("de-DE")
       val de = Lang("de")
-      val enUs = Lang("en", "US")
+      val enUs = Lang("en-US")
+
+      implicit val app = GuiceApplicationBuilder().configure("play.i18n.langs" -> Seq(enUs, esEs, de).map(_.code)).build()
+      val langs = app.injector.instanceOf[Langs]
 
       "with exact match" in {
-        Lang.preferred(Seq(esEs)) must_== esEs
+        langs.preferred(Seq(esEs)) must_== esEs
       }
 
       "with just language match" in {
-        Lang.preferred(Seq(de)) must_== de
+        langs.preferred(Seq(de)) must_== de
       }
 
       "with just language match country specific" in {
-        Lang.preferred(Seq(es)) must_== esEs
+        langs.preferred(Seq(es)) must_== esEs
       }
 
       "with language and country not match just language" in {
-        Lang.preferred(Seq(deDe)) must_== enUs
+        langs.preferred(Seq(deDe)) must_== enUs
       }
 
       "with case insensitive match" in {
-        Lang.preferred(Seq(Lang("ES", "es"))) must_== esEs
+        langs.preferred(Seq(Lang("ES-es"))) must_== esEs
       }
 
       "in order" in {
-        Lang.preferred(Seq(esEs, enUs)) must_== esEs
+        langs.preferred(Seq(esEs, enUs)) must_== esEs
       }
     }
 
@@ -47,6 +49,8 @@ class LangSpec extends PlaySpecification {
       Lang.get("EN-us") must_== Lang.get("en-US")
       Lang.get("ES-419") must_== Lang.get("es-419")
       Lang.get("en-us").hashCode must_== Lang.get("en-US").hashCode
+      Lang("zh-hans").code must_== "zh-Hans"
+      Lang("ZH-hant").code must_== "zh-Hant"
       Lang("en-us").code must_== "en-US"
       Lang("EN-us").code must_== "en-US"
       Lang("EN").code must_== "en"
@@ -60,9 +64,7 @@ class LangSpec extends PlaySpecification {
     "forbid instantiation of language code" in {
 
       "with wrong format" in {
-        Lang.get("en-UUS") must_== None
-        Lang.get("e-US") must_== None
-        Lang.get("engl-US") must_== None
+        Lang.get("e_US") must_== None
         Lang.get("en_US") must_== None
       }
 
@@ -78,37 +80,75 @@ class LangSpec extends PlaySpecification {
       }
 
       "preferred language" in {
-        implicit val app = GuiceApplicationBuilder().configure("application.langs" -> "crh-UA,ber,ast-ES").build()
-
-        val crhUA = Lang("crh", "UA")
+        val crhUA = Lang("crh-UA")
         val crh = Lang("crh")
         val ber = Lang("ber")
-        val berDZ = Lang("ber", "DZ")
-        val astES = Lang("ast", "ES")
+        val berDZ = Lang("ber-DZ")
+        val astES = Lang("ast-ES")
         val ast = Lang("ast")
 
+        implicit val app = GuiceApplicationBuilder().configure("play.i18n.langs" -> Seq(crhUA, ber, astES).map(_.code)).build()
+        val langs = app.injector.instanceOf[Langs]
+
         "with exact match" in {
-          Lang.preferred(Seq(crhUA)) must_== crhUA
+          langs.preferred(Seq(crhUA)) must_== crhUA
         }
 
         "with just language match" in {
-          Lang.preferred(Seq(ber)) must_== ber
+          langs.preferred(Seq(ber)) must_== ber
         }
 
         "with just language match country specific" in {
-          Lang.preferred(Seq(ast)) must_== astES
+          langs.preferred(Seq(ast)) must_== astES
         }
 
         "with language and country not match just language" in {
-          Lang.preferred(Seq(berDZ)) must_== crhUA
+          langs.preferred(Seq(berDZ)) must_== crhUA
         }
 
         "with case insensitive match" in {
-          Lang.preferred(Seq(Lang("AST", "es"))) must_== astES
+          langs.preferred(Seq(Lang("AST-es"))) must_== astES
         }
 
         "in order" in {
-          Lang.preferred(Seq(astES, crhUA)) must_== astES
+          langs.preferred(Seq(astES, crhUA)) must_== astES
+        }
+
+      }
+    }
+
+    "allow script codes" in {
+      "Lang instance" in {
+        Lang("zh-Hans").code must_== "zh-Hans"
+        Lang("sr-Latn").code must_== "sr-Latn"
+      }
+
+      "preferred language" in {
+        val enUS = Lang("en-US")
+        val az = Lang("az")
+        val azCyrl = Lang("az-Cyrl")
+        val azLatn = Lang("az-Latn")
+        val zh = Lang("zh")
+        val zhHans = Lang("zh-Hans")
+        val zhHant = Lang("zh-Hant")
+
+        implicit val app = GuiceApplicationBuilder().configure("play.i18n.langs" -> Seq(zhHans, zh, azCyrl, enUS).map(_.code)).build()
+        val langs = app.injector.instanceOf[Langs]
+
+        "with exact match" in {
+          langs.preferred(Seq(zhHans)) must_== zhHans
+        }
+
+        "with just language match script specific" in {
+          langs.preferred(Seq(az)) must_== azCyrl
+        }
+
+        "with case insensitive match" in {
+          langs.preferred(Seq(Lang("AZ-cyrl"))) must_== azCyrl
+        }
+
+        "in order" in {
+          langs.preferred(Seq(azCyrl, zhHans, enUS)) must_== azCyrl
         }
 
       }

--- a/framework/src/play-java/src/main/java/play/data/format/Formats.java
+++ b/framework/src/play-java/src/main/java/play/data/format/Formats.java
@@ -76,7 +76,7 @@ public class Formats {
             if(text == null || text.trim().isEmpty()) {
                 return null;
             }
-            Lang lang = new Lang(new play.api.i18n.Lang(locale.getLanguage(), locale.getCountry()));
+            Lang lang = new Lang(locale);
             SimpleDateFormat sdf = new SimpleDateFormat(Optional.ofNullable(this.messagesApi)
                 .map(messages -> messages.get(lang, pattern))
                 .orElse(patternNoApp), locale);
@@ -95,7 +95,7 @@ public class Formats {
             if(value == null) {
                 return "";
             }
-            Lang lang = new Lang(new play.api.i18n.Lang(locale.getLanguage(), locale.getCountry()));
+            Lang lang = new Lang(locale);
             return new SimpleDateFormat(Optional.ofNullable(this.messagesApi)
                 .map(messages -> messages.get(lang, pattern))
                 .orElse(patternNoApp), locale).format(value);
@@ -147,7 +147,7 @@ public class Formats {
             if(text == null || text.trim().isEmpty()) {
                 return null;
             }
-            Lang lang = new Lang(new play.api.i18n.Lang(locale.getLanguage(), locale.getCountry()));
+            Lang lang = new Lang(locale);
             SimpleDateFormat sdf = new SimpleDateFormat(Optional.ofNullable(this.messagesApi)
                 .map(messages -> messages.get(lang, annotation.pattern()))
                 .orElse(annotation.pattern()), locale);
@@ -167,7 +167,7 @@ public class Formats {
             if(value == null) {
                 return "";
             }
-            Lang lang = new Lang(new play.api.i18n.Lang(locale.getLanguage(), locale.getCountry()));
+            Lang lang = new Lang(locale);
             return new SimpleDateFormat(Optional.ofNullable(this.messagesApi)
                 .map(messages -> messages.get(lang, annotation.pattern()))
                 .orElse(annotation.pattern()), locale).format(value);

--- a/framework/src/play/src/main/java/play/i18n/Lang.java
+++ b/framework/src/play/src/main/java/play/i18n/Lang.java
@@ -14,49 +14,54 @@ import play.libs.*;
  */
 public class Lang extends play.api.i18n.Lang {
 
-    public final play.api.i18n.Lang underlyingLang;
-
     public Lang(play.api.i18n.Lang underlyingLang) {
-        super(underlyingLang.language(), underlyingLang.country());
-        this.underlyingLang = underlyingLang;
+        super(underlyingLang.locale());
+    }
+
+    public Lang(java.util.Locale locale) {
+        this(new play.api.i18n.Lang(locale));
     }
 
     /**
      * A valid ISO Language Code.
      */
     public String language() {
-        return underlyingLang.language();
+        return locale().getLanguage();
     }
 
     /**
      * A valid ISO Country Code.
      */
     public String country() {
-        return underlyingLang.country();
+        return locale().getCountry();
     }
 
     /**
-     * The Lang code (such as fr or en-US).
+     * The script tag for this Lang
+     */
+    public String script() {
+        return locale().getScript();
+    }
+
+    /**
+     * The variant tag for this Lang
+     */
+    public String variant() {
+        return locale().getVariant();
+    }
+
+    /**
+     * The language tag (such as fr or en-US).
      */
     public String code() {
-        return underlyingLang.code();
+        return locale().toLanguageTag();
     }
 
     /**
      * Convert to a Java Locale value.
      */
     public java.util.Locale toLocale() {
-        return underlyingLang.toLocale();
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        return underlyingLang.equals(other);
-    }
-
-    @Override
-    public int hashCode() {
-        return underlyingLang.hashCode();
+        return locale();
     }
 
     /**
@@ -110,7 +115,7 @@ public class Lang extends play.api.i18n.Lang {
         play.api.Application app = Play.current();
         List<play.api.i18n.Lang> result = new ArrayList<play.api.i18n.Lang>();
         for(play.i18n.Lang lang: langs) {
-            result.add(lang.underlyingLang);
+            result.add(lang);
         }
         return new Lang(play.api.i18n.Lang.preferred(Scala.toSeq(result), app));
     }
@@ -125,7 +130,7 @@ public class Lang extends play.api.i18n.Lang {
     public static Lang preferred(Application app, List<Lang> langs) {
         List<play.api.i18n.Lang> result = new ArrayList<play.api.i18n.Lang>();
         for(play.i18n.Lang lang: langs) {
-            result.add(lang.underlyingLang);
+            result.add(lang);
         }
         return new Lang(play.api.i18n.Lang.preferred(Scala.toSeq(result), app.getWrappedApplication()));
     }

--- a/framework/src/play/src/main/java/play/i18n/Messages.java
+++ b/framework/src/play/src/main/java/play/i18n/Messages.java
@@ -28,8 +28,7 @@ public class Messages {
         if(play.mvc.Http.Context.current.get() != null) {
             lang = play.mvc.Http.Context.current().lang();
         } else {
-            Locale defaultLocale = Locale.getDefault();
-            lang = new Lang(new play.api.i18n.Lang(defaultLocale.getLanguage(), defaultLocale.getCountry()));
+            lang = new Lang(new play.api.i18n.Lang(Locale.getDefault()));
         }
         return lang;
     }

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -26,6 +26,8 @@ import scala.util.parsing.input._
  */
 case class Lang(locale: Locale) {
 
+  def this(language: String, country: String = "") = this(new Locale.Builder().setLanguage(language).setRegion(country).build())
+
   /**
    * Convert to a Java Locale value.
    */

--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -5,8 +5,9 @@ package play.api.mvc {
 
   import java.security.cert.X509Certificate
   import java.util.Locale
+import java.util.Locale.LanguageRange
 
-  import play.api._
+import play.api._
   import play.api.http._
   import play.api.i18n.Lang
   import play.api.libs.crypto.CookieSigner

--- a/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
@@ -28,8 +28,9 @@ object MessagesSpec extends Specification {
     override protected def loadAllMessages = testMessages
   }
 
-  def translate(msg: String, lang: String, reg: String): Option[String] =
+  def translate(msg: String, lang: String, reg: String): Option[String] = {
     api.translate(msg, Nil)(Lang(lang, reg))
+  }
 
   def isDefinedAt(msg: String, lang: String, reg: String): Boolean =
     api.isDefinedAt(msg)(Lang(lang, reg))
@@ -87,9 +88,9 @@ object MessagesSpec extends Specification {
 
     }
 
-    "report error for unsupported lang" in {
+    "report error for invalid lang" in {
       new DefaultMessagesApi(new Environment(new File("."), this.getClass.getClassLoader, Mode.Dev),
-        Configuration.reference, new DefaultLangs(Configuration.reference ++ Configuration.from(Map("play.i18n.langs" -> Seq("wrong"))))
+        Configuration.reference, new DefaultLangs(Configuration.reference ++ Configuration.from(Map("play.i18n.langs" -> Seq("invalid_language"))))
       ) must throwA[PlayException]
     }
   }

--- a/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -39,21 +39,21 @@ class RequestHeaderSpec extends Specification {
       }
 
       "parse a single accept language and country" in {
-        accept("en-US") must contain(exactly(Lang("en", "US")))
+        accept("en-US") must contain(exactly(Lang("en-US")))
       }
 
       "parse multiple accept languages" in {
-        accept("en-US, es") must contain(exactly(Lang("en", "US"), Lang("es")).inOrder)
+        accept("en-US, es") must contain(exactly(Lang("en-US"), Lang("es")).inOrder)
       }
 
       "sort accept languages by quality" in {
-        accept("en-US;q=0.8, es;q=0.7") must contain(exactly(Lang("en", "US"), Lang("es")).inOrder)
-        accept("en-US;q=0.7, es;q=0.8") must contain(exactly(Lang("es"), Lang("en", "US")).inOrder)
+        accept("en-US;q=0.8, es;q=0.7") must contain(exactly(Lang("en-US"), Lang("es")).inOrder)
+        accept("en-US;q=0.7, es;q=0.8") must contain(exactly(Lang("es"), Lang("en-US")).inOrder)
       }
 
       "default accept language quality to 1" in {
-        accept("en-US, es;q=0.7") must contain(exactly(Lang("en", "US"), Lang("es")).inOrder)
-        accept("en-US;q=0.7, es") must contain(exactly(Lang("es"), Lang("en", "US")).inOrder)
+        accept("en-US, es;q=0.7") must contain(exactly(Lang("en-US"), Lang("es")).inOrder)
+        accept("en-US;q=0.7, es") must contain(exactly(Lang("es"), Lang("en-US")).inOrder)
       }
 
     }


### PR DESCRIPTION
Backports #5805 to the 2.5.x branch.

@gmethvin See the second commit, I think we only need to add this constructor so it matches to "old" 2.5.x api.