### PR TITLE
[2.5.x] Support non-ISO8859-1 filename in Content-Disposition header

### DIFF
--- a/documentation/manual/releases/release25/migration25/Migration25.md
+++ b/documentation/manual/releases/release25/migration25/Migration25.md
@@ -44,7 +44,7 @@ Or:
 
 ```scala
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-slick" % "2.0.0"
+  "com.typesafe.play" %% "play-slick" % "2.0.0",
   "com.typesafe.play" %% "play-slick-evolutions" % "2.0.0"
 )
 ```
@@ -63,7 +63,7 @@ If your project is using [[ScalaTest + Play|ScalaTestingWithScalaTest]], you nee
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.0" % "test"
+  "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % "test"
 )
 ```
 
@@ -322,3 +322,19 @@ Modify any `play.server.netty.option` keys to use the new keys defined in [Chann
 | `play.server.netty.option.backlog` | `play.server.netty.option.SO_BACKLOG` |
 | `play.server.netty.option.child.keepAlive` | `play.server.netty.option.child.SO_KEEPALIVE` |
 | `play.server.netty.option.child.tcpNoDelay` | `play.server.netty.option.child.TCP_NODELAY` |
+
+## Changes to `sendFile`, `sendPath` and `sendResource` methods
+
+Java (`play.mvc.StatusHeader`) and Scala (`play.api.mvc.Results.Status`) APIs had the following behavior before:
+
+| API   | Method                                    | Default      |
+|:------|:------------------------------------------|:-------------|
+| Scala | `play.api.mvc.Results.StatussendResource` | `inline`     |
+| Scala | `play.api.mvc.Results.StatussendPath`     | `attachment` |
+| Scala | `play.api.mvc.Results.StatussendFile`     | `attachment` |
+| Java  | `play.mvc.StatusHeader.sendInputStream`   | `none`       |
+| Java  | `play.mvc.StatusHeader.sendResource`      | `inline`     |
+| Java  | `play.mvc.StatusHeader.sendPath`          | `attachment` |
+| Java  | `play.mvc.StatusHeader.sendFile`          | `inline`     |
+
+In other words, they were mixing `inline` and `attachment` modes when delivering files. Now, when delivering files, paths and resources uses `inline` as the default behavior. Of course, you can alternate between these two modes using the parameters present in these methods.

--- a/framework/src/play/src/main/java/play/mvc/StatusHeader.java
+++ b/framework/src/play/src/main/java/play/mvc/StatusHeader.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import play.api.libs.streams.Streams;
 import play.http.HttpEntity;
 import play.libs.Json;
+import play.utils.UriEncoding;
 import scala.Option;
 import scala.compat.java8.OptionConverters;
 
@@ -28,6 +29,8 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+
+import static java.nio.charset.StandardCharsets.*;
 
 /**
  * A status with no body
@@ -269,7 +272,7 @@ public class StatusHeader extends Result {
         Map<String, String> headers = Collections.singletonMap(
                 Http.HeaderNames.CONTENT_DISPOSITION,
                 (inline ? "inline" : "attachment") +
-                (resourceName.isPresent() ? "; filename=\"" + resourceName.get() + "\"" : "")
+                (resourceName.isPresent() ? "; filename=\"" + resourceName.get() + "\"; filename*=utf-8''" + UriEncoding.encodePathSegment(resourceName.get(), UTF_8) : "")
         );
 
         return new Result(status(), headers, new HttpEntity.Streamed(

--- a/framework/src/play/src/main/java/play/mvc/StatusHeader.java
+++ b/framework/src/play/src/main/java/play/mvc/StatusHeader.java
@@ -34,7 +34,8 @@ import java.util.Optional;
  */
 public class StatusHeader extends Result {
 
-    private static final int defaultChunkSize = 1024 * 8;
+    private static final int DEFAULT_CHUNK_SIZE = 1024 * 8;
+    private static final boolean DEFAULT_INLINE_MODE = true;
 
     public StatusHeader(int status) {
         super(status);
@@ -52,7 +53,7 @@ public class StatusHeader extends Result {
         if (stream == null) {
             throw new NullPointerException("Null stream");
         }
-        return new Result(status(), HttpEntity.chunked(StreamConverters.fromInputStream(() -> stream, defaultChunkSize),
+        return new Result(status(), HttpEntity.chunked(StreamConverters.fromInputStream(() -> stream, DEFAULT_CHUNK_SIZE),
                 Optional.empty()));
     }
 
@@ -65,9 +66,9 @@ public class StatusHeader extends Result {
      */
     public Result sendInputStream(InputStream stream, long contentLength) {
         if (stream == null) {
-            throw new NullPointerException("Null content");
+            throw new NullPointerException("Null stream");
         }
-        return new Result(status(), new HttpEntity.Streamed(StreamConverters.fromInputStream(() -> stream, defaultChunkSize),
+        return new Result(status(), new HttpEntity.Streamed(StreamConverters.fromInputStream(() -> stream, DEFAULT_CHUNK_SIZE),
                 Optional.of(contentLength), Optional.empty()));
     }
 
@@ -77,10 +78,10 @@ public class StatusHeader extends Result {
      * The resource will be loaded from the same classloader that this class comes from.
      *
      * @param resourceName The path of the resource to load.
-     * @return an inlined '200 OK' result containing the resource in the body with in-line content disposition.
+     * @return a '200 OK' result containing the resource in the body with in-line content disposition.
      */
     public Result sendResource(String resourceName) {
-        return sendResource(resourceName, true);
+        return sendResource(resourceName, DEFAULT_INLINE_MODE);
     }
 
     /**
@@ -91,7 +92,7 @@ public class StatusHeader extends Result {
      * @return a '200 OK' result containing the resource in the body with in-line content disposition.
      */
     public Result sendResource(String resourceName, ClassLoader classLoader) {
-        return sendResource(resourceName, classLoader, true);
+        return sendResource(resourceName, classLoader, DEFAULT_INLINE_MODE);
     }
 
     /**
@@ -121,13 +122,41 @@ public class StatusHeader extends Result {
     }
 
     /**
+     * Send the given resource.
+     * <p>
+     * The resource will be loaded from the same classloader that this class comes from.
+     *
+     * @param resourceName The path of the resource to load.
+     * @param inline       Whether it should be served as an inline file, or as an attachment.
+     * @param filename     The file name of the resource.
+     * @return a '200 OK' result containing the resource in the body.
+     */
+    public Result sendResource(String resourceName, boolean inline, String filename) {
+        return sendResource(resourceName, this.getClass().getClassLoader(), inline, filename);
+    }
+
+    /**
+     * Send the given resource from the given classloader.
+     *
+     * @param resourceName The path of the resource to load.
+     * @param classLoader  The classloader to load it from.
+     * @param inline       Whether it should be served as an inline file, or as an attachment.
+     * @param filename     The file name of the resource.
+     * @return a '200 OK' result containing the resource in the body.
+     */
+    public Result sendResource(String resourceName, ClassLoader classLoader, boolean inline, String filename) {
+        return doSendResource(StreamConverters.fromInputStream(() -> classLoader.getResourceAsStream(resourceName)),
+                Optional.empty(), Optional.of(filename), inline);
+    }
+
+    /**
      * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions.
      *
      * @param path The path to send.
      * @return a '200 OK' result containing the file at the provided path with inline content disposition.
      */
     public Result sendPath(Path path) {
-        return sendPath(path, false);
+        return sendPath(path, DEFAULT_INLINE_MODE);
     }
 
     /**
@@ -139,6 +168,17 @@ public class StatusHeader extends Result {
      */
     public Result sendPath(Path path, boolean inline) {
         return sendPath(path, inline, path.getFileName().toString());
+    }
+
+    /**
+     * Sends the given path if it is a valid file. Otherwise throws RuntimeExceptions.
+     *
+     * @param path     The path to send.
+     * @param filename The file name of the path.
+     * @return a '200 OK' result containing the file at the provided path
+     */
+    public Result sendPath(Path path, String filename) {
+        return sendPath(path, DEFAULT_INLINE_MODE, filename);
     }
 
     /**
@@ -170,8 +210,8 @@ public class StatusHeader extends Result {
      *
      * @param file The file to send.
      */
-    private Result sendFile(File file) {
-        return sendFile(file, true);
+    public Result sendFile(File file) {
+        return sendFile(file, DEFAULT_INLINE_MODE);
     }
 
     /**
@@ -194,13 +234,25 @@ public class StatusHeader extends Result {
     }
 
     /**
-     * Send the given file as an attachment.
+     * Send the given file.
      *
      * @param file The file to send.
      * @param fileName The name of the attachment
      * @return a '200 OK' result containing the file
      */
     public Result sendFile(File file, String fileName) {
+        return sendFile(file, DEFAULT_INLINE_MODE, fileName);
+    }
+
+    /**
+     * Send the given file.
+     *
+     * @param file     The file to send.
+     * @param fileName The name of the attachment
+     * @param inline   True if the file should be sent inline, false if it should be sent as an attachment.
+     * @return a '200 OK' result containing the file
+     */
+    public Result sendFile(File file, boolean inline, String fileName) {
         if (file == null) {
             throw new NullPointerException("null file");
         }
@@ -208,7 +260,7 @@ public class StatusHeader extends Result {
                 FileIO.fromFile(file),
                 Optional.of(file.length()),
                 Optional.of(fileName),
-                true
+                inline
         );
     }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/RangeResult.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/RangeResult.scala
@@ -3,6 +3,8 @@
  */
 package play.api.mvc
 
+import java.nio.charset.StandardCharsets
+
 import akka.NotUsed
 import akka.stream.scaladsl.{ FileIO, Flow, Source }
 import akka.stream.stage._
@@ -10,6 +12,7 @@ import akka.util.ByteString
 import play.api.http.HeaderNames._
 import play.api.http.Status._
 import play.api.http.{ ContentTypes, HttpEntity }
+import play.utils.UriEncoding
 
 import scala.math.Ordered.orderingToOrdered
 
@@ -255,7 +258,7 @@ object RangeResult {
   def ofSource(entityLength: Long, source: Source[ByteString, _], rangeHeader: Option[String], fileName: Option[String], contentType: Option[String]): Result = {
     val commonHeaders = Seq(
       Some(ACCEPT_RANGES -> "bytes"),
-      fileName.map(f => CONTENT_DISPOSITION -> s"""attachment; filename="$f"""")
+      fileName.map(f => CONTENT_DISPOSITION -> s"""attachment; filename="$f"; filename*=utf-8''${UriEncoding.encodePathSegment(f, StandardCharsets.UTF_8)}""")
     ).flatten.toMap
 
     RangeSet(entityLength, rangeHeader) match {

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -3,6 +3,7 @@
  */
 package play.api.mvc
 
+import java.nio.charset.StandardCharsets
 import java.nio.file.{ Files, Path }
 
 import akka.stream.scaladsl.{ FileIO, Source, StreamConverters }
@@ -15,6 +16,7 @@ import play.api.i18n.{ Lang, MessagesApi }
 import play.api.libs.iteratee._
 import play.api.libs.streams.Streams
 import play.core.utils.CaseInsensitiveOrdered
+import play.utils.UriEncoding
 
 import scala.collection.immutable.TreeMap
 
@@ -381,7 +383,7 @@ trait Results {
           Map(
             CONTENT_DISPOSITION -> {
               val dispositionType = if (inline) "inline" else "attachment"
-              dispositionType + "; filename=\"" + name + "\""
+              s"""$dispositionType; filename="$name"; filename*=utf-8''${UriEncoding.encodePathSegment(name, StandardCharsets.UTF_8)}"""
             }
           )
         ),

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -400,7 +400,7 @@ trait Results {
      * @param inline Use Content-Disposition inline or attachment.
      * @param fileName Function to retrieve the file name. By default the name of the file is used.
      */
-    def sendFile(content: java.io.File, inline: Boolean = false, fileName: java.io.File => String = _.getName, onClose: () => Unit = () => ()): Result = {
+    def sendFile(content: java.io.File, inline: Boolean = true, fileName: java.io.File => String = _.getName, onClose: () => Unit = () => ()): Result = {
       streamFile(FileIO.fromFile(content), fileName(content), content.length, inline)
     }
 
@@ -411,7 +411,7 @@ trait Results {
      * @param inline Use Content-Disposition inline or attachment.
      * @param fileName Function to retrieve the file name. By default the name of the file is used.
      */
-    def sendPath(content: Path, inline: Boolean = false, fileName: Path => String = _.getFileName.toString, onClose: () => Unit = () => ()): Result = {
+    def sendPath(content: Path, inline: Boolean = true, fileName: Path => String = _.getFileName.toString, onClose: () => Unit = () => ()): Result = {
       streamFile(FileIO.fromFile(content.toFile), fileName(content), Files.size(content), inline)
     }
 
@@ -422,8 +422,7 @@ trait Results {
      * @param classLoader The classloader to load it from, defaults to the classloader for this class.
      * @param inline Whether it should be served as an inline file, or as an attachment.
      */
-    def sendResource(resource: String, classLoader: ClassLoader = Results.getClass.getClassLoader,
-      inline: Boolean = true): Result = {
+    def sendResource(resource: String, classLoader: ClassLoader = Results.getClass.getClassLoader, inline: Boolean = true): Result = {
       val stream = classLoader.getResourceAsStream(resource)
       val fileName = resource.split('/').last
       streamFile(StreamConverters.fromInputStream(() => stream), fileName, stream.available(), inline)

--- a/framework/src/play/src/main/scala/play/utils/UriEncoding.scala
+++ b/framework/src/play/src/main/scala/play/utils/UriEncoding.scala
@@ -3,8 +3,9 @@
  */
 package play.utils
 
-import java.util.BitSet
 import java.io.ByteArrayOutputStream
+import java.nio.charset.Charset
+import java.util.BitSet
 
 /**
  * Provides support for correctly encoding pieces of URIs.
@@ -60,6 +61,17 @@ object UriEncoding {
   }
 
   /**
+   * Encode a string so that it can be used safely in the "path segment" part of a URI.
+   *
+   * @param s The string to encode.
+   * @param inputCharset The charset of the encoding that the string `s` is encoded with.
+   * @return An encoded string in the US-ASCII character set.
+   */
+  def encodePathSegment(s: String, inputCharset: Charset): String = {
+    encodePathSegment(s, inputCharset.name)
+  }
+
+  /**
    * Decode a string according to the rules for the "path segment"
    * part of a URI. A path segment is defined in RFC 3986. In a URI such
    * as `http://www.example.com/abc/def?a=1&b=2` both `abc` and `def`
