### PR TITLE
Suggestion: validating bin compatibility with all the patch versions in 2.5 series

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -27,8 +27,8 @@ import interplay.PlayBuildBase.autoImport._
 import scala.util.control.NonFatal
 
 object BuildSettings {
-  // Binary compatibility is tested against this version
-  val previousVersion = "2.5.0"
+  // Binary compatibility is tested against these versions
+  val previousVersions = (0 to 4).map(patch => s"2.5.$patch").toSet
 
   // Argument for setting size of permgen space or meta space for all forked processes
   val maxMetaspace = s"-XX:MaxMetaspaceSize=384m"
@@ -72,9 +72,9 @@ object BuildSettings {
   def playRuntimeSettings: Seq[Setting[_]] = playCommonSettings ++ mimaDefaultSettings ++ Seq(
     previousArtifacts := {
       if (crossPaths.value) {
-        Set(organization.value % s"${moduleName.value}_${scalaBinaryVersion.value}" % previousVersion)
+        previousVersions.map(v => organization.value % s"${moduleName.value}_${scalaBinaryVersion.value}" %  v)
       } else {
-        Set(organization.value % moduleName.value % previousVersion)
+        previousVersions.map(v => organization.value % moduleName.value %  v)
       }
     },
     Docs.apiDocsInclude := true


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Purpose

This pull request is just a suggestion on migration manager usage.

Currently, the `master` branch checks bin-compatibility with only 2.5.0. But the current setting may miss bin-incompatibility in some cases. For instance, it cannot detect unexpected deletion of new methods introduced 2.5.{1,2,3,4}.
