### PR TITLE
Update application.conf

### DIFF
--- a/templates/play-common/conf/application.conf
+++ b/templates/play-common/conf/application.conf
@@ -69,7 +69,7 @@ play.modules {
 # Depending on your IDE, you can add a hyperlink for errors that will jump you
 # directly to the code location in the IDE in dev mode. The following line makes 
 # use of the IntelliJ IDEA REST interface: 
-#play.editor=http://localhost:63342/api/file/?file=%s&line=%s 
+#play.editor="http://localhost:63342/api/file/?file=%s&line=%s"
 
 ## Internationalisation
 # https://www.playframework.com/documentation/latest/JavaI18N


### PR DESCRIPTION
Uncommenting the line that defines play.editor causes an error because the value needs to be quoted, like this:

    play.editor="http://localhost:63342/api/file/?file=%s&line=%s"
