### PR TITLE
shutdown hooks will now be called correctly in dev mode

### DIFF
--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -19,6 +19,7 @@ import play.api.inject.guice.{ GuiceApplicationBuilder, GuiceApplicationLoader }
 import play.api.{ Mode, Configuration, Environment }
 import play.api.ApplicationLoader.Context
 import play.core.DefaultWebCommands
+import play.api.inject.DefaultApplicationLifecycle
 
 /**
  * Specs for the global CSRF filter
@@ -144,7 +145,8 @@ class CSRFFilterSpec extends CSRFCommonSpecs {
       environment,
       None,
       new DefaultWebCommands,
-      Configuration.load(environment)
+      Configuration.load(environment),
+      new DefaultApplicationLifecycle()
     )
     def loader = new GuiceApplicationLoader
     "allow injecting CSRF filters" in {

--- a/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
+++ b/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
@@ -6,6 +6,7 @@ package play.api.inject.guice
 import play.api.{ Application, ApplicationLoader, OptionalSourceMapper }
 import play.api.inject.bind
 import play.core.WebCommands
+import play.api.inject.ApplicationLifecycle
 
 /**
  * An ApplicationLoader that uses Guice to bootstrap the application.
@@ -50,6 +51,7 @@ object GuiceApplicationLoader {
   def defaultOverrides(context: ApplicationLoader.Context): Seq[GuiceableModule] = {
     Seq(
       bind[OptionalSourceMapper] to new OptionalSourceMapper(context.sourceMapper),
-      bind[WebCommands] to context.webCommands)
+      bind[WebCommands] to context.webCommands,
+      bind[ApplicationLifecycle] to context.lifecycle)
   }
 }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -25,6 +25,7 @@ import io.netty.handler.logging.{ LogLevel, LoggingHandler }
 import io.netty.handler.ssl.SslHandler
 import io.netty.handler.timeout.IdleStateHandler
 import play.api._
+import play.api.inject.DefaultApplicationLifecycle
 import play.api.mvc.{ Handler, RequestHeader }
 import play.api.routing.Router
 import play.core._
@@ -342,6 +343,7 @@ trait NettyServerComponents {
   lazy val sourceMapper: Option[SourceMapper] = None
   lazy val webCommands: WebCommands = new DefaultWebCommands
   lazy val configuration: Configuration = Configuration(ConfigFactory.load())
+  lazy val applicationLifecycle: DefaultApplicationLifecycle = new DefaultApplicationLifecycle
 
   def application: Application
 

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -12,6 +12,7 @@ import scala.language.postfixOps
 import play.api._
 import play.api.mvc._
 import play.core.{ DefaultWebCommands, ApplicationProvider }
+import play.api.inject.DefaultApplicationLifecycle
 
 import scala.util.{ Success, Failure }
 import scala.concurrent.Future
@@ -138,7 +139,8 @@ object Server {
   def withRouter[T](config: ServerConfig = ServerConfig(port = Some(0), mode = Mode.Test))(routes: PartialFunction[RequestHeader, Handler])(block: Port => T)(implicit provider: ServerProvider): T = {
     val application = new BuiltInComponentsFromContext(ApplicationLoader.Context(
       Environment.simple(path = config.rootDir, mode = config.mode),
-      None, new DefaultWebCommands(), Configuration(ConfigFactory.load())
+      None, new DefaultWebCommands(), Configuration(ConfigFactory.load()),
+      new DefaultApplicationLifecycle
     )) {
       def router = Router.from(routes)
     }.application
@@ -152,7 +154,8 @@ private[play] object JavaServerHelper {
     val r = router
     val application = new BuiltInComponentsFromContext(ApplicationLoader.Context(
       Environment.simple(mode = mode),
-      None, new DefaultWebCommands(), Configuration(ConfigFactory.load())
+      None, new DefaultWebCommands(), Configuration(ConfigFactory.load()),
+      new DefaultApplicationLifecycle
     )) {
       def router = r
     }.application

--- a/framework/src/play/src/main/java/play/ApplicationLoader.java
+++ b/framework/src/play/src/main/java/play/ApplicationLoader.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import com.typesafe.config.Config;
+import play.api.inject.DefaultApplicationLifecycle;
 import play.core.SourceMapper;
 import play.core.DefaultWebCommands;
 import play.libs.Scala;
@@ -76,7 +77,8 @@ public interface ApplicationLoader {
            environment.underlying(),
            scala.Option.empty(),
            new play.core.DefaultWebCommands(),
-           play.api.Configuration.load(environment.underlying(), play.libs.Scala.asScala(initialSettings)));
+           play.api.Configuration.load(environment.underlying(), play.libs.Scala.asScala(initialSettings)),
+           new DefaultApplicationLifecycle());
     }
 
     /**
@@ -131,7 +133,8 @@ public interface ApplicationLoader {
            environment.underlying(),
            underlying.sourceMapper(),
            underlying.webCommands(),
-           underlying.initialConfiguration());
+           underlying.initialConfiguration(),
+           new DefaultApplicationLifecycle());
         return new Context(scalaContext);
     }
 
@@ -147,7 +150,8 @@ public interface ApplicationLoader {
            underlying.environment(),
            underlying.sourceMapper(),
            underlying.webCommands(),
-           initialConfiguration.getWrappedConfiguration());
+           initialConfiguration.getWrappedConfiguration(),
+           new DefaultApplicationLifecycle());
         return new Context(scalaContext);
     }
 
@@ -162,7 +166,8 @@ public interface ApplicationLoader {
           underlying.environment(),
           underlying.sourceMapper(),
           underlying.webCommands(),
-          new play.api.Configuration(initialConfiguration));
+          new play.api.Configuration(initialConfiguration),
+          new DefaultApplicationLifecycle());
       return new Context(scalaContext);
     }
 
@@ -188,7 +193,8 @@ public interface ApplicationLoader {
             environment.underlying(),
             Scala.asScala(initialSettings),
             Scala.<SourceMapper>None(),
-            new DefaultWebCommands());
+            new DefaultWebCommands(),
+            new DefaultApplicationLifecycle());
         return new Context(scalaContext);
     }
 

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -233,6 +233,7 @@ trait BuiltInComponents {
   def sourceMapper: Option[SourceMapper]
   def webCommands: WebCommands
   def configuration: Configuration
+  def applicationLifecycle: DefaultApplicationLifecycle
 
   def router: Router
 
@@ -244,7 +245,6 @@ trait BuiltInComponents {
     Some(router))
   lazy val httpFilters: Seq[EssentialFilter] = Nil
 
-  lazy val applicationLifecycle: DefaultApplicationLifecycle = new DefaultApplicationLifecycle
   lazy val application: Application = new DefaultApplication(environment, applicationLifecycle, injector,
     configuration, httpRequestHandler, httpErrorHandler, actorSystem, materializer)
 

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -5,6 +5,7 @@ package play.api
 
 import play.core.{ DefaultWebCommands, SourceMapper, WebCommands }
 import play.utils.Reflect
+import play.api.inject.DefaultApplicationLifecycle
 
 /**
  * Loads an application.  This is responsible for instantiating an application given a context.
@@ -33,6 +34,8 @@ trait ApplicationLoader {
 
 object ApplicationLoader {
 
+  import play.api.inject.DefaultApplicationLifecycle
+
   // Method to call if we cannot find a configured ApplicationLoader
   private def loaderNotFound(): Nothing = {
     sys.error("No application loader is configured. Please configure an application loader either using the " +
@@ -54,7 +57,7 @@ object ApplicationLoader {
    *                             configuration used by the application, as the ApplicationLoader may, through it's own
    *                             mechanisms, modify it or completely ignore it.
    */
