### PR TITLE
[2.4] Fix thread leak caused by idle-timeout support

### DIFF
--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -41,6 +41,8 @@ class NettyServer(
 
   private val nettyConfig = config.configuration.underlying.getConfig("play.server.netty")
 
+  private val idleTimeoutTimer = new HashedWheelTimer()
+
   import NettyServer._
 
   def mode = config.mode
@@ -115,7 +117,7 @@ class NettyServer(
       }
       idleTimeoutMs.foreach { idleTimeout =>
         logger.trace(s"using idle timeout of $idleTimeout ms on port $port")
-        newPipeline.addLast("idle-handler", new IdleStateHandler(new HashedWheelTimer(), idleTimeout, idleTimeout, idleTimeout, TimeUnit.MILLISECONDS))
+        newPipeline.addLast("idle-handler", new IdleStateHandler(idleTimeoutTimer, idleTimeout, idleTimeout, idleTimeout, TimeUnit.MILLISECONDS))
       }
       newPipeline.addLast("handler", defaultUpStreamHandler)
       newPipeline


### PR DESCRIPTION
## Fixes

Idle timeout support introduced for 2.4 would cause thread exhaustion because a HashedWheelTimer was being created per request. Instead we should be using a single one. This isn't an issue in 2.5+ because Netty's IdleStateHandler no longer requires a Timer.
