### PR TITLE
update docs about compile time di and evolutions

### DIFF
--- a/documentation/manual/working/commonGuide/database/Evolutions.md
+++ b/documentation/manual/working/commonGuide/database/Evolutions.md
@@ -226,3 +226,8 @@ By default, each statement of each evolution script will be executed immediately
 
 Evolutions are stored in your database in a table called `play_evolutions`.  A Text column stores the actual evolution script.  Your database probably has a 64kb size limit on a text column.  To work around the 64kb limitation you could: manually alter the play_evolutions table structure changing the column type or (preferred) create multiple evolutions scripts less than 64kb in size.
 
+
+### Using evolutions with compile time dependency injection
+
+If you are using Macwire or similar for dependency injection then you can use the trait `EvolutionsComponents` to get ahold of the evolutions plugin. After that when your application is loaded you can call `this.applicationEvolutions.start()` to get the `Database needs evolution` screen. 
+


### PR DESCRIPTION
Hi,

I'd like to add this change to the docs because I wasted around a 3 hours on this. 

Got it from this repo: https://github.com/martijnblankestijn/play-2.4-macwire/commit/fc451730cef7a07e028580d16251d993003829d1

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?


## Purpose

Clarifies documentation about evolutions and compile time dependency injection.

## Background Context

I am not sure if this is the correct approach to start the evolutions. Let me know if not. 

## References

Are there any relevant issues / PRs / mailing lists discussions?

As soon as I realised that I have to call start() I started looking for it. Found it here:
https://github.com/martijnblankestijn/play-2.4-macwire/commit/fc451730cef7a07e028580d16251d993003829d1
