### PR TITLE
Remove duplicate typo words in documentation

### DIFF
--- a/documentation/manual/gettingStarted/Installing.md
+++ b/documentation/manual/gettingStarted/Installing.md
@@ -31,7 +31,7 @@ You can download Activator from [https://playframework.com/download](https://pla
 
 [[images/download.png]]
 
-The "offline distribution" comes with all of Activator's possible dependencies included.  It's a much larger initial download, but installing the offline distribution means that that starting up a new Play project is **much** faster, as all the dependencies are already resolved.
+The "offline distribution" comes with all of Activator's possible dependencies included.  It's a much larger initial download, but installing the offline distribution means that starting up a new Play project is **much** faster, as all the dependencies are already resolved.
 
 ### Extracting Activator
 

--- a/documentation/manual/hacking/Translations.md
+++ b/documentation/manual/hacking/Translations.md
@@ -75,7 +75,7 @@ Copy a markdown page from the Play repository into your project.  It is importan
 
 For example, if you choose to start with `manual/scalaGuide/main/http/ScalaActions.md`, then you need to ensure that it is in `manual/scalaGuide/main/http/ScalaActions.md` in your project.
 
-> **Note:** It may be tempting to start by copying the entire Play manual into your project.  If you do do this, make sure you only copy the markdown files, that you don't copy the code samples as well.  If you copy the code samples, they will override the code samples from Play, and you will lose the benefit of having those code samples automatically maintained for you.
+> **Note:** It may be tempting to start by copying the entire Play manual into your project.  If you do this, make sure you only copy the markdown files, that you don't copy the code samples as well.  If you copy the code samples, they will override the code samples from Play, and you will lose the benefit of having those code samples automatically maintained for you.
 
 Now you can start translating the file.
 

--- a/documentation/manual/releases/release21/Highlights21.md
+++ b/documentation/manual/releases/release21/Highlights21.md
@@ -139,7 +139,7 @@ The new Scala JSON API provide great features such as transformation and validat
 
 Play 2.1 provides a new and really powerful filter API allowing to intercept each part of the HTTP request or response, in a fully non-blocking way.
 
-For that, we introduced a new new simpler type replacing the old `Action[A]` type, called `EssentialAction` which is defined as:
+For that, we introduced a new simpler type replacing the old `Action[A]` type, called `EssentialAction` which is defined as:
 
 ```
 RequestHeader => Iteratee[Array[Byte], Result]

--- a/documentation/manual/releases/release21/Migration21.md
+++ b/documentation/manual/releases/release21/Migration21.md
@@ -42,7 +42,7 @@ If any compilation errors cropped up, this document will help you figure out wha
 
 Because Play 2.1 introduces further modularization, you now have to explicitly specify the dependencies your application needs. By default any `play.Project` will only contain a dependency to the core Play library.  You have to select the exact set of optional dependencies your application need.  Here are the new modularized dependencies in **Play 2.1**:
 
-- `jdbc` : The **JDBC** connection pool and the the `play.api.db` API.
+- `jdbc` : The **JDBC** connection pool and the `play.api.db` API.
 - `anorm` : The **Anorm** component.
 - `javaCore` : The core **Java** API.
 - `javaJdbc` : The Java database API.

--- a/documentation/manual/releases/release24/migration24/Migration24.md
+++ b/documentation/manual/releases/release24/migration24/Migration24.md
@@ -541,7 +541,7 @@ The API should be backward compatible with your code using Play 2.3 so there is 
 
 ## Distribution
 
-Previously, Play added all the resources to the the `conf` directory in the distribution, but didn't add the `conf` directory to the classpath.  Now Play adds the `conf` directory to the classpath by default.
+Previously, Play added all the resources to the `conf` directory in the distribution, but didn't add the `conf` directory to the classpath.  Now Play adds the `conf` directory to the classpath by default.
 
 This can be turned off by setting `PlayKeys.externalizeResources := false`, which will cause no `conf` directory to be created in the distribution, and it will not be on the classpath.  The contents of the applications `conf` directory will still be on the classpath by virtue of the fact that it's included in the applications jar file.
 

--- a/documentation/manual/working/commonGuide/filters/SecurityHeaders.md
+++ b/documentation/manual/working/commonGuide/filters/SecurityHeaders.md
@@ -27,7 +27,7 @@ play.http.filters = "filters.MyFilters"
 
 Scaladoc is available in the [play.filters.headers](api/scala/play/filters/headers/package.html) package.
 
-The filter will set headers in the HTTP response automatically.  The settings can can be configured through the following settings in `application.conf`
+The filter will set headers in the HTTP response automatically.  The settings can be configured through the following settings in `application.conf`
 
 * `play.filters.headers.frameOptions` - sets [X-Frame-Options](https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options), "DENY" by default.
 * `play.filters.headers.xssProtection` - sets [X-XSS-Protection](https://blogs.msdn.microsoft.com/ie/2008/07/02/ie8-security-part-iv-the-xss-filter/), "1; mode=block" by default.

--- a/documentation/manual/working/commonGuide/production/HTTPServer.md
+++ b/documentation/manual/working/commonGuide/production/HTTPServer.md
@@ -198,7 +198,7 @@ ProxyPassReverse / http://localhost:9998
 
 Play supports various forwarded headers used by proxies to indicate the incoming IP address and protocol of requests. Play uses this configuration to calculate the correct value for the `remoteAddress` and `secure` fields of `RequestHeader`.
 
-It is trivial for an HTTP client, whether it's a browser or other client, to forge forwarded headers, thereby spoofing the IP address and protocol that Play reports, consequently, Play needs to know which proxies are trusted. Play provides a configuration option to configure a list of trusted proxies, and will validate the incoming forwarded headers to verify that they are trusted, taking the first untrusted IP address that it finds as the reported user remote address (or the the last IP address if all proxies are trusted.)
+It is trivial for an HTTP client, whether it's a browser or other client, to forge forwarded headers, thereby spoofing the IP address and protocol that Play reports, consequently, Play needs to know which proxies are trusted. Play provides a configuration option to configure a list of trusted proxies, and will validate the incoming forwarded headers to verify that they are trusted, taking the first untrusted IP address that it finds as the reported user remote address (or the last IP address if all proxies are trusted.)
 
 To configure the list of trusted proxies, you can configure `play.http.forwarded.trustedProxies`.  This takes a list of IP address or CIDR subnet ranges.  Both IPv4 and IPv6 are supported.  For example:
 

--- a/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
+++ b/documentation/manual/working/commonGuide/production/cloud/ProductionHeroku.md
@@ -213,7 +213,7 @@ web: target/universal/stage/bin/myapp -Dhttp.port=${PORT} -Dplay.evolutions.db.d
 
 This instructs Heroku that for the process named `web` it will run Play and override the `play.evolutions.db.default.autoApply`, `db.default.driver`, and `db.default.url` configuration parameters.  Note that the `Procfile` command can be maximum 255 characters long.  Alternatively, use the `-Dconfig.resource=` or `-Dconfig.file=` mentioned in [[production configuration|ProductionConfiguration]] page.
 
-Also, be aware the the `DATABASE_URL` is in the platform independent format:
+Also, be aware the `DATABASE_URL` is in the platform independent format:
 
 ```text
 vendor://username:password@host:port/db

--- a/documentation/manual/working/javaGuide/advanced/routing/JavaRoutingDsl.md
+++ b/documentation/manual/working/javaGuide/advanced/routing/JavaRoutingDsl.md
@@ -13,7 +13,7 @@ A simple example of the DSL's use is:
 
 @[simple](code/javaguide/advanced/routing/JavaRoutingDsl.java)
 
-The `:to` parameter is extracted out and passed as the first parameter to the router.  Note that the name you give to parameters in the the path pattern is irrelevant, the important thing is that parameters in the path are in the same order as parameters in your lambda.  You can have anywhere from 0 to 3 parameters in the path pattern, and other HTTP methods, such as `POST`, `PUT` and `DELETE` are supported.
+The `:to` parameter is extracted out and passed as the first parameter to the router.  Note that the name you give to parameters in the path pattern is irrelevant, the important thing is that parameters in the path are in the same order as parameters in your lambda.  You can have anywhere from 0 to 3 parameters in the path pattern, and other HTTP methods, such as `POST`, `PUT` and `DELETE` are supported.
 
 Like Play's compiled router, the DSL also supports matching multi path segment parameters, this is done by prefixing the parameter with `*`:
 

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
 # Dependency Injection
 
-Dependency injection is a widely used design pattern that helps to separate your components' behaviour from dependency resolution.  Components declare their dependencies, usually as constructor parameters, and a dependency injection framework helps you wire together those components so you you don't have to do so manually.
+Dependency injection is a widely used design pattern that helps to separate your components' behaviour from dependency resolution.  Components declare their dependencies, usually as constructor parameters, and a dependency injection framework helps you wire together those components so you don't have to do so manually.
 
 Out of the box, Play provides dependency injection support based on [JSR 330](https://jcp.org/en/jsr/detail?id=330).  The default JSR 330 implementation that comes with Play is [Guice](https://github.com/google/guice), but other JSR 330 implementations can be plugged in. The [Guice wiki](https://github.com/google/guice/wiki/) is a great resource for learning more about the features of Guice and DI design patterns in general.
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

This is just a documentation fix, so I think I can keep unchecked some checklists above.

## Fixes

There is no issue, because this is just a documentation fix.

## Purpose

Remove unnecessary duplications.

## Background Context

While I'm translating the docs into Japanese, I found these duplications.

## References

There're not any relevant issues / PRs / mailing lists discussions.

