### PR TITLE
Fixes serialization of big decimals to json (#6530)

### DIFF
--- a/framework/src/play-json/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/jackson/JacksonJson.scala
@@ -62,8 +62,10 @@ private[jackson] object JsValueSerializer extends JsonSerializer[JsValue] {
         val stripped = v.bigDecimal.stripTrailingZeros
         val raw = if (shouldWritePlain) stripped.toPlainString else stripped.toString
 
-        if (raw contains ".") json.writeTree(new DecimalNode(new JBigDec(raw)))
-        else json.writeTree(new BigIntegerNode(new BigInteger(raw)))
+        if (raw.indexOf('E') < 0 && raw.indexOf('.') < 0)
+          json.writeTree(new BigIntegerNode(new BigInteger(raw)))
+        else
+          json.writeTree(new DecimalNode(new JBigDec(raw)))
       }
       case JsString(v) => json.writeString(v)
       case JsBoolean(v) => json.writeBoolean(v)

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/JsonSpec.scala
@@ -308,6 +308,12 @@ class JsonSpec extends org.specs2.mutable.Specification {
       jsonString must_== "0.001234"
     }
 
+    "Write BigDecimals with integer base" in {
+      val n = BigDecimal("2e128")
+      val jsonString = stringify(toJson(n))
+      jsonString must_== "2E+128"
+    }
+
     "Not lose precision when parsing big integers" in {
       // By big integers, we just mean integers that overflow long, since Jackson has different code paths for them
       // from decimals


### PR DESCRIPTION
Possible fix for #6530 

Fixes serialization of BigDecimals to json in some particular case which was failing