### PR TITLE
Fixes jdbcdslog logback.xml

### DIFF
--- a/framework/src/play-logback/src/main/resources/logback-play-logSql.xml
+++ b/framework/src/play-logback/src/main/resources/logback-play-logSql.xml
@@ -30,9 +30,9 @@
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
 
-  <logger name="logger.org.jdbcdslog.ConnectionLogger" level="OFF"  /> <!-- Won' log connections -->
-  <logger name="logger.org.jdbcdslog.StatementLogger"  level="INFO" /> <!-- Will log all statements -->
-  <logger name="logger.org.jdbcdslog.ResultSetLogger"  level="OFF"  /> <!-- Won' log result sets -->
+  <logger name="org.jdbcdslog.ConnectionLogger" level="OFF"  /> <!-- Won' log connections -->
+  <logger name="org.jdbcdslog.StatementLogger"  level="INFO" /> <!-- Will log all statements -->
+  <logger name="org.jdbcdslog.ResultSetLogger"  level="OFF"  /> <!-- Won' log result sets -->
 
   <root level="WARN">
     <appender-ref ref="ASYNCFILE" />


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Purpose

Actually inside the logback-play-logSql.xml there was a bug so that the documentation here:
- https://www.playframework.com/documentation/2.5.x/JavaDatabase#Log-Statement-Text-/-Slow-Query-Logging
- https://www.playframework.com/documentation/2.5.x/ScalaDatabase#How-to-configure-SQL-log-statement

wouldn't output anything, since the ConnectionLogger, StatementLogger, ResultSetLogger aren't sitting in ``logger.org.*`` they are sitting in ``org.jdbcslog.*``

