### PR TITLE
Fix configuration key name in ScalaDoc for ApplicationLoader trait

### DIFF
--- a/framework/src/play/src/main/java/play/ApplicationLoader.java
+++ b/framework/src/play/src/main/java/play/ApplicationLoader.java
@@ -23,7 +23,7 @@ import play.libs.Scala;
  * Out of the box Play provides a Java and Scala default implementation based on Guice. The Java implementation is the
  * {@link play.inject.guice.GuiceApplicationLoader} and the Scala implementation is {@link play.api.inject.guice.GuiceApplicationLoader}.
  *
- * A custom application loader can be configured using the `application.loader` configuration property.
+ * A custom application loader can be configured using the `play.application.loader` configuration property.
  * Implementations must define a no-arg constructor.
  */
 public interface ApplicationLoader {

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -20,7 +20,7 @@ import play.utils.Reflect
  * Out of the box Play provides a Java and Scala default implementation based on Guice. The Scala implementation is the
  * [[play.api.inject.guice.GuiceApplicationLoader]].
  *
- * A custom application loader can be configured using the `application.loader` configuration property.
+ * A custom application loader can be configured using the `play.application.loader` configuration property.
  * Implementations must define a no-arg constructor.
  */
 trait ApplicationLoader {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Purpose

The documentation [says](https://www.playframework.com/documentation/2.5.x/ScalaCompileTimeDependencyInjection#Application-entry-point) that the configuration key for setting a custom application loader is `play.application.loader`, but in ScalaDoc it was `application.loader`.