### PR TITLE
Change guiceSupport to guice and add to migration guide

### DIFF
--- a/documentation/manual/gettingStarted/NewApplication.md
+++ b/documentation/manual/gettingStarted/NewApplication.md
@@ -102,10 +102,10 @@ $ sbt
 
 sbt will load your project and fetch the dependencies.
 
-By default, the `PlayJava` and `PlayScala` plugins do not depend on any specific dependency injection solution. If you want to use Play's Guice module, add `guiceSupport` to your library dependencies:
+By default, the `PlayJava` and `PlayScala` plugins do not depend on any specific dependency injection solution. If you want to use Play's Guice module, add `guice` to your library dependencies:
 
 ```scala
-libraryDependencies += guiceSupport
+libraryDependencies += guice
 ```
 
-Be aware that you should either be manually defining an `ApplicationLoader` or have a dependency on another module (such as `guiceSupport`) that provides one.
+Be aware that you should either be manually defining an `ApplicationLoader` or have a dependency on another module (such as `guice`) that provides one.

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -19,7 +19,7 @@ If you still need support for the Play YAML integration you need to add `snakeya
 ```
 libraryDependencies += "org.yaml" % "snakeyaml" % "1.17"
 ```
- 
+
 And create the following Wrapper in your Code:
 
 ```
@@ -31,7 +31,7 @@ public class Yaml {
     public Yaml(play.Environment environment) {
         this.environment = environment;
     }
-    
+
     /**
      * Load a Yaml file from the classpath.
      */
@@ -41,8 +41,8 @@ public class Yaml {
             environment.classLoader()
         );
     }
