### PR TITLE
Make Yaml methods non static

### DIFF
--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -39,7 +39,7 @@ public class Yaml {
     /**
      * Load a Yaml file from the classpath.
      */
-    public static Object load(String resourceName) {
+    public Object load(String resourceName) {
         return load(
             environment.resourceAsStream(resourceName),
             environment.classLoader()
@@ -51,7 +51,7 @@ public class Yaml {
      *
      * @param classloader The classloader to use to instantiate Java objects.
      */
-    public static Object load(InputStream is, ClassLoader classloader) {
+    public Object load(InputStream is, ClassLoader classloader) {
         org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml(new CustomClassLoaderConstructor(classloader));
         return yaml.load(is);
     }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Not related to any issue

## Purpose

Fix documentation in the Migration Guide from 2.5 to 2.6

## Background Context

The `Yaml` class is calling instance fields in static methods.

## References

Are there any relevant issues / PRs / mailing lists discussions?

Since they are calling an instance field they should not be static anymore.