### PR TITLE
Remove casting in query

### DIFF
--- a/templates/play-java-intro/app/controllers/PersonController.java
+++ b/templates/play-java-intro/app/controllers/PersonController.java
@@ -38,8 +38,7 @@ public class PersonController extends Controller {
 
     @Transactional(readOnly = true)
     public Result getPersons() {
-        //noinspection unchecked
-        List<Person> persons = (List<Person>) jpaApi.em().createQuery("select p from Person p").getResultList();
+        List<Person> persons = jpaApi.em().createQuery("select p from Person p", Person.class).getResultList();
         return ok(toJson(persons));
     }
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ x] Have you [squashed your commits](https://www.playframework.com/documentation/2.4.x/WorkingWithGit#Squashing-commits)?
* [ x] Have you added copyright headers to new files?
* [ x] Have you checked that both Scala and Java APIs are updated?
* [ x] Have you updated the documentation for both Scala and Java sections?
* [ x] Have you added tests for any changed functionality?

## Fixes

No issues

## Purpose

This PR is just to remove a useless casting in the play-java-intro template.

## Background Context

Casting is usually not a good practice and the JPA api offers overloaded methods to avoid doing it.

## References
http://docs.oracle.com/javaee/7/api/javax/persistence/EntityManager.html#createQuery-java.lang.String-java.lang.Class-

Make use of the overloaded createQuery methods to return already a List of Persons instead of using casting