### PR TITLE
JSON macros don't work for generic classes

### DIFF
--- a/framework/src/play-json/src/test/scala/play/api/libs/json/ReadsSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/ReadsSpec.scala
@@ -445,4 +445,22 @@ class ReadsSpec extends org.specs2.mutable.Specification {
       }
     }
   }
+
+  "Macro" should {
+    "generate Reads for simple case class" in {
+      Json.reads[Foo].reads(Json.obj("bar" -> "lorem")).get must_== Foo("lorem")
+    }
+
+    "generate Formats for a generic case class" in {
+      val fmt = Json.format[Lorem[Double]]
+
+      fmt.reads(Json.obj("ipsum" -> 0.123D, "age" -> 1)).get must_== Lorem(
+        0.123D, 1)
+    }
+  }
+
+  // ---
+
+  case class Foo(bar: String)
+  case class Lorem[T](ipsum: T, age: Int)
 }

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/WritesSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/WritesSpec.scala
@@ -173,7 +173,21 @@ class WritesSpec extends org.specs2.mutable.Specification {
     }
   }
 
+  "Macro" should {
+    "generate Writes for simple case class" in {
+      Json.writes[Foo].writes(Foo("lorem")) must_== Json.obj("bar" -> "lorem")
+    }
+
+    "generate Formats for a generic case class" in {
+      val fmt = Json.format[Lorem[Float]]
+
+      fmt.writes(Lorem(2, 2.34F)) must_== Json.obj(
+        "value" -> 2, "ipsum" -> 2.34F)
+    }
+  }
+
   // ---
 
   case class Foo(bar: String)
+  case class Lorem[A](value: Int, ipsum: A)
 }


### PR DESCRIPTION
```scala
import play.api.libs.json.Json

case class Foo[T](value: T)

object Foo {
  val writes = Json.writes[Foo[Int]]
}
```

yields the compilation error

```
error: No apply function found matching unapply parameters
         val writes = Json.writes[Foo[Int]]
                                 ^
```

```Json.reads``` has the same problem.