### PR TITLE
[WIP] BodyParser error messages in correct Content-Type

### DIFF
--- a/documentation/manual/working/javaGuide/main/application/code/javaguide/application/def/ErrorHandler.java
+++ b/documentation/manual/working/javaGuide/main/application/code/javaguide/application/def/ErrorHandler.java
@@ -11,6 +11,7 @@ import play.api.OptionalSourceMapper;
 import play.api.UsefulException;
 import play.api.routing.Router;
 import play.http.DefaultHttpErrorHandler;
+import play.http.HttpClientError;
 import play.mvc.Http.*;
 import play.mvc.*;
 
@@ -33,7 +34,7 @@ public class ErrorHandler extends DefaultHttpErrorHandler {
         );
     }
 
-    protected CompletionStage<Result> onForbidden(RequestHeader request, String message) {
+    protected CompletionStage<Result> onForbidden(HttpClientError error) {
         return CompletableFuture.completedFuture(
                 Results.forbidden("You're not allowed to access this resource.")
         );

--- a/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaEmbeddingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaEmbeddingPlay.scala
@@ -4,6 +4,7 @@
 package scalaguide.advanced.embedding
 
 import org.specs2.mutable.Specification
+import play.api.http.HttpClientError
 import play.api.test.WsTestClient
 
 import scala.concurrent.Await
@@ -79,7 +80,7 @@ object ScalaEmbeddingPlay extends Specification with WsTestClient {
         override lazy val httpErrorHandler = new DefaultHttpErrorHandler(environment,
           configuration, sourceMapper, Some(router)) {
 
-          override protected def onNotFound(request: RequestHeader, message: String) = {
+          override protected def onNotFound(error: HttpClientError) = {
             Future.successful(Results.NotFound("Nothing was found!"))
           }
         }

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
@@ -19,7 +19,7 @@ import java.net.InetSocketAddress
 import akka.http.scaladsl.settings.ServerSettings
 import akka.util.ByteString
 import play.api._
-import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
+import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler, HttpServerError }
 import play.api.libs.streams.{ Accumulator, MaterializeOnDemandPublisher }
 import play.api.mvc._
 import play.core.ApplicationProvider
@@ -170,7 +170,7 @@ class AkkaHttpServer(
         val actionWithErrorHandling = EssentialAction { rh =>
           import play.core.Execution.Implicits.trampoline
           action(rh).recoverWith {
-            case error => errorHandler.onServerError(taggedRequestHeader, error)
+            case error => errorHandler.onError(new HttpServerError(taggedRequestHeader, error))
           }
         }
         executeAction(request, taggedRequestHeader, requestBodySource, actionWithErrorHandling, errorHandler)

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
@@ -7,12 +7,11 @@ import java.util.Locale
 
 import scala.collection.immutable
 import scala.concurrent.Future
-
 import java.net.{ URI, URISyntaxException }
 
 import play.api.LoggerLike
-import play.api.http.{ HttpErrorHandler, HeaderNames, HttpVerbs }
-import play.api.mvc.{ RequestHeader, Results, Result }
+import play.api.http._
+import play.api.mvc.{ RequestHeader, Result, Results }
 
 /**
  * An abstraction for providing [[play.api.mvc.Action]]s and [[play.api.mvc.Filter]]s that support Cross-Origin
@@ -143,10 +142,10 @@ private[cors] trait AbstractCORSPolicy {
       // We must recover any errors so that we can add the headers to them to allow clients to see the result
       val result = try {
         next(taggedRequest).recoverWith {
-          case e: Throwable => errorHandler.onServerError(taggedRequest, e)
+          case e: Throwable => errorHandler.onError(new HttpServerError(taggedRequest, e))
         }
       } catch {
-        case e: Throwable => errorHandler.onServerError(taggedRequest, e)
+        case e: Throwable => errorHandler.onError(new HttpServerError(taggedRequest, e))
       }
       result.map(_.withHeaders(headerBuilder.result(): _*))
     }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -16,6 +16,7 @@ import play.api.mvc.Results._
 import play.api.mvc._
 import play.core.j.JavaHelpers
 import play.filters.csrf.CSRF.{ CSRFHttpErrorHandler, Token, _ }
+import play.api.http.HttpError
 import play.mvc.Http
 import play.utils.Reflect
 
@@ -235,7 +236,7 @@ object CSRF {
 
   class CSRFHttpErrorHandler @Inject() (httpErrorHandler: HttpErrorHandler) extends ErrorHandler {
     import play.api.http.Status.FORBIDDEN
-    def handle(req: RequestHeader, msg: String) = httpErrorHandler.onClientError(req, FORBIDDEN, msg)
+    def handle(req: RequestHeader, msg: String) = httpErrorHandler.onError(HttpError.fromString(req, FORBIDDEN, msg))
   }
 
   object DefaultErrorHandler extends ErrorHandler {

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -5,7 +5,7 @@ package play.filters.hosts
 
 import javax.inject.{ Inject, Provider, Singleton }
 
-import play.api.http.{ HttpErrorHandler, Status }
+import play.api.http.{ HttpError, HttpErrorHandler, Status }
 import play.api.inject.Module
 import play.api.libs.streams.Accumulator
 import play.api.mvc.{ EssentialAction, EssentialFilter }
@@ -29,7 +29,7 @@ case class AllowedHostsFilter @Inject() (config: AllowedHostsConfig, errorHandle
     if (hostMatchers.exists(_(req.host))) {
       next(req)
     } else {
-      Accumulator.done(errorHandler.onClientError(req, Status.BAD_REQUEST, s"Host not allowed: ${req.host}"))
+      Accumulator.done(errorHandler.onError(HttpError.fromString(req, Status.BAD_REQUEST, s"Host not allowed: ${req.host}")))
     }
   }
 }

--- a/framework/src/play/src/main/java/play/http/HttpClientError.java
+++ b/framework/src/play/src/main/java/play/http/HttpClientError.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.http;
+
+import play.mvc.Http;
+import play.mvc.Result;
+import play.mvc.Results;
+
+public class HttpClientError implements HttpError<Object> {
+
+    private final Http.RequestHeader request;
+    private final int statusCode;
+    private final Object error;
+    private final HttpEntity entity;
+
+    public HttpClientError(Http.RequestHeader request, int statusCode, Object error, HttpEntity entity) {
+        this.request = request;
+        this.statusCode = statusCode;
+        this.error = error;
+        this.entity = entity;
+    }
+
+    public int statusCode() {
+        return statusCode;
+    };
+
+    @Override
+    public Object error() {
+        return error;
+    }
+
+    @Override
+    public HttpEntity entity() {
+        return entity;
+    }
+
+    @Override
+    public Http.RequestHeader request() {
+        return request;
+    }
+
+    @Override
+    public play.api.http.HttpClientError asScala() {
+        return new play.api.http.HttpClientError(request._underlyingHeader(), statusCode, error, entity.asScala());
+    }
+
+    public Result asResult() {
+        return Results.status(statusCode).sendEntity(entity);
+    }
+
+}

--- a/framework/src/play/src/main/java/play/http/HttpError.java
+++ b/framework/src/play/src/main/java/play/http/HttpError.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.http;
+
+import play.mvc.Http;
+import play.mvc.Result;
+
+import java.nio.charset.StandardCharsets;
+
+public interface HttpError<T> {
+
+    T error();
+
+    HttpEntity entity();
+
+    Http.RequestHeader request();
+
+    play.api.http.HttpError<T> asScala();
+
+    Result asResult();
+
+    static HttpClientError fromString(Http.RequestHeader request, int statusCode, String message) {
+        HttpEntity entity = HttpEntity.fromString(message, StandardCharsets.UTF_8.name());
+        return new HttpClientError(request, statusCode, message, entity);
+    };
+
+}

--- a/framework/src/play/src/main/java/play/http/HttpErrorHandler.java
+++ b/framework/src/play/src/main/java/play/http/HttpErrorHandler.java
@@ -3,8 +3,13 @@
  */
 package play.http;
 
+
 import play.mvc.Http.RequestHeader;
 import play.mvc.Result;
+import scala.Enumeration;
+import scala.Function1;
+import scala.Option;
+import scala.Tuple3;
 
 import java.util.concurrent.CompletionStage;
 
@@ -16,19 +21,10 @@ import java.util.concurrent.CompletionStage;
 public interface HttpErrorHandler {
 
     /**
-     * Invoked when a client error occurs, that is, an error in the 4xx series.
+     * Invoked when a error occurs.
      *
-     * @param request The request that caused the client error.
-     * @param statusCode The error status code.  Must be greater or equal to 400, and less than 500.
-     * @param message The error message.
+     * @param error The error.
      */
-    CompletionStage<Result> onClientError(RequestHeader request, int statusCode, String message);
+    CompletionStage<Result> onError(HttpError<?> error);
 
-    /**
-     * Invoked when a server error occurs.
-     *
-     * @param request The request that triggered the server error.
-     * @param exception The server error.
-     */
-    CompletionStage<Result> onServerError(RequestHeader request, Throwable exception);
 }

--- a/framework/src/play/src/main/java/play/http/HttpServerError.java
+++ b/framework/src/play/src/main/java/play/http/HttpServerError.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.http;
+
+import play.mvc.Http;
+import play.mvc.Result;
+import play.mvc.Results;
+
+public class HttpServerError implements HttpError<Throwable> {
+
+    private final Http.RequestHeader request;
+    private final Throwable error;
+
+    public HttpServerError(Http.RequestHeader request, Throwable error) {
+        this.request = request;
+        this.error = error;
+    }
+
+    @Override
+    public Throwable error() {
+        return error;
+    }
+
+    @Override
+    public HttpEntity entity() {
+        return asScala().entity().asJava();
+    }
+
+    @Override
+    public Http.RequestHeader request() {
+        return request;
+    }
+
+    @Override
+    public play.api.http.HttpError<Throwable> asScala() {
+        return play.api.http.HttpServerError.apply(request._underlyingHeader(), error);
+    }
+
+    public Result asResult() {
+        return Results.internalServerError().sendEntity(entity());
+    }
+
+}

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -16,6 +16,7 @@ import play.api.mvc.MaxSizeNotExceeded$;
 import play.api.mvc.MaxSizeStatus;
 import play.core.j.JavaParsers;
 import play.core.parsers.FormUrlEncodedParser;
+import play.http.HttpError;
 import play.http.HttpErrorHandler;
 import play.libs.F;
 import play.libs.XML;
@@ -366,7 +367,7 @@ public interface BodyParser<A> {
                   if (status instanceof MaxSizeNotExceeded$) {
                       return resultFuture;
                   } else {
-                      return errorHandler.onClientError(request, Status$.MODULE$.REQUEST_ENTITY_TOO_LARGE(), "Request entity too large")
+                      return errorHandler.onError(HttpError.fromString(request, Status$.MODULE$.REQUEST_ENTITY_TOO_LARGE(), "Request entity too large"))
                               .thenApply(F.Either::<Result, A>Left);
                   }
                })
@@ -405,7 +406,7 @@ public interface BodyParser<A> {
                 try {
                     return CompletableFuture.completedFuture(F.Either.Right(parse(request, bytes)));
                 } catch (Exception e) {
-                    return errorHandler.onClientError(request, Status$.MODULE$.BAD_REQUEST(), errorMessage + ": " + e.getMessage())
+                    return errorHandler.onError(HttpError.fromString(request, Status$.MODULE$.BAD_REQUEST(), errorMessage + ": " + e.getMessage()))
                             .thenApply(F.Either::<Result, A>Left);
                 }
             }, JavaParsers.trampoline());

--- a/framework/src/play/src/main/java/play/mvc/BodyParsers.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParsers.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 import play.api.http.Status$;
+import play.http.HttpError;
 import play.http.HttpErrorHandler;
 import play.libs.F;
 import play.libs.streams.Accumulator;
@@ -41,7 +42,7 @@ public class BodyParsers {
             return parser.apply(request);
         } else {
             CompletionStage<Result> result =
-                    errorHandler.onClientError(request, Status$.MODULE$.UNSUPPORTED_MEDIA_TYPE(), errorMessage);
+                    errorHandler.onError(HttpError.fromString(request, Status$.MODULE$.UNSUPPORTED_MEDIA_TYPE(), errorMessage));
             return Accumulator.done(result.thenApply(F.Either::Left));
         }
     }

--- a/framework/src/play/src/main/scala/play/api/http/HttpError.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpError.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.http
+
+import play.api.libs.json.{ JsError, Json }
+import play.api.mvc.{ Codec, RequestHeader, Result, Results }
+import play.core.j.JavaHelpers
+
+sealed trait HttpError[T] {
+
+  def error: T
+
+  def entity: HttpEntity
+
+  def request: RequestHeader
+
+  def asJava: play.http.HttpError[T]
+
+  def asResult: Result
+
+}
+
+case class HttpClientError(request: RequestHeader, statusCode: Int, error: AnyRef, entity: HttpEntity) extends HttpError[AnyRef] {
+
+  override def asJava: play.http.HttpClientError = JavaHelpers.withContext(request) { ctx =>
+    new play.http.HttpClientError(ctx.request(), statusCode, error, entity.asJava)
+  }
+
+  override def asResult: Result = Results.Status(statusCode).sendEntity(entity)
+
+}
+
+object HttpError {
+
+  def fromString(request: RequestHeader, statusCode: Int, message: String = ""): HttpClientError = {
+    val entity = HttpEntity.Strict(Codec.utf_8.encode(message), Option(ContentTypes.HTML))
+    new HttpClientError(request, statusCode, message, entity)
+  }
+
+  def fromJsError(request: RequestHeader, statusCode: Int, jsError: JsError): HttpClientError = {
+    val entity = HttpEntity.Strict(Codec.utf_8.encode(Json.stringify(JsError.toJson(jsError))), Option(ContentTypes.JSON))
+    new HttpClientError(request, statusCode, jsError, entity)
+  }
+
+}
+
+case class HttpServerError(request: RequestHeader, error: Throwable) extends HttpError[Throwable] {
+
+  override def entity: HttpEntity = {
+    HttpEntity.Strict(Codec.utf_8.encode(s"A server error occurred:  ${error.getMessage}"), Option(ContentTypes.TEXT))
+  }
+
+  override def asJava: play.http.HttpError[Throwable] = JavaHelpers.withContext(request) { ctx =>
+    new play.http.HttpServerError(ctx.request(), error)
+  }
+
+  override def asResult: Result = Results.InternalServerError.sendEntity(entity)
+
+}

--- a/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -108,7 +108,7 @@ class DefaultHttpRequestHandler(router: Router, errorHandler: HttpErrorHandler, 
   def handlerForRequest(request: RequestHeader) = {
 
     def notFoundHandler = Action.async(BodyParsers.parse.empty)(req =>
-      errorHandler.onClientError(req, NOT_FOUND)
+      errorHandler.onError(HttpError.fromString(req, NOT_FOUND))
     )
 
     val (routedRequest, handler) = routeRequest(request) map {

--- a/framework/src/play/src/main/scala/play/core/j/JavaHttpErrorHandlerAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHttpErrorHandlerAdapter.scala
@@ -5,20 +5,20 @@ package play.core.j
 
 import javax.inject.Inject
 
-import play.api.http.HttpErrorHandler
-import play.api.mvc.RequestHeader
+import play.api.http.{ HttpError, HttpErrorHandler }
+import play.api.mvc.{ RequestHeader, Result }
 import play.http.{ HttpErrorHandler => JHttpErrorHandler }
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import scala.compat.java8.FutureConverters
+import scala.concurrent.Future
 
 /**
  * Adapter from a Java HttpErrorHandler to a Scala HttpErrorHandler
  */
 class JavaHttpErrorHandlerAdapter @Inject() (underlying: JHttpErrorHandler) extends HttpErrorHandler {
 
-  def onClientError(request: RequestHeader, statusCode: Int, message: String) = {
-    JavaHelpers.invokeWithContext(request, req => underlying.onClientError(req, statusCode, message))
+  override def onError(error: HttpError[_]): Future[Result] = {
+    FutureConverters.toScala(underlying.onError(error.asJava)).map(_.asScala())
   }
 
-  def onServerError(request: RequestHeader, exception: Throwable) = {
-    JavaHelpers.invokeWithContext(request, req => underlying.onServerError(req, exception))
-  }
 }

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -9,6 +9,7 @@ import akka.stream.{ Attributes, FlowShape, Inlet, Outlet }
 import akka.stream.stage._
 import akka.util.ByteString
 import play.api.Play
+import play.api.http.HttpError
 import play.api.libs.Files.TemporaryFile
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
@@ -18,7 +19,6 @@ import play.api.http.Status._
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
-
 import play.core.Execution.Implicits.trampoline
 
 /**
@@ -213,7 +213,7 @@ object Multipart {
 
   private def createBadResult[A](msg: String, status: Int = BAD_REQUEST): RequestHeader => Future[Either[Result, A]] = { request =>
     Play.privateMaybeApplication.fold(Future.successful(Left(Results.Status(status): Result)))(
-      _.errorHandler.onClientError(request, status, msg).map(Left(_)))
+      _.errorHandler.onError(HttpError.fromString(request, status, msg)).map(Left(_)))
   }
 
   private type RawPart = Either[Part[Unit], ByteString]

--- a/framework/src/play/src/main/scala/play/core/routing/GeneratedRouter.scala
+++ b/framework/src/play/src/main/scala/play/core/routing/GeneratedRouter.scala
@@ -3,7 +3,7 @@
  */
 package play.core.routing
 
-import play.api.http.HttpErrorHandler
+import play.api.http.{ HttpError, HttpErrorHandler }
 import play.api.mvc._
 import play.api.routing.Router
 
@@ -86,7 +86,7 @@ abstract class GeneratedRouter extends Router {
   def errorHandler: HttpErrorHandler
 
   def badRequest(error: String) = Action.async { request =>
-    errorHandler.onClientError(request, play.api.http.Status.BAD_REQUEST, error)
+    errorHandler.onError(HttpError.fromString(request, play.api.http.Status.BAD_REQUEST, error))
   }
 
   def call(generator: => Handler): Handler = {


### PR DESCRIPTION
## Purpose

This PR adds a way to send Writeable's to onClientError so that BodyParsers could send their error message with their own data structure

## Goals:

- BodyParsers should response with the Content Type they try to represent (#3893)
- Better default content types for error pages (#5782)
- Improve the onClientError
- Implement the suggestion from gmethivn (#6171)

## Tasks:

- [x] create a HttpError class that contains a HttpEntity
- [x] create Helpers for constructing a HttpError
- [x] create a onError method that takes an HttpError
- [x] Java API
- [x] Fix Documentation Tests
- [x] Return the correct BodyParser Type
- [ ] XML Returns? Is there any "schema" or something how xml errors should be returned?
- [ ] Java Errors (looks like they are harder than I tought)
- [ ] Tests
- [ ] Documentation