### PR TITLE
Support non-ISO8859-1 filename in Content-Disposition header

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/StatusHeader.java
+++ b/framework/src/play/src/main/java/play/mvc/StatusHeader.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import play.http.HttpEntity;
 import play.libs.Json;
-import scala.Option;
+import play.utils.UriEncoding;
 import scala.compat.java8.OptionConverters;
 
 import java.io.File;
@@ -27,6 +27,8 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.*;
 
 /**
  * A status with no body
@@ -268,7 +270,7 @@ public class StatusHeader extends Result {
         Map<String, String> headers = Collections.singletonMap(
                 Http.HeaderNames.CONTENT_DISPOSITION,
                 (inline ? "inline" : "attachment") +
-                (resourceName.isPresent() ? "; filename=\"" + resourceName.get() + "\"" : "")
+                (resourceName.isPresent() ? "; filename=\"" + resourceName.get() + "\"; filename*=utf-8''" + UriEncoding.encodePathSegment(resourceName.get(), UTF_8) : "")
         );
 
         return new Result(status(), headers, new HttpEntity.Streamed(

--- a/framework/src/play/src/main/scala/play/api/mvc/RangeResult.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/RangeResult.scala
@@ -3,6 +3,8 @@
  */
 package play.api.mvc
 
+import java.nio.charset.StandardCharsets
+
 import akka.NotUsed
 import akka.stream.scaladsl.{ FileIO, Flow, Source }
 import akka.stream.stage._
@@ -10,6 +12,7 @@ import akka.util.ByteString
 import play.api.http.HeaderNames._
 import play.api.http.Status._
 import play.api.http.{ ContentTypes, HttpEntity }
+import play.utils.UriEncoding
 
 import scala.math.Ordered.orderingToOrdered
 
