### PR TITLE
Refactor I18n API

### DIFF
--- a/documentation/manual/releases/release26/migration26/MessagesMigration26.md
+++ b/documentation/manual/releases/release26/migration26/MessagesMigration26.md
@@ -1,0 +1,169 @@
+# Messages API Migration
+
+There are a number of changes to the I18N API to make working with messages and languages easier to use, particularly with forms and templates.
+
+## Java API
+
+### Refactored Messages API to interfaces
+
+The `play.i18n` package has changed to make access to [`Messages`](api/java/play/i18n/Messages.html) easier.  These changes should be transparent to the user, but are provided here for teams extending the I18N API.
+
+[`Messages`](api/java/play/i18n/Messages.html) is now an interface, and there is a [`MessagesImpl`](api/java/play/i18n/MessagesImpl.html) class that implements that interface.
+
+### Deprecated / Removed Methods
+
+The static deprecated methods in [`play.i18n.Messages`](api/java/play/i18n/Messages.html) have been removed in 2.6.x, as there are equivalent methods on the [`MessagesApi`](api/java/play/i18n/MessagesApi.html) instance.
+
+## Scala API
+
+### Refactored Messages API to traits
+
+ The `play.api.i18n` package has changed to make access to [`Messages`](api/scala/play/api/i18n/Messages.html) instances easier and reduce the number of implicits in play.  These changes should be transparent to the user, but are provided here for teams extending the I18N API.
+
+[`Messages`](api/scala/play/api/i18n/Messages.html) is now a trait (rather than a case class).  The case class is now [`MessagesImpl`](api/scala/play/api/i18n/MessagesImpl.html), which implements [`Messages`](api/scala/play/api/i18n/Messages.html).
+
+### Smoother I18nSupport
+
+Using a form inside a controller is a smoother experience in 2.6.x.   [`ControllerComponents`](api/scala/play/api/mvc/ControllerComponents.html) contains a [`MessagesApi`](api/scala/play/api/i18n/MessagesApi.html) instance, which is exposed by [`AbstractController`](api/scala/play/api/mvc/AbstractController.html).  This means that the [`I18nSupport`](api/scala/play/api/i18n/I18nSupport.html) trait does not require an explicit `val messagesApi: MessagesApi` declaration.
+
+```scala
+class FormController @Inject()(components: ControllerComponents)
+  extends AbstractController(components) with I18nSupport {
+
+  import play.api.data.validation.Constraints._
+
+  val userForm = Form(
+    mapping(
+      "name" -> text.verifying(nonEmpty),
+      "age" -> number.verifying(min(0), max(100))
+    )(UserData.apply)(UserData.unapply)
+  )
+
+  def index = Action { implicit request =>    
+    // use request2messages implicit conversion method
+    Ok(views.html.user(userForm))
+  }
+  
+  def showMessage = Action { request =>
+    // uses type enrichment 
+    Ok(request.messages("hello.world"))
+  }
+
+  def userPost = Action { implicit request =>
+    userForm.bindFromRequest.fold(
+      formWithErrors => {
+        BadRequest(views.html.user(formWithErrors))
+      },
+      user => {
+        Redirect(routes.FormController.index()).flashing("success" -> s"User is ${user}!")
+      }
+    )
+  }
+}
+```
+
+Note there is now also type enrichment in [`I18nSupport`](api/scala/play/api/i18n/I18nSupport.html) which adds `request.messages` and `request.lang`.  This can be added either by extending from [`I18nSupport`](api/scala/play/api/i18n/I18nSupport.html), or by `import I18nSupport._`.  The import version does not contain the `request2messages` implicit conversion.
+ 
+### MessagesProvider trait
+ 
+A new [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) trait is available, which exposes a [`Messages`](api/scala/play/api/i18n/Messages.html) instance.
+
+```scala
+trait MessagesProvider {
+  def messages: Messages
+}
+```
+
+[`MessagesImpl`](api/scala/play/api/i18n/MessagesImpl.html) implements [`Messages`](api/scala/play/api/i18n/Messages.html) and [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html), and returns itself by default.
+
+All the template helpers now take [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) as an implicit parameter, rather than a straight `Messages` object, i.e. `inputText.scala.html` takes the following:
+
+```twirl
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messagesProvider: play.api.i18n.MessagesProvider)
+```
+ 
+The benefit to using a [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) is to loosen the binding so that a [`Messages`](api/scala/play/api/i18n/Messages.html) instance can be produced from other locations without involving [`I18nSupport`](api/scala/play/api/i18n/I18nSupport.html) type enrichment:
+
+```scala
+class MessagesRequest[A](request: Request[A], val messages: Messages)
+  extends WrappedRequest(request) with play.api.i18n.MessagesProvider {
+    def lang: Lang = messages.lang
+  }
+
+abstract class AbstractMessagesController(cc: ControllerComponents)
+  extends AbstractController(cc) {
+
+  def MessagesAction: ActionBuilder[MessagesRequest, AnyContent] = {
+    cc.actionBuilder.andThen(new ActionTransformer[Request, MessagesRequest] {
+      def transform[A](request: Request[A]) = Future.successful {
+        val messages = cc.messagesApi.preferred(request)
+        new MessagesRequest(request, messages)
+      }
+      override protected def executionContext: ExecutionContext = cc.executionContext
+    })
+  }
+}
+
+class MessagesController @Inject() (
+  addToken: CSRFAddToken,
+  checkToken: CSRFCheck,
+  components: ControllerComponents
+) extends AbstractMessagesController(components) {
+
+  import play.api.data.Form
+  import play.api.data.Forms._
+
+  val userForm = Form(
+    mapping(
+      "name" -> text,
+      "age" -> number
+    )(UserData.apply)(UserData.unapply)
+  )
+
+  def index = addToken {
+    MessagesAction { implicit request =>
+      Ok(views.html.formpage(userForm))
+    }
+  }
+
+  def userPost = checkToken {
+    MessagesAction { implicit request =>
+      userForm.bindFromRequest.fold(
+        formWithErrors => {
+          play.api.Logger.info(s"unsuccessful user submission")
+          BadRequest(views.html.formpage(formWithErrors))
+        },
+        user => {
+          play.api.Logger.info(s"successful user submission ${user}")
+          Redirect(routes.MessagesController.index()).flashing("success" -> s"User is ${user}!")
+        }
+      )
+    }
+  }
+}
+```
+
+This is also useful for passing around a single implicit request, especially when CSRF checks are involved:
+
+```twirl
+@(userForm: Form[UserData])(implicit request: MessagesRequest[_])
+
+@helper.form(action = routes.MessagesController.userPost()) {
+    @views.html.helper.CSRF.formField
+    @helper.inputText(userForm("name"))
+    @helper.inputText(userForm("age"))
+    <input type="submit" value="SUBMIT"/>
+}
+```
+
+Please see [[Passing Messages to Form Helpers|ScalaForms]] for more details.
+
+### Deprecated Methods
+
+`play.api.i18n.Messages.Implicits.applicationMessagesApi` and `play.api.i18n.Messages.Implicits.applicationMessages` have been deprecated, because they rely on an implicit `Application` instance.
+
+The `play.api.mvc.Controller.request2lang` method has been deprecated, because it was using a global `Application` under the hood.
+
+The `play.api.i18n.I18nSupport.request2Messages` implicit conversion method has been moved to `I18NSupportLowPriorityImplicits.request2Messages`, and deprecated in favor of `request.messages` type enrichment, which is clearer overall.
+
+The `I18NSupportLowPriorityImplicits.lang2Messages` implicit conversion has been moved out to `LangImplicits.lang2Messages`, because of confusion when both implicit Request and a Lang were in scope. Please extend the [`play.api.i18n.LangImplicits`](api/scala/play/api/i18n/LangImplicits.html) trait specifically if you want to use i18n with an implicit Lang.

--- a/documentation/manual/releases/release26/migration26/MessagesMigration26.md
+++ b/documentation/manual/releases/release26/migration26/MessagesMigration26.md
@@ -1,4 +1,4 @@
-# Messages API Migration
+# I18N API Migration
 
 There are a number of changes to the I18N API to make working with messages and languages easier to use, particularly with forms and templates.
 
@@ -82,7 +82,7 @@ All the template helpers now take [`MessagesProvider`](api/scala/play/api/i18n/M
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messagesProvider: play.api.i18n.MessagesProvider)
 ```
  
-The benefit to using a [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) is to loosen the binding so that a [`Messages`](api/scala/play/api/i18n/Messages.html) instance can be produced from other locations without involving [`I18nSupport`](api/scala/play/api/i18n/I18nSupport.html) type enrichment:
+The benefit to using a [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) is that otherwise, if you used implicit `Messages`, you would have to introduce implicit conversions from other types like `Request` in places where those implicits could be confusing:
 
 ```scala
 class MessagesRequest[A](request: Request[A], val messages: Messages)
