### PR TITLE
[doc] Fix link to ScalaTestingWithGuice page

### DIFF
--- a/documentation/manual/working/scalaGuide/advanced/extending/ScalaPlayModules.md
+++ b/documentation/manual/working/scalaGuide/advanced/extending/ScalaPlayModules.md
@@ -43,7 +43,7 @@ Modules can be tested using Play's built in test functionality, using the `Guice
 
 @[module-bindings](code/ScalaExtendingPlay.scala)
 
-Please see [[Testing with Guice|ScalaTestingWithGuice#Bindings-and-Modules] for more details.
+Please see [[Testing with Guice|ScalaTestingWithGuice#Bindings-and-Modules]] for more details.
 
 ## Listing Existing Play Modules
 


### PR DESCRIPTION
Note: The Java counterpart (documentation/manual/working/javaGuide/advanced/extending/JavaPlayModules.md) was not affected, so there is no need to fix the documentation for Java.