### PR TITLE
Deprecate executioncontext import

### DIFF
--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -272,42 +272,48 @@ The `play.api.libs.concurrent.Execution` class has been deprecated, as it was us
 If you want to specify the implicit behavior that you had previously, then you should pass in the execution context implicitly in the constructor using [[dependency injection|ScalaDependencyInjection]]:
 
 ```scala
-class MyController @Inject()(implicit ec:ExecutionContext) {
+class MyController @Inject()(implicit ec: ExecutionContext) {
 
 }
 ```
 
 or from BuiltInComponents if you are using [[compile time dependency injection|ScalaCompileTimeDependencyInjection]]:
 
-```
-class MyComponents(context: ApplicationLoader.Context) extends BuiltInComponentsFromContext(context)
-val ec = myComponents.executionContext
+```scala
+class MyComponentsFromContext(context: ApplicationLoader.Context)
+  extends BuiltInComponentsFromContext(context) {
+  val myComponent: MyComponent = new MyComponent(executionContext)
+}
 ```
 
-However, there are some good reasons why you may not want to import an execution context even in the general case.  In the general case, the application's execution context is good for rendering actions, and executing CPU-bound activities that do not involve blocking API calls or I/O activity.  If you are calling out to a database, or making network calls, then you may want to define your own custom execution context:
+However, there are some good reasons why you may not want to import an execution context even in the general case.  In the general case, the application's execution context is good for rendering actions, and executing CPU-bound activities that do not involve blocking API calls or I/O activity.  If you are calling out to a database, or making network calls, then you may want to define your own custom execution context.
+
+The recommended way to create a custom execution context is through `CustomExecutionContext`, which uses the Akka dispatcher system ([java](http://doc.akka.io/docs/akka/current/java/dispatchers.html) / [scala](http://doc.akka.io/docs/akka/current/scala/dispatchers.html))  so that executors can be defined through configuration.
+
+To use your own execution context, extend the `CustomExecutionContext` abstract class with the full path to the dispatcher in the `application.conf` file:
 
 ```scala
