### PR TITLE
Don't throw NPE when variables in a Form or a Field are null

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/Form.java
+++ b/framework/src/play-java/src/main/java/play/data/Form.java
@@ -594,10 +594,10 @@ public class Form<T> {
         if (arguments != null) {
             return arguments.stream().map(arg -> {
                     if (arg instanceof String) {
-                        return messagesApi.get(lang, (String)arg);
+                        return messagesApi != null ? messagesApi.get(lang, (String)arg) : (String)arg;
                     }
                     if (arg instanceof List) {
-                        return ((List<?>) arg).stream().map(key -> messagesApi.get(lang, (String)key)).collect(Collectors.toList());
+                        return ((List<?>) arg).stream().map(key -> messagesApi != null ? messagesApi.get(lang, (String)key) : (String)key).collect(Collectors.toList());
                     }
                     return arg;
                 }).collect(Collectors.toList());
@@ -710,8 +710,12 @@ public class Form<T> {
                 if (beanWrapper.isReadableProperty(objectKey)) {
                     Object oValue = beanWrapper.getPropertyValue(objectKey);
                     if (oValue != null) {
-                        final String objectKeyFinal = objectKey;
-                        fieldValue = withRequestLocale(() -> formatters.print(beanWrapper.getPropertyTypeDescriptor(objectKeyFinal), oValue));
+                        if(formatters != null) {
+                            final String objectKeyFinal = objectKey;
+                            fieldValue = withRequestLocale(() -> formatters.print(beanWrapper.getPropertyTypeDescriptor(objectKeyFinal), oValue));
+                        } else {
+                            fieldValue = oValue.toString();
+                        }
                     }
                 }
             }
@@ -763,7 +767,7 @@ public class Form<T> {
             classType = beanWrapper.getPropertyType(leafKey.substring(0, p));
             leafKey = leafKey.substring(p + 1);
         }
-        if (classType != null) {
+        if (classType != null && this.validator != null) {
             BeanDescriptor beanDescriptor = this.validator.getConstraintsForClass(classType);
             if (beanDescriptor != null) {
                 PropertyDescriptor property = beanDescriptor.getConstraintsForProperty(leafKey);
@@ -886,6 +890,9 @@ public class Form<T> {
          */
         @SuppressWarnings("rawtypes")
         public List<Integer> indexes() {
+            if(form == null) {
+                return new ArrayList<>(0);
+            }
             return form.value().map((Function<Object, List<Integer>>) value -> {
                 BeanWrapper beanWrapper = new BeanWrapperImpl(value);
                 beanWrapper.setAutoGrowNestedPaths(true);

--- a/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
+++ b/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
@@ -32,16 +32,16 @@ object PlayMagicForJava {
     new play.api.data.Field(
       null,
       jField.name,
-      jField.constraints.asScala.map { jT =>
+      Option(jField.constraints).map(c => c.asScala.map { jT =>
         jT._1 -> jT._2.asScala
-      },
+      }).getOrElse(Nil),
       Option(jField.format).map(f => f._1 -> f._2.asScala),
-      jField.errors.asScala.map { jE =>
+      Option(jField.errors).map(e => e.asScala.map { jE =>
         play.api.data.FormError(
           jE.key,
           jE.messages.asScala,
           jE.arguments.asScala)
-      },
+      }).getOrElse(Nil),
       Option(jField.value)) {
 
       override def apply(key: String) = {

--- a/framework/src/play-java/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/DynamicFormSpec.scala
@@ -73,5 +73,22 @@ object DynamicFormSpec extends Specification {
       form("foo").value() must_== "bar"
     }
 
+    "don't throw NullPointerException when all components of form are null" in {
+      val form = new DynamicForm(null, null, null).fill(Map("foo" -> "bar"))
+      form("foo").value() must_== "bar"
+    }
+
+    "convert jField to scala Field when all components of jField are null" in {
+      val jField = new play.data.Form.Field(null, null, null, null, null, null)
+      jField.indexes() must_== new java.util.ArrayList(0)
+
+      val sField = javaFieldtoScalaField(jField)
+      sField.name must_== null
+      sField.id must_== ""
+      sField.label must_== ""
+      sField.constraints must_== Nil
+      sField.errors must_== Nil
+    }
+
   }
 }

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -286,7 +286,7 @@ case class Field(private val form: Form[_], name: String, constraints: Seq[(Stri
   /**
    * The field ID - the same as the field name but with '.' replaced by '_'.
    */
-  lazy val id: String = name.replace('.', '_').replace('[', '_').replace("]", "")
+  lazy val id: String = Option(name).map(n => n.replace('.', '_').replace('[', '_').replace("]", "")).getOrElse("")
 
   /**
    * Returns the first error associated with this field, if it exists.
@@ -319,7 +319,7 @@ case class Field(private val form: Form[_], name: String, constraints: Seq[(Stri
   /**
    * The label for the field.  Transforms repeat names from foo[0] etc to foo.0.
    */
-  lazy val label: String = name.replaceAll("\\[(\\d+)\\]", ".$1")
+  lazy val label: String = Option(name).map(n => n.replaceAll("\\[(\\d+)\\]", ".$1")).getOrElse("")
 
 }
 


### PR DESCRIPTION
Just a small fix.
We have a test where we create a `DynamicForm` or `Field` without any injected components (no `MessagesApi`, `Validator`, etc.)
When we want to access a field on this dummy `DynamicForm` we get a `NullPointerException` because no validator is set.
E.g. this line throws the NPE:
```
new DynamicForm(null, null, null).field("somefield");
```

Please backport before the `2.5.3` release, thanks!