### PR TITLE
Add @Inject annotation to a few constructors

### DIFF
--- a/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
@@ -8,6 +8,7 @@ import javax.inject.{ Inject, Provider, Singleton }
 
 import com.google.inject.{ ProvisionException, CreationException }
 import org.specs2.mutable.Specification
+import play.api.i18n.I18nModule
 import play.api.{ Configuration, Environment }
 
 object GuiceApplicationBuilderSpec extends Specification {
@@ -77,7 +78,15 @@ object GuiceApplicationBuilderSpec extends Specification {
       new GuiceApplicationBuilder()
         .load(new BuiltinModule, bind[C].to[C1])
         .eagerlyLoaded()
-        .injector() must throwAn[CreationException]
+        .injector() must throwA[CreationException]
+    }
+
+    "work with built in modules and requireAtInjectOnConstructors" in {
+      new GuiceApplicationBuilder()
+        .load(new BuiltinModule, new I18nModule)
+        .requireAtInjectOnConstructors()
+        .eagerlyLoaded()
+        .injector() must not(throwA[CreationException])
     }
 
     "set lazy load singletons" in {

--- a/framework/src/play/src/main/scala/play/api/http/HttpFilters.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpFilters.scala
@@ -50,7 +50,7 @@ object HttpFilters {
 /**
  * A filters provider that provides no filters.
  */
-class NoHttpFilters extends DefaultHttpFilters
+class NoHttpFilters @Inject() () extends DefaultHttpFilters
 
 object NoHttpFilters extends NoHttpFilters
 

--- a/framework/src/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
@@ -5,7 +5,7 @@ package play.api.inject
 
 import java.util.concurrent.{ CompletionStage, Callable }
 
-import javax.inject.Singleton
+import javax.inject.{Inject, Singleton}
 import play.api.Logger
 
 import scala.compat.java8.FutureConverters
@@ -71,7 +71,7 @@ trait ApplicationLifecycle {
  * Default implementation of the application lifecycle.
  */
 @Singleton
-class DefaultApplicationLifecycle extends ApplicationLifecycle {
+class DefaultApplicationLifecycle @Inject() () extends ApplicationLifecycle {
   private val mutex = new Object()
   @volatile private var hooks = List.empty[() => Future[_]]
 


### PR DESCRIPTION
Fixes #6384.

It should be possible to use Play's built-in components with Guice's `requireAtInjectOnConstructors` option.

(needs backport to 2.5.x)