### PR TITLE
[Backport] Group(s) in form should take an array/varargs

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/Form.java
+++ b/framework/src/play-java/src/main/java/play/data/Form.java
@@ -84,6 +84,11 @@ public class Form<T> {
         return new Form<>(name, clazz, group, injector().instanceOf(MessagesApi.class), injector().instanceOf(Formatters.class), injector().instanceOf(javax.validation.Validator.class));
     }
 
+    @Deprecated
+    public static <T> Form<T> form(String name, Class<T> clazz, Class<?>... groups) {
+        return new Form<>(name, clazz, groups, injector().instanceOf(MessagesApi.class), injector().instanceOf(Formatters.class), injector().instanceOf(javax.validation.Validator.class));
+    }
+
     /**
      * Instantiates a new form that wraps the specified class.
      *
@@ -92,6 +97,11 @@ public class Form<T> {
     @Deprecated
     public static <T> Form<T> form(Class<T> clazz, Class<?> group) {
         return new Form<>(null, clazz, group, injector().instanceOf(MessagesApi.class), injector().instanceOf(Formatters.class), injector().instanceOf(javax.validation.Validator.class));
+    }
+
+    @Deprecated
+    public static <T> Form<T> form(Class<T> clazz, Class<?>... groups) {
+        return new Form<>(null, clazz, groups, injector().instanceOf(MessagesApi.class), injector().instanceOf(Formatters.class), injector().instanceOf(javax.validation.Validator.class));
     }
 
     // ---
@@ -113,7 +123,7 @@ public class Form<T> {
     private final Map<String,String> data;
     private final Map<String,List<ValidationError>> errors;
     private final Optional<T> value;
-    private final Class<?> groups;
+    private final Class<?>[] groups;
     final MessagesApi messagesApi;
     final Formatters formatters;
     final javax.validation.Validator validator;
@@ -139,18 +149,24 @@ public class Form<T> {
         this(null, clazz, messagesApi, formatters, validator);
     }
 
-    @SuppressWarnings("unchecked")
-    public Form(String name, Class<T> clazz, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
-        this(name, clazz, new HashMap<>(), new HashMap<>(), Optional.empty(), null, messagesApi, formatters, validator);
+    public Form(String rootName, Class<T> clazz, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
+        this(rootName, clazz, (Class<?>)null, messagesApi, formatters, validator);
     }
 
-    @SuppressWarnings("unchecked")
-    public Form(String name, Class<T> clazz, Class<?> groups, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
-        this(name, clazz, new HashMap<>(), new HashMap<>(), Optional.empty(), groups, messagesApi, formatters, validator);
+    public Form(String rootName, Class<T> clazz, Class<?> group, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
+        this(rootName, clazz, group != null ? new Class[]{group} : null, messagesApi, formatters, validator);
+    }
+
+    public Form(String rootName, Class<T> clazz, Class<?>[] groups, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
+        this(rootName, clazz, new HashMap<>(), new HashMap<>(), Optional.empty(), groups, messagesApi, formatters, validator);
     }
 
     public Form(String rootName, Class<T> clazz, Map<String,String> data, Map<String,List<ValidationError>> errors, Optional<T> value, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
-        this(rootName, clazz, data, errors, value, null, messagesApi, formatters, validator);
+        this(rootName, clazz, data, errors, value, (Class<?>)null, messagesApi, formatters, validator);
+    }
+
+    public Form(String rootName, Class<T> clazz, Map<String,String> data, Map<String,List<ValidationError>> errors, Optional<T> value, Class<?> group, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
+        this(rootName, clazz, data, errors, value, group != null ? new Class[]{group} : null, messagesApi, formatters, validator);
     }
 
     /**
@@ -163,7 +179,7 @@ public class Form<T> {
      * @param messagesApi needed to look up various messages
      * @param formatters used for parsing and printing form fields
      */
-    public Form(String rootName, Class<T> clazz, Map<String,String> data, Map<String,List<ValidationError>> errors, Optional<T> value, Class<?> groups, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
+    public Form(String rootName, Class<T> clazz, Map<String,String> data, Map<String,List<ValidationError>> errors, Optional<T> value, Class<?>[] groups, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
         this.rootName = rootName;
         this.backedType = clazz;
         this.data = data;

--- a/framework/src/play-java/src/main/java/play/data/FormFactory.java
+++ b/framework/src/play-java/src/main/java/play/data/FormFactory.java
@@ -56,11 +56,19 @@ public class FormFactory {
         return new Form<>(name, clazz, group, messagesApi, formatters, validator);
     }
 
+    public <T> Form<T> form(String name, Class<T> clazz, Class<?>... groups) {
+        return new Form<>(name, clazz, groups, messagesApi, formatters, validator);
+    }
+
     /**
      * Instantiates a new form that wraps the specified class.
      */
     public <T> Form<T> form(Class<T> clazz, Class<?> group) {
         return new Form<>(null, clazz, group, messagesApi, formatters, validator);
+    }
+
+    public <T> Form<T> form(Class<T> clazz, Class<?>... groups) {
+        return new Form<>(null, clazz, groups, messagesApi, formatters, validator);
     }
 
 }


### PR DESCRIPTION
Backport of #6124, except that I can't remove the static form methods because of backwards compatibility - so I simply changed the second argument to take varargs.