### PR TITLE
jdbcdslog is now enabled at the connection pool / data source level

### DIFF
--- a/framework/src/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
+++ b/framework/src/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
@@ -12,6 +12,7 @@ import javax.sql.DataSource;
 import com.google.common.collect.ImmutableMap;
 import com.jolbox.bonecp.BoneCPDataSource;
 
+import org.jdbcdslog.LogSqlDataSource;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.junit.Test;
@@ -186,5 +187,14 @@ public class DatabaseTest {
         exception.expect(SQLException.class);
         exception.expectMessage(endsWith("has been closed."));
         db.getConnection().close();
+    }
+
+    @Test
+    public void useLogSqlDataSourceWhenLogSqlIsTrue() throws Exception {
+        Map<String, String> config = ImmutableMap.of("jndiName", "DefaultDS", "logSql", "true");
+        Database db = Databases.createFrom("test", "org.h2.Driver", "jdbc:h2:mem:test", config);
+        assertThat(db.getDataSource(), instanceOf(LogSqlDataSource.class));
+        assertThat(JNDI.initialContext().lookup("DefaultDS"), instanceOf(LogSqlDataSource.class));
+        db.shutdown();
     }
 }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
@@ -123,22 +123,25 @@ class BoneConnectionPool @Inject() (environment: Environment) extends Connection
     config.getDeprecated[Option[String]]("bonecp.initSQL", "initSQL").foreach(datasource.setInitSQL)
     config.getDeprecated[Option[String]]("bonecp.connectionTestStatement", "connectionTestStatement").foreach(datasource.setConnectionTestStatement)
 
+    val wrappedDataSource = ConnectionPool.maybeWrapDataSource(datasource, conf)
+
     // Bind in JNDI
-    dbConfig.jndiName foreach { name =>
-      JNDI.initialContext.rebind(name, datasource)
-      val visibleUrl = datasource.getJdbcUrl
-      logger.info(s"""datasource [$visibleUrl] bound to JNDI as $name""")
+    dbConfig.jndiName foreach { jndiName =>
+      JNDI.initialContext.rebind(jndiName, wrappedDataSource)
+      logger.info(s"""datasource [$name] bound to JNDI as $jndiName""")
     }
 
-    datasource
+    wrappedDataSource
   }
 
   /**
    * Close the given data source.
    */
-  def close(ds: DataSource): Unit = ds match {
-    case bcp: BoneCPDataSource => bcp.close()
-    case _ => sys.error("Unable to close data source: not a BoneCPDataSource")
+  def close(ds: DataSource): Unit = {
+    ConnectionPool.unwrapDataSource(ds) match {
+      case bcp: BoneCPDataSource => bcp.close()
+      case _ => sys.error("Unable to close data source: not a BoneCPDataSource")
+    }
   }
 
 }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
@@ -123,7 +123,7 @@ class BoneConnectionPool @Inject() (environment: Environment) extends Connection
     config.getDeprecated[Option[String]]("bonecp.initSQL", "initSQL").foreach(datasource.setInitSQL)
     config.getDeprecated[Option[String]]("bonecp.connectionTestStatement", "connectionTestStatement").foreach(datasource.setConnectionTestStatement)
 
