### PR TITLE
Fix documentation using static WS methods

### DIFF
--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ScalaFunctionalTestSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ScalaFunctionalTestSpec.scala
@@ -124,8 +124,10 @@ class ScalaFunctionalTestSpec extends ExampleSpecification {
       // The test payment gateway requires a callback to this server before it returns a result...
       val callbackURL = s"http://$myPublicAddress/callback"
 
+      val ws = app.injector.instanceOf[WSClient]
+
       // await is from play.api.test.FutureAwaits
-      val response = await(WS.url(testPaymentGatewayURL).withQueryString("callbackURL" -> callbackURL).get())
+      val response = await(ws.url(testPaymentGatewayURL).withQueryString("callbackURL" -> callbackURL).get())
 
       response.status must equalTo(OK)
     }
@@ -139,7 +141,8 @@ class ScalaFunctionalTestSpec extends ExampleSpecification {
     }).build()
 
     "test WS logic" in new WithServer(app = appWithRoutes, port = 3333) {
-      await(WS.url("http://localhost:3333").get()).status must equalTo(OK)
+      val ws = app.injector.instanceOf[WSClient]
+      await(ws.url("http://localhost:3333").get()).status must equalTo(OK)
     }
     // #scalafunctionaltest-testws
 

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -1,9 +1,9 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
 # The Play WS API
 
-Sometimes we would like to call other HTTP services from within a Play application. Play supports this via its [WS library](api/scala/play/api/libs/ws/package.html), which provides a way to make asynchronous HTTP calls.
+Sometimes we would like to call other HTTP services from within a Play application. Play supports this via its [WS library](api/scala/play/api/libs/ws/package.html), which provides a way to make asynchronous HTTP calls through a WSClient instance.
 
-There are two important parts to using the WS API: making a request, and processing the response.  We'll discuss how to make both GET and POST HTTP requests first, and then show how to process the response from WS.  Finally, we'll discuss some common use cases.
+There are two important parts to using the WSClient: making a request, and processing the response.  We'll discuss how to make both GET and POST HTTP requests first, and then show how to process the response from WSClient.  Finally, we'll discuss some common use cases.
 
 ## Making a Request
 
@@ -192,9 +192,9 @@ Of course, you can use any other valid HTTP verb.
 
 ## Common Patterns and Use Cases
 
-### Chaining WS calls
+### Chaining WSClient calls
 
-Using for comprehensions is a good way to chain WS calls in a trusted environment.  You should use for comprehensions together with [Future.recover](http://www.scala-lang.org/api/current/index.html#scala.concurrent.Future) to handle possible failure.
+Using for comprehensions is a good way to chain WSClient calls in a trusted environment.  You should use for comprehensions together with [Future.recover](http://www.scala-lang.org/api/current/index.html#scala.concurrent.Future) to handle possible failure.
 
 @[scalaws-forcomprehension](code/ScalaWSSpec.scala)
 
@@ -204,7 +204,7 @@ When making a request from a controller, you can map the response to a `Future[R
 
 @[async-result](code/ScalaWSSpec.scala)
 
-## Using WSClient
+## Directly creating WSClient
 
 We recommend that you get your `WSClient` instances using dependency injection as described above. `WSClient` instances created through dependency injection are simpler to use because they are automatically created when the application starts and cleaned up when the application stops.
 
@@ -228,7 +228,7 @@ This is important in a couple of cases.  WS has a couple of limitations that req
 
 * `WS` does not support streaming body upload.  In this case, you should use the `FeedableBodyGenerator` provided by AsyncHttpClient.
 
-## Configuring WS
+## Configuring WS client
 
 Use the following properties in `application.conf` to configure the WS client:
 
@@ -237,13 +237,13 @@ Use the following properties in `application.conf` to configure the WS client:
 * `play.ws.useragent`: To configure the User-Agent header field.
 * `play.ws.compressionEnabled`: Set it to true to use gzip/deflater encoding *(default is **false**)*.
 
-### Configuring WS with SSL
+### Configuring WS client with SSL
 
 To configure WS for use with HTTP over SSL/TLS (HTTPS), please see [[Configuring WS SSL|WsSSL]].
 
 ### Configuring Timeouts
 
-There are 3 different timeouts in WS. Reaching a timeout causes the WS request to interrupt.
+There are 3 different timeouts in WSClient. Reaching a timeout causes the WSClient request to interrupt.
 
 * `play.ws.timeout.connection`: The maximum time to wait when connecting to the remote host *(default is **120 seconds**)*.
 * `play.ws.timeout.idle`: The maximum time the request can stay idle (connection is established but waiting for more data) *(default is **120 seconds**)*.

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -490,49 +490,6 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
       //#async-result
     }
 
-    "allow working with clients directly" in withSimpleServer { ws =>
-
-      //#implicit-client
-      implicit val sslClient = AhcWSClient()
-      // close with sslClient.close() when finished with client
-      val response = WS.clientUrl(url).get()
-      //#implicit-client
-
-      await(response).status must_== OK
-
-      {
-        //#direct-client
-        val response = sslClient.url(url).get()
-        //#direct-client
-        await(response).status must_== OK
-      }
-
-      sslClient.close()
-      ok
-    }
-
-    "allow using pair magnets" in withSimpleServer { ws =>
-      //#pair-magnet
-      object PairMagnet {
-        implicit def fromPair(pair: (WSClient, java.net.URL)) =
-          new WSRequestMagnet {
-            def apply(): WSRequest = {
-              val (client, netUrl) = pair
-              client.url(netUrl.toString)
-            }
-          }
-      }
-
-      import scala.language.implicitConversions
-      import PairMagnet._
-
-      val exampleURL = new java.net.URL(url)
-      val response = WS.url(ws -> exampleURL).get()
-      //#pair-magnet
-
-      await(response).status must_== OK
-    }
-
     "allow programmatic configuration" in new WithApplication() {
 
       //#ws-custom-client
@@ -549,7 +506,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
       val environment = Environment(new File("."), this.getClass.getClassLoader, Mode.Prod)
 
       val parser = new WSConfigParser(configuration, environment)
-      val config = new AhcWSClientConfig(wsClientConfig = parser.parse())
+      val config = AhcWSClientConfig(wsClientConfig = parser.parse())
       val builder = new AhcConfigBuilder(config)
       val logging = new AsyncHttpClientConfig.AdditionalChannelInitializer() {
         override def initChannel(channel: io.netty.channel.Channel): Unit = {


### PR DESCRIPTION
Removes the static WS methods in documentation.  This is related to https://github.com/playframework/playframework/pull/6402 but can be backported to 2.5.x easily.

There is a change in the method signature of WsTestClient, where if you're passing in a custom client you have to pass it in as a function parameter now.  I think that this should be okay as it's very unlikely to be used, and can be done as (_, _) => client inline so it's a very light code change overall.  (This was prompted by the problem that the WsTestClient doesn't reliably close off the actorsystem and the client after running, other approaches welcome.)