### PR TITLE
Fix config file name in Clever Cloud deployment docs

### DIFF
--- a/documentation/manual/working/commonGuide/production/cloud/Deploying-CleverCloud.md
+++ b/documentation/manual/working/commonGuide/production/cloud/Deploying-CleverCloud.md
@@ -37,7 +37,7 @@ You can check the deployment of your application by visiting the ***logs*** sect
 
 
 ## [Optional] Configure your application
-You can custom your application with a `clevercloud/play.json` file.
+You can custom your application with a `clevercloud/sbt.json` file.
 
 The file must contain the following fields:
 


### PR DESCRIPTION
If play.json is used instead of sbt.json the application is detected as a Play 1.x app.