### PR TITLE
Strip '\r' suffix from source line when reporting routes compilation error on Windows

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
@@ -185,7 +185,7 @@ object RoutesCompiler extends AutoPlugin {
           lazy val lineContent = {
             line flatMap { lineNo =>
               sourceFile.flatMap { file =>
-                IO.read(file).split('\n').lift(lineNo - 1)
+                IO.read(file).split('\n').lift(lineNo - 1).map(_.stripSuffix("\r"))
               }
             } getOrElse ""
           }

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
@@ -160,7 +160,7 @@ object RoutesCompiler extends AutoPlugin {
   private def reportCompilationError(log: Logger, error: PlayException.ExceptionSource) = {
     // log the source file and line number with the error message
     log.error(Option(error.sourceName).getOrElse("") + Option(error.line).map(":" + _).getOrElse("") + ": " + error.getMessage)
-    Option(error.interestingLines(0)).map(_.focus).flatMap(_.headOption) map { line =>
+    Option(error.interestingLines(0)).map(_.focus).flatMap(_.headOption).map(_.stripSuffix("\r")) map { line =>
       // log the line
       log.error(line)
       Option(error.position).map { pos =>


### PR DESCRIPTION
Windows new line contains two characters "\r\n". After splitting source file content using '\n' as separator every line ends with '\r' character.
These characters are not visible on the console, but when redirecting SBT output to a file they are visible as additional empty lines. Now the output looks like:
```
[error] G:\scm.gslowikowski\github.git\play2-maven-plugin\play2-maven-test-projects-with-problems\routes-bugs\play26snap\conf\routes:6: Compilation error[Controller method call expected]
[error] GET     /                           controllers.Application

[error]                                                            ^
```
With this PR:
```
[error] G:\scm.gslowikowski\github.git\play2-maven-plugin\play2-maven-test-projects-with-problems\routes-bugs\play26snap\conf\routes:6: Compilation error[Controller method call expected]
[error] GET     /                           controllers.Application
[error]                                                            ^
```

You will not see this problem on Linus machines.