### PR TITLE
Fixes #6152 by customizing the HttpContentDecompressor

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
@@ -89,6 +89,20 @@ class BasicHttpClient(port: Int, secure: Boolean) {
     }
   }
 
+  def sendRaw(data: Array[Byte], headers: Map[String, String]): BasicResponse = {
+    val outputStream = s.getOutputStream
+    outputStream.write("POST / HTTP/1.1\r\n".getBytes("UTF-8"))
+    outputStream.write("Host: localhost\r\n".getBytes("UTF-8"))
+    headers.foreach { header =>
+      outputStream.write(s"${header._1}: ${header._2}\r\n".getBytes("UTF-8"))
+    }
+    outputStream.flush()
+
+    outputStream.write("\r\n".getBytes("UTF-8"))
+    outputStream.write(data)
+    readResponse("0 continue")
+  }
+
   /**
    * Send a request
    *

--- a/framework/src/play-netty-server/src/main/java/play/core/server/netty/PlayHttpContentDecompressor.java
+++ b/framework/src/play-netty-server/src/main/java/play/core/server/netty/PlayHttpContentDecompressor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.server.netty;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.*;
+
+import java.util.List;
+
+public class PlayHttpContentDecompressor extends HttpContentDecompressor {
+    private boolean contentLength = false;
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, HttpObject msg, List<Object> out) throws Exception {
+        // This will fix https://github.com/playframework/playframework/issues/6152
+        // And could be removed if https://github.com/netty/netty/issues/5428 is fixed
+        if (msg instanceof HttpRequest) {
+            HttpRequest request = (HttpRequest)msg;
+            // This will check if there is a Content-Length header and if it is greater than zero
+            contentLength = HttpHeaders.getContentLength(request, 0) != 0;
+        }
+
+        // delegate to the original decode method
+        super.decode(ctx, msg, out);
+
+        if (msg instanceof HttpRequest) {
+            HttpRequest request = (HttpRequest)msg;
+            // if the request was gzipped and the Content-Length header was set, we check if it is still there
+            // since netty-reactive-stream needs to know if this message has a body which is determined
+            // by the Content-Length or Transfer-Encoding Header
+            if (contentLength && !HttpHeaders.isContentLengthSet(request)) {
+                HttpHeaders.setTransferEncodingChunked(request);
+            }
+        }
+    }
+
+}

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -172,7 +172,7 @@ class NettyServer(
       // Netty HTTP decoders/encoders/etc
       pipeline.addLast("decoder", new HttpRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize))
       pipeline.addLast("encoder", new HttpResponseEncoder())
-      pipeline.addLast("decompressor", new HttpContentDecompressor())
+      pipeline.addLast("decompressor", new PlayHttpContentDecompressor())
       if (logWire) {
         pipeline.addLast("logging", new LoggingHandler(LogLevel.DEBUG))
       }


### PR DESCRIPTION
Fixes #6152 
This implements what jroper suggested https://github.com/typesafehub/netty-reactive-streams/pull/19#issuecomment-226998199

Akka Test is pending until fixed (it can't decode deflate/gzip yet)