### PR TITLE
[Backport 2.5.x] Disallow users to send a message-body and Content-Length header field for 1xx, 204 and 304 responses (#6261)

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
@@ -9,10 +9,9 @@ import java.security.cert.X509Certificate
 import javax.net.ssl.SSLContext
 import javax.net.ssl.X509TrustManager
 
-import play.api.test.Helpers._
 import org.apache.commons.io.IOUtils
-
-import scala.annotation.tailrec
+import play.api.test.Helpers._
+import play.core.server.common.ServerResultUtils
 
 object BasicHttpClient {
 
@@ -225,7 +224,7 @@ class BasicHttpClient(port: Int, secure: Boolean) {
         headers.get(CONTENT_LENGTH).map { length =>
           readCompletely(length.toInt)
         } getOrElse {
-          if (status != CONTINUE && status != NOT_MODIFIED && status != NO_CONTENT) {
+          if (ServerResultUtils.mayHaveEntity(status)) {
             consumeRemaining(reader)
           } else {
             ""

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -4,27 +4,21 @@
 package play.it.http
 
 import java.util.Locale.ENGLISH
-import java.util.concurrent.{ LinkedBlockingQueue }
 
 import akka.stream.scaladsl.Source
-import akka.util.{ ByteString, Timeout }
-import play.api._
+import akka.util.ByteString
 import play.api.http._
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
-import play.api.mvc.Results._
-import play.api.routing.Router
 import play.api.test._
 import play.api.libs.ws._
-import play.api.libs.iteratee._
 import play.api.libs.EventSource
 import play.core.server.common.ServerResultException
 import play.it._
 
 import scala.util.Try
 import scala.concurrent.Future
-import play.api.http.{ HttpEntity, HttpChunk, Status }
 
 object NettyScalaResultsHandlingSpec extends ScalaResultsHandlingSpec with NettyIntegrationSpecification
 object AkkaHttpScalaResultsHandlingSpec extends ScalaResultsHandlingSpec with AkkaHttpIntegrationSpecification

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -291,6 +291,30 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       }
     }
 
+    "not have a message body even when a 100 response with a non-empty body is returned" in withServer(
+      Result(header = ResponseHeader(CONTINUE),
+        body = HttpEntity.Strict(ByteString("foo"), None)
+      )
+    ) { port =>
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("POST", "/", "HTTP/1.1", Map(), "")
+        ).head
+        response.body must beLeft("")
+        response.headers.get(CONTENT_LENGTH) must beNone
+      }
+
+    "not have a message body even when a 101 response with a non-empty body is returned" in withServer(
+      Result(header = ResponseHeader(SWITCHING_PROTOCOLS),
+        body = HttpEntity.Strict(ByteString("foo"), None)
+      )
+    ) { port =>
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        ).head
+        response.body must beLeft("")
+        response.headers.get(CONTENT_LENGTH) must beNone
+      }
+
     "not have a message body even when a 204 response with a non-empty body is returned" in withServer(
       Result(header = ResponseHeader(NO_CONTENT),
         body = HttpEntity.Strict(ByteString("foo"), None)
@@ -300,6 +324,7 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
           BasicRequest("PUT", "/", "HTTP/1.1", Map(), "")
         ).head
         response.body must beLeft("")
+        response.headers.get(CONTENT_LENGTH) must beNone
       }
 
     "not have a message body even when a 304 response with a non-empty body is returned" in withServer(
@@ -313,6 +338,26 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
         response.body must beLeft("")
       }
 
+    "not have a message body, nor Content-Length, when a 100 response is returned" in withServer(
+      Results.Continue
+    ) { port =>
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("POST", "/", "HTTP/1.1", Map(), "")
+        ).head
+        response.body must beLeft("")
+        response.headers.get(CONTENT_LENGTH) must beNone
+      }
+
+    "not have a message body, nor Content-Length, when a 101 response is returned" in withServer(
+      Results.SwitchingProtocols
+    ) { port =>
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        ).head
+        response.body must beLeft("")
+        response.headers.get(CONTENT_LENGTH) must beNone
+      }
+
     "not have a message body, nor Content-Length, when a 204 response is returned" in withServer(
       Results.NoContent
     ) { port =>
@@ -323,17 +368,7 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
         response.headers.get(CONTENT_LENGTH) must beNone
       }
 
