### PR TITLE
Add java.time.LocalDate support to Forms Mapping

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/Forms.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Forms.scala
@@ -616,6 +616,72 @@ object Forms {
    */
   val boolean: Mapping[Boolean] = of[Boolean]
 
+  /**
+   * Constructs a simple mapping for a date field (mapped as `java.time.LocalDate type`).
+   *
+   * For example:
+   * {{{
+   * Form("birthdate" -> localDate)
+   * }}}
+   */
+  val localDate: Mapping[java.time.LocalDate] = of[java.time.LocalDate]
+
+  /**
+   * Constructs a simple mapping for a date field (mapped as `java.time.LocalDate type`).
+   *
+   * For example:
+   * {{{
+   * Form("birthdate" -> localDate("dd-MM-yyyy"))
+   * }}}
+   *
+   * @param pattern the date pattern, as defined in `java.time.format.DateTimeFormatter`
+   */
+  def localDate(pattern: String): Mapping[java.time.LocalDate] = of[java.time.LocalDate] as localDateFormat(pattern)
+
+  /**
+   * Constructs a simple mapping for a date field (mapped as `java.time.LocalDateTime type`).
+   *
+   * For example:
+   * {{{
+   * Form("dateTime" -> localDateTime)
+   * }}}
+   */
+  val localDateTime: Mapping[java.time.LocalDateTime] = of[java.time.LocalDateTime]
+
+  /**
+   * Constructs a simple mapping for a date field (mapped as `java.time.LocalDateTime type`).
+   *
+   * For example:
+   * {{{
+   * Form("dateTime" -> localDateTime("dd-MM-yyyy HH:mm:ss"))
+   * }}}
+   *
+   * @param pattern the date pattern, as defined in `java.time.format.DateTimeFormatter`
+   */
+  def localDateTime(pattern: String): Mapping[java.time.LocalDateTime] = of[java.time.LocalDateTime] as localDateTimeFormat(pattern)
+
+  /**
+   * Constructs a simple mapping for a date field (mapped as `java.time.LocalTime type`).
+   *
+   * For example:
+   * {{{
+   * Form("time" -> localTime)
+   * }}}
+   */
+  val localTime: Mapping[java.time.LocalTime] = of[java.time.LocalTime]
+
+  /**
+   * Constructs a simple mapping for a date field (mapped as `java.time.LocalTime type`).
+   *
+   * For example:
+   * {{{
+   * Form("time" -> localTime("HH:mm:ss"))
+   * }}}
+   *
+   * @param pattern the date pattern, as defined in `java.time.format.DateTimeFormatter`
+   */
+  def localTime(pattern: String): Mapping[java.time.LocalTime] = of[java.time.LocalTime] as localTimeFormat(pattern)
+
   def checked(msg: String): Mapping[Boolean] = boolean verifying (msg, _ == true)
 
 }

