### PR TITLE
Set Form value even when form has errors

### DIFF
--- a/framework/src/play-java/src/main/java/play/data/Form.java
+++ b/framework/src/play-java/src/main/java/play/data/Form.java
@@ -361,7 +361,7 @@ public class Form<T> {
                 errors.put("", globalErrors);
             }
 
-            return new Form(rootName, backedType, data, errors, Optional.empty(), groups, messagesApi, formatters, this.validator);
+            return new Form(rootName, backedType, data, errors, Optional.ofNullable((T)result.getTarget()), groups, messagesApi, formatters, this.validator);
         } else {
             Object globalError = null;
             if (result.getTarget() != null) {
@@ -390,7 +390,7 @@ public class Form<T> {
                 } else if (globalError instanceof Map) {
                     errors = (Map<String,List<ValidationError>>)globalError;
                 }
-                return new Form(rootName, backedType, data, errors, Optional.empty(), groups, messagesApi, formatters, this.validator);
+                return new Form(rootName, backedType, data, errors, Optional.ofNullable((T)result.getTarget()), groups, messagesApi, formatters, this.validator);
             }
             return new Form(rootName, backedType, new HashMap<>(data), new HashMap<>(errors), Optional.ofNullable((T)result.getTarget()), groups, messagesApi, formatters, this.validator);
         }
@@ -421,7 +421,7 @@ public class Form<T> {
     }
 
     /**
-     * Retrieves the actual form value.
+     * Retrieves the actual form value - even when the form contains validation errors.
      */
     public Optional<T> value() {
         return value;
@@ -556,7 +556,8 @@ public class Form<T> {
     }
 
     /**
-     * Gets the concrete value if the submission was a success.
+     * Gets the concrete value only if the submission was a success. If the form is invalid because of validation errors this method will throw an exception.
+     * If you want to retrieve the value even when the form is invalid use <code>value()</code> instead.
      *
      * @throws IllegalStateException if there are errors binding the form, including the errors as JSON in the message
      */


### PR DESCRIPTION
Fixes https://groups.google.com/d/topic/play-framework/95d3ZsWGm4M/discussion
We also bumped into this limitation - the fix is quite easy :smile: 

Details:
Right now it's impossible to get the form value when the form has errors - because in such a case the value never gets set!
I expect [`myform.value()`](https://github.com/playframework/playframework/blob/2.5.4/framework/src/play-java/src/main/java/play/data/Form.java#L494-L496) to return the backed value even if the form has errors - it returns an `Optional` anyway.
The very similiar [`myform.get()`](https://github.com/playframework/playframework/blob/2.5.4/framework/src/play-java/src/main/java/play/data/Form.java#L631-L636) will still throw an exception when the form has errors - that's ok.