### PR TITLE
upgraded specs2 and cleaned up tests with class based specs

### DIFF
--- a/documentation/manual/gettingStarted/code/PlayConsole.scala
+++ b/documentation/manual/gettingStarted/code/PlayConsole.scala
@@ -6,7 +6,7 @@ package gettingStarted
 import org.specs2.mutable.Specification
 import play.api._
 
-object PlayConsole extends Specification {
+class PlayConsole extends Specification {
   "Play console" should { 
     "support creating an instance of the Play application" in { 
       val app = new consoleapp.MyConsole().createApplication()

--- a/documentation/manual/working/commonGuide/configuration/code/ThreadPools.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/ThreadPools.scala
@@ -18,7 +18,7 @@ import scala.collection.JavaConverters._
 import java.io.File
 import org.specs2.execute.AsResult
 
-object ThreadPoolsSpec extends PlaySpecification {
+class ThreadPoolsSpec extends PlaySpecification {
 
   "Play's thread pools" should {
 

--- a/documentation/manual/working/commonGuide/filters/code/GzipEncoding.scala
+++ b/documentation/manual/working/commonGuide/filters/code/GzipEncoding.scala
@@ -7,7 +7,7 @@ import akka.stream.ActorMaterializer
 import play.api.test._
 import detailedtopics.configuration.gzipencoding.CustomFilters
 
-object GzipEncoding extends PlaySpecification {
+class GzipEncoding extends PlaySpecification {
 
   //#filters
   import javax.inject.Inject
@@ -16,7 +16,7 @@ object GzipEncoding extends PlaySpecification {
   import play.filters.gzip.GzipFilter
 
   class Filters @Inject() (gzipFilter: GzipFilter)
-    extends DefaultHttpFilters(gzipFilter)
+      extends DefaultHttpFilters(gzipFilter)
   //#filters
 
   "gzip filter" should {

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaFormHelpers.scala
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaFormHelpers.scala
@@ -9,7 +9,7 @@ import play.data.Form
 import javaguide.forms.html.{UserForm, User}
 import java.util
 
-object JavaFormHelpers extends PlaySpecification {
+class JavaFormHelpers extends PlaySpecification {
 
   "java form helpers" should {
     {

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaErrorHandling.scala
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaErrorHandling.scala
@@ -11,7 +11,7 @@ import play.api.test._
 
 import scala.reflect.ClassTag
 
-object JavaErrorHandling extends PlaySpecification with WsTestClient {
+class JavaErrorHandling extends PlaySpecification with WsTestClient {
 
   def fakeApp[A](implicit ct: ClassTag[A]) = {
     GuiceApplicationBuilder()

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaRouting.scala
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaRouting.scala
@@ -16,7 +16,7 @@ import play.api.test.FakeRequest
 import javaguide.testhelpers.MockJavaAction
 import play.libs.F
 
-object JavaRouting extends Specification {
+class JavaRouting extends Specification {
 
   "the java router" should {
     "support simple routing with a long parameter" in {

--- a/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaEmbeddingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaEmbeddingPlay.scala
@@ -9,7 +9,7 @@ import play.api.test.WsTestClient
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-object ScalaEmbeddingPlay extends Specification with WsTestClient {
+class ScalaEmbeddingPlay extends Specification with WsTestClient {
 
   "Embedding play" should {
     "be very simple" in {

--- a/documentation/manual/working/scalaGuide/advanced/extending/code/ScalaExtendingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/extending/code/ScalaExtendingPlay.scala
@@ -10,47 +10,46 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.Result
 import play.mvc.Http.RequestHeader
 
+class MyMessagesApi extends MessagesApi {
+  override def messages: Map[String, Map[String, String]] = ???
+  override def preferred(candidates: Seq[Lang]): Messages = ???
+  override def preferred(request: mvc.RequestHeader): Messages = ???
+  override def preferred(request: RequestHeader): Messages = ???
+  override def langCookieHttpOnly: Boolean = ???
+  override def clearLang(result: Result): Result = ???
+  override def langCookieSecure: Boolean = ???
+  override def langCookieName: String = ???
+  override def setLang(result: Result, lang: Lang): Result = ???
+  override def apply(key: String, args: Any*)(implicit lang: Lang): String = ???
+  override def apply(keys: Seq[String], args: Any*)(implicit lang: Lang): String = ???
+  override def isDefinedAt(key: String)(implicit lang: Lang): Boolean = ???
+  override def translate(key: String, args: Seq[Any])(implicit lang: Lang): Option[String] = ???
+}
 
-object ScalaExtendingPlay extends Specification {
+// #module-definition
+class MyCode {
+  // add functionality here
+}
 
-  class MyMessagesApi extends MessagesApi {
-    override def messages: Map[String, Map[String, String]] = ???
-    override def preferred(candidates: Seq[Lang]): Messages = ???
-    override def preferred(request: mvc.RequestHeader): Messages = ???
-    override def preferred(request: RequestHeader): Messages = ???
-    override def langCookieHttpOnly: Boolean = ???
-    override def clearLang(result: Result): Result = ???
-    override def langCookieSecure: Boolean = ???
-    override def langCookieName: String = ???
-    override def setLang(result: Result, lang: Lang): Result = ???
-    override def apply(key: String, args: Any*)(implicit lang: Lang): String = ???
-    override def apply(keys: Seq[String], args: Any*)(implicit lang: Lang): String = ???
-    override def isDefinedAt(key: String)(implicit lang: Lang): Boolean = ???
-    override def translate(key: String, args: Seq[Any])(implicit lang: Lang): Option[String] = ???
+class MyModule extends play.api.inject.Module {
+  def bindings(environment: Environment, configuration: Configuration) = {
+    Seq(bind[MyCode].toInstance(new MyCode))
   }
+}
+// #module-definition
 
-  // #module-definition
-  class MyCode {
-    // add functionality here
+// #builtin-module-definition
+class MyI18nModule extends play.api.inject.Module {
+  def bindings(environment: Environment, configuration: Configuration) = {
+    Seq(
+      bind[Langs].to[DefaultLangs],
+      bind[MessagesApi].to[MyMessagesApi]
+    )
   }
+}
+// #builtin-module-definition
 
-  class MyModule extends play.api.inject.Module {
-    def bindings(environment: Environment, configuration: Configuration) = {
-        Seq(bind[MyCode].toInstance(new MyCode))
-    }
-  }
-  // #module-definition
-
-  // #builtin-module-definition
-  class MyI18nModule extends play.api.inject.Module {
-    def bindings(environment: Environment, configuration: Configuration) = {
-      Seq(
-        bind[Langs].to[DefaultLangs],
-        bind[MessagesApi].to[MyMessagesApi]
-      )
-    }
-  }
-  // #builtin-module-definition
+class ScalaExtendingPlay extends Specification {
 
   "Extending Play" should {
 

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/ScalaSirdRouter.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/ScalaSirdRouter.scala
@@ -7,7 +7,7 @@ import controllers.Assets
 import org.specs2.mutable.Specification
 import play.api.test.FakeRequest
 
-object ScalaSirdRouter extends Specification {
+class ScalaSirdRouter extends Specification {
 
   //#imports
   import play.api.mvc._

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
@@ -13,7 +13,7 @@ import play.api.mvc._
 import play.api.test._
 import akka.pattern.after
 
-object ScalaAsyncSpec extends PlaySpecification {
+class ScalaAsyncSpec extends PlaySpecification {
 
   def samples(implicit app: Application): ScalaAsyncSamples = app.injector.instanceOf[ScalaAsyncSamples]
 

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaComet.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaComet.scala
@@ -15,28 +15,26 @@ import play.api.mvc._
 
 import play.api.test._
 
-object ScalaCometSpec extends PlaySpecification {
+class MockController(val materializer: Materializer) extends Controller {
 
-  class MockController(val materializer: Materializer) extends Controller {
-
-    //#comet-string
-    def cometString = Action {
-      implicit val m = materializer
-      def stringSource: Source[String, _] = Source(List("kiki", "foo", "bar"))
-      Ok.chunked(stringSource via Comet.string("parent.cometMessage")).as(ContentTypes.HTML)
-    }
-    //#comet-string
-
-    //#comet-json
-    def cometJson = Action {
-      implicit val m = materializer
-      def jsonSource: Source[JsValue, _] = Source(List(JsString("jsonString")))
-      Ok.chunked(jsonSource via Comet.json("parent.cometMessage")).as(ContentTypes.HTML)
-    }
-    //#comet-json
+  //#comet-string
+  def cometString = Action {
+    implicit val m = materializer
+    def stringSource: Source[String, _] = Source(List("kiki", "foo", "bar"))
+    Ok.chunked(stringSource via Comet.string("parent.cometMessage")).as(ContentTypes.HTML)
   }
+  //#comet-string
 
+  //#comet-json
+  def cometJson = Action {
+    implicit val m = materializer
+    def jsonSource: Source[JsValue, _] = Source(List(JsString("jsonString")))
+    Ok.chunked(jsonSource via Comet.json("parent.cometMessage")).as(ContentTypes.HTML)
+  }
+  //#comet-json
+}
 
+class ScalaCometSpec extends PlaySpecification {
 
   "play comet" should {
 

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
@@ -7,7 +7,7 @@ import play.api.http.websocket.{ TextMessage, Message }
 import play.api.test._
 import scala.concurrent.{ Future, Promise }
 
-object ScalaWebSockets extends PlaySpecification {
+class ScalaWebSockets extends PlaySpecification {
 
   import java.io.Closeable
   import play.api.mvc.{Result, WebSocket}

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
@@ -7,11 +7,11 @@ import java.io.File
 
 import org.specs2.mutable.Specification
 
-object CompileTimeDependencyInjection extends Specification {
+class CompileTimeDependencyInjection extends Specification {
 
   import play.api._
 
-  val environment = Environment(new File("."), CompileTimeDependencyInjection.getClass.getClassLoader, Mode.Test)
+  val environment = Environment(new File("."), this.getClass.getClassLoader, Mode.Test)
 
   "compile time dependency injection" should {
     "allow creating an application with the built in components from context" in {

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/RuntimeDependencyInjection.scala
@@ -6,7 +6,7 @@ package scalaguide.dependencyinjection
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test._
 
-object RuntimeDependencyInjection extends PlaySpecification {
+class RuntimeDependencyInjection extends PlaySpecification {
 
   "Play's runtime dependency injection support" should {
     "support constructor injection" in new WithApplication() {

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaCsrf.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaCsrf.scala
@@ -11,21 +11,21 @@ import play.api.mvc.Call
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.Future
 
-object ScalaCsrf extends PlaySpecification {
+//#csrf-controller
+import play.api.mvc._
+import play.api.mvc.Results._
+import play.filters.csrf._
+import play.filters.csrf.CSRF.Token
 
-  //#csrf-controller
-  import play.api.mvc._
-  import play.api.mvc.Results._
-  import play.filters.csrf._
-  import play.filters.csrf.CSRF.Token
+class CSRFController(addToken: CSRFAddToken, checkToken: CSRFCheck) extends Controller {
+  def getToken = addToken(Action { implicit request =>
+    val Token(name, value) = CSRF.getToken.get
+    Ok(s"$name=$value")
+  })
+}
+//#csrf-controller
 
-  class CSRFController(addToken: CSRFAddToken, checkToken: CSRFCheck) extends Controller {
-    def getToken = addToken(Action { implicit request =>
-      val Token(name, value) = CSRF.getToken.get
-      Ok(s"$name=$value")
-    })
-  }
-  //#csrf-controller
+class ScalaCsrf extends PlaySpecification {
 
   // used to make sure CSRFController gets the proper things injected
   implicit def addToken[A](action: Action[A])(implicit app: Application): Action[A] = app.injector.instanceOf(classOf[CSRFAddToken])(action)

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaFieldConstructor.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaFieldConstructor.scala
@@ -7,7 +7,7 @@ import org.specs2.mutable.Specification
 import play.api.{Environment, Configuration}
 import play.api.i18n.{DefaultLangs, DefaultMessagesApi, Messages}
 
-object ScalaFieldConstructorSpec extends Specification {
+class ScalaFieldConstructorSpec extends Specification {
 
   val conf = Configuration.reference
   implicit val messages: Messages = new DefaultMessagesApi(Environment.simple(), conf, new DefaultLangs(conf)).preferred(Seq.empty)

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActions.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActions.scala
@@ -12,7 +12,7 @@ import play.api.libs.json._
 import scala.concurrent.Future
 import org.specs2.execute.AsResult
 
-object ScalaActionsSpec extends Specification with Controller {
+class ScalaActionsSpec extends Specification with Controller {
 
   "A scala action" should {
     "allow writing a simple echo action" in {

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
@@ -9,7 +9,7 @@ import play.api.test._
 
 import scala.reflect.ClassTag
 
-object ScalaErrorHandling extends PlaySpecification with WsTestClient {
+class ScalaErrorHandling extends PlaySpecification with WsTestClient {
 
   def fakeApp[A](implicit ct: ClassTag[A]) = {
     GuiceApplicationBuilder()

--- a/documentation/manual/working/scalaGuide/main/tests/code/database/ScalaTestingWithDatabases.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/database/ScalaTestingWithDatabases.scala
@@ -7,7 +7,7 @@ import java.sql.SQLException
 
 import org.specs2.mutable.Specification
 
-object ScalaTestingWithDatabases extends Specification {
+class ScalaTestingWithDatabases extends Specification {
 
   // We don't test this code because otherwise it would try to connect to MySQL
   class NotTested {

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleControllerSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleControllerSpec.scala
@@ -8,7 +8,7 @@ import play.api.mvc._
 import play.api.test._
 import scala.concurrent.Future
 
-object ExampleControllerSpec extends PlaySpecification with Results {
+class ExampleControllerSpec extends PlaySpecification with Results {
 
   "Example Page#index" should {
     "should be valid" in {

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleEssentialActionSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleEssentialActionSpec.scala
@@ -9,7 +9,7 @@ import play.api.mvc.Results._
 import play.api.libs.json.Json
 
 // #scalatest-exampleessentialactionspec
-object ExampleEssentialActionSpec extends PlaySpecification {
+class ExampleEssentialActionSpec extends PlaySpecification {
 
   "An essential action" should {
     "can parse a JSON body" in new WithApplication() {

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExamplePlaySpecificationSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExamplePlaySpecificationSpec.scala
@@ -6,7 +6,7 @@ package scalaguide.tests.specs2
 import play.api.test._
 
 // #scalafunctionaltest-playspecification
-object ExamplePlaySpecificationSpec extends PlaySpecification {
+class ExamplePlaySpecificationSpec extends PlaySpecification {
   "The specification" should {
 
     "have access to HeaderNames" in {

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/FunctionalExampleControllerSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/FunctionalExampleControllerSpec.scala
@@ -7,7 +7,7 @@ import scalaguide.tests.controllers
 
 import play.api.test._
 
-object FunctionalExampleControllerSpec extends PlaySpecification {
+class FunctionalExampleControllerSpec extends PlaySpecification {
 
   // #scalafunctionaltest-functionalexamplecontrollerspec
   "respond to the index Action" in {

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/FunctionalTemplateSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/FunctionalTemplateSpec.scala
@@ -10,7 +10,7 @@ import play.api.mvc._
 import play.api.test._
 import play.api.test.Helpers._
 
-object FunctionalTemplateSpec extends Specification {
+class FunctionalTemplateSpec extends Specification {
 
   // #scalatest-functionaltemplatespec
   "render index template" in new WithApplication {

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/UserServiceSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/UserServiceSpec.scala
@@ -10,7 +10,7 @@ import scalaguide.tests.models._
 import scalaguide.tests.services._
 
 // #scalatest-userservicespec
-object UserServiceSpec extends Specification with Mockito {
+class UserServiceSpec extends Specification with Mockito {
 
   "UserService#isAdmin" should {
     "be true when the role is admin" in {

--- a/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
@@ -40,7 +40,7 @@ import scala.concurrent.duration._
 import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
 
-object GitHubClientSpec extends Specification with NoTimeConversions {
+  class GitHubClientSpec extends Specification with NoTimeConversions {
 
   "GitHubClient" should {
     "get all repositories" in {
@@ -69,7 +69,7 @@ import scala.concurrent.duration._
 import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
 
-object ScalaTestingWebServiceClients extends Specification with NoTimeConversions {
+class ScalaTestingWebServiceClients extends Specification with NoTimeConversions {
 
   "webservice testing" should {
     "allow mocking a service" in {

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOAuthSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOAuthSpec.scala
@@ -31,7 +31,7 @@ object routes {
 }
 
 
-object ScalaOAuthSpec extends PlaySpecification {
+class ScalaOAuthSpec extends PlaySpecification {
 
   "Scala OAuth" should {
     "be injectable" in new WithApplication() {

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
@@ -22,7 +22,7 @@ class Application @Inject() (openIdClient: OpenIdClient) extends Controller {
 //#dependency
 
 
-object ScalaOpenIdSpec extends PlaySpecification {
+class ScalaOpenIdSpec extends PlaySpecification {
 
   "Scala OpenId" should {
     "be injectable" in new WithApplication() {

--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -50,7 +50,6 @@ object BuildSettings {
     homepage := Some(url("https://playframework.com")),
     ivyLoggingLevel := UpdateLogging.DownloadOnly,
     resolvers ++= Seq(
-      "Scalaz Bintray Repo" at "https://dl.bintray.com/scalaz/releases",
       Resolver.typesafeRepo("releases"),
       Resolver.typesafeIvyRepo("releases")
     ),

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
 
   val akkaVersion = "2.4.8"
 
-  val specsVersion = "3.6.6"
+  val specsVersion = "3.8.4"
   val specsBuild = Seq(
     "specs2-core",
     "specs2-junit",
@@ -252,7 +252,7 @@ object Dependencies {
 
   val scalacheckDependencies = Seq(
     "org.specs2"     %% "specs2-scalacheck" % specsVersion % Test,
-    "org.scalacheck" %% "scalacheck"        % "1.12.5"     % Test
+    "org.scalacheck" %% "scalacheck"        % "1.13.2"     % Test
   )
 
   val playServerDependencies = Seq(

--- a/framework/src/fork-run-protocol/src/test/scala/play/forkrun/protocol/SerializersSpec.scala
+++ b/framework/src/fork-run-protocol/src/test/scala/play/forkrun/protocol/SerializersSpec.scala
@@ -8,7 +8,7 @@ import play.forkrun.protocol.Serializers._
 import play.runsupport.Reloader.{ Source, CompileSuccess, CompileFailure, CompileResult }
 import sbt.serialization._
 
-object SerializersSpec extends Specification with PicklingTestUtils {
+class SerializersSpec extends Specification with PicklingTestUtils {
 
   def file(path: String): java.io.File = {
     (new java.io.File(path)).getAbsoluteFile

--- a/framework/src/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHttpServerSpec.scala
+++ b/framework/src/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHttpServerSpec.scala
@@ -12,7 +12,7 @@ import play.api.test._
 import scala.concurrent.Future
 import akka.util.Timeout
 
-object AkkaHttpServerSpec extends PlaySpecification with WsTestClient {
+class AkkaHttpServerSpec extends PlaySpecification with WsTestClient {
   // Provide a flag to disable Akka HTTP tests
   private val runTests: Boolean = (System.getProperty("run.akka.http.tests", "true") == "true")
   skipAllIf(!runTests)

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSActionBuilderSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSActionBuilderSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.filters.cors
+
+import play.api.mvc.Results
+import play.api.{ Application, Configuration }
+
+class CORSActionBuilderSpec extends CORSCommonSpec {
+
+  def withApplication[T](conf: Map[String, _ <: Any] = Map.empty)(block: Application => T): T = {
+    running(_.routes {
+      case (_, "/error") => CORSActionBuilder(Configuration.reference ++ Configuration.from(conf)) { req =>
+        throw sys.error("error")
+      }
+      case _ => CORSActionBuilder(Configuration.reference ++ Configuration.from(conf))(Results.Ok)
+    })(block)
+  }
+
+  def withApplicationWithPathConfiguredAction[T](configPath: String, conf: Map[String, _ <: Any] = Map.empty)(block: Application => T): T = {
+    running(_.configure(conf).routes {
+      case (_, "/error") => CORSActionBuilder(Configuration.reference ++ Configuration.from(conf), configPath = configPath) { req =>
+        throw sys.error("error")
+      }
+      case _ => CORSActionBuilder(Configuration.reference ++ Configuration.from(conf), configPath = configPath)(Results.Ok)
+    })(block)
+  }
+
+  "The CORSActionBuilder with" should {
+
+    val restrictOriginsPathConf = Map("myaction.allowedOrigins" -> Seq("http://example.org", "http://localhost:9000"))
+
+    "handle a cors request with a subpath of app configuration" in withApplicationWithPathConfiguredAction(configPath = "myaction", conf = restrictOriginsPathConf) {
+      app =>
+        val result = route(app, fakeRequest().withHeaders(ORIGIN -> "http://localhost:9000")).get
+
+        status(result) must_== OK
+        header(ACCESS_CONTROL_ALLOW_CREDENTIALS, result) must beSome("true")
+        header(ACCESS_CONTROL_ALLOW_HEADERS, result) must beNone
+        header(ACCESS_CONTROL_ALLOW_METHODS, result) must beNone
+        header(ACCESS_CONTROL_ALLOW_ORIGIN, result) must beSome("http://localhost:9000")
+        header(ACCESS_CONTROL_EXPOSE_HEADERS, result) must beNone
+        header(ACCESS_CONTROL_MAX_AGE, result) must beNone
+        header(VARY, result) must beSome(ORIGIN)
+    }
+
+    commonTests
+  }
+}
+

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSFilterSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.filters.cors
+
+import javax.inject.Inject
+
+import play.api.Application
+import play.api.http.HttpFilters
+import play.api.inject.bind
+import play.api.mvc.{ Action, Results }
+import play.api.routing.Router
+import play.api.routing.sird._
+
+object CORSFilterSpec {
+
+  class Filters @Inject()(corsFilter: CORSFilter) extends HttpFilters {
+    def filters = Seq(corsFilter)
+  }
+
+}
+
+class CORSFilterSpec extends CORSCommonSpec {
+
+  def withApplication[T](conf: Map[String, _ <: Any] = Map.empty)(block: Application => T): T = {
+    running(_.configure(conf).overrides(
+      bind[Router].to(Router.from {
+        case p"/error" => Action { req => throw sys.error("error") }
+        case _ => Action(Results.Ok)
+      }),
+      bind[HttpFilters].to[CORSFilterSpec.Filters]
+    ))(block)
+  }
+
+  "The CORSFilter" should {
+
+    val restrictPaths = Map("play.filters.cors.pathPrefixes" -> Seq("/foo", "/bar"))
+
+    "pass through a cors request that doesn't match the path prefixes" in withApplication(conf = restrictPaths) { app =>
+      val result = route(app, fakeRequest("GET", "/baz").withHeaders(ORIGIN -> "http://localhost")).get
+
+      status(result) must_== OK
+      mustBeNoAccessControlResponseHeaders(result)
+    }
+
+    commonTests
+  }
+}

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSWithCSRFSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSWithCSRFSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.filters.cors
+
+import javax.inject.Inject
+
+import play.api.Application
+import play.api.http.{ ContentTypes, HttpFilters }
+import play.api.inject.bind
+import play.api.mvc.{ Action, Results }
+import play.api.routing.Router
+import play.api.routing.sird._
+import play.filters.csrf.{ CSRFCheck, CSRFFilter }
+
+object CORSWithCSRFSpec {
+
+  class Filters @Inject()(corsFilter: CORSFilter, csrfFilter: CSRFFilter) extends HttpFilters {
+    def filters = Seq(corsFilter, csrfFilter)
+  }
+
+  class FiltersWithoutCors @Inject()(csrfFilter: CSRFFilter) extends HttpFilters {
+    def filters = Seq(csrfFilter)
+  }
+
+}
+
+class CORSWithCSRFSpec extends CORSCommonSpec {
+
+  def withApp[T](filters: Class[_ <: HttpFilters] = classOf[CORSWithCSRFSpec.Filters], conf: Map[String, _ <: Any] = Map())(block: Application => T): T = {
+    running(_.configure(conf).overrides(
+      bind[Router].to(Router.from {
+        case p"/error" => Action { req => throw sys.error("error") }
+        case _ => CSRFCheck(Action(Results.Ok))
+      }),
+      bind[HttpFilters].to(filters)
+    ))(block)
+  }
+
+  def withApplication[T](conf: Map[String, _] = Map.empty)(block: Application => T) =
+    withApp(classOf[CORSWithCSRFSpec.Filters], conf)(block)
+
+  private def corsRequest =
+    fakeRequest("POST", "/baz")
+        .withHeaders(
+          ORIGIN -> "http://localhost",
+          CONTENT_TYPE -> ContentTypes.FORM,
+          COOKIE -> "foo=bar"
+        )
+        .withBody("foo=1&bar=2")
+
+  "The CORSFilter" should {
+
+    "Mark CORS requests so the CSRF filter will let them through" in withApp() { app =>
+      val result = route(app, corsRequest).get
+
+      status(result) must_== OK
+      header(ACCESS_CONTROL_ALLOW_ORIGIN, result) must beSome
+    }
+
+    "Forbid CSRF requests when CORS filter is not installed" in withApp(classOf[CORSWithCSRFSpec.FiltersWithoutCors]) { app =>
+      val result = route(app, corsRequest).get
+
+      status(result) must_== FORBIDDEN
+      header(ACCESS_CONTROL_ALLOW_ORIGIN, result) must beNone
+    }
+
+    commonTests
+  }
+}
+

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -23,7 +23,7 @@ import play.core.DefaultWebCommands
 /**
  * Specs for the global CSRF filter
  */
-object CSRFFilterSpec extends CSRFCommonSpecs {
+class CSRFFilterSpec extends CSRFCommonSpecs {
 
   sequential
 
@@ -204,10 +204,11 @@ object CSRFFilterSpec extends CSRFCommonSpecs {
       }
   }
 
-  class CustomErrorHandler extends CSRF.ErrorHandler {
-    import play.api.mvc.Results.Unauthorized
-    def handle(req: RequestHeader, msg: String) = Future.successful(Unauthorized(msg))
-  }
+}
+
+class CustomErrorHandler extends CSRF.ErrorHandler {
+  import play.api.mvc.Results.Unauthorized
+  def handle(req: RequestHeader, msg: String) = Future.successful(Unauthorized(msg))
 }
 
 class JavaErrorHandler extends CSRFErrorHandler {

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/ScalaCSRFActionSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/ScalaCSRFActionSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.Future
 /**
  * Specs for the Scala per action CSRF actions
  */
-object ScalaCSRFActionSpec extends CSRFCommonSpecs {
+class ScalaCSRFActionSpec extends CSRFCommonSpecs {
 
   def buildCsrfCheckRequest(sendUnauthorizedResult: Boolean, configuration: (String, String)*) = new CsrfTester {
     def apply[T](makeRequest: (WSRequest) => Future[WSResponse])(handleResponse: (WSResponse) => T) = withServer(configuration) {

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -23,7 +23,11 @@ import scala.concurrent.Future
 import scala.util.Random
 import org.specs2.matcher.DataTables
 
-object GzipFilterSpec extends PlaySpecification with DataTables {
+class Filters @Inject() (gzipFilter: GzipFilter) extends HttpFilters {
+  def filters = Seq(gzipFilter)
+}
+
+class GzipFilterSpec extends PlaySpecification with DataTables {
 
   sequential
 
@@ -136,10 +140,6 @@ object GzipFilterSpec extends PlaySpecification with DataTables {
       checkGzipped(result)
       header(VARY, result) must beSome.which(header => header.split(",").filter(_.toLowerCase(java.util.Locale.ENGLISH) == ACCEPT_ENCODING.toLowerCase(java.util.Locale.ENGLISH)).size == 1)
     }
-  }
-
-  class Filters @Inject() (gzipFilter: GzipFilter) extends HttpFilters {
-    def filters = Seq(gzipFilter)
   }
 
   def withApplication[T](result: Result, chunkedThreshold: Int = 1024)(block: Application => T): T = {

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
@@ -17,15 +17,15 @@ import play.api.Configuration
 import play.api.inject.bind
 import play.api.Application
 
-object SecurityHeadersFilterSpec extends PlaySpecification {
+class Filters @Inject() (securityHeadersFilter: SecurityHeadersFilter) extends HttpFilters {
+  def filters = Seq(securityHeadersFilter)
+}
+
+class SecurityHeadersFilterSpec extends PlaySpecification {
 
   import SecurityHeadersFilter._
 
   sequential
-
-  class Filters @Inject() (securityHeadersFilter: SecurityHeadersFilter) extends HttpFilters {
-    def filters = Seq(securityHeadersFilter)
-  }
 
   def configure(rawConfig: String) = {
     val typesafeConfig = ConfigFactory.parseString(rawConfig)

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/hosts/AllowedHostsFilterSpec.scala
@@ -19,7 +19,11 @@ import play.api.{ Application, Configuration }
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-object AllowedHostsFilterSpec extends PlaySpecification {
+class Filters @Inject() (allowedHostsFilter: AllowedHostsFilter) extends HttpFilters {
+  def filters = Seq(allowedHostsFilter)
+}
+
+class AllowedHostsFilterSpec extends PlaySpecification {
 
   sequential
 
@@ -31,10 +35,6 @@ object AllowedHostsFilterSpec extends PlaySpecification {
   }
 
   private val okWithHost = (req: RequestHeader) => Ok(req.host)
-
-  class Filters @Inject() (allowedHostsFilter: AllowedHostsFilter) extends HttpFilters {
-    def filters = Seq(allowedHostsFilter)
-  }
 
   def newApplication(result: RequestHeader => Result, config: String): Application = {
     new GuiceApplicationBuilder()

--- a/framework/src/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
@@ -16,7 +16,7 @@ import play.core.test.{ FakeRequest, Fakes }
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, Future }
 
-object HttpErrorHandlerSpec extends Specification {
+class HttpErrorHandlerSpec extends Specification {
 
   def await[T](future: Future[T]) = Await.result(future, Duration.Inf)
 
@@ -78,18 +78,18 @@ object HttpErrorHandlerSpec extends Specification {
       )).instanceOf[HttpErrorHandler]
   }
 
-  class CustomScalaErrorHandler extends HttpErrorHandler {
-    def onClientError(request: RequestHeader, statusCode: Int, message: String) =
-      Future.successful(Results.Ok)
-    def onServerError(request: RequestHeader, exception: Throwable) =
-      Future.successful(Results.Ok)
-  }
+}
 
-  class CustomJavaErrorHandler extends play.http.HttpErrorHandler {
-    def onClientError(req: play.mvc.Http.RequestHeader, status: Int, msg: String) =
-      CompletableFuture.completedFuture(play.mvc.Results.ok())
-    def onServerError(req: play.mvc.Http.RequestHeader, exception: Throwable) =
-      CompletableFuture.completedFuture(play.mvc.Results.ok())
-  }
+class CustomScalaErrorHandler extends HttpErrorHandler {
+  def onClientError(request: RequestHeader, statusCode: Int, message: String) =
+    Future.successful(Results.Ok)
+  def onServerError(request: RequestHeader, exception: Throwable) =
+    Future.successful(Results.Ok)
+}
 
+class CustomJavaErrorHandler extends play.http.HttpErrorHandler {
+  def onClientError(req: play.mvc.Http.RequestHeader, status: Int, msg: String) =
+    CompletableFuture.completedFuture(play.mvc.Results.ok())
+  def onServerError(req: play.mvc.Http.RequestHeader, exception: Throwable) =
+    CompletableFuture.completedFuture(play.mvc.Results.ok())
 }

--- a/framework/src/play-guice/src/test/scala/play/utils/ReflectSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/utils/ReflectSpec.scala
@@ -12,7 +12,7 @@ import play.api.{ Configuration, Environment, PlayException }
 
 import scala.reflect.ClassTag
 
-object ReflectSpec extends Specification {
+class ReflectSpec extends Specification {
 
   "Reflect" should {
 
@@ -62,36 +62,6 @@ object ReflectSpec extends Specification {
     bindings(configured, implicitly[ClassTag[Default]].runtimeClass.getName)
   }
 
-  trait Duck {
-    def quack: String
-  }
-
-  trait JavaDuck {
-    def getQuack: String
-  }
-
-  class JavaDuckAdapter @Inject() (underlying: JavaDuck) extends Duck {
-    def quack = underlying.getQuack
-  }
-
-  class DefaultDuck extends Duck {
-    def quack = "quack"
-  }
-
-  class CustomDuck extends Duck {
-    def quack = "custom quack"
-  }
-
-  class CustomJavaDuck extends JavaDuck {
-    def getQuack = "java quack"
-  }
-
-  class JavaDuckDelegate @Inject() (delegate: Duck) extends JavaDuck {
-    def getQuack = delegate.quack
-  }
-
-  class NotADuck
-
   def doQuack(bindings: Seq[Binding[_]]): String = {
     val injector = new GuiceInjectorBuilder().bindings(bindings).injector
     val duck = injector.instanceOf[Duck]
@@ -104,3 +74,33 @@ object ReflectSpec extends Specification {
   }
 
 }
+
+trait Duck {
+  def quack: String
+}
+
+trait JavaDuck {
+  def getQuack: String
+}
+
+class JavaDuckAdapter @Inject() (underlying: JavaDuck) extends Duck {
+  def quack = underlying.getQuack
+}
+
+class DefaultDuck extends Duck {
+  def quack = "quack"
+}
+
+class CustomDuck extends Duck {
+  def quack = "custom quack"
+}
+
+class CustomJavaDuck extends JavaDuck {
+  def getQuack = "java quack"
+}
+
+class JavaDuckDelegate @Inject() (delegate: Duck) extends JavaDuck {
+  def getQuack = delegate.quack
+}
+
+class NotADuck

--- a/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecificationSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecificationSpec.scala
@@ -8,11 +8,11 @@ import play.api.mvc._
 import play.api.mvc.Results._
 import play.api.test._
 
-object NettyServerIntegrationSpecificationSpec extends ServerIntegrationSpecificationSpec with NettyIntegrationSpecification {
+class NettyServerIntegrationSpecificationSpec extends ServerIntegrationSpecificationSpec with NettyIntegrationSpecification {
   override def isAkkaHttpServer = false
   override def expectedServerTag = None
 }
-object AkkaHttpServerIntegrationSpecificationSpec extends ServerIntegrationSpecificationSpec with AkkaHttpIntegrationSpecification {
+class AkkaHttpServerIntegrationSpecificationSpec extends ServerIntegrationSpecificationSpec with AkkaHttpIntegrationSpecification {
   override def isAkkaHttpServer = true
   override def expectedServerTag = Some("akka-http")
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/ContentNegotiationSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/ContentNegotiationSpec.scala
@@ -7,7 +7,7 @@ import play.api.test.{ FakeRequest, PlaySpecification }
 import play.api.mvc.{ Action, Controller }
 import scala.concurrent.Future
 
-object ContentNegotiationSpec extends PlaySpecification with Controller {
+class ContentNegotiationSpec extends PlaySpecification with Controller {
 
   "rendering" should {
     "work with simple results" in {

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/EssentialActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/EssentialActionSpec.scala
@@ -10,7 +10,7 @@ import play.api.test.{ FakeRequest, PlaySpecification }
 
 import scala.concurrent.Promise
 
-object EssentialActionSpec extends PlaySpecification {
+class EssentialActionSpec extends PlaySpecification {
 
   "an EssentialAction" should {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
@@ -22,8 +22,8 @@ import play.it.tools.HttpBinApplication._
 import scala.concurrent.ExecutionContext.Implicits.global
 import org.asynchttpclient.netty.NettyResponse
 
-object NettyHeadActionSpec extends HeadActionSpec with NettyIntegrationSpecification
-object AkkaHttpHeadActionSpec extends HeadActionSpec with AkkaHttpIntegrationSpecification
+class NettyHeadActionSpec extends HeadActionSpec with NettyIntegrationSpecification
+class AkkaHttpHeadActionSpec extends HeadActionSpec with AkkaHttpIntegrationSpecification
 
 trait HeadActionSpec extends Specification with FutureAwaits with DefaultAwaitTimeout with ServerIntegrationSpecification {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
@@ -10,7 +10,7 @@ import play.api.mvc._
 import scala.concurrent.Future
 import play.api.test.FakeApplication
 
-object SecuritySpec extends PlaySpecification {
+class SecuritySpec extends PlaySpecification {
 
   "AuthenticatedBuilder" should {
     "block unauthenticated requests" in withApplication {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
@@ -12,8 +12,8 @@ import play.it._
 import scala.concurrent.Future
 import scala.util.Random
 
-object NettyBadClientHandlingSpec extends BadClientHandlingSpec with NettyIntegrationSpecification
-object AkkaHttpBadClientHandlingSpec extends BadClientHandlingSpec with AkkaHttpIntegrationSpecification
+class NettyBadClientHandlingSpec extends BadClientHandlingSpec with NettyIntegrationSpecification
+class AkkaHttpBadClientHandlingSpec extends BadClientHandlingSpec with AkkaHttpIntegrationSpecification
 
 trait BadClientHandlingSpec extends PlaySpecification with ServerIntegrationSpecification {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/Expect100ContinueSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/Expect100ContinueSpec.scala
@@ -9,8 +9,8 @@ import play.it._
 import play.api.mvc._
 import play.api.test._
 
-object NettyExpect100ContinueSpec extends Expect100ContinueSpec with NettyIntegrationSpecification
-object AkkaHttpExpect100ContinueSpec extends Expect100ContinueSpec with AkkaHttpIntegrationSpecification
+class NettyExpect100ContinueSpec extends Expect100ContinueSpec with NettyIntegrationSpecification
+class AkkaHttpExpect100ContinueSpec extends Expect100ContinueSpec with AkkaHttpIntegrationSpecification
 
 trait Expect100ContinueSpec extends PlaySpecification with ServerIntegrationSpecification {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
@@ -11,8 +11,8 @@ import play.api.libs.ws.{ WSClient, WSCookie, WSResponse }
 import play.core.server.Server
 import play.it._
 
-object NettyFlashCookieSpec extends FlashCookieSpec with NettyIntegrationSpecification
-object AkkaHttpFlashCookieSpec extends FlashCookieSpec with AkkaHttpIntegrationSpecification
+class NettyFlashCookieSpec extends FlashCookieSpec with NettyIntegrationSpecification
+class AkkaHttpFlashCookieSpec extends FlashCookieSpec with AkkaHttpIntegrationSpecification
 
 trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecification with WsTestClient {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FormFieldOrderSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FormFieldOrderSpec.scala
@@ -12,8 +12,8 @@ import play.api.test._
 import play.api.libs.ws._
 import play.it._
 
-object NettyFormFieldOrderSpec extends FormFieldOrderSpec with NettyIntegrationSpecification
-object AkkaHttpFormFieldOrderSpec extends FormFieldOrderSpec with AkkaHttpIntegrationSpecification
+class NettyFormFieldOrderSpec extends FormFieldOrderSpec with NettyIntegrationSpecification
+class AkkaHttpFormFieldOrderSpec extends FormFieldOrderSpec with AkkaHttpIntegrationSpecification
 
 trait FormFieldOrderSpec extends PlaySpecification with ServerIntegrationSpecification {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/HttpPipeliningSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/HttpPipeliningSpec.scala
@@ -15,8 +15,8 @@ import akka.pattern.after
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-object NettyHttpPipeliningSpec extends HttpPipeliningSpec with NettyIntegrationSpecification
-object AkkaHttpHttpPipeliningSpec extends HttpPipeliningSpec with AkkaHttpIntegrationSpecification
+class NettyHttpPipeliningSpec extends HttpPipeliningSpec with NettyIntegrationSpecification
+class AkkaHttpHttpPipeliningSpec extends HttpPipeliningSpec with AkkaHttpIntegrationSpecification
 
 trait HttpPipeliningSpec extends PlaySpecification with ServerIntegrationSpecification {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
@@ -21,9 +21,9 @@ import scala.concurrent.ExecutionContext.Implicits._
 import scala.util.Random
 import scala.collection.JavaConverters._
 
-object NettyIdleTimeoutSpec extends IdleTimeoutSpec with NettyIntegrationSpecification
+class NettyIdleTimeoutSpec extends IdleTimeoutSpec with NettyIntegrationSpecification
 
-object AkkaIdleTimeoutSpec extends IdleTimeoutSpec with AkkaHttpIntegrationSpecification
+class AkkaIdleTimeoutSpec extends IdleTimeoutSpec with AkkaHttpIntegrationSpecification
 
 trait IdleTimeoutSpec extends PlaySpecification with ServerIntegrationSpecification {
   val httpsPort = 9443

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -10,7 +10,7 @@ import play.api.test.{PlaySpecification, TestServer, WsTestClient}
 import play.it.http.ActionCompositionOrderTest.{ActionAnnotation, ControllerAnnotation, WithUsername}
 import play.mvc.{Result, Results}
 
-object JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
+class JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
 
   def makeRequest[T](controller: MockController, configuration: Map[String, _ <: Any] = Map.empty)(block: WSResponse => T) = {
     implicit val port = testServerPort

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -17,8 +17,8 @@ import play.it._
 import play.libs.{ Comet, EventSource, Json }
 import play.mvc.{ Http, Results }
 
-object NettyJavaResultsHandlingSpec extends JavaResultsHandlingSpec with NettyIntegrationSpecification
-object AkkaHttpJavaResultsHandlingSpec extends JavaResultsHandlingSpec with AkkaHttpIntegrationSpecification
+class NettyJavaResultsHandlingSpec extends JavaResultsHandlingSpec with NettyIntegrationSpecification
+class AkkaHttpJavaResultsHandlingSpec extends JavaResultsHandlingSpec with AkkaHttpIntegrationSpecification
 
 trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
@@ -16,8 +16,8 @@ import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.Future
 import scala.util.Random
 
-object NettyRequestBodyHandlingSpec extends RequestBodyHandlingSpec with NettyIntegrationSpecification
-object AkkaHttpRequestBodyHandlingSpec extends RequestBodyHandlingSpec with AkkaHttpIntegrationSpecification
+class NettyRequestBodyHandlingSpec extends RequestBodyHandlingSpec with NettyIntegrationSpecification
+class AkkaHttpRequestBodyHandlingSpec extends RequestBodyHandlingSpec with AkkaHttpIntegrationSpecification
 
 trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSpecification {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -23,8 +23,8 @@ import scala.util.Try
 import scala.concurrent.Future
 import play.api.http.{ HttpEntity, HttpChunk, Status }
 
-object NettyScalaResultsHandlingSpec extends ScalaResultsHandlingSpec with NettyIntegrationSpecification
-object AkkaHttpScalaResultsHandlingSpec extends ScalaResultsHandlingSpec with AkkaHttpIntegrationSpecification
+class NettyScalaResultsHandlingSpec extends ScalaResultsHandlingSpec with NettyIntegrationSpecification
+class AkkaHttpScalaResultsHandlingSpec extends ScalaResultsHandlingSpec with AkkaHttpIntegrationSpecification
 
 trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
@@ -8,7 +8,7 @@ import play.api.test._
 import play.api.mvc._
 import play.api.mvc.Results._
 
-object ScalaResultsSpec extends PlaySpecification {
+class ScalaResultsSpec extends PlaySpecification {
 
   "support session helper" in withApplication() {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/SecureFlagSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/SecureFlagSpec.scala
@@ -14,8 +14,8 @@ import java.security.cert.X509Certificate
 import scala.io.Source
 import java.net.URL
 
-object NettySecureFlagSpec extends SecureFlagSpec with NettyIntegrationSpecification
-object AkkaHttpSecureFlagSpec extends SecureFlagSpec with AkkaHttpIntegrationSpecification
+class NettySecureFlagSpec extends SecureFlagSpec with NettyIntegrationSpecification
+class AkkaHttpSecureFlagSpec extends SecureFlagSpec with AkkaHttpIntegrationSpecification
 
 /**
  * Specs for the "secure" flag on requests

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
@@ -13,8 +13,8 @@ import play.api.Mode
 import play.core.server.{ ServerConfig, Server }
 import play.it._
 
-object NettyAssetsSpec extends AssetsSpec with NettyIntegrationSpecification
-object AkkaHttpAssetsSpec extends AssetsSpec with AkkaHttpIntegrationSpecification
+class NettyAssetsSpec extends AssetsSpec with NettyIntegrationSpecification
+class AkkaHttpAssetsSpec extends AssetsSpec with AkkaHttpIntegrationSpecification
 
 trait AssetsSpec extends PlaySpecification
     with WsTestClient with ServerIntegrationSpecification {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/AnyContentBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/AnyContentBodyParserSpec.scala
@@ -9,7 +9,7 @@ import akka.util.ByteString
 import play.api.mvc._
 import play.api.test._
 
-object AnyContentBodyParserSpec extends PlaySpecification {
+class AnyContentBodyParserSpec extends PlaySpecification {
 
   "The anyContent body parser" should {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/BodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/BodyParserSpec.scala
@@ -17,7 +17,7 @@ import play.api.test.{ FakeRequest, PlaySpecification }
 import org.specs2.ScalaCheck
 import org.scalacheck.{ Arbitrary, Gen }
 
-object BodyParserSpec extends PlaySpecification with ScalaCheck {
+class BodyParserSpec extends PlaySpecification with ScalaCheck {
 
   def run[A](bodyParser: BodyParser[A]) = {
     import scala.concurrent.ExecutionContext.Implicits.global

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/DefaultBodyParserSpec.scala
@@ -9,7 +9,7 @@ import akka.util.ByteString
 import play.api.mvc._
 import play.api.test._
 
-object DefaultBodyParserSpec extends PlaySpecification {
+class DefaultBodyParserSpec extends PlaySpecification {
 
   "The default body parser" should {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/EmptyBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/EmptyBodyParserSpec.scala
@@ -9,7 +9,7 @@ import akka.util.ByteString
 import play.api.test._
 import play.api.mvc.BodyParsers
 
-object EmptyBodyParserSpec extends PlaySpecification {
+class EmptyBodyParserSpec extends PlaySpecification {
 
   "The empty body parser" should {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/IgnoreBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/IgnoreBodyParserSpec.scala
@@ -9,7 +9,7 @@ import akka.util.ByteString
 import play.api.test._
 import play.api.mvc.BodyParsers
 
-object IgnoreBodyParserSpec extends PlaySpecification {
+class IgnoreBodyParserSpec extends PlaySpecification {
 
   "The ignore body parser" should {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/JsonBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/JsonBodyParserSpec.scala
@@ -11,7 +11,7 @@ import play.api.mvc.Results.BadRequest
 import play.api.mvc.{ BodyParser, BodyParsers }
 import play.api.test._
 
-object JsonBodyParserSpec extends PlaySpecification {
+class JsonBodyParserSpec extends PlaySpecification {
 
   private case class Foo(a: Int, b: String)
   private implicit val fooFormat = Json.format[Foo]

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -11,7 +11,7 @@ import play.api.test._
 import play.core.parsers.Multipart.FileInfoMatcher
 import play.utils.PlayIO
 
-object MultipartFormDataParserSpec extends PlaySpecification {
+class MultipartFormDataParserSpec extends PlaySpecification {
 
   val body =
     """

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/TextBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/TextBodyParserSpec.scala
@@ -9,7 +9,7 @@ import akka.util.ByteString
 import play.api.test._
 import play.api.mvc.{ BodyParser, BodyParsers }
 
-object TextBodyParserSpec extends PlaySpecification {
+class TextBodyParserSpec extends PlaySpecification {
 
   "The text body parser" should {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/XmlBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/XmlBodyParserSpec.scala
@@ -12,7 +12,7 @@ import scala.xml.NodeSeq
 import java.io.File
 import org.apache.commons.io.FileUtils
 
-object XmlBodyParserSpec extends PlaySpecification {
+class XmlBodyParserSpec extends PlaySpecification {
 
   "The XML body parser" should {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -25,8 +25,8 @@ import scala.concurrent.duration._
 import scala.concurrent.{Future, Promise}
 import scala.reflect.ClassTag
 
-object NettyWebSocketSpec extends WebSocketSpec with NettyIntegrationSpecification
-object AkkaHttpWebSocketSpec extends WebSocketSpec with AkkaHttpIntegrationSpecification
+class NettyWebSocketSpec extends WebSocketSpec with NettyIntegrationSpecification
+class AkkaHttpWebSocketSpec extends WebSocketSpec with AkkaHttpIntegrationSpecification
 
 trait WebSocketSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
@@ -8,7 +8,7 @@ import play.api.mvc.Controller
 import play.api.i18n._
 import play.api.Mode
 
-object MessagesSpec extends PlaySpecification with Controller {
+class MessagesSpec extends PlaySpecification with Controller {
 
   sequential
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/JavaFormSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/JavaFormSpec.scala
@@ -11,7 +11,7 @@ import scala.annotation.meta.field
 import scala.beans.BeanProperty
 import scala.collection.JavaConverters._
 
-object JavaFormSpec extends PlaySpecification {
+class JavaFormSpec extends PlaySpecification {
 
   "A Java form" should {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
@@ -27,9 +27,9 @@ import play.mvc.Http
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 
-object NettyWSSpec extends WSSpec with NettyIntegrationSpecification
+class NettyWSSpec extends WSSpec with NettyIntegrationSpecification
 
-object AkkaHttpWSSpec extends WSSpec with AkkaHttpIntegrationSpecification
+class AkkaHttpWSSpec extends WSSpec with AkkaHttpIntegrationSpecification
 
 trait WSSpec extends PlaySpecification with ServerIntegrationSpecification {
 
@@ -203,9 +203,9 @@ trait WSSpec extends PlaySpecification with ServerIntegrationSpecification {
     }
 
     "sending a multipart form body" in withServer { ws =>
-      val file = new File(this.getClass.getResource("/testassets/bar.txt").toURI)
+      val file = new File(this.getClass.getResource("/testassets/bar.txt").toURI).toPath
       val dp = new Http.MultipartFormData.DataPart("hello", "world")
-      val fp = new Http.MultipartFormData.FilePart("upload", "bar.txt", "text/plain", FileIO.fromFile(file).asJava)
+      val fp = new Http.MultipartFormData.FilePart("upload", "bar.txt", "text/plain", FileIO.fromPath(file).asJava)
       val source = akka.stream.javadsl.Source.from(util.Arrays.asList(dp, fp))
 
       val res = ws.url("/post").post(source)
@@ -345,9 +345,9 @@ trait WSSpec extends PlaySpecification with ServerIntegrationSpecification {
     }
 
     "send a multipart request body" in withServer { ws =>
-      val file = new File(this.getClass.getResource("/testassets/foo.txt").toURI)
+      val file = new File(this.getClass.getResource("/testassets/foo.txt").toURI).toPath
       val dp = MultipartFormData.DataPart("hello", "world")
-      val fp = MultipartFormData.FilePart("upload", "foo.txt", None, FileIO.fromFile(file))
+      val fp = MultipartFormData.FilePart("upload", "foo.txt", None, FileIO.fromPath(file))
       val source = Source(List(dp, fp))
       val res = ws.url("/post").post(source)
       val body = await(res).json

--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -20,8 +20,8 @@ import scala.concurrent.duration.Duration
 import scala.concurrent._
 import play.api.libs.concurrent.Execution.{ defaultContext => ec }
 
-object NettyDefaultFiltersSpec extends DefaultFiltersSpec with NettyIntegrationSpecification
-object AkkaDefaultHttpFiltersSpec extends DefaultFiltersSpec with AkkaHttpIntegrationSpecification
+class NettyDefaultFiltersSpec extends DefaultFiltersSpec with NettyIntegrationSpecification
+class AkkaDefaultHttpFiltersSpec extends DefaultFiltersSpec with AkkaHttpIntegrationSpecification
 
 trait DefaultFiltersSpec extends FiltersSpec {
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/HttpSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/HttpSpec.scala
@@ -6,7 +6,7 @@ package play.api.mvc
 import play.api.http.HeaderNames
 import play.api.test.FakeRequest
 
-object HttpSpec extends org.specs2.mutable.Specification {
+class HttpSpec extends org.specs2.mutable.Specification {
 
   title("HTTP")
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/views/DevErrorPageSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/views/DevErrorPageSpec.scala
@@ -7,7 +7,7 @@ import play.api.{ Configuration, Environment, Mode }
 import play.api.http.DefaultHttpErrorHandler
 import play.api.test._
 
-object DevErrorPageSpec extends PlaySpecification {
+class DevErrorPageSpec extends PlaySpecification {
 
   "devError.scala.html" should {
 

--- a/framework/src/play-java-jdbc/src/test/scala/play/db/DBSpec.scala
+++ b/framework/src/play-java-jdbc/src/test/scala/play/db/DBSpec.scala
@@ -6,7 +6,7 @@ package play.db
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeApplication
 
-object DBSpec extends org.specs2.mutable.Specification {
+class DBSpec extends org.specs2.mutable.Specification {
 
   title("Java DB utility")
 

--- a/framework/src/play-java-ws/src/test/scala/play/libs/ws/WSSpec.scala
+++ b/framework/src/play-java-ws/src/test/scala/play/libs/ws/WSSpec.scala
@@ -10,7 +10,7 @@ import play.api.test._
 import play.libs.ws.ahc.{ AhcWSRequest, AhcWSClient }
 import play.test.WithApplication
 
-object WSSpec extends PlaySpecification {
+class WSSpec extends PlaySpecification {
 
   sequential
 

--- a/framework/src/play-java-ws/src/test/scala/play/libs/ws/ahc/AhcWSResponseSpec.scala
+++ b/framework/src/play-java-ws/src/test/scala/play/libs/ws/ahc/AhcWSResponseSpec.scala
@@ -14,7 +14,7 @@ import org.specs2.mutable._
 
 import org.asynchttpclient.{ Response }
 
-object AhcWSResponseSpec extends Specification with Mockito {
+class AhcWSResponseSpec extends Specification with Mockito {
 
   private val emptyMap = new java.util.HashMap[String, java.util.Collection[String]]
 

--- a/framework/src/play-java/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/DynamicFormSpec.scala
@@ -7,7 +7,7 @@ import com.typesafe.config.ConfigFactory
 import org.specs2.mutable.Specification
 import play.api.{ Configuration, Environment }
 import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
-import play.data.format.Formatters;
+import play.data.format.Formatters
 import views.html.helper.inputText
 import play.core.j.PlayMagicForJava.javaFieldtoScalaField
 import views.html.helper.FieldConstructor.defaultField
@@ -17,7 +17,7 @@ import javax.validation.Validation
 /**
  * Specs for Java dynamic forms
  */
-object DynamicFormSpec extends Specification {
+class DynamicFormSpec extends Specification {
   val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
   implicit val messages = messagesApi.preferred(Seq.empty)
   val jMessagesApi = new play.i18n.MessagesApi(messagesApi)

--- a/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
@@ -20,7 +20,7 @@ import play.twirl.api.Html
 import javax.validation.groups.Default
 import javax.validation.Validation
 
-object FormSpec extends Specification {
+class FormSpec extends Specification {
 
   val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
   val jMessagesApi = new play.i18n.MessagesApi(messagesApi)
@@ -28,21 +28,21 @@ object FormSpec extends Specification {
 
   "a java form" should {
     "be valid" in {
-      val req = dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "done" -> Array("true"), "dueDate" -> Array("15/12/2009")))
+      val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "done" -> Array("true"), "dueDate" -> Array("15/12/2009")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
     }
     "be valid with mandatory params passed" in {
-      val req = dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009")))
+      val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
     }
     "have an error due to badly formatted date" in new WithApplication() {
-      val req = dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
+      val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
@@ -57,14 +57,14 @@ object FormSpec extends Specification {
       myForm.value().get().getName() must beEqualTo("peter")
     }
     "throws an exception when trying to access value of invalid form via get()" in new WithApplication() {
-      val req = dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
+      val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm.get must throwAn[IllegalStateException]
     }
     "allow to access the value of an invalid form even when not even one valid value was supplied" in new WithApplication() {
-      val req = dummyRequest(Map("id" -> Array("notAnInt"), "dueDate" -> Array("2009/11e/11")))
+      val req = FormSpec.dummyRequest(Map("id" -> Array("notAnInt"), "dueDate" -> Array("2009/11e/11")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
@@ -72,7 +72,7 @@ object FormSpec extends Specification {
       myForm.value().get().getName() must_== null
     }
     "have an error due to badly formatted date after using setTransientLang" in new WithApplication(GuiceApplicationBuilder().configure("play.i18n.langs" -> Seq("en", "en-US", "fr")).build()) {
-      val req = dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
+      val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       Context.current.get().setTransientLang("fr");
@@ -86,7 +86,7 @@ object FormSpec extends Specification {
       myForm.errors.get("dueDate").get(0).message() must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
     }
     "have an error due to badly formatted date after using changeLang" in new WithApplication(GuiceApplicationBuilder().configure("play.i18n.langs" -> Seq("en", "en-US", "fr")).build()) {
-      val req = dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
+      val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       Context.current.get().changeLang("fr");
@@ -100,7 +100,7 @@ object FormSpec extends Specification {
       myForm.errors.get("dueDate").get(0).message() must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
     }
     "have an error due to missing required value" in new WithApplication() {
-      val req = dummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter")))
+      val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
@@ -108,7 +108,7 @@ object FormSpec extends Specification {
       myForm.errors.get("dueDate").get(0).messages().asScala must contain("error.required")
     }
     "have an error due to bad value in Id field" in new WithApplication() {
-      val req = dummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter"), "dueDate" -> Array("12/12/2009")))
+      val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891x"), "name" -> Array("peter"), "dueDate" -> Array("12/12/2009")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
@@ -116,14 +116,14 @@ object FormSpec extends Specification {
       myForm.errors.get("id").get(0).messages().asScala must contain("error.invalid")
     }
     "be valid with default date binder" in {
-      val req = dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009"), "endDate" -> Array("2008-11-21")))
+      val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009"), "endDate" -> Array("2008-11-21")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
     }
     "have an error due to badly formatted date for default date binder" in new WithApplication() {
-      val req = dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009"), "endDate" -> Array("2008-11e-21")))
+      val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009"), "endDate" -> Array("2008-11e-21")))
       Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava))
 
       val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
@@ -133,23 +133,23 @@ object FormSpec extends Specification {
 
     "support repeated values for Java binding" in {
 
-      val user1 = formFactory.form(classOf[AnotherUser]).bindFromRequest(dummyRequest(Map("name" -> Array("Kiki")))).get
+      val user1 = formFactory.form(classOf[AnotherUser]).bindFromRequest(FormSpec.dummyRequest(Map("name" -> Array("Kiki")))).get
       user1.getName must beEqualTo("Kiki")
       user1.getEmails.size must beEqualTo(0)
 
-      val user2 = formFactory.form(classOf[AnotherUser]).bindFromRequest(dummyRequest(Map("name" -> Array("Kiki"), "emails[0]" -> Array("kiki@gmail.com")))).get
+      val user2 = formFactory.form(classOf[AnotherUser]).bindFromRequest(FormSpec.dummyRequest(Map("name" -> Array("Kiki"), "emails[0]" -> Array("kiki@gmail.com")))).get
       user2.getName must beEqualTo("Kiki")
       user2.getEmails.size must beEqualTo(1)
 
-      val user3 = formFactory.form(classOf[AnotherUser]).bindFromRequest(dummyRequest(Map("name" -> Array("Kiki"), "emails[0]" -> Array("kiki@gmail.com"), "emails[1]" -> Array("kiki@zen.com")))).get
+      val user3 = formFactory.form(classOf[AnotherUser]).bindFromRequest(FormSpec.dummyRequest(Map("name" -> Array("Kiki"), "emails[0]" -> Array("kiki@gmail.com"), "emails[1]" -> Array("kiki@zen.com")))).get
       user3.getName must beEqualTo("Kiki")
       user3.getEmails.size must beEqualTo(2)
 
-      val user4 = formFactory.form(classOf[AnotherUser]).bindFromRequest(dummyRequest(Map("name" -> Array("Kiki"), "emails[]" -> Array("kiki@gmail.com")))).get
+      val user4 = formFactory.form(classOf[AnotherUser]).bindFromRequest(FormSpec.dummyRequest(Map("name" -> Array("Kiki"), "emails[]" -> Array("kiki@gmail.com")))).get
       user4.getName must beEqualTo("Kiki")
       user4.getEmails.size must beEqualTo(1)
 
-      val user5 = formFactory.form(classOf[AnotherUser]).bindFromRequest(dummyRequest(Map("name" -> Array("Kiki"), "emails[]" -> Array("kiki@gmail.com", "kiki@zen.com")))).get
+      val user5 = formFactory.form(classOf[AnotherUser]).bindFromRequest(FormSpec.dummyRequest(Map("name" -> Array("Kiki"), "emails[]" -> Array("kiki@gmail.com", "kiki@zen.com")))).get
       user5.getName must beEqualTo("Kiki")
       user5.getEmails.size must beEqualTo(2)
 
@@ -171,10 +171,10 @@ object FormSpec extends Specification {
     }
 
     "support optional deserialization of a request" in {
-      val user1 = formFactory.form(classOf[AnotherUser]).bindFromRequest(dummyRequest(Map("name" -> Array("Kiki")))).get
+      val user1 = formFactory.form(classOf[AnotherUser]).bindFromRequest(FormSpec.dummyRequest(Map("name" -> Array("Kiki")))).get
       user1.getCompany.isPresent must beEqualTo(false)
 
-      val user2 = formFactory.form(classOf[AnotherUser]).bindFromRequest(dummyRequest(Map("name" -> Array("Kiki"), "company" -> Array("Acme")))).get
+      val user2 = formFactory.form(classOf[AnotherUser]).bindFromRequest(FormSpec.dummyRequest(Map("name" -> Array("Kiki"), "company" -> Array("Acme")))).get
       user2.getCompany.get must beEqualTo("Acme")
     }
 
@@ -420,6 +420,10 @@ object FormSpec extends Specification {
       }
     }
   }
+
+}
+
+object FormSpec {
 
   def dummyRequest(data: Map[String, Array[String]]): Request = {
     new RequestBuilder()

--- a/framework/src/play-java/src/test/scala/play/libs/XPathSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/libs/XPathSpec.scala
@@ -6,7 +6,7 @@ package play.libs
 import org.specs2.mutable.Specification
 import scala.collection.JavaConverters._
 
-object XPathSpec extends Specification {
+class XPathSpec extends Specification {
   //XPathFactory.newInstance() used internally by XPath is not thread safe so forcing sequential execution
   sequential
 

--- a/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/DefaultEvolutionsConfigParserSpec.scala
+++ b/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/DefaultEvolutionsConfigParserSpec.scala
@@ -6,7 +6,7 @@ package play.api.db.evolutions
 import org.specs2.mutable.Specification
 import play.api.Configuration
 
-object DefaultEvolutionsConfigParserSpec extends Specification {
+class DefaultEvolutionsConfigParserSpec extends Specification {
 
   def parse(config: (String, Any)*): EvolutionsConfig = {
     new DefaultEvolutionsConfigParser(Configuration.reference ++ Configuration.from(config.toMap)).get

--- a/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsReaderSpec.scala
+++ b/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsReaderSpec.scala
@@ -7,7 +7,7 @@ import java.io.File
 import org.specs2.mutable.Specification
 import play.api.{ Environment, Mode }
 
-object EvolutionsReaderSpec extends Specification {
+class EvolutionsReaderSpec extends Specification {
 
   "EnvironmentEvolutionsReader" should {
 

--- a/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsSpec.scala
+++ b/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/EvolutionsSpec.scala
@@ -10,7 +10,7 @@ import play.api.db.{ Database, Databases }
 
 // TODO: fuctional test with InvalidDatabaseRevision exception
 
-object EvolutionsSpec extends Specification {
+class EvolutionsSpec extends Specification {
 
   sequential
 

--- a/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/ScriptSpec.scala
+++ b/framework/src/play-jdbc-evolutions/src/test/scala/play/api/db/evolutions/ScriptSpec.scala
@@ -5,7 +5,7 @@ package play.api.db.evolutions
 
 import org.specs2.mutable.Specification
 
-object ScriptSpec extends Specification {
+class ScriptSpec extends Specification {
   "Script.statements" should {
 
     "separate SQL into semicolon-delimited statements" in {

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/DatabasesSpec.scala
@@ -8,7 +8,7 @@ import com.zaxxer.hikari.HikariDataSource
 import org.jdbcdslog.LogSqlDataSource
 import org.specs2.mutable.{ After, Specification }
 
-object DatabasesSpec extends Specification {
+class DatabasesSpec extends Specification {
 
   "Databases" should {
 

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/DriverRegistrationSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/DriverRegistrationSpec.scala
@@ -9,7 +9,7 @@ import org.specs2.mutable.Specification
 import play.api.Configuration
 import scala.util.Try
 
-object DriverRegistrationSpec extends Specification {
+class DriverRegistrationSpec extends Specification {
 
   sequential
 

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsObjectSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsObjectSpec.scala
@@ -6,7 +6,7 @@ package play.api.libs.json
 import org.specs2.mutable._
 import play.api.libs.json.Json._
 
-object JsObjectSpec extends Specification {
+class JsObjectSpec extends Specification {
 
   "JsObject.deepMerge" should {
     "not fail when the objects are empty" in {

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsPathSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsPathSpec.scala
@@ -12,7 +12,7 @@ import java.text.ParseException
 
 import play.api.data.validation.ValidationError
 
-object JsPathSpec extends Specification {
+class JsPathSpec extends Specification {
 
   "JsPath" should {
     "retrieve simple path" in {

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsResultSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsResultSpec.scala
@@ -7,7 +7,7 @@ import play.api.libs.functional.Functor
 
 import JsResult.functorJsResult
 
-object JsResultSpec extends org.specs2.mutable.Specification {
+class JsResultSpec extends org.specs2.mutable.Specification {
 
   title("JSON result")
 

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala
@@ -76,7 +76,7 @@ object CustomApply {
   def apply(): CustomApply = apply(10, "foo")
 }
 
-object JsonExtensionSpec extends Specification {
+class JsonExtensionSpec extends Specification {
 
   "JsonExtension" should {
     "create a reads[User]" in {

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonRichSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonRichSpec.scala
@@ -10,7 +10,7 @@ import play.api.libs.json.Json._
 import scala.util.control.Exception._
 import java.text.ParseException
 
-object JsonRichSpec extends Specification {
+class JsonRichSpec extends Specification {
 
   "JSON" should {
     "create json with rich syntax" in {

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -11,7 +11,7 @@ import play.api.libs.json.Json._
 
 import scala.collection.immutable.ListMap
 
-object JsonSpec extends org.specs2.mutable.Specification {
+class JsonSpec extends org.specs2.mutable.Specification {
 
   title("JSON")
 

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonTransSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonTransSpec.scala
@@ -14,7 +14,7 @@ import play.api.libs.json.util._
 import play.api.libs.json.Reads._
 import play.api.libs.functional.syntax._
 
-object JsonTransSpec extends Specification {
+class JsonTransSpec extends Specification {
   "JSON transformers " should {
     val js = Json.obj(
       "field1" -> "alpha",

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
@@ -11,7 +11,7 @@ import java.text.ParseException
 import play.api.data.validation.ValidationError
 import play.api.libs.functional.syntax._
 
-object JsonValidSpec extends Specification {
+class JsonValidSpec extends Specification {
   "JSON reads" should {
     "validate simple types" in {
       JsString("string").validate[String] must equalTo(JsSuccess("string"))

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/ReadsSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/ReadsSpec.scala
@@ -17,7 +17,7 @@ import java.time.{
 import java.time.format.DateTimeFormatter
 import play.api.data.validation.ValidationError
 
-object ReadsSpec extends org.specs2.mutable.Specification {
+class ReadsSpec extends org.specs2.mutable.Specification {
 
   title("JSON Reads")
 

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/WritesSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/WritesSpec.scala
@@ -13,7 +13,7 @@ import java.time.{
 }
 import java.time.format.DateTimeFormatter
 
-object WritesSpec extends org.specs2.mutable.Specification {
+class WritesSpec extends org.specs2.mutable.Specification {
 
   title("JSON Writes")
 

--- a/framework/src/play-netty-server/src/test/scala/play/core/server/netty/NettyHeadersWrapperSpec.scala
+++ b/framework/src/play-netty-server/src/test/scala/play/core/server/netty/NettyHeadersWrapperSpec.scala
@@ -7,7 +7,7 @@ import io.netty.handler.codec.http.DefaultHttpHeaders
 import org.specs2.mutable._
 import play.api.mvc._
 
-object NettyHeadersWrapperSpec extends Specification {
+class NettyHeadersWrapperSpec extends Specification {
 
   val headers: Headers = {
     val nettyHeaders = new DefaultHttpHeaders()

--- a/framework/src/play-server/src/test/scala/play/core/server/ServerConfigSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/ServerConfigSpec.scala
@@ -8,7 +8,7 @@ import java.util.Properties
 import org.specs2.mutable.Specification
 import play.core.ApplicationProvider
 
-object ServerConfigSpec extends Specification {
+class ServerConfigSpec extends Specification {
 
   "ServerConfig construction" should {
     "fail when both http and https ports are missing" in {

--- a/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -7,7 +7,7 @@ import org.specs2.mutable.Specification
 import play.api.mvc._
 import play.api.mvc.Results._
 
-object ServerResultUtilsSpec extends Specification {
+class ServerResultUtilsSpec extends Specification {
 
   case class CookieRequestHeader(cookie: Option[(String, String)]) extends RequestHeader {
     def id = 1

--- a/framework/src/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
+++ b/framework/src/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
@@ -18,7 +18,7 @@ import org.specs2.specification.Scope
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-object FakesSpec extends PlaySpecification {
+class FakesSpec extends PlaySpecification {
 
   sequential
 

--- a/framework/src/play-specs2/src/test/scala/play/api/test/SpecsSpec.scala
+++ b/framework/src/play-specs2/src/test/scala/play/api/test/SpecsSpec.scala
@@ -8,7 +8,7 @@ import org.specs2.mutable._
 import play.api.inject.guice.{ GuiceApplicationBuilder, GuiceApplicationLoader }
 import play.api.{ Play, Application }
 
-object SpecsSpec extends Specification {
+class SpecsSpec extends Specification {
 
   def getConfig(key: String)(implicit app: Application) = app.configuration.getOptional[String](key)
 

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
@@ -15,7 +15,7 @@ import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
-object AccumulatorSpec extends Specification {
+class AccumulatorSpec extends Specification {
 
   def withMaterializer[T](block: Materializer => T) = {
     val system = ActorSystem("test")

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/ExecutionSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/ExecutionSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.language.reflectiveCalls
 import scala.util.Try
 
-object ExecutionSpec extends Specification {
+class ExecutionSpec extends Specification {
   import Execution.trampoline
 
   val waitTime = Duration(5, SECONDS)

--- a/framework/src/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
@@ -20,7 +20,7 @@ import akka.japi.function.{ Function => JFn, Function2 => JFn2 }
 
 import org.reactivestreams.{ Subscription, Subscriber, Publisher }
 
-object AccumulatorSpec extends org.specs2.mutable.Specification {
+class AccumulatorSpec extends org.specs2.mutable.Specification {
   import scala.collection.JavaConversions.asJavaIterable
 
   def withMaterializer[T](block: Materializer => T) = {

--- a/framework/src/play-ws/src/test/scala/play/api/libs/openid/DiscoveryClientSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/openid/DiscoveryClientSpec.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Await
 import java.util.concurrent.TimeUnit
 import play.api.libs.ws._
 
-object DiscoveryClientSpec extends Specification with Mockito {
+class DiscoveryClientSpec extends Specification with Mockito {
 
   val dur = Duration(10, TimeUnit.SECONDS)
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/openid/OpenIDSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/openid/OpenIDSpec.scala
@@ -15,7 +15,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import java.util.concurrent.TimeUnit
 
-object OpenIDSpec extends Specification with Mockito {
+class OpenIDSpec extends Specification with Mockito {
 
   val claimedId = "http://example.com/openid?id=C123"
   val identity = "http://example.com/openid?id=C123&id"

--- a/framework/src/play-ws/src/test/scala/play/api/libs/openid/UserInfoSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/openid/UserInfoSpec.scala
@@ -5,7 +5,7 @@ package play.api.libs.openid
 
 import org.specs2.mutable.Specification
 
-object UserInfoSpec extends Specification {
+class UserInfoSpec extends Specification {
 
   val claimedId = "http://example.com/openid?id=C123"
   val identity = "http://example.com/openid?id=C123&id"

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/WSConfigParserSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/WSConfigParserSpec.scala
@@ -10,7 +10,7 @@ import play.api.test.WithApplication
 
 import scala.concurrent.duration._
 
-object WSConfigParserSpec extends Specification {
+class WSConfigParserSpec extends Specification {
 
   "WSConfigParser" should {
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ahc/AhcConfigSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ahc/AhcConfigSpec.scala
@@ -22,7 +22,7 @@ import play.api.test.WithApplication
 
 import scala.concurrent.duration._
 
-object AhcConfigSpec extends Specification with Mockito {
+class AhcConfigSpec extends Specification with Mockito {
 
   val defaultWsConfig = new WSClientConfig()
   val defaultConfig = new AhcWSClientConfig(defaultWsConfig)

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
@@ -23,7 +23,7 @@ import play.core.server.Server
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
-object AhcWSSpec extends PlaySpecification with Mockito {
+class AhcWSSpec extends PlaySpecification with Mockito {
 
   sequential
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmCheckerSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmCheckerSpec.scala
@@ -13,7 +13,7 @@ import org.specs2.mutable._
 import play.api.libs.ws.ssl.AlgorithmConstraintsParser._
 import play.core.server.ssl.CertificateGenerator
 
-object AlgorithmCheckerSpec extends Specification {
+class AlgorithmCheckerSpec extends Specification {
 
   "AlgorithmChecker" should {
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmConstraintsParserSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmConstraintsParserSpec.scala
@@ -9,7 +9,7 @@ import org.specs2.mutable._
 import scala.util.parsing.input.CharSequenceReader
 import org.specs2.matcher.{ ExpectedParsedResult, ParserMatchers }
 
-object AlgorithmConstraintsParserSpec extends Specification with ParserMatchers {
+class AlgorithmConstraintsParserSpec extends Specification with ParserMatchers {
 
   val parsers = AlgorithmConstraintsParser
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmsSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmsSpec.scala
@@ -14,7 +14,7 @@ import java.util.Date
 import play.core.server.ssl.CertificateGenerator
 import sun.security.x509.AlgorithmId
 
-object AlgorithmsSpec extends Specification {
+class AlgorithmsSpec extends Specification {
   import Algorithms._
 
   "keySize" should {

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/CompositeX509KeyManagerSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/CompositeX509KeyManagerSpec.scala
@@ -17,7 +17,7 @@ import org.specs2.mock._
 import org.specs2.mutable._
 import java.security.cert.X509Certificate
 
-object CompositeX509KeyManagerSpec extends Specification with Mockito {
+class CompositeX509KeyManagerSpec extends Specification with Mockito {
 
   def mockExtendedX509KeyManager(clientResponse: String = null, serverResponse: String = null) = new X509ExtendedKeyManager() {
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/CompositeX509TrustManagerSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/CompositeX509TrustManagerSpec.scala
@@ -13,7 +13,7 @@ import java.security.cert.{ CertificateException, X509Certificate }
 
 import play.core.server.ssl.CertificateGenerator
 
-object CompositeX509TrustManagerSpec extends Specification with Mockito {
+class CompositeX509TrustManagerSpec extends Specification with Mockito {
 
   "CompositeX509TrustManager" should {
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/DebugBuilderSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/DebugBuilderSpec.scala
@@ -7,7 +7,7 @@ package play.api.libs.ws.ssl
 
 import org.specs2.mutable._
 
-object DebugBuilderSpec extends Specification {
+class DebugBuilderSpec extends Specification {
 
   "JavaSecurityDebugBuilder" should {
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/SSLConfigParserSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/SSLConfigParserSpec.scala
@@ -10,10 +10,10 @@ import com.typesafe.config.ConfigFactory
 import org.slf4j.LoggerFactory
 import play.api.Configuration
 import play.api.libs.ws.ahc.AhcConfigBuilder
-import play.api.libs.ws.ahc.AhcConfigSpec._
+
 import play.api.test.WithApplication
 
-object SSLConfigParserSpec extends Specification {
+class SSLConfigParserSpec extends Specification {
 
   // We can get horrible concurrent modification exceptions in the logger if we run
   // several WithApplication at the same time.  Usually happens in the build.

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/SystemPropertiesSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/SystemPropertiesSpec.scala
@@ -10,7 +10,7 @@ import java.security.Security
 
 import play.api.libs.ws.WSClientConfig
 
-object SystemPropertiesSpec extends Specification with After {
+class SystemPropertiesSpec extends Specification with After {
 
   sequential
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/debug/DebugConfigurationSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/debug/DebugConfigurationSpec.scala
@@ -9,7 +9,7 @@ import org.specs2.mutable.Specification
 import org.specs2.specification.After
 import play.api.libs.ws.ssl.SSLDebugConfig
 
-object DebugConfigurationSpec extends Specification with After {
+class DebugConfigurationSpec extends Specification with After {
 
   def after = {
     System.clearProperty("java.security.debug")

--- a/framework/src/play/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/ConfigurationSpec.scala
@@ -10,7 +10,7 @@ import org.specs2.mutable.Specification
 
 import scala.util.control.NonFatal
 
-object ConfigurationSpec extends Specification {
+class ConfigurationSpec extends Specification {
 
   def config(data: (String, Any)*) = Configuration.from(data.toMap)
 

--- a/framework/src/play/src/test/scala/play/api/controllers/AssetsInfoSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/controllers/AssetsInfoSpec.scala
@@ -9,7 +9,7 @@ import org.specs2.mutable.Specification
 import java.util.Date
 import java.time.format.DateTimeFormatter
 
-object AssetInfoSpec extends Specification {
+class AssetsInfoSpec extends Specification {
 
   "AssetInfo.parseModifiedDate" should {
 

--- a/framework/src/play/src/test/scala/play/api/controllers/AssetsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/controllers/AssetsSpec.scala
@@ -9,7 +9,7 @@ import org.specs2.mutable.Specification
 import play.api.mvc.ResponseHeader
 import play.utils.InvalidUriEncodingException
 
-object AssetsSpec extends Specification {
+class AssetsSpec extends Specification {
 
   "Assets controller" should {
 
@@ -103,7 +103,7 @@ object AssetsSpec extends Specification {
     }
 
     "use the unescaped path when finding the last modified date of an asset" in {
-      val url = AssetsSpec.getClass.getClassLoader.getResource("file withspace.css")
+      val url = this.getClass.getClassLoader.getResource("file withspace.css")
       val assetInfo = new AssetInfo("file withspace.css", url, None, None)
       val lastModified = ResponseHeader.httpDateFormat.parse(assetInfo.lastModified.get)
       // If it uses the escaped path, the file won't be found, and so last modified will be 0

--- a/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
@@ -11,7 +11,7 @@ import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
 import play.api.libs.json.Json
 import org.specs2.mutable.Specification
 
-object FormSpec extends Specification {
+class FormSpec extends Specification {
   "A form" should {
     "have an error due to a malformed email" in {
       val f5 = ScalaForms.emailForm.fillAndValidate(("john@", "John"))

--- a/framework/src/play/src/test/scala/play/api/data/format/FormatSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/format/FormatSpec.scala
@@ -9,7 +9,7 @@ import java.util.{ UUID, Date, TimeZone }
 import play.api.data._
 import play.api.data.Forms._
 
-object FormatSpec extends Specification {
+class FormatSpec extends Specification {
   "dateFormat" should {
     "support custom time zones" in {
       val data = Map("date" -> "00:00")

--- a/framework/src/play/src/test/scala/play/api/data/format/PlayDateSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/format/PlayDateSpec.scala
@@ -9,7 +9,7 @@ import java.time.format.DateTimeFormatter
 
 import org.specs2.mutable.Specification
 
-object PlayDateSpec extends Specification {
+class PlayDateSpec extends Specification {
 
   "PlayDate.toZonedDateTime(ZoneId)" should {
     "return a valid date" in {

--- a/framework/src/play/src/test/scala/play/api/data/validation/ValidationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/validation/ValidationSpec.scala
@@ -10,7 +10,7 @@ import play.api.data.Forms._
 import play.api.data.format.Formats._
 import play.api.data.validation.Constraints._
 
-object ValidationSpec extends Specification {
+class ValidationSpec extends Specification {
 
   "text" should {
     "throw an IllegalArgumentException if maxLength is negative" in {

--- a/framework/src/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
@@ -8,7 +8,7 @@ import org.specs2.mutable.Specification
 import play.api.{ PlayException, Configuration }
 import play.core.netty.utils.{ ClientCookieEncoder, ClientCookieDecoder, ServerCookieDecoder, ServerCookieEncoder }
 
-object HttpConfigurationSpec extends Specification {
+class HttpConfigurationSpec extends Specification {
 
   "HttpConfiguration" should {
 

--- a/framework/src/play/src/test/scala/play/api/http/MediaRangeSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/MediaRangeSpec.scala
@@ -6,7 +6,7 @@ package play.api.http
 import org.specs2.mutable._
 import java.net.URLEncoder
 
-object MediaRangeSpec extends Specification {
+class MediaRangeSpec extends Specification {
 
   "A MediaRange" should {
 

--- a/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
@@ -11,7 +11,7 @@ import play.api.{ PlayException, Mode, Environment, Configuration }
 import play.api.i18n.Messages.MessageSource
 import play.core.test.FakeRequest
 
-object MessagesSpec extends Specification {
+class MessagesSpec extends Specification {
   val testMessages = Map(
     "default" -> Map(
       "title" -> "English Title",

--- a/framework/src/play/src/test/scala/play/api/libs/EventSourceSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/EventSourceSpec.scala
@@ -8,7 +8,7 @@ import org.specs2.mutable.Specification
 import play.api.http.ContentTypes
 import play.api.mvc.Results
 
-object EventSourceSpec extends Specification {
+class EventSourceSpec extends Specification {
 
   import EventSource.Event
 

--- a/framework/src/play/src/test/scala/play/api/libs/FilesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/FilesSpec.scala
@@ -16,7 +16,7 @@ import play.api.libs.Files.{ DefaultTemporaryFileCreator, TemporaryFile }
 import play.api.routing.Router
 import play.utils.PlayIO
 
-object FilesSpec extends Specification with After {
+class FilesSpec extends Specification with After {
 
   val parentDirectory = new File("/tmp/play/specs/")
   val utf8 = Charset.forName("UTF8")

--- a/framework/src/play/src/test/scala/play/api/libs/MimeTypesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/MimeTypesSpec.scala
@@ -5,7 +5,7 @@ package play.api.libs
 
 import org.specs2.mutable._
 
-object MimeTypesSpec extends Specification {
+class MimeTypesSpec extends Specification {
 
   "Mime types" should {
     "choose the correct mime type for file with lowercase extension" in {

--- a/framework/src/play/src/test/scala/play/api/mvc/BindersSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/BindersSpec.scala
@@ -6,7 +6,7 @@ package play.api.mvc
 import java.util.UUID
 import org.specs2.mutable._
 
-object BindersSpec extends Specification {
+class BindersSpec extends Specification {
 
   val uuid = UUID.randomUUID
 

--- a/framework/src/play/src/test/scala/play/api/mvc/CookiesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/CookiesSpec.scala
@@ -6,7 +6,7 @@ package play.api.mvc
 import org.specs2.mutable._
 import play.core.test._
 
-object CookiesSpec extends Specification {
+class CookiesSpec extends Specification {
 
   "object Cookies#fromCookieHeader" should {
 

--- a/framework/src/play/src/test/scala/play/api/mvc/FlashCookieSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/FlashCookieSpec.scala
@@ -8,7 +8,7 @@ import java.net.URLEncoder
 
 import play.api.http.HttpConfiguration
 
-object FlashCookieSpec extends Specification {
+class FlashCookieSpec extends Specification {
 
   def oldEncoder(data: Map[String, String]): String = {
     URLEncoder.encode(

--- a/framework/src/play/src/test/scala/play/api/mvc/HttpSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/HttpSpec.scala
@@ -7,7 +7,7 @@ import org.specs2.mutable._
 
 import play.core.test._
 
-object HttpSpec extends Specification {
+class HttpSpec extends Specification {
   "HTTP" title
 
   val headers = Headers("a" -> "a1", "a" -> "a2", "b" -> "b1", "b" -> "b2", "B" -> "b3", "c" -> "c1")

--- a/framework/src/play/src/test/scala/play/api/mvc/MaxLengthBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/MaxLengthBodyParserSpec.scala
@@ -17,7 +17,7 @@ import scala.util.{ Failure, Try }
 /**
  * All tests relating to max length handling
  */
-object MaxLengthBodyParserSpec extends Specification with AfterAll {
+class MaxLengthBodyParserSpec extends Specification with AfterAll {
 
   val MaxLength10 = 10
   val MaxLength20 = 20

--- a/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.api.mvc
 
-import java.io.{ File, FileOutputStream }
+import java.io.{ File, FileOutputStream, InputStream }
 import java.nio.file.Path
 
 import akka.actor.ActorSystem
@@ -18,9 +18,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import org.specs2.mutable.Specification
 
-import scala.tools.nsc.interpreter.InputStream
-
-object ByteRangeSpec extends Specification {
+class ByteRangeSpec extends Specification {
 
   "Distance" in {
     "Between 0-10 and 20-30 is 10" in {
@@ -46,7 +44,7 @@ object ByteRangeSpec extends Specification {
   }
 }
 
-object RangeSpec extends Specification {
+class RangeSpec extends Specification {
 
   def checkRange(entityLength: Long, header: String, expected: Range) = {
     val range = Range(Some(entityLength), header)
@@ -240,7 +238,7 @@ object RangeSpec extends Specification {
   }
 }
 
-object RangeSetSpec extends Specification {
+class RangeSetSpec extends Specification {
 
   "Satisfiable range sets" in {
 
@@ -325,7 +323,7 @@ object RangeSetSpec extends Specification {
   }
 }
 
-object RangeResultSpec extends Specification {
+class RangeResultSpec extends Specification {
 
   "Result" should {
 

--- a/framework/src/play/src/test/scala/play/api/mvc/RawBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RawBodyParserSpec.scala
@@ -20,7 +20,7 @@ import scala.concurrent.Future
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-object RawBodyParserSpec extends Specification with AfterAll {
+class RawBodyParserSpec extends Specification with AfterAll {
 
   implicit val system = ActorSystem("content-types-spec")
   implicit val materializer = ActorMaterializer()(system)

--- a/framework/src/play/src/test/scala/play/api/mvc/RawBufferSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RawBufferSpec.scala
@@ -7,7 +7,7 @@ import akka.util.ByteString
 import org.specs2.mutable.Specification
 import play.utils.PlayIO
 
-object RawBufferSpec extends Specification {
+class RawBufferSpec extends Specification {
 
   "RawBuffer" should {
     implicit def stringToBytes(s: String): ByteString = ByteString(s, "utf-8")

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -23,7 +23,7 @@ import play.core.test._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-object ResultsSpec extends Specification {
+class ResultsSpec extends Specification {
 
   import play.api.mvc.Results._
 

--- a/framework/src/play/src/test/scala/play/api/routing/sird/DslSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/routing/sird/DslSpec.scala
@@ -6,7 +6,7 @@ package play.api.routing.sird
 import org.specs2.mutable.Specification
 import play.core.test.FakeRequest
 
-object DslSpec extends Specification {
+class DslSpec extends Specification {
 
   "Play routing DSL" should {
 

--- a/framework/src/play/src/test/scala/play/api/routing/sird/UrlContextSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/routing/sird/UrlContextSpec.scala
@@ -8,7 +8,7 @@ import java.net.{ URL, URI }
 import org.specs2.mutable.Specification
 import play.core.test.FakeRequest
 
-object UrlContextSpec extends Specification {
+class UrlContextSpec extends Specification {
 
   "path interpolation" should {
 

--- a/framework/src/play/src/test/scala/play/api/templates/TemplatesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/templates/TemplatesSpec.scala
@@ -9,7 +9,7 @@ import play.api.http.{ HttpEntity, Writeable }
 import play.api.mvc.Results
 import play.mvc.{ Results => JResults }
 
-object TemplatesSpec extends Specification {
+class TemplatesSpec extends Specification {
   "toHtmlArgs" should {
     "escape attribute values" in {
       PlayMagic.toHtmlArgs(Map('foo -> """bar <>&"'""")).body must_== """foo="bar &lt;&gt;&amp;&quot;&#x27;""""

--- a/framework/src/play/src/test/scala/play/core/ClosableLazySpec.scala
+++ b/framework/src/play/src/test/scala/play/core/ClosableLazySpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-object ClosableLazySpec extends Specification {
+class ClosableLazySpec extends Specification {
 
   "ClosableLazy" should {
 

--- a/framework/src/play/src/test/scala/play/core/parsers/FormUrlEncodedParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/parsers/FormUrlEncodedParserSpec.scala
@@ -5,7 +5,7 @@ package play.core.parsers
 
 import org.specs2.mutable.Specification
 
-object FormUrlEncodedParserSpec extends Specification {
+class FormUrlEncodedParserSpec extends Specification {
   "FormUrlEncodedParser" should {
     "decode forms" in {
       FormUrlEncodedParser.parse("foo1=bar1&foo2=bar2") must_== Map("foo1" -> List("bar1"), "foo2" -> List("bar2"))

--- a/framework/src/play/src/test/scala/play/core/routing/RouterSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/routing/RouterSpec.scala
@@ -5,7 +5,7 @@ package play.core.routing
 
 import org.specs2.mutable.Specification
 
-object RouterSpec extends Specification {
+class RouterSpec extends Specification {
 
   "Router dynamic string builder" should {
     "handle empty parts" in {

--- a/framework/src/play/src/test/scala/play/core/utils/ThreadsSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/utils/ThreadsSpec.scala
@@ -7,7 +7,7 @@ import util.control.Exception._
 import org.specs2.mutable.Specification
 import play.utils.Threads
 
-object ThreadsSpec extends Specification {
+class ThreadsSpec extends Specification {
   "Threads" should {
     "restore the correct class loader" in {
       "if the block returns successfully" in {

--- a/framework/src/play/src/test/scala/play/libs/FTupleSpec.scala
+++ b/framework/src/play/src/test/scala/play/libs/FTupleSpec.scala
@@ -8,7 +8,7 @@ import org.scalacheck.{ Arbitrary, Gen }
 import org.specs2.mutable.Specification
 import org.specs2.ScalaCheck
 
-object FTupleSpec extends Specification with ScalaCheck {
+class FTupleSpec extends Specification with ScalaCheck {
 
   import ArbitraryTuples._
 

--- a/framework/src/play/src/test/scala/play/libs/XMLSpec.scala
+++ b/framework/src/play/src/test/scala/play/libs/XMLSpec.scala
@@ -8,7 +8,7 @@ import java.io.{ FileOutputStream, File }
 import org.specs2.mutable.Specification
 import org.xml.sax.SAXException
 
-object XMLSpec extends Specification {
+class XMLSpec extends Specification {
 
   "The Java XML support" should {
 

--- a/framework/src/play/src/test/scala/play/mvc/RawBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/mvc/RawBodyParserSpec.scala
@@ -23,7 +23,7 @@ import scala.concurrent.Future
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-object RawBodyParserSpec extends Specification with AfterAll {
+class RawBodyParserSpec extends Specification with AfterAll {
   "Java RawBodyParserSpec" title
 
   implicit val system = ActorSystem("content-types-spec")

--- a/framework/src/play/src/test/scala/play/mvc/ResultSpec.scala
+++ b/framework/src/play/src/test/scala/play/mvc/ResultSpec.scala
@@ -15,7 +15,7 @@ import play.api.mvc.{ Cookie, Results }
 /**
  *
  */
-object ResultSpec extends Specification {
+class ResultSpec extends Specification {
 
   "Result" should {
 

--- a/framework/src/play/src/test/scala/play/utils/ResourcesSpec.scala
+++ b/framework/src/play/src/test/scala/play/utils/ResourcesSpec.scala
@@ -13,7 +13,7 @@ import play.api.PlayCoreTestApplication
 /**
  * Tests for Resources object
  */
-object ResourcesSpec extends Specification {
+class ResourcesSpec extends Specification {
   import Resources._
 
   lazy val app = PlayCoreTestApplication()

--- a/framework/src/play/src/test/scala/play/utils/UriEncodingSpec.scala
+++ b/framework/src/play/src/test/scala/play/utils/UriEncodingSpec.scala
@@ -8,7 +8,7 @@ import org.specs2.mutable._
 /**
  * Tests for the UriEncoding object.
  */
-object UriEncodingSpec extends Specification {
+class UriEncodingSpec extends Specification {
   import UriEncoding._
 
   sealed trait EncodingResult

--- a/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -11,7 +11,7 @@ import play.api.i18n.{ DefaultLangs, DefaultMessagesApi, Lang }
 import play.twirl.api.Html
 import scala.beans.BeanProperty
 
-object HelpersSpec extends Specification {
+class HelpersSpec extends Specification {
   import FieldConstructor.defaultField
   val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
   implicit val messages = messagesApi.preferred(Seq.empty)

--- a/framework/src/play/src/test/scala/views/js/helper/HelpersSpec.scala
+++ b/framework/src/play/src/test/scala/views/js/helper/HelpersSpec.scala
@@ -5,7 +5,7 @@ package views.js.helper
 
 import org.specs2.mutable.Specification
 
-object HelpersSpec extends Specification {
+class HelpersSpec extends Specification {
 
   "@json" should {
     "Produce valid JavaScript strings" in {

--- a/framework/src/routes-compiler/src/test/scala/play/routes/compiler/RoutesCompilerSpec.scala
+++ b/framework/src/routes-compiler/src/test/scala/play/routes/compiler/RoutesCompilerSpec.scala
@@ -9,7 +9,7 @@ import org.specs2.mutable.Specification
 import org.specs2.matcher.FileMatchers
 import play.routes.compiler.RoutesCompiler.RoutesCompilerTask
 
-object RoutesCompilerSpec extends Specification with FileMatchers {
+class RoutesCompilerSpec extends Specification with FileMatchers {
 
   sequential
 

--- a/framework/src/routes-compiler/src/test/scala/play/routes/compiler/RoutesFileParserSpec.scala
+++ b/framework/src/routes-compiler/src/test/scala/play/routes/compiler/RoutesFileParserSpec.scala
@@ -8,7 +8,7 @@ import java.io.File
 import org.specs2.execute.Result
 import org.specs2.mutable.Specification
 
-object RoutesFileParserSpec extends Specification {
+class RoutesFileParserSpec extends Specification {
 
   "route file parser" should {
 

--- a/framework/src/routes-compiler/src/test/scala/play/routes/compiler/templates/TemplatesSpec.scala
+++ b/framework/src/routes-compiler/src/test/scala/play/routes/compiler/templates/TemplatesSpec.scala
@@ -6,7 +6,7 @@ package play.routes.compiler.templates
 import org.specs2.mutable.Specification
 import play.routes.compiler._
 
-object TemplatesSpec extends Specification {
+class TemplatesSpec extends Specification {
   "javascript reverse routes" should {
     "collect parameter names with index appended" in {
       val reverseParams: Seq[(Parameter, Int)] = reverseParametersJavascript(Seq(

--- a/framework/src/run-support/src/test/scala/play/runsupport/FilterArgsSpec.scala
+++ b/framework/src/run-support/src/test/scala/play/runsupport/FilterArgsSpec.scala
@@ -6,7 +6,7 @@ package play.runsupport
 import org.specs2.mutable._
 import org.specs2.execute.Result
 
-object FilterArgsSpec extends Specification {
+class FilterArgsSpec extends Specification {
 
   val defaultHttpPort = 9000
   val defaultHttpAddress = "0.0.0.0"

--- a/framework/src/sbt-plugin/src/test/scala/play/sbt/ApplicationSecretGeneratorSpec.scala
+++ b/framework/src/sbt-plugin/src/test/scala/play/sbt/ApplicationSecretGeneratorSpec.scala
@@ -6,7 +6,7 @@ package play.sbt
 import com.typesafe.config.ConfigFactory
 import org.specs2.mutable._
 
-object ApplicationSecretGeneratorSpec extends Specification {
+class ApplicationSecretGeneratorSpec extends Specification {
   "ApplicationSecretGenerator" should {
     "override literal secret" in {
       val configContent =

--- a/framework/src/sbt-plugin/src/test/scala/play/sbt/PlayRunHookSpec.scala
+++ b/framework/src/sbt-plugin/src/test/scala/play/sbt/PlayRunHookSpec.scala
@@ -7,7 +7,7 @@ import org.specs2.mutable._
 
 import scala.collection.mutable.HashMap
 
-object PlayRunHookSpec extends Specification {
+class PlayRunHookSpec extends Specification {
 
   "PlayRunHook runner" should {
 


### PR DESCRIPTION
## Purpose

This upgrades specs2, scalacheck and removes the scalaz repository.
It also changes all specs2 tests to class based tests so that there aren't sometimes object tests and sometimes not.
Also I tried to clean up some things I stumbled upon.
Here is a short list of things I cleaned up in `framework/`:

#### Static Injects moved top-level
- play.filters.headers.SecurityHeadersFilterSpec
- play.filters.hosts.AllowedHostsFilterSpec
- play.filters.gzip.GzipFilterSpec
- play.filters.csrf.CSRFFilterSpec
- play.utils.ReflectSpec
- play.api.http.HttpErrorHandlerSpec

#### Reordered due to static inject
- play.filters.cors

#### Companion Object
- play.core.server.ProdServerStartSpec
- play.data.FormSpec
- play.api.inject.GuiceApplicationBuilderSpec
- play.api.inject.GuiceInjectorBuilderSpec
- play.filters.csrf.JavaCSRFActionSpec

#### Strange Import
- play.api.mvc.ByteRangeSpec imported a InputStream from scala nsc tools changed to the java.io counterpart

#### Removed deprecations
- Changed all FileIO.fromFile to FileIO.fromPath inside WSSpec

Actually under `documentation/` things were simple so I didn't make a change list.