### PR TITLE
Change Travis CI script to run CI test in serial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,8 @@ addons:
       - oracle-java8-installer
 jdk:
   - oraclejdk8
-env:
-  # Define scripts here so they run concurrently
-  - SCRIPT=checkCodeStyle
-  - SCRIPT=test
-  - SCRIPT=testSbtPlugins
-  - SCRIPT=testDocumentation
-  - SCRIPT=testTemplates
-  - SCRIPT=rehearseMicrobenchmarks
 script:
-  # Force sbt to run on a single CPU, this limits the resources Play uses
-  - framework/bin/$SCRIPT "set concurrentRestrictions in Global += Tags.limitAll(1)"
+  - framework/bin/travis
 cache:
   directories:
     - $HOME/.ivy2/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,15 @@ script:
 cache:
   directories:
     - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
 before_cache:
   # Ensure changes to the cache aren't persisted
   - rm -rf $HOME/.ivy2/cache/com.typesafe.play/*
   - rm -rf $HOME/.ivy2/cache/scala_*/sbt_*/com.typesafe.play/*
   # Delete all ivydata files since ivy touches them on each build
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print0 | xargs -n10 -0 rm
+  # Delete any SBT lock files
+  - find $HOME/.sbt -name "*.lock" -delete
 notifications:
   webhooks:
     urls:

--- a/framework/bin/travis
+++ b/framework/bin/travis
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# The CI box is limited to 3GB overall, with 2 cores for a container build.
+# https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
+#
+# https://docs.travis-ci.com/user/common-build-problems/#My-build-script-is-killed-without-any-error
+#
+# "This is usually caused by the script or one of the programs it runs exhausting the memory 
+# available in the build sandbox, which is currently 3GB. Plus, there are two cores available, bursted."
+#
+# "For parallel processes running at the same time, try to reduce the number. More 
+# than two to four processes should be fine, beyond that, resources are likely to be exhausted."
+#
+# We have SBT run with mx=2GB, and we get timeouts if we overstress the CPU, so
+# we can run the tasks serially.
+declare -a TASKS=(checkCodeStyle test testSbtPlugins testDocumentation testTemplates rehearseMicrobenchmarks)
+
+for TASK in "${TASKS[@]}" 
+do
+  # Don't limit the number of cores the container runs on.
+  # "set concurrentRestrictions in Global += Tags.limitAll(1)"
+  framework/bin/$TASK 
+done


### PR DESCRIPTION
Adjusts the build constraints to run Travis CI serially.  We are running into OutOfMemoryErrors and timeouts, and it probably results from running everything in parallel on the same container.