-class MyExecutionContext(val underlying: ExecutionContext)
+import play.api.libs.concurrent.CustomExecutionContext
+
+class MyExecutionContext @Inject()(actorSystem: ActorSystem)
+ extends CustomExecutionContext(actorSystem, "my.dispatcher.name")
 ```
 
-and provide it through an Akka dispatcher:
-
-```scala
-@Singleton
-class MyExecutionContextProvider @Inject()(actorSystem: ActorSystem)
-  extends Provider[MyExecutionContext] {
-  override lazy val get: MyExecutionContext = {
-    val ec = actorSystem.dispatchers.lookup("my.dispatcher")
-    new MyExecutionContext(ec)
-  }
+``` java
+import play.libs.concurrent.CustomExecutionContext;
+class MyExecutionContext extends CustomExecutionContext {
+   @Inject
+   public MyExecutionContext(ActorSystem actorSystem) {
+     super(actorSystem, "my.dispatcher.name");
+   }
 }
 ```
 
 and then inject your custom execution context as appropriate:
 
 ```scala
-class MyBlockingRepository @Inject()(myExecutionContext: MyExecutionContext) {
-  private implicit val ec: ExecutionContext = myExecutionContext.underlying
+class MyBlockingRepository @Inject()(implicit myExecutionContext: MyExecutionContext) {
+   // do things with custom execution context  
 }
 ```
 

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -257,8 +257,7 @@ If you used any of the `Router.Tags.*` tags, you should change your code to use 
 The attribute contains a `HandlerDef` object that contains all the information that is currently in the tags. The relationship between a `HandlerDef` object and its tags is as follows:
 
 ```scala
-RoutePattern -> han
-dlerDef.path
+RoutePattern -> handlerDef.path
 RouteVerb -> handlerDef.verb
 RouteController -> handlerDef.controller
 RouteActionMethod -> handlerDef.method

--- a/documentation/manual/working/commonGuide/configuration/ThreadPools.md
+++ b/documentation/manual/working/commonGuide/configuration/ThreadPools.md
@@ -39,17 +39,13 @@ Play uses a number of different thread pools for different purposes:
 
 All actions in Play Framework use the default thread pool.  When doing certain asynchronous operations, for example, calling `map` or `flatMap` on a future, you may need to provide an implicit execution context to execute the given functions in.  An execution context is basically another name for a `ThreadPool`.
 
-In most situations, the appropriate execution context to use will be the **Play default thread pool**.   This is accessible through `@Inject()(implicit ec: ExecutionContext)` This can be used by importing it into your Scala source file:
+In most situations, the appropriate execution context to use will be the **Play default thread pool**.   This is accessible through `@Inject()(implicit ec: ExecutionContext)` This can be used by injecting it into your Scala source file:
 
 @[global-thread-pool](code/ThreadPools.scala)
 
 or using [`CompletionStage`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html) with an [`HttpExecutionContext`](api/java/play/libs/concurrent/HttpExecutionContext.html) in Java code:
 
-```
-CompletionStage<Result> result = calculation().thenApplyAsync(result -> {
-         return ok("answer was " + result);
- }, httpExecutionContext.current();
-```
+@[http-execution-context](code/detailedtopics/httpec/MyController.java)
 
 This execution context connects directly to the Application's `ActorSystem` and uses the [default dispatcher](http://doc.akka.io/docs/akka/current/scala/dispatchers.html).
 

--- a/documentation/manual/working/commonGuide/configuration/ThreadPools.md
+++ b/documentation/manual/working/commonGuide/configuration/ThreadPools.md
@@ -39,11 +39,19 @@ Play uses a number of different thread pools for different purposes:
 
 All actions in Play Framework use the default thread pool.  When doing certain asynchronous operations, for example, calling `map` or `flatMap` on a future, you may need to provide an implicit execution context to execute the given functions in.  An execution context is basically another name for a `ThreadPool`.
 
-In most situations, the appropriate execution context to use will be the **Play default thread pool**.   This is accessible through `play.api.libs.concurrent.Execution.Implicits._` This can be used by importing it into your Scala source file:
+In most situations, the appropriate execution context to use will be the **Play default thread pool**.   This is accessible through `@Inject()(implicit ec: ExecutionContext)` This can be used by importing it into your Scala source file:
 
 @[global-thread-pool](code/ThreadPools.scala)
 
-The Play thread pool connects directly to the Application's `ActorSystem` and uses the [default dispatcher](http://doc.akka.io/docs/akka/2.4.3/scala/dispatchers.html).
+or using [`CompletionStage`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html) with an [`HttpExecutionContext`](api/java/play/libs/concurrent/HttpExecutionContext.html) in Java code:
+
+```
+CompletionStage<Result> result = calculation().thenApplyAsync(result -> {
+         return ok("answer was " + result);
+ }, httpExecutionContext.current();
+```
+
+This execution context connects directly to the Application's `ActorSystem` and uses the [default dispatcher](http://doc.akka.io/docs/akka/current/scala/dispatchers.html).
 
 ### Configuring the default thread pool
 
@@ -57,7 +65,7 @@ You can also try the default Akka configuration:
 
 @[akka-default-config](code/ThreadPools.scala)
 
-The full configuration options available to you can be found [here](http://doc.akka.io/docs/akka/2.4.3/general/configuration.html#Listing_of_the_Reference_Configuration).
+The full configuration options available to you can be found [here](http://doc.akka.io/docs/akka/current/general/configuration.html#Listing_of_the_Reference_Configuration).
 
 ## Using other thread pools
 

--- a/documentation/manual/working/commonGuide/configuration/ThreadPools.md
+++ b/documentation/manual/working/commonGuide/configuration/ThreadPools.md
@@ -73,7 +73,9 @@ In certain circumstances, you may wish to dispatch work to other thread pools.  
 
 @[my-context-usage](code/ThreadPools.scala)
 
-In this case, we are using Akka to create the `ExecutionContext`, but you could also easily create your own `ExecutionContext`s using Java executors, or the Scala fork join thread pool, for example.  To configure this Akka execution context, you can add the following configuration to your `application.conf`:
+In this case, we are using Akka to create the `ExecutionContext`, but you could also easily create your own `ExecutionContext`s using Java executors, or the Scala fork join thread pool, for example.  Play provides `play.libs.concurrent.CustomExecutionContext` and `play.api.libs.concurrent.CustomExecutionContext` that can be used to create your own execution contexts.
+
+To configure this Akka execution context, you can add the following configuration to your `application.conf`:
 
 @[my-context-config](code/ThreadPools.scala)
 

--- a/documentation/manual/working/javaGuide/advanced/routing/code/AppLoader.scala
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/AppLoader.scala
@@ -3,13 +3,7 @@
  */
 import play.api.ApplicationLoader.Context
 import play.api._
-import play.api.libs.concurrent.Execution.Implicits._
-import play.api.mvc.Results._
-import play.api.mvc._
 import play.api.routing.Router
-import play.api.routing.sird._
-import scala.concurrent.Future
-import play.api.inject.bind
 import router.RoutingDslBuilder
 
 //#load

--- a/documentation/manual/working/javaGuide/code/MockJavaAction.scala
+++ b/documentation/manual/working/javaGuide/code/MockJavaAction.scala
@@ -5,7 +5,6 @@ package javaguide.testhelpers {
 
 import java.util.concurrent.{CompletionStage, CompletableFuture}
 
-import akka.stream.Materializer
 import play.api.mvc.{Action, Request}
 import play.core.j.{DefaultJavaHandlerComponents, JavaHelpers, JavaActionAnnotations, JavaAction}
 import play.http.DefaultActionCreator
@@ -13,6 +12,7 @@ import play.mvc.{Controller, Http, Result}
 import play.api.http.HttpConfiguration
 import play.api.test.Helpers
 import java.lang.reflect.Method
+import akka.stream.Materializer
 
 abstract class MockJavaAction extends Controller with Action[Http.RequestBody] {
   self =>

--- a/documentation/manual/working/javaGuide/main/async/JavaAsync.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaAsync.md
@@ -31,7 +31,7 @@ A simple way to execute a block of code asynchronously and to get a `CompletionS
 
 Using `supplyAsync` creates a new task which will be placed on the fork join pool, and may be called from a different thread -- although, here it's using the default executor, and in practice you will specify an executor explicitly.
 
-> Only the "*Async" methods from `CompletionStage` provide asynchronous execution. 
+> Only the "\*Async" methods from `CompletionStage` provide asynchronous execution.
 
 ## Using HttpExecutionContext
 
@@ -60,7 +60,7 @@ You will need to define a custom dispatcher in `application.conf`, which is done
 Once you have the custom dispatcher, add in the explicit executor and wrap it with [`HttpExection.fromThread`](api/java/play/libs/concurrent/HttpExecution.html#fromThread-java.util.concurrent.Executor-):
 
 @[async-explicit-ec](code/javaguide/async/controllers/Application.java)
-     
+
 > You can't magically turn synchronous IO into asynchronous by wrapping it in a `CompletionStage`. If you can't change the application's architecture to avoid blocking operations, at some point that operation will have to be executed, and that thread is going to block. So in addition to enclosing the operation in a `CompletionStage`, it's necessary to configure it to run in a separate execution context that has been configured with enough threads to deal with the expected concurrency. See [[Understanding Play thread pools|ThreadPools]] for more information.
 
 ## Actions are asynchronous by default

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaAsync.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaAsync.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.*;
 import static play.mvc.Results.ok;
@@ -20,6 +21,7 @@ public class JavaAsync {
     public void promisePi() throws Exception {
         //#promise-pi
         CompletionStage<Double> promiseOfPIValue = computePIAsynchronously();
+        // Runs in same thread
         CompletionStage<Result> promiseOfResult = promiseOfPIValue.thenApply(pi ->
                         ok("PI value computed: " + pi)
         );
@@ -30,7 +32,10 @@ public class JavaAsync {
     @Test
     public void promiseAsync() throws Exception {
         //#promise-async
-        CompletionStage<Integer> promiseOfInt = CompletableFuture.supplyAsync(() -> intensiveComputation());
+        // import static java.util.concurrent.CompletableFuture.supplyAsync;
+        // creates new task
+        CompletionStage<Integer> promiseOfInt = supplyAsync(() ->
+                intensiveComputation());
         //#promise-async
         assertEquals(intensiveComputation(), promiseOfInt.toCompletableFuture().get(1, TimeUnit.SECONDS));
     }

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/controllers/Application.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/controllers/Application.java
@@ -5,32 +5,31 @@ package javaguide.async.controllers;
 
 import play.mvc.Result;
 import play.mvc.Controller;
+
 //#async-explicit-ec-imports
 import play.libs.concurrent.HttpExecution;
 import java.util.concurrent.Executor;
+import java.util.concurrent.CompletionStage;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
 //#async-explicit-ec-imports
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-
+//#async-explicit-ec
 public class Application extends Controller {
-    //#async
-    public CompletionStage<Result> index() {
-        return CompletableFuture.supplyAsync(() -> intensiveComputation())
-                .thenApply(i -> ok("Got result: " + i));
+
+    private MyExecutionContext myExecutionContext;
+
+    @javax.inject.Inject
+    public Application(MyExecutionContext myExecutionContext) {
+        this.myExecutionContext = myExecutionContext;
     }
-    //#async
 
-    private Executor myThreadPool = null;
-
-    //#async-explicit-ec
-    public CompletionStage<Result> index2() {
+    public CompletionStage<Result> index() {
         // Wrap an existing thread pool, using the context from the current thread
-        Executor myEc = HttpExecution.fromThread(myThreadPool);
-        return CompletableFuture.supplyAsync(() -> intensiveComputation(), myEc)
+        Executor myEc = HttpExecution.fromThread((Executor) myExecutionContext);
+        return supplyAsync(() -> intensiveComputation(), myEc)
                 .thenApplyAsync(i -> ok("Got result: " + i), myEc);
     }
-    //#async-explicit-ec
 
     public int intensiveComputation() { return 2;}
 }
+//#async-explicit-ec

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/controllers/MyExecutionContextImpl.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/controllers/MyExecutionContextImpl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package javaguide.async.controllers;
+
+import akka.actor.ActorSystem;
+import play.libs.concurrent.CustomExecutionContext;
+import scala.concurrent.ExecutionContextExecutor;
+
+//#custom-execution-context
+interface MyExecutionContext extends ExecutionContextExecutor {}
+
+// bind MyExecutionContext to MyExecutionContextImpl through DI
+public class MyExecutionContextImpl
+        extends CustomExecutionContext
+        implements MyExecutionContext {
+
+    @javax.inject.Inject
+    public MyExecutionContextImpl(ActorSystem actorSystem) {
+        // uses a custom thread pool defined in application.conf
+        super(actorSystem, "my.dispatcher");
+    }
+}
+//#custom-execution-context

--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -17,6 +17,8 @@ Now any controller or component that wants to use WS will have to add the follow
 
 @[ws-controller](code/javaguide/ws/Application.java)
 
+> If you are calling out to an [unreliable network](https://queue.acm.org/detail.cfm?id=2655736) or doing any blocking work, including any kind of DNS work such as calling [`java.util.URL.equals()`](https://docs.oracle.com/javase/8/docs/api/java/net/URL.html#equals-java.lang.Object-), then you should use a custom execution context as described in [[ThreadPools]].  You should size the pool to leave a safety margin large enough to account for timeouts, and consider using [`play.libs.concurrent.Futures.timeout`](api/java/play/libs/concurrent/Futures.html) and a [Failsafe Circuit Breaker](https://github.com/jhalterman/failsafe#circuit-breakers).
+
 To build an HTTP request, you start with `ws.url()` to specify the URL.
 
 @[ws-holder](code/javaguide/ws/JavaWS.java)

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/SirdAppLoader.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/SirdAppLoader.scala
@@ -3,13 +3,10 @@
  */
 import play.api.ApplicationLoader.Context
 import play.api._
-import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.routing.Router
 import play.api.routing.sird._
-import scala.concurrent.Future
-import play.api.inject.bind
 
 //#load
 class SirdAppLoader extends ApplicationLoader {

--- a/documentation/manual/working/scalaGuide/main/akka/code/ScalaAkka.scala
+++ b/documentation/manual/working/scalaGuide/main/akka/code/ScalaAkka.scala
@@ -39,7 +39,6 @@ class ScalaAkkaSpec extends PlaySpecification {
       import actors.HelloActor.SayHello
 
       //#ask
-      import play.api.libs.concurrent.Execution.Implicits.defaultContext
       import scala.concurrent.duration._
       import akka.pattern.ask
       implicit val timeout = 5.seconds
@@ -69,7 +68,6 @@ class ScalaAkkaSpec extends PlaySpecification {
     ) { _ =>
       import play.api.inject.bind
       import akka.actor._
-      import play.api.libs.concurrent.Execution.Implicits.defaultContext
       import scala.concurrent.duration._
       import akka.pattern.ask
       implicit val timeout = 5.seconds
@@ -100,7 +98,6 @@ class ScalaAkkaSpec extends PlaySpecification {
       val file = new File("/tmp/nofile")
       file.mkdirs()
       //#schedule-callback
-      import play.api.libs.concurrent.Execution.Implicits.defaultContext
       system.scheduler.scheduleOnce(10.milliseconds) {
         file.delete()
       }

--- a/documentation/manual/working/scalaGuide/main/application/code/FiltersRouting.scala
+++ b/documentation/manual/working/scalaGuide/main/application/code/FiltersRouting.scala
@@ -9,17 +9,15 @@ import akka.stream.Materializer
 import play.api.mvc.{Result, RequestHeader, Filter}
 import play.api.Logger
 import play.api.routing.Router.Tags
-import scala.concurrent.Future
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import scala.concurrent.{Future, ExecutionContext}
 
-class LoggingFilter @Inject() (implicit val mat: Materializer) extends Filter {
+class LoggingFilter @Inject() (implicit val mat: Materializer, ec: ExecutionContext) extends Filter {
   def apply(nextFilter: RequestHeader => Future[Result])
            (requestHeader: RequestHeader): Future[Result] = {
 
     val startTime = System.currentTimeMillis
 
     nextFilter(requestHeader).map { result =>
-
       val action = requestHeader.tags(Tags.RouteController) +
         "." + requestHeader.tags(Tags.RouteActionMethod)
       val endTime = System.currentTimeMillis

--- a/documentation/manual/working/scalaGuide/main/async/ScalaAsync.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaAsync.md
@@ -17,6 +17,24 @@ A `Future[Result]` will eventually be redeemed with a value of type `Result`. By
 
 The web client will be blocked while waiting for the response, but nothing will be blocked on the server, and server resources can be used to serve other clients.
 
+Using a `Future` is only half of the picture though!  If you are calling out to a blocking API such as JDBC, then you still will need to have your ExecutionStage run with a different executor, to move it off Play's rendering thread pool.  You can do this by creating a subclass of `play.api.libs.concurrent.CustomExecutionContext` with a reference to the [custom dispatcher](http://doc.akka.io/docs/akka/current/scala/dispatchers.html).
+
+```scala
+class DatabaseExecutionContext @Inject()(system: ActorSystem)
+     extends CustomExecutionContext(system, "my.database.executor")
+
+class HomeController @Inject()(databaseExecutionContext: DatabaseExecutionContext) extends Controller {
+  def index = Action.async {
+    Future {
+      // Call some blocking API
+      Ok("result of database call")
+    }(databaseExecutionContext)
+  }
+}
+```
+
+Please see [[ThreadPools]] for more information on using custom execution contexts effectively.
+
 ## How to create a `Future[Result]`
 
 To create a `Future[Result]` we need another future first: the future that will give us the actual value we need to compute the result:

--- a/documentation/manual/working/scalaGuide/main/async/ScalaAsync.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaAsync.md
@@ -19,19 +19,7 @@ The web client will be blocked while waiting for the response, but nothing will 
 
 Using a `Future` is only half of the picture though!  If you are calling out to a blocking API such as JDBC, then you still will need to have your ExecutionStage run with a different executor, to move it off Play's rendering thread pool.  You can do this by creating a subclass of `play.api.libs.concurrent.CustomExecutionContext` with a reference to the [custom dispatcher](http://doc.akka.io/docs/akka/current/scala/dispatchers.html).
 
-```scala
-class DatabaseExecutionContext @Inject()(system: ActorSystem)
-     extends CustomExecutionContext(system, "my.database.executor")
-
-class HomeController @Inject()(databaseExecutionContext: DatabaseExecutionContext) extends Controller {
-  def index = Action.async {
-    Future {
-      // Call some blocking API
-      Ok("result of database call")
-    }(databaseExecutionContext)
-  }
-}
-```
+@[my-execution-context](code/ScalaAsync.scala)
 
 Please see [[ThreadPools]] for more information on using custom execution contexts effectively.
 

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
@@ -11,7 +11,6 @@ import play.api._
 import play.api.mvc._
 
 import play.api.test._
-import akka.pattern.after
 
 class ScalaAsyncSpec extends PlaySpecification {
 
@@ -36,6 +35,24 @@ class ScalaAsyncSpec extends PlaySpecification {
     }
   }
 }
+
+//#my-execution-context
+import play.api.libs.concurrent.CustomExecutionContext
+
+trait MyExecutionContext extends ExecutionContext
+
+class MyExecutionContextImpl @Inject()(system: ActorSystem)
+  extends CustomExecutionContext(system, "my.executor") with MyExecutionContext
+
+class HomeController @Inject()(myExecutionContext: MyExecutionContext) extends Controller {
+  def index = Action.async {
+    Future {
+      // Call some blocking API
+      Ok("result of blocking call")
+    }(myExecutionContext)
+  }
+}
+//#my-execution-context
 
 class ScalaAsyncSamples @Inject() (implicit actorSystem: ActorSystem,  ec: ExecutionContext) extends Controller {
 

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
@@ -54,7 +54,7 @@ class HomeController @Inject()(myExecutionContext: MyExecutionContext) extends C
 }
 //#my-execution-context
 
-class ScalaAsyncSamples @Inject() (implicit actorSystem: ActorSystem,  ec: ExecutionContext) extends Controller {
+class ScalaAsyncSamples @Inject() (implicit actorSystem: ActorSystem, ec: ExecutionContext) extends Controller {
 
   def futureResult = {
     def computePIAsynchronously() = Future.successful(3.14)

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaAsync.scala
@@ -5,7 +5,7 @@ package scalaguide.async.scalaasync
 
 import javax.inject.Inject
 
-import scala.concurrent.Future
+import scala.concurrent.{Future, ExecutionContext}
 import akka.actor._
 import play.api._
 import play.api.mvc._
@@ -37,14 +37,11 @@ class ScalaAsyncSpec extends PlaySpecification {
   }
 }
 
-// If we want to show examples of importing the Play defaultContext, it can't be in a spec, since
-// Specification already defines a field called defaultContext, and this interferes with the implicits
-class ScalaAsyncSamples @Inject() (implicit actorSystem: ActorSystem) extends Controller {
+class ScalaAsyncSamples @Inject() (implicit actorSystem: ActorSystem,  ec: ExecutionContext) extends Controller {
 
   def futureResult = {
     def computePIAsynchronously() = Future.successful(3.14)
     //#future-result
-    import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
     val futurePIValue: Future[Double] = computePIAsynchronously()
     val futureResult: Future[Result] = futurePIValue.map { pi =>
@@ -58,8 +55,6 @@ class ScalaAsyncSamples @Inject() (implicit actorSystem: ActorSystem) extends Co
 
   def intensiveComp = {
     //#intensive-computation
-    import play.api.libs.concurrent.Execution.Implicits.defaultContext
-
     val futureInt: Future[Int] = scala.concurrent.Future {
       intensiveComputation()
     }
@@ -70,8 +65,6 @@ class ScalaAsyncSamples @Inject() (implicit actorSystem: ActorSystem) extends Co
   def asyncResult = {
 
     //#async-result
-    import play.api.libs.concurrent.Execution.Implicits.defaultContext
-
     def index = Action.async {
       val futureInt = scala.concurrent.Future { intensiveComputation() }
       futureInt.map(i => Ok("Got result: " + i))
@@ -87,7 +80,6 @@ class ScalaAsyncSamples @Inject() (implicit actorSystem: ActorSystem) extends Co
       10
     }
     //#timeout
-    import play.api.libs.concurrent.Execution.Implicits.defaultContext
     import scala.concurrent.duration._
     import akka.pattern.after
 

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -160,7 +160,6 @@ class ScalaActionsCompositionSpec extends Specification with Controller {
 
       //#modify-result
       import play.api.mvc._
-      import play.api.libs.concurrent.Execution.Implicits._
 
       def addUaHeader[A](action: Action[A]) = Action.async(action.parser) { request =>
         action(request).map(_.withHeaders("X-UA-Compatible" -> "Chrome=1"))

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
@@ -18,6 +18,7 @@ import org.specs2.execute.AsResult
 
   @RunWith(classOf[JUnitRunner])
   class ScalaBodyParsersSpec extends Specification with Controller {
+    import scala.concurrent.ExecutionContext.Implicits.global
 
     def helloRequest = FakeRequest("POST", "/").withJsonBody(Json.obj("name" -> "foo"))
 
@@ -134,7 +135,6 @@ import org.specs2.execute.AsResult
         //#csv
         import play.api.mvc._
         import play.api.libs.streams._
-        import play.api.libs.concurrent.Execution.Implicits.defaultContext
         import akka.util.ByteString
         import akka.stream.scaladsl._
 

--- a/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
@@ -6,12 +6,13 @@ package scalaguide.tests.webservice
 package client {
 //#client
 import javax.inject.Inject
-import play.api.libs.ws.WSClient
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
-import scala.concurrent.Future
 
-class GitHubClient(ws: WSClient, baseUrl: String) {
-  @Inject def this(ws: WSClient) = this(ws, "https://api.github.com")
+import play.api.libs.ws.WSClient
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class GitHubClient(ws: WSClient, baseUrl: String)(implicit ec: ExecutionContext) {
+  @Inject def this(ws: WSClient, ec: ExecutionContext) = this(ws, "https://api.github.com")(ec)
 
   def repositories(): Future[Seq[String]] = {
     ws.url(baseUrl + "/repositories").get().map { response =>
@@ -40,7 +41,8 @@ import scala.concurrent.duration._
 import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
 
-  class GitHubClientSpec extends Specification with NoTimeConversions {
+class GitHubClientSpec extends Specification with NoTimeConversions {
+  import scala.concurrent.ExecutionContext.Implicits.global
 
   "GitHubClient" should {
     "get all repositories" in {
@@ -70,6 +72,7 @@ import org.specs2.mutable.Specification
 import org.specs2.time.NoTimeConversions
 
 class ScalaTestingWebServiceClients extends Specification with NoTimeConversions {
+  import scala.concurrent.ExecutionContext.Implicits.global
 
   "webservice testing" should {
     "allow mocking a service" in {

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -15,9 +15,11 @@ libraryDependencies ++= Seq(
 )
 ```
 
-Now any controller or component that wants to use WS will have to declare a dependency on the `WSClient`:
+Now any component that wants to use WS will have to declare a dependency on the `WSClient`:
 
 @[dependency](code/ScalaWSSpec.scala)
+
+> If you are calling out to an [unreliable network](https://queue.acm.org/detail.cfm?id=2655736) or doing any blocking work, including any kind of DNS work such as calling [`java.util.URL.equals()`](https://docs.oracle.com/javase/8/docs/api/java/net/URL.html#equals-java.lang.Object-), then you should use a custom execution context as described in [[ThreadPools]].  You should size the pool to leave a safety margin large enough to account for timeouts, and consider using `play.api.libs.concurrent.Timeout` and a [Failsafe Circuit Breaker](https://github.com/jhalterman/failsafe#circuit-breakers).
 
 We've called the `WSClient` instance `ws`, all the following examples will assume this name.
 

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -53,15 +53,13 @@ case class Person(name: String, age: Int)
 class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
 
   // #scalaws-context-injected
-  class PersonService @Inject()(implicit context: ExecutionContext) {
+  // Configure with a custom execution context from akka.dispatchers.lookup()
+  class MyExecutionContext(ec: ExecutionContext)
+  class PersonService @Inject()(ec: MyExecutionContext) {
     // ...
   }
   // #scalaws-context-injected
   val url = s"http://localhost:$testServerPort/"
-
-  // #scalaws-context
-  implicit val context = play.api.libs.concurrent.Execution.Implicits.defaultContext
-  // #scalaws-context
 
   val system = ActorSystem()
   implicit val materializer = ActorMaterializer()(system)
@@ -100,6 +98,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
   }
 
   "WS" should {
+    import scala.concurrent.ExecutionContext.Implicits.global
 
     "allow making a request" in withSimpleServer { ws =>
       //#simple-holder

--- a/framework/src/play-cache/src/main/scala/play/api/cache/Cached.scala
+++ b/framework/src/play-cache/src/main/scala/play/api/cache/Cached.scala
@@ -13,7 +13,6 @@ import play.api.libs.Codecs
 import play.api.libs.streams.Accumulator
 import play.api.mvc.Results.NotModified
 import play.api.mvc._
-import play.core.Execution.Implicits.internalContext
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -121,6 +120,8 @@ final class CachedBuilder(
    * Compose the cache with an action
    */
   def build(action: EssentialAction): EssentialAction = EssentialAction { request =>
+    implicit val ec = materializer.executionContext
+
     val resultKey = key(request)
     val etagKey = s"$resultKey-etag"
 

--- a/framework/src/play-docs/src/main/scala/play/docs/DocServerStart.scala
+++ b/framework/src/play-docs/src/main/scala/play/docs/DocServerStart.scala
@@ -13,8 +13,6 @@ import play.core.server._
 import scala.concurrent.Future
 import scala.util.Success
 
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
-
 /**
  * Used to start the documentation server.
  */
@@ -35,7 +33,7 @@ class DocServerStart {
     Play.start(application)
 
     val applicationProvider = new ApplicationProvider {
-
+      implicit val ec = application.actorSystem.dispatcher
       override def get = Success(application)
       override def handleWebCommand(request: RequestHeader) =
         buildDocHandler.maybeHandleDocRequest(request).asInstanceOf[Option[Result]].orElse(

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
@@ -55,7 +55,6 @@ trait HeadActionSpec extends Specification with FutureAwaits with DefaultAwaitTi
     def withServer[T](block: WSClient => T): T = {
       // Routes from HttpBinApplication
       Server.withRouter()(routes) { implicit port =>
-        implicit val mat = Play.current.materializer
         WsTestClient.withClient(block)
       }
     }
@@ -64,7 +63,6 @@ trait HeadActionSpec extends Specification with FutureAwaits with DefaultAwaitTi
       Server.withRouter() {
         case _ => handler
       } { implicit port =>
-        implicit val mat = Play.current.materializer
         WsTestClient.withClient(block)
       }
     }

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
@@ -32,7 +32,7 @@ class NettyWSSpec extends WSSpec with NettyIntegrationSpecification
 class AkkaHttpWSSpec extends WSSpec with AkkaHttpIntegrationSpecification
 
 trait WSSpec extends PlaySpecification with ServerIntegrationSpecification {
-  import play.core.Execution.Implicits._
+  import scala.concurrent.ExecutionContext.Implicits.global
 
   "Web service client" title
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/WSSpec.scala
@@ -32,6 +32,7 @@ class NettyWSSpec extends WSSpec with NettyIntegrationSpecification
 class AkkaHttpWSSpec extends WSSpec with AkkaHttpIntegrationSpecification
 
 trait WSSpec extends PlaySpecification with ServerIntegrationSpecification {
+  import play.core.Execution.Implicits._
 
   "Web service client" title
 
@@ -60,7 +61,6 @@ trait WSSpec extends PlaySpecification with ServerIntegrationSpecification {
 
     def withEchoServer[T](block: play.libs.ws.WSClient => T) = {
       def echo = BodyParser { req =>
-        import play.api.libs.concurrent.Execution.Implicits.defaultContext
         Accumulator.source[ByteString].mapFuture { source =>
           Future.successful(source).map(Right.apply)
         }
@@ -269,7 +269,6 @@ trait WSSpec extends PlaySpecification with ServerIntegrationSpecification {
 
     def withEchoServer[T](block: play.api.libs.ws.WSClient => T) = {
       def echo = BodyParser { req =>
-        import play.api.libs.concurrent.Execution.Implicits.defaultContext
         Accumulator.source[ByteString].mapFuture { source =>
           Future.successful(source).map(Right.apply)
         }

--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -246,7 +246,7 @@ trait FiltersSpec extends Specification with ServerIntegrationSpecification {
         try {
           next.apply(request).recover(new java.util.function.Function[Throwable, Result]() {
             def apply(t: Throwable) = getResult(t)
-          }, play.core.Execution.internalContext)
+          }, ec)
         } catch {
           case t: Throwable => Accumulator.done(getResult(t))
         }

--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -18,7 +18,8 @@ import play.core.server.Server
 import play.it._
 import scala.concurrent.duration.Duration
 import scala.concurrent._
-import play.api.libs.concurrent.Execution.{ defaultContext => ec }
+
+import scala.concurrent.ExecutionContext.Implicits.{ global => ec }
 
 class NettyDefaultFiltersSpec extends DefaultFiltersSpec with NettyIntegrationSpecification
 class AkkaDefaultHttpFiltersSpec extends DefaultFiltersSpec with AkkaHttpIntegrationSpecification
@@ -224,7 +225,7 @@ trait FiltersSpec extends Specification with ServerIntegrationSpecification {
         next(request).recover {
           case t: Throwable =>
             Results.InternalServerError(t.getMessage)
-        }(play.api.libs.concurrent.Execution.Implicits.defaultContext)
+        }(ec)
       } catch {
         case t: Throwable => Accumulator.done(Results.InternalServerError(t.getMessage))
       }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -110,7 +110,7 @@ private[play] class PlayRequestHandler(val server: NettyServer) extends ChannelI
         val bufferLimit = app.configuration.getBytes("play.websocket.buffer.limit").getOrElse(65536L).asInstanceOf[Int]
         val factory = new WebSocketServerHandshakerFactory(wsUrl, "*", true, bufferLimit)
 
-        val executed = Future(ws(requestHeader))(play.api.libs.concurrent.Execution.defaultContext)
+        val executed = Future(ws(requestHeader))(play.core.Execution.internalContext)
 
         import play.core.Execution.Implicits.trampoline
         executed.flatMap(identity).flatMap {

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/Execution.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/Execution.scala
@@ -45,7 +45,7 @@ private[play] object Execution {
      *       - a Runnable is running and trampoline is active
      *       - no more Runnables are enqueued for execution after the current Runnable
      *         completes
-     * - next: Runnable => 
+     * - next: Runnable =>
      *       - a Runnable is running and trampoline is active
      *       - one Runnable is scheduled for execution after the current Runnable
      *         completes
@@ -70,7 +70,7 @@ private[play] object Execution {
             runnable.run()
             executeScheduled()
           } finally {
-            // We've run all the Runnables, so show that the 
+            // We've run all the Runnables, so show that the
             // trampoline has been shut down.
             local.set(null)
           }

--- a/framework/src/play-ws/src/test/scala/play/api/libs/openid/DiscoveryClientSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/openid/DiscoveryClientSpec.scala
@@ -13,6 +13,8 @@ import scala.concurrent.Await
 import java.util.concurrent.TimeUnit
 import play.api.libs.ws._
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class DiscoveryClientSpec extends Specification with Mockito {
 
   val dur = Duration(10, TimeUnit.SECONDS)

--- a/framework/src/play-ws/src/test/scala/play/api/libs/openid/OpenIDSpec.scala
+++ b/framework/src/play-ws/src/test/scala/play/api/libs/openid/OpenIDSpec.scala
@@ -15,6 +15,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import java.util.concurrent.TimeUnit
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class OpenIDSpec extends Specification with Mockito {
 
   val claimedId = "http://example.com/openid?id=C123"

--- a/framework/src/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java
+++ b/framework/src/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java
@@ -36,6 +36,11 @@ public abstract class CustomExecutionContext implements ExecutionContextExecutor
     }
 
     @Override
+    public ExecutionContext prepare() {
+        return executionContext.prepare();
+    }
+
+    @Override
     public void execute(Runnable command) {
         executionContext.execute(command);
     }

--- a/framework/src/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java
+++ b/framework/src/play/src/main/java/play/libs/concurrent/CustomExecutionContext.java
@@ -1,0 +1,47 @@
+package play.libs.concurrent;
+
+import akka.actor.ActorSystem;
+import scala.concurrent.ExecutionContext;
+import scala.concurrent.ExecutionContextExecutor;
+
+/**
+ * Provides a custom execution context from an Akka dispatcher.
+ *
+ * Subclass this to create your own custom execution context, using
+ * the full path to the Akka dispatcher.
+ *
+ * <pre>
+ * {@code
+ * class MyCustomExecutionContext extends CustomExecutionContext {
+ *   // Dependency inject the actorsystem from elsewhere
+ *   public MyCustomExecutionContext(ActorSystem actorSystem) {
+ *     super(actorSystem, "full.path.to.my-custom-executor");
+ *   }
+ * }
+ * }
+ * </pre>
+ *
+ * Then use your custom execution context where you have blocking
+ * operations that require processing outside of Play's main rendering
+ * thread.
+ *
+ * @see <a href="http://doc.akka.io/docs/akka/current/java/dispatchers.html">Dispatchers</a>
+ * @see <a href="https://www.playframework.com/documentation/latest/ThreadPools">Thread Pools</a>
+ */
+public abstract class CustomExecutionContext implements ExecutionContextExecutor {
+    private final ExecutionContext executionContext;
+
+    public CustomExecutionContext(ActorSystem actorSystem, String name) {
+        this.executionContext = actorSystem.dispatchers().lookup(name);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        executionContext.execute(command);
+    }
+
+    @Override
+    public void reportFailure(Throwable cause) {
+        executionContext.reportFailure(cause);
+    }
+}

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/CustomExecutionContext.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/CustomExecutionContext.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.libs.concurrent
+
+import akka.actor.ActorSystem
+import akka.dispatch.MessageDispatcher
+
+import scala.concurrent.ExecutionContextExecutor
+
+/**
+ * This class defines a custom execution context that delegates to an [[ActorSystem]].
+ *
+ * It is very useful for situations in which the default execution context should not
+ * be used, for example if a database or blocking I/O is being used.
+ *
+ * To define a custom context, subclass DispatcherExecutionContext with the dispatcher
+ * name and have it bound through dependency injection:
+ *
+ * {{{
+ * @Singleton
+ * class DatabaseExecutionContext @Inject()(system: ActorSystem)
+ *    extends CustomExecutionContext(system, "database-dispatcher")
+ * }}}
+ *
+ * and then have the execution context passed in as a class parameter:
+ *
+ * {{{
+ * class DatabaseService @Inject()(implicit executionContext: DatabaseExecutionContext) {
+ *   ...
+ * }
+ * }}}
+ *
+ * @see <a href="http://doc.akka.io/docs/akka/current/java/dispatchers.html">Dispatchers</a>
+ * @see <a href="https://www.playframework.com/documentation/latest/ThreadPools">Thread Pools</a>
+ *
+ * @param system the actor system
+ * @param name   the full path of the dispatcher name in Typesafe Config.
+ */
+abstract class CustomExecutionContext(system: ActorSystem, name: String) extends ExecutionContextExecutor {
+  private val dispatcher: MessageDispatcher = system.dispatchers.lookup(name)
+
+  override def execute(command: Runnable) = dispatcher.execute(command)
+
+  override def reportFailure(cause: Throwable) = dispatcher.reportFailure(cause)
+}

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Execution.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Execution.scala
@@ -6,6 +6,7 @@ package play.api.libs.concurrent
 import play.core.{ Execution => CoreExecution }
 import scala.concurrent.ExecutionContext
 
+@deprecated("Please see https://www.playframework.com/documentation/2.6.x/Migration26#Execution", "2.6.0")
 object Execution {
 
   object Implicits {

--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -28,7 +28,7 @@ trait EssentialAction extends (RequestHeader => Accumulator[ByteString, Result])
   def apply() = this
 
   def asJava: play.mvc.EssentialAction = new play.mvc.EssentialAction() {
-    import play.api.libs.concurrent.Execution.Implicits.defaultContext
+    import play.core.Execution.Implicits._
     def apply(rh: play.mvc.Http.RequestHeader) = self(rh._underlyingHeader).map(_.asJava).asJava
     override def apply(rh: RequestHeader) = self(rh)
   }
@@ -103,7 +103,7 @@ trait Action[A] extends EssentialAction {
    *
    * @return The execution context to run the action in
    */
-  def executionContext: ExecutionContext = play.api.libs.concurrent.Execution.defaultContext
+  protected def executionContext: ExecutionContext = play.core.Execution.internalContext
 
   /**
    * Returns itself, for better support in the routes file.
@@ -270,7 +270,7 @@ trait ActionFunction[-R[_], +P[_]] {
    *
    * @return The execution context
    */
-  protected def executionContext: ExecutionContext = play.api.libs.concurrent.Execution.defaultContext
+  protected def executionContext: ExecutionContext = play.core.Execution.internalContext
 
   /**
    * Compose this ActionFunction with another, with this one applied first.

--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -28,8 +28,10 @@ trait EssentialAction extends (RequestHeader => Accumulator[ByteString, Result])
   def apply() = this
 
   def asJava: play.mvc.EssentialAction = new play.mvc.EssentialAction() {
-    import play.core.Execution.Implicits._
-    def apply(rh: play.mvc.Http.RequestHeader) = self(rh._underlyingHeader).map(_.asJava).asJava
+    def apply(rh: play.mvc.Http.RequestHeader) = {
+      implicit val ec = play.core.Execution.internalContext
+      self(rh._underlyingHeader).map(_.asJava).asJava
+    }
     override def apply(rh: RequestHeader) = self(rh)
   }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -415,7 +415,6 @@ trait ActionBuilder[+R[_]] extends ActionFunction[Request, R] {
       // LinkageError is similarly harmless in Play Framework, since automatic reloading could easily trigger it
       case e: LinkageError => throw new RuntimeException(e)
     }
-    override def executionContext = ActionBuilder.this.executionContext
   })
 
   /**

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -736,7 +736,7 @@ trait BodyParsers {
       val takeUpToFlow = Flow.fromGraph(new BodyParsers.TakeUpTo(maxLength))
       Accumulator(takeUpToFlow.toMat(accumulator.toSink) { (statusFuture, resultFuture) =>
         import play.core.Execution.Implicits.trampoline
-        val defaultCtx = play.api.libs.concurrent.Execution.Implicits.defaultContext
+        val defaultCtx = play.core.Execution.internalContext
 
         statusFuture.flatMap {
           case MaxSizeExceeded(_) =>

--- a/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Filters.scala
@@ -5,7 +5,6 @@ package play.api.mvc
 
 import akka.stream.Materializer
 import akka.util.ByteString
-import play.api._
 import play.api.libs.streams.Accumulator
 import scala.concurrent.{ Promise, Future }
 
@@ -45,9 +44,8 @@ trait Filter extends EssentialFilter {
   def apply(f: RequestHeader => Future[Result])(rh: RequestHeader): Future[Result]
 
   def apply(next: EssentialAction): EssentialAction = {
+    implicit val ec = mat.executionContext
     new EssentialAction {
-      import play.api.libs.concurrent.Execution.Implicits.defaultContext
-
       def apply(rh: RequestHeader): Accumulator[ByteString, Result] = {
 
         // Promised result returned to this filter when it invokes the delegate function (the next filter in the chain)

--- a/framework/src/play/src/main/scala/play/core/Execution.scala
+++ b/framework/src/play/src/main/scala/play/core/Execution.scala
@@ -4,7 +4,7 @@
 package play.core
 
 import java.util.concurrent.ForkJoinPool
-import play.api.{ Application, Play }
+import play.api.Play
 import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
 
 /**
@@ -22,10 +22,7 @@ private[play] object Execution {
   def trampoline = play.api.libs.streams.Execution.trampoline
 
   object Implicits {
-
-    implicit def internalContext = Execution.internalContext
-    implicit def trampoline = play.api.libs.streams.Execution.trampoline
-
+    implicit def trampoline = Execution.trampoline
   }
 
   /**

--- a/framework/src/play/src/test/scala/play/api/inject/DefaultApplicationLifecycleSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/DefaultApplicationLifecycleSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 
 class DefaultApplicationLifecycleSpec extends Specification {
 
-  import play.api.libs.concurrent.Execution.Implicits.defaultContext
+  import play.core.Execution.Implicits._
 
   "DefaultApplicationLifecycle" should {
     // This test ensure's two things

--- a/framework/src/play/src/test/scala/play/api/inject/DefaultApplicationLifecycleSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/DefaultApplicationLifecycleSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 
 class DefaultApplicationLifecycleSpec extends Specification {
 
-  import play.core.Execution.Implicits._
+  import scala.concurrent.ExecutionContext.Implicits.global
 
   "DefaultApplicationLifecycle" should {
     // This test ensure's two things

--- a/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
@@ -11,7 +11,6 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.http.HttpEntity
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 import scala.collection.mutable
 import scala.concurrent.Await
@@ -19,6 +18,7 @@ import scala.concurrent.duration.Duration
 import org.specs2.mutable.Specification
 
 class ByteRangeSpec extends Specification {
+  import play.core.Execution.Implicits._
 
   "Distance" in {
     "Between 0-10 and 20-30 is 10" in {
@@ -325,6 +325,7 @@ class RangeSetSpec extends Specification {
 }
 
 class RangeResultSpec extends Specification {
+  import scala.concurrent.ExecutionContext.Implicits.global
 
   "Result" should {
 

--- a/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
@@ -18,7 +18,7 @@ import scala.concurrent.duration.Duration
 import org.specs2.mutable.Specification
 
 class ByteRangeSpec extends Specification {
-  import play.core.Execution.Implicits._
+  import scala.concurrent.ExecutionContext.Implicits.global
 
   "Distance" in {
     "Between 0-10 and 20-30 is 10" in {

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -23,7 +23,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class ResultsSpec extends Specification {
-  import play.core.Execution.Implicits._
+  import scala.concurrent.ExecutionContext.Implicits.global
 
   import play.api.mvc.Results._
 

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -16,7 +16,6 @@ import org.specs2.mutable._
 import play.api.http.HeaderNames._
 import play.api.http.Status._
 import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.{ Configuration, Environment, Play }
 import play.core.test._
 
@@ -24,6 +23,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class ResultsSpec extends Specification {
+  import play.core.Execution.Implicits._
 
   import play.api.mvc.Results._
 


### PR DESCRIPTION
Fixes https://github.com/playframework/playframework/issues/6425

This refactors internal code so that it uses internalContext (which is Play private) and deprecates the public `play.api.libs.concurrent.Execution` class with a reference to the migration guide.