### PR TITLE
Updated example to 2.5.x (play.routing.JavaScriptReverseRouter)

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/controllers/Application.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/controllers/Application.java
@@ -6,7 +6,7 @@ package javaguide.binder.controllers;
 //#javascript-router-resource-imports
 import play.mvc.Controller;
 import play.mvc.Result;
-import play.Routes;
+import play.routing.JavaScriptReverseRouter;
 //#javascript-router-resource-imports
 
 // import static javaguide.binder.controllers.routes;
@@ -16,7 +16,7 @@ public class Application extends Controller {
     //#javascript-router-resource
     public Result javascriptRoutes() {
         return ok(
-            Routes.javascriptRouter("jsRoutes",
+            JavaScriptReverseRouter.create("jsRoutes",
                 routes.javascript.Users.list(),
                 routes.javascript.Users.get()
             )
@@ -27,7 +27,7 @@ public class Application extends Controller {
     public Result javascriptRoutes2() {
         return ok(
             //#javascript-router-resource-custom-method
-            Routes.javascriptRouter("jsRoutes", "myAjaxMethod",
+            JavaScriptReverseRouter.create("jsRoutes", "myAjaxMethod",
                 routes.javascript.Users.list(),
                 routes.javascript.Users.get()
             )


### PR DESCRIPTION
## Fixes

Small update on example to use JavaScriptReverseRouter
https://www.playframework.com/documentation/2.5.x/api/java/play/routing/JavaScriptReverseRouter.html

## References

play.Routes and Routes.javascriptRouter has been deprecated