@@ -255,7 +258,7 @@ object RangeResult {
   def ofSource(entityLength: Long, source: Source[ByteString, _], rangeHeader: Option[String], fileName: Option[String], contentType: Option[String]): Result = {
     val commonHeaders = Seq(
       Some(ACCEPT_RANGES -> "bytes"),
-      fileName.map(f => CONTENT_DISPOSITION -> s"""attachment; filename="$f"""")
+      fileName.map(f => CONTENT_DISPOSITION -> s"""attachment; filename="$f"; filename*=utf-8''${UriEncoding.encodePathSegment(f, StandardCharsets.UTF_8)}""")
     ).flatten.toMap
 
     RangeSet(entityLength, rangeHeader) match {

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -3,6 +3,7 @@
  */
 package play.api.mvc
 
+import java.nio.charset.StandardCharsets
 import java.nio.file.{ Files, Path }
 
 import akka.stream.scaladsl.{ FileIO, Source, StreamConverters }
@@ -13,6 +14,7 @@ import play.api.http.HeaderNames._
 import play.api.http._
 import play.api.i18n.{ Lang, MessagesApi }
 import play.core.utils.CaseInsensitiveOrdered
+import play.utils.UriEncoding
 
 import scala.collection.immutable.TreeMap
 
@@ -373,7 +375,7 @@ trait Results {
           Map(
             CONTENT_DISPOSITION -> {
               val dispositionType = if (inline) "inline" else "attachment"
-              dispositionType + "; filename=\"" + name + "\""
+              s"""$dispositionType; filename="$name"; filename*=utf-8''${UriEncoding.encodePathSegment(name, StandardCharsets.UTF_8)}"""
             }
           )
         ),

--- a/framework/src/play/src/main/scala/play/utils/UriEncoding.scala
+++ b/framework/src/play/src/main/scala/play/utils/UriEncoding.scala
@@ -3,8 +3,9 @@
  */
 package play.utils
 
-import java.util.BitSet
 import java.io.ByteArrayOutputStream
+import java.nio.charset.Charset
+import java.util.BitSet
 
 /**
  * Provides support for correctly encoding pieces of URIs.
@@ -60,6 +61,17 @@ object UriEncoding {
   }
 
   /**
+   * Encode a string so that it can be used safely in the "path segment" part of a URI.
+   *
+   * @param s The string to encode.
+   * @param inputCharset The charset of the encoding that the string `s` is encoded with.
+   * @return An encoded string in the US-ASCII character set.
+   */
+  def encodePathSegment(s: String, inputCharset: Charset): String = {
+    encodePathSegment(s, inputCharset.name)
+  }
+
+  /**
    * Decode a string according to the rules for the "path segment"
    * part of a URI. A path segment is defined in RFC 3986. In a URI such
    * as `http://www.example.com/abc/def?a=1&b=2` both `abc` and `def`
@@ -84,7 +96,7 @@ object UriEncoding {
    * @param s The string to decode. Must use the US-ASCII character set.
    * @param outputCharset The name of the encoding that the output should be encoded with.
    *     The output string will be converted from octets (bytes) using this character encoding.
-   * @throws play.utils.InvalidEncodingException If the input is not a valid encoded path segment.
+   * @throws play.utils.InvalidUriEncodingException If the input is not a valid encoded path segment.
    * @return A decoded string in the `outputCharset` character set.
    */
   def decodePathSegment(s: String, outputCharset: String): String = {
@@ -120,7 +132,20 @@ object UriEncoding {
   }
 
   /**
-   * Decode the path path of a URI. Each path segment will be decoded
+   * Decode a string according to the rules for the "path segment" part of a URI.
+   *
+   * @param s The string to decode. Must use the US-ASCII character set.
+   * @param outputCharset The charset of the encoding that the output should be encoded with.
+   *     The output string will be converted from octets (bytes) using this character encoding.
+   * @throws play.utils.InvalidUriEncodingException If the input is not a valid encoded path segment.
+   * @return A decoded string in the `outputCharset` character set.
+   */
+  def decodePathSegment(s: String, outputCharset: Charset): String = {
+    decodePathSegment(s, outputCharset.name)
+  }
+
+  /**
+   * Decode the path of a URI. Each path segment will be decoded
    * using the same rules as ``decodePathSegment``. No normalization is performed:
    * leading, trailing and duplicated slashes, if present are left as they are and
    * if absent remain absent; dot-segments (".." and ".") are ignored.
@@ -131,7 +156,7 @@ object UriEncoding {
    * @param s The string to decode. Must use the US-ASCII character set.
    * @param outputCharset The name of the encoding that the output should be encoded with.
    *     The output string will be converted from octets (bytes) using this character encoding.
-   * @throws play.utils.InvalidEncodingException If the input is not a valid encoded path.
+   * @throws play.utils.InvalidUriEncodingException If the input is not a valid encoded path.
    * @return A decoded string in the `outputCharset` character set.
    */
   def decodePath(s: String, outputCharset: String): String = {
@@ -139,6 +164,20 @@ object UriEncoding {
     // This would allow better handling of paths segments with encoded slashes in them.
     // However, there is no need for this yet, so the method hasn't been added yet.
     splitString(s, '/').map(decodePathSegment(_, outputCharset)).mkString("/")
+  }
+
+  /**
+   * Decode the path of a URI. Each path segment will be decoded
+   * using the same rules as ``decodePathSegment``.
+   *
+   * @param s The string to decode. Must use the US-ASCII character set.
+   * @param outputCharset The charset of the encoding that the output should be encoded with.
+   *     The output string will be converted from octets (bytes) using this character encoding.
+   * @throws play.utils.InvalidUriEncodingException If the input is not a valid encoded path.
+   * @return A decoded string in the `outputCharset` character set.
+   */
+  def decodePath(s: String, outputCharset: Charset): String = {
+    decodePath(s, outputCharset.name)
   }
 
   // RFC 3986, 3.3. Path

--- a/framework/src/play/src/test/java/play/mvc/RangeResultsTest.java
+++ b/framework/src/play/src/test/java/play/mvc/RangeResultsTest.java
@@ -60,7 +60,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofPath(path);
 
         assertEquals(result.status(), PARTIAL_CONTENT);
-        assertEquals("attachment; filename=\"test.tmp\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -70,7 +70,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofPath(path);
 
         assertEquals(result.status(), OK);
-        assertEquals("attachment; filename=\"test.tmp\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -79,7 +79,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofPath(path, "file.txt");
 
         assertEquals(result.status(), PARTIAL_CONTENT);
-        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -89,7 +89,27 @@ public class RangeResultsTest {
         Result result = RangeResults.ofPath(path, "file.txt");
 
         assertEquals(result.status(), OK);
-        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
+    }
+
+    @Test
+    public void shouldReturnRangeResultForPathWhenFilenameHasSpecialChars() {
+        this.mockRangeRequest();
+
+        Result result = RangeResults.ofPath(path, "测 试.tmp");
+
+        assertEquals(result.status(), PARTIAL_CONTENT);
+        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
+    }
+
+    @Test
+    public void shouldNotReturnRangeResultForPathWhenFilenameHasSpecialChars() {
+        this.mockRegularRequest();
+
+        Result result = RangeResults.ofPath(path, "测 试.tmp");
+
+        assertEquals(result.status(), OK);
+        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     // -- Files
@@ -100,7 +120,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofFile(path.toFile());
 
         assertEquals(result.status(), PARTIAL_CONTENT);
-        assertEquals("attachment; filename=\"test.tmp\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -110,7 +130,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofFile(path.toFile());
 
         assertEquals(result.status(), OK);
-        assertEquals("attachment; filename=\"test.tmp\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -119,7 +139,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofFile(path.toFile(), "file.txt");
 
         assertEquals(result.status(), PARTIAL_CONTENT);
-        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -129,7 +149,27 @@ public class RangeResultsTest {
         Result result = RangeResults.ofFile(path.toFile(), "file.txt");
 
         assertEquals(result.status(), OK);
-        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
+    }
+
+    @Test
+    public void shouldReturnRangeResultForFileWhenFilenameHasSpecialChars() {
+        this.mockRangeRequest();
+
+        Result result = RangeResults.ofFile(path.toFile(), "测 试.tmp");
+
+        assertEquals(result.status(), PARTIAL_CONTENT);
+        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
+    }
+
+    @Test
+    public void shouldNotReturnRangeResultForFileWhenFilenameHasSpecialChars() {
+        this.mockRegularRequest();
+
+        Result result = RangeResults.ofFile(path.toFile(), "测 试.tmp");
+
+        assertEquals(result.status(), OK);
+        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     // -- Sources
@@ -165,7 +205,7 @@ public class RangeResultsTest {
 
         assertEquals(result.status(), PARTIAL_CONTENT);
         assertEquals(BINARY, result.body().contentType().orElse(""));
-        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -177,7 +217,7 @@ public class RangeResultsTest {
 
         assertEquals(result.status(), OK);
         assertEquals(BINARY, result.body().contentType().orElse(""));
-        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -190,7 +230,32 @@ public class RangeResultsTest {
 
         assertEquals(result.status(), PARTIAL_CONTENT);
         assertEquals(TEXT, result.body().contentType().orElse(""));
-        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
+    }
+
+    @Test
+    public void shouldNotReturnRangeResultForStreamWhenFilenameHasSpecialChars() throws IOException {
+        this.mockRegularRequest();
+
+        Source<ByteString, CompletionStage<IOResult>> source = FileIO.fromFile(path.toFile());
+        Result result = RangeResults.ofSource(path.toFile().length(), source, "测 试.tmp", BINARY);
+
+        assertEquals(result.status(), OK);
+        assertEquals(BINARY, result.body().contentType().orElse(""));
+        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
+    }
+
+    @Test
+    public void shouldReturnRangeResultForStreamWhenFilenameHasSpecialChars() throws IOException {
+        this.mockRangeRequest();
+
+        long entityLength = path.toFile().length();
+        Source<ByteString, CompletionStage<IOResult>> source = FileIO.fromFile(path.toFile());
+        Result result = RangeResults.ofSource(entityLength, source, "测 试.tmp", TEXT);
+
+        assertEquals(result.status(), PARTIAL_CONTENT);
+        assertEquals(TEXT, result.body().contentType().orElse(""));
+        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     private void mockRegularRequest() {

--- a/framework/src/play/src/test/java/play/mvc/ResultsTest.java
+++ b/framework/src/play/src/test/java/play/mvc/ResultsTest.java
@@ -44,42 +44,49 @@ public class ResultsTest {
   public void sendPathWithOKStatus() throws IOException {
     Result result = Results.ok().sendPath(file);
     assertEquals(result.status(), Http.Status.OK);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
   }
 
   @Test
   public void sendPathWithUnauthorizedStatus() throws IOException {
     Result result = Results.unauthorized().sendPath(file);
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
   }
 
   @Test
   public void sendPathAsAttachmentWithUnauthorizedStatus() throws IOException {
     Result result = Results.unauthorized().sendPath(file, /*inline*/ false);
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
   }
 
   @Test
   public void sendPathAsAttachmentWithOkStatus() throws IOException {
-    Result result = Results.unauthorized().sendPath(file, /* inline */ false);
-    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
+    Result result = Results.ok().sendPath(file, /* inline */ false);
+    assertEquals(result.status(), Http.Status.OK);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
   }
 
   @Test
   public void sendPathWithFileName() throws IOException {
     Result result = Results.unauthorized().sendPath(file, "foo.bar");
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"; filename*=utf-8''foo.bar");
   }
 
   @Test
   public void sendPathInlineWithFileName() throws IOException {
     Result result = Results.unauthorized().sendPath(file, true, "foo.bar");
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"; filename*=utf-8''foo.bar");
+  }
+
+  @Test
+  public void sendPathWithFileNameHasSpecialChars() throws IOException {
+    Result result = Results.ok().sendPath(file, true, "测 试.tmp");
+    assertEquals(result.status(), Http.Status.OK);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp");
   }
 
   // -- File tests
@@ -93,41 +100,48 @@ public class ResultsTest {
   public void sendFileWithOKStatus() throws IOException {
     Result result = Results.ok().sendFile(file.toFile());
     assertEquals(result.status(), Http.Status.OK);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
   }
 
   @Test
   public void sendFileWithUnauthorizedStatus() throws IOException {
     Result result = Results.unauthorized().sendFile(file.toFile());
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
   }
 
   @Test
   public void sendFileAsAttachmentWithUnauthorizedStatus() throws IOException {
     Result result = Results.unauthorized().sendFile(file.toFile(), /* inline */ false);
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
   }
 
   @Test
   public void sendFileAsAttachmentWithOkStatus() throws IOException {
-    Result result = Results.unauthorized().sendFile(file.toFile(), /* inline */ false);
-    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
+    Result result = Results.ok().sendFile(file.toFile(), /* inline */ false);
+    assertEquals(result.status(), Http.Status.OK);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
   }
 
   @Test
   public void sendFileWithFileName() throws IOException {
     Result result = Results.unauthorized().sendFile(file.toFile(), "foo.bar");
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"; filename*=utf-8''foo.bar");
   }
 
   @Test
   public void sendFileInlineWithFileName() throws IOException {
     Result result = Results.ok().sendFile(file.toFile(), true, "foo.bar");
     assertEquals(result.status(), Http.Status.OK);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"; filename*=utf-8''foo.bar");
+  }
+
+  @Test
+  public void sendFileWithFileNameHasSpecialChars() throws IOException {
+    Result result = Results.ok().sendFile(file.toFile(), true, "测 试.tmp");
+    assertEquals(result.status(), Http.Status.OK);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp");
   }
 }

--- a/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
@@ -304,7 +304,14 @@ object RangeResultSpec extends Specification {
       val stream = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3))
       val source = StreamConverters.fromInputStream(() => stream)
       val Result(ResponseHeader(_, headers, _), _) = RangeResult.ofSource(stream.available(), source, None, Some("video.mp4"), None)
-      headers must havePair("Content-Disposition" -> "attachment; filename=\"video.mp4\"")
+      headers must havePair("Content-Disposition" -> "attachment; filename=\"video.mp4\"; filename*=utf-8''video.mp4")
+    }
+
+    "support non-ISO-8859-1 filename in Content-Disposition header" in {
+      val stream = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3))
+      val source = StreamConverters.fromInputStream(() => stream)
+      val Result(ResponseHeader(_, headers, _), _) = RangeResult.ofSource(stream.available(), source, None, Some("测 试.tmp"), None)
+      headers must havePair("Content-Disposition" -> "attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp")
     }
 
     "support first byte position" in {
@@ -334,7 +341,7 @@ object RangeResultSpec extends Specification {
       val file = createFile(java.nio.file.Paths.get("path.mp4"))
       try {
         val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(_, _, contentType)) = RangeResult.ofPath(file.toPath, None, Some("video/mp4"))
-        headers must havePair("Content-Disposition" -> "attachment; filename=\"path.mp4\"")
+        headers must havePair("Content-Disposition" -> "attachment; filename=\"path.mp4\"; filename*=utf-8''path.mp4")
         contentType must beSome("video/mp4")
       } finally {
         java.nio.file.Files.delete(file.toPath)
@@ -345,7 +352,7 @@ object RangeResultSpec extends Specification {
       val file = createFile(java.nio.file.Paths.get("file.mp4"))
       try {
         val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(_, _, contentType)) = RangeResult.ofFile(file, None, Some("video/mp4"))
-        headers must havePair("Content-Disposition" -> "attachment; filename=\"file.mp4\"")
+        headers must havePair("Content-Disposition" -> "attachment; filename=\"file.mp4\"; filename*=utf-8''file.mp4")
         contentType must beSome("video/mp4")
       } finally {
         java.nio.file.Files.delete(file.toPath)

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -158,56 +158,70 @@ object ResultsSpec extends Specification {
       val rh = Ok.sendFile(file).header
 
       (rh.status aka "status" must_== OK) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName"; filename*=utf-8''$fileName"""))
     }
 
     "support sending a file with Unauthorized status" in withFile { (file, fileName) =>
       val rh = Unauthorized.sendFile(file).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName"; filename*=utf-8''$fileName"""))
     }
 
     "support sending a file attached with Unauthorized status" in withFile { (file, fileName) =>
       val rh = Unauthorized.sendFile(file, inline = false).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName"; filename*=utf-8''$fileName"""))
     }
 
     "support sending a file with PaymentRequired status" in withFile { (file, fileName) =>
       val rh = PaymentRequired.sendFile(file).header
 
       (rh.status aka "status" must_== PAYMENT_REQUIRED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName"; filename*=utf-8''$fileName"""))
     }
 
     "support sending a file attached with PaymentRequired status" in withFile { (file, fileName) =>
       val rh = PaymentRequired.sendFile(file, inline = false).header
 
       (rh.status aka "status" must_== PAYMENT_REQUIRED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName"; filename*=utf-8''$fileName"""))
+    }
+
+    "support sending a file with filename" in withFile { (file, fileName) =>
+      val rh = Ok.sendFile(file, fileName = _ => "测 试.tmp").header
+
+      (rh.status aka "status" must_== OK) and
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="测 试.tmp"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp"""))
     }
 
     "support sending a path with Ok status" in withPath { (file, fileName) =>
       val rh = Ok.sendPath(file).header
 
       (rh.status aka "status" must_== OK) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName"; filename*=utf-8''$fileName"""))
     }
 
     "support sending a path with Unauthorized status" in withPath { (file, fileName) =>
       val rh = Unauthorized.sendPath(file).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName"; filename*=utf-8''$fileName"""))
     }
 
     "support sending a path attached with Unauthorized status" in withPath { (file, fileName) =>
       val rh = Unauthorized.sendPath(file, inline = false).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName"; filename*=utf-8''$fileName"""))
+    }
+
+    "support sending a path with filename" in withPath { (file, fileName) =>
+      val rh = Ok.sendPath(file, fileName = _ => "测 试.tmp").header
+
+      (rh.status aka "status" must_== OK) and
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="测 试.tmp"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp"""))
     }
 
     "allow checking content length" in withPath { (file, fileName) =>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #5253

## Purpose

Support non-ISO8859-1 filename n Content-Disposition header (see [RFC 6266](https://tools.ietf.org/html/rfc6266)).

## References

See #5253

