### PR TITLE
Add back the sbt concurrent limitations to build

### DIFF
--- a/framework/bin/travis
+++ b/framework/bin/travis
@@ -13,13 +13,13 @@
 #
 # We have SBT run with mx=2GB, and we get timeouts if we overstress the CPU, so
 # we can run the tasks serially.
-set -e
+set -ev
 
 declare -a TASKS=(checkCodeStyle test testSbtPlugins testDocumentation testTemplates rehearseMicrobenchmarks)
 
 for TASK in "${TASKS[@]}" 
-do
-  # Don't limit the number of cores the container runs on.
-  # "set concurrentRestrictions in Global += Tags.limitAll(1)"
-  framework/bin/$TASK 
+do  
+  # We have multi-threaded tests and see concurrent modification when starting logback,
+  # so always run tests sequentually.
+  framework/bin/$TASK "set concurrentRestrictions in Global += Tags.limitAll(1)" 
 done


### PR DESCRIPTION
Adds back:

```
framework/bin/$TASK "set concurrentRestrictions in Global += Tags.limitAll(1)" 
```

I'm seeing concurrent modification errors in logback, and I think it's from tasks running in parallel.

```
04:01:38,763 |-ERROR in ch.qos.logback.core.joran.spi.Interpreter@4:16 - RuntimeException in Action for tag [configuration] java.util.ConcurrentModificationException
	at java.util.ConcurrentModificationException
	at 	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1437)
	at 	at java.util.HashMap$EntryIterator.next(HashMap.java:1471)
	at 	at java.util.HashMap$EntryIterator.next(HashMap.java:1469)
	at 	at java.util.HashMap.putMapEntries(HashMap.java:511)
	at 	at java.util.HashMap.<init>(HashMap.java:489)
	at 	at ch.qos.logback.core.ContextBase.getCopyOfPropertyMap(ContextBase.java:80)
	at 	at ch.qos.logback.classic.spi.LoggerContextVO.<init>(LoggerContextVO.java:46)
	at 	at ch.qos.logback.classic.LoggerContext.updateLoggerContextVO(LoggerContext.java:96)
	at 	at ch.qos.logback.classic.LoggerContext.putProperty(LoggerContext.java:102)
	at 	at ch.qos.logback.core.util.ContextUtil.addHostNameAsProperty(ContextUtil.java:68)
```

https://travis-ci.org/playframework/playframework/builds/155235692#L3513