### PR TITLE
Clean deprecation warnings in spec code

### DIFF
--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -8,6 +8,7 @@ import javax.inject.Inject
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import play.api.Application
 import play.api.http.{ HttpEntity, HttpFilters }
 import play.api.inject._
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -28,8 +29,8 @@ object GzipFilterSpec extends PlaySpecification with DataTables {
 
   "The GzipFilter" should {
 
-    "gzip responses" in withApplication(Ok("hello")) { implicit mat =>
-      checkGzippedBody(makeGzipRequest, "hello")
+    "gzip responses" in withApplication(Ok("hello")) { implicit app =>
+      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
     }
 
     """gzip a response if (and only if) it is accepted and preferred by the request.
@@ -38,7 +39,7 @@ object GzipFilterSpec extends PlaySpecification with DataTables {
       |codings are assigned a qvalue of 0, except the identity coding which gets q=0.001,
       |which is the lowest possible acceptable qvalue.
       |This seems to be the most consistent behaviour with respect to the other "accept"
-      |header fields described in sect 14.1-5.""".stripMargin in withApplication(Ok("meep")) { implicit mat =>
+      |header fields described in sect 14.1-5.""".stripMargin in withApplication(Ok("meep")) { implicit app =>
 
       val (plain, gzipped) = (None, Some("gzip"))
 
@@ -73,65 +74,65 @@ object GzipFilterSpec extends PlaySpecification with DataTables {
         "" !! plain |> {
 
           (codings, expectedEncoding) =>
-            header(CONTENT_ENCODING, requestAccepting(codings)) must be equalTo (expectedEncoding)
+            header(CONTENT_ENCODING, requestAccepting(app, codings)) must be equalTo (expectedEncoding)
         }
     }
 
-    "not gzip empty responses" in withApplication(Ok) { implicit mat =>
-      checkNotGzipped(makeGzipRequest, "")
+    "not gzip empty responses" in withApplication(Ok) { implicit app =>
+      checkNotGzipped(makeGzipRequest(app), "")(app.materializer)
     }
 
-    "not gzip responses when not requested" in withApplication(Ok("hello")) { implicit mat =>
-      checkNotGzipped(route(FakeRequest()).get, "hello")
+    "not gzip responses when not requested" in withApplication(Ok("hello")) { implicit app =>
+      checkNotGzipped(route(app, FakeRequest()).get, "hello")(app.materializer)
     }
 
-    "not gzip HEAD requests" in withApplication(Ok) { implicit mat =>
-      checkNotGzipped(route(FakeRequest("HEAD", "/").withHeaders(ACCEPT_ENCODING -> "gzip")).get, "")
+    "not gzip HEAD requests" in withApplication(Ok) { implicit app =>
+      checkNotGzipped(route(app, FakeRequest("HEAD", "/").withHeaders(ACCEPT_ENCODING -> "gzip")).get, "")(app.materializer)
     }
 
-    "not gzip no content responses" in withApplication(NoContent) { implicit mat =>
-      checkNotGzipped(makeGzipRequest, "")
+    "not gzip no content responses" in withApplication(NoContent) { implicit app =>
+      checkNotGzipped(makeGzipRequest(app), "")(app.materializer)
     }
 
-    "not gzip not modified responses" in withApplication(NotModified) { implicit mat =>
-      checkNotGzipped(makeGzipRequest, "")
+    "not gzip not modified responses" in withApplication(NotModified) { implicit app =>
+      checkNotGzipped(makeGzipRequest(app), "")(app.materializer)
     }
 
-    "gzip chunked responses" in withApplication(Ok.chunked(Source(List("foo", "bar")))) { implicit mat =>
-      val result = makeGzipRequest
-      checkGzippedBody(result, "foobar")
+    "gzip chunked responses" in withApplication(Ok.chunked(Source(List("foo", "bar")))) { implicit app =>
+      val result = makeGzipRequest(app)
+      checkGzippedBody(result, "foobar")(app.materializer)
       await(result).body must beAnInstanceOf[HttpEntity.Chunked]
     }
 
     val body = Random.nextString(1000)
 
     "not buffer more than the configured threshold" in withApplication(
-      Ok.sendEntity(HttpEntity.Streamed(Source.single(ByteString(body)), Some(1000), None)), chunkedThreshold = 512) { implicit mat =>
-        val result = makeGzipRequest
-        checkGzippedBody(result, body)
+      Ok.sendEntity(HttpEntity.Streamed(Source.single(ByteString(body)), Some(1000), None)), chunkedThreshold = 512) { implicit app =>
+        val result = makeGzipRequest(app)
+        checkGzippedBody(result, body)(app.materializer)
         await(result).body must beAnInstanceOf[HttpEntity.Chunked]
       }
 
-    "zip a strict body even if it exceeds the threshold" in withApplication(Ok(body), 512) { implicit mat =>
-      val result = makeGzipRequest
-      checkGzippedBody(result, body)
+    "zip a strict body even if it exceeds the threshold" in withApplication(Ok(body), 512) { implicit app =>
+      val result = makeGzipRequest(app)
+      checkGzippedBody(result, body)(app.materializer)
       await(result).body must beAnInstanceOf[HttpEntity.Strict]
     }
 
-    "preserve original headers" in withApplication(Ok("hello").withHeaders(SERVER -> "Play")) { implicit mat =>
-      val result = makeGzipRequest
+    "preserve original headers" in withApplication(Ok("hello").withHeaders(SERVER -> "Play")) { implicit app =>
+      val result = makeGzipRequest(app)
       checkGzipped(result)
       header(SERVER, result) must beSome("Play")
     }
 
-    "preserve original Vary header values" in withApplication(Ok("hello").withHeaders(VARY -> "original")) { implicit mat =>
-      val result = makeGzipRequest
+    "preserve original Vary header values" in withApplication(Ok("hello").withHeaders(VARY -> "original")) { implicit app =>
+      val result = makeGzipRequest(app)
       checkGzipped(result)
       header(VARY, result) must beSome.which(header => header contains "original,")
     }
 
-    "preserve original Vary header values and not duplicate case-insensitive ACCEPT-ENCODING" in withApplication(Ok("hello").withHeaders(VARY -> "original,ACCEPT-encoding")) { implicit mat =>
-      val result = makeGzipRequest
+    "preserve original Vary header values and not duplicate case-insensitive ACCEPT-ENCODING" in withApplication(Ok("hello").withHeaders(VARY -> "original,ACCEPT-encoding")) { implicit app =>
+      val result = makeGzipRequest(app)
       checkGzipped(result)
       header(VARY, result) must beSome.which(header => header.split(",").filter(_.toLowerCase(java.util.Locale.ENGLISH) == ACCEPT_ENCODING.toLowerCase(java.util.Locale.ENGLISH)).size == 1)
     }
@@ -141,7 +142,7 @@ object GzipFilterSpec extends PlaySpecification with DataTables {
     def filters = Seq(gzipFilter)
   }
 
-  def withApplication[T](result: Result, chunkedThreshold: Int = 1024)(block: Materializer => T): T = {
+  def withApplication[T](result: Result, chunkedThreshold: Int = 1024)(block: Application => T): T = {
     val application = new GuiceApplicationBuilder()
       .configure(
         "play.filters.gzip.chunkedThreshold" -> chunkedThreshold,
@@ -152,14 +153,14 @@ object GzipFilterSpec extends PlaySpecification with DataTables {
           }),
           bind[HttpFilters].to[Filters]
         ).build
-    running(application)(block(application.materializer))
+    running(application)(block(application))
   }
 
   def gzipRequest = FakeRequest().withHeaders(ACCEPT_ENCODING -> "gzip")
 
-  def makeGzipRequest = route(gzipRequest).get
+  def makeGzipRequest(app: Application) = route(app, gzipRequest).get
 
-  def requestAccepting(codings: String) = route(FakeRequest().withHeaders(ACCEPT_ENCODING -> codings)).get
+  def requestAccepting(app: Application, codings: String) = route(app, FakeRequest().withHeaders(ACCEPT_ENCODING -> codings)).get
 
   def gunzip(bytes: ByteString): String = {
     val is = new GZIPInputStream(new ByteArrayInputStream(bytes.toArray))

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
@@ -6,7 +6,7 @@
 package play.filters.headers
 
 import javax.inject.Inject
-
+import play.api.inject.guice.GuiceApplicationBuilder
 import com.typesafe.config.ConfigFactory
 import play.api.http.HttpFilters
 import play.api.routing.Router
@@ -15,6 +15,7 @@ import play.api.mvc.{ Action, Result }
 import play.api.mvc.Results._
 import play.api.Configuration
 import play.api.inject.bind
+import play.api.Application
 
 object SecurityHeadersFilterSpec extends PlaySpecification {
 
@@ -31,21 +32,21 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
     Configuration(typesafeConfig)
   }
 
-  def withApplication[T](result: Result, config: String)(block: => T): T = {
-    running(_
+  def withApplication[T](result: Result, config: String)(block: Application => T): T = {
+    val app = new GuiceApplicationBuilder()
       .configure(configure(config))
       .overrides(
         bind[Router].to(Router.from {
           case _ => Action(result)
         }),
         bind[HttpFilters].to[Filters]
-      )
-    )(_ => block)
+      ).build
+    running(app)(block(app))
   }
 
   "security headers" should {
 
-    "work with default singleton apply method with all default options" in new WithApplication() {
+    "work with default singleton apply method with all default options" in new WithApplication() { app =>
       val filter = SecurityHeadersFilter()
       // Play.current is set at this point...
       val rh = FakeRequest()
@@ -59,7 +60,7 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
       header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("default-src 'self'")
     }
 
-    "work with singleton apply method using configuration" in new WithApplication() {
+    "work with singleton apply method using configuration" in new WithApplication() { app =>
       val filter = SecurityHeadersFilter(Configuration.reference)
       val rh = FakeRequest()
       val action = Action(Ok("success"))
@@ -77,8 +78,9 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
       "work with custom frame options" in withApplication(Ok("hello"),
         """
           |play.filters.headers.frameOptions=some frame option
-        """.stripMargin) {
-          val result = route(FakeRequest()).get
+        """.stripMargin) { app =>
+
+          val result = route(app, FakeRequest()).get
 
           header(X_FRAME_OPTIONS_HEADER, result) must beSome("some frame option")
         }
@@ -86,9 +88,9 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
       "work with no frame options" in withApplication(Ok("hello"),
         """
           |play.filters.headers.frameOptions=null
-        """.stripMargin) {
+        """.stripMargin) { app =>
 
-          val result = route(FakeRequest()).get
+          val result = route(app, FakeRequest()).get
 
           header(X_FRAME_OPTIONS_HEADER, result) must beNone
         }
@@ -99,8 +101,8 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
       "work with custom xss protection" in withApplication(Ok("hello"),
         """
           |play.filters.headers.xssProtection=some xss protection
-        """.stripMargin) {
-          val result = route(FakeRequest()).get
+        """.stripMargin) { app =>
+          val result = route(app, FakeRequest()).get
 
           header(X_XSS_PROTECTION_HEADER, result) must beSome("some xss protection")
         }
@@ -108,8 +110,9 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
       "work with no xss protection" in withApplication(Ok("hello"),
         """
           |play.filters.headers.xssProtection=null
-        """.stripMargin) {
-          val result = route(FakeRequest()).get
+        """.stripMargin) { app =>
+
+          val result = route(app, FakeRequest()).get
 
           header(X_XSS_PROTECTION_HEADER, result) must beNone
         }
@@ -120,8 +123,8 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
       "work with custom content type options protection" in withApplication(Ok("hello"),
         """
           |play.filters.headers.contentTypeOptions="some content type option"
-        """.stripMargin) {
-          val result = route(FakeRequest()).get
+        """.stripMargin) { app =>
+          val result = route(app, FakeRequest()).get
 
           header(X_CONTENT_TYPE_OPTIONS_HEADER, result) must beSome("some content type option")
         }
@@ -129,8 +132,9 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
       "work with no content type options protection" in withApplication(Ok("hello"),
         """
           |play.filters.headers.contentTypeOptions=null
-        """.stripMargin) {
-          val result = route(FakeRequest()).get
+        """.stripMargin) { app =>
+
+          val result = route(app, FakeRequest()).get
 
           header(X_CONTENT_TYPE_OPTIONS_HEADER, result) must beNone
         }
@@ -141,8 +145,9 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
       "work with custom" in withApplication(Ok("hello"),
         """
           |play.filters.headers.permittedCrossDomainPolicies="some very long word"
-        """.stripMargin) {
-          val result = route(FakeRequest()).get
+        """.stripMargin) { app =>
+
+          val result = route(app, FakeRequest()).get
 
           header(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, result) must beSome("some very long word")
         }
@@ -150,8 +155,9 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
       "work with none" in withApplication(Ok("hello"),
         """
           |play.filters.headers.permittedCrossDomainPolicies=null
-        """.stripMargin) {
-          val result = route(FakeRequest()).get
+        """.stripMargin) { app =>
+
+          val result = route(app, FakeRequest()).get
 
           header(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, result) must beNone
         }
@@ -162,8 +168,8 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
       "work with custom" in withApplication(Ok("hello"),
         """
           |play.filters.headers.contentSecurityPolicy="some content security policy"
-        """.stripMargin) {
-          val result = route(FakeRequest()).get
+        """.stripMargin) { app =>
+          val result = route(app, FakeRequest()).get
 
           header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("some content security policy")
         }
@@ -171,8 +177,9 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
       "work with none" in withApplication(Ok("hello"),
         """
           |play.filters.headers.contentSecurityPolicy=null
-        """.stripMargin) {
-          val result = route(FakeRequest()).get
+        """.stripMargin) { app =>
+
+          val result = route(app, FakeRequest()).get
 
           header(CONTENT_SECURITY_POLICY_HEADER, result) must beNone
         }
@@ -184,9 +191,9 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
         """
           |play.filters.headers.contentSecurityPolicy="some content security policy"
           |play.filters.headers.allowActionSpecificHeaders=true
-        """.stripMargin) {
+        """.stripMargin) { app =>
 
-          val result = route(FakeRequest()).get
+          val result = route(app, FakeRequest()).get
 
           header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("my action-specific header")
           header(X_FRAME_OPTIONS_HEADER, result) must beSome("DENY")
@@ -196,9 +203,8 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
         .withHeaders(CONTENT_SECURITY_POLICY_HEADER → "my action-specific header"),
         """
           |play.filters.headers.allowActionSpecificHeaders=true
-        """.stripMargin) {
-
-          val result = route(FakeRequest()).get
+        """.stripMargin) { app =>
+          val result = route(app, FakeRequest()).get
 
           header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("my action-specific header")
           header(X_FRAME_OPTIONS_HEADER, result) must beSome("DENY")
@@ -209,9 +215,8 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
         """
           |play.filters.headers.contentSecurityPolicy="some content security policy"
           |play.filters.headers.allowActionSpecificHeaders=false
-        """.stripMargin) {
-
-          val result = route(FakeRequest()).get
+        """.stripMargin) { app =>
+          val result = route(app, FakeRequest()).get
 
           // from config
           header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("some content security policy")
@@ -223,9 +228,8 @@ object SecurityHeadersFilterSpec extends PlaySpecification {
         .withHeaders(CONTENT_SECURITY_POLICY_HEADER → "my action-specific header"),
         """
           |play.filters.headers.contentSecurityPolicy="some content security policy"
-        """.stripMargin) {
-
-          val result = route(FakeRequest()).get
+        """.stripMargin) { app =>
+          val result = route(app, FakeRequest()).get
 
           // from config
           header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("some content security policy")


### PR DESCRIPTION
Fixes deprecation warnings 
`   Method route in trait RouteInvokers is deprecated: Use the version that takes an application` 

in spec/test code:
-   `SecurityHeadersFilterSpec`, 
-  `GzipFilterSpec`,
-  `CORSSpec`,
-  `AllowedHostsFilterSpec`

