### PR TITLE
Websocket actor termination fix

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -348,6 +348,20 @@ trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerInteg
         }
       }
 
+      "close when the consumer is terminated" in closeWhenTheConsumerIsDone { implicit app =>
+        import app.materializer
+        implicit val system = app.actorSystem
+        WebSocket.accept[String, String] { req =>
+          ActorFlow.actorRef({ out =>
+            Props(new Actor() {
+              def receive = {
+                case _ => context.stop(self)
+              }
+            })
+          })
+        }
+      }
+
       "clean up when closed" in cleanUpWhenClosed { implicit app =>
         cleanedUp =>
           import app.materializer

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
@@ -40,7 +40,7 @@ object ActorFlow {
 
         def receive = {
           case Status.Success(_) | Status.Failure(_) => flowActor ! PoisonPill
-          case Terminated =>
+          case Terminated(_) =>
             println("Child terminated, stopping")
             context.stop(self)
           case other => flowActor ! other


### PR DESCRIPTION
Fixes #5838 

Fix the pattern match so that `Terminated` messages are processed correctly.



