### PR TITLE
Add async try-with-resources for java api

### DIFF
--- a/framework/src/play-java/src/main/java/play/libs/Resources.java
+++ b/framework/src/play-java/src/main/java/play/libs/Resources.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.libs;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+/**
+ * Provides utility functions to work with resources.
+ */
+
+public class Resources {
+
+    public static <T extends AutoCloseable, U> CompletionStage<U> asyncTryWithResource(
+            T resource, Function<T, CompletionStage<U>> body
+    ) {
+        try {
+            CompletionStage<U> completionStage = body.apply(resource);
+            completionStage.whenCompleteAsync((u, throwable) -> tryCloseResource(resource));
+            return completionStage;
+        } catch (RuntimeException e) {
+            tryCloseResource(resource);
+            throw e;
+        } catch (Exception e) {
+            tryCloseResource(resource);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static <T extends AutoCloseable> void tryCloseResource(T resource) {
+        try {
+            resource.close();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/framework/src/play-java/src/test/java/play/libs/ResourcesTest.java
+++ b/framework/src/play-java/src/test/java/play/libs/ResourcesTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.libs;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ResourcesTest {
+
+    @Test
+    public void testAsyncTryWithResource() throws Exception {
+        InputStream inputStream = mock(InputStream.class);
+        CompletionStage<Void> completionStage = Resources.asyncTryWithResource(
+                inputStream,
+                is -> CompletableFuture.completedFuture(null)
+        );
+
+        completionStage.toCompletableFuture().get();
+        verify(inputStream).close();
+    }
+
+    @Test
+    public void testAsyncTryWithResourceExceptionInFuture() throws Exception {
+        InputStream inputStream = mock(InputStream.class);
+        CompletionStage<Void> completionStage = Resources.asyncTryWithResource(
+                inputStream,
+                is -> CompletableFuture.runAsync(() -> { throw new RuntimeException(); })
+        );
+
+        try {
+            completionStage.toCompletableFuture().get();
+        } catch(Exception ignored) {}
+
+        verify(inputStream).close();
+    }
+
+    @Test
+    public void testAsyncTryWithResourceException() throws Exception {
+        InputStream inputStream = mock(InputStream.class);
+        try {
+            CompletionStage<Void> completionStage = Resources.asyncTryWithResource(
+                    inputStream,
+                    is -> { throw new RuntimeException(); }
+            );
+            completionStage.toCompletableFuture().get();
+        } catch(Exception ignored) {}
+
+        verify(inputStream).close();
+    }
+}


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #5547

## Purpose

Introduces function for async try-with-resource 

## Background Context

## References

