### PR TITLE
Fix all javadoc warnings, remove -Xdoclint:none

### DIFF
--- a/framework/project/Docs.scala
+++ b/framework/project/Docs.scala
@@ -130,7 +130,6 @@ object Docs {
         "-notimestamp",
         "-subpackages", "play",
         "-Xmaxwarns", "1000",
-        "-Xdoclint:none",
         "-exclude", "play.api:play.core"
       )
 

--- a/framework/src/play-cache/src/main/scala/play/api/cache/SyncCacheApi.scala
+++ b/framework/src/play-cache/src/main/scala/play/api/cache/SyncCacheApi.scala
@@ -49,7 +49,7 @@ trait SyncCacheApi {
 /**
  * A cache API. This class is deprecated and will be removed in future versions.
  */
-@deprecated("Use SyncCacheApi or AsyncCacheApi instead")
+@deprecated("Use SyncCacheApi or AsyncCacheApi instead", "2.6.0")
 trait CacheApi {
 
   /**

--- a/framework/src/play-java/src/main/java/play/libs/Classpath.java
+++ b/framework/src/play-java/src/main/java/play/libs/Classpath.java
@@ -96,7 +96,7 @@ public class Classpath {
      *
      * @param packageName the root package to scan
      * @param classLoader class loader to be used in reflections
-     * @return
+     * @return the configuration builder
      */
     public static ConfigurationBuilder getReflectionsConfiguration(String packageName, ClassLoader classLoader) {
         return new ConfigurationBuilder()

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DB.scala
@@ -16,8 +16,7 @@ import play.api.Application
  * val conn = DB.getConnection("customers")
  * }}}
  */
-@deprecated(since = "2.4.3",
-  message = "Use [[play.api.db.Database]]")
+@deprecated(since = "2.4.3", message = "Use [[play.api.db.Database]]")
 object DB {
 
   private val dbCache = Application.instanceCache[DBApi]

--- a/framework/src/play-logback/src/main/scala/play/api/Logger$ColoredLevel.scala
+++ b/framework/src/play-logback/src/main/scala/play/api/Logger$ColoredLevel.scala
@@ -7,7 +7,7 @@ import ch.qos.logback.core.joran.util.ConfigurationWatchListUtil
 import play.api.libs.logback.ColoredLevel
 
 /**
- * Provides the old play.api.Logger$ColoredLevel library so that a deprecation message can be logged.
+ * Provides the old play.api.Logger\$ColoredLevel library so that a deprecation message can be logged.
  */
 @deprecated("Use play.api.libs.logback.ColoredLevel instead", "2.5.0")
 class Logger$ColoredLevel extends ColoredLevel {

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/SynchronousMappedStreams.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/SynchronousMappedStreams.scala
@@ -57,7 +57,7 @@ object SynchronousMappedStreams {
   /**
    * Does a map and contramap on the processor.
    *
-   * @see [[map()]] and [[contramap()]].
+   * @see [[map]] and [[contramap]].
    */
   def transform[A1, B1, A2, B2](processor: Processor[B1, A2], f: A1 => B1, g: A2 => B2): Processor[A1, B2] =
     new JoinedProcessor[A1, B2](contramap(processor, f), map(processor, g))

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/ActorFlow.scala
@@ -18,10 +18,10 @@ object ActorFlow {
    * Create a flow that is handled by an actor.
    *
    * Messages can be sent downstream by sending them to the actor passed into the props function.  This actor meets
-   * the contract of the actor returned by [[akka.stream.scaladsl.Source.actorRef]].
+   * the contract of the actor returned by [[http://doc.akka.io/api/akka/current/index.html#akka.stream.scaladsl.Source$@actorRef[T](bufferSize:Int,overflowStrategy:akka.stream.OverflowStrategy):akka.stream.scaladsl.Source[T,akka.actor.ActorRef] akka.stream.scaladsl.Source.actorRef]].
    *
    * The props function should return the props for an actor to handle the flow. This actor will be created using the
-   * passed in [[akka.actor.ActorRefFactory]]. Each message received will be sent to the actor - there is no back pressure,
+   * passed in [[http://doc.akka.io/api/akka/current/index.html#akka.actor.ActorRefFactory akka.actor.ActorRefFactory]]. Each message received will be sent to the actor - there is no back pressure,
    * if the actor is unable to process the messages, they will queue up in the actors mailbox. The upstream can be
    * cancelled by the actor terminating itself.
    *

--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -234,7 +234,7 @@ case class Configuration(underlying: Config) {
   /**
     * Get a prototyped sequence of objects.
     *
-    * Each object in the sequence will fallback to the object loaded from prototype.$path.
+    * Each object in the sequence will fallback to the object loaded from prototype.\$path.
     */
   def getPrototypedSeq(path: String, prototypePath: String = "prototype.$path"): Seq[Configuration] = {
     val prototype = underlying.getConfig(prototypePath.replace("$path", path))
@@ -246,7 +246,7 @@ case class Configuration(underlying: Config) {
   /**
     * Get a prototyped map of objects.
     *
-    * Each value in the map will fallback to the object loaded from prototype.$path.
+    * Each value in the map will fallback to the object loaded from prototype.\$path.
     */
   def getPrototypedMap(path: String, prototypePath: String = "prototype.$path"): Map[String, Configuration] = {
     val prototype = if (prototypePath.isEmpty) {

--- a/framework/src/play/src/main/scala/play/core/formatters/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/formatters/Multipart.scala
@@ -40,7 +40,7 @@ object Multipart {
   /**
    * Creates a new random number of the given length and base64 encodes it (using a custom "safe" alphabet).
    *
-   * @throws IllegalArgumentException if the length is greater than 70 or less than 1 as specified in
+   * @throws java.lang.IllegalArgumentException if the length is greater than 70 or less than 1 as specified in
    *                                  <a href="https://tools.ietf.org/html/rfc2046#section-5.1.1">rfc2046</a>
    */
   def randomBoundary(length: Int = 18, random: java.util.Random = ThreadLocalRandom.current()): String = {


### PR DESCRIPTION
Fixes #https://github.com/playframework/playframework/issues/4995

All the javadoc warnings are fixed, and -Xdoclint:none is removed from the javadoc.  