### PR TITLE
Better Result error handling

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
@@ -19,7 +19,7 @@ import java.net.InetSocketAddress
 import akka.http.scaladsl.settings.ServerSettings
 import akka.util.ByteString
 import play.api._
-import play.api.http.DefaultHttpErrorHandler
+import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
 import play.api.libs.streams.{ Accumulator, MaterializeOnDemandPublisher }
 import play.api.mvc._
 import play.core.ApplicationProvider
@@ -156,25 +156,33 @@ class AkkaHttpServer(
 
     val upgradeToWebSocket = request.header[UpgradeToWebSocket]
 
+    // Get the app's HttpErroHandler or fallback to a default value
+    val errorHandler: HttpErrorHandler = {
+      tryApp match {
+        case Success(app) => app.errorHandler
+        case Failure(_) => DefaultHttpErrorHandler
+      }
+    }
+
     (handler, upgradeToWebSocket) match {
       //execute normal action
       case (action: EssentialAction, _) =>
         val actionWithErrorHandling = EssentialAction { rh =>
           import play.core.Execution.Implicits.trampoline
           action(rh).recoverWith {
-            case error => handleHandlerError(tryApp, taggedRequestHeader, error)
+            case error => errorHandler.onServerError(taggedRequestHeader, error)
           }
         }
-        executeAction(tryApp, request, taggedRequestHeader, requestBodySource, actionWithErrorHandling)
+        executeAction(request, taggedRequestHeader, requestBodySource, actionWithErrorHandling, errorHandler)
 
       case (websocket: WebSocket, Some(upgrade)) =>
         import play.core.Execution.Implicits.trampoline
 
-        websocket(taggedRequestHeader).map {
+        websocket(taggedRequestHeader).flatMap {
           case Left(result) =>
-            modelConversion.convertResult(taggedRequestHeader, result, request.protocol)
+            modelConversion.convertResult(taggedRequestHeader, result, request.protocol, errorHandler)
           case Right(flow) =>
-            WebSocketHandler.handleWebSocket(upgrade, flow, 16384)
+            Future.successful(WebSocketHandler.handleWebSocket(upgrade, flow, 16384))
         }
 
       case (websocket: WebSocket, None) =>
@@ -185,20 +193,12 @@ class AkkaHttpServer(
     }
   }
 
-  /** Error handling to use during execution of a handler (e.g. an action) */
-  private def handleHandlerError(tryApp: Try[Application], rh: RequestHeader, t: Throwable): Future[Result] = {
-    tryApp match {
-      case Success(app) => app.errorHandler.onServerError(rh, t)
-      case Failure(_) => DefaultHttpErrorHandler.onServerError(rh, t)
-    }
-  }
-
   def executeAction(
-    tryApp: Try[Application],
     request: HttpRequest,
     taggedRequestHeader: RequestHeader,
     requestBodySource: Option[Source[ByteString, _]],
-    action: EssentialAction): Future[HttpResponse] = {
+    action: EssentialAction,
+    errorHandler: HttpErrorHandler): Future[HttpResponse] = {
 
     import play.core.Execution.Implicits.trampoline
     val actionAccumulator: Accumulator[ByteString, Result] = action(taggedRequestHeader)
@@ -218,9 +218,9 @@ class AkkaHttpServer(
       case None => actionAccumulator.run()
       case Some(s) => actionAccumulator.run(s)
     }
-    val responseFuture: Future[HttpResponse] = resultFuture.map { result =>
+    val responseFuture: Future[HttpResponse] = resultFuture.flatMap { result =>
       val cleanedResult: Result = ServerResultUtils.cleanFlashCookie(taggedRequestHeader, result)
-      modelConversion.convertResult(taggedRequestHeader, cleanedResult, request.protocol)
+      modelConversion.convertResult(taggedRequestHeader, cleanedResult, request.protocol, errorHandler)
     }
     responseFuture
   }

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -12,11 +12,11 @@ import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.Logger
 import play.api.http.HeaderNames._
-import play.api.http.{ HttpChunk, HttpEntity => PlayHttpEntity }
+import play.api.http.{ HttpChunk, HttpErrorHandler, HttpEntity => PlayHttpEntity, Status }
 import play.api.mvc._
 import play.core.server.common.{ ConnectionInfo, ForwardedHeaderHandler, ServerResultUtils }
-
 import scala.collection.immutable
+import scala.concurrent.Future
 
 /**
  * Conversions between Akka's and Play's HTTP model objects.
@@ -125,19 +125,35 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
   def convertResult(
     requestHeaders: RequestHeader,
     unvalidated: Result,
-    protocol: HttpProtocol)(implicit mat: Materializer): HttpResponse = {
+    protocol: HttpProtocol,
+    errorHandler: HttpErrorHandler)(implicit mat: Materializer): Future[HttpResponse] = {
 
-    val result = ServerResultUtils.validateResult(requestHeaders, unvalidated)
-    val convertedHeaders: AkkaHttpHeaders = convertResponseHeaders(result.header.headers)
-    val entity = convertResultBody(requestHeaders, convertedHeaders, result, protocol)
-    val connectionHeader = ServerResultUtils.determineConnectionHeader(requestHeaders, result)
-    val closeHeader = connectionHeader.header.map(Connection(_))
-    HttpResponse(
-      status = result.header.status,
-      headers = convertedHeaders.misc ++ closeHeader,
-      entity = entity,
-      protocol = protocol
-    )
+    import play.core.Execution.Implicits.trampoline
+
+    ServerResultUtils.resultConversionWithErrorHandling(requestHeaders, unvalidated, errorHandler) { unvalidated =>
+      // Convert result
+      ServerResultUtils.validateResult(requestHeaders, unvalidated, errorHandler).map { validated: Result =>
+        val convertedHeaders: AkkaHttpHeaders = convertResponseHeaders(validated.header.headers)
+        val entity = convertResultBody(requestHeaders, convertedHeaders, validated, protocol)
+        val connectionHeader = ServerResultUtils.determineConnectionHeader(requestHeaders, validated)
+        val closeHeader = connectionHeader.header.map(Connection(_))
+        val response = HttpResponse(
+          status = validated.header.status,
+          headers = convertedHeaders.misc ++ closeHeader,
+          entity = entity,
+          protocol = protocol
+        )
+        response
+      }
+    } {
+      // Fallback response in case an exception is thrown during normal error handling
+      HttpResponse(
+        status = Status.INTERNAL_SERVER_ERROR,
+        headers = immutable.Seq(Connection("close")),
+        entity = HttpEntity.Empty,
+        protocol = protocol
+      )
+    }
   }
 
   def convertResultBody(

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaRequestsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaRequestsSpec.scala
@@ -61,7 +61,7 @@ class JavaRequestsSpec extends PlaySpecification with Mockito {
     }
 
     "create a request without a body" in {
-      val requestHeader: Request[Http.RequestBody] = Request[Http.RequestBody](FakeRequest(), new RequestBody())
+      val requestHeader: Request[Http.RequestBody] = Request[Http.RequestBody](FakeRequest(), new RequestBody(null))
       val javaContext: Context = JavaHelpers.createJavaContext(requestHeader)
       val javaRequest = javaContext.request()
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -4,15 +4,23 @@
 package play.it.http
 
 import java.util.Locale.ENGLISH
+import java.util.concurrent.{ LinkedBlockingQueue }
 import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import akka.util.{ ByteString, Timeout }
+import play.api._
+import play.api.http._
+import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
+import play.api.mvc.Results._
+import play.api.routing.Router
 import play.api.test._
 import play.api.libs.ws._
 import play.api.libs.EventSource
+import play.core.server.common.ServerResultException
 import play.it._
 import scala.util.Try
+import scala.concurrent.Future
 import play.api.http.{ HttpEntity, HttpChunk, Status }
 
 object NettyScalaResultsHandlingSpec extends ScalaResultsHandlingSpec with NettyIntegrationSpecification
@@ -33,9 +41,13 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       tryRequest(result)(tryResult => block(tryResult.get))
     }
 
-    def withServer[T](result: => Result)(block: Port => T) = {
+    def withServer[T](result: => Result, errorHandler: HttpErrorHandler = DefaultHttpErrorHandler)(block: Port => T) = {
       val port = testServerPort
-      running(TestServer(port, GuiceApplicationBuilder().routes { case _ => Action(result) }.build())) {
+      val app = GuiceApplicationBuilder()
+        .overrides(bind[HttpErrorHandler].to(errorHandler))
+        .routes { case _ => Action(result) }
+        .build()
+      running(TestServer(port, app)) {
         block(port)
       }
     }
@@ -188,6 +200,17 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
         trailers.get("Chunks") must beSome("3")
       }
 
+    "keep chunked connections alive by default" in withServer(
+      Results.Ok.chunked(Source(List("a", "b", "c")))
+    ) { port =>
+        val responses = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), ""),
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        )
+        responses(0).status must_== 200
+        responses(1).status must_== 200
+      }
+
     "Strip malformed cookies" in withServer(
       Results.Ok
     ) { port =>
@@ -200,13 +223,24 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       }
 
     "reject HTTP 1.0 requests for chunked results" in withServer(
-      Results.Ok.chunked(Source(List("a", "b", "c")))
+      Results.Ok.chunked(Source(List("a", "b", "c"))),
+      errorHandler = new HttpErrorHandler {
+        override def onClientError(request: RequestHeader, statusCode: Int, message: String = ""): Future[Result] = ???
+        override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
+          request.path must_== "/"
+          exception must beLike {
+            case e: ServerResultException =>
+              // Check original result
+              e.result.header.status must_== 200
+          }
+          Future.successful(Results.Status(500))
+        }
+      }
     ) { port =>
         val response = BasicHttpClient.makeRequests(port)(
           BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
-        )(0)
-        response.status must_== HTTP_VERSION_NOT_SUPPORTED
-        response.body must beLeft("The response to this request is chunked and hence requires HTTP 1.1 to be sent, but this is a HTTP 1.0 request.")
+        ).head
+        response.status must_== 505
       }
 
     "return a 500 error on response with null header" in withServer(
@@ -320,12 +354,42 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
 
     "return a 500 response if a forbidden character is used in a response's header field" in withServer(
       // both colon and space characters are not allowed in a header's field name
-      Results.Ok.withHeaders("BadFieldName: " -> "SomeContent")
+      Results.Ok.withHeaders("BadFieldName: " -> "SomeContent"),
+      errorHandler = new HttpErrorHandler {
+        override def onClientError(request: RequestHeader, statusCode: Int, message: String = ""): Future[Result] = ???
+        override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
+          request.path must_== "/"
+          exception must beLike {
+            case e: ServerResultException =>
+              // Check original result
+              e.result.header.status must_== 200
+              e.result.header.headers.get("BadFieldName: ") must beSome("SomeContent")
+          }
+          Future.successful(Results.Status(500))
+        }
+      }
     ) { port =>
         val response = BasicHttpClient.makeRequests(port)(
           BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
         ).head
-        response.status must_== Status.INTERNAL_SERVER_ERROR
+        response.status must_== 500
+        (response.headers -- Set(CONNECTION, CONTENT_LENGTH, DATE, SERVER)) must be(Map.empty)
+      }
+
+    "return a 500 response if an error occurs during the onError" in withServer(
+      // both colon and space characters are not allowed in a header's field name
+      Results.Ok.withHeaders("BadFieldName: " -> "SomeContent"),
+      errorHandler = new HttpErrorHandler {
+        override def onClientError(request: RequestHeader, statusCode: Int, message: String = ""): Future[Result] = ???
+        override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
+          throw new Exception("Failing on purpose :)")
+        }
+      }
+    ) { port =>
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        ).head
+        response.status must_== 500
         (response.headers -- Set(CONNECTION, CONTENT_LENGTH, DATE, SERVER)) must be(Map.empty)
       }
   }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -249,25 +249,30 @@ private[play] class PlayRequestHandler(val server: NettyServer) extends ChannelI
     implicit val mat: Materializer = app.fold(server.materializer)(_.materializer)
     import play.core.Execution.Implicits.trampoline
 
-    val body = modelConversion.convertRequestBody(request)
-    val bodyParser = action(requestHeader)
-    val resultFuture = body match {
-      case None =>
-        bodyParser.run()
-      case Some(source) =>
-        bodyParser.run(source)
-    }
-
-    resultFuture.recoverWith {
-      case error =>
-        logger.error("Cannot invoke the action", error)
-        errorHandler(app).onServerError(requestHeader, error)
-    }.map {
-      case result =>
-        val cleanedResult = ServerResultUtils.cleanFlashCookie(requestHeader, result)
-        val validated = ServerResultUtils.validateResult(requestHeader, cleanedResult)
-        modelConversion.convertResult(validated, requestHeader, request.getProtocolVersion)
-    }
+    for {
+      // Execute the action and get a result
+      actionResult <- {
+        val body = modelConversion.convertRequestBody(request)
+        val bodyParser = action(requestHeader)
+        (body match {
+          case None => bodyParser.run()
+          case Some(source) => bodyParser.run(source)
+        }).recoverWith {
+          case error =>
+            logger.error("Cannot invoke the action", error)
+            errorHandler(app).onServerError(requestHeader, error)
+        }
+      }
+      // Clean and validate the action's result
+      validatedResult <- {
+        val cleanedResult = ServerResultUtils.cleanFlashCookie(requestHeader, actionResult)
+        ServerResultUtils.validateResult(requestHeader, cleanedResult, errorHandler(app))
+      }
+      // Convert the result to a Netty HttpResponse
+      convertedResult <- {
+        modelConversion.convertResult(validatedResult, requestHeader, request.getProtocolVersion, errorHandler(app))
+      }
+    } yield convertedResult
   }
 
   /**

--- a/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultException.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultException.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.server.common
+
+import play.api.mvc._
+
+/**
+ * This exception occurs when the Play server experiences an error
+ * while processing a Result. For example, this exception might occur
+ * when attempting to convert the Play result to the backend server's
+ * internal response format.
+ *
+ * @param message The reason for the exception.
+ * @param result The invalid result.
+ * @param cause The original cause (may be null).
+ */
+class ServerResultException(message: String, val result: Result, cause: Throwable) extends Exception(message, cause)

--- a/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -6,11 +6,16 @@ package play.core.server.common
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import akka.util.ByteString
+import play.api.Logger
 import play.api.mvc._
-import play.api.http.{ Status, HttpEntity, HttpProtocol }
+import play.api.http._
 import play.api.http.HeaderNames._
+import scala.concurrent.Future
+import scala.util.control.NonFatal
 
 object ServerResultUtils {
+
+  private val logger = Logger(ServerResultUtils.getClass)
 
   /**
    * Determine whether the connection should be closed, and what header, if any, should be added to the response.
@@ -44,18 +49,85 @@ object ServerResultUtils {
    *
    * Returns the validated result, which may be an error result if validation failed.
    */
-  def validateResult(request: RequestHeader, result: Result)(implicit mat: Materializer): Result = {
+  def validateResult(request: RequestHeader, result: Result, httpErrorHandler: HttpErrorHandler)(implicit mat: Materializer): Future[Result] = {
     if (request.version == HttpProtocol.HTTP_1_0 && result.body.isInstanceOf[HttpEntity.Chunked]) {
       cancelEntity(result.body)
-      Results.Status(Status.HTTP_VERSION_NOT_SUPPORTED)
-        .apply("The response to this request is chunked and hence requires HTTP 1.1 to be sent, but this is a HTTP 1.0 request.")
-        .withHeaders(CONNECTION -> CLOSE)
+      val exception = new ServerResultException("HTTP 1.0 client does not support chunked response", result, null)
+      val errorResult: Future[Result] = httpErrorHandler.onServerError(request, exception)
+      import play.core.Execution.Implicits.trampoline
+      errorResult.map { originalErrorResult: Result =>
+        // Update the original error with a new status code and a "Connection: close" header
+        import originalErrorResult.{ header => h }
+        val newHeader = h.copy(
+          status = Status.HTTP_VERSION_NOT_SUPPORTED,
+          headers = h.headers + (CONNECTION -> CLOSE)
+        )
+        originalErrorResult.copy(header = newHeader)
+      }
     } else if (!mayHaveEntity(result.header.status) && !result.body.isKnownEmpty) {
       cancelEntity(result.body)
-      result.copy(body = HttpEntity.Strict(ByteString.empty, result.body.contentType))
+      Future.successful(result.copy(body = HttpEntity.Strict(ByteString.empty, result.body.contentType)))
     } else {
-      result
+      Future.successful(result)
     }
+  }
+
+  /**
+   * Handles result conversion in a safe way.
+   *
+   * 1. Tries to convert the `Result`.
+   * 2. If there's an error, calls the `HttpErrorHandler` to get a new
+   *    `Result`, then converts that.
+   * 3. If there's an error with *that* `Result`, uses the
+   *    `DefaultHttpErrorHandler` to get another `Result`, then converts
+   *    that.
+   * 4. Hopefully there are no more errors. :)
+   * 5. If calling an `HttpErrorHandler` throws an exception, then a
+   *    fallback response is returned, without an conversion.
+   */
+  def resultConversionWithErrorHandling[R](
+    requestHeader: RequestHeader,
+    result: Result,
+    errorHandler: HttpErrorHandler)(resultConverter: Result => Future[R])(fallbackResponse: => R): Future[R] = {
+
+    import play.core.Execution.Implicits.trampoline
+
+    def handleConversionError(conversionError: Throwable): Future[R] = {
+      try {
+        // Log some information about the error
+        if (logger.isErrorEnabled) {
+          val prettyHeaders = result.header.headers.map { case (name, value) => s"<$name>: <$value>" }.mkString("[", ", ", "]")
+          val msg = s"Exception occurred while converting Result with headers $prettyHeaders. Calling HttpErrorHandler to get alternative Result."
+          logger.error(msg, conversionError)
+        }
+
+        // Call the HttpErrorHandler to generate an alternative error
+        errorHandler.onServerError(
+          requestHeader,
+          new ServerResultException("Error converting Play Result for server backend", result, conversionError)
+        ).flatMap { errorResult =>
+            // Convert errorResult using normal conversion logic. This time use
+            // the DefaultErrorHandler if there are any problems, e.g. if the
+            // current HttpErrorHandler returns an invalid Result.
+            resultConversionWithErrorHandling(requestHeader, errorResult, DefaultHttpErrorHandler)(resultConverter)(fallbackResponse)
+          }
+      } catch {
+        case NonFatal(onErrorError) =>
+          // Conservatively handle exceptions thrown by HttpErrorHandlers by
+          // returning a fallback response.
+          logger.error("Error occurred during error handling. Original error: ", conversionError)
+          logger.error("Error occurred during error handling. Error handling error: ", onErrorError)
+          Future.successful(fallbackResponse)
+      }
+    }
+
+    try {
+      // Try to convert the result
+      resultConverter(result).recoverWith { case t => handleConversionError(t) }
+    } catch {
+      case NonFatal(e) => handleConversionError(e)
+    }
+
   }
 
   private def mayHaveEntity(status: Int) =


### PR DESCRIPTION
Fixes #6099.

When the backend server (Netty, Akka HTTP) discovers an error in a result (e.g. invalid headers) the server needs to abort processing the result and send an error result to the user. Previously, this error
handling was done with custom error handling code for the server.

This pull request changes the server behavior to use the application's `HttpErrorHandler` to generate the error result instead of the server generating a custom error response. Using the existing error handler makes the error handling more standardized. It also means that the application will be notified when an error occurs during result generation, which will make it easier to track errors that occur in Play applications (see #6098, #6099).

This pull request changes the signature of `HttpErrorHandler`'s `onServerError` method to take a status code parameter. Previously the method always assumed a status code of 500. Now, the method takes a
status code parameter so that it can support additional status codes such as 505, which is needed by this pull request.

Play's error handling code now calls the new method with the status code. The old method is deprecated and no longer called. User code will need to upgrade. This is documented in the Play 2.6 migration documentation.