### PR TITLE
Fixed incorrect config reference in scala doc [#6341]

### DIFF
--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/ServerSSLEngine.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/ServerSSLEngine.scala
@@ -11,7 +11,7 @@ import play.core.ApplicationProvider
 
 /**
  * This singleton object looks for a class of {{play.server.api.SSLEngineProvider}} or {{play.server.SSLEngineProvider}}
- * in the system property <pre>play.http.sslengineprovider</pre>.  if there is no instance found, it uses
+ * in the system property <pre>play.server.https.engineProvider</pre>.  if there is no instance found, it uses
  * DefaultSSLEngineProvider.
  *
  * If the class of {{SSLEngineProvider}} defined has a constructor with {{play.core.ApplicationProvider}} (for Scala) or

--- a/framework/src/play/src/main/scala/play/server/api/SSLEngineProvider.scala
+++ b/framework/src/play/src/main/scala/play/server/api/SSLEngineProvider.scala
@@ -12,7 +12,7 @@ import javax.net.ssl.SSLEngine
  * If you want to specify your own SSL engine, define a class implementing this interface.  If the implementing class
  * takes ApplicationProvider in the constructor, then the applicationProvider is passed into it, if available.
  *
- * The path to this class should be configured with the system property <pre>play.http.sslengineprovider</pre>
+ * The path to this class should be configured with the system property <pre>play.server.https.engineProvider</pre>
  */
 trait SSLEngineProvider extends play.server.SSLEngineProvider {
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #6341 

## Purpose

What does this PR do?

Scaladoc has incorrect `play.http.sslengineprovider` config reference. Fixed that to correct reference `play.server.https.engineProvider`

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?

