### PR TITLE
Use repo.typesafe.com rather than dl.bintray.com

### DIFF
--- a/documentation/manual/gettingStarted/NewApplication.md
+++ b/documentation/manual/gettingStarted/NewApplication.md
@@ -54,7 +54,7 @@ In `project/plugins.sbt`, add:
 
 ```scala
 // The Typesafe repository
-resolvers += "Typesafe repository" at "https://dl.bintray.com/typesafe/maven-releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/maven-releases/"
 
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "%PLAY_VERSION%")

--- a/documentation/manual/hacking/Repositories.md
+++ b/documentation/manual/hacking/Repositories.md
@@ -3,7 +3,7 @@
 
 ## Typesafe repository
 
-All Play artifacts are published to the Typesafe repository at <https://dl.bintray.com/typesafe/maven-releases/>.
+All Play artifacts are published to the Typesafe repository at <https://repo.typesafe.com/typesafe/maven-releases/>.
 
 > **Note:** it's a Maven2 compatible repository.
 
@@ -11,7 +11,7 @@ To enable it in your sbt build, you must add a proper resolver (typically in `pl
 
 ```scala
 // The Typesafe repository
-resolvers += "Typesafe Releases" at "https://dl.bintray.com/typesafe/maven-releases/"
+resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/maven-releases/"
 ```
 
 ## Accessing snapshots


### PR DESCRIPTION
dl.bintray.com is considered the implementation detail for where those artefacts
are served from. repo.typesafe.com is the canonical URL.