### PR TITLE
[2.5.x] Fix several binary compatibility issues

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -243,7 +243,12 @@ object PlayBuild extends Build {
 
         twirlSources ++ twirlCompiledSources
       },
-      Docs.apiDocsIncludeManaged := true
+      Docs.apiDocsIncludeManaged := true,
+      binaryIssueFilters := Seq(
+        ProblemFilters.exclude[MissingMethodProblem]("play.core.parsers.Multipart.partParser"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.api.BuiltInComponents.crypto"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.api.BuiltInComponents.aesCrypter")
+      )
     ).settings(Docs.playdocSettings: _*)
      .dependsOn(
       BuildLinkProject,
@@ -381,20 +386,37 @@ object PlayBuild extends Build {
       libraryDependencies ++= playWsDeps,
       parallelExecution in Test := false,
       // quieten deprecation warnings in tests
-      scalacOptions in Test := (scalacOptions in Test).value diff Seq("-deprecation")
+      scalacOptions in Test := (scalacOptions in Test).value diff Seq("-deprecation"),
+      binaryIssueFilters := Seq(
+        ProblemFilters.exclude[MissingMethodProblem]("play.api.libs.ws.WSRequest.put"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.api.libs.ws.WSRequest.post"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.api.libs.ws.WSRequest.patch"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.api.libs.ws.WSRequest.withMultipartBody")
+      )
     ).dependsOn(PlayProject)
     .dependsOn(PlaySpecs2Project % "test")
 
   lazy val PlayWsJavaProject = PlayCrossBuiltProject("Play-Java-WS", "play-java-ws")
       .settings(
         libraryDependencies ++= playWsDeps,
-        parallelExecution in Test := false
+        parallelExecution in Test := false,
+        binaryIssueFilters := Seq(
+          ProblemFilters.exclude[MissingMethodProblem]("play.libs.ws.WSRequest.put"),
+          ProblemFilters.exclude[MissingMethodProblem]("play.libs.ws.WSRequest.post"),
+          ProblemFilters.exclude[MissingMethodProblem]("play.libs.ws.WSRequest.patch"),
+          ProblemFilters.exclude[MissingMethodProblem]("play.libs.ws.WSRequest.withMultipartBody")
+        )
       ).dependsOn(PlayProject)
     .dependsOn(PlayWsProject % "test->test;compile->compile", PlayJavaProject)
 
   lazy val PlayFiltersHelpersProject = PlayCrossBuiltProject("Filters-Helpers", "play-filters-helpers")
     .settings(
-      parallelExecution in Test := false
+      parallelExecution in Test := false,
+      binaryIssueFilters := Seq(
+        // We needed to change this since the method names did not line up with BuiltInComponents
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFComponents.tokenSigner"),
+        ProblemFilters.exclude[MissingMethodProblem]("play.filters.csrf.CSRFComponents.csrfTokenSigner")
+      )
     ).dependsOn(PlayProject, PlayJavaProject, PlaySpecs2Project % "test", PlayWsProject % "test")
 
   // This project is just for testing Play, not really a public artifact

--- a/framework/src/play/src/main/java/play/i18n/Lang.java
+++ b/framework/src/play/src/main/java/play/i18n/Lang.java
@@ -14,8 +14,15 @@ import play.libs.*;
  */
 public class Lang extends play.api.i18n.Lang {
 
+    /**
+     * @deprecated All instances of play.i18n.Lang can be used as a play.api.i18n.Lang (2.5.1)
+     */
+    @Deprecated
+    public final play.api.i18n.Lang underlyingLang;
+
     public Lang(play.api.i18n.Lang underlyingLang) {
         super(underlyingLang.locale());
+        this.underlyingLang = underlyingLang;
     }
 
     public Lang(java.util.Locale locale) {

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -71,6 +71,9 @@ case class Lang(locale: Locale) {
    * The language tag (such as fr or en-US).
    */
   lazy val code: String = locale.toLanguageTag
+
+  @deprecated("This method only exists for binary compatibility.", "2.5.1")
+  def copy(language: String, country: String): Lang = Lang(language, country)
 }
 
 /**
@@ -88,6 +91,8 @@ object Lang {
    *  throw exception if language is unrecognized
    */
   def apply(code: String): Lang = Lang(new Locale.Builder().setLanguageTag(code).build())
+
+  def apply(language: String, country: String): Lang = apply(language, country, script = "", variant = "")
 
   /**
    * Create a Lang value from a code (such as fr or en-US) and
@@ -129,6 +134,7 @@ object Lang {
   def preferred(langs: Seq[Lang])(implicit app: Application): Lang = {
     langsCache(app).preferred(langs)
   }
+
 }
 
 /**


### PR DESCRIPTION
Rationale for the exclusions:
 - `Multipart.partParser` was broken and is unlikely to be used externally at this point.
 - There is only one major implementation of WS, so it should be okay to add those methods for multipart.
 - The `BuiltInComponents` and `CSRFComponents` traits were changed to make compile-time DI work properly and expose all the necessary components. Those traits are not intended to be used by external libraries, so all the code using it should be recompiled.

Several other issues have been fixed.

/cc @jroper 

We still need to decide what to do about the changes in #5888.