### PR TITLE
Add Marker support to Logger API

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
@@ -102,6 +102,20 @@ Here's an example of configuration that uses a rolling file appender, as well as
         </encoder>
     </appender>
 
+    <appender name="SECURITY_FILE" class="ch.qos.logback.core.FileAppender">
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+                <marker>SECURITY</marker>
+            </evaluator>
+            <OnMismatch>DENY</OnMismatch>
+            <OnMatch>ACCEPT</OnMatch>
+        </filter>
+        <file>${application.home:-.}/logs/security.log</file>
+        <encoder>
+            <pattern>%date [%level] [%marker] from %logger in %thread - %message%n%xException</pattern>
+        </encoder>
+    </appender>
+
     <appender name="ACCESS_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${user.dir}/web/logs/access.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -124,6 +138,7 @@ Here's an example of configuration that uses a rolling file appender, as well as
 
     <root level="INFO">
         <appender-ref ref="FILE"/>
+        <appender-ref ref="SECURITY_FILE"/>
     </root>
 
 </configuration>
@@ -135,8 +150,10 @@ This demonstrates a few useful features:
 - It uses `RollingFileAppender` which can help manage growing log files.
 - It writes log files to a directory external to the application so they aren't affected by upgrades, etc.
 - The `FILE` appender uses an expanded message format that can be parsed by third party log analytics providers such as Sumo Logic.
-- The `access` logger is routed to a separate log file using the `ACCESS_FILE_APPENDER`.
+- The `access` logger is routed to a separate log file using the `ACCESS_FILE` appender.
+- Any log messages sent with the "SECURITY" marker attached are logged to the `security.log` file using the [EvaluatorFilter](http://logback.qos.ch/manual/filters.html#evalutatorFilter) and the [OnMarkerEvaluator](http://logback.qos.ch/manual/appenders.html#OnMarkerEvaluator).
 - All loggers are set to a threshold of `INFO` which is a common choice for production logging.
+
 
 ## Including Properties
 

--- a/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
@@ -10,6 +10,9 @@ import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import scala.concurrent.ExecutionContext
 
+import org.slf4j._
+import play.api._
+
 @RunWith(classOf[JUnitRunner])
 class ScalaLoggingSpec extends Specification with Mockito {
 
@@ -178,6 +181,71 @@ class ScalaLoggingSpec extends Specification with Mockito {
 
       loggerName must equalTo("access")
     }
+  }
+
+  //#logging-default-marker-context
+  val someMarker: org.slf4j.Marker = MarkerFactory.getMarker("SOMEMARKER")      
+  case object SomeMarkerContext extends play.api.DefaultMarkerContext(someMarker)
+  //#logging-default-marker-context
+
+  "MarkerContext" should {
+    "return some marker" in {
+      import play.api.Logger      
+      val logger: Logger = Logger("access")
+
+      //#logging-marker-context
+      val marker: org.slf4j.Marker = MarkerFactory.getMarker("SOMEMARKER")
+      val mc: MarkerContext = MarkerContext(marker)
+      //#logging-marker-context
+      mc.marker must beSome.which(_ must be_==(marker))
+    }
+
+    "logger.info with explicit marker context" in {
+      import play.api.Logger      
+      val logger: Logger = Logger("access")
+
+      //#logging-log-info-with-explicit-markercontext
+      // use a typed marker as input
+      logger.info("log message with explicit marker context with case object")(SomeMarkerContext)
+      
+      // Use a specified marker.
+      val otherMarker: Marker = MarkerFactory.getMarker("OTHER")      
+      val otherMarkerContext: MarkerContext = MarkerContext(otherMarker)
+      logger.info("log message with explicit marker context")(otherMarkerContext)
+      //#logging-log-info-with-explicit-markercontext
+
+      success
+    }
+
+    "logger.info with implicit marker context" in {
+      import play.api.Logger      
+      val logger: Logger = Logger("access")
+
+      //#logging-log-info-with-implicit-markercontext
+      val marker: Marker = MarkerFactory.getMarker("SOMEMARKER")      
+      implicit val mc: MarkerContext = MarkerContext(marker)
+
+      // Use the implicit MarkerContext in logger.info...
+      logger.info("log message with implicit marker context")
+      //#logging-log-info-with-implicit-markercontext
+
+      mc.marker must beSome.which(_ must be_==(marker))
+    }
+
+    "implicitly convert a Marker to a MarkerContext" in {
+      import play.api.Logger      
+      val logger: Logger = Logger("access")
+
+      //#logging-log-info-with-implicit-conversion
+      val mc: MarkerContext = MarkerFactory.getMarker("SOMEMARKER")
+            
+      // Use the marker that has been implicitly converted to MarkerContext      
+      logger.info("log message with implicit marker context")(mc)
+      //#logging-log-info-with-implicit-conversion
+      
+      success
+    }
+
   }
 
 }

