### PR TITLE
Ensure actorSystem stops before starting new test

### DIFF
--- a/framework/src/play-java-ws/src/main/java/play/test/WSTestClient.java
+++ b/framework/src/play-java-ws/src/main/java/play/test/WSTestClient.java
@@ -4,6 +4,7 @@
 package play.test;
 
 import akka.actor.ActorSystem;
+import akka.actor.Terminated;
 import akka.stream.ActorMaterializer;
 import akka.stream.ActorMaterializerSettings;
 
@@ -14,6 +15,9 @@ import org.asynchttpclient.AsyncHttpClientConfig;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 import play.libs.ws.ahc.AhcWSClient;
 import play.libs.ws.*;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Duration;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -59,10 +63,15 @@ public class WSTestClient {
             }
             public void close() throws IOException {
                 try {
-                    client.close();
-                }
-                finally {
-                    system.terminate();
+                    try {
+                        client.close();
+                    }
+                    finally {
+                        final Future<Terminated> terminate = system.terminate();
+                        Await.result(terminate, Duration.Inf());
+                    }
+                } catch (Exception e) {
+                    throw new IOException(e);
                 }
             }
         };

--- a/framework/src/play-ws/src/main/scala/play/api/test/WSTestClient.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/test/WSTestClient.scala
@@ -6,9 +6,11 @@ package play.api.test
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import play.api.libs.ws._
-import play.api.libs.ws.ahc.{ AhcWSClientConfig, AhcWSClient }
-
+import play.api.libs.ws.ahc.{ AhcWSClient, AhcWSClientConfig }
 import play.api.mvc.Call
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 /**
  * A standalone test client that is useful for running standalone integration tests.
@@ -46,6 +48,7 @@ trait WsTestClient {
     def close(): Unit = {
       client.close()
       system.terminate()
+      Await.result(system.whenTerminated, Duration.Inf)
     }
   }
 

--- a/framework/src/play-ws/src/main/scala/play/api/test/WSTestClient.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/test/WSTestClient.scala
@@ -9,9 +9,6 @@ import play.api.libs.ws._
 import play.api.libs.ws.ahc.{ AhcWSClient, AhcWSClientConfig }
 import play.api.mvc.Call
 
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
-
 /**
  * A standalone test client that is useful for running standalone integration tests.
  */
@@ -19,41 +16,8 @@ trait WsTestClient {
 
   type Port = Int
 
-  /**
-   * Creates a standalone WSClient, using its own ActorSystem and Netty thread pool.
-   *
-   * This client has no dependencies at all on the underlying system, but is wasteful of resources.
-   *
-   * @param port the port to connect to the server on.
-   * @param scheme the scheme to connect on ("http" or "https")
-   */
-  class InternalWSClient(scheme: String, port: Port) extends WSClient {
-    private val name = "ws-test-client-" + WsTestClient.instanceNumber.getAndIncrement
-    private val system = ActorSystem(name)
-    private val materializer = ActorMaterializer(namePrefix = Some(name))(system)
-    // Don't retry for tests
-    private val client = AhcWSClient(AhcWSClientConfig(maxRequestRetry = 0))(materializer)
-
-    def underlying[T] = client.underlying.asInstanceOf[T]
-
-    def url(url: String): WSRequest = {
-      if (url.startsWith("/") && port != -1) {
-        val httpPort = new play.api.http.Port(port)
-        client.url(s"$scheme://localhost:$httpPort$url")
-      } else {
-        client.url(url)
-      }
-    }
-
-    def close(): Unit = {
-      client.close()
-      system.terminate()
-      Await.result(system.whenTerminated, Duration.Inf)
-    }
-  }
-
   private val clientProducer: (Port, String) => WSClient = { (port, scheme) =>
-    new InternalWSClient(scheme, port)
+    new WsTestClient.InternalWSClient(scheme, port)
   }
 
   /**
@@ -68,16 +32,7 @@ trait WsTestClient {
    * }}}
    */
   def wsCall(call: Call)(implicit port: Port, client: (Port, String) => WSClient = clientProducer, scheme: String = "http"): WSRequest = {
-    try {
-      wsUrl(call.url)
-    } finally {
-      client match {
-        case internal: InternalWSClient =>
-          internal.close()
-        case _ =>
-        // do nothing
-      }
-    }
+    wsUrl(call.url)
   }
 
   /**
@@ -121,8 +76,38 @@ trait WsTestClient {
 }
 
 object WsTestClient extends WsTestClient {
-  import java.util.concurrent.atomic.AtomicInteger
-  // This is used to create fresh names when creating `ActorMaterializer` instances in `WsTestClient.withClient`.
-  // The motivation is that it can be useful for debugging.
-  private val instanceNumber = new AtomicInteger(1)
+
+  // Accept the overhead of having a client open through all the integration tests
+  private lazy val singletonInstance: WSClient = {
+    val name = "ws-test-client"
+    val system = ActorSystem(name)
+    val materializer = ActorMaterializer(namePrefix = Some(name))(system)
+    // Don't retry for tests
+    AhcWSClient(AhcWSClientConfig(maxRequestRetry = 0))(materializer)
+  }
+
+  /**
+   * Creates a standalone WSClient, using its own ActorSystem and Netty thread pool.
+   *
+   * This client has no dependencies at all on the underlying system, but is wasteful of resources.
+   *
+   * @param port the port to connect to the server on.
+   * @param scheme the scheme to connect on ("http" or "https")
+   */
+  class InternalWSClient(scheme: String, port: Port) extends WSClient {
+
+    def underlying[T] = singletonInstance.underlying.asInstanceOf[T]
+
+    def url(url: String): WSRequest = {
+      if (url.startsWith("/") && port != -1) {
+        val httpPort = new play.api.http.Port(port)
+        singletonInstance.url(s"$scheme://localhost:$httpPort$url")
+      } else {
+        singletonInstance.url(url)
+      }
+    }
+
+    /** Closes this client, and releases underlying resources. */
+    override def close(): Unit = {}
+  }
 }


### PR DESCRIPTION
## Fixes

Fixes the Travis CI build.

This should stop the OOM seen after a few hundred ws-test-client instances:

https://travis-ci.org/playframework/playframework/builds/156315711#L2617

[INFO] [08/30/2016 19:36:16.989] [ws-test-client-163-scheduler-1] [akka.actor.ActorSystemImpl(ws-test-client-163)] starting new LARS thread