### PR TITLE
Only add/display constraint(s) which match the used validation group(s)

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/Form.java
+++ b/framework/src/play-java/src/main/java/play/data/Form.java
@@ -5,6 +5,7 @@ package play.data;
 
 import javax.validation.*;
 import javax.validation.metadata.*;
+import javax.validation.groups.Default;
 
 import java.util.*;
 import java.util.function.Function;
@@ -720,7 +721,9 @@ public class Form<T> {
             if (beanDescriptor != null) {
                 PropertyDescriptor property = beanDescriptor.getConstraintsForProperty(leafKey);
                 if (property != null) {
-                    constraints = Constraints.displayableConstraint(property.getConstraintDescriptors());
+                    constraints = Constraints.displayableConstraint(
+                            property.findConstraints().unorderedAndMatchingGroups(groups != null ? groups : new Class[]{Default.class}).getConstraintDescriptors()
+                        );
                 }
             }
         }

--- a/framework/src/play-java/src/test/java/play/data/LoginCheck.java
+++ b/framework/src/play-java/src/test/java/play/data/LoginCheck.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.data;
+
+public interface LoginCheck {
+}

--- a/framework/src/play-java/src/test/java/play/data/PasswordCheck.java
+++ b/framework/src/play-java/src/test/java/play/data/PasswordCheck.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.data;
+
+public interface PasswordCheck {
+}

--- a/framework/src/play-java/src/test/java/play/data/SomeUser.java
+++ b/framework/src/play-java/src/test/java/play/data/SomeUser.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.data;
+
+import javax.validation.groups.Default;
+
+import play.data.validation.Constraints.Email;
+import play.data.validation.Constraints.MaxLength;
+import play.data.validation.Constraints.MinLength;
+import play.data.validation.Constraints.Required;
+
+public class SomeUser {
+
+    @Required(groups = {Default.class, LoginCheck.class})
+    @Email(groups = {LoginCheck.class})
+    @MaxLength(255)
+    private String email;
+
+    @Required
+    @MaxLength(255)
+    private String firstName;
+
+    @Required(groups = {Default.class})
+    @MinLength(2)
+    @MaxLength(255)
+    private String lastName;
+    
+    @Required(groups = {PasswordCheck.class, LoginCheck.class})
+    @MinLength(5)
+    @MaxLength(255)
+    private String password;
+    
+    @Required(groups = {PasswordCheck.class})
+    @MinLength(5)
+    @MaxLength(255)
+    private String repeatPassword;
+
+    public String getEmail() {
+        return this.email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getFirstName() {
+        return this.firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return this.lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getPassword() {
+        return this.password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getRepeatPassword() {
+        return this.repeatPassword;
+    }
+
+    public void setRepeatPassword(String repeatPassword) {
+        this.repeatPassword = repeatPassword;
+    }
+
+}


### PR DESCRIPTION
Now that we finally can use as many validation groups in forms as we want (#6124), there is one thing I would consider a bug.

Right now, when you retrieve a field from a form (via `myForm.field("fieldname")`), we *always* return the field with **all** of its constraints, no matter if we told the form to use a specific validation group or not.
This is wrong.
If you create a form and tell it to use (a) specific validation group(s) than only the constraints should be added (to a field) which match any of the validation groups the form actually currently uses.
For example if you display all fields of a form in a view, and all fields contain the `@Required` constraint, but some of this constraints use a specific validation group like `@Required(groups = MyGroup.class)` and you create the form via `formFactory.form(myForm.class, MyGroup.class)` then in the view only the fields should display the required constraint (`"This field is required"`) who's required annotation actually matches the group - because of course all other fields are actually not required for the current form submission scenario (and of course don't raise a validation error if they are empty on submission).
Right now always all constraints get added/shown.

Fortunately we can make use of the `unorderedAndMatchingGroups` method which does exactly what we want. ([javadoc](http://docs.jboss.org/hibernate/beanvalidation/spec/1.1/api/javax/validation/metadata/ElementDescriptor.ConstraintFinder.html#unorderedAndMatchingGroups(java.lang.Class...))) More on it's usage can also be found in the hibernate validation docs [here](http://docs.jboss.org/hibernate/validator/5.2/reference/en-US/html/ch09.html#validator-metadata-api-elementdescriptor) and the Bean Validation specification [here](http://beanvalidation.org/1.1/spec/) (just grep for `unorderedAndMatchingGroups`)

One more thing: When no groups are used, we still need to supply the `Default.class` group, because that's what is getting used by default by the `.validate(...)` method we use [here](https://github.com/playframework/playframework/blob/2.5.3/framework/src/play-java/src/main/java/play/data/Form.java#L355):
>  the group or list of groups targeted for validation (defaults to `Default`)

(From the javadocs [here](http://docs.jboss.org/hibernate/beanvalidation/spec/1.1/api/javax/validation/Validator.html#validate(T, java.lang.Class...)))


We already use the change of this PR in our own custom Play `2.5.4-SNAPSHOT` build since two days and it is working like a charm.