### PR TITLE
Fix displaying runtime exception coming from Twirl template while running in development mode - PR for branch 2.5.x

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -169,6 +169,7 @@ object Dependencies {
 
   def runSupportDependencies(sbtVersion: String, scalaVersion: String) = Seq(
     sbtIO(sbtVersion, scalaVersion),
+    "com.typesafe.play" %% "twirl-compiler" % BuildInfo.sbtTwirlVersion,
     logback % Test
   ) ++ specsBuild.map(_ % Test)
 

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -33,7 +33,7 @@ object PlayReload {
   }
 
   def originalSource(file: File): Option[File] = {
-    play.twirl.compiler.MaybeGeneratedSource.unapply(file).map(_.file)
+    play.twirl.compiler.MaybeGeneratedSource.unapply(file).flatMap(_.source)
   }
 
   def compileFailure(streams: Option[Streams])(incomplete: Incomplete): CompileResult = {


### PR DESCRIPTION
Fixes #6190 for `2.5.x` branch