### PR TITLE
remove redunant call to deprecated API in TestingWebServices docs

### DIFF
--- a/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
@@ -50,7 +50,6 @@ object GitHubClientSpec extends Specification with NoTimeConversions {
           Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
         }
       } { implicit port =>
-        implicit val materializer = Play.current.materializer
         WsTestClient.withClient { client =>
           val result = Await.result(
             new GitHubClient(client, "").repositories(), 10.seconds)
@@ -104,7 +103,6 @@ object ScalaTestingWebServiceClients extends Specification with NoTimeConversion
           Results.Ok.sendResource("github/repositories.json")
         }
       } { implicit port =>
-        implicit val materializer = Play.current.materializer
         //#send-resource
         WsTestClient.withClient { client =>
           Await.result(new GitHubClient(client, "").repositories(), 10.seconds) must_== Seq("octocat/Hello-World")
@@ -126,7 +124,6 @@ object ScalaTestingWebServiceClients extends Specification with NoTimeConversion
             Results.Ok.sendResource("github/repositories.json")
           }
         } { implicit port =>
-          implicit val materializer = Play.current.materializer
           WsTestClient.withClient { client =>
             block(new GitHubClient(client, ""))
           }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [N/A] Have you added copyright headers to new files?
* [N/A] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [N/A] Have you added tests for any changed functionality?

## Fixes

Fixes #6105

## Purpose

Fixes call to deprecated API in documentation 

## Background Context

Following the documentation caused me to use deprecated API which caused build warnings