-    
-    /** 
+
+    /**
      * Load the specified InputStream as Yaml.
      *
      * @param classloader The classloader to use to instantiate Java objects.
@@ -51,10 +51,21 @@ public class Yaml {
         org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml(new CustomClassLoaderConstructor(classloader));
         return yaml.load(is);
     }
-    
+
 }
 ```
 
+### Guice DI support moved to separate module
+
+In Play 2.6, the core Play module no longer includes Guice. You can add it by adding `guice` to your `libraryDependencies`:
+
+```
+libraryDependencies += guice
+```
+
+If you explicitly depend on an alternate DI library for play, or have defined your own custom application loader, no changes should be required.
+
+Libraries that provide Play DI support should define the `play.application.loader` configuration key. If no external DI library is provided, Play will refuse to start unless you point that to an `ApplicationLoader`.
 
 ### Removed Libraries
 

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
@@ -3,10 +3,10 @@
 
 Dependency injection is a widely used design pattern that helps to separate your components' behaviour from dependency resolution.  Components declare their dependencies, usually as constructor parameters, and a dependency injection framework helps you wire together those components so you don't have to do so manually.
 
-Out of the box, Play provides dependency injection support based on [JSR 330](https://jcp.org/en/jsr/detail?id=330).  The default JSR 330 implementation that comes with Play is [Guice](https://github.com/google/guice), but other JSR 330 implementations can be plugged in. To enable the Play-provided Guice module, make sure you have `guiceSupport` in your library dependencies in build.sbt, e.g.:
+Out of the box, Play provides dependency injection support based on [JSR 330](https://jcp.org/en/jsr/detail?id=330).  The default JSR 330 implementation that comes with Play is [Guice](https://github.com/google/guice), but other JSR 330 implementations can be plugged in. To enable the Play-provided Guice module, make sure you have `guice` in your library dependencies in build.sbt, e.g.:
 
 ```scala
-libraryDependencies += guiceSupport
+libraryDependencies += guice
 ```
 
 The [Guice wiki](https://github.com/google/guice/wiki/) is a great resource for learning more about the features of Guice and DI design patterns in general.

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaCompileTimeDependencyInjection.md
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaCompileTimeDependencyInjection.md
@@ -27,7 +27,7 @@ To configure Play to use this application loader, configure the `play.applicatio
 
     play.application.loader=MyApplicationLoader
 
-In addition, if you're modifying an existing project that uses the built-in Guice module, you should be able to remove `guiceSupport` from your `libraryDependencies` in `build.sbt`.
+In addition, if you're modifying an existing project that uses the built-in Guice module, you should be able to remove `guice` from your `libraryDependencies` in `build.sbt`.
 
 ## Configuring Logging
 

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/build.sbt
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/build.sbt
@@ -15,7 +15,7 @@ scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.8")
 scalaSource in Test <<= baseDirectory(_ / "tests")
 
 libraryDependencies ++= Seq(
-  guiceSupport,
+  guice,
   ws,
   specs2 % Test
 )

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/system-property/build.sbt
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/system-property/build.sbt
@@ -13,7 +13,7 @@ scalaSource in Test <<= baseDirectory(_ / "tests")
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-akka-http-server-experimental" % sys.props("project.version"),
-  guiceSupport,
+  guice,
   ws,
   specs2 % Test
 )

--- a/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/build.sbt
+++ b/framework/src/sbt-fork-run-plugin/src/sbt-test/fork-run/dev-mode/build.sbt
@@ -4,7 +4,7 @@
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-libraryDependencies += guiceSupport
+libraryDependencies += guice
 
 DevModeBuild.settings
 

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -47,7 +47,7 @@ object PlayImport {
 
   val json = component("play-json")
 
-  val guiceSupport = component("play-guice")
+  val guice = component("play-guice")
 
   val ws = component("play-ws")
 

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
@@ -4,7 +4,7 @@
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-libraryDependencies += guiceSupport
+libraryDependencies += guice
 
 scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.8")
 

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
@@ -8,7 +8,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-libraryDependencies += guiceSupport
+libraryDependencies += guice
 
 scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.8")
 

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/build.sbt
@@ -24,7 +24,7 @@ lazy val nonplaymodule = (project in file("nonplaymodule"))
 
 def common: Seq[Setting[_]] = Seq(
   scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.8"),
-  libraryDependencies += guiceSupport
+  libraryDependencies += guice
 )
 
 TaskKey[Unit]("checkPlayMonitoredFiles") := {

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/nested-secret/project/Build.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/nested-secret/project/Build.scala
@@ -15,7 +15,7 @@ object ApplicationBuild extends Build {
 
   val main = Project(appName, file(".")).enablePlugins(PlayScala).settings(
     version := appVersion,
-    libraryDependencies += guiceSupport,
+    libraryDependencies += guice,
     TaskKey[Unit]("checkSecret") := {
       val file: File = baseDirectory.value / "conf/application.conf"
       val config: Config = ConfigFactory.parseFileAnySyntax(file)

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/build.sbt
@@ -10,7 +10,7 @@ lazy val root = (project in file("."))
 
 def commonSettings: Seq[Setting[_]] = Seq(
   scalaVersion := sys.props.get("scala.version").getOrElse("2.11.8"),
-  libraryDependencies += guiceSupport,
+  libraryDependencies += guice,
   routesGenerator := play.routes.compiler.InjectedRoutesGenerator,
   // This makes it possible to run tests on the output regardless of scala version
   crossPaths := false

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/build.sbt
@@ -4,7 +4,7 @@
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-libraryDependencies ++= Seq(guiceSupport, specs2 % Test)
+libraryDependencies ++= Seq(guice, specs2 % Test)
 
 scalaVersion := sys.props.get("scala.version").getOrElse("2.11.8")
 

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/build.sbt
@@ -4,7 +4,7 @@
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-libraryDependencies ++= Seq(guiceSupport, specs2 % Test)
+libraryDependencies ++= Seq(guice, specs2 % Test)
 
 scalaVersion := sys.props.get("scala.version").getOrElse("2.11.8")
 

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/build.sbt
@@ -5,7 +5,7 @@ import scala.reflect._
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-libraryDependencies += guiceSupport
+libraryDependencies += guice
 
 scalaVersion := sys.props.get("scala.version").getOrElse("2.11.8")
 

--- a/templates/play-java-intro/build.sbt
+++ b/templates/play-java-intro/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayJava)
 scalaVersion := "%SCALA_VERSION%"
 
 libraryDependencies ++= Seq(
-  guiceSupport,
+  guice,
   // If you enable PlayEbean plugin you must remove these
   // JPA dependencies to avoid conflicts.
   javaJpa,

--- a/templates/play-java/build.sbt
+++ b/templates/play-java/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayJava)
 scalaVersion := "%SCALA_VERSION%"
 
 libraryDependencies ++= Seq(
-  guiceSupport,
+  guice,
   javaJdbc,
   cache,
   javaWs,

--- a/templates/play-scala-intro/build.sbt
+++ b/templates/play-scala-intro/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 scalaVersion := "%SCALA_VERSION%"
 
 libraryDependencies ++= Seq(
-  guiceSupport,
+  guice,
   "com.typesafe.play" %% "play-slick" % "%PLAY_SLICK_VERSION%",
   "com.typesafe.play" %% "play-slick-evolutions" % "%PLAY_SLICK_VERSION%",
   "com.h2database" % "h2" % "1.4.191",

--- a/templates/play-scala/build.sbt
+++ b/templates/play-scala/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 scalaVersion := "%SCALA_VERSION%"
 
 libraryDependencies ++= Seq(
-  guiceSupport,
+  guice,
   jdbc,
   cache,
   ws,


### PR DESCRIPTION
After discussing with Will, I think it makes more sense to name the key `PlayKeys.guice` instead of  `PlayKeys.guiceSupport`. I also added an explanation about it to the migration guide.