### PR TITLE
Fixed/improved ning deprecation messages

### DIFF
--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingConfig.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingConfig.scala
@@ -30,7 +30,7 @@ import scala.concurrent.duration._
  * @param disableUrlEncoding Whether the raw URL should be used.
  * @param keepAlive whether connection pooling should be used.
  */
-@deprecated("Use AhcWSClientConfig", "2.5")
+@deprecated("Use play.api.libs.ws.ahc.AhcWSClientConfig", "2.5")
 case class NingWSClientConfig(wsClientConfig: WSClientConfig = WSClientConfig(),
   maxConnectionsPerHost: Int = -1,
   maxConnectionsTotal: Int = -1,
@@ -44,7 +44,7 @@ case class NingWSClientConfig(wsClientConfig: WSClientConfig = WSClientConfig(),
 /**
  * Factory for creating NingWSClientConfig, for use from Java.
  */
-@deprecated("Use AhcWSConfigBuilder", "2.5")
+@deprecated("Use play.api.libs.ws.ahc.AhcWSConfigBuilder", "2.5")
 object NingWSClientConfigFactory {
 
   def forClientConfig(config: WSClientConfig) = {
@@ -57,7 +57,7 @@ object NingWSClientConfigFactory {
  *
  * @param ningConfig the ning client configuration.
  */
-@deprecated("Use AhcConfigBuilder", "2.5")
+@deprecated("Use play.api.libs.ws.ahc.AhcConfigBuilder", "2.5")
 class NingAsyncHttpClientConfigBuilder(ningConfig: NingWSClientConfig = NingWSClientConfig()) {
 
   protected val addCustomSettings: DefaultAsyncHttpClientConfig.Builder => DefaultAsyncHttpClientConfig.Builder = identity

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ning/NingWS.scala
@@ -18,7 +18,7 @@ import play.api.libs.ws.ssl._
  *
  * @param config a client configuration object
  */
-@deprecated("Use AhcWSClient instead", "2.5")
+@deprecated("Use play.api.libs.ws.ahc.AhcWSClient instead", "2.5")
 case class NingWSClient(config: AsyncHttpClientConfig)(implicit materializer: Materializer) extends WSClient {
 
   private val ahcWsClient = AhcWSClient(config)
@@ -32,7 +32,7 @@ case class NingWSClient(config: AsyncHttpClientConfig)(implicit materializer: Ma
   def url(url: String): WSRequest = AhcWSRequest(ahcWsClient, url, "GET", EmptyBody, Map(), Map(), None, None, None, None, None, None, None)
 }
 
-@deprecated("Use AhcWSClient instead", "2.5")
+@deprecated("Use play.api.libs.ws.ahc.AhcWSClient instead", "2.5")
 object NingWSClient {
   /**
    * Convenient factory method that uses a [[WSClientConfig]] value for configuration instead of an [[https://asynchttpclient.github.io/async-http-client/apidocs/com/ning/http/client/AsyncHttpClientConfig.html org.asynchttpclient.AsyncHttpClientConfig]].
@@ -60,7 +60,7 @@ object NingWSClient {
 /**
  * Ning WS API implementation components.
  */
-@deprecated("Use AhcWSClient instead", "2.5")
+@deprecated("Use play.api.libs.ws.ahc.AhcWSComponents instead", "2.5")
 trait NingWSComponents {
 
   def environment: Environment


### PR DESCRIPTION
Ensured deprecated NingWSComponents points to AhcWSComponents, not AhcWSClient, and made all deprecation messages point to fully qualified class names.

I've made this PR against 2.5.x because the components will likely be deleted on master, so the changes aren't really needed there.