@@ -156,7 +156,7 @@ This is also useful for passing around a single implicit request, especially whe
 }
 ```
 
-Please see [[Passing Messages to Form Helpers|ScalaForms]] for more details.
+Please see [[passing messages to form helpers|ScalaForms#passing-messages-to-form-helpers]] for more details.
 
 ### Deprecated Methods
 
@@ -166,4 +166,4 @@ The `play.api.mvc.Controller.request2lang` method has been deprecated, because i
 
 The `play.api.i18n.I18nSupport.request2Messages` implicit conversion method has been moved to `I18NSupportLowPriorityImplicits.request2Messages`, and deprecated in favor of `request.messages` type enrichment, which is clearer overall.
 
-The `I18NSupportLowPriorityImplicits.lang2Messages` implicit conversion has been moved out to `LangImplicits.lang2Messages`, because of confusion when both implicit Request and a Lang were in scope. Please extend the [`play.api.i18n.LangImplicits`](api/scala/play/api/i18n/LangImplicits.html) trait specifically if you want to use i18n with an implicit Lang.
+The `I18NSupportLowPriorityImplicits.lang2Messages` implicit conversion has been moved out to `LangImplicits.lang2Messages`, because of confusion when both implicit Request and a Lang were in scope. Please extend the [`play.api.i18n.LangImplicits`](api/scala/play/api/i18n/LangImplicits.html) trait specifically if you want to create a `Messages` from an implicit `Lang`.

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -32,6 +32,10 @@ This trait makes `Action` and `parse` refer to injected instances rather than th
 
 See [[JPAMigration26]].
 
+## I18n Migration Notes
+
+See [[MessagesMigration26]].
+
 ## Removed Crypto API
 
 The Crypto API has removed the deprecated class `play.api.libs.Crypto` and `play.libs.Crypto` and `AESCTRCrypter`.  The CSRF references to `Crypto` have been replaced by `CSRFTokenSigner`.  The session cookie references to `Crypto` have been replaced with `CookieSigner`.  Please see [[CryptoMigration25]] for more information.

--- a/documentation/manual/releases/release26/migration26/index.toc
+++ b/documentation/manual/releases/release26/migration26/index.toc
@@ -1,1 +1,2 @@
 Migration26:Migration Guide
+MessagesMigration26:Messages Migration

--- a/documentation/manual/working/javaGuide/main/i18n/JavaI18N.md
+++ b/documentation/manual/working/javaGuide/main/i18n/JavaI18N.md
@@ -1,5 +1,5 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
-# Externalising messages and internationalization
+# Internationalization with Messages
 
 ## Specifying languages supported by your application
 
@@ -19,7 +19,7 @@ You can externalize messages in the `conf/messages.xxx` files.
 
 The default `conf/messages` file matches all languages. You can specify additional language messages files, such as `conf/messages.fr` or `conf/messages.en-US`.
 
-You can retrieve messages for the _current language_ using the `play.i18n.Messages` object:
+You can retrieve messages for the _current language_ using the [`play.i18n.Messages`](api/java/play/i18n/Messages.html) object:
 
 @[current-lang-render](code/javaguide/i18n/JavaI18N.java)
 
@@ -36,17 +36,34 @@ If you don't want to use the current language you can specify a message's langua
 
 @[specify-lang-render](code/javaguide/i18n/JavaI18N.java)
 
+Note that you should inject the [`play.i18n.MessagesApi`](api/java/play/i18n/MessagesApi.html) class, using [[dependency injection|JavaDependencyInjection]].  For example, using Guice you would do the following:
+
+```
+public MyClass {
+    @javax.inject.Inject 
+    public MyClass(play.i18n.MessagesApi messagesApi) { ... }
+}
+```
+
+## Use in Controllers
+
+If you are in a Controller, you get the `Messages` instance through `Http.Context`, using `Http.Context.current().messages()`:
+
+@[show-context-messages](code/javaguide/i18n/JavaI18N.java)
+
 ## Use in templates
 
-You can use the `Messages.get` method from within a template. This will localize a message with the current language.
+Once you have the Messages object, you can pass it into the template:
 
-@[template](code/javaguide/i18n/hellotemplate.scala.html)
+@[template](code/javaguide/i18n/explicitjavatemplate.scala.html)
 
-You can also use the Scala `Messages` object from within templates. The Scala `Messages` object has a shorter form that's equivalent to `Messages.get` which many people find useful. If you use the Scala `Messages` object remember not to import the Java `play.i18n.Messages` class or they will conflict!
+You can also use the Scala `Messages` object from within templates. The Scala `Messages` object has a shorter form that's equivalent to `messages.at` which many people find useful.
+
+If you use the Scala `Messages` object remember not to import the Java `play.i18n.Messages` class or they will conflict!
 
 @[template](code/javaguide/i18n/helloscalatemplate.scala.html)
 
-Localized templates that use `Messages.get` or the Scala `Messages` object are invoked like normal:
+Localized templates that use `messages.at` or the Scala `Messages` object are invoked like normal:
 
 @[default-lang-render](code/javaguide/i18n/JavaI18N.java)
 

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/explicitjavatemplate.scala.html
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/explicitjavatemplate.scala.html
@@ -1,0 +1,4 @@
+@* #template *@
+@(messages: play.i18n.Messages)
+@messages.at("hello")
+@* #template *@

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/hellotemplate.scala.html
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/hellotemplate.scala.html
@@ -1,3 +1,5 @@
 @* #template *@
-@play.i18n.Messages.get("hello")
+@import play.mvc.Http.Context.Implicit._
+@()
+@{messages().at("hello")}
 @* #template *@

--- a/documentation/manual/working/javaGuide/main/i18n/index.toc
+++ b/documentation/manual/working/javaGuide/main/i18n/index.toc
@@ -1,1 +1,1 @@
-JavaI18N:Internationalization
+JavaI18N:Internationalization with Messages

--- a/documentation/manual/working/javaGuide/main/index.toc
+++ b/documentation/manual/working/javaGuide/main/index.toc
@@ -10,7 +10,7 @@ sql:Accessing an SQL database
 cache:Using the Cache
 ws:Calling WebServices
 akka:Integrating with Akka
-i18n:Internationalization
+i18n:Internationalization with Messages
 dependencyinjection:Dependency Injection
 application:Application Settings
 tests:Testing your application

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
@@ -147,6 +147,8 @@ There are several input helpers, but the most helpful are:
 * [`checkbox`](api/scala/views/html/helper/checkbox$.html): renders a [checkbox](http://www.w3.org/TR/html-markup/input.checkbox.html#input.checkbox) element.
 * [`input`](api/scala/views/html/helper/input$.html): renders a generic input element (which requires explicit arguments).
 
+> **Note:** The source code for each of these templates is defined as Twirl templates under `views/helper` package, and so the packaged version corresponds to the generated Scala source code.  For reference, it can be useful to see the [`views/helper` ](https://github.com/playframework/playframework/tree/master/framework/src/play/src/main/scala/views/helper) package on Github.
+
 As with the `form` helper, you can specify an extra set of parameters that will be added to the generated Html:
 
 @[form-user-parameters](code/scalaguide/forms/scalaforms/views/user.scala.html)
@@ -158,6 +160,35 @@ The generic `input` helper mentioned above will let you code the desired HTML re
 > **Note:** All extra parameters will be added to the generated Html, unless they start with the **\_** character. Arguments starting with **\_** are reserved for [[field constructor arguments|ScalaCustomFieldConstructors]].
 
 For complex form elements, you can also create your own custom view helpers (using scala classes in the `views` package) and [[custom field constructors|ScalaCustomFieldConstructors]].
+
+### Passing Messages to Form Helpers
+
+The form helpers above -- [`input`](api/scala/views/html/helper/input$.html), [`checkbox`](api/scala/views/html/helper/checkbox$.html), and so on -- all take [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) as an implicit parameter.  The form handlers need to take [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) because they need to provide error messages mapped to the language defined in the request.
+
+There are two ways to pass in the [`Messages`](api/scala/play/api/i18n/Messages.html) object required.
+  
+The first way is to make the controller extend [`play.api.i18n.I18nSupport`](api/scala/play/api/i18n/I18nSupport.html), which makes use of an injected [`MessagesApi`](api/scala/play/api/i18n/MessagesApi.html):
+
+@[messages-controller](code/ScalaForms.scala)
+
+The second way is to use the [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) trait.  This is useful because to use [[CSRF|ScalaCsrf]] with forms, both a `Request` (technically a `RequestHeader`) and a `Messages` object must be available to the template.  By using a `WrappedRequest` that extends [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html), only a single implicit parameter needs to be made available to templates.
+
+The implementation of a `MessagesRequest` is straightforward:
+
+@[messages-request](code/ScalaForms.scala)
+
+The `MessagesRequest` is used inside an action by using an `ActionTransformer` (see [[the action composition section|ScalaActionsComposition]]) that transforms a `Request` into a `MessagesRequest`:
+
+@[messages-action-transformer](code/ScalaForms.scala)
+
+An example of a form that uses the `AbstractMessagesController`:
+
+@[messages-request-controller](code/ScalaForms.scala)
+
+Finally, the implicit request does double duty as both a [`RequestHeader`](api/scala/play/api/mvc/RequestHeader.html) and a [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) in the template:
+
+@[form-define](code/scalaguide/forms/scalaforms/views/messages.scala.html)
+
 
 ### Displaying errors in a view template
 

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -3,17 +3,19 @@
  */
 package scalaguide.forms.scalaforms {
 
-import play.api.{Environment, Configuration}
-import play.api.i18n.{DefaultLangs, DefaultMessagesApi, Messages}
+import javax.inject.Inject
+
+import play.api.{Configuration, Environment}
+import play.api.i18n._
 
 import scalaguide.forms.scalaforms.controllers.routes
-
 import play.api.mvc._
-import play.api.test._
-
+import play.api.test.{WithApplication, _}
 import org.specs2.mutable.Specification
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
+
+import scala.concurrent.{ExecutionContext, Future}
 
 // #form-imports
 import play.api.data._
@@ -32,8 +34,7 @@ class ScalaFormsSpec extends Specification with Controller {
 
   "A scala forms" should {
 
-    "generate from map" in {
-
+    "generate from map" in new WithApplication {
       val userForm = controllers.Application.userForm
 
       //#userForm-generate-map
@@ -44,7 +45,7 @@ class ScalaFormsSpec extends Specification with Controller {
       userData.name === "bob"
     }
 
-    "generate from request" in {
+    "generate from request" in new WithApplication {
 
       import play.api.libs.json.Json
       val userForm = controllers.Application.userForm
@@ -58,7 +59,7 @@ class ScalaFormsSpec extends Specification with Controller {
       userData.name === "bob"
     }
 
-    "get user info from form" in {
+    "get user info from form" in new WithApplication  {
 
       controllers.Application.userFormName === "bob"
 
@@ -81,7 +82,7 @@ class ScalaFormsSpec extends Specification with Controller {
       controllers.Application.userFormTupleName === "bob"
     }
 
-    "handling form with errors" in {
+    "handling form with errors" in new WithApplication {
       val userFormConstraints2 = controllers.Application.userFormConstraints2
 
       implicit val request = FakeRequest().withFormUrlEncodedBody("name" -> "", "age" -> "25")
@@ -92,7 +93,7 @@ class ScalaFormsSpec extends Specification with Controller {
       //#userForm-constraints-2-with-errors
     }
 
-    "handling binding failure" in {
+    "handling binding failure" in new WithApplication {
       val userForm = controllers.Application.userFormConstraints
 
       implicit val request = FakeRequest().withFormUrlEncodedBody("name" -> "", "age" -> "25")
@@ -101,7 +102,7 @@ class ScalaFormsSpec extends Specification with Controller {
       boundForm.hasErrors must beTrue
     }
 
-    "display global errors user template" in {
+    "display global errors user template" in new WithApplication {
       val userForm = controllers.Application.userFormConstraintsAdHoc
       
       implicit val request = FakeRequest().withFormUrlEncodedBody("name" -> "Johnny Utah", "age" -> "25")
@@ -113,7 +114,7 @@ class ScalaFormsSpec extends Specification with Controller {
       html.body must contain("Failed form constraints!")
     }
 
-    "map single values" in {
+    "map single values" in new WithApplication {
 
       //#form-single-value
       val singleForm = Form(
@@ -127,7 +128,7 @@ class ScalaFormsSpec extends Specification with Controller {
       emailValue must beEqualTo("bob@example.com")
     }
 
-    "fill selects with options and set their defaults" in {
+    "fill selects with options and set their defaults" in new WithApplication {
       val boundForm = controllers.Application.filledAddressSelectForm
       val html = views.html.select(boundForm)
       html.body must contain("option value=\"London\" selected")
@@ -167,6 +168,13 @@ case class UserListData(name: String, emails: List[String])
 case class UserOptionalData(name: String, email: Option[String])
 // #userData-optional
 
+//#messages-request
+class MessagesRequest[A](request: Request[A], val messages: Messages)
+  extends WrappedRequest(request) with play.api.i18n.MessagesProvider {
+  def lang: Lang = messages.lang
+}
+//#messages-request
+
 }
 
 package views.html.contact {
@@ -190,12 +198,16 @@ case class ContactInformation(label: String,
 
 package controllers {
 
+import play.api.i18n.{I18nSupport, Lang}
+
 import views.html._
 import views.html.contact._
-import play.api.i18n.Messages.Implicits._
-import play.api.Play.current
 
-class Application extends Controller {
+class Application extends Controller with I18nSupport {
+
+  val messagesApi: MessagesApi = {
+    play.api.i18n.Messages.Implicits.applicationMessagesApi(play.api.Play.current)
+  }
 
   //#userForm-define
   val userForm = Form(
@@ -211,7 +223,7 @@ class Application extends Controller {
   }
 
   // #form-render
-  def index = Action {
+  def index = Action { implicit request =>
     Ok(views.html.user(userForm))
   }
   // #form-render
@@ -246,7 +258,10 @@ class Application extends Controller {
   // #form-bodyparser
 
   // #form-bodyparser-errors
-  val userPostWithErrors = Action(parse.form(userForm, onErrors = (formWithErrors: Form[UserData]) => BadRequest(views.html.user(formWithErrors)))) { implicit request =>
+  val userPostWithErrors = Action(parse.form(userForm, onErrors = (formWithErrors: Form[UserData]) => {
+    implicit val messages = messagesApi.preferred(Seq(Lang.defaultLang))
+    BadRequest(views.html.user(formWithErrors))
+  })) { implicit request =>
     val userData = request.body
     val newUser = models.User(userData.name, userData.age)
     val id = models.User.create(newUser)
@@ -473,7 +488,7 @@ class Application extends Controller {
   // #contact-form
 
   // #contact-edit
-  def editContact = Action {
+  def editContact = Action { implicit request =>
     val existingContact = Contact(
       "Fake", "Contact", Some("Fake company"), informations = List(
         ContactInformation(
@@ -512,6 +527,72 @@ class Application extends Controller {
 }
 
 object Application extends Application
+
+
+//#messages-controller
+class MessagesController @Inject()(cc: ControllerComponents)
+  extends AbstractController(cc) with play.api.i18n.I18nSupport {
+
+  import play.api.data.Form
+  import play.api.data.Forms._
+
+  val userForm = Form(
+    mapping(
+      "name" -> text,
+      "age" -> number
+    )(views.html.UserData.apply)(views.html.UserData.unapply)
+  )
+
+  def index = Action { implicit request =>
+    Ok(views.html.user(userForm))
+  }
+}
+//#messages-controller
+
+//#messages-action-transformer
+// Exposes a "MessagesAction" to the user while hiding the underpinnings
+abstract class AbstractMessagesController(cc: ControllerComponents)
+  extends AbstractController(cc) {
+
+  private val messagesRequestTransformer = {
+    new ActionTransformer[Request, MessagesRequest] {
+      def transform[A](request: Request[A]) = Future.successful {
+        val messages = cc.messagesApi.preferred(request)
+        new MessagesRequest(request, messages)
+      }
+      override protected def executionContext = cc.executionContext
+    }
+  }
+
+  def MessagesAction: ActionBuilder[MessagesRequest, AnyContent] = {
+    cc.actionBuilder.andThen(messagesRequestTransformer)
+  }
+}
+//#messages-action-transformer
+
+//#messages-request-controller
+// Example form that uses a MessagesRequest, which is also a MessagesProvider
+class MessagesRequestController @Inject()(components: ControllerComponents)
+  extends AbstractMessagesController(components) {
+
+  import play.api.data.Form
+  import play.api.data.Forms._
+
+  val userForm = Form(
+    mapping(
+      "name" -> text,
+      "age" -> number
+    )(views.html.UserData.apply)(views.html.UserData.unapply)
+  )
+
+  def index = MessagesAction { implicit request: MessagesRequest[_] =>
+    Ok(views.html.messages(userForm))
+  }
+
+  def post() = TODO
+}
+//#messages-request-controller
+
 }
 
 }

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide.forms.scalaforms.routes
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide.forms.scalaforms.routes
@@ -7,3 +7,9 @@ POST        /user            controllers.Application.userPost
 POST        /submit          controllers.Application.submit
 
 POST        /contact/save    controllers.Application.saveContact
+
+GET         /messages        controllers.MessagesController.index
+
+GET         /messageRequest  controllers.MessagesRequestController.index
+
+POST        /messageRequest  controllers.MessagesRequestController.post

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/messages.scala.html
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/messages.scala.html
@@ -1,0 +1,14 @@
+@import scalaguide.forms.scalaforms._
+@import scalaguide.forms.scalaforms.controllers.routes
+
+@* #form-define *@
+@(userForm: Form[UserData])(implicit request: MessagesRequest[_])
+
+@import helper._
+
+@helper.form(action = routes.MessagesRequestController.post()) {
+  @CSRF.formField                     @* <- takes a RequestHeader    *@
+  @helper.inputText(userForm("name")) @* <- takes a MessagesProvider *@
+  @helper.inputText(userForm("age"))  @* <- takes a MessagesProvider *@
+}
+@* #form-define *@

--- a/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
+++ b/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
@@ -1,5 +1,5 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
-# Messages and internationalization
+# Internationalization with Messages
 
 ## Specifying languages supported by your application
 
@@ -11,7 +11,19 @@ To start you need to specify the languages supported by your application in the 
 play.i18n.langs = [ "en", "en-US", "fr" ]
 ```
 
