### PR TITLE
update doc for play-json DefaultInstantReads

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
@@ -599,7 +599,7 @@ trait DefaultReads extends LowPriorityDefaultReads {
 
   /**
    * The default typeclass to reads `java.time.Instant` from JSON.
-   * Accepts instant formats as '2011-12-03T10:15:30', '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30+01:00[Europe/Paris]'.
+   * Accepts instant formats as '2011-12-03T10:15:30Z', '2011-12-03T10:15:30+01:00' or '2011-12-03T10:15:30+01:00[Europe/Paris]'.
    */
   implicit val DefaultInstantReads =
     instantReads(DateTimeFormatter.ISO_DATE_TIME)


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Purpose

Revise the doc for `DefaultInstantReads`.
It will throw exception if user follows the comment.

## Background Context

`JsString("2011-12-03T10:15:30")` cannot be read `as[Instant]`, because there is no time zone info in the `TemporalAccessor` parsed by `DateTimeFormatter.ISO_DATE_TIME`.