### PR TITLE
Added the Entity Headers of play-akka-http to Actions

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -85,12 +85,12 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
    */
   private def convertRequestHeaders(request: HttpRequest): Headers = {
     val entityHeaders: Seq[(String, String)] = request.entity match {
-      case HttpEntity.Strict(contentType, _) =>
-        Seq((CONTENT_TYPE, contentType.value))
+      case s: HttpEntity.Strict =>
+        Seq((CONTENT_TYPE, s.contentType.value), (CONTENT_LENGTH, s.contentLength.toString))
       case HttpEntity.Default(contentType, contentLength, _) =>
         Seq((CONTENT_TYPE, contentType.value), (CONTENT_LENGTH, contentLength.toString))
       case HttpEntity.Chunked(contentType, _) =>
-        Seq((CONTENT_TYPE, contentType.value))
+        Seq((CONTENT_TYPE, contentType.value), (TRANSFER_ENCODING, "chunked"))
     }
     val normalHeaders: Seq[(String, String)] = request.headers
       .filter(_.isNot(`Raw-Request-URI`.lowercaseName))

--- a/framework/src/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHttpServerSpec.scala
+++ b/framework/src/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHttpServerSpec.scala
@@ -206,5 +206,19 @@ object AkkaHttpServerSpec extends PlaySpecification with WsTestClient {
       }
     }
 
+    "pass Header Content-Length to Actions" in {
+      requestFromServer("/httpServerHeader") { request =>
+        request.post("10")
+      } {
+        case ("POST", "/httpServerHeader") => Action { implicit request =>
+          val contentLength = request.headers.get(CONTENT_LENGTH).map(_.mkString).getOrElse("")
+          Ok(contentLength)
+        }
+      } { response =>
+        response.status must_== 200
+        response.body must_== "2"
+      }
+    }
+
   }
 }


### PR DESCRIPTION
## Purpose

Currently in play-netty your Action could see the `Content-Length` or `Transfer-Encoding` Header. However in play-akka-http this was not present. So this PR resolves this issue.

## References

See: https://github.com/playframework/playframework/pull/6003