@@ -84,7 +96,7 @@ object UriEncoding {
    * @param s The string to decode. Must use the US-ASCII character set.
    * @param outputCharset The name of the encoding that the output should be encoded with.
    *     The output string will be converted from octets (bytes) using this character encoding.
-   * @throws InvalidUriEncodingException If the input is not a valid encoded path segment.
+   * @throws play.utils.InvalidUriEncodingException If the input is not a valid encoded path segment.
    * @return A decoded string in the `outputCharset` character set.
    */
   def decodePathSegment(s: String, outputCharset: String): String = {
@@ -120,7 +132,20 @@ object UriEncoding {
   }
 
   /**
-   * Decode the path path of a URI. Each path segment will be decoded
+   * Decode a string according to the rules for the "path segment" part of a URI.
+   *
+   * @param s The string to decode. Must use the US-ASCII character set.
+   * @param outputCharset The charset of the encoding that the output should be encoded with.
+   *     The output string will be converted from octets (bytes) using this character encoding.
+   * @throws play.utils.InvalidUriEncodingException If the input is not a valid encoded path segment.
+   * @return A decoded string in the `outputCharset` character set.
+   */
+  def decodePathSegment(s: String, outputCharset: Charset): String = {
+    decodePathSegment(s, outputCharset.name)
+  }
+
+  /**
+   * Decode the path of a URI. Each path segment will be decoded
    * using the same rules as ``decodePathSegment``. No normalization is performed:
    * leading, trailing and duplicated slashes, if present are left as they are and
    * if absent remain absent; dot-segments (".." and ".") are ignored.
@@ -131,7 +156,7 @@ object UriEncoding {
    * @param s The string to decode. Must use the US-ASCII character set.
    * @param outputCharset The name of the encoding that the output should be encoded with.
    *     The output string will be converted from octets (bytes) using this character encoding.
-   * @throws InvalidUriEncodingException If the input is not a valid encoded path.
+   * @throws play.utils.InvalidUriEncodingException If the input is not a valid encoded path.
    * @return A decoded string in the `outputCharset` character set.
    */
   def decodePath(s: String, outputCharset: String): String = {
@@ -139,6 +164,20 @@ object UriEncoding {
     // This would allow better handling of paths segments with encoded slashes in them.
     // However, there is no need for this yet, so the method hasn't been added yet.
     splitString(s, '/').map(decodePathSegment(_, outputCharset)).mkString("/")
+  }
+
+  /**
+   * Decode the path of a URI. Each path segment will be decoded
+   * using the same rules as ``decodePathSegment``.
+   *
+   * @param s The string to decode. Must use the US-ASCII character set.
+   * @param outputCharset The charset of the encoding that the output should be encoded with.
+   *     The output string will be converted from octets (bytes) using this character encoding.
+   * @throws play.utils.InvalidUriEncodingException If the input is not a valid encoded path.
+   * @return A decoded string in the `outputCharset` character set.
+   */
+  def decodePath(s: String, outputCharset: Charset): String = {
+    decodePath(s, outputCharset.name)
   }
 
   // RFC 3986, 3.3. Path

--- a/framework/src/play/src/test/java/play/mvc/RangeResultsTest.java
+++ b/framework/src/play/src/test/java/play/mvc/RangeResultsTest.java
@@ -60,7 +60,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofPath(path);
 
         assertEquals(result.status(), PARTIAL_CONTENT);
-        assertEquals("attachment; filename=\"test.tmp\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -70,7 +70,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofPath(path);
 
         assertEquals(result.status(), OK);
-        assertEquals("attachment; filename=\"test.tmp\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -79,7 +79,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofPath(path, "file.txt");
 
         assertEquals(result.status(), PARTIAL_CONTENT);
-        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -89,7 +89,27 @@ public class RangeResultsTest {
         Result result = RangeResults.ofPath(path, "file.txt");
 
         assertEquals(result.status(), OK);
-        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
+    }
+
+    @Test
+    public void shouldReturnRangeResultForPathWhenFilenameHasSpecialChars() {
+        this.mockRangeRequest();
+
+        Result result = RangeResults.ofPath(path, "测 试.tmp");
+
+        assertEquals(result.status(), PARTIAL_CONTENT);
+        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
+    }
+
+    @Test
+    public void shouldNotReturnRangeResultForPathWhenFilenameHasSpecialChars() {
+        this.mockRegularRequest();
+
+        Result result = RangeResults.ofPath(path, "测 试.tmp");
+
+        assertEquals(result.status(), OK);
+        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     // -- Files
@@ -100,7 +120,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofFile(path.toFile());
 
         assertEquals(result.status(), PARTIAL_CONTENT);
-        assertEquals("attachment; filename=\"test.tmp\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -110,7 +130,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofFile(path.toFile());
 
         assertEquals(result.status(), OK);
-        assertEquals("attachment; filename=\"test.tmp\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -119,7 +139,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofFile(path.toFile(), "file.txt");
 
         assertEquals(result.status(), PARTIAL_CONTENT);
-        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -129,7 +149,27 @@ public class RangeResultsTest {
         Result result = RangeResults.ofFile(path.toFile(), "file.txt");
 
         assertEquals(result.status(), OK);
-        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
+    }
+
+    @Test
+    public void shouldReturnRangeResultForFileWhenFilenameHasSpecialChars() {
+        this.mockRangeRequest();
+
+        Result result = RangeResults.ofFile(path.toFile(), "测 试.tmp");
+
+        assertEquals(result.status(), PARTIAL_CONTENT);
+        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
+    }
+
+    @Test
+    public void shouldNotReturnRangeResultForFileWhenFilenameHasSpecialChars() {
+        this.mockRegularRequest();
+
+        Result result = RangeResults.ofFile(path.toFile(), "测 试.tmp");
+
+        assertEquals(result.status(), OK);
+        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     // -- Sources
@@ -165,7 +205,7 @@ public class RangeResultsTest {
 
         assertEquals(result.status(), PARTIAL_CONTENT);
         assertEquals(BINARY, result.body().contentType().orElse(""));
-        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -177,7 +217,7 @@ public class RangeResultsTest {
 
         assertEquals(result.status(), OK);
         assertEquals(BINARY, result.body().contentType().orElse(""));
-        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -190,7 +230,32 @@ public class RangeResultsTest {
 
         assertEquals(result.status(), PARTIAL_CONTENT);
         assertEquals(TEXT, result.body().contentType().orElse(""));
-        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
+    }
+
+    @Test
+    public void shouldNotReturnRangeResultForStreamWhenFilenameHasSpecialChars() throws IOException {
+        this.mockRegularRequest();
+
+        Source<ByteString, CompletionStage<IOResult>> source = FileIO.fromFile(path.toFile());
+        Result result = RangeResults.ofSource(path.toFile().length(), source, "测 试.tmp", BINARY);
+
+        assertEquals(result.status(), OK);
+        assertEquals(BINARY, result.body().contentType().orElse(""));
+        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
+    }
+
+    @Test
+    public void shouldReturnRangeResultForStreamWhenFilenameHasSpecialChars() throws IOException {
+        this.mockRangeRequest();
+
+        long entityLength = path.toFile().length();
+        Source<ByteString, CompletionStage<IOResult>> source = FileIO.fromFile(path.toFile());
+        Result result = RangeResults.ofSource(entityLength, source, "测 试.tmp", TEXT);
+
+        assertEquals(result.status(), PARTIAL_CONTENT);
+        assertEquals(TEXT, result.body().contentType().orElse(""));
+        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     private void mockRegularRequest() {

--- a/framework/src/play/src/test/java/play/mvc/ResultsTest.java
+++ b/framework/src/play/src/test/java/play/mvc/ResultsTest.java
@@ -44,42 +44,49 @@ public class ResultsTest {
   public void sendPathWithOKStatus() throws IOException {
     Result result = Results.ok().sendPath(file);
     assertEquals(result.status(), Http.Status.OK);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
   }
 
   @Test
   public void sendPathWithUnauthorizedStatus() throws IOException {
     Result result = Results.unauthorized().sendPath(file);
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
   }
 
   @Test
   public void sendPathAsAttachmentWithUnauthorizedStatus() throws IOException {
     Result result = Results.unauthorized().sendPath(file, /*inline*/ false);
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
   }
 
   @Test
   public void sendPathAsAttachmentWithOkStatus() throws IOException {
-    Result result = Results.unauthorized().sendPath(file, /* inline */ false);
-    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
+    Result result = Results.ok().sendPath(file, /* inline */ false);
+    assertEquals(result.status(), Http.Status.OK);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
   }
 
   @Test
   public void sendPathWithFileName() throws IOException {
     Result result = Results.unauthorized().sendPath(file, "foo.bar");
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"; filename*=utf-8''foo.bar");
   }
 
   @Test
   public void sendPathInlineWithFileName() throws IOException {
     Result result = Results.unauthorized().sendPath(file, true, "foo.bar");
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"; filename*=utf-8''foo.bar");
+  }
+
+  @Test
+  public void sendPathWithFileNameHasSpecialChars() throws IOException {
+    Result result = Results.ok().sendPath(file, true, "测 试.tmp");
+    assertEquals(result.status(), Http.Status.OK);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp");
   }
 
   // -- File tests
@@ -93,41 +100,48 @@ public class ResultsTest {
   public void sendFileWithOKStatus() throws IOException {
     Result result = Results.ok().sendFile(file.toFile());
     assertEquals(result.status(), Http.Status.OK);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
   }
 
   @Test
   public void sendFileWithUnauthorizedStatus() throws IOException {
     Result result = Results.unauthorized().sendFile(file.toFile());
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
   }
 
   @Test
   public void sendFileAsAttachmentWithUnauthorizedStatus() throws IOException {
     Result result = Results.unauthorized().sendFile(file.toFile(), /* inline */ false);
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
   }
 
   @Test
   public void sendFileAsAttachmentWithOkStatus() throws IOException {
-    Result result = Results.unauthorized().sendFile(file.toFile(), /* inline */ false);
-    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
+    Result result = Results.ok().sendFile(file.toFile(), /* inline */ false);
+    assertEquals(result.status(), Http.Status.OK);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
   }
 
   @Test
   public void sendFileWithFileName() throws IOException {
     Result result = Results.unauthorized().sendFile(file.toFile(), "foo.bar");
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"; filename*=utf-8''foo.bar");
   }
 
   @Test
   public void sendFileInlineWithFileName() throws IOException {
     Result result = Results.ok().sendFile(file.toFile(), true, "foo.bar");
     assertEquals(result.status(), Http.Status.OK);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"; filename*=utf-8''foo.bar");
+  }
+
+  @Test
+  public void sendFileWithFileNameHasSpecialChars() throws IOException {
+    Result result = Results.ok().sendFile(file.toFile(), true, "测 试.tmp");
+    assertEquals(result.status(), Http.Status.OK);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp");
   }
 }

--- a/framework/src/play/src/test/java/play/mvc/ResultsTest.java
+++ b/framework/src/play/src/test/java/play/mvc/ResultsTest.java
@@ -3,18 +3,37 @@
  */
 package play.mvc;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 
 import play.mvc.Http.HeaderNames;
 
 import static org.junit.Assert.*;
 
 public class ResultsTest {
+
+  private static Path file;
+
+  @BeforeClass
+  public static void createFile() throws Exception {
+    file = Paths.get("test.tmp");
+    Files.createFile(file);
+    Files.write(file, "Some content for the file".getBytes(), StandardOpenOption.APPEND);
+  }
+
+  @AfterClass
+  public static void deleteFile() throws IOException {
+    Files.deleteIfExists(file);
+  }
+
+  // -- Path tests
 
   @Test(expected = NullPointerException.class)
   public void shouldThrowNullPointerExceptionIfPathIsNull() throws IOException {
@@ -23,45 +42,92 @@ public class ResultsTest {
 
   @Test
   public void sendPathWithOKStatus() throws IOException {
-    Path file = Paths.get("test.tmp");
-    Files.createFile(file);
     Result result = Results.ok().sendPath(file);
-    Files.delete(file);
-
     assertEquals(result.status(), Http.Status.OK);
-    assertEquals("attachment; filename=\"test.tmp\"", result.header(HeaderNames.CONTENT_DISPOSITION).get());
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
   }
 
   @Test
   public void sendPathWithUnauthorizedStatus() throws IOException {
-    Path file = Paths.get("test.tmp");
-    Files.createFile(file);
     Result result = Results.unauthorized().sendPath(file);
-    Files.delete(file);
-
-    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
-  }
-
-  @Test
-  public void sendPathInlineWithUnauthorizedStatus() throws IOException {
-    Path file = Paths.get("test.tmp");
-    Files.createFile(file);
-    Result result = Results.unauthorized().sendPath(file, true);
-    Files.delete(file);
-
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
     assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
   }
 
   @Test
-  public void sendPathWithFileName() throws IOException {
-    Path file = Paths.get("test.tmp");
-    Files.createFile(file);
-    Result result = Results.unauthorized().sendPath(file, false, "foo.bar");
-    Files.delete(file);
-
+  public void sendPathAsAttachmentWithUnauthorizedStatus() throws IOException {
+    Result result = Results.unauthorized().sendPath(file, /*inline*/ false);
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"foo.bar\"");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
+  }
+
+  @Test
+  public void sendPathAsAttachmentWithOkStatus() throws IOException {
+    Result result = Results.unauthorized().sendPath(file, /* inline */ false);
+    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
+  }
+
+  @Test
+  public void sendPathWithFileName() throws IOException {
+    Result result = Results.unauthorized().sendPath(file, "foo.bar");
+    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
+  }
+
+  @Test
+  public void sendPathInlineWithFileName() throws IOException {
+    Result result = Results.unauthorized().sendPath(file, true, "foo.bar");
+    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
+  }
+
+  // -- File tests
+
+  @Test(expected = NullPointerException.class)
+  public void shouldThrowNullPointerExceptionIfFileIsNull() throws IOException {
+    Results.ok().sendFile(null);
+  }
+
+  @Test
+  public void sendFileWithOKStatus() throws IOException {
+    Result result = Results.ok().sendFile(file.toFile());
+    assertEquals(result.status(), Http.Status.OK);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
+  }
+
+  @Test
+  public void sendFileWithUnauthorizedStatus() throws IOException {
+    Result result = Results.unauthorized().sendFile(file.toFile());
+    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
+  }
+
+  @Test
+  public void sendFileAsAttachmentWithUnauthorizedStatus() throws IOException {
+    Result result = Results.unauthorized().sendFile(file.toFile(), /* inline */ false);
+    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
+  }
+
+  @Test
+  public void sendFileAsAttachmentWithOkStatus() throws IOException {
+    Result result = Results.unauthorized().sendFile(file.toFile(), /* inline */ false);
+    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
+  }
+
+  @Test
+  public void sendFileWithFileName() throws IOException {
+    Result result = Results.unauthorized().sendFile(file.toFile(), "foo.bar");
+    assertEquals(result.status(), Http.Status.UNAUTHORIZED);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
+  }
+
+  @Test
+  public void sendFileInlineWithFileName() throws IOException {
+    Result result = Results.ok().sendFile(file.toFile(), true, "foo.bar");
+    assertEquals(result.status(), Http.Status.OK);
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
   }
 }

--- a/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
@@ -304,7 +304,14 @@ object RangeResultSpec extends Specification {
       val stream = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3))
       val source = StreamConverters.fromInputStream(() => stream)
       val Result(ResponseHeader(_, headers, _), _) = RangeResult.ofSource(stream.available(), source, None, Some("video.mp4"), None)
-      headers must havePair("Content-Disposition" -> "attachment; filename=\"video.mp4\"")
+      headers must havePair("Content-Disposition" -> "attachment; filename=\"video.mp4\"; filename*=utf-8''video.mp4")
+    }
+
+    "support non-ISO-8859-1 filename in Content-Disposition header" in {
+      val stream = new java.io.ByteArrayInputStream(Array[Byte](1, 2, 3))
+      val source = StreamConverters.fromInputStream(() => stream)
+      val Result(ResponseHeader(_, headers, _), _) = RangeResult.ofSource(stream.available(), source, None, Some("测 试.tmp"), None)
+      headers must havePair("Content-Disposition" -> "attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp")
     }
 
     "support first byte position" in {
@@ -334,7 +341,7 @@ object RangeResultSpec extends Specification {
       val file = createFile(java.nio.file.Paths.get("path.mp4"))
       try {
         val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(_, _, contentType)) = RangeResult.ofPath(file.toPath, None, Some("video/mp4"))
-        headers must havePair("Content-Disposition" -> "attachment; filename=\"path.mp4\"")
+        headers must havePair("Content-Disposition" -> "attachment; filename=\"path.mp4\"; filename*=utf-8''path.mp4")
         contentType must beSome("video/mp4")
       } finally {
         java.nio.file.Files.delete(file.toPath)
@@ -345,7 +352,7 @@ object RangeResultSpec extends Specification {
       val file = createFile(java.nio.file.Paths.get("file.mp4"))
       try {
         val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(_, _, contentType)) = RangeResult.ofFile(file, None, Some("video/mp4"))
-        headers must havePair("Content-Disposition" -> "attachment; filename=\"file.mp4\"")
+        headers must havePair("Content-Disposition" -> "attachment; filename=\"file.mp4\"; filename*=utf-8''file.mp4")
         contentType must beSome("video/mp4")
       } finally {
         java.nio.file.Files.delete(file.toPath)

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -158,56 +158,56 @@ object ResultsSpec extends Specification {
       val rh = Ok.sendFile(file).header
 
       (rh.status aka "status" must_== OK) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="${fileName}""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
     }
 
     "support sending a file with Unauthorized status" in withFile { (file, fileName) =>
       val rh = Unauthorized.sendFile(file).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="${fileName}""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
     }
 
-    "support sending a file inline with Unauthorized status" in withFile { (file, fileName) =>
-      val rh = Unauthorized.sendFile(file, inline = true).header
+    "support sending a file attached with Unauthorized status" in withFile { (file, fileName) =>
+      val rh = Unauthorized.sendFile(file, inline = false).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="${fileName}""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName""""))
     }
 
     "support sending a file with PaymentRequired status" in withFile { (file, fileName) =>
       val rh = PaymentRequired.sendFile(file).header
 
       (rh.status aka "status" must_== PAYMENT_REQUIRED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="${fileName}""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
     }
 
-    "support sending a file inline with PaymentRequired status" in withFile { (file, fileName) =>
-      val rh = PaymentRequired.sendFile(file, inline = true).header
+    "support sending a file attached with PaymentRequired status" in withFile { (file, fileName) =>
+      val rh = PaymentRequired.sendFile(file, inline = false).header
 
       (rh.status aka "status" must_== PAYMENT_REQUIRED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="${fileName}""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName""""))
     }
 
     "support sending a path with Ok status" in withPath { (file, fileName) =>
       val rh = Ok.sendPath(file).header
 
       (rh.status aka "status" must_== OK) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="${fileName}""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
     }
 
     "support sending a path with Unauthorized status" in withPath { (file, fileName) =>
       val rh = Unauthorized.sendPath(file).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="${fileName}""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
     }
 
-    "support sending a path inline with Unauthorized status" in withPath { (file, fileName) =>
-      val rh = Unauthorized.sendPath(file, inline = true).header
+    "support sending a path attached with Unauthorized status" in withPath { (file, fileName) =>
+      val rh = Unauthorized.sendPath(file, inline = false).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="${fileName}""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName""""))
     }
 
     "allow checking content length" in withPath { (file, fileName) =>

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -158,56 +158,70 @@ object ResultsSpec extends Specification {
       val rh = Ok.sendFile(file).header
 
       (rh.status aka "status" must_== OK) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName"; filename*=utf-8''$fileName"""))
     }
 
     "support sending a file with Unauthorized status" in withFile { (file, fileName) =>
       val rh = Unauthorized.sendFile(file).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName"; filename*=utf-8''$fileName"""))
     }
 
     "support sending a file attached with Unauthorized status" in withFile { (file, fileName) =>
       val rh = Unauthorized.sendFile(file, inline = false).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName"; filename*=utf-8''$fileName"""))
     }
 
     "support sending a file with PaymentRequired status" in withFile { (file, fileName) =>
       val rh = PaymentRequired.sendFile(file).header
 
       (rh.status aka "status" must_== PAYMENT_REQUIRED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName"; filename*=utf-8''$fileName"""))
     }
 
     "support sending a file attached with PaymentRequired status" in withFile { (file, fileName) =>
       val rh = PaymentRequired.sendFile(file, inline = false).header
 
       (rh.status aka "status" must_== PAYMENT_REQUIRED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName"; filename*=utf-8''$fileName"""))
+    }
+
+    "support sending a file with filename" in withFile { (file, fileName) =>
+      val rh = Ok.sendFile(file, fileName = _ => "测 试.tmp").header
+
+      (rh.status aka "status" must_== OK) and
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="测 试.tmp"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp"""))
     }
 
     "support sending a path with Ok status" in withPath { (file, fileName) =>
       val rh = Ok.sendPath(file).header
 
       (rh.status aka "status" must_== OK) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName"; filename*=utf-8''$fileName"""))
     }
 
     "support sending a path with Unauthorized status" in withPath { (file, fileName) =>
       val rh = Unauthorized.sendPath(file).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName"; filename*=utf-8''$fileName"""))
     }
 
     "support sending a path attached with Unauthorized status" in withPath { (file, fileName) =>
       val rh = Unauthorized.sendPath(file, inline = false).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName""""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName"; filename*=utf-8''$fileName"""))
+    }
+
+    "support sending a path with filename" in withPath { (file, fileName) =>
+      val rh = Ok.sendPath(file, fileName = _ => "测 试.tmp").header
+
+      (rh.status aka "status" must_== OK) and
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="测 试.tmp"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp"""))
     }
 
     "allow checking content length" in withPath { (file, fileName) =>


### PR DESCRIPTION

## Purpose

Backports #5981 and #6042.
