### PR TITLE
stop hooks won't be called when Play.stop(app) was called

### DIFF
--- a/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
+++ b/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
@@ -4,9 +4,8 @@
 package play.api.inject.guice
 
 import play.api.{ Application, ApplicationLoader, OptionalSourceMapper }
-import play.api.inject.bind
+import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle, bind }
 import play.core.WebCommands
-import play.api.inject.ApplicationLifecycle
 
 /**
  * An ApplicationLoader that uses Guice to bootstrap the application.
@@ -52,6 +51,6 @@ object GuiceApplicationLoader {
     Seq(
       bind[OptionalSourceMapper] to new OptionalSourceMapper(context.sourceMapper),
       bind[WebCommands] to context.webCommands,
-      bind[ApplicationLifecycle] to context.lifecycle)
+      bind[DefaultApplicationLifecycle] to context.lifecycle)
   }
 }


### PR DESCRIPTION
# Helpful things

## Fixes

Fixes #6466

## Purpose

Fixes the stop hooks, again.

## Background Context

Actually due to the wrong override it would've registered the `DefaultApplicationLifecycle` to `ApplicationLifecycle`, however that would happen anyway (https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala#L45) as you can see we would now have a new `DefaultApplicationLifecycle` bind to self and one bind to `ApplicationLifecycle` and this is pretty pretty bad. The override should've targeted `DefaultApplicationLifecycle`.

This is even worse than before since stop hooks would've only be called in dev mode. 