### PR TITLE
Add custom typed properties to requests

### DIFF
--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -3,7 +3,7 @@
  */
 package play.core.server.netty
 
-import java.net.{ URI, InetSocketAddress }
+import java.net.{ InetSocketAddress, URI }
 import java.security.cert.X509Certificate
 import javax.net.ssl.SSLEngine
 import javax.net.ssl.SSLPeerUnverifiedException
@@ -19,8 +19,9 @@ import io.netty.util.ReferenceCountUtil
 import play.api.Logger
 import play.api.http._
 import play.api.http.HeaderNames._
+import play.api.libs.typedmap.TypedMap
 import play.api.mvc._
-import play.core.server.common.{ ConnectionInfo, ServerResultUtils, ForwardedHeaderHandler }
+import play.core.server.common.{ ConnectionInfo, ForwardedHeaderHandler, ServerResultUtils }
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
@@ -73,41 +74,49 @@ private[server] class NettyModelConversion(forwardedHeaderHandler: ForwardedHead
     parameters: Map[String, Seq[String]], _remoteAddress: InetSocketAddress,
     sslHandler: Option[SslHandler]): RequestHeader = {
 
-    new RequestHeader {
-      override val id = requestId
-      override val tags = Map.empty[String, String]
-      override def uri = request.getUri
-      override def path = parsedPath
-      override def method = request.getMethod.name()
-      override def version = request.getProtocolVersion.text()
-      override def queryString = parameters
-      override val headers = new NettyHeadersWrapper(request.headers)
-      private lazy val remoteConnection: ConnectionInfo = {
-        forwardedHeaderHandler.remoteConnection(_remoteAddress.getAddress, sslHandler.isDefined, headers)
-      }
-      override def remoteAddress = remoteConnection.address.getHostAddress
-      override def secure = remoteConnection.secure
-      override lazy val clientCertificateChain = clientCertificatesFromSslEngine(sslHandler.map(_.engine()))
+    val headers = new NettyHeadersWrapper(request.headers)
+    lazy val remoteConnection: ConnectionInfo = {
+      forwardedHeaderHandler.remoteConnection(_remoteAddress.getAddress, sslHandler.isDefined, headers)
     }
+
+    new RequestHeaderImpl(
+      id = requestId,
+      tags = Map.empty,
+      uri = request.getUri,
+      path = parsedPath,
+      method = request.getMethod.name(),
+      version = request.getProtocolVersion.text(),
+      queryString = parameters,
+      headers = headers,
+      remoteAddressFunc = () => remoteConnection.address.toString,
+      secureFunc = () => remoteConnection.secure,
+      clientCertificateChain = clientCertificatesFromSslEngine(sslHandler.map(_.engine())),
+      properties = TypedMap.empty
+    )
   }
 
   /** Create an unparsed request header. Used when even Netty couldn't parse the request. */
   def createUnparsedRequestHeader(requestId: Long, request: HttpRequest, _remoteAddress: InetSocketAddress, sslHandler: Option[SslHandler]) = {
 
-    new RequestHeader {
-      override def id = requestId
-      override def tags = Map.empty[String, String]
-      override def uri = request.getUri
-      override lazy val path = {
+    val headers = new NettyHeadersWrapper(request.headers)
+    lazy val remoteConnection: ConnectionInfo = {
+      forwardedHeaderHandler.remoteConnection(_remoteAddress.getAddress, sslHandler.isDefined, headers)
+    }
+
+    new RequestHeaderImpl(
+      id = requestId,
+      tags = Map.empty,
+      uri = request.getUri,
+      path = {
         // The URI may be invalid, so instead, do a crude heuristic to drop the host and query string from it to get the
         // path, and don't decode.
         val withoutHost = request.getUri.dropWhile(_ != '/')
         val withoutQueryString = withoutHost.split('?').head
         if (withoutQueryString.isEmpty) "/" else withoutQueryString
-      }
-      override def method = request.getMethod.name()
-      override def version = request.getProtocolVersion.text()
-      override lazy val queryString: Map[String, Seq[String]] = {
+      },
+      method = request.getMethod.name(),
+      version = request.getProtocolVersion.text(),
+      queryString = {
         // Very rough parse of query string that doesn't decode
         if (request.getUri.contains("?")) {
           request.getUri.split("\\?", 2)(1).split('&').map { keyPair =>
@@ -121,12 +130,13 @@ private[server] class NettyModelConversion(forwardedHeaderHandler: ForwardedHead
         } else {
           Map.empty
         }
-      }
-      override val headers = new NettyHeadersWrapper(request.headers)
-      override def remoteAddress = _remoteAddress.getAddress.toString
-      override def secure = sslHandler.isDefined
-      override lazy val clientCertificateChain = clientCertificatesFromSslEngine(sslHandler.map(_.engine()))
-    }
+      },
+      headers = headers,
+      remoteAddressFunc = () => remoteConnection.address.toString,
+      secureFunc = () => remoteConnection.secure,
+      clientCertificateChain = clientCertificatesFromSslEngine(sslHandler.map(_.engine())),
+      properties = TypedMap.empty
+    )
   }
 
   /** Create the source for the request body */

--- a/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -4,28 +4,32 @@
 package play.core.server.common
 
 import org.specs2.mutable.Specification
+import play.api.libs.typedmap.TypedMap
 import play.api.mvc._
 import play.api.mvc.Results._
 
 object ServerResultUtilsSpec extends Specification {
 
-  case class CookieRequestHeader(cookie: Option[(String, String)]) extends RequestHeader {
-    def id = 1
-    def tags = Map()
-    def uri = ""
-    def path = ""
-    def method = ""
-    def version = ""
-    def queryString = Map()
-    def remoteAddress = ""
-    def secure = false
-    override def clientCertificateChain = None
-    val headers = new Headers(cookie.map { case (name, value) => "Cookie" -> s"$name=$value" }.toSeq)
+  private def cookieRequestHeader(cookie: Option[(String, String)]): RequestHeader = {
+    new RequestHeaderImpl(
+      id = 1L,
+      tags = Map.empty,
+      uri = "",
+      path = "",
+      method = "",
+      version = "",
+      queryString = Map.empty,
+      headers = new Headers(cookie.map { case (name, value) => "Cookie" -> s"$name=$value" }.toSeq),
+      remoteAddress = "",
+      secure = false,
+      clientCertificateChain = None,
+      properties = TypedMap.empty
+    )
   }
 
   "ServerResultUtils.cleanFlashCookie" should {
     def flashCookieResult(cookie: Option[(String, String)], result: Result): Option[Seq[Cookie]] = {
-      val rh = CookieRequestHeader(cookie)
+      val rh = cookieRequestHeader(cookie)
       ServerResultUtils.cleanFlashCookie(rh, result).header.headers.get("Set-Cookie").map(Cookies.decodeSetCookieHeader)
     }
 

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Lists;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import play.api.libs.json.JsValue;
+import play.api.libs.typedmap.TypedMap;
 import play.api.mvc.Headers;
 import play.core.j.JavaParsers;
 import play.core.system.RequestIdProvider;
@@ -963,7 +964,6 @@ public class Http {
          */
         public RequestImpl build() {
             return new RequestImpl(new play.api.mvc.RequestImpl(
-                body(),
                 id,
                 asScala(tags()),
                 uri.toString(),
@@ -974,7 +974,10 @@ public class Http {
                 buildHeaders(),
                 remoteAddress,
                 secure,
-                OptionConverters.toScala(clientCertificateChain.map(lst -> scala.collection.JavaConversions.asScalaBuffer(lst).toSeq()))));
+                OptionConverters.toScala(clientCertificateChain.map(lst -> scala.collection.JavaConversions.asScalaBuffer(lst).toSeq())),
+                TypedMap.empty(),
+                body()
+            ));
         }
 
         // -------------------

--- a/framework/src/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.libs.typedmap
+
+import scala.annotation.varargs
+import scala.collection.immutable
+
+/**
+ * A PropMap is an immutable map containing [[TypedKey]]s and their values.
+ *
+ * @param m The map used to store values.
+ */
+final class TypedMap private (m: immutable.Map[TypedKey[_], Any]) {
+  def apply[A](prop: TypedKey[A]): A = m.apply(prop).asInstanceOf[A]
+  def get[A](prop: TypedKey[A]): Option[A] = m.get(prop).asInstanceOf[Option[A]]
+  def getOrElse[A](prop: TypedKey[A], default: => A): A = m.getOrElse(prop, default).asInstanceOf[A]
+  def contains[A](p: TypedKey[A]): Boolean = m.contains(p)
+  def updated[A](prop: TypedKey[A], value: A): TypedMap = new TypedMap(m.updated(prop, value))
+  def +(entry: TypedEntry[_]): TypedMap = {
+    // Use `helper` to bind the key and value to the same type variable, A
+    def helper[A](e: TypedEntry[A]): TypedMap = updated(e.key, e.value)
+    helper(entry)
+  }
+  def +(entry: TypedEntry[_], entries: TypedEntry[_]*): TypedMap = {
+    val m1 = entries.foldLeft(m.updated(entry.key, entry.value)) {
+      case (m, e) => m.updated(e.key, e.value)
+    }
+    new TypedMap(m1)
+  }
+  override def toString: String = m.mkString
+}
+
+object TypedMap {
+
+  /**
+   * Create an empty [[TypedMap]].
+   */
+  val empty = new TypedMap(immutable.Map.empty)
+
+  /**
+   * Builds a [[TypedMap]] from a list of props and values.
+   */
+  def apply(entry: TypedEntry[_]): TypedMap = TypedMap.empty + entry
+  def apply(entry: TypedEntry[_], entries: TypedEntry[_]*): TypedMap = {
+    TypedMap.empty.+(entry, entries: _*)
+  }
+
+  /**
+   * Builds a [[TypedMap]] from a list of props and values. This method
+   * is like `apply` but it can be used in varargs style from Java.
+   */
+  def withEntries(entry: TypedEntry[_]): TypedMap = apply(entry)
+  @varargs def withEntries(entry: TypedEntry[_], entries: TypedEntry[_]*): TypedMap = {
+    apply(entry, entries: _*)
+  }
+}
+
+/**
+ * A property is a key that can be used to get and set values on an
+ * object that implements [[HasProps]].
+ *
+ * @tparam A The type of values associated with this property.
+ */
+trait TypedKey[A] {
+
+  /**
+   * Bind this property to a value.
+   *
+   * @param value The value to bind this property to.
+   * @return A bound value.
+   */
+  def bindValue(value: A): TypedEntry[A] = TypedEntry(this, value)
+
+  /**
+   * Bind this property to a value.
+   *
+   * @param value
+   * @return
+   */
+  def ->(value: A): TypedEntry[A] = bindValue(value)
+}
+
+/**
+ * Helper for working with `Prop`s.
+ */
+object TypedKey {
+  /**
+   *
+   * @param displayName
+   * @tparam A
+   * @return
+   */
+  def apply[A](displayName: String): TypedKey[A] = new TypedKey[A] {
+    override def toString: String = displayName
+  }
+}
+
+final case class TypedEntry[A](key: TypedKey[A], value: A) {
+  def toPair: (TypedKey[A], A) = (key, value)
+}

--- a/framework/src/play/src/main/scala/play/api/mvc/Security.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Security.scala
@@ -91,7 +91,9 @@ object Security {
    *
    * @param user The user that made the request
    */
-  class AuthenticatedRequest[A, U](val user: U, request: Request[A]) extends WrappedRequest[A](request)
+  class AuthenticatedRequest[A, U](val user: U, request: Request[A]) extends WrappedRequest[A](request) {
+    override protected def newWrapper[B](newRequest: Request[B]): AuthenticatedRequest[B, U] = new AuthenticatedRequest[B, U](user, newRequest)
+  }
 
   /**
    * An authenticated action builder.

--- a/framework/src/play/src/main/scala/play/api/mvc/WrappedRequest.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/WrappedRequest.scala
@@ -3,6 +3,8 @@
  */
 package play.api.mvc
 
+import play.api.libs.typedmap.{ TypedEntry, TypedKey }
+
 /**
  * Wrap an existing request. Useful to extend a request.
  */
@@ -19,4 +21,18 @@ class WrappedRequest[+A](request: Request[A]) extends Request[A] {
   override def remoteAddress = request.remoteAddress
   override def secure = request.secure
   override def clientCertificateChain = request.clientCertificateChain
+
+  /**
+   * Create a copy of this wrapper, but wrapping a new request.
+   * Subclasses can override this method.
+   */
+  protected def newWrapper[B](newRequest: Request[B]): WrappedRequest[B] = new WrappedRequest[B](newRequest)
+
+  override def withBody[B](body: B): WrappedRequest[B] = newWrapper(request.withBody(body))
+  override def updated[B](key: TypedKey[B], value: B): WrappedRequest[A] = newWrapper(request.updated(key, value))
+  override def +(entry: TypedEntry[_]): WrappedRequest[A] = newWrapper(request + entry)
+  override def +(entry: TypedEntry[_], entries: TypedEntry[_]*): WrappedRequest[A] = newWrapper(request + (entry, entries: _*))
+  override def get[A](key: TypedKey[A]): Option[A] = request.get(key)
+  override def apply[A](key: TypedKey[A]): A = request.apply(key)
+  override def contains(key: TypedKey[_]): Boolean = request.contains(key)
 }

--- a/framework/src/play/src/test/scala/play/core/test/Fakes.scala
+++ b/framework/src/play/src/test/scala/play/core/test/Fakes.scala
@@ -9,6 +9,7 @@ import akka.util.ByteString
 import play.api.inject.{ Binding, Injector }
 import play.api.libs.Files.TemporaryFile
 import play.api.libs.json.JsValue
+import play.api.libs.typedmap.TypedMap
 import play.api.mvc._
 
 import scala.concurrent.Future
@@ -21,7 +22,18 @@ import scala.xml.NodeSeq
  */
 case class FakeHeaders(data: Seq[(String, String)] = Seq.empty) extends Headers(data)
 
-case class FakeRequest[A](method: String, uri: String, headers: Headers, body: A, remoteAddress: String = "127.0.0.1", version: String = "HTTP/1.1", id: Long = 666, tags: Map[String, String] = Map.empty[String, String], secure: Boolean = false, clientCertificateChain: Option[Seq[X509Certificate]] = None) extends Request[A] {
+case class FakeRequest[A](
+    method: String,
+    uri: String,
+    headers: Headers,
+    body: A,
+    remoteAddress: String = "127.0.0.1",
+    version: String = "HTTP/1.1",
+    id: Long = 666,
+    tags: Map[String, String] = Map.empty[String, String],
+    secure: Boolean = false,
+    clientCertificateChain: Option[Seq[X509Certificate]] = None,
+    properties: TypedMap = TypedMap.empty) extends Request[A] with WithPropertiesMap[FakeRequest[A]] {
 
   private def _copy[B](
     id: Long = this.id,
@@ -34,6 +46,7 @@ case class FakeRequest[A](method: String, uri: String, headers: Headers, body: A
     remoteAddress: String = this.remoteAddress,
     secure: Boolean = this.secure,
     clientCertificateChain: Option[Seq[X509Certificate]] = this.clientCertificateChain,
+    properties: TypedMap = this.properties,
     body: B = this.body): FakeRequest[B] = {
     new FakeRequest[B](
       method, uri, headers, body, remoteAddress, version, id, tags, secure, clientCertificateChain
@@ -140,6 +153,11 @@ case class FakeRequest[A](method: String, uri: String, headers: Headers, body: A
     _copy(body = body)
   }
 
+  override protected def withProperties(newProperties: TypedMap): FakeRequest[A] = {
+    new FakeRequest[A](
+      method, uri, headers, body, remoteAddress, version, id, tags, secure, clientCertificateChain, newProperties
+    )
+  }
   /**
    * Returns the current method
    */


### PR DESCRIPTION
RequestHeader and Request can now have custom properties added to
them. This lets plugins and users add their own data to requests.
Adding custom properties was sort of possible by using tags, but tag
values could only be strings. The new API adds support for typed
properties.

Typed properties are accessed using methods similar to Maps. For
example, the `+` method adds a new property and `apply` or `get` can
be used to retrieve a property.

I have intentionally restricted the API to hide internal details of
how properties are implemented. This is because I want to make it
possible to change the underlying implementation later if we want to
support more complicated features. For example, I've avoided exposing
the underlying map that's used to store the properties. This is
because we might want to support lazy or dynamic properties later, and
these might not be implemented by storing them in a simple map.

Fixes #5814.

TODO:

- [ ] Scaladoc
- [ ] Java API
- [ ] More tests
- [ ] Use typed tags for router
- [ ] Use typed tags for CSRF filter