### PR TITLE
Expose play config properties to logback

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/code/Log4j2LoggerConfigurator.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/Log4j2LoggerConfigurator.scala
@@ -1,0 +1,75 @@
+import java.io.File
+import java.net.{URI, URL}
+
+/*
+// #log4j2-import
+import play.api.{Mode, Configuration, Environment, LoggerConfigurator}
+
+import org.slf4j.ILoggerFactory
+
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.core._
+import org.apache.logging.log4j.core.config.Configurator
+// #log4j2-import
+*/
+
+import play.api.{Mode, Configuration, Environment, LoggerConfigurator}
+import org.slf4j.ILoggerFactory
+
+//#log4j2-class
+class Log4J2LoggerConfigurator extends LoggerConfigurator {
+
+  private var factory: ILoggerFactory = _
+
+  override def init(rootPath: File, mode: Mode.Mode): Unit = {
+    val properties = Map("application.home" -> rootPath.getAbsolutePath)
+    val resourceName = "log4j2.xml"
+    val resourceUrl = Option(this.getClass.getClassLoader.getResource(resourceName))
+    configure(properties, resourceUrl)
+  }
+
+  override def shutdown(): Unit = {
+    val context = LogManager.getContext().asInstanceOf[LoggerContext]
+    Configurator.shutdown(context)
+  }
+
+  override def configure(env: Environment): Unit = {
+    val properties = LoggerConfigurator.generateProperties(env, Configuration.empty, Map.empty)
+    val resourceUrl = env.resource("log4j2.xml")
+    configure(properties, resourceUrl)
+  }
+
+  override def configure(env: Environment, configuration: Configuration, optionalProperties: Map[String, String]): Unit = {
+    // LoggerConfigurator.generateProperties enables play.logger.includeConfigProperties=true
+    val properties = LoggerConfigurator.generateProperties(env, configuration, optionalProperties)
+    val resourceUrl = env.resource("log4j2.xml")
+    configure(properties, resourceUrl)
+  }
+
+  override def configure(properties: Map[String, String], config: Option[URL]): Unit = {
+    val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
+    context.setConfigLocation(config.get.toURI)
+
+    factory = org.slf4j.impl.StaticLoggerBinder.getSingleton.getLoggerFactory
+  }
+
+  override def loggerFactory: ILoggerFactory = factory
+}
+//#log4j2-class
+
+object Configurator {
+  def shutdown(context: Any): Unit = ???
+
+}
+
+object LogManager {
+  def getContext() = ???
+
+  def getContext(b: Boolean) = ???
+
+}
+
+class LoggerContext {
+  def setConfigLocation(toURI: URI): Unit = ???
+
+}

