### PR TITLE
Upgrade dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Gitter](https://img.shields.io/gitter/room/gitterHQ/gitter.svg)](https://gitter.im/playframework/playframework?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)[<img src="https://img.shields.io/travis/playframework/playframework.svg"/>](https://travis-ci.org/playframework/playframework)
+[![Gitter](https://img.shields.io/gitter/room/gitterHQ/gitter.svg)](https://gitter.im/playframework/playframework?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [<img src="https://img.shields.io/travis/playframework/playframework.svg"/>](https://travis-ci.org/playframework/playframework)
 
 ## Play Framework - The High Velocity Web Framework
 

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -25,10 +25,10 @@ object Dependencies {
     "com.fasterxml.jackson.core" % "jackson-databind",
     "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8",
     "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310"
-  ).map(_ % "2.7.1")
+  ).map(_ % "2.7.3")
 
-  val slf4j = Seq("slf4j-api", "jul-to-slf4j", "jcl-over-slf4j").map("org.slf4j" % _ % "1.7.16")
-  val logback = Seq("logback-core", "logback-classic").map("ch.qos.logback" % _ % "1.1.4")
+  val slf4j = Seq("slf4j-api", "jul-to-slf4j", "jcl-over-slf4j").map("org.slf4j" % _ % "1.7.19")
+  val logback = Seq("logback-core", "logback-classic").map("ch.qos.logback" % _ % "1.1.6")
 
   val guava = "com.google.guava" % "guava" % "19.0"
   val findBugs = "com.google.code.findbugs" % "jsr305" % "3.0.1" // Needed by guava
@@ -37,7 +37,7 @@ object Dependencies {
   val h2database = "com.h2database" % "h2" % "1.4.191"
   val derbyDatabase = "org.apache.derby" % "derby" % "10.12.1.1"
 
-  val acolyteVersion = "1.0.34-j7p"
+  val acolyteVersion = "1.0.36-j7p"
   val acolyte = "org.eu.acolyte" % "jdbc-driver" % acolyteVersion
 
   val jdbcDeps = Seq(
@@ -61,12 +61,12 @@ object Dependencies {
     case _ => Nil
   }
 
-  val springFrameworkVersion = "4.2.4.RELEASE"
+  val springFrameworkVersion = "4.2.5.RELEASE"
 
   val javaDeps = Seq(
     scalaJava8Compat,
 
-    "org.yaml" % "snakeyaml" % "1.16",
+    "org.yaml" % "snakeyaml" % "1.17",
     "org.hibernate" % "hibernate-validator" % "5.2.4.Final",
     "javax.el"      % "javax.el-api"        % "3.0.0", // required by hibernate-validator
 
@@ -93,7 +93,7 @@ object Dependencies {
     guava,
     findBugs,
 
-    "org.apache.tomcat" % "tomcat-servlet-api" % "8.0.32"
+    "org.apache.tomcat" % "tomcat-servlet-api" % "8.0.33"
   ) ++ specsBuild.map(_ % Test) ++ logback.map(_ % Test)
 
   val junitInterface = "com.novocode" % "junit-interface" % "0.11"
@@ -230,7 +230,7 @@ object Dependencies {
   )
 
   val playDocsDependencies = Seq(
-    "com.typesafe.play" %% "play-doc" % "1.2.2"
+    "com.typesafe.play" %% "play-doc" % "1.4.0"
   ) ++ playdocWebjarDependencies
 
   val iterateesDependencies = Seq(


### PR DESCRIPTION
## Purpose

Keep up with minor dependencies upgrades.

## Details

1. Jackson from 2.7.1 to 2.7.3
2. slf4j from 1.7.16 to 1.7.19
3. Logback from 1.1.4 to 1.1.6
4. Acolyte from 1.0.34-j7p to 1.0.36-j7p
5. Spring from 4.2.4 to 4.2.5
6. Snake YAML from 1.16 to 1.17
7. Tomcat-servlet-api from 8.0.32 to 8.0.33
8. play-doc from 1.2.2 to 1.4.0