### PR TITLE
Prefer constructor injection in documentation

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/code/detailedtopics/httpec/MyController.java
+++ b/documentation/manual/working/commonGuide/configuration/code/detailedtopics/httpec/MyController.java
@@ -12,8 +12,14 @@ import javax.inject.Inject;
 import java.util.concurrent.CompletionStage;
 
 public class MyController extends Controller {
-    @Inject HttpExecutionContext ec;
-    @Inject WSClient ws;
+    private HttpExecutionContext ec;
+    private WSClient ws;
+
+    @Inject
+    public MyController(HttpExecutionContext ec, WSClient ws) {
+        this.ec = ec;
+        this.ws = ws;
+    }
 
     public CompletionStage<Result> index() {
         String checkUrl = request().getQueryString("url");

--- a/documentation/manual/working/commonGuide/filters/code/GzipEncoding.scala
+++ b/documentation/manual/working/commonGuide/filters/code/GzipEncoding.scala
@@ -46,7 +46,7 @@ object GzipEncoding extends PlaySpecification {
       running(app) {
         implicit val mat = ActorMaterializer()(app.actorSystem)
 
-        val filter = (new CustomFilters).gzipFilter
+        val filter = (new CustomFilters(mat)).filters()(0)
 
         header(CONTENT_ENCODING,
           filter(Action(Results.Ok("foo")))(gzipRequest).run()

--- a/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/gzipencoding/CustomFilters.java
+++ b/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/gzipencoding/CustomFilters.java
@@ -13,17 +13,21 @@ import javax.inject.Inject;
 
 public class CustomFilters implements HttpFilters {
 
-    @Inject Materializer materializer;
+    private EssentialFilter[] filters;
 
-    //#gzip-filter
-    GzipFilter gzipFilter = new GzipFilter(
-      new GzipFilterConfig().withShouldGzip((req, res) ->
-        res.body().contentType().orElse("").startsWith("text/html")
-      ), materializer
-    );
-    //#gzip-filter
+    @Inject
+    public CustomFilters(Materializer materializer) {
+        //#gzip-filter
+        GzipFilter gzipFilter = new GzipFilter(
+          new GzipFilterConfig().withShouldGzip((req, res) ->
+            res.body().contentType().orElse("").startsWith("text/html")
+          ), materializer
+        );
+        //#gzip-filter
+        filters = new EssentialFilter[] { gzipFilter.asJava() };
+    }
 
     public EssentialFilter[] filters() {
-        return new EssentialFilter[] { gzipFilter.asJava() };
+        return filters;
     }
 }

--- a/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/gzipencoding/Filters.java
+++ b/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/gzipencoding/Filters.java
@@ -12,11 +12,15 @@ import javax.inject.Inject;
 
 public class Filters implements HttpFilters {
 
+    private EssentialFilter[] filters;
+
     @Inject
-    GzipFilter gzipFilter;
+    public Filters(GzipFilter gzipFilter) {
+        filters = new EssentialFilter[] { gzipFilter.asJava() };
+    }
 
     public EssentialFilter[] filters() {
-        return new EssentialFilter[] { gzipFilter.asJava() };
+        return filters;
     }
 }
 //#filters

--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/ConfiguredActor.java
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/ConfiguredActor.java
@@ -11,7 +11,12 @@ import javax.inject.Inject;
 
 public class ConfiguredActor extends UntypedActor {
 
-    @Inject Configuration configuration;
+    private Configuration configuration;
+
+    @Inject
+    public ConfiguredActor(Configuration configuration) {
+        this.configuration = configuration;
+    }
 
     @Override
     public void onReceive(Object message) throws Exception {

--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/ParentActor.java
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/ParentActor.java
@@ -12,7 +12,12 @@ import javax.inject.Inject;
 
 public class ParentActor extends UntypedActor implements InjectedActorSupport {
 
-    @Inject ConfiguredChildActorProtocol.Factory childFactory;
+    private ConfiguredChildActorProtocol.Factory childFactory;
+
+    @Inject
+    public ParentActor(ConfiguredChildActorProtocol.Factory childFactory) {
+        this.childFactory = childFactory;
+    }
 
     @Override
     public void onReceive(Object message) throws Exception {

--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/inject/Application.java
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/inject/Application.java
@@ -17,8 +17,12 @@ import static akka.pattern.Patterns.ask;
 
 public class Application extends Controller {
 
-    @Inject @Named("configured-actor")
-    ActorRef configuredActor;
+    private ActorRef configuredActor;
+
+    @Inject
+    public Application(@Named("configured-actor") ActorRef configuredActor) {
+       this.configuredActor = configuredActor;
+    }
 
     public CompletionStage<Result> getConfig() {
         return FutureConverters.toJava(ask(configuredActor,

--- a/documentation/manual/working/javaGuide/main/cache/code/javaguide/cache/inject/Application.java
+++ b/documentation/manual/working/javaGuide/main/cache/code/javaguide/cache/inject/Application.java
@@ -10,7 +10,12 @@ import javax.inject.Inject;
 
 public class Application extends Controller {
 
-    @Inject CacheApi cache;
+    private CacheApi cache;
+
+    @Inject
+    public Application(CacheApi cache) {
+        this.cache = cache;
+    }
 
     // ...
 }

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
@@ -25,9 +25,9 @@ To use constructor injection:
 
 @[constructor](code/javaguide/di/constructor/MyComponent.java)
 
-For brevity, in the Play documentation, we use field injection, but in Play itself, we use constructor injection.
+Field injection is shorter, but we recommend using constructor injection in your application.  It is the most testable, since in a unit test you need to pass all the constructor arguments to create an instance of your class, and the compiler makes sure the dependencies are all there.  It is also easy to understand what is going on, since there is no "magic" setting of fields going on.  The DI framework is just automating the same constructor call you could write manually.
 
-Constructor injection is the most testable, since all the dependencies are required up front to construct an instance of the class. Guice also has several other [types of injections](https://github.com/google/guice/wiki/Injections) which may be useful in some cases. If you are migrating an application that uses statics, you may find its static injection support useful.
+Guice also has several other [types of injections](https://github.com/google/guice/wiki/Injections) which may be useful in some cases. If you are migrating an application that uses statics, you may find its static injection support useful.
 
 ## Dependency injecting controllers
 

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/guice/CircularDependencies.java
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/guice/CircularDependencies.java
@@ -11,13 +11,19 @@ class CircularDependencies {
 class NoProvider {
 //#circular
 public class Foo {
-  @Inject Bar bar;
+  @Inject public Foo(Bar bar) {
+    //...
+  }
 }
 public class Bar {
-  @Inject Baz baz;
+  @Inject public Bar(Baz baz) {
+    // ...
+  }
 }
 public class Baz {
-  @Inject Foo foo;
+  @Inject public Baz(Foo foo) {
+    // ...
+  }
 }
 //#circular
 }
@@ -25,13 +31,19 @@ public class Baz {
 class WithProvider {
 //#circular-provider
 public class Foo {
-  @Inject Bar bar;
+  @Inject public Foo(Bar bar) {
+    // ...
+  }
 }
 public class Bar {
-  @Inject Baz baz;
+  @Inject public Bar(Baz baz) {
+    // ...
+  }
 }
 public class Baz {
-  @Inject Provider<Foo> fooProvider;
+  @Inject public Baz(Provider<Foo> fooProvider) {
+    // ...
+  }
 }
 //#circular-provider
 }

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaBodyParsers.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaBodyParsers.java
@@ -75,8 +75,15 @@ public class JavaBodyParsers extends WithApplication {
 
     //#composing-class
     public static class UserBodyParser implements BodyParser<User> {
-        @Inject BodyParser.Json jsonParser;
-        @Inject Executor executor;
+
+        private BodyParser.Json jsonParser;
+        private Executor executor;
+
+        @Inject
+        public UserBodyParser(BodyParser.Json jsonParser, Executor executor) {
+            this.jsonParser = jsonParser;
+            this.executor = executor;
+        }
     //#composing-class
 
         //#composing-apply
@@ -145,8 +152,15 @@ public class JavaBodyParsers extends WithApplication {
 
     //#forward-body
     public static class ForwardingBodyParser implements BodyParser<WSResponse> {
-        @Inject WSClient ws;
-        @Inject Executor executor;
+        private WSClient ws;
+        private Executor executor;
+
+        @Inject
+        public ForwardingBodyParser(WSClient ws, Executor executor) {
+            this.ws = ws;
+            this.executor = executor;
+        }
+
         String url = "http://example.com";
 
         public Accumulator<ByteString, F.Either<Result, WSResponse>> apply(RequestHeader request) {
@@ -166,7 +180,12 @@ public class JavaBodyParsers extends WithApplication {
 
     //#csv
     public static class CsvBodyParser implements BodyParser<List<List<String>>> {
-        @Inject Executor executor;
+        private Executor executor;
+
+        @Inject
+        public CsvBodyParser(Executor executor) {
+            this.executor = executor;
+        }
 
         @Override
         public Accumulator<ByteString, F.Either<Result, List<List<String>>>> apply(RequestHeader request) {

--- a/documentation/manual/working/javaGuide/main/sql/code/JavaApplicationDatabase.java
+++ b/documentation/manual/working/javaGuide/main/sql/code/JavaApplicationDatabase.java
@@ -9,6 +9,13 @@ import play.mvc.*;
 import play.db.*;
 
 class JavaApplicationDatabase extends Controller {
-    @Inject Database db;
+
+    private Database db;
+
+    @Inject
+    public JavaApplicationDatabase(Database db) {
+        this.db = db;
+    }
+
     // ...
 }

--- a/documentation/manual/working/javaGuide/main/sql/code/JavaJdbcConnection.java
+++ b/documentation/manual/working/javaGuide/main/sql/code/JavaJdbcConnection.java
@@ -12,7 +12,12 @@ import play.db.Database;
 
 // inject "orders" database instead of "default"
 class JavaJdbcConnection extends Controller {
-    @Inject Database db;
+    private Database db;
+
+    @Inject
+    public JavaJdbcConnection(Database db) {
+        this.db = db;
+    }
     // get jdbc connection
     Connection connection = db.getConnection();
 }

--- a/documentation/manual/working/javaGuide/main/sql/code/JavaNamedDatabase.java
+++ b/documentation/manual/working/javaGuide/main/sql/code/JavaNamedDatabase.java
@@ -11,6 +11,12 @@ import play.db.Database;
 
 // inject "orders" database instead of "default"
 class JavaNamedDatabase extends Controller {
-    @Inject @NamedDatabase("orders") Database db;
+    private Database db;
+
+    @Inject
+    public JavaNamedDatabase(@NamedDatabase("orders") Database db) {
+        this.db = db;
+    }
+
     // do whatever you need with the db
 }

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/GitHubClient.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/GitHubClient.java
@@ -13,7 +13,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import play.libs.ws.WSClient;
 
 class GitHubClient {
-    @Inject WSClient ws;
+    private WSClient ws;
+
+    @Inject
+    public GitHubClient(WSClient ws) {
+        this.ws = ws;
+    }
+
     String baseUrl = "https://api.github.com";
 
     public CompletionStage<List<String>> getRepositories() {

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/GitHubClientTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/GitHubClientTest.java
@@ -38,9 +38,8 @@ public class GitHubClientTest {
 
         server = Server.forRouter(router);
         ws = WS.newClient(server.httpPort());
-        client = new GitHubClient();
+        client = new GitHubClient(ws);
         client.baseUrl = "";
-        client.ws = ws;
     }
 
     @After

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/InjectionTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/InjectionTest.java
@@ -40,8 +40,8 @@ public class InjectionTest {
       GuiceApplicationBuilder builder = new GuiceApplicationLoader()
           .builder(new Context(Environment.simple()))
           .overrides(testModule);
-      Guice.createInjector(builder.applicationModule()).injectMembers(this);      
-      
+      Guice.createInjector(builder.applicationModule()).injectMembers(this);
+
       Helpers.start(application);
     }
 

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/JavaTestingWebServiceClients.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/JavaTestingWebServiceClients.java
@@ -53,9 +53,8 @@ public class JavaTestingWebServiceClients {
         Server server = Server.forRouter(router);
 
         WSClient ws = WS.newClient(server.httpPort());
-        GitHubClient client = new GitHubClient();
+        GitHubClient client = new GitHubClient(ws);
         client.baseUrl = "";
-        client.ws = ws;
 
         try {
             List<String> repos = client.getRepositories().toCompletableFuture().get(10, TimeUnit.SECONDS);


### PR DESCRIPTION
As discussed in #5837, constructor injection is easier to understand for newbies to DI, and is the right way to use DI in a real application, so I've converted all the documentation examples to use constructor injection instead of field injection.