### PR TITLE
Add a trait with no behavior for the reverse router.

### DIFF
--- a/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/reverseRouter.scala.twirl
+++ b/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/reverseRouter.scala.twirl
@@ -15,7 +15,22 @@ import @if(!i.startsWith("_root_.")){_root_.}@i}
 package @packageName @ob
 @for((controller, routes) <- groupRoutesByController(routes)) {
   @markLines(routes: _*)
-  class Reverse@(controller.replace(".", "_"))(_prefix: => String) @ob
+  trait Reverse@(controller.replace(".", "_"))Trait @ob
+    def _defaultPrefix: String
+
+    @for(((method, _), routes) <- groupRoutesByMethod(routes)) {@routes match {
+      case Seq(route: Route) => {
+        @markLines(route)
+        def @(method)(@reverseSignature(routes)): Call
+      }
+      case _ => {
+        @markLines(routes: _*)
+        def @(method)(@reverseSignature(routes)): Call
+      }
+    }}
+  @cb
+
+  class Reverse@(controller.replace(".", "_"))(_prefix: => String) extends Reverse@(controller.replace(".", "_"))Trait @ob
     def _defaultPrefix: String = @ob
       if (_prefix.endsWith("/")) "" else "/"
     @cb


### PR DESCRIPTION
## Purpose

This adds a ReverseRouter trait that provides method signatures, but no implementation.
## Background Context

If you are trying to define URLs dynamically and want to have access to the request information, then you can call a reverse router from inside an action.  However, you have to override each method individually, and if you forget, the compiler doesn't care.  If you extend the trait, that behavior is explicitly in your hands.

As an example, given

```
GET     /                               controllers.HomeController.index(param1: Option[String])
GET     /javascriptRoutes      controllers.HomeController.javascriptRoutes
```

then using the patch, the reverse router generated is:

``` scala

  // @LINE:6
  trait ReverseHomeControllerTrait {
    def _defaultPrefix: String


        // @LINE:6
        def index(param1:Option[String]): Call

        // @LINE:15
        def javascriptRoutes(): Call

  }

  class ReverseHomeController(_prefix: => String) extends ReverseHomeControllerTrait {
    def _defaultPrefix: String = {
      if (_prefix.endsWith("/")) "" else "/"
    }


    // @LINE:6
    def index(param1:Option[String]): Call = {
      import ReverseRouteContext.empty
      Call("GET", _prefix + queryString(List(Some(implicitly[QueryStringBindable[Option[String]]].unbind("param1", param1)))))
    }

    // @LINE:15
    def javascriptRoutes(): Call = {
      import ReverseRouteContext.empty
      Call("GET", _prefix + { _defaultPrefix } + "javascriptRoutes")
    }

  }

```

then you could define a URL starting with the reverse router as  `ReverseHomeControllerTrait`:

``` scala
  def routing(implicit request: Request[_]) = {
    new ReverseHomeControllerTrait {
      def _prefix = RoutesPrefix.byNamePrefix()

      def _defaultPrefix: String = {
        if (_prefix.endsWith("/")) "" else "/"
      }


      val function = routes.getUrlFunction[GET, String].map
      val url = function("foo")

      override def index(param1: Option[String]): Call = {
        import ReverseRouteContext.empty        
        val call = Call("GET", _prefix + queryString(List(Some(implicitly[QueryStringBindable[Option[String]]].unbind("param1", param1)))))
        val name = "hello"
        request.getQueryString(name).map { value =>
          import com.netaporter.uri.dsl._
          call.copy(url = call.url ? (name -> value))
        }.getOrElse(call)
      }

       def javascriptRoutes(): Call = {
         import ReverseRouteContext.empty
         Call("GET", _prefix + { _defaultPrefix } + "javascriptRoutes")
       }

    }
  }
```

This is still fairly clunky -- the best solution would be to have a routes map hanging off the application with typed information that would return appropriate URL generation functions -- but it will do for now.
