### PR TITLE
Improved idle timeouts

### DIFF
--- a/framework/src/play-akka-http-server/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/reference.conf
@@ -5,12 +5,14 @@
 # Configuration for Play's AkkaHttpServer
 play {
 
-  # The server provider class name
-  server.provider = "play.core.server.akkahttp.AkkaHttpServerProvider"
+  server {
+    # The server provider class name
+    provider = "play.core.server.akkahttp.AkkaHttpServerProvider"
 
-  akka {
-    # How long to wait when binding to the listening socket
-    http-bind-timeout = 5 seconds
+    akka {
+      # How long to wait when binding to the listening socket
+      bindTimeout = 5 seconds
+    }
   }
 
 }

--- a/framework/src/play-server/src/main/resources/reference.conf
+++ b/framework/src/play-server/src/main/resources/reference.conf
@@ -19,7 +19,8 @@ play {
       address = ${?http.address}
 
       # The idle timeout for an open connection after which it will be closed
-      # idleTimeout = "90 seconds"
+      # Set to null to disable the timeout
+      idleTimeout = 75 seconds
     }
 
     # HTTPS configuration
@@ -33,7 +34,8 @@ play {
       address = ${?https.address}
 
       # The idle timeout for an open connection after which it will be closed
-      # idleTimeout = "90 seconds"
+      # Set to null to disable the timeout
+      idleTimeout = ${play.server.http.idleTimeout}
 
       # The SSL engine provider
       engineProvider = "play.core.server.ssl.DefaultSSLEngineProvider"
@@ -62,6 +64,15 @@ play {
         # If true, does not do CA verification on client side certificates
         noCaVerification = false
       }
+
+      # Whether JSSE want client auth mode should be used. This means, the server
+      # will request a client certificate, but won't fail if one isn't provided.
+      wantClientAuth = false
+
+      # Whether JSSE need client auth mode should be used. This means, the server
+      # will request a client certificate, and will fail and terminate the session
+      # if one isn't provided.
+      needClientAuth = false
     }
 
     # The path to the process id file created by the server when it runs.

--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -21,7 +21,7 @@ import play.twirl.api.Content;
 import org.openqa.selenium.firefox.*;
 import org.openqa.selenium.htmlunit.*;
 import scala.compat.java8.FutureConverters;
-
+import scala.compat.java8.OptionConverters;
 
 import java.util.*;
 import java.util.concurrent.Callable;
@@ -446,7 +446,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
             try {
                 start(server);
                 startedServer = server;
-                browser = testBrowser(webDriver, server.port());
+                browser = testBrowser(webDriver, (Integer) OptionConverters.toJava(server.config().port()).get());
                 block.accept(browser);
             }
             finally {

--- a/framework/src/play-test/src/main/java/play/test/TestServer.java
+++ b/framework/src/play-test/src/main/java/play/test/TestServer.java
@@ -4,8 +4,14 @@
 package play.test;
 
 import play.Application;
+import play.api.Mode;
+import play.core.server.ServerConfig;
 import play.core.server.ServerProvider;
 import scala.Option;
+import scala.compat.java8.OptionConverters;
+
+import java.io.File;
+import java.util.Optional;
 
 /**
  * A test Netty web server.
@@ -19,7 +25,8 @@ public class TestServer extends play.api.test.TestServer {
      * @param application The Application to load in this server.
      */
     public TestServer(int port, Application application) {
-        super(port, application.getWrappedApplication(), play.libs.Scala.<Object>None(), play.libs.Scala.<ServerProvider>None());
+        super(createServerConfig(Optional.of(port), Optional.empty()), application.getWrappedApplication(),
+                play.libs.Scala.<ServerProvider>None());
     }
 
     /**
@@ -29,7 +36,14 @@ public class TestServer extends play.api.test.TestServer {
      * @param sslPort HTTPS port to bind on
      */
     public TestServer(int port, Application application, int sslPort) {
-        super(port, application.getWrappedApplication(), Option.<Object>apply(sslPort), play.libs.Scala.<ServerProvider>None());
+        super(createServerConfig(Optional.of(port), Optional.of(sslPort)), application.getWrappedApplication(),
+                play.libs.Scala.<ServerProvider>None());
+    }
+
+    private static ServerConfig createServerConfig(Optional<Integer> port, Optional<Integer> sslPort) {
+        return ServerConfig.apply(TestServer.class.getClassLoader(), new File("."),
+                (Option) OptionConverters.toScala(port), (Option) OptionConverters.toScala(sslPort), "0.0.0.0",
+                Mode.Test(), System.getProperties());
     }
 
 }


### PR DESCRIPTION
* Modified test API to remove hacks in idle timeout specs
* Set a default idle timeout of 75 seconds (this matches nginx keep alive timeout)
* Changed config to read Duration and use null as infinite
* Refactored NettyServer to use PlayConfig