### PR TITLE
Documentation fix for multipart/form data in ws

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -77,9 +77,15 @@ The easiest way to post JSON data is to use the [[JSON library|JavaJsonActions]]
 
 ### Submitting multipart/form data
 
-The easiest way to post multipart/form data is to use a `Source<Http.MultipartFormData<Source<ByteString>, ?>, ?>`
+The easiest way to post multipart/form data is to use a `Source<Http.MultipartFormData.Part<Source<ByteString>, ?>, ?>`
+
+@[multipart-imports](code/javaguide/ws/JavaWS.java)
 
 @[ws-post-multipart](code/javaguide/ws/JavaWS.java)
+
+To Upload a File you need to pass a `Http.MultipartFormData.FilePart<Source<ByteString>, ?>` to the `Source`:
+
+@[ws-post-multipart2](code/javaguide/ws/JavaWS.java)
 
 ### Streaming data
 

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -9,6 +9,8 @@ import javaguide.testhelpers.MockJavaAction;
 import org.slf4j.Logger;
 import play.api.libs.ws.ahc.AhcCurlRequestLogger;
 import play.libs.ws.*;
+
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -18,6 +20,10 @@ import java.util.concurrent.CompletionStage;
 import com.fasterxml.jackson.databind.JsonNode;
 import play.libs.Json;
 // #json-imports
+
+// #multipart-imports
+import play.mvc.Http.MultipartFormData.*;
+// #multipart-imports
 
 import play.libs.ws.ahc.AhcWSClient;
 import play.mvc.Http;
@@ -117,8 +123,16 @@ public class JavaWS {
             // #ws-post-json
 
             // #ws-post-multipart
-            ws.url(url).post(Source.single(new Http.MultipartFormData.DataPart("hello", "world")));
+            ws.url(url).post(Source.single(new DataPart("hello", "world")));
             // #ws-post-multipart
+
+            // #ws-post-multipart2
+            Source<ByteString, ?> file = FileIO.fromFile(new File("hello.txt"));
+            FilePart<Source<ByteString, ?>> fp = new FilePart<>("hello", "hello.txt", "text/plain", file);
+            DataPart dp = new DataPart("key", "value");
+
+            ws.url(url).post(Source.from(Arrays.asList(fp, dp)));
+            // #ws-post-multipart2
 
             String value = IntStream.range(0,100).boxed().
                 map(i -> "abcdefghij").reduce("", (a,b) -> a + b);

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -83,9 +83,13 @@ To post url-form-encoded data a `Map[String, Seq[String]]` needs to be passed in
 
 ### Submitting multipart/form data
 
-To post multipart-form-encoded data a `Seq[org.asynchttpclient.request.body.multipart.Part]` needs to be passed into `post`.
+To post multipart-form-encoded data a `Source[play.api.mvc.MultipartFormData.Part[Source[ByteString, Any]], Any]` needs to be passed into `post`.
 
 @[multipart-encoded](code/ScalaWSSpec.scala)
+
+To upload a file you need to pass a `play.api.mvc.MultipartFormData.FilePart[Source[ByteString, Any]]` to the `Source`:
+
+@[multipart-encoded2](code/ScalaWSSpec.scala)
 
 ### Submitting JSON data
 


### PR DESCRIPTION
Actually the Documentation of multipart/form data had a bug
that it pointed to the underyling parts of async-http-client
which play doesn't use.
I also added some file upload examples

I found the error cause of #5988 

Actually this needs a backport.