### PR TITLE
Configuration refactor

### DIFF
--- a/documentation/manual/working/javaGuide/main/application/code/javaguide/application/def/ErrorHandler.java
+++ b/documentation/manual/working/javaGuide/main/application/code/javaguide/application/def/ErrorHandler.java
@@ -4,6 +4,8 @@
 package javaguide.application.def;
 
 //#default
+import com.typesafe.config.Config;
+
 import play.*;
 import play.api.OptionalSourceMapper;
 import play.api.UsefulException;
@@ -19,9 +21,9 @@ import java.util.concurrent.CompletionStage;
 public class ErrorHandler extends DefaultHttpErrorHandler {
 
     @Inject
-    public ErrorHandler(Configuration configuration, Environment environment,
+    public ErrorHandler(Config config, Environment environment,
                         OptionalSourceMapper sourceMapper, Provider<Router> routes) {
-        super(configuration, environment, sourceMapper, routes);
+        super(config, environment, sourceMapper, routes);
     }
 
     protected CompletionStage<Result> onProdServerError(RequestHeader request, UsefulException exception) {

--- a/documentation/manual/working/javaGuide/main/tests/code/tests/guice/JavaGuiceApplicationBuilderTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/tests/guice/JavaGuiceApplicationBuilderTest.java
@@ -3,6 +3,7 @@
  */
 package javaguide.tests.guice;
 
+import com.typesafe.config.ConfigFactory;
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.net.URL;
@@ -104,7 +105,7 @@ public class JavaGuiceApplicationBuilderTest {
     public void overrideConfiguration() {
         // #override-configuration
         Application application = new GuiceApplicationBuilder()
-            .loadConfig(env -> Configuration.load(env))
+            .withConfigLoader(env -> ConfigFactory.load(env.classLoader()))
             .build();
         // #override-configuration
     }

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
@@ -15,7 +15,6 @@ import akka.http.scaladsl.model.ws.UpgradeToWebSocket
 import akka.stream.Materializer
 import akka.stream.scaladsl._
 import java.net.InetSocketAddress
-import java.util.concurrent.TimeUnit
 
 import akka.http.scaladsl.settings.ServerSettings
 import akka.util.ByteString
@@ -48,7 +47,7 @@ class AkkaHttpServer(
 
   assert(config.port.isDefined || config.sslPort.isDefined, "AkkaHttpServer must be given at least one of an HTTP and an HTTPS port")
 
-  private val serverConfig = PlayConfig(config.configuration).get[PlayConfig]("play.server")
+  private val serverConfig = config.configuration.get[Configuration]("play.server")
 
   def mode = config.mode
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
@@ -3,12 +3,11 @@
  */
 package play.filters.cors
 
-import com.typesafe.config.Config
 import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
 
 import scala.concurrent.Future
 
-import play.api.{ PlayConfig, Logger, Configuration }
+import play.api.{ Logger, Configuration }
 import play.api.mvc.{ ActionBuilder, Request, Result }
 
 /**
@@ -56,17 +55,16 @@ object CORSActionBuilder {
   /**
    * Construct an action builder that uses a subtree of the application configuration.
    *
-   * @param  configuration  The configuration to load the config from
+   * @param  config  The configuration to load the config from
    * @param  configPath  The path to the subtree of the application configuration.
    */
-  def apply(configuration: Configuration, errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
+  def apply(config: Configuration, errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
     configPath: String = "play.filters.cors"): CORSActionBuilder = {
     val eh = errorHandler
     new CORSActionBuilder {
       override protected def corsConfig = {
-        val config = PlayConfig(configuration)
-        val prototype = config.get[Config]("play.filters.cors")
-        val corsConfig = PlayConfig(config.get[Config](configPath).withFallback(prototype))
+        val prototype = config.get[Configuration]("play.filters.cors")
+        val corsConfig = prototype ++ config.get[Configuration](configPath)
         CORSConfig.fromUnprefixedConfiguration(corsConfig)
       }
       override protected val errorHandler = eh

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSConfig.scala
@@ -3,7 +3,7 @@
  */
 package play.filters.cors
 
-import play.api.{ PlayConfig, Configuration }
+import play.api.Configuration
 import play.filters.cors.CORSConfig.Origins
 
 import scala.concurrent.duration._
@@ -107,11 +107,11 @@ object CORSConfig {
    * }}}
    */
   def fromConfiguration(conf: Configuration): CORSConfig = {
-    val config = PlayConfig(conf).get[PlayConfig]("play.filters.cors")
+    val config = conf.get[Configuration]("play.filters.cors")
     fromUnprefixedConfiguration(config)
   }
 
-  private[cors] def fromUnprefixedConfiguration(config: PlayConfig): CORSConfig = {
+  private[cors] def fromUnprefixedConfiguration(config: Configuration): CORSConfig = {
     CORSConfig(
       allowedOrigins = config.get[Option[Seq[String]]]("allowedOrigins") match {
         case Some(allowed) => Origins.Matching(allowed.toSet)

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
@@ -7,7 +7,7 @@ import javax.inject.{ Inject, Provider }
 
 import akka.stream.Materializer
 import play.api.http.HttpErrorHandler
-import play.api.{ Environment, PlayConfig, Configuration }
+import play.api.{ Environment, Configuration }
 import play.api.inject.Module
 
 /**
@@ -23,7 +23,7 @@ class CORSConfigProvider @Inject() (configuration: Configuration) extends Provid
 class CORSFilterProvider @Inject() (configuration: Configuration, errorHandler: HttpErrorHandler, corsConfig: CORSConfig,
     materializer: Materializer) extends Provider[CORSFilter] {
   lazy val get = {
-    val pathPrefixes = PlayConfig(configuration).get[Seq[String]]("play.filters.cors.pathPrefixes")
+    val pathPrefixes = configuration.get[Seq[String]]("play.filters.cors.pathPrefixes")
     new CORSFilter(corsConfig, errorHandler, pathPrefixes)(materializer)
   }
 }
@@ -48,5 +48,5 @@ trait CORSComponents {
 
   lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(configuration)
   lazy val corsFilter: CORSFilter = new CORSFilter(corsConfig, httpErrorHandler, corsPathPrefixes)
-  lazy val corsPathPrefixes: Seq[String] = PlayConfig(configuration).get[Seq[String]]("play.filters.cors.pathPrefixes")
+  lazy val corsPathPrefixes: Seq[String] = configuration.get[Seq[String]]("play.filters.cors.pathPrefixes")
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -91,7 +91,7 @@ object CSRFConfig {
   def global = Play.privateMaybeApplication.map(_.injector.instanceOf[CSRFConfig]).getOrElse(CSRFConfig())
 
   def fromConfiguration(conf: Configuration): CSRFConfig = {
-    val config = PlayConfig(conf).getDeprecatedWithFallback("play.filters.csrf", "csrf")
+    val config = conf.getDeprecatedWithFallback("play.filters.csrf", "csrf")
 
     val methodWhiteList = config.get[Seq[String]]("method.whiteList").toSet
     val methodBlackList = config.get[Seq[String]]("method.blackList").toSet
@@ -256,7 +256,7 @@ object CSRF {
 
   object ErrorHandler {
     def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
-      Reflect.bindingsFromConfiguration[ErrorHandler, CSRFErrorHandler, JavaCSRFErrorHandlerAdapter, JavaCSRFErrorHandlerDelegate, CSRFHttpErrorHandler](environment, PlayConfig(configuration),
+      Reflect.bindingsFromConfiguration[ErrorHandler, CSRFErrorHandler, JavaCSRFErrorHandlerAdapter, JavaCSRFErrorHandlerDelegate, CSRFHttpErrorHandler](environment, configuration,
         "play.filters.csrf.errorHandler", "CSRFErrorHandler")
     }
   }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -13,7 +13,7 @@ import akka.util.ByteString
 import com.typesafe.config.ConfigMemorySize
 import play.api.inject.Module
 import play.api.libs.streams.GzipFlow
-import play.api.{ Environment, PlayConfig, Configuration }
+import play.api.{ Environment, Configuration }
 import play.api.mvc._
 import play.core.j
 import scala.concurrent.Future
@@ -197,7 +197,7 @@ case class GzipFilterConfig(bufferSize: Int = 8192,
 object GzipFilterConfig {
 
   def fromConfiguration(conf: Configuration) = {
-    val config = PlayConfig(conf).get[PlayConfig]("play.filters.gzip")
+    val config = conf.get[Configuration]("play.filters.gzip")
 
     GzipFilterConfig(
       bufferSize = config.get[ConfigMemorySize]("bufferSize").toBytes.toInt,

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
@@ -7,7 +7,7 @@ import javax.inject.{ Singleton, Inject, Provider }
 
 import play.api.inject.Module
 import play.api.mvc._
-import play.api.{ Environment, PlayConfig, Configuration }
+import play.api.{ Environment, Configuration }
 
 /**
  * This class sets a number of common security headers on the HTTP request.
@@ -99,7 +99,7 @@ case class SecurityHeadersConfig(frameOptions: Option[String] = Some("DENY"),
 object SecurityHeadersConfig {
 
   def fromConfiguration(conf: Configuration): SecurityHeadersConfig = {
-    val config = PlayConfig(conf).get[PlayConfig]("play.filters.headers")
+    val config = conf.get[Configuration]("play.filters.headers")
 
     SecurityHeadersConfig(
       frameOptions = config.get[Option[String]]("frameOptions"),

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -9,7 +9,7 @@ import play.api.http.{ HttpErrorHandler, Status }
 import play.api.inject.Module
 import play.api.libs.streams.Accumulator
 import play.api.mvc.{ EssentialAction, EssentialFilter }
-import play.api.{ Configuration, Environment, PlayConfig }
+import play.api.{ Configuration, Environment }
 import play.core.j.JavaHttpErrorHandlerAdapter
 
 /**
@@ -74,7 +74,7 @@ object AllowedHostsConfig {
    * Parses out the AllowedHostsConfig from play.api.Configuration (usually this means application.conf).
    */
   def fromConfiguration(conf: Configuration): AllowedHostsConfig = {
-    AllowedHostsConfig(PlayConfig(conf).get[Seq[String]]("play.filters.hosts.allowed"))
+    AllowedHostsConfig(conf.get[Seq[String]]("play.filters.hosts.allowed"))
   }
 }
 

--- a/framework/src/play-java-jdbc/src/main/java/play/db/ConnectionPool.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/ConnectionPool.java
@@ -4,6 +4,7 @@
 package play.db;
 
 import javax.sql.DataSource;
+import com.typesafe.config.Config;
 
 import play.Configuration;
 import play.Environment;
@@ -21,7 +22,22 @@ public interface ConnectionPool {
      * @param environment the database environment
      * @return a data source backed by a connection pool
      */
-    public DataSource create(String name, Configuration configuration, Environment environment);
+    DataSource create(String name, Config configuration, Environment environment);
+
+    /**
+     * Create a data source with the given configuration.
+     *
+     * @param name the database name
+     * @param configuration the data source configuration
+     * @param environment the database environment
+     * @return a data source backed by a connection pool
+     *
+     * @deprecated Use create(String, Config, Environment
+     */
+    @Deprecated
+    default DataSource create(String name, Configuration configuration, Environment environment) {
+        return create(name, configuration.underlying(), environment);
+    }
 
     /**
      * Close the given data source.

--- a/framework/src/play-java-jdbc/src/main/java/play/db/DefaultConnectionPool.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/DefaultConnectionPool.java
@@ -7,9 +7,8 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.sql.DataSource;
 
-import play.Configuration;
+import com.typesafe.config.Config;
 import play.Environment;
-import play.api.PlayConfig;
 import play.api.db.DatabaseConfig;
 
 /**
@@ -25,9 +24,8 @@ public class DefaultConnectionPool implements ConnectionPool {
         this.cp = connectionPool;
     }
 
-    public DataSource create(String name, Configuration configuration, Environment environment) {
-        PlayConfig config = new PlayConfig(configuration.getWrappedConfiguration().underlying());
-        return cp.create(name, DatabaseConfig.fromConfig(config, environment.underlying()), config.underlying());
+    public DataSource create(String name, Config config, Environment environment) {
+        return cp.create(name, DatabaseConfig.fromConfig(new play.api.Configuration(config), environment.underlying()), config);
     }
 
     public void close(DataSource dataSource) {

--- a/framework/src/play-java-jdbc/src/main/java/play/db/DefaultDatabase.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/DefaultDatabase.java
@@ -7,9 +7,10 @@ import java.sql.Connection;
 import java.util.Map;
 import javax.sql.DataSource;
 
-import play.Configuration;
+import com.typesafe.config.Config;
 
 import com.typesafe.config.ConfigFactory;
+import play.Configuration;
 
 /**
  * Default delegating implementation of the database API.
@@ -28,11 +29,23 @@ public class DefaultDatabase implements Database {
      * @param name name for the db's underlying datasource
      * @param configuration the database's configuration
      */
-    public DefaultDatabase(String name, Configuration configuration) {
+    public DefaultDatabase(String name, Config configuration) {
         this(new play.api.db.PooledDatabase(name, new play.api.Configuration(
-                configuration.underlying()
-                        .withFallback(ConfigFactory.defaultReference().getConfig("play.db.prototype"))
+                configuration.withFallback(ConfigFactory.defaultReference().getConfig("play.db.prototype"))
         )));
+    }
+
+    /**
+     * Create a default BoneCP-backed database.
+     *
+     * @param name name for the db's underlying datasource
+     * @param configuration the database's configuration
+     *
+     * @deprecated use the version that accepts Config
+     */
+    @Deprecated
+    public DefaultDatabase(String name, Configuration configuration) {
+        this(name, configuration.underlying());
     }
 
     /**

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAConfig.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAConfig.java
@@ -4,15 +4,17 @@
 package play.db.jpa;
 
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
-import play.Configuration;
+import com.typesafe.config.Config;
 
 import com.google.common.collect.ImmutableSet;
+import com.typesafe.config.ConfigValue;
 
 /**
  * Default JPA configuration.
@@ -39,14 +41,14 @@ public class DefaultJPAConfig implements JPAConfig {
         private final JPAConfig jpaConfig;
 
         @Inject
-        public JPAConfigProvider(Configuration configuration) {
+        public JPAConfigProvider(Config configuration) {
             ImmutableSet.Builder<JPAConfig.PersistenceUnit> persistenceUnits = new ImmutableSet.Builder<JPAConfig.PersistenceUnit>();
-            Configuration jpa = configuration.getConfig("jpa");
+            Config jpa = configuration.getConfig("jpa");
             if (jpa != null) {
-                for (String name : jpa.keys()) {
-                    String unitName = jpa.getString(name);
-                    persistenceUnits.add(new JPAConfig.PersistenceUnit(name, unitName));
-                }
+                jpa.entrySet().forEach(entry -> {
+                    String key = entry.getKey();
+                    persistenceUnits.add(new JPAConfig.PersistenceUnit(key, jpa.getString(key)));
+                });
             }
             jpaConfig = new DefaultJPAConfig(persistenceUnits.build());
         }

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
@@ -45,7 +45,7 @@ public class JPA {
      */
     @Deprecated
     public static JPAApi jpaApi() {
-        JPAConfig jpaConfig = new DefaultJPAConfig.JPAConfigProvider(play.Play.application().configuration()).get();
+        JPAConfig jpaConfig = new DefaultJPAConfig.JPAConfigProvider(play.Play.application().config()).get();
         return new DefaultJPAApi(jpaConfig, entityManagerContext).start();
     }
 

--- a/framework/src/play-java/src/main/java/play/inject/guice/GuiceApplicationLoader.java
+++ b/framework/src/play-java/src/main/java/play/inject/guice/GuiceApplicationLoader.java
@@ -43,7 +43,7 @@ public class GuiceApplicationLoader implements ApplicationLoader {
     public GuiceApplicationBuilder builder(ApplicationLoader.Context context) {
         return initialBuilder
             .in(context.environment())
-            .loadConfig(context.initialConfiguration())
+            .loadConfig(context.initialConfig())
             .overrides(overrides(context));
     }
 

--- a/framework/src/play-java/src/main/java/play/inject/guice/GuiceBuilder.java
+++ b/framework/src/play-java/src/main/java/play/inject/guice/GuiceBuilder.java
@@ -5,6 +5,7 @@ package play.inject.guice;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Module;
+import com.typesafe.config.Config;
 import play.Configuration;
 import play.Environment;
 import play.Mode;
@@ -75,8 +76,19 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
      * @param conf the configuration to add
      * @return a copy of this builder configured with the supplied configuration
      */
+    @Deprecated
     public final Self configure(Configuration conf) {
         return newBuilder(delegate.configure(conf.getWrappedConfiguration()));
+    }
+
+    /**
+     * Add additional configuration.
+     *
+     * @param conf the configuration to add
+     * @return a copy of this builder configured with the supplied configuration
+     */
+    public final Self configure(Config conf) {
+        return newBuilder(delegate.configure(new play.api.Configuration(conf)));
     }
 
     /**

--- a/framework/src/play-java/src/test/java/play/inject/guice/GuiceApplicationLoaderTest.java
+++ b/framework/src/play-java/src/test/java/play/inject/guice/GuiceApplicationLoaderTest.java
@@ -3,18 +3,18 @@
  */
 package play.inject.guice;
 
-import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import play.Application;
 import play.ApplicationLoader;
-import play.Configuration;
 import play.Environment;
-import play.libs.Scala;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static play.inject.Bindings.bind;
 
 public class GuiceApplicationLoaderTest {
@@ -43,10 +43,10 @@ public class GuiceApplicationLoaderTest {
         ApplicationLoader loader = new GuiceApplicationLoader() {
             @Override
             public GuiceApplicationBuilder builder(ApplicationLoader.Context context) {
-                Configuration extra = new Configuration("a = 1");
+                Config extra = ConfigFactory.parseString("a = 1");
                 return initialBuilder
                     .in(context.environment())
-                    .loadConfig(extra.withFallback(context.initialConfiguration()))
+                    .loadConfig(extra.withFallback(context.initialConfig()))
                     .overrides(overrides(context));
             }
         };

--- a/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
@@ -13,25 +13,27 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import javax.validation.Validator;
+
+import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import org.junit.Test;
 import play.Application;
-import play.Configuration;
 import play.Environment;
+import play.Play;
 import play.data.Birthday;
-import play.data.models.Task;
 import play.data.Form;
 import play.data.FormFactory;
 import play.data.Formats;
 import play.data.Money;
 import play.data.format.Formatters;
+import play.data.models.Task;
 import play.data.validation.ValidationError;
 import play.i18n.MessagesApi;
-import play.Play;
 import play.inject.guice.GuiceApplicationBuilder;
-import play.mvc.Http.*;
-import org.junit.Test;
-
-import javax.validation.Validator;
+import play.mvc.Http.Context;
+import play.mvc.Http.Cookie;
+import play.mvc.Http.RequestBuilder;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -53,15 +55,15 @@ public class HttpTest {
         return value;
     }
 
-    private static Configuration addLangs(Environment environment) {
-      Configuration langOverrides = new Configuration(ConfigFactory.parseString("play.i18n.langs = [\"en\", \"en-US\", \"fr\" ]"));
-      Configuration loaded = Configuration.load(environment);
+    private static Config addLangs(Environment environment) {
+      Config langOverrides = ConfigFactory.parseString("play.i18n.langs = [\"en\", \"en-US\", \"fr\" ]");
+      Config loaded = ConfigFactory.load(environment.classLoader());
       return langOverrides.withFallback(loaded);
     }
 
     private static void withApplication(Consumer<Application> r) {
         Application app = new GuiceApplicationBuilder()
-          .loadConfig(HttpTest::addLangs)
+          .withConfigLoader(HttpTest::addLangs)
           .build();
         play.api.Play.start(app.getWrappedApplication());
         try {

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
@@ -50,7 +50,7 @@ class BoneConnectionPool @Inject() (environment: Environment) extends Connection
    */
   def create(name: String, dbConfig: DatabaseConfig, conf: Config): DataSource = {
 
-    val config = PlayConfig(conf)
+    val config = Configuration(conf)
 
     val datasource = new BoneCPDataSource
 

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DBModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DBModule.scala
@@ -65,7 +65,7 @@ class DBApiProvider @Inject() (environment: Environment, configuration: Configur
     val pool = ConnectionPool.fromConfig(config.getString("play.db.pool"), injector,
       environment, defaultConnectionPool)
     val configs = if (config.hasPath(dbKey)) {
-      PlayConfig(config).getPrototypedMap(dbKey, "play.db.prototype").mapValues(_.underlying)
+      Configuration(config).getPrototypedMap(dbKey, "play.db.prototype").mapValues(_.underlying)
     } else Map.empty[String, Config]
     val db = new DefaultDBApi(configs, pool, environment)
     lifecycle.addStopHook { () => Future.successful(db.shutdown()) }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DatabaseConfig.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DatabaseConfig.scala
@@ -3,7 +3,7 @@
  */
 package play.api.db
 
-import play.api.{ Environment, PlayConfig }
+import play.api.{ Configuration, Environment }
 
 /**
  * The generic database configuration.
@@ -18,7 +18,7 @@ case class DatabaseConfig(driver: Option[String], url: Option[String], username:
 
 object DatabaseConfig {
 
-  def fromConfig(config: PlayConfig, environment: Environment) = {
+  def fromConfig(config: Configuration, environment: Environment) = {
 
     val driver = config.get[Option[String]]("driver")
     val (url, userPass) = ConnectionPool.extractUrl(config.get[Option[String]]("url"), environment.mode)

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/Databases.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/Databases.scala
@@ -11,7 +11,7 @@ import play.utils.{ ProxyDriver, Reflect }
 
 import com.typesafe.config.Config
 import scala.util.control.{ NonFatal, ControlThrowable }
-import play.api.{ Environment, Configuration, PlayConfig }
+import play.api.{ Environment, Configuration }
 
 /**
  * Creation helpers for manually instantiating databases.
@@ -94,7 +94,7 @@ object Databases {
  */
 abstract class DefaultDatabase(val name: String, configuration: Config, environment: Environment) extends Database {
 
-  private val config = PlayConfig(configuration)
+  private val config = Configuration(configuration)
   val databaseConfig = DatabaseConfig.fromConfig(config, environment)
 
   // abstract methods to be implemented

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
@@ -49,7 +49,7 @@ class HikariCPConnectionPool @Inject() (environment: Environment) extends Connec
    * @return a data source backed by a connection pool
    */
   override def create(name: String, dbConfig: DatabaseConfig, configuration: Config): DataSource = {
-    val config = PlayConfig(configuration)
+    val config = Configuration(configuration)
 
     Try {
       Logger.info(s"Creating Pool for datasource '$name'")
@@ -87,12 +87,12 @@ class HikariCPConnectionPool @Inject() (environment: Environment) extends Connec
 /**
  * HikariCP config
  */
-class HikariCPConfig(dbConfig: DatabaseConfig, configuration: PlayConfig) {
+private[db] class HikariCPConfig(dbConfig: DatabaseConfig, configuration: Configuration) {
 
   def toHikariConfig: HikariConfig = {
     val hikariConfig = new HikariConfig()
 
-    val config = configuration.get[PlayConfig]("hikaricp")
+    val config = configuration.get[Configuration]("hikaricp")
 
     // Essentials configurations
     config.get[Option[String]]("dataSourceClassName").foreach(hikariConfig.setDataSourceClassName)
@@ -105,7 +105,7 @@ class HikariCPConfig(dbConfig: DatabaseConfig, configuration: PlayConfig) {
 
     import scala.collection.JavaConverters._
 
-    val dataSourceConfig = config.get[PlayConfig]("dataSource")
+    val dataSourceConfig = config.get[Configuration]("dataSource")
     dataSourceConfig.underlying.root().keySet().asScala.foreach { key =>
       hikariConfig.addDataSourceProperty(key, dataSourceConfig.get[String](key))
     }

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
@@ -4,10 +4,10 @@
 package play.api.db
 
 import com.zaxxer.hikari.HikariConfig
-import play.api.{ PlayConfig, Configuration }
-
-import org.specs2.specification.Scope
 import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import play.api.Configuration
+
 import scala.concurrent.duration._
 
 class HikariCPConfigSpec extends Specification {
@@ -163,6 +163,6 @@ class HikariCPConfigSpec extends Specification {
 
 trait Configs extends Scope {
   val dbConfig = DatabaseConfig(Some("org.h2.Driver"), Some("jdbc:h2:mem:"), None, None, None)
-  val reference = PlayConfig(Configuration.reference).get[PlayConfig]("play.db.prototype")
-  def from(props: (String, String)*) = PlayConfig(Configuration(reference.underlying) ++ Configuration.from(props.toMap))
+  val reference = Configuration.reference.get[Configuration]("play.db.prototype")
+  def from(props: (String, String)*) = reference ++ Configuration.from(props.toMap)
 }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -50,8 +50,8 @@ class NettyServer(
     stopHook: () => Future[_],
     val actorSystem: ActorSystem)(implicit val materializer: Materializer) extends Server {
 
-  private val serverConfig = PlayConfig(config.configuration).get[PlayConfig]("play.server")
-  private val nettyConfig = serverConfig.get[PlayConfig]("netty")
+  private val serverConfig = config.configuration.get[Configuration]("play.server")
+  private val nettyConfig = serverConfig.get[Configuration]("netty")
   private val maxInitialLineLength = nettyConfig.get[Int]("maxInitialLineLength")
   private val maxHeaderSize = nettyConfig.get[Int]("maxHeaderSize")
   private val maxChunkSize = nettyConfig.get[Int]("maxChunkSize")
@@ -187,7 +187,7 @@ class NettyServer(
         case Duration(timeout, timeUnit) =>
           logger.trace(s"using idle timeout of $timeout $timeUnit on port $port")
           // only timeout if both reader and writer have been idle for the specified time
-          pipeline.addLast("idle-handler", new IdleStateHandler(0, 0, timeout, TimeUnit.MILLISECONDS))
+          pipeline.addLast("idle-handler", new IdleStateHandler(0, 0, timeout, timeUnit))
       }
 
       val requestHandler = new PlayRequestHandler(this)

--- a/framework/src/play-server/src/main/scala/play/core/server/ProdServerStart.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ProdServerStart.scala
@@ -77,7 +77,8 @@ object ProdServerStart {
     }
 
     val rootDir: File = {
-      val path = configuration.getString("play.server.dir").getOrElse(throw ServerStartException("No root server path supplied"))
+      val path = configuration.getOptional[String]("play.server.dir")
+        .getOrElse(throw ServerStartException("No root server path supplied"))
       val file = new File(path)
       if (!(file.exists && file.isDirectory)) {
         throw ServerStartException(s"Bad root server path: $path")
@@ -86,7 +87,7 @@ object ProdServerStart {
     }
 
     def parsePort(portType: String): Option[Int] = {
-      configuration.getString(s"play.server.${portType}.port").flatMap {
+      configuration.getOptional[String](s"play.server.${portType}.port").flatMap {
         case "disabled" => None
         case str =>
           val i = try Integer.parseInt(str) catch {
@@ -100,7 +101,7 @@ object ProdServerStart {
     val httpsPort = parsePort("https")
     if (!(httpPort orElse httpsPort).isDefined) throw ServerStartException("Must provide either an HTTP or HTTPS port")
 
-    val address = configuration.getString("play.server.http.address").getOrElse("0.0.0.0")
+    val address = configuration.getOptional[String]("play.server.http.address").getOrElse("0.0.0.0")
 
     ServerConfig(
       rootDir = rootDir,
@@ -117,7 +118,8 @@ object ProdServerStart {
    * Create a pid file for the current process.
    */
   def createPidFile(process: ServerProcess, configuration: Configuration): Option[File] = {
-    val pidFilePath = configuration.getString("play.server.pidfile.path").getOrElse(throw ServerStartException("Pid file path not configured"))
+    val pidFilePath = configuration.getOptional[String]("play.server.pidfile.path")
+      .getOrElse(throw ServerStartException("Pid file path not configured"))
     if (pidFilePath == "/dev/null") None else {
       val pidFile = new File(pidFilePath).getAbsoluteFile
 

--- a/framework/src/play-server/src/main/scala/play/core/server/ServerProvider.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ServerProvider.scala
@@ -53,7 +53,8 @@ object ServerProvider {
    */
   def fromConfiguration(classLoader: ClassLoader, configuration: Configuration): ServerProvider = {
     val ClassNameConfigKey = "play.server.provider"
-    val className: String = configuration.getString(ClassNameConfigKey).getOrElse(throw new ServerStartException(s"No ServerProvider configured with key '$ClassNameConfigKey'"))
+    val className: String = configuration.getOptional[String](ClassNameConfigKey)
+      .getOrElse(throw new ServerStartException(s"No ServerProvider configured with key '$ClassNameConfigKey'"))
     val clazz = try classLoader.loadClass(className) catch {
       case _: ClassNotFoundException => throw ServerStartException(s"Couldn't find ServerProvider class '$className'")
     }

--- a/framework/src/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
@@ -4,7 +4,7 @@
 package play.core.server.common
 
 import java.net.InetAddress
-import play.api.{ PlayConfig, Configuration, Logger }
+import play.api.{ Configuration, Logger }
 import play.api.mvc.Headers
 import play.core.server.common.NodeIdentifierParser.Ip
 import scala.annotation.tailrec
@@ -213,7 +213,7 @@ private[server] object ForwardedHeaderHandler {
 
   object ForwardedHeaderHandlerConfig {
     def apply(configuration: Option[Configuration]): ForwardedHeaderHandlerConfig = {
-      val config = PlayConfig(configuration.getOrElse(Configuration.reference)).get[PlayConfig]("play.http.forwarded")
+      val config = configuration.getOrElse(Configuration.reference).get[Configuration]("play.http.forwarded")
 
       val version = config.get[String]("version") match {
         case "x-forwarded" => Xforwarded

--- a/framework/src/play-specs2/src/test/scala/play/api/test/SpecsSpec.scala
+++ b/framework/src/play-specs2/src/test/scala/play/api/test/SpecsSpec.scala
@@ -10,11 +10,11 @@ import play.api.{ Play, Application }
 
 object SpecsSpec extends Specification {
 
-  def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
+  def getConfig(key: String)(implicit app: Application) = app.configuration.getOptional[String](key)
 
   "WithApplication context" should {
     "provide an app" in new WithApplication(_.configure("foo" -> "bar", "ehcacheplugin" -> "disabled")) {
-      app.configuration.getString("foo") must beSome("bar")
+      app.configuration.getOptional[String]("foo") must beSome("bar")
     }
     "make the app available implicitly" in new WithApplication(_.configure("foo" -> "bar", "ehcacheplugin" -> "disabled")) {
       getConfig("foo") must beSome("bar")

--- a/framework/src/play-test/src/main/java/play/test/FakeApplication.java
+++ b/framework/src/play-test/src/main/java/play/test/FakeApplication.java
@@ -6,8 +6,9 @@ package play.test;
 import java.io.File;
 import java.util.Map;
 
+import com.typesafe.config.Config;
+
 import play.api.mvc.Handler;
-import play.Configuration;
 import play.inject.Injector;
 import play.libs.Scala;
 
@@ -20,7 +21,7 @@ import play.libs.Scala;
 public class FakeApplication implements play.Application {
 
     private final play.api.test.FakeApplication application;
-    private final Configuration configuration;
+    private final Config config;
     private final Injector injector;
 
     /**
@@ -42,7 +43,7 @@ public class FakeApplication implements play.Application {
             Scala.asScala((Map<String, Object>) additionalConfiguration),
             scala.PartialFunction$.MODULE$.<scala.Tuple2<String, String>, Handler>empty()
         );
-        this.configuration = application.injector().instanceOf(Configuration.class);
+        this.config = application.injector().instanceOf(Config.class);
         this.injector = application.injector().instanceOf(Injector.class);
     }
 
@@ -56,8 +57,18 @@ public class FakeApplication implements play.Application {
     /**
      * Get the application configuration.
      */
-    public Configuration configuration() {
-        return configuration;
+    public Config config() {
+        return config;
+    }
+
+    /**
+     * Get the application configuration.
+     *
+     * @deprecated Use config
+     */
+    @Deprecated
+    public play.Configuration configuration() {
+        return new play.Configuration(config);
     }
 
     /**

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/Config.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/Config.scala
@@ -8,7 +8,7 @@ package play.api.libs.ws
 import javax.inject.{ Singleton, Inject, Provider }
 
 import play.api.libs.ws.ssl.{ SSLConfigParser, SSLConfig }
-import play.api.{ PlayConfig, Environment, Configuration }
+import play.api.{ Environment, Configuration }
 
 import scala.concurrent.duration._
 
@@ -34,7 +34,7 @@ class WSConfigParser @Inject() (configuration: Configuration, environment: Envir
 
   def parse(): WSClientConfig = {
 
-    val config = PlayConfig(configuration).getDeprecatedWithFallback("play.ws", "ws")
+    val config = configuration.getDeprecatedWithFallback("play.ws", "ws")
 
     val connectionTimeout = config.get[Duration]("timeout.connection")
     val idleTimeout = config.get[Duration]("timeout.idle")
@@ -47,7 +47,7 @@ class WSConfigParser @Inject() (configuration: Configuration, environment: Envir
 
     val compressionEnabled = config.get[Boolean]("compressionEnabled")
 
-    val sslConfig = new SSLConfigParser(config.get[PlayConfig]("ssl"), environment.classLoader).parse()
+    val sslConfig = new SSLConfigParser(config.get[Configuration]("ssl"), environment.classLoader).parse()
 
     WSClientConfig(
       connectionTimeout = connectionTimeout,

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcConfig.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcConfig.scala
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory
 import org.asynchttpclient.{ DefaultAsyncHttpClientConfig, AsyncHttpClientConfig }
 
 import javax.net.ssl._
-import play.api.{ ConfigLoader, PlayConfig, Environment, Configuration }
+import play.api.{ ConfigLoader, Environment, Configuration }
 import play.api.libs.ws.ssl._
 import play.api.libs.ws.WSClientConfig
 
@@ -66,9 +66,8 @@ class AhcWSClientConfigParser @Inject() (wsClientConfig: WSClientConfig,
 
   def parse(): AhcWSClientConfig = {
 
-    val playConfig = PlayConfig(configuration)
     def get[A: ConfigLoader](name: String): A =
-      playConfig.getDeprecated[A](s"play.ws.ahc.$name", s"play.ws.ning.$name")
+      configuration.getDeprecated[A](s"play.ws.ahc.$name", s"play.ws.ning.$name")
 
     val maximumConnectionsPerHost = get[Int]("maxConnectionsPerHost")
     val maximumConnectionsTotal = get[Int]("maxConnectionsTotal")
@@ -82,11 +81,11 @@ class AhcWSClientConfigParser @Inject() (wsClientConfig: WSClientConfig,
     // allowPoolingConnection and allowSslConnectionPool were merged into keepAlive in AHC 2.0
     // We want one value, keepAlive, and we don't want to confuse anyone who has to migrate.
     // keepAlive
-    if (playConfig.underlying.hasPath("play.ws.ahc.keepAlive")) {
+    if (configuration.underlying.hasPath("play.ws.ahc.keepAlive")) {
       val msg = "Both allowPoolingConnection and allowSslConnectionPool have been replaced by keepAlive!"
       Seq("play.ws.ning.allowPoolingConnection", "play.ws.ning.allowSslConnectionPool").foreach { s =>
-        if (playConfig.underlying.hasPath(s)) {
-          throw playConfig.reportError(s, msg)
+        if (configuration.underlying.hasPath(s)) {
+          throw configuration.reportError(s, msg)
         }
       }
     }

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/Config.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/Config.scala
@@ -5,10 +5,11 @@
  */
 package play.api.libs.ws.ssl
 
-import play.api.{ Configuration, PlayConfig }
-import java.security.{ KeyStore, SecureRandom }
 import java.net.URL
-import javax.net.ssl.{ TrustManagerFactory, KeyManagerFactory }
+import java.security.{ KeyStore, SecureRandom }
+import javax.net.ssl.{ KeyManagerFactory, TrustManagerFactory }
+
+import play.api.Configuration
 
 /**
  * Configuration for a keystore.
@@ -196,9 +197,7 @@ object SSLConfigFactory {
   def defaultConfig = SSLConfig()
 }
 
-class SSLConfigParser private[play] (c: PlayConfig, classLoader: ClassLoader) {
-
-  def this(c: Configuration, classLoader: ClassLoader) = this(PlayConfig(c), classLoader)
+class SSLConfigParser private[play] (c: Configuration, classLoader: ClassLoader) {
 
   def parse(): SSLConfig = {
 
@@ -209,8 +208,8 @@ class SSLConfigParser private[play] (c: PlayConfig, classLoader: ClassLoader) {
       c.get[Seq[String]]("revocationLists").map(new URL(_))
     ).filter(_.nonEmpty)
 
-    val debug = parseDebug(c.get[PlayConfig]("debug"))
-    val looseOptions = parseLooseOptions(c.get[PlayConfig]("loose"))
+    val debug = parseDebug(c.get[Configuration]("debug"))
+    val looseOptions = parseLooseOptions(c.get[Configuration]("loose"))
 
     val ciphers = Some(c.get[Seq[String]]("enabledCipherSuites")).filter(_.nonEmpty)
     val protocols = Some(c.get[Seq[String]]("enabledProtocols")).filter(_.nonEmpty)
@@ -218,9 +217,9 @@ class SSLConfigParser private[play] (c: PlayConfig, classLoader: ClassLoader) {
     val disabledSignatureAlgorithms = c.get[Seq[String]]("disabledSignatureAlgorithms")
     val disabledKeyAlgorithms = c.get[Seq[String]]("disabledKeyAlgorithms")
 
-    val keyManagers = parseKeyManager(c.get[PlayConfig]("keyManager"))
+    val keyManagers = parseKeyManager(c.get[Configuration]("keyManager"))
 
-    val trustManagers = parseTrustManager(c.get[PlayConfig]("trustManager"))
+    val trustManagers = parseTrustManager(c.get[Configuration]("trustManager"))
 
     SSLConfig(
       default = default,
@@ -241,7 +240,7 @@ class SSLConfigParser private[play] (c: PlayConfig, classLoader: ClassLoader) {
   /**
    * Parses "ws.ssl.loose" section.
    */
-  def parseLooseOptions(config: PlayConfig): SSLLooseConfig = {
+  def parseLooseOptions(config: Configuration): SSLLooseConfig = {
 
     val allowWeakProtocols = config.get[Boolean]("allowWeakProtocols")
     val allowWeakCiphers = config.get[Boolean]("allowWeakCiphers")
@@ -261,7 +260,7 @@ class SSLConfigParser private[play] (c: PlayConfig, classLoader: ClassLoader) {
   /**
    * Parses the "ws.ssl.debug" section.
    */
-  def parseDebug(config: PlayConfig): SSLDebugConfig = {
+  def parseDebug(config: Configuration): SSLDebugConfig = {
     val certpath = config.get[Boolean]("certpath")
 
     if (config.get[Boolean]("all")) {
@@ -311,7 +310,7 @@ class SSLConfigParser private[play] (c: PlayConfig, classLoader: ClassLoader) {
   /**
    * Parses the "ws.ssl.keyManager { stores = [ ... ]" section of configuration.
    */
-  def parseKeyStoreInfo(config: PlayConfig): KeyStoreConfig = {
+  def parseKeyStoreInfo(config: Configuration): KeyStoreConfig = {
     val storeType = config.get[Option[String]]("type").getOrElse(KeyStore.getDefaultType)
     val path = config.get[Option[String]]("path")
     val data = config.get[Option[String]]("data")
@@ -323,7 +322,7 @@ class SSLConfigParser private[play] (c: PlayConfig, classLoader: ClassLoader) {
   /**
    * Parses the "ws.ssl.trustManager { stores = [ ... ]" section of configuration.
    */
-  def parseTrustStoreInfo(config: PlayConfig): TrustStoreConfig = {
+  def parseTrustStoreInfo(config: Configuration): TrustStoreConfig = {
     val storeType = config.get[Option[String]]("type").getOrElse(KeyStore.getDefaultType)
     val path = config.get[Option[String]]("path")
     val data = config.get[Option[String]]("data")
@@ -334,7 +333,7 @@ class SSLConfigParser private[play] (c: PlayConfig, classLoader: ClassLoader) {
   /**
    * Parses the "ws.ssl.keyManager" section of the configuration.
    */
-  def parseKeyManager(config: PlayConfig): KeyManagerConfig = {
+  def parseKeyManager(config: Configuration): KeyManagerConfig = {
 
     val algorithm = config.get[Option[String]]("algorithm") match {
       case None => KeyManagerFactory.getDefaultAlgorithm
@@ -352,7 +351,7 @@ class SSLConfigParser private[play] (c: PlayConfig, classLoader: ClassLoader) {
    * Parses the "ws.ssl.trustManager" section of configuration.
    */
 
-  def parseTrustManager(config: PlayConfig): TrustManagerConfig = {
+  def parseTrustManager(config: Configuration): TrustManagerConfig = {
     val algorithm = config.get[Option[String]]("algorithm") match {
       case None => TrustManagerFactory.getDefaultAlgorithm
       case Some(other) => other

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/SSLConfigParserSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/SSLConfigParserSpec.scala
@@ -8,7 +8,7 @@ package play.api.libs.ws.ssl
 import org.specs2.mutable._
 
 import com.typesafe.config.ConfigFactory
-import play.api.PlayConfig
+import play.api.Configuration
 import play.api.test.WithApplication
 
 object SSLConfigParserSpec extends Specification {
@@ -21,7 +21,7 @@ object SSLConfigParserSpec extends Specification {
 
     def parseThis(input: String)(implicit app: play.api.Application) = {
       val config = ConfigFactory.parseString(input).withFallback(ConfigFactory.defaultReference().getConfig("play.ws.ssl"))
-      val parser = new SSLConfigParser(PlayConfig(config), app.classloader)
+      val parser = new SSLConfigParser(Configuration(config), app.classloader)
       parser.parse()
     }
 

--- a/framework/src/play/src/main/java/play/Application.java
+++ b/framework/src/play/src/main/java/play/Application.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
 
+import com.typesafe.config.Config;
 import play.inject.Injector;
 import play.libs.Scala;
 
@@ -29,7 +30,17 @@ public interface Application {
      *
      * @return the configuration
      */
-    Configuration configuration();
+    @Deprecated
+    default Configuration configuration() {
+        return new Configuration(this.config());
+    }
+
+    /**
+     * Get the application configuration.
+     *
+     * @return the configuration
+     */
+    Config config();
 
     /**
      * Get the injector for this application.

--- a/framework/src/play/src/main/java/play/ApplicationLoader.java
+++ b/framework/src/play/src/main/java/play/ApplicationLoader.java
@@ -6,6 +6,7 @@ package play;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import com.typesafe.config.Config;
 import play.core.SourceMapper;
 import play.core.DefaultWebCommands;
 import play.libs.Scala;
@@ -103,8 +104,20 @@ public interface ApplicationLoader {
      *
      * @return the initial configuration
      */
+    @Deprecated
     public Configuration initialConfiguration() {
         return new Configuration(underlying.initialConfiguration());
+    }
+
+    /**
+     * Get the configuration from the context. This configuration is not necessarily the same
+     * configuration used by the application, as the ApplicationLoader may, through it's own
+     * mechanisms, modify it or completely ignore it.
+     *
+     * @return the initial configuration
+     */
+    public Config initialConfig() {
+      return underlying.initialConfiguration().underlying();
     }
 
     /**
@@ -128,6 +141,7 @@ public interface ApplicationLoader {
      * @param initialConfiguration the configuration to use in the created context
      * @return the created context
      */
+    @Deprecated
     public Context withConfiguration(Configuration initialConfiguration) {
         play.api.ApplicationLoader.Context scalaContext = new play.api.ApplicationLoader.Context(
            underlying.environment(),
@@ -135,6 +149,21 @@ public interface ApplicationLoader {
            underlying.webCommands(),
            initialConfiguration.getWrappedConfiguration());
         return new Context(scalaContext);
+    }
+
+    /**
+     * Create a new context with a different configuration.
+     *
+     * @param initialConfiguration the configuration to use in the created context
+     * @return the created context
+     */
+    public Context withConfig(Config initialConfiguration) {
+      play.api.ApplicationLoader.Context scalaContext = new play.api.ApplicationLoader.Context(
+          underlying.environment(),
+          underlying.sourceMapper(),
+          underlying.webCommands(),
+          new play.api.Configuration(initialConfiguration));
+      return new Context(scalaContext);
     }
 
     // The following static methods are on the Context inner class rather

--- a/framework/src/play/src/main/java/play/Configuration.java
+++ b/framework/src/play/src/main/java/play/Configuration.java
@@ -20,8 +20,11 @@ import javax.inject.Singleton;
 
 /**
  * The current application configuration.
+ *
+ * @deprecated Use Config instead.
  */
 @Singleton
+@Deprecated
 public class Configuration {
 
     /**

--- a/framework/src/play/src/main/java/play/DefaultApplication.java
+++ b/framework/src/play/src/main/java/play/DefaultApplication.java
@@ -5,6 +5,8 @@ package play;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import com.typesafe.config.Config;
 import play.inject.Injector;
 
 /**
@@ -16,8 +18,22 @@ import play.inject.Injector;
 public class DefaultApplication implements Application {
 
     private final play.api.Application application;
-    private final Configuration configuration;
+    private final Config config;
     private final Injector injector;
+
+    /**
+     * Create an application that wraps a Scala application.
+     *
+     * @param application the application to wrap
+     * @param config the new application's configuration
+     * @param injector the new application's injector
+     */
+    @Inject
+    public DefaultApplication(play.api.Application application, Config config, Injector injector) {
+        this.application = application;
+        this.config = config;
+        this.injector = injector;
+    }
 
     /**
      * Create an application that wraps a Scala application.
@@ -25,11 +41,13 @@ public class DefaultApplication implements Application {
      * @param application the application to wrap
      * @param configuration the new application's configuration
      * @param injector the new application's injector
+     *
+     * @deprecated Use the constructor that accepts Config
      */
-    @Inject
+    @Deprecated
     public DefaultApplication(play.api.Application application, Configuration configuration, Injector injector) {
         this.application = application;
-        this.configuration = configuration;
+        this.config = configuration.underlying();
         this.injector = injector;
     }
 
@@ -40,7 +58,7 @@ public class DefaultApplication implements Application {
      * @param injector the new application's injector
      */
     public DefaultApplication(play.api.Application application, Injector injector) {
-        this(application, new Configuration(application.configuration()), injector);
+        this(application, application.configuration().underlying(), injector);
     }
 
     /**
@@ -57,8 +75,8 @@ public class DefaultApplication implements Application {
      *
      * @return the configuration
      */
-    public Configuration configuration() {
-        return configuration;
+    public Config config() {
+        return config;
     }
 
     /**

--- a/framework/src/play/src/main/java/play/http/DefaultHttpErrorHandler.java
+++ b/framework/src/play/src/main/java/play/http/DefaultHttpErrorHandler.java
@@ -3,20 +3,25 @@
  */
 package play.http;
 
-import play.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import com.typesafe.config.Config;
+import play.Configuration;
+import play.Environment;
+import play.Logger;
 import play.api.OptionalSourceMapper;
 import play.api.UsefulException;
 import play.api.http.HttpErrorHandlerExceptions;
 import play.api.routing.Router;
-import play.mvc.Http.*;
+import play.mvc.Http.RequestHeader;
 import play.mvc.Result;
 import play.mvc.Results;
 import scala.Option;
 import scala.Some;
-
-import javax.inject.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 
 /**
  * Default implementation of the http error handler.
@@ -31,13 +36,19 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
     private final Provider<Router> routes;
 
     @Inject
-    public DefaultHttpErrorHandler(Configuration configuration, Environment environment,
-                                   OptionalSourceMapper sourceMapper, Provider<Router> routes) {
+    public DefaultHttpErrorHandler(
+        Config config, Environment environment, OptionalSourceMapper sourceMapper, Provider<Router> routes) {
         this.environment = environment;
         this.sourceMapper = sourceMapper;
         this.routes = routes;
 
-        this.playEditor = Option.apply(configuration.getString("play.editor"));
+        this.playEditor = Option.apply(config.hasPath("play.editor") ? config.getString("play.editor") : null);
+    }
+
+    @Deprecated
+    public DefaultHttpErrorHandler(
+        Configuration config, Environment environment, OptionalSourceMapper sourceMapper, Provider<Router> routes) {
+        this(config.underlying(), environment, sourceMapper, routes);
     }
 
     /**
@@ -102,7 +113,7 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
     }
 
     /**
-     * Invoked when a client error occurs, that is, an error in the 4xx series, which is not handled 
+     * Invoked when a client error occurs, that is, an error in the 4xx series, which is not handled
      * by any of the other methods in this class already.
      *
      * @param request The request that caused the client error.

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -51,7 +51,7 @@ object ApplicationLoader {
    */
   def apply(context: Context): ApplicationLoader = {
     Reflect.configuredClass[ApplicationLoader, play.ApplicationLoader, GuiceApplicationLoader](
-      context.environment, PlayConfig(context.initialConfiguration), "play.application.loader", classOf[GuiceApplicationLoader].getName
+      context.environment, context.initialConfiguration, "play.application.loader", classOf[GuiceApplicationLoader].getName
     ) match {
         case None =>
           new GuiceApplicationLoader

--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -98,13 +98,13 @@ private object AssetInfo {
     resource <- app.resource(name)
   } yield resource
 
-  lazy val defaultCharSet = config(_.getString("default.charset")).getOrElse("utf-8")
+  lazy val defaultCharSet = config(_.getOptional[String]("default.charset")).getOrElse("utf-8")
 
-  lazy val defaultCacheControl = config(_.getString("assets.defaultCache")).getOrElse("public, max-age=3600")
+  lazy val defaultCacheControl = config(_.getOptional[String]("assets.defaultCache")).getOrElse("public, max-age=3600")
 
-  lazy val aggressiveCacheControl = config(_.getString("assets.aggressiveCache")).getOrElse("public, max-age=31536000")
+  lazy val aggressiveCacheControl = config(_.getOptional[String]("assets.aggressiveCache")).getOrElse("public, max-age=31536000")
 
-  lazy val digestAlgorithm = config(_.getString("assets.digest.algorithm")).getOrElse("md5")
+  lazy val digestAlgorithm = config(_.getOptional[String]("assets.digest.algorithm")).getOrElse("md5")
 
   import ResponseHeader.basicDateFormatPattern
 
@@ -166,7 +166,7 @@ private class AssetInfo(
   def addCharsetIfNeeded(mimeType: String): String =
     if (MimeTypes.isText(mimeType)) s"$mimeType; charset=$defaultCharSet" else mimeType
 
-  val configuredCacheControl = config(_.getString("\"assets.cache." + name + "\""))
+  val configuredCacheControl = config(_.getOptional[String]("\"assets.cache." + name + "\""))
 
   def cacheControl(aggressiveCaching: Boolean): String = {
     configuredCacheControl.getOrElse {

--- a/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -6,7 +6,7 @@ package play.api.http
 import javax.inject.{ Singleton, Inject, Provider }
 
 import com.typesafe.config.ConfigMemorySize
-import play.api.{ PlayConfig, Application, Play, Configuration }
+import play.api.{ Application, Play, Configuration }
 import play.core.netty.utils.{ ServerCookieDecoder, ClientCookieEncoder, ClientCookieDecoder, ServerCookieEncoder }
 
 import scala.concurrent.duration.FiniteDuration
@@ -103,12 +103,11 @@ object HttpConfiguration {
     lazy val get = fromConfiguration(configuration)
   }
 
-  def fromConfiguration(configuration: Configuration) = {
-    val config = PlayConfig(configuration)
+  def fromConfiguration(config: Configuration) = {
     val context = {
       val ctx = config.getDeprecated[String]("play.http.context", "application.context")
       if (!ctx.startsWith("/")) {
-        throw configuration.globalError("play.http.context must start with a /")
+        throw config.globalError("play.http.context must start with a /")
       }
       ctx
     }

--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -51,7 +51,7 @@ object HttpErrorHandler {
    * Get the bindings for the error handler from the configuration
    */
   def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
-    Reflect.bindingsFromConfiguration[HttpErrorHandler, play.http.HttpErrorHandler, JavaHttpErrorHandlerAdapter, JavaHttpErrorHandlerDelegate, DefaultHttpErrorHandler](environment, PlayConfig(configuration),
+    Reflect.bindingsFromConfiguration[HttpErrorHandler, play.http.HttpErrorHandler, JavaHttpErrorHandlerAdapter, JavaHttpErrorHandlerDelegate, DefaultHttpErrorHandler](environment, configuration,
       "play.http.errorHandler", "ErrorHandler")
   }
 }
@@ -78,7 +78,7 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
     this(environment, configuration, sourceMapper.sourceMapper, Some(router.get))
 
   // Hyperlink string to wrap around Play error messages.
-  private var playEditor: Option[String] = configuration.getString("play.editor")
+  private var playEditor: Option[String] = configuration.getOptional[String]("play.editor")
 
   /**
    * Sets the play editor to the given string after initialization.  Used for

--- a/framework/src/play/src/main/scala/play/api/http/HttpFilters.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpFilters.scala
@@ -5,7 +5,7 @@ package play.api.http
 
 import javax.inject.Inject
 
-import play.api.{ PlayConfig, Configuration, Environment }
+import play.api.{ Configuration, Environment }
 import play.api.mvc.EssentialFilter
 import play.utils.Reflect
 
@@ -25,7 +25,7 @@ trait HttpFilters {
 object HttpFilters {
 
   def bindingsFromConfiguration(environment: Environment, configuration: Configuration) = {
-    Reflect.bindingsFromConfiguration[HttpFilters, play.http.HttpFilters, JavaHttpFiltersAdapter, JavaHttpFiltersDelegate, NoHttpFilters](environment, PlayConfig(configuration), "play.http.filters", "Filters")
+    Reflect.bindingsFromConfiguration[HttpFilters, play.http.HttpFilters, JavaHttpFiltersAdapter, JavaHttpFiltersDelegate, NoHttpFilters](environment, configuration, "play.http.filters", "Filters")
   }
 
   def apply(filters: EssentialFilter*): HttpFilters = {

--- a/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -10,8 +10,8 @@ import play.api.inject.{ Binding, BindingKey }
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.api.routing.Router
-import play.api.{ Configuration, Environment, PlayConfig }
-import play.core.j.{ JavaHttpRequestHandlerDelegate, JavaHandler, JavaHandlerComponents }
+import play.api.{ Configuration, Environment }
+import play.core.j.{ JavaHandler, JavaHandlerComponents, JavaHttpRequestHandlerDelegate }
 import play.utils.Reflect
 
 /**
@@ -46,7 +46,7 @@ object HttpRequestHandler {
   def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
 
     val fromConfiguration = Reflect.bindingsFromConfiguration[HttpRequestHandler, play.http.HttpRequestHandler, play.core.j.JavaHttpRequestHandlerAdapter, play.http.DefaultHttpRequestHandler, JavaCompatibleHttpRequestHandler](environment,
-      PlayConfig(configuration), "play.http.requestHandler", "RequestHandler")
+      configuration, "play.http.requestHandler", "RequestHandler")
 
     val javaComponentsBindings = Seq(BindingKey(classOf[play.core.j.JavaHandlerComponents]).to[play.core.j.DefaultJavaHandlerComponents])
 
@@ -59,7 +59,7 @@ object ActionCreator {
 
   def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
     Reflect.configuredClass[ActionCreator, ActionCreator, HttpRequestHandlerActionCreator](environment,
-      PlayConfig(configuration), "play.http.actionCreator", "ActionCreator").fold(Seq[Binding[_]]()) { either =>
+      configuration, "play.http.actionCreator", "ActionCreator").fold(Seq[Binding[_]]()) { either =>
         val impl = either.fold(identity, identity)
         Seq(BindingKey(classOf[ActionCreator]).to(impl))
       }

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -155,12 +155,10 @@ trait Langs {
 }
 
 @Singleton
-class DefaultLangs @Inject() (configuration: Configuration) extends Langs {
-
-  private val config = PlayConfig(configuration)
+class DefaultLangs @Inject() (config: Configuration) extends Langs {
 
   val availables: Seq[Lang] = {
-    val langs = configuration.getString("application.langs") map { langsStr =>
+    val langs = config.getOptional[String]("application.langs") map { langsStr =>
       Logger.warn("application.langs is deprecated, use play.i18n.langs instead")
       langsStr.split(",").map(_.trim).toSeq
     } getOrElse {
@@ -169,7 +167,7 @@ class DefaultLangs @Inject() (configuration: Configuration) extends Langs {
 
     langs.map { lang =>
       try { Lang(lang) } catch {
-        case NonFatal(e) => throw configuration.reportError("play.i18n.langs",
+        case NonFatal(e) => throw config.reportError("play.i18n.langs",
           "Invalid language code [" + lang + "]", Some(e))
       }
     }
@@ -471,9 +469,7 @@ trait MessagesApi {
  * The internationalisation API.
  */
 @Singleton
-class DefaultMessagesApi @Inject() (environment: Environment, configuration: Configuration, langs: Langs) extends MessagesApi {
-
-  private val config = PlayConfig(configuration)
+class DefaultMessagesApi @Inject() (environment: Environment, config: Configuration, langs: Langs) extends MessagesApi {
 
   import java.text._
 

--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -8,6 +8,7 @@ import javax.inject.{ Inject, Provider, Singleton }
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
+import com.typesafe.config.Config
 import play.api._
 import play.api.http._
 import play.api.libs.Files.{ DefaultTemporaryFileCreator, TemporaryFileCreator }
@@ -35,6 +36,7 @@ class BuiltinModule extends Module {
       bind[Environment] to env,
       bind[ConfigurationProvider].to(new ConfigurationProvider(configuration)),
       bind[Configuration].toProvider[ConfigurationProvider],
+      bind[Config].toProvider[ConfigProvider],
       bind[HttpConfiguration].toProvider[HttpConfiguration.HttpConfigurationProvider],
 
       // Application lifecycle, bound both to the interface, and its implementation, so that Application can access it
@@ -72,6 +74,10 @@ class BuiltinModule extends Module {
 // This allows us to access the original configuration via this
 // provider while overriding the binding for Configuration itself.
 class ConfigurationProvider(val get: Configuration) extends Provider[Configuration]
+
+class ConfigProvider @Inject() (configuration: Configuration) extends Provider[Config] {
+  override def get() = configuration.underlying
+}
 
 @Singleton
 class RoutesProvider @Inject() (injector: Injector, environment: Environment, configuration: Configuration, httpConfig: HttpConfiguration) extends Provider[Router] {

--- a/framework/src/play/src/main/scala/play/api/inject/Module.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Module.scala
@@ -134,6 +134,8 @@ object Modules {
       {
         tryConstruct(environment, configuration)
       } orElse {
+        tryConstruct(new JavaEnvironment(environment), configuration.underlying)
+      } orElse {
         tryConstruct(new JavaEnvironment(environment), new JavaConfiguration(configuration))
       } orElse {
         tryConstruct()

--- a/framework/src/play/src/main/scala/play/api/libs/JNDI.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/JNDI.scala
@@ -24,14 +24,14 @@ object JNDI {
     val env = new java.util.Hashtable[String, String]
 
     env.put(INITIAL_CONTEXT_FACTORY, {
-      Play.privateMaybeApplication.flatMap(_.configuration.getString(INITIAL_CONTEXT_FACTORY)).getOrElse {
+      Play.privateMaybeApplication.flatMap(_.configuration.getOptional[String](INITIAL_CONTEXT_FACTORY)).getOrElse {
         System.setProperty(INITIAL_CONTEXT_FACTORY, IN_MEMORY_JNDI)
         IN_MEMORY_JNDI
       }
     })
 
     env.put(PROVIDER_URL, {
-      Play.privateMaybeApplication.flatMap(_.configuration.getString(PROVIDER_URL)).getOrElse {
+      Play.privateMaybeApplication.flatMap(_.configuration.getOptional[String](PROVIDER_URL)).getOrElse {
         System.setProperty(PROVIDER_URL, IN_MEMORY_URL)
         IN_MEMORY_URL
       }

--- a/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/MimeTypes.scala
@@ -34,10 +34,7 @@ object MimeTypes {
   def applicationTypes: Map[String, String] = play.api.Play.privateMaybeApplication.flatMap { application =>
     application.configuration.getConfig("mimetype").map { config =>
       config.subKeys.map { key =>
-        (key, config.getString(key))
-      }.collect {
-        case ((key, Some(value))) =>
-          (key, value)
+        key -> config.get[String](key)
       }.toMap
     }
   }.getOrElse(Map.empty)

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -287,9 +287,7 @@ object ActorSystemProvider {
    * Start an ActorSystem, using the given configuration and ClassLoader.
    * @return The ActorSystem and a function that can be used to stop it.
    */
-  def start(classLoader: ClassLoader, configuration: Configuration): (ActorSystem, StopHook) = {
-    val config = PlayConfig(configuration)
-
+  def start(classLoader: ClassLoader, config: Configuration): (ActorSystem, StopHook) = {
     val akkaConfig: Config = {
       val akkaConfigRoot = config.get[String]("play.akka.config")
       // Need to fallback to root config so we can lookup dispatchers defined outside the main namespace

--- a/framework/src/play/src/main/scala/play/api/libs/crypto/Crypto.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/crypto/Crypto.scala
@@ -460,11 +460,9 @@ case class CryptoConfig(secret: String,
   @deprecated("This field is deprecated and will be removed in future versions", "2.5.0") aesTransformation: String = "AES/CTR/NoPadding")
 
 @Singleton
-class CryptoConfigParser @Inject() (environment: Environment, configuration: Configuration) extends Provider[CryptoConfig] {
+class CryptoConfigParser @Inject() (environment: Environment, config: Configuration) extends Provider[CryptoConfig] {
 
   lazy val get = {
-
-    val config = PlayConfig(configuration)
 
     /*
      * The Play secret.

--- a/framework/src/play/src/main/scala/play/api/mvc/Security.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Security.scala
@@ -57,7 +57,8 @@ object Security {
   /**
    * Key of the username attribute stored in session.
    */
-  lazy val username: String = Play.privateMaybeApplication.flatMap(_.configuration.getString("session.username")) getOrElse ("username")
+  lazy val username: String =
+    Play.privateMaybeApplication.flatMap(_.configuration.getOptional[String]("session.username")) getOrElse "username"
 
   /**
    * Wraps another action, allowing only authenticated HTTP requests.

--- a/framework/src/play/src/main/scala/play/api/routing/Router.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/Router.scala
@@ -3,7 +3,7 @@
  */
 package play.api.routing
 
-import play.api.{ PlayConfig, Configuration, Environment }
+import play.api.{ Configuration, Environment }
 import play.api.mvc.{ RequestHeader, Handler }
 import play.core.j.JavaRouterAdapter
 import play.utils.Reflect
@@ -58,7 +58,7 @@ object Router {
    * @return The router class if configured or if a default one in the root package was detected.
    */
   def load(env: Environment, configuration: Configuration): Option[Class[_ <: Router]] = {
-    val className = PlayConfig(configuration).getDeprecated[Option[String]]("play.http.router", "application.router")
+    val className = configuration.getDeprecated[Option[String]]("play.http.router", "application.router")
 
     try {
       Some(Reflect.getClass[Router](className.getOrElse("router.Routes"), env.classLoader))

--- a/framework/src/play/src/main/scala/play/utils/Reflect.scala
+++ b/framework/src/play/src/main/scala/play/utils/Reflect.scala
@@ -3,8 +3,9 @@
  */
 package play.utils
 
-import play.api.{ PlayConfig, Environment, PlayException }
-import play.api.inject.{ BindingKey, Binding }
+import play.api.inject.{Binding, BindingKey}
+import play.api.{Configuration, Environment, PlayException}
+
 import scala.reflect.ClassTag
 
 object Reflect {
@@ -40,7 +41,7 @@ object Reflect {
    * @return Zero or more bindings to provide `ScalaTrait`
    */
   def bindingsFromConfiguration[ScalaTrait, JavaInterface, JavaAdapter <: ScalaTrait, JavaDelegate <: JavaInterface, Default <: ScalaTrait](
-    environment: Environment, config: PlayConfig, key: String, defaultClassName: String)(implicit scalaTrait: SubClassOf[ScalaTrait],
+    environment: Environment, config: Configuration, key: String, defaultClassName: String)(implicit scalaTrait: SubClassOf[ScalaTrait],
       javaInterface: SubClassOf[JavaInterface], javaAdapter: ClassTag[JavaAdapter], javaDelegate: ClassTag[JavaDelegate], default: ClassTag[Default]): Seq[Binding[_]] = {
 
     def bind[T: SubClassOf]: BindingKey[T] = BindingKey(implicitly[SubClassOf[T]].runtimeClass)
@@ -90,7 +91,7 @@ object Reflect {
    * @tparam Default The default implementation of `ScalaTrait` if no user implementation has been provided
    */
   def configuredClass[ScalaTrait, JavaInterface, Default <: ScalaTrait](
-    environment: Environment, config: PlayConfig, key: String, defaultClassName: String)(implicit scalaTrait: SubClassOf[ScalaTrait],
+    environment: Environment, config: Configuration, key: String, defaultClassName: String)(implicit scalaTrait: SubClassOf[ScalaTrait],
       javaInterface: SubClassOf[JavaInterface], default: ClassTag[Default]): Option[Either[Class[_ <: ScalaTrait], Class[_ <: JavaInterface]]] = {
 
     def loadClass(className: String, notFoundFatal: Boolean): Option[Class[_]] = {

--- a/framework/src/play/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
@@ -5,15 +5,16 @@ package play.api.http
 
 import java.util.concurrent.CompletableFuture
 
+import com.typesafe.config.Config
 import org.specs2.mutable.Specification
 import play.api.inject.BindingKey
-import play.api.{ OptionalSourceMapper, Configuration, Mode, Environment }
-import play.api.mvc.{ Results, RequestHeader }
+import play.api.mvc.{ RequestHeader, Results }
 import play.api.routing._
+import play.api.{ Configuration, Environment, Mode, OptionalSourceMapper }
 import play.core.test.{ FakeRequest, Fakes }
 
-import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, Future }
 
 object HttpErrorHandlerSpec extends Specification {
 
@@ -72,6 +73,7 @@ object HttpErrorHandlerSpec extends Specification {
         BindingKey(classOf[Router]).to(Router.empty),
         BindingKey(classOf[OptionalSourceMapper]).to(new OptionalSourceMapper(None)),
         BindingKey(classOf[Configuration]).to(config),
+        BindingKey(classOf[Config]).to(config.underlying),
         BindingKey(classOf[Environment]).to(env)
       )).instanceOf[HttpErrorHandler]
   }

--- a/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
@@ -33,7 +33,7 @@ object GuiceApplicationBuilderSpec extends Specification {
           bind[A].to[A2])
         .build
 
-      app.configuration.getInt("a") must beSome(1)
+      app.configuration.get[Int]("a") must_== 1
       app.injector.instanceOf[A] must beAnInstanceOf[A2]
     }
 
@@ -54,7 +54,7 @@ object GuiceApplicationBuilderSpec extends Specification {
         .loadConfig(env => Configuration.load(env) ++ extraConfig)
         .build
 
-      app.configuration.getInt("a") must beSome(1)
+      app.configuration.get[Int]("a") must_== 1
     }
 
     "set module loader" in {

--- a/framework/src/play/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
@@ -47,11 +47,11 @@ object GuiceInjectorBuilderSpec extends Specification {
         .injector.instanceOf[Configuration]
 
       conf.subKeys must contain(allOf("a", "b", "c", "d"))
-      conf.getInt("a") must beSome(1)
-      conf.getInt("b") must beSome(2)
-      conf.getInt("c") must beSome(3)
-      conf.getInt("d.1") must beSome(4)
-      conf.getInt("d.2") must beSome(5)
+      conf.get[Int]("a") must_== 1
+      conf.get[Int]("b") must_== 2
+      conf.get[Int]("c") must_== 3
+      conf.get[Int]("d.1") must_== 4
+      conf.get[Int]("d.2") must_== 5
     }
 
     "support various bindings" in {
@@ -89,8 +89,8 @@ object GuiceInjectorBuilderSpec extends Specification {
       val env = injector.instanceOf[Environment]
       val conf = injector.instanceOf[Configuration]
       env.mode must_== Mode.Test
-      conf.getInt("a") must beNone
-      conf.getInt("b") must beSome(2)
+      conf.has("a") must beFalse
+      conf.get[Int]("b") must_== 2
     }
 
     "disable modules" in {

--- a/framework/src/play/src/test/scala/play/utils/ReflectSpec.scala
+++ b/framework/src/play/src/test/scala/play/utils/ReflectSpec.scala
@@ -8,7 +8,7 @@ import javax.inject.Inject
 import org.specs2.mutable.Specification
 import play.api.inject.Binding
 import play.api.inject.guice.GuiceInjectorBuilder
-import play.api.{ PlayConfig, PlayException, Configuration, Environment }
+import play.api.{ PlayException, Configuration, Environment }
 
 import scala.reflect.ClassTag
 
@@ -55,7 +55,7 @@ object ReflectSpec extends Specification {
 
   def bindings(configured: String, defaultClassName: String): Seq[Binding[_]] = {
     Reflect.bindingsFromConfiguration[Duck, JavaDuck, JavaDuckAdapter, JavaDuckDelegate, DefaultDuck](
-      Environment.simple(), PlayConfig(Configuration.from(Map("duck" -> configured))), "duck", defaultClassName)
+      Environment.simple(), Configuration.from(Map("duck" -> configured)), "duck", defaultClassName)
   }
 
   def bindings[Default: ClassTag](configured: String): Seq[Binding[_]] = {


### PR DESCRIPTION
 - Deprecate Java `play.Configuration` and prefer raw `com.typesafe.config.Config`.
 - Deprecate several methods in `play.api.Configuration` and prefer several methods currently on `play.api.PlayConfig`, including `get[T: ConfigLoader]` and `getOptional[T: ConfigLoader]` that use the `ConfigLoader` typeclass to load arbitrary types.
 - Replace several config uses in the codebase with the new versions and deprecate old methods using `play.Configuration`.

This fixes several API issues with the current classes:
 - The methods in the Configuration APIs don't promote the use of `reference.conf` to declare default values. This is not idiomatic Config usage.
 - `play.api.Configuration` has many apparently unnecessary that return Java types. Now there is one method that can be used with a typeclass to load any type you want.
 - `play.Configuration` provides little in terms of functionality over raw `Config` and is an unnecessary level of indirection.