### PR TITLE
Add check for play.editor setting

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/views/DevErrorPageSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/views/DevErrorPageSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.it.views
 
-import play.api.{ Configuration, Mode, Environment }
+import play.api.{ Configuration, Environment, Mode }
 import play.api.http.DefaultHttpErrorHandler
 import play.api.test._
 
@@ -18,10 +18,9 @@ object DevErrorPageSpec extends PlaySpecification {
       def sourceName = "someSourceFile"
     }
 
-    "link the error line if play.editor is configured" in new WithApplication(
-      _.configure("play.editor" -> "someEditorLinkWith %s:%s")
-    ) {
-      val result = app.errorHandler.onServerError(FakeRequest(), testExceptionSource)
+    "link the error line if play.editor is configured" in {
+      DefaultHttpErrorHandler.setPlayEditor("someEditorLinkWith %s:%s")
+      val result = DefaultHttpErrorHandler.onServerError(FakeRequest(), testExceptionSource)
       contentAsString(result) must contain("""href="someEditorLinkWith someSourceFile:100" """)
     }
 
@@ -31,5 +30,4 @@ object DevErrorPageSpec extends PlaySpecification {
       Helpers.contentAsString(result) must contain("Oops, an error occurred")
     }
   }
-
 }

--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -119,7 +119,18 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
     router: Provider[Router]) =
     this(environment, configuration, sourceMapper.sourceMapper, Some(router.get))
 
-  private val playEditor = configuration.getString("play.editor")
+  // Hyperlink string to wrap around Play error messages.
+  private var playEditor: Option[String] = configuration.getString("play.editor")
+
+  /**
+   * Sets the play editor to the given string after initialization.  Used for
+   * tests, or cases where the existing configuration isn't sufficient.
+   *
+   * @param editor the play editor string.
+   */
+  def setPlayEditor(editor: String): Unit = {
+    playEditor = Option(editor)
+  }
 
   /**
    * Invoked when a client error occurs, that is, an error in the 4xx series.
@@ -281,7 +292,9 @@ object HttpErrorHandlerExceptions {
 /**
  * A default HTTP error handler that can be used when there's no application available
  */
-object DefaultHttpErrorHandler extends DefaultHttpErrorHandler(Environment.simple(), Configuration.empty, None, None)
+object DefaultHttpErrorHandler extends DefaultHttpErrorHandler(Environment.simple(), Configuration.load(Environment.simple()), None, None) {
+
+}
 
 /**
  * A lazy HTTP error handler, that looks up the error handler from the current application

--- a/templates/play-common/conf/application.conf
+++ b/templates/play-common/conf/application.conf
@@ -63,6 +63,14 @@ play.modules {
   #disabled += ""
 }
 
+## IDE
+# https://www.playframework.com/documentation/latest/IDE
+# ~~~~~
+# Depending on your IDE, you can add a hyperlink for errors that will jump you
+# directly to the code location in the IDE in dev mode. The following line makes 
+# use of the IntelliJ IDEA REST interface: 
+#play.editor=http://localhost:63342/api/file/?file=%s&line=%s 
+
 ## Internationalisation
 # https://www.playframework.com/documentation/latest/JavaI18N
 # https://www.playframework.com/documentation/latest/ScalaI18N


### PR DESCRIPTION
# Fixes

Fixes https://github.com/playframework/playframework/issues/3892

# Purpose 

The `play.editor` setting was not being applied -- this change ensures that error pages can read the value in for the DefaultHttpErrorHandler singleton object.