### PR TITLE
Doc fix: Correctly look up validation errors in messages

### DIFF
--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/view.scala.html
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/view.scala.html
@@ -3,13 +3,15 @@
 @* #global-errors *@
 @if(form.hasGlobalErrors) {
     <p class="error">
-        @form.globalError.message
+        @for(error <- form.globalErrors) {
+            <p>@Messages(error.messages, error.arguments.toArray: _*)</p>
+        }
     </p>
 }
 @* #global-errors *@
 
 @* #field-errors *@
 @for(error <- form("email").errors) {
-    <p>@error.message</p>
+    <p>@Messages(error.messages, error.arguments.toArray: _*)</p>
 }
 @* #field-errors *@

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/user.scala.html
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/user.scala.html
@@ -29,7 +29,7 @@
 @if(userForm.hasGlobalErrors) {
   <ul>
   @for(error <- userForm.globalErrors) {
-    <li>@error.message</li>
+    <li>@Messages(error.messages, error.args)</li>
   }
   </ul>
 }


### PR DESCRIPTION
Only displaying `error.message` is wrong. Right now the documentation doesn't take the validation error arguments into account.

We for example create (global) `ValidationError`s (the java ones) like this:
```java
new ValidationError("", "msgkey", Arrays.asList("msgarg1", "msgarg2"));
```