### PR TITLE
Add Timeout trait to play.api.libs.concurrent

### DIFF
--- a/documentation/manual/working/javaGuide/main/async/JavaAsync.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaAsync.md
@@ -70,3 +70,13 @@ Play [[actions|JavaActions]] are asynchronous by default. For instance, in the c
 @[simple-action](../http/code/javaguide/http/JavaActions.java)
 
 > **Note:** Whether the action code returns a `Result` or a `CompletionStage<Result>`, both kinds of returned object are handled internally in the same way. There is a single kind of `Action`, which is asynchronous, and not two kinds (a synchronous one and an asynchronous one). Returning a `CompletionStage` is a technique for writing non-blocking code.
+
+
+## Handling time-outs
+
+It is often useful to handle time-outs properly, to avoid having the web browser block and wait if something goes wrong. You can use [`play.libs.concurrent.Timeout.timeout`](api/java/play/libs/concurrent/Timeout.html) method to wrap a CompletionStage in a non-blocking timeout.
+
+@[timeout](code/javaguide/async/JavaAsync.java)
+
+> **Note:** Timeout is not the same as cancellation -- even in case of timeout, the given future will still complete, even though that completed value is not returned.
+

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaAsync.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaAsync.java
@@ -6,16 +6,30 @@ package javaguide.async;
 import org.junit.Test;
 import play.mvc.Result;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
