### PR TITLE
Java 2.5 migration guide (Thread Local attributes)

### DIFF
--- a/documentation/manual/releases/release25/migration25/JavaMigration25.md
+++ b/documentation/manual/releases/release25/migration25/JavaMigration25.md
@@ -150,7 +150,7 @@ Here follows a short table that should ease the migration:
 
 ## Thread Local attributes
 
-Thread Local attributes such as Http.Context, Http.Session etc are no longer passed to a different execution context when used with `CompletionStage` and `*Async` callbacks. 
+Thread Local attributes such as `Http.Context`, `Http.Session` etc are no longer passed to a different execution context when used with `CompletionStage` and `*Async` callbacks. 
 More information is [here](https://www.playframework.com/documentation/2.5.x/ThreadPools#Java-thread-locals)
 
 ## Deprecated static APIs

--- a/documentation/manual/releases/release25/migration25/JavaMigration25.md
+++ b/documentation/manual/releases/release25/migration25/JavaMigration25.md
@@ -148,6 +148,11 @@ Here follows a short table that should ease the migration:
 
 `Optional` has a lot more combinators, so we highly encourage you to [learn its API](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html) if you are not familiar with it already.
 
+## Thread Local attributes
+
+Thread Local attributes such as Http.Context, Http.Session etc are no longer passed to a different execution context when used with `CompletionStage` and `*Async` callbacks. 
+More information is [here](https://www.playframework.com/documentation/2.5.x/ThreadPools#Java-thread-locals)
+
 ## Deprecated static APIs
 
 Several static APIs were deprecated in Play 2.5, in favour of using dependency injected components. Using static global state is bad for testability and modularity, and it is recommended that you move to dependency injection for accessing these APIs. You should refer to the list in the [[Play 2.4 Migration Guide|Migration24#Dependency-Injected-Components]] to find the equivalent dependency injected component for your static API.


### PR DESCRIPTION
# Pull Request Checklist

* [Yes ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [Yes ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [Yes ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [Yes] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [No new files added] Have you added copyright headers to new files?
* [Related to Java only] Have you checked that both Scala and Java APIs are updated?
* [ Related to Java only ] Have you updated the documentation for both Scala and Java sections?
* [Documentation related ] Have you added tests for any changed functionality?

## Fixes

Fixes Migrationguide2.5

## Purpose

Highlights one of the points developers to need to take while upgrading to 2.5.x

## Background Context

While migrating, I faced an issue and there is no mention about that issue in migration guide

## References

No

Thread Local attributes are not longer copied when we change the execution context. This PR highlights that and points to relevant documentation.