--- a/documentation/manual/working/commonGuide/configuration/code/ThreadPools.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/ThreadPools.scala
@@ -214,7 +214,7 @@ class Samples @Inject() (wsClient: WSClient) {
   import play.api.libs.concurrent.Execution.Implicits._
 
   def someAsyncAction = Action.async {
-    wsClient.url("http://www.playframework.com").get().map { response =>
+    wsClient.url("http://www.example.com").get().map { response =>
       // This code block is executed in the imported default execution context
       // which happens to be the same thread pool in which the outer block of
       // code in this action will be executed.

--- a/framework/src/play/src/main/scala/play/api/LoggerConfigurator.scala
+++ b/framework/src/play/src/main/scala/play/api/LoggerConfigurator.scala
@@ -6,6 +6,9 @@ package play.api
 import java.net.URL
 import java.util.Properties
 
+import com.typesafe.config.ConfigValueType
+import org.slf4j.ILoggerFactory
+
 /**
  * Runs through underlying logger configuration.
  */
@@ -17,19 +20,41 @@ trait LoggerConfigurator {
   def init(rootPath: java.io.File, mode: Mode.Mode): Unit
 
   /**
-   * Reconfigures the underlying logger infrastructure.
+   * This is a convenience method that adds no extra properties.
    */
   def configure(env: Environment): Unit
 
   /**
-   * Reconfigures the underlying  logger infrastructure.
+   * Configures the logger with the environment and the application configuration.
+   *
+   * This is what full applications will run, and the place to put extra properties,
+   * either through optionalProperties or by setting configuration properties and
+   * having "play.logger.includeConfigProperties=true" in the config.
+   *
+   * @param env the application environment
+   * @param configuration the application's configuration
+   * @param optionalProperties any optional properties (you can use Map.empty otherwise)
+   */
+  def configure(env: Environment, configuration: Configuration, optionalProperties: Map[String, String]): Unit
+
+  /**
+   * Configures the logger with a list of properties and an optional URL.
+   *
+   * This is the engine's entrypoint method that has all the properties pre-assembled.
    */
   def configure(properties: Map[String, String], config: Option[URL]): Unit
+
+  /**
+   * Returns the logger factory for the configurator.  Only safe to call after configuration.
+   * @return an instance of ILoggerFactory
+   */
+  def loggerFactory: ILoggerFactory
 
   /**
    * Shutdown the logger infrastructure.
    */
   def shutdown()
+
 }
 
 object LoggerConfigurator {
@@ -38,6 +63,29 @@ object LoggerConfigurator {
     findFromResources(classLoader).flatMap { className =>
       apply(className, this.getClass.getClassLoader)
     }
+  }
+
+  /**
+   * Generates the map of properties used by the logging framework.
+   */
+  def generateProperties(env: Environment, config: Configuration, optionalProperties: Map[String, String]): Map[String, String] = {
+    import scala.collection.JavaConverters._
+    val mutableMap = new scala.collection.mutable.HashMap[String, String]()
+    mutableMap.put("application.home", env.rootPath.getAbsolutePath)
+
+    if (config.getBoolean("play.logger.includeConfigProperties").contains(true)) {
+      val entrySet = config.underlying.entrySet.asScala
+      for (entry <- entrySet) {
+        val value = entry.getValue
+        value.valueType() match {
+          case ConfigValueType.STRING =>
+            mutableMap.put(entry.getKey, value.unwrapped().asInstanceOf[String])
+          case other =>
+            mutableMap.put(entry.getKey, value.render())
+        }
+      }
+    }
+    (mutableMap ++ optionalProperties).toMap
   }
 
   def apply(loggerConfiguratorClassName: String, classLoader: ClassLoader): Option[LoggerConfigurator] = {

--- a/framework/src/play/src/test/scala/play/api/LoggerConfiguratorSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/LoggerConfiguratorSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api
+
+import org.specs2.mutable.Specification
+
+class LoggerConfiguratorSpec extends Specification {
+
+  "generateProperties" should {
+
+    "generate in the simplest case" in {
+      val env = Environment.simple()
+      val config = Configuration.empty
+      val properties = LoggerConfigurator.generateProperties(env, config, Map.empty)
+      properties.size must beEqualTo(1)
+      properties must havePair("application.home" -> env.rootPath.getAbsolutePath)
+    }
+
+    "generate in the case of including string config property" in {
+      val env = Environment.simple()
+      val config = Configuration(
+        "play.logger.includeConfigProperties" -> true,
+        "my.string.in.application.conf" -> "hello"
+      )
+      val properties = LoggerConfigurator.generateProperties(env, config, Map.empty)
+      properties must havePair("my.string.in.application.conf" -> "hello")
+    }
+
+    "generate in the case of including integer config property" in {
+      val env = Environment.simple()
+      val config = Configuration(
+        "play.logger.includeConfigProperties" -> true,
+        "my.number.in.application.conf" -> 1
+      )
+      val properties = LoggerConfigurator.generateProperties(env, config, Map.empty)
+      properties must havePair("my.number.in.application.conf" -> "1")
+    }
+
+    "generate in the case of including null config property" in {
+      val env = Environment.simple()
+      val config = Configuration(
+        "play.logger.includeConfigProperties" -> true,
+        "my.null.in.application.conf" -> null
+      )
+      val properties = LoggerConfigurator.generateProperties(env, config, Map.empty)
+      // nulls are excluded, you must specify them directly
+      // https://typesafehub.github.io/config/latest/api/com/typesafe/config/Config.html#entrySet--
+      properties must not haveKey ("my.null.in.application.conf")
+    }
+
+    "generate in the case of direct properties" in {
+      val env = Environment.simple()
+      val config = Configuration.empty
+      val optProperties = Map("direct.map.property" -> "goodbye")
+      val properties = LoggerConfigurator.generateProperties(env, config, optProperties)
+
+      properties.size must beEqualTo(2)
+      properties must havePair("application.home" -> env.rootPath.getAbsolutePath)
+      properties must havePair("direct.map.property" -> "goodbye")
+    }
+
+    "generate a null using direct properties" in {
+      val env = Environment.simple()
+      val config = Configuration.empty
+      val optProperties = Map("direct.null.property" -> null)
+      val properties = LoggerConfigurator.generateProperties(env, config, optProperties)
+
+      properties must havePair("direct.null.property" -> null)
+    }
+
+    "override config property with direct properties" in {
+      val env = Environment.simple()
+      val config = Configuration("some.property" -> "AAA")
+      val optProperties = Map("some.property" -> "BBB")
+      val properties = LoggerConfigurator.generateProperties(env, config, optProperties)
+
+      properties must havePair("some.property" -> "BBB")
+    }
+
+  }
+
+}


### PR DESCRIPTION
## Fixes

Fixes https://github.com/playframework/playframework/issues/2833

## Purpose

This PR exposes configuration properties from application.conf to Logback.    So given a "play.http.context" property in application.conf, you can expose it with `${play.http.context}`:

```

    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
        <encoder>
            <pattern>%coloredLevel context = ${play.http.context} - %logger - %message%n%xException</pattern>
        </encoder>
    </appender>
```

## Background Context

This is a deliberately unclever implementation that passes everything through properties, so that there's no logic in Play-Logback itself if necessary and it's all done in GuiceApplicationLoader.  This means that anyone who wants to pass in custom properties to the logger or modify the logic can do it through ApplicationLoader rather than touching the backend engine.

The assumption is that users will not specify "play" or "akka" properties that would conflict with this code.