### PR TITLE
Explains how to upgrade Play at the migration guide

### DIFF
--- a/documentation/manual/releases/release25/Highlights25.md
+++ b/documentation/manual/releases/release25/Highlights25.md
@@ -91,8 +91,3 @@ Thanks to various performance optimizations, Play 2.5's performance testing fram
 ## WS Improvements
 
 Play WS has been upgraded to AsyncHttpClient 2.0, and now includes a request pipeline filter ([[Scala|ScalaWS#Request-Filters]], [[Java|JavaWS#Request-Filters]]) that can be used to log requests in [cURL format](https://curl.haxx.se/docs/manpage.html).  
-
-## ScalaTest Improvements
-
-Play has upgraded to [Scalatest 3.0](http://scalatest.org/release_notes/3.0.0) as the default Scala testing framework and example ScalaTests included with the seed templates.  For more information, please see [[Testing your Application with ScalaTest|ScalaTestingWithScalaTest]].
-

--- a/documentation/manual/releases/release25/migration25/Migration25.md
+++ b/documentation/manual/releases/release25/migration25/Migration25.md
@@ -8,16 +8,63 @@ As well as the information contained on this page, there is more detailed migrat
 - [[Streams Migration Guide|StreamsMigration25]] – Migrating to Akka streams, now used in place of iteratees in many Play APIs
 - [[Java Migration Guide|JavaMigration25]] - Migrating Java applications. Play now uses native Java types for functional types and offers several new customizable components in Java.
 
-## sbt upgrade to 0.13.11
+## How to migrate
+
+The following steps need to be taken to update your sbt build before you can load/run a Play project in sbt.
+
+### Play upgrade
+
+Update the Play version number in project/plugins.sbt to upgrade Play:
+
+```scala
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.x")
+```
+
+Where the "x" in `2.5.x` is the minor version of Play you want to use, per instance `2.5.0`.
+
+### sbt upgrade to 0.13.11
 
 Although Play 2.5 will still work with sbt 0.13.8, we recommend upgrading to the latest sbt version, 0.13.11.  The 0.13.11 release of sbt has a number of [improvements and bug fixes](https://github.com/sbt/sbt/releases/tag/v0.13.11).
-
-### How to migrate
 
 Update your `project/build.properties` so that it reads:
 
 ```
 sbt.version=0.13.11
+```
+
+### Play Slick upgrade
+
+If your project is using Play Slick, you need to upgrade it:
+
+```scala
+libraryDependencies += "com.typesafe.play" %% "play-slick" % "2.0.0"
+```
+
+Or:
+
+```scala
+libraryDependencies ++= Seq(
+  "com.typesafe.play" %% "play-slick" % "2.0.0"
+  "com.typesafe.play" %% "play-slick-evolutions" % "2.0.0"
+)
+```
+
+### Play Ebean upgrade
+
+If your project is using Play Ebean, you need to upgrade it:
+
+```scala
+addSbtPlugin("com.typesafe.sbt" % "sbt-play-ebean" % "3.0.0")
+```
+
+### ScalaTest + Plus upgrade
+
+If your project is using [[ScalaTest + Play|ScalaTestingWithScalaTest]], you need to upgrade it:
+
+```scala
+libraryDependencies ++= Seq(
+  "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.0" % "test"
+)
 ```
 
 ## Scala 2.10 support discontinued


### PR DESCRIPTION
## Purpose

Migration guide for 2.5.x does not includes information about how to upgrade Play plugin.

## References

See this message at the mailing list:

https://groups.google.com/forum/#!msg/play-framework/aFEkSOaAEbk/CtubkgIxHAAJ

This PR must be backported to 2.5.x. branch.

