### PR TITLE
Remove procedure syntax in LogbackLoggerConfigurator.shutdown

### DIFF
--- a/framework/src/play-logback/src/main/scala/play.api.libs.logback/LogbackLoggerConfigurator.scala
+++ b/framework/src/play-logback/src/main/scala/play.api.libs.logback/LogbackLoggerConfigurator.scala
@@ -100,7 +100,7 @@ class LogbackLoggerConfigurator extends LoggerConfigurator {
   /**
    * Shutdown the logger infrastructure.
    */
-  def shutdown() {
+  def shutdown(): Unit = {
 
     val ctx = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
     ctx.stop()


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?

## Purpose

Remove usage of deprecated procedure syntax in `LogbackLoggerConfigurator.shutdown`
