### PR TITLE
Do not add Content-Disposition header when serving assets

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
@@ -323,6 +323,16 @@ trait AssetsSpec extends PlaySpecification
 
         result.header(CONTENT_RANGE) must beSome.which(_ == "bytes */10000")
       }
+
+      "No Content-Disposition header when serving assets" in withServer { client =>
+        val result = await(
+          client.url("/range.txt")
+            .withHeaders(RANGE -> "bytes=10500-10600")
+            .get()
+        )
+
+        result.header(CONTENT_DISPOSITION) must beNone
+      }
     }
   }
 }

--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -454,8 +454,9 @@ class AssetsBuilder(errorHandler: HttpErrorHandler) extends Controller {
         } else {
           val stream = connection.getInputStream
           val source = StreamConverters.fromInputStream(() => stream)
-          // TODO this is a lie - stream.available does not necessarily return the length of the file, to do that we
-          val result = RangeResult.ofSource(stream.available(), source, request.headers.get(RANGE), Option(file), Option(assetInfo.mimeType))
+          // FIXME stream.available does not necessarily return the length of the file. According to the docs "It is never
+          // correct to use the return value of this method to allocate a buffer intended to hold all data in this stream."
+          val result = RangeResult.ofSource(stream.available(), source, request.headers.get(RANGE), None, Option(assetInfo.mimeType))
 
           Future.successful(maybeNotModified(request, assetInfo, aggressiveCaching).getOrElse {
             cacheableResult(


### PR DESCRIPTION
## Pull Request Checklist

* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you added tests for any changed functionality?

## Purpose

Assets controller was adding a `Content-Disposition` header when serving files. This is not necessary and also changes the way this was working before. This must be backported.

## References

See discussion at gitter channel: https://gitter.im/playframework/playframework?at=5715069c2c9711166432efb1