### PR TITLE
Provide helper for creating HttpFilters

### DIFF
--- a/documentation/manual/working/commonGuide/filters/code/AllowedHostsFilter.scala
+++ b/documentation/manual/working/commonGuide/filters/code/AllowedHostsFilter.scala
@@ -6,10 +6,9 @@ package detailedtopics.configuration.allowedhosts.sapi
 //#filters
 import javax.inject.Inject
 
-import play.api.http.HttpFilters
+import play.api.http.DefaultHttpFilters
 import play.filters.hosts.AllowedHostsFilter
 
-class Filters @Inject() (allowedHostsFilter: AllowedHostsFilter) extends HttpFilters {
-  def filters = Seq(allowedHostsFilter)
-}
+class Filters @Inject() (allowedHostsFilter: AllowedHostsFilter)
+  extends DefaultHttpFilters(allowedHostsFilter)
 //#filters

--- a/documentation/manual/working/commonGuide/filters/code/CorsFilter.scala
+++ b/documentation/manual/working/commonGuide/filters/code/CorsFilter.scala
@@ -6,10 +6,9 @@ package detailedtopics.configuration.cors.sapi
 //#filters
 import javax.inject.Inject
 
-import play.api.http.HttpFilters
+import play.api.http.DefaultHttpFilters
 import play.filters.cors.CORSFilter
 
-class Filters @Inject() (corsFilter: CORSFilter) extends HttpFilters {
-  def filters = Seq(corsFilter)
-}
+class Filters @Inject() (corsFilter: CORSFilter)
+  extends DefaultHttpFilters(corsFilter)
 //#filters

