### PR TITLE
[doc] Add SIRD routing documentation

### DIFF
--- a/documentation/manual/working/scalaGuide/advanced/routing/ScalaSirdRouter.md
+++ b/documentation/manual/working/scalaGuide/advanced/routing/ScalaSirdRouter.md
@@ -59,26 +59,14 @@ Configuring an application to use a sird Router can be achieved in many ways, de
 
 ### Using SIRD router from a routes files
 
-To use SIRD in conjunction with a regular Play project that uses [[ScalaRouting]], extend the [`SimpleRouter`](api/scala/play/api/routing/SimpleRouter.html):
+To use the routing DSL in conjunction with a regular Play project that uses [[a routes file|ScalaRouting]] and [[controllers|ScalaActions]], extend the [`SimpleRouter`](api/scala/play/api/routing/SimpleRouter.html):
 
-```
-package api
-
-import play.api.mvc._
-import play.api.routing._
-import play.api.routing.sird._
-
-class MyRouter extends SimpleRouter {
-  def routes = {
-    ...
-  }
-}
-```
+@[inject-sird-router](code/ApiRouter.scala)
 
 Add the following line to conf/routes:
 
 ```
-->      /api                        api.MyRouter
+->      /api                        api.ApiRouter
 ```
 
 ### Embedding play

--- a/documentation/manual/working/scalaGuide/advanced/routing/ScalaSirdRouter.md
+++ b/documentation/manual/working/scalaGuide/advanced/routing/ScalaSirdRouter.md
@@ -69,6 +69,14 @@ Add the following line to conf/routes:
 ->      /api                        api.ApiRouter
 ```
 
+### Composing SIRD routers
+
+You can compose multiple routers together, because Routes are partial functions:
+
+``` scala
+mainRouter.routes.orElse(injectedOtherRouter.withPrefix("/prefix").routes)
+```
+
 ### Embedding play
 
 An example of embedding a play server with sird router can be found in [[Embedding Play|ScalaEmbeddingPlay]] section.

--- a/documentation/manual/working/scalaGuide/advanced/routing/ScalaSirdRouter.md
+++ b/documentation/manual/working/scalaGuide/advanced/routing/ScalaSirdRouter.md
@@ -57,7 +57,32 @@ To further the point that these are just regular extractor objects, you can see 
 
 Configuring an application to use a sird Router can be achieved in many ways, depending on use case:
 
+### Using SIRD router from a routes files
+
+To use SIRD in conjunction with a regular Play project that uses [[ScalaRouting]], extend the [`SimpleRouter`](api/scala/play/api/routing/SimpleRouter.html):
+
+```
+package api
+
+import play.api.mvc._
+import play.api.routing._
+import play.api.routing.sird._
+
+class MyRouter extends SimpleRouter {
+  def routes = {
+    ...
+  }
+}
+```
+
+Add the following line to conf/routes:
+
+```
+->      /api                        api.MyRouter
+```
+
 ### Embedding play
+
 An example of embedding a play server with sird router can be found in [[Embedding Play|ScalaEmbeddingPlay]] section.
 
 ### Providing a DI router

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/ApiRouter.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/ApiRouter.scala
@@ -1,0 +1,22 @@
+//#inject-sird-router
+package api
+
+import javax.inject.Inject
+
+import play.api.mvc._
+import play.api.routing.Router.Routes
+import play.api.routing.SimpleRouter
+import play.api.routing.sird._
+
+class ApiRouter @Inject()(controller: ApiController)
+  extends SimpleRouter
+{
+  override def routes: Routes = {
+    case GET(p"/") => controller.index
+  }
+}
+//#inject-sird-router
+
+class ApiController extends Controller {
+  def index() = TODO
+}

--- a/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
@@ -38,6 +38,14 @@ You can also add comments to the route file, with the `#` character.
 
 @[clients-show-comment](code/scalaguide.http.routing.routes)
 
+You can tell the routes file to use a different router under a specific prefix by using "->" followed by the given prefix:
+
+```
+->      /api                        api.MyRouter
+```
+
+This is especially useful when combined with [String Interpolating Routing DSL|ScalaSirdRouter] also known as SIRD routing, or when working with [[sub projects|SBTSubProjects]] that route using several routes files.
+
 ## The HTTP method
 
 The HTTP method can be any of the valid methods supported by HTTP (`GET`, `PATCH`, `POST`, `PUT`, `DELETE`, `HEAD`).
@@ -149,5 +157,7 @@ You can then reverse the URL to the `hello` action method, by using the `control
 @[reverse-router](code/ScalaRouting.scala)
 
 ## Custom routing
+
+Play provides a DSL for defining embedded routers called the *String Interpolating Routing DSL*, or sird for short.  This DSL has many uses, including embedding a light weight Play server, providing custom or more advanced routing capabilities to a regular Play application, and mocking REST services for testing.
 
 See [[String Interpolating Routing DSL|ScalaSirdRouter]]


### PR DESCRIPTION
Fixes https://github.com/playframework/playframework/issues/4586

Describes SIRD routing in context of a conf/routes file and by extending SimpleRouter.