### PR TITLE
Resolve small inconsistencies at Results API

### DIFF
--- a/documentation/manual/releases/release25/migration25/Migration25.md
+++ b/documentation/manual/releases/release25/migration25/Migration25.md
@@ -44,7 +44,7 @@ Or:
 
 ```scala
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-slick" % "2.0.0"
+  "com.typesafe.play" %% "play-slick" % "2.0.0",
   "com.typesafe.play" %% "play-slick-evolutions" % "2.0.0"
 )
 ```
@@ -63,7 +63,7 @@ If your project is using [[ScalaTest + Play|ScalaTestingWithScalaTest]], you nee
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.0" % "test"
+  "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % "test"
 )
 ```
 
@@ -322,3 +322,19 @@ Modify any `play.server.netty.option` keys to use the new keys defined in [Chann
 | `play.server.netty.option.backlog` | `play.server.netty.option.SO_BACKLOG` |
 | `play.server.netty.option.child.keepAlive` | `play.server.netty.option.child.SO_KEEPALIVE` |
 | `play.server.netty.option.child.tcpNoDelay` | `play.server.netty.option.child.TCP_NODELAY` |
+
+## Changes to `sendFile`, `sendPath` and `sendResource` methods
+
+Java (`play.mvc.StatusHeader`) and Scala (`play.api.mvc.Results.Status`) APIs had the following behavior before:
+
+| API   | Method                                    | Default      |
+|:------|:------------------------------------------|:-------------|
+| Scala | `play.api.mvc.Results.StatussendResource` | `inline`     |
+| Scala | `play.api.mvc.Results.StatussendPath`     | `attachment` |
+| Scala | `play.api.mvc.Results.StatussendFile`     | `attachment` |
+| Java  | `play.mvc.StatusHeader.sendInputStream`   | `none`       |
+| Java  | `play.mvc.StatusHeader.sendResource`      | `inline`     |
+| Java  | `play.mvc.StatusHeader.sendPath`          | `attachment` |
+| Java  | `play.mvc.StatusHeader.sendFile`          | `inline`     |
+
+In other words, they were mixing `inline` and `attachment` modes when delivering files. Now, when delivering files, paths and resources uses `inline` as the default behavior. Of course, you can alternate between these two modes using the parameters present in these methods.

--- a/framework/src/play/src/main/java/play/mvc/StatusHeader.java
+++ b/framework/src/play/src/main/java/play/mvc/StatusHeader.java
@@ -33,7 +33,8 @@ import java.util.Optional;
  */
 public class StatusHeader extends Result {
 
-    private static final int defaultChunkSize = 1024 * 8;
+    private static final int DEFAULT_CHUNK_SIZE = 1024 * 8;
+    private static final boolean DEFAULT_INLINE_MODE = true;
 
     public StatusHeader(int status) {
         super(status);
@@ -51,7 +52,7 @@ public class StatusHeader extends Result {
         if (stream == null) {
             throw new NullPointerException("Null stream");
         }
-        return new Result(status(), HttpEntity.chunked(StreamConverters.fromInputStream(() -> stream, defaultChunkSize),
+        return new Result(status(), HttpEntity.chunked(StreamConverters.fromInputStream(() -> stream, DEFAULT_CHUNK_SIZE),
                 Optional.empty()));
     }
 
@@ -64,9 +65,9 @@ public class StatusHeader extends Result {
      */
     public Result sendInputStream(InputStream stream, long contentLength) {
         if (stream == null) {
-            throw new NullPointerException("Null content");
+            throw new NullPointerException("Null stream");
         }
-        return new Result(status(), new HttpEntity.Streamed(StreamConverters.fromInputStream(() -> stream, defaultChunkSize),
+        return new Result(status(), new HttpEntity.Streamed(StreamConverters.fromInputStream(() -> stream, DEFAULT_CHUNK_SIZE),
                 Optional.of(contentLength), Optional.empty()));
     }
 
@@ -76,10 +77,10 @@ public class StatusHeader extends Result {
      * The resource will be loaded from the same classloader that this class comes from.
      *
      * @param resourceName The path of the resource to load.
-     * @return an inlined '200 OK' result containing the resource in the body with in-line content disposition.
+     * @return a '200 OK' result containing the resource in the body with in-line content disposition.
      */
     public Result sendResource(String resourceName) {
-        return sendResource(resourceName, true);
+        return sendResource(resourceName, DEFAULT_INLINE_MODE);
     }
 
     /**
@@ -90,7 +91,7 @@ public class StatusHeader extends Result {
      * @return a '200 OK' result containing the resource in the body with in-line content disposition.
      */
     public Result sendResource(String resourceName, ClassLoader classLoader) {
-        return sendResource(resourceName, classLoader, true);
+        return sendResource(resourceName, classLoader, DEFAULT_INLINE_MODE);
     }
 
     /**
@@ -120,13 +121,41 @@ public class StatusHeader extends Result {
     }
 
     /**
+     * Send the given resource.
+     * <p>
+     * The resource will be loaded from the same classloader that this class comes from.
+     *
+     * @param resourceName The path of the resource to load.
+     * @param inline       Whether it should be served as an inline file, or as an attachment.
+     * @param filename     The file name of the resource.
+     * @return a '200 OK' result containing the resource in the body.
+     */
+    public Result sendResource(String resourceName, boolean inline, String filename) {
+        return sendResource(resourceName, this.getClass().getClassLoader(), inline, filename);
+    }
+
+    /**
+     * Send the given resource from the given classloader.
+     *
+     * @param resourceName The path of the resource to load.
+     * @param classLoader  The classloader to load it from.
+     * @param inline       Whether it should be served as an inline file, or as an attachment.
+     * @param filename     The file name of the resource.
+     * @return a '200 OK' result containing the resource in the body.
+     */
+    public Result sendResource(String resourceName, ClassLoader classLoader, boolean inline, String filename) {
+        return doSendResource(StreamConverters.fromInputStream(() -> classLoader.getResourceAsStream(resourceName)),
+                Optional.empty(), Optional.of(filename), inline);
+    }
+
+    /**
      * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions.
      *
      * @param path The path to send.
      * @return a '200 OK' result containing the file at the provided path with inline content disposition.
      */
     public Result sendPath(Path path) {
-        return sendPath(path, false);
+        return sendPath(path, DEFAULT_INLINE_MODE);
     }
 
     /**
@@ -138,6 +167,17 @@ public class StatusHeader extends Result {
      */
     public Result sendPath(Path path, boolean inline) {
         return sendPath(path, inline, path.getFileName().toString());
+    }
+
+    /**
+     * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions.
+     *
+     * @param path     The path to send.
+     * @param filename The file name of the path.
+     * @return a '200 OK' result containing the file at the provided path
+     */
+    public Result sendPath(Path path, String filename) {
+        return sendPath(path, DEFAULT_INLINE_MODE, filename);
     }
 
     /**
@@ -169,8 +209,8 @@ public class StatusHeader extends Result {
      *
      * @param file The file to send.
      */
-    private Result sendFile(File file) {
-        return sendFile(file, true);
+    public Result sendFile(File file) {
+        return sendFile(file, DEFAULT_INLINE_MODE);
     }
 
     /**
@@ -193,13 +233,25 @@ public class StatusHeader extends Result {
     }
 
     /**
-     * Send the given file as an attachment.
+     * Send the given file.
      *
      * @param file The file to send.
      * @param fileName The name of the attachment
      * @return a '200 OK' result containing the file
      */
     public Result sendFile(File file, String fileName) {
+        return sendFile(file, DEFAULT_INLINE_MODE, fileName);
+    }
+
+    /**
+     * Send the given file.
+     *
+     * @param file     The file to send.
+     * @param fileName The name of the attachment
+     * @param inline   True if the file should be sent inline, false if it should be sent as an attachment.
+     * @return a '200 OK' result containing the file
+     */
+    public Result sendFile(File file, boolean inline, String fileName) {
         if (file == null) {
             throw new NullPointerException("null file");
         }
@@ -207,7 +259,7 @@ public class StatusHeader extends Result {
                 FileIO.fromFile(file),
                 Optional.of(file.length()),
                 Optional.of(fileName),
-                true
+                inline
         );
     }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -392,7 +392,7 @@ trait Results {
      * @param inline Use Content-Disposition inline or attachment.
      * @param fileName Function to retrieve the file name. By default the name of the file is used.
      */
-    def sendFile(content: java.io.File, inline: Boolean = false, fileName: java.io.File => String = _.getName, onClose: () => Unit = () => ()): Result = {
+    def sendFile(content: java.io.File, inline: Boolean = true, fileName: java.io.File => String = _.getName, onClose: () => Unit = () => ()): Result = {
       streamFile(FileIO.fromFile(content), fileName(content), content.length, inline)
     }
 
@@ -403,7 +403,7 @@ trait Results {
      * @param inline Use Content-Disposition inline or attachment.
      * @param fileName Function to retrieve the file name. By default the name of the file is used.
      */
-    def sendPath(content: Path, inline: Boolean = false, fileName: Path => String = _.getFileName.toString, onClose: () => Unit = () => ()): Result = {
+    def sendPath(content: Path, inline: Boolean = true, fileName: Path => String = _.getFileName.toString, onClose: () => Unit = () => ()): Result = {
       streamFile(FileIO.fromFile(content.toFile), fileName(content), Files.size(content), inline)
     }
 
@@ -414,8 +414,7 @@ trait Results {
      * @param classLoader The classloader to load it from, defaults to the classloader for this class.
      * @param inline Whether it should be served as an inline file, or as an attachment.
      */
-    def sendResource(resource: String, classLoader: ClassLoader = Results.getClass.getClassLoader,
-      inline: Boolean = true): Result = {
+    def sendResource(resource: String, classLoader: ClassLoader = Results.getClass.getClassLoader, inline: Boolean = true): Result = {
       val stream = classLoader.getResourceAsStream(resource)
       val fileName = resource.split('/').last
       streamFile(StreamConverters.fromInputStream(() => stream), fileName, stream.available(), inline)

--- a/framework/src/play/src/test/java/play/mvc/ResultsTest.java
+++ b/framework/src/play/src/test/java/play/mvc/ResultsTest.java
@@ -3,18 +3,37 @@
  */
 package play.mvc;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 
 import play.mvc.Http.HeaderNames;
 
 import static org.junit.Assert.*;
 
 public class ResultsTest {
+
+  private static Path file;
+
+  @BeforeClass
+  public static void createFile() throws Exception {
+    file = Paths.get("test.tmp");
+    Files.createFile(file);
+    Files.write(file, "Some content for the file".getBytes(), StandardOpenOption.APPEND);
+  }
+
+  @AfterClass
+  public static void deleteFile() throws IOException {
+    Files.deleteIfExists(file);
+  }
+
+  // -- Path tests
 
   @Test(expected = NullPointerException.class)
   public void shouldThrowNullPointerExceptionIfPathIsNull() throws IOException {
@@ -23,45 +42,92 @@ public class ResultsTest {
 
   @Test
   public void sendPathWithOKStatus() throws IOException {
-    Path file = Paths.get("test.tmp");
-    Files.createFile(file);
     Result result = Results.ok().sendPath(file);
-    Files.delete(file);
-
     assertEquals(result.status(), Http.Status.OK);
-    assertEquals("attachment; filename=\"test.tmp\"", result.header(HeaderNames.CONTENT_DISPOSITION).get());
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
   }
 
   @Test
   public void sendPathWithUnauthorizedStatus() throws IOException {
-    Path file = Paths.get("test.tmp");
-    Files.createFile(file);
     Result result = Results.unauthorized().sendPath(file);
-    Files.delete(file);
-
-    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
-  }
-
-  @Test
-  public void sendPathInlineWithUnauthorizedStatus() throws IOException {
-    Path file = Paths.get("test.tmp");
-    Files.createFile(file);
-    Result result = Results.unauthorized().sendPath(file, true);
-    Files.delete(file);
-
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
     assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
   }
 
   @Test
-  public void sendPathWithFileName() throws IOException {
-    Path file = Paths.get("test.tmp");
-    Files.createFile(file);
-    Result result = Results.unauthorized().sendPath(file, false, "foo.bar");
-    Files.delete(file);
-
+  public void sendPathAsAttachmentWithUnauthorizedStatus() throws IOException {
+    Result result = Results.unauthorized().sendPath(file, /*inline*/ false);
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"foo.bar\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
+  }
+
+  @Test
+  public void sendPathAsAttachmentWithOkStatus() throws IOException {
+    Result result = Results.unauthorized().sendPath(file, /* inline */ false);
+    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
+  }
+
+  @Test
+  public void sendPathWithFileName() throws IOException {
+    Result result = Results.unauthorized().sendPath(file, "foo.bar");
+    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
+  }
+
+  @Test
+  public void sendPathInlineWithFileName() throws IOException {
+    Result result = Results.unauthorized().sendPath(file, true, "foo.bar");
+    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
+  }
+
+  // -- File tests
+
+  @Test(expected = NullPointerException.class)
+  public void shouldThrowNullPointerExceptionIfFileIsNull() throws IOException {
+    Results.ok().sendFile(null);
+  }
+
+  @Test
+  public void sendFileWithOKStatus() throws IOException {
+    Result result = Results.ok().sendFile(file.toFile());
+    assertEquals(result.status(), Http.Status.OK);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
+  }
+
+  @Test
+  public void sendFileWithUnauthorizedStatus() throws IOException {
+    Result result = Results.unauthorized().sendFile(file.toFile());
+    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
+  }
+
+  @Test
+  public void sendFileAsAttachmentWithUnauthorizedStatus() throws IOException {
+    Result result = Results.unauthorized().sendFile(file.toFile(), /* inline */ false);
+    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
+  }
+
+  @Test
+  public void sendFileAsAttachmentWithOkStatus() throws IOException {
+    Result result = Results.unauthorized().sendFile(file.toFile(), /* inline */ false);
+    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
+  }
+
+  @Test
+  public void sendFileWithFileName() throws IOException {
+    Result result = Results.unauthorized().sendFile(file.toFile(), "foo.bar");
+    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
+  }
+
+  @Test
+  public void sendFileInlineWithFileName() throws IOException {
+    Result result = Results.ok().sendFile(file.toFile(), true, "foo.bar");
+    assertEquals(result.status(), Http.Status.OK);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
   }
 }

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -158,56 +158,56 @@ object ResultsSpec extends Specification {
       val rh = Ok.sendFile(file).header
 
       (rh.status aka "status" must_== OK) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="${fileName}""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
     }
 
     "support sending a file with Unauthorized status" in withFile { (file, fileName) =>
       val rh = Unauthorized.sendFile(file).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="${fileName}""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
     }
 
-    "support sending a file inline with Unauthorized status" in withFile { (file, fileName) =>
-      val rh = Unauthorized.sendFile(file, inline = true).header
+    "support sending a file attached with Unauthorized status" in withFile { (file, fileName) =>
+      val rh = Unauthorized.sendFile(file, inline = false).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="${fileName}""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName""""))
     }
 
     "support sending a file with PaymentRequired status" in withFile { (file, fileName) =>
       val rh = PaymentRequired.sendFile(file).header
 
       (rh.status aka "status" must_== PAYMENT_REQUIRED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="${fileName}""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
     }
 
-    "support sending a file inline with PaymentRequired status" in withFile { (file, fileName) =>
-      val rh = PaymentRequired.sendFile(file, inline = true).header
+    "support sending a file attached with PaymentRequired status" in withFile { (file, fileName) =>
+      val rh = PaymentRequired.sendFile(file, inline = false).header
 
       (rh.status aka "status" must_== PAYMENT_REQUIRED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="${fileName}""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName""""))
     }
 
     "support sending a path with Ok status" in withPath { (file, fileName) =>
       val rh = Ok.sendPath(file).header
 
       (rh.status aka "status" must_== OK) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="${fileName}""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
     }
 
     "support sending a path with Unauthorized status" in withPath { (file, fileName) =>
       val rh = Unauthorized.sendPath(file).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="${fileName}""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
     }
 
-    "support sending a path inline with Unauthorized status" in withPath { (file, fileName) =>
-      val rh = Unauthorized.sendPath(file, inline = true).header
+    "support sending a path attached with Unauthorized status" in withPath { (file, fileName) =>
+      val rh = Unauthorized.sendPath(file, inline = false).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="${fileName}""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName""""))
     }
 
     "allow checking content length" in withPath { (file, fileName) =>


### PR DESCRIPTION
## Pull Request Checklist

* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #5872.

## Purpose

This made Java Results API more consistent while sending files/paths and resources. It was also checked against Scala API to ensure consistent between the two APIs (at least in relation to sending files, paths and resources).

## References

See #5872.