### PR TITLE
Add tests of ServerResultUtils#validateResult to make sure an empty body is sent for 1xx, 204 and 304 responses

### DIFF
--- a/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -3,9 +3,18 @@
  */
 package play.core.server.common
 
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.util.ByteString
 import org.specs2.mutable.Specification
+import play.api.http.{ DefaultHttpErrorHandler, HttpEntity }
+import play.api.http.Status._
 import play.api.mvc._
 import play.api.mvc.Results._
+
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
+import scala.util.{ Success, Try }
 
 class ServerResultUtilsSpec extends Specification {
 
@@ -66,6 +75,89 @@ class ServerResultUtilsSpec extends Specification {
         cookie.name must_== "PLAY_FLASH"
         cookie.value must_== "c=d"
       }
+    }
+  }
+
+  "ServerResultUtils#validateResult" should {
+    implicit val system = ActorSystem()
+    implicit val materializer = ActorMaterializer()
+
+    val header = new RequestHeader {
+      def id = 1
+      def tags = Map()
+      def uri = ""
+      def path = ""
+      def method = ""
+      def version = ""
+      def queryString = Map()
+      def remoteAddress = ""
+      def secure = false
+      def clientCertificateChain = None
+      def headers = new Headers(Seq())
+    }
+
+    def hasNoEntity(response: Future[Result], responseStatus: Int) = {
+      Await.ready(response, 5.seconds)
+      response.value must beSome[Try[Result]].like {
+        case Success(res) =>
+          res.header.status must_== responseStatus
+          res.body must_== HttpEntity.NoEntity
+          ok
+        case _ =>
+          ko("failed to obtain a response.")
+      }
+    }
+
+    "cancel a message-body when a 100 response is returned" in {
+      val response = ServerResultUtils.validateResult(header, Results.Continue, DefaultHttpErrorHandler)
+
+      hasNoEntity(response, 100)
+    }
+
+    "cancel a message-body when a 101 response is returned" in {
+      val response = ServerResultUtils.validateResult(header, Results.SwitchingProtocols, DefaultHttpErrorHandler)
+
+      hasNoEntity(response, 101)
+    }
+
+    "cancel a message-body when a 204 response is returned" in {
+      val response = ServerResultUtils.validateResult(header, Results.NoContent, DefaultHttpErrorHandler)
+
+      hasNoEntity(response, 204)
+    }
+
+    "cancel a message-body when a 304 response is returned" in {
+      val response = ServerResultUtils.validateResult(header, Results.NotModified, DefaultHttpErrorHandler)
+
+      hasNoEntity(response, 304)
+    }
+
+    "cancel a message-body when a 100 response with a non-empty body is returned" in {
+      val result = Result(header = ResponseHeader(CONTINUE), body = HttpEntity.Strict(ByteString("foo"), None))
+      val response = ServerResultUtils.validateResult(header, result, DefaultHttpErrorHandler)
+
+      hasNoEntity(response, 100)
+    }
+
+    "cancel a message-body when a 101 response with a non-empty body is returned" in {
+      val result = Result(header = ResponseHeader(SWITCHING_PROTOCOLS), body = HttpEntity.Strict(ByteString("foo"), None))
+      val response = ServerResultUtils.validateResult(header, result, DefaultHttpErrorHandler)
+
+      hasNoEntity(response, 101)
+    }
+
+    "cancel a message-body when a 204 response with a non-empty body is returned" in {
+      val result = Result(header = ResponseHeader(NO_CONTENT), body = HttpEntity.Strict(ByteString("foo"), None))
+      val response = ServerResultUtils.validateResult(header, result, DefaultHttpErrorHandler)
+
+      hasNoEntity(response, 204)
+    }
+
+    "cancel a message-body when a 304 response with a non-empty body is returned" in {
+      val result = Result(header = ResponseHeader(NOT_MODIFIED), body = HttpEntity.Strict(ByteString("foo"), None))
+      val response = ServerResultUtils.validateResult(header, result, DefaultHttpErrorHandler)
+
+      hasNoEntity(response, 304)
     }
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose
Currently there's no tests to check if the returned body of 1xx, 204 and 304 responses is empty, which is required by RFC7230. To make sure that no entity is sent to a client, we can add unit tests of `ServerResultUtils#validateResult`[1] that takes responsibility for cancelling a body if necessary.

## Background Context
PR(#6261)[2] was merged to meet the requirement of RFC7230. `BasicHttpClient` is used for the integration tests to check if an empty body is returned for 1xx, 204 and 304 responses. These integration tests, however, don't guarantee that those responses return an empty body as our `BasicHttpClient` just returns an empty body instead of sending an actual body.[3]

## References
PR(#6261)[2]
PR Comment[4]

[1] https://github.com/playframework/playframework/blob/2.5.4/framework/src/play-server/src/main/scala/play/core/server/common/ServerResultUtils.scala#L67-L68
[2] https://github.com/playframework/playframework/pull/6261
[3] https://github.com/playframework/playframework/blob/2.5.4/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala#L214-L218
[4] https://github.com/playframework/playframework/pull/6261#issuecomment-235596925