### PR TITLE
Fix WebsocketSpec failures 

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -51,7 +51,8 @@ object BuildSettings {
     ivyLoggingLevel := UpdateLogging.DownloadOnly,
     resolvers ++= Seq(
       Resolver.typesafeRepo("releases"),
-      Resolver.typesafeIvyRepo("releases")
+      Resolver.typesafeIvyRepo("releases"),
+      "Akka Snapshot Repository" at "http://repo.akka.io/snapshots/"
     ),
     fork in Test := true,
     parallelExecution in Test := false,

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -6,7 +6,7 @@ import buildinfo.BuildInfo
 
 object Dependencies {
 
-  val akkaVersion = "2.4.9"
+  val akkaVersion = "2.4.8"
 
   val specsVersion = "3.8.4"
   val specsBuild = Seq(

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -68,7 +68,7 @@ trait PingWebSocketSpec extends PlaySpecification with WsTestClient with NettyIn
         closeFrame()
       ))
     }
-  }.skipUntilNettyHttpFixed
+  }
 
   "not respond to pongs" in {
     withServer(app => WebSocket.accept[String, String] { req =>
@@ -85,7 +85,7 @@ trait PingWebSocketSpec extends PlaySpecification with WsTestClient with NettyIn
         closeFrame()
       ))
     }
-  }.skipUntilNettyHttpFixed
+  }
 
 }
 


### PR DESCRIPTION
Fixes https://github.com/playframework/playframework/issues/6504 

Downgrades to Akka 2.4.8 and enables PingWebSocketSpec again.