### PR TITLE
upgrade specs2 to 3.6.6

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -6,7 +6,7 @@ import buildinfo.BuildInfo
 
 object Dependencies {
 
-  val specsVersion = "3.6"
+  val specsVersion = "3.6.6"
   val specsBuild = Seq(
     "specs2-core",
     "specs2-junit",


### PR DESCRIPTION
So that the scalaz-stream bintray resolver is not needed