### PR TITLE
tests won't run under linux if locale is different than en_*

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
@@ -64,7 +64,7 @@ trait IdleTimeoutSpec extends PlaySpecification with ServerIntegrationSpecificat
     "support sub-second timeouts" in withServer(300.millis)(EssentialAction { req =>
       Accumulator(Sink.ignore).map(_ => Results.Ok)
     }) { port =>
-      doRequests(port, trickle = 400L) must throwA[SocketException]("Broken pipe|Connection reset")
+      doRequests(port, trickle = 400L) must throwA[SocketException]
     }
 
     "support a separate timeout for https" in withServer(1.second, httpsPort = Some(httpsPort), httpsTimeout = 400.millis)(EssentialAction { req =>
@@ -75,13 +75,13 @@ trait IdleTimeoutSpec extends PlaySpecification with ServerIntegrationSpecificat
       responses(0).status must_== 200
       responses(1).status must_== 200
 
-      doRequests(httpsPort, trickle = 600L, secure = true) must throwA[SocketException]("Broken pipe|Connection reset")
+      doRequests(httpsPort, trickle = 600L, secure = true) must throwA[SocketException]
     }
 
     "support multi-second timeouts" in withServer(1500.millis)(EssentialAction { req =>
       Accumulator(Sink.ignore).map(_ => Results.Ok)
     }) { port =>
-      doRequests(port, trickle = 1600L) must throwA[SocketException]("Broken pipe|Connection reset")
+      doRequests(port, trickle = 1600L) must throwA[SocketException]
     }
 
     "not timeout for slow requests with a sub-second timeout" in withServer(700.millis)(EssentialAction { req =>


### PR DESCRIPTION
actually play tried to parse connection reset or broken pipe, however under
different locales than en_* it will actually give a "localized message (broken pipe)" this can't be parsed by specs2. However SocketException already is known for the broken pipe so we can just omit the message parsing