### PR TITLE
Trigger 400 error if path is null

### DIFF
--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -59,7 +59,10 @@ private[server] class NettyModelConversion(forwardedHeaderHandler: ForwardedHead
         }
       }
       // wrapping into URI to handle absoluteURI
-      val path = new URI(uri.path()).getRawPath
+      val path = Option(new URI(uri.path).getRawPath).getOrElse {
+        // if the URI has no path, this will trigger a 400 error
+        throw new IllegalStateException(s"Cannot parse path from URI: ${uri.path}")
+      }
       createRequestHeader(request, requestId, path, parameters, remoteAddress, sslHandler)
     }
   }


### PR DESCRIPTION
If the path of the URI is null, it can cause NPEs in the router and in user code. This normally doesn't happen in an HTTP request, but it seems it can happen if you send a URI which does not have a path component defined, for example:
```
GET mailto:foo@example.com HTTP/1.1
```
It seems appropriate to send a 400 error in this case. I've done that here by throwing an exception.

This was discussed on the mailing list as well: https://groups.google.com/forum/#!topic/play-framework/-bsLA-UTyis.