### PR TITLE
Add csrfCheck and csrfAddToken to the components

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -289,5 +289,7 @@ trait CSRFComponents {
   lazy val csrfTokenProvider: CSRF.TokenProvider = new CSRF.TokenProviderProvider(csrfConfig, csrfTokenSigner).get
   lazy val csrfErrorHandler: CSRF.ErrorHandler = new CSRFHttpErrorHandler(httpErrorHandler)
   lazy val csrfFilter: CSRFFilter = new CSRFFilter(csrfConfig, csrfTokenSigner, csrfTokenProvider, csrfErrorHandler)
+  lazy val csrfCheck: CSRFCheck = new CSRFCheck(csrfConfig, csrfTokenSigner)
+  lazy val csrfAddToken: CSRFAddToken = new CSRFAddToken(csrfConfig, csrfTokenSigner)
 
 }


### PR DESCRIPTION
## Fixes

Fixes the absence of `CSRFCheck` and `CSRFAddToken` in the `CSRFComponents` trait

## Purpose

This will help users trying to use CSRF per endpoint when they use compile time dependency injection as these two components are currently missing.

If this PR is accepted I'll create the same onto master.

