### PR TITLE
Closing leaked connection when there is a problem in checkEvolutionsD…

### DIFF
--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -123,10 +123,8 @@ class DatabaseEvolutions(database: Database, schema: String = "") {
   private def databaseEvolutions(): Seq[Evolution] = {
     implicit val connection = database.getConnection(autocommit = true)
 
-    checkEvolutionsState()
-
     try {
-
+      checkEvolutionsState()
       Collections.unfoldLeft(executeQuery(
         """
             select id, hash, apply_script, revert_script from ${schema}play_evolutions order by id


### PR DESCRIPTION
# Pull Request Checklist

* [Yes ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [Yes ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ Yes] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ Yes] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [No new files] Have you added copyright headers to new files?
* [Scala] Have you checked that both Scala and Java APIs are updated?
* [Minor change ] Have you updated the documentation for both Scala and Java sections?
* [Moving the line into try block] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

Releases the db connection if there is an exception while checking the evolutions status

If the db is inconsistent state, `play.api.db.evolutions.InconsistentDatabase` exception thrown and it is going out of the databaseEvolutions method, hence the connection is still there.