### PR TITLE
Fixes #5866: Use StreamConverters in favor of FileIO

### DIFF
--- a/documentation/manual/releases/release25/migration25/StreamsMigration25.md
+++ b/documentation/manual/releases/release25/migration25/StreamsMigration25.md
@@ -381,7 +381,7 @@ Here's a list of some common mappings for enumerator factory methods:
 | `Enumerator.unfold` | `Source.unfold` | |
 | `Enumerator.generateM` | `Source.unfoldAsync` | |
 | `Enumerator.fromStream` | `StreamConverters.fromInputStream` | |
-| `Enumerator.fromFile` | `FileIO.fromFile` | |
+| `Enumerator.fromFile` | `StreamConverters.fromInputStream` | You have to create an `InputStream` for the `java.io.File` |
 
 ### Migrating `Iteratee`s to `Sink`s and `Accumulator`s
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?

## Fixes

Fixes #5866

## Purpose

This removes calls to `FileIO.fromFile` to create a `Source` and, instead uses `StreamConverters.fromInputStream`. As discussed at #5866, by using `FileIO.fromFile` the following exception was being logged even if for successful responses:

```
[warn] i.n.u.c.SingleThreadEventExecutor - A task raised an exception.
java.util.NoSuchElementException: http-handler-body-subscriber
        at io.netty.channel.DefaultChannelPipeline.getContextOrDie(DefaultChannelPipeline.java:971)
        at io.netty.channel.DefaultChannelPipeline.remove(DefaultChannelPipeline.java:298)
        at com.typesafe.netty.http.HttpStreamsHandler.completeBody(HttpStreamsHandler.java:291)
        at com.typesafe.netty.http.HttpStreamsHandler.access$100(HttpStreamsHandler.java:16)
        at com.typesafe.netty.http.HttpStreamsHandler$2$1.run(HttpStreamsHandler.java:272)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:358)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:357)
        at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:112)
        at java.lang.Thread.run(Thread.java:745)
```

## References

See #5866.

