### PR TITLE
Explicitly throw error when no application is in scope for Crypto

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Crypto.scala
@@ -53,13 +53,7 @@ object Crypto {
 
   def crypto: Crypto = {
     Play.privateMaybeApplication.fold {
-      val config = new CryptoConfigParser(
-        Environment.simple(), Configuration.from(Map("play.crypto.aes.transformation" -> "AES/CTR/NoPadding"))
-      ).get
-      val cookieSigner = new CookieSignerProvider(config).get
-      val tokenSigner = new CSRFTokenSignerProvider(cookieSigner).get
-      val crypter = new AESCTRCrypter(config)
-      new Crypto(cookieSigner, tokenSigner, crypter)
+      sys.error("The global crypto instance requires a running application!")
     }(cryptoCache)
   }
 


### PR DESCRIPTION
Fixes #5425

Requires backport to 2.5.x/2.4.x