-    val wrappedDataSource = ConnectionPool.maybeWrapDataSource(datasource, conf)
+    val wrappedDataSource = ConnectionPool.wrapToLogSql(datasource, conf)
 
     // Bind in JNDI
     dbConfig.jndiName foreach { jndiName =>
@@ -138,7 +138,7 @@ class BoneConnectionPool @Inject() (environment: Environment) extends Connection
    * Close the given data source.
    */
   def close(ds: DataSource): Unit = {
-    ConnectionPool.unwrapDataSource(ds) match {
+    ConnectionPool.unwrap(ds) match {
       case bcp: BoneCPDataSource => bcp.close()
       case _ => sys.error("Unable to close data source: not a BoneCPDataSource")
     }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/ConnectionPool.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/ConnectionPool.scala
@@ -83,7 +83,7 @@ object ConnectionPool {
   /**
    * Wraps a data source in a org.jdbcdslog.LogSqlDataSource if the logSql configuration property is set to true.
    */
-  def maybeWrapDataSource(dataSource: DataSource, configuration: Config): DataSource = {
+  private[db] def wrapToLogSql(dataSource: DataSource, configuration: Config): DataSource = {
     if (configuration.getBoolean("logSql")) {
       val proxyDataSource = new LogSqlDataSource()
       proxyDataSource.setTargetDSDirect(dataSource)
@@ -96,7 +96,7 @@ object ConnectionPool {
   /**
    * Unwraps a data source if it has been previously wrapped in a org.jdbcdslog.LogSqlDataSource.
    */
-  def unwrapDataSource(dataSource: DataSource): DataSource = {
+  private[db] def unwrap(dataSource: DataSource): DataSource = {
     dataSource match {
       case ds: LogSqlDataSource => ds.getTargetDatasource
       case _ => dataSource

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/ConnectionPool.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/ConnectionPool.scala
@@ -6,6 +6,7 @@ package play.api.db
 import javax.sql.DataSource
 
 import com.typesafe.config.Config
+import org.jdbcdslog.LogSqlDataSource
 import play.api.{ Environment, Mode }
 import play.api.inject.Injector
 import play.utils.Reflect
@@ -77,5 +78,28 @@ object ConnectionPool {
         None -> None
     }
 
+  }
+
+  /**
+   * Wraps a data source in a org.jdbcdslog.LogSqlDataSource if the logSql configuration property is set to true.
+   */
+  def maybeWrapDataSource(dataSource: DataSource, configuration: Config): DataSource = {
+    if (configuration.getBoolean("logSql")) {
+      val proxyDataSource = new LogSqlDataSource()
+      proxyDataSource.setTargetDSDirect(dataSource)
+      proxyDataSource
+    } else {
+      dataSource
+    }
+  }
+
+  /**
+   * Unwraps a data source if it has been previously wrapped in a org.jdbcdslog.LogSqlDataSource.
+   */
+  def unwrapDataSource(dataSource: DataSource): DataSource = {
+    dataSource match {
+      case ds: LogSqlDataSource => ds.getTargetDatasource
+      case _ => dataSource
+    }
   }
 }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/Databases.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/Databases.scala
@@ -6,7 +6,6 @@ package play.api.db
 import java.sql.{ Connection, Driver, DriverManager }
 import javax.sql.DataSource
 
-import org.jdbcdslog.LogSqlDataSource
 import play.utils.{ ProxyDriver, Reflect }
 
 import com.typesafe.config.Config
@@ -197,21 +196,11 @@ class PooledDatabase(name: String, configuration: Config, environment: Environme
   def this(name: String, configuration: Configuration) = this(name, configuration.underlying, Environment.simple(), new HikariCPConnectionPool(Environment.simple()))
 
   def createDataSource(): DataSource = {
-    val datasource: DataSource = pool.create(name, databaseConfig, configuration)
-    if (configuration.getBoolean("logSql")) {
-      val proxyDatasource = new LogSqlDataSource()
-      proxyDatasource.setTargetDSDirect(datasource)
-      proxyDatasource
-    } else {
-      datasource
-    }
+    pool.create(name, databaseConfig, configuration)
   }
 
   def closeDataSource(dataSource: DataSource): Unit = {
-    dataSource match {
-      case ds: LogSqlDataSource => pool.close(ds.getTargetDatasource)
-      case _ => pool.close(dataSource)
-    }
+    pool.close(dataSource)
   }
 
 }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
@@ -56,7 +56,7 @@ class HikariCPConnectionPool @Inject() (environment: Environment) extends Connec
 
       val hikariConfig = new HikariCPConfig(dbConfig, config).toHikariConfig
       val datasource = new HikariDataSource(hikariConfig)
-      val wrappedDataSource = ConnectionPool.maybeWrapDataSource(datasource, configuration)
+      val wrappedDataSource = ConnectionPool.wrapToLogSql(datasource, configuration)
 
       // Bind in JNDI
       dbConfig.jndiName.foreach { jndiName =>
@@ -78,7 +78,7 @@ class HikariCPConnectionPool @Inject() (environment: Environment) extends Connec
    */
   override def close(dataSource: DataSource) = {
     Logger.info("Shutting down connection pool.")
-    ConnectionPool.unwrapDataSource(dataSource) match {
+    ConnectionPool.unwrap(dataSource) match {
       case ds: HikariDataSource => ds.close()
       case _ => sys.error("Unable to close data source: not a HikariDataSource")
     }

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/ConnectionPoolConfigSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/ConnectionPoolConfigSpec.scala
@@ -72,6 +72,22 @@ class ConnectionPoolConfigSpec extends PlaySpecification {
       }
     }
 
+    "do not use LogSqlDataSource by default" in new WithApplication(_.configure(
+      "db.default.driver" -> "org.h2.Driver",
+      "db.default.url" -> "jdbc:h2:mem:default"
+    )) {
+      val db = app.injector.instanceOf[DBApi]
+      db.database("default").dataSource.getClass.getName must not contain ("LogSqlDataSource")
+    }
+
+    "use LogSqlDataSource when logSql is true" in new WithApplication(_.configure(
+      "db.default.driver" -> "org.h2.Driver",
+      "db.default.url" -> "jdbc:h2:mem:default",
+      "db.default.logSql" -> "true"
+    )) {
+      val db = app.injector.instanceOf[DBApi]
+      db.database("default").dataSource.getClass.getName must contain("LogSqlDataSource")
+    }
   }
 
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #6149 

## Purpose

To enable SQL logging with jdbcdslog the data source needs to be wrapped in a org.jdbcdslog.LogSqlDataSource. This was previously done at the database API level (in Databases.scala) before data sources were registered with JNDI. This causes database operations that use JPA to not be logged as their data source is not wrapped in a org.jdbcdslog.LogSqlDataSource. Now each supported connection pool wraps its own data sources when they are created and unwraps them before they are closed.

## Background Context

The data sources are already registered with JNDI in the implementation classes for both supported connection pools, so I modified both to also automatically wrap the data source in a org.jdbcdslog.LogSqlDataSource if logSql is set to true. I have also moved the code that unwraps a data source when it needs to be closed. Since the functionality is the same for both connection pool implementations I placed the two methods (wrap data source and unwrap data source) in the ConnectionPool object.

It seems that registering any new data sources with JNDI is left up to the implementation of each connection pool at the moment, so it seemed appropriate that wrapping and unwrapping their data sources to support logging would be done there as well. Although I am not a huge fan of this as it makes implementing a new connection pool more difficult (have to remember to bind its data sources to JNDI and to wrap / unwrap the data sources to enable logging).

The code that actually wraps / unwraps the data sources could be copied into both implementations directly and removed from ConnectionPool to match what is done with JNDI registration code at the moment if that is preferable.

Apologies for not writing any test cases for this, not sure how I would go about that unfortunately. Maybe someone can direct me? But I can confirm I have tested the changes with both Java and Scala versions of Play.

Edit: I have now added a few tests to check whether the logSql configuration property is applied correctly and whether the right data source class is used both using the Database API and the JPA API.

## References

Here's the original post about this issue on the Google group:

https://groups.google.com/d/msgid/play-framework/bd37c292-60b7-457c-a01c-018e824c8c70%40googlegroups.com?utm_medium=email&utm_source=footer
