### PR TITLE
The file should be named conf/logger.xml to be picked up automatically

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
@@ -22,7 +22,7 @@ For any custom configuration, you will need to specify your own Logback configur
 
 ### Using a configuration file from project source
 
-You can provide a default logging configuration by providing a file `conf/logback.xml`.
+You can provide a default logging configuration by providing a file `conf/logger.xml`.
 
 ### Using an external configuration file
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

N/A

## Purpose

Fixes a mistake in the documentation regarding logger configuration

## Background Context

If you create conf/logback.xml, as the docs suggest, that logback configuration won't be picked up by default. However, if you create conf/logger.xml it will be picked up by default. Hence, I propose to update the docs.

## References

N/A