-  final case class Context(environment: Environment, sourceMapper: Option[SourceMapper], webCommands: WebCommands, initialConfiguration: Configuration)
+  final case class Context(environment: Environment, sourceMapper: Option[SourceMapper], webCommands: WebCommands, initialConfiguration: Configuration, lifecycle: DefaultApplicationLifecycle)
 
   /**
    * Locate and instantiate the ApplicationLoader.
@@ -102,9 +105,10 @@ object ApplicationLoader {
   def createContext(environment: Environment,
     initialSettings: Map[String, AnyRef] = Map.empty[String, AnyRef],
     sourceMapper: Option[SourceMapper] = None,
-    webCommands: WebCommands = new DefaultWebCommands) = {
+    webCommands: WebCommands = new DefaultWebCommands,
+    lifecycle: DefaultApplicationLifecycle = new DefaultApplicationLifecycle()) = {
     val configuration = Configuration.load(environment, initialSettings)
-    Context(environment, sourceMapper, webCommands, configuration)
+    Context(environment, sourceMapper, webCommands, configuration, lifecycle)
   }
 
 }
@@ -117,5 +121,6 @@ abstract class BuiltInComponentsFromContext(context: ApplicationLoader.Context) 
   lazy val sourceMapper = context.sourceMapper
   lazy val webCommands = context.webCommands
   lazy val configuration = context.initialConfiguration
+  lazy val applicationLifecycle: DefaultApplicationLifecycle = context.lifecycle
 }
 

--- a/framework/src/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/ApplicationLifecycle.scala
@@ -3,15 +3,14 @@
  */
 package play.api.inject
 
