### PR TITLE
Properly forward the persistence unit name in Java DefaultJPAApi

### DIFF
--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -104,7 +104,7 @@ public class DefaultJPAApi implements JPAApi {
      * @return code execution result
      */
     public <T> T withTransaction(String name, Function<EntityManager, T> block) {
-        return withTransaction("default", false, block);
+        return withTransaction(name, false, block);
     }
 
     /**


### PR DESCRIPTION
## Fixes

Properly forward the persistence unit name instead of the `default` one. Fixes wrong persistence unit name that use the `default` instead of the provided one.

## Purpose

Very simple quick fix. We are using 2 persistence unit (none of them are named `default`) and that's why we saw the error.

## Background Context

Well very simple fix :)

## References

Nop