### PR TITLE
removes h2 from play-jdbc as a compile dependency

### DIFF
--- a/documentation/project/Build.scala
+++ b/documentation/project/Build.scala
@@ -18,6 +18,7 @@ object ApplicationBuild extends Build {
     resolvers += Resolver.sonatypeRepo("releases"), // TODO: Delete this eventually, just needed for lag between deploying to sonatype and getting on maven central
     version := PlayVersion.current,
     libraryDependencies ++= Seq(
+      "com.h2database" % "h2" % "1.4.191" % Test,
       "org.mockito" % "mockito-core" % "1.9.5" % "test"
     ),
 

--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -286,23 +286,22 @@ object PlayBuild extends Build {
     .settings(libraryDependencies += derbyDatabase % Test)
     .dependsOn(PlayJdbcApiProject)
     .dependsOn(PlaySpecs2Project % "test")
-    .dependsOn(PlayJdbcProject % "test")
+    .dependsOn(PlayJdbcProject % "test->test")
     .dependsOn(PlayJavaJdbcProject % "test")
 
   lazy val PlayJavaJdbcProject = PlayCrossBuiltProject("Play-Java-JDBC", "play-java-jdbc")
-    .settings(libraryDependencies ++= javaJdbcDeps)
-    .dependsOn(PlayJdbcProject, PlayJavaProject)
+    .dependsOn(PlayJdbcProject % "compile->compile;test->test", PlayJavaProject)
     .dependsOn(PlaySpecs2Project % "test", PlayGuiceProject % "test")
 
   lazy val PlayJpaProject = PlayCrossBuiltProject("Play-Java-JPA", "play-java-jpa")
     .settings(libraryDependencies ++= jpaDeps)
-    .dependsOn(PlayJavaJdbcProject)
+    .dependsOn(PlayJavaJdbcProject % "compile->compile;test->test")
     .dependsOn(PlayJdbcEvolutionsProject % "test")
     .dependsOn(PlaySpecs2Project % "test")
 
   lazy val PlayTestProject = PlayCrossBuiltProject("Play-Test", "play-test")
     .settings(
-      libraryDependencies ++= testDependencies,
+      libraryDependencies ++= testDependencies ++ Seq(h2database % "test"),
       parallelExecution in Test := false
     ).dependsOn(
       PlayGuiceProject,
@@ -414,6 +413,7 @@ object PlayBuild extends Build {
   // This project is just for testing Play, not really a public artifact
   lazy val PlayIntegrationTestProject = PlayCrossBuiltProject("Play-Integration-Test", "play-integration-test")
     .settings(
+      libraryDependencies += h2database % Test,
       parallelExecution in Test := false,
       previousArtifacts := Set.empty
     )

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -44,12 +44,10 @@ object Dependencies {
     "com.jolbox" % "bonecp" % "0.8.0.RELEASE",
     "com.zaxxer" % "HikariCP" % "2.4.3",
     "com.googlecode.usc" % "jdbcdslog" % "1.0.6.2",
-    h2database,
+    h2database % Test,
     acolyte % Test,
     logback % Test,
     "tyrex" % "tyrex" % "1.0.1") ++ specsBuild.map(_ % Test)
-
-  val javaJdbcDeps = Seq(acolyte % Test)
 
   val jpaDeps = Seq(
     "org.hibernate.javax.persistence" % "hibernate-jpa-2.1-api" % "1.0.0.Final",

--- a/templates/play-java-intro/build.sbt
+++ b/templates/play-java-intro/build.sbt
@@ -11,6 +11,7 @@ libraryDependencies ++= Seq(
   // If you enable PlayEbean plugin you must remove these
   // JPA dependencies to avoid conflicts.
   javaJpa,
+  "com.h2database" % "h2" % "1.4.191",
   "org.hibernate" % "hibernate-entitymanager" % "5.1.0.Final"
 )
 

--- a/templates/play-java/build.sbt
+++ b/templates/play-java/build.sbt
@@ -10,5 +10,6 @@ libraryDependencies ++= Seq(
   guiceSupport,
   javaJdbc,
   cache,
-  javaWs
+  javaWs,
+  "com.h2database" % "h2" % "1.4.191" % Test
 )

--- a/templates/play-scala-intro/build.sbt
+++ b/templates/play-scala-intro/build.sbt
@@ -10,7 +10,7 @@ libraryDependencies ++= Seq(
   guiceSupport,
   "com.typesafe.play" %% "play-slick" % "%PLAY_SLICK_VERSION%",
   "com.typesafe.play" %% "play-slick-evolutions" % "%PLAY_SLICK_VERSION%",
-  "com.h2database" % "h2" % "1.4.190",
+  "com.h2database" % "h2" % "1.4.191",
   specs2 % Test
 )
 


### PR DESCRIPTION
## Background Context

Actually I don't think its a good idea to directly ship a database driver. So I think this one should be exludeded.

## References

https://groups.google.com/forum/#!topic/play-framework/FEMIT-40tks

