### PR TITLE
Fix #5320: rename testProd command to runProd

### DIFF
--- a/documentation/manual/working/commonGuide/production/Deploying.md
+++ b/documentation/manual/working/commonGuide/production/Deploying.md
@@ -175,12 +175,12 @@ $ target/universal/stage/bin/my-first-app -Dconfig.file=/full/path/to/conf/appli
 
 Play provides a convenient utility for running a test application in prod mode.
 
-> This is not intended for production usage.
+> **Note:** This is not intended for production usage.
 
-To run an application in prod mode, run `testProd`:
+To run an application in prod mode, run `runProd`:
 
 ```bash
-[my-first-app] $ testProd
+[my-first-app] $ runProd
 ```
 
 ## Using the SBT assembly plugin

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -68,7 +68,7 @@ object PlaySettings {
     playDocsModule := Some("com.typesafe.play" %% playDocsName.value % play.core.PlayVersion.current % DocsApplication.name),
     libraryDependencies ++= playDocsModule.value.toSeq,
     manageClasspath(DocsApplication),
-    playDocsJar := (managedClasspath in DocsApplication).value.files.filter(_.getName.startsWith(playDocsName.value)).headOption,
+    playDocsJar := (managedClasspath in DocsApplication).value.files.find(_.getName.startsWith(playDocsName.value)),
 
     parallelExecution in Test := false,
 
@@ -86,7 +86,7 @@ object PlaySettings {
     commands ++= {
       import PlayCommands._
       import PlayRun._
-      Seq(playStartCommand, playTestProdCommand, playStopProdCommand, h2Command)
+      Seq(playStartCommand, playRunProdCommand, playTestProdCommand, playStopProdCommand, h2Command)
     },
 
     // THE `in Compile` IS IMPORTANT!

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -186,7 +186,13 @@ object PlayRun {
     new AssetsClassLoader(parent, playAllAssets.value)
   }
 
-  val playTestProdCommand = Command.args("testProd", "<port>")(testProd)
+  val playRunProdCommand = Command.args("runProd", "<port>")(testProd)
+
+  val playTestProdCommand = Command.args("testProd", "<port>") { (state: State, args: Seq[String]) =>
+    state.log.warn("The testProd command is deprecated, and will be removed in a future version of Play.")
+    state.log.warn("To test your application using production mode, run 'runProd' instead.")
+    testProd(state, args)
+  }
 
   val playStartCommand = Command.args("start", "<port>") { (state: State, args: Seq[String]) =>
     state.log.warn("The start command is deprecated, and will be removed in a future version of Play.")

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/test
@@ -12,14 +12,14 @@ $ exists target/universal/stage/lib
 $ exists target/universal/stage/share/doc/api
 
 # Run it to make sure everything works
-> testProd --no-exit-sbt
+> runProd --no-exit-sbt
 > checkConfig foo
 > countApplicationConf 1
 > stopProd --no-exit-sbt
 
 # Change the configuration in the conf directory, make sure it takes effect
 $ copy-file conf/alternate.conf target/universal/stage/conf/application.conf
-> testProd --no-exit-sbt
+> runProd --no-exit-sbt
 > checkConfig bar
 > stopProd --no-exit-sbt
 
@@ -30,7 +30,7 @@ $ copy-file conf/alternate.conf target/universal/stage/conf/application.conf
 -$ exists target/universal/stage/lib/dist-sample.dist-sample-1.0-SNAPSHOT-sans-externalized.jar
 $ exists target/universal/stage/lib/dist-sample.dist-sample-1.0-SNAPSHOT.jar
 > checkStartScript no-conf
-> testProd --no-exit-sbt
+> runProd --no-exit-sbt
 > checkConfig foo
 > countApplicationConf 1
 > stopProd --no-exit-sbt


### PR DESCRIPTION
## Fixes

Fixes #5320.

## Purpose

Rename `testProd` command to `runProd`. The testProd still exists but shows a deprecation warning.