### PR TITLE
removed scala-stm

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -116,7 +116,6 @@ object Dependencies {
     Seq("akka-actor", "akka-slf4j").map("com.typesafe.akka" %% _ % akkaVersion) ++
     jacksons ++
     Seq(
-      "org.scala-stm" %% "scala-stm" % "0.7",
       "commons-codec" % "commons-codec" % "1.10",
 
       guava,


### PR DESCRIPTION
after playing with scala 2.12.0-m5 i found out that play has a really unnecessary dependency.

I'm not sure but I guess we could drop that one even for 2.5.x I guess that wouldn't even make a mima incompatibility. and I guess for 99% of the people it would not break anything.
Tests would run on 2.5.x, just fine.