### PR TITLE
Add `Link` header to StandardValues

### DIFF
--- a/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
@@ -257,6 +257,7 @@ trait HeaderNames {
   val IF_UNMODIFIED_SINCE = "If-Unmodified-Since"
 
   val LAST_MODIFIED = "Last-Modified"
+  val LINK = "Link"
   val LOCATION = "Location"
 
   val MAX_FORWARDS = "Max-Forwards"


### PR DESCRIPTION
The `Link` header is used for many things including server push in HTTP/2 so it would be convenient to have it provided here.