### PR TITLE
Read play.editor from environment variables as fallback

### DIFF
--- a/framework/src/play-server/src/main/resources/reference.conf
+++ b/framework/src/play-server/src/main/resources/reference.conf
@@ -81,5 +81,6 @@ play {
     pidfile.path = ${?pidfile.path}
   }
 
+  editor = ${?PLAY_EDITOR}
 
 }


### PR DESCRIPTION
Right now you can set `play.editor` in `application.conf`.
The problem is on compilation errors this setting will not (better: can't) be read and therefore in such a case no link is available.

A workaround, which works now already, is to set
```
javaOptions += "-Dplay.editor=http://localhost:63342/api/file/?file=%s&line=%s"
```
in `build.sbt`.
This also displays a link even when compilation errors occur - because this java system property gets also read and set even when the `application.conf` doesn't/can't get loaded/read (which happens when compilation errors occur).

But IMHO putting this settings in `build.sbt` isn't really nice.
Also a problem is different developers use different IDE's which need different links.

Therefore I added the feature to read `play_editor` from the environment variables as fallback.
This allows us to keep `build.sbt` clean and also each developer can set different `play_editor` environment variables on her/his machine. Plus it works even when compilation errors occur :smile: 