--- a/framework/src/play/src/main/scala/play/api/data/format/Format.scala
+++ b/framework/src/play/src/main/scala/play/api/data/format/Format.scala
@@ -281,6 +281,79 @@ object Formats {
   implicit val jodaLocalDateFormat: Formatter[org.joda.time.LocalDate] = jodaLocalDateFormat("yyyy-MM-dd")
 
   /**
+   * Formatter for the `java.time.LocalDate` type.
+   *
+   * @param pattern a date pattern as specified in `java.time.format.DateTimeFormatter`.
+   */
+  def localDateFormat(pattern: String): Formatter[java.time.LocalDate] = new Formatter[java.time.LocalDate] {
+
+    import java.time.LocalDate
+
+    val formatter = java.time.format.DateTimeFormatter.ofPattern(pattern)
+    def localDateParse(data: String) = LocalDate.parse(data, formatter)
+
+    override val format = Some(("format.date", Seq(pattern)))
+
+    def bind(key: String, data: Map[String, String]) = parsing(localDateParse, "error.date", Nil)(key, data)
+
+    def unbind(key: String, value: LocalDate) = Map(key -> value.format(formatter))
+  }
+
+  /**
+   * Default formatter for `java.time.LocalDate` type with pattern `yyyy-MM-dd`.
+   */
+  implicit val localDateFormat: Formatter[java.time.LocalDate] = localDateFormat("yyyy-MM-dd")
+
+  /**
+   * Formatter for the `java.time.LocalDateTime` type.
+   *
+   * @param pattern a date pattern as specified in `java.time.format.DateTimeFormatter`.
+   * @param zoneId the `java.time.ZoneId` to use for parsing and formatting
+   */
+  def localDateTimeFormat(pattern: String, zoneId: java.time.ZoneId = java.time.ZoneId.systemDefault()): Formatter[java.time.LocalDateTime] = new Formatter[java.time.LocalDateTime] {
+
+    import java.time.LocalDateTime
+
+    val formatter = java.time.format.DateTimeFormatter.ofPattern(pattern).withZone(zoneId)
+    def localDateTimeParse(data: String) = LocalDateTime.parse(data, formatter)
+
+    override val format = Some(("format.localDateTime", Seq(pattern)))
+
+    def bind(key: String, data: Map[String, String]) = parsing(localDateTimeParse, "error.localDateTime", Nil)(key, data)
+
+    def unbind(key: String, value: LocalDateTime) = Map(key -> value.format(formatter))
+  }
+
+  /**
+   * Default formatter for `java.time.LocalDateTime` type with pattern `yyyy-MM-dd`.
+   */
+  implicit val localDateTimeFormat: Formatter[java.time.LocalDateTime] = localDateTimeFormat("yyyy-MM-dd HH:mm:ss")
+
+  /**
+   * Formatter for the `java.time.LocalTime` type.
+   *
+   * @param pattern a date pattern as specified in `java.time.format.DateTimeFormatter`.
+   */
+  def localTimeFormat(pattern: String): Formatter[java.time.LocalTime] = new Formatter[java.time.LocalTime] {
+
+    import java.time.LocalTime
+
+    val formatter = java.time.format.DateTimeFormatter.ofPattern(pattern)
+    def localTimeParse(data: String) = LocalTime.parse(data, formatter)
+
+    override val format = Some(("format.localTime", Seq(pattern)))
+
+    def bind(key: String, data: Map[String, String]) = parsing(localTimeParse, "error.localTime", Nil)(key, data)
+
+    def unbind(key: String, value: LocalTime) = Map(key -> value.format(formatter))
+  }
+
+  /**
+   * Default formatter for `java.time.LocalTime` type with pattern `HH:mm:ss`.
+   */
+  implicit val localTimeFormat: Formatter[java.time.LocalTime] = localTimeFormat("HH:mm:ss")
+
+  /**
    * Default formatter for the `java.util.UUID` type.
    */
   implicit def uuidFormat: Formatter[UUID] = new Formatter[UUID] {

--- a/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
@@ -293,6 +293,48 @@ object FormSpec extends Specification {
     val form = Form(single("foo" -> Forms.text), Map.empty, Seq(FormError("foo", "error.custom", Seq("error.customarg"))), None)
     (form.errorsAsJson \ "foo")(0).asOpt[String] must beSome("This is a custom error")
   }
+
+  "render form using java.time.LocalDate" in {
+    import java.time.LocalDate
+    val dateForm = Form(("date" -> localDate))
+    val data = Map("date" -> "2012-01-01")
+    dateForm.bind(data).get mustEqual (LocalDate.of(2012, 1, 1))
+  }
+
+  "render form using java.time.LocalDate with format(15/6/2016)" in {
+    import java.time.LocalDate
+    val dateForm = Form(("date" -> localDate("dd/MM/yyyy")))
+    val data = Map("date" -> "15/06/2016")
+    dateForm.bind(data).get mustEqual (LocalDate.of(2016, 6, 15))
+  }
+
+  "render form using java.time.LocalDateTime" in {
+    import java.time.LocalDateTime
+    val dateForm = Form(("date" -> localDateTime))
+    val data = Map("date" -> "2012-01-01 10:10:10")
+    dateForm.bind(data).get mustEqual (LocalDateTime.of(2012, 1, 1, 10, 10, 10))
+  }
+
+  "render form using java.time.LocalDateTime with format(17/06/2016T17:15:33)" in {
+    import java.time.LocalDateTime
+    val dateForm = Form(("date" -> localDateTime("dd/MM/yyyy HH:mm:ss")))
+    val data = Map("date" -> "17/06/2016 10:10:10")
+    dateForm.bind(data).get mustEqual (LocalDateTime.of(2016, 6, 17, 10, 10, 10))
+  }
+
+  "render form using java.time.LocalTime" in {
+    import java.time.LocalTime
+    val dateForm = Form(("date" -> localTime))
+    val data = Map("date" -> "10:10:10")
+    dateForm.bind(data).get mustEqual (LocalTime.of(10, 10, 10))
+  }
+
+  "render form using java.time.LocalTime with format(HH-mm-ss)" in {
+    import java.time.LocalTime
+    val dateForm = Form(("date" -> localTime("HH-mm-ss")))
+    val data = Map("date" -> "10-11-12")
+    dateForm.bind(data).get mustEqual (LocalTime.of(10, 11, 12))
+  }
 }
 
 object ScalaForms {

--- a/framework/src/play/src/test/scala/play/api/data/format/FormatSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/format/FormatSpec.scala
@@ -24,6 +24,28 @@ object FormatSpec extends Specification {
     }
   }
 
+  "java.time Types" should {
+    import java.time.LocalDateTime
+    "support LocalDateTime formatting with a pattern" in {
+      val pattern = "yyyy/MM/dd HH:mm:ss"
+      val data = Map("localDateTime" -> "2016/06/06 00:30:30")
+
+      val format = Formats.localDateTimeFormat(pattern)
+      val bind: Either[Seq[FormError], LocalDateTime] = format.bind("localDateTime", data)
+      bind.right.map(dt => {
+        (dt.getYear, dt.getMonthValue, dt.getDayOfMonth, dt.getHour, dt.getMinute, dt.getSecond)
+      }) should beRight((2016, 6, 6, 0, 30, 30))
+    }
+
+    "support LocalDateTime formatting with default pattern" in {
+      val data = Map("localDateTime" -> "2016-10-10 11:11:11")
+      val format = Formats.localDateTimeFormat
+      format.bind("localDateTime", data).right.map { dt =>
+        (dt.getYear, dt.getMonthValue, dt.getDayOfMonth, dt.getHour, dt.getMinute, dt.getSecond)
+      } should beRight((2016, 10, 10, 11, 11, 11))
+    }
+  }
+
   "A simple mapping of BigDecimalFormat" should {
     "return a BigDecimal" in {
       Form("value" -> bigDecimal).bind(Map("value" -> "10.23")).fold(


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes No java.time.LocalDate form mappings available

## Purpose

Form mappings do not support java.time.LocalDate. This PR adds this functionality for form mapping

## Background Context

Currently, to use java.time.LocalDate in domain objects mapped to form definitions, one has to take in the LocalDate in as a joda LocalDate and convert to java.time LocalDate. By introducing a localdate mapping for form data, one can use the new java.time.LocalDate directly.

