### PR TITLE
[WIP] Typed request properties

### DIFF
--- a/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -4,23 +4,15 @@
 package play.core.server.common
 
 import org.specs2.mutable.Specification
+import play.api.libs.prop.PropMap
 import play.api.mvc._
 import play.api.mvc.Results._
 
 object ServerResultUtilsSpec extends Specification {
 
-  case class CookieRequestHeader(cookie: Option[(String, String)]) extends RequestHeader {
-    def id = 1
-    def tags = Map()
-    def uri = ""
-    def path = ""
-    def method = ""
-    def version = ""
-    def queryString = Map()
-    def remoteAddress = ""
-    def secure = false
-    override def clientCertificateChain = None
+  def CookieRequestHeader(cookie: Option[(String, String)]): RequestHeader = {
     val headers = new Headers(cookie.map { case (name, value) => "Cookie" -> s"$name=$value" }.toSeq)
+    new RequestHeaderImpl(RequestHeader.defaultBehavior, PropMap(RequestHeaderProp.Headers ~> headers))
   }
 
   "ServerResultUtils.cleanFlashCookie" should {

--- a/framework/src/play/src/main/scala/play/api/libs/prop/HasProps.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/prop/HasProps.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.libs.prop
+
+/**
+ * An object that contains properties. Each property uses a [[Prop]]
+ * as a key. `Prop`s identify each property and also define its type.
+ *
+ * @tparam Repr The concrete representation of the `HasProps`. This
+ *              type is used when constructing a new instance.
+ */
+trait HasProps[+Repr] {
+
+  protected def propBehavior: HasProps.Behavior
+  protected def propState: HasProps.State[Repr]
+
+  def prop[A](p: Prop[A]): A = {
+    val b = propBehavior
+    val s = propState
+    b.propBehaviorGet(b, s, p)
+  }
+  def propOrElse[A](p: Prop[A], default: => A): A = {
+    val b = propBehavior
+    val s = propState
+    if (b.propBehaviorContains(b, s, p)) b.propBehaviorGet(b, s, p) else default
+  }
+  def withProp[A](p: Prop[A], v: A): Repr = {
+    val b = propBehavior
+    val s = propState
+    b.propBehaviorUpdate(b, s, p, v).propStateToRepr
+  }
+  def containsProp[A](p: Prop[A]): Boolean = {
+    val b = propBehavior
+    val s = propState
+    b.propBehaviorContains(b, s, p)
+  }
+  def withProps(ps: Prop.WithValue[_]*): Repr = {
+    val b = propBehavior
+    val s = propState
+    val s2 = ps.foldLeft(s) { case (s1, p) => b.propBehaviorUpdate(b, s1, p.prop, p.value) }
+    s2.propStateToRepr
+  }
+}
+
+object HasProps {
+
+  /**
+   * A `Behavior` describes the way that properties are accessed and updated
+   * in a [[HasProps]] object. By implementing a `Behavior` it is possible to implement
+   * things like default values, lazy values, etc. You can use composition to
+   * extend one behavior with another.
+   */
+  trait Behavior {
+    // All methods are prefixed with 'propBehavior' to allow easy mixing in
+    def propBehaviorGet[A](behavior: Behavior, state: State[_], p: Prop[A]): A
+    def propBehaviorContains[A](behavior: Behavior, state: State[_], p: Prop[A]): Boolean
+    def propBehaviorUpdate[Repr, A](behavior: Behavior, state: State[Repr], p: Prop[A], v: A): State[Repr]
+  }
+
+  /**
+   * A `State` object stores the mutable state of a [[HasProps]] object.
+   * A simple implementation is to use a [[PropMap]]. See [[WithMapState]].
+   * You can also provide your own implementation, for example if you want
+   * to store some properties in a more efficient way.
+   *
+   * @tparam Repr The type of the `HasProps` that this state is linked to.
+   *              The `propStateToRepr` method converts this state to that
+   *              representation.
+   */
+  trait State[+Repr] {
+    // All methods are prefixed with 'propState' to allow easy mixing in
+    def propStateGet[A](p: Prop[A]): A
+    def propStateGetOrElse[A](p: Prop[A], default: => A): A
+    def propStateContains[A](p: Prop[A]): Boolean
+    def propStateUpdate[A](p: Prop[A], v: A): State[Repr]
+    def propStateToRepr: Repr
+    def propStateToString: String
+  }
+
+  /**
+   * A [[HasProps]] and [[State]] implementation backed by a [[PropMap]].
+   *
+   * @tparam Repr The concrete representation of the `HasProps`. This
+   *              type is used when constructing a new instance.
+   */
+  trait WithMapState[+Repr] extends HasProps[Repr] with State[Repr] {
+    self: Repr =>
+    protected def propMap: PropMap
+    protected def newState(newMap: PropMap): State[Repr]
+
+    override protected def propState: HasProps.State[Repr] = this
+    override def propStateGet[A](p: Prop[A]): A = {
+      propMap(p)
+    }
+    override def propStateGetOrElse[A](p: Prop[A], default: => A): A = {
+      propMap.getOrElse(p, default)
+    }
+    override def propStateContains[A](p: Prop[A]): Boolean = {
+      propMap.contains(p)
+    }
+    override def propStateUpdate[A](p: Prop[A], v: A): HasProps.State[Repr] = {
+      newState(propMap.updated(p, v))
+    }
+    override def propStateToRepr: Repr = this
+    override def propStateToString: String = propMap.toString
+  }
+
+}

--- a/framework/src/play/src/main/scala/play/api/libs/prop/HasProps.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/prop/HasProps.scala
@@ -12,98 +12,35 @@ package play.api.libs.prop
  */
 trait HasProps[+Repr] {
 
-  protected def propBehavior: HasProps.Behavior
-  protected def propState: HasProps.State[Repr]
+  protected val propBehavior: PropBehavior
+  protected var propState: PropState
+  protected def withPropState(s: PropState): Repr
 
-  def prop[A](p: Prop[A]): A = {
-    val b = propBehavior
-    val s = propState
-    b.propBehaviorGet(b, s, p)
+  final def prop[A](p: Prop[A]): A = {
+    val (newState, value): (PropState, A) = propBehavior.doGet(propBehavior, propState, p)
+    propState = newState
+    value
   }
-  def propOrElse[A](p: Prop[A], default: => A): A = {
-    val b = propBehavior
-    val s = propState
-    if (b.propBehaviorContains(b, s, p)) b.propBehaviorGet(b, s, p) else default
+  final def propOrElse[A](p: Prop[A], default: => A): A = {
+    if (containsProp(p)) { prop(p) } else { default }
   }
-  def withProp[A](p: Prop[A], v: A): Repr = {
-    val b = propBehavior
-    val s = propState
-    b.propBehaviorUpdate(b, s, p, v).propStateToRepr
+  final def withProp[A](p: Prop[A], v: A): Repr = {
+    val newState = propBehavior.doUpdate(propBehavior, propState, p, v)
+    withPropState(newState)
   }
-  def containsProp[A](p: Prop[A]): Boolean = {
-    val b = propBehavior
-    val s = propState
-    b.propBehaviorContains(b, s, p)
+  final def containsProp[A](p: Prop[A]): Boolean = {
+    val (newState, contained) = propBehavior.doContains(propBehavior, propState, p)
+    propState = newState
+    contained
   }
-  def withProps(ps: Prop.WithValue[_]*): Repr = {
-    val b = propBehavior
-    val s = propState
-    val s2 = ps.foldLeft(s) { case (s1, p) => b.propBehaviorUpdate(b, s1, p.prop, p.value) }
-    s2.propStateToRepr
+  final def withProps(ps: Prop.WithValue[_]*): Repr = {
+    val newState = ps.foldLeft(propState) {
+      case (stateAcc, p) => propBehavior.doUpdate(propBehavior, stateAcc, p.prop, p.value)
+    }
+    withPropState(newState)
   }
 }
 
-object HasProps {
-
-  /**
-   * A `Behavior` describes the way that properties are accessed and updated
-   * in a [[HasProps]] object. By implementing a `Behavior` it is possible to implement
-   * things like default values, lazy values, etc. You can use composition to
-   * extend one behavior with another.
-   */
-  trait Behavior {
-    // All methods are prefixed with 'propBehavior' to allow easy mixing in
-    def propBehaviorGet[A](behavior: Behavior, state: State[_], p: Prop[A]): A
-    def propBehaviorContains[A](behavior: Behavior, state: State[_], p: Prop[A]): Boolean
-    def propBehaviorUpdate[Repr, A](behavior: Behavior, state: State[Repr], p: Prop[A], v: A): State[Repr]
-  }
-
-  /**
-   * A `State` object stores the mutable state of a [[HasProps]] object.
-   * A simple implementation is to use a [[PropMap]]. See [[WithMapState]].
-   * You can also provide your own implementation, for example if you want
-   * to store some properties in a more efficient way.
-   *
-   * @tparam Repr The type of the `HasProps` that this state is linked to.
-   *              The `propStateToRepr` method converts this state to that
-   *              representation.
-   */
-  trait State[+Repr] {
-    // All methods are prefixed with 'propState' to allow easy mixing in
-    def propStateGet[A](p: Prop[A]): A
-    def propStateGetOrElse[A](p: Prop[A], default: => A): A
-    def propStateContains[A](p: Prop[A]): Boolean
-    def propStateUpdate[A](p: Prop[A], v: A): State[Repr]
-    def propStateToRepr: Repr
-    def propStateToString: String
-  }
-
-  /**
-   * A [[HasProps]] and [[State]] implementation backed by a [[PropMap]].
-   *
-   * @tparam Repr The concrete representation of the `HasProps`. This
-   *              type is used when constructing a new instance.
-   */
-  trait WithMapState[+Repr] extends HasProps[Repr] with State[Repr] {
-    self: Repr =>
-    protected def propMap: PropMap
-    protected def newState(newMap: PropMap): State[Repr]
-
-    override protected def propState: HasProps.State[Repr] = this
-    override def propStateGet[A](p: Prop[A]): A = {
-      propMap(p)
-    }
-    override def propStateGetOrElse[A](p: Prop[A], default: => A): A = {
-      propMap.getOrElse(p, default)
-    }
-    override def propStateContains[A](p: Prop[A]): Boolean = {
-      propMap.contains(p)
-    }
-    override def propStateUpdate[A](p: Prop[A], v: A): HasProps.State[Repr] = {
-      newState(propMap.updated(p, v))
-    }
-    override def propStateToRepr: Repr = this
-    override def propStateToString: String = propMap.toString
-  }
-
-}
+abstract class DefaultHasProps[+Repr](
+  override protected val propBehavior: PropBehavior,
+  override protected var propState: PropState) extends HasProps[Repr]

--- a/framework/src/play/src/main/scala/play/api/libs/prop/Prop.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/prop/Prop.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.libs.prop
+
+/**
+ * A property is a key that can be used to get and set values on an
+ * object that implements [[HasProps]].
+ *
+ * @tparam A The type of values associated with this property.
+ */
+trait Prop[A] {
+
+  /**
+   * Bind this property to a value.
+   *
+   * @param value The value to bind this property to.
+   * @return A bound value.
+   */
+  def withValue(value: A): Prop.WithValue[A] = Prop.WithValue(this, value)
+
+  /**
+   * Bind this property to a value.
+   * @param value
+   * @return
+   */
+  def ~>(value: A): Prop.WithValue[A] = withValue(value)
+}
+
+/**
+ * Helper for working with `Prop`s.
+ */
+object Prop {
+  /**
+   *
+   * @param displayName
+   * @tparam A
+   * @return
+   */
+  def apply[A](displayName: String): Prop[A] = new Prop[A] {
+    override def toString: String = displayName
+  }
+  final case class WithValue[A](prop: Prop[A], value: A)
+}

--- a/framework/src/play/src/main/scala/play/api/libs/prop/PropBehavior.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/prop/PropBehavior.scala
@@ -7,13 +7,30 @@ package play.api.libs.prop
  * extend one behavior with another.
  */
 trait PropBehavior {
-  // All methods are prefixed with 'propBehavior' to allow easy mixing in
   def doGet[A](behavior: PropBehavior, state: PropState, p: Prop[A]): (PropState, A)
   def doContains[A](behavior: PropBehavior, state: PropState, p: Prop[A]): (PropState, Boolean)
   def doUpdate[A](behavior: PropBehavior, state: PropState, p: Prop[A], v: A): PropState
+
+  /**
+   * Get some value if it exists or none otherwise. Subclasses may wish to override
+   * this with a more efficient implementation.
+   */
+  def doOptGet[A](self: PropBehavior, state: PropState, p: Prop[Any]): (PropState, Option[Any]) = {
+    val (afterContainsState, contains) = doContains(self, state, p)
+    if (contains) {
+      val (afterGetState, value) = doGet(self, afterContainsState, p)
+      (afterGetState, Some(value))
+    } else {
+      (afterContainsState, None)
+    }
+  }
 }
 
 object PropBehavior {
+
+  /**
+   * This behavior has no logic, it simply loads and stores from the state.
+   */
   object Basic extends PropBehavior {
     override def doGet[A](behavior: PropBehavior, state: PropState, p: Prop[A]): (PropState, A) =
       (state, state(p))
@@ -21,5 +38,8 @@ object PropBehavior {
       (state, state.contains(p))
     override def doUpdate[A](behavior: PropBehavior, state: PropState, p: Prop[A], v: A): PropState =
       state.update(p, v)
+    override def doOptGet[A](self: PropBehavior, state: PropState, p: Prop[Any]): (PropState, Option[Any]) = {
+      (state, state.get(p))
+    }
   }
 }

--- a/framework/src/play/src/main/scala/play/api/libs/prop/PropBehavior.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/prop/PropBehavior.scala
@@ -1,0 +1,25 @@
+package play.api.libs.prop
+
+/**
+ * A `PropBehavior` describes the way that properties are accessed and updated
+ * in a [[HasProps]] object. By implementing a `Behavior` it is possible to implement
+ * things like default values, lazy values, etc. You can use composition to
+ * extend one behavior with another.
+ */
+trait PropBehavior {
+  // All methods are prefixed with 'propBehavior' to allow easy mixing in
+  def doGet[A](behavior: PropBehavior, state: PropState, p: Prop[A]): (PropState, A)
+  def doContains[A](behavior: PropBehavior, state: PropState, p: Prop[A]): (PropState, Boolean)
+  def doUpdate[A](behavior: PropBehavior, state: PropState, p: Prop[A], v: A): PropState
+}
+
+object PropBehavior {
+  object Basic extends PropBehavior {
+    override def doGet[A](behavior: PropBehavior, state: PropState, p: Prop[A]): (PropState, A) =
+      (state, state(p))
+    override def doContains[A](behavior: PropBehavior, state: PropState, p: Prop[A]): (PropState, Boolean) =
+      (state, state.contains(p))
+    override def doUpdate[A](behavior: PropBehavior, state: PropState, p: Prop[A], v: A): PropState =
+      state.update(p, v)
+  }
+}

--- a/framework/src/play/src/main/scala/play/api/libs/prop/PropMap.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/prop/PropMap.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.libs.prop
+
+import scala.annotation.varargs
+import scala.collection.immutable
+
+/**
+ * A PropMap is an immutable map containing [[Prop]]s and their values.
+ *
+ * @param m The map used to store values.
+ */
+class PropMap private (m: immutable.Map[Prop[_], Any]) {
+  def contains[A](p: Prop[A]): Boolean = m.contains(p)
+  def updated[A](prop: Prop[A], value: A): PropMap = new PropMap(m.updated(prop, value))
+  //  def updatedWithValue[A](propWithValue: Prop.WithValue[A]): PropMap = new PropMap(m.updated(propWithValue.prop, propWithValue.value))
+  def updated(propsWithValues: Prop.WithValue[_]*): PropMap = {
+    val m1 = propsWithValues.foldLeft(m) { case (m, pwv) => m.updated(pwv.prop, pwv.value) }
+    new PropMap(m1)
+  }
+  def apply[A](prop: Prop[A]): A = m.apply(prop).asInstanceOf[A]
+  def get[A](prop: Prop[A]): Option[A] = m.get(prop).asInstanceOf[Option[A]]
+  def getOrElse[A](prop: Prop[A], default: => A): A = m.getOrElse(prop, default).asInstanceOf[A]
+  override def toString: String = m.mkString
+}
+
+object PropMap {
+
+  /**
+   * Create an empty [[PropMap]].
+   */
+  val empty = new PropMap(immutable.Map.empty)
+
+  /**
+   * Builds a [[PropMap]] from a list of props and values.
+   */
+  def apply(ps: Prop.WithValue[_]*): PropMap = PropMap.empty.updated(ps: _*)
+
+  /**
+   * Builds a [[PropMap]] from a list of props and values. This method
+   * is like `apply` but it can be used in varargs style from Java.
+   */
+  @varargs def withProps(ps: Prop.WithValue[_]*): PropMap = PropMap.empty.updated(ps: _*)
+}

--- a/framework/src/play/src/main/scala/play/api/libs/prop/PropMap.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/prop/PropMap.scala
@@ -11,18 +11,18 @@ import scala.collection.immutable
  *
  * @param m The map used to store values.
  */
-class PropMap private (m: immutable.Map[Prop[_], Any]) {
-  def contains[A](p: Prop[A]): Boolean = m.contains(p)
-  def updated[A](prop: Prop[A], value: A): PropMap = new PropMap(m.updated(prop, value))
-  //  def updatedWithValue[A](propWithValue: Prop.WithValue[A]): PropMap = new PropMap(m.updated(propWithValue.prop, propWithValue.value))
-  def updated(propsWithValues: Prop.WithValue[_]*): PropMap = {
+class PropMap private (m: immutable.Map[Prop[_], Any]) extends PropState {
+  override def contains[A](p: Prop[A]): Boolean = m.contains(p)
+  override def update[A](prop: Prop[A], value: A): PropMap = new PropMap(m.updated(prop, value))
+  override def apply[A](prop: Prop[A]): A = m.apply(prop).asInstanceOf[A]
+  override def get[A](prop: Prop[A]): Option[A] = m.get(prop).asInstanceOf[Option[A]]
+  override def getOrElse[A](prop: Prop[A], default: => A): A = m.getOrElse(prop, default).asInstanceOf[A]
+  override def toString: String = m.mkString
+
+  def update(propsWithValues: Prop.WithValue[_]*): PropMap = {
     val m1 = propsWithValues.foldLeft(m) { case (m, pwv) => m.updated(pwv.prop, pwv.value) }
     new PropMap(m1)
   }
-  def apply[A](prop: Prop[A]): A = m.apply(prop).asInstanceOf[A]
-  def get[A](prop: Prop[A]): Option[A] = m.get(prop).asInstanceOf[Option[A]]
-  def getOrElse[A](prop: Prop[A], default: => A): A = m.getOrElse(prop, default).asInstanceOf[A]
-  override def toString: String = m.mkString
 }
 
 object PropMap {
@@ -35,11 +35,11 @@ object PropMap {
   /**
    * Builds a [[PropMap]] from a list of props and values.
    */
-  def apply(ps: Prop.WithValue[_]*): PropMap = PropMap.empty.updated(ps: _*)
+  def apply(ps: Prop.WithValue[_]*): PropMap = PropMap.empty.update(ps: _*)
 
   /**
    * Builds a [[PropMap]] from a list of props and values. This method
    * is like `apply` but it can be used in varargs style from Java.
    */
-  @varargs def withProps(ps: Prop.WithValue[_]*): PropMap = PropMap.empty.updated(ps: _*)
+  @varargs def withProps(ps: Prop.WithValue[_]*): PropMap = apply(ps: _*)
 }

--- a/framework/src/play/src/main/scala/play/api/libs/prop/PropState.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/prop/PropState.scala
@@ -1,0 +1,19 @@
+package play.api.libs.prop
+
+/**
+ * A `PropState` object stores the mutable propState of a [[HasProps]] object.
+ * A simple implementation is to use a [[PropMap]]. See [[WithMapState]].
+ * You can also provide your own implementation, for example if you want
+ * to store some properties in a more efficient way.
+ *
+ * @tparam Repr The type of the `HasProps` that this propState is linked to.
+ *              The `propStateToRepr` method converts this propState to that
+ *              representation.
+ */
+trait PropState {
+  def apply[A](p: Prop[A]): A
+  def get[A](p: Prop[A]): Option[A]
+  def getOrElse[A](p: Prop[A], default: => A): A
+  def contains[A](p: Prop[A]): Boolean
+  def update[A](p: Prop[A], v: A): PropState
+}

--- a/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -58,6 +58,34 @@ class RequestHeaderSpec extends Specification {
       }
     }
 
+    "support typed headers" in {
+
+      def checkTypedHeader[P](typedHeaderProp: Prop[P], typedValue: P, headers: Headers) = {
+        s"for typed header $typedHeaderProp" in {
+          "lazily initialize typed header from raw string headers" in {
+            val rh = newRequestHeader(RequestHeaderProp.Headers ~> headers)
+            rh.propState.contains(typedHeaderProp) must beFalse
+            rh.prop(typedHeaderProp) must_== typedValue
+            rh.propState.contains(typedHeaderProp) must beTrue
+          }
+          "not initialize typed header when checked if present" in {
+            val rh = newRequestHeader(RequestHeaderProp.Headers ~> headers)
+            rh.propState.contains(typedHeaderProp) must beFalse
+            rh.containsProp(typedHeaderProp) must beTrue
+            rh.propState.contains(typedHeaderProp) must beFalse
+          }
+          "eagerly initialize raw string headers from typed header" in {
+            var rh = newRequestHeader()
+            rh.prop(RequestHeaderProp.Headers) must_== Headers()
+            rh = rh.withProp(typedHeaderProp, typedValue)
+            rh.prop(RequestHeaderProp.Headers) must_== headers
+          }
+        }
+      }
+
+      checkTypedHeader(RequestHeaderProp.AcceptLanguage, Seq(Lang("en")), Headers("Accept-Language" -> "en"))
+    }
+
     "support the copy method" in {
       "for copying headers" in {
         val rh = newRequestHeader()

--- a/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -8,30 +8,72 @@ import java.net.URI
 import org.specs2.mutable.Specification
 import play.api.http.HeaderNames._
 import play.api.i18n.Lang
+import play.api.libs.prop.{ Prop, PropMap }
 
 class RequestHeaderSpec extends Specification {
 
+  def newRequestHeader(ps: Prop.WithValue[_]*): RequestHeader = new RequestHeaderImpl(RequestHeader.defaultBehavior, PropMap(ps: _*))
+
   "request header" should {
+
+    "have default values for its properties" in {
+      "headers should be present and empty" in {
+        val rh = newRequestHeader()
+        rh.containsProp(RequestHeaderProp.Headers) must beTrue
+        val headers: Headers = rh.prop(RequestHeaderProp.Headers)
+        headers must not(beNull)
+        headers.toMap must beEmpty
+      }
+    }
+
+    "allow some properties to be accessed through helpers" in {
+      "headers" in {
+        val rh = newRequestHeader(RequestHeaderProp.Headers ~> Headers("X" -> "y"))
+        rh.headers must_== Headers("X" -> "y")
+      }
+    }
+
+    "support the copy method" in {
+      "for copying headers" in {
+        val rh = newRequestHeader()
+        rh.copy(headers = Headers("A" -> "b")).headers must_== Headers("A" -> "b")
+      }
+    }
 
     "handle host" in {
       "relative uri with host header" in {
-        val rh = DummyRequestHeader("GET", "/", Headers(HOST -> "playframework.com"))
+        val rh = newRequestHeader(
+          RequestHeaderProp.Uri ~> "/",
+          RequestHeaderProp.Headers ~> Headers(HOST -> "playframework.com")
+        )
         rh.host must_== "playframework.com"
       }
       "absolute uri" in {
-        val rh = DummyRequestHeader("GET", "https://example.com/test", Headers(HOST -> "playframework.com"))
+        val rh = newRequestHeader(
+          RequestHeaderProp.Uri ~> "https://example.com/test",
+          RequestHeaderProp.Headers ~> Headers(HOST -> "playframework.com")
+        )
         rh.host must_== "example.com"
       }
       "absolute uri with port" in {
-        val rh = DummyRequestHeader("GET", "https://example.com:8080/test", Headers(HOST -> "playframework.com"))
+        val rh = newRequestHeader(
+          RequestHeaderProp.Uri ~> "https://example.com:8080/test",
+          RequestHeaderProp.Headers ~> Headers(HOST -> "playframework.com")
+        )
         rh.host must_== "example.com:8080"
       }
       "absolute uri with port and invalid characters" in {
-        val rh = DummyRequestHeader("GET", "https://example.com:8080/classified-search/classifieds?version=GTI|V8", Headers(HOST -> "playframework.com"))
+        val rh = newRequestHeader(
+          RequestHeaderProp.Uri ~> "https://example.com:8080/classified-search/classifieds?version=GTI|V8",
+          RequestHeaderProp.Headers ~> Headers(HOST -> "playframework.com")
+        )
         rh.host must_== "example.com:8080"
       }
       "relative uri with invalid characters" in {
-        val rh = DummyRequestHeader("GET", "/classified-search/classifieds?version=GTI|V8", Headers(HOST -> "playframework.com"))
+        val rh = newRequestHeader(
+          RequestHeaderProp.Uri ~> "/classified-search/classifieds?version=GTI|V8",
+          RequestHeaderProp.Headers ~> Headers(HOST -> "playframework.com")
+        )
         rh.host must_== "playframework.com"
       }
     }
@@ -39,7 +81,8 @@ class RequestHeaderSpec extends Specification {
     "parse accept languages" in {
 
       "return an empty sequence when no accept languages specified" in {
-        DummyRequestHeader().acceptLanguages must beEmpty
+        // FIXME: Handle missing prop
+        newRequestHeader(RequestHeaderProp.Headers ~> Headers()).acceptLanguages must beEmpty
       }
 
       "parse a single accept language" in {
@@ -67,23 +110,8 @@ class RequestHeaderSpec extends Specification {
     }
   }
 
-  def accept(value: String) = DummyRequestHeader(
-    headers = Headers("Accept-Language" -> value)
+  def accept(value: String) = newRequestHeader(
+    RequestHeaderProp.Headers ~> Headers("Accept-Language" -> value)
   ).acceptLanguages
 
-  case class DummyRequestHeader(
-      requestMethod: String = "GET",
-      requestUri: String = "/",
-      headers: Headers = Headers()) extends RequestHeader {
-    def id = 1
-    def tags = Map()
-    def uri = requestUri
-    def path = new URI(requestUri).getPath // this just won't work for invalid URIs
-    def method = requestMethod
-    def version = ""
-    def queryString = Map()
-    def remoteAddress = ""
-    def secure = false
-    override def clientCertificateChain = None
-  }
 }

--- a/framework/src/play/src/test/scala/play/core/test/Fakes.scala
+++ b/framework/src/play/src/test/scala/play/core/test/Fakes.scala
@@ -9,7 +9,7 @@ import akka.util.ByteString
 import play.api.inject.guice.GuiceInjectorBuilder
 import play.api.inject.{ Binding, Injector }
 import play.api.libs.Files.TemporaryFile
-import play.api.libs.prop.{ HasProps, PropMap }
+import play.api.libs.prop._
 import play.api.libs.json.JsValue
 import play.api.mvc._
 
@@ -40,10 +40,12 @@ object Fakes {
  */
 case class FakeHeaders(data: Seq[(String, String)] = Seq.empty) extends Headers(data)
 
-class FakeRequest[+A](override protected val propBehavior: HasProps.Behavior,
-    override protected val propMap: PropMap) extends RequestLike[A, FakeRequest] with Request[A] with HasProps.WithMapState[FakeRequest[A]] {
+class FakeRequest[+A](propBehavior: PropBehavior, propState: PropState)
+    extends DefaultHasProps[FakeRequest[A]](propBehavior, propState)
+    with Request[A] with RequestLike[A, FakeRequest] {
 
-  override protected def newState(newMap: PropMap): HasProps.State[FakeRequest[A]] = new FakeRequest[A](propBehavior, newMap)
+  override protected def withPropState(newState: PropState): FakeRequest[A] =
+    new FakeRequest[A](propBehavior, newState)
 
   /**
    * The request path.


### PR DESCRIPTION
Goals:
- let users and plugins set typed values into a request (#5814)
- support typed headers (#5811)
- backwards compatible
- reasonably efficient
- can compose plugins and user code together
- don't lose a user's wrapper if they extend Copy

Tasks:
- [x] convert existing RequestHeader/Request fields to props
- [x] support arbitrary props
- [ ] convert existing lazy fields to props
- [ ] support overriding behavior in plugins
- [ ] support typed headers in a backwards compatible way
- [ ] support tags in a backwards compatible way
- [ ] convert some existing plugins to use typed properties 

Java API
- [ ] RequestBuilder using properties
- [ ] access to properties
- [ ] reduce mutable state, e.g. context becomes mutable var holding immutable Request?

Tidying:
- [ ] try to simplify types, i.e. Request*Like objects
- [ ] tidy up type variables and make them consistent, e.g. P = Prop, B = body

Performance:
- [ ] profile and make efficient
- [ ] make more props lazy, e.g. request id?
- [ ] make Netty/Akka RequestHeader objects more efficient, e.g. delay conversion?
- [ ] use a custom State object to store Request properties, i.e. put common props into fields instead of a map