### PR TITLE
WIP Define MessageApi configuration in a provider.

### DIFF
--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaCompileTimeDependencyInjection.md
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaCompileTimeDependencyInjection.md
@@ -76,8 +76,8 @@ To use this router in an actual application:
 
 ## Using other components
 
-As described before, Play provides a number of helper traits for wiring in other components.  For example, if you wanted to use the messages module, you can mix in [I18nComponents](api/scala/play/api/i18n/I18nComponents.html) into your components cake, like so:
+As described before, Play provides a number of helper traits for wiring in other components.  The helper traits are usually called by "*Components" -- for example, if you wanted to use the WS module, you can mix in [AhcWsComponents](api/scala/play/api/libs/ws/ahc/AhcWSComponents.html) into your components, like so:
 
-@[messages](code/CompileTimeDependencyInjection.scala)
+@[wscomponent](code/CompileTimeDependencyInjection.scala)
 
-Other helper traits are also available as the [CSRFComponents](api/scala/play/filters/csrf/CSRFComponents.html) or the [AhcWsComponents](api/scala/play/api/libs/ws/ahc/AhcWSComponents.html)
+Other helper traits are also available as the [CSRFComponents](api/scala/play/filters/csrf/CSRFComponents.html) or  [SecurityHeaderComponents](api/scala/play/filters/headers/SecurityHeadersComponents.html).

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
@@ -18,16 +18,16 @@ class CompileTimeDependencyInjection extends Specification {
       val context = ApplicationLoader.createContext(environment,
         Map("play.application.loader" -> classOf[basic.MyApplicationLoader].getName)
       )
-      val components = new messages.MyComponents(context)
+      val components = new wscomponent.MyComponents(context)
       val application = ApplicationLoader(context).load(context)
       application must beAnInstanceOf[Application]
       components.router.documentation must beEmpty
     }
     "allow using other components" in {
       val context = ApplicationLoader.createContext(environment)
-      val components = new messages.MyComponents(context)
+      val components = new wscomponent.MyComponents(context)
       components.application must beAnInstanceOf[Application]
-      components.myComponent must beAnInstanceOf[messages.MyComponent]
+      components.myComponent must beAnInstanceOf[wscomponent.MyComponent]
     }
     "allow declaring a custom router" in {
       val context = ApplicationLoader.createContext(environment)
@@ -70,26 +70,26 @@ class MyApplicationLoaderWithInitialization extends ApplicationLoader {
 
 }
 
-package messages {
+package wscomponent {
 
 import play.api._
 import play.api.ApplicationLoader.Context
 import play.api.routing.Router
 
-//#messages
-import play.api.i18n._
+//#wscomponent
+import play.api.libs.ws._
+import play.api.libs.ws.ahc._
 
-class MyComponents(context: Context) extends BuiltInComponentsFromContext(context)
-                                     with I18nComponents {
+class MyComponents(context: Context) extends BuiltInComponentsFromContext(context) with AhcWSComponents {
   lazy val router = Router.empty
 
-  lazy val myComponent = new MyComponent(messagesApi)
+  lazy val myComponent = new MyComponent(wsClient)
 }
 
-class MyComponent(messages: MessagesApi) {
+class MyComponent(ws: WSClient) {
   // ...
 }
-//#messages
+//#wscomponent
 
 }
 

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaFieldConstructor.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaFieldConstructor.scala
@@ -4,13 +4,14 @@
 package scalaguide.forms.scalafieldconstructor {
 
 import org.specs2.mutable.Specification
-import play.api.{Environment, Configuration}
-import play.api.i18n.{DefaultLangs, DefaultMessagesApi, Messages}
+import play.api.{Configuration, Environment}
+import play.api.i18n._
 
 class ScalaFieldConstructorSpec extends Specification {
 
   val conf = Configuration.reference
-  implicit val messages: Messages = new DefaultMessagesApi(Environment.simple(), conf, new DefaultLangs(conf)).preferred(Seq.empty)
+  val messagesApi = new MessagesApiProvider(Environment.simple(), conf, new LangsProvider(conf).get).get
+  implicit val messages: Messages = messagesApi.preferred(Seq.empty)
 
   "field constructors" should {
 

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -3,14 +3,12 @@
  */
 package scalaguide.forms.scalaforms {
 
-import play.api.{Environment, Configuration}
-import play.api.i18n.{DefaultLangs, DefaultMessagesApi, Messages}
+import play.api.{Configuration, Environment}
+import play.api.i18n._
 
 import scalaguide.forms.scalaforms.controllers.routes
-
 import play.api.mvc._
 import play.api.test._
-
 import org.specs2.mutable.Specification
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
@@ -28,7 +26,8 @@ import play.api.data.validation.Constraints._
 class ScalaFormsSpec extends Specification with Controller {
 
   val conf = Configuration.reference
-  implicit val messages: Messages = new DefaultMessagesApi(Environment.simple(), conf, new DefaultLangs(conf)).preferred(Seq.empty)
+  val messagesApi = new MessagesApiProvider(Environment.simple(), conf, new LangsProvider(conf).get).get
+  implicit val messages: Messages = messagesApi.preferred(Seq.empty)
 
   "A scala forms" should {
 

--- a/documentation/manual/working/scalaGuide/main/i18n/code/ScalaI18N.scala
+++ b/documentation/manual/working/scalaGuide/main/i18n/code/ScalaI18N.scala
@@ -8,7 +8,7 @@ import play.api.test._
 
 import play.api._
 import play.api.mvc._
-import play.api.i18n.{DefaultLangs, DefaultMessagesApi, Messages, MessagesApi}
+import play.api.i18n._
 
 @RunWith(classOf[JUnitRunner])
 class ScalaI18nSpec extends PlaySpecification with Controller {
@@ -36,7 +36,7 @@ class ScalaI18nSpec extends PlaySpecification with Controller {
   }
 
   val conf = Configuration.reference ++ Configuration.from(Map("play.i18n.path" -> "scalaguide/i18n"))
-  val messagesApi = new DefaultMessagesApi(Environment.simple(), conf, new DefaultLangs(conf))
+  val messagesApi = new MessagesApiProvider(Environment.simple(), conf, new LangsProvider(conf).get).get
 
   new MyController(messagesApi)
 

--- a/framework/src/play-java/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/DynamicFormSpec.scala
@@ -6,11 +6,12 @@ package play.data
 import com.typesafe.config.ConfigFactory
 import org.specs2.mutable.Specification
 import play.api.{ Configuration, Environment }
-import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
+import play.api.i18n.{ DefaultLangs, DefaultMessagesApi, LangsProvider, MessagesApiProvider }
 import play.data.format.Formatters
 import views.html.helper.inputText
 import play.core.j.PlayMagicForJava.javaFieldtoScalaField
 import views.html.helper.FieldConstructor.defaultField
+
 import scala.collection.JavaConversions._
 import javax.validation.Validation
 
@@ -18,7 +19,10 @@ import javax.validation.Validation
  * Specs for Java dynamic forms
  */
 class DynamicFormSpec extends Specification {
-  val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
+
+  val langs = new LangsProvider(Configuration.reference).get
+  val messagesApi = new MessagesApiProvider(Environment.simple(), Configuration.reference, langs).get
+
   implicit val messages = messagesApi.preferred(Seq.empty)
   val jMessagesApi = new play.i18n.MessagesApi(messagesApi)
   val validator = Validation.buildDefaultValidatorFactory().getValidator()

--- a/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/FormSpec.scala
@@ -8,10 +8,11 @@ import java.util.Optional
 
 import org.specs2.mutable.Specification
 import play.mvc.Http.{ Context, Request, RequestBuilder }
+
 import scala.collection.JavaConverters._
 import scala.beans.BeanProperty
 import play.api.{ Configuration, Environment }
-import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
+import play.api.i18n.{ DefaultLangs, DefaultMessagesApi, LangsProvider, MessagesApiProvider }
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.WithApplication
 import play.data.FormFactory
@@ -22,7 +23,9 @@ import javax.validation.Validation
 
 class FormSpec extends Specification {
 
-  val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
+  val langs = new LangsProvider(Configuration.reference).get
+  val messagesApi = new MessagesApiProvider(Environment.simple(), Configuration.reference, langs).get
+
   val jMessagesApi = new play.i18n.MessagesApi(messagesApi)
   val formFactory = new FormFactory(jMessagesApi, new Formatters(jMessagesApi), Validation.buildDefaultValidatorFactory().getValidator())
 

--- a/framework/src/play-java/src/test/scala/play/data/PartialValidationSpec.scala
+++ b/framework/src/play-java/src/test/scala/play/data/PartialValidationSpec.scala
@@ -4,18 +4,22 @@
 package play.data
 
 import validation.Constraints.{ MaxLength, Required }
+
 import beans.BeanProperty
 import org.specs2.mutable.Specification
+
 import scala.collection.JavaConverters._
 import play.api.{ Configuration, Environment }
-import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
+import play.api.i18n.{ DefaultLangs, DefaultMessagesApi, LangsProvider, MessagesApiProvider }
 import play.data.FormFactory
 import play.data.format.Formatters
 import javax.validation.Validation
 
 class PartialValidationSpec extends Specification {
 
-  val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
+  val langs = new LangsProvider(Configuration.reference).get
+  val messagesApi = new MessagesApiProvider(Environment.simple(), Configuration.reference, langs).get
+
   val jMessagesApi = new play.i18n.MessagesApi(messagesApi)
   val formFactory = new FormFactory(jMessagesApi, new Formatters(jMessagesApi), Validation.buildDefaultValidatorFactory().getValidator())
 

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -5,7 +5,7 @@ package play.api.i18n
 
 import java.net.URL
 import java.util.Locale
-import javax.inject.{ Inject, Singleton }
+import javax.inject.{ Inject, Provider, Singleton }
 
 import play.api._
 import play.api.inject.Module
@@ -155,9 +155,9 @@ trait Langs {
 }
 
 @Singleton
-class DefaultLangs @Inject() (config: Configuration) extends Langs {
+class LangsProvider @Inject() (config: Configuration) extends Provider[Langs] {
 
-  val availables: Seq[Lang] = {
+  def availables: Seq[Lang] = {
     val langs = config.getOptional[String]("application.langs") map { langsStr =>
       Logger.warn("application.langs is deprecated, use play.i18n.langs instead")
       langsStr.split(",").map(_.trim).toSeq
@@ -173,6 +173,13 @@ class DefaultLangs @Inject() (config: Configuration) extends Langs {
     }
   }
 
+  lazy val get: Langs = {
+    new DefaultLangs(availables)
+  }
+}
+
+@Singleton
+class DefaultLangs @Inject() (val availables: Seq[Lang] = Seq(Lang.defaultLang)) extends Langs {
   def preferred(candidates: Seq[Lang]): Lang = candidates.collectFirst(Function.unlift { lang =>
     availables.find(_.satisfies(lang))
   }).getOrElse(availables.headOption.getOrElse(Lang.defaultLang))
@@ -465,17 +472,67 @@ trait MessagesApi {
 
 }
 
+@Singleton
+class MessagesApiProvider @Inject() (environment: Environment, config: Configuration, langs: Langs) extends Provider[MessagesApi] {
+
+  def messagesPrefix = config.getDeprecated[Option[String]]("play.i18n.path", "messages.path")
+
+  def loadMessages(file: String): Map[String, String] = {
+    import scala.collection.JavaConverters._
+
+    environment.classLoader.getResources(joinPaths(messagesPrefix, file)).asScala.toList
+      .filterNot(url => Resources.isDirectory(environment.classLoader, url)).reverse
+      .map { messageFile =>
+        Messages.parse(Messages.UrlMessageSource(messageFile), messageFile.toString).fold(e => throw e, identity)
+      }.foldLeft(Map.empty[String, String]) { _ ++ _ }
+  }
+
+  def loadAllMessages: Map[String, Map[String, String]] = {
+    langs.availables.map(_.code).map { lang =>
+      (lang, loadMessages("messages." + lang))
+    }.toMap
+      .+("default" -> loadMessages("messages"))
+      .+("default.play" -> loadMessages("messages.default"))
+  }
+
+  def joinPaths(first: Option[String], second: String) = first match {
+    case Some(parent) => new java.io.File(parent, second).getPath
+    case None => second
+  }
+
+  def langCookieName =
+    config.getDeprecated[String]("play.i18n.langCookieName", "application.lang.cookie")
+
+  def langCookieSecure =
+    config.get[Boolean]("play.i18n.langCookieSecure")
+
+  def langCookieHttpOnly =
+    config.get[Boolean]("play.i18n.langCookieHttpOnly")
+
+  override lazy val get: MessagesApi = {
+    new DefaultMessagesApi(
+      loadAllMessages,
+      langs,
+      langCookieName = langCookieName,
+      langCookieSecure = langCookieSecure,
+      langCookieHttpOnly = langCookieHttpOnly
+    )
+  }
+
+}
+
 /**
  * The internationalisation API.
  */
 @Singleton
-class DefaultMessagesApi @Inject() (environment: Environment, config: Configuration, langs: Langs) extends MessagesApi {
+class DefaultMessagesApi @Inject() (
+    val messages: Map[String, Map[String, String]] = Map.empty,
+    langs: Langs = new DefaultLangs(),
+    val langCookieName: String = "PLAY_LANG",
+    val langCookieSecure: Boolean = false,
+    val langCookieHttpOnly: Boolean = false) extends MessagesApi {
 
   import java.text._
-
-  protected val messagesPrefix =
-    config.getDeprecated[Option[String]]("play.i18n.path", "messages.path")
-  val messages: Map[String, Map[String, String]] = loadAllMessages
 
   def preferred(candidates: Seq[Lang]) = Messages(langs.preferred(candidates), this)
 
@@ -522,46 +579,13 @@ class DefaultMessagesApi @Inject() (environment: Environment, config: Configurat
       acc || messages.get(lang).exists(_.isDefinedAt(key))
     })
   }
-
-  private def joinPaths(first: Option[String], second: String) = first match {
-    case Some(parent) => new java.io.File(parent, second).getPath
-    case None => second
-  }
-
-  protected def loadMessages(file: String): Map[String, String] = {
-    import scala.collection.JavaConverters._
-
-    environment.classLoader.getResources(joinPaths(messagesPrefix, file)).asScala.toList
-      .filterNot(url => Resources.isDirectory(environment.classLoader, url)).reverse
-      .map { messageFile =>
-        Messages.parse(Messages.UrlMessageSource(messageFile), messageFile.toString).fold(e => throw e, identity)
-      }.foldLeft(Map.empty[String, String]) { _ ++ _ }
-  }
-
-  protected def loadAllMessages: Map[String, Map[String, String]] = {
-    langs.availables.map(_.code).map { lang =>
-      (lang, loadMessages("messages." + lang))
-    }.toMap
-      .+("default" -> loadMessages("messages"))
-      .+("default.play" -> loadMessages("messages.default"))
-  }
-
-  lazy val langCookieName =
-    config.getDeprecated[String]("play.i18n.langCookieName", "application.lang.cookie")
-
-  lazy val langCookieSecure =
-    config.get[Boolean]("play.i18n.langCookieSecure")
-
-  lazy val langCookieHttpOnly =
-    config.get[Boolean]("play.i18n.langCookieHttpOnly")
-
 }
 
 class I18nModule extends Module {
   def bindings(environment: Environment, configuration: Configuration) = {
     Seq(
-      bind[Langs].to[DefaultLangs],
-      bind[MessagesApi].to[DefaultMessagesApi]
+      bind[Langs].toProvider[LangsProvider],
+      bind[MessagesApi].toProvider[MessagesApiProvider]
     )
   }
 }
@@ -574,7 +598,7 @@ trait I18nComponents {
   def environment: Environment
   def configuration: Configuration
 
-  lazy val messagesApi: MessagesApi = new DefaultMessagesApi(environment, configuration, langs)
-  lazy val langs: Langs = new DefaultLangs(configuration)
+  lazy val messagesApi: MessagesApi = new MessagesApiProvider(environment, configuration, langs).get
+  lazy val langs: Langs = new LangsProvider(configuration).get
 
 }

--- a/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
@@ -7,7 +7,7 @@ import play.api.{ Configuration, Environment }
 import play.api.data.Forms._
 import play.api.data.validation.Constraints._
 import play.api.data.format.Formats._
-import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
+import play.api.i18n._
 import play.api.libs.json.Json
 import org.specs2.mutable.Specification
 
@@ -268,7 +268,11 @@ class FormSpec extends Specification {
   }
 
   "correctly lookup error messages when using errorsAsJson" in {
-    val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
+    val messagesApi: MessagesApi = {
+      val config = Configuration.reference
+      val langs = new LangsProvider(config).get
+      new MessagesApiProvider(Environment.simple(), config, langs).get
+    }
     implicit val messages = messagesApi.preferred(Seq.empty)
 
     val form = Form(single("foo" -> Forms.text), Map.empty, Seq(FormError("foo", "error.custom", Seq("error.customarg"))), None)

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -15,7 +15,7 @@ import akka.stream.scaladsl.Sink
 import org.specs2.mutable._
 import play.api.http.HeaderNames._
 import play.api.http.Status._
-import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
+import play.api.i18n._
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.{ Configuration, Environment, Play }
 import play.core.test._
@@ -146,7 +146,8 @@ class ResultsSpec extends Specification {
     }
 
     "support clearing a language cookie using clearingLang" in withApplication {
-      implicit val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
+      val langs = new LangsProvider(Configuration.reference).get
+      implicit val messagesApi = new MessagesApiProvider(Environment.simple(), Configuration.reference, langs).get
       val cookie = Cookies.decodeSetCookieHeader(Ok.clearingLang.header.headers("Set-Cookie")).head
       cookie.name must_== Play.langCookieName
       cookie.value must_== ""

--- a/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -7,13 +7,16 @@ import org.specs2.mutable.Specification
 import play.api.{ Configuration, Environment }
 import play.api.data.Forms._
 import play.api.data._
-import play.api.i18n.{ DefaultLangs, DefaultMessagesApi, Lang }
+import play.api.i18n._
 import play.twirl.api.Html
+
 import scala.beans.BeanProperty
 
 class HelpersSpec extends Specification {
   import FieldConstructor.defaultField
-  val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
+
+  val langs = new LangsProvider(Configuration.reference).get
+  val messagesApi = new MessagesApiProvider(Environment.simple(), Configuration.reference, langs).get
   implicit val messages = messagesApi.preferred(Seq.empty)
 
   "@inputText" should {


### PR DESCRIPTION
DO NOT MERGE, NEEDS DOCS

This commit moves the DefaultMessagesApi logic apart from the configuration / environment logic.  This means that you can instantiate a DefaultMessagesApi without needing access to env / config -- just pass in the Map.

This makes it much easier to supply a MessagesApi object to FakeRequest without having to go through Environment / Configuration, and sets things up for a MessagesApi injected through a request attribute.