-These language tags will be validated used to create `Lang` instances. To access the languages supported by your application, you can inject a `Langs` instance into your component.
+These language tags will be validated used to create [`play.api.i18n.Lang`](api/scala/play/api/i18n/Lang.html) instances. To access the languages supported by your application, you can inject a [`play.api.i18n.Langs`](api/scala/play/api/i18n/Langs.html) component into your class:
+
+```scala
+class MyService @Inject()(langs: Langs) {
+  val availableLangs = langs.available
+}
+```
+
+An individual [`play.api.i18n.Lang`](api/scala/play/api/i18n/Lang.html) can be converted to a [`java.util.Locale`](https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html) object by using `lang.toLocale`:
+
+```scala
+val locale: java.util.Locale = lang.toLocale
+```
 
 ## Externalizing messages
 
@@ -19,21 +31,97 @@ You can externalize messages in the `conf/messages.xxx` files.
 
 The default `conf/messages` file matches all languages. Additionally you can specify language-specific message files such as `conf/messages.fr` or `conf/messages.en-US`.
 
-You can then retrieve messages using the `play.api.i18n.Messages` object:
+Messages are available through the [`MessagesApi`](api/scala/play/api/i18n/MessagesApi.html) instance, which can be added via injection.  You can then retrieve messages using the [`play.api.i18n.MessagesApi`](api/scala/play/api/i18n/MessagesApi.html) object:
 
 ```scala
+class MyService @Inject()(langs: Langs, messagesApi: MessagesApi) {
+  val lang: Lang = langs.availables.head
+
+  val title = messagesApi("home.title")(lang)
+}
+```
+
+You can also make the language implicit rather than declare it:
+
+```scala
+class MyService @Inject()(langs: Langs, messagesApi: MessagesApi) {
+  implicit val lang: Lang = langs.availables.head
+
+  val title = messagesApi("home.title")
+}
+```
+
+## Using Messages and MessagesProvider
+
+Because it's common to want to use messages without having to provide an argument, you can wrap a given `Lang` together with the [`MessagesApi`](api/scala/play/api/i18n/MessagesApi.html) to create a [`play.api.i18n.Messages`](api/scala/play/api/i18n/MessagesImpl.html) instance.  The [`play.api.i18n.MessagesImpl`](api/scala/play/api/i18n/MessagesImpl.html) case class implements the [`Messages`](api/scala/play/api/i18n/Messages.html) trait if you want to create one directly:
+
+```scala
+val messages: Messages = MessagesImpl(lang, messagesApi)
+val title = messages("home.title")
+```
+
+You can also use Singleton object methods with an implicit [`play.api.i18n.MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html):
+
+```scala
+implicit val messagesProvider: MessagesProvider = {
+  MessagesImpl(lang, messagesApi)
+}
+ // uses implicit messages
 val title = Messages("home.title")
 ```
 
-All internationalization API calls take an implicit `play.api.i18n.Messages` argument retrieved from the current scope. This implicit value contains both the language to use and (essentially) the internationalized messages.
+A [`play.api.i18n.MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) is a trait that can provide a [`Messages`](api/scala/play/api/i18n/Messages.html) object on demand.  An instance of [`Messages`](api/scala/play/api/i18n/Messages.html) extends [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) and returns itself.
+  
+[`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) is most useful when extended by something that is not a `Messages`:
 
-The simplest way to get such an implicit value is to use the `I18nSupport` trait. For instance you can use it as follows in your controllers:
+```
+implicit val messagesProvider: MessagesProvider = new MessagesProvider {
+  // resolve messages at runtime
+  def messages = {
+    ...  
+  }
+}
+ // uses implicit messages
+val title = Messages("home.title")
+```
+
+> **Note:** An example of a [`WrappedRequest`](api/scala/play/api/mvc/WrappedRequest.html) that extends [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) is covered in [[passing messages to form helpers|ScalaForms#passing-messages-to-form-helpers]] in the [[ScalaForms]] page.
+
+## Using Messages with Controllers
+
+You can add an implicit [`Messages`](api/scala/play/api/i18n/Messages.html) to your actions by adding the [`play.api.i18n.I18nSupport`](api/scala/play/api/i18n/I18nSupport.html) trait to your controller.  The [`play.api.i18n.I18nSupport`](api/scala/play/api/i18n/I18nSupport.html) trait gives you an implicit `Messages` value as long as there is a `RequestHeader` in the implicit scope.  
+
+If you extend [`Controller`](api/scala/play/api/mvc/Controller.html) directly, this will require that you add `val messagesApi: MessagesApi` to your controller as [`I18nSupport`](api/scala/play/api/i18n/I18nSupport.html) depends on it.  If you extend [`AbstractController`](api/scala/play/api/mvc/AbstractController.html), then `val messagesApi: MessagesApi` is already provided under the hood and all you have to do is extend [`I18nSupport`](api/scala/play/api/i18n/I18nSupport.html):
 
 @[i18n-support](code/ScalaI18N.scala)
 
-The `I18nSupport` trait gives you an implicit `Messages` value as long as there is a `Lang` or a `RequestHeader` in the implicit scope.
+The [`I18nSupport`](api/scala/play/api/i18n/I18nSupport.html) is useful (if not essential) because all the form helpers in Twirl templates take [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html), and it is assumed that a [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) is passed into the template as an implicit parameter when processing a form.  
 
-It adds two convenient methods to `Result`, `clearingLang` and `withLang(lang: Lang)`, which can be used to set the language. For example:
+```twirl
+@(form: Form[Foo])(implicit messages: MessagesProvider)
+
+@helper.inputText(field = form("name")) @* <- takes MessagesProvider *@
+```
+
+> **Note:** This is not a complete guide to form helpers. Please see [[showing forms in a view template|ScalaForms#showing-forms-in-a-view-template]] in the [[ScalaForms]] page for more detailed examples.
+
+### Request Types
+
+[`I18nSupport`](api/scala/play/api/i18n/I18nSupport.html) also adds the following methods to a [`Request`](api/scala/play/api/mvc/Request.html):
+
+* `request.messages` returns an instance of `Messages`, using an implicit `MessagesApi` 
+* `request.lang` returns the preferred `Lang`, using an implicit `MessagesApi` 
+
+The preferred language is extracted from the `Accept-Language` header (and optionally the language cookie) and matching one of the `MessagesApi` supported languages using `messagesApi.preferred`.
+
+### Language Cookie Support
+
+The [`I18nSupport`](api/scala/play/api/i18n/I18nSupport.html) also adds two convenient methods to `Result`:
+
+* `result.withLang(lang: Lang)` is used to set the language using Play's language cookie. 
+* `result.clearingLang` is used to clear the language cookie.
+
+For example:
 
 ```scala
   def homePageInFrench = Action {
@@ -50,9 +138,18 @@ The `withLang` method sets the cookie named `PLAY_LANG` for future requests, whi
 
 The cookie name can be changed by changing the configuration parameter: `play.i18n.langCookieName`.
 
-> **Note:** If you have a `RequestHeader` in the implicit scope, it will use the preferred language extracted from the `Accept-Language` header and matching one of the `MessagesApi` supported languages. You should add a `Messages` implicit parameter to your template like this: `@()(implicit messages: Messages)`.
+## Implicit Lang Conversion
 
-> **Note:** Also, Play “knows” out of the box how to inject a `MessagesApi` value (that uses the `DefaultMessagesApi` implementation), so you can just annotate your controller with the `@javax.inject.Inject` annotation and let Play automatically wire the components for you.
+The [`LangImplicits`](api/scala/play/api/i18n/LangImplicits.html) trait can be declared on a controller to implicitly convert a request to a `Messages` given an implicit `Lang` instance.
+
+```scala
+class MyClass @Inject()(val messagesApi: MessagesApi) extends LangImplicits {
+  def convertToMessage: Unit = {
+    implicit val lang = Lang("en")
+    val messages: Messages = lang // implicit conversion
+  }
+}
+```
 
 ## Messages format
 

--- a/documentation/manual/working/scalaGuide/main/i18n/code/ScalaI18N.scala
+++ b/documentation/manual/working/scalaGuide/main/i18n/code/ScalaI18N.scala
@@ -4,41 +4,88 @@
 package scalaguide.i18n.scalai18n {
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
+import play.api._
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc._
 import play.api.test._
 
-import play.api._
-import play.api.mvc._
-import play.api.i18n.{DefaultLangs, DefaultMessagesApi, Messages, MessagesApi}
+package views.html {
+  object formpage {
+    def apply()(implicit messages: play.api.i18n.Messages): String = {
+      ""
+    }
+  }
+}
+
+//#i18n-support
+import javax.inject.Inject
+import play.api.i18n._
+
+class MyController @Inject()(cc: ControllerComponents) extends AbstractController(cc) with I18nSupport {
+
+  def index = Action { implicit request =>
+    // type enrichment through I18nSupport
+    val messages: Messages = request.messages
+    val message: String = messages("info.error")
+    Ok(message)
+  }
+
+  def messages2 = Action { implicit request =>
+    // type enrichment through I18nSupport
+    val lang: Lang = request.lang
+    val message: String = messagesApi("info.error")(lang)
+    Ok(message)
+  }
+
+  def messages3 = Action { request =>
+    // direct access with no implicits required
+    val messages: Messages = messagesApi.preferred(request)
+    val lang = messages.lang
+    val message: String = messages("info.error")
+    Ok(message)
+  }
+
+  def messages4 = Action { implicit request =>
+    // takes implicit Messages, converted using request2messages
+    // template defined with @()(implicit messages: Messages)
+    Ok(views.html.formpage())
+  }
+}
+//#i18n-support
 
 @RunWith(classOf[JUnitRunner])
 class ScalaI18nSpec extends PlaySpecification with Controller {
+  val conf = Configuration.reference ++ Configuration.from(Map("play.i18n.path" -> "scalaguide/i18n"))
 
-//#i18n-support
-  import javax.inject.Inject
-  import play.api.i18n.I18nSupport
-  class MyController @Inject()(val messagesApi: MessagesApi) extends Controller with I18nSupport {
-    // ...
-//#i18n-support
+  "A controller" should {
 
-    "A Scala translation" should {
-      "escape single quotes" in {
-//#apostrophe-messages
-        Messages("info.error") == "You aren't logged in!"
-//#apostrophe-messages
-      }
+    "return the right message" in new WithApplication(GuiceApplicationBuilder().loadConfig(conf).build()) {
+      val controller = app.injector.instanceOf[MyController]
 
-      "escape parameter substitution" in {
-//#parameter-escaping
-        Messages("example.formatting") == "When using MessageFormat, '{0}' is replaced with the first parameter."
-//#parameter-escaping
-      }
+      val result = controller.index(FakeRequest())
+      contentAsString(result) must contain("You aren't logged in!")
     }
   }
 
-  val conf = Configuration.reference ++ Configuration.from(Map("play.i18n.path" -> "scalaguide/i18n"))
-  val messagesApi = new DefaultMessagesApi(Environment.simple(), conf, new DefaultLangs(conf))
+  "A Scala translation" should {
 
-  new MyController(messagesApi)
+    val langs = new DefaultLangs(conf)
+    val messagesApi = new DefaultMessagesApi(Environment.simple(), conf, langs)
+
+    implicit val lang = Lang("en")
+
+    "escape single quotes" in {
+      //#apostrophe-messages
+      messagesApi("info.error") == "You aren't logged in!"
+      //#apostrophe-messages
+    }
+
+    "escape parameter substitution" in {
+      //#parameter-escaping
+      messagesApi("example.formatting") == "When using MessageFormat, '{0}' is replaced with the first parameter."
+      //#parameter-escaping
+    }
+  }
 
 }
 

--- a/documentation/manual/working/scalaGuide/main/i18n/index.toc
+++ b/documentation/manual/working/scalaGuide/main/i18n/index.toc
@@ -1,1 +1,1 @@
-ScalaI18N:Internationalization
+ScalaI18N:Internationalization with Messages

--- a/documentation/manual/working/scalaGuide/main/index.toc
+++ b/documentation/manual/working/scalaGuide/main/index.toc
@@ -10,7 +10,7 @@ sql:Accessing an SQL database
 cache:Using the Cache
 ws:Calling WebServices
 akka:Integrating with Akka
-i18n:Internationalization
+i18n:Internationalization with Messages
 dependencyinjection:Dependency injection
 application:Application Settings
 tests:Testing your application

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/FormBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/FormBodyParserSpec.scala
@@ -10,11 +10,12 @@ import play.api.Application
 import play.api.data.Form
 import play.api.data.Forms.{ mapping, nonEmptyText, number }
 import play.api.http.{ MimeTypes, Writeable }
+import play.api.i18n.MessagesApi
 import play.api.libs.json.Json
 import play.api.mvc.{ BodyParser, BodyParsers, Result, Results }
 import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
-import scala.collection.JavaConverters._
 
+import scala.collection.JavaConverters._
 import scala.concurrent.Future
 
 class FormBodyParserSpec extends PlaySpecification {
@@ -45,7 +46,8 @@ class FormBodyParserSpec extends PlaySpecification {
     }
 
     "allow users to override the error reporting behaviour" in new WithApplication() {
-      import play.api.i18n.Messages.Implicits.applicationMessages
+      val messagesApi = app.injector.instanceOf[MessagesApi]
+      implicit val messages = messagesApi.preferred(Seq.empty)
       parse(Json.obj("age" -> "Alice"), BodyParsers.parse.form(userForm, onErrors = (form: Form[User]) => Results.BadRequest(form.errorsAsJson))) must beLeft.which { result =>
         result.header.status must equalTo(BAD_REQUEST)
         val json = contentAsJson(Future.successful(result))

--- a/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
@@ -6,23 +6,23 @@ package play.it.i18n
 import play.api.test.{ PlaySpecification, WithApplication }
 import play.api.mvc.Controller
 import play.api.i18n._
-import play.api.Mode
 
 class MessagesSpec extends PlaySpecification with Controller {
 
   sequential
 
   implicit val lang = Lang("en-US")
-  import play.api.i18n.Messages.Implicits.applicationMessages
 
   "Messages" should {
     "provide default messages" in new WithApplication() {
-      val msg = Messages("constraint.email")
+      val messagesApi = app.injector.instanceOf[MessagesApi]
+      val msg = messagesApi("constraint.email")
 
       msg must ===("Email")
     }
     "permit default override" in new WithApplication() {
-      val msg = Messages("constraint.required")
+      val messagesApi = app.injector.instanceOf[MessagesApi]
+      val msg = messagesApi("constraint.required")
 
       msg must ===("Required!")
     }
@@ -33,20 +33,24 @@ class MessagesSpec extends PlaySpecification with Controller {
     import java.util
     val enUS: Lang = new play.i18n.Lang(play.api.i18n.Lang("en-US"))
     "allow translation without parameters" in new WithApplication() {
-      val msg = Messages.get(enUS, "constraint.email")
+      val messagesApi = app.injector.instanceOf[MessagesApi]
+      val msg = messagesApi.get(enUS, "constraint.email")
 
       msg must ===("Email")
     }
     "allow translation with any non-list parameter" in new WithApplication() {
-      val msg = Messages.get(enUS, "constraint.min", "Croissant")
+      val messagesApi = app.injector.instanceOf[MessagesApi]
+      val msg = messagesApi.get(enUS, "constraint.min", "Croissant")
 
       msg must ===("Minimum value: Croissant")
     }
     "allow translation with any list parameter" in new WithApplication() {
+      val messagesApi = app.injector.instanceOf[MessagesApi]
+
       val msg = {
         val list: util.ArrayList[String] = new util.ArrayList[String]()
         list.add("Croissant")
-        Messages.get(enUS, "constraint.min", list)
+        messagesApi.get(enUS, "constraint.min", list)
       }
 
       msg must ===("Minimum value: Croissant")

--- a/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -3,7 +3,6 @@
  */
 package play.data
 
-import com.typesafe.config.ConfigFactory
 import org.specs2.mutable.Specification
 import play.api.{ Configuration, Environment }
 import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
@@ -11,6 +10,7 @@ import play.data.format.Formatters
 import views.html.helper.inputText
 import play.core.j.PlayFormsMagicForJava.javaFieldtoScalaField
 import views.html.helper.FieldConstructor.defaultField
+
 import scala.collection.JavaConversions._
 import javax.validation.Validation
 

--- a/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
+++ b/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
@@ -29,14 +29,14 @@ object PlayMagicForJava {
 
   implicit def implicitJavaMessages: play.api.i18n.Messages =
     try {
-      val jmessages = play.mvc.Http.Context.current().messages()
-      play.api.i18n.Messages(jmessages.lang(), jmessages.messagesApi().scalaApi())
+      val context = play.mvc.Http.Context.current()
+      context.messages().asScala
     } catch {
       case NonFatal(_) =>
         val app = play.api.Play.privateMaybeApplication.get
         val api = play.api.i18n.Messages.messagesApiCache(app)
         val lang = play.api.i18n.Lang.defaultLang
-        play.api.i18n.Messages(lang, api)
+        play.api.i18n.MessagesImpl(lang, api)
     }
 
 }

--- a/framework/src/play/src/main/java/play/i18n/Messages.java
+++ b/framework/src/play/src/main/java/play/i18n/Messages.java
@@ -3,181 +3,22 @@
  */
 package play.i18n;
 
-import org.apache.commons.lang3.ArrayUtils;
-import play.api.Application;
-import scala.collection.mutable.Buffer;
-
-import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 
 /**
- * A messages and a language.
+ * A Messages will produce messages using a specific language.
  *
- * This class serves two purposes. One is for backwards compatibility, it serves the old static API for accessing
- * messages.  The other is a new API, which carries an inject messages, and a selected language.
- *
- * The methods for looking up messages on the old API are called get, on the new API, they are called at. In Play 3.0,
- * when we remove the old API, we may alias the at methods to the get names.
+ * This interface that is typically backed by MessagesImpl, but does not
+ * return MessagesApi.
  */
-public class Messages {
-
-    // All these methods below will be removed once we get rid of the global state
-    private static Lang getLang(){
-        Lang lang = null;
-        if(play.mvc.Http.Context.current.get() != null) {
-            lang = play.mvc.Http.Context.current().lang();
-        } else {
-            lang = new Lang(new play.api.i18n.Lang(Locale.getDefault()));
-        }
-        return lang;
-    }
-
-    private static Messages getMessages(Lang lang) {
-        Application app = play.api.Play.current();
-        MessagesApi scalaApi = app.injector().instanceOf(MessagesApi.class);
-        return new Messages(lang, scalaApi);
-    }
+public interface Messages {
 
     /**
-     * Converts the varargs to a scala buffer,
-     * takes care of wrapping varargs into a intermediate list if necessary
+     * Get the lang for these messages.
      *
-     * @param args the message arguments
-     * @return scala type for message processing
+     * @return the chosen language
      */
-    private static Buffer<Object> convertArgsToScalaBuffer(final Object... args) {
-        return scala.collection.JavaConverters.asScalaBufferConverter(wrapArgsToListIfNeeded(args)).asScala();
-    }
-
-    /**
-     * Wraps arguments passed into a list if necessary.
-     *
-     * Returns the first value as is if it is the only argument and a subtype of `java.util.List`
-     * Otherwise, it calls Arrays.asList on args
-     * @param args arguments as a List
-     */
-    static <T> List<T> wrapArgsToListIfNeeded(final T... args) {
-        List<T> out = null;
-        if (ArrayUtils.isNotEmpty(args)
-            && args.length == 1
-            && args[0] instanceof List){
-            out = (List<T>) args[0];
-        }else{
-            out = Arrays.asList(args);
-        }
-        return out;
-    }
-
-    /**
-    * Translates a message.
-    *
-    * Uses `java.text.MessageFormat` internally to format the message.
-    *
-    * @param lang the message lang
-    * @param key the message key
-    * @param args the message arguments
-    * @return the formatted message or a default rendering if the key wasn't defined
-     * @deprecated Please use messages.at(key, args). since 2.5.0
-    */
-    @Deprecated
-    public static String get(Lang lang, String key, Object... args) {
-        return getMessages(lang).at(key, args);
-    }
-
-    /**
-    * Translates the first defined message.
-    *
-    * Uses `java.text.MessageFormat` internally to format the message.
-    *
-    * @param lang the message lang
-    * @param keys the messages keys
-    * @param args the message arguments
-    * @return the formatted message or a default rendering if the key wasn't defined
-     * @deprecated Please use messages.at(keys, args)
-    */
-    @Deprecated
-    public static String get(Lang lang, List<String> keys, Object... args) {
-        return getMessages(lang).at(keys, args);
-    }
-
-    /**
-    * Translates a message.
-    *
-    * Uses `java.text.MessageFormat` internally to format the message.
-    *
-    * @param key the message key
-    * @param args the message arguments
-    * @return the formatted message or a default rendering if the key wasn't defined
-     * @deprecated use messages.at(key, args).  Deprecated since 2.5.0
-    */
-    @Deprecated
-    public static String get(String key, Object... args) {
-        return getMessages(getLang()).at(key, args);
-    }
-
-    /**
-    * Translates the first defined message.
-    *
-    * Uses `java.text.MessageFormat` internally to format the message.
-    *
-    * @param keys the messages keys
-    * @param args the message arguments
-    * @return the formatted message or a default rendering if the key wasn't defined
-     * @deprecated use messages.at(keys, args).  Deprecated since 2.5.0
-    */
-    @Deprecated
-    public static String get(List<String> keys, Object... args) {
-        return getMessages(getLang()).at(keys, args);
-    }
-
-    /**
-    * Check if a message key is defined.
-    * @param lang the message lang
-    * @param key the message key
-    * @return a Boolean
-     * @deprecated Use messages.isDefinedAt(key).  Deprecated since 2.5.0
-    */
-    @Deprecated
-    public static Boolean isDefined(Lang lang, String key) {
-        return getMessages(lang).isDefinedAt(key);
-    }
-
-    /**
-    * Check if a message key is defined.
-    * @param key the message key
-    * @return a Boolean
-     * @deprecated Use messages.isDefinedAt(key).  Deprecated since 2.5.0
-    */
-    @Deprecated
-    public static Boolean isDefined(String key) {
-        return getMessages(getLang()).isDefinedAt(key);
-    }
-
-    // All these methods are the new API
-    private final Lang lang;
-    private final MessagesApi messages;
-
-    public Messages(Lang lang, MessagesApi messages) {
-        this.lang = lang;
-        this.messages = messages;
-    }
-
-    /**
-     * The lang for these messages
-     *
-     * @return the language
-     */
-    public Lang lang() {
-        return lang;
-    }
-
-    /**
-     * @return The underlying API
-     */
-    public MessagesApi messagesApi() {
-        return messages;
-    }
+    public Lang lang();
 
     /**
      * Get the message at the given key.
@@ -188,9 +29,7 @@ public class Messages {
      * @param args the message arguments
      * @return the formatted message or a default rendering if the key wasn't defined
      */
-    public String at(String key, Object... args) {
-        return messages.get(lang, key, args);
-    }
+    public String at(String key, Object... args);
 
     /**
      * Get the message at the first defined key.
@@ -201,9 +40,7 @@ public class Messages {
      * @param args the message arguments
      * @return the formatted message or a default rendering if the key wasn't defined
      */
-    public String at(List<String> keys, Object... args) {
-        return messages.get(lang, keys, args);
-    }
+    public String at(List<String> keys, Object... args);
 
     /**
      * Check if a message key is defined.
@@ -211,8 +48,8 @@ public class Messages {
      * @param key the message key
      * @return a Boolean
      */
-    public Boolean isDefinedAt(String key) {
-        return messages.isDefinedAt(lang, key);
-    }
+    public Boolean isDefinedAt(String key);
 
+
+    public play.api.i18n.Messages asScala();
 }

--- a/framework/src/play/src/main/java/play/i18n/MessagesApi.java
+++ b/framework/src/play/src/main/java/play/i18n/MessagesApi.java
@@ -50,6 +50,7 @@ public class MessagesApi {
      * Otherwise, it calls Arrays.asList on args
      * @param args arguments as a List
      */
+    @SafeVarargs
     private static <T> List<T> wrapArgsToListIfNeeded(final T... args) {
         List<T> out;
         if (ArrayUtils.isNotEmpty(args)
@@ -116,7 +117,7 @@ public class MessagesApi {
     public Messages preferred(Collection<Lang> candidates) {
         Seq<Lang> cs = JavaConversions.collectionAsScalaIterable(candidates).toSeq();
         play.api.i18n.Messages msgs = messages.preferred((Seq) cs);
-        return new Messages(new Lang(msgs.lang()), this);
+        return new MessagesImpl(new Lang(msgs.lang()), this);
     }
 
 
@@ -131,7 +132,7 @@ public class MessagesApi {
      */
     public Messages preferred(Http.RequestHeader request) {
         play.api.i18n.Messages msgs = messages.preferred(request);
-        return new Messages(new Lang(msgs.lang()), this);
+        return new MessagesImpl(new Lang(msgs.lang()), this);
     }
 
     public String langCookieName() {

--- a/framework/src/play/src/main/java/play/i18n/MessagesImpl.java
+++ b/framework/src/play/src/main/java/play/i18n/MessagesImpl.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.i18n;
+
+import java.util.List;
+
+/**
+ * This class implements the Messages interface.
+ *
+ * This class serves two purposes. One is for backwards compatibility, it serves the old static API for accessing
+ * messages.  The other is a new API, which carries an inject messages, and a selected language.
+ *
+ * The methods for looking up messages on the old API are called get, on the new API, they are called at. In Play 3.0,
+ * when we remove the old API, we may alias the at methods to the get names.
+ */
+public class MessagesImpl implements Messages {
+
+    private final Lang lang;
+    private final MessagesApi messagesApi;
+
+    public MessagesImpl(Lang lang, MessagesApi messagesApi) {
+        this.lang = lang;
+        this.messagesApi = messagesApi;
+    }
+
+    /**
+     * @return the selected language for the messages.
+     */
+    public Lang lang() {
+        return lang;
+    }
+
+    /**
+     * @return The underlying API
+     */
+    public MessagesApi messagesApi() {
+        return messagesApi;
+    }
+
+    /**
+     * Get the message at the given key.
+     *
+     * Uses `java.text.MessageFormat` internally to format the message.
+     *
+     * @param key the message key
+     * @param args the message arguments
+     * @return the formatted message or a default rendering if the key wasn't defined
+     */
+    public String at(String key, Object... args) {
+        return messagesApi.get(lang, key, args);
+    }
+
+    /**
+     * Get the message at the first defined key.
+     *
+     * Uses `java.text.MessageFormat` internally to format the message.
+     *
+     * @param keys the messages keys
+     * @param args the message arguments
+     * @return the formatted message or a default rendering if the key wasn't defined
+     */
+    public String at(List<String> keys, Object... args) {
+        return messagesApi.get(lang, keys, args);
+    }
+
+    /**
+     * Check if a message key is defined.
+     *
+     * @param key the message key
+     * @return a Boolean
+     */
+    public Boolean isDefinedAt(String key) {
+        return messagesApi.isDefinedAt(lang, key);
+    }
+
+    @Override
+    public play.api.i18n.Messages asScala() {
+        return new play.api.i18n.MessagesImpl(lang, messagesApi.scalaApi());
+    }
+}

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -20,10 +20,7 @@ import play.api.mvc.SessionCookieBaker;
 import play.core.j.JavaContextComponents;
 import play.core.j.JavaParsers;
 import play.core.system.RequestIdProvider;
-import play.i18n.Lang;
-import play.i18n.Langs;
-import play.i18n.Messages;
-import play.i18n.MessagesApi;
+import play.i18n.*;
 import play.libs.Json;
 import play.libs.XML;
 import scala.Tuple2;
@@ -375,8 +372,6 @@ public class Http {
             }
 
             /**
-             * Returns the messages for the current lang
-             *
              * @return the messages for the current lang
              */
             public static Messages messages() {

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -128,6 +128,7 @@ abstract class BuiltInComponentsFromContext(context: ApplicationLoader.Context) 
   lazy val applicationLifecycle: DefaultApplicationLifecycle = context.lifecycle
 
   lazy val javaContextComponents = JavaHelpers.createContextComponents(messagesApi, langs, httpConfiguration)
-  override lazy val injector: Injector = new SimpleInjector(NewInstanceInjector) + router + cookieSigner + csrfTokenSigner + httpConfiguration + tempFileCreator + javaContextComponents
+  override lazy val injector: Injector = new SimpleInjector(NewInstanceInjector) + router + cookieSigner +
+    csrfTokenSigner + httpConfiguration + tempFileCreator + messagesApi + langs + javaContextComponents
 }
 

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -223,10 +223,10 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
   /**
    * Returns the form errors serialized as Json.
    */
-  def errorsAsJson(implicit messages: play.api.i18n.Messages): play.api.libs.json.JsValue = {
+  def errorsAsJson(implicit provider: play.api.i18n.MessagesProvider): play.api.libs.json.JsValue = {
 
     import play.api.libs.json._
-
+    val messages = provider.messages
     Json.toJson(
       errors.groupBy(_.key).mapValues { errors =>
         errors.map(e => messages(e.message, e.args.map(a => translateMsgArg(a)): _*))
@@ -235,11 +235,11 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
 
   }
 
-  private def translateMsgArg(msgArg: Any)(implicit messages: play.api.i18n.Messages) = msgArg match {
-    case key: String => messages(key)
+  private def translateMsgArg(msgArg: Any)(implicit provider: play.api.i18n.MessagesProvider) = msgArg match {
+    case key: String => provider.messages(key)
     case keys: Seq[_] =>
       val k = keys.asInstanceOf[Seq[String]]
-      k.map(key => messages(key))
+      k.map(key => provider.messages(key))
     case _ => msgArg
   }
 

--- a/framework/src/play/src/main/scala/play/api/i18n/I18nModule.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/I18nModule.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.i18n
+
+import play.api.{ Configuration, Environment }
+import play.api.inject.Module
+
+class I18nModule extends Module {
+  def bindings(environment: Environment, configuration: Configuration) = {
+    Seq(
+      bind[Langs].to[DefaultLangs],
+      bind[MessagesApi].to[DefaultMessagesApi]
+    )
+  }
+}
+
+/**
+ * Injection helper for i18n components
+ */
+trait I18nComponents {
+
+  def environment: Environment
+  def configuration: Configuration
+
+  lazy val messagesApi: MessagesApi = new DefaultMessagesApi(environment, configuration, langs)
+  lazy val langs: Langs = new DefaultLangs(configuration)
+
+}

--- a/framework/src/play/src/main/scala/play/api/i18n/I18nSupport.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/I18nSupport.scala
@@ -3,73 +3,130 @@
  */
 package play.api.i18n
 
-import play.api.mvc.{ RequestHeader, Result }
+import play.api.mvc._
 
 /**
- * Brings a convenient implicit conversion from [[play.api.mvc.RequestHeader]] to [[Messages]].
+ * Brings convenient implicit conversions from [[play.api.mvc.RequestHeader]] to [[Messages]].
  *
  * Example:
  * {{{
  *   import play.api.i18n.Messages
- *   class MyController(val messagesApi: MessagesApi) extends ControllerLike with I18nSupport {
+ *   class MyController(val messagesApi: MessagesApi ...)
+ *     extends Controller(cc) with I18nSupport {
  *     val action = Action { implicit request =>
- *       Ok(Messages("some.key")) // Uses the client’s preferred language
+ *       val messageFromRequest = request.messages("hello.world")
+ *       Ok(s"\$messageFromRequest")
  *     }
  *   }
  * }}}
  */
 trait I18nSupport extends I18NSupportLowPriorityImplicits {
-
-  /** The [[MessagesApi]] to use. */
   def messagesApi: MessagesApi
 
   /**
+   * Converts from a request directly into a Messages.
+   *
+   * @param request the incoming request
    * @return The preferred [[Messages]] according to the given [[play.api.mvc.RequestHeader]]
    */
   implicit def request2Messages(implicit request: RequestHeader): Messages = messagesApi.preferred(request)
+}
+
+/**
+ * A static object with type enrichment for request and responses.
+ *
+ * {{{
+ * import I18nSupport._
+ * }}}
+ */
+object I18nSupport extends I18NSupportLowPriorityImplicits
+
+/**
+ * Implicit conversions for using i18n with requests and results.
+ */
+trait I18NSupportLowPriorityImplicits {
+
+  /**
+   * Adds convenient methods to handle the messages.
+   */
+  implicit class RequestWithMessagesApi(request: RequestHeader) {
+    /**
+     * Adds a `messages` method that can be used on a request,
+     * returning the Messages object in the preferred language
+     * of the request.
+     *
+     * For example:
+     * {{{
+     *   implicit val messagesApi: MessagesApi = ...
+     *   val messageFromRequest: Messages = request.messages("hello.world")
+     * }}}
+     */
+    def messages(implicit messagesApi: MessagesApi): Messages = {
+      messagesApi.preferred(request)
+    }
+
+    /**
+     * Adds a `lang` method that can be used on a request,
+     * returning the lang corresponding to the preferred language
+     * of the request.
+     *
+     * For example:
+     * {{{
+     *   implicit val messagesApi: MessagesApi = ...
+     *   val lang: Lang = request.lang
+     * }}}
+     */
+    def lang(implicit messagesApi: MessagesApi): Lang = {
+      messagesApi.preferred(request).lang
+    }
+  }
 
   /**
    * Adds convenient methods to handle the client-side language
    */
-  implicit class ResultWithLang(result: Result) {
-
+  implicit class ResultWithMessagesApi(result: Result) {
     /**
      * Sets the user's language permanently for future requests by storing it in a cookie.
      *
      * For example:
      * {{{
-     * implicit val lang = Lang("fr-FR")
+     * implicit val messagesApi: MessagesApi = ...
+     * val lang = Lang("fr-FR")
      * Ok(Messages("hello.world")).withLang(lang)
      * }}}
      *
      * @param lang the language to store for the user
      * @return the new result
      */
-    def withLang(lang: Lang): Result =
+    def withLang(lang: Lang)(implicit messagesApi: MessagesApi): Result = {
       messagesApi.setLang(result, lang)
+    }
 
     /**
      * Clears the user's language by discarding the language cookie set by withLang
      *
      * For example:
      * {{{
+     * implicit val messagesApi: MessagesApi = ...
      * Ok(Messages("hello.world")).clearingLang
      * }}}
      *
      * @return the new result
      */
-    def clearingLang: Result =
+    def clearingLang(implicit messagesApi: MessagesApi): Result = {
       messagesApi.clearLang(result)
-
+    }
   }
-
 }
 
-trait I18NSupportLowPriorityImplicits { this: I18nSupport =>
+/**
+ * A trait for extracting a Messages instance from Langs
+ */
+trait LangImplicits {
+  def messagesApi: MessagesApi
 
   /**
-   * @return A [[Messages]] value that uses the [[Lang]] found in the implicit scope
+   * @return A [[Messages]] value that uses the [[Lang]] found in the implicit scope.
    */
-  implicit def lang2Messages(implicit lang: Lang): Messages = Messages(lang, messagesApi)
-
+  implicit def lang2Messages(implicit lang: Lang): Messages = MessagesImpl(lang, messagesApi)
 }

--- a/framework/src/play/src/main/scala/play/api/i18n/Langs.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Langs.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.i18n
+
+import java.util.Locale
+import javax.inject.{ Inject, Singleton }
+
+import play.api.{ Application, Configuration, Logger }
+
+import scala.util.Try
+import scala.util.control.NonFatal
+
+/**
+ * A Lang supported by the application.
+ */
+case class Lang(locale: Locale) {
+
+  /**
+   * Convert to a Java Locale value.
+   */
+  def toLocale: Locale = locale
+
+  /**
+   * @return The language for this Lang.
+   */
+  def language: String = locale.getLanguage
+
+  /**
+   * @return The country for this Lang, or "" if none exists.
+   */
+  def country: String = locale.getCountry
+
+  /**
+   * @return The script tag for this Lang, or "" if none exists.
+   */
+  def script: String = locale.getScript
+
+  /**
+   * @return The variant tag for this Lang, or "" if none exists.
+   */
+  def variant: String = locale.getVariant
+
+  /**
+   * Whether this lang satisfies the given lang.
+   *
+   * If the other lang defines a country code, then this is equivalent to equals, if it doesn't, then the equals is
+   * only done on language and the country of this lang is ignored.
+   *
+   * This implements the language matching specified by RFC2616 Section 14.4.  Equality is case insensitive as per
+   * Section 3.10.
+   *
+   * @param accept The accepted language
+   */
+  def satisfies(accept: Lang): Boolean = {
+    import scala.collection.JavaConverters._
+    Locale.lookup(Seq(new Locale.LanguageRange(code)).asJava, Seq(accept.locale).asJava) != null
+  }
+
+  /**
+   * The language tag (such as fr or en-US).
+   */
+  lazy val code: String = locale.toLanguageTag
+}
+
+/**
+ * Utilities related to Lang values.
+ */
+object Lang {
+
+  /**
+   * The default Lang to use if nothing matches (platform default)
+   */
+  implicit lazy val defaultLang: Lang = Lang(java.util.Locale.getDefault)
+
+  /**
+   * Create a Lang value from a code (such as fr or en-US) and
+   *  throw exception if language is unrecognized
+   */
+  def apply(code: String): Lang = Lang(new Locale.Builder().setLanguageTag(code).build())
+
+  /**
+   * Create a Lang value from a code (such as fr or en-US) and
+   *  throw exception if language is unrecognized
+   */
+  def apply(language: String, country: String = "", script: String = "", variant: String = ""): Lang =
+    Lang(new Locale.Builder()
+      .setLanguage(language)
+      .setRegion(country)
+      .setScript(script)
+      .setVariant(variant)
+      .build())
+
+  /**
+   * Create a Lang value from a code (such as fr or en-US) or none
+   * if language is unrecognized.
+   */
+  def get(code: String): Option[Lang] = Try(apply(code)).toOption
+
+  private val langsCache = Application.instanceCache[Langs]
+
+  /**
+   * Retrieve Lang availables from the application configuration.
+   *
+   * {{{
+   * play.i18n.langs = ["fr", "en", "de"]
+   * }}}
+   */
+  @deprecated("Inject Langs into your component", "2.5.0")
+  def availables(implicit app: Application): Seq[Lang] = {
+    langsCache(app).availables
+  }
+
+  /**
+   * Guess the preferred lang in the langs set passed as argument.
+   * The first Lang that matches an available Lang wins, otherwise returns the first Lang available in this application.
+   */
+  @deprecated("Inject Langs into your component", "2.5.0")
+  def preferred(langs: Seq[Lang])(implicit app: Application): Lang = {
+    langsCache(app).preferred(langs)
+  }
+}
+
+/**
+ * Manages languages in Play
+ */
+trait Langs {
+
+  /**
+   * The available languages.
+   *
+   * These can be configured in `application.conf`, like so:
+   *
+   * {{{
+   * play.i18n.langs = ["fr", "en", "de"]
+   * }}}
+   */
+  def availables: Seq[Lang]
+
+  /**
+   * Select a preferred language, given the list of candidates.
+   *
+   * Will select the preferred language, based on what languages are available, or return the default language if
+   * none of the candidates are available.
+   */
+  def preferred(candidates: Seq[Lang]): Lang
+}
+
+@Singleton
+class DefaultLangs @Inject() (config: Configuration) extends Langs {
+
+  val availables: Seq[Lang] = {
+    val langs = config.getOptional[String]("application.langs") map { langsStr =>
+      Logger.warn("application.langs is deprecated, use play.i18n.langs instead")
+      langsStr.split(",").map(_.trim).toSeq
+    } getOrElse {
+      config.get[Seq[String]]("play.i18n.langs")
+    }
+
+    langs.map { lang =>
+      try { Lang(lang) } catch {
+        case NonFatal(e) => throw config.reportError(
+          "play.i18n.langs",
+          "Invalid language code [" + lang + "]", Some(e))
+      }
+    }
+  }
+
+  def preferred(candidates: Seq[Lang]): Lang = candidates.collectFirst(Function.unlift { lang =>
+    availables.find(_.satisfies(lang))
+  }).getOrElse(availables.headOption.getOrElse(Lang.defaultLang))
+}

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -4,180 +4,17 @@
 package play.api.i18n
 
 import java.net.URL
-import java.util.Locale
 import javax.inject.{ Inject, Singleton }
 
 import play.api._
-import play.api.inject._
-import play.api.mvc.{ Cookie, DiscardingCookie, RequestHeader, Result, Session }
+import play.api.mvc._
 import play.mvc.Http
 import play.utils.{ PlayIO, Resources }
 
-import scala.collection.JavaConverters._
 import scala.io.Codec
-import scala.language.postfixOps
-import scala.util.Try
-import scala.util.control.NonFatal
+import scala.language._
 import scala.util.parsing.combinator._
 import scala.util.parsing.input._
-
-/**
- * A Lang supported by the application.
- */
-case class Lang(locale: Locale) {
-
-  /**
-   * Convert to a Java Locale value.
-   */
-  def toLocale: Locale = locale
-
-  /**
-   * @return The language for this Lang.
-   */
-  def language: String = locale.getLanguage
-
-  /**
-   * @return The country for this Lang, or "" if none exists.
-   */
-  def country: String = locale.getCountry
-
-  /**
-   * @return The script tag for this Lang, or "" if none exists.
-   */
-  def script: String = locale.getScript
-
-  /**
-   * @return The variant tag for this Lang, or "" if none exists.
-   */
-  def variant: String = locale.getVariant
-
-  /**
-   * Whether this lang satisfies the given lang.
-   *
-   * If the other lang defines a country code, then this is equivalent to equals, if it doesn't, then the equals is
-   * only done on language and the country of this lang is ignored.
-   *
-   * This implements the language matching specified by RFC2616 Section 14.4.  Equality is case insensitive as per
-   * Section 3.10.
-   *
-   * @param accept The accepted language
-   */
-  def satisfies(accept: Lang): Boolean =
-    Locale.lookup(Seq(new Locale.LanguageRange(code)).asJava, Seq(accept.locale).asJava) != null
-
-  /**
-   * The language tag (such as fr or en-US).
-   */
-  lazy val code: String = locale.toLanguageTag
-}
-
-/**
- * Utilities related to Lang values.
- */
-object Lang {
-
-  /**
-   * The default Lang to use if nothing matches (platform default)
-   */
-  implicit lazy val defaultLang: Lang = Lang(java.util.Locale.getDefault)
-
-  /**
-   * Create a Lang value from a code (such as fr or en-US) and
-   *  throw exception if language is unrecognized
-   */
-  def apply(code: String): Lang = Lang(new Locale.Builder().setLanguageTag(code).build())
-
-  /**
-   * Create a Lang value from a code (such as fr or en-US) and
-   *  throw exception if language is unrecognized
-   */
-  def apply(language: String, country: String = "", script: String = "", variant: String = ""): Lang =
-    Lang(new Locale.Builder()
-      .setLanguage(language)
-      .setRegion(country)
-      .setScript(script)
-      .setVariant(variant)
-      .build())
-
-  /**
-   * Create a Lang value from a code (such as fr or en-US) or none
-   * if language is unrecognized.
-   */
-  def get(code: String): Option[Lang] = Try(apply(code)).toOption
-
-  private val langsCache = Application.instanceCache[Langs]
-
-  /**
-   * Retrieve Lang availables from the application configuration.
-   *
-   * {{{
-   * play.i18n.langs = ["fr", "en", "de"]
-   * }}}
-   */
-  @deprecated("Inject Langs into your component", "2.5.0")
-  def availables(implicit app: Application): Seq[Lang] = {
-    langsCache(app).availables
-  }
-
-  /**
-   * Guess the preferred lang in the langs set passed as argument.
-   * The first Lang that matches an available Lang wins, otherwise returns the first Lang available in this application.
-   */
-  @deprecated("Inject Langs into your component", "2.5.0")
-  def preferred(langs: Seq[Lang])(implicit app: Application): Lang = {
-    langsCache(app).preferred(langs)
-  }
-}
-
-/**
- * Manages languages in Play
- */
-trait Langs {
-
-  /**
-   * The available languages.
-   *
-   * These can be configured in `application.conf`, like so:
-   *
-   * {{{
-   * play.i18n.langs = ["fr", "en", "de"]
-   * }}}
-   */
-  def availables: Seq[Lang]
-
-  /**
-   * Select a preferred language, given the list of candidates.
-   *
-   * Will select the preferred language, based on what languages are available, or return the default language if
-   * none of the candidates are available.
-   */
-  def preferred(candidates: Seq[Lang]): Lang
-}
-
-@Singleton
-class DefaultLangs @Inject() (config: Configuration) extends Langs {
-
-  val availables: Seq[Lang] = {
-    val langs = config.getOptional[String]("application.langs") map { langsStr =>
-      Logger.warn("application.langs is deprecated, use play.i18n.langs instead")
-      langsStr.split(",").map(_.trim).toSeq
-    } getOrElse {
-      config.get[Seq[String]]("play.i18n.langs")
-    }
-
-    langs.map { lang =>
-      try { Lang(lang) } catch {
-        case NonFatal(e) => throw config.reportError(
-          "play.i18n.langs",
-          "Invalid language code [" + lang + "]", Some(e))
-      }
-    }
-  }
-
-  def preferred(candidates: Seq[Lang]): Lang = candidates.collectFirst(Function.unlift { lang =>
-    availables.find(_.satisfies(lang))
-  }).getOrElse(availables.headOption.getOrElse(Lang.defaultLang))
-}
 
 /**
  * Internationalisation API.
@@ -192,14 +29,27 @@ object Messages {
   private[play] val messagesApiCache = Application.instanceCache[MessagesApi]
 
   /**
-   * Implicit conversions providing [[Messages]] or [[MessagesApi]] using an implicit [[Application]], for a smooth upgrade to 2.4
+   * Implicit conversions providing [[Messages]] or [[MessagesApi]].
+   *
+   * The implicit [[Application]] is deprecated as Application should only be
+   * exposed to the underlying module system.
    */
   object Implicits {
     import scala.language.implicitConversions
+
+    /**
+     * @deprecated Since 2.6.0, please use an injected [[MessagesApi]].
+     */
+    @deprecated("See https://www.playframework.com/documentation/2.6.x/MessagesMigration26", "2.6.0")
     implicit def applicationMessagesApi(implicit application: Application): MessagesApi =
       messagesApiCache(application)
+
+    /**
+     * @deprecated Since 2.6.0, please use messagesApi.preferred(Seq(lang)).
+     */
+    @deprecated("See https://www.playframework.com/documentation/2.6.x/MessagesMigration26", "2.6.0")
     implicit def applicationMessages(implicit lang: Lang, application: Application): Messages =
-      new Messages(lang, messagesApiCache(application))
+      MessagesImpl(lang, messagesApiCache(application))
   }
 
   /**
@@ -211,8 +61,8 @@ object Messages {
    * @param args the message arguments
    * @return the formatted message or a default rendering if the key wasn’t defined
    */
-  def apply(key: String, args: Any*)(implicit messages: Messages): String = {
-    messages(key, args: _*)
+  def apply(key: String, args: Any*)(implicit provider: MessagesProvider): String = {
+    provider.messages(key, args: _*)
   }
 
   /**
@@ -224,8 +74,8 @@ object Messages {
    * @param args the message arguments
    * @return the formatted message or a default rendering if the key wasn’t defined
    */
-  def apply(keys: Seq[String], args: Any*)(implicit messages: Messages): String = {
-    messages(keys, args: _*)
+  def apply(keys: Seq[String], args: Any*)(implicit provider: MessagesProvider): String = {
+    provider.messages(keys, args: _*)
   }
 
   /**
@@ -233,8 +83,8 @@ object Messages {
    * @param key the message key
    * @return a boolean
    */
-  def isDefinedAt(key: String)(implicit messages: Messages): Boolean = {
-    messages.isDefinedAt(key)
+  def isDefinedAt(key: String)(implicit provider: MessagesProvider): Boolean = {
+    provider.messages.isDefinedAt(key)
   }
 
   /**
@@ -326,21 +176,20 @@ object Messages {
         )
       }
     }
-
   }
-
 }
 
 /**
  * Provides messages for a particular language.
  *
- * This intended for use to carry both the messages and the current language, particularly useful in templates so that
- * both can be captured by one parameter.
+ * This intended for use to carry both the messages and the current language,
+ * particularly useful in templates so that both can be captured by one
+ * parameter.
  *
  * @param lang The lang (context)
- * @param messages The messages
+ * @param messagesApi The messages API
  */
-case class Messages(lang: Lang, messages: MessagesApi) {
+case class MessagesImpl(lang: Lang, messagesApi: MessagesApi) extends Messages {
 
   /**
    * Translates a message.
@@ -351,7 +200,9 @@ case class Messages(lang: Lang, messages: MessagesApi) {
    * @param args the message arguments
    * @return the formatted message or a default rendering if the key wasn’t defined
    */
-  def apply(key: String, args: Any*): String = messages(key, args: _*)(lang)
+  override def apply(key: String, args: Any*): String = {
+    messagesApi(key, args: _*)(lang)
+  }
 
   /**
    * Translates the first defined message.
@@ -362,7 +213,9 @@ case class Messages(lang: Lang, messages: MessagesApi) {
    * @param args the message arguments
    * @return the formatted message or a default rendering if the key wasn’t defined
    */
-  def apply(keys: Seq[String], args: Any*): String = messages(keys, args: _*)(lang)
+  override def apply(keys: Seq[String], args: Any*): String = {
+    messagesApi(keys, args: _*)(lang)
+  }
 
   /**
    * Translates a message.
@@ -373,14 +226,87 @@ case class Messages(lang: Lang, messages: MessagesApi) {
    * @param args the message arguments
    * @return the formatted message, if this key was defined
    */
-  def translate(key: String, args: Seq[Any]): Option[String] = messages.translate(key, args)(lang)
+  override def translate(key: String, args: Seq[Any]): Option[String] = {
+    messagesApi.translate(key, args)(lang)
+  }
 
   /**
    * Check if a message key is defined.
    * @param key the message key
    * @return a boolean
    */
-  def isDefinedAt(key: String): Boolean = messages.isDefinedAt(key)(lang)
+  override def isDefinedAt(key: String): Boolean = {
+    messagesApi.isDefinedAt(key)(lang)
+  }
+}
+
+/**
+ * A messages returns string messages using a chosen language.
+ *
+ * This is commonly backed by a MessagesImpl case class, but does
+ * extend Product and does not expose MessagesApi as part of
+ * its interface.
+ */
+trait Messages extends MessagesProvider {
+
+  /**
+   * Every Messages is also a MessagesProvider.
+   * @return the messages itself.
+   */
+  def messages: Messages = this
+
+  /**
+   * Returns the language associated with the messages.
+   * @return the selected language.
+   */
+  def lang: Lang
+
+  /**
+   * Translates a message.
+   *
+   * Uses `java.text.MessageFormat` internally to format the message.
+   *
+   * @param key the message key
+   * @param args the message arguments
+   * @return the formatted message or a default rendering if the key wasn’t defined
+   */
+  def apply(key: String, args: Any*): String
+
+  /**
+   * Translates the first defined message.
+   *
+   * Uses `java.text.MessageFormat` internally to format the message.
+   *
+   * @param keys the message key
+   * @param args the message arguments
+   * @return the formatted message or a default rendering if the key wasn’t defined
+   */
+  def apply(keys: Seq[String], args: Any*): String
+
+  /**
+   * Translates a message.
+   *
+   * Uses `java.text.MessageFormat` internally to format the message.
+   *
+   * @param key the message key
+   * @param args the message arguments
+   * @return the formatted message, if this key was defined
+   */
+  def translate(key: String, args: Seq[Any]): Option[String]
+
+  /**
+   * Check if a message key is defined.
+   * @param key the message key
+   * @return a boolean
+   */
+  def isDefinedAt(key: String): Boolean
+}
+
+/**
+ * This trait is used to indicate when a Messages instance can be produced.
+ */
+trait MessagesProvider {
+  def messages: Messages
 }
 
 /**
@@ -410,13 +336,6 @@ trait MessagesApi {
    * Get the preferred messages for the given Java request
    */
   def preferred(request: play.mvc.Http.RequestHeader): Messages
-
-  /**
-   * Set the language on the result
-   */
-  def setLang(result: Result, lang: Lang): Result
-
-  def clearLang(result: Result): Result
 
   /**
    * Translates a message.
@@ -458,56 +377,62 @@ trait MessagesApi {
    */
   def isDefinedAt(key: String)(implicit lang: Lang): Boolean
 
+  /**
+   * Set the language on the result
+   */
+  def setLang(result: Result, lang: Lang): Result
+
+  def clearLang(result: Result): Result
+
   def langCookieName: String
 
   def langCookieSecure: Boolean
 
   def langCookieHttpOnly: Boolean
-
 }
 
 /**
- * The internationalisation API.
+ * The Messages API.
  */
 @Singleton
-class DefaultMessagesApi @Inject() (environment: Environment, config: Configuration, langs: Langs) extends MessagesApi {
+class DefaultMessagesApi @Inject() (environment: Environment, config: Configuration, langs: Langs)
+    extends MessagesApi {
 
   import java.text._
 
   protected val messagesPrefix =
     config.getDeprecated[Option[String]]("play.i18n.path", "messages.path")
+
   val messages: Map[String, Map[String, String]] = loadAllMessages
 
-  def preferred(candidates: Seq[Lang]) = Messages(langs.preferred(candidates), this)
-
-  def preferred(request: RequestHeader) = {
-    val maybeLangFromCookie = request.cookies.get(langCookieName).flatMap(c => Lang.get(c.value))
-    val lang = langs.preferred(maybeLangFromCookie.toSeq ++ request.acceptLanguages)
-    Messages(lang, this)
+  override def preferred(candidates: Seq[Lang]): Messages = {
+    MessagesImpl(langs.preferred(candidates), this)
   }
 
-  def preferred(request: Http.RequestHeader) = preferred(request._underlyingHeader())
+  override def preferred(request: RequestHeader): Messages = {
+    val maybeLangFromCookie = request.cookies.get(langCookieName).flatMap(c => Lang.get(c.value))
+    val lang = langs.preferred(maybeLangFromCookie.toSeq ++ request.acceptLanguages)
+    MessagesImpl(lang, this)
+  }
 
-  def setLang(result: Result, lang: Lang) = result.withCookies(Cookie(langCookieName, lang.code, path = Session.path, domain = Session.domain,
-    secure = langCookieSecure, httpOnly = langCookieHttpOnly))
+  override def preferred(request: Http.RequestHeader): Messages = {
+    preferred(request._underlyingHeader())
+  }
 
-  def clearLang(result: Result) = result.discardingCookies(DiscardingCookie(langCookieName, path = Session.path, domain = Session.domain,
-    secure = langCookieSecure))
-
-  def apply(key: String, args: Any*)(implicit lang: Lang): String = {
+  override def apply(key: String, args: Any*)(implicit lang: Lang): String = {
     translate(key, args).getOrElse(noMatch(key, args))
   }
 
-  def apply(keys: Seq[String], args: Any*)(implicit lang: Lang): String = {
+  override def apply(keys: Seq[String], args: Any*)(implicit lang: Lang): String = {
     keys.foldLeft[Option[String]](None) {
       case (None, key) => translate(key, args)
       case (acc, _) => acc
     }.getOrElse(noMatch(keys.last, args))
   }
 
-  protected def noMatch(key: String, args: Seq[Any])(implicit lang: Lang) = key
+  protected def noMatch(key: String, args: Seq[Any])(implicit lang: Lang): String = key
 
-  def translate(key: String, args: Seq[Any])(implicit lang: Lang): Option[String] = {
+  override def translate(key: String, args: Seq[Any])(implicit lang: Lang): Option[String] = {
     val codesToTry = Seq(lang.code, lang.language, "default", "default.play")
     val pattern: Option[String] =
       codesToTry.foldLeft[Option[String]](None)((res, lang) =>
@@ -516,7 +441,7 @@ class DefaultMessagesApi @Inject() (environment: Environment, config: Configurat
       new MessageFormat(pattern, lang.toLocale).format(args.map(_.asInstanceOf[java.lang.Object]).toArray))
   }
 
-  def isDefinedAt(key: String)(implicit lang: Lang): Boolean = {
+  override def isDefinedAt(key: String)(implicit lang: Lang): Boolean = {
     val codesToTry = Seq(lang.code, lang.language, "default", "default.play")
 
     codesToTry.foldLeft[Boolean](false)({ (acc, lang) =>
@@ -524,9 +449,11 @@ class DefaultMessagesApi @Inject() (environment: Environment, config: Configurat
     })
   }
 
-  private def joinPaths(first: Option[String], second: String) = first match {
-    case Some(parent) => new java.io.File(parent, second).getPath
-    case None => second
+  private def joinPaths(first: Option[String], second: String): String = {
+    first match {
+      case Some(parent) => new java.io.File(parent, second).getPath
+      case None => second
+    }
   }
 
   protected def loadMessages(file: String): Map[String, String] = {
@@ -547,31 +474,23 @@ class DefaultMessagesApi @Inject() (environment: Environment, config: Configurat
       .+("default.play" -> loadMessages("messages.default"))
   }
 
-  lazy val langCookieName =
+  override def setLang(result: Result, lang: Lang): Result = {
+    result.withCookies(Cookie(langCookieName, lang.code, path = Session.path, domain = Session.domain,
+      secure = langCookieSecure, httpOnly = langCookieHttpOnly))
+  }
+
+  override def clearLang(result: Result): Result = {
+    result.discardingCookies(DiscardingCookie(langCookieName, path = Session.path, domain = Session.domain,
+      secure = langCookieSecure))
+  }
+
+  lazy val langCookieName: String =
     config.getDeprecated[String]("play.i18n.langCookieName", "application.lang.cookie")
 
-  lazy val langCookieSecure =
+  lazy val langCookieSecure: Boolean =
     config.get[Boolean]("play.i18n.langCookieSecure")
 
-  lazy val langCookieHttpOnly =
+  lazy val langCookieHttpOnly: Boolean =
     config.get[Boolean]("play.i18n.langCookieHttpOnly")
-
-}
-
-class I18nModule extends SimpleModule(
-  bind[Langs].to[DefaultLangs],
-  bind[MessagesApi].to[DefaultMessagesApi]
-)
-
-/**
- * Injection helper for i18n components
- */
-trait I18nComponents {
-
-  def environment: Environment
-  def configuration: Configuration
-
-  lazy val messagesApi: MessagesApi = new DefaultMessagesApi(environment, configuration, langs)
-  lazy val langs: Langs = new DefaultLangs(configuration)
 
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
@@ -104,7 +104,7 @@ trait Controller extends BodyParsers with BaseController {
 abstract class AbstractController(components: ControllerComponents) extends BaseController {
   def Action = components.actionBuilder
   def parse = components.parsers
-  implicit val messagesApi = components.messagesApi
+  implicit def messagesApi: MessagesApi = components.messagesApi
   lazy val TODO: Action[AnyContent] = Action {
     NotImplemented[Html](views.html.defaultpages.todo())
   }

--- a/framework/src/play/src/main/scala/views/helper/Helpers.scala
+++ b/framework/src/play/src/main/scala/views/helper/Helpers.scala
@@ -9,7 +9,7 @@ import scala.collection.JavaConverters._
  */
 package views.html.helper {
 
-  case class FieldElements(id: String, field: play.api.data.Field, input: Html, args: Map[Symbol, Any], messages: play.api.i18n.Messages) {
+  case class FieldElements(id: String, field: play.api.data.Field, input: Html, args: Map[Symbol, Any], p: play.api.i18n.MessagesProvider) {
 
     def infos: Seq[String] = {
       args.get('_help).map(m => Seq(m.toString)).getOrElse {
@@ -17,22 +17,22 @@ package views.html.helper {
           case Some(false) => false
           case _ => true
         }) {
-          field.constraints.map(c => messages(c._1, c._2.map(a => translateMsgArg(a)): _*)) ++
-            field.format.map(f => messages(f._1, f._2.map(a => translateMsgArg(a)): _*))
+          field.constraints.map(c => p.messages(c._1, c._2.map(a => translateMsgArg(a)): _*)) ++
+            field.format.map(f => p.messages(f._1, f._2.map(a => translateMsgArg(a)): _*))
         } else Nil)
       }
     }
 
     def errors: Seq[String] = {
       (args.get('_error) match {
-        case Some(Some(play.api.data.FormError(_, message, args))) => Some(Seq(messages(message, args.map(a => translateMsgArg(a)): _*)))
+        case Some(Some(play.api.data.FormError(_, message, args))) => Some(Seq(p.messages(message, args.map(a => translateMsgArg(a)): _*)))
         case _ => None
       }).getOrElse {
         (if (args.get('_showErrors) match {
           case Some(false) => false
           case _ => true
         }) {
-          field.errors.map(e => messages(e.message, e.args.map(a => translateMsgArg(a)): _*))
+          field.errors.map(e => p.messages(e.message, e.args.map(a => translateMsgArg(a)): _*))
         } else Nil)
       }
     }
@@ -42,18 +42,19 @@ package views.html.helper {
     }
 
     def label: Any = {
-      args.get('_label).getOrElse(messages(field.label))
+      args.get('_label).getOrElse(p.messages(field.label))
     }
 
     def hasName: Boolean = args.get('_name).isDefined
 
     def name: Any = {
-      args.get('_name).getOrElse(messages(field.label))
+      args.get('_name).getOrElse(p.messages(field.label))
     }
 
     private def translateMsgArg(msgArg: Any) = msgArg match {
-      case key: String => messages(key)
-      case keys: Seq[_] => keys.asInstanceOf[Seq[String]].map(key => messages(key))
+      case key: String => p.messages(key)
+      case keys: Seq[_] =>
+        keys.asInstanceOf[Seq[String]].map(key => p.messages(key))
       case _ => msgArg
     }
 

--- a/framework/src/play/src/main/scala/views/helper/checkbox.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/checkbox.scala.html
@@ -9,8 +9,9 @@
  * @param field The form field.
  * @param args Set of extra HTML attributes ('''id''' and '''label''' are 2 special arguments).
  * @param handler The field constructor.
+ * @param messages the provider of messages
  *@
-@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
 
 @boxValue = @{ args.toMap.get('value).getOrElse("true") }
 

--- a/framework/src/play/src/main/scala/views/helper/input.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/input.scala.html
@@ -1,7 +1,7 @@
 @**
  * Prepare a generic HTML input.
  *@
-@(field: play.api.data.Field, args: (Symbol, Any)* )(inputDef: (String, String, Option[String], Map[Symbol,Any]) => Html)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
+@(field: play.api.data.Field, args: (Symbol, Any)* )(inputDef: (String, String, Option[String], Map[Symbol,Any]) => Html)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
 
 @id = @{ args.toMap.get('id).map(_.toString).getOrElse(field.id) }
 

--- a/framework/src/play/src/main/scala/views/helper/inputCheckboxGroup.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputCheckboxGroup.scala.html
@@ -16,7 +16,7 @@
 * @param args Set of extra HTML attributes.
 * @param handler The field constructor.
 *@
-@(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
+@(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
 
 @input(field, args.map{ x => if(x._1 == '_label) '_name -> x._2 else x }:_*) { (id, name, value, htmlArgs) =>
   <span class="buttonset" id="@id">

--- a/framework/src/play/src/main/scala/views/helper/inputDate.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputDate.scala.html
@@ -10,7 +10,7 @@
  * @param args Set of extra attributes.
  * @param handler The field constructor.
  *@
-@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
 
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     <input type="date" id="@id" name="@name" value="@value" @toHtmlArgs(htmlArgs)/>

--- a/framework/src/play/src/main/scala/views/helper/inputFile.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputFile.scala.html
@@ -10,7 +10,7 @@
  * @param args Set of extra attributes.
  * @param handler The field constructor.
  *@
-@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
 
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     <input type="file" id="@id" name="@name" @toHtmlArgs(htmlArgs)/>

--- a/framework/src/play/src/main/scala/views/helper/inputPassword.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputPassword.scala.html
@@ -10,7 +10,7 @@
  * @param args Set of extra attributes.
  * @param handler The field constructor.
  *@
-@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
 
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     <input type="password" id="@id" name="@name" @toHtmlArgs(htmlArgs)/>

--- a/framework/src/play/src/main/scala/views/helper/inputRadioGroup.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputRadioGroup.scala.html
@@ -15,7 +15,7 @@
  * @param args Set of extra HTML attributes.
  * @param handler The field constructor.
  *@
-@(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
+@(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
 
 @input(field, args.map{ x => if(x._1 == '_label) '_name -> x._2 else x }:_*) { (id, name, value, htmlArgs) =>
   <span class="buttonset" id="@id">

--- a/framework/src/play/src/main/scala/views/helper/inputText.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/inputText.scala.html
@@ -10,7 +10,7 @@
  * @param args Set of extra attributes.
  * @param handler The field constructor.
  *@
-@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
 
 @inputType = @{ args.toMap.get('type).map(_.toString).getOrElse("text") }
 

--- a/framework/src/play/src/main/scala/views/helper/select.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/select.scala.html
@@ -21,7 +21,7 @@
  * @param args Set of extra attributes.
  * @param handler The field constructor.
  *@
-@(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
+@(field: play.api.data.Field, options: Seq[(String,String)], args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
 
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     @defining( if( htmlArgs.contains('multiple) ) "%s[]".format(name) else name ) { selectName =>

--- a/framework/src/play/src/main/scala/views/helper/textarea.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/textarea.scala.html
@@ -10,7 +10,7 @@
  * @param args Set of extra attributes.
  * @param handler The field constructor.
  *@
-@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.MessagesProvider)
 
 @input(field, args:_*) { (id, name, value, htmlArgs) =>
     <textarea id="@id" name="@name" @toHtmlArgs(htmlArgs)>@value</textarea>

--- a/framework/src/play/src/test/java/play/i18n/MessagesTest.java
+++ b/framework/src/play/src/test/java/play/i18n/MessagesTest.java
@@ -5,55 +5,23 @@ package play.i18n;
 
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.List;
+import static org.mockito.Mockito.*;
 
 import static org.fest.assertions.Assertions.assertThat;
 
 public class MessagesTest {
-    
+
     @Test
-    public void wrapNoVarArgsToEmptyList(){
-        final List<Object> resultList = Messages.wrapArgsToListIfNeeded();
-        assertThat(resultList).isNotNull();
-        assertThat(resultList.size()).isEqualTo(0);
-    }
-    
-    @Test
-    public void wrapOneStringElementToList(){
-        final List<String> resultList = Messages.wrapArgsToListIfNeeded("Croissant");
-        assertThat(resultList).isNotNull();
-        assertThat(resultList.size()).isEqualTo(1);
-        assertThat(resultList.get(0)).isEqualTo("Croissant");
-    }
-    
-    @Test
-    public void wrapTwoStringElementsToList(){
-        final List<String> resultList = Messages.wrapArgsToListIfNeeded("Croissant", "Baguette");
-        assertThat(resultList).isNotNull();
-        assertThat(resultList.size()).isEqualTo(2);
-        assertThat(resultList.contains("Croissant")).isTrue();
-        assertThat(resultList.contains("Baguette")).isTrue();
-    }
-    
-    @Test
-    public void wrapOneListElementReturnsIt(){
-        final List<String> stringList = Arrays.asList("Croissant", "Baguette");
-        final List<List<String>> resultList = Messages.wrapArgsToListIfNeeded(stringList);
-        assertThat(resultList).isNotNull();
-        assertThat(resultList.size()).isEqualTo(2);
-        assertThat(resultList.contains("Croissant")).isTrue();
-        assertThat(resultList.contains("Baguette")).isTrue();
-    }
-    
-    @Test
-    public void wrapOneListAndOneStringShouldNotFlattenTheList(){
-        final List<String> stringList = Arrays.asList("Croissant", "Baguette");
-        final List<Object> resultList = Messages.wrapArgsToListIfNeeded(stringList, "Pain");
-        assertThat(resultList).isNotNull();
-        assertThat(resultList.size()).isEqualTo(2);
-        assertThat(resultList.contains(stringList)).isTrue();
-        assertThat(resultList.contains("Pain")).isTrue();
-        
+    public void testMessageCall() {
+        MessagesApi messagesApi = mock(MessagesApi.class);
+        Lang lang = Lang.forCode("en-US");
+        MessagesImpl messages = new MessagesImpl(lang, messagesApi);
+
+        when(messagesApi.get(lang, "hello.world")).thenReturn("hello world!");
+
+        String actual = messages.at("hello.world");
+        String expected = "hello world!";
+        assertThat(actual).isEqualTo(expected);
+        verify(messagesApi);
     }
 }

--- a/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -7,8 +7,9 @@ import org.specs2.mutable.Specification
 import play.api.{ Configuration, Environment }
 import play.api.data.Forms._
 import play.api.data._
-import play.api.i18n.{ DefaultLangs, DefaultMessagesApi, Lang }
+import play.api.i18n._
 import play.twirl.api.Html
+
 import scala.beans.BeanProperty
 
 class HelpersSpec extends Specification {


### PR DESCRIPTION
Fixes: https://github.com/playframework/playframework/issues/5966


So, this is going to be fairly long, and is partly inspired by @cb372's post on Twitter:

> Trying to guide a Play beginner through all the steps needed to add a simple form to a Play 2.4.x app is just embarrassing -- https://twitter.com/cbirchall/status/679359109234339840

and expanded on at https://www.theguardian.com/info/developer-blog/2015/dec/30/how-to-add-a-form-to-a-play-application and https://github.com/cb372/play-forms-tutorial

To get a message out of Play you need:

1. A `MessagesApi` reference
2. A `Lang` reference
3. The key / value to actually call the message.

```
val message = messagesApi.apply(key)(implicit lang)
```

There is a case class `Messages`, which locks down the `Lang` reference, and lets you call just one thing:

```
val message = messages.apply(key)
```

But there's a problem in that `Messages` is a concrete case class, which doesn't just expose `apply` like it should.  It also exposes messagesApi (not great) and extends Product (which means `copy` et al) and it means that delegating / mocking out those methods is basically impossible.  

This gets even worse when you look at the form helpers signature:

```
@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit handler: FieldConstructor, messages: play.api.i18n.Messages)
```

Because all the form helpers require the `Messages` case class to be passed in to the template, that means that for any template with a form helper, there must be an implicit Messages in scope.  This means we have to specify an implicit messages in template:

```
@(form: Form[UserData])(implicit m: Messages)

@main("Welcome to Play") {
  @helper.inputText(form("name"))
  @helper.inputText(form("age"))
}
```

So if you declare a form:


```
class HomeController @Inject() extends Controller {
  import play.api.data.Forms._
  import play.api.data._

  val form = Form(
    mapping = mapping(
      "name" -> text,
      "age" -> number
    )(UserData.apply)(UserData.unapply)
  )

  def index = Action {
    Ok(views.html.index(form))
  }
}
```

Nope: "could not find implicit value for parameter m: play.api.i18n.Messages".  Using `(implicit r: Request[_])` doesn't work either, because you don't have a reference to `MessagesApi` from the request.  (Ironically, you can get one from a Java template, because Http.Context will provide one implicitly, but we're talking about Scala.)

The canonical way to do it is to use I18NSupport:

```
class HomeController @Inject()
  (val messagesApi: play.api.i18n.MessagesApi) 
  extends Controller with play.api.i18n.I18nSupport {

}
```

At which point the implicit conversion of request2Messages will kick in, and `@(form: Form[UserData])(implicit m: Messages)` will work.  

But we're not done yet.  We want to use CSRF in the form,  

```
@helper.CSRF.formField
```

But when we try this, we get `Cannot find any HTTP Request Header here`.

 which means we have to include the request implicitly as well:

```
@(form: Form[UserData])(implicit request: Request[_], m: Messages)
```

Which means for a basic "hello world" type form, we have to implement and / or inject `MessagesApi`, `I18nSupport`, `Request[_]` and `Messages` into the controller and template.  

What this PR does instead is:

* Provide Messages functionality through a `Messager` interface ("Messenger" was considered too confusing)
* Create a `MessagerProvider` interface with a single `messager: Messager` interface.
* Make `Messages` extends `Messager` and `MessageProvider` so existing code will continue to work
* Make the form helpers take `MessagerProvider` instead of `Messages`.

Using a MessagerProvider means that we can break out the messagesApi from the controller, and move it into the request or the action:

```
abstract class MessagesRequest[A](request: Request[A])
  extends WrappedRequest(request) with MessagerProvider

class MessagesAction @Inject()(messagesApi: MessagesApi) extends ActionBuilder[MessagesRequest] {
  override def invokeBlock[A](request: Request[A], block: (MessagesRequest[A]) => Future[Result]) = {
    block(new MessagesRequest[A](request) {
      lazy val messager: Messager = messagesApi.preferred(request)
    })
  }
}
``` 

which means the following is all that's required in the controller:

```
class HomeController @Inject() (action: MessagesAction) extends Controller {
  def index = action { implicit request =>
    Ok(views.html.index(form))
  }
}
```

And this is all that's needed in the template:

```
@()(implicit mr: MessagesRequest[_])
```

Technically this could be `MessagesProvider`, but it's not great that something that is essentially a partially applied function on `messages.get(lang)(key)` is being exposed as a case class.  Everything still returns `Messages`, so it's only classes that take `Messages` as input that should switch to `Messager`.
