### PR TITLE
Add an example of the FakeRequest being explained

### DIFF
--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ApplicationTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ApplicationTest.java
@@ -47,10 +47,8 @@ public class ApplicationTest extends WithApplication {
   //#test-controller-routes
   @Test
   public void testCallIndex() {
-    //###replace: RequestBuilder request = fakeRequest("GET", "/");
     Result result = route(
-      //###replace:     controllers.routes.HomeController.index(),
-      //###replace:     request
+      //###replace:     fakeRequest()
       javaguide.tests.controllers.routes.HomeController.index()
     );
     assertEquals(OK, result.status());

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ApplicationTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/ApplicationTest.java
@@ -47,8 +47,10 @@ public class ApplicationTest extends WithApplication {
   //#test-controller-routes
   @Test
   public void testCallIndex() {
+    //###replace: RequestBuilder request = fakeRequest("GET", "/");
     Result result = route(
       //###replace:     controllers.routes.HomeController.index(),
+      //###replace:     request
       javaguide.tests.controllers.routes.HomeController.index()
     );
     assertEquals(OK, result.status());


### PR DESCRIPTION
## Purpose

Documentation fix

The docs are explaining how to use a FakeRequest [here](https://www.playframework.com/documentation/2.5.x/JavaTest#Unit-testing-controllers), but the example omits that. Here is the original:

> You can also retrieve an action reference from the reverse router and invoke it. This also allows you to use FakeRequest which is a mock for request data:

> ```
@Test
public void testCallIndex() {
  Result result = route(
    controllers.routes.HomeController.index(),
  );
  assertEquals(OK, result.status());
}
```