### PR TITLE
Allow page-specific overrides to the security headers provided by Sec…

### DIFF
--- a/documentation/manual/working/commonGuide/filters/SecurityHeaders.md
+++ b/documentation/manual/working/commonGuide/filters/SecurityHeaders.md
@@ -40,3 +40,13 @@ Any of the headers can be disabled by setting a configuration value of `null`, f
     play.filters.headers.frameOptions = null
 
 For a full listing of configuration options, see the Play filters [`reference.conf`](resources/confs/filters-helpers/reference.conf).
+
+## Action-specific overrides
+
+Security headers may be overridden in specific actions using `withHeaders` on the result:
+
+@[allowActionSpecificHeaders](code/SecurityHeaders.scala)
+
+Any security headers not mentioned in `withHeaders` will use the usual configured values
+(if present) or the defaults.  Action-specific security headers are ignored unless 
+`play.filters.headers.allowActionSpecificHeaders` is set to `true` in the configuration.

--- a/documentation/manual/working/commonGuide/filters/code/SecurityHeaders.scala
+++ b/documentation/manual/working/commonGuide/filters/code/SecurityHeaders.scala
@@ -16,4 +16,12 @@ object SecurityHeaders {
     def filters = Seq(securityHeadersFilter)
   }
   //#filters
+
+  import play.api.mvc.Action
+  import play.api.mvc.Results.Ok
+  def index = Action {
+  //#allowActionSpecificHeaders
+  	Ok("Index").withHeaders(SecurityHeadersFilter.CONTENT_SECURITY_POLICY_HEADER -> "my page-specific header")
+  //#allowActionSpecificHeaders
+  }
 }

--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -113,6 +113,9 @@ play.filters {
 
     # The Content-Security-Policy header. If null, the header is not set.
     contentSecurityPolicy = "default-src 'self'"
+
+    # If true, allow an action to use .withHeaders to replace one or more of the above headers
+    allowActionSpecificHeaders = false
   }
 
   # Allowed hosts filter configuration

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
@@ -22,6 +22,7 @@ import play.api.{ Environment, PlayConfig, Configuration }
  * <li>{{play.filters.headers.contentTypeOptions}} - sets contentTypeOptions. Some("nosniff") by default.
  * <li>{{play.filters.headers.permittedCrossDomainPolicies}} - sets permittedCrossDomainPolicies. Some("master-only") by default.
  * <li>{{play.filters.headers.contentSecurityPolicy}} - sets contentSecurityPolicy. Some("default-src 'self'") by default.
+ * <li>{{play.filters.headers.allowActionSpecificHeaders}} - sets whether .withHeaders may be used to provide page-specific overrides.  False by default.
  * </ul>
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options">X-Frame-Options</a>
@@ -71,7 +72,8 @@ case class SecurityHeadersConfig(frameOptions: Option[String] = Some("DENY"),
     xssProtection: Option[String] = Some("1; mode=block"),
     contentTypeOptions: Option[String] = Some("nosniff"),
     permittedCrossDomainPolicies: Option[String] = Some("master-only"),
-    contentSecurityPolicy: Option[String] = Some("default-src 'self'")) {
+    contentSecurityPolicy: Option[String] = Some("default-src 'self'"),
+    allowActionSpecificHeaders: Boolean = false) {
   def this() {
     this(frameOptions = Some("DENY"))
   }
@@ -104,7 +106,8 @@ object SecurityHeadersConfig {
       xssProtection = config.get[Option[String]]("xssProtection"),
       contentTypeOptions = config.get[Option[String]]("contentTypeOptions"),
       permittedCrossDomainPolicies = config.get[Option[String]]("permittedCrossDomainPolicies"),
-      contentSecurityPolicy = config.get[Option[String]]("contentSecurityPolicy"))
+      contentSecurityPolicy = config.get[Option[String]]("contentSecurityPolicy"),
+      allowActionSpecificHeaders = config.get[Option[Boolean]]("allowActionSpecificHeaders").getOrElse(false))
   }
 }
 
@@ -118,22 +121,33 @@ class SecurityHeadersFilter @Inject() (config: SecurityHeadersConfig) extends Es
 
   /**
    * Returns the security headers for a request.
-   * All security headers applied to all requests by default. Override to alter that behavior.
+   * All security headers applied to all requests by default.
+   * Omit any headers explicitly provided in the result object, provided
+   * play.filters.headers.allowActionSpecificHeaders is true.
+   * Override this method to alter that behavior.
    */
-  protected def headers(request: RequestHeader): Seq[(String, String)] = Seq(
-    config.frameOptions.map(X_FRAME_OPTIONS_HEADER -> _),
-    config.xssProtection.map(X_XSS_PROTECTION_HEADER -> _),
-    config.contentTypeOptions.map(X_CONTENT_TYPE_OPTIONS_HEADER -> _),
-    config.permittedCrossDomainPolicies.map(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER -> _),
-    config.contentSecurityPolicy.map(CONTENT_SECURITY_POLICY_HEADER -> _)
-  ).flatten
+  protected def headers(request: RequestHeader, result: Result): Seq[(String, String)] = {
+    val headers = Seq(
+      config.frameOptions.map(X_FRAME_OPTIONS_HEADER -> _),
+      config.xssProtection.map(X_XSS_PROTECTION_HEADER -> _),
+      config.contentTypeOptions.map(X_CONTENT_TYPE_OPTIONS_HEADER -> _),
+      config.permittedCrossDomainPolicies.map(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER -> _),
+      config.contentSecurityPolicy.map(CONTENT_SECURITY_POLICY_HEADER -> _)
+    ).flatten
+
+    if (config.allowActionSpecificHeaders) {
+      headers.filter { case (name, _) => result.header.headers.get(name).isEmpty }
+    } else {
+      headers
+    }
+  }
 
   /**
    * Applies the filter to an action, appending the headers to the result so it shows in the HTTP response.
    */
   def apply(next: EssentialAction) = EssentialAction { req =>
     import play.core.Execution.Implicits.trampoline
-    next(req).map(_.withHeaders(headers(req): _*))
+    next(req).map(result => result.withHeaders(headers(req, result): _*))
   }
 }
 


### PR DESCRIPTION
## Fixes

Fixes #6011

## Purpose

Allow security headers such as CONTENT_SECURITY_POLICY_HEADER to be overridden on specific pages.  

## Background Context

The current implementation of `SecurityHeadersFilter` overwrites any security headers set with `.withHeaders`.  This pull request modifies `SecurityHeadersFilter` avoid that, provided `play.filters.headers.allowPageSpecificOverrides` has been set to true.

The basic approach is a collaborative effort between myself and @gmethvin at #6011.

