### PR TITLE
Fix bug in application.conf template

### DIFF
--- a/templates/play-common/conf/application.conf
+++ b/templates/play-common/conf/application.conf
@@ -116,7 +116,7 @@ play.http {
   # common logic for all your actions, e.g. adding common headers.
   # Defaults to "Filters" in the root package (aka "apps" folder)
   # Alternatively you can explicitly register a class here.
-  #filters += my.application.Filters
+  #filters = my.application.Filters
 
   ## Session & Flash
   # https://www.playframework.com/documentation/latest/JavaSessionFlash

--- a/templates/play-java-intro/conf/application.conf
+++ b/templates/play-java-intro/conf/application.conf
@@ -116,7 +116,7 @@ play.http {
   # common logic for all your actions, e.g. adding common headers.
   # Defaults to "Filters" in the root package (aka "apps" folder)
   # Alternatively you can explicitly register a class here.
-  #filters += my.application.Filters
+  #filters = my.application.Filters
 
   ## Session & Flash
   # https://www.playframework.com/documentation/latest/JavaSessionFlash

--- a/templates/play-scala-intro/conf/application.conf
+++ b/templates/play-scala-intro/conf/application.conf
@@ -116,7 +116,7 @@ play.http {
   # common logic for all your actions, e.g. adding common headers.
   # Defaults to "Filters" in the root package (aka "apps" folder)
   # Alternatively you can explicitly register a class here.
-  #filters += my.application.Filters
+  #filters = my.application.Filters
 
   ## Session & Flash
   # https://www.playframework.com/documentation/latest/JavaSessionFlash


### PR DESCRIPTION
`play.http.filters` isn't a sequence/list. [See](https://github.com/playframework/playframework/blob/2.5.1/framework/src/play/src/main/resources/reference.conf#L60) `reference.conf`.
When using `+=` you get following exception:

```
play.api.Configuration$$anon$1: Configuration error[reference.conf @ jar:file:.../jars/play_2.11.jar!/reference.conf: 60: Cannot concatenate object or list with a non-object-or-list, ConfigNull(null) and SimpleConfigList(["filter.Filters"]) are not compatible]
	at play.api.Configuration$.configError(Configuration.scala:154)
	at play.api.Configuration$.load(Configuration.scala:101)
	at play.api.Configuration$.load(Configuration.scala:109)
	at play.api.ApplicationLoader$.createContext(ApplicationLoader.scala:91)
	at play.core.server.DevServerStart$$anonfun$mainDev$1$$anon$1$$anonfun$get$1$$anonfun$apply$1$$anonfun$1$$anonfun$2.apply(DevServerStart.scala:156)
	at play.core.server.DevServerStart$$anonfun$mainDev$1$$anon$1$$anonfun$get$1$$anonfun$apply$1$$anonfun$1$$anonfun$2.apply(DevServerStart.scala:155)
	at play.utils.Threads$.withContextClassLoader(Threads.scala:21)
	at play.core.server.DevServerStart$$anonfun$mainDev$1$$anon$1$$anonfun$get$1$$anonfun$apply$1$$anonfun$1.apply(DevServerStart.scala:155)
	at play.core.server.DevServerStart$$anonfun$mainDev$1$$anon$1$$anonfun$get$1$$anonfun$apply$1$$anonfun$1.apply(DevServerStart.scala:126)
	at scala.Option.map(Option.scala:146)
Caused by: com.typesafe.config.ConfigException$WrongType: reference.conf @ jar:file:.../jars/play_2.11.jar!/reference.conf: 60: Cannot concatenate object or list with a non-object-or-list, ConfigNull(null) and SimpleConfigList(["filter.Filters"]) are not compatible
	at com.typesafe.config.impl.ConfigConcatenation.join(ConfigConcatenation.java:124)
	at com.typesafe.config.impl.ConfigConcatenation.consolidate(ConfigConcatenation.java:161)
	at com.typesafe.config.impl.ConfigConcatenation.resolveSubstitutions(ConfigConcatenation.java:218)
	at com.typesafe.config.impl.ResolveContext.realResolve(ResolveContext.java:179)
	at com.typesafe.config.impl.ResolveContext.resolve(ResolveContext.java:142)
	at com.typesafe.config.impl.ConfigDelayedMerge.resolveSubstitutions(ConfigDelayedMerge.java:132)
	at com.typesafe.config.impl.ConfigDelayedMerge.resolveSubstitutions(ConfigDelayedMerge.java:59)
	at com.typesafe.config.impl.ResolveContext.realResolve(ResolveContext.java:179)
	at com.typesafe.config.impl.ResolveContext.resolve(ResolveContext.java:142)
	at com.typesafe.config.impl.SimpleConfigObject$ResolveModifier.modifyChildMayThrow(SimpleConfigObject.java:379)

```

Needs backport.