### PR TITLE
Improve scripted resolver performance

### DIFF
--- a/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/build.sbt
+++ b/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/build.sbt
@@ -2,6 +2,10 @@
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
 
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 DevModeBuild.settings

--- a/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/project/plugins.sbt
+++ b/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/project/plugins.sbt
@@ -2,6 +2,10 @@
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
 
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 addSbtPlugin("com.typesafe.play" % "sbt-fork-run-plugin" % playVersion)
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.0")

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
@@ -2,6 +2,10 @@
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
 
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.7")

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/plugins.sbt
@@ -2,6 +2,9 @@
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
 
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.0")

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
@@ -2,6 +2,10 @@
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
 
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 name := "dist-sample"
 
 version := "1.0-SNAPSHOT"

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/project/plugins.sbt
@@ -2,6 +2,9 @@
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
 
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.0")

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/build.sbt
@@ -5,6 +5,10 @@
 import java.net.URLClassLoader
 import com.typesafe.sbt.packager.Keys.executableScriptName
 
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 name := "assets-sample"
 
 version := "1.0-SNAPSHOT"

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/project/plugins.sbt
@@ -2,6 +2,9 @@
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
 
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.0")

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/build.sbt
@@ -1,3 +1,5 @@
+import sbt.Keys._
+
 //
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
@@ -23,7 +25,10 @@ lazy val nonplaymodule = (project in file("nonplaymodule"))
   .settings(common: _*)
 
 def common: Seq[Setting[_]] = Seq(
-  scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+  scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.7"),
+  // Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+  fullResolvers := Resolver.defaultLocal +: fullResolvers.value,
+  updateOptions := updateOptions.value.withLatestSnapshots(false)
 )
 
 TaskKey[Unit]("checkPlayMonitoredFiles") := {

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/project/plugins.sbt
@@ -2,4 +2,8 @@
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
 
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/nested-secret/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/nested-secret/project/plugins.sbt
@@ -1,4 +1,9 @@
 //
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
+
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/Build.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/Build.scala
@@ -4,7 +4,7 @@
 
 import play.sbt.PlayScala
 import sbt._
-import Keys._
+import sbt.Keys._
 
 object ApplicationBuild extends Build {
 
@@ -49,6 +49,10 @@ object ApplicationBuild extends Build {
   }
 
   val main = Project(appName, file(".")).enablePlugins(PlayScala).settings(
+    // Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+    fullResolvers := Resolver.defaultLocal +: fullResolvers.value,
+    updateOptions := updateOptions.value.withLatestSnapshots(false),
+
     version := appVersion,
     extraLoggers ~= { currentFunction =>
       (key: ScopedKey[_]) => {

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/plugins.sbt
@@ -1,4 +1,9 @@
 //
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
+
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/project/plugins.sbt
@@ -1,4 +1,9 @@
 //
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
+
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/build.sbt
@@ -9,6 +9,10 @@ lazy val root = (project in file("."))
   .aggregate(common, a, b, c, nonplay)
 
 def commonSettings: Seq[Setting[_]] = Seq(
+  // Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+  fullResolvers := Resolver.defaultLocal +: fullResolvers.value,
+  updateOptions := updateOptions.value.withLatestSnapshots(false),
+
   scalaVersion := sys.props.get("scala.version").getOrElse("2.11.7"),
   routesGenerator := play.routes.compiler.InjectedRoutesGenerator,
   // This makes it possible to run tests on the output regardless of scala version

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/project/plugins.sbt
@@ -1,4 +1,9 @@
 //
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
+
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/incremental-compilation/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/incremental-compilation/build.sbt
@@ -1,6 +1,11 @@
 //
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
+
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 lazy val root = (project in file(".")).enablePlugins(RoutesCompiler)
 
 scalaVersion := sys.props.get("scala.version").getOrElse("2.11.7")

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/incremental-compilation/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/incremental-compilation/project/plugins.sbt
@@ -1,4 +1,9 @@
 //
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
+
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/build.sbt
@@ -2,6 +2,10 @@
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
 
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 libraryDependencies += specs2 % Test

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/project/plugins.sbt
@@ -2,5 +2,9 @@
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
 
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "1.1.0")

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/build.sbt
@@ -2,6 +2,10 @@
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
 
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 libraryDependencies += specs2 % Test

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/project/plugins.sbt
@@ -2,5 +2,9 @@
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
 
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "1.1.0")

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/build.sbt
@@ -3,6 +3,10 @@
 //
 import scala.reflect._
 
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 scalaVersion := sys.props.get("scala.version").getOrElse("2.11.7")

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/project/plugins.sbt
@@ -1,4 +1,9 @@
 //
 // Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 //
+
+// Ensure sbt just goes straight to local for SNAPSHOTs, and doesn't try anything else
+fullResolvers := Resolver.defaultLocal +: fullResolvers.value
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))


### PR DESCRIPTION
This is an experiment to see if this will speed up the performance of scripted tests.  One of the slowest things about scripted tests is that sbt will go to every resolver to resolve SNAPSHOTs in order to ensure it gets the latest.  This is not needed in scripted tests, and means a lot of misses, which slows things down.

So this does two things to each scripted test, it configures sbt to not go to all resolvers for snapshots, and ensures that the local resolver is the first one in the list.