### PR TITLE
Migrate PushPullStage based implementations to GraphStage

### DIFF
--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/GzipFlow.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/GzipFlow.scala
@@ -6,7 +6,8 @@ package play.api.libs.streams
 import java.util.zip.GZIPOutputStream
 
 import akka.stream.scaladsl.Flow
-import akka.stream.stage.{ Context, PushPullStage }
+import akka.stream.stage._
+import akka.stream._
 import akka.util.ByteString
 
 /**
@@ -20,46 +21,59 @@ object GzipFlow {
    * Create a Gzip Flow with the given buffer size.
    */
   def gzip(bufferSize: Int = 512): Flow[ByteString, ByteString, _] = {
-    Flow[ByteString].transform(() => new GzipStage(bufferSize))
+    Flow[ByteString].via(new GzipStage(bufferSize))
   }
 
-  private class GzipStage(bufferSize: Int) extends PushPullStage[ByteString, ByteString] {
+  private class GzipStage(bufferSize: Int) extends GraphStage[FlowShape[ByteString, ByteString]] {
 
-    val builder = ByteString.newBuilder
-    // Uses syncFlush mode
-    val gzipOs = new GZIPOutputStream(builder.asOutputStream, bufferSize, true)
+    val in = Inlet[ByteString]("GzipStage.in")
+    val out = Outlet[ByteString]("GzipStage.out")
 
-    def onPush(elem: ByteString, ctx: Context[ByteString]) = {
-      // For each chunk, we write it to the gzip output stream, flush which forces it to be entirely written to the
-      // underlying ByteString builder, then we create the ByteString and clear the builder.
-      gzipOs.write(elem.toArray)
-      gzipOs.flush()
-      val result = builder.result()
-      builder.clear()
-      ctx.push(result)
-    }
+    override val shape = FlowShape.of(in, out)
 
-    def onPull(ctx: Context[ByteString]) = {
-      // If finished, push the last ByteString
-      if (ctx.isFinishing) {
-        ctx.pushAndFinish(builder.result())
-      } else {
-        // Otherwise request more demand from upstream
-        ctx.pull()
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+      new GraphStageLogic(shape) with InHandler with OutHandler {
+
+        val builder = ByteString.newBuilder
+        // Uses syncFlush mode
+        val gzipOs = new GZIPOutputStream(builder.asOutputStream, bufferSize, true)
+
+        override def onPush(): Unit = {
+          // For each chunk, we write it to the gzip output stream, flush which forces it to be entirely written to the
+          // underlying ByteString builder, then we create the ByteString and clear the builder.
+          val elem = grab(in)
+          gzipOs.write(elem.toArray)
+          gzipOs.flush()
+          val result = builder.result()
+          builder.clear()
+          push(out, result)
+        }
+
+        override def onPull(): Unit = {
+          // If finished, push the last ByteString
+          if (isClosed(in)) {
+            push(out, builder.result())
+            completeStage()
+          } else {
+            // Otherwise request more demand from upstream
+            pull(in)
+          }
+        }
+
+        override def onUpstreamFinish() = {
+          // Absorb termination, so we can send the last chunk out of the gzip output stream on the next pull
+          gzipOs.close()
+          if (isAvailable(out)) onPull()
+        }
+
+        override def postStop() = {
+          // Close in case it's not already closed to release native deflate resources
+          gzipOs.close()
+          builder.clear()
+        }
+
+        setHandlers(in, out, this)
       }
-    }
-
-    override def onUpstreamFinish(ctx: Context[ByteString]) = {
-      // Absorb termination, so we can send the last chunk out of the gzip output stream on the next pull
-      gzipOs.close()
-      ctx.absorbTermination()
-    }
-
-    override def postStop() = {
-      // Close in case it's not already closed to release native deflate resources
-      gzipOs.close()
-      builder.clear()
-    }
   }
 
 }


### PR DESCRIPTION
PushPullStage based implementations are deprecated and must be migrated to GraphStage.


* [x]  GzipFlow
* [x]  play.core.parsers.Multipart
* [x]  AkkaStreams
* [x]  Probes
* [x]  play.core.formatters.Multipart

## References

Related to PR https://github.com/playframework/playframework/pull/6022