### PR TITLE
Update Writeable to write JsValue to bytes with play-json 2.6.0-M2

### DIFF
--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -45,6 +45,14 @@ libraryDependencies += "com.typesafe.play" %% "play-json" % "2.6.0"
 
 Also, Play JSON has a separate versioning scheme, so the version no longer is in sync with the Play version.
 
+## Writeable[JsValue] changes
+
+Previously, the default Scala `Writeable[JsValue]` allowed you to define an implicit `Codec`, which would allow you to write using a different charset. This could be a problem since `application/json` does not act like text-based content types. It only allows Unicode charsets (`UTF-8`, `UTF-16` and `UTF-32`) and does not define a `charset` parameter like many text-based content types.
+
+Now, the default `Writeable[JsValue]` takes no implicit parameters and always writes to `UTF-8`. This covers the majority of cases, since most users want to use UTF-8 for JSON. It also allows us to easily use more efficient built-in methods for writing JSON to a byte array.
+
+If you need the old behavior back, you can define a `Writeable` with an arbitrary codec using `play.api.http.Writeable.writeableOf_JsValue(codec, contentType)` for your desired Codec and Content-Type.
+
 ## Scala ActionBuilder and BodyParser changes:
 
 The Scala `ActionBuilder` trait has been modified to specify the type of the body as a type parameter, and add an abstract `parser` member as the default body parsers. You will need to modify your ActionBuilders and pass the body parser directly.

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
 
   val akkaVersion = "2.4.16"
   val akkaHttpVersion = "10.0.3"
-  val playJsonVersion = "2.6.0-M1"
+  val playJsonVersion = "2.6.0-M2"
 
   val specsVersion = "3.8.6"
   val specsBuild = Seq(
@@ -254,7 +254,7 @@ object Dependencies {
   val playWsDeps = Seq(
     "com.typesafe.play" %% "play-ws-standalone" % playWsStandaloneVersion,
     logback % Test
-  ) ++    
+  ) ++
     (specsBuild :+ specsMatcherExtra).map(_ % Test) :+
     mockitoAll % Test
 

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -130,8 +130,11 @@ object PlayRunners {
 }
 
 trait Writeables {
-  implicit def writeableOf_AnyContentAsJson(implicit codec: Codec): Writeable[AnyContentAsJson] =
-    Writeable.writeableOf_JsValue.map(c => c.json)
+  def writeableOf_AnyContentAsJson(codec: Codec, contentType: Option[String] = None): Writeable[AnyContentAsJson] =
+    Writeable.writeableOf_JsValue(codec, contentType).map(_.json)
+
+  implicit def writeableOf_AnyContentAsJson: Writeable[AnyContentAsJson] =
+    Writeable.writeableOf_JsValue.map(_.json)
 
   implicit def writeableOf_AnyContentAsXml(implicit codec: Codec): Writeable[AnyContentAsXml] =
     Writeable.writeableOf_NodeSeq.map(c => c.xml)

--- a/framework/src/play/src/main/scala/play/api/http/Writeable.scala
+++ b/framework/src/play/src/main/scala/play/api/http/Writeable.scala
@@ -89,10 +89,17 @@ trait DefaultWriteables extends LowPriorityWriteables {
   }
 
   /**
-   * `Writeable` for `JsValue` values - Json
+   * `Writeable` for `JsValue` values that writes to UTF-8, so they can be sent with the application/json media type.
    */
-  implicit def writeableOf_JsValue(implicit codec: Codec): Writeable[JsValue] = {
-    Writeable(a => codec.encode(Json.stringify(a)))
+  implicit def writeableOf_JsValue: Writeable[JsValue] = {
+    Writeable(a => ByteString(Json.toBytes(a)))
+  }
+
+  /**
+   * `Writeable` for `JsValue` values using an arbitrary codec. Can be used to force a non-UTF-8 encoding for JSON.
+   */
+  def writeableOf_JsValue(codec: Codec, contentType: Option[String] = None): Writeable[JsValue] = {
+    Writeable(a => codec.encode(Json.stringify(a)), contentType)
   }
 
   /**


### PR DESCRIPTION
Instead of writing our `JsValue`s to a string and then to bytes when writing them out, let's just write directly to a byte array.

One small API change here is that the implicit `Writeable` for `JsValue` always uses UTF-8. I decided to make the implicit `Writeable` not take a `Codec` and always write to UTF-8 and make another non-implicit one that allows setting a codec. The reasoning is that almost always you want to write as UTF-8, and since JSON is always Unicode, you would produce an invalid response if you happened to have the wrong codec in scope.
