### PR TITLE
Fix displaying runtime exception coming from Twirl template while running in development mode - PR for branch 2.4.x

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -158,7 +158,8 @@ object Dependencies {
   }
 
   def runSupportDependencies(sbtVersion: String, scalaVersion: String) = Seq(
-    sbtIO(sbtVersion, scalaVersion)
+    sbtIO(sbtVersion, scalaVersion),
+    "com.typesafe.play" %% "twirl-compiler" % BuildInfo.sbtTwirlVersion
   ) ++ specsBuild.map(_ % Test)
 
   // use partial version so that non-standard scala binary versions from dbuild also work

--- a/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -10,6 +10,7 @@ import java.util.jar.JarFile
 import play.api.PlayException
 import play.core.{ Build, BuildLink, BuildDocHandler }
 import play.runsupport.classloader.{ ApplicationClassLoaderProvider, DelegatingClassLoader }
+import play.twirl.compiler.MaybeGeneratedSource
 import sbt.{ PathFinder, WatchState, SourceModificationWatch }
 
 object Reloader {
@@ -370,7 +371,15 @@ class Reloader(
     val topType = className.split('$').head
     currentSourceMap.flatMap { sources =>
       sources.get(topType).map { source =>
-        Array[java.lang.Object](source.original.getOrElse(source.file), line)
+        source.original match {
+          case Some(origFile) if line != null =>
+            val origLine: java.lang.Integer = MaybeGeneratedSource.unapply(source.file).map(_.mapLine(line): java.lang.Integer).orNull
+            Array[java.lang.Object](origFile, origLine)
+          case Some(origFile) =>
+            Array[java.lang.Object](origFile, null)
+          case None =>
+            Array[java.lang.Object](source.file, line)
+        }
       }
     }.orNull
   }

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -33,7 +33,7 @@ object PlayReload {
   }
 
   def originalSource(file: File): Option[File] = {
-    play.twirl.compiler.MaybeGeneratedSource.unapply(file).map(_.file)
+    play.twirl.compiler.MaybeGeneratedSource.unapply(file).flatMap(_.source)
   }
 
   def compileFailure(streams: Option[Streams])(incomplete: Incomplete): CompileResult = {


### PR DESCRIPTION
Fixes #6190 for `2.4.x` branch