+import java.util.concurrent.*;
 
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static play.mvc.Results.ok;
 
 public class JavaAsync {
+
+    @Test
+    public void promiseWithTimeout() throws Exception {
+        //#timeout
+        class MyClass implements play.libs.concurrent.Timeout {
+            CompletionStage<Double> callWithOneSecondTimeout() {
+                return timeout(computePIAsynchronously(), Duration.ofSeconds(1));
+            }
+        }
+        //#timeout
+        final Double actual = new MyClass().callWithOneSecondTimeout().toCompletableFuture().get(1, TimeUnit.SECONDS);
+        final Double expected = Math.PI;
+        assertThat(actual, equalTo(expected));
+    }
 
     @Test
     public void promisePi() throws Exception {

--- a/documentation/manual/working/scalaGuide/main/async/ScalaAsync.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaAsync.md
@@ -57,6 +57,8 @@ Play [[actions|ScalaActions]] are asynchronous by default. For instance, in the 
 
 ## Handling time-outs
 
-It is often useful to handle time-outs properly, to avoid having the web browser block and wait if something goes wrong. You can easily compose a future with a timeout to handle these cases. This can be done using `akka.pattern.after`, which uses your actor system's scheduler to complete the future after a certain amount of time. (Note that we assume you've injected the `actorSystem: ActorSystem` into your controller here to access its scheduler.)
+It is often useful to handle time-outs properly, to avoid having the web browser block and wait if something goes wrong. You can use [`play.api.libs.concurrent.Timeout`](api/scala/play/api/libs/concurrent/Timeout.html) to wrap a Future in a non-blocking timeout.
 
 @[timeout](code/ScalaAsync.scala)
+
+> **Note:** Timeout is not the same as cancellation -- even in case of timeout, the given future will still complete, even though that completed value is not returned.

--- a/framework/src/play/src/main/java/play/libs/concurrent/Futures.java
+++ b/framework/src/play/src/main/java/play/libs/concurrent/Futures.java
@@ -12,6 +12,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Utilities for creating {@link java.util.concurrent.CompletionStage}.
  */
@@ -92,12 +94,14 @@ public class Futures {
      * @param unit The time Unit.
      * @return a CompletionStage that failed exceptionally
      */
-    public static <A> CompletionStage<A> timeout(long delay, TimeUnit unit) {
+    public static <A> CompletionStage<A> timeout(final long delay, final TimeUnit unit) {
+        requireNonNull(unit, "Null unit");
         final CompletableFuture<A> future = new CompletableFuture<>();
         timer.schedule(new TimerTask() {
             @Override
             public void run() {
-                final F.PromiseTimeoutException ex = new F.PromiseTimeoutException("Timeout in promise");
+                String msg = "Timeout in promise after " + delay + " " + unit.toString();
+                final F.PromiseTimeoutException ex = new F.PromiseTimeoutException(msg);
                 future.completeExceptionally(ex);
             }
         }, unit.toMillis(delay));

--- a/framework/src/play/src/main/java/play/libs/concurrent/Timeout.java
+++ b/framework/src/play/src/main/java/play/libs/concurrent/Timeout.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.libs.concurrent;
+
+import java.time.Duration;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+/**
+ * This interface is used to provide a non-blocking timeout on an operation
+ * that returns a CompletionStage.
+ */
+public interface Timeout {
+
+    /**
+     * Creates a CompletionStage that returns either the input stage, or a timeout.
+     *
+     * Note that timeout is not the same as cancellation.  Even in case of timeout,
+     * the given completion stage will still complete, even though that completed value
+     * is not returned.
+     *
+     * @param <A> the completion stage that should be wrapped with a timeout.
+     * @param delay The delay (expressed with the corresponding unit).
+     * @param unit The time Unit.
+     * @return either the completed future, or a completion stage that failed with timeout.
+     */
+    default <A> CompletionStage<A> timeout(CompletionStage<A> stage, long delay, TimeUnit unit) {
+        final CompletionStage<A> timeoutFuture = Futures.timeout(delay, unit);
+        // use this stage's default asynchronous execution facility for non-blocking.
+        return stage.applyToEitherAsync(timeoutFuture, Function.identity());
+    }
+
+    /**
+     * An alias for timeout(stage, delay, unit) that uses a java.time.Duration.
+     *
+     * @param <A> the completion stage that should be wrapped with a future.
+     * @param delay The delay (expressed with the corresponding unit).
+     * @return the completion stage, or a completion stage that failed with timeout.
+     */
+    default <A> CompletionStage<A> timeout(CompletionStage<A> stage, Duration delay) {
+        return timeout(stage, delay.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+}

--- a/framework/src/play/src/main/java/play/libs/concurrent/Timeout.java
+++ b/framework/src/play/src/main/java/play/libs/concurrent/Timeout.java
@@ -8,6 +8,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * This interface is used to provide a non-blocking timeout on an operation
  * that returns a CompletionStage.
@@ -26,7 +28,9 @@ public interface Timeout {
      * @param unit The time Unit.
      * @return either the completed future, or a completion stage that failed with timeout.
      */
-    default <A> CompletionStage<A> timeout(CompletionStage<A> stage, long delay, TimeUnit unit) {
+    default <A> CompletionStage<A> timeout(final CompletionStage<A> stage, final long delay, final TimeUnit unit) {
+        requireNonNull(stage, "Null stage");
+        requireNonNull(unit, "Null unit");
         final CompletionStage<A> timeoutFuture = Futures.timeout(delay, unit);
         // use this stage's default asynchronous execution facility for non-blocking.
         return stage.applyToEitherAsync(timeoutFuture, Function.identity());
@@ -39,7 +43,9 @@ public interface Timeout {
      * @param delay The delay (expressed with the corresponding unit).
      * @return the completion stage, or a completion stage that failed with timeout.
      */
-    default <A> CompletionStage<A> timeout(CompletionStage<A> stage, Duration delay) {
+    default <A> CompletionStage<A> timeout(final CompletionStage<A> stage, final Duration delay) {
+        requireNonNull(stage, "Null stage");
+        requireNonNull(delay, "Null delay");
         return timeout(stage, delay.toMillis(), TimeUnit.MILLISECONDS);
     }
 

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Timeout.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Timeout.scala
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.libs.concurrent
+
+import akka.actor.ActorSystem
+
+import scala.concurrent.{ Future, TimeoutException }
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * This trait is used to provide a non-blocking timeout on an operation that returns a Future.
+ *
+ * Please note that the [[play.api.Application]] default [[ActorSystem]] should
+ * be used as input here, as the actorSystem.scheduler is responsible for scheduling
+ * the timeout, using <a href="http://doc.akka.io/docs/akka/current/scala/futures.html#After">akka.pattern.actor</a> under the hood.
+ *
+ * You can dependency inject the ActorSystem as follows to create a Future that will
+ * timeout after a certain period of time:
+ *
+ * {{{
+ * class MyService(val actorSystem: ActorSystem) extends Timeout {
+ *
+ *   def calculateWithTimeout(timeoutDuration: FiniteDuration): Future[Int] = {
+ *     timeout(actorSystem, timeoutDuration)(rawCalculation())
+ *   }
+ *
+ *   def rawCalculation(): Future[Int] = {
+ *     import akka.pattern.after
+ *     implicit val ec = actorSystem.dispatcher
+ *     akka.pattern.after(300 millis, actorSystem.scheduler)(Future(42))(actorSystem.dispatcher)
+ *   }
+ * }
+ * }}}
+ *
+ * You should check for timeout by using [[Future.recover()]] or [[Future.recoverWith()]]
+ * and checking for [[TimeoutException]]:
+ *
+ * {{{
+ * val future = myService.calculateWithTimeout(100 millis).recover {
+ *   case _: TimeoutException =>
+ *     -1
+ * }
+ * }}}
+ *
+ * @see [[http://docs.scala-lang.org/overviews/core/futures.html Futures and Promises]]
+ *
+ */
+trait Timeout {
+
+  /**
+   * Creates a future which will resolve to a timeout exception if the
+   * given [[Future]] has not successfully completed within timeoutDuration.
+   *
+   * Note that timeout is not the same as cancellation.  Even in case of timeout,
+   * the given future will still complete, even though that completed value
+   * is not returned.
+   *
+   * @tparam A the result type used in the Future.
+   * @param actorSystem the application's actor system.
+   * @param timeoutDuration the duration after which a Future.failed(TimeoutException) should be thrown.
+   * @param f a call by value Future[A]
+   * @return the future that completes first, either the failed future, or the operation.
+   */
+  def timeout[A](actorSystem: ActorSystem, timeoutDuration: FiniteDuration)(f: Future[A]): Future[A] = {
+    implicit val ec = actorSystem.dispatchers.defaultGlobalDispatcher
+    val timeoutFuture = akka.pattern.after(timeoutDuration, actorSystem.scheduler) {
+      val msg = s"Timeout after $timeoutDuration"
+      Future.failed(new TimeoutException(msg))
+    }
+    Future.firstCompletedOf(Seq(f, timeoutFuture))
+  }
+
+}
+
+/**
+ * This is a static object that can be used to import timeout implicits, as a convenience.
+ *
+ * {{{
+ * import play.api.libs.concurrent.Timeout._
+ * }}}
+ */
+object Timeout extends Timeout with LowPriorityTimeoutImplicits
+
+/**
+ * Low priority timeouts to add `withTimeout` methods to [[scala.concurrent.Future]].
+ */
+trait LowPriorityTimeoutImplicits {
+
+  implicit class FutureTimeout[T](future: Future[T]) extends Timeout {
+
+    /**
+     * Creates a future which will resolve to a timeout exception if the
+     * given [[Future]] has not successfully completed within timeoutDuration.
+     *
+     * Note that timeout is not the same as cancellation.  Even in case of timeout,
+     * the given future will still complete, even though that completed value
+     * is not returned.
+     *
+     * @param timeoutDuration the duration after which a Future.failed(TimeoutException) should be thrown.
+     * @param actorSystem the application's actor system.
+     * @return the future that completes first, either the failed future, or the operation.
+     */
+    def withTimeout(timeoutDuration: FiniteDuration)(implicit actorSystem: ActorSystem): Future[T] = {
+      timeout(actorSystem, timeoutDuration)(future)
+    }
+
+    /**
+     * Creates a future which will resolve to a timeout exception if the
+     * given [[Future]] has not successfully completed within timeoutDuration.
+     *
+     * This version uses an implicit [[akka.util.Timeout]] rather than a [[FiniteDuration]].
+     *
+     * Note that timeout is not the same as cancellation.  Even in case of timeout,
+     * the given future will still complete, even though that completed value
+     * is not returned.
+     *
+     * @param timeoutDuration the duration after which a Future.failed(TimeoutException) should be thrown.
+     * @param actorSystem the application's actor system.
+     * @return the future that completes first, either the failed future, or the operation.
+     */
+    def withTimeout(implicit timeoutDuration: akka.util.Timeout, actorSystem: ActorSystem): Future[T] = {
+      timeout(actorSystem, timeoutDuration.duration)(future)
+    }
+  }
+}

--- a/framework/src/play/src/test/java/play/libs/concurrent/TimeoutTest.java
+++ b/framework/src/play/src/test/java/play/libs/concurrent/TimeoutTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.libs.concurrent;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class TimeoutTest {
+
+    @Test
+    public void successfulTimeout() throws Exception {
+        class MyClass implements play.libs.concurrent.Timeout {
+            CompletionStage<Double> callWithTimeout() {
+                return timeout(computePIAsynchronously(), Duration.ofSeconds(1));
+            }
+        }
+        final Double actual = new MyClass().callWithTimeout().toCompletableFuture().get(1, TimeUnit.SECONDS);
+        final Double expected = Math.PI;
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void failedTimeout() throws Exception {
+        class MyClass implements play.libs.concurrent.Timeout {
+            CompletionStage<Double> callWithTimeout() {
+                return timeout(delayedFuture(), Duration.ofMillis(300));
+            }
+        }
+        final Double actual = new MyClass()
+                .callWithTimeout()
+                .toCompletableFuture()
+                .exceptionally(e -> 100d)
+                .get(1, TimeUnit.SECONDS);
+        final Double expected = 100d;
+        assertThat(actual, equalTo(expected));
+    }
+
+    private static CompletionStage<Double> computePIAsynchronously() {
+        return CompletableFuture.completedFuture(Math.PI);
+    }
+
+
+    private static CompletionStage<Double> delayedFuture() {
+        return Futures.delayed(() -> Math.PI, 1, TimeUnit.SECONDS, ForkJoinPool.commonPool());
+    }
+
+    private static Integer intensiveComputation() {
+        return 1 + 1;
+    }
+}

--- a/framework/src/play/src/test/scala/play/api/libs/concurrent/TimeoutSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/concurrent/TimeoutSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.libs.concurrent
+
+import akka.actor.ActorSystem
+import org.specs2.mutable.Specification
+
+import scala.concurrent._
+import scala.concurrent.duration._
+
+// testOnly play.api.libs.concurrent.TimeoutSpec
+class TimeoutSpec extends Specification {
+
+  class MyService(val actorSystem: ActorSystem) extends Timeout {
+
+    def calculateWithTimeout(timeoutDuration: FiniteDuration): Future[Int] = {
+      timeout(actorSystem, timeoutDuration)(rawCalculation())
+    }
+
+    def rawCalculation(): Future[Int] = {
+      import akka.pattern.after
+      implicit val ec = actorSystem.dispatcher
+      after(300 millis, actorSystem.scheduler)(Future(42))(actorSystem.dispatcher)
+    }
+  }
+
+  val timeoutDuration = 10 seconds
+
+  "Timeout" should {
+
+    "timeout if duration is too small" in {
+      val actorSystem = ActorSystem()
+      implicit val ec = actorSystem.dispatcher
+      val future = new MyService(actorSystem).calculateWithTimeout(100 millis).recover {
+        case _: TimeoutException =>
+          -1
+      }
+      val result = Await.result(future, timeoutDuration) must be_==(-1)
+      actorSystem.terminate()
+      result
+    }
+
+    "succeed eventually with the raw calculation" in {
+      val actorSystem = ActorSystem()
+      implicit val ec = actorSystem.dispatcher
+      val future = new MyService(actorSystem).rawCalculation().recover {
+        case _: TimeoutException =>
+          -1
+      }
+      val result = Await.result(future, timeoutDuration) must be_==(42)
+      actorSystem.terminate()
+      result
+    }
+
+    "succeed with a timeout duration" in {
+      val actorSystem = ActorSystem()
+      implicit val ec = actorSystem.dispatcher
+      val future = new MyService(actorSystem).calculateWithTimeout(600 millis).recover {
+        case _: TimeoutException =>
+          -1
+      }
+      val result = Await.result(future, timeoutDuration) must be_==(42)
+      actorSystem.terminate()
+      result
+    }
+
+  }
+
+  "Future enriched with FutureTimeout implicit class" should {
+
+    "timeout with a duration" in {
+      import Timeout._
+
+      implicit val actorSystem = ActorSystem()
+      implicit val ec = actorSystem.dispatcher
+      val future = new MyService(actorSystem).rawCalculation().withTimeout(100 millis).recover {
+        case _: TimeoutException =>
+          -1
+      }
+      val result = Await.result(future, timeoutDuration) must be_==(-1)
+      actorSystem.terminate()
+      result
+    }
+
+    "succeed with a duration" in {
+      import Timeout._
+
+      implicit val actorSystem = ActorSystem()
+      implicit val ec = actorSystem.dispatcher
+      val future = new MyService(actorSystem).rawCalculation().withTimeout(500 millis).recover {
+        case _: TimeoutException =>
+          -1
+      }
+      val result = Await.result(future, timeoutDuration) must be_==(42)
+      actorSystem.terminate()
+      result
+    }
+
+    "timeout with an implicit akka.util.Timeout" in {
+      import Timeout._
+
+      implicit val actorSystem = ActorSystem()
+      implicit val ec = actorSystem.dispatcher
+      implicit val implicitTimeout = akka.util.Timeout(100 millis)
+      val future = new MyService(actorSystem).rawCalculation().withTimeout.recover {
+        case _: TimeoutException =>
+          -1
+      }
+      val result = Await.result(future, timeoutDuration) must be_==(-1)
+      actorSystem.terminate()
+      result
+    }
+
+    "succeed with an implicit akka.util.Timeout" in {
+      import Timeout._
+
+      implicit val actorSystem = ActorSystem()
+      implicit val ec = actorSystem.dispatcher
+      implicit val implicitTimeout = akka.util.Timeout(500 millis)
+      val future = new MyService(actorSystem).rawCalculation().withTimeout.recover {
+        case _: TimeoutException =>
+          -1
+      }
+      val result = Await.result(future, timeoutDuration) must be_==(42)
+      actorSystem.terminate()
+      result
+    }
+  }
+
+}


### PR DESCRIPTION
## Fixes

Fixes https://github.com/playframework/playframework/issues/6400

## Purpose

This PR adds a Timeout trait which replaces the deprecated Promise.timeout method, and provides an implicit class so we can use `future.withTimeout(100 millis)` in a Play app where we know that actorSystem is in context.

We have [Futures.timeout](https://playframework.com/documentation/latest/api/java/play/libs/concurrent/Futures.html#timeout-long-java.util.concurrent.TimeUnit-) in the Java API already, so we don't need to add anything on the Java API side.

## Background Context

Timeout operations are applicable all through Play HTTP requests in the form of `Future[Result]` and `Future[WSResponse]` -- while there are underlying timeouts, it's not well known how to do non-blocking timeouts, and there are multiple instances of applications using `Thread.sleep` or the like.

## References

https://github.com/johanandren/futiles#timeouts---markattafutilestimeouts

https://github.com/semberal/semberal.github.io/blob/master/scala-future-timeout-patterns.md

http://doc.akka.io/docs/akka/current/scala/futures.html#After

https://groups.google.com/d/topic/play-framework/Gv3GfFwZo2k/discussion