--- a/documentation/manual/working/commonGuide/filters/code/GzipEncoding.scala
+++ b/documentation/manual/working/commonGuide/filters/code/GzipEncoding.scala
@@ -12,12 +12,11 @@ object GzipEncoding extends PlaySpecification {
   //#filters
   import javax.inject.Inject
 
-  import play.api.http.HttpFilters
+  import play.api.http.DefaultHttpFilters
   import play.filters.gzip.GzipFilter
 
-  class Filters @Inject() (gzipFilter: GzipFilter) extends HttpFilters {
-    def filters = Seq(gzipFilter)
-  }
+  class Filters @Inject() (gzipFilter: GzipFilter)
+    extends DefaultHttpFilters(gzipFilter)
   //#filters
 
   "gzip filter" should {

--- a/documentation/manual/working/commonGuide/filters/code/SecurityHeaders.scala
+++ b/documentation/manual/working/commonGuide/filters/code/SecurityHeaders.scala
@@ -9,12 +9,10 @@ object SecurityHeaders {
   //#filters
   import javax.inject.Inject
 
-  import play.api.http.HttpFilters
+  import play.api.http.DefaultHttpFilters
   import play.filters.headers.SecurityHeadersFilter
 
-  class Filters @Inject() (securityHeadersFilter: SecurityHeadersFilter) extends HttpFilters {
-    def filters = Seq(securityHeadersFilter)
-  }
+  class Filters @Inject() (securityHeadersFilter: SecurityHeadersFilter) extends DefaultHttpFilters(securityHeadersFilter)
   //#filters
 
   import play.api.mvc.Action

--- a/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/cors/Filters.java
+++ b/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/cors/Filters.java
@@ -6,17 +6,13 @@ package detailedtopics.configuration.cors;
 //#filters
 import play.mvc.EssentialFilter;
 import play.filters.cors.CORSFilter;
-import play.http.HttpFilters;
+import play.http.DefaultHttpFilters;
 
 import javax.inject.Inject;
 
-public class Filters implements HttpFilters {
-
-    @Inject
-    CORSFilter corsFilter;
-
-    public EssentialFilter[] filters() {
-        return new EssentialFilter[] { corsFilter.asJava() };
+public class Filters extends DefaultHttpFilters {
+    @Inject public Filters(CORSFilter corsFilter) {
+        super(corsFilter);
     }
 }
 //#filters

--- a/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/headers/Filters.java
+++ b/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/headers/Filters.java
@@ -6,17 +6,13 @@ package detailedtopics.configuration.headers;
 //#filters
 import play.mvc.EssentialFilter;
 import play.filters.headers.SecurityHeadersFilter;
-import play.http.HttpFilters;
+import play.http.DefaultHttpFilters;
 
 import javax.inject.Inject;
 
-public class Filters implements HttpFilters {
-
-    @Inject
-    SecurityHeadersFilter securityHeadersFilter;
-
-    public EssentialFilter[] filters() {
-        return new EssentialFilter[] { securityHeadersFilter.asJava() };
+public class Filters extends DefaultHttpFilters {
+    @Inject public Filters(SecurityHeadersFilter securityHeadersFilter) {
+        super(securityHeadersFilter);
     }
 }
 //#filters

--- a/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/hosts/Filters.java
+++ b/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/hosts/Filters.java
@@ -6,17 +6,13 @@ package detailedtopics.configuration.hosts;
 //#filters
 import play.mvc.EssentialFilter;
 import play.filters.hosts.AllowedHostsFilter;
-import play.http.HttpFilters;
+import play.http.DefaultHttpFilters;
 
 import javax.inject.Inject;
 
-public class Filters implements HttpFilters {
-
-    @Inject
-    AllowedHostsFilter allowedHostsFilter;
-
-    public EssentialFilter[] filters() {
-        return new EssentialFilter[] { allowedHostsFilter.asJava() };
+public class Filters extends DefaultHttpFilters {
+    @Inject public Filters(AllowedHostsFilter allowedHostsFilter) {
+        super(allowedHostsFilter);
     }
 }
 //#filters

--- a/documentation/manual/working/javaGuide/main/application/JavaHttpFilters.md
+++ b/documentation/manual/working/javaGuide/main/application/JavaHttpFilters.md
@@ -27,7 +27,7 @@ We save a timestamp before invoking the next filter in the chain. Invoking the n
 
 ## Using filters
 
-The simplest way to use a filter is to provide an implementation of the [`HttpFilters`](api/java/play/http/HttpFilters.html) interface in the root package called `Filters`:
+The simplest way to use a filter is to provide an implementation of the [`HttpFilters`](api/java/play/http/HttpFilters.html) interface in the root package called `Filters`. Typically you should extend the [`DefaultHttpFilters`](api/java/play/http/DefaultHttpFilters.html) class and pass your filters to the varargs constructor:
 
 @[filters](code/javaguide/application/httpfilters/Filters.java)
 

--- a/documentation/manual/working/javaGuide/main/application/code/javaguide/application/httpfilters/Filters.java
+++ b/documentation/manual/working/javaGuide/main/application/code/javaguide/application/httpfilters/Filters.java
@@ -5,24 +5,14 @@ package javaguide.application.httpfilters;
 
 // #filters
 import play.mvc.EssentialFilter;
-import play.http.HttpFilters;
+import play.http.DefaultHttpFilters;
 import play.filters.gzip.GzipFilter;
 import javax.inject.Inject;
 
-public class Filters implements HttpFilters {
-
-  private final GzipFilter gzip;
-  private final LoggingFilter logging;
-
+public class Filters extends DefaultHttpFilters {
   @Inject
   public Filters(GzipFilter gzip, LoggingFilter logging) {
-    this.gzip = gzip;
-    this.logging = logging;
-  }
-
-  @Override
-  public EssentialFilter[] filters() {
-    return new EssentialFilter[] { gzip.asJava(), logging.asJava() };
+    super(gzip, logging);
   }
 }
 //#filters

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/csrf/Filters.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/csrf/Filters.java
@@ -4,18 +4,15 @@
 package javaguide.forms.csrf;
 
 //#filters
-import play.http.HttpFilters;
+import play.http.DefaultHttpFilters;
 import play.mvc.EssentialFilter;
 import play.filters.csrf.CSRFFilter;
 import javax.inject.Inject;
 
-public class Filters implements HttpFilters {
-
-    @Inject CSRFFilter csrfFilter;
-
-    @Override
-    public EssentialFilter[] filters() {
-        return new EssentialFilter[] { csrfFilter.asJava() };
+public class Filters extends DefaultHttpFilters {
+    @Inject
+    public Filters(CSRFFilter csrfFilter) {
+      super(csrfFilter);
     }
 }
 //#filters

--- a/documentation/manual/working/scalaGuide/main/application/ScalaHttpFilters.md
+++ b/documentation/manual/working/scalaGuide/main/application/ScalaHttpFilters.md
@@ -27,7 +27,7 @@ We save a timestamp before invoking the next filter in the chain. Invoking the n
 
 ## Using filters
 
-The simplest way to use a filter is to provide an implementation of the [`HttpFilters`](api/scala/play/api/http/HttpFilters.html) trait in the root package:
+The simplest way to use a filter is to provide an implementation of the [`HttpFilters`](api/scala/play/api/http/HttpFilters.html) trait in the root package. Typically you should extend the [`DefaultHttpFilters`](api/scala/play/api/http/DefaultHttpFilters.html) class and pass your filters to the varargs constructor:
 
 @[filters](code/ScalaHttpFilters.scala)
 

--- a/documentation/manual/working/scalaGuide/main/application/code/ScalaHttpFilters.scala
+++ b/documentation/manual/working/scalaGuide/main/application/code/ScalaHttpFilters.scala
@@ -40,15 +40,12 @@ import simple.LoggingFilter
 
 // #filters
 import javax.inject.Inject
-import play.api.http.HttpFilters
+import play.api.http.DefaultHttpFilters
 import play.filters.gzip.GzipFilter
 
 class Filters @Inject() (
   gzip: GzipFilter,
   log: LoggingFilter
-) extends HttpFilters {
-
-  val filters = Seq(gzip, log)
-}
+) extends DefaultHttpFilters(gzip, log)
 //#filters
 }

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaCsrf.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaCsrf.scala
@@ -34,13 +34,12 @@ object ScalaCsrf extends PlaySpecification {
   "Play's CSRF protection" should {
     "allow global configuration" in new WithApplication() {
       //#http-filters
-      import play.api.http.HttpFilters
+      import play.api.http.DefaultHttpFilters
       import play.filters.csrf.CSRFFilter
       import javax.inject.Inject
 
-      class Filters @Inject() (csrfFilter: CSRFFilter) extends HttpFilters {
-        def filters = Seq(csrfFilter)
-      }
+      class Filters @Inject() (csrfFilter: CSRFFilter)
+        extends DefaultHttpFilters(csrfFilter)
       //#http-filters
       ok
     }
@@ -61,7 +60,7 @@ object ScalaCsrf extends PlaySpecification {
 
     def tokenFormAction(implicit app: Application) = addToken(Action { implicit request =>
       Ok(scalaguide.forms.html.csrf())
-    }) 
+    })
 
     "allow rendering a token in a query string" in new WithApplication() {
       val originalToken = Crypto.generateSignedToken

--- a/framework/src/play/src/main/java/play/http/DefaultHttpFilters.java
+++ b/framework/src/play/src/main/java/play/http/DefaultHttpFilters.java
@@ -1,0 +1,22 @@
+package play.http;
+
+import java.util.Arrays;
+
+import play.mvc.EssentialFilter;
+
+/**
+ * Helper class which has a varargs constructor taking the filters. Reduces boilerplate for defining HttpFilters.
+ */
+public class DefaultHttpFilters implements HttpFilters {
+
+  private final EssentialFilter[] filters;
+
+  public DefaultHttpFilters(play.api.mvc.EssentialFilter... filters) {
+    this.filters = (EssentialFilter[]) Arrays.stream(filters).map(f -> f.asJava()).toArray();
+  }
+
+  @Override
+  public EssentialFilter[] filters() {
+    return filters;
+  }
+}

--- a/templates/play-java/app/Filters.java
+++ b/templates/play-java/app/Filters.java
@@ -39,7 +39,7 @@ public class Filters implements HttpFilters {
       if (env.mode().equals(Mode.DEV)) {
           return new EssentialFilter[] { exampleFilter };
       } else {
-         return new EssentialFilter[] {};      
+         return new EssentialFilter[] {};
       }
     }
 


### PR DESCRIPTION
Fixes #6115.

This creates a `DefaultHttpFilters` class that extends `HttpFilters` in both Java and Scala. This makes the Java API in particular much easier to use for simple cases:

```java
public class Filters extends DefaultHttpFilters {
  @Inject public Filters(GzipFilter gzip, LoggingFilter logging) {
    super(gzip, logging);
  }
}
```
Another advantage is that this doesn't require the `.asJava()` conversion on the filters.

One limitation is that since we're using `super`, you can't do much logic in the constructor since `super` has to be the first call, but I think most of that logic should be done by either binding a different `HttpFilters` implementation (for example based on application mode) or by binding different implementations of those filters.