### PR TITLE
[Backport 2.5.x] stop hooks won't be called when Play.stop(app) was called (#6469)

### DIFF
--- a/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
@@ -4,7 +4,7 @@
 package play.api.inject.guice
 
 import play.api.{ Application, ApplicationLoader, OptionalSourceMapper }
-import play.api.inject.{ ApplicationLifecycle, bind }
+import play.api.inject.{ DefaultApplicationLifecycle, bind }
 import play.core.WebCommands
 
 /**
@@ -51,6 +51,6 @@ object GuiceApplicationLoader {
     Seq(
       bind[OptionalSourceMapper] to new OptionalSourceMapper(context.sourceMapper),
       bind[WebCommands] to context.webCommands,
-      bind[ApplicationLifecycle] to context.lifecycle)
+      bind[DefaultApplicationLifecycle] to context.lifecycle)
   }
 }

--- a/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
@@ -4,12 +4,12 @@
 package play.api.inject.guice
 
 import org.specs2.mutable.Specification
-
 import com.google.inject.AbstractModule
-
-import play.{ Configuration => JavaConfiguration, Environment => JavaEnvironment }
-import play.api.{ ApplicationLoader, Configuration, Environment }
+import play.{Configuration => JavaConfiguration, Environment => JavaEnvironment}
+import play.api.{ApplicationLoader, Configuration, Environment}
 import play.api.inject.BuiltinModule
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 
 class GuiceApplicationLoaderSpec extends Specification {
 
@@ -50,6 +50,16 @@ class GuiceApplicationLoaderSpec extends Specification {
       val loader = new GuiceApplicationLoader()
       val app = loader.load(fakeContextWithModule(classOf[JavaConfiguredModule]))
       app.injector.instanceOf[Foo] must beAnInstanceOf[JavaConfiguredFoo]
+    }
+
+    "call the stop hooks from the context" in {
+      val context = ApplicationLoader.createContext(Environment.simple())
+      var hooksCalled = false
+      context.lifecycle.addStopHook(() => Future.successful(hooksCalled = true))
+      val loader = new GuiceApplicationLoader()
+      val app = loader.load(context)
+      Await.ready(app.stop(), 5.minutes)
+      hooksCalled must_== true
     }
 
   }


### PR DESCRIPTION
Backport of #6469