### PR TITLE
typo in csrf documentation

### DIFF
--- a/documentation/manual/working/javaGuide/main/forms/JavaCsrf.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaCsrf.md
@@ -27,7 +27,7 @@ Alternatively, you can set `play.filters.csrf.header.bypassHeaders` to match com
 This configuration would look like:
 
 ```
-play.filters.csrf.headers.bypassHeaders {
+play.filters.csrf.header.bypassHeaders {
   X-Requested-With = "*"
   Csrf-Token = "nocheck"
 }

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaCsrf.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaCsrf.md
@@ -27,7 +27,7 @@ Alternatively, you can set `play.filters.csrf.header.bypassHeaders` to match com
 This configuration would look like:
 
 ```
-play.filters.csrf.headers.bypassHeaders {
+play.filters.csrf.header.bypassHeaders {
   X-Requested-With = "*"
   Csrf-Token = "nocheck"
 }


### PR DESCRIPTION
csrf bypassHeaders configuration example has incorrect config key "play.filters.csrf.headers.bypassHeaders" when it is "play.filters.csrf.header.bypassHeaders" in the code.
