### PR TITLE
Add type ascription to play.api.mvc.Request.apply

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -315,7 +315,7 @@ import play.api._
 
   object Request {
 
-    def apply[A](rh: RequestHeader, a: A) = new Request[A] {
+    def apply[A](rh: RequestHeader, a: A): Request[A] = new Request[A] {
       override def id = rh.id
       override def tags = rh.tags
       override def uri = rh.uri


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?
## Purpose

Add an explicit type annotation to the public `play.api.mvc.Request.apply` method.

DISCLAIMER: I did not yet have a chance to take a deeper look why the inferencer is led astray here, but I think everybody agrees that you don't want to leak that type to API users ;)

Inferred type without ascription:
```scala
def apply[A](rh: RequestHeader, a: A): Request[A] with Object {val clientCertificateChain: Option[Seq[X509Certificate]]; def id: Long; def method: String; def version: String; def path: String; val secure: Boolean; val remoteAddress: String; def queryString: Map[String, Seq[String]]; def uri: String; def tags: Map[String, String]; val body: A; def headers: Headers} = ???
```

changed it to

```scala
def apply[A](rh: RequestHeader, a: A): Request[A] = ???
```