### PR TITLE
Fix typo in play-ws/reference.conf comment

### DIFF
--- a/framework/src/play-ws/src/main/resources/reference.conf
+++ b/framework/src/play-ws/src/main/resources/reference.conf
@@ -3,7 +3,7 @@ play {
     enabled += "play.api.libs.ws.ahc.AhcWSModule"
     enabled += "play.api.libs.openid.OpenIDModule"
   }
-  # Configuratino for Play ws
+  # Configuration for Play ws
   ws {
 
     timeout {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes "Configuratino" to "Configuration" on play-ws/reference.conf

## Purpose

Fix typo in conf file comment.

## Background Context

While reading code for study, I found this typo.

## References

There're not any relevant issues / PRs / mailing lists discussions.

