### PR TITLE
Upgrade scalariform to 0.1.8

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -11,7 +11,10 @@ import com.typesafe.tools.mima.plugin.MimaKeys.{
 }
 import com.typesafe.tools.mima.core._
 
+import scalariform.formatter.preferences._
 import com.typesafe.sbt.SbtScalariform.scalariformSettings
+import com.typesafe.sbt.SbtScalariform.ScalariformKeys
+
 import pl.project13.scala.sbt.JmhPlugin
 import play.twirl.sbt.SbtTwirl
 import play.twirl.sbt.Import.TwirlKeys
@@ -47,6 +50,16 @@ object BuildSettings {
    * These settings are used by all projects
    */
   def playCommonSettings: Seq[Setting[_]] = scalariformSettings ++ Seq(
+      ScalariformKeys.preferences := ScalariformKeys.preferences.value
+        .setPreference(SpacesAroundMultiImports, true)
+        .setPreference(SpaceInsideParentheses, false)
+        .setPreference(DanglingCloseParenthesis, Preserve)
+        .setPreference(PreserveSpaceBeforeArguments, true)        
+        .setPreference(DoubleIndentClassDeclaration, true)
+        //.setPreference(DoubleIndentMethodDeclaration, true)
+        //.setPreference(FirstParameterOnNewline, Preserve)        
+        //.setPreference(FirstArgumentOnNewline, Preserve)
+    ) ++ Seq(
     homepage := Some(url("https://playframework.com")),
     ivyLoggingLevel := UpdateLogging.DownloadOnly,
     resolvers ++= Seq(

--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -56,9 +56,6 @@ object BuildSettings {
         .setPreference(DanglingCloseParenthesis, Preserve)
         .setPreference(PreserveSpaceBeforeArguments, true)        
         .setPreference(DoubleIndentClassDeclaration, true)
-        //.setPreference(DoubleIndentMethodDeclaration, true)
-        //.setPreference(FirstParameterOnNewline, Preserve)        
-        //.setPreference(FirstArgumentOnNewline, Preserve)
     ) ++ Seq(
     homepage := Some(url("https://playframework.com")),
     ivyLoggingLevel := UpdateLogging.DownloadOnly,

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -19,7 +19,7 @@ scalacOptions ++= Seq("-deprecation", "-language:_")
 addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "1.1.2"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % sbtTwirlVersion)
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.8")
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.7")
 
 libraryDependencies ++= Seq(
@@ -27,8 +27,6 @@ libraryDependencies ++= Seq(
   "org.webjars" % "webjars-locator-core" % "0.26"
 )
 
-// override scalariform version to get some fixes
-libraryDependencies += "org.scalariform" %% "scalariform" % "0.1.5-20140822-69e2e30"
 resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")

--- a/framework/src/play-akka-http-server/src/main/scala/akka/http/play/WebSocketHandler.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/akka/http/play/WebSocketHandler.scala
@@ -115,7 +115,8 @@ object WebSocketHandler {
 
   private def frameToRawMessage(header: FrameHeader, data: ByteString) = {
     val unmasked = FrameEventParser.mask(data, header.mask)
-    RawMessage(frameOpCodeToMessageType(header.opcode),
+    RawMessage(
+      frameOpCodeToMessageType(header.opcode),
       unmasked, header.fin)
   }
 

--- a/framework/src/play-cache/src/main/scala/play/api/cache/SerializableResult.scala
+++ b/framework/src/play-cache/src/main/scala/play/api/cache/SerializableResult.scala
@@ -14,7 +14,8 @@ import scala.annotation.tailrec
  */
 private[play] final class SerializableResult(constructorResult: Result) extends Externalizable {
 
-  assert(Option(constructorResult).forall(_.body.isInstanceOf[HttpEntity.Strict]),
+  assert(
+    Option(constructorResult).forall(_.body.isInstanceOf[HttpEntity.Strict]),
     "Only strict entities can be cached, streamed entities cannot be cached")
 
   /**

--- a/framework/src/play-cache/src/test/scala/play/api/cache/CacheApiSpec.scala
+++ b/framework/src/play-cache/src/test/scala/play/api/cache/CacheApiSpec.scala
@@ -22,9 +22,9 @@ class CacheApiSpec extends PlaySpecification {
       _.overrides(
         bind[CacheManager].toProvider[CustomCacheManagerProvider]
       ).configure(
-          "play.cache.createBoundCaches" -> false,
-          "play.cache.bindCaches" -> Seq("custom")
-        )
+        "play.cache.createBoundCaches" -> false,
+        "play.cache.bindCaches" -> Seq("custom")
+      )
     ) {
       app.injector.instanceOf[NamedCacheController]
     }

--- a/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsValidation.scala
+++ b/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsValidation.scala
@@ -32,7 +32,8 @@ object PlayDocsValidation {
    *
    * This is the main markdown report for validating markdown docs.
    */
-  case class MarkdownRefReport(markdownFiles: Seq[File],
+  case class MarkdownRefReport(
+    markdownFiles: Seq[File],
     wikiLinks: Seq[LinkRef],
     resourceLinks: Seq[LinkRef],
     codeSamples: Seq[CodeSampleRef],
@@ -59,13 +60,15 @@ object PlayDocsValidation {
   case class CodeSample(source: String, segment: String,
     sourcePosition: Int, segmentPosition: Int)
 
-  case class TranslationReport(missingFiles: Seq[String],
+  case class TranslationReport(
+    missingFiles: Seq[String],
     introducedFiles: Seq[String],
     changedPathFiles: Seq[(String, String)],
     codeSampleIssues: Seq[TranslationCodeSamples],
     okFiles: Seq[String],
     total: Int)
-  case class TranslationCodeSamples(name: String,
+  case class TranslationCodeSamples(
+    name: String,
     missingCodeSamples: Seq[CodeSample],
     introducedCodeSamples: Seq[CodeSample],
     totalCodeSamples: Int)
@@ -388,14 +391,16 @@ object PlayDocsValidation {
       case link if !relativeLinkOk(link) => link
     }, "Bad relative link")
 
-    assertLinksNotMissing("Missing wiki resources test",
+    assertLinksNotMissing(
+      "Missing wiki resources test",
       report.resourceLinks.collect {
         case link if !fileExists(link.link) => link
       }, "Could not find resource")
 
     val (existing, nonExisting) = report.codeSamples.partition(sample => fileExists(sample.source))
 
-    assertLinksNotMissing("Missing source files test",
+    assertLinksNotMissing(
+      "Missing source files test",
       nonExisting.map(sample => LinkRef(sample.source, sample.file, sample.sourcePosition)),
       "Could not find source file")
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -30,7 +30,8 @@ import scala.concurrent.Future
  * @param next The composed action that is being protected.
  * @param errorHandler handling failed token error.
  */
-class CSRFAction(next: EssentialAction,
+class CSRFAction(
+    next: EssentialAction,
     config: CSRFConfig = CSRFConfig(),
     tokenSigner: CSRFTokenSigner,
     tokenProvider: TokenProvider,

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -37,7 +37,8 @@ import scala.concurrent.Future
  * @param shouldProtect A function that decides based on the headers of the request if a check is needed.
  * @param bypassCorsTrustedOrigins Whether to bypass the CSRF check if the CORS filter trusts this origin
  */
-case class CSRFConfig(tokenName: String = "csrfToken",
+case class CSRFConfig(
+    tokenName: String = "csrfToken",
     cookieName: Option[String] = None,
     secureCookie: Boolean = false,
     httpOnlyCookie: Boolean = false,

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -178,7 +178,8 @@ class GzipFilter @Inject() (config: GzipFilterConfig)(implicit mat: Materializer
  * @param shouldGzip Whether the given request/result should be gzipped.  This can be used, for example, to implement
  *                   black/white lists for gzipping by content type.
  */
-case class GzipFilterConfig(bufferSize: Int = 8192,
+case class GzipFilterConfig(
+    bufferSize: Int = 8192,
     chunkedThreshold: Int = 102400,
     shouldGzip: (RequestHeader, Result) => Boolean = (_, _) => true) {
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
@@ -68,7 +68,8 @@ object SecurityHeadersFilter {
  * @param permittedCrossDomainPolicies "X-Permitted-Cross-Domain-Policies".
  * @param contentSecurityPolicy "Content-Security-Policy"
  */
-case class SecurityHeadersConfig(frameOptions: Option[String] = Some("DENY"),
+case class SecurityHeadersConfig(
+    frameOptions: Option[String] = Some("DENY"),
     xssProtection: Option[String] = Some("1; mode=block"),
     contentTypeOptions: Option[String] = Some("nosniff"),
     permittedCrossDomainPolicies: Option[String] = Some("master-only"),

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSCommonSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSCommonSpec.scala
@@ -5,7 +5,7 @@ package play.filters.cors
 
 import play.api.Application
 import play.api.mvc.Result
-import play.api.test.{FakeRequest, PlaySpecification}
+import play.api.test.{ FakeRequest, PlaySpecification }
 
 import scala.concurrent.Future
 

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSFilterSpec.scala
@@ -8,9 +8,9 @@ import javax.inject.Inject
 import play.api.Application
 import play.api.http.HttpFilters
 import play.api.inject.bind
-import play.api.mvc.{Action, DefaultActionBuilder, Results}
+import play.api.mvc.{ Action, DefaultActionBuilder, Results }
 import play.api.routing.sird._
-import play.api.routing.{Router, SimpleRouterImpl}
+import play.api.routing.{ Router, SimpleRouterImpl }
 import play.filters.cors.CORSFilterSpec._
 
 object CORSFilterSpec {
@@ -40,7 +40,7 @@ class CORSFilterSpec extends CORSCommonSpec {
     val restrictPaths = Map("play.filters.cors.pathPrefixes" -> Seq("/foo", "/bar"))
 
     "pass through a cors request that doesn't match the path prefixes" in withApplication(conf = restrictPaths) { app =>
-      val result = route(app,fakeRequest("GET", "/baz").withHeaders(ORIGIN -> "http://localhost")).get
+      val result = route(app, fakeRequest("GET", "/baz").withHeaders(ORIGIN -> "http://localhost")).get
 
       status(result) must_== OK
       mustBeNoAccessControlResponseHeaders(result)

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSWithCSRFSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSWithCSRFSpec.scala
@@ -15,11 +15,11 @@ import play.filters.csrf._
 
 object CORSWithCSRFSpec {
 
-  class Filters @Inject()(corsFilter: CORSFilter, csrfFilter: CSRFFilter) extends HttpFilters {
+  class Filters @Inject() (corsFilter: CORSFilter, csrfFilter: CSRFFilter) extends HttpFilters {
     def filters = Seq(corsFilter, csrfFilter)
   }
 
-  class FiltersWithoutCors @Inject()(csrfFilter: CSRFFilter) extends HttpFilters {
+  class FiltersWithoutCors @Inject() (csrfFilter: CSRFFilter) extends HttpFilters {
     def filters = Seq(csrfFilter)
   }
 
@@ -53,12 +53,12 @@ class CORSWithCSRFSpec extends CORSCommonSpec {
 
   private def corsRequest =
     fakeRequest("POST", "/baz")
-        .withHeaders(
-          ORIGIN -> "http://localhost",
-          CONTENT_TYPE -> ContentTypes.FORM,
-          COOKIE -> "foo=bar"
-        )
-        .withBody("foo=1&bar=2")
+      .withHeaders(
+        ORIGIN -> "http://localhost",
+        CONTENT_TYPE -> ContentTypes.FORM,
+        COOKIE -> "foo=bar"
+      )
+      .withBody("foo=1&bar=2")
 
   "The CORSFilter" should {
 

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -229,7 +229,8 @@ trait CSRFCommonSpecs extends Specification with PlaySpecification {
     }
 
     "allow configuring a header bypass" in {
-      def csrfCheckRequest = buildCsrfCheckRequest(false,
+      def csrfCheckRequest = buildCsrfCheckRequest(
+        false,
         "play.filters.csrf.header.bypassHeaders.X-Requested-With" -> "*",
         "play.filters.csrf.header.bypassHeaders.Csrf-Token" -> "nocheck"
       )

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
@@ -80,7 +80,8 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
 
     "frame options" should {
 
-      "work with custom frame options" in withApplication(Ok("hello"),
+      "work with custom frame options" in withApplication(
+        Ok("hello"),
         """
           |play.filters.headers.frameOptions=some frame option
         """.stripMargin) { app =>
@@ -90,7 +91,8 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
           header(X_FRAME_OPTIONS_HEADER, result) must beSome("some frame option")
         }
 
-      "work with no frame options" in withApplication(Ok("hello"),
+      "work with no frame options" in withApplication(
+        Ok("hello"),
         """
           |play.filters.headers.frameOptions=null
         """.stripMargin) { app =>
@@ -103,7 +105,8 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
 
     "xss protection" should {
 
-      "work with custom xss protection" in withApplication(Ok("hello"),
+      "work with custom xss protection" in withApplication(
+        Ok("hello"),
         """
           |play.filters.headers.xssProtection=some xss protection
         """.stripMargin) { app =>
@@ -112,7 +115,8 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
           header(X_XSS_PROTECTION_HEADER, result) must beSome("some xss protection")
         }
 
-      "work with no xss protection" in withApplication(Ok("hello"),
+      "work with no xss protection" in withApplication(
+        Ok("hello"),
         """
           |play.filters.headers.xssProtection=null
         """.stripMargin) { app =>
@@ -125,7 +129,8 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
 
     "content type options protection" should {
 
-      "work with custom content type options protection" in withApplication(Ok("hello"),
+      "work with custom content type options protection" in withApplication(
+        Ok("hello"),
         """
           |play.filters.headers.contentTypeOptions="some content type option"
         """.stripMargin) { app =>
@@ -134,7 +139,8 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
           header(X_CONTENT_TYPE_OPTIONS_HEADER, result) must beSome("some content type option")
         }
 
-      "work with no content type options protection" in withApplication(Ok("hello"),
+      "work with no content type options protection" in withApplication(
+        Ok("hello"),
         """
           |play.filters.headers.contentTypeOptions=null
         """.stripMargin) { app =>
@@ -147,7 +153,8 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
 
     "permitted cross domain policies" should {
 
-      "work with custom" in withApplication(Ok("hello"),
+      "work with custom" in withApplication(
+        Ok("hello"),
         """
           |play.filters.headers.permittedCrossDomainPolicies="some very long word"
         """.stripMargin) { app =>
@@ -157,7 +164,8 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
           header(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, result) must beSome("some very long word")
         }
 
-      "work with none" in withApplication(Ok("hello"),
+      "work with none" in withApplication(
+        Ok("hello"),
         """
           |play.filters.headers.permittedCrossDomainPolicies=null
         """.stripMargin) { app =>
@@ -170,7 +178,8 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
 
     "content security policy protection" should {
 
-      "work with custom" in withApplication(Ok("hello"),
+      "work with custom" in withApplication(
+        Ok("hello"),
         """
           |play.filters.headers.contentSecurityPolicy="some content security policy"
         """.stripMargin) { app =>
@@ -179,7 +188,8 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
           header(CONTENT_SECURITY_POLICY_HEADER, result) must beSome("some content security policy")
         }
 
-      "work with none" in withApplication(Ok("hello"),
+      "work with none" in withApplication(
+        Ok("hello"),
         """
           |play.filters.headers.contentSecurityPolicy=null
         """.stripMargin) { app =>
@@ -191,8 +201,9 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
     }
 
     "action-specific headers" should {
-      "use provided header instead of config value if allowActionSpecificHeaders=true in config" in withApplication(Ok("hello")
-        .withHeaders(CONTENT_SECURITY_POLICY_HEADER → "my action-specific header"),
+      "use provided header instead of config value if allowActionSpecificHeaders=true in config" in withApplication(
+        Ok("hello")
+          .withHeaders(CONTENT_SECURITY_POLICY_HEADER → "my action-specific header"),
         """
           |play.filters.headers.contentSecurityPolicy="some content security policy"
           |play.filters.headers.allowActionSpecificHeaders=true
@@ -204,8 +215,9 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
           header(X_FRAME_OPTIONS_HEADER, result) must beSome("DENY")
         }
 
-      "use provided header instead of default if allowActionSpecificHeaders=true in config" in withApplication(Ok("hello")
-        .withHeaders(CONTENT_SECURITY_POLICY_HEADER → "my action-specific header"),
+      "use provided header instead of default if allowActionSpecificHeaders=true in config" in withApplication(
+        Ok("hello")
+          .withHeaders(CONTENT_SECURITY_POLICY_HEADER → "my action-specific header"),
         """
           |play.filters.headers.allowActionSpecificHeaders=true
         """.stripMargin) { app =>
@@ -215,8 +227,9 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
           header(X_FRAME_OPTIONS_HEADER, result) must beSome("DENY")
         }
 
-      "reject action-specific override if allowActionSpecificHeaders=false in config" in withApplication(Ok("hello")
-        .withHeaders(CONTENT_SECURITY_POLICY_HEADER → "my action-specific header"),
+      "reject action-specific override if allowActionSpecificHeaders=false in config" in withApplication(
+        Ok("hello")
+          .withHeaders(CONTENT_SECURITY_POLICY_HEADER → "my action-specific header"),
         """
           |play.filters.headers.contentSecurityPolicy="some content security policy"
           |play.filters.headers.allowActionSpecificHeaders=false
@@ -229,8 +242,9 @@ class SecurityHeadersFilterSpec extends PlaySpecification {
           header(X_FRAME_OPTIONS_HEADER, result) must beSome("DENY")
         }
 
-      "reject action-specific override if allowActionSpecificHeaders is not mentioned in config" in withApplication(Ok("hello")
-        .withHeaders(CONTENT_SECURITY_POLICY_HEADER → "my action-specific header"),
+      "reject action-specific override if allowActionSpecificHeaders is not mentioned in config" in withApplication(
+        Ok("hello")
+          .withHeaders(CONTENT_SECURITY_POLICY_HEADER → "my action-specific header"),
         """
           |play.filters.headers.contentSecurityPolicy="some content security policy"
         """.stripMargin) { app =>

--- a/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
+++ b/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
@@ -29,8 +29,8 @@ final case class GuiceApplicationBuilder(
   eagerly: Boolean = false,
   loadConfiguration: Environment => Configuration = Configuration.load,
   loadModules: (Environment, Configuration) => Seq[GuiceableModule] = GuiceableModule.loadModules) extends GuiceBuilder[GuiceApplicationBuilder](
-    environment, configuration, modules, overrides, disabled, binderOptions, eagerly
-  ) {
+  environment, configuration, modules, overrides, disabled, binderOptions, eagerly
+) {
 
   // extra constructor for creating from Java
   def this() = this(environment = Environment.simple())
@@ -63,8 +63,8 @@ final case class GuiceApplicationBuilder(
     load((env, conf) => modules)
 
   /**
-    * Override the router with a fake router having the given routes, before falling back to the default router
-    */
+   * Override the router with a fake router having the given routes, before falling back to the default router
+   */
   def routes(routes: PartialFunction[(String, String), Handler]): GuiceApplicationBuilder =
     bindings(bind[FakeRouterConfig] to FakeRouterConfig(routes))
       .overrides(bind[Router].toProvider[FakeRouterProvider])
@@ -111,9 +111,9 @@ final case class GuiceApplicationBuilder(
    */
   def configureLoggerFactory(configuration: Configuration): ILoggerFactory = {
     val loggerFactory: ILoggerFactory = LoggerConfigurator(environment.classLoader).map { lc =>
-        lc.configure(environment, configuration, Map.empty)
-        lc.loggerFactory
-      }.getOrElse(org.slf4j.LoggerFactory.getILoggerFactory)
+      lc.configure(environment, configuration, Map.empty)
+      lc.loggerFactory
+    }.getOrElse(org.slf4j.LoggerFactory.getILoggerFactory)
 
     if (shouldDisplayLoggerDeprecationMessage(configuration)) {
       val logger = loggerFactory.getLogger("application")
@@ -202,7 +202,6 @@ private class AdditionalRouterProvider(additional: Router) extends Provider[Rout
   @Inject private var fallback: RoutesProvider = _
   lazy val get = Router.from(additional.routes.orElse(fallback.get.routes))
 }
-
 
 private class FakeRoutes(
     injected: PartialFunction[(String, String), Handler], fallback: Router) extends Router {

--- a/framework/src/play-guice/src/main/scala/play/api/libs/concurrent/AkkaGuiceSupport.scala
+++ b/framework/src/play-guice/src/main/scala/play/api/libs/concurrent/AkkaGuiceSupport.scala
@@ -9,24 +9,24 @@ import com.google.inject.assistedinject.FactoryModuleBuilder
 import scala.reflect._
 
 /**
-  * Support for binding actors with Guice.
-  *
-  * Mix this trait in with a Guice AbstractModule to get convenient support for binding actors.  For example:
-  * {{{
-  *   class MyModule extends AbstractModule with AkkaGuiceSupport {
-  *     def configure = {
-  *       bindActor[MyActor]("myActor")
-  *     }
-  *   }
-  * }}}
-  *
-  * Then to use the above actor in your application, add a qualified injected dependency, like so:
-  * {{{
-  *   class MyController @Inject() (@Named("myActor") myActor: ActorRef) extends Controller {
-  *     ...
-  *   }
-  * }}}
-  */
+ * Support for binding actors with Guice.
+ *
+ * Mix this trait in with a Guice AbstractModule to get convenient support for binding actors.  For example:
+ * {{{
+ *   class MyModule extends AbstractModule with AkkaGuiceSupport {
+ *     def configure = {
+ *       bindActor[MyActor]("myActor")
+ *     }
+ *   }
+ * }}}
+ *
+ * Then to use the above actor in your application, add a qualified injected dependency, like so:
+ * {{{
+ *   class MyController @Inject() (@Named("myActor") myActor: ActorRef) extends Controller {
+ *     ...
+ *   }
+ * }}}
+ */
 trait AkkaGuiceSupport {
   self: AbstractModule =>
 
@@ -42,18 +42,18 @@ trait AkkaGuiceSupport {
   }
 
   /**
-    * Bind an actor.
-    *
-    * This will cause the actor to be instantiated by Guice, allowing it to be dependency injected itself.  It will
-    * bind the returned ActorRef for the actor will be bound, qualified with the passed in name, so that it can be
-    * injected into other components.
-    *
-    * @param name The name of the actor.
-    * @param props A function to provide props for the actor. The props passed in will just describe how to create the
-    *              actor, this function can be used to provide additional configuration such as router and dispatcher
-    *              configuration.
-    * @tparam T The class that implements the actor.
-    */
+   * Bind an actor.
+   *
+   * This will cause the actor to be instantiated by Guice, allowing it to be dependency injected itself.  It will
+   * bind the returned ActorRef for the actor will be bound, qualified with the passed in name, so that it can be
+   * injected into other components.
+   *
+   * @param name The name of the actor.
+   * @param props A function to provide props for the actor. The props passed in will just describe how to create the
+   *              actor, this function can be used to provide additional configuration such as router and dispatcher
+   *              configuration.
+   * @tparam T The class that implements the actor.
+   */
   def bindActor[T <: Actor: ClassTag](name: String, props: Props => Props = identity): Unit = {
     accessBinder.bind(classOf[ActorRef])
       .annotatedWith(Names.named(name))
@@ -62,54 +62,54 @@ trait AkkaGuiceSupport {
   }
 
   /**
-    * Bind an actor factory.
-    *
-    * This is useful for when you want to have child actors injected, and want to pass parameters into them, as well as
-    * have Guice provide some of the parameters.  It is intended to be used with Guice's AssistedInject feature.
-    *
-    * Let's say you have an actor that looks like this:
-    *
-    * {{{
-    * class MyChildActor @Inject() (db: Database, @Assisted id: String) extends Actor {
-    *   ...
-    * }
-    * }}}
-    *
-    * So `db` should be injected, while `id` should be passed.  Now, define a trait that takes the id, and returns
-    * the actor:
-    *
-    * {{{
-    * trait MyChildActorFactory {
-    *   def apply(id: String): Actor
-    * }
-    * }}}
-    *
-    * Now you can use this method to bind the child actor in your module:
-    *
-    * {{{
-    *   class MyModule extends AbstractModule with AkkaGuiceSupport {
-    *     def configure = {
-    *       bindActorFactory[MyChildActor, MyChildActorFactory]
-    *     }
-    *   }
-    * }}}
-    *
-    * Now, when you want an actor to instantiate this as a child actor, inject `MyChildActorFactory`:
-    *
-    * {{{
-    * class MyActor @Inject() (myChildActorFactory: MyChildActorFactory) extends Actor with InjectedActorSupport {
-    *
-    *   def receive {
-    *     case CreateChildActor(id) =>
-    *       val child: ActorRef = injectedChild(myChildActoryFactory(id), id)
-    *       sender() ! child
-    *   }
-    * }
-    * }}}
-    *
-    * @tparam ActorClass The class that implements the actor that the factory creates
-    * @tparam FactoryClass The class of the actor factory
-    */
+   * Bind an actor factory.
+   *
+   * This is useful for when you want to have child actors injected, and want to pass parameters into them, as well as
+   * have Guice provide some of the parameters.  It is intended to be used with Guice's AssistedInject feature.
+   *
+   * Let's say you have an actor that looks like this:
+   *
+   * {{{
+   * class MyChildActor @Inject() (db: Database, @Assisted id: String) extends Actor {
+   *   ...
+   * }
+   * }}}
+   *
+   * So `db` should be injected, while `id` should be passed.  Now, define a trait that takes the id, and returns
+   * the actor:
+   *
+   * {{{
+   * trait MyChildActorFactory {
+   *   def apply(id: String): Actor
+   * }
+   * }}}
+   *
+   * Now you can use this method to bind the child actor in your module:
+   *
+   * {{{
+   *   class MyModule extends AbstractModule with AkkaGuiceSupport {
+   *     def configure = {
+   *       bindActorFactory[MyChildActor, MyChildActorFactory]
+   *     }
+   *   }
+   * }}}
+   *
+   * Now, when you want an actor to instantiate this as a child actor, inject `MyChildActorFactory`:
+   *
+   * {{{
+   * class MyActor @Inject() (myChildActorFactory: MyChildActorFactory) extends Actor with InjectedActorSupport {
+   *
+   *   def receive {
+   *     case CreateChildActor(id) =>
+   *       val child: ActorRef = injectedChild(myChildActoryFactory(id), id)
+   *       sender() ! child
+   *   }
+   * }
+   * }}}
+   *
+   * @tparam ActorClass The class that implements the actor that the factory creates
+   * @tparam FactoryClass The class of the actor factory
+   */
   def bindActorFactory[ActorClass <: Actor: ClassTag, FactoryClass: ClassTag]: Unit = {
     accessBinder.install(new FactoryModuleBuilder()
       .implement(classOf[Actor], implicitly[ClassTag[ActorClass]].runtimeClass.asInstanceOf[Class[_ <: Actor]])

--- a/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
@@ -5,11 +5,11 @@ package play.api.inject.guice
 
 import org.specs2.mutable.Specification
 import com.google.inject.AbstractModule
-import play.{Configuration => JavaConfiguration, Environment => JavaEnvironment}
-import play.api.{ApplicationLoader, Configuration, Environment}
-import play.api.inject.{BuiltinModule, DefaultApplicationLifecycle}
+import play.{ Configuration => JavaConfiguration, Environment => JavaEnvironment }
+import play.api.{ ApplicationLoader, Configuration, Environment }
+import play.api.inject.{ BuiltinModule, DefaultApplicationLifecycle }
 
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
 class GuiceApplicationLoaderSpec extends Specification {

--- a/framework/src/play-integration-test/src/test/scala/play/it/LogTester.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/LogTester.scala
@@ -46,7 +46,8 @@ class LogBuffer extends AppenderBase[ILoggingEvent] {
     buffer.append(eventObject)
   }
 
-  def find(level: Option[Level] = None,
+  def find(
+    level: Option[Level] = None,
     logger: Option[String] = None,
     messageContains: Option[String] = None): List[ILoggingEvent] = buffer.synchronized {
     val byLevel = level.fold(buffer) { l => buffer.filter(_.getLevel == l) }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/HttpPipeliningSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/HttpPipeliningSpec.scala
@@ -38,7 +38,8 @@ trait HttpPipeliningSpec extends PlaySpecification with ServerIntegrationSpecifi
         case _ => Accumulator.done(Results.NotFound)
       }
     }) { port =>
-      val responses = BasicHttpClient.pipelineRequests(port,
+      val responses = BasicHttpClient.pipelineRequests(
+        port,
         BasicRequest("GET", "/long", "HTTP/1.1", Map(), ""),
         BasicRequest("GET", "/short", "HTTP/1.1", Map(), "")
       )
@@ -57,7 +58,8 @@ trait HttpPipeliningSpec extends PlaySpecification with ServerIntegrationSpecifi
         case _ => Accumulator.done(Results.NotFound)
       }
     }) { port =>
-      val responses = BasicHttpClient.pipelineRequests(port,
+      val responses = BasicHttpClient.pipelineRequests(
+        port,
         BasicRequest("GET", "/long", "HTTP/1.1", Map(), ""),
         BasicRequest("GET", "/short", "HTTP/1.1", Map(), "")
       )

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
@@ -41,7 +41,8 @@ trait IdleTimeoutSpec extends PlaySpecification with ServerIntegrationSpecificat
         "play.server.https.idleTimeout" -> getTimeout(httpsTimeout)
       ).asJava)
       val serverConfig = ServerConfig(port = Some(port), sslPort = httpsPort, mode = Mode.Test, properties = props)
-      running(play.api.test.TestServer(config = serverConfig,
+      running(play.api.test.TestServer(
+        config = serverConfig,
         application = new GuiceApplicationBuilder()
           .routes({
             case _ => action

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -6,9 +6,9 @@ package play.it.http
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.WSResponse
-import play.api.test.{PlaySpecification, TestServer, WsTestClient}
-import play.it.http.ActionCompositionOrderTest.{ActionAnnotation, ControllerAnnotation, WithUsername}
-import play.mvc.{Result, Results}
+import play.api.test.{ PlaySpecification, TestServer, WsTestClient }
+import play.it.http.ActionCompositionOrderTest.{ ActionAnnotation, ControllerAnnotation, WithUsername }
+import play.mvc.{ Result, Results }
 
 class JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
 
@@ -75,33 +75,37 @@ class JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     "execute request handler action first and action composition before controller composition" in makeRequest(new ComposedController {
       @ActionAnnotation
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false",
-           "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
-           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+    }, Map(
+      "play.http.actionComposition.controllerAnnotationsFirst" -> "false",
+      "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
+      "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
       response.body must beEqualTo("actioncreatoractioncontroller")
     }
 
     "execute request handler action first and controller composition before action composition" in makeRequest(new ComposedController {
       @ActionAnnotation
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "true",
-           "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
-           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+    }, Map(
+      "play.http.actionComposition.controllerAnnotationsFirst" -> "true",
+      "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
+      "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
       response.body must beEqualTo("actioncreatorcontrolleraction")
     }
 
     "execute request handler action first with only controller composition" in makeRequest(new ComposedController {
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
-           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+    }, Map(
+      "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
+      "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
       response.body must beEqualTo("actioncreatorcontroller")
     }
 
     "execute request handler action first with only action composition" in makeRequest(new MockController {
       @ActionAnnotation
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
-           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+    }, Map(
+      "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
+      "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
       response.body must beEqualTo("actioncreatoraction")
     }
   }
@@ -110,49 +114,55 @@ class JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
     "execute request handler action last and action composition before controller composition" in makeRequest(new ComposedController {
       @ActionAnnotation
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false",
-           "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
-           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+    }, Map(
+      "play.http.actionComposition.controllerAnnotationsFirst" -> "false",
+      "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
+      "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
       response.body must beEqualTo("actioncontrolleractioncreator")
     }
 
     "execute request handler action last and controller composition before action composition" in makeRequest(new ComposedController {
       @ActionAnnotation
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "true",
-           "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
-           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+    }, Map(
+      "play.http.actionComposition.controllerAnnotationsFirst" -> "true",
+      "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
+      "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
       response.body must beEqualTo("controlleractionactioncreator")
     }
 
     "execute request handler action last with only controller composition" in makeRequest(new ComposedController {
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
-           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+    }, Map(
+      "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
+      "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
       response.body must beEqualTo("controlleractioncreator")
     }
 
     "execute request handler action last with only action composition" in makeRequest(new MockController {
       @ActionAnnotation
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
-           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+    }, Map(
+      "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
+      "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
       response.body must beEqualTo("actionactioncreator")
     }
 
     "execute request handler action last is the default and controller composition before action composition" in makeRequest(new ComposedController {
       @ActionAnnotation
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "true",
-           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+    }, Map(
+      "play.http.actionComposition.controllerAnnotationsFirst" -> "true",
+      "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
       response.body must beEqualTo("controlleractionactioncreator")
     }
 
     "execute request handler action last is the default and action composition before controller composition" in makeRequest(new ComposedController {
       @ActionAnnotation
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.controllerAnnotationsFirst" -> "false",
-           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+    }, Map(
+      "play.http.actionComposition.controllerAnnotationsFirst" -> "false",
+      "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
       response.body must beEqualTo("actioncontrolleractioncreator")
     }
   }
@@ -160,15 +170,17 @@ class JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
   "When request handler is configured without action composition" should {
     "execute request handler action last without action composition" in makeRequest(new MockController {
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
-           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+    }, Map(
+      "play.http.actionComposition.executeActionCreatorActionFirst" -> "false",
+      "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
       response.body must beEqualTo("actioncreator")
     }
 
     "execute request handler action first without action composition" in makeRequest(new MockController {
       override def action: Result = Results.ok()
-    }, Map("play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
-           "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
+    }, Map(
+      "play.http.actionComposition.executeActionCreatorActionFirst" -> "true",
+      "play.http.actionCreator" -> "play.it.http.ActionCompositionActionCreator")) { response =>
       response.body must beEqualTo("actioncreator")
     }
   }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -124,43 +124,43 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
     "close the connection when the connection close header is present" in withServer(
       Results.Ok
     ) { port =>
-        BasicHttpClient.makeRequests(port, checkClosed = true)(
-          BasicRequest("GET", "/", "HTTP/1.1", Map("Connection" -> "close"), "")
-        )(0).status must_== 200
-      }
+      BasicHttpClient.makeRequests(port, checkClosed = true)(
+        BasicRequest("GET", "/", "HTTP/1.1", Map("Connection" -> "close"), "")
+      )(0).status must_== 200
+    }
 
     "close the connection when the connection when protocol is HTTP 1.0" in withServer(
       Results.Ok
     ) { port =>
-        BasicHttpClient.makeRequests(port, checkClosed = true)(
-          BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
-        )(0).status must_== 200
-      }
+      BasicHttpClient.makeRequests(port, checkClosed = true)(
+        BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
+      )(0).status must_== 200
+    }
 
     "honour the keep alive header for HTTP 1.0" in withServer(
       Results.Ok
     ) { port =>
-        val responses = BasicHttpClient.makeRequests(port)(
-          BasicRequest("GET", "/", "HTTP/1.0", Map("Connection" -> "keep-alive"), ""),
-          BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
-        )
-        responses(0).status must_== 200
-        responses(0).headers.get(CONNECTION) must beSome.like {
-          case s => s.toLowerCase(ENGLISH) must_== "keep-alive"
-        }
-        responses(1).status must_== 200
+      val responses = BasicHttpClient.makeRequests(port)(
+        BasicRequest("GET", "/", "HTTP/1.0", Map("Connection" -> "keep-alive"), ""),
+        BasicRequest("GET", "/", "HTTP/1.0", Map(), "")
+      )
+      responses(0).status must_== 200
+      responses(0).headers.get(CONNECTION) must beSome.like {
+        case s => s.toLowerCase(ENGLISH) must_== "keep-alive"
       }
+      responses(1).status must_== 200
+    }
 
     "keep alive HTTP 1.1 connections" in withServer(
       Results.Ok
     ) { port =>
-        val responses = BasicHttpClient.makeRequests(port)(
-          BasicRequest("GET", "/", "HTTP/1.1", Map(), ""),
-          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
-        )
-        responses(0).status must_== 200
-        responses(1).status must_== 200
-      }
+      val responses = BasicHttpClient.makeRequests(port)(
+        BasicRequest("GET", "/", "HTTP/1.1", Map(), ""),
+        BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+      )
+      responses(0).status must_== 200
+      responses(1).status must_== 200
+    }
 
     "close chunked connections when requested" in withServer(
       Results.Ok.chunked(Source(List("a", "b", "c")))
@@ -183,7 +183,8 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       }
 
     "allow sending trailers" in withServer(
-      Result(ResponseHeader(200, Map(TRANSFER_ENCODING -> CHUNKED, TRAILER -> "Chunks")),
+      Result(
+        ResponseHeader(200, Map(TRANSFER_ENCODING -> CHUNKED, TRAILER -> "Chunks")),
         HttpEntity.Chunked(Source(List(
           chunk("aa"), chunk("bb"), chunk("cc"), HttpChunk.LastChunk(new Headers(Seq("Chunks" -> "3")))
         )), None)
@@ -214,13 +215,13 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
     "Strip malformed cookies" in withServer(
       Results.Ok
     ) { port =>
-        val response = BasicHttpClient.makeRequests(port)(
-          BasicRequest("GET", "/", "HTTP/1.1", Map("Cookie" -> """£"""), "")
-        )(0)
+      val response = BasicHttpClient.makeRequests(port)(
+        BasicRequest("GET", "/", "HTTP/1.1", Map("Cookie" -> """£"""), "")
+      )(0)
 
-        response.status must_== 200
-        response.body must beLeft
-      }
+      response.status must_== 200
+      response.body must beLeft
+    }
 
     "reject HTTP 1.0 requests for chunked results" in withServer(
       Results.Ok.chunked(Source(List("a", "b", "c"))),
@@ -258,19 +259,19 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       Results.Ok
     ) { port =>
 
-        forall(List(
-          "aaa" -> "bbb\fccc",
-          "ddd" -> "eee\u000bfff"
-        )) { header =>
+      forall(List(
+        "aaa" -> "bbb\fccc",
+        "ddd" -> "eee\u000bfff"
+      )) { header =>
 
-          val response = BasicHttpClient.makeRequests(port)(
-            BasicRequest("GET", "/", "HTTP/1.1", Map(header), "")
-          ).head
+        val response = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(header), "")
+        ).head
 
-          response.status must_== 400
-          response.body must beLeft
-        }
+        response.status must_== 400
+        response.body must beLeft
       }
+    }
 
     "split Set-Cookie headers" in {
       import play.api.mvc.Cookie
@@ -291,7 +292,8 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
     }
 
     "not have a message body even when a 100 response with a non-empty body is returned" in withServer(
-      Result(header = ResponseHeader(CONTINUE),
+      Result(
+        header = ResponseHeader(CONTINUE),
         body = HttpEntity.Strict(ByteString("foo"), None)
       )
     ) { port =>
@@ -303,7 +305,8 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       }
 
     "not have a message body even when a 101 response with a non-empty body is returned" in withServer(
-      Result(header = ResponseHeader(SWITCHING_PROTOCOLS),
+      Result(
+        header = ResponseHeader(SWITCHING_PROTOCOLS),
         body = HttpEntity.Strict(ByteString("foo"), None)
       )
     ) { port =>
@@ -315,7 +318,8 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       }
 
     "not have a message body even when a 204 response with a non-empty body is returned" in withServer(
-      Result(header = ResponseHeader(NO_CONTENT),
+      Result(
+        header = ResponseHeader(NO_CONTENT),
         body = HttpEntity.Strict(ByteString("foo"), None)
       )
     ) { port =>
@@ -327,7 +331,8 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       }
 
     "not have a message body even when a 304 response with a non-empty body is returned" in withServer(
-      Result(header = ResponseHeader(NOT_MODIFIED),
+      Result(
+        header = ResponseHeader(NOT_MODIFIED),
         body = HttpEntity.Strict(ByteString("foo"), None)
       )
     ) { port =>
@@ -340,42 +345,42 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
     "not have a message body, nor Content-Length, when a 100 response is returned" in withServer(
       Results.Continue
     ) { port =>
-        val response = BasicHttpClient.makeRequests(port)(
-          BasicRequest("POST", "/", "HTTP/1.1", Map(), "")
-        ).head
-        response.body must beLeft("")
-        response.headers.get(CONTENT_LENGTH) must beNone
-      }
+      val response = BasicHttpClient.makeRequests(port)(
+        BasicRequest("POST", "/", "HTTP/1.1", Map(), "")
+      ).head
+      response.body must beLeft("")
+      response.headers.get(CONTENT_LENGTH) must beNone
+    }
 
     "not have a message body, nor Content-Length, when a 101 response is returned" in withServer(
       Results.SwitchingProtocols
     ) { port =>
-        val response = BasicHttpClient.makeRequests(port)(
-          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
-        ).head
-        response.body must beLeft("")
-        response.headers.get(CONTENT_LENGTH) must beNone
-      }
+      val response = BasicHttpClient.makeRequests(port)(
+        BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+      ).head
+      response.body must beLeft("")
+      response.headers.get(CONTENT_LENGTH) must beNone
+    }
 
     "not have a message body, nor Content-Length, when a 204 response is returned" in withServer(
       Results.NoContent
     ) { port =>
-        val response = BasicHttpClient.makeRequests(port)(
-          BasicRequest("PUT", "/", "HTTP/1.1", Map(), "")
-        ).head
-        response.body must beLeft("")
-        response.headers.get(CONTENT_LENGTH) must beNone
-      }
+      val response = BasicHttpClient.makeRequests(port)(
+        BasicRequest("PUT", "/", "HTTP/1.1", Map(), "")
+      ).head
+      response.body must beLeft("")
+      response.headers.get(CONTENT_LENGTH) must beNone
+    }
 
     "not have a message body, nor Content-Length, when a 304 response is returned" in withServer(
       Results.NotModified
     ) { port =>
-        val response = BasicHttpClient.makeRequests(port)(
-          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
-        ).head
-        response.body must beLeft("")
-        response.headers.get(CONTENT_LENGTH) must beNone
-      }
+      val response = BasicHttpClient.makeRequests(port)(
+        BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+      ).head
+      response.body must beLeft("")
+      response.headers.get(CONTENT_LENGTH) must beNone
+    }
 
     "not have a message body, nor Content-Length, even when a 100 response with an explicit Content-Length is returned" in withServer(
       Results.Continue.withHeaders("Content-Length" -> "0")

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/XmlBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/XmlBodyParserSpec.scala
@@ -108,7 +108,8 @@ class XmlBodyParserSpec extends PlaySpecification {
     "parse XML bodies without loading in a related schema from a parameter" in new WithApplication() {
       val externalParameterEntity = File.createTempFile("xep", ".dtd")
       val externalGeneralEntity = File.createTempFile("xxe", ".txt")
-      FileUtils.writeStringToFile(externalParameterEntity,
+      FileUtils.writeStringToFile(
+        externalParameterEntity,
         s"""
           |<!ENTITY % xge SYSTEM "${externalGeneralEntity.toURI}">
           |<!ENTITY % pe "<!ENTITY xxe '%xge;'>">

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -99,19 +99,18 @@ trait WebSocketSpec extends PlaySpecification
 
   "Plays WebSockets" should {
     "allow handling WebSockets using Akka streams" in {
-      "allow consuming messages" in allowConsumingMessages { _ =>
-        consumed =>
-          WebSocket.accept[String, String] { req =>
-            Flow.fromSinkAndSource(onFramesConsumed[String](consumed.success(_)),
-              Source.maybe[String])
-          }
+      "allow consuming messages" in allowConsumingMessages { _ => consumed =>
+        WebSocket.accept[String, String] { req =>
+          Flow.fromSinkAndSource(
+            onFramesConsumed[String](consumed.success(_)),
+            Source.maybe[String])
+        }
       }
 
-      "allow sending messages" in allowSendingMessages { _ =>
-        messages =>
-          WebSocket.accept[String, String] { req =>
-            Flow.fromSinkAndSource(Sink.ignore, Source(messages))
-          }
+      "allow sending messages" in allowSendingMessages { _ => messages =>
+        WebSocket.accept[String, String] { req =>
+          Flow.fromSinkAndSource(Sink.ignore, Source(messages))
+        }
       }
 
       "close when the consumer is done" in closeWhenTheConsumerIsDone { _ =>
@@ -120,17 +119,17 @@ trait WebSocketSpec extends PlaySpecification
         }
       }
 
-      "allow rejecting a websocket with a result" in allowRejectingTheWebSocketWithAResult { _ =>
-        statusCode =>
-          WebSocket.acceptOrResult[String, String] { req =>
-            Future.successful(Left(Results.Status(statusCode)))
-          }
+      "allow rejecting a websocket with a result" in allowRejectingTheWebSocketWithAResult { _ => statusCode =>
+        WebSocket.acceptOrResult[String, String] { req =>
+          Future.successful(Left(Results.Status(statusCode)))
+        }
       }
 
       "aggregate text frames" in {
         val consumed = Promise[List[String]]()
         withServer(app => WebSocket.accept[String, String] { req =>
-          Flow.fromSinkAndSource(onFramesConsumed[String](consumed.success(_)),
+          Flow.fromSinkAndSource(
+            onFramesConsumed[String](consumed.success(_)),
             Source.maybe[String])
         }) { app =>
           import app.materializer
@@ -153,7 +152,8 @@ trait WebSocketSpec extends PlaySpecification
         val consumed = Promise[List[ByteString]]()
 
         withServer(app => WebSocket.accept[ByteString, ByteString] { req =>
-          Flow.fromSinkAndSource(onFramesConsumed[ByteString](consumed.success(_)),
+          Flow.fromSinkAndSource(
+            onFramesConsumed[ByteString](consumed.success(_)),
             Source.maybe[ByteString])
         }) { app =>
           import app.materializer
@@ -210,41 +210,39 @@ trait WebSocketSpec extends PlaySpecification
 
     "allow handling a WebSocket with an actor" in {
 
-      "allow consuming messages" in allowConsumingMessages { implicit app =>
-        consumed =>
-          import app.materializer
-          implicit val system = app.actorSystem
-          WebSocket.accept[String, String] { req =>
-            ActorFlow.actorRef({ out =>
-              Props(new Actor() {
-                var messages = List.empty[String]
-                def receive = {
-                  case msg: String =>
-                    messages = msg :: messages
-                }
-                override def postStop() = {
-                  consumed.success(messages.reverse)
-                }
-              })
+      "allow consuming messages" in allowConsumingMessages { implicit app => consumed =>
+        import app.materializer
+        implicit val system = app.actorSystem
+        WebSocket.accept[String, String] { req =>
+          ActorFlow.actorRef({ out =>
+            Props(new Actor() {
+              var messages = List.empty[String]
+              def receive = {
+                case msg: String =>
+                  messages = msg :: messages
+              }
+              override def postStop() = {
+                consumed.success(messages.reverse)
+              }
             })
-          }
+          })
+        }
       }
 
-      "allow sending messages" in allowSendingMessages { implicit app =>
-        messages =>
-          import app.materializer
-          implicit val system = app.actorSystem
-          WebSocket.accept[String, String] { req =>
-            ActorFlow.actorRef({ out =>
-              Props(new Actor() {
-                messages.foreach { msg =>
-                  out ! msg
-                }
-                out ! Status.Success(())
-                def receive = PartialFunction.empty
-              })
+      "allow sending messages" in allowSendingMessages { implicit app => messages =>
+        import app.materializer
+        implicit val system = app.actorSystem
+        WebSocket.accept[String, String] { req =>
+          ActorFlow.actorRef({ out =>
+            Props(new Actor() {
+              messages.foreach { msg =>
+                out ! msg
+              }
+              out ! Status.Success(())
+              def receive = PartialFunction.empty
             })
-          }
+          })
+        }
       }
 
       "close when the consumer is done" in closeWhenTheConsumerIsDone { implicit app =>
@@ -274,28 +272,26 @@ trait WebSocketSpec extends PlaySpecification
         }
       }
 
-      "clean up when closed" in cleanUpWhenClosed { implicit app =>
-        cleanedUp =>
-          import app.materializer
-          implicit val system = app.actorSystem
-          WebSocket.accept[String, String] { req =>
-            ActorFlow.actorRef({ out =>
-              Props(new Actor() {
-                def receive = PartialFunction.empty
-                override def postStop() = {
-                  cleanedUp.success(true)
-                }
-              })
+      "clean up when closed" in cleanUpWhenClosed { implicit app => cleanedUp =>
+        import app.materializer
+        implicit val system = app.actorSystem
+        WebSocket.accept[String, String] { req =>
+          ActorFlow.actorRef({ out =>
+            Props(new Actor() {
+              def receive = PartialFunction.empty
+              override def postStop() = {
+                cleanedUp.success(true)
+              }
             })
-          }
+          })
+        }
       }
 
-      "allow rejecting a websocket with a result" in allowRejectingTheWebSocketWithAResult { implicit app =>
-        statusCode =>
+      "allow rejecting a websocket with a result" in allowRejectingTheWebSocketWithAResult { implicit app => statusCode =>
 
-          WebSocket.acceptOrResult[String, String] { req =>
-            Future.successful(Left(Results.Status(statusCode)))
-          }
+        WebSocket.acceptOrResult[String, String] { req =>
+          Future.successful(Left(Results.Status(statusCode)))
+        }
       }
 
     }
@@ -317,25 +313,22 @@ trait WebSocketSpec extends PlaySpecification
         invoker.call(javaHandler)
       }
 
-      "allow consuming messages" in allowConsumingMessages { _ =>
-        consumed =>
-          val javaConsumed = Promise[JList[String]]()
-          consumed.completeWith(javaConsumed.future.map(_.asScala.toList))
-          WebSocketSpecJavaActions.allowConsumingMessages(javaConsumed)
+      "allow consuming messages" in allowConsumingMessages { _ => consumed =>
+        val javaConsumed = Promise[JList[String]]()
+        consumed.completeWith(javaConsumed.future.map(_.asScala.toList))
+        WebSocketSpecJavaActions.allowConsumingMessages(javaConsumed)
       }
 
-      "allow sending messages" in allowSendingMessages { _ =>
-        messages =>
-          WebSocketSpecJavaActions.allowSendingMessages(messages.asJava)
+      "allow sending messages" in allowSendingMessages { _ => messages =>
+        WebSocketSpecJavaActions.allowSendingMessages(messages.asJava)
       }
 
       "close when the consumer is done" in closeWhenTheConsumerIsDone { _ =>
         WebSocketSpecJavaActions.closeWhenTheConsumerIsDone()
       }
 
-      "allow rejecting a websocket with a result" in allowRejectingTheWebSocketWithAResult { _ =>
-        statusCode =>
-          WebSocketSpecJavaActions.allowRejectingAWebSocketWithAResult(statusCode)
+      "allow rejecting a websocket with a result" in allowRejectingTheWebSocketWithAResult { _ => statusCode =>
+        WebSocketSpecJavaActions.allowRejectingAWebSocketWithAResult(statusCode)
       }
 
     }

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/util/CollectionUtil.scala
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/util/CollectionUtil.scala
@@ -3,14 +3,15 @@
  */
 package play.libs.ws.util
 
-import java.{ util =>ju }
+import java.{ util => ju }
 import scala.collection.convert.WrapAsJava._
 
-/** Utility class for converting a Scala `Map` with a nested collection type into its idiomatic Java counterpart. 
- *  The reason why this source is written in Scala is that doing the conversion using Java is a lot more involved. 
+/**
+ * Utility class for converting a Scala `Map` with a nested collection type into its idiomatic Java counterpart.
+ *  The reason why this source is written in Scala is that doing the conversion using Java is a lot more involved.
  *  This utility class is used by `play.libs.ws.StreamedResponse`.
  */
 private[ws] object CollectionUtil {
   def convert(headers: Map[String, Seq[String]]): ju.Map[String, ju.List[String]] =
-    mapAsJavaMap(headers.map { case (k, v) => k -> seqAsJavaList(v)})
+    mapAsJavaMap(headers.map { case (k, v) => k -> seqAsJavaList(v) })
 }

--- a/framework/src/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
+++ b/framework/src/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
@@ -68,7 +68,8 @@ private[routing] object RouterBuilderHelper {
                   // it to instantiate the default body parser, we have to instantiate it ourselves.
                   val app = Play.privateMaybeApplication.get // throw exception if no current app
                   val bp = PlayBodyParsers(ParserConfiguration(), app.errorHandler, app.materializer)
-                  new play.mvc.BodyParser.Default(new JavaHttpErrorHandlerDelegate(app.errorHandler),
+                  new play.mvc.BodyParser.Default(
+                    new JavaHttpErrorHandlerDelegate(app.errorHandler),
                     app.injector.instanceOf[HttpConfiguration], bp)
                 }
                 ActionBuilder.ignoringBody.async(parser) { request =>

--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
@@ -254,7 +254,8 @@ case class DefaultEvolutionsDatasourceConfig(
 /**
  * Default evolutions configuration.
  */
-class DefaultEvolutionsConfig(defaultDatasourceConfig: EvolutionsDatasourceConfig,
+class DefaultEvolutionsConfig(
+    defaultDatasourceConfig: EvolutionsDatasourceConfig,
     datasources: Map[String, EvolutionsDatasourceConfig]) extends EvolutionsConfig {
   def forDatasource(db: String) = datasources.getOrElse(db, defaultDatasourceConfig)
 }

--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -122,7 +122,8 @@ object Evolutions {
   def updateEvolutionScript(db: String = "default", revision: Int = 1, comment: String = "Generated", ups: String, downs: String)(implicit environment: Environment) {
     val evolutions = environment.getFile(fileName(db, revision))
     Files.createDirectory(environment.getFile(directoryName(db)).toPath)
-    writeFileIfChanged(evolutions,
+    writeFileIfChanged(
+      evolutions,
       """|# --- %s
          |
          |# --- !Ups

--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -485,7 +485,8 @@ class EnvironmentEvolutionsReader @Inject() (environment: Environment) extends R
  * @param prefix A prefix that gets added to the resource file names, for example, this could be used to namespace
  *               evolutions in different environments to work with different databases.
  */
-class ClassLoaderEvolutionsReader(classLoader: ClassLoader = classOf[ClassLoaderEvolutionsReader].getClassLoader,
+class ClassLoaderEvolutionsReader(
+    classLoader: ClassLoader = classOf[ClassLoaderEvolutionsReader].getClassLoader,
     prefix: String = "") extends ResourceEvolutionsReader {
   def loadResource(db: String, revision: Int) = {
     Option(classLoader.getResourceAsStream(prefix + Evolutions.resourceName(db, revision)))

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
@@ -61,7 +61,8 @@ class BoneConnectionPool @Inject() (environment: Environment) extends Connection
       case "READ_UNCOMMITTED" => Connection.TRANSACTION_READ_UNCOMMITTED
       case "REPEATABLE_READ" => Connection.TRANSACTION_REPEATABLE_READ
       case "SERIALIZABLE" => Connection.TRANSACTION_SERIALIZABLE
-      case unknown => throw config.reportError("bonecp.isolation",
+      case unknown => throw config.reportError(
+        "bonecp.isolation",
         s"Unknown isolation level [$unknown]")
     }
     val catalog = config.getDeprecated[Option[String]]("bonecp.defaultCatalog", "defaultCatalog")

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -57,7 +57,7 @@ object JsMacroImpl {
     // writes or both.
     def conditionalList[T](ifReads: T, ifWrites: T): List[T] =
       (if (reads) List(ifReads) else Nil) :::
-    (if (writes) List(ifWrites) else Nil)
+        (if (writes) List(ifWrites) else Nil)
 
     import c.universe._
 
@@ -126,16 +126,17 @@ object JsMacroImpl {
           case Some((TypeRef(NoPrefix, a, _),
             TypeRef(NoPrefix, b, _))) => { // for generic parameter
             if (a.fullName != b.fullName) {
-              c.warning(c.enclosingPosition,
+              c.warning(
+                c.enclosingPosition,
                 s"Type symbols are not compatible: $a != $b")
 
               false
-            }
-            else conforms(types.tail)
+            } else conforms(types.tail)
           }
 
           case Some((a, b)) if (a.typeArgs.size != b.typeArgs.size) => {
-            c.warning(c.enclosingPosition,
+            c.warning(
+              c.enclosingPosition,
               s"Type parameters are not matching: $a != $b")
 
             false
@@ -143,14 +144,16 @@ object JsMacroImpl {
 
           case Some((a, b)) if a.typeArgs.isEmpty =>
             if (a =:= b) conforms(types.tail) else {
-              c.warning(c.enclosingPosition,
+              c.warning(
+                c.enclosingPosition,
                 s"Types are not compatible: $a != $b")
 
               false
             }
 
           case Some((a, b)) if (a.baseClasses != b.baseClasses) => {
-            c.warning(c.enclosingPosition,
+            c.warning(
+              c.enclosingPosition,
               s"Generic types are not compatible: $a != $b")
 
             false
@@ -237,7 +240,8 @@ object JsMacroImpl {
     val (applyFunction, tparams, params) = ApplyUnapply.applyFunction match {
       case Some(info) => info
 
-      case _ => c.abort(c.enclosingPosition,
+      case _ => c.abort(
+        c.enclosingPosition,
         s"No apply function found matching unapply parameters")
     }
 
@@ -284,7 +288,7 @@ object JsMacroImpl {
       }
 
       /**
-       * Replaces any reference to the type itself by the Placeholder type. 
+       * Replaces any reference to the type itself by the Placeholder type.
        * @return the normalized type + whether any self reference has been found
        */
       private def normalized(tpe: Type): (Type, Boolean) =
@@ -373,11 +377,12 @@ object JsMacroImpl {
 
         // if any implicit is missing, abort
         val missingImplicits = effectiveImplicits.collect {
-          case Implicit(_, t, EmptyTree/* ~= not found */, _, _) => t
+          case Implicit(_, t, EmptyTree /* ~= not found */ , _, _) => t
         }
 
         if (missingImplicits.nonEmpty) {
-          c.abort(c.enclosingPosition,
+          c.abort(
+            c.enclosingPosition,
             s"No instance of ${natag.tpe.typeSymbol.fullName} is available for ${missingImplicits.map(prettyType(_)).mkString(", ")} in the implicit scope (Hint: if declared in the same file, make sure it's declared before)")
         }
 

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
@@ -460,12 +460,12 @@ trait DefaultReads extends LowPriorityDefaultReads {
    * @see [[DefaultWrites.TemporalFormatter]]
    *
    * {{{
-    * import play.api.libs.json.Reads.offsetDateTimeReads
-    *
-    * val customReads1 = offsetDateTimeReads("dd/MM/yyyy, HH:mm:ss (Z)")
-    * val customReads2 = offsetDateTimeReads(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-    * val customReads3 = offsetDateTimeReads(
-    *   DateTimeFormatter.ISO_OFFSET_DATE_TIME, _.drop(1))
+   * import play.api.libs.json.Reads.offsetDateTimeReads
+   *
+   * val customReads1 = offsetDateTimeReads("dd/MM/yyyy, HH:mm:ss (Z)")
+   * val customReads2 = offsetDateTimeReads(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+   * val customReads3 = offsetDateTimeReads(
+   *   DateTimeFormatter.ISO_OFFSET_DATE_TIME, _.drop(1))
    * }}}
    */
   def offsetDateTimeReads[T](parsing: T, corrector: String => String = identity)(implicit p: T => TemporalParser[OffsetDateTime]): Reads[OffsetDateTime] = new Reads[OffsetDateTime] {

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
@@ -287,17 +287,17 @@ trait DefaultWrites extends LowPriorityWrites {
   }
 
   /**
-    * The default typeclass to write a `java.time.LocalDateTime`,
-    * using '2011-12-03T10:15:30' format.
-    */
+   * The default typeclass to write a `java.time.LocalDateTime`,
+   * using '2011-12-03T10:15:30' format.
+   */
   implicit val DefaultLocalDateTimeWrites =
     temporalWrites[LocalDateTime, DateTimeFormatter](
       DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
   /**
-    * The default typeclass to write a `java.time.OffsetDateTime`,
-    * using '2011-12-03T10:15:30+02:00' format.
-    */
+   * The default typeclass to write a `java.time.OffsetDateTime`,
+   * using '2011-12-03T10:15:30+02:00' format.
+   */
   implicit val DefaultOffsetDateTimeWrites =
     temporalWrites[OffsetDateTime, DateTimeFormatter](
       DateTimeFormatter.ISO_OFFSET_DATE_TIME)

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonTransSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonTransSpec.scala
@@ -30,20 +30,20 @@ class JsonTransSpec extends Specification {
       js.transform(
         (__ \ 'field3).json.pick
       ).get must beEqualTo(
-          Json.obj(
-            "field31" -> "beta", "field32" -> 345
-          )
+        Json.obj(
+          "field31" -> "beta", "field32" -> 345
         )
+      )
     }
 
     "pick a branch" in {
       js.transform(
         (__ \ 'field3).json.pickBranch
       ).get must beEqualTo(
-          Json.obj(
-            "field3" -> Json.obj("field31" -> "beta", "field32" -> 345)
-          )
+        Json.obj(
+          "field3" -> Json.obj("field31" -> "beta", "field32" -> 345)
         )
+      )
     }
 
     "copy input JSON and update a branch (merge the updated branch with input JSON)" in {
@@ -109,12 +109,12 @@ class JsonTransSpec extends Specification {
       js.transform(
         (__ \ 'field3).json.prune
       ).get must beEqualTo(
-          Json.obj(
-            "field1" -> "alpha",
-            "field2" -> 123L,
-            "field4" -> Json.arr("alpha", 2, true, Json.obj("field41" -> "toto", "field42" -> "tata"))
-          )
+        Json.obj(
+          "field1" -> "alpha",
+          "field2" -> 123L,
+          "field4" -> Json.arr("alpha", 2, true, Json.obj("field41" -> "toto", "field42" -> "tata"))
         )
+      )
     }
 
     "pick a single branch and prune a sub-branch" in {

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonValidSpec.scala
@@ -434,18 +434,18 @@ class JsonValidSpec extends Specification {
         (__ \ "key1").json.pickBranch and
         (__ \ "key2").json.pickBranch(
           (
-            (__ \ "key22").json.update((__ \ "key222").json.pick) and
-            (__ \ "key233").json.copyFrom((__ \ "key23").json.pick)
-          ).reduce
+          (__ \ "key22").json.update((__ \ "key222").json.pick) and
+          (__ \ "key233").json.copyFrom((__ \ "key23").json.pick)
+        ).reduce
         ) and
-          (__ \ "key3").json.pickBranch[JsArray](pure(Json.arr("delta"))) and
-          (__ \ "key4").json.put(
-            Json.obj(
-              "key41" -> 345,
-              "key42" -> "alpha",
-              "key43" -> func
-            )
+        (__ \ "key3").json.pickBranch[JsArray](pure(Json.arr("delta"))) and
+        (__ \ "key4").json.put(
+          Json.obj(
+            "key41" -> 345,
+            "key42" -> "alpha",
+            "key43" -> func
           )
+        )
       ).reduce
 
       val res = Json.obj(
@@ -566,7 +566,7 @@ class JsonValidSpec extends Specification {
         (__ \ 'data).read(
           Reads.verifyingIf[JsObject] { case JsObject(fields) => !fields.isEmpty }(
             ((__ \ "title").read[String] and
-              (__ \ "created").read[java.util.Date]).tupled
+            (__ \ "created").read[java.util.Date]).tupled
           )
         )
       ).tupled

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -167,9 +167,10 @@ private[server] class NettyModelConversion(forwardedHeaderHandler: ForwardedHead
 
   /** Create a Netty response from the result */
   def convertResult(
-    result: Result, requestHeader: RequestHeader, httpVersion: HttpVersion, errorHandler: HttpErrorHandler)(
-    implicit
-    mat: Materializer): Future[HttpResponse] = {
+    result: Result,
+    requestHeader: RequestHeader,
+    httpVersion: HttpVersion,
+    errorHandler: HttpErrorHandler)(implicit mat: Materializer): Future[HttpResponse] = {
 
     ServerResultUtils.resultConversionWithErrorHandling(requestHeader, result, errorHandler) { result =>
 

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -61,7 +61,8 @@ private[server] class NettyModelConversion(forwardedHeaderHandler: ForwardedHead
    *
    * Will return a failure if there's a protocol error or some other error in the header.
    */
-  def convertRequest(requestId: Long,
+  def convertRequest(
+    requestId: Long,
     remoteAddress: InetSocketAddress,
     sslHandler: Option[SslHandler],
     request: HttpRequest): Try[RequestHeader] = {
@@ -167,7 +168,8 @@ private[server] class NettyModelConversion(forwardedHeaderHandler: ForwardedHead
   /** Create a Netty response from the result */
   def convertResult(
     result: Result, requestHeader: RequestHeader, httpVersion: HttpVersion, errorHandler: HttpErrorHandler)(
-      implicit mat: Materializer): Future[HttpResponse] = {
+    implicit
+    mat: Materializer): Future[HttpResponse] = {
 
     ServerResultUtils.resultConversionWithErrorHandling(requestHeader, result, errorHandler) { result =>
 

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -61,7 +61,8 @@ private[play] class PlayRequestHandler(val server: NettyServer) extends ChannelI
     import play.core.Execution.Implicits.trampoline
 
     val requestId = RequestIdProvider.requestIDs.incrementAndGet()
-    val tryRequest = modelConversion.convertRequest(requestId,
+    val tryRequest = modelConversion.convertRequest(
+      requestId,
       channel.remoteAddress().asInstanceOf[InetSocketAddress], Option(channel.pipeline().get(classOf[SslHandler])),
       request)
 

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/WebSocketHandler.scala
@@ -28,7 +28,8 @@ private[server] object WebSocketHandler {
 
     // The reason we use a processor is that we *must* release the buffers synchronously, since Akka streams drops
     // messages, which will mean we can't release the ByteBufs in the messages.
-    SynchronousMappedStreams.transform(WebSocketFlowHandler.webSocketProtocol(bufferLimit).join(flow).toProcessor.run(),
+    SynchronousMappedStreams.transform(
+      WebSocketFlowHandler.webSocketProtocol(bufferLimit).join(flow).toProcessor.run(),
       frameToMessage, messageToFrame)
   }
 

--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/ServerSSLEngine.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/ServerSSLEngine.scala
@@ -39,7 +39,8 @@ object ServerSSLEngine {
     }
   }
 
-  private def createJavaSSLEngineProvider(providerClass: Class[JavaSSLEngineProvider],
+  private def createJavaSSLEngineProvider(
+    providerClass: Class[JavaSSLEngineProvider],
     serverConfig: ServerConfig, applicationProvider: ApplicationProvider): JavaSSLEngineProvider = {
     var serverConfigProviderArgsConstructor: Constructor[_] = null
     var providerArgsConstructor: Constructor[_] = null
@@ -73,7 +74,8 @@ object ServerSSLEngine {
     }
   }
 
-  private def createScalaSSLEngineProvider(providerClass: Class[ScalaSSLEngineProvider],
+  private def createScalaSSLEngineProvider(
+    providerClass: Class[ScalaSSLEngineProvider],
     serverConfig: ServerConfig, applicationProvider: ApplicationProvider): ScalaSSLEngineProvider = {
 
     var serverConfigProviderArgsConstructor: Constructor[ScalaSSLEngineProvider] = null

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/AkkaStreams.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/AkkaStreams.scala
@@ -31,7 +31,8 @@ object AkkaStreams {
    * If the splitter flow produces Left, they will be fed into the flow. If it produces Right, they will bypass the
    * flow.
    */
-  def bypassWith[In, FlowIn, Out](splitter: Flow[In, Either[FlowIn, Out], _],
+  def bypassWith[In, FlowIn, Out](
+    splitter: Flow[In, Either[FlowIn, Out], _],
     mergeStrategy: Graph[UniformFanInShape[Out, Out], _] = onlyFirstCanFinishMerge[Out](2)): Flow[FlowIn, Out, _] => Flow[In, Out, _] = { flow =>
 
     val bypasser = Flow.fromGraph(GraphDSL.create[FlowShape[Either[FlowIn, Out], Out]]() { implicit builder =>
@@ -112,14 +113,13 @@ object AkkaStreams {
    * A flow that will ignore downstream cancellation, and instead will continue receiving and ignoring the stream.
    */
   def ignoreAfterCancellation[T]: Flow[T, T, Future[Done]] = {
-    Flow.fromGraph(GraphDSL.create(Sink.ignore) { implicit builder =>
-      ignore =>
-        import GraphDSL.Implicits._
-        // This pattern is an effective way to absorb cancellation, Sink.ignore will keep the broadcast always flowing
-        // even after sink.inlet cancels.
-        val broadcast = builder.add(Broadcast[T](2, eagerCancel = false))
-        broadcast.out(0) ~> ignore.in
-        FlowShape(broadcast.in, broadcast.out(1))
+    Flow.fromGraph(GraphDSL.create(Sink.ignore) { implicit builder => ignore =>
+      import GraphDSL.Implicits._
+      // This pattern is an effective way to absorb cancellation, Sink.ignore will keep the broadcast always flowing
+      // even after sink.inlet cancels.
+      val broadcast = builder.add(Broadcast[T](2, eagerCancel = false))
+      broadcast.out(0) ~> ignore.in
+      FlowShape(broadcast.in, broadcast.out(1))
     })
   }
 }

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/ExecutionSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/ExecutionSpec.scala
@@ -64,13 +64,17 @@ class ExecutionSpec extends Specification {
       }
 
       trampoline.execute(
-        TestRunnable(0,
+        TestRunnable(
+          0,
           TestRunnable(1),
-          TestRunnable(2,
-            TestRunnable(4,
+          TestRunnable(
+            2,
+            TestRunnable(
+              4,
               TestRunnable(6),
               TestRunnable(7)),
-            TestRunnable(5,
+            TestRunnable(
+              5,
               TestRunnable(8))),
           TestRunnable(3))
       )

--- a/framework/src/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
@@ -34,7 +34,8 @@ class AccumulatorSpec extends org.specs2.mutable.Specification {
   }
 
   def sum: Accumulator[Int, Int] =
-    Accumulator.fromSink(Sink.fold[Int, Int](0,
+    Accumulator.fromSink(Sink.fold[Int, Int](
+      0,
       new JFn2[Int, Int, Int] { def apply(a: Int, b: Int) = a + b }))
 
   def source = Source from asJavaIterable(1 to 3)

--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -49,7 +49,7 @@ case class FakeRequest[A](
     secure: Boolean = false,
     clientCertificateChain: Option[Seq[X509Certificate]] = None,
     attrMap: TypedMap = TypedMap.empty
-  ) extends Request[A] with WithAttrMap[FakeRequest[A]] {
+) extends Request[A] with WithAttrMap[FakeRequest[A]] {
 
   def copyFakeRequest[B](
     id: Long = this.id,
@@ -91,7 +91,8 @@ case class FakeRequest[A](
    */
   def withFlash(data: (String, String)*): FakeRequest[A] = {
     withHeaders(play.api.http.HeaderNames.COOKIE ->
-      Cookies.mergeCookieHeader(headers.get(play.api.http.HeaderNames.COOKIE).getOrElse(""),
+      Cookies.mergeCookieHeader(
+        headers.get(play.api.http.HeaderNames.COOKIE).getOrElse(""),
         Seq(Flash.encodeAsCookie(new Flash(flash.data ++ data)))
       )
     )
@@ -111,7 +112,8 @@ case class FakeRequest[A](
    */
   def withSession(newSessions: (String, String)*): FakeRequest[A] = {
     withHeaders(play.api.http.HeaderNames.COOKIE ->
-      Cookies.mergeCookieHeader(headers.get(play.api.http.HeaderNames.COOKIE).getOrElse(""),
+      Cookies.mergeCookieHeader(
+        headers.get(play.api.http.HeaderNames.COOKIE).getOrElse(""),
         Seq(Session.encodeAsCookie(new Session(session.data ++ newSessions)))
       )
     )

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -34,8 +34,8 @@ trait PlayRunners extends HttpVerbs {
   val FIREFOX = classOf[FirefoxDriver]
 
   /**
-    * The base builder used in the running method.
-    */
+   * The base builder used in the running method.
+   */
   lazy val baseApplicationBuilder = new GuiceApplicationBuilder()
 
   def running[T]()(block: Application => T): T = {

--- a/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
@@ -3,7 +3,6 @@
  */
 package play.api.test
 
-
 import org.openqa.selenium._
 import org.openqa.selenium.firefox._
 import org.openqa.selenium.htmlunit._

--- a/framework/src/play-ws/src/main/scala/play/api/libs/openid/OpenIdClient.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/openid/OpenIdClient.scala
@@ -64,7 +64,8 @@ trait OpenIdClient {
   /**
    * Retrieve the URL where the user should be redirected to start the OpenID authentication process
    */
-  def redirectURL(openID: String,
+  def redirectURL(
+    openID: String,
     callbackURL: String,
     axRequired: Seq[(String, String)] = Seq.empty,
     axOptional: Seq[(String, String)] = Seq.empty,
@@ -87,7 +88,8 @@ class WsOpenIdClient @Inject() (ws: WSClient, discovery: Discovery)(implicit ec:
   /**
    * Retrieve the URL where the user should be redirected to start the OpenID authentication process
    */
-  def redirectURL(openID: String,
+  def redirectURL(
+    openID: String,
     callbackURL: String,
     axRequired: Seq[(String, String)] = Seq.empty,
     axOptional: Seq[(String, String)] = Seq.empty,
@@ -126,7 +128,8 @@ class WsOpenIdClient @Inject() (ws: WSClient, discovery: Discovery)(implicit ec:
   }
 
   private def verifiedId(queryString: Map[String, Seq[String]]): Future[UserInfo] = {
-    (queryString.get("openid.mode").flatMap(_.headOption),
+    (
+      queryString.get("openid.mode").flatMap(_.headOption),
       queryString.get("openid.claimed_id").flatMap(_.headOption)) match { // The Claimed Identifier. "openid.claimed_id" and "openid.identity" SHALL be either both present or both absent.
         case (Some("id_res"), Some(id)) => {
           // MUST perform discovery on the claimedId to resolve the op_endpoint.
@@ -150,7 +153,8 @@ class WsOpenIdClient @Inject() (ws: WSClient, discovery: Discovery)(implicit ec:
     })
   }
 
-  private def axParameters(axRequired: Seq[(String, String)],
+  private def axParameters(
+    axRequired: Seq[(String, String)],
     axOptional: Seq[(String, String)]): Seq[(String, String)] = {
     if (axRequired.isEmpty && axOptional.isEmpty)
       Nil

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/Config.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/Config.scala
@@ -15,7 +15,8 @@ import scala.concurrent.duration._
 /**
  * WS client config
  */
-case class WSClientConfig(connectionTimeout: Duration = 2.minutes,
+case class WSClientConfig(
+  connectionTimeout: Duration = 2.minutes,
   idleTimeout: Duration = 2.minutes,
   requestTimeout: Duration = 2.minutes,
   followRedirects: Boolean = true,

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcConfig.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcConfig.scala
@@ -34,7 +34,8 @@ import scala.concurrent.duration._
  * @param disableUrlEncoding Whether the raw URL should be used.
  * @param keepAlive keeps thread pool active, replaces allowPoolingConnection and allowSslConnectionPool
  */
-case class AhcWSClientConfig(wsClientConfig: WSClientConfig = WSClientConfig(),
+case class AhcWSClientConfig(
+  wsClientConfig: WSClientConfig = WSClientConfig(),
   maxConnectionsPerHost: Int = -1,
   maxConnectionsTotal: Int = -1,
   maxConnectionLifetime: Duration = Duration.Inf,
@@ -58,7 +59,8 @@ object AhcWSClientConfigFactory {
  * This class creates a DefaultWSClientConfig object from the play.api.Configuration.
  */
 @Singleton
-class AhcWSClientConfigParser @Inject() (wsClientConfig: WSClientConfig,
+class AhcWSClientConfigParser @Inject() (
+    wsClientConfig: WSClientConfig,
     configuration: Configuration,
     environment: Environment) extends Provider[AhcWSClientConfig] {
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcWS.scala
@@ -104,7 +104,8 @@ case object AhcWSRequest {
 /**
  * A Ahc WS Request.
  */
-case class AhcWSRequest(client: AhcWSClient,
+case class AhcWSRequest(
+    client: AhcWSClient,
     url: String,
     method: String,
     body: WSBody,

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/Algorithms.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/Algorithms.scala
@@ -106,19 +106,19 @@ object Algorithms {
     val keyAlgName = getKeyAlgorithmName(pubk)
     foldVersion(
       run16 = {
-        keyAlgName match {
-          case "EC" =>
-            // If we are on 1.6, then we can't use the EC factory and have to pull it directly.
-            translateECKey(pubk)
-          case _ =>
-            val keyFactory = KeyFactory.getInstance(keyAlgName)
-            keyFactory.translateKey(pubk)
-        }
-      },
-      runHigher = {
-        val keyFactory = KeyFactory.getInstance(keyAlgName)
-        keyFactory.translateKey(pubk)
+      keyAlgName match {
+        case "EC" =>
+          // If we are on 1.6, then we can't use the EC factory and have to pull it directly.
+          translateECKey(pubk)
+        case _ =>
+          val keyFactory = KeyFactory.getInstance(keyAlgName)
+          keyFactory.translateKey(pubk)
       }
+    },
+      runHigher = {
+      val keyFactory = KeyFactory.getInstance(keyAlgName)
+      keyFactory.translateKey(pubk)
+    }
     )
   }
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/Config.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/Config.scala
@@ -22,7 +22,8 @@ import play.api.Configuration
  * @param data The data to load the key store file from.
  * @param password The password to use to load the key store file, if the file is password protected.
  */
-case class KeyStoreConfig(storeType: String = KeyStore.getDefaultType,
+case class KeyStoreConfig(
+    storeType: String = KeyStore.getDefaultType,
     filePath: Option[String] = None,
     data: Option[String] = None,
     password: Option[String] = None) {
@@ -39,7 +40,8 @@ case class KeyStoreConfig(storeType: String = KeyStore.getDefaultType,
  * @param filePath The path of the key store file.
  * @param data The data to load the key store file from.
  */
-case class TrustStoreConfig(storeType: String = KeyStore.getDefaultType,
+case class TrustStoreConfig(
+    storeType: String = KeyStore.getDefaultType,
     filePath: Option[String],
     data: Option[String]) {
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/KeyStore.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/KeyStore.scala
@@ -68,7 +68,8 @@ class StringBasedKeyStoreBuilder(data: String) extends KeyStoreBuilder {
  *
  * @see java.security.cert.CertificateFactory
  */
-class FileBasedKeyStoreBuilder(keyStoreType: String,
+class FileBasedKeyStoreBuilder(
+    keyStoreType: String,
     filePath: String,
     password: Option[Array[Char]]) extends KeyStoreBuilder {
 

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/SSLContextBuilder.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ssl/SSLContextBuilder.scala
@@ -17,7 +17,8 @@ trait SSLContextBuilder {
  * A simple SSL context builder.  If the keyManagers or trustManagers are empty, then null is used in the init method.
  * Likewise, if secureRandom is None then null is used.
  */
-class SimpleSSLContextBuilder(protocol: String,
+class SimpleSSLContextBuilder(
+    protocol: String,
     keyManagers: Seq[KeyManager],
     trustManagers: Seq[TrustManager],
     secureRandom: Option[SecureRandom]) extends SSLContextBuilder {
@@ -90,7 +91,8 @@ class DefaultTrustManagerFactoryWrapper(trustManagerAlgorithm: String) extends T
 /**
  * Creates an SSL context builder from info objects.
  */
-class ConfigSSLContextBuilder(info: SSLConfig,
+class ConfigSSLContextBuilder(
+    info: SSLConfig,
     keyManagerFactory: KeyManagerFactoryWrapper,
     trustManagerFactory: TrustManagerFactoryWrapper) extends SSLContextBuilder {
 
@@ -116,7 +118,8 @@ class ConfigSSLContextBuilder(info: SSLConfig,
     Seq(buildCompositeTrustManager(info.trustManagerConfig, info.checkRevocation.getOrElse(false), revocationLists, algorithmChecker))
   } else Nil
 
-  def buildSSLContext(protocol: String,
+  def buildSSLContext(
+    protocol: String,
     keyManagers: Seq[KeyManager],
     trustManagers: Seq[TrustManager],
     secureRandom: Option[SecureRandom]) = {
@@ -132,7 +135,8 @@ class ConfigSSLContextBuilder(info: SSLConfig,
     new CompositeX509KeyManager(keyManagers)
   }
 
-  def buildCompositeTrustManager(trustManagerInfo: TrustManagerConfig,
+  def buildCompositeTrustManager(
+    trustManagerInfo: TrustManagerConfig,
     revocationEnabled: Boolean,
     revocationLists: Option[Seq[CRL]], algorithmChecker: AlgorithmChecker) = {
 
@@ -270,7 +274,8 @@ class ConfigSSLContextBuilder(info: SSLConfig,
     }
   }
 
-  def buildTrustManagerParameters(trustStore: KeyStore,
+  def buildTrustManagerParameters(
+    trustStore: KeyStore,
     revocationEnabled: Boolean,
     revocationLists: Option[Seq[CRL]],
     algorithmChecker: AlgorithmChecker): CertPathTrustManagerParameters = {
@@ -298,7 +303,8 @@ class ConfigSSLContextBuilder(info: SSLConfig,
   /**
    * Builds trust managers, using a TrustManagerFactory internally.
    */
-  def buildTrustManager(tsc: TrustStoreConfig,
+  def buildTrustManager(
+    tsc: TrustStoreConfig,
     revocationEnabled: Boolean,
     revocationLists: Option[Seq[CRL]], algorithmChecker: AlgorithmChecker): X509TrustManager = {
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/oauth/OAuthSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/oauth/OAuthSpec.scala
@@ -22,25 +22,22 @@ class OAuthSpec extends PlaySpecification {
   "OAuth" should {
 
     "sign a simple get request" in {
-      val (request, body, hostUrl) = receiveRequest { ws =>
-        hostUrl =>
-          ws.url(hostUrl + "/foo").sign(oauthCalculator).get()
+      val (request, body, hostUrl) = receiveRequest { ws => hostUrl =>
+        ws.url(hostUrl + "/foo").sign(oauthCalculator).get()
       }
       OAuthRequestVerifier.verifyRequest(request, body, hostUrl, consumerKey, requestToken)
     }
 
     "sign a get request with query parameters" in {
-      val (request, body, hostUrl) = receiveRequest { ws =>
-        hostUrl =>
-          ws.url(hostUrl + "/foo").withQueryString("param" -> "paramValue").sign(oauthCalculator).get()
+      val (request, body, hostUrl) = receiveRequest { ws => hostUrl =>
+        ws.url(hostUrl + "/foo").withQueryString("param" -> "paramValue").sign(oauthCalculator).get()
       }
       OAuthRequestVerifier.verifyRequest(request, body, hostUrl, consumerKey, requestToken)
     }
 
     "sign a post request with a body" in {
-      val (request, body, hostUrl) = receiveRequest { ws =>
-        hostUrl =>
-          ws.url(hostUrl + "/foo").sign(oauthCalculator).post(Map("param" -> Seq("paramValue")))
+      val (request, body, hostUrl) = receiveRequest { ws => hostUrl =>
+        ws.url(hostUrl + "/foo").sign(oauthCalculator).post(Map("param" -> Seq("paramValue")))
       }
       OAuthRequestVerifier.verifyRequest(request, body, hostUrl, consumerKey, requestToken)
     }

--- a/framework/src/play-ws/src/test/scala/play/api/libs/openid/DiscoveryClientSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/openid/DiscoveryClientSpec.scala
@@ -251,7 +251,8 @@ class DiscoveryClientSpec extends Specification with Mockito {
   }
 
   // See 9.1 http://openid.net/specs/openid-authentication-2_0.html#anchor27
-  private def verifyValidOpenIDRequest(params: Map[String, Seq[String]],
+  private def verifyValidOpenIDRequest(
+    params: Map[String, Seq[String]],
     claimedId: String,
     returnTo: String,
     opLocalIdentifier: Option[String] = None,

--- a/framework/src/play-ws/src/test/scala/play/api/libs/openid/package.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/openid/package.scala
@@ -33,7 +33,8 @@ package object openid {
 
   // See 10.1 - Positive Assertions
   // http://openid.net/specs/openid-authentication-2_0.html#positive_assertions
-  def createDefaultResponse(claimedId: String,
+  def createDefaultResponse(
+    claimedId: String,
     identity: String,
     defaultSigned: String = "op_endpoint,claimed_id,identity,return_to,response_nonce,assoc_handle"): Map[String, Seq[String]] = Map(
     "openid.ns" -> "http://specs.openid.net/auth/2.0",

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ahc/AhcWSSpec.scala
@@ -135,7 +135,8 @@ class AhcWSSpec extends PlaySpecification with Mockito {
     "support a custom signature calculator" in {
       var called = false
       val calc = new org.asynchttpclient.SignatureCalculator with WSSignatureCalculator {
-        override def calculateAndAddSignature(request: org.asynchttpclient.Request,
+        override def calculateAndAddSignature(
+          request: org.asynchttpclient.Request,
           requestBuilder: org.asynchttpclient.RequestBuilderBase[_]): Unit = {
           called = true
         }

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmCheckerSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/AlgorithmCheckerSpec.scala
@@ -18,7 +18,8 @@ class AlgorithmCheckerSpec extends Specification {
   "AlgorithmChecker" should {
 
     def checker(sigs: Seq[String], keys: Seq[String]) = {
-      new AlgorithmChecker(sigs.map(s => parseAll(expression, s).get).toSet,
+      new AlgorithmChecker(
+        sigs.map(s => parseAll(expression, s).get).toSet,
         keys.map(s => parseAll(expression, s).get).toSet)
     }
 

--- a/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/ConfigSSLContextBuilderSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/ws/ssl/ConfigSSLContextBuilderSpec.scala
@@ -138,7 +138,8 @@ class ConfigSSLContextBuilderSpec extends Specification with Mockito {
       val checkRevocation = false
       val revocationLists = None
 
-      val actual = builder.buildCompositeTrustManager(trustManagerConfig,
+      val actual = builder.buildCompositeTrustManager(
+        trustManagerConfig,
         checkRevocation,
         revocationLists, algorithmChecker)
       actual must beAnInstanceOf[CompositeX509TrustManager]

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -206,7 +206,8 @@ object Application {
 class OptionalSourceMapper(val sourceMapper: Option[SourceMapper])
 
 @Singleton
-class DefaultApplication @Inject() (environment: Environment,
+class DefaultApplication @Inject() (
+    environment: Environment,
     applicationLifecycle: DefaultApplicationLifecycle,
     override val injector: Injector,
     override val configuration: Configuration,

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -71,23 +71,23 @@ object ApplicationLoader {
     Reflect.configuredClass[ApplicationLoader, play.ApplicationLoader, NoApplicationLoader](
       context.environment, context.initialConfiguration, LoaderKey, classOf[NoApplicationLoader].getName
     ) match {
-        case None =>
-          loaderNotFound()
-        case Some(Left(scalaClass)) =>
-          scalaClass.newInstance
-        case Some(Right(javaClass)) =>
-          val javaApplicationLoader: play.ApplicationLoader = javaClass.newInstance
-          // Create an adapter from a Java to a Scala ApplicationLoader. This class is
-          // effectively anonymous, but let's give it a name to make debugging easier.
-          class JavaApplicationLoaderAdapter extends ApplicationLoader {
-            override def load(context: ApplicationLoader.Context): Application = {
-              val javaContext = new play.ApplicationLoader.Context(context)
-              val javaApplication = javaApplicationLoader.load(javaContext)
-              javaApplication.getWrappedApplication
-            }
+      case None =>
+        loaderNotFound()
+      case Some(Left(scalaClass)) =>
+        scalaClass.newInstance
+      case Some(Right(javaClass)) =>
+        val javaApplicationLoader: play.ApplicationLoader = javaClass.newInstance
+        // Create an adapter from a Java to a Scala ApplicationLoader. This class is
+        // effectively anonymous, but let's give it a name to make debugging easier.
+        class JavaApplicationLoaderAdapter extends ApplicationLoader {
+          override def load(context: ApplicationLoader.Context): Application = {
+            val javaContext = new play.ApplicationLoader.Context(context)
+            val javaApplication = javaApplicationLoader.load(javaContext)
+            javaApplication.getWrappedApplication
           }
-          new JavaApplicationLoaderAdapter
-      }
+        }
+        new JavaApplicationLoaderAdapter
+    }
   }
 
   /**
@@ -102,7 +102,8 @@ object ApplicationLoader {
    *                        into the application.
    * @param sourceMapper An optional source mapper.
    */
-  def createContext(environment: Environment,
+  def createContext(
+    environment: Environment,
     initialSettings: Map[String, AnyRef] = Map.empty[String, AnyRef],
     sourceMapper: Option[SourceMapper] = None,
     webCommands: WebCommands = new DefaultWebCommands,

--- a/framework/src/play/src/main/scala/play/api/Configuration.scala
+++ b/framework/src/play/src/main/scala/play/api/Configuration.scala
@@ -12,7 +12,7 @@ import com.typesafe.config.impl.ConfigImpl
 import play.utils.PlayIO
 
 import scala.collection.JavaConverters._
-import scala.concurrent.duration.{Duration, FiniteDuration, _}
+import scala.concurrent.duration.{ Duration, FiniteDuration, _ }
 import scala.util.control.NonFatal
 
 /**
@@ -179,18 +179,18 @@ case class Configuration(underlying: Config) {
   }
 
   /**
-    * Merge two configurations.
-    */
+   * Merge two configurations.
+   */
   def ++(other: Configuration): Configuration = {
     Configuration(other.underlying.withFallback(underlying))
   }
 
   /**
-    * Reads a value from the underlying implementation.
-    * If the value is not set this will return None, otherwise returns Some.
-    *
-    * Does not check neither for incorrect type nor null value, but catches and wraps the error.
-    */
+   * Reads a value from the underlying implementation.
+   * If the value is not set this will return None, otherwise returns Some.
+   *
+   * Does not check neither for incorrect type nor null value, but catches and wraps the error.
+   */
   private def readValue[T](path: String, v: => T): Option[T] = {
     try {
       if (underlying.hasPathOrNull(path)) Some(v) else None
@@ -201,20 +201,20 @@ case class Configuration(underlying: Config) {
   }
 
   /**
-    * Check if the given path exists.
-    */
+   * Check if the given path exists.
+   */
   def has(path: String): Boolean = underlying.hasPath(path)
 
   /**
-    * Get the config at the given path.
-    */
+   * Get the config at the given path.
+   */
   def get[A](path: String)(implicit loader: ConfigLoader[A]): A = {
     loader.load(underlying, path)
   }
 
   /**
-    * Get the config at the given path and validate against a set of valid values.
-    */
+   * Get the config at the given path and validate against a set of valid values.
+   */
   def getAndValidate[A](path: String, values: Set[A])(implicit loader: ConfigLoader[A]): A = {
     val value = get(path)
     if (!values(value)) {
@@ -224,18 +224,18 @@ case class Configuration(underlying: Config) {
   }
 
   /**
-    * Get a value that may either not exist or be null. Note that this is not generally considered idiomatic Config
-    * usage. Instead you should define all config keys in a reference.conf file.
-    */
+   * Get a value that may either not exist or be null. Note that this is not generally considered idiomatic Config
+   * usage. Instead you should define all config keys in a reference.conf file.
+   */
   def getOptional[A](path: String)(implicit loader: ConfigLoader[A]): Option[A] = {
     readValue(path, get[A](path))
   }
 
   /**
-    * Get a prototyped sequence of objects.
-    *
-    * Each object in the sequence will fallback to the object loaded from prototype.\$path.
-    */
+   * Get a prototyped sequence of objects.
+   *
+   * Each object in the sequence will fallback to the object loaded from prototype.\$path.
+   */
   def getPrototypedSeq(path: String, prototypePath: String = "prototype.$path"): Seq[Configuration] = {
     val prototype = underlying.getConfig(prototypePath.replace("$path", path))
     get[Seq[Config]](path).map { config =>
@@ -244,10 +244,10 @@ case class Configuration(underlying: Config) {
   }
 
   /**
-    * Get a prototyped map of objects.
-    *
-    * Each value in the map will fallback to the object loaded from prototype.\$path.
-    */
+   * Get a prototyped map of objects.
+   *
+   * Each value in the map will fallback to the object loaded from prototype.\$path.
+   */
   def getPrototypedMap(path: String, prototypePath: String = "prototype.$path"): Map[String, Configuration] = {
     val prototype = if (prototypePath.isEmpty) {
       underlying
@@ -260,12 +260,12 @@ case class Configuration(underlying: Config) {
   }
 
   /**
-    * Get a deprecated configuration item.
-    *
-    * If the deprecated configuration item is defined, it will be returned, and a warning will be logged.
-    *
-    * Otherwise, the configuration from path will be looked up.
-    */
+   * Get a deprecated configuration item.
+   *
+   * If the deprecated configuration item is defined, it will be returned, and a warning will be logged.
+   *
+   * Otherwise, the configuration from path will be looked up.
+   */
   def getDeprecated[A: ConfigLoader](path: String, deprecatedPaths: String*): A = {
     deprecatedPaths.collectFirst {
       case deprecated if underlying.hasPath(deprecated) =>
@@ -277,13 +277,13 @@ case class Configuration(underlying: Config) {
   }
 
   /**
-    * Get a deprecated configuration.
-    *
-    * If the deprecated configuration is defined, it will be returned, falling back to the new configuration, and a
-    * warning will be logged.
-    *
-    * Otherwise, the configuration from path will be looked up and used as is.
-    */
+   * Get a deprecated configuration.
+   *
+   * If the deprecated configuration is defined, it will be returned, falling back to the new configuration, and a
+   * warning will be logged.
+   *
+   * Otherwise, the configuration from path will be looked up and used as is.
+   */
   def getDeprecatedWithFallback(path: String, deprecated: String, parent: String = ""): Configuration = {
     val config = get[Config](path)
     val merged = if (underlying.hasPath(deprecated)) {
@@ -372,20 +372,20 @@ case class Configuration(underlying: Config) {
   def getMilliseconds(path: String): Option[Long] = getOptional[Duration](path).map(_.toMillis)
 
   /**
-    * Retrieves a configuration value as `Milliseconds`.
-    *
-    * For example:
-    * {{{
-    * val configuration = Configuration.load()
-    * val timeout = configuration.getMillis("engine.timeout")
-    * }}}
-    *
-    * The configuration must be provided as:
-    *
-    * {{{
-    * engine.timeout = 1 second
-    * }}}
-    */
+   * Retrieves a configuration value as `Milliseconds`.
+   *
+   * For example:
+   * {{{
+   * val configuration = Configuration.load()
+   * val timeout = configuration.getMillis("engine.timeout")
+   * }}}
+   *
+   * The configuration must be provided as:
+   *
+   * {{{
+   * engine.timeout = 1 second
+   * }}}
+   */
   def getMillis(path: String): Long = get[Duration](path).toMillis
 
   /**
@@ -407,20 +407,20 @@ case class Configuration(underlying: Config) {
   def getNanoseconds(path: String): Option[Long] = getOptional[Duration](path).map(_.toNanos)
 
   /**
-    * Retrieves a configuration value as `Milliseconds`.
-    *
-    * For example:
-    * {{{
-    * val configuration = Configuration.load()
-    * val timeout = configuration.getNanos("engine.timeout")
-    * }}}
-    *
-    * The configuration must be provided as:
-    *
-    * {{{
-    * engine.timeout = 1 second
-    * }}}
-    */
+   * Retrieves a configuration value as `Milliseconds`.
+   *
+   * For example:
+   * {{{
+   * val configuration = Configuration.load()
+   * val timeout = configuration.getNanos("engine.timeout")
+   * }}}
+   *
+   * The configuration must be provided as:
+   *
+   * {{{
+   * engine.timeout = 1 second
+   * }}}
+   */
   def getNanos(path: String): Long = get[Duration](path).toNanos
 
   /**
@@ -953,8 +953,8 @@ case class Configuration(underlying: Config) {
    * val configuration = Configuration.load()
    * val subKeys = configuration.subKeys
    * }}}
-    *
-    * @return the set of direct sub-keys available in this configuration
+   *
+   * @return the set of direct sub-keys available in this configuration
    */
   def subKeys: Set[String] = underlying.root().keySet().asScala.toSet
 

--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -2,23 +2,23 @@
  * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
  */
 import java.io._
-import java.net.{JarURLConnection, URL, URLConnection}
+import java.net.{ JarURLConnection, URL, URLConnection }
 import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.regex.Pattern
-import javax.inject.{Inject, Singleton}
+import javax.inject.{ Inject, Singleton }
 
 import play.api._
-import play.api.http.{ContentTypes, HttpErrorHandler, LazyHttpErrorHandler}
+import play.api.http.{ ContentTypes, HttpErrorHandler, LazyHttpErrorHandler }
 import play.api.libs._
 import play.api.mvc._
 import play.core.routing.ReverseRouteContext
-import play.utils.{InvalidUriEncodingException, Resources, UriEncoding}
+import play.utils.{ InvalidUriEncodingException, Resources, UriEncoding }
 
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.{ExecutionContext, Future, Promise, blocking}
+import scala.concurrent.{ ExecutionContext, Future, Promise, blocking }
 import scala.util.control.NonFatal
-import scala.util.{Failure, Success}
+import scala.util.{ Failure, Success }
 
 package play.api.controllers {
 
@@ -30,471 +30,472 @@ package play.api.controllers {
 
 package controllers {
 
-import java.time._
+  import java.time._
 
-import akka.stream.scaladsl.StreamConverters
-import play.api.controllers.TrampolineContextProvider
+  import akka.stream.scaladsl.StreamConverters
+  import play.api.controllers.TrampolineContextProvider
 
-object Execution extends TrampolineContextProvider
+  object Execution extends TrampolineContextProvider
 
-import Execution.trampoline
+  import Execution.trampoline
 
-/*
- * A map designed to prevent the "thundering herds" issue.
- *
- * This could be factored out into its own thing, improved and made available more widely. We could also
- * use spray-cache once it has been re-worked into the Akka code base.
- *
- * The essential mechanics of the cache are that all asset requests are remembered, unless their lookup fails or if
- * the asset doesn't exist, in which case we don't remember them in order to avoid an exploit where we would otherwise
- * run out of memory.
- *
- * The population function is executed using the passed-in execution context
- * which may mean that it is on a separate thread thus permitting long running operations to occur. Other threads
- * requiring the same resource will be given the future of the result immediately.
- *
- * There are no explicit bounds on the cache as it isn't considered likely that the number of distinct asset requests would
- * result in an overflow of memory. Bounds are implied given the number of distinct assets that are available to be
- * served by the project.
- *
- * Instead of a SelfPopulatingMap, a better strategy would be to furnish the assets controller with all of the asset
- * information on startup. This shouldn't be that difficult as sbt-web has that information available. Such an
- * approach would result in an immutable map being used which in theory should be faster.
+  /*
+   * A map designed to prevent the "thundering herds" issue.
+   *
+   * This could be factored out into its own thing, improved and made available more widely. We could also
+   * use spray-cache once it has been re-worked into the Akka code base.
+   *
+   * The essential mechanics of the cache are that all asset requests are remembered, unless their lookup fails or if
+   * the asset doesn't exist, in which case we don't remember them in order to avoid an exploit where we would otherwise
+   * run out of memory.
+   *
+   * The population function is executed using the passed-in execution context
+   * which may mean that it is on a separate thread thus permitting long running operations to occur. Other threads
+   * requiring the same resource will be given the future of the result immediately.
+   *
+   * There are no explicit bounds on the cache as it isn't considered likely that the number of distinct asset requests would
+   * result in an overflow of memory. Bounds are implied given the number of distinct assets that are available to be
+   * served by the project.
+   *
+   * Instead of a SelfPopulatingMap, a better strategy would be to furnish the assets controller with all of the asset
+   * information on startup. This shouldn't be that difficult as sbt-web has that information available. Such an
+   * approach would result in an immutable map being used which in theory should be faster.
  */
-private class SelfPopulatingMap[K, V] {
-  private val store = TrieMap[K, Future[Option[V]]]()
+  private class SelfPopulatingMap[K, V] {
+    private val store = TrieMap[K, Future[Option[V]]]()
 
-  def putIfAbsent(k: K)(pf: K => Option[V])(implicit ec: ExecutionContext): Future[Option[V]] = {
-    lazy val p = Promise[Option[V]]()
-    store.putIfAbsent(k, p.future) match {
-      case Some(f) => f
-      case None =>
-        val f = Future(pf(k))(ec.prepare())
-        f.onComplete {
-          case Failure(_) | Success(None) => store.remove(k)
-          case _ => // Do nothing, the asset was successfully found and is now cached
-        }
-        p.completeWith(f)
-        p.future
+    def putIfAbsent(k: K)(pf: K => Option[V])(implicit ec: ExecutionContext): Future[Option[V]] = {
+      lazy val p = Promise[Option[V]]()
+      store.putIfAbsent(k, p.future) match {
+        case Some(f) => f
+        case None =>
+          val f = Future(pf(k))(ec.prepare())
+          f.onComplete {
+            case Failure(_) | Success(None) => store.remove(k)
+            case _ => // Do nothing, the asset was successfully found and is now cached
+          }
+          p.completeWith(f)
+          p.future
+      }
     }
   }
-}
 
-/*
+  /*
  * Retains meta information regarding an asset that can be readily cached.
  */
-private object AssetInfo {
+  private object AssetInfo {
 
-  def config[T](lookup: Configuration => T): Option[T] = Play.maybeApplication.map(app => lookup(app.configuration))
+    def config[T](lookup: Configuration => T): Option[T] = Play.maybeApplication.map(app => lookup(app.configuration))
 
-  def isDev = Play.maybeApplication.fold(false)(_.mode == Mode.Dev)
+    def isDev = Play.maybeApplication.fold(false)(_.mode == Mode.Dev)
 
-  def isProd = Play.maybeApplication.fold(false)(_.mode == Mode.Prod)
+    def isProd = Play.maybeApplication.fold(false)(_.mode == Mode.Prod)
 
-  def resource(name: String): Option[URL] = for {
-    app <- Play.maybeApplication
-    resource <- app.resource(name)
-  } yield resource
+    def resource(name: String): Option[URL] = for {
+      app <- Play.maybeApplication
+      resource <- app.resource(name)
+    } yield resource
 
-  lazy val defaultCharSet = config(_.getDeprecated[String]("play.assets.default.charset", "default.charset")).getOrElse("utf-8")
+    lazy val defaultCharSet = config(_.getDeprecated[String]("play.assets.default.charset", "default.charset")).getOrElse("utf-8")
 
-  lazy val defaultCacheControl = config(_.getDeprecated[String]("play.assets.defaultCache", "assets.defaultCache")).getOrElse("public, max-age=3600")
+    lazy val defaultCacheControl = config(_.getDeprecated[String]("play.assets.defaultCache", "assets.defaultCache")).getOrElse("public, max-age=3600")
 
-  lazy val aggressiveCacheControl = config(_.getDeprecated[String]("play.assets.aggressiveCache", "assets.aggressiveCache")).getOrElse("public, max-age=31536000")
+    lazy val aggressiveCacheControl = config(_.getDeprecated[String]("play.assets.aggressiveCache", "assets.aggressiveCache")).getOrElse("public, max-age=31536000")
 
-  lazy val digestAlgorithm = config(_.getDeprecated[String]("play.assets.digest.algorithm", "assets.digest.algorithm")).getOrElse("md5")
+    lazy val digestAlgorithm = config(_.getDeprecated[String]("play.assets.digest.algorithm", "assets.digest.algorithm")).getOrElse("md5")
 
-  import ResponseHeader.basicDateFormatPattern
+    import ResponseHeader.basicDateFormatPattern
 
-  val standardDateParserWithoutTZ: DateTimeFormatter =
-    DateTimeFormatter.ofPattern(basicDateFormatPattern).withLocale(java.util.Locale.ENGLISH).withZone(ZoneOffset.UTC)
-  val alternativeDateFormatWithTZOffset: DateTimeFormatter =
-    DateTimeFormatter.ofPattern("EEE MMM dd yyyy HH:mm:ss 'GMT'Z").withLocale(java.util.Locale.ENGLISH)
+    val standardDateParserWithoutTZ: DateTimeFormatter =
+      DateTimeFormatter.ofPattern(basicDateFormatPattern).withLocale(java.util.Locale.ENGLISH).withZone(ZoneOffset.UTC)
+    val alternativeDateFormatWithTZOffset: DateTimeFormatter =
+      DateTimeFormatter.ofPattern("EEE MMM dd yyyy HH:mm:ss 'GMT'Z").withLocale(java.util.Locale.ENGLISH)
 
-  /**
-    * A regex to find two types of date format. This regex silently ignores any
-    * trailing info such as extra header attributes ("; length=123") or
-    * timezone names ("(Pacific Standard Time").
-    * - "Sat, 18 Oct 2014 20:41:26" and "Sat, 29 Oct 1994 19:43:31 GMT" use the first
-    * matcher. (The " GMT" is discarded to give them the same format.)
-    * - "Wed Jan 07 2015 22:54:20 GMT-0800" uses the second matcher.
-    */
-  private val dateRecognizer = Pattern.compile(
-    """^(((\w\w\w, \d\d \w\w\w \d\d\d\d \d\d:\d\d:\d\d)(( GMT)?))|""" +
-      """(\w\w\w \w\w\w \d\d \d\d\d\d \d\d:\d\d:\d\d GMT.\d\d\d\d))(\b.*)""")
+    /**
+     * A regex to find two types of date format. This regex silently ignores any
+     * trailing info such as extra header attributes ("; length=123") or
+     * timezone names ("(Pacific Standard Time").
+     * - "Sat, 18 Oct 2014 20:41:26" and "Sat, 29 Oct 1994 19:43:31 GMT" use the first
+     * matcher. (The " GMT" is discarded to give them the same format.)
+     * - "Wed Jan 07 2015 22:54:20 GMT-0800" uses the second matcher.
+     */
+    private val dateRecognizer = Pattern.compile(
+      """^(((\w\w\w, \d\d \w\w\w \d\d\d\d \d\d:\d\d:\d\d)(( GMT)?))|""" +
+        """(\w\w\w \w\w\w \d\d \d\d\d\d \d\d:\d\d:\d\d GMT.\d\d\d\d))(\b.*)""")
 
-  def parseModifiedDate(date: String): Option[Date] = {
-    val matcher = dateRecognizer.matcher(date)
-    if (matcher.matches()) {
-      val standardDate = matcher.group(3)
-      try {
-        if (standardDate != null) {
-          Some(Date.from(ZonedDateTime.parse(standardDate, standardDateParserWithoutTZ).toInstant))
-        } else {
-          val alternativeDate = matcher.group(6) // Cannot be null otherwise match would have failed
-          Some(Date.from(ZonedDateTime.parse(alternativeDate, alternativeDateFormatWithTZOffset).toInstant))
+    def parseModifiedDate(date: String): Option[Date] = {
+      val matcher = dateRecognizer.matcher(date)
+      if (matcher.matches()) {
+        val standardDate = matcher.group(3)
+        try {
+          if (standardDate != null) {
+            Some(Date.from(ZonedDateTime.parse(standardDate, standardDateParserWithoutTZ).toInstant))
+          } else {
+            val alternativeDate = matcher.group(6) // Cannot be null otherwise match would have failed
+            Some(Date.from(ZonedDateTime.parse(alternativeDate, alternativeDateFormatWithTZOffset).toInstant))
+          }
+        } catch {
+          case e: IllegalArgumentException =>
+            Logger.debug(s"An invalid date was received: couldn't parse: $date", e)
+            None
         }
-      } catch {
-        case e: IllegalArgumentException =>
-          Logger.debug(s"An invalid date was received: couldn't parse: $date", e)
-          None
+      } else {
+        Logger.debug(s"An invalid date was received: unrecognized format: $date")
+        None
       }
-    } else {
-      Logger.debug(s"An invalid date was received: unrecognized format: $date")
-      None
     }
   }
-}
 
-/*
+  /*
  * Retain meta information regarding an asset.
  */
-private class AssetInfo(
-                         val name: String,
-                         val url: URL,
-                         val gzipUrl: Option[URL],
-                         val digest: Option[String]) {
+  private class AssetInfo(
+      val name: String,
+      val url: URL,
+      val gzipUrl: Option[URL],
+      val digest: Option[String]) {
 
-  import AssetInfo._
-  import ResponseHeader._
+    import AssetInfo._
+    import ResponseHeader._
 
-  def addCharsetIfNeeded(mimeType: String): String =
-    if (MimeTypes.isText(mimeType)) s"$mimeType; charset=$defaultCharSet" else mimeType
+    def addCharsetIfNeeded(mimeType: String): String =
+      if (MimeTypes.isText(mimeType)) s"$mimeType; charset=$defaultCharSet" else mimeType
 
-  val configuredCacheControl = config(_.getOptional[String]("\"play.assets.cache." + name + "\"")).flatten
+    val configuredCacheControl = config(_.getOptional[String]("\"play.assets.cache." + name + "\"")).flatten
 
-  def cacheControl(aggressiveCaching: Boolean): String = {
-    configuredCacheControl.getOrElse {
-      if (isProd) {
-        if (aggressiveCaching) aggressiveCacheControl else defaultCacheControl
-      } else {
-        "no-cache"
-      }
-    }
-  }
-
-  val lastModified: Option[String] = {
-    def getLastModified[T <: URLConnection](f: (T) => Long): Option[String] = {
-      Option(url.openConnection).map {
-        case urlConnection: T@unchecked =>
-          try {
-            f(urlConnection)
-          } finally {
-            Resources.closeUrlConnection(urlConnection)
-          }
-      }.filterNot(_ == -1).map(millis => httpDateFormat.format(Instant.ofEpochMilli(millis)))
-    }
-
-    url.getProtocol match {
-      case "file" => Some(httpDateFormat.format(Instant.ofEpochMilli(new File(url.toURI).lastModified)))
-      case "jar" => getLastModified[JarURLConnection](c => c.getJarEntry.getTime)
-      case "bundle" => getLastModified[URLConnection](c => c.getLastModified)
-      case _ => None
-    }
-  }
-
-  val etag: Option[String] =
-    digest orElse {
-      lastModified map (m => Codecs.sha1(m + " -> " + url.toExternalForm))
-    } map ("\"" + _ + "\"")
-
-  val mimeType: String = MimeTypes.forFileName(name).fold(ContentTypes.BINARY)(addCharsetIfNeeded)
-
-  val parsedLastModified = lastModified flatMap parseModifiedDate
-
-  def url(gzipAvailable: Boolean): URL = {
-    gzipUrl match {
-      case Some(x) => if (gzipAvailable) x else url
-      case None => url
-    }
-  }
-}
-
-/**
-  * Controller that serves static resources.
-  *
-  * Resources are searched in the classpath.
-  *
-  * It handles Last-Modified and ETag header automatically.
-  * If a gzipped version of a resource is found (Same resource name with the .gz suffix), it is served instead. If a
-  * digest file is available for a given asset then its contents are read and used to supply a digest value. This value will be used for
-  * serving up ETag values and for the purposes of reverse routing. For example given "a.js", if there is an "a.js.md5"
-  * file available then the latter contents will be used to determine the Etag value.
-  * The reverse router also uses the digest in order to translate any file to the form &lt;digest&gt;-&lt;asset&gt; for
-  * example "a.js" may be also found at "d41d8cd98f00b204e9800998ecf8427e-a.js".
-  * If there is no digest file found then digest values for ETags are formed by forming a sha1 digest of the last-modified
-  * time.
-  *
-  * The default digest algorithm to search for is "md5". You can override this quite easily. For example if the SHA-1
-  * algorithm is preferred:
-  *
-  * {{{
-  * "play.assets.digest.algorithm" = "sha1"
-  * }}}
-  *
-  * You can set a custom Cache directive for a particular resource if needed. For example in your application.conf file:
-  *
-  * {{{
-  * "play.assets.cache./public/images/logo.png" = "max-age=3600"
-  * }}}
-  *
-  * You can use this controller in any application, just by declaring the appropriate route. For example:
-  * {{{
-  * GET     /assets/\uFEFF*file               controllers.Assets.at(path="/public", file)
-  * }}}
-  */
-object Assets extends AssetsBuilder(LazyHttpErrorHandler) {
-
-  import AssetInfo._
-
-  // Caching. It is unfortunate that we require both a digestCache and an assetInfo cache given that digest info is
-  // part of asset information. The reason for this is that the assetInfo cache returns a Future[AssetInfo] in order to
-  // avoid any thundering herds issue. The unbind method of the assetPathBindable doesn't support the return of a
-  // Future - unbinds are expected to be blocking. Thus we separate out the caching of a digest from the caching of
-  // full asset information. At least the determination of the digest should be relatively quick (certainly not as
-  // involved as determining the full asset info).
-
-  val digestCache = TrieMap[String, Option[String]]()
-
-  private[controllers] def digest(path: String): Option[String] = {
-    digestCache.getOrElse(path, {
-      val maybeDigestUrl: Option[URL] = resource(path + "." + digestAlgorithm)
-      val maybeDigest: Option[String] = maybeDigestUrl.map(scala.io.Source.fromURL(_).mkString.trim)
-      if (!isDev && maybeDigest.isDefined) digestCache.put(path, maybeDigest)
-      maybeDigest
-    })
-  }
-
-  // Sames goes for the minified paths cache.
-  val minifiedPathsCache = TrieMap[String, String]()
-
-  lazy val checkForMinified = config(_.getDeprecated[Option[Boolean]]("play.assets.checkForMinified", "assets.checkForMinified").getOrElse(!isDev)).getOrElse(true)
-
-  private[controllers] def minifiedPath(path: String): String = {
-    minifiedPathsCache.getOrElse(path, {
-      def minifiedPathFor(delim: Char): Option[String] = {
-        val ext = path.reverse.takeWhile(_ != '.').reverse
-        val noextPath = path.dropRight(ext.length + 1)
-        val minPath = noextPath + delim + "min." + ext
-        resource(minPath).map(_ => minPath)
-      }
-      val maybeMinifiedPath = if (checkForMinified) {
-        minifiedPathFor('.').orElse(minifiedPathFor('-')).getOrElse(path)
-      } else {
-        path
-      }
-      if (!isDev) minifiedPathsCache.put(path, maybeMinifiedPath)
-      maybeMinifiedPath
-    })
-  }
-
-  private[controllers] lazy val assetInfoCache = new SelfPopulatingMap[String, AssetInfo]()
-
-  private def assetInfoFromResource(name: String): Option[AssetInfo] = {
-    blocking {
-      for {
-        url <- resource(name)
-      } yield {
-        val gzipUrl: Option[URL] = resource(name + ".gz")
-        new AssetInfo(name, url, gzipUrl, digest(name))
-      }
-    }
-  }
-
-  private def assetInfo(name: String): Future[Option[AssetInfo]] = {
-    if (isDev) {
-      Future.successful(assetInfoFromResource(name))
-    } else {
-      assetInfoCache.putIfAbsent(name)(assetInfoFromResource)
-    }
-  }
-
-  private[controllers] def assetInfoForRequest(request: RequestHeader, name: String): Future[Option[(AssetInfo, Boolean)]] = {
-    val gzipRequested = request.headers.get(ACCEPT_ENCODING).exists(_.split(',').exists(_.trim == "gzip"))
-    assetInfo(name).map(_.map(_ -> gzipRequested))
-  }
-
-  /**
-    * An asset.
-    *
-    * @param name The name of the asset.
-    */
-  case class Asset(name: String)
-
-  object Asset {
-
-    import scala.language.implicitConversions
-
-    implicit def string2Asset(name: String): Asset = new Asset(name)
-
-    private def pathFromParams(rrc: ReverseRouteContext): String = {
-      rrc.fixedParams.getOrElse("path",
-        throw new RuntimeException("Asset path bindable must be used in combination with an action that accepts a path parameter")
-      ).toString
-    }
-
-    implicit def assetPathBindable(implicit rrc: ReverseRouteContext) = new PathBindable[Asset] {
-      def bind(key: String, value: String) = Right(new Asset(value))
-
-      def unbind(key: String, value: Asset): String = {
-        val base = pathFromParams(rrc)
-        val path = base + "/" + value.name
-        blocking {
-          val minPath = minifiedPath(path)
-          digest(minPath).fold(minPath) { dgst =>
-            val lastSep = minPath.lastIndexOf("/")
-            minPath.take(lastSep + 1) + dgst + "-" + minPath.drop(lastSep + 1)
-          }.drop(base.length + 1)
-        }
-      }
-    }
-  }
-}
-
-@Singleton
-class Assets @Inject()(errorHandler: HttpErrorHandler) extends AssetsBuilder(errorHandler)
-
-class AssetsBuilder(errorHandler: HttpErrorHandler) extends BaseController {
-
-  import AssetInfo._
-  import Assets._
-
-  private val Action = new ActionBuilder.IgnoringBody()(Execution.trampoline)
-
-  private def maybeNotModified(request: RequestHeader, assetInfo: AssetInfo, aggressiveCaching: Boolean): Option[Result] = {
-    // First check etag. Important, if there is an If-None-Match header, we MUST not check the
-    // If-Modified-Since header, regardless of whether If-None-Match matches or not. This is in
-    // accordance with section 14.26 of RFC2616.
-    request.headers.get(IF_NONE_MATCH) match {
-      case Some(etags) =>
-        assetInfo.etag.filter(someEtag => etags.split(',').exists(_.trim == someEtag)).flatMap(_ => Some(cacheableResult(assetInfo, aggressiveCaching, NotModified)))
-      case None =>
-        for {
-          ifModifiedSinceStr <- request.headers.get(IF_MODIFIED_SINCE)
-          ifModifiedSince <- parseModifiedDate(ifModifiedSinceStr)
-          lastModified <- assetInfo.parsedLastModified
-          if !lastModified.after(ifModifiedSince)
-        } yield {
-          NotModified
-        }
-    }
-  }
-
-  private def cacheableResult[A <: Result](assetInfo: AssetInfo, aggressiveCaching: Boolean, r: A): Result = {
-
-    def addHeaderIfValue(name: String, maybeValue: Option[String], response: Result): Result = {
-      maybeValue.fold(response)(v => response.withHeaders(name -> v))
-    }
-
-    val r1 = addHeaderIfValue(ETAG, assetInfo.etag, r)
-    val r2 = addHeaderIfValue(LAST_MODIFIED, assetInfo.lastModified, r1)
-
-    r2.withHeaders(CACHE_CONTROL -> assetInfo.cacheControl(aggressiveCaching))
-  }
-
-  private def asGzipResult(response: Result, gzipRequested: Boolean, gzipAvailable: Boolean): Result = {
-    if (gzipRequested && gzipAvailable) {
-      response.withHeaders(VARY -> ACCEPT_ENCODING, CONTENT_ENCODING -> "gzip")
-    } else if (gzipAvailable) {
-      response.withHeaders(VARY -> ACCEPT_ENCODING)
-    } else {
-      response
-    }
-  }
-
-  /**
-    * Generates an `Action` that serves a versioned static resource.
-    */
-  def versioned(path: String, file: Asset): Action[AnyContent] = Action.async { implicit request =>
-    val f = new File(file.name)
-    // We want to detect if it's a fingerprinted asset, because if it's fingerprinted, we can aggressively cache it,
-    // otherwise we can't.
-    val requestedDigest = f.getName.takeWhile(_ != '-')
-    if (!requestedDigest.isEmpty) {
-      val bareFile = new File(f.getParent, f.getName.drop(requestedDigest.length + 1)).getPath.replace('\\', '/')
-      val bareFullPath = path + "/" + bareFile
-      blocking(digest(bareFullPath)) match {
-        case Some(`requestedDigest`) => assetAt(path, bareFile, aggressiveCaching = true)
-        case _ => assetAt(path, file.name, aggressiveCaching = false)
-      }
-    } else {
-      assetAt(path, file.name, aggressiveCaching = false)
-    }
-  }
-
-  /**
-    * Generates an `Action` that serves a static resource.
-    *
-    * @param path the root folder for searching the static resource files, such as `"/public"`. Not URL encoded.
-    * @param file the file part extracted from the URL. May be URL encoded (note that %2F decodes to literal /).
-    * @param aggressiveCaching if true then an aggressive set of caching directives will be used. Defaults to false.
-    */
-  def at(path: String, file: String, aggressiveCaching: Boolean = false): Action[AnyContent] = Action.async { implicit request =>
-    assetAt(path, file, aggressiveCaching)
-  }
-
-  private def assetAt(path: String, file: String, aggressiveCaching: Boolean)(implicit request: RequestHeader): Future[Result] = {
-    val assetName: Option[String] = resourceNameAt(path, file)
-    val assetInfoFuture: Future[Option[(AssetInfo, Boolean)]] = assetName.map { name =>
-      assetInfoForRequest(request, name)
-    } getOrElse Future.successful(None)
-
-    def notFound = errorHandler.onClientError(request, NOT_FOUND, "Resource not found by Assets controller")
-
-    val pendingResult: Future[Result] = assetInfoFuture.flatMap {
-      case Some((assetInfo, gzipRequested)) =>
-        val connection = assetInfo.url(gzipRequested).openConnection()
-        // Make sure it's not a directory
-        if (Resources.isUrlConnectionADirectory(connection)) {
-          Resources.closeUrlConnection(connection)
-          notFound
+    def cacheControl(aggressiveCaching: Boolean): String = {
+      configuredCacheControl.getOrElse {
+        if (isProd) {
+          if (aggressiveCaching) aggressiveCacheControl else defaultCacheControl
         } else {
-          val stream = connection.getInputStream
-          val source = StreamConverters.fromInputStream(() => stream)
-          // FIXME stream.available does not necessarily return the length of the file. According to the docs "It is never
-          // correct to use the return value of this method to allocate a buffer intended to hold all data in this stream."
-          val result = RangeResult.ofSource(stream.available(), source, request.headers.get(RANGE), None, Option(assetInfo.mimeType))
-
-          Future.successful(maybeNotModified(request, assetInfo, aggressiveCaching).getOrElse {
-            cacheableResult(
-              assetInfo,
-              aggressiveCaching,
-              asGzipResult(result, gzipRequested, assetInfo.gzipUrl.isDefined)
-            )
-          })
+          "no-cache"
         }
-      case None => notFound
+      }
     }
 
-    pendingResult.recoverWith {
-      case e: InvalidUriEncodingException =>
-        errorHandler.onClientError(request, BAD_REQUEST, s"Invalid URI encoding for $file at $path: " + e.getMessage)
-      case NonFatal(e) =>
-        // Add a bit more information to the exception for better error reporting later
-        errorHandler.onServerError(request, new RuntimeException(s"Unexpected error while serving $file at $path: " + e.getMessage, e))
+    val lastModified: Option[String] = {
+      def getLastModified[T <: URLConnection](f: (T) => Long): Option[String] = {
+        Option(url.openConnection).map {
+          case urlConnection: T @unchecked =>
+            try {
+              f(urlConnection)
+            } finally {
+              Resources.closeUrlConnection(urlConnection)
+            }
+        }.filterNot(_ == -1).map(millis => httpDateFormat.format(Instant.ofEpochMilli(millis)))
+      }
+
+      url.getProtocol match {
+        case "file" => Some(httpDateFormat.format(Instant.ofEpochMilli(new File(url.toURI).lastModified)))
+        case "jar" => getLastModified[JarURLConnection](c => c.getJarEntry.getTime)
+        case "bundle" => getLastModified[URLConnection](c => c.getLastModified)
+        case _ => None
+      }
+    }
+
+    val etag: Option[String] =
+      digest orElse {
+        lastModified map (m => Codecs.sha1(m + " -> " + url.toExternalForm))
+      } map ("\"" + _ + "\"")
+
+    val mimeType: String = MimeTypes.forFileName(name).fold(ContentTypes.BINARY)(addCharsetIfNeeded)
+
+    val parsedLastModified = lastModified flatMap parseModifiedDate
+
+    def url(gzipAvailable: Boolean): URL = {
+      gzipUrl match {
+        case Some(x) => if (gzipAvailable) x else url
+        case None => url
+      }
     }
   }
 
   /**
-    * Get the name of the resource for a static resource. Used by `at`.
-    *
-    * @param path the root folder for searching the static resource files, such as `"/public"`. Not URL encoded.
-    * @param file the file part extracted from the URL. May be URL encoded (note that %2F decodes to literal /).
-    */
-  private[controllers] def resourceNameAt(path: String, file: String): Option[String] = {
-    val decodedFile = UriEncoding.decodePath(file, "utf-8")
-    def dblSlashRemover(input: String): String = dblSlashPattern.replaceAllIn(input, "/")
-    val resourceName = dblSlashRemover(s"/$path/$decodedFile")
-    val resourceFile = new File(resourceName)
-    val pathFile = new File(path)
-    if (!resourceFile.getCanonicalPath.startsWith(pathFile.getCanonicalPath)) {
-      None
-    } else {
-      Some(resourceName)
+   * Controller that serves static resources.
+   *
+   * Resources are searched in the classpath.
+   *
+   * It handles Last-Modified and ETag header automatically.
+   * If a gzipped version of a resource is found (Same resource name with the .gz suffix), it is served instead. If a
+   * digest file is available for a given asset then its contents are read and used to supply a digest value. This value will be used for
+   * serving up ETag values and for the purposes of reverse routing. For example given "a.js", if there is an "a.js.md5"
+   * file available then the latter contents will be used to determine the Etag value.
+   * The reverse router also uses the digest in order to translate any file to the form &lt;digest&gt;-&lt;asset&gt; for
+   * example "a.js" may be also found at "d41d8cd98f00b204e9800998ecf8427e-a.js".
+   * If there is no digest file found then digest values for ETags are formed by forming a sha1 digest of the last-modified
+   * time.
+   *
+   * The default digest algorithm to search for is "md5". You can override this quite easily. For example if the SHA-1
+   * algorithm is preferred:
+   *
+   * {{{
+   * "play.assets.digest.algorithm" = "sha1"
+   * }}}
+   *
+   * You can set a custom Cache directive for a particular resource if needed. For example in your application.conf file:
+   *
+   * {{{
+   * "play.assets.cache./public/images/logo.png" = "max-age=3600"
+   * }}}
+   *
+   * You can use this controller in any application, just by declaring the appropriate route. For example:
+   * {{{
+   * GET     /assets/\uFEFF*file               controllers.Assets.at(path="/public", file)
+   * }}}
+   */
+  object Assets extends AssetsBuilder(LazyHttpErrorHandler) {
+
+    import AssetInfo._
+
+    // Caching. It is unfortunate that we require both a digestCache and an assetInfo cache given that digest info is
+    // part of asset information. The reason for this is that the assetInfo cache returns a Future[AssetInfo] in order to
+    // avoid any thundering herds issue. The unbind method of the assetPathBindable doesn't support the return of a
+    // Future - unbinds are expected to be blocking. Thus we separate out the caching of a digest from the caching of
+    // full asset information. At least the determination of the digest should be relatively quick (certainly not as
+    // involved as determining the full asset info).
+
+    val digestCache = TrieMap[String, Option[String]]()
+
+    private[controllers] def digest(path: String): Option[String] = {
+      digestCache.getOrElse(path, {
+        val maybeDigestUrl: Option[URL] = resource(path + "." + digestAlgorithm)
+        val maybeDigest: Option[String] = maybeDigestUrl.map(scala.io.Source.fromURL(_).mkString.trim)
+        if (!isDev && maybeDigest.isDefined) digestCache.put(path, maybeDigest)
+        maybeDigest
+      })
+    }
+
+    // Sames goes for the minified paths cache.
+    val minifiedPathsCache = TrieMap[String, String]()
+
+    lazy val checkForMinified = config(_.getDeprecated[Option[Boolean]]("play.assets.checkForMinified", "assets.checkForMinified").getOrElse(!isDev)).getOrElse(true)
+
+    private[controllers] def minifiedPath(path: String): String = {
+      minifiedPathsCache.getOrElse(path, {
+        def minifiedPathFor(delim: Char): Option[String] = {
+          val ext = path.reverse.takeWhile(_ != '.').reverse
+          val noextPath = path.dropRight(ext.length + 1)
+          val minPath = noextPath + delim + "min." + ext
+          resource(minPath).map(_ => minPath)
+        }
+        val maybeMinifiedPath = if (checkForMinified) {
+          minifiedPathFor('.').orElse(minifiedPathFor('-')).getOrElse(path)
+        } else {
+          path
+        }
+        if (!isDev) minifiedPathsCache.put(path, maybeMinifiedPath)
+        maybeMinifiedPath
+      })
+    }
+
+    private[controllers] lazy val assetInfoCache = new SelfPopulatingMap[String, AssetInfo]()
+
+    private def assetInfoFromResource(name: String): Option[AssetInfo] = {
+      blocking {
+        for {
+          url <- resource(name)
+        } yield {
+          val gzipUrl: Option[URL] = resource(name + ".gz")
+          new AssetInfo(name, url, gzipUrl, digest(name))
+        }
+      }
+    }
+
+    private def assetInfo(name: String): Future[Option[AssetInfo]] = {
+      if (isDev) {
+        Future.successful(assetInfoFromResource(name))
+      } else {
+        assetInfoCache.putIfAbsent(name)(assetInfoFromResource)
+      }
+    }
+
+    private[controllers] def assetInfoForRequest(request: RequestHeader, name: String): Future[Option[(AssetInfo, Boolean)]] = {
+      val gzipRequested = request.headers.get(ACCEPT_ENCODING).exists(_.split(',').exists(_.trim == "gzip"))
+      assetInfo(name).map(_.map(_ -> gzipRequested))
+    }
+
+    /**
+     * An asset.
+     *
+     * @param name The name of the asset.
+     */
+    case class Asset(name: String)
+
+    object Asset {
+
+      import scala.language.implicitConversions
+
+      implicit def string2Asset(name: String): Asset = new Asset(name)
+
+      private def pathFromParams(rrc: ReverseRouteContext): String = {
+        rrc.fixedParams.getOrElse(
+          "path",
+          throw new RuntimeException("Asset path bindable must be used in combination with an action that accepts a path parameter")
+        ).toString
+      }
+
+      implicit def assetPathBindable(implicit rrc: ReverseRouteContext) = new PathBindable[Asset] {
+        def bind(key: String, value: String) = Right(new Asset(value))
+
+        def unbind(key: String, value: Asset): String = {
+          val base = pathFromParams(rrc)
+          val path = base + "/" + value.name
+          blocking {
+            val minPath = minifiedPath(path)
+            digest(minPath).fold(minPath) { dgst =>
+              val lastSep = minPath.lastIndexOf("/")
+              minPath.take(lastSep + 1) + dgst + "-" + minPath.drop(lastSep + 1)
+            }.drop(base.length + 1)
+          }
+        }
+      }
     }
   }
 
-  private val dblSlashPattern = """//+""".r
-}
+  @Singleton
+  class Assets @Inject() (errorHandler: HttpErrorHandler) extends AssetsBuilder(errorHandler)
+
+  class AssetsBuilder(errorHandler: HttpErrorHandler) extends BaseController {
+
+    import AssetInfo._
+    import Assets._
+
+    private val Action = new ActionBuilder.IgnoringBody()(Execution.trampoline)
+
+    private def maybeNotModified(request: RequestHeader, assetInfo: AssetInfo, aggressiveCaching: Boolean): Option[Result] = {
+      // First check etag. Important, if there is an If-None-Match header, we MUST not check the
+      // If-Modified-Since header, regardless of whether If-None-Match matches or not. This is in
+      // accordance with section 14.26 of RFC2616.
+      request.headers.get(IF_NONE_MATCH) match {
+        case Some(etags) =>
+          assetInfo.etag.filter(someEtag => etags.split(',').exists(_.trim == someEtag)).flatMap(_ => Some(cacheableResult(assetInfo, aggressiveCaching, NotModified)))
+        case None =>
+          for {
+            ifModifiedSinceStr <- request.headers.get(IF_MODIFIED_SINCE)
+            ifModifiedSince <- parseModifiedDate(ifModifiedSinceStr)
+            lastModified <- assetInfo.parsedLastModified
+            if !lastModified.after(ifModifiedSince)
+          } yield {
+            NotModified
+          }
+      }
+    }
+
+    private def cacheableResult[A <: Result](assetInfo: AssetInfo, aggressiveCaching: Boolean, r: A): Result = {
+
+      def addHeaderIfValue(name: String, maybeValue: Option[String], response: Result): Result = {
+        maybeValue.fold(response)(v => response.withHeaders(name -> v))
+      }
+
+      val r1 = addHeaderIfValue(ETAG, assetInfo.etag, r)
+      val r2 = addHeaderIfValue(LAST_MODIFIED, assetInfo.lastModified, r1)
+
+      r2.withHeaders(CACHE_CONTROL -> assetInfo.cacheControl(aggressiveCaching))
+    }
+
+    private def asGzipResult(response: Result, gzipRequested: Boolean, gzipAvailable: Boolean): Result = {
+      if (gzipRequested && gzipAvailable) {
+        response.withHeaders(VARY -> ACCEPT_ENCODING, CONTENT_ENCODING -> "gzip")
+      } else if (gzipAvailable) {
+        response.withHeaders(VARY -> ACCEPT_ENCODING)
+      } else {
+        response
+      }
+    }
+
+    /**
+     * Generates an `Action` that serves a versioned static resource.
+     */
+    def versioned(path: String, file: Asset): Action[AnyContent] = Action.async { implicit request =>
+      val f = new File(file.name)
+      // We want to detect if it's a fingerprinted asset, because if it's fingerprinted, we can aggressively cache it,
+      // otherwise we can't.
+      val requestedDigest = f.getName.takeWhile(_ != '-')
+      if (!requestedDigest.isEmpty) {
+        val bareFile = new File(f.getParent, f.getName.drop(requestedDigest.length + 1)).getPath.replace('\\', '/')
+        val bareFullPath = path + "/" + bareFile
+        blocking(digest(bareFullPath)) match {
+          case Some(`requestedDigest`) => assetAt(path, bareFile, aggressiveCaching = true)
+          case _ => assetAt(path, file.name, aggressiveCaching = false)
+        }
+      } else {
+        assetAt(path, file.name, aggressiveCaching = false)
+      }
+    }
+
+    /**
+     * Generates an `Action` that serves a static resource.
+     *
+     * @param path the root folder for searching the static resource files, such as `"/public"`. Not URL encoded.
+     * @param file the file part extracted from the URL. May be URL encoded (note that %2F decodes to literal /).
+     * @param aggressiveCaching if true then an aggressive set of caching directives will be used. Defaults to false.
+     */
+    def at(path: String, file: String, aggressiveCaching: Boolean = false): Action[AnyContent] = Action.async { implicit request =>
+      assetAt(path, file, aggressiveCaching)
+    }
+
+    private def assetAt(path: String, file: String, aggressiveCaching: Boolean)(implicit request: RequestHeader): Future[Result] = {
+      val assetName: Option[String] = resourceNameAt(path, file)
+      val assetInfoFuture: Future[Option[(AssetInfo, Boolean)]] = assetName.map { name =>
+        assetInfoForRequest(request, name)
+      } getOrElse Future.successful(None)
+
+      def notFound = errorHandler.onClientError(request, NOT_FOUND, "Resource not found by Assets controller")
+
+      val pendingResult: Future[Result] = assetInfoFuture.flatMap {
+        case Some((assetInfo, gzipRequested)) =>
+          val connection = assetInfo.url(gzipRequested).openConnection()
+          // Make sure it's not a directory
+          if (Resources.isUrlConnectionADirectory(connection)) {
+            Resources.closeUrlConnection(connection)
+            notFound
+          } else {
+            val stream = connection.getInputStream
+            val source = StreamConverters.fromInputStream(() => stream)
+            // FIXME stream.available does not necessarily return the length of the file. According to the docs "It is never
+            // correct to use the return value of this method to allocate a buffer intended to hold all data in this stream."
+            val result = RangeResult.ofSource(stream.available(), source, request.headers.get(RANGE), None, Option(assetInfo.mimeType))
+
+            Future.successful(maybeNotModified(request, assetInfo, aggressiveCaching).getOrElse {
+              cacheableResult(
+                assetInfo,
+                aggressiveCaching,
+                asGzipResult(result, gzipRequested, assetInfo.gzipUrl.isDefined)
+              )
+            })
+          }
+        case None => notFound
+      }
+
+      pendingResult.recoverWith {
+        case e: InvalidUriEncodingException =>
+          errorHandler.onClientError(request, BAD_REQUEST, s"Invalid URI encoding for $file at $path: " + e.getMessage)
+        case NonFatal(e) =>
+          // Add a bit more information to the exception for better error reporting later
+          errorHandler.onServerError(request, new RuntimeException(s"Unexpected error while serving $file at $path: " + e.getMessage, e))
+      }
+    }
+
+    /**
+     * Get the name of the resource for a static resource. Used by `at`.
+     *
+     * @param path the root folder for searching the static resource files, such as `"/public"`. Not URL encoded.
+     * @param file the file part extracted from the URL. May be URL encoded (note that %2F decodes to literal /).
+     */
+    private[controllers] def resourceNameAt(path: String, file: String): Option[String] = {
+      val decodedFile = UriEncoding.decodePath(file, "utf-8")
+      def dblSlashRemover(input: String): String = dblSlashPattern.replaceAllIn(input, "/")
+      val resourceName = dblSlashRemover(s"/$path/$decodedFile")
+      val resourceFile = new File(resourceName)
+      val pathFile = new File(path)
+      if (!resourceFile.getCanonicalPath.startsWith(pathFile.getCanonicalPath)) {
+        None
+      } else {
+        Some(resourceName)
+      }
+    }
+
+    private val dblSlashPattern = """//+""".r
+  }
 
 }

--- a/framework/src/play/src/main/scala/play/api/http/HttpEntity.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpEntity.scala
@@ -94,7 +94,8 @@ object HttpEntity {
   final case class Streamed(data: Source[ByteString, _], contentLength: Option[Long], contentType: Option[String]) extends HttpEntity {
     def isKnownEmpty = false
     def dataStream = data
-    def asJava = new JHttpEntity.Streamed(data.asJava,
+    def asJava = new JHttpEntity.Streamed(
+      data.asJava,
       OptionConverters.toJava(contentLength.asInstanceOf[Option[java.lang.Long]]),
       OptionConverters.toJava(contentType))
     def as(contentType: String) = copy(contentType = Some(contentType))

--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -161,7 +161,8 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
    */
   def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
     try {
-      val usefulException = HttpErrorHandlerExceptions.throwableToUsefulException(sourceMapper,
+      val usefulException = HttpErrorHandlerExceptions.throwableToUsefulException(
+        sourceMapper,
         environment.mode == Mode.Prod, exception)
 
       logServerError(request, usefulException)
@@ -186,7 +187,8 @@ class DefaultHttpErrorHandler(environment: Environment, configuration: Configura
    * @param usefulException The server error.
    */
   protected def logServerError(request: RequestHeader, usefulException: UsefulException) {
-    Logger.error("""
+    Logger.error(
+      """
                     |
                     |! @%s - Internal server error, for (%s) [%s] ->
                     | """.stripMargin.format(usefulException.id, request.method, request.uri),

--- a/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpRequestHandler.scala
@@ -46,7 +46,8 @@ object HttpRequestHandler {
 
   def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
 
-    val fromConfiguration = Reflect.bindingsFromConfiguration[HttpRequestHandler, play.http.HttpRequestHandler, play.core.j.JavaHttpRequestHandlerAdapter, play.http.DefaultHttpRequestHandler, JavaCompatibleHttpRequestHandler](environment,
+    val fromConfiguration = Reflect.bindingsFromConfiguration[HttpRequestHandler, play.http.HttpRequestHandler, play.core.j.JavaHttpRequestHandlerAdapter, play.http.DefaultHttpRequestHandler, JavaCompatibleHttpRequestHandler](
+      environment,
       configuration, "play.http.requestHandler", "RequestHandler")
 
     val javaComponentsBindings = Seq(BindingKey(classOf[play.core.j.JavaHandlerComponents]).to[play.core.j.DefaultJavaHandlerComponents])
@@ -59,11 +60,12 @@ object ActionCreator {
   import play.http.{ ActionCreator, HttpRequestHandlerActionCreator }
 
   def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
-    Reflect.configuredClass[ActionCreator, ActionCreator, HttpRequestHandlerActionCreator](environment,
+    Reflect.configuredClass[ActionCreator, ActionCreator, HttpRequestHandlerActionCreator](
+      environment,
       configuration, "play.http.actionCreator", "ActionCreator").fold(Seq[Binding[_]]()) { either =>
-        val impl = either.fold(identity, identity)
-        Seq(BindingKey(classOf[ActionCreator]).to(impl))
-      }
+      val impl = either.fold(identity, identity)
+      Seq(BindingKey(classOf[ActionCreator]).to(impl))
+    }
   }
 }
 

--- a/framework/src/play/src/main/scala/play/api/http/MediaRange.scala
+++ b/framework/src/play/src/main/scala/play/api/http/MediaRange.scala
@@ -39,7 +39,8 @@ case class MediaType(mediaType: String, mediaSubType: String, parameters: Seq[(S
  * @param qValue The Q value
  * @param acceptExtensions The accept extensions
  */
-class MediaRange(mediaType: String,
+class MediaRange(
+    mediaType: String,
     mediaSubType: String,
     parameters: Seq[(String, Option[String])],
     val qValue: Option[BigDecimal],

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -167,7 +167,8 @@ class DefaultLangs @Inject() (config: Configuration) extends Langs {
 
     langs.map { lang =>
       try { Lang(lang) } catch {
-        case NonFatal(e) => throw config.reportError("play.i18n.langs",
+        case NonFatal(e) => throw config.reportError(
+          "play.i18n.langs",
           "Invalid language code [" + lang + "]", Some(e))
       }
     }

--- a/framework/src/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
@@ -3,8 +3,8 @@
  */
 package play.api.inject
 
-import java.util.concurrent.{Callable, CompletionStage, ConcurrentLinkedDeque, LinkedBlockingDeque}
-import javax.inject.{Inject, Singleton}
+import java.util.concurrent.{ Callable, CompletionStage, ConcurrentLinkedDeque, LinkedBlockingDeque }
+import javax.inject.{ Inject, Singleton }
 
 import play.api.Logger
 
@@ -72,7 +72,7 @@ trait ApplicationLifecycle {
  * Default implementation of the application lifecycle.
  */
 @Singleton
-class DefaultApplicationLifecycle @Inject()() extends ApplicationLifecycle {
+class DefaultApplicationLifecycle @Inject() () extends ApplicationLifecycle {
   private val hooks = new ConcurrentLinkedDeque[() => Future[_]]()
 
   def addStopHook(hook: () => Future[_]) = hooks.push(hook)

--- a/framework/src/play/src/main/scala/play/api/inject/Binding.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Binding.scala
@@ -10,7 +10,6 @@ import scala.reflect.ClassTag
 
 import play.inject.SourceProvider
 
-
 /**
  * A binding.
  *

--- a/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/EventSource.scala
@@ -85,7 +85,8 @@ object EventSource {
      * and the nameExtractor and idExtractor will implicitly resolve to `None`.
      *
      */
-    def apply[A](a: A)(implicit dataExtractor: EventDataExtractor[A],
+    def apply[A](a: A)(implicit
+      dataExtractor: EventDataExtractor[A],
       nameExtractor: EventNameExtractor[A],
       idExtractor: EventIdExtractor[A]): Event = {
       Event(dataExtractor.eventData(a), idExtractor.eventId(a), nameExtractor.eventName(a))

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -4,17 +4,17 @@
 package play.api.libs.concurrent
 
 import java.util.concurrent.TimeoutException
-import javax.inject.{Inject, Provider, Singleton}
+import javax.inject.{ Inject, Provider, Singleton }
 
 import akka.actor._
-import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.{ ActorMaterializer, Materializer }
 import com.typesafe.config.Config
 import play.api._
-import play.api.inject.{ApplicationLifecycle, Binding, Injector, bind}
+import play.api.inject.{ ApplicationLifecycle, Binding, Injector, bind }
 import play.core.ClosableLazy
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContextExecutor, Future}
+import scala.concurrent.{ Await, ExecutionContextExecutor, Future }
 import scala.reflect.ClassTag
 
 /**
@@ -177,29 +177,29 @@ object ActorSystemProvider {
 }
 
 /**
-  * Support for creating injected child actors.
-  */
+ * Support for creating injected child actors.
+ */
 trait InjectedActorSupport {
 
   /**
-    * Create an injected child actor.
-    *
-    * @param create A function to create the actor.
-    * @param name The name of the actor.
-    * @param props A function to provide props for the actor. The props passed in will just describe how to create the
-    *              actor, this function can be used to provide additional configuration such as router and dispatcher
-    *              configuration.
-    * @param context The context to create the actor from.
-    * @return An ActorRef for the created actor.
-    */
+   * Create an injected child actor.
+   *
+   * @param create A function to create the actor.
+   * @param name The name of the actor.
+   * @param props A function to provide props for the actor. The props passed in will just describe how to create the
+   *              actor, this function can be used to provide additional configuration such as router and dispatcher
+   *              configuration.
+   * @param context The context to create the actor from.
+   * @return An ActorRef for the created actor.
+   */
   def injectedChild(create: => Actor, name: String, props: Props => Props = identity)(implicit context: ActorContext): ActorRef = {
     context.actorOf(props(Props(create)), name)
   }
 }
 
 /**
-  * Provider for creating actor refs
-  */
+ * Provider for creating actor refs
+ */
 class ActorRefProvider[T <: Actor: ClassTag](name: String, props: Props => Props) extends Provider[ActorRef] {
 
   @Inject private var actorSystem: ActorSystem = _

--- a/framework/src/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/typedmap/TypedMap.scala
@@ -140,7 +140,7 @@ final class TypedKey[A] private (val displayName: Option[String]) {
    * @param value The value to bind.
    * @return An entry binding this key to a value of the right type.
    */
-  def ->(value: A): TypedEntry[A] = bindValue(value)
+  def -> (value: A): TypedEntry[A] = bindValue(value)
 
   override def toString: String = displayName.getOrElse(super.toString)
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -3,7 +3,7 @@
  */
 package play.api.mvc
 
-import java.net.{URLDecoder, URLEncoder}
+import java.net.{ URLDecoder, URLEncoder }
 import java.util.Locale
 
 import play.api._
@@ -294,10 +294,10 @@ trait CookieBaker[T <: AnyRef] {
 
     def urldecode(data: String) = {
       data
-          .split("&")
-          .map(_.split("=", 2))
-          .map(p => URLDecoder.decode(p(0), "UTF-8") -> URLDecoder.decode(p(1), "UTF-8"))
-          .toMap
+        .split("&")
+        .map(_.split("=", 2))
+        .map(p => URLDecoder.decode(p(0), "UTF-8") -> URLDecoder.decode(p(1), "UTF-8"))
+        .toMap
     }
 
     // Do not change this unless you understand the security issues behind timing attacks.

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -378,7 +378,8 @@ trait Results {
 
     private def streamFile(file: Source[ByteString, _], name: String, length: Long, inline: Boolean): Result = {
       Result(
-        ResponseHeader(status,
+        ResponseHeader(
+          status,
           Map(
             CONTENT_DISPOSITION -> {
               val dispositionType = if (inline) "inline" else "attachment"

--- a/framework/src/play/src/main/scala/play/api/mvc/WebSocket.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/WebSocket.scala
@@ -111,7 +111,8 @@ object WebSocket {
           AkkaStreams.bypassWith[Message, String, Message](Flow[Message] collect {
             case TextMessage(text) => Left(text)
             case BinaryMessage(_) =>
-              Right(CloseMessage(Some(CloseCodes.Unacceptable),
+              Right(CloseMessage(
+                Some(CloseCodes.Unacceptable),
                 "This WebSocket only supports text frames"))
           })(flow map TextMessage.apply)
         }
@@ -127,7 +128,8 @@ object WebSocket {
           AkkaStreams.bypassWith[Message, ByteString, Message](Flow[Message] collect {
             case BinaryMessage(data) => Left(data)
             case TextMessage(_) =>
-              Right(CloseMessage(Some(CloseCodes.Unacceptable),
+              Right(CloseMessage(
+                Some(CloseCodes.Unacceptable),
                 "This WebSocket only supports binary frames"))
           })(flow map BinaryMessage.apply)
         }
@@ -148,7 +150,8 @@ object WebSocket {
       def closeOnException[T](block: => T) = try {
         Left(block)
       } catch {
-        case NonFatal(e) => Right(CloseMessage(Some(CloseCodes.Unacceptable),
+        case NonFatal(e) => Right(CloseMessage(
+          Some(CloseCodes.Unacceptable),
           "Unable to parse json message"))
       }
 

--- a/framework/src/play/src/main/scala/play/api/routing/Router.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/Router.scala
@@ -4,8 +4,8 @@
 package play.api.routing
 
 import play.api.libs.typedmap.TypedKey
-import play.api.{Configuration, Environment}
-import play.api.mvc.{Handler, RequestHeader}
+import play.api.{ Configuration, Environment }
+import play.api.mvc.{ Handler, RequestHeader }
 import play.core.j.JavaRouterAdapter
 import play.core.routing.HandlerDef
 import play.utils.Reflect

--- a/framework/src/play/src/main/scala/play/core/formatters/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/formatters/Multipart.scala
@@ -115,7 +115,8 @@ object Multipart {
 
   }
 
-  private def streamed(boundary: String,
+  private def streamed(
+    boundary: String,
     nioCharset: Charset, chunkSize: Int): GraphStage[FlowShape[MultipartFormData.Part[Source[ByteString, _]], Source[ByteString, Any]]] =
 
     new GraphStage[FlowShape[MultipartFormData.Part[Source[ByteString, _]], Source[ByteString, Any]]] {

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -137,9 +137,9 @@ trait JavaHandlerComponents {
  * The components necessary to handle a Java handler.
  */
 class DefaultJavaHandlerComponents @Inject() (
-  injector: Injector,
-  val actionCreator: play.http.ActionCreator,
-  val httpConfiguration: HttpConfiguration
+    injector: Injector,
+    val actionCreator: play.http.ActionCreator,
+    val httpConfiguration: HttpConfiguration
 ) extends JavaHandlerComponents {
   def getBodyParser[A <: JBodyParser[_]](parserClass: Class[A]): A = injector.instanceOf(parserClass)
   def getAction[A <: JAction[_]](actionClass: Class[A]): A = injector.instanceOf(actionClass)

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -44,7 +44,8 @@ trait JavaHelpers {
       }
 
       private def makeJavaCookie(cookie: Cookie): JCookie = {
-        new JCookie(cookie.name,
+        new JCookie(
+          cookie.name,
           cookie.value,
           cookie.maxAge.map(i => new Integer(i)).orNull,
           cookie.path,

--- a/framework/src/play/src/main/scala/play/core/j/JavaResults.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaResults.scala
@@ -28,7 +28,8 @@ object JavaResultExtractor {
       }
 
       private def makeJavaCookie(cookie: Cookie): JCookie = {
-        new JCookie(cookie.name,
+        new JCookie(
+          cookie.name,
           cookie.value,
           cookie.maxAge.map(i => new Integer(i)).orNull,
           cookie.path,

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -202,9 +202,9 @@ object Multipart {
       for {
         values <- headers.get("content-disposition").map(
           _.split(";").map(_.trim).map {
-            case KeyValue(key, v) => (key.trim, v.trim)
-            case key => (key.trim, "")
-          }.toMap)
+          case KeyValue(key, v) => (key.trim, v.trim)
+          case key => (key.trim, "")
+        }.toMap)
         _ <- values.get("form-data")
         partName <- values.get("name")
       } yield partName

--- a/framework/src/play/src/main/scala/play/core/routing/HandlerInvoker.scala
+++ b/framework/src/play/src/main/scala/play/core/routing/HandlerInvoker.scala
@@ -4,17 +4,17 @@
 package play.core.routing
 
 import java.util.Optional
-import java.util.concurrent.{CompletableFuture, CompletionStage}
+import java.util.concurrent.{ CompletableFuture, CompletionStage }
 
 import akka.stream.scaladsl.Flow
 import org.apache.commons.lang3.reflect.MethodUtils
 import play.api.http.ActionCompositionConfiguration
 import play.api.mvc._
 import play.core.j
-import play.core.j.{JavaHelpers, JavaActionAnnotations, JavaHandler, JavaHandlerComponents}
-import play.mvc.Http.{Context, RequestBody}
+import play.core.j.{ JavaHelpers, JavaActionAnnotations, JavaHandler, JavaHandlerComponents }
+import play.mvc.Http.{ Context, RequestBody }
 
-import scala.compat.java8.{FutureConverters, OptionConverters}
+import scala.compat.java8.{ FutureConverters, OptionConverters }
 import scala.util.control.NonFatal
 
 /**
@@ -148,7 +148,7 @@ object HandlerInvokerFactory {
   implicit def javaWebSocket: HandlerInvokerFactory[JWebSocket] = new HandlerInvokerFactory[JWebSocket] {
     import play.api.http.websocket._
     import play.core.Execution.Implicits.trampoline
-    import play.http.websocket.{Message => JMessage}
+    import play.http.websocket.{ Message => JMessage }
 
     def createInvoker(fakeCall: => JWebSocket, handlerDef: HandlerDef) = new HandlerInvoker[JWebSocket] {
       def call(call: => JWebSocket) = WebSocket.acceptOrResult[Message, Message] { request =>

--- a/framework/src/play/src/main/scala/play/utils/Reflect.scala
+++ b/framework/src/play/src/main/scala/play/utils/Reflect.scala
@@ -3,8 +3,8 @@
  */
 package play.utils
 
-import play.api.inject.{Binding, BindingKey}
-import play.api.{Configuration, Environment, PlayException}
+import play.api.inject.{ Binding, BindingKey }
+import play.api.{ Configuration, Environment, PlayException }
 
 import scala.reflect.ClassTag
 
@@ -41,8 +41,9 @@ object Reflect {
    * @return Zero or more bindings to provide `ScalaTrait`
    */
   def bindingsFromConfiguration[ScalaTrait, JavaInterface, JavaAdapter <: ScalaTrait, JavaDelegate <: JavaInterface, Default <: ScalaTrait](
-    environment: Environment, config: Configuration, key: String, defaultClassName: String)(implicit scalaTrait: SubClassOf[ScalaTrait],
-      javaInterface: SubClassOf[JavaInterface], javaAdapter: ClassTag[JavaAdapter], javaDelegate: ClassTag[JavaDelegate], default: ClassTag[Default]): Seq[Binding[_]] = {
+    environment: Environment, config: Configuration, key: String, defaultClassName: String)(implicit
+    scalaTrait: SubClassOf[ScalaTrait],
+    javaInterface: SubClassOf[JavaInterface], javaAdapter: ClassTag[JavaAdapter], javaDelegate: ClassTag[JavaDelegate], default: ClassTag[Default]): Seq[Binding[_]] = {
 
     def bind[T: SubClassOf]: BindingKey[T] = BindingKey(implicitly[SubClassOf[T]].runtimeClass)
 
@@ -91,8 +92,9 @@ object Reflect {
    * @tparam Default The default implementation of `ScalaTrait` if no user implementation has been provided
    */
   def configuredClass[ScalaTrait, JavaInterface, Default <: ScalaTrait](
-    environment: Environment, config: Configuration, key: String, defaultClassName: String)(implicit scalaTrait: SubClassOf[ScalaTrait],
-      javaInterface: SubClassOf[JavaInterface], default: ClassTag[Default]): Option[Either[Class[_ <: ScalaTrait], Class[_ <: JavaInterface]]] = {
+    environment: Environment, config: Configuration, key: String, defaultClassName: String)(implicit
+    scalaTrait: SubClassOf[ScalaTrait],
+    javaInterface: SubClassOf[JavaInterface], default: ClassTag[Default]): Option[Either[Class[_ <: ScalaTrait], Class[_ <: JavaInterface]]] = {
 
     def loadClass(className: String, notFoundFatal: Boolean): Option[Class[_]] = {
       try {

--- a/framework/src/play/src/test/scala/play/api/PlayCoreTestApplication.scala
+++ b/framework/src/play/src/test/scala/play/api/PlayCoreTestApplication.scala
@@ -12,7 +12,8 @@ import java.io.File
  * Fake application as used by Play core tests.  This is needed since Play core can't depend on the Play test API.
  * It's also a lot simpler, doesn't load default config files etc.
  */
-private[play] case class PlayCoreTestApplication(config: Map[String, Any] = Map(),
+private[play] case class PlayCoreTestApplication(
+    config: Map[String, Any] = Map(),
     path: File = new File("."),
     mode: Mode.Mode = Mode.Test) extends Application {
 

--- a/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
@@ -22,7 +22,8 @@ class MessagesSpec extends Specification {
       "foo" -> "foo francais"),
     "fr-CH" -> Map(
       "title" -> "Titre suisse"))
-  val api = new DefaultMessagesApi(new Environment(new File("."), this.getClass.getClassLoader, Mode.Dev),
+  val api = new DefaultMessagesApi(
+    new Environment(new File("."), this.getClass.getClassLoader, Mode.Dev),
     Configuration.reference, new DefaultLangs(Configuration.reference ++ Configuration.from(Map("play.i18n.langs" -> Seq("en", "fr", "fr-CH"))))
   ) {
     override protected def loadAllMessages = testMessages
@@ -89,7 +90,8 @@ class MessagesSpec extends Specification {
     }
 
     "report error for invalid lang" in {
-      new DefaultMessagesApi(new Environment(new File("."), this.getClass.getClassLoader, Mode.Dev),
+      new DefaultMessagesApi(
+        new Environment(new File("."), this.getClass.getClassLoader, Mode.Dev),
         Configuration.reference, new DefaultLangs(Configuration.reference ++ Configuration.from(Map("play.i18n.langs" -> Seq("invalid_language"))))
       ) must throwA[PlayException]
     }

--- a/framework/src/play/src/test/scala/play/api/libs/crypto/CryptoConfigParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/crypto/CryptoConfigParserSpec.scala
@@ -16,7 +16,8 @@ class CryptoConfigParserSpec extends Specification {
       val Secret = "abcdefghijklmnopqrs"
 
       def parseSecret(mode: Mode.Mode, secret: Option[String] = None) = {
-        new CryptoConfigParser(Environment.simple(mode = mode),
+        new CryptoConfigParser(
+          Environment.simple(mode = mode),
           Configuration.reference ++ Configuration.from(
             secret.map("play.crypto.secret" -> _).toMap
           )).get.secret

--- a/framework/src/play/src/test/scala/play/core/routing/GeneratedRouterSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/routing/GeneratedRouterSpec.scala
@@ -50,7 +50,8 @@ object GeneratedRouterSpec extends Specification {
 
     "route requests to Scala controllers" in {
       val handler = Action(Results.Ok("Hello world"))
-      val handlerDef = HandlerDef(handler.getClass.getClassLoader,
+      val handlerDef = HandlerDef(
+        handler.getClass.getClassLoader,
         "router",
         "ControllerClassName",
         "handler",
@@ -76,7 +77,8 @@ object GeneratedRouterSpec extends Specification {
 
     "route requests to Java controllers" in {
       val controller = new JavaController
-      val handlerDef = HandlerDef(controller.getClass.getClassLoader,
+      val handlerDef = HandlerDef(
+        controller.getClass.getClassLoader,
         "router",
         controller.getClass.getName,
         "index",

--- a/framework/src/play/src/test/scala/play/core/test/Fakes.scala
+++ b/framework/src/play/src/test/scala/play/core/test/Fakes.scala
@@ -76,7 +76,8 @@ case class FakeRequest[A](
    */
   def withFlash(data: (String, String)*): FakeRequest[A] = {
     withHeaders(play.api.http.HeaderNames.COOKIE ->
-      Cookies.mergeCookieHeader(headers.get(play.api.http.HeaderNames.COOKIE).getOrElse(""),
+      Cookies.mergeCookieHeader(
+        headers.get(play.api.http.HeaderNames.COOKIE).getOrElse(""),
         Seq(Flash.encodeAsCookie(new Flash(flash.data ++ data)))
       )
     )
@@ -96,7 +97,8 @@ case class FakeRequest[A](
    */
   def withSession(newSessions: (String, String)*): FakeRequest[A] = {
     withHeaders(play.api.http.HeaderNames.COOKIE ->
-      Cookies.mergeCookieHeader(headers.get(play.api.http.HeaderNames.COOKIE).getOrElse(""),
+      Cookies.mergeCookieHeader(
+        headers.get(play.api.http.HeaderNames.COOKIE).getOrElse(""),
         Seq(Session.encodeAsCookie(new Session(session.data ++ newSessions)))
       )
     )

--- a/framework/src/play/src/test/scala/play/libs/XMLSpec.scala
+++ b/framework/src/play/src/test/scala/play/libs/XMLSpec.scala
@@ -46,7 +46,8 @@ class XMLSpec extends Specification {
     "parse XML bodies without loading in a related schema from a parameter" in {
       val externalParameterEntity = File.createTempFile("xep", ".dtd")
       val externalGeneralEntity = File.createTempFile("xxe", ".txt")
-      writeStringToFile(externalParameterEntity,
+      writeStringToFile(
+        externalParameterEntity,
         s"""
           |<!ENTITY % xge SYSTEM "${externalGeneralEntity.toURI}">
           |<!ENTITY % pe "<!ENTITY xxe '%xge;'>">

--- a/framework/src/play/src/test/scala/play/mvc/RawBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/mvc/RawBodyParserSpec.scala
@@ -70,7 +70,8 @@ class RawBodyParserSpec extends Specification with AfterAll {
             new DefaultHttpErrorHandler(play.api.Environment.simple(), play.api.Configuration.empty),
             ActorMaterializer()
           ).raw
-          val javaParser = new BodyParser.DelegatingBodyParser[RawBuffer, RawBuffer](scalaParser,
+          val javaParser = new BodyParser.DelegatingBodyParser[RawBuffer, RawBuffer](
+            scalaParser,
             java.util.function.Function.identity[RawBuffer]) {}
 
           stage.complete(javaParser)

--- a/framework/src/run-support/src/main/scala/play/runsupport/FileWatchService.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/FileWatchService.scala
@@ -157,7 +157,8 @@ private object JNotifyFileWatchService {
    */
   class JNotifyDelegate(classLoader: ClassLoader, listenerClass: Class[_], addWatchMethod: Method, removeWatchMethod: Method) {
     def addWatch(fileOrDirectory: String, listener: AnyRef): Int = {
-      addWatchMethod.invoke(null,
+      addWatchMethod.invoke(
+        null,
         fileOrDirectory, // The file or directory to watch
         15: java.lang.Integer, // flags to say watch for all events
         true: java.lang.Boolean, // Watch subtree
@@ -367,7 +368,8 @@ private[runsupport] object GlobalStaticVar {
     // Now we construct a MBean that exposes the AtomicReference.get method
     val getMethod = classOf[AtomicReference[_]].getMethod("get")
     val getInfo = new ModelMBeanOperationInfo("The value", getMethod)
-    val mmbi = new ModelMBeanInfoSupport("GlobalStaticVar",
+    val mmbi = new ModelMBeanInfoSupport(
+      "GlobalStaticVar",
       "A global static variable",
       null, // no attributes
       null, // no constructors

--- a/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -64,7 +64,8 @@ object Reloader {
     }
   }
 
-  def filterArgs(args: Seq[String],
+  def filterArgs(
+    args: Seq[String],
     defaultHttpPort: Int,
     defaultHttpAddress: String,
     devSettings: Seq[(String, String)]): (Seq[(String, String)], Option[Int], Option[Int], String) = {

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/ApplicationSecretGenerator.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/ApplicationSecretGenerator.scala
@@ -73,7 +73,8 @@ object ApplicationSecretGenerator {
     } else {
       val lineNumber: Int = secretConfigOrigin.lineNumber - 1
 
-      val newLines: List[String] = lines.updated(lineNumber,
+      val newLines: List[String] = lines.updated(
+        lineNumber,
         lines(lineNumber).replace(secretConfigValue.unwrapped().asInstanceOf[String], newSecret))
 
       // removes existing application.secret key

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/routes/RoutesCompiler.scala
@@ -20,9 +20,11 @@ object RoutesKeys {
   val routes = TaskKey[Seq[File]]("playRoutes", "Compile the routes files")
   val routesImport = SettingKey[Seq[String]]("playRoutesImports", "Imports for the router")
   val routesGenerator = SettingKey[RoutesGenerator]("playRoutesGenerator", "The routes generator")
-  val generateReverseRouter = SettingKey[Boolean]("playGenerateReverseRouter",
+  val generateReverseRouter = SettingKey[Boolean](
+    "playGenerateReverseRouter",
     "Whether the reverse router should be generated. Setting to false may reduce compile times if it's not needed.")
-  val namespaceReverseRouter = SettingKey[Boolean]("playNamespaceReverseRouter",
+  val namespaceReverseRouter = SettingKey[Boolean](
+    "playNamespaceReverseRouter",
     "Whether the reverse router should be namespaced. Useful if you have many routers that use the same actions.")
 
   /**
@@ -38,7 +40,8 @@ object RoutesKeys {
     implicit def fromProject(project: => Project): LazyProjectReference = new LazyProjectReference(project)
   }
 
-  val aggregateReverseRoutes = SettingKey[Seq[LazyProjectReference]]("playAggregateReverseRoutes",
+  val aggregateReverseRoutes = SettingKey[Seq[LazyProjectReference]](
+    "playAggregateReverseRoutes",
     "A list of projects that reverse routes should be aggregated from.")
 
   val InjectedRoutesGenerator = play.routes.compiler.InjectedRoutesGenerator

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -46,7 +46,8 @@ object PlayRun {
    * Do not change its signature without first consulting the Activator team.  Do not change its signature in a minor
    * release.
    */
-  def playRunTask(runHooks: TaskKey[Seq[play.sbt.PlayRunHook]],
+  def playRunTask(
+    runHooks: TaskKey[Seq[play.sbt.PlayRunHook]],
     dependencyClasspath: TaskKey[Classpath], dependencyClassLoader: TaskKey[ClassLoaderCreator],
     reloaderClasspath: TaskKey[Classpath], reloaderClassLoader: TaskKey[ClassLoaderCreator],
     assetsClassLoader: TaskKey[ClassLoader => ClassLoader]): Def.Initialize[InputTask[Unit]] = Def.inputTask {


### PR DESCRIPTION
Upgrades Scalariform to 0.1.8.  See https://github.com/scala-ide/scalariform#usage-within-a-project

This should fix the parser errors we were getting earlier:

```
[warn] Scalariform parser error for /home/travis/build/playframework/playframework/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala: Expected token RBRACKET but got Token(XML_START_OPEN,<,3066,<)
```