### PR TITLE
Optional entity length for range requests

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/RangeResults.java
+++ b/framework/src/play/src/main/java/play/mvc/RangeResults.java
@@ -34,6 +34,60 @@ public class RangeResults {
     }
 
     /**
+     * Returns the stream as a result considering "Range" header. If the header is present and
+     * it is satisfiable, then a Result containing just the requested part will be returned.
+     * If the header is not present or is unsatisfiable, then a regular Result will be returned.
+     *
+     * @param stream the content stream
+     * @return range result if "Range" header is present and regular result if not
+     */
+    public static Result ofStream(InputStream stream) {
+        return JavaRangeResult.ofStream(stream, rangeHeader(), null, Optional.empty());
+    }
+
+    /**
+     * Returns the stream as a result considering "Range" header. If the header is present and
+     * it is satisfiable, then a Result containing just the requested part will be returned.
+     * If the header is not present or is unsatisfiable, then a regular Result will be returned.
+     *
+     * @param stream the content stream
+     * @param contentLength the entity length
+     * @return range result if "Range" header is present and regular result if not
+     */
+    public static Result ofStream(InputStream stream, long contentLength) {
+        return JavaRangeResult.ofStream(contentLength, stream, rangeHeader(), null, Optional.empty());
+    }
+
+    /**
+     * Returns the stream as a result considering "Range" header. If the header is present and
+     * it is satisfiable, then a Result containing just the requested part will be returned.
+     * If the header is not present or is unsatisfiable, then a regular Result will be returned.
+     *
+     * @param stream the content stream
+     * @param contentLength the entity length
+     * @param filename filename used at the Content-Disposition header
+     * @return range result if "Range" header is present and regular result if not
+     */
+    public static Result ofStream(InputStream stream, long contentLength, String filename) {
+        return JavaRangeResult.ofStream(contentLength, stream, rangeHeader(), filename, Optional.empty());
+    }
+
+    /**
+     * Returns the stream as a result considering "Range" header. If the header is present and
+     * it is satisfiable, then a Result containing just the requested part will be returned.
+     * If the header is not present or is unsatisfiable, then a regular Result will be returned.
+     *
+     * @param stream the content stream
+     * @param contentLength the entity length
+     * @param filename filename used at the Content-Disposition header
+     * @param contentType the content type for this stream
+     * @return range result if "Range" header is present and regular result if not
+     */
+    public static Result ofStream(InputStream stream, long contentLength, String filename, String contentType) {
+        return JavaRangeResult.ofStream(contentLength, stream, rangeHeader(), filename, Optional.ofNullable(contentType));
+    }
+
+    /**
      * Returns the path as a result considering "Range" header. If the header is present and
      * it is satisfiable, then a Result containing just the requested part will be returned.
      * If the header is not present or is unsatisfiable, then a regular Result will be returned.

--- a/framework/src/play/src/main/scala/play/core/j/JavaRangeResult.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaRangeResult.scala
@@ -22,6 +22,14 @@ object JavaRangeResult {
 
   private type OptString = Optional[String]
 
+  def ofStream(stream: InputStream, rangeHeader: OptString, fileName: String, contentType: OptString): Result = {
+    RangeResult.ofStream(stream, rangeHeader.asScala, fileName, contentType.asScala).asJava
+  }
+
+  def ofStream(entityLength: Long, stream: InputStream, rangeHeader: OptString, fileName: String, contentType: OptString): Result = {
+    RangeResult.ofStream(entityLength, stream, rangeHeader.asScala, fileName, contentType.asScala).asJava
+  }
+
   def ofPath(path: Path, rangeHeader: OptString, contentType: OptString): Result = {
     RangeResult.ofPath(path, rangeHeader.asScala, contentType.asScala).asJava
   }
@@ -40,5 +48,9 @@ object JavaRangeResult {
 
   def ofSource(entityLength: Long, source: Source[ByteString, _], rangeHeader: OptString, fileName: OptString, contentType: OptString): Result = {
     RangeResult.ofSource(entityLength, source.asScala, rangeHeader.asScala, fileName.asScala, contentType.asScala).asJava
+  }
+
+  def ofSource(entityLength: Optional[Long], source: Source[ByteString, _], rangeHeader: OptString, fileName: OptString, contentType: OptString): Result = {
+    RangeResult.ofSource(entityLength.asScala, source.asScala, rangeHeader.asScala, fileName.asScala, contentType.asScala).asJava
   }
 }

--- a/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
@@ -8,7 +8,7 @@ import java.nio.file.Path
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.StreamConverters
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.http.HttpEntity
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
@@ -17,6 +17,8 @@ import scala.collection.mutable
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import org.specs2.mutable.Specification
+
+import scala.tools.nsc.interpreter.InputStream
 
 object ByteRangeSpec extends Specification {
 
@@ -47,9 +49,9 @@ object ByteRangeSpec extends Specification {
 object RangeSpec extends Specification {
 
   def checkRange(entityLength: Long, header: String, expected: Range) = {
-    val range = Range(entityLength, header)
+    val range = Range(Some(entityLength), header)
     range must beSome[Range]
-    range must beSome.which(_.entityLength == expected.entityLength)
+    range must beSome.which(_.getEntityLength == expected.getEntityLength)
     range must beSome.which(_.byteRange == expected.byteRange)
   }
 
@@ -59,21 +61,21 @@ object RangeSpec extends Specification {
       checkRange(
         entityLength = 120,
         header = "0-10",
-        expected = Range(entityLength = 120, Some(0), Some(10))
+        expected = WithEntityLengthRange(entityLength = 120, Some(0), Some(10))
       )
     }
     "80-100" in {
       checkRange(
         entityLength = 120,
         header = "80-100",
-        expected = Range(entityLength = 120, Some(80), Some(100))
+        expected = WithEntityLengthRange(entityLength = 120, Some(80), Some(100))
       )
     }
     "80-" in {
       checkRange(
         entityLength = 120,
         header = "80-",
-        expected = Range(entityLength = 120, Some(80), Some(119))
+        expected = WithEntityLengthRange(entityLength = 120, Some(80), Some(119))
       )
     }
 
@@ -81,7 +83,7 @@ object RangeSpec extends Specification {
       checkRange(
         entityLength = 120,
         header = "-100",
-        expected = Range(entityLength = 120, Some(20), Some(119))
+        expected = WithEntityLengthRange(entityLength = 120, Some(20), Some(119))
       )
     }
 
@@ -90,7 +92,7 @@ object RangeSpec extends Specification {
         checkRange(
           entityLength = 120,
           header = "-20",
-          expected = Range(entityLength = 120, Some(100), Some(119))
+          expected = WithEntityLengthRange(entityLength = 120, Some(100), Some(119))
         )
       }
     }
@@ -100,21 +102,21 @@ object RangeSpec extends Specification {
         checkRange(
           entityLength = 120,
           header = "100-",
-          expected = Range(entityLength = 120, Some(100), Some(119))
+          expected = WithEntityLengthRange(entityLength = 120, Some(100), Some(119))
         )
       }
       "When last-byte-pos value is greater than entity length" in {
         checkRange(
           entityLength = 120,
           header = "100-140",
-          expected = Range(entityLength = 120, Some(100), Some(119))
+          expected = WithEntityLengthRange(entityLength = 120, Some(100), Some(119))
         )
       }
       "When last-byte-pos value is equal to entity length" in {
         checkRange(
           entityLength = 120,
           header = "100-120",
-          expected = Range(entityLength = 120, Some(100), Some(119))
+          expected = WithEntityLengthRange(entityLength = 120, Some(100), Some(119))
         )
       }
     }
@@ -122,37 +124,37 @@ object RangeSpec extends Specification {
 
   "Unsatisfiable ranges" in {
     "When both first and last bytes are not specified" in {
-      Range(entityLength = 100, range = "-") must beNone
+      Range(entityLength = Some(100), range = "-") must beNone
     }
 
     "When range header is empty" in {
-      Range(entityLength = 100, range = "") must beNone
+      Range(entityLength = Some(100), range = "") must beNone
     }
   }
 
   "Ordering ranges" in {
     "by first byte" in {
-      val range1 = Range(120, "0-10")
-      val range2 = Range(120, "10-20")
+      val range1 = Range(Some(120), "0-10")
+      val range2 = Range(Some(120), "10-20")
       range1 must beLessThan(range2)
     }
 
     "by last byte when first bytes are equals" in {
-      val range1 = Range(120, "0-20")
-      val range2 = Range(120, "0-21")
+      val range1 = Range(Some(120), "0-20")
+      val range2 = Range(Some(120), "0-21")
       range1 must beLessThan(range2)
     }
 
     "when first byte is not specified" in {
       "first the range with a first byte specified" in {
-        val range1 = Range(120, "10-20")
-        val range2 = Range(120, "-21")
+        val range1 = Range(Some(120), "10-20")
+        val range2 = Range(Some(120), "-21")
         range1 must beLessThan(range2)
       }
 
       "first the range that selects more bytes starting from the end" in {
-        val range1 = Range(120, "-30")
-        val range2 = Range(120, "-20")
+        val range1 = Range(Some(120), "-30")
+        val range2 = Range(Some(120), "-20")
         range1 must beLessThan(range2)
       }
     }
@@ -160,26 +162,26 @@ object RangeSpec extends Specification {
 
   "Content length" in {
     "500-999 has content-length = 500" in {
-      val range = Range(entityLength = 1000, range = "500-999")
-      range must beSome.which(_.length == 500)
+      val range = Range(entityLength = Some(1000), range = "500-999")
+      range must beSome.which(_.length.contains(500))
     }
     "0-499 has content-length = 500" in {
-      val range = Range(entityLength = 1000, range = "0-499")
-      range must beSome.which(_.length == 500)
+      val range = Range(entityLength = Some(1000), range = "0-499")
+      range must beSome.which(_.length.contains(500))
     }
     "0-10 has content-length = 11" in {
-      val range = Range(entityLength = 1000, range = "0-10")
-      range must beSome.which(_.length == 11)
+      val range = Range(entityLength = Some(1000), range = "0-10")
+      range must beSome.which(_.length.contains(11))
     }
     "with range 9500- and 10000 bytes available has content-length = 500" in {
-      val range = Range(entityLength = 10000, range = "9500-")
-      range must beSome.which(_.length == 500)
+      val range = Range(entityLength = Some(10000), range = "9500-")
+      range must beSome.which(_.length.contains(500))
     }
   }
 
   "Merge ranges" in {
-    val range1 = Range(entityLength = 10000, range = "0-10")
-    val range2 = Range(entityLength = 10000, range = "5-15")
+    val range1 = Range(entityLength = Some(10000), range = "0-10")
+    val range2 = Range(entityLength = Some(10000), range = "5-15")
     val merged = (range1, range2) match {
       case (Some(r1), Some(r2)) => r1.merge(r2)
     }
@@ -190,21 +192,48 @@ object RangeSpec extends Specification {
   "Validate ranges" in {
     "Invalid when" in {
       "last-byte-pos value less than its first-byte-pos" in {
-        val range = Range(entityLength = 10000, range = "200-100")
+        val range = Range(entityLength = Some(10000), range = "200-100")
         range must beSome.which(_.isValid == false)
       }
       "first-byte-pos greater than entity length" in {
-        val range = Range(entityLength = 1000, range = "2000-3000")
+        val range = Range(entityLength = Some(1000), range = "2000-3000")
         range must beSome.which(_.isValid == false)
       }
     }
     "Valid" in {
       "last-byte-pos is equal to first-byte-pos" in {
-        val range = Range(entityLength = 10000, range = "100-100")
+        val range = Range(entityLength = Some(10000), range = "100-100")
         range must beSome.which(_.isValid == true)
       }
       "first-byte-pos is less than entity length" in {
-        val range = Range(entityLength = 10000, range = "200-300")
+        val range = Range(entityLength = Some(10000), range = "200-300")
+        range must beSome.which(_.isValid == true)
+      }
+    }
+  }
+
+  "Ranges without Entity Length" in {
+    "Invalid when" in {
+      "last-byte-pos value less than its first-byte-pos" in {
+        val range = Range(entityLength = None, range = "200-100")
+        range must beSome.which(_.isValid == false)
+      }
+      "start value is not present" in {
+        val range = Range(entityLength = None, range = "-3000")
+        range must beSome.which(_.isValid == false)
+      }
+      "end value is not present" in {
+        val range = Range(entityLength = None, range = "3000-")
+        range must beSome.which(_.isValid == false)
+      }
+    }
+    "Valid" in {
+      "last-byte-pos is equal to first-byte-pos" in {
+        val range = Range(entityLength = None, range = "100-100")
+        range must beSome.which(_.isValid == true)
+      }
+      "first-byte-pos is less than entity length" in {
+        val range = Range(entityLength = None, range = "200-300")
         range must beSome.which(_.isValid == true)
       }
     }
@@ -216,68 +245,83 @@ object RangeSetSpec extends Specification {
   "Satisfiable range sets" in {
 
     "bytes=0-5,100-110" in {
-      val rangeSet = RangeSet(entityLength = 120, rangeHeader = Some("bytes=0-5,100-110"))
+      val rangeSet = RangeSet(entityLength = Some(120), rangeHeader = Some("bytes=0-5,100-110"))
       rangeSet must beAnInstanceOf[SatisfiableRangeSet]
-      rangeSet.entityLength must beEqualTo(120)
+      rangeSet.entityLength must beSome.which(_ == 120)
       rangeSet.toString must beEqualTo("bytes 0-5,100-110/120")
     }
 
     "bytes=0-0,-1" in {
-      val rangeSet = RangeSet(entityLength = 120, rangeHeader = Some("bytes=0-0,-1"))
+      val rangeSet = RangeSet(entityLength = Some(120), rangeHeader = Some("bytes=0-0,-1"))
       rangeSet must beAnInstanceOf[SatisfiableRangeSet]
-      rangeSet.entityLength must beEqualTo(120)
+      rangeSet.entityLength must beSome.which(_ == 120)
       rangeSet.toString must beEqualTo("bytes 0-0,119-119/120")
     }
 
     "bytes=500-600,801-999" in {
-      val rangeSet = RangeSet(entityLength = 1200, rangeHeader = Some("bytes=500-600,801-999"))
+      val rangeSet = RangeSet(entityLength = Some(1200), rangeHeader = Some("bytes=500-600,801-999"))
       rangeSet must beAnInstanceOf[SatisfiableRangeSet]
-      rangeSet.entityLength must beEqualTo(1200)
+      rangeSet.entityLength must beSome.which(_ == 1200)
       rangeSet.toString must beEqualTo("bytes 500-600,801-999/1200")
     }
 
     "Normalize" in {
       "bytes=500-600,601-650,1000-1100 to bytes=500-650,1000-1100" in {
-        val rangeSet = RangeSet(entityLength = 1200, rangeHeader = Some("bytes=500-600,601-650,1000-1100"))
+        val rangeSet = RangeSet(entityLength = Some(1200), rangeHeader = Some("bytes=500-600,601-650,1000-1100"))
         rangeSet must beAnInstanceOf[SatisfiableRangeSet]
         rangeSet.toString must beEqualTo("bytes 500-650,1000-1100/1200")
       }
       "bytes=500-600,601-650,680-700,1000-1100 to bytes=500-700,1000-1100" in {
-        val rangeSet = RangeSet(entityLength = 1200, rangeHeader = Some("bytes=500-600,601-650,680-700,1000-1100"))
+        val rangeSet = RangeSet(entityLength = Some(1200), rangeHeader = Some("bytes=500-600,601-650,680-700,1000-1100"))
         rangeSet must beAnInstanceOf[SatisfiableRangeSet]
         rangeSet.toString must beEqualTo("bytes 500-700,1000-1100/1200")
       }
       "bytes=500-600,400-650,680-700,1000- to bytes=400-700,1000-1199" in {
-        val rangeSet = RangeSet(entityLength = 1200, rangeHeader = Some("bytes=500-600,400-650,680-700,1000-"))
+        val rangeSet = RangeSet(entityLength = Some(1200), rangeHeader = Some("bytes=500-600,400-650,680-700,1000-"))
         rangeSet must beAnInstanceOf[SatisfiableRangeSet]
         rangeSet.toString must beEqualTo("bytes 400-700,1000-1199/1200")
       }
       "bytes=500-600 to bytes=500-600" in {
-        val rangeSet = RangeSet(entityLength = 1200, rangeHeader = Some("bytes=500-600"))
+        val rangeSet = RangeSet(entityLength = Some(1200), rangeHeader = Some("bytes=500-600"))
         rangeSet must beAnInstanceOf[SatisfiableRangeSet]
         rangeSet.toString must beEqualTo("bytes 500-600/1200")
       }
+    }
+
+    "No header present" in {
+      val rangeSet = RangeSet(entityLength = Some(120), rangeHeader = None)
+      rangeSet.entityLength must beSome.which(_ == 120)
+      rangeSet must beAnInstanceOf[NoHeaderRangeSet]
     }
   }
 
   "Unsatisfiable range sets" in {
 
     "When last-byte-pos less than first-byte-pos" in {
-      val rangeSet = RangeSet(entityLength = 120, rangeHeader = Some("bytes=20-30,40-10"))
-      rangeSet.entityLength must beEqualTo(120)
+      val rangeSet = RangeSet(entityLength = Some(120), rangeHeader = Some("bytes=20-30,40-10"))
+      rangeSet.entityLength must beSome.which(_ == 120)
       rangeSet must beAnInstanceOf[UnsatisfiableRangeSet]
     }
     "When first-byte-pos more than entity length" in {
-      val rangeSet = RangeSet(entityLength = 120, rangeHeader = Some("bytes=0-0,200-210"))
-      rangeSet.entityLength must beEqualTo(120)
+      val rangeSet = RangeSet(entityLength = Some(120), rangeHeader = Some("bytes=0-0,200-210"))
+      rangeSet.entityLength must beSome.which(_ == 120)
       rangeSet must beAnInstanceOf[UnsatisfiableRangeSet]
     }
   }
 
-  "No header present" in {
-    val rangeSet = RangeSet(entityLength = 120, rangeHeader = None)
-    rangeSet.entityLength must beEqualTo(120)
-    rangeSet must beAnInstanceOf[NoHeaderRangeSet]
+  "Without Entity Length" in {
+    "Unsatisfiable when range first-byte-pos is not specified" in {
+      val rangeSet = RangeSet(entityLength = None, rangeHeader = Some("bytes=-20"))
+      rangeSet must beAnInstanceOf[UnsatisfiableRangeSet]
+    }
+    "Unsatisfiable when range last-byte-pos is not specified" in {
+      val rangeSet = RangeSet(entityLength = None, rangeHeader = Some("bytes=20-"))
+      rangeSet must beAnInstanceOf[UnsatisfiableRangeSet]
+    }
+    "Satisfiable when both first-byte-pos and last-byte-pos are specified and first-byte-pos is less last-byte-pos" in {
+      val rangeSet = RangeSet(entityLength = None, rangeHeader = Some("bytes=20-30,200-210"))
+      rangeSet must beAnInstanceOf[UnsatisfiableRangeSet]
+    }
   }
 }
 
@@ -286,38 +330,38 @@ object RangeResultSpec extends Specification {
   "Result" should {
 
     "have status ok when there is no range" in {
-      val stream = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3))
-      val source = StreamConverters.fromInputStream(() => stream)
-      val Result(ResponseHeader(status, _, _), _) = RangeResult.ofSource(stream.available(), source, None, None, None)
+      val bytes: List[Byte] = List[Byte](1, 2, 3)
+      val source = Source(bytes).map(b => ByteString.fromArray(Array[Byte](b)))
+      val Result(ResponseHeader(status, _, _), _) = RangeResult.ofSource(bytes.length, source, None, None, None)
       status must_== 200
     }
 
     "have headers" in {
-      val stream = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3))
-      val source = StreamConverters.fromInputStream(() => stream)
-      val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(_, _, contentType)) = RangeResult.ofSource(stream.available(), source, None, None, None)
+      val bytes: List[Byte] = List[Byte](1, 2, 3)
+      val source = Source(bytes).map(b => ByteString.fromArray(Array[Byte](b)))
+      val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(_, _, contentType)) = RangeResult.ofSource(bytes.length, source, None, None, None)
       headers must havePair("Accept-Ranges" -> "bytes")
       contentType must beSome("application/octet-stream")
     }
 
     "support Content-Disposition header" in {
-      val stream = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3))
-      val source = StreamConverters.fromInputStream(() => stream)
-      val Result(ResponseHeader(_, headers, _), _) = RangeResult.ofSource(stream.available(), source, None, Some("video.mp4"), None)
+      val bytes: List[Byte] = List[Byte](1, 2, 3)
+      val source = Source(bytes).map(b => ByteString.fromArray(Array[Byte](b)))
+      val Result(ResponseHeader(_, headers, _), _) = RangeResult.ofSource(bytes.length, source, None, Some("video.mp4"), None)
       headers must havePair("Content-Disposition" -> "attachment; filename=\"video.mp4\"; filename*=utf-8''video.mp4")
     }
 
     "support non-ISO-8859-1 filename in Content-Disposition header" in {
-      val stream = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3))
-      val source = StreamConverters.fromInputStream(() => stream)
-      val Result(ResponseHeader(_, headers, _), _) = RangeResult.ofSource(stream.available(), source, None, Some("测 试.tmp"), None)
+      val bytes: List[Byte] = List[Byte](1, 2, 3)
+      val source = Source(bytes).map(b => ByteString.fromArray(Array[Byte](b)))
+      val Result(ResponseHeader(_, headers, _), _) = RangeResult.ofSource(bytes.length, source, None, Some("测 试.tmp"), None)
       headers must havePair("Content-Disposition" -> "attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp")
     }
 
     "support first byte position" in {
-      val stream = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3))
-      val source = StreamConverters.fromInputStream(() => stream)
-      val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(data, _, _)) = RangeResult.ofSource(stream.available(), source, Some("bytes=1-"), None, None)
+      val bytes: List[Byte] = List[Byte](1, 2, 3)
+      val source = Source(bytes).map(b => ByteString.fromArray(Array[Byte](b)))
+      val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(data, _, _)) = RangeResult.ofSource(bytes.length, source, Some("bytes=1-"), None, None)
       headers must havePair("Content-Range" -> "bytes 1-2/3")
 
       implicit val system = ActorSystem()
@@ -327,9 +371,9 @@ object RangeResultSpec extends Specification {
     }
 
     "support last byte position" in {
-      val stream = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3, 4, 5, 6))
-      val source = StreamConverters.fromInputStream(() => stream)
-      val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(data, _, _)) = RangeResult.ofSource(stream.available(), source, Some("bytes=2-4"), None, None)
+      val bytes: List[Byte] = List[Byte](1, 2, 3, 4, 5, 6)
+      val source = Source(bytes).map(b => ByteString.fromArray(Array[Byte](b)))
+      val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(data, _, _)) = RangeResult.ofSource(bytes.length, source, Some("bytes=2-4"), None, None)
       headers must havePair("Content-Range" -> "bytes 2-4/6")
       implicit val system = ActorSystem()
       implicit val materializer = ActorMaterializer()
@@ -358,9 +402,35 @@ object RangeResultSpec extends Specification {
         java.nio.file.Files.delete(file.toPath)
       }
     }
+
+    "support sending an input stream without entity length" in {
+      val file = createFile(java.nio.file.Paths.get("input1.mp4"))
+      val inputStream = java.nio.file.Files.newInputStream(file.toPath)
+      try {
+        val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(_, _, contentType)) = RangeResult.ofStream(inputStream, None, "file.mp4", Some("video/mp4"))
+        headers must havePair("Content-Disposition" -> "attachment; filename=\"file.mp4\"; filename*=utf-8''file.mp4")
+        contentType must beSome("video/mp4")
+      } finally {
+        closeWithoutError(inputStream)
+        java.nio.file.Files.delete(file.toPath)
+      }
+    }
+
+    "support sending an input stream with the entity length" in {
+      val file = createFile(java.nio.file.Paths.get("input2.mp4"))
+      val inputStream = java.nio.file.Files.newInputStream(file.toPath)
+      try {
+        val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(_, _, contentType)) = RangeResult.ofStream(file.length(), inputStream, None, "file.mp4", Some("video/mp4"))
+        headers must havePair("Content-Disposition" -> "attachment; filename=\"file.mp4\"; filename*=utf-8''file.mp4")
+        contentType must beSome("video/mp4")
+      } finally {
+        closeWithoutError(inputStream)
+        java.nio.file.Files.delete(file.toPath)
+      }
+    }
   }
 
-  def createFile(path: Path): File = {
+  private def createFile(path: Path): File = {
     if (!java.nio.file.Files.exists(path)) {
       java.nio.file.Files.createFile(path)
       val fos = new FileOutputStream(path.toFile)
@@ -371,5 +441,13 @@ object RangeResultSpec extends Specification {
       }
     }
     path.toFile
+  }
+
+  private def closeWithoutError(input: InputStream) {
+    try {
+      input.close()
+    } catch {
+      case ex: Exception => // do nothing
+    }
   }
 }


### PR DESCRIPTION
## Pull Request Checklist

* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you added tests for any changed functionality?

## Purpose

Support optional entity-length for range requests, as documented by [RFC 7233](http://tools.ietf.org/html/rfc7233#section-4.2). This PR can be safety backported to 2.5.x after being merged.

## References

See #5961.

----------------

@schmitch and @mkurz you may be interested in reviewing this. ;-)