### PR TITLE
Recreate temp directory if it is deleted

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -35,7 +35,16 @@ object Files {
    */
   @Singleton
   class DefaultTemporaryFileCreator @Inject() (applicationLifecycle: ApplicationLifecycle) extends TemporaryFileCreator {
-    private lazy val playTempFolder = JFiles.createTempDirectory("playtemp")
+    private var _playTempFolder: Option[Path] = None
+
+    private[libs] def playTempFolder: Path = _playTempFolder match {
+      // We may need to recreate the file if it was deleted (e.g. by tmpwatch)
+      case Some(folder) if JFiles.exists(folder) => folder
+      case _ =>
+        val folder = JFiles.createTempDirectory("playtemp")
+        _playTempFolder = Some(folder)
+        folder
+    }
 
     /**
      * Application stop hook which deletes the temporary folder recursively (including subfolders).

--- a/framework/src/play/src/test/scala/play/api/libs/FilesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/FilesSpec.scala
@@ -1,17 +1,19 @@
 /*
  * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
  */
-package play.libs
+package play.api.libs
 
 import java.io.File
 import java.nio.charset.Charset
+import java.nio.file.{ Files => JFiles }
 
 import org.specs2.mutable.Specification
 import org.specs2.specification.After
 import play.api.ApplicationLoader.Context
-import play.api.routing.Router
 import play.api._
-import play.api.libs.Files.TemporaryFile
+import play.api.inject.DefaultApplicationLifecycle
+import play.api.libs.Files.{ DefaultTemporaryFileCreator, TemporaryFile }
+import play.api.routing.Router
 import play.utils.PlayIO
 
 object FilesSpec extends Specification with After {
@@ -25,6 +27,19 @@ object FilesSpec extends Specification with After {
   }
 
   "Files" should {
+
+    "DefaultTemporaryFileCreator" should {
+      "recreate directory if it is deleted" in {
+        val lifecycle = new DefaultApplicationLifecycle
+        val creator = new DefaultTemporaryFileCreator(lifecycle)
+        val file = creator.create("foo", "bar")
+        JFiles.delete(file.toPath)
+        JFiles.delete(creator.playTempFolder)
+        creator.create("foo", "baz")
+        lifecycle.stop()
+        success
+      }
+    }
 
     "Temporary files" should {
 


### PR DESCRIPTION
Fixes #5936 

I think there could still be a race condition here (if the directory is deleted after we call Files.exists but before we create the temp file), but at least if it happens we don't need to restart the app to get things working again.