### PR TITLE
Fix range result pattern match bug

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/RangeResult.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/RangeResult.scala
@@ -266,7 +266,7 @@ private[mvc] object RangeSet {
         }
       }).getOrElse(
         header match {
-          case WithoutEntityLengthRangeSetPattern() => headerToRanges(entityLength, header)
+          case WithoutEntityLengthRangeSetPattern(_) => headerToRanges(entityLength, header)
           case _ => NoHeaderRangeSet(entityLength)
         }
       ).normalize


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Purpose

Currently the regular expression in https://github.com/playframework/playframework/blob/2.5.4/framework/src/play/src/main/scala/play/api/mvc/RangeResult.scala#L268-L271 will not match expected range header values.

E.g.
```scala
val WithoutEntityLengthRangeSetPattern = """^bytes=([0-9]+-[0-9]+,?)+""".r
val header = "bytes=1-2"

header match {
    case WithoutEntityLengthRangeSetPattern() => ...
    case _ => ...
}
```

Will incorrectly fall through to `case _ => ...` even though `header.matches(WithoutEntityLengthRangeSetPattern.regex)` is `true`

We need to add a parameter or `_` to the case statement as I have in this PR to allow it to successfully match.

```scala
header match {
    case WithoutEntityLengthRangeSetPattern(_) => ...
    case _ => ...
}
```

Will match correctly.

