### PR TITLE
Apply Netty's cookie encoder/decoder updates.

### DIFF
--- a/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/CookieUtil.java
+++ b/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/CookieUtil.java
@@ -19,9 +19,29 @@ import java.util.BitSet;
 
 final class CookieUtil {
 
+    private static final BitSet VALID_COOKIE_NAME_OCTETS = validCookieNameOctets();
+
     private static final BitSet VALID_COOKIE_VALUE_OCTETS = validCookieValueOctets();
 
-    private static final BitSet VALID_COOKIE_NAME_OCTETS = validCookieNameOctets();
+    private static final BitSet VALID_COOKIE_ATTRIBUTE_VALUE_OCTETS = validCookieAttributeValueOctets();
+
+    // token = 1*<any CHAR except CTLs or separators>
+    // separators = "(" | ")" | "<" | ">" | "@"
+    // | "," | ";" | ":" | "\" | <">
+    // | "/" | "[" | "]" | "?" | "="
+    // | "{" | "}" | SP | HT
+    private static BitSet validCookieNameOctets() {
+        BitSet bits = new BitSet();
+        for (int i = 32; i < 127; i++) {
+            bits.set(i);
+        }
+        int[] separators = new int[]
+                { '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}', ' ', '\t' };
+        for (int separator : separators) {
+            bits.set(separator, false);
+        }
+        return bits;
+    }
 
     // cookie-octet = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
     // US-ASCII characters excluding CTLs, whitespace, DQUOTE, comma, semicolon, and backslash
@@ -43,21 +63,13 @@ final class CookieUtil {
         return bits;
     }
 
-    // token = 1*<any CHAR except CTLs or separators>
-    // separators = "(" | ")" | "<" | ">" | "@"
-    // | "," | ";" | ":" | "\" | <">
-    // | "/" | "[" | "]" | "?" | "="
-    // | "{" | "}" | SP | HT
-    private static BitSet validCookieNameOctets() {
+    // path-value        = <any CHAR except CTLs or ";">
+    private static BitSet validCookieAttributeValueOctets() {
         BitSet bits = new BitSet();
         for (int i = 32; i < 127; i++) {
             bits.set(i);
         }
-        int[] separators = new int[]
-                { '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}', ' ', '\t' };
-        for (int separator : separators) {
-            bits.set(separator, false);
-        }
+        bits.set(';', false);
         return bits;
     }
 
@@ -141,6 +153,21 @@ final class CookieUtil {
             }
         }
         return cs;
+    }
+
+    static String validateAttributeValue(String name, String value) {
+        if (value == null) {
+            return null;
+        }
+        value = value.trim();
+        if (value.isEmpty()) {
+            return null;
+        }
+        int i = firstInvalidOctet(value, VALID_COOKIE_ATTRIBUTE_VALUE_OCTETS);
+        if (i != -1) {
+            throw new IllegalArgumentException(name + " contains the prohibited characters: " + value.charAt(i));
+        }
+        return value;
     }
 
     private CookieUtil() {

--- a/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/DefaultCookie.java
+++ b/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/DefaultCookie.java
@@ -15,6 +15,8 @@
  */
 package play.core.netty.utils;
 
+import static play.core.netty.utils.CookieUtil.validateAttributeValue;
+
 /**
  * The default {@link Cookie} implementation.
  */
@@ -40,28 +42,6 @@ public class DefaultCookie implements Cookie {
         if (name.length() == 0) {
             throw new IllegalArgumentException("empty name");
         }
-
-        for (int i = 0; i < name.length(); i ++) {
-            char c = name.charAt(i);
-            if (c > 127) {
-                throw new IllegalArgumentException(
-                        "name contains non-ascii character: " + name);
-            }
-
-            // Check prohibited characters.
-            switch (c) {
-            case '\t': case '\n': case 0x0b: case '\f': case '\r':
-            case ' ':  case ',':  case ';':  case '=':
-                throw new IllegalArgumentException(
-                        "name contains one of the following prohibited characters: " +
-                        "=,; \\t\\r\\n\\v\\f: " + name);
-            }
-        }
-
-        if (name.charAt(0) == '$') {
-            throw new IllegalArgumentException("name starting with '$' not allowed: " + name);
-        }
-
         this.name = name;
         setValue(value);
     }
@@ -94,7 +74,7 @@ public class DefaultCookie implements Cookie {
     }
 
     public void setDomain(String domain) {
-        this.domain = validateValue("domain", domain);
+        this.domain = validateAttributeValue("domain", domain);
     }
 
     public String path() {
@@ -102,7 +82,7 @@ public class DefaultCookie implements Cookie {
     }
 
     public void setPath(String path) {
-        this.path = validateValue("path", path);
+        this.path = validateAttributeValue("path", path);
     }
 
     public int maxAge() {
@@ -205,6 +185,19 @@ public class DefaultCookie implements Cookie {
         return 0;
     }
 
+    /**
+     * Validate a cookie attribute value, throws a {@link IllegalArgumentException} otherwise.
+     * Only intended to be used by {@link play.core.netty.utils.DefaultCookie}.
+     * @param name attribute name
+     * @param value attribute value
+     * @return the trimmed, validated attribute value
+     * @deprecated CookieUtil is package private, will be removed once old Cookie API is dropped
+     */
+    @Deprecated
+    protected String validateValue(String name, String value) {
+        return validateAttributeValue(name, value);
+    }
+
     public String toString() {
         StringBuilder buf = new StringBuilder()
             .append(name())
@@ -230,25 +223,5 @@ public class DefaultCookie implements Cookie {
             buf.append(", HTTPOnly");
         }
         return buf.toString();
-    }
-
-    protected String validateValue(String name, String value) {
-        if (value == null) {
-            return null;
-        }
-        value = value.trim();
-        if (value.length() == 0) {
-            return null;
-        }
-        for (int i = 0; i < value.length(); i ++) {
-            char c = value.charAt(i);
-            switch (c) {
-            case '\r': case '\n': case '\f': case 0x0b: case ';':
-                throw new IllegalArgumentException(
-                        name + " contains one of the following prohibited characters: " +
-                        ";\\r\\n\\f\\v (" + value + ')');
-            }
-        }
-        return value;
     }
 }

--- a/framework/src/play/src/test/scala/play/api/mvc/CookiesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/CookiesSpec.scala
@@ -39,6 +39,11 @@ object CookiesSpec extends Specification {
       val output = encoder.encode("TestCookie", "!#$%&'()*+-./:<=>?@[]^_`{|}~")
       output must be_==("TestCookie=!#$%&'()*+-./:<=>?@[]^_`{|}~")
     }
+
+    "properly encode field name which starts with $" in {
+      val output = encoder.encode("$Test", "Test")
+      output must be_==("$Test=Test")
+    }
   }
 
   "trait Cookies#get" should {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

no issues

## Purpose

This commit applies [1] to the Play's cookie encoder/decoder implementation, for better RFC6265 following

## Background Context

This commit applies [1] to the Play's cookie encoder/decoder implementation.

Netty was update cookie encoder/decoder at 2015/4/14 [2] and 2016/5/19 [1].
And Play was update cookie encoder/decoder at 2015/5/11. So, [1] is not applied to Play yet.

[1] is `Drop broken DefaultCookie name validation`.
Detail is discussed in issue [4] `DefaultCookie's own name validation doesn't conform to RFC6265 #4999`.

I think, current Play's DefaultCookie has the same issue.

> it doesn't conform to RFC6265, eg seperators such as @ are allowed
> it's redundant with the checks performed in CookieEncoder/Decoder in STRICT mode (those are RFC6265 compliant)

And, RFC6265 accepts, cookie-name which starts with `$` [5] [6]

```
cookie-name       = token

token          = 1*<any CHAR except CTLs or separators>
separators     = "(" | ")" | "<" | ">" | "@"
                | "," | ";" | ":" | "\" | <">
                | "/" | "[" | "]" | "?" | "="
                | "{" | "}" | SP | HT
```

However, current play implementation throws an exception at [7].
(and, some android clients maybe send such fields...)

So, I think applying [1] is suitable for better RFC following.

## References

- [1]: https://github.com/netty/netty/commit/1d9c58baa18f9332f6e9af245d12b0ccc5004e7c
- [2]: https://github.com/netty/netty/commit/97d871a7553a01384b43df855dccdda5205ae77a
- [3]: https://github.com/playframework/playframework/commit/663dadb2e3c9908e20d208c424239ebde350c638
- [4]: https://github.com/netty/netty/issues/4999
- [5]: https://tools.ietf.org/html/rfc6265#section-4.1.1
- [6]: https://tools.ietf.org/html/rfc2616#section-2.2
- [7]: https://github.com/playframework/playframework/blob/2.5.4/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/DefaultCookie.java#L61-L63