-import java.util.concurrent.{ CompletionStage, Callable }
-
+import java.util.concurrent.{Callable, CompletionStage, ConcurrentLinkedDeque, LinkedBlockingDeque}
 import javax.inject.{Inject, Singleton}
+
 import play.api.Logger
 
+import scala.annotation.tailrec
 import scala.compat.java8.FutureConverters
 import scala.concurrent.Future
-import java.util.concurrent.ConcurrentLinkedQueue
-import scala.annotation.tailrec
 
 /**
  * Application lifecycle register.
@@ -22,9 +21,9 @@ import scala.annotation.tailrec
  *
  * - It simplifies implementation, if you want to start something, just do it in the constructor.
  * - It simplifies state, there's no transitional state where an object has been created but not started yet. Hence,
- *   as long as you have a reference to something, it's safe to use it.
+ * as long as you have a reference to something, it's safe to use it.
  * - It solves startup dependencies in a type safe manner - the order that components must be started is enforced by the
- *   order that they must be instantiated due to the component graph.
+ * order that they must be instantiated due to the component graph.
  *
  * Stop hooks are executed when the application is shutdown, in reverse from when they were registered. Due to this
  * reverse ordering, a component can know that it is safe to use the components it depends on as long as it hasn't
@@ -73,10 +72,10 @@ trait ApplicationLifecycle {
  * Default implementation of the application lifecycle.
  */
 @Singleton
-class DefaultApplicationLifecycle @Inject() () extends ApplicationLifecycle {
-  private val hooks = new ConcurrentLinkedQueue[() => Future[_]]()
+class DefaultApplicationLifecycle @Inject()() extends ApplicationLifecycle {
+  private val hooks = new ConcurrentLinkedDeque[() => Future[_]]()
 
-  def addStopHook(hook: () => Future[_]) = hooks.add(hook)
+  def addStopHook(hook: () => Future[_]) = hooks.push(hook)
 
   /**
    * Call to shutdown the application.
@@ -90,11 +89,12 @@ class DefaultApplicationLifecycle @Inject() () extends ApplicationLifecycle {
 
     @tailrec
     def clearHooks(previous: Future[Any] = Future.successful[Any](())): Future[Any] = {
-      if (!hooks.isEmpty) clearHooks(previous.flatMap { _ =>
-          hooks.poll().apply().recover {
-            case e => Logger.error("Error executing stop hook", e)
-          }
-        })
+      val hook = hooks.poll()
+      if (hook != null) clearHooks(previous.flatMap { _ =>
+        hook().recover {
+          case e => Logger.error("Error executing stop hook", e)
+        }
+      })
       else previous
     }
 

--- a/framework/src/play/src/test/scala/play/api/inject/DefaultApplicationLifecycleSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/DefaultApplicationLifecycleSpec.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.inject
+
+import org.specs2.mutable.Specification
+
+import scala.collection.mutable
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
+
+class DefaultApplicationLifecycleSpec extends Specification {
+
+  import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
+  "DefaultApplicationLifecycle" should {
+    // This test ensure's two things
+    // 1. Stop Hooks will be called in LIFO order
+    // 2. Stop Hooks won't datarace, they will never run in parallel
+    "stop all the hooks in the correct order" in {
+      val lifecycle = new DefaultApplicationLifecycle()
+      val buffer = mutable.ListBuffer[Int]()
+      lifecycle.addStopHook(() => Future(buffer.append(1)))
+      lifecycle.addStopHook(() => Future(buffer.append(2)))
+      lifecycle.addStopHook(() => Future(buffer.append(3)))
+      Await.result(lifecycle.stop(), 10.seconds)
+      Await.result(lifecycle.stop(), 10.seconds)
+      buffer.toList must beEqualTo(List(3, 2, 1))
+    }
+  }
+
+}


### PR DESCRIPTION
# Helpful things

## Fixes

Fixes #6433

## Purpose

It actually ensure's that Shutdown Hooks will be only called **once** and that they will **always** be called in dev mode. This ensure's that nothing can go stale.

## Background Context

Actually without breaking backwards compatibility I didn't see any other way of having a good way to do it.

So this isn't back portable since it will break mima and definitly add some problems when people **didn't** used BuiltInComponentsWithContext.

Another problem still happens or at least I don't if it will, it still never garbage collects the ReloadableClassLoader which I can't actually fix without a profiler like Yourkit (VisualVM is too dumb), I guess something still holds a reference to something but since nothing is running there it isn't a big deal. 
