### PR TITLE
shouldReturnRangeResultForStream was duplicated

### DIFF
--- a/framework/src/play/src/test/java/play/mvc/RangeResultsTest.java
+++ b/framework/src/play/src/test/java/play/mvc/RangeResultsTest.java
@@ -136,19 +136,6 @@ public class RangeResultsTest {
     // -- Sources
 
     @Test
-    public void shouldReturnRangeResultForStream() throws IOException {
-        this.mockRangeRequest();
-
-        InputStream stream = Files.newInputStream(path);
-        Source<ByteString, CompletionStage<IOResult>> source = StreamConverters.fromInputStream(() -> stream);
-        Result result = RangeResults.ofSource(path.toFile().length(), source, path.toFile().getName(), BINARY);
-        closeStreamSilently(stream);
-
-        assertEquals(result.status(), PARTIAL_CONTENT);
-        assertEquals(BINARY, result.header(CONTENT_TYPE).orElse(""));
-    }
-
-    @Test
     public void shouldNotReturnRangeResultForStreamWhenHeaderIsNotPresent() throws IOException {
         this.mockRegularRequest();
 


### PR DESCRIPTION
This will fix the 2.5.x branch since it removes the duplicated test that wasn't updated.