### PR TITLE
Json Reads Validation min and max with ordering

### DIFF
--- a/documentation/manual/working/scalaGuide/main/json/ScalaJsonCombinators.md
+++ b/documentation/manual/working/scalaGuide/main/json/ScalaJsonCombinators.md
@@ -67,9 +67,9 @@ The `JsValue.validate` method was introduced in [[JSON basics|ScalaJson]] as the
 Default validation for `Reads` is minimal, such as checking for type conversion errors. You can define custom validation rules by using `Reads` validation helpers. Here are some that are commonly used: 
 
 - `Reads.email` - Validates a String has email format.  
-- `Reads.minLength(nb)` - Validates the minimum length of a String.
-- `Reads.min` - Validates a minimum numeric value.
-- `Reads.max` - Validates a maximum numeric value.
+- `Reads.minLength(nb)` - Validates the minimum length of a collection or String.
+- `Reads.min` - Validates a minimum value.
+- `Reads.max` - Validates a maximum value.
 - `Reads[A] keepAnd Reads[B] => Reads[A]` - Operator that tries `Reads[A]` and `Reads[B]` but only keeps the result of `Reads[A]` (For those who know Scala parser combinators `keepAnd == <~` ).
 - `Reads[A] andKeep Reads[B] => Reads[B]` - Operator that tries `Reads[A]` and `Reads[B]` but only keeps the result of `Reads[B]` (For those who know Scala parser combinators `andKeep == ~>` ).
 - `Reads[A] or Reads[B] => Reads` - Operator that performs a logical OR and keeps the result of the last `Reads` checked.

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsConstraints.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsConstraints.scala
@@ -4,7 +4,6 @@
 package play.api.libs.json
 
 import play.api.data.validation.ValidationError
-import Json._
 
 trait ConstraintFormat {
   def of[A](implicit fmt: Format[A]): Format[A] = fmt
@@ -103,18 +102,18 @@ trait ConstraintReads {
   def map[A](implicit reads: Reads[A]): Reads[collection.immutable.Map[String, A]] = Reads.mapReads[A]
 
   /**
-   * Defines a minimum value for a numeric Reads. Combine with `max` using `or`, e.g.
-   * `.read(Reads.min(0) or Reads.max(100))`.
+   * Defines a minimum value for a Reads. Combine with `max` using `andKeep`, e.g.
+   * `.read(Reads.min(0) andKeep Reads.max(100))`.
    */
-  def min[N](m: N)(implicit reads: Reads[N], num: Numeric[N]) =
-    filterNot[N](ValidationError("error.min", m))(num.lt(_, m))(reads)
+  def min[O](m: O)(implicit reads: Reads[O], ord: Ordering[O]) =
+    filterNot[O](ValidationError("error.min", m))(ord.lt(_, m))(reads)
 
   /**
-   * Defines a maximum value for a numeric Reads. Combine with `min` using `or`, e.g.
-   * `.read(Reads.min(0.1) or Reads.max(1.0))`.
+   * Defines a maximum value for a Reads. Combine with `min` using `andKeep`, e.g.
+   * `.read(Reads.min(0.1) andKeep Reads.max(1.0))`.
    */
-  def max[N](m: N)(implicit reads: Reads[N], num: Numeric[N]) =
-    filterNot[N](ValidationError("error.max", m))(num.gt(_, m))(reads)
+  def max[O](m: O)(implicit reads: Reads[O], ord: Ordering[O]) =
+    filterNot[O](ValidationError("error.max", m))(ord.gt(_, m))(reads)
 
   def filterNot[A](error: ValidationError)(p: A => Boolean)(implicit reads: Reads[A]) =
     Reads[A](js => reads.reads(js).filterNot(JsError(error))(p))


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files? (no new files)
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Allows to use any type with an ordering for the Json-Combinators `min` and `max`.

## Purpose

For me this allows to use SI units like meter in https://github.com/KarolS/units like Int and Double. Other possible use-cases would be ordered enum types like log levels. (e.g. `(__ \ 'level).read[LogLevel](min(warning))`)

Implementing Numeric is something between awkward (the signature of multiplication makes no sense for meters) and impossible (translation from and to Int for LogLevels?). Luckily we need much less to implement `min` and `max`: [`Ordering`](http://www.scala-lang.org/api/2.11.8/#scala.math.Ordering).
