### PR TITLE
[Backport ]Use ctx.messages() instead of msgApi.preferred(req) when binding form

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -314,6 +314,7 @@ object PlayBuild extends Build {
     .settings(libraryDependencies ++= javaDeps ++ javaTestDeps)
     .dependsOn(PlayProject % "compile;test->test")
     .dependsOn(PlayTestProject % "test")
+    .dependsOn(PlaySpecs2Project % "test")
 
   lazy val PlayDocsProject = PlayCrossBuiltProject("Play-Docs", "play-docs")
     .settings(Docs.settings: _*)

--- a/framework/src/play-java/src/main/java/play/data/Form.java
+++ b/framework/src/play-java/src/main/java/play/data/Form.java
@@ -430,7 +430,7 @@ public class Form<T> {
                 ValidationError validationError;
                 if (error.isBindingFailure()) {
                     ImmutableList.Builder<String> builder = ImmutableList.builder();
-                    Optional<Messages> msgs = Optional.ofNullable(Http.Context.current.get()).map(c -> messagesApi.preferred(c.request()));
+                    Optional<Messages> msgs = Optional.ofNullable(Http.Context.current.get()).map(c -> c.messages());
                     for (String code: error.getCodes()) {
                         code = code.replace("typeMismatch", "error.invalid");
                         if(!msgs.isPresent() || msgs.get().isDefinedAt(code)) {


### PR DESCRIPTION
Backports #5894