### PR TITLE
This fixes a ClassCastException introduced in DefaultHttpFilters.java

### DIFF
--- a/framework/src/play/src/main/java/play/http/DefaultHttpFilters.java
+++ b/framework/src/play/src/main/java/play/http/DefaultHttpFilters.java
@@ -12,7 +12,7 @@ public class DefaultHttpFilters implements HttpFilters {
   private final EssentialFilter[] filters;
 
   public DefaultHttpFilters(play.api.mvc.EssentialFilter... filters) {
-    this.filters = (EssentialFilter[]) Arrays.stream(filters).map(f -> f.asJava()).toArray();
+    this.filters = Arrays.stream(filters).map(f -> f.asJava()).toArray(EssentialFilter[]::new);
   }
 
   @Override


### PR DESCRIPTION
## Fixes

Fixes #6237

## Purpose

This PR addresses a ClassCastException in DefaultHttpFilters.java

## Background Context

This seemed like an intuitive approach given the StreamAPI toArray() interface.

## References

https://github.com/playframework/playframework/issues/6237