### PR TITLE
append fragment in Results.Redirect(call, status)

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -650,6 +650,6 @@ trait Results {
    * @param call Call defining the URL to redirect to, which typically comes from the reverse router
    * @param status HTTP status for redirect, such as SEE_OTHER, MOVED_TEMPORARILY or MOVED_PERMANENTLY
    */
-  def Redirect(call: Call, status: Int): Result = Redirect(call.url, Map.empty, status)
+  def Redirect(call: Call, status: Int): Result = Redirect(call.path, Map.empty, status)
 
 }

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -266,5 +266,19 @@ object ResultsSpec extends Specification {
     "support redirects for reverse routed calls with custom statuses" in {
       Results.Redirect(Call("GET", "/path"), TEMPORARY_REDIRECT).header must_== Status(TEMPORARY_REDIRECT).withHeaders(LOCATION -> "/path").header
     }
+
+    "redirect with a fragment" in {
+      val url = "http://host:port/path?k1=v1&k2=v2"
+      val fragment = "my-fragment"
+      val expectedLocation = url + "#" + fragment
+      Results.Redirect(Call("GET", url, fragment)).header.headers.get(LOCATION) must_== Option(expectedLocation)
+    }
+
+    "redirect with a fragment and status" in {
+      val url = "http://host:port/path?k1=v1&k2=v2"
+      val fragment = "my-fragment"
+      val expectedLocation = url + "#" + fragment
+      Results.Redirect(Call("GET", url, fragment), 301).header.headers.get(LOCATION) must_== Option(expectedLocation)
+    }
   }
 }

--- a/framework/src/play/src/test/scala/play/mvc/ResultSpec.scala
+++ b/framework/src/play/src/test/scala/play/mvc/ResultSpec.scala
@@ -9,9 +9,8 @@ import java.util.Optional
 import akka.util.ByteString
 import org.specs2.mutable._
 
-import play.api.http.HeaderNames
 import play.api.http.HttpEntity.Strict
-import play.api.mvc.{ Call, Cookie, Results }
+import play.api.mvc.{ Cookie, Results }
 
 /**
  *
@@ -52,13 +51,6 @@ object ResultSpec extends Specification {
       val contentType = s"text/plain;charset=$charset"
       val javaResult = Results.Ok.sendEntity(new Strict(ByteString.fromString("foo", charset), Some(contentType))).asJava
       javaResult.charset() must_== Optional.of(charset)
-    }
-
-    "redirect with a fragment" in {
-      val url = "http://host:port/path?k1=v1&k2=v2"
-      val fragment = "my-fragment"
-      val expectedLocation = url + "#" + fragment
-      Results.Redirect(Call("GET", url, fragment)).header.headers.get(HeaderNames.LOCATION) must_== Option(expectedLocation)
     }
   }
 }


### PR DESCRIPTION
# Helpful things

## Fixes

Finally Fixes #6360

## References

Actually in https://github.com/playframework/playframework/pull/6363 we fixed the Fragment URL, but somehow one method slipped through, this fixes it so that #6360 could be closed. 

Also needs backport. This also moves the tests on the correct place.

