### PR TITLE
Backport "Add csrfCheck and csrfAddToken to the components"

### DIFF
--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaCompileTimeDependencyInjection.md
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaCompileTimeDependencyInjection.md
@@ -74,3 +74,5 @@ To use this router in an actual application:
 As described before, Play provides a number of helper traits for wiring in other components.  For example, if you wanted to use the messages module, you can mix in [I18nComponents](api/scala/play/api/i18n/I18nComponents.html) into your components cake, like so:
 
 @[messages](code/CompileTimeDependencyInjection.scala)
+
+Other helper traits are also available as the [CSRFComponents](api/scala/play/filters/csrf/CSRFComponents.html) or the [AhcWsComponents](api/scala/play/api/libs/ws/ahc/AhcWSComponents.html)

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaCsrf.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaCsrf.md
@@ -129,3 +129,7 @@ The full range of CSRF configuration options can be found in the filters [refere
 * `play.filters.csrf.cookie.secure` - If `play.filters.csrf.cookie.name` is set, whether the CSRF cookie should have the secure flag set.  Defaults to the same value as `play.http.session.secure`.
 * `play.filters.csrf.body.bufferSize` - In order to read tokens out of the body, Play must first buffer the body and potentially parse it.  This sets the maximum buffer size that will be used to buffer the body.  Defaults to 100k.
 * `play.filters.csrf.token.sign` - Whether Play should use signed CSRF tokens.  Signed CSRF tokens ensure that the token value is randomised per request, thus defeating BREACH style attacks.
+
+## Using CSRF with compile time dependency injection
+
+You can use all the above features if your application is using compile time dependency injection. The wiring is helped by the trait [CSRFComponents](api/scala/play/filters/csrf/CSRFComponents.html) that you can mix in your application components cake. For more details about compile time dependency injection, please refer to the [[associated documentation page|ScalaCompileTimeDependencyInjection]].

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -289,5 +289,7 @@ trait CSRFComponents {
   lazy val csrfTokenProvider: CSRF.TokenProvider = new CSRF.TokenProviderProvider(csrfConfig, csrfTokenSigner).get
   lazy val csrfErrorHandler: CSRF.ErrorHandler = new CSRFHttpErrorHandler(httpErrorHandler)
   lazy val csrfFilter: CSRFFilter = new CSRFFilter(csrfConfig, csrfTokenSigner, csrfTokenProvider, csrfErrorHandler)
+  lazy val csrfCheck: CSRFCheck = new CSRFCheck(csrfConfig, csrfTokenSigner)
+  lazy val csrfAddToken: CSRFAddToken = new CSRFAddToken(csrfConfig, csrfTokenSigner)
 
 }


### PR DESCRIPTION
## Fixes
This is following https://github.com/playframework/playframework/pull/6325
It backports the commit that adds `csrfCheck` and `csrfToken` to the trait `CSRFComponents`.

## Purpose
This will help users trying to use CSRF per endpoint when they use compile time dependency injection as these two components are currently missing.

## References
https://github.com/playframework/playframework/pull/6325
(cherry picked from commit 313d9cb)

Please let me know if this doesn't justify a 2.5.x release or if it isn't judged necessary to backport that fix and I'll happily close this PR.