### PR TITLE
Document Default controller in routing docs

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/JavaRouting.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaRouting.md
@@ -161,6 +161,14 @@ You can then reverse the URL to the `hello` action method, by using the `control
 
 The reverse action method works quite simply: it takes your parameters and substitutes them back into the route pattern.  In the case of path segments (`:foo`), the value is encoded before the substitution is done.  For regex and wildcard patterns the string is substituted in raw form, since the value may span multiple segments.  Make sure you escape those components as desired when passing them to the reverse route, and avoid passing unvalidated user input.
 
+## The Default Controller
+
+Play includes a [`Default` controller](api/scala/controllers/Default.html) which provides a handful of useful actions. These can be invoked directly from the routes file:
+
+@[defaultcontroller](code/javaguide.http.routing.defaultcontroller.routes)
+
+In this example, `GET /` redirects to an external website, but it's also possible to redirect to another action (such as `/posts` in the above example).
+
 ## Advanced Routing
 
 See [[Routing DSL|JavaRoutingDsl]].

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide.http.routing.defaultcontroller.routes
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide.http.routing.defaultcontroller.routes
@@ -1,0 +1,13 @@
+# #defaultcontroller
+# Redirects to https://www.playframework.com/ with 303 See Other
+GET   /about      controllers.Default.redirect(to = "https://www.playframework.com/")
+
+# Responds with 404 Not Found
+GET   /orders     controllers.Default.notFound
+
+# Responds with 500 Internal Server Error
+GET   /clients    controllers.Default.error
+
+# Responds with 501 Not Implemented
+GET   /posts      controllers.Default.todo
+# #defaultcontroller

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaRouting.scala
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaRouting.scala
@@ -124,15 +124,5 @@ class Clients extends Controller {
 }
 
 package routing.defaultcontroller.controllers {
-import play.api.mvc.Controller
-import _root_.controllers.{Default => PlayDefault}
-
-class Default extends Controller {
-
-  def redirect(to: String) = PlayDefault.redirect(to)
-  def notFound = PlayDefault.notFound
-  def error = PlayDefault.error
-  def todo = PlayDefault.todo
-
-}
+class Default extends _root_.controllers.Default
 }

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaRouting.scala
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaRouting.scala
@@ -48,6 +48,12 @@ class JavaRouting extends Specification {
       contentOf(FakeRequest("GET", "/clients"), classOf[defaultvalue.Routes]) must_== "clients page 1"
       contentOf(FakeRequest("GET", "/clients?page=2"), classOf[defaultvalue.Routes]) must_== "clients page 2"
     }
+    "support invoking Default controller actions" in {
+      statusOf(FakeRequest("GET", "/about"), classOf[defaultcontroller.Routes]) must_== SEE_OTHER
+      statusOf(FakeRequest("GET", "/orders"), classOf[defaultcontroller.Routes]) must_== NOT_FOUND
+      statusOf(FakeRequest("GET", "/clients"), classOf[defaultcontroller.Routes]) must_== INTERNAL_SERVER_ERROR
+      statusOf(FakeRequest("GET", "/posts"), classOf[defaultcontroller.Routes]) must_== NOT_IMPLEMENTED
+    }
     "support optional values for parameters" in {
       contentOf(FakeRequest("GET", "/api/list-all")) must_== "version null"
       contentOf(FakeRequest("GET", "/api/list-all?version=3.0")) must_== "version 3.0"
@@ -71,6 +77,17 @@ class JavaRouting extends Specification {
       })
     }
   }
+
+
+  def statusOf(rh: RequestHeader, router: Class[_ <: Router] = classOf[Routes]) = {
+    running(_.configure("play.http.router" -> router.getName)) { app =>
+      implicit val mat = ActorMaterializer()(app.actorSystem)
+      status(app.requestHandler.handlerForRequest(rh)._2 match {
+        case e: EssentialAction => e(rh).run()
+      })
+    }
+  }
+
 }
 
 package routing.query.controllers {
@@ -106,3 +123,16 @@ class Clients extends Controller {
 }
 }
 
+package routing.defaultcontroller.controllers {
+import play.api.mvc.Controller
+import _root_.controllers.{Default => PlayDefault}
+
+class Default extends Controller {
+
+  def redirect(to: String) = PlayDefault.redirect(to)
+  def notFound = PlayDefault.notFound
+  def error = PlayDefault.error
+  def todo = PlayDefault.todo
+
+}
+}

--- a/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
@@ -44,7 +44,7 @@ You can tell the routes file to use a different router under a specific prefix b
 ->      /api                        api.MyRouter
 ```
 
