### PR TITLE
upgrades play-doc, twirl and fixes some hiccups while trying to get scala 2.12 to work

### DIFF
--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/csrf.scala.html
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/csrf.scala.html
@@ -1,16 +1,14 @@
 
-@import scalaguide.forms.csrf.routes
-
 @* #csrf-call *@
 @import helper._
 
-@form(CSRF(routes.ItemsController.save())) {
+@form(CSRF(scalaguide.forms.csrf.routes.ItemsController.save())) {
     ...
 }
 @* #csrf-call *@
 
 @* #csrf-input *@
-@form(routes.ItemsController.save()) {
+@form(scalaguide.forms.csrf.routes.ItemsController.save()) {
     @CSRF.formField
     ...
 }

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/hellotemplate.scala.html
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/hellotemplate.scala.html
@@ -1,4 +1,3 @@
 @* #template *@
-@import play.i18n._
-@Messages.get("hello")
+@play.i18n.Messages.get("hello")
 @* #template *@

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
 
   val akkaVersion = "2.4.10"
 
-  val specsVersion = "3.8.4"
+  val specsVersion = "3.8.5"
   val specsBuild = Seq(
     "specs2-core",
     "specs2-junit",

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -54,7 +54,7 @@ object Dependencies {
     "org.hibernate" % "hibernate-entitymanager" % "5.1.0.Final" % "test"
   )
 
-  val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.7.0"
+  val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0-RC7"
   def scalaParserCombinators(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, major)) if major >= 11 => Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4")
     case _ => Nil

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -231,7 +231,7 @@ object Dependencies {
   )
 
   val playDocsDependencies = Seq(
-    "com.typesafe.play" %% "play-doc" % "1.4.0"
+    "com.typesafe.play" %% "play-doc" % "1.6.0"
   ) ++ playdocWebjarDependencies
 
   val streamsDependencies = Seq(

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -5,7 +5,7 @@ buildInfoSettings
 sourceGenerators in Compile <+= buildInfo
 
 val sbtNativePackagerVersion = "1.1.1"
-val sbtTwirlVersion = sys.props.getOrElse("twirl.version", "1.1.1")
+val sbtTwirlVersion = sys.props.getOrElse("twirl.version", "1.2.0")
 
 buildInfoKeys := Seq[BuildInfoKey](
   "sbtNativePackagerVersion" -> sbtNativePackagerVersion,

--- a/framework/src/play-cache/src/test/scala/play/api/cache/CachedSpec.scala
+++ b/framework/src/play-cache/src/test/scala/play/api/cache/CachedSpec.scala
@@ -9,7 +9,7 @@ import javax.inject._
 
 import play.api.cache.ehcache.EhCacheApi
 import play.api.{ Application, http }
-import play.api.mvc.{ Action, Results }
+import play.api.mvc.{ Action, Request, Results }
 import play.api.test._
 
 import scala.concurrent.duration._
@@ -146,13 +146,13 @@ class CachedSpec extends PlaySpecification {
     }
   }
 
-  val dummyAction = Action { request =>
+  val dummyAction = Action { request: Request[_] =>
     Results.Ok {
       Random.nextInt().toString
     }
   }
 
-  val notFoundAction = Action { request =>
+  val notFoundAction = Action { request: Request[_] =>
     Results.NotFound(Random.nextInt().toString)
   }
 

--- a/framework/src/play-docs/src/main/scala/play/docs/DocumentationHandler.scala
+++ b/framework/src/play-docs/src/main/scala/play/docs/DocumentationHandler.scala
@@ -77,8 +77,8 @@ class DocumentationHandler(repo: FileRepository, apiRepo: FileRepository, toClos
       case wikiPage(page) => Some(
         playDoc.renderPage(page) match {
           case None => NotFound(views.html.play20.manual(page, None, None, locator))
-          case Some(RenderedPage(mainPage, None, _)) => Ok(views.html.play20.manual(page, Some(mainPage), None, locator))
-          case Some(RenderedPage(mainPage, Some(sidebar), _)) => Ok(views.html.play20.manual(page, Some(mainPage), Some(sidebar), locator))
+          case Some(RenderedPage(mainPage, None, _, _)) => Ok(views.html.play20.manual(page, Some(mainPage), None, locator))
+          case Some(RenderedPage(mainPage, Some(sidebar), _, _)) => Ok(views.html.play20.manual(page, Some(mainPage), Some(sidebar), locator))
         }
       )
       case _ => None

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -189,7 +189,7 @@ case class GzipFilterConfig(
   def withShouldGzip(shouldGzip: (RequestHeader, Result) => Boolean): GzipFilterConfig = copy(shouldGzip = shouldGzip)
 
   def withShouldGzip(shouldGzip: BiFunction[play.mvc.Http.RequestHeader, play.mvc.Result, Boolean]): GzipFilterConfig =
-    withShouldGzip((req, res) => shouldGzip.asScala(new j.RequestHeaderImpl(req), res.asJava))
+    withShouldGzip((req: RequestHeader, res: Result) => shouldGzip.asScala(new j.RequestHeaderImpl(req), res.asJava))
 
   def withChunkedThreshold(threshold: Int): GzipFilterConfig = copy(chunkedThreshold = threshold)
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/auth/SecuritySpec.scala
@@ -14,12 +14,12 @@ class SecuritySpec extends PlaySpecification {
 
   "AuthenticatedBuilder" should {
     "block unauthenticated requests" in withApplication { implicit app =>
-      status(TestAction(app) { req =>
+      status(TestAction(app) { req: Security.AuthenticatedRequest[_, String] =>
         Results.Ok(req.user)
       }(FakeRequest())) must_== UNAUTHORIZED
     }
     "allow authenticated requests" in withApplication { implicit app =>
-      val result = TestAction(app) { req =>
+      val result = TestAction(app) { req: Security.AuthenticatedRequest[_, String] =>
         Results.Ok(req.user)
       }(FakeRequest().withSession("username" -> "john"))
       status(result) must_== OK
@@ -27,7 +27,7 @@ class SecuritySpec extends PlaySpecification {
     }
 
     "allow use as an ActionBuilder" in withApplication { implicit app =>
-      val result = Authenticated(app) { req =>
+      val result = Authenticated(app) { req: AuthenticatedDbRequest[_] =>
         Results.Ok(s"${req.conn.name}:${req.user.name}")
       }(FakeRequest().withSession("user" -> "Phil"))
       status(result) must_== OK

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/SecureFlagSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/SecureFlagSpec.scala
@@ -25,8 +25,8 @@ trait SecureFlagSpec extends PlaySpecification with ServerIntegrationSpecificati
   sequential
 
   /** An action whose result is just "true" or "false" depending on the value of result.secure */
-  val secureFlagAction = Action {
-    request => Results.Ok(request.secure.toString)
+  val secureFlagAction = Action { request: Request[_] =>
+    Results.Ok(request.secure.toString)
   }
 
   // this step seems necessary to allow the generated keystore to be written

--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -19,7 +19,7 @@ import play.it._
 import scala.concurrent.duration.Duration
 import scala.concurrent._
 
-import scala.concurrent.ExecutionContext.Implicits.{ global => ec }
+import scala.concurrent.ExecutionContext.{ global => ec }
 
 class NettyDefaultFiltersSpec extends DefaultFiltersSpec with NettyIntegrationSpecification
 class AkkaDefaultHttpFiltersSpec extends DefaultFiltersSpec with AkkaHttpIntegrationSpecification

--- a/framework/src/play-server/src/main/java/play/server/Server.java
+++ b/framework/src/play-server/src/main/java/play/server/Server.java
@@ -7,7 +7,6 @@ import play.Mode;
 import play.routing.Router;
 import play.core.j.JavaModeConverter;
 import play.core.server.JavaServerHelper;
-import scala.Int;
 
 import java.net.InetSocketAddress;
 import java.util.HashMap;
@@ -42,7 +41,7 @@ public class Server {
      */
     public int httpPort() {
         if (server.httpPort().isDefined()) {
-            return Int.unbox(server.httpPort().get());
+            return (Integer)server.httpPort().get();
         } else {
             throw new IllegalStateException("Server has no HTTP port. Try starting it with \"new Server.Builder().http(<port num>)\"?");
         }
@@ -56,7 +55,7 @@ public class Server {
      */
     public int httpsPort() {
         if (server.httpsPort().isDefined()) {
-            return Int.unbox(server.httpsPort().get());
+            return (Integer)server.httpsPort().get();
         } else {
             throw new IllegalStateException("Server has no HTTPS port. Try starting it with \"new Server.Builder.https(<port num>)\"?");
         }

--- a/framework/src/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
+++ b/framework/src/play-specs2/src/test/scala/play/api/test/FakesSpec.scala
@@ -98,7 +98,7 @@ class FakesSpec extends PlaySpecification {
 
   def contentTypeForFakeRequest[T](request: FakeRequest[AnyContentAsJson])(implicit mat: Materializer): String = {
     var testContentType: Option[String] = None
-    val action = Action { request => testContentType = request.headers.get(CONTENT_TYPE); Ok }
+    val action = Action { request: Request[_] => testContentType = request.headers.get(CONTENT_TYPE); Ok }
     val headers = new WrappedRequest(request)
     val execution = (new TestActionCaller).call(action, headers, request.body)
     Await.result(execution, Duration(3, TimeUnit.SECONDS))

--- a/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -288,8 +288,6 @@ trait BodyParsers {
  */
 trait BodyParserUtils {
 
-  private val logger = Logger(this.getClass)
-
   /**
    * Don't parse the body content.
    */
@@ -382,7 +380,7 @@ object PlayBodyParsers {
  */
 trait PlayBodyParsers extends BodyParserUtils {
 
-  private val logger = Logger(this.getClass)
+  private val logger = Logger(classOf[PlayBodyParsers])
 
   private[play] implicit def materializer: Materializer
   private[play] def config: ParserConfiguration

--- a/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
@@ -6,7 +6,8 @@ package play.api.mvc
 import akka.stream.Materializer
 import akka.util.ByteString
 import play.api.libs.streams.Accumulator
-import scala.concurrent.{ Promise, Future }
+
+import scala.concurrent.{ Future, Promise }
 
 trait EssentialFilter {
   def apply(next: EssentialAction): EssentialAction

--- a/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
@@ -6,8 +6,7 @@ package play.api.mvc
 import akka.stream.Materializer
 import akka.util.ByteString
 import play.api.libs.streams.Accumulator
-
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{ Promise, Future }
 
 trait EssentialFilter {
   def apply(next: EssentialAction): EssentialAction

--- a/framework/src/play/src/main/scala/play/core/j/AbstractFilter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/AbstractFilter.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.j
+
+import akka.stream.Materializer
+import play.api.mvc.{ Filter => SFilter }
+import play.mvc.{ EssentialFilter, Filter }
+
+/**
+ * This class is a Wrapper Class to get around the different trait Encodings
+ * between Scala 2.11 and Scala 2.12
+ *
+ * @param materializer a simple Materializer
+ * @param underlying the Filter that should be converted to scala
+ */
+private[play] abstract class AbstractFilter(materializer: Materializer, underlying: Filter) extends SFilter {
+
+  override implicit def mat: Materializer = materializer
+
+  override def asJava: EssentialFilter = underlying
+
+}

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -18,7 +18,7 @@ import play.mvc.Security
 import scala.compat.java8.{ FutureConverters, OptionConverters }
 import scala.concurrent.Future
 import collection.JavaConverters._
-import collection.JavaConversions._
+import collection.JavaConversions
 
 /**
  * Provides helper methods that manage Java to Scala Result and Scala to Java Context
@@ -27,7 +27,7 @@ import collection.JavaConversions._
 trait JavaHelpers {
 
   def attrsToScalaSeq(attrs: java.util.List[TypedEntry[_]]): Seq[TypedEntry[_]] = {
-    asScalaBuffer(attrs)
+    JavaConversions.asScalaBuffer(attrs)
   }
 
   def cookiesToScalaCookies(cookies: java.lang.Iterable[play.mvc.Http.Cookie]): Seq[Cookie] = {

--- a/framework/src/play/src/main/scala/play/core/j/JavaRouterAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaRouterAdapter.scala
@@ -21,5 +21,5 @@ class JavaRouterAdapter @Inject() (underlying: play.api.routing.Router) extends 
     case (httpMethod, pathPattern, controllerMethodInvocation) =>
       new RouteDocumentation(httpMethod, pathPattern, controllerMethodInvocation)
   }.asJava
-  def asScala = underlying
+  override def asScala = underlying
 }


### PR DESCRIPTION
actually these adds a wrapper class JFilter which actually works around the different trait encoding
that will be introduced by scala 2.12
and it removes some calls to Int.unbox() in java which aren't necessary since we can just cast these to Integer (which Int.unbox) will do anyway, calling the intValue() isn't needed since this won't be so much overhead here and the jvm can unbox it anyway
it also adds the newest version of twirl and play-doc

Guess it's fine to merge as is
