### PR TITLE
Avoid OutOfMemoryError when writing JSON BigDecimals

### DIFF
--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -278,6 +278,36 @@ object JsonSpec extends org.specs2.mutable.Specification {
       parse(stringify(json)) must equalTo(json)
     }
 
+    "Write BigDecimals with large exponents in scientific notation" in {
+      val n = BigDecimal("1.2e1000")
+      val jsonString = stringify(toJson(n))
+      jsonString must_== "1.2E+1000"
+    }
+
+    "Write negative BigDecimals with large exponents in scientific notation" in {
+      val n = BigDecimal("-2.5e1000")
+      val jsonString = stringify(toJson(n))
+      jsonString must_== "-2.5E+1000"
+    }
+
+    "Write BigDecimals with large negative exponents in scientific notation" in {
+      val n = BigDecimal("6.75e-1000")
+      val jsonString = stringify(toJson(n))
+      jsonString must_== "6.75E-1000"
+    }
+
+    "Write BigDecimals with small exponents as a plain string" in {
+      val n = BigDecimal("1.234e3")
+      val jsonString = stringify(toJson(n))
+      jsonString must_== "1234"
+    }
+
+    "Write BigDecimals with small negative exponents as a plain string" in {
+      val n = BigDecimal("1.234e-3")
+      val jsonString = stringify(toJson(n))
+      jsonString must_== "0.001234"
+    }
+
     "Not lose precision when parsing big integers" in {
       // By big integers, we just mean integers that overflow long, since Jackson has different code paths for them
       // from decimals


### PR DESCRIPTION
This places limits on the minimum and maximum values that can are written out using `BigDecimal#toPlainString` in play-json. There are really two issues when dealing with large BigDecimal values that this attempts to fix:
 1. Normally you do not want to print out every digit of a large `BigDecimal` value if most of the digits are leading or trailing zeroes. I understand the desire to avoid scientific notation for shorter numbers (so we still support that), but JSON is a data format, so we should strive for compactness in general.
 2. In an extreme case, trying to use `toPlainString` on a very large number, we will get an `OutOfMemoryError`:
```
scala> BigDecimal("1e100000000").bigDecimal.toPlainString
java.lang.OutOfMemoryError: Java heap space
  at java.lang.AbstractStringBuilder.<init>(AbstractStringBuilder.java:68)
  at java.lang.StringBuilder.<init>(StringBuilder.java:101)
  at java.math.BigDecimal.toPlainString(BigDecimal.java:2964)
  ... 29 elided
```
There is also a similar issue in Jackson, reported here: FasterXML/jackson-databind#1316 