### PR TITLE
Fixes #6352: added a note to the h2 doc

### DIFF
--- a/documentation/manual/working/commonGuide/database/Developing-with-the-H2-Database.md
+++ b/documentation/manual/working/commonGuide/database/Developing-with-the-H2-Database.md
@@ -1,6 +1,12 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
 # H2 database
 
+> **Note:** From Play 2.6.x onwards you actually need to include the H2 Dependency on your own. To do this you just need to add the following to your build.sbt:
+>
+> ```
+> libraryDependencies += "com.h2database" % "h2" % "1.4.192"
+> ```
+
 The H2 in memory database is very convenient for development because your evolutions are run from scratch when play is restarted.  If you are using Anorm, you probably need it to closely mimic your planned production database.  To tell h2 that you want to mimic a particular database you add a parameter to the database url in your application.conf file, for example:
 
 ```

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayCommands.scala
@@ -5,12 +5,10 @@ package play.sbt
 
 import java.nio.file.Path
 
-import sbt._
-import sbt.Keys._
-
-import play.sbt.PlayInternalKeys._
-
 import com.typesafe.sbt.web.SbtWeb.autoImport._
+import play.sbt.PlayInternalKeys._
+import sbt.Keys._
+import sbt._
 
 object PlayCommands {
 
@@ -77,7 +75,9 @@ object PlayCommands {
       val h2ServerClass = commonLoader.loadClass("org.h2.tools.Server")
       h2ServerClass.getMethod("main", classOf[Array[String]]).invoke(null, Array.empty[String])
     } catch {
-      case e: Exception => e.printStackTrace
+      case _: ClassNotFoundException => state.log.error(s"""|H2 Dependency not loaded, please add H2 to your Classpath!
+                                                             |Take a look at https://www.playframework.com/documentation/${play.core.PlayVersion.current}/Developing-with-the-H2-Database#H2-database on how to do it.""".stripMargin)
+      case e: Exception => e.printStackTrace()
     }
     state
   }


### PR DESCRIPTION
Actually this takes the first approach it adds a note on the H2 Documentation and also gives a nice error message when calling `h2-browser`.

Another possible resolution would be removing all, which is feasable, too I guess since H2 shouldn't be encouraged to be used in Production anyways. And h2-browser is also just a wrapper around the H2-Browser.