### PR TITLE
Minor: Add missing return type and uniformize the naming of generic type

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsResult.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsResult.scala
@@ -63,12 +63,12 @@ sealed trait JsResult[+A] { self =>
   def isSuccess: Boolean = this.isInstanceOf[JsSuccess[_]]
   def isError: Boolean = this.isInstanceOf[JsError]
 
-  def fold[X](invalid: Seq[(JsPath, Seq[ValidationError])] => X, valid: A => X): X = this match {
+  def fold[B](invalid: Seq[(JsPath, Seq[ValidationError])] => B, valid: A => B): B = this match {
     case JsSuccess(v, _) => valid(v)
     case JsError(e) => invalid(e)
   }
 
-  def map[X](f: A => X): JsResult[X] = this match {
+  def map[B](f: A => B): JsResult[B] = this match {
     case JsSuccess(v, path) => JsSuccess(f(v), path)
     case e: JsError => e
   }
@@ -90,7 +90,7 @@ sealed trait JsResult[+A] { self =>
     case _ => JsError(otherwise)
   }
 
-  def flatMap[X](f: A => JsResult[X]): JsResult[X] = this match {
+  def flatMap[B](f: A => JsResult[B]): JsResult[B] = this match {
     case JsSuccess(v, path) => f(v).repath(path)
     case e: JsError => e
   }

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala
@@ -65,7 +65,7 @@ trait Reads[A] { self =>
   def filterNot(error: ValidationError)(f: A => Boolean): Reads[A] =
     Reads[A] { json => self.reads(json).filterNot(JsError(error))(f) }
 
-  def collect[B](error: ValidationError)(f: PartialFunction[A, B]) =
+  def collect[B](error: ValidationError)(f: PartialFunction[A, B]): Reads[B] =
     Reads[B] { json => self.reads(json).collect(error)(f) }
 
   def orElse(v: Reads[A]): Reads[A] =


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [ ] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

This is only about code style:
* in `Reads.scala`, all methods have a return type but one
* in `JsResults.scala`, instead of using `[A, B]` and `[A, X]` as generic names, only use `[A, B]`
