### PR TITLE
Get host properly even if full URI is invalid

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -3,12 +3,11 @@
  */
 package play.api.mvc {
 
-  import java.net.{URI, URLDecoder, URLEncoder}
+  import java.net.{URLDecoder, URLEncoder}
   import java.security.cert.X509Certificate
   import java.util.Locale
-import java.util.Locale.LanguageRange
 
-import play.api._
+  import play.api._
   import play.api.http._
   import play.api.i18n.Lang
   import play.api.libs.crypto.CookieSigner
@@ -115,10 +114,9 @@ import play.api._
      * The HTTP host (domain, optionally port)
      */
     lazy val host: String = {
-      val u = new URI(uri)
-      (u.getHost, u.getPort) match {
-        case (h, p) if h != null && p > 0 => s"$h:$p"
-        case (h, _) if h != null => h
+      val AbsoluteUri = """(?is)^(https?)://([^/]+)(/.*|$)""".r
+      uri match {
+        case AbsoluteUri(proto, hostPort, rest) => hostPort
         case _ => headers.get(HeaderNames.HOST).getOrElse("")
       }
     }

--- a/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -26,6 +26,14 @@ class RequestHeaderSpec extends Specification {
         val rh = DummyRequestHeader("GET", "https://example.com:8080/test", Headers(HOST -> "playframework.com"))
         rh.host must_== "example.com:8080"
       }
+      "absolute uri with port and invalid characters" in {
+        val rh = DummyRequestHeader("GET", "https://example.com:8080/classified-search/classifieds?version=GTI|V8", Headers(HOST -> "playframework.com"))
+        rh.host must_== "example.com:8080"
+      }
+      "relative uri with invalid characters" in {
+        val rh = DummyRequestHeader("GET", "/classified-search/classifieds?version=GTI|V8", Headers(HOST -> "playframework.com"))
+        rh.host must_== "playframework.com"
+      }
     }
 
     "parse accept languages" in {
@@ -67,11 +75,10 @@ class RequestHeaderSpec extends Specification {
       requestMethod: String = "GET",
       requestUri: String = "/",
       headers: Headers = Headers()) extends RequestHeader {
-    private[this] val parsedUri = new URI(requestUri)
     def id = 1
     def tags = Map()
     def uri = requestUri
-    def path = parsedUri.getPath
+    def path = new URI(requestUri).getPath // this just won't work for invalid URIs
     def method = requestMethod
     def version = ""
     def queryString = Map()


### PR DESCRIPTION
Fixes #6066

This uses a regex since we are only trying to extract the host and port, and we don't really care if the rest of the URI is valid. I think this is a better solution than throwing an exception unexpectedly, especially since in many cases the host is just the value of the `Host` header and has nothing to do with the request URI.