### PR TITLE
Fixes #2289 adds a bodyMultipart function to the request builder

### DIFF
--- a/framework/src/play/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/framework/src/play/src/test/java/play/mvc/RequestBuilderTest.java
@@ -3,6 +3,7 @@
  */
 package play.mvc;
 
+import akka.stream.javadsl.Source;
 import play.api.Application;
 import play.api.Play;
 import play.api.inject.guice.GuiceApplicationBuilder;
@@ -10,6 +11,12 @@ import play.mvc.Http.Context;
 import play.mvc.Http.Request;
 import play.mvc.Http.RequestBuilder;
 import org.junit.Test;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
 import static org.junit.Assert.*;
 
 public class RequestBuilderTest {
@@ -64,4 +71,26 @@ public class RequestBuilderTest {
         assertNull(req1.username());
         assertEquals("user2", req2.username());
     }
+
+  @Test
+  public void multipartForm() throws ExecutionException, InterruptedException {
+    Application app = new GuiceApplicationBuilder().build();
+    Play.start(app);
+    Http.MultipartFormData.DataPart dp = new Http.MultipartFormData.DataPart("hello", "world");
+    final Request request = new RequestBuilder().uri("http://playframework.com/")
+            .bodyMultipart(Collections.singletonList(dp), app.materializer())
+            .build();
+
+   Optional<Http.MultipartFormData<File>> parts = new BodyParser.MultipartFormData()
+           .apply(request)
+           .run(Source.single(request.body().asBytes()), app.materializer())
+           .toCompletableFuture()
+           .get()
+           .right;
+    assertEquals(true, parts.isPresent());
+    assertArrayEquals(new String[]{"world"}, parts.get().asFormUrlEncoded().get("hello"));
+
+    Play.stop(app);
+  }
+
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #2289

## Purpose

Adds a bodyMultipart function to the RequestBuilder

## Background Context

Actually inside the bodyMultipart there needs to happen a blocking call, since Helpers.route doesn't accept any CompletionStage / CompletableFuture value.


