### PR TITLE
WIP: uri decoding / encoding

### DIFF
--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -7,6 +7,12 @@ This is a guide for migrating from Play 2.5 to Play 2.6. If you need to migrate 
 
 The following steps need to be taken to update your sbt build before you can load/run a Play project in sbt.
 
+## Uri Parsing
+
+Play now uses scala-uri to parse underlying URI's. This comes with some breaking changes.
+
+A Query String of `?foo` now yields a `Map(foo -> Nil)` instead of a `Map(foo -> Buffer(""))`.
+
 ## Scala ActionBuilder and BodyParser changes:
 
 The Scala `ActionBuilder` trait has been modified to specify the type of the body as a type parameter, and add an abstract `parser` member as the default body parsers. You will need to modify your ActionBuilders and pass the body parser directly.
@@ -31,6 +37,10 @@ This trait makes `Action` and `parse` refer to injected instances rather than th
 ## JPA Migration Notes
 
 See [[JPAMigration26]].
+
+## WS Migration Notes
+
+See [[WSMigration26]].
 
 ## Removed Crypto API
 

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -7,11 +7,12 @@ This is a guide for migrating from Play 2.5 to Play 2.6. If you need to migrate 
 
 The following steps need to be taken to update your sbt build before you can load/run a Play project in sbt.
 
-## Uri Parsing
+## Uri Decoding / Encoding
 
