### PR TITLE
remove file log appenders from default configs - fixes #6361

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
@@ -5,16 +5,46 @@ Play uses SLF4J for logging, backed by [Logback](http://logback.qos.ch/) as its 
 
 ## Default configuration
 
+In dev mode Play uses the following default configuration:
+
+@[](/confs/play-logback/logback-play-dev.xml)
+
 Play uses the following default configuration in production:
 
 @[](/confs/play-logback/logback-play-default.xml)
 
-A few things to note about this configuration:
+A few things to note about these configurations:
 
-* This specifies a file appender that writes to `logs/application.log`.
-* The file logger logs full exception stack traces, while the console logger only logs 10 lines of an exception stack trace.
+* These default configs specify only a console logger which outputs only 10 lines of an exception stack trace.
 * Play uses ANSI color codes by default in level messages.
-* Play puts both the console and the file logger behind the logback [AsyncAppender](http://logback.qos.ch/manual/appenders.html#AsyncAppender).  For details on the performance implications on this, see this [blog post](https://blog.takipi.com/how-to-instantly-improve-your-java-logging-with-7-logback-tweaks/).
+* For production, the default config puts the console logger behind the logback [AsyncAppender](http://logback.qos.ch/manual/appenders.html#AsyncAppender).  For details on the performance implications on this, see this [blog post](https://blog.takipi.com/how-to-instantly-improve-your-java-logging-with-7-logback-tweaks/).
+
+To add a file logger, add the following appender to your `conf/logback.xml` file:
+
+```xml
+<appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>${application.home:-.}/logs/application.log</file>
+    <encoder>
+        <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
+    </encoder>
+</appender>
+```
+
+Optionally use the async appender to wrap the `FileAppender`:
+```xml
+<appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="FILE" />
+</appender>
+```
+
+Add the necessary appender(s) to the root:
+```xml
+<root level="WARN">
+    <appender-ref ref="ASYNCFILE" />
+    <appender-ref ref="ASYNCSTDOUT" />
+</root>
+```
+
 
 ## Using a custom application loader
 

--- a/framework/src/play-logback/src/main/resources/logback-play-default.xml
+++ b/framework/src/play-logback/src/main/resources/logback-play-default.xml
@@ -3,24 +3,13 @@
   -->
 <!-- The default logback configuration that Play uses if no other configuration is provided -->
 <configuration>
-    
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-     <file>${application.home:-.}/logs/application.log</file>
-     <encoder>
-       <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
-     </encoder>
-  </appender>
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
     </encoder>
-  </appender>
-
-  <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
-    <appender-ref ref="FILE" />
   </appender>
 
   <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
@@ -29,12 +18,11 @@
 
   <logger name="play" level="INFO" />
   <logger name="application" level="INFO" />
-  
+
   <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
 
   <root level="WARN">
-    <appender-ref ref="ASYNCFILE" />
     <appender-ref ref="ASYNCSTDOUT" />
   </root>
-  
+
 </configuration>

--- a/framework/src/play-logback/src/main/resources/logback-play-dev.xml
+++ b/framework/src/play-logback/src/main/resources/logback-play-dev.xml
@@ -6,27 +6,19 @@
 
   <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-     <file>${application.home:-.}/logs/application.log</file>
-     <encoder>
-       <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
-     </encoder>
-   </appender>
-
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
     </encoder>
   </appender>
-  
+
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
-  
+
   <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
 
   <root level="WARN">
     <appender-ref ref="STDOUT" />
-    <appender-ref ref="FILE" />
   </root>
-  
+
 </configuration>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #6361 

## Purpose

Because the default log file appenders can not be easily removed via user config, they are removed from the default configs.  If the user needs file logging they can add it in their own `logback.xml` config.
