### PR TITLE
Disallow users to send a message-body and Content-Length header field for 1xx, 204 and 304 responses

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
@@ -9,10 +9,9 @@ import java.security.cert.X509Certificate
 import javax.net.ssl.SSLContext
 import javax.net.ssl.X509TrustManager
 
-import play.api.test.Helpers._
 import org.apache.commons.io.IOUtils
-
-import scala.annotation.tailrec
+import play.api.test.Helpers._
+import play.core.server.common.ServerResultUtils
 
 object BasicHttpClient {
 
@@ -225,7 +224,7 @@ class BasicHttpClient(port: Int, secure: Boolean) {
         headers.get(CONTENT_LENGTH).map { length =>
           readCompletely(length.toInt)
         } getOrElse {
-          if (status != CONTINUE && status != NOT_MODIFIED && status != NO_CONTENT) {
+          if (ServerResultUtils.mayHaveEntity(status)) {
             consumeRemaining(reader)
           } else {
             ""

--- a/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -10,6 +10,7 @@ import play.api.Logger
 import play.api.mvc._
 import play.api.http._
 import play.api.http.HeaderNames._
+import play.api.http.Status._
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
@@ -130,8 +131,13 @@ object ServerResultUtils {
 
   }
 
-  private def mayHaveEntity(status: Int) =
-    status != Status.NO_CONTENT && status != Status.NOT_MODIFIED
+  /** Whether the given status may have an entity or not. */
+  def mayHaveEntity(status: Int): Boolean = status match {
+    case CONTINUE | SWITCHING_PROTOCOLS | NO_CONTENT | NOT_MODIFIED =>
+      false
+    case _ =>
+      true
+  }
 
   /**
    * Cancel the entity.

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -461,6 +461,12 @@ trait Results {
     }
   }
 
+  /** Generates a ‘100 Continue’ result. */
+  val Continue = Result(header = ResponseHeader(CONTINUE), body = HttpEntity.NoEntity)
+
+  /** Generates a ‘101 Switching Protocols’ result. */
+  val SwitchingProtocols = Result(header = ResponseHeader(SWITCHING_PROTOCOLS), body = HttpEntity.NoEntity)
+
   /** Generates a ‘200 OK’ result. */
   val Ok = new Status(OK)
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

This fix makes sure that Play never sends Content-Length header field for a 204 response.

## Purpose

As described in [RFC7230 section-3.3.2](https://tools.ietf.org/html/rfc7230#section-3.3.2), sending a Content-Length header field is not allowed in any response with a status code of 1xx (Informational) or 204 (No Content). This requirement was not forced in Play, which means a user can intentionally set a Content-Length header. To follow the RFC section, we need to make sure that we don't send the header field.
~~With regard to a Content-Length header field in a 304 response, a server May send it as mentioned in RFC7230 section-3.3.2. Thus it'd be better for us to allow users to set the field if they like.~~
With regard to a Content-Length header field in a 304 response, we don't allow users to do it currently even a server May send it as mentioned in RFC7230 section-3.3.2.

Additionally, as described in RFC7230 [section-3.3](https://tools.ietf.org/html/rfc7230#section-3.3), 1xx responses don't include a message body. With this commit, a message body isn't sent to meet the requirement.

## Background Context

As I've mentioned in Purpose.

## References

- Related Issues/PRs
  - [content-length header included in 304 response which is forbidden by the HTTP spec](https://github.com/playframework/playframework/issues/3899)
  - [Don't include body and Content-Length in 204 and 304 responses. Fixes #3899](https://github.com/playframework/playframework/pull/3939)

- The following is the partial citation from RFC7230 section-3.3.2 and 3.3.
```
A server MUST NOT send a Content-Length header field in any response with
a status code of 1xx (Informational) or 204 (No Content). A server MUST NOT send
a Content-Length header field in any 2xx(Successful) response to a CONNECT request
(Section 4.3.6 of [RFC7231]).
```
```
A server MAY send a Content-Length header field in a 304 (Not Modified) response to
a conditional GET request (Section 4.1 of [RFC7232]); a server MUST NOT send
Content-Length in such a response unless its field-value equals the decimal number of
octets that would have been sent in the payload body of a 200 (OK) response to
the same request.
```

```
All 1xx (Informational), 204 (No Content), and 304 (Not Modified) responses do not
include a message body. All other responses do include a message body, although
the body might be of zero length.
```

P.S.
`play.it.http.NettyScalaResultsHandlingSpec` appends a `Content-Length: 0` header field
when we explicitly send it, but `AkkaHttpIntegrationSpecification` does not.

