### PR TITLE
[2.5.x] Fix binary compatibility issues in MessagesApi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jdk:
   - oraclejdk8
 env:
   # Define scripts here so they run concurrently
-  - SCRIPT=checkCodeStyle
+  - SCRIPT=codeChecks
   - SCRIPT=test
   - SCRIPT=testSbtPlugins
   - SCRIPT=testDocumentation

--- a/documentation/manual/working/scalaGuide/advanced/extending/code/ScalaExtendingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/extending/code/ScalaExtendingPlay.scala
@@ -17,9 +17,7 @@ object ScalaExtendingPlay extends Specification {
     override def messages: Map[String, Map[String, String]] = ???
     override def preferred(candidates: Seq[Lang]): Messages = ???
     override def preferred(request: mvc.RequestHeader): Messages = ???
-    override def preferred(request: mvc.RequestHeader, ctxLang: Lang): Messages = ???
     override def preferred(request: RequestHeader): Messages = ???
-    override def preferred(request: RequestHeader, ctxLang: Lang): Messages = ???
     override def langCookieHttpOnly: Boolean = ???
     override def clearLang(result: Result): Result = ???
     override def langCookieSecure: Boolean = ???

--- a/framework/bin/codeChecks
+++ b/framework/bin/codeChecks
@@ -13,3 +13,10 @@ git diff --exit-code || (
   echo "Additionally, please squash your commits (eg, use git commit --amend) if you're going to update this pull request."
   false
 )
+
+echo "[info]"
+echo "[info] ---- CHECKING BINARY COMPATIBILITY"
+echo "[info]"
+
+build mimaReportBinaryIssues
+

--- a/framework/src/play/src/main/java/play/i18n/MessagesApi.java
+++ b/framework/src/play/src/main/java/play/i18n/MessagesApi.java
@@ -131,21 +131,7 @@ public class MessagesApi {
      * @return the preferred messages context for the request
      */
     public Messages preferred(Http.RequestHeader request) {
-        return preferred(request, null);
-    }
-
-    /**
-     * Get a messages context appropriate for the given request.
-     *
-     * Will select a language from the request and the current context lang, based on the languages available, and fallback to the default language
-     * if none of the candidates are available.
-     *
-     * @param request the incoming request
-     * @param ctxLang the language of the current context
-     * @return the preferred messages context for the request
-     */
-    public Messages preferred(Http.RequestHeader request, Lang ctxLang) {
-        play.api.i18n.Messages msgs = messages.preferred(request, ctxLang);
+        play.api.i18n.Messages msgs = messages.preferred(request);
         return new Messages(new Lang(msgs.lang()), this);
     }
 

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -8,6 +8,7 @@ import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Lists;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import play.api.libs.json.JsValue;
@@ -191,7 +192,16 @@ public class Http {
          * @return the messages for the current lang
          */
         public Messages messages() {
-            return messagesApi().preferred(request(), lang);
+            Cookie langCookie = request().cookies().get(messagesApi().langCookieName());
+            Lang cookieLang = langCookie == null ? null : new Lang(play.api.i18n.Lang.apply(langCookie.value()));
+            LinkedList<Lang> langs = Lists.newLinkedList(request().acceptLanguages());
+            if (cookieLang != null) {
+                langs.addFirst(cookieLang);
+            }
+            if (lang != null) {
+                langs.addFirst(lang);
+            }
+            return messagesApi().preferred(langs);
         }
 
         /**

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -416,19 +416,9 @@ trait MessagesApi {
   def preferred(request: RequestHeader): Messages
 
   /**
-   * Get the preferred messages for the given request and the current context lang
-   */
-  def preferred(request: RequestHeader, ctxLang: Lang): Messages
-
-  /**
    * Get the preferred messages for the given Java request
    */
   def preferred(request: play.mvc.Http.RequestHeader): Messages
-
-  /**
-   * Get the preferred messages for the given Java request and the current context lang
-   */
-  def preferred(request: play.mvc.Http.RequestHeader, ctxLang: Lang): Messages
 
   /**
    * Set the language on the result
@@ -501,19 +491,13 @@ class DefaultMessagesApi @Inject() (environment: Environment, configuration: Con
 
   def preferred(candidates: Seq[Lang]) = Messages(langs.preferred(candidates), this)
 
-  def preferred(request: RequestHeader) = preferred(request, null)
-
-  def preferred(request: RequestHeader, ctxLang: Lang) = {
-    val maybeLangFromContext = Option(ctxLang)
-    val maybeLangFromCookie = request.cookies.get(langCookieName)
-      .flatMap(c => Lang.get(c.value))
-    val lang = langs.preferred(maybeLangFromContext.toSeq ++ maybeLangFromCookie.toSeq ++ request.acceptLanguages)
+  def preferred(request: RequestHeader) = {
+    val maybeLangFromCookie = request.cookies.get(langCookieName).flatMap(c => Lang.get(c.value))
+    val lang = langs.preferred(maybeLangFromCookie.toSeq ++ request.acceptLanguages)
     Messages(lang, this)
   }
 
-  def preferred(request: Http.RequestHeader) = preferred(request, null)
-
-  def preferred(request: Http.RequestHeader, ctxLang: Lang) = preferred(request._underlyingHeader(), ctxLang)
+  def preferred(request: Http.RequestHeader) = preferred(request._underlyingHeader())
 
   def setLang(result: Result, lang: Lang) = result.withCookies(Cookie(langCookieName, lang.code, path = Session.path, domain = Session.domain,
     secure = langCookieSecure, httpOnly = langCookieHttpOnly))


### PR DESCRIPTION
Removes the extra methods added to `MessagesApi` and uses an alternative strategy to achieve the same result.

Also enables MiMa on the 2.5.x branch (closes #5900).