### PR TITLE
fixes the travis script

### DIFF
--- a/framework/bin/travis
+++ b/framework/bin/travis
@@ -13,6 +13,8 @@
 #
 # We have SBT run with mx=2GB, and we get timeouts if we overstress the CPU, so
 # we can run the tasks serially.
+set -e
+
 declare -a TASKS=(checkCodeStyle test testSbtPlugins testDocumentation testTemplates rehearseMicrobenchmarks)
 
 for TASK in "${TASKS[@]}" 


### PR DESCRIPTION
travis script won't fail on error in a task

however the websocketspec is failing all the time so the script should abort after a failure.