-Play now uses scala-uri to parse underlying URI's. This comes with some breaking changes.
+Play now uses [scala-uri](https://github.com/NET-A-PORTER/scala-uri) to decode and encode URI's.
+This will maybe change your code if you rely on some more exotic URI encoding / decoding.
 
-A Query String of `?foo` now yields a `Map(foo -> Nil)` instead of a `Map(foo -> Buffer(""))`.
+We explain everything in Detail here: [[common|Uri]]
 
 ## Scala ActionBuilder and BodyParser changes:
 
@@ -37,10 +38,6 @@ This trait makes `Action` and `parse` refer to injected instances rather than th
 ## JPA Migration Notes
 
 See [[JPAMigration26]].
-
-## WS Migration Notes
-
-See [[WSMigration26]].
 
 ## Removed Crypto API
 

--- a/documentation/manual/releases/release26/migration26/index.toc
+++ b/documentation/manual/releases/release26/migration26/index.toc
@@ -1,1 +1,3 @@
 Migration26:Migration Guide
+JPAMigration26:JPA Migration Guide
+WSMigration26:WS Migration Guide

--- a/documentation/manual/working/commonGuide/Uri.md
+++ b/documentation/manual/working/commonGuide/Uri.md
@@ -1,0 +1,35 @@
+<!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
+# Play's Uri Encoding / Decoding
+
+Play uses the following Strategies to decode / encode Uri's.
+If your code needs some more exotic Strategies you need to parse Query Strings and Paths by yourself.
+
+## Path
+
+### Decoding
+
+TODO
+
+### Encoding
+
+TODO
+
+## Query Strings
+
+### Decoding
+
+Basically Play will only split Query String's by `?` and `&` and Key-Value-Pairs with `=` we won't split Matrix Param.
+In concret, this means that a `?filter=a&filter=b` will be `List("a", "b")` while a `?filter=a,b` or `?filter=a;b` will be a `List("a,b")` or `List("a;b")`.
+
+Here are some more Example's:
+
+- A Query String of `?foo` will yield a `Map(foo -> Nil)`
+- A Query String of `?filter=a,b` will yield a `Map(filter -> List("a,b"))`
+- A Query String of `?filter=a,b&filter=c` will yield a `Map(filter -> List("a,b", "c"))`
+- A Query String of `?=hello` will yield a `Map("" -> List("hello"))`
+
+This follows closely [[RFC3896]](https://tools.ietf.org/html/rfc3986#section-3.4), the spec actually won't say anything about how other (sub) delimiters should be treated so we won't treat them as is and won't split on any of those.
+
+### Encoding
+
+TODO

--- a/documentation/manual/working/commonGuide/index.toc
+++ b/documentation/manual/working/commonGuide/index.toc
@@ -1,5 +1,6 @@
 !build:The build system
 !configuration:Configuration
+!Uri:Uri's in Play
 !assets:Static assets
 !filters:Built-in HTTP filters
 !Modules:Extending Play with modules

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -113,6 +113,7 @@ object Dependencies {
     Seq("akka-actor", "akka-slf4j").map("com.typesafe.akka" %% _ % akkaVersion) ++
     jacksons ++
     Seq(
+      "com.netaporter" %% "scala-uri" % "0.4.14",
       "commons-codec" % "commons-codec" % "1.10",
 
       guava,

--- a/framework/src/play-akka-http-server/src/main/resources/play/reference-overrides.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/play/reference-overrides.conf
@@ -18,9 +18,6 @@ akka {
   http.server {
     # Disable Akka-HTTP's transparent HEAD handling. so that play's HEAD handling can take action
     transparent-head-requests = false
-
-    # Enable Raw-Request-URI header to get actual request URI
-    raw-request-uri-header = true
   }
 
 }

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaHttpServer.scala
@@ -65,6 +65,7 @@ class AkkaHttpServer(
       serverConfig.get[Duration]("http.idleTimeout")
     }
     val serverSettings = initialSettings.withTimeouts(initialSettings.timeouts.withIdleTimeout(idleTimeout))
+      .withRawRequestUriHeader(true)
 
     // TODO: pass in Inet.SocketOption and LoggerAdapter params?
     val serverSource: Source[Http.IncomingConnection, Future[Http.ServerBinding]] =

--- a/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
@@ -30,7 +30,7 @@ object HttpBinApplication {
     def writes(r: RequestHeader): JsValue = Json.obj(
       "origin" -> r.remoteAddress,
       "url" -> "",
-      "args" -> r.queryString.mapValues(_.head),
+      "args" -> r.queryString.mapValues(_.headOption.getOrElse("")),
       "headers" -> r.headers.toSimpleMap
     )
   }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -20,7 +20,7 @@ import io.netty.util.ReferenceCountUtil
 import play.api.Logger
 import play.api.http.HeaderNames._
 import play.api.http._
-import play.api.libs.typedmap.{ TypedKey, TypedMap }
+import play.api.libs.typedmap.TypedMap
 import play.api.mvc._
 import play.core.server.common.{ ConnectionInfo, ForwardedHeaderHandler, ServerResultUtils }
 

--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -8,6 +8,7 @@ import java.security.cert.X509Certificate
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.util.ByteString
+import com.netaporter.uri.Uri
 import play.api._
 import play.api.http._
 import play.api.inject._
@@ -68,16 +69,17 @@ case class FakeRequest[A](
     )
   }
 
+  private lazy val parsedUri = Uri.parse(uri)
+
   /**
    * The request path.
    */
-  lazy val path = uri.split('?').take(1).mkString
+  lazy val path = parsedUri.path
 
   /**
    * The request query String
    */
-  lazy val queryString: Map[String, Seq[String]] =
-    play.core.parsers.FormUrlEncodedParser.parse(rawQueryString)
+  lazy val queryString: Map[String, Seq[String]] = parsedUri.query.paramMap
 
   /**
    * Constructs a new request with additional headers. Any existing headers of the same name will be replaced.

--- a/framework/src/play/src/test/scala/play/core/test/Fakes.scala
+++ b/framework/src/play/src/test/scala/play/core/test/Fakes.scala
@@ -6,6 +6,7 @@ package play.core.test
 import java.security.cert.X509Certificate
 
 import akka.util.ByteString
+import com.netaporter.uri.Uri
 import play.api.inject.{ Binding, Injector }
 import play.api.libs.Files.TemporaryFile
 import play.api.libs.json.JsValue
@@ -53,16 +54,17 @@ case class FakeRequest[A](
     )
   }
 
+  private lazy val parsedUri = Uri.parse(uri)
+
   /**
    * The request path.
    */
-  lazy val path = uri.split('?').take(1).mkString
+  lazy val path = parsedUri.path
 
   /**
    * The request query String
    */
-  lazy val queryString: Map[String, Seq[String]] =
-    play.core.parsers.FormUrlEncodedParser.parse(rawQueryString)
+  lazy val queryString: Map[String, Seq[String]] = parsedUri.query.paramMap
 
   /**
    * Constructs a new request with additional headers. Any existing headers of the same name will be replaced.


### PR DESCRIPTION
TODO:

- [ ] Java
- [ ] `Call` interface
- [ ] Cleanup
- [ ] Tests

Actually scala-uri is only suitable for uri encoding/decoding, however `java.net.URI` is already good to parse the URL.

This comes with breaking changes:
- Path is now decoded. So Users which are checking the request.path will now see a different result i.e. `/foo%20bar.txt` will be `/foo bar.txt` we could convert that back, but I guess decode the path correctly is way more sane.
- Query Strings are working correctly now especially edge cases: https://github.com/playframework/playframework/issues/6509

Will Fix:
- https://github.com/playframework/playframework/issues/6509
- https://github.com/playframework/playframework/issues/6450
- https://github.com/playframework/playframework/issues/6549

Maybe / Could be out of scope:
- https://github.com/playframework/playframework/issues/3247
