### PR TITLE
[doc] Add an example showing a custom FilePartHandler

### DIFF
--- a/documentation/manual/working/scalaGuide/main/upload/ScalaFileUpload.md
+++ b/documentation/manual/working/scalaGuide/main/upload/ScalaFileUpload.md
@@ -15,7 +15,7 @@ Now define the `upload` action using a `multipartFormData` body parser:
 
 @[upload-file-action](code/ScalaFileUpload.scala)
 
-The `ref` attribute give you a reference to a `TemporaryFile`. This is the default way the `mutipartFormData` parser handles file upload.
+The `ref` attribute give you a reference to a `TemporaryFile`. This is the default way the `multipartFormData` parser handles file upload.
 
 > **Note:** As always, you can also use the `anyContent` body parser and retrieve it as `request.body.asMultipartFormData`.
 
@@ -35,4 +35,8 @@ In this case we can just use a body parser to store the request body content in 
 
 If you want to handle the file upload directly without buffering it in a temporary file, you can just write your own `BodyParser`. In this case, you will receive chunks of data that you are free to push anywhere you want.
 
-If you want to use `multipart/form-data` encoding, you can still use the default `mutipartFormData` parser by providing your own `PartHandler[FilePart[A]]`. You receive the part headers, and you have to provide an `Iteratee[Array[Byte], FilePart[A]]` that will produce the right `FilePart`.
+If you want to use `multipart/form-data` encoding, you can still use the default `multipartFormData` parser by providing a `FilePartHandler[A]` and using a different Sink to accumulate data.  For example, you can use a `FilePartHandler[File]` rather than a TemporaryFile by specifying an `Accumulator(fileSink)`:
+
+@[upload-file-customparser](code/ScalaFileUpload.scala)
+
+

--- a/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
+++ b/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
@@ -14,6 +14,25 @@ package scalaguide.upload.fileupload {
   import play.api.libs.Files.TemporaryFile
   import play.api.mvc.MultipartFormData.FilePart
 
+  import java.io.File
+  import java.nio.file.attribute.PosixFilePermission._
+  import java.nio.file.attribute.PosixFilePermissions
+  import java.nio.file.{Files, Path}
+  import java.util
+  import javax.inject._
+
+  import akka.stream.IOResult
+  import akka.stream.scaladsl._
+  import akka.util.ByteString
+  import play.api._
+  import play.api.libs.streams._
+  import play.api.mvc.MultipartFormData.FilePart
+  import play.api.mvc._
+  import play.core.parsers.Multipart.FileInfo
+
+  import scala.concurrent.Future
+
+
   @RunWith(classOf[JUnitRunner])
   class ScalaFileUploadSpec extends PlaySpecification with Controller {
 
@@ -100,6 +119,32 @@ package scalaguide.upload.fileupload {
       def index = Action { request =>
         Ok("Upload failed")
       }
+
+      //#upload-file-customparser
+      type FilePartHandler[A] = FileInfo => Accumulator[ByteString, FilePart[A]]
+
+      def handleFilePartAsFile: FilePartHandler[File] = {
+        case FileInfo(partName, filename, contentType) =>
+          val perms = java.util.EnumSet.of(OWNER_READ, OWNER_WRITE)
+          val attr = PosixFilePermissions.asFileAttribute(perms)
+          val path = Files.createTempFile("multipartBody", "tempFile", attr)
+          val file = path.toFile
+          val fileSink = FileIO.toFile(file)
+          val accumulator = Accumulator(fileSink)
+          accumulator.map { case IOResult(count, status) =>
+            FilePart(partName, filename, contentType, file)
+          }(play.api.libs.concurrent.Execution.defaultContext)
+      }
+
+      def uploadCustom = Action(parse.multipartFormData(handleFilePartAsFile)) { request =>
+        val fileOption = request.body.file("name").map {
+          case FilePart(key, filename, contentType, file) =>
+            file.toPath
+        }
+
+        Ok(s"File uploaded: $fileOption")
+      }
+      //#upload-file-customparser
 
     }
   }


### PR DESCRIPTION
## Fixes

Fixes https://github.com/playframework/playframework/issues/6182

## Purpose

This code sample adds a snippet to ScalaFileUpload.md and uses code from https://github.com/wsargent/play-fileupload-scala to show how to use a custom FilePartHandler with Akka Streams.

## Background Context

The page previously referenced an Iteratee and a PartHandler, and did not have an example.
