### PR TITLE
Add a delegating file part handler for Java

### DIFF
--- a/documentation/manual/working/javaGuide/main/upload/JavaFileUpload.md
+++ b/documentation/manual/working/javaGuide/main/upload/JavaFileUpload.md
@@ -28,3 +28,13 @@ Now let’s define the `upload` action:
 Another way to send files to the server is to use Ajax to upload files asynchronously from a form. In this case, the request body will not be encoded as `multipart/form-data`, but will just contain the plain file contents.
 
 @[asyncUpload](code/JavaFileUpload.java)
+
+### Writing a custom multipart file part body parser
+
+The multipart upload specified by [`MultipartFormData`](api/java/play/mvc/BodyParser.MultipartFormData.html) takes uploaded data from the request and puts into a TemporaryFile object.  It is possible to override this behavior so that `Multipart.FileInfo` information is streamed to another class, using the `DelegatingMultipartFormDataBodyParser` class:
+
+@[customfileparthandler](code/JavaFileUpload.java)
+
+Here, `akka.stream.javadsl.FileIO` class is used to create a sink that sends the `ByteString` from the Accumulator into a `java.io.File` object, rather than a TemporaryFile object.
+ 
+Using a custom file part handler also means that behavior can be injected, so a running count of uploaded bytes can be sent elsewhere in the system.

--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
@@ -1,13 +1,48 @@
 /*
  * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
  */
+import akka.stream.IOResult;
+import akka.stream.Materializer;
+import akka.stream.javadsl.FileIO;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+import javaguide.http.JavaBodyParsers;
+import org.junit.Test;
+import play.core.parsers.Multipart;
+import play.libs.streams.Accumulator;
+import play.mvc.BodyParser;
 import play.mvc.Controller;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import play.mvc.Http;
 import play.mvc.Http.MultipartFormData;
 import play.mvc.Http.MultipartFormData.FilePart;
 import play.mvc.Result;
+import play.test.WithApplication;
 
-public class JavaFileUpload {
+import javax.inject.Inject;
+
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static play.test.Helpers.contentAsString;
+import static play.test.Helpers.fakeRequest;
+
+import static javaguide.testhelpers.MockJavaActionHelper.*;
+
+public class JavaFileUpload extends WithApplication {
 
     static class SyncUpload extends Controller {
         //#syncUpload
@@ -34,5 +69,71 @@ public class JavaFileUpload {
             return ok("File uploaded");
         }
         //#asyncUpload
+    }
+
+    //#customfileparthandler
+    public static class MultipartFormDataWithFileBodyParser extends BodyParser.DelegatingMultipartFormDataBodyParser<File> {
+
+        @Inject
+        public MultipartFormDataWithFileBodyParser(Materializer materializer, play.api.http.HttpConfiguration config) {
+            super(materializer, config.parser().maxDiskBuffer());
+        }
+
+        /**
+         * Creates a file part handler that uses a custom accumulator.
+         */
+        @Override
+        public Function<Multipart.FileInfo, Accumulator<ByteString, FilePart<File>>> createFilePartHandler() {
+            return (Multipart.FileInfo fileInfo) -> {
+                final String filename = fileInfo.fileName();
+                final String partname = fileInfo.partName();
+                final String contentType = fileInfo.contentType().getOrElse(null);
+                final File file = generateTempFile();
+
+                final Sink<ByteString, CompletionStage<IOResult>> sink = FileIO.toFile(file);
+                return Accumulator.fromSink(
+                        sink.mapMaterializedValue(completionStage ->
+                                completionStage.thenApplyAsync(results ->
+                                        new Http.MultipartFormData.FilePart(partname,
+                                                filename,
+                                                contentType,
+                                                file))
+                        ));
+            };
+        }
+
+        /**
+         * Generates a temp file directly without going through TemporaryFile.
+         */
+        private File generateTempFile() {
+            try {
+                final EnumSet<PosixFilePermission> attrs = EnumSet.of(OWNER_READ, OWNER_WRITE);
+                final FileAttribute<?> attr = PosixFilePermissions.asFileAttribute(attrs);
+                final Path path = Files.createTempFile("multipartBody", "tempFile", attr);
+                return path.toFile();
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+    }
+    //#customfileparthandler
+
+    @Test
+    public void testCustomMultipart() throws IOException {
+        Source source = FileIO.fromPath(Files.createTempFile("temp", "txt"));
+        Http.MultipartFormData.FilePart dp = new Http.MultipartFormData.FilePart<Source>("name", "filename", "text/plain", source);
+        assertThat(contentAsString(call(new javaguide.testhelpers.MockJavaAction() {
+                    @BodyParser.Of(MultipartFormDataWithFileBodyParser.class)
+                    public Result uploadCustomMultiPart() throws Exception {
+                        final Http.MultipartFormData<File> formData = request().body().asMultipartFormData();
+                        final Http.MultipartFormData.FilePart<File> filePart = formData.getFile("name");
+                        final File file = filePart.getFile();
+                        final long size = Files.size(file.toPath());
+                        Files.deleteIfExists(file.toPath());
+                        return ok("Got: file size = " + size + "");
+                    }
+                }, fakeRequest("POST", "/").bodyMultipart(Collections.singletonList(dp), mat), mat)),
+                equalTo("Got: file size = 0"));
     }
 }

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -16,13 +16,18 @@ import play.api.mvc.MaxSizeNotExceeded$;
 import play.api.mvc.MaxSizeStatus;
 import play.core.j.JavaParsers;
 import play.core.parsers.FormUrlEncodedParser;
+import play.core.parsers.Multipart;
 import play.http.HttpErrorHandler;
 import play.libs.F;
 import play.libs.XML;
 import play.libs.streams.Accumulator;
-import play.api.libs.streams.Accumulator$;
+import scala.Function1;
+import scala.Option;
+import scala.collection.Seq;
 import scala.compat.java8.FutureConverters;
+import scala.compat.java8.OptionConverters;
 import scala.concurrent.Future;
+import scala.runtime.AbstractFunction1;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -30,14 +35,17 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Executor;
-import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static scala.collection.JavaConverters.mapAsJavaMapConverter;
+import static scala.collection.JavaConverters.seqAsJavaListConverter;
 
 /**
  * A body parser parses the HTTP request body content.
@@ -472,6 +480,135 @@ public interface BodyParser<A> {
             CompletionStage<Accumulator<ByteString, F.Either<Result, A>>> completion = underlying.thenApply(parser -> parser.apply(request));
 
             return Accumulator.flatten(completion, this.materializer);
+        }
+    }
+
+    /**
+     * A body parser that exposes a file part handler as an
+     * abstract method and delegates the implementation to the underlying
+     * Scala multipartParser.
+     */
+    abstract class DelegatingMultipartFormDataBodyParser<A> implements BodyParser<Http.MultipartFormData<A>> {
+
+        private final Materializer materializer;
+        private final long maxLength;
+        private final play.api.mvc.BodyParser<play.api.mvc.MultipartFormData<A>> delegate;
+
+        public DelegatingMultipartFormDataBodyParser(Materializer materializer, long maxLength) {
+            this.maxLength = maxLength;
+            this.materializer = materializer;
+            delegate = multipartParser();
+        }
+
+        /**
+         * Returns a FilePartHandler expressed as a Java function.
+         */
+        public abstract Function<Multipart.FileInfo, play.libs.streams.Accumulator<ByteString, Http.MultipartFormData.FilePart<A>>> createFilePartHandler();
+
+        /**
+         * Calls out to the Scala API to create a multipart parser.
+         */
+        private play.api.mvc.BodyParser<play.api.mvc.MultipartFormData<A>> multipartParser() {
+            ScalaFilePartHandler filePartHandler = new ScalaFilePartHandler();
+            return Multipart.multipartParser((int) maxLength, filePartHandler, materializer);
+        }
+
+        private class ScalaFilePartHandler extends AbstractFunction1<Multipart.FileInfo, play.api.libs.streams.Accumulator<ByteString, play.api.mvc.MultipartFormData.FilePart<A>>> {
+            @Override
+            public play.api.libs.streams.Accumulator<ByteString, play.api.mvc.MultipartFormData.FilePart<A>> apply(Multipart.FileInfo fileInfo) {
+                return createFilePartHandler()
+                        .apply(fileInfo)
+                        .asScala()
+                        .map(new JavaFilePartToScalaFilePart(), materializer.executionContext());
+            }
+        }
+
+        private class JavaFilePartToScalaFilePart extends AbstractFunction1<Http.MultipartFormData.FilePart<A>, play.api.mvc.MultipartFormData.FilePart<A>> {
+            @Override
+            public play.api.mvc.MultipartFormData.FilePart<A> apply(Http.MultipartFormData.FilePart<A> filePart) {
+                return toScala(filePart);
+            }
+        }
+
+        /**
+         * Delegates underlying functionality to another body parser and converts the
+         * result to Java API.
+         */
+        @Override
+        public play.libs.streams.Accumulator<ByteString, F.Either<Result, Http.MultipartFormData<A>>> apply(Http.RequestHeader request) {
+            return delegate.apply(request._underlyingHeader())
+                    .asJava()
+                    .map(result -> {
+                                if (result.isLeft()) {
+                                    return F.Either.Left(result.left().get().asJava());
+                                } else {
+                                    final play.api.mvc.MultipartFormData<A> scalaData = result.right().get();
+                                    return F.Either.Right(new DelegatingMultipartFormData(scalaData));
+                                }
+                            },
+                            JavaParsers.trampoline()
+                    );
+        }
+
+
+        /**
+         * Extends Http.MultipartFormData to use File specifically,
+         * converting from Scala API to Java API.
+         */
+        private class DelegatingMultipartFormData extends Http.MultipartFormData<A> {
+
+            private play.api.mvc.MultipartFormData<A> scalaFormData;
+
+            DelegatingMultipartFormData(play.api.mvc.MultipartFormData<A> scalaFormData) {
+                this.scalaFormData = scalaFormData;
+            }
+
+            @Override
+            public Map<String, String[]> asFormUrlEncoded() {
+                return mapAsJavaMapConverter(
+                        scalaFormData.asFormUrlEncoded().mapValues(arrayFunction())
+                ).asJava();
+            }
+
+            // maps from Scala Seq to String array
+            private Function1<Seq<String>, String[]> arrayFunction() {
+                return new AbstractFunction1<Seq<String>, String[]>() {
+                    @Override
+                    public String[] apply(Seq<String> v1) {
+                        String[] array = new String[v1.size()];
+                        v1.copyToArray(array);
+                        return array;
+                    }
+                };
+            }
+
+            @Override
+            public List<FilePart<A>> getFiles() {
+                return seqAsJavaListConverter(scalaFormData.files())
+                        .asJava()
+                        .stream()
+                        .map(part -> toJava(part))
+                        .collect(Collectors.toList());
+            }
+
+        }
+
+        private Http.MultipartFormData.FilePart<A> toJava(play.api.mvc.MultipartFormData.FilePart<A> filePart) {
+            return new Http.MultipartFormData.FilePart<>(
+                    filePart.key(),
+                    filePart.filename(),
+                    OptionConverters.toJava(filePart.contentType()).orElse(null),
+                    filePart.ref()
+            );
+        }
+
+        private play.api.mvc.MultipartFormData.FilePart<A> toScala(Http.MultipartFormData.FilePart<A> filePart) {
+            return new play.api.mvc.MultipartFormData.FilePart<>(
+                    filePart.getKey(),
+                    filePart.getFilename(),
+                    Option.apply(filePart.getContentType()),
+                    filePart.getFile()
+            );
         }
     }
 }


### PR DESCRIPTION
## Purpose

This PR adds a custom FilePartHandler to the Java Multipart BodyParser API.

This brings the Java API up to parity with the Scala API, which allows for custom FilePartHandler:

https://www.playframework.com/documentation/2.5.x/ScalaFileUpload#Writing-your-own-body-parser

https://github.com/playframework/playframework/blob/2.5.4/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala#L655

