### PR TITLE
Add note about HTTP execution context

### DIFF
--- a/documentation/manual/releases/release25/migration25/JavaMigration25.md
+++ b/documentation/manual/releases/release25/migration25/JavaMigration25.md
@@ -17,6 +17,24 @@ The [`HttpRequestHandler`](api/java/play/http/HttpRequestHandler.html) actually 
 
 In 2.5, `HttpRequestHandler`'s main purpose is to provide a handler for the request right after it comes in. This is now consistent with what the Scala implementation does, and provides a way for Java users to intercept the handling of all HTTP requests. Normally, the `HttpRequestHandler` will call the router to find an action for the request, so the new API allows you to intercept that request in Java before it goes to the router.
 
+## Using CompletionStage inside an Action
+
+You must supply the HTTP execution context explicitly as an executor when using a Java `CompletionStage` inside an [[Action|JavaActions]], to ensure that the HTTP.Context remains in scope.  If you don't supply the HTTP execution context, you'll get "There is no HTTP Context available from here" errors when you call `request()` or other methods that depend on `Http.Context`.
+
+You can supply the [`play.libs.concurrent.HttpExecutionContext`](api/java/play/libs/concurrent/HttpExecutionContext.html) instance through dependency injection:
+
+``` java
+public class Application extends Controller {
+    @Inject HttpExecutionContext ec;
+
+    public CompletionStage<Result> index() {
+        someCompletableFuture.supplyAsync(() -> { 
+          // do something with request()
+        }, ec.current());
+    }
+}
+```
+
 ## Replaced functional types with Java 8 functional types
 
 A big change in Play 2.5 is the change to use standard Java 8 classes where possible. All functional types have been replaced with their Java 8 counterparts, for example `F.Function1<A,R>` has been replaced with `java.util.function.Function<A,R>`.

--- a/documentation/manual/working/javaGuide/main/async/JavaAsync.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaAsync.md
@@ -35,6 +35,24 @@ A simple way to execute a block of code asynchronously and to get a `CompletionS
 >
 > It can also be helpful to use Actors for blocking operations. Actors provide a clean model for handling timeouts and failures, setting up blocking execution contexts, and managing any state that may be associated with the service. Also Actors provide patterns like `ScatterGatherFirstCompletedRouter` to address simultaneous cache and database requests and allow remote execution on a cluster of backend servers. But an Actor may be overkill depending on what you need.
 
+## Using CompletionStage inside an Action
+
+You must supply the HTTP execution context explicitly as an executor when using a Java `CompletionStage` inside an [[Action|JavaActions]], to ensure that the HTTP.Context remains in scope.  If you don't supply the HTTP execution context, you'll get "There is no HTTP Context available from here" errors when you call `request()` or other methods that depend on `Http.Context`.
+
+You can supply the [`play.libs.concurrent.HttpExecutionContext`](api/java/play/libs/concurrent/HttpExecutionContext.html) instance through dependency injection:
+
+``` java
+public class Application extends Controller {
+    @Inject HttpExecutionContext ec;
+
+    public CompletionStage<Result> index() {
+        someCompletableFuture.supplyAsync(() -> { 
+          // do something with request()
+        }, ec.current());
+    }
+}
+```
+
 ## Async results
 
 We have been returning `Result` up until now. To send an asynchronous result our action needs to return a `CompletionStage<Result>`:


### PR DESCRIPTION
Fixes https://github.com/playframework/playframework/issues/6451.

There is actually a note about `HttpExecutionContext`, but it's under ThreadPools(!):

https://www.playframework.com/documentation/2.5.x/ThreadPools#Java-thread-locals

So added it to the migration notes and JavaAsync.md.