### PR TITLE
[Backport 2.4.x]  Append fragment (use Call.path instead of Call.url) when redirecting (#6363)

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Results.java
+++ b/framework/src/play/src/main/java/play/mvc/Results.java
@@ -1019,7 +1019,7 @@ public class Results {
      * @param call Call defining the url to redirect (typically comes from reverse router).
      */
     public static Result redirect(Call call) {
-        return new Redirect(303, call.url());
+        return new Redirect(303, call.path());
     }
 
     // -- Found
@@ -1039,7 +1039,7 @@ public class Results {
      * @param call Call defining the url to redirect (typically comes from reverse router).
      */
     public static Result found(Call call) {
-        return new Redirect(302, call.url());
+        return new Redirect(302, call.path());
     }
 
     // -- Moved Permanently
@@ -1059,7 +1059,7 @@ public class Results {
      * @param call Call defining the url to redirect (typically comes from reverse router).
      */
     public static Result movedPermanently(Call call) {
-        return new Redirect(301, call.url());
+        return new Redirect(301, call.path());
     }
 
     // -- See Other
@@ -1079,7 +1079,7 @@ public class Results {
      * @param call Call defining the url to redirect (typically comes from reverse router).
      */
     public static Result seeOther(Call call) {
-        return new Redirect(303, call.url());
+        return new Redirect(303, call.path());
     }
 
     // -- Temporary Redirect
@@ -1099,7 +1099,7 @@ public class Results {
      * @param call Call defining the url to redirect (typically comes from reverse router).
      */
     public static Result temporaryRedirect(Call call) {
-        return new Redirect(307, call.url());
+        return new Redirect(307, call.path());
     }
 
     // -- Definitions

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -855,7 +855,7 @@ trait Results {
    *
    * @param call Call defining the URL to redirect to, which typically comes from the reverse router
    */
-  def Redirect(call: Call): Result = Redirect(call.url)
+  def Redirect(call: Call): Result = Redirect(call.path)
 
   /**
    * Generates a redirect simple result.
@@ -863,6 +863,6 @@ trait Results {
    * @param call Call defining the URL to redirect to, which typically comes from the reverse router
    * @param status HTTP status for redirect, such as SEE_OTHER, MOVED_TEMPORARILY or MOVED_PERMANENTLY
    */
-  def Redirect(call: Call, status: Int): Result = Redirect(call.url, Map.empty, status)
+  def Redirect(call: Call, status: Int): Result = Redirect(call.path, Map.empty, status)
 
 }

--- a/framework/src/play/src/test/scala/play/mvc/ResultSpec.scala
+++ b/framework/src/play/src/test/scala/play/mvc/ResultSpec.scala
@@ -1,9 +1,11 @@
 package play.test
 
 import org.specs2.mutable._
+import play.api.http.HeaderNames
 import play.mvc.Result
+
 import scala.concurrent.Future
-import play.api.mvc.{ Cookie, Results, Result => ScalaResult }
+import play.api.mvc.{ Call, Cookie, Results, Result => ScalaResult }
 
 /**
  *
@@ -27,5 +29,13 @@ object ResultSpec extends Specification {
       cookie.name() must be_==("name1")
       cookie.value() must be_==("value1")
     }
+
+    "redirect with a fragment" in {
+      val url = "http://host:port/path?k1=v1&k2=v2"
+      val fragment = "my-fragment"
+      val expectedLocation = url + "#" + fragment
+      Results.Redirect(Call("GET", url, fragment)).header.headers.get(HeaderNames.LOCATION) must_== Option(expectedLocation)
+    }
+
   }
 }


### PR DESCRIPTION
## Fixes

Fixes #6360 

Actually this includes the fix in https://github.com/playframework/playframework/pull/6366

@gmethvin maybe we could actually make a 2.4.x release after that?

**Edit** Build only fails on Travis-CI. Unrelated to my change.
