### PR TITLE
Handle null response headers

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -24,16 +24,16 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
 
   "scala body handling" should {
 
-    def tryRequest[T](result: Result)(block: Try[WSResponse] => T) = withServer(result) { implicit port =>
+    def tryRequest[T](result: => Result)(block: Try[WSResponse] => T) = withServer(result) { implicit port =>
       val response = Try(await(wsUrl("/").get()))
       block(response)
     }
 
-    def makeRequest[T](result: Result)(block: WSResponse => T) = {
+    def makeRequest[T](result: => Result)(block: WSResponse => T) = {
       tryRequest(result)(tryResult => block(tryResult.get))
     }
 
-    def withServer[T](result: Result)(block: Port => T) = {
+    def withServer[T](result: => Result)(block: Port => T) = {
       val port = testServerPort
       running(TestServer(port, GuiceApplicationBuilder().routes { case _ => Action(result) }.build())) {
         block(port)
@@ -217,7 +217,7 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
         ).head
 
         response.status must_== 500
-        response.body must beLeft("")
+        response.body must beLeft
       }
 
     "return a 400 error on Header value contains a prohibited character" in withServer(

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -1737,6 +1737,12 @@ public class Http {
          * @param value The value of the header, must not be null
          */
         public void setHeader(String name, String value) {
+            if (name == null) {
+                throw new NullPointerException("Header name cannot be null!");
+            }
+            if (value == null) {
+                throw new NullPointerException("Header value cannot be null!");
+            }
             this.headers.put(name, value);
         }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -30,6 +30,12 @@ final class ResponseHeader(val status: Int, _headers: Map[String, String] = Map.
 
   val headers: Map[String, String] = TreeMap[String, String]()(CaseInsensitiveOrdered) ++ _headers
 
+  // validate headers so we know this response header is well formed
+  for ((name, value) <- headers) {
+    if (name eq null) throw new NullPointerException("Response header names cannot be null!")
+    if (value eq null) throw new NullPointerException(s"Response header '$name' has null value!")
+  }
+
   def copy(status: Int = status, headers: Map[String, String] = headers, reasonPhrase: Option[String] = reasonPhrase): ResponseHeader =
     new ResponseHeader(status, headers, reasonPhrase)
 


### PR DESCRIPTION
This is actually a follow-up fix to #1403.

By throwing the exception up front, it makes it easier to determine where the null header is inserted, and also makes it possible for filters to detect this type of error.