### PR TITLE
Treat empty query param as not existing (except for String)

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -311,7 +311,7 @@ object QueryStringBindable {
   class Parsing[A](parse: String => A, serialize: A => String, error: (String, Exception) => String)
       extends QueryStringBindable[A] {
 
-    def bind(key: String, params: Map[String, Seq[String]]) = params.get(key).flatMap(_.headOption).map { p =>
+    def bind(key: String, params: Map[String, Seq[String]]) = params.get(key).flatMap(_.headOption).filter(_.nonEmpty).map { p =>
       try {
         Right(parse(p))
       } catch {
@@ -334,7 +334,7 @@ object QueryStringBindable {
    * QueryString binder for Char.
    */
   implicit object bindableChar extends QueryStringBindable[Char] {
-    def bind(key: String, params: Map[String, Seq[String]]) = params.get(key).flatMap(_.headOption).map { value =>
+    def bind(key: String, params: Map[String, Seq[String]]) = params.get(key).flatMap(_.headOption).filter(_.nonEmpty).map { value =>
       if (value.length != 1) Left(s"Cannot parse parameter $key with value '$value' as Char: $key must be exactly one digit in length.")
       else Right(value.charAt(0))
     }


### PR DESCRIPTION
When you have this very simple route
```
GET / controllers.HomeController.index(page: Int)
```
and call it via `http://127.0.0.1:9000/?page=` you will get a `Bad Request - Cannot parse parameter page as Int: For input string: ""`.

That's because we try to parse an empty `String` as `Int` (via `.toInt`) (see [this line](https://github.com/playframework/playframework/blob/2.5.x/framework/src/play/src/main/scala/play/api/mvc/Binders.scala#L348)) which causes an Exception.
Actually all implicit objects that `extends Parsing` try to parse an empty String to a Long, Double, Float,  UUID, etc. via e.g `_.toLong`, `UUID.fromString(...)` etc. and in this case all this methods fail with an exception and produce a bad request.

IMHO when trying to parse such types instead of failing and returning a bad request we should just completely ignore an empty param and act like it does not exist. E.g. we have some cases where the user submits a form but via `GET` instead of `POST` (a search result page) and some values can be empty. In this case we just want to handle the empty values as non existing.

The only exception which will stay as it is (and to keep backward compatibility) is when the desired type is not an `Int`, `Long`, etc. but a `String`. I think this makes sense because a developer, who expects an String (`controllers.HomeController.index(page: String)`) may also really want to handle `someparam=` as empty string in the controller action.

What do you think?