### PR TITLE
Fix typo in documentation for WS

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -236,7 +236,7 @@ Please refer to the [AsyncHttpClientConfig Documentation](http://static.javadoc.
 * `play.ws.ahc.keepAlive`
 * `play.ws.ahc.maxConnectionsPerHost`
 * `play.ws.ahc.maxConnectionsTotal`
-* `play.ws.ahc.maxConnectionLifeTime`
+* `play.ws.ahc.maxConnectionLifetime`
 * `play.ws.ahc.idleConnectionInPoolTimeout`
 * `play.ws.ahc.maxNumberOfRedirects`
 * `play.ws.ahc.maxRequestRetry`

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -262,7 +262,7 @@ Please refer to the [AsyncHttpClientConfig Documentation](http://static.javadoc.
 * `play.ws.ahc.keepAlive`
 * `play.ws.ahc.maxConnectionsPerHost`
 * `play.ws.ahc.maxConnectionsTotal`
-* `play.ws.ahc.maxConnectionLifeTime`
+* `play.ws.ahc.maxConnectionLifetime`
 * `play.ws.ahc.idleConnectionInPoolTimeout`
 * `play.ws.ahc.maxNumberOfRedirects`
 * `play.ws.ahc.maxRequestRetry`


### PR DESCRIPTION
I know this probably will avoid someone not understand why their application does not behave as expected because of a silly `T` character instead of `t`.

See [AhcConfigSpec](https://github.com/playframework/playframework/blob/master/framework/src/play-ws/src/test/scala/play/api/libs/ws/ahc/AhcConfigSpec.scala) and [reference.conf](https://github.com/playframework/playframework/blob/master/framework/src/play-ws/src/main/resources/reference.conf)

I think it should be backported to `master`.

