### PR TITLE
Ensure that custom signature calculator works in Java

### DIFF
--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ahc/AhcWSRequest.java
@@ -555,7 +555,10 @@ public class AhcWSRequest implements WSRequest {
 
         if (this.calculator != null) {
             if (this.calculator instanceof OAuth.OAuthCalculator) {
-                OAuthSignatureCalculator calc = ((OAuth.OAuthCalculator) this.calculator).getCalculator();
+                SignatureCalculator calc = ((OAuth.OAuthCalculator) this.calculator).getCalculator();
+                builder.setSignatureCalculator(calc);
+            } else if (this.calculator instanceof SignatureCalculator) {
+                SignatureCalculator calc = ((SignatureCalculator) this.calculator);
                 builder.setSignatureCalculator(calc);
             } else {
                 throw new IllegalStateException("Use OAuth.OAuthCalculator");


### PR DESCRIPTION
## Fixes

Fixes the hardcoding of OAuth SignatureCalculator reported in https://groups.google.com/d/topic/play-framework/onkvUUMrg8w/discussion

## Purpose

Leverages the AHC 2.0 API so an AHC SignatureCalculator is passed through if the type matches.  This is only applicable in Java -- the Scala API works fine.

Added tests for both Java and Scala just to double check.