### PR TITLE
Fix data-attibutes in devError and requireJs partials

### DIFF
--- a/framework/src/play/src/main/scala/views/defaultpages/devError.scala.html
+++ b/framework/src/play/src/main/scala/views/defaultpages/devError.scala.html
@@ -156,12 +156,12 @@
                                 @interesting.focus.zipWithIndex.map {
 
                                     case (line,index) if index == interesting.errorLine => {
-                                        <pre class="error" chunks-file="@name" chunks-line="@(interesting.firstLine+index)" @Option(source.position).map { c => chunks-column="@c" }><span class="line">@(interesting.firstLine+index)</span><span class="code">@(Option(source.position).map(pos => (line+" ").zipWithIndex.map{ case (c,i) if i == pos => Html("""<span class="marker">""" + c + """</span>"""); case (c,_) => c}).getOrElse(line))</span></pre>
+                                        <pre class="error" data-file="@name" data-line="@(interesting.firstLine+index)" @Option(source.position).map { c => data-column="@c" }><span class="line">@(interesting.firstLine+index)</span><span class="code">@(Option(source.position).map(pos => (line+" ").zipWithIndex.map{ case (c,i) if i == pos => Html("""<span class="marker">""" + c + """</span>"""); case (c,_) => c}).getOrElse(line))</span></pre>
 
                                     }
 
                                     case (line, index) => {
-                                        <pre chunks-file="@name" chunks-line="@(interesting.firstLine+index)"><span class="line">@(interesting.firstLine+index)</span><span class="code">@line</span></pre>
+                                        <pre data-file="@name" data-line="@(interesting.firstLine+index)"><span class="line">@(interesting.firstLine+index)</span><span class="code">@line</span></pre>
                                     }
 
                                 }

--- a/framework/src/play/src/main/scala/views/helper/requireJs.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/requireJs.scala.html
@@ -15,4 +15,4 @@
 @(module: String, core: String, productionFolderPrefix: String = "-min", folder: String= "javascripts")
 
 
- <script type="text/javascript" chunks-main="@{if(play.api.Mode.Prod == play.api.Play.maybeApplication.map(_.mode).getOrElse(play.api.Mode.Dev)) module.replace(folder,folder+productionFolderPrefix) else module}" src="@core"></script>
+ <script type="text/javascript" data-main="@{if(play.api.Mode.Prod == play.api.Play.maybeApplication.map(_.mode).getOrElse(play.api.Mode.Dev)) module.replace(folder,folder+productionFolderPrefix) else module}" src="@core"></script>


### PR DESCRIPTION
Partially reverts 65610c1890d9ee07caa8b10bba590c429f17da05

The `requireJs.scala.html` template stopped working for us since 2.5.0 and I think the changes @jroper made to `requireJs.scala.html` and `devError.scala.html` may have been accidental.

Please have a look.