-This is especially useful when combined with [String Interpolating Routing DSL|ScalaSirdRouter] also known as SIRD routing, or when working with [[sub projects|SBTSubProjects]] that route using several routes files.
+This is especially useful when combined with [[String Interpolating Routing DSL|ScalaSirdRouter]] also known as SIRD routing, or when working with [[sub projects|SBTSubProjects]] that route using several routes files.
 
 ## The HTTP method
 
@@ -163,6 +163,14 @@ You can then reverse the URL to the `hello` action method, by using the `control
 > **Note:** There is a `routes` subpackage for each controller package. So the action `controllers.admin.Application.hello` can be reversed via `controllers.admin.routes.Application.hello` (as long as there is no other route before it in the routes file that happens to match the generated path).
 
 The reverse action method works quite simply: it takes your parameters and substitutes them back into the route pattern.  In the case of path segments (`:foo`), the value is encoded before the substitution is done.  For regex and wildcard patterns the string is substituted in raw form, since the value may span multiple segments.  Make sure you escape those components as desired when passing them to the reverse route, and avoid passing unvalidated user input.
+
+## The Default Controller
+
+Play includes a [`Default` controller](api/scala/controllers/Default.html) which provides a handful of useful actions. These can be invoked directly from the routes file:
+
+@[defaultcontroller](code/scalaguide.http.routing.defaultcontroller.routes)
+
+In this example, `GET /` redirects to an external website, but it's also possible to redirect to another action (such as `/posts` in the above example).
 
 ## Custom routing
 

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
@@ -73,17 +73,7 @@ package defaultvalue.controllers {
 }
 
 package defaultcontroller.controllers {
-  import _root_.controllers.{Default => PlayDefault}
-
-  class Default extends Controller {
-
-    def redirect(to: String) = PlayDefault.redirect(to)
-    def notFound = PlayDefault.notFound
-    def error = PlayDefault.error
-    def todo = PlayDefault.todo
-
-  }
-
+  class Default extends _root_.controllers.Default
 }
 
 // #reverse-controller

--- a/documentation/manual/working/scalaGuide/main/http/code/scalaguide.http.routing.defaultcontroller.routes
+++ b/documentation/manual/working/scalaGuide/main/http/code/scalaguide.http.routing.defaultcontroller.routes
@@ -1,0 +1,13 @@
+# #defaultcontroller
+# Redirects to https://www.playframework.com/ with 303 See Other
+GET   /about      controllers.Default.redirect(to = "https://www.playframework.com/")
+
+# Responds with 404 Not Found
+GET   /orders     controllers.Default.notFound
+
+# Responds with 500 Internal Server Error
+GET   /clients    controllers.Default.error
+
+# Responds with 501 Not Implemented
+GET   /posts      controllers.Default.todo
+# #defaultcontroller

--- a/framework/src/play/src/main/scala/play/api/controllers/Default.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Default.scala
@@ -45,7 +45,7 @@ class Default @Inject() () extends Controller {
   }
 
   /**
-   * Returns a 302 Redirect response.
+   * Returns a 303 SeeOther response.
    *
    * Example:
    * {{{


### PR DESCRIPTION
I found the `Default` controller useful and thought it'd be good to mention it in the routing documentation. This PR does that, along with some other minor documentation fixes.