-    "not have a message body, but may have a Content-Length, when a 204 response with an explicit Content-Length is returned" in withServer(
-      Results.NoContent.withHeaders("Content-Length" -> "0")
-    ) { port =>
-        val response = BasicHttpClient.makeRequests(port)(
-          BasicRequest("PUT", "/", "HTTP/1.1", Map(), "")
-        ).head
-        response.body must beLeft("")
-        response.headers.get(CONTENT_LENGTH) must beOneOf(None, Some("0")) // Both header values are valid
-      }
-
-    "not have a message body, nor a Content-Length, when a 304 response is returned" in withServer(
+    "not have a message body, nor Content-Length, when a 304 response is returned" in withServer(
       Results.NotModified
     ) { port =>
         val response = BasicHttpClient.makeRequests(port)(
@@ -343,14 +378,44 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
         response.headers.get(CONTENT_LENGTH) must beNone
       }
 
-    "not have a message body, but may have a Content-Length, when a 304 response with an explicit Content-Length is returned" in withServer(
+    "not have a message body, nor Content-Length, even when a 100 response with an explicit Content-Length is returned" in withServer(
+      Results.Continue.withHeaders("Content-Length" -> "0")
+    ) { port =>
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("POST", "/", "HTTP/1.1", Map(), "")
+        ).head
+        response.body must beLeft("")
+        response.headers.get(CONTENT_LENGTH) must beNone
+      }
+
+    "not have a message body, nor Content-Length, even when a 101 response with an explicit Content-Length is returned" in withServer(
+      Results.SwitchingProtocols.withHeaders("Content-Length" -> "0")
+    ) { port =>
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        ).head
+        response.body must beLeft("")
+        response.headers.get(CONTENT_LENGTH) must beNone
+      }
+
+    "not have a message body, nor Content-Length, even when a 204 response with an explicit Content-Length is returned" in withServer(
+      Results.NoContent.withHeaders("Content-Length" -> "0")
+    ) { port =>
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("PUT", "/", "HTTP/1.1", Map(), "")
+        ).head
+        response.body must beLeft("")
+        response.headers.get(CONTENT_LENGTH) must beNone
+      }
+
+    "not have a message body, nor Content-Length, even when a 304 response with an explicit Content-Length is returned" in withServer(
       Results.NotModified.withHeaders("Content-Length" -> "0")
     ) { port =>
         val response = BasicHttpClient.makeRequests(port)(
           BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
         ).head
         response.body must beLeft("")
-        response.headers.get(CONTENT_LENGTH) must beOneOf(None, Some("0")) // Both header values are valid
+        response.headers.get(CONTENT_LENGTH) must beNone
       }
 
     "return a 500 response if a forbidden character is used in a response's header field" in withServer(

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -25,7 +25,6 @@ import play.core.server.common.{ ConnectionInfo, ServerResultUtils, ForwardedHea
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.util.{ Failure, Try }
-import scala.util.control.NonFatal
 
 private[server] class NettyModelConversion(forwardedHeaderHandler: ForwardedHeaderHandler) {
 
@@ -192,7 +191,7 @@ private[server] class NettyModelConversion(forwardedHeaderHandler: ForwardedHead
       }
 
       // Content type and length
-      if (mayHaveContentLength(result.header.status)) {
+      if (ServerResultUtils.mayHaveEntity(result.header.status)) {
         result.body.contentLength.foreach { contentLength =>
           if (HttpHeaders.isContentLengthSet(response)) {
             val manualContentLength = response.headers.get(CONTENT_LENGTH)
@@ -204,6 +203,10 @@ private[server] class NettyModelConversion(forwardedHeaderHandler: ForwardedHead
           }
           HttpHeaders.setContentLength(response, contentLength)
         }
+      } else if (HttpHeaders.isContentLengthSet(response)) {
+        val manualContentLength = response.headers.get(CONTENT_LENGTH)
+        logger.warn(s"Ignoring manual Content-Length ($manualContentLength) since it is not allowed for ${result.header.status} responses.")
+        response.headers.remove(CONTENT_LENGTH)
       }
       result.body.contentType.foreach { contentType =>
         if (response.headers().contains(CONTENT_TYPE)) {
@@ -262,10 +265,6 @@ private[server] class NettyModelConversion(forwardedHeaderHandler: ForwardedHead
     HttpHeaders.setTransferEncodingChunked(response)
     response
   }
-
-  /** Whether the given status may have a content length header or not. */
-  private def mayHaveContentLength(status: Int) =
-    status != Status.NO_CONTENT && status != Status.NOT_MODIFIED
 
   /** Convert a ByteString to a Netty ByteBuf. */
   private def byteStringToByteBuf(bytes: ByteString): ByteBuf = {

--- a/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala
@@ -10,6 +10,7 @@ import play.api.Logger
 import play.api.mvc._
 import play.api.http._
 import play.api.http.HeaderNames._
+import play.api.http.Status._
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
@@ -130,8 +131,13 @@ object ServerResultUtils {
 
   }
 
-  private def mayHaveEntity(status: Int) =
-    status != Status.NO_CONTENT && status != Status.NOT_MODIFIED
+  /** Whether the given status may have an entity or not. */
+  def mayHaveEntity(status: Int): Boolean = status match {
+    case CONTINUE | SWITCHING_PROTOCOLS | NO_CONTENT | NOT_MODIFIED =>
+      false
+    case _ =>
+      true
+  }
 
   /**
    * Cancel the entity.

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -493,6 +493,12 @@ trait Results {
     }
   }
 
+  /** Generates a ‘100 Continue’ result. */
+  val Continue = Result(header = ResponseHeader(CONTINUE), body = HttpEntity.NoEntity)
+
+  /** Generates a ‘101 Switching Protocols’ result. */
+  val SwitchingProtocols = Result(header = ResponseHeader(SWITCHING_PROTOCOLS), body = HttpEntity.NoEntity)
+
   /** Generates a ‘200 OK’ result. */
   val Ok = new Status(OK)
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -493,12 +493,6 @@ trait Results {
     }
   }
 
-  /** Generates a ‘100 Continue’ result. */
-  val Continue = Result(header = ResponseHeader(CONTINUE), body = HttpEntity.NoEntity)
-
-  /** Generates a ‘101 Switching Protocols’ result. */
-  val SwitchingProtocols = Result(header = ResponseHeader(SWITCHING_PROTOCOLS), body = HttpEntity.NoEntity)
-
   /** Generates a ‘200 OK’ result. */
   val Ok = new Status(OK)
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Backport of https://github.com/playframework/playframework/pull/6261

## References
Please have a look at https://github.com/playframework/playframework/pull/6261

