### PR TITLE
[2.5.x] fixes the uri encoding/decoding with netty 4.0.40.Final

### DIFF
--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -48,7 +48,7 @@ private[server] class NettyModelConversion(forwardedHeaderHandler: ForwardedHead
     val parameters: Map[String, Seq[String]] = {
       val decodedParameters = decoder.parameters()
       if (decodedParameters.isEmpty) Map.empty
-      else decodedParameters.asScala.mapValues(_.asScala).toMap
+      else decodedParameters.asScala.mapValues(_.asScala.mkString.split(",").toList).toMap
     }
     (path, parameters)
   }

--- a/framework/src/play-netty-server/src/test/scala/play/core/server/netty/NettyModelConversionSpec.scala
+++ b/framework/src/play-netty-server/src/test/scala/play/core/server/netty/NettyModelConversionSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.server.netty
+
+import java.net.URISyntaxException
+
+import org.specs2.mutable._
+import play.core.server.common.ForwardedHeaderHandler
+import play.core.server.common.ForwardedHeaderHandler.{ ForwardedHeaderHandlerConfig, Xforwarded }
+
+class NettyModelConversionSpec extends Specification {
+
+  val forwardedHeader = new ForwardedHeaderHandler(ForwardedHeaderHandlerConfig(Xforwarded, List()))
+  val modelConversion = new NettyModelConversion(forwardedHeader)
+
+  "NettyModelConversion#parseUri" should {
+
+    "successfully parse a uri with special characters" in {
+      val (path, query) = modelConversion.parseUri("/projects/1234/users/18620538586%20%7C%20上海/characteristic?hello=海")
+      path must_== "/projects/1234/users/18620538586%20%7C%20上海/characteristic"
+      query must_== Map("hello" -> List("海"))
+    }
+
+    "throw a URISyntaxException if it contains whitespace" in {
+      modelConversion.parseUri("/projects/1234/users/186205 86%20%7C%") must throwA[URISyntaxException]
+    }
+
+  }
+
+}

--- a/framework/src/play-netty-server/src/test/scala/play/core/server/netty/NettyModelConversionSpec.scala
+++ b/framework/src/play-netty-server/src/test/scala/play/core/server/netty/NettyModelConversionSpec.scala
@@ -22,6 +22,11 @@ class NettyModelConversionSpec extends Specification {
       query must_== Map("hello" -> List("海"))
     }
 
+    "parse all query params correctly" in {
+      val (_, query) = modelConversion.parseUri("/?filter=a=b,c")
+      query must_== Map("filter" -> List("a=b", "c"))
+    }
+
     "throw a URISyntaxException if it contains whitespace" in {
       modelConversion.parseUri("/projects/1234/users/186205 86%20%7C%") must throwA[URISyntaxException]
     }

--- a/framework/src/play-netty-server/src/test/scala/play/core/server/netty/NettyModelConversionSpec.scala
+++ b/framework/src/play-netty-server/src/test/scala/play/core/server/netty/NettyModelConversionSpec.scala
@@ -19,12 +19,17 @@ class NettyModelConversionSpec extends Specification {
     "successfully parse a uri with special characters" in {
       val (path, query) = modelConversion.parseUri("/projects/1234/users/18620538586%20%7C%20上海/characteristic?hello=海")
       path must_== "/projects/1234/users/18620538586%20%7C%20上海/characteristic"
-      query must_== Map("hello" -> List("海"))
+      query must_== Map("hello" -> Seq("海"))
     }
 
     "parse all query params correctly" in {
       val (_, query) = modelConversion.parseUri("/?filter=a=b,c")
-      query must_== Map("filter" -> List("a=b", "c"))
+      query must havePair("filter" -> Seq("a=b", "c"))
+    }
+
+    "work against a empty query" in {
+      val (_, query) = modelConversion.parseUri("?a")
+      query must havePair("a" -> Seq(""))
     }
 
     "throw a URISyntaxException if it contains whitespace" in {


### PR DESCRIPTION
This will actually fix the error that will come up with netty 4.0.40.Final.
We don't need to Backport the Netty Decoder since `java.net.URI` is already correct.

Only fails: https://travis-ci.org/playframework/playframework/jobs/157826296#L3011
NettyWebSocketSpec.

