### PR TITLE
[2.5.x] Backport #5795 - Make default body parser parse if and only if a body is present

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/JavaBodyParsers.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaBodyParsers.md
@@ -28,7 +28,9 @@ The following is a mapping of types supported by the default body parser:
 - **`multipart/form-data`**: [`MultipartFormData`](api/java/play/mvc/Http.MultipartFormData.html), accessible via `asMultipartFormData()`.
 - Any other content type: [`RawBuffer`](api/java/play/mvc/Http.RawBuffer.html), accessible via `asRaw()`.
 
-The default body parser, for performance reasons, won't attempt to parse the body if the request method is not defined to have a meaningful body, as defined by the HTTP spec.  This means it only parses bodies of `POST`, `PUT` and `PATCH` requests, but not `GET`, `HEAD` or `DELETE`.  If you would like to parse request bodies for these methods, you can use the `AnyContent` body parser, described [below](#Choosing-an-explicit-body-parser).
+The default body parser tries to determine if the request has a body before it tries to parse. According to the HTTP spec, the presence of either the `Content-Length` or `Transfer-Encoding` header signals the presence of a body, so the parser will only parse if one of those headers is present, or on `FakeRequest` when a non-empty body has explicitly been set.
+
+If you would like to try to parse a body in all cases, you can use the `AnyContent` body parser, described [below](#Choosing-an-explicit-body-parser).
 
 ### Choosing an explicit body parser
 
@@ -59,7 +61,7 @@ Most of the built in body parsers buffer the body in memory, and some buffer it 
 The memory buffer limit is configured using `play.http.parser.maxMemoryBuffer`, and defaults to 100KB, while the disk buffer limit is configured using `play.http.parser.maxDiskBuffer`, and defaults to 10MB.  These can both be configured in `application.conf`, for example, to increase the memory buffer limit to 256KB:
 
     play.http.parser.maxMemoryBuffer = 256kb
-    
+
 You can also limit the amount of memory used on a per action basis by writing a custom body parser, see [below](#Writing-a-custom-max-length-body-parser) for details.
 
 ## Writing a custom body parser

--- a/documentation/manual/working/scalaGuide/main/http/ScalaBodyParsers.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaBodyParsers.md
@@ -19,7 +19,7 @@ First we see that there is a generic type `A`, and then that an action must defi
 
 The `A` type is the type of the request body. We can use any Scala type as the request body, for example `String`, `NodeSeq`, `Array[Byte]`, `JsonValue`, or `java.io.File`, as long as we have a body parser able to process it.
 
-To summarize, an `Action[A]` uses a `BodyParser[A]` to retrieve a value of type `A` from the HTTP request, and to build a `Request[A]` object that is passed to the action code. 
+To summarize, an `Action[A]` uses a `BodyParser[A]` to retrieve a value of type `A` from the HTTP request, and to build a `Request[A]` object that is passed to the action code.
 
 ## Using the built in body parsers
 
@@ -42,7 +42,9 @@ The following is a mapping of types supported by the default body parser:
 - **multipart/form-data**: [`MultipartFormData`](api/scala/play/api/mvc/MultipartFormData.html), accessible via `asMultipartFormData`.
 - Any other content type: [`RawBuffer`](api/scala/play/api/mvc/RawBuffer.html), accessible via `asRaw`.
 
-The default body parser, for performance reasons, won't attempt to parse the body if the request method is not defined to have a meaningful body, as defined by the HTTP spec.  This means it only parses bodies of `POST`, `PUT` and `PATCH` requests, but not `GET`, `HEAD` or `DELETE`.  If you would like to parse request bodies for these methods, you can use the `anyContent` body parser, described [below](#Choosing-an-explicit-body-parser).
+The default body parser tries to determine if the request has a body before it tries to parse. According to the HTTP spec, the presence of either the `Content-Length` or `Transfer-Encoding` header signals the presence of a body, so the parser will only parse if one of those headers is present, or on `FakeRequest` when a non-empty body has explicitly been set.
+
+If you would like to try to parse a body in all cases, you can use the `anyContent` body parser, described [below](#Choosing-an-explicit-body-parser).
 
 ## Choosing an explicit body parser
 

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -85,12 +85,12 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
    */
   private def convertRequestHeaders(request: HttpRequest): Headers = {
     val entityHeaders: Seq[(String, String)] = request.entity match {
-      case HttpEntity.Strict(contentType, _) =>
-        Seq((CONTENT_TYPE, contentType.value))
+      case HttpEntity.Strict(contentType, data) =>
+        Seq(CONTENT_TYPE -> contentType.value, CONTENT_LENGTH -> data.length.toString)
       case HttpEntity.Default(contentType, contentLength, _) =>
-        Seq((CONTENT_TYPE, contentType.value), (CONTENT_LENGTH, contentLength.toString))
+        Seq(CONTENT_TYPE -> contentType.value, CONTENT_LENGTH -> contentLength.toString)
       case HttpEntity.Chunked(contentType, _) =>
-        Seq((CONTENT_TYPE, contentType.value))
+        Seq(CONTENT_TYPE -> contentType.value, TRANSFER_ENCODING -> play.api.http.HttpProtocol.CHUNKED)
     }
     val normalHeaders: Seq[(String, String)] = request.headers
       .filter(_.isNot(`Raw-Request-URI`.lowercaseName))

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaRequestsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaRequestsSpec.scala
@@ -12,9 +12,6 @@ import play.core.j.JavaHelpers
 import play.mvc.Http
 import play.mvc.Http.{ Context, RequestBody, RequestImpl }
 
-/**
- *
- */
 class JavaRequestsSpec extends PlaySpecification with Mockito {
 
   "JavaHelpers" should {
@@ -61,6 +58,24 @@ class JavaRequestsSpec extends PlaySpecification with Mockito {
       cookieList.size must be equalTo 1
       cookieList.head.name must be equalTo "name1"
       cookieList.head.value must be equalTo "value1"
+    }
+
+    "create a request without a body" in {
+      val requestHeader: Request[Http.RequestBody] = Request[Http.RequestBody](FakeRequest(), new RequestBody())
+      val javaContext: Context = JavaHelpers.createJavaContext(requestHeader)
+      val javaRequest = javaContext.request()
+
+      requestHeader.hasBody must beFalse
+      javaRequest.hasBody must beFalse
+    }
+
+    "create a request with a body" in {
+      val requestHeader: Request[Http.RequestBody] = Request[Http.RequestBody](FakeRequest(), new RequestBody("foo"))
+      val javaContext: Context = JavaHelpers.createJavaContext(requestHeader)
+      val javaRequest = javaContext.request()
+
+      requestHeader.hasBody must beTrue
+      javaRequest.hasBody must beTrue
     }
 
   }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
@@ -14,24 +14,25 @@ object DefaultBodyParserSpec extends PlaySpecification {
   "The default body parser" should {
 
     def parse(method: String, contentType: Option[String], body: ByteString)(implicit mat: Materializer) = {
-      val request = FakeRequest(method, "/x").withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*)
+      val request = FakeRequest(method, "/x").withHeaders(
+        contentType.map(CONTENT_TYPE -> _).toSeq :+ (CONTENT_LENGTH -> body.length.toString): _*)
       await(BodyParsers.parse.default(request).run(Source.single(body)))
     }
 
-    "ignore text bodies for DELETE requests" in new WithApplication() {
-      parse("GET", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsEmpty)
+    "parse text bodies for DELETE requests" in new WithApplication() {
+      parse("GET", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
     }
 
-    "ignore text bodies for GET requests" in new WithApplication() {
-      parse("GET", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsEmpty)
+    "parse text bodies for GET requests" in new WithApplication() {
+      parse("GET", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
     }
 
-    "ignore text bodies for HEAD requests" in new WithApplication() {
-      parse("HEAD", None, ByteString("bar")) must beRight(AnyContentAsEmpty)
+    "parse text bodies for HEAD requests" in new WithApplication() {
+      parse("HEAD", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
     }
 
-    "ignore text bodies for OPTIONS requests" in new WithApplication() {
-      parse("GET", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsEmpty)
+    "parse text bodies for OPTIONS requests" in new WithApplication() {
+      parse("GET", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
     }
 
     "parse XML bodies for PATCH requests" in new WithApplication() {

--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -10,13 +10,14 @@ import akka.stream.Materializer
 import akka.util.ByteString
 import play.api._
 import play.api.http._
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.inject._
-import play.api.mvc._
-import play.api.libs.json.JsValue
-import scala.concurrent.Future
-import xml.NodeSeq
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.Files.TemporaryFile
+import play.api.libs.json.JsValue
+import play.api.mvc._
+
+import scala.concurrent.Future
+import scala.xml.NodeSeq
 
 /**
  * Fake HTTP headers implementation.

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -67,7 +67,7 @@ public interface BodyParser<A> {
     }
 
     /**
-     * If PATCH, POST, or PUT, guess the body content by checking the Content-Type header.
+     * If the request has a body, guess the body content by checking the Content-Type header.
      */
     class Default extends AnyContent {
         @Inject
@@ -77,7 +77,7 @@ public interface BodyParser<A> {
 
         @Override
         public Accumulator<ByteString, F.Either<Result, Object>> apply(Http.RequestHeader request) {
-            if (request.method().equals("POST") || request.method().equals("PUT") || request.method().equals("PATCH")) {
+            if (request.hasHeader(Http.HeaderNames.CONTENT_LENGTH) || request.hasHeader(Http.HeaderNames.TRANSFER_ENCODING)) {
                 return super.apply(request);
             } else {
                 return (Accumulator) new Empty().apply(request);

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -576,6 +576,14 @@ public class Http {
         String getHeader(String headerName);
 
         /**
+         * Checks if the request has a body.
+         */
+        default boolean hasBody() {
+            play.api.mvc.RequestHeader underlying = _underlyingHeader();
+            return underlying != null && underlying.hasBody();
+        }
+
+        /**
          * Checks if the request has the header.
          *
          * @param headerName The name of the header (case-insensitive)
@@ -709,6 +717,13 @@ public class Http {
         }
 
         /**
+         * @return whether the underlying request has a body.
+         */
+        public boolean hasBody() {
+            return underlying != null && underlying.hasBody();
+        }
+
+        /**
          * @return the username
          */
         public String username() {
@@ -804,6 +819,16 @@ public class Http {
          * @return the modified builder
          */
         protected RequestBuilder body(RequestBody body) {
+            if (body == null || body.as(Object.class) == null) {
+                // assume null sigifies no body; RequestBody is a wrapper for the actual body content
+                this.headers.remove(HeaderNames.CONTENT_LENGTH);
+                this.headers.remove(HeaderNames.TRANSFER_ENCODING);
+            } else {
+                int length = body.asBytes().length();
+                if (header(HeaderNames.TRANSFER_ENCODING) == null) {
+                    this.headers.put(HeaderNames.CONTENT_LENGTH, new String[] {Integer.toString(length)});
+                }
+            }
             this.body = body;
             return this;
         }

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -582,15 +582,15 @@ trait BodyParsers {
     // -- Magic any content
 
     /**
-     * If the request is a PATCH, POST, or PUT, parse the body content by checking the Content-Type header.
+     * If the request has a body, parse the body content by checking the Content-Type header.
      */
     def default: BodyParser[AnyContent] = default(None)
 
     /**
-     * If the request is a PATCH, POST, or PUT, parse the body content by checking the Content-Type header.
+     * If the request has a body, parse the body content by checking the Content-Type header.
      */
     def default(maxLength: Option[Long]): BodyParser[AnyContent] = using { request =>
-      if (request.method == HttpVerbs.PATCH || request.method == HttpVerbs.POST || request.method == HttpVerbs.PUT) {
+      if (request.hasBody) {
         anyContent(maxLength)
       } else {
         ignore(AnyContentAsEmpty)

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -212,6 +212,8 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
     getHeader(headerName) != null
   }
 
+  def hasBody: Boolean = header.hasBody
+
   private def createHeaderMap(headers: Headers): java.util.Map[String, Array[String]] = {
     val map = new java.util.TreeMap[String, Array[String]](play.core.utils.CaseInsensitiveOrdered)
     map.putAll(headers.toMap.mapValues(_.toArray).asJava)


### PR DESCRIPTION
Backports #5795.

@gmethvin, the only difference between this PR and #5795 is that `play.mvc.Http.RequestHeader#hasBody` now has a `default` implementation to avoid compilation problems with classes that implements `play.mvc.Http.RequestHeader`.

@schmitch, this is important to #6003.