### PR TITLE
[doc] Rename title to match the TOC

### DIFF
--- a/documentation/manual/working/commonGuide/production/ProductionConfiguration.md
+++ b/documentation/manual/working/commonGuide/production/ProductionConfiguration.md
@@ -1,5 +1,5 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
-# Additional configuration
+# Production Configuration
 
 There are a number of different types of configuration that you can configure in production.  The three mains types are:
 


### PR DESCRIPTION
The title is "Additional Configuration" but it is "Production Configuration" in the TOC and URL.  Changing to "Production Configuration".