### PR TITLE
Add HttpEntity.Head for responding to HEAD requests

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -155,6 +155,10 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
     }
 
     result.body match {
+      case PlayHttpEntity.Head(Some(contentLength), _) =>
+        HttpEntity.Default(contentType, contentLength, Source.empty)
+      case PlayHttpEntity.Head(_, _) =>
+        HttpEntity.CloseDelimited(contentType, Source.empty)
       case PlayHttpEntity.Strict(data, _) =>
         HttpEntity.Strict(contentType, data)
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -170,6 +170,17 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
         responses(1).status must_== 200
       }
 
+    "send Content-Length with no content in response to HEAD requests" in withServer(
+      Results.Ok.sendEntity(HttpEntity.Head(Some(1000)))
+    ) { port =>
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("HEAD", "/", "HTTP/1.1", Map(), "")
+        ).head
+        response.status must_== 200
+        response.headers.get(CONTENT_LENGTH) must beSome("1000")
+        response.body must beLeft("")
+      }
+
     "allow sending trailers" in withServer(
       Result(ResponseHeader(200, Map(TRANSFER_ENCODING -> CHUNKED, TRAILER -> "Chunks")),
         HttpEntity.Chunked(Source(List(


### PR DESCRIPTION
Fixes #6126
- Adds a new entity type for handling HEAD requests. This allows a user to send a response without a body but with an explicitly defined content type.
- Adds warnings for common error cases when trying to respond to HEAD requests explicitly.

I'm not positive this is the right solution to the problem, though. We need to make sure any solution we provide also doesn't break HEAD requests to existing GET actions, though.
