### PR TITLE
Group(s) in form should be an array/varargs

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/Form.java
+++ b/framework/src/play-java/src/main/java/play/data/Form.java
@@ -38,64 +38,6 @@ import com.google.common.collect.ImmutableList;
  */
 public class Form<T> {
 
-    // -- Form utilities
-
-    private static play.api.inject.Injector injector() {
-        return play.api.Play.current().injector();
-    }
-
-    /**
-     * Instantiates a dynamic form.
-     *
-     * @deprecated inject a {@link FormFactory} instead, since 2.5.0
-     */
-    @Deprecated
-    public static DynamicForm form() {
-        return new DynamicForm(injector().instanceOf(MessagesApi.class), injector().instanceOf(Formatters.class), injector().instanceOf(javax.validation.Validator.class));
-    }
-
-    /**
-     * Instantiates a new form that wraps the specified class.
-     *
-     * @deprecated inject a {@link FormFactory} instead, since 2.5.0
-     */
-    @Deprecated
-    public static <T> Form<T> form(Class<T> clazz) {
-        return new Form<>(clazz, injector().instanceOf(MessagesApi.class), injector().instanceOf(Formatters.class), injector().instanceOf(javax.validation.Validator.class));
-    }
-
-    /**
-     * Instantiates a new form that wraps the specified class.
-     *
-     * @deprecated inject a {@link FormFactory} instead, since 2.5.0
-     */
-    @Deprecated
-    public static <T> Form<T> form(String name, Class<T> clazz) {
-        return new Form<>(name, clazz, injector().instanceOf(MessagesApi.class), injector().instanceOf(Formatters.class), injector().instanceOf(javax.validation.Validator.class));
-    }
-
-    /**
-     * Instantiates a new form that wraps the specified class.
-     *
-     * @deprecated inject a {@link FormFactory} instead, since 2.5.0
-     */
-    @Deprecated
-    public static <T> Form<T> form(String name, Class<T> clazz, Class<?> group) {
-        return new Form<>(name, clazz, group, injector().instanceOf(MessagesApi.class), injector().instanceOf(Formatters.class), injector().instanceOf(javax.validation.Validator.class));
-    }
-
-    /**
-     * Instantiates a new form that wraps the specified class.
-     *
-     * @deprecated inject a {@link FormFactory} instead, since 2.5.0
-     */
-    @Deprecated
-    public static <T> Form<T> form(Class<T> clazz, Class<?> group) {
-        return new Form<>(null, clazz, group, injector().instanceOf(MessagesApi.class), injector().instanceOf(Formatters.class), injector().instanceOf(javax.validation.Validator.class));
-    }
-
-    // ---
-
     /**
      * Defines a form element's display name.
      */
@@ -113,7 +55,7 @@ public class Form<T> {
     private final Map<String,String> data;
     private final Map<String,List<ValidationError>> errors;
     private final Optional<T> value;
-    private final Class<?> groups;
+    private final Class<?>[] groups;
     final MessagesApi messagesApi;
     final Formatters formatters;
     final javax.validation.Validator validator;
@@ -139,18 +81,24 @@ public class Form<T> {
         this(null, clazz, messagesApi, formatters, validator);
     }
 
-    @SuppressWarnings("unchecked")
-    public Form(String name, Class<T> clazz, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
-        this(name, clazz, new HashMap<>(), new HashMap<>(), Optional.empty(), null, messagesApi, formatters, validator);
+    public Form(String rootName, Class<T> clazz, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
+        this(rootName, clazz, (Class<?>)null, messagesApi, formatters, validator);
     }
 
-    @SuppressWarnings("unchecked")
-    public Form(String name, Class<T> clazz, Class<?> groups, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
-        this(name, clazz, new HashMap<>(), new HashMap<>(), Optional.empty(), groups, messagesApi, formatters, validator);
+    public Form(String rootName, Class<T> clazz, Class<?> group, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
+        this(rootName, clazz, group != null ? new Class[]{group} : null, messagesApi, formatters, validator);
+    }
+
+    public Form(String rootName, Class<T> clazz, Class<?>[] groups, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
+        this(rootName, clazz, new HashMap<>(), new HashMap<>(), Optional.empty(), groups, messagesApi, formatters, validator);
     }
 
     public Form(String rootName, Class<T> clazz, Map<String,String> data, Map<String,List<ValidationError>> errors, Optional<T> value, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
-        this(rootName, clazz, data, errors, value, null, messagesApi, formatters, validator);
+        this(rootName, clazz, data, errors, value, (Class<?>)null, messagesApi, formatters, validator);
+    }
+
+    public Form(String rootName, Class<T> clazz, Map<String,String> data, Map<String,List<ValidationError>> errors, Optional<T> value, Class<?> group, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
+        this(rootName, clazz, data, errors, value, group != null ? new Class[]{group} : null, messagesApi, formatters, validator);
     }
 
     /**
@@ -163,7 +111,7 @@ public class Form<T> {
      * @param messagesApi needed to look up various messages
      * @param formatters used for parsing and printing form fields
      */
-    public Form(String rootName, Class<T> clazz, Map<String,String> data, Map<String,List<ValidationError>> errors, Optional<T> value, Class<?> groups, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
+    public Form(String rootName, Class<T> clazz, Map<String,String> data, Map<String,List<ValidationError>> errors, Optional<T> value, Class<?>[] groups, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
         this.rootName = rootName;
         this.backedType = clazz;
         this.data = data;

--- a/framework/src/play-java/src/main/java/play/data/FormFactory.java
+++ b/framework/src/play-java/src/main/java/play/data/FormFactory.java
@@ -52,15 +52,15 @@ public class FormFactory {
     /**
      * Instantiates a new form that wraps the specified class.
      */
-    public <T> Form<T> form(String name, Class<T> clazz, Class<?> group) {
-        return new Form<>(name, clazz, group, messagesApi, formatters, validator);
+    public <T> Form<T> form(String name, Class<T> clazz, Class<?>... groups) {
+        return new Form<>(name, clazz, groups, messagesApi, formatters, validator);
     }
 
     /**
      * Instantiates a new form that wraps the specified class.
      */
-    public <T> Form<T> form(Class<T> clazz, Class<?> group) {
-        return new Form<>(null, clazz, group, messagesApi, formatters, validator);
+    public <T> Form<T> form(Class<T> clazz, Class<?>... groups) {
+        return new Form<>(null, clazz, groups, messagesApi, formatters, validator);
     }
 
 }


### PR DESCRIPTION
[`validator.validate(...)`](https://github.com/playframework/playframework/blob/2.5.3/framework/src/play-java/src/main/java/play/data/Form.java#L353) actually takes an array/varargs as second argument. We should reflect this in the Play Form api as well.
Right now it is not possible to use more than one validation group, which is a pain. We actually ran into this limitation today - we have a complex form in which we want to use three validation groups to distinct different form submission scenarios.
I overloaded the form constructors to accept a groups array in addition to the single group object.
I also removed the deprecated static methods for creating a form in favor of DI.