### PR TITLE
removed the tomcat-servlet-api

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -91,9 +91,7 @@ object Dependencies {
 
     guava,
     findBugs,
-    logback % Test,
-
-    "org.apache.tomcat" % "tomcat-servlet-api" % "8.0.33"
+    logback % Test
   ) ++ specsBuild.map(_ % Test)
 
   val junitInterface = "com.novocode" % "junit-interface" % "0.11"


### PR DESCRIPTION
Actually I'm not sure about this one, I searched the history and only found that:
https://github.com/playframework/playframework/commit/0981b80ed1ab019f966740572e52f39c516352c0

Which just changes javax.servlet to tomcat-servlet-api. But I guess it's not needed at least not in the runtime (maybe it's used in the tests but I couldn't track it, if it makes problems we could at least readd it)