### PR TITLE
[2.5.x] Update cookie encoder to cover valid chars like !

### DIFF
--- a/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/CookieUtil.java
+++ b/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/CookieUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The Netty Project
+ * Copyright 2015 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -21,45 +21,43 @@ final class CookieUtil {
 
     private static final BitSet VALID_COOKIE_VALUE_OCTETS = validCookieValueOctets();
 
-    private static final BitSet VALID_COOKIE_NAME_OCTETS = validCookieNameOctets(VALID_COOKIE_VALUE_OCTETS);
+    private static final BitSet VALID_COOKIE_NAME_OCTETS = validCookieNameOctets();
 
+    // cookie-octet = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
     // US-ASCII characters excluding CTLs, whitespace, DQUOTE, comma, semicolon, and backslash
     private static BitSet validCookieValueOctets() {
-        BitSet bits = new BitSet(8);
-        for (int i = 35; i < 127; i++) {
-            // US-ASCII characters excluding CTLs (%x00-1F / %x7F)
+        BitSet bits = new BitSet();
+        bits.set(0x21);
+        for (int i = 0x23; i <= 0x2B; i++) {
             bits.set(i);
         }
-        bits.set('"', false);  // exclude DQUOTE = %x22
-        bits.set(',', false);  // exclude comma = %x2C
-        bits.set(';', false);  // exclude semicolon = %x3B
-        bits.set('\\', false); // exclude backslash = %x5C
+        for (int i = 0x2D; i <= 0x3A; i++) {
+            bits.set(i);
+        }
+        for (int i = 0x3C; i <= 0x5B; i++) {
+            bits.set(i);
+        }
+        for (int i = 0x5D; i <= 0x7E; i++) {
+            bits.set(i);
+        }
         return bits;
     }
 
-    //    token          = 1*<any CHAR except CTLs or separators>
-    //    separators     = "(" | ")" | "<" | ">" | "@"
-    //                   | "," | ";" | ":" | "\" | <">
-    //                   | "/" | "[" | "]" | "?" | "="
-    //                   | "{" | "}" | SP | HT
-    private static BitSet validCookieNameOctets(BitSet validCookieValueOctets) {
-        BitSet bits = new BitSet(8);
-        bits.or(validCookieValueOctets);
-        bits.set('(', false);
-        bits.set(')', false);
-        bits.set('<', false);
-        bits.set('>', false);
-        bits.set('@', false);
-        bits.set(':', false);
-        bits.set('/', false);
-        bits.set('[', false);
-        bits.set(']', false);
-        bits.set('?', false);
-        bits.set('=', false);
-        bits.set('{', false);
-        bits.set('}', false);
-        bits.set(' ', false);
-        bits.set('\t', false);
+    // token = 1*<any CHAR except CTLs or separators>
+    // separators = "(" | ")" | "<" | ">" | "@"
+    // | "," | ";" | ":" | "\" | <">
+    // | "/" | "[" | "]" | "?" | "="
+    // | "{" | "}" | SP | HT
+    private static BitSet validCookieNameOctets() {
+        BitSet bits = new BitSet();
+        for (int i = 32; i < 127; i++) {
+            bits.set(i);
+        }
+        int[] separators = new int[]
+                { '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}', ' ', '\t' };
+        for (int separator : separators) {
+            bits.set(separator, false);
+        }
         return bits;
     }
 

--- a/framework/src/play/src/test/scala/play/api/mvc/CookiesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/CookiesSpec.scala
@@ -25,6 +25,22 @@ object CookiesSpec extends Specification {
     }
   }
 
+  "Cookie" should {
+
+    val encoder = play.core.netty.utils.ServerCookieEncoder.STRICT
+
+    "properly encode ! character" in {
+      val output = encoder.encode("TestCookie", "!")
+      output must be_==("TestCookie=!")
+    }
+
+    // see #4460 for the gory details
+    "properly encode all special characters" in {
+      val output = encoder.encode("TestCookie", "!#$%&'()*+-./:<=>?@[]^_`{|}~")
+      output must be_==("TestCookie=!#$%&'()*+-./:<=>?@[]^_`{|}~")
+    }
+  }
+
   "trait Cookies#get" should {
     val originalCookie = Cookie(name = "cookie", value = "value")
     def headerString = Cookies.encodeCookieHeader(Seq(originalCookie))


### PR DESCRIPTION
Backport of https://github.com/playframework/playframework/pull/5907 for https://github.com/playframework/playframework/issues/4460 for 2.5.x branch.