### PR TITLE
ErrorHandlers should be singletons in docs

### DIFF
--- a/documentation/manual/working/javaGuide/main/application/code/javaguide/application/def/ErrorHandler.java
+++ b/documentation/manual/working/javaGuide/main/application/code/javaguide/application/def/ErrorHandler.java
@@ -16,6 +16,7 @@ import javax.inject.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+@Singleton
 public class ErrorHandler extends DefaultHttpErrorHandler {
 
     @Inject

--- a/documentation/manual/working/javaGuide/main/application/code/javaguide/application/root/ErrorHandler.java
+++ b/documentation/manual/working/javaGuide/main/application/code/javaguide/application/root/ErrorHandler.java
@@ -9,7 +9,9 @@ import play.mvc.*;
 import play.mvc.Http.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import javax.inject.Singleton;
 
+@Singleton
 public class ErrorHandler implements HttpErrorHandler {
     public CompletionStage<Result> onClientError(RequestHeader request, int statusCode, String message) {
         return CompletableFuture.completedFuture(

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
@@ -50,7 +50,9 @@ import play.api.http.HttpErrorHandler
 import play.api.mvc._
 import play.api.mvc.Results._
 import scala.concurrent._
+import javax.inject.Singleton;
 
+@Singleton
 class ErrorHandler extends HttpErrorHandler {
 
   def onClientError(request: RequestHeader, statusCode: Int, message: String) = {
@@ -79,6 +81,7 @@ import play.api.mvc.Results._
 import play.api.routing.Router
 import scala.concurrent._
 
+@Singleton
 class ErrorHandler @Inject() (
     env: Environment,
     config: Configuration,


### PR DESCRIPTION
Play's own `DefaultHttpErrorHandler` [is a singleton](https://github.com/playframework/playframework/blob/fc86a2e3993ca6cdc80d80ef937712d31d6e6c06/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala#L70-L71) as well.