### PR TITLE
[doc] added implicit Materializer to resolve compile error

### DIFF
--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleEssentialActionSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleEssentialActionSpec.scala
@@ -4,12 +4,16 @@
 package scalaguide.tests.specs2
 
 import play.api.mvc._
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test._
 import play.api.mvc.Results._
 import play.api.libs.json.Json
 
 // #scalatest-exampleessentialactionspec
 object ExampleEssentialActionSpec extends PlaySpecification {
+
+  lazy val app = new GuiceApplicationBuilder().build()
+  implicit lazy val mat = app.materializer
 
   "An essential action" should {
     "can parse a JSON body" in new WithApplication() {


### PR DESCRIPTION
## Fixes

Fixes compile error on Unit Testing EssentialAction with Specs2

## Background Context

When I test controller with Specs2 and calling `call` method, I got compile error below

> could not find implicit value for parameter mat: akka.stream.Materializer

https://www.playframework.com/documentation/2.5.x/ScalaTestingWithSpecs2#unit-testing-essentialaction

There is not defined `akka.stream.Materializer`. 

Instead, ScalaTestingWithScalaTest is written about implicit value on code.

https://www.playframework.com/documentation/2.5.x/ScalaTestingWithScalaTest#Unit-Testing-EssentialAction

I referenced `OneAppPerSuite` trait of ScalaTest to get `Materializer` through `GuiceApplicationBuilder`.