### PR TITLE
Add format methods to FormError

### DIFF
--- a/documentation/manual/working/javaGuide/main/forms/JavaForms.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaForms.md
@@ -9,7 +9,7 @@ The `play.data` package contains several helpers to handle HTTP form data submis
 
 @[user](code/javaguide/forms/u1/User.java)
 
-To wrap a class you have to inject a `play.data.FormFactory` into your Controller which then allows you to create the form:
+To wrap a class you have to inject a [`play.data.FormFactory`](api/java/play/data/FormFactory.html) into your Controller which then allows you to create the form:
 
 @[create](code/javaguide/forms/JavaForms.java)
 
@@ -35,7 +35,7 @@ You can also define an ad-hoc validation by adding a `validate` method to your t
 
 @[user](code/javaguide/forms/u3/User.java)
 
-The message returned in the above example will become a global error.
+The message returned in the above example will become a global error.  Errors are defined as [`play.data.validation.ValidationError`](api/java/play/data/validation/ValidationError.html).
 
 The `validate`-method can return the following types: `String`, `List<ValidationError>` or `Map<String,List<ValidationError>>`
 
@@ -57,10 +57,11 @@ Typically, as shown above, the form simply gets passed to a template.  Global er
 
 @[global-errors](code/javaguide/forms/view.scala.html)
 
-Errors for a particular field can be rendered in the following manner:
+Errors for a particular field can be rendered in the following manner with [`error.format`](api/scala/play/api/data/FormError.html):
 
 @[field-errors](code/javaguide/forms/view.scala.html)
 
+Note that `error.format` takes `messages()` as an argument -- this is an [`play.18n.Messages`](api/java/play/i18n/Messages.html) instance defined in [[JavaI18n]].
 
 ## Filling a form with initial default values
 

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/view.scala.html
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/view.scala.html
@@ -4,7 +4,7 @@
 @if(form.hasGlobalErrors) {
     <p class="error">
         @for(error <- form.globalErrors) {
-            <p>@Messages(error.messages, error.arguments.toArray: _*)</p>
+            <p>@error.format(messages())</p>
         }
     </p>
 }
@@ -12,6 +12,6 @@
 
 @* #field-errors *@
 @for(error <- form("email").errors) {
-    <p>@Messages(error.messages, error.arguments.toArray: _*)</p>
+    <p>@error.format(messages())</p>
 }
 @* #field-errors *@

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
@@ -209,6 +209,8 @@ Errors attached to a field will render automatically using the form helpers, so 
 
 @[form-user-generated](code/scalaguide/forms/scalaforms/views/user.scala.html)
 
+Errors that are not attached to a field can be converted to a string with `error.format`, which takes an implicit [play.api.i18n.Messages](api/scala/play/api/i18n/Messages.html) instance.
+
 Global errors that are not bound to a key do not have a helper and must be defined explicitly in the page:
 
 @[global-errors](code/scalaguide/forms/scalaforms/views/user.scala.html)

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/user.scala.html
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/user.scala.html
@@ -29,7 +29,7 @@
 @if(userForm.hasGlobalErrors) {
   <ul>
   @for(error <- userForm.globalErrors) {
-    <li>@Messages(error.messages, error.args)</li>
+    <li>@error.format</li>
   }
   </ul>
 }

--- a/framework/src/play-java-forms/src/main/java/play/data/validation/ValidationError.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/ValidationError.java
@@ -6,6 +6,7 @@ package play.data.validation;
 import java.util.*;
 
 import com.google.common.collect.ImmutableList;
+import play.i18n.Messages;
 
 /**
  * A form validation error.
@@ -86,6 +87,16 @@ public class ValidationError {
      */
     public List<Object> arguments() {
         return arguments;
+    }
+
+    /**
+     * Returns the formatted error message (message + arguments) in the given Messages.
+     *
+     * @param messagesObj the play.i18n.Messages object containing the language.
+     * @return the results of messagesObj.at(messages, arguments).
+     */
+    public String format(Messages messagesObj) {
+        return messagesObj.at(messages, arguments);
     }
 
     public String toString() {

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -420,6 +420,27 @@ case class FormError(key: String, messages: Seq[String], args: Seq[Any] = Nil) {
    * @param message The new message.
    */
   def withMessage(message: String): FormError = FormError(key, message)
+
+  /**
+   * Displays the formatted message, for use in a template.
+   */
+  def format(implicit messages: play.api.i18n.Messages): String = {
+    format(messages.messages, messages.lang)
+  }
+
+  /**
+   * Displays the formatted message, for use in a template.
+   */
+  def format(implicit messagesApi: play.api.i18n.MessagesApi, locale: java.util.Locale): String = {
+    format(messagesApi, play.api.i18n.Lang(locale))
+  }
+
+  /**
+   * Displays the formatted message, for use in a template.
+   */
+  def format(implicit messagesApi: play.api.i18n.MessagesApi, lang: play.api.i18n.Lang): String = {
+    messagesApi.apply(message, args: _*)(lang)
+  }
 }
 
 object FormError {

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -425,21 +425,7 @@ case class FormError(key: String, messages: Seq[String], args: Seq[Any] = Nil) {
    * Displays the formatted message, for use in a template.
    */
   def format(implicit messages: play.api.i18n.Messages): String = {
-    format(messages.messages, messages.lang)
-  }
-
-  /**
-   * Displays the formatted message, for use in a template.
-   */
-  def format(implicit messagesApi: play.api.i18n.MessagesApi, locale: java.util.Locale): String = {
-    format(messagesApi, play.api.i18n.Lang(locale))
-  }
-
-  /**
-   * Displays the formatted message, for use in a template.
-   */
-  def format(implicit messagesApi: play.api.i18n.MessagesApi, lang: play.api.i18n.Lang): String = {
-    messagesApi.apply(message, args: _*)(lang)
+    messages.apply(message, args)
   }
 }
 


### PR DESCRIPTION
## Purpose

Adds format method to `FormError`.
## Background Context

If you're using a form error in Twirl, then the way to do it is:

```
@Messages(error.messages, error.args)
```

https://www.playframework.com/documentation/2.5.x/ScalaForms#Displaying-errors-in-a-view-template

Since you have to pass in an implicit Messages anyway (again, from the docs above):

```
@(userForm: Form[UserData])(implicit messages: Messages)
```

and the Messages singleton object takes that same implicit messages, there's a whole bunch of typing that could just as well be:

```
@error.format
```

So... that's what this PR does.
