### PR TITLE
Make sure headers are handled case-insensitively in AhcWSRequest

### DIFF
--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcWS.scala
@@ -45,7 +45,7 @@ case class AhcWSClient(config: AsyncHttpClientConfig)(implicit materializer: Mat
 
   def close(): Unit = asyncHttpClient.close()
 
-  def url(url: String): WSRequest = AhcWSRequest(this, url, "GET", EmptyBody, Map(), Map(), None, None, None, None, None, None, None)
+  def url(url: String): WSRequest = AhcWSRequest(this, url, "GET", EmptyBody, TreeMap()(CaseInsensitiveOrdered), Map(), None, None, None, None, None, None, None)
 }
 
 object AhcWSClient {
@@ -212,12 +212,7 @@ case class AhcWSRequest(client: AhcWSClient,
       .build()
   }
 
-  def contentType: Option[String] = {
-    this.headers.find(p => p._1 == HttpHeaders.Names.CONTENT_TYPE).map {
-      case (header, values) =>
-        values.head
-    }
-  }
+  def contentType: Option[String] = this.headers.get(HttpHeaders.Names.CONTENT_TYPE).map(_.head)
 
   /**
    * Creates and returns an AHC request, running all operations on it.

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
@@ -111,9 +111,11 @@ object AhcWSSpec extends PlaySpecification with Mockito {
     "not make Content-Type header if there is Content-Type in headers already" in new WithApplication {
       import scala.collection.JavaConverters._
       val req: AHCRequest = WS.url("http://playframework.com/")
-        .withHeaders("Content-Type" -> "fake/contenttype; charset=utf-8").withBody(<aaa>value1</aaa>).asInstanceOf[AhcWSRequest]
+        .withHeaders("content-type" -> "fake/contenttype; charset=utf-8")
+        .withBody(<aaa>value1</aaa>)
+        .asInstanceOf[AhcWSRequest]
         .buildRequest()
-      req.getHeaders.get("Content-Type") must_== ("fake/contenttype; charset=utf-8")
+      req.getHeaders.getAll("Content-Type").asScala must_== Seq("fake/contenttype; charset=utf-8")
     }
 
     "Have form params on POST of content type application/x-www-form-urlencoded" in new WithApplication {
@@ -204,17 +206,7 @@ object AhcWSSpec extends PlaySpecification with Mockito {
         .withBody("HELLO WORLD")
         .asInstanceOf[AhcWSRequest]
         .buildRequest()
-      req.getHeaders.get("Content-Type") must_== ("text/plain; charset=US-ASCII")
-    }
-
-    "Only send first content type header if two are sent" in new WithApplication {
-      import scala.collection.JavaConverters._
-      val req: AHCRequest = WS.url("http://playframework.com/")
-        .withHeaders("Content-Type" -> "application/json")
-        .withHeaders("Content-Type" -> "application/xml") // second content type header is ignored
-        .withBody("HELLO WORLD").asInstanceOf[AhcWSRequest]
-        .buildRequest()
-      req.getHeaders.get("Content-Type") must_== ("application/json")
+      req.getHeaders.getAll("Content-Type").asScala must_== Seq("text/plain; charset=US-ASCII")
     }
 
     "POST binary data as is" in new WithApplication {


### PR DESCRIPTION
Fixes #6057 

The headers map is now created using the case insensitive ordering, and I checked to see that methods that extract headers use the case-insensitive comparison.

We might want to consider refactoring how this is done in the future. Having `AhcWSRequest` accept a generic `Map` type does not give the guarantees we want. We should probably fix it when we fix #5811.

This should be backported to 2.5.x.