### PR TITLE
[docs] Minor ScalaBodyParsers wording fix

### DIFF
--- a/documentation/manual/working/scalaGuide/main/http/ScalaBodyParsers.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaBodyParsers.md
@@ -46,7 +46,7 @@ The default body parser, for performance reasons, won't attempt to parse the bod
 
 ## Choosing an explicit body parser
 
-If you want to explicitly select a body parser, this can by passing a body parser to the `Action` [`apply`](api/scala/play/api/mvc/ActionBuilder.html#apply[A]\(bodyParser:play.api.mvc.BodyParser[A]\)\(block:R[A]=%3Eplay.api.mvc.Result\):play.api.mvc.Action[A]) or [`async`](api/scala/play/api/mvc/ActionBuilder.html#async[A]\(bodyParser:play.api.mvc.BodyParser[A]\)\(block:R[A]=%3Escala.concurrent.Future[play.api.mvc.Result]\):play.api.mvc.Action[A]) method.
+If you want to explicitly select a body parser, this can be done by passing a body parser to the `Action` [`apply`](api/scala/play/api/mvc/ActionBuilder.html#apply[A]\(bodyParser:play.api.mvc.BodyParser[A]\)\(block:R[A]=%3Eplay.api.mvc.Result\):play.api.mvc.Action[A]) or [`async`](api/scala/play/api/mvc/ActionBuilder.html#async[A]\(bodyParser:play.api.mvc.BodyParser[A]\)\(block:R[A]=%3Escala.concurrent.Future[play.api.mvc.Result]\):play.api.mvc.Action[A]) method.
 
 Play provides a number of body parsers out of the box, this is made available through the [`BodyParsers.parse`](api/scala/play/api/mvc/BodyParsers$parse$.html) object, which is conveniently pulled in by the [`Controller`](api/scala/play/api/mvc/Controller.html) trait.
 


### PR DESCRIPTION
Java version doesn't have this issue.

"this can by passing a body parser" => "this can **be done** by passing a body parser"