### PR TITLE
Fixes #6351 made the parameter onClose of sendFile working again

### DIFF
--- a/framework/src/play-docs/src/main/scala/play/docs/DocServerStart.scala
+++ b/framework/src/play-docs/src/main/scala/play/docs/DocServerStart.scala
@@ -13,6 +13,8 @@ import play.core.server._
 import scala.concurrent.Future
 import scala.util.Success
 
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
 /**
  * Used to start the documentation server.
  */

--- a/framework/src/play/src/main/scala/play/api/controllers/ExternalAssets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/ExternalAssets.scala
@@ -7,8 +7,9 @@ import javax.inject.Inject
 
 import play.api._
 import play.api.mvc._
-
 import java.io._
+
+import scala.concurrent.ExecutionContext
 
 /**
  * Controller that serves static resources from an external folder.
@@ -27,7 +28,7 @@ import java.io._
  * }}}
  *
  */
-class ExternalAssets @Inject() (environment: Environment) extends Controller {
+class ExternalAssets @Inject() (environment: Environment)(implicit ec: ExecutionContext) extends Controller {
 
   val AbsolutePath = """^(/|[a-zA-Z]:\\).*""".r
 

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -9,12 +9,19 @@ import java.nio.file.{ Files, Path, Paths }
 import java.time.{ LocalDateTime, ZoneOffset }
 import java.util.concurrent.atomic.AtomicInteger
 
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Sink
 import org.specs2.mutable._
 import play.api.http.HeaderNames._
 import play.api.http.Status._
 import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.{ Configuration, Environment, Play }
 import play.core.test._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 object ResultsSpec extends Specification {
 
@@ -230,6 +237,26 @@ object ResultsSpec extends Specification {
       val rh = Ok.sendPath(file)
 
       rh.body.contentLength must beSome(content.length)
+    }
+
+    "sendFile should honor onClose" in withFile { (file, fileName) =>
+      implicit val system = ActorSystem()
+      implicit val mat = ActorMaterializer()
+      try {
+        var fileSent = false
+        val res = Results.Ok.sendFile(file, onClose = () => {
+          fileSent = true
+        })
+
+        // Actually we need to wait until the Stream completes
+        Await.ready(res.body.dataStream.runWith(Sink.ignore), 60.seconds)
+        // and then we need to wait until the onClose completes
+        Thread.sleep(500)
+
+        fileSent must be_==(true)
+      } finally {
+        Await.ready(system.terminate(), 60.seconds)
+      }
     }
 
     "support redirects for reverse routed calls" in {


### PR DESCRIPTION
## Fixes

Fixes #6351

## Purpose

Makes onClose of Results#sendFile working

## Background Context

Actually if somebody has an idea to make the Unittest better, tell me

Actually if we backport it we could actually put `play.api.libs.concurrent.Execution.defaultContext` as a paramter directly instead of having a `implicit ec: ExecutionContext`

