### PR TITLE
Added note on LoggerConfigurator in AppLoader.

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
@@ -24,6 +24,8 @@ For any custom configuration, you will need to specify your own Logback configur
 
 You can provide a default logging configuration by providing a file `conf/logback.xml`.
 
+> Note: If you run your Play application with a dedicated application loader (because you want to make use of compile time dependency injection), then in order to make Play pick up your own Logback configuration file, you need to add the following to the `load` method of your application loader: `LoggerConfigurator(context.environment.classLoader).foreach { _.configure(context.environment) }`.
+
 ### Using an external configuration file
 
 You can also specify a configuration file via a System property.  This is particularly useful for production environments where the configuration file may be managed outside of your application source.


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?

## Purpose

Enhances the SettingsLogger doc chapter in order to avoid confusion for people who add their own logback configuration to their project without it being picked up (because a LoggerConfigurator statement has to be added if a dedicated application loader is used).

## Background Context

The current version of SettingsLogger for 2.5.x creates the impression that in any case, adding a logback config file is all that is required in order to override Play's default logging behaviour. The exception,  however, is when one provides a dedicated application loader. This is indirectly mentioned in the Migration25 documentation, but as my own hour-long search shows, it's probably worth to make this clear here as well, as this provides a more thorough coverage of all things logging.