### PR TITLE
adds a source-part to multipart form data for arbitrary data

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -89,6 +89,10 @@ To Upload a File you need to pass a `Http.MultipartFormData.FilePart<Source<Byte
 
 @[ws-post-multipart2](code/javaguide/ws/JavaWS.java)
 
+To Upload arbitrary data you need to pass a `Http.MultipartFormData.SourcePart`:
+
+@[ws-post-multipart3](code/javaguide/ws/JavaWS.java)
+
 ### Streaming data
 
 It's also possible to stream data.

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -134,6 +134,15 @@ public class JavaWS {
             ws.url(url).post(Source.from(Arrays.asList(fp, dp)));
             // #ws-post-multipart2
 
+            // #ws-post-multipart3
+            Source<ByteString, ?> multipartJson = Source.single(Json.newObject()
+                    .put("hello", "world").toString())
+                    .map(ByteString::fromString);
+            Optional<String> contentType = Optional.of("application/json");
+            SourcePart sp = new SourcePart("key", multipartJson, contentType);
+            ws.url(url).post(Source.from(Collections.singletonList(sp)));
+            // #ws-post-multipart3
+
             String value = IntStream.range(0,100).boxed().
                 map(i -> "abcdefghij").reduce("", (a,b) -> a + b);
             ByteString seedValue = ByteString.fromString(value);

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -139,7 +139,7 @@ public class JavaWS {
                     .put("hello", "world").toString())
                     .map(ByteString::fromString);
             Optional<String> contentType = Optional.of("application/json");
-            SourcePart sp = new SourcePart("key", multipartJson, contentType);
+            SourcePart sp = new SourcePart("key", multipartJson, Optional.empty(), contentType);
             ws.url(url).post(Source.from(Collections.singletonList(sp)));
             // #ws-post-multipart3
 

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -91,6 +91,23 @@ To upload a file you need to pass a `play.api.mvc.MultipartFormData.FilePart[Sou
 
 @[multipart-encoded2](code/ScalaWSSpec.scala)
 
+To upload arbitrary data like a json part you can pass it to a `play.api.mvc.MultipartFormData.SourcePart`:
+
+@[multipart-encoded3-encoding](code/ScalaWSSpec.scala)
+
+@[multipart-encoded3](code/ScalaWSSpec.scala)
+
+This will generate something like the following:
+
+```
+--boundary
+Content-Disposition: form-data; name="key"
+Content-Type: application/json
+
+{"hello":"world"}
+--boundary--
+```
+
 ### Submitting JSON data
 
 The easiest way to post JSON data is to use the [[JSON|ScalaJson]] library.

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -7,17 +7,16 @@ import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import org.asynchttpclient.AsyncHttpClientConfig
-
-import play.api.{Mode, Environment}
+import play.api.{ Environment, Mode }
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.ahc._
 import play.api.test._
-
 import java.io._
 
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import org.specs2.specification.AfterAll
+import play.api.libs.json.Json
 
 //#dependency
 import javax.inject.Inject
@@ -212,6 +211,21 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
         await(response).body must_== "value"
       }
 
+      "post with multipart/form encoded body and different content types" in withServer{
+        case("POST", "/") => Action(BodyParsers.parse.multipartFormData)(r => Ok(r.body.asFormUrlEncoded("key").head))
+      } { ws =>
+        import play.api.mvc.MultipartFormData._
+        //#multipart-encoded3-encoding
+        val json = Source.single(Json.stringify(Json.obj("hello" -> "world"))).map(ByteString.apply)
+        //#multipart-encoded3-encoding
+        val response =
+        //#multipart-encoded3
+         ws.url(url).post(Source.single(SourcePart("key", json, Option("application/json"), None, None, None)))
+        //#multipart-encoded3
+
+        await(response).body must_== """{"hello":"world"}"""
+      }
+
       "post with multipart/form encoded body from a file" in withServer {
         case("POST", "/") => Action(BodyParsers.parse.multipartFormData){r =>
             val file = r.body.file("hello").head
@@ -224,7 +238,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
         import play.api.mvc.MultipartFormData._
         val response =
         //#multipart-encoded2
-        ws.url(url).post(Source(FilePart("hello", "hello.txt", Option("text/plain"), FileIO.fromFile(tmpFile)) :: DataPart("key", "value") :: List()))
+        ws.url(url).post(Source(FilePart("hello", "hello.txt", Option("text/plain"), FileIO.fromPath(tmpFile.toPath)) :: DataPart("key", "value") :: List()))
         //#multipart-encoded2
 
         await(response).body must_== "world"

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -220,7 +220,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
         //#multipart-encoded3-encoding
         val response =
         //#multipart-encoded3
-         ws.url(url).post(Source.single(SourcePart("key", json, Option("application/json"), None, None, None)))
+         ws.url(url).post(Source.single(SourcePart("key", json, None, Option("application/json"))))
         //#multipart-encoded3
 
         await(response).body must_== """{"hello":"world"}"""

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
@@ -23,8 +23,8 @@ import play.core.server.Server
 import play.it._
 import play.it.tools.HttpBinApplication
 import play.mvc.Http
-import scala.compat.java8.OptionConverters._
 
+import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 
@@ -205,7 +205,7 @@ trait WSSpec extends PlaySpecification with ServerIntegrationSpecification {
 
     "sending a json multipart form body" in withServer { ws =>
       val contentType = Option("application/json").asJava
-      val source = new Http.MultipartFormData.SourcePart("key", Source.single("""{"hello":"world"}""").map(ByteString.fromString).asJava, contentType)
+      val source = new Http.MultipartFormData.SourcePart("key", Source.single("""{"hello":"world"}""").map(ByteString.fromString).asJava, java.util.Optional.empty(), contentType)
       val res = ws.url("/post").post(Source.single(source).asJava)
       val body = res.toCompletableFuture.get().asJson()
 
@@ -368,7 +368,7 @@ trait WSSpec extends PlaySpecification with ServerIntegrationSpecification {
 
     "send a multipart request body with json" in withServer { ws =>
       val json = Source.single(Json.stringify(Json.obj("hello" -> "world"))).map(ByteString.apply)
-      val sp = MultipartFormData.SourcePart("hello", json, Option("application/json"), None, None, None)
+      val sp = MultipartFormData.SourcePart("hello", json, None, Option("application/json"))
       val res = ws.url("/post").post(Source.single(sp))
       val body = await(res).json
 

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -1457,7 +1457,6 @@ public class Http {
         }
 
         public static interface Part<A> {
-
         }
 
         /**
@@ -1518,43 +1517,61 @@ public class Http {
         public static class SourcePart implements Part<Source<ByteString, ?>> {
             private final String key;
             private final Source<ByteString, ?> value;
+            private final Optional<String> filename;
             private final Optional<String> contentType;
             private final Optional<String> charset;
             private final Optional<String> transferEncoding;
             private final Optional<String> contentId;
 
             public SourcePart(String key,
-                              Source<ByteString, ?> value,
-                              Optional<String> contentType) {
-                this(key, value, contentType, Optional.empty(),
-                        Optional.empty(), Optional.empty());
+                              Source<ByteString, ?> value) {
+                this(key, value, Optional.empty());
             }
 
             public SourcePart(String key,
                               Source<ByteString, ?> value,
+                              Optional<String> filename) {
+                this(key, value, filename, Optional.empty());
+            }
+
+            public SourcePart(String key,
+                              Source<ByteString, ?> value,
+                              Optional<String> filename,
+                              Optional<String> contentType) {
+                this(key, value, filename, contentType, Optional.empty());
+            }
+
+
+
+            public SourcePart(String key,
+                              Source<ByteString, ?> value,
+                              Optional<String> filename,
                               Optional<String> contentType,
                               Optional<String> charset) {
-                this(key, value, contentType, charset,
-                        Optional.empty(), Optional.empty());
+                this(key, value, filename, contentType, charset,
+                        Optional.empty());
             }
 
             public SourcePart(String key,
                               Source<ByteString, ?> value,
+                              Optional<String> filename,
                               Optional<String> contentType,
                               Optional<String> charset,
                               Optional<String> transferEncoding) {
-                this(key, value, contentType, charset,
+                this(key, value, filename, contentType, charset,
                         transferEncoding, Optional.empty());
             }
 
             public SourcePart(String key,
                               Source<ByteString, ?> value,
+                              Optional<String> filename,
                               Optional<String> contentType,
                               Optional<String> charset,
                               Optional<String> transferEncoding,
                               Optional<String> contentId) {
                 this.key = key;
                 this.value = value;
+                this.filename = filename;
                 this.contentType = contentType;
                 this.charset = charset;
                 this.transferEncoding = transferEncoding;
@@ -1567,6 +1584,10 @@ public class Http {
 
             public Source<ByteString, ?> getValue() {
                 return value;
+            }
+
+            public Optional<String> getFilename() {
+                return filename;
             }
 
             public Optional<String> getContentType() {
@@ -1589,6 +1610,7 @@ public class Http {
                 return new play.api.mvc.MultipartFormData.SourcePart(
                         key,
                         value.asScala(),
+                        OptionConverters.toScala(filename),
                         OptionConverters.toScala(contentType),
                         OptionConverters.toScala(charset),
                         OptionConverters.toScala(transferEncoding),
@@ -1624,6 +1646,8 @@ public class Http {
             public String getValue() {
                 return value;
             }
+
+
 
         }
 

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -1515,6 +1515,89 @@ public class Http {
 
         }
 
+        public static class SourcePart implements Part<Source<ByteString, ?>> {
+            private final String key;
+            private final Source<ByteString, ?> value;
+            private final Optional<String> contentType;
+            private final Optional<String> charset;
+            private final Optional<String> transferEncoding;
+            private final Optional<String> contentId;
+
+            public SourcePart(String key,
+                              Source<ByteString, ?> value,
+                              Optional<String> contentType) {
+                this(key, value, contentType, Optional.empty(),
+                        Optional.empty(), Optional.empty());
+            }
+
+            public SourcePart(String key,
+                              Source<ByteString, ?> value,
+                              Optional<String> contentType,
+                              Optional<String> charset) {
+                this(key, value, contentType, charset,
+                        Optional.empty(), Optional.empty());
+            }
+
+            public SourcePart(String key,
+                              Source<ByteString, ?> value,
+                              Optional<String> contentType,
+                              Optional<String> charset,
+                              Optional<String> transferEncoding) {
+                this(key, value, contentType, charset,
+                        transferEncoding, Optional.empty());
+            }
+
+            public SourcePart(String key,
+                              Source<ByteString, ?> value,
+                              Optional<String> contentType,
+                              Optional<String> charset,
+                              Optional<String> transferEncoding,
+                              Optional<String> contentId) {
+                this.key = key;
+                this.value = value;
+                this.contentType = contentType;
+                this.charset = charset;
+                this.transferEncoding = transferEncoding;
+                this.contentId = contentId;
+            }
+
+            public String getKey() {
+                return key;
+            }
+
+            public Source<ByteString, ?> getValue() {
+                return value;
+            }
+
+            public Optional<String> getContentType() {
+                return contentType;
+            }
+
+            public Optional<String> getCharset() {
+                return charset;
+            }
+
+            public Optional<String> getTransferEncoding() {
+                return transferEncoding;
+            }
+
+            public Optional<String> getContentId() {
+                return contentId;
+            }
+
+            public play.api.mvc.MultipartFormData.SourcePart asScala() {
+                return new play.api.mvc.MultipartFormData.SourcePart(
+                        key,
+                        value.asScala(),
+                        OptionConverters.toScala(contentType),
+                        OptionConverters.toScala(charset),
+                        OptionConverters.toScala(transferEncoding),
+                        OptionConverters.toScala(contentId)
+                );
+            }
+
+        }
+
         public static class DataPart implements Part<Source<ByteString, ?>> {
             private final String key;
             private final String value;

--- a/framework/src/play/src/main/java/play/mvc/MultipartFormatter.java
+++ b/framework/src/play/src/main/java/play/mvc/MultipartFormatter.java
@@ -28,6 +28,8 @@ public class MultipartFormatter {
             if (part instanceof Http.MultipartFormData.DataPart) {
                 Http.MultipartFormData.DataPart dp = (Http.MultipartFormData.DataPart) part;
                 return (MultipartFormData.Part) new MultipartFormData.DataPart(dp.getKey(), dp.getValue());
+            } else if (part instanceof Http.MultipartFormData.SourcePart) {
+                return ((Http.MultipartFormData.SourcePart)part).asScala();
             } else if (part instanceof Http.MultipartFormData.FilePart) {
                 Http.MultipartFormData.FilePart fp = (Http.MultipartFormData.FilePart) part;
                 if (fp.file instanceof Source) {

--- a/framework/src/play/src/main/java/play/mvc/MultipartFormatter.java
+++ b/framework/src/play/src/main/java/play/mvc/MultipartFormatter.java
@@ -10,6 +10,7 @@ import play.core.formatters.Multipart;
 import scala.Option;
 
 import java.nio.charset.Charset;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 
@@ -24,24 +25,22 @@ public class MultipartFormatter {
     }
 
     public static Source<ByteString, ?> transform(Source<? super Http.MultipartFormData.Part<Source<ByteString, ?>>, ?> parts, String boundary) {
-        Source<MultipartFormData.Part<akka.stream.scaladsl.Source<ByteString, ?>>, ?> source = parts.map((part) -> {
+        return parts.map((part) -> {
             if (part instanceof Http.MultipartFormData.DataPart) {
                 Http.MultipartFormData.DataPart dp = (Http.MultipartFormData.DataPart) part;
-                return (MultipartFormData.Part) new MultipartFormData.DataPart(dp.getKey(), dp.getValue());
+                return new Http.MultipartFormData.SourcePart(dp.getKey(), Source.single(ByteString.fromString(dp.getValue()))).asScala();
             } else if (part instanceof Http.MultipartFormData.SourcePart) {
-                return ((Http.MultipartFormData.SourcePart)part).asScala();
+                return ((Http.MultipartFormData.SourcePart) part).asScala();
             } else if (part instanceof Http.MultipartFormData.FilePart) {
                 Http.MultipartFormData.FilePart fp = (Http.MultipartFormData.FilePart) part;
                 if (fp.file instanceof Source) {
                     Source ref = (Source) fp.file;
-                    Option<String> ct = Option.apply(fp.getContentType());
-                    return (MultipartFormData.Part)new MultipartFormData.FilePart<akka.stream.scaladsl.Source<ByteString, ?>>(fp.getKey(), fp.getFilename(), ct, ref.asScala());
+                    return new Http.MultipartFormData.SourcePart(fp.getKey(), ref, Optional.of(fp.filename), Optional.of(fp.getContentType())).asScala();
                 }
             }
             throw new UnsupportedOperationException("Unsupported Part Class");
-        });
+        }).via(Multipart.format(boundary, Charset.defaultCharset(), 4096));
 
-        return source.via(Multipart.format(boundary, Charset.defaultCharset(), 4096));
     }
 
 

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -155,7 +155,7 @@ object MultipartFormData {
   /**
    * A source part.
    */
-  case class SourcePart(key: String, value: Source[ByteString, _], contentType: Option[String], charset: Option[String], transferEncoding: Option[String], contentId: Option[String]) extends Part[Source[ByteString, _]]
+  case class SourcePart(key: String, value: Source[ByteString, _], filename: Option[String] = None, contentType: Option[String] = None, charset: Option[String] = None, transferEncoding: Option[String] = None, contentId: Option[String] = None) extends Part[Source[ByteString, _]]
 
   /**
    * A part that has not been properly parsed.

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -8,13 +8,11 @@ import java.util.Locale
 
 import scala.util.control.NonFatal
 import scala.xml._
-import scala.concurrent.{ Future, ExecutionContext, Promise }
-
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 import akka.stream._
-import akka.stream.scaladsl.{ Flow, Sink, StreamConverters }
+import akka.stream.scaladsl.{ Flow, Sink, Source, StreamConverters }
 import akka.stream.stage._
 import akka.util.ByteString
-
 import play.api._
 import play.api.data.Form
 import play.api.http.Status._
@@ -153,6 +151,11 @@ object MultipartFormData {
    * A file part.
    */
   case class FilePart[A](key: String, filename: String, contentType: Option[String], ref: A) extends Part[A]
+
+  /**
+   * A source part.
+   */
+  case class SourcePart(key: String, value: Source[ByteString, _], contentType: Option[String], charset: Option[String], transferEncoding: Option[String], contentId: Option[String]) extends Part[Source[ByteString, _]]
 
   /**
    * A part that has not been properly parsed.

--- a/framework/src/play/src/test/scala/play/core/formatters/MultipartSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/formatters/MultipartSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.formatters
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ Sink, Source }
+import akka.util.ByteString
+import org.specs2.mutable.Specification
+import org.specs2.specification.AfterAll
+import play.api.mvc.MultipartFormData.SourcePart
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class MultipartSpec extends Specification with AfterAll {
+
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()(system)
+
+  def afterAll(): Unit = {
+    materializer.shutdown()
+    system.terminate()
+  }
+
+  val reduce = Sink.reduce[ByteString]((v1, v2) => v1 ++ v2)
+
+  def source(contentId: Option[String] = None, transferEncoding: Option[String] = None,
+    contentType: Option[String] = None, charset: Option[String] = None) = {
+    val data = Source.single(ByteString.fromString("world"))
+    Source.single(SourcePart("hello", data, contentType, charset, transferEncoding, contentId))
+  }
+
+  "Multipart.transform" should {
+
+    "generate a Content-ID" in {
+      val res = Await.result(Multipart.transform(source(Option("123")), "play")
+        .runWith(reduce).map(_.utf8String), 10.seconds)
+
+      res must contain("Content-ID: 123")
+    }
+
+    "generate a Content-Transfer-Encoding" in {
+      val res = Await.result(Multipart.transform(source(None, Option("8-bit")), "play")
+        .runWith(reduce).map(_.utf8String), 10.seconds)
+
+      res must contain("Content-Transfer-Encoding: 8-bit")
+    }
+
+    "generate a Content-Type with charset" in {
+      val res = Await.result(Multipart.transform(source(None, None, Option("text/plain"), Option("UTF-8")), "play")
+        .runWith(reduce).map(_.utf8String), 10.seconds)
+
+      res must contain("Content-Type: text/plain; charset=UTF-8")
+    }
+
+  }
+
+}

--- a/framework/src/play/src/test/scala/play/core/formatters/MultipartSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/formatters/MultipartSpec.scala
@@ -29,7 +29,7 @@ class MultipartSpec extends Specification with AfterAll {
   def source(contentId: Option[String] = None, transferEncoding: Option[String] = None,
     contentType: Option[String] = None, charset: Option[String] = None) = {
     val data = Source.single(ByteString.fromString("world"))
-    Source.single(SourcePart("hello", data, contentType, charset, transferEncoding, contentId))
+    Source.single(SourcePart("hello", data, None, contentType, charset, transferEncoding, contentId))
   }
 
   "Multipart.transform" should {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Currently multipart form upload only supported DataParts as simple text messages, this actually adds a new type `SourcePart` which allows arbitary data, i.e. json/xml and also soap messages with attachments: https://www.w3.org/TR/SOAP-attachments useful if play-soap.

So `Multipart.format` now can support all possible types of Data.

## Background Context

Actually I guess thats the best way to add a new object to MultipartFormData (maybe we should actually rename it since it's MultipartData and not only dependent on Forms).

Actually I also think that this class could be used to make the Multipart.parsing a little bit more "intelligent". At the moment it actually only decodes it to either a file or a DataPart based on https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala#L352 the headers / filename that is really really dumb and doesn't support casading multipart data and other data.

This is a limitation of the underlying `Multipart.partParser`. And maybe we could also take a look at it and have a way to create a custom multipartFormData that is more intelligently splitting the parts.

If people like it I will add a Java API.

We came up with that as a actual usage in our product which needs to send multiple stuff with form data to a c# web api which wants  multiple data structures: key/value string pairs, json data and a file.