--- a/framework/src/play/src/main/java/play/Logger.java
+++ b/framework/src/play/src/main/java/play/Logger.java
@@ -3,6 +3,9 @@
  */
 package play;
 
+import org.slf4j.Marker;
+import play.api.DefaultMarkerContext;
+
 /**
  * High level API for logging operations.
  *
@@ -261,6 +264,8 @@ public class Logger {
      */
     public static class ALogger {
 
+        private final play.api.MarkerContext noMarker = new play.api.DefaultMarkerContext(null);
+
         private final play.api.Logger logger;
 
         public ALogger(play.api.Logger logger) {
@@ -270,7 +275,7 @@ public class Logger {
         /**
          * Get the underlying SLF4J logger.
          *
-         * @return the SLF4J loger
+         * @return the SLF4J logger
          */
         public org.slf4j.Logger underlying() {
             return logger.underlyingLogger();
@@ -282,7 +287,19 @@ public class Logger {
          * @return <code>true</code> if the logger instance has TRACE level logging enabled.
          */
         public boolean isTraceEnabled() {
-            return logger.isTraceEnabled();
+            return logger.isTraceEnabled(noMarker);
+        }
+
+        /**
+         * Similar to {@link #isTraceEnabled()} method except that the
+         * marker data is also taken into account.
+         *
+         * @param marker The marker data to take into consideration
+         * @return True if this Logger is enabled for the TRACE level,
+         *         false otherwise.
+         */
+        public boolean isTraceEnabled(Marker marker) {
+            return logger.isTraceEnabled(new DefaultMarkerContext(marker));
         }
 
         /**
@@ -291,7 +308,19 @@ public class Logger {
          * @return <code>true</code> if the logger instance has DEBUG level logging enabled.
          */
         public boolean isDebugEnabled() {
-            return logger.isDebugEnabled();
+            return logger.isDebugEnabled(noMarker);
+        }
+
+        /**
+         * Similar to {@link #isDebugEnabled()} method except that the
+         * marker data is also taken into account.
+         *
+         * @param marker The marker data to take into consideration
+         * @return True if this Logger is enabled for the DEBUG level,
+         *         false otherwise.
+         */
+        public boolean isDebugEnabled(Marker marker) {
+            return logger.isDebugEnabled(new DefaultMarkerContext(marker));
         }
 
         /**
@@ -300,7 +329,18 @@ public class Logger {
          * @return <code>true</code> if the logger instance has INFO level logging enabled.
          */
         public boolean isInfoEnabled() {
-            return logger.isInfoEnabled();
+            return logger.isInfoEnabled(noMarker);
+        }
+
+        /**
+         * Similar to {@link #isInfoEnabled()} method except that the marker
+         * data is also taken into consideration.
+         *
+         * @param marker The marker data to take into consideration
+         * @return true if this logger is warn enabled, false otherwise
+         */
+        public boolean isInfoEnabled(Marker marker) {
+            return logger.isInfoEnabled(new DefaultMarkerContext(marker));
         }
 
         /**
@@ -309,7 +349,19 @@ public class Logger {
          * @return <code>true</code> if the logger instance has WARN level logging enabled.
          */
         public boolean isWarnEnabled() {
-            return logger.isWarnEnabled();
+            return logger.isWarnEnabled(noMarker);
+        }
+
+        /**
+         * Similar to {@link #isWarnEnabled()} method except that the marker
+         * data is also taken into consideration.
+         *
+         * @param marker The marker data to take into consideration
+         * @return True if this Logger is enabled for the WARN level,
+         *         false otherwise.
+         */
+        public boolean isWarnEnabled(Marker marker) {
+            return logger.isWarnEnabled(new DefaultMarkerContext(marker));
         }
 
         /**
@@ -318,7 +370,19 @@ public class Logger {
          * @return <code>true</code> if the logger instance has ERROR level logging enabled.
          */
         public boolean isErrorEnabled() {
-            return logger.isWarnEnabled();
+            return logger.isErrorEnabled(noMarker);
+        }
+
+        /**
+         * Similar to {@link #isErrorEnabled()} method except that the
+         * marker data is also taken into consideration.
+         *
+         * @param marker The marker data to take into consideration
+         * @return True if this Logger is enabled for the ERROR level,
+         *         false otherwise.
+         */
+        public boolean isErrorEnabled(Marker marker) {
+            return logger.isErrorEnabled(new DefaultMarkerContext(marker));
         }
 
         /**
@@ -333,11 +397,33 @@ public class Logger {
         /**
          * Logs a message with the TRACE level.
          *
+         * @param marker the marker data specific to this log statement
+         * @param message message to log
+         */
+        public void trace(Marker marker, String message) {
+            logger.underlyingLogger().trace(marker, message);
+        }
+
+        /**
+         * Logs a message with the TRACE level.
+         *
          * @param message message to log
          * @param args The arguments to apply to the message string
          */
         public void trace(String message, Object... args) {
             logger.underlyingLogger().trace(message, args);
+        }
+
+        /**
+         *  This method is similar to {@link #trace(String, Object...)} method except that the
+         * marker data is also taken into consideration.
+         *
+         * @param marker the marker data specific to this log statement
+         * @param message message to log
+         * @param args The arguments to apply to the message string
+         */
+        public void trace(Marker marker, String message, Object... args) {
+            logger.underlyingLogger().trace(marker, message, args);
         }
 
         /**
@@ -348,6 +434,18 @@ public class Logger {
          */
         public void trace(String message, Throwable error) {
             logger.underlyingLogger().trace(message, error);
+        }
+
+
+        /**
+         * Logs a message with the TRACE level, with the given error.
+         *
+         * @param marker the marker data specific to this log statement
+         * @param message message to log
+         * @param error associated exception
+         */
+        public void trace(Marker marker, String message, Throwable error) {
+            logger.underlyingLogger().trace(marker, message, error);
         }
 
         /**
@@ -362,11 +460,32 @@ public class Logger {
         /**
          * Logs a message with the DEBUG level.
          *
+         * @param marker the marker data specific to this log statement
+         * @param message Message to log
+         */
+        public void debug(Marker marker, String message) {
+            logger.underlyingLogger().debug(marker, message);
+        }
+
+        /**
+         * Logs a message with the DEBUG level.
+         *
          * @param message Message to log
          * @param args The arguments to apply to the message string
          */
         public void debug(String message, Object... args) {
             logger.underlyingLogger().debug(message, args);
+        }
+
+        /**
+         * Logs a message with the DEBUG level.
+         *
+         * @param marker the marker data specific to this log statement
+         * @param message Message to log
+         * @param args The arguments to apply to the message string
+         */
+        public void debug(Marker marker, String message, Object... args) {
+            logger.underlyingLogger().debug(marker, message, args);
         }
 
         /**
@@ -377,6 +496,17 @@ public class Logger {
          */
         public void debug(String message, Throwable error) {
             logger.underlyingLogger().debug(message, error);
+        }
+
+        /**
+         * Logs a message with the DEBUG level, with the given error.
+         *
+         * @param marker the marker data specific to this log statement
+         * @param message Message to log
+         * @param error associated exception
+         */
+        public void debug(Marker marker, String message, Throwable error) {
+            logger.underlyingLogger().debug(marker, message, error);
         }
 
         /**
@@ -392,10 +522,30 @@ public class Logger {
          * Logs a message with the INFO level.
          *
          * @param message message to log
+         */
+        public void info(Marker marker, String message) {
+            logger.underlyingLogger().info(marker, message);
+        }
+
+        /**
+         * Logs a message with the INFO level.
+         *
+         * @param message message to log
          * @param args The arguments to apply to the message string
          */
         public void info(String message, Object... args) {
             logger.underlyingLogger().info(message, args);
+        }
+
+        /**
+         * Logs a message with the INFO level.
+         *
+         * @param marker the marker data specific to this log statement
+         * @param message message to log
+         * @param args The arguments to apply to the message string
+         */
+        public void info(Marker marker, String message, Object... args) {
+            logger.underlyingLogger().info(marker, message, args);
         }
 
         /**
@@ -406,6 +556,17 @@ public class Logger {
          */
         public void info(String message, Throwable error) {
             logger.underlyingLogger().info(message, error);
+        }
+
+        /**
+         * Logs a message with the INFO level, with the given error.
+         *
+         * @param marker the marker data specific to this log statement
+         * @param message message to log
+         * @param error associated exception
+         */
+        public void info(Marker marker, String message, Throwable error) {
+            logger.underlyingLogger().info(marker, message, error);
         }
 
         /**
@@ -420,11 +581,32 @@ public class Logger {
         /**
          * Log a message with the WARN level.
          *
+         * @param marker the marker data specific to this log statement
+         * @param message message to log
+         */
+        public void warn(Marker marker, String message) {
+            logger.underlyingLogger().warn(marker, message);
+        }
+
+        /**
+         * Log a message with the WARN level.
+         *
          * @param message message to log
          * @param args The arguments to apply to the message string
          */
         public void warn(String message, Object... args) {
             logger.underlyingLogger().warn(message, args);
+        }
+
+        /**
+         * Log a message with the WARN level.
+         *
+         * @param marker the marker data specific to this log statement
+         * @param message message to log
+         * @param args The arguments to apply to the message string
+         */
+        public void warn(Marker marker, String message, Object... args) {
+            logger.underlyingLogger().warn(marker, message, args);
         }
 
         /**
@@ -435,6 +617,17 @@ public class Logger {
          */
         public void warn(String message, Throwable error) {
             logger.underlyingLogger().warn(message, error);
+        }
+
+        /**
+         * Log a message with the WARN level, with the given error.
+         *
+         * @param marker the marker data specific to this log statement
+         * @param message message to log
+         * @param error associated exception
+         */
+        public void warn(Marker marker, String message, Throwable error) {
+            logger.underlyingLogger().warn(marker, message, error);
         }
 
         /**
@@ -449,11 +642,32 @@ public class Logger {
         /**
          * Log a message with the ERROR level.
          *
+         * @param marker the marker data specific to this log statement
+         * @param message message to log
+         */
+        public void error(Marker marker, String message) {
+            logger.underlyingLogger().error(marker, message);
+        }
+
+        /**
+         * Log a message with the ERROR level.
+         *
          * @param message message to log
          * @param args The arguments to apply to the message string
          */
         public void error(String message, Object... args) {
             logger.underlyingLogger().error(message, args);
+        }
+
+        /**
+         * Log a message with the ERROR level.
+         *
+         * @param marker the marker data specific to this log statement
+         * @param message message to log
+         * @param args The arguments to apply to the message string
+         */
+        public void error(Marker marker, String message, Object... args) {
+            logger.underlyingLogger().error(marker, message, args);
         }
 
         /**
@@ -466,6 +680,16 @@ public class Logger {
             logger.underlyingLogger().error(message, error);
         }
 
+        /**
+         * Log a message with the ERROR level, with the given error.
+         *
+         * @param marker the marker data specific to this log statement
+         * @param message message to log
+         * @param error associated exception
+         */
+        public void error(Marker marker, String message, Throwable error) {
+            logger.underlyingLogger().error(marker, message, error);
+        }
     }
 
 }

--- a/framework/src/play/src/main/scala/play/api/Logger.scala
+++ b/framework/src/play/src/main/scala/play/api/Logger.scala
@@ -3,7 +3,9 @@
  */
 package play.api
 
-import org.slf4j.{ Logger => Slf4jLogger, LoggerFactory }
+import org.slf4j.{ LoggerFactory, Marker, Logger => Slf4jLogger }
+
+import scala.language.implicitConversions
 
 /**
  * Typical logger interface.
@@ -23,54 +25,97 @@ trait LoggerLike {
   /**
    * `true` if the logger instance is enabled for the `TRACE` level.
    */
-  def isTraceEnabled = logger.isTraceEnabled
+  def isTraceEnabled(implicit mc: MarkerContext): Boolean = mc.marker match {
+    case None =>
+      logger.isTraceEnabled
+    case Some(marker) =>
+      logger.isTraceEnabled(marker)
+  }
 
   /**
    * `true` if the logger instance is enabled for the `DEBUG` level.
    */
-  def isDebugEnabled = logger.isDebugEnabled
+  def isDebugEnabled(implicit mc: MarkerContext): Boolean = mc.marker match {
+    case None =>
+      logger.isDebugEnabled
+    case Some(marker) =>
+      logger.isDebugEnabled(marker)
+  }
 
   /**
    * `true` if the logger instance is enabled for the `INFO` level.
    */
-  def isInfoEnabled = logger.isInfoEnabled
+  def isInfoEnabled(implicit mc: MarkerContext): Boolean = mc.marker match {
+    case None =>
+      logger.isInfoEnabled
+    case Some(marker) =>
+      logger.isInfoEnabled(marker)
+  }
 
   /**
    * `true` if the logger instance is enabled for the `WARN` level.
    */
-  def isWarnEnabled = logger.isWarnEnabled
+  def isWarnEnabled(implicit mc: MarkerContext): Boolean = mc.marker match {
+    case None =>
+      logger.isWarnEnabled()
+    case Some(marker) =>
+      logger.isWarnEnabled(marker)
+  }
 
   /**
    * `true` if the logger instance is enabled for the `ERROR` level.
    */
-  def isErrorEnabled = logger.isErrorEnabled
-
-  /**
-   * Logs a message with the `TRACE` level.
-   *
-   * @param message the message to log
-   */
-  def trace(message: => String) {
-    if (logger.isTraceEnabled) logger.trace(message)
+  def isErrorEnabled(implicit mc: MarkerContext): Boolean = mc.marker match {
+    case None =>
+      logger.isErrorEnabled()
+    case Some(marker) =>
+      logger.isErrorEnabled(marker)
   }
 
   /**
    * Logs a message with the `TRACE` level.
    *
    * @param message the message to log
-   * @param error the associated exception
+   * @param mc the implicit marker context, if defined.
    */
-  def trace(message: => String, error: => Throwable) {
-    if (logger.isTraceEnabled) logger.trace(message, error)
+  def trace(message: => String)(implicit mc: MarkerContext): Unit = {
+    mc.marker match {
+      case None =>
+        if (logger.isTraceEnabled()) logger.trace(message)
+      case Some(marker) =>
+        if (logger.isTraceEnabled(marker)) logger.trace(marker, message)
+    }
+  }
+
+  /**
+   * Logs a message with the `TRACE` level.
+   *
+   * @param message the message to log
+   * @param error the associated exception
+   * @param mc the implicit marker context, if defined.
+   */
+  def trace(message: => String, error: => Throwable)(implicit mc: MarkerContext): Unit = {
+    mc.marker match {
+      case None =>
+        if (logger.isTraceEnabled()) logger.trace(message, error)
+      case Some(marker) =>
+        if (logger.isTraceEnabled(marker)) logger.trace(marker, message, error)
+    }
   }
 
   /**
    * Logs a message with the `DEBUG` level.
    *
    * @param message the message to log
+   * @param mc the implicit marker context, if defined.
    */
-  def debug(message: => String) {
-    if (logger.isDebugEnabled) logger.debug(message)
+  def debug(message: => String)(implicit mc: MarkerContext): Unit = {
+    mc.marker match {
+      case None =>
+        if (logger.isDebugEnabled()) logger.debug(message)
+      case Some(marker) =>
+        if (logger.isDebugEnabled(marker)) logger.debug(marker, message)
+    }
   }
 
   /**
@@ -78,18 +123,30 @@ trait LoggerLike {
    *
    * @param message the message to log
    * @param error the associated exception
+   * @param mc the implicit marker context, if defined.
    */
-  def debug(message: => String, error: => Throwable) {
-    if (logger.isDebugEnabled) logger.debug(message, error)
+  def debug(message: => String, error: => Throwable)(implicit mc: MarkerContext): Unit = {
+    mc.marker match {
+      case None =>
+        if (logger.isDebugEnabled()) logger.debug(message, error)
+      case Some(marker) =>
+        if (logger.isDebugEnabled(marker)) logger.debug(marker, message, error)
+    }
   }
 
   /**
    * Logs a message with the `INFO` level.
    *
    * @param message the message to log
+   * @param mc the implicit marker context, if defined.
    */
-  def info(message: => String) {
-    if (logger.isInfoEnabled) logger.info(message)
+  def info(message: => String)(implicit mc: MarkerContext): Unit = {
+    mc.marker match {
+      case None =>
+        if (logger.isInfoEnabled) logger.info(message)
+      case Some(marker) =>
+        if (logger.isInfoEnabled(marker)) logger.info(marker, message)
+    }
   }
 
   /**
@@ -97,18 +154,30 @@ trait LoggerLike {
    *
    * @param message the message to log
    * @param error the associated exception
+   * @param mc the implicit marker context, if defined.
    */
-  def info(message: => String, error: => Throwable) {
-    if (logger.isInfoEnabled) logger.info(message, error)
+  def info(message: => String, error: => Throwable)(implicit mc: MarkerContext): Unit = {
+    mc.marker match {
+      case None =>
+        if (logger.isInfoEnabled) logger.info(message, error)
+      case Some(marker) =>
+        if (logger.isInfoEnabled(marker)) logger.info(marker, message, error)
+    }
   }
 
   /**
    * Logs a message with the `WARN` level.
    *
    * @param message the message to log
+   * @param mc the implicit marker context, if defined.
    */
-  def warn(message: => String) {
-    if (logger.isWarnEnabled) logger.warn(message)
+  def warn(message: => String)(implicit mc: MarkerContext): Unit = {
+    mc.marker match {
+      case None =>
+        if (logger.isWarnEnabled) logger.warn(message)
+      case Some(marker) =>
+        if (logger.isWarnEnabled(marker)) logger.warn(marker, message)
+    }
   }
 
   /**
@@ -116,18 +185,31 @@ trait LoggerLike {
    *
    * @param message the message to log
    * @param error the associated exception
+   * @param mc the implicit marker context, if defined.
    */
-  def warn(message: => String, error: => Throwable) {
+  def warn(message: => String, error: => Throwable)(implicit mc: MarkerContext): Unit = {
     if (logger.isWarnEnabled) logger.warn(message, error)
+    mc.marker match {
+      case None =>
+        if (logger.isWarnEnabled) logger.warn(message, error)
+      case Some(marker) =>
+        if (logger.isWarnEnabled(marker)) logger.warn(marker, message, error)
+    }
   }
 
   /**
    * Logs a message with the `ERROR` level.
    *
    * @param message the message to log
+   * @param mc the implicit marker context, if defined.
    */
-  def error(message: => String) {
-    if (logger.isErrorEnabled) logger.error(message)
+  def error(message: => String)(implicit mc: MarkerContext): Unit = {
+    mc.marker match {
+      case None =>
+        if (logger.isErrorEnabled()) logger.error(message)
+      case Some(marker) =>
+        if (logger.isErrorEnabled(marker)) logger.error(marker, message)
+    }
   }
 
   /**
@@ -135,9 +217,15 @@ trait LoggerLike {
    *
    * @param message the message to log
    * @param error the associated exception
+   * @param mc the implicit marker context, if defined.
    */
-  def error(message: => String, error: => Throwable) {
-    if (logger.isErrorEnabled) logger.error(message, error)
+  def error(message: => String, error: => Throwable)(implicit mc: MarkerContext): Unit = {
+    mc.marker match {
+      case None =>
+        if (logger.isErrorEnabled()) logger.error(message, error)
+      case Some(marker) =>
+        if (logger.isErrorEnabled(marker)) logger.error(marker, message, error)
+    }
   }
 
 }
@@ -185,4 +273,83 @@ object Logger extends LoggerLike {
    */
   def apply[T](clazz: Class[T]): Logger = new Logger(LoggerFactory.getLogger(clazz.getName.stripSuffix("$")))
 
+}
+
+/**
+ * A MarkerContext trait, to provide easy access to org.slf4j.Marker in Logger API.  This is usually accessed
+ * with a marker through an implicit conversion from a Marker.
+ *
+ * {{{
+ *   implicit val markerContext: MarkerContext = org.slf4j.MarkerFactory.getMarker("EXAMPLEMARKER")
+ *   log.error("This message will be logged with the EXAMPLEMARKER marker")
+ * }}}
+ *
+ */
+trait MarkerContext {
+  /**
+   * @return an SLF4J marker, if one has been defined.
+   */
+  def marker: Option[Marker]
+}
+
+object MarkerContext extends LowPriorityMarkerContextImplicits {
+
+  /**
+   * Provides an instance of a MarkerContext from a Marker.  The explicit form is useful when
+   * you want to explicitly tag a log message with a particular Marker and you already have a
+   * Marker in implicit scope.
+   *
+   * {{{
+   *   implicit val implicitContext: MarkerContext = ...
+   *   val explicitContext: MarkerContext = MarkerContext(MarkerFactory.getMarker("EXPLICITMARKER"))
+   *
+   *   // do not use the implicit MarkerContext
+   *   log.error("This message is logged with EXPLICITMARKER")(explicitContext)
+   * }}}
+   *
+   * @param marker the marker to wrap in DefaultMarkerContext
+   * @return an instance of DefaultMarkerContext.
+   */
+  def apply(marker: Marker): MarkerContext = {
+    new DefaultMarkerContext(marker)
+  }
+}
+
+trait LowPriorityMarkerContextImplicits {
+
+  /**
+   * A MarkerContext that returns None.  This is used as the "default" marker context if
+   * no implicit MarkerContext is found in local scope (meaning there is nothing defined
+   * through import or "implicit val").
+   */
+  implicit val NoMarker = MarkerContext(null)
+
+  /**
+   * Enables conversion from a marker to a MarkerContext:
+   *
+   * {{{
+   *  val mc: MarkerContext = MarkerFactory.getMarker("SOMEMARKER")
+   * }}}
+   *
+   * @param marker the SLF4J marker to convert
+   * @return the result of `MarkerContext.apply(marker)`
+   */
+  implicit def markerToMarkerContext(marker: Marker): MarkerContext = {
+    MarkerContext(marker)
+  }
+}
+
+/**
+ * A default marker context.  This is used by `MarkerContext.apply`, but can also be used to provide
+ * explicit typing for markers.  For example, to define a SecurityContext marker, you can define a case
+ * object extending DefaultMarkerContext
+ *
+ * {{{
+ * case object SecurityMarkerContext extends DefaultMarkerContext(MarkerFactory.getMarker("SECURITY"))
+ * }}}
+ *
+ * @param someMarker a marker used in the `marker` method.
+ */
+class DefaultMarkerContext(someMarker: Marker) extends MarkerContext {
+  def marker: Option[Marker] = Option(someMarker)
 }

--- a/framework/src/play/src/test/scala/play/api/LoggerSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/LoggerSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api
+
+import org.slf4j.{ Marker, MarkerFactory }
+import org.specs2.mutable.Specification
+
+class LoggerSpec extends Specification {
+
+  "MarkerContext.apply" should {
+
+    "return some marker" in {
+      val marker = MarkerFactory.getMarker("SOMEMARKER")
+      val mc = MarkerContext(marker)
+      mc.marker must beSome.which(_ must be_==(marker))
+    }
+
+    "return a MarkerContext with None if passed null" in {
+      val mc = MarkerContext(null)
+      mc.marker must beNone
+    }
+  }
+
+  "MarkerContext" should {
+    "implicitly convert a Marker to a MarkerContext" in {
+      val marker: Marker = MarkerFactory.getMarker("SOMEMARKER")
+      implicit val mc: MarkerContext = marker
+
+      mc.marker must beSome.which(_ must be_==(marker))
+    }
+  }
+
+  "DefaultMarkerContext" should {
+    "define a case object" in {
+      val marker = MarkerFactory.getMarker("SOMEMARKER")
+      case object SomeMarkerContext extends DefaultMarkerContext(marker)
+      SomeMarkerContext.marker must beSome.which(_ must be_==(marker))
+    }
+
+  }
+
+}


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

This PR adds the SLF4J Marker API to play.Logger and play.api.Logger interfaces. 

In the Java API, it is a straight port of the SLF4J Logger API.

In the Scala API, markers are added through a MarkerContext trait, which is added as an implicit parameter to the logger methods, i.e. 

```scala
import play.api._
logger.info("some info message")(MarkerContext(someMarker))
```

This opens the door for implicit markers to be passed for logging in several statements, which makes adding context to logging much easier.  In particular, see what you can do with the [Logstash Logback Encoder](https://github.com/logstash/logstash-logback-encoder#event-specific-custom-fields):

```scala
implicit def requestToMarkerContext[A](request: Request[A]): MarkerContext = {
  import net.logstash.logback.marker.LogstashMarker
  import net.logstash.logback.marker.Markers._

  val requestMarkers: LogstashMarker = append("host", request.host)
    .and(append("path", request.path))

  MarkerContext(requestMarkers)
}

def index = Action { request =>  
  logger.debug("index: ")(request)
  Ok("testing")
}
```

## Background Context

First, because play.api.Logger does not take Marker, at all, so it should be added.  There's a number of teams that use SLF4J because the underlying API is richer.  The static API for play.Logger / play.api.Logger is a distinct issue and is not being touched here.

Second, By using an implicit context, one of the main problems with logging contextual information can be resolved without using MDC / thread locals.  

Thirdly, if we can't get rid of the Logger API, we should make it useful.  This should help with things like [logstash-logback-encoder](https://github.com/logstash/logstash-logback-encoder), for example, although it doesn't touch StructuredArguments:

```
logger.info("My Message {}", StructuredArguments.keyValue("key", "value"))
```

## References

Deprecate Play Logger (note does not deal with Scala Logger): https://github.com/playframework/playframework/issues/1669

