### PR TITLE
Fix default charset in FormUrlEncoded

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/FormBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/FormBodyParserSpec.scala
@@ -5,12 +5,15 @@ package play.it.http.parsing
 
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import play.api.Application
 import play.api.data.Form
 import play.api.data.Forms.{ mapping, nonEmptyText, number }
-import play.api.http.Writeable
+import play.api.http.{ MimeTypes, Writeable }
 import play.api.libs.json.Json
 import play.api.mvc.{ BodyParser, BodyParsers, Result, Results }
 import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
+import scala.collection.JavaConverters._
 
 import scala.concurrent.Future
 
@@ -51,6 +54,30 @@ class FormBodyParserSpec extends PlaySpecification {
       }
     }
 
+  }
+
+  "The Java form body parser" should {
+    def javaParserTest(bodyString: String, bodyData: Map[String, Seq[String]], bodyCharset: Option[String] = None)(implicit app: Application): Unit = {
+      val parser = app.injector.instanceOf[play.mvc.BodyParser.FormUrlEncoded]
+      val mat = app.injector.instanceOf[Materializer]
+      val bs = akka.stream.javadsl.Source.single(ByteString.fromString(bodyString, bodyCharset.getOrElse("UTF-8")))
+      val contentType = bodyCharset.fold(MimeTypes.FORM)(charset => s"${MimeTypes.FORM};charset=$charset")
+      val req = new play.mvc.Http.RequestBuilder().header(CONTENT_TYPE, contentType).build()
+      val result = parser(req).run(bs, mat).toCompletableFuture.get
+      result.right.get.asScala.mapValues(_.toSeq) must_== bodyData
+    }
+
+    "parse bodies in UTF-8" in new WithApplication() {
+      val bodyString = "name=%C3%96sten&age=42"
+      val bodyData = Map("name" -> Seq("Östen"), "age" -> Seq("42"))
+      javaParserTest(bodyString, bodyData)
+    }
+
+    "parse bodies in ISO-8859-1" in new WithApplication() {
+      val bodyString = "name=%D6sten&age=42"
+      val bodyData = Map("name" -> Seq("Östen"), "age" -> Seq("42"))
+      javaParserTest(bodyString, bodyData, Some("ISO-8859-1"))
+    }
   }
 
 }

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -11,8 +11,6 @@ import org.w3c.dom.Document;
 import play.api.http.HttpConfiguration;
 import play.api.http.Status$;
 import play.api.libs.Files;
-import play.api.mvc.BodyParsers$;
-import play.api.mvc.MaxSizeNotExceeded;
 import play.api.mvc.MaxSizeNotExceeded$;
 import play.api.mvc.MaxSizeStatus;
 import play.core.j.JavaParsers;
@@ -26,7 +24,10 @@ import scala.concurrent.Future;
 
 import javax.inject.Inject;
 import java.io.File;
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -62,7 +63,7 @@ public interface BodyParser<A> {
          * @return the class
          */
         Class<? extends BodyParser> value();
-      
+
     }
 
     /**
@@ -313,8 +314,9 @@ public interface BodyParser<A> {
 
         @Override
         protected Map<String, String[]> parse(Http.RequestHeader request, ByteString bytes) throws Exception {
-            String charset = request.charset().orElse("ISO-8859-1");
-            return FormUrlEncodedParser.parseAsJavaArrayValues(bytes.decodeString(charset), charset);
+            String charset = request.charset().orElse("UTF-8");
+            String urlEncodedString = bytes.decodeString("UTF-8");
+            return FormUrlEncodedParser.parseAsJavaArrayValues(urlEncodedString, charset);
         }
     }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -3,26 +3,28 @@
  */
 package play.api.mvc
 
-import akka.util.ByteString
-import play.api.data.Form
-import play.api.libs.streams.Accumulator
-import play.core.parsers.Multipart
-import scala.language.reflectiveCalls
 import java.io._
-import scala.concurrent.{ Promise, Future }
-import scala.xml._
-import play.api._
-import play.api.libs.json._
-import play.api.libs.Files.TemporaryFile
-import MultipartFormData._
 import java.util.Locale
-import scala.util.control.NonFatal
-import play.api.http.{ LazyHttpErrorHandler, ParserConfiguration, HttpConfiguration, HttpVerbs }
-import play.utils.PlayIO
-import play.api.http.Status._
+
 import akka.stream._
-import akka.stream.scaladsl.{ StreamConverters, Flow, Sink }
+import akka.stream.scaladsl.{ Flow, Sink, StreamConverters }
 import akka.stream.stage._
+import akka.util.ByteString
+import play.api._
+import play.api.data.Form
+import play.api.http.Status._
+import play.api.http._
+import play.api.libs.Files.TemporaryFile
+import play.api.libs.json._
+import play.api.libs.streams.Accumulator
+import play.api.mvc.MultipartFormData._
+import play.core.parsers.Multipart
+import play.utils.PlayIO
+
+import scala.concurrent.{ Future, Promise }
+import scala.language.reflectiveCalls
+import scala.util.control.NonFatal
+import scala.xml._
 
 /**
  * A request body that adapts automatically according the request Content-Type.
@@ -549,8 +551,9 @@ trait BodyParsers {
     def tolerantFormUrlEncoded(maxLength: Int): BodyParser[Map[String, Seq[String]]] =
       tolerantBodyParser("urlFormEncoded", maxLength, "Error parsing application/x-www-form-urlencoded") { (request, bytes) =>
         import play.core.parsers._
-        FormUrlEncodedParser.parse(bytes.decodeString(request.charset.getOrElse("utf-8")),
-          request.charset.getOrElse("utf-8"))
+        val charset = request.charset.getOrElse("UTF-8")
+        val urlEncodedString = bytes.decodeString("UTF-8")
+        FormUrlEncodedParser.parse(urlEncodedString, charset)
       }
 
     /**


### PR DESCRIPTION
Fixes #5919.

Requires backport to 2.5.x.