### PR TITLE
Add setting to disable global application

### DIFF
--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -9,6 +9,9 @@
 promise.akka.actor.typed.timeout=5s
 
 play {
+  # Defines whether the global application is allowed
+  globalApplication = true
+
   http {
 
     # The application context.

--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -59,7 +59,7 @@ object Play {
    * @deprecated This is a static reference to application, use DI, since 2.5.0
    */
   @deprecated("This is a static reference to application, use DI", "2.5.0")
-  def unsafeApplication: Application = _currentApp
+  def unsafeApplication: Application = privateMaybeApplication.orNull
 
   /**
    * Optionally returns the current running application.
@@ -67,12 +67,18 @@ object Play {
    * @deprecated This is a static reference to application, use DI, since 2.5.0
    */
   @deprecated("This is a static reference to application, use DI instead", "2.5.0")
-  def maybeApplication: Option[Application] = Option(_currentApp)
+  def maybeApplication: Option[Application] = privateMaybeApplication
 
-  private[play] def privateMaybeApplication: Option[Application] = Option(_currentApp)
+  private[play] def privateMaybeApplication: Option[Application] = {
+    Option(_currentApp) match {
+      case Some(app) if !app.configuration.getBoolean("play.globalApplication").getOrElse(true) =>
+        sys.error("The global application is disabled. Set play.globalApplication to allow global state here")
+      case opt => opt
+    }
+  }
 
   /* Used by the routes compiler to resolve an application for the injector.  Treat as private. */
-  def routesCompilerMaybeApplication: Option[Application] = Option(_currentApp)
+  def routesCompilerMaybeApplication: Option[Application] = privateMaybeApplication
 
   /**
    * Implicitly import the current running application in the context.
@@ -85,7 +91,7 @@ object Play {
   @deprecated("This is a static reference to application, use DI instead", "2.5.0")
   implicit def current: Application = privateMaybeApplication.getOrElse(sys.error("There is no started application"))
 
-  @volatile private[play] var _currentApp: Application = _
+  @volatile private var _currentApp: Application = _
 
   /**
    * Starts this application.

--- a/framework/src/play/src/main/scala/play/core/Execution.scala
+++ b/framework/src/play/src/main/scala/play/core/Execution.scala
@@ -13,10 +13,9 @@ import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
 private[play] object Execution {
 
   def internalContext: ExecutionContextExecutor = {
-    val appOrNull: Application = Play._currentApp
-    appOrNull match {
-      case null => common
-      case app: Application => app.actorSystem.dispatcher
+    Play.privateMaybeApplication match {
+      case None => common
+      case Some(app) => app.actorSystem.dispatcher
     }
   }
 


### PR DESCRIPTION
This should allow us to selectively disable global state in tests. Obviously it's disabled by default because it breaks a ton of tests, but it's a good way of seeing where the issues are.

/cc @jroper 