### PR TITLE
removed scalaz repository in play-scala template

### DIFF
--- a/templates/play-scala/build.sbt
+++ b/templates/play-scala/build.sbt
@@ -14,4 +14,3 @@ libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play" % "%SCALATESTPLUS_PLAY_VERSION%" % Test
 )
 
-resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"


### PR DESCRIPTION
## Purpose

Tests using scalatest so there is no need for the scalaz repository
