### PR TITLE
added a warning inside the play ws ssl config parser

### DIFF
--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/Config.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/Config.scala
@@ -9,6 +9,7 @@ import java.net.URL
 import java.security.{ KeyStore, SecureRandom }
 import javax.net.ssl.{ KeyManagerFactory, TrustManagerFactory }
 
+import org.slf4j.LoggerFactory
 import play.api.Configuration
 
 /**
@@ -141,9 +142,9 @@ case class SSLDebugRecordOptions(plaintext: Boolean = false, packet: Boolean = f
  * @param allowWeakCiphers Whether weak ciphers should be allowed or not.
  * @param allowWeakProtocols Whether weak protocols should be allowed or not.
  * @param allowLegacyHelloMessages Whether legacy hello messages should be allowed or not.  If None, uses the platform
- *                                 default.
+ * default.
  * @param allowUnsafeRenegotiation Whether unsafe renegotiation should be allowed or not. If None, uses the platform
- *                                 default.
+ * default.
  * @param acceptAnyCertificate Whether any X.509 certificate should be accepted or not.
  */
 case class SSLLooseConfig(
@@ -192,12 +193,15 @@ object SSLConfigFactory {
 
   /**
    * Create an instance of the default config
+   *
    * @return
    */
   def defaultConfig = SSLConfig()
 }
 
 class SSLConfigParser private[play] (c: Configuration, classLoader: ClassLoader) {
+
+  private[ssl] val logger = LoggerFactory.getLogger(this.getClass)
 
   def parse(): SSLConfig = {
 
@@ -247,6 +251,13 @@ class SSLConfigParser private[play] (c: Configuration, classLoader: ClassLoader)
     val allowMessages = config.get[Option[Boolean]]("allowLegacyHelloMessages")
     val allowUnsafeRenegotiation = config.get[Option[Boolean]]("allowUnsafeRenegotiation")
     val acceptAnyCertificate = config.get[Boolean]("acceptAnyCertificate")
+
+    if (acceptAnyCertificate) {
+      logger.warn("""
+        |You've enabled play.ws.ssl.loose.acceptAnyCertificate,
+        |please be sure to disable that on production!
+        |""".stripMargin)
+    }
 
     SSLLooseConfig(
       allowWeakCiphers = allowWeakCiphers,

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/SSLConfigParserSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/SSLConfigParserSpec.scala
@@ -6,9 +6,11 @@
 package play.api.libs.ws.ssl
 
 import org.specs2.mutable._
-
 import com.typesafe.config.ConfigFactory
+import org.slf4j.LoggerFactory
 import play.api.Configuration
+import play.api.libs.ws.ahc.AhcConfigBuilder
+import play.api.libs.ws.ahc.AhcConfigSpec._
 import play.api.test.WithApplication
 
 object SSLConfigParserSpec extends Specification {
@@ -199,6 +201,28 @@ object SSLConfigParserSpec extends Specification {
                    |  ]
                    |}
                  """.stripMargin).must(throwAn[AssertionError])
+    }
+
+    "log a warning if ws.ssl.loose.acceptAnyCertificate is true" in {
+      import ch.qos.logback.classic.spi._
+      import ch.qos.logback.classic._
+
+      val config = ConfigFactory.parseString("loose.acceptAnyCertificate = true").withFallback(ConfigFactory.defaultReference().getConfig("play.ws.ssl"))
+      val configParser = new SSLConfigParser(Configuration(config), this.getClass.getClassLoader)
+
+      // this only works with test:test, has a different type in test:testQuick and test:testOnly!
+      val logger = configParser.logger.asInstanceOf[ch.qos.logback.classic.Logger]
+      val appender = new ch.qos.logback.core.read.ListAppender[ILoggingEvent]()
+      val lc = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+      appender.setContext(lc)
+      appender.start()
+      logger.addAppender(appender)
+      logger.setLevel(Level.WARN)
+
+      configParser.parse()
+
+      val warahcs = appender.list
+      warahcs.size must beGreaterThan(0)
     }
 
   }


### PR DESCRIPTION
actually there should be a warning so that you don't enable acceptAnyCertificate in production

As discussed here: https://github.com/playframework/playframework/pull/6170