### PR TITLE
renamed withMultipartBody to withBody and made it public

### DIFF
--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
@@ -272,6 +272,11 @@ public interface WSRequest {
     WSRequest setBody(Source<ByteString,?> body);
 
     /**
+     * Set the multipart body this request should use.
+     */
+    WSRequest setMultipartBody(Source<? super Http.MultipartFormData.Part<Source<ByteString, ?>>, ?> body);
+
+    /**
      * Adds a header to the request.  Note that duplicate headers are allowed
      * by the HTTP specification, and removing a header is not available
      * through this API.

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
@@ -230,6 +230,14 @@ public class AhcWSRequest implements WSRequest {
     }
 
     @Override
+    public WSRequest setMultipartBody(Source<? super Http.MultipartFormData.Part<Source<ByteString, ?>>, ?> body) {
+        String boundary = MultipartFormatter.randomBoundary();
+        this.body = MultipartFormatter.transform(body, boundary);
+        setHeader("Content-Type", MultipartFormatter.boundaryToContentType(boundary));
+        return this;
+    }
+
+    @Override
     public String getUrl() {
         return this.url;
     }
@@ -319,7 +327,8 @@ public class AhcWSRequest implements WSRequest {
     @Override
     public CompletionStage<WSResponse> patch(Source<? super Http.MultipartFormData.Part<Source<ByteString, ?>>, ?> body) {
         setMethod("PATCH");
-        return executeWithBody(body);
+        setMultipartBody(body);
+        return execute();
     }
 
     //-------------------------------------------------------------------------
@@ -357,7 +366,8 @@ public class AhcWSRequest implements WSRequest {
     @Override
     public CompletionStage<WSResponse> post(Source<? super Http.MultipartFormData.Part<Source<ByteString, ?>>, ?> body) {
         setMethod("POST");
-        return executeWithBody(body);
+        setMultipartBody(body);
+        return execute();
     }
 
     //-------------------------------------------------------------------------
@@ -395,7 +405,8 @@ public class AhcWSRequest implements WSRequest {
     @Override
     public CompletionStage<WSResponse> put(Source<? super Http.MultipartFormData.Part<Source<ByteString, ?>>, ?> body) {
         setMethod("PUT");
-        return executeWithBody(body);
+        setMultipartBody(body);
+        return execute();
     }
 
     @Override
@@ -427,15 +438,6 @@ public class AhcWSRequest implements WSRequest {
             return ahcWsRequest.execute(ahcRequest);
         }, filters.iterator());
         return executor.apply(this);
-    }
-
-
-    private CompletionStage<WSResponse> executeWithBody(Source<? super Http.MultipartFormData.Part<Source<ByteString, ?>>, ?> body) {
-        String boundary = MultipartFormatter.randomBoundary();
-        Source<ByteString, ?> innerBody = MultipartFormatter.transform(body, boundary);
-        setBody(innerBody);
-        setHeader("Content-Type", MultipartFormatter.boundaryToContentType(boundary));
-        return execute();
     }
 
     @Override

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala
@@ -432,9 +432,9 @@ trait WSRequest {
   }
 
   /**
-   * Helper method for multipart body
+   * Sets a multipart body for this request
    */
-  private[libs] def withMultipartBody(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): WSRequest = {
+  def withBody(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): WSRequest = {
     val boundary = Multipart.randomBoundary()
     val contentType = s"multipart/form-data; boundary=$boundary"
     withBody(StreamedBody(Multipart.transform(body, boundary))).withHeaders("Content-Type" -> contentType)
@@ -466,7 +466,7 @@ trait WSRequest {
    * Perform a PATCH on the request asynchronously.
    */
   def patch(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): Future[WSResponse] = {
-    withMethod("PATCH").withMultipartBody(body).execute()
+    withMethod("PATCH").withBody(body).execute()
   }
 
   /**
@@ -485,7 +485,7 @@ trait WSRequest {
    * Perform a POST on the request asynchronously.
    */
   def post(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): Future[WSResponse] = {
-    withMethod("POST").withMultipartBody(body).execute()
+    withMethod("POST").withBody(body).execute()
   }
 
   /**
@@ -504,7 +504,7 @@ trait WSRequest {
    * Perform a PUT on the request asynchronously.
    */
   def put(body: Source[MultipartFormData.Part[Source[ByteString, _]], _]): Future[WSResponse] = {
-    withMethod("PUT").withMultipartBody(body).execute()
+    withMethod("PUT").withBody(body).execute()
   }
 
   /**


### PR DESCRIPTION
## Purpose

Makes the Method withMultipartBody public and renames it to withBody.
Actually that can't work on Java since there is a `WSRequest setBody(Source<ByteString,?> body);` and due to type erasure we can't have a `setBody(Source<? extends..)` any ideas to do that aswell?

## References

had a Conversation with @akkie that it's better to make it public
