### PR TITLE
Add basic auth params to AHCRequestLogger

### DIFF
--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
@@ -8,7 +8,6 @@ import java.nio.charset.StandardCharsets
 import org.asynchttpclient.util.HttpUtils
 import org.slf4j.LoggerFactory
 import play.api.libs.ws._
-
 import scala.concurrent.Future
 
 /**
@@ -52,6 +51,15 @@ trait CurlFormat {
     // method
     b.append(s"  --request ${request.method}")
     b.append(" \\\n")
+
+    //authentication
+    request.auth match {
+      case Some((userName, password, WSAuthScheme.BASIC)) => {
+        b.append(s"  --user $userName:$password")
+        b.append(" \\\n")
+      }
+      case _ => Unit
+    }
 
     // headers
     request.headers.foreach {

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
@@ -9,7 +9,8 @@ import org.asynchttpclient.util.HttpUtils
 import org.slf4j.LoggerFactory
 import play.api.libs.ws._
 import scala.concurrent.Future
-
+import com.google.common.io.BaseEncoding
+import com.google.common.base.Charsets
 /**
  * Logs WSRequest and pulls information into Curl format to an SLF4J logger.
  *
@@ -55,7 +56,9 @@ trait CurlFormat {
     //authentication
     request.auth match {
       case Some((userName, password, WSAuthScheme.BASIC)) => {
-        b.append(s"  --user $userName:$password")
+        val encodedPassword = BaseEncoding.base64()
+          .encode(s"$userName:$password".getBytes(Charsets.US_ASCII))
+        b.append(s"""  --header "Authorization: Basic ${quote(encodedPassword)}""")
         b.append(" \\\n")
       }
       case _ => Unit

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
@@ -137,6 +137,22 @@ class AhcCurlRequestLoggerSpec extends PlaySpecification
 
         there was one(logger).info(curlStatement)
       }
+
+      "log a request with Basic auth" in new WithServer {
+        val client = wsUrl("/")
+        val logger = mock[Logger]
+        val responseFuture = client.withRequestFilter(AhcCurlRequestLogger(logger))
+          .withAuth("username1", "password1", WSAuthScheme.BASIC)
+          .get()
+
+        responseFuture must beAnInstanceOf[AhcWSResponse].await
+        val curlStatement = s"""curl \\
+                                |  --verbose \\
+                                |  --request GET \\
+                                |  --user username1:password1 \\
+                                |  'http://localhost:$testServerPort/'""".stripMargin
+        there was one(logger).info(curlStatement)
+      }
       //
       //      "log a request with a proxy" in new WithServer {
       //        val client = wsUrl("/")


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you added tests for any changed functionality?

## Purpose

This adds basic authentication to WSRequest Logging

## Background Context

I wanted to check for feedback on this change before implementing curl request conversion for more WsRequests. 

## References

None

The request logger doesn't log auth for curl requests, this change
adds the --user flag to the curl request when auth is basic.