### PR TITLE
Remove JPA methods

### DIFF
--- a/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
+++ b/documentation/manual/working/javaGuide/main/sql/JavaJPA.md
@@ -91,19 +91,12 @@ It is likely that you need to run transactions that are not coupled with request
 * `JPAApi.withTransaction(Function<EntityManager, T>)`
 * `JPAApi.withTransaction(String, Function<EntityManager, T>)`
 * `JPAApi.withTransaction(String, boolean, Function<EntityManager, T>)`
-* `JPAApi.withTransaction(Supplier<T>)`
-* `JPAApi.withTransaction(Runnable)`
-* `JPAApi.withTransaction(String, boolean, Supplier<T>)`
 
 ### Examples:
 
 Using `JPAApi.withTransaction(Function<EntityManager, T>)`:
 
 @[jpa-withTransaction-function](code/controllers/JPAController.java)
-
-Using `JPAApi.withTransaction(Runnable)` to run a batch update:
-
-@[jpa-withTransaction-runnable](code/controllers/JPAController.java)
 
 ## Enabling Play database evolutions
 

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -55,6 +55,7 @@ public class DefaultJPAApi implements JPAApi {
     /**
      * Initialise JPA entity manager factories.
      */
+    @Override
     public JPAApi start() {
         jpaConfig.persistenceUnits().forEach(persistenceUnit ->
                 emfs.put(persistenceUnit.name, Persistence.createEntityManagerFactory(persistenceUnit.unitName))
@@ -63,10 +64,11 @@ public class DefaultJPAApi implements JPAApi {
     }
 
     /**
-     * Get the EntityManager for the specified persistence unit name.
+     * Get a newly created EntityManager for the specified persistence unit name.
      *
      * @param name The persistence unit name
      */
+    @Override
     public EntityManager em(String name) {
         EntityManagerFactory emf = emfs.get(name);
         if (emf == null) {
@@ -79,36 +81,42 @@ public class DefaultJPAApi implements JPAApi {
      * Get the EntityManager for a particular persistence unit for this thread.
      *
      * @return EntityManager for the specified persistence unit name
+     *
+     * @deprecated The EntityManager is supplied as lambda parameter instead when using {@link #withTransaction(Function)}
      */
+    @Override
+    @Deprecated
     public EntityManager em() {
         return entityManagerContext.em();
     }
 
     /**
-     * Run a block of code with the EntityManager for the named Persistence Unit.
+     * Run a block of code with a newly created EntityManager.
      *
      * @param block Block of code to execute
      * @param <T> type of result
      * @return code execution result
      */
+    @Override
     public <T> T withTransaction(Function<EntityManager, T> block) {
-        return withTransaction("default", false, block);
+        return withTransaction("default", block);
     }
 
     /**
-     * Run a block of code with the EntityManager for the named Persistence Unit.
+     * Run a block of code with a newly created EntityManager for the named Persistence Unit.
      *
      * @param name The persistence unit name
      * @param block Block of code to execute
      * @param <T> type of result
      * @return code execution result
      */
+    @Override
     public <T> T withTransaction(String name, Function<EntityManager, T> block) {
-        return withTransaction("default", false, block);
+        return withTransaction(name, false, block);
     }
 
     /**
-     * Run a block of code with the EntityManager for the named Persistence Unit.
+     * Run a block of code with a newly created EntityManager for the named Persistence Unit.
      *
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
@@ -116,6 +124,7 @@ public class DefaultJPAApi implements JPAApi {
      * @param <T> type of result
      * @return code execution result
      */
+    @Override
     public <T> T withTransaction(String name, boolean readOnly, Function<EntityManager, T> block) {
         EntityManager entityManager = null;
         EntityTransaction tx = null;
@@ -124,7 +133,7 @@ public class DefaultJPAApi implements JPAApi {
             entityManager = em(name);
 
             if (entityManager == null) {
-                throw new RuntimeException("No JPA entity manager defined for '" + name + "'");
+                throw new RuntimeException("Could not create JPA entity manager for '" + name + "'");
             }
 
             entityManagerContext.push(entityManager, true);
@@ -163,7 +172,11 @@ public class DefaultJPAApi implements JPAApi {
      * Run a block of code in a JPA transaction.
      *
      * @param block Block of code to execute
+     *
+     * @deprecated Use {@link #withTransaction(Function)}
      */
+    @Override
+    @Deprecated
     public <T> T withTransaction(Supplier<T> block) {
         return withTransaction("default", false, block);
     }
@@ -172,7 +185,11 @@ public class DefaultJPAApi implements JPAApi {
      * Run a block of code in a JPA transaction.
      *
      * @param block Block of code to execute
+     *
+     * @deprecated Use {@link #withTransaction(Function)}
      */
+    @Override
+    @Deprecated
     public void withTransaction(final Runnable block) {
         try {
             withTransaction("default", false, () -> {
@@ -190,7 +207,11 @@ public class DefaultJPAApi implements JPAApi {
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
      * @param block Block of code to execute
+     *
+     * @deprecated Use {@link #withTransaction(String, boolean, Function)}
      */
+    @Override
+    @Deprecated
     public <T> T withTransaction(String name, boolean readOnly, Supplier<T> block) {
         return withTransaction(name, readOnly, entityManager -> {
             return block.get();
@@ -200,6 +221,7 @@ public class DefaultJPAApi implements JPAApi {
     /**
      * Close all entity manager factories.
      */
+    @Override
     public void shutdown() {
         emfs.values().forEach(EntityManagerFactory::close);
     }

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
@@ -50,7 +50,7 @@ public class JPA {
     }
 
     /**
-     * Get the EntityManager for a particular persistence unit for this thread.
+     * Get a newly created EntityManager for a particular persistence unit.
      *
      * @param key name of the EntityManager to return
      * @return the EntityManager
@@ -59,7 +59,7 @@ public class JPA {
     public static EntityManager em(String key) {
         EntityManager em = jpaApi().em(key);
         if (em == null) {
-            throw new RuntimeException("No JPA EntityManagerFactory configured for name [" + key + "]");
+            throw new RuntimeException("Could not create JPA EntityManagerFactory for name [" + key + "]");
         }
 
         return em;
@@ -80,7 +80,10 @@ public class JPA {
      * If no HTTP context is available the EntityManager gets bound to the current thread instead.
      *
      * @param em the EntityManager to bind to this HTTP context.
+     *
+     * @deprecated Use JPAEntityManagerContext.push or JPAEntityManagerContext.pop
      */
+    @Deprecated
     public static void bindForSync(EntityManager em) {
         entityManagerContext.pushOrPopEm(em, true);
     }

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
@@ -21,7 +21,7 @@ public interface JPAApi {
     public JPAApi start();
 
     /**
-     * Get the EntityManager for the specified persistence unit name.
+     * Get a newly created EntityManager for the specified persistence unit name.
      *
      * @param name The persistence unit name
      * @return EntityManager for the specified persistence unit name
@@ -32,11 +32,14 @@ public interface JPAApi {
      * Get the EntityManager for a particular persistence unit for this thread.
      *
      * @return EntityManager for the specified persistence unit name
+     *
+     * @deprecated The EntityManager is supplied as lambda parameter instead when using {@link #withTransaction(Function)}
      */
+    @Deprecated
     public EntityManager em();
 
     /**
-     * Run a block of code with a given EntityManager.
+     * Run a block of code with a newly created EntityManager.
      *
      * @param block Block of code to execute
      * @param <T> type of result
@@ -45,7 +48,7 @@ public interface JPAApi {
     public <T> T withTransaction(Function<EntityManager, T> block);
 
     /**
-     * Run a block of code with a given EntityManager.
+     * Run a block of code with a newly created EntityManager for the named Persistence Unit.
      *
      * @param name The persistence unit name
      * @param block Block of code to execute
@@ -55,7 +58,7 @@ public interface JPAApi {
     public <T> T withTransaction(String name, Function<EntityManager, T> block);
 
     /**
-     * Run a block of code with a given EntityManager.
+     * Run a block of code with a newly created EntityManager for the named Persistence Unit.
      *
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
@@ -71,14 +74,20 @@ public interface JPAApi {
      * @param block Block of code to execute
      * @param <T> type of result
      * @return code execution result
+     *
+     * @deprecated Use {@link #withTransaction(Function)}
      */
+    @Deprecated
     public <T> T withTransaction(Supplier<T> block);
 
     /**
      * Run a block of code in a JPA transaction.
      *
      * @param block Block of code to execute
+     *
+     * @deprecated Use {@link #withTransaction(Function)}
      */
+    @Deprecated
     public void withTransaction(Runnable block);
 
     /**
@@ -89,7 +98,10 @@ public interface JPAApi {
      * @param block Block of code to execute
      * @param <T> type of result
      * @return code execution result
+     *
+     * @deprecated Use {@link #withTransaction(String, boolean, Function)}
      */
+    @Deprecated
     public <T> T withTransaction(String name, boolean readOnly, Supplier<T> block);
 
     /**

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/TransactionalAction.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/TransactionalAction.java
@@ -21,11 +21,12 @@ public class TransactionalAction extends Action<Transactional> {
         this.jpaApi = jpaApi;
     }
 
+    @Override
     public CompletionStage<Result> call(final Context ctx) {
         return jpaApi.withTransaction(
             configuration.value(),
             configuration.readOnly(),
-            () -> delegate.call(ctx)
+            (em) -> delegate.call(ctx)
         );
     }
 


### PR DESCRIPTION
Deprecated some methods which should have been deprecated before the 2.5 release already.
Also clearified some comments and exceptions.

I want to backport this to 2.5.x so people are aware of the deprecations (they can use alternative methods in 2.5 already anyway) so we can clean up for the 2.6.x release - I have some pull requests with enhancements for the JPA in the queue.
