### PR TITLE
Limited support for recursive types within Json macro (reads/writes/format)

### DIFF
--- a/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonAutomatedSpec.scala
@@ -90,8 +90,9 @@ class ScalaJsonAutomatedSpec extends Specification {
       implicit val residentFormat = Json.format[Resident]
       //#auto-format
 
-      sampleJson.as[Resident] must_=== sampleData
-      Json.toJson(sampleData) must_=== sampleJson
+      sampleJson.as[Resident] must_=== sampleData and {
+        Json.toJson(sampleData) must_=== sampleJson
+      }
     }
 
     "produce a working Writes with SnakeCase" in {
@@ -100,7 +101,7 @@ class ScalaJsonAutomatedSpec extends Specification {
 
       implicit val config = JsonConfiguration(SnakeCase)
 
-      implicit val userWrites: Writes[PlayUser] = Json.writes[PlayUser]
+      implicit val userWrites: OWrites[PlayUser] = Json.writes[PlayUser]
       //#auto-naming-writes
 
       Json.toJson(sampleData2) must_=== sampleJson2
@@ -112,11 +113,12 @@ class ScalaJsonAutomatedSpec extends Specification {
 
       implicit val config = JsonConfiguration(SnakeCase)
 
-      implicit val userFormat: Format[PlayUser] = Json.format[PlayUser]
+      implicit val userFormat: OFormat[PlayUser] = Json.format[PlayUser]
       //#auto-naming-format
 
-      sampleJson2.as[PlayUser] must_=== sampleData2
-      Json.toJson(sampleData2) must_=== sampleJson2
+      sampleJson2.as[PlayUser] must_=== sampleData2 and {
+        Json.toJson(sampleData2) must_=== sampleJson2
+      }
     }
 
     "produce a working Reads with SnakeCase" in {
@@ -141,12 +143,12 @@ class ScalaJsonAutomatedSpec extends Specification {
 
       implicit val config = JsonConfiguration(Lightbend)
 
-      implicit val customWrites: Format[PlayUser] = Json.format[PlayUser]
+      implicit val customWrites: OFormat[PlayUser] = Json.format[PlayUser]
       //#auto-custom-naming-format
 
-      sampleJson3.as[PlayUser] must_=== sampleData2
-      Json.toJson(sampleData2) must_=== sampleJson3
+      sampleJson3.as[PlayUser] must_=== sampleData2 and {
+        Json.toJson(sampleData2) must_=== sampleJson3
+      }
     }
   }
-
 }

--- a/framework/src/play-functional/src/main/scala/play/api/libs/functional/Functors.scala
+++ b/framework/src/play-functional/src/main/scala/play/api/libs/functional/Functors.scala
@@ -8,47 +8,33 @@ import scala.language.higherKinds
 sealed trait Variant[M[_]]
 
 trait Functor[M[_]] extends Variant[M] {
-
   def fmap[A, B](m: M[A], f: A => B): M[B]
-
 }
 
 object Functor {
-
   implicit val functorOption: Functor[Option] = new Functor[Option] {
     def fmap[A, B](a: Option[A], f: A => B): Option[B] = a.map(f)
   }
-
 }
 
 trait InvariantFunctor[M[_]] extends Variant[M] {
-
   def inmap[A, B](m: M[A], f1: A => B, f2: B => A): M[B]
-
 }
 
 trait ContravariantFunctor[M[_]] extends Variant[M] {
-
   def contramap[A, B](m: M[A], f1: B => A): M[B]
-
 }
 
 class FunctorOps[M[_], A](ma: M[A])(implicit fu: Functor[M]) {
-
   def fmap[B](f: A => B): M[B] = fu.fmap(ma, f)
-
 }
 
 class ContravariantFunctorOps[M[_], A](ma: M[A])(implicit fu: ContravariantFunctor[M]) {
-
   def contramap[B](f: B => A): M[B] = fu.contramap(ma, f)
-
 }
 
 class InvariantFunctorOps[M[_], A](ma: M[A])(implicit fu: InvariantFunctor[M]) {
-
   def inmap[B](f: A => B, g: B => A): M[B] = fu.inmap(ma, f, g)
-
 }
 
 // Work around the fact that Scala does not support higher-kinded type patterns (type variables can only be simple identifiers)

--- a/framework/src/play-functional/src/main/scala/play/api/libs/functional/syntax/package.scala
+++ b/framework/src/play-functional/src/main/scala/play/api/libs/functional/syntax/package.scala
@@ -23,7 +23,9 @@ object `package` {
   implicit def toMonoidOps[A](a: A)(implicit m: Monoid[A]): MonoidOps[A] = new MonoidOps(a)
 
   implicit def toFunctorOps[M[_], A](ma: M[A])(implicit fu: Functor[M]): FunctorOps[M, A] = new FunctorOps(ma)
+
   implicit def toContraFunctorOps[M[_], A](ma: M[A])(implicit fu: ContravariantFunctor[M]): ContravariantFunctorOps[M, A] = new ContravariantFunctorOps(ma)
+
   implicit def toInvariantFunctorOps[M[_], A](ma: M[A])(implicit fu: InvariantFunctor[M]): InvariantFunctorOps[M, A] = new InvariantFunctorOps(ma)
 
   def unapply[B, A](f: B => Option[A]): B => A = { b: B => f(b).get }

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Format.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Format.scala
@@ -19,10 +19,7 @@ object OFormat {
   implicit def functionalCanBuildFormats(implicit rcb: FunctionalCanBuild[Reads], wcb: FunctionalCanBuild[OWrites]): FunctionalCanBuild[OFormat] = new FunctionalCanBuild[OFormat] {
 
     def apply[A, B](fa: OFormat[A], fb: OFormat[B]): OFormat[A ~ B] =
-      OFormat[A ~ B](
-        rcb(fa, fb),
-        wcb(fa, fb)
-      )
+      OFormat[A ~ B](rcb(fa, fb), wcb(fa, fb))
 
   }
 
@@ -63,13 +60,10 @@ object Format extends PathFormat with ConstraintFormat with DefaultFormat {
         Format(fa.map(f1), Writes(b => fa.writes(f2(b))))
     }
 
-  def apply[A](fjs: Reads[A], tjs: Writes[A]): Format[A] = {
-    new Format[A] {
-      def reads(json: JsValue) = fjs.reads(json)
-      def writes(o: A) = tjs.writes(o)
-    }
+  def apply[A](fjs: Reads[A], tjs: Writes[A]): Format[A] = new Format[A] {
+    def reads(json: JsValue) = fjs.reads(json)
+    def writes(o: A) = tjs.writes(o)
   }
-
 }
 
 /**

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala
@@ -11,18 +11,28 @@ import scala.reflect.macros.blackbox
  * Implementation for the JSON macro.
  */
 object JsMacroImpl {
+  /** Only for internal purposes */
+  final class Placeholder {}
 
-  def formatImpl[A: c.WeakTypeTag](c: blackbox.Context): c.Expr[OFormat[A]] = {
-    macroImpl[A, OFormat, Format](c, "format", "inmap", reads = true, writes = true)
+  /** Only for internal purposes */
+  object Placeholder {
+    implicit object Format extends OFormat[Placeholder] {
+      val success = JsSuccess(new Placeholder())
+      def reads(json: JsValue): JsResult[Placeholder] = success
+      def writes(pl: Placeholder) = Json.obj()
+    }
   }
 
-  def readsImpl[A: c.WeakTypeTag](c: blackbox.Context): c.Expr[Reads[A]] = {
+  def formatImpl[A: c.WeakTypeTag](c: blackbox.Context): c.Expr[OFormat[A]] =
+    macroImpl[A, OFormat, Format](
+      c, "format", "inmap", reads = true, writes = true)
+
+  def readsImpl[A: c.WeakTypeTag](c: blackbox.Context): c.Expr[Reads[A]] =
     macroImpl[A, Reads, Reads](c, "read", "map", reads = true, writes = false)
-  }
 
-  def writesImpl[A: c.WeakTypeTag](c: blackbox.Context): c.Expr[OWrites[A]] = {
-    macroImpl[A, OWrites, Writes](c, "write", "contramap", reads = false, writes = true)
-  }
+  def writesImpl[A: c.WeakTypeTag](c: blackbox.Context): c.Expr[OWrites[A]] =
+    macroImpl[A, OWrites, Writes](
+      c, "write", "contramap", reads = false, writes = true)
 
   /**
    * Generic implementation of the macro
@@ -43,27 +53,23 @@ object JsMacroImpl {
    * @param natag The class of the reads/writes/format.
    */
   private def macroImpl[A, M[_], N[_]](c: blackbox.Context, methodName: String, mapLikeMethod: String, reads: Boolean, writes: Boolean)(implicit atag: c.WeakTypeTag[A], matag: c.WeakTypeTag[M[A]], natag: c.WeakTypeTag[N[A]]): c.Expr[M[A]] = {
-
     // Helper function to create parameter lists for function invocations based on whether this is a reads,
     // writes or both.
     def conditionalList[T](ifReads: T, ifWrites: T): List[T] =
       (if (reads) List(ifReads) else Nil) :::
-          (if (writes) List(ifWrites) else Nil)
+    (if (writes) List(ifWrites) else Nil)
 
     import c.universe._
 
-    // The call is the term name, either "read", "write" or "format", that gets invoked on JsPath,
-    // eg (__ \ "foo").read
-    val call = TermName(methodName)
-    // callNullable is the equivalent of call for options
-    // eg (__ \ "foo").readNullable
-    val callNullable = TermName(s"${methodName}Nullable")
-    // Used for doing lazy reads (when recursive)
-    val lazyCall = TermName(s"lazy${methodName.capitalize}")
+    val TypeRef(_, _, tpeArgs) = atag.tpe
 
-    val companioned = weakTypeOf[A].typeSymbol
-    val companionObject = companioned.companion
-    val companionType = companionObject.typeSignature
+    // The call is the term name, either "read", "write" or "format",
+    // that gets invoked on JsPath (e.g. `(__ \ "foo").read`)
+    val call = TermName(methodName)
+
+    // callNullable is the equivalent of call for options
+    // e.g. `(__ \ "foo").readNullable`
+    val callNullable = TermName(s"${methodName}Nullable")
 
     // All these can be sort of thought as imports that can then be used later in quasi quote interpolation
     val libs = q"_root_.play.api.libs"
@@ -74,230 +80,405 @@ object JsMacroImpl {
     val Reads = q"$json.Reads"
     val Writes = q"$json.Writes"
     val unlift = q"$syntax.unlift"
-    val LazyHelper = tq"$utilPkg.LazyHelper"
 
-    // First find the unapply for the object
-    val unapply = companionType.decl(TermName("unapply"))
-    val unapplySeq = companionType.decl(TermName("unapplySeq"))
-    val hasVarArgs = unapplySeq != NoSymbol
+    val companioned = weakTypeOf[A].typeSymbol
+    val companionObject = companioned.companion
+    val companionType = companionObject.typeSignature
 
-    val effectiveUnapply = Seq(unapply, unapplySeq).find(_ != NoSymbol) match {
-      case None => c.abort(c.enclosingPosition, "No unapply or unapplySeq function found")
-      case Some(s) => s.asMethod
-    }
+    // Utility about apply/unapply
+    object ApplyUnapply {
+      private val unapply = companionType.decl(TermName("unapply"))
+      private val unapplySeq = companionType.decl(TermName("unapplySeq"))
 
-    val unapplyReturnTypes: Option[List[Type]] = effectiveUnapply.returnType match {
-      case TypeRef(_, _, Nil) =>
-        c.abort(c.enclosingPosition, s"Unapply of $companionObject has no parameters. Are you using an empty case class?")
-        None
+      val hasVarArgs = unapplySeq != NoSymbol
 
-      case TypeRef(_, _, args) =>
-        args.head match {
-          case t@TypeRef(_, _, Nil) => Some(List(t))
-          case t@TypeRef(_, _, args) =>
-            import c.universe.definitions.TupleClass
-            if (!TupleClass.seq.exists(tupleSym => t.baseType(tupleSym) ne NoType)) Some(List(t))
-            else if (t <:< typeOf[Product]) Some(args)
-            else None
+      // Returns the unapply symbol
+      private val effectiveUnapply: MethodSymbol =
+        Seq(unapply, unapplySeq).find(_ != NoSymbol) match {
+          case None => c.abort(c.enclosingPosition, s"No unapply or unapplySeq function found for $companioned: $unapply / $unapplySeq")
+          case Some(s) => s.asMethod
+        }
+
+      val unapplyReturnTypes: Option[List[Type]] =
+        effectiveUnapply.returnType match {
+          case TypeRef(_, _, Nil) => {
+            c.abort(c.enclosingPosition, s"Unapply of $companionObject has no parameters. Are you using an empty case class?")
+            None
+          }
+
+          case TypeRef(_, _, args) => args.head match {
+            case t @ TypeRef(_, _, Nil) => Some(List(t))
+            case t @ TypeRef(_, _, args) =>
+              import c.universe.definitions.TupleClass
+              if (!TupleClass.seq.exists(tupleSym => t.baseType(tupleSym) ne NoType)) Some(List(t))
+              else if (t <:< typeOf[Product]) Some(args)
+              else None
+            case _ => None
+          }
+
           case _ => None
         }
-      case _ => None
-    }
 
-    // Now the apply methods for the object
-    val applies =
-      companionType.decl(TermName("apply")) match {
+      /* Deep check for type compatibility */
+      @annotation.tailrec
+      private def conforms(types: Seq[(Type, Type)]): Boolean =
+        types.headOption match {
+          case Some((TypeRef(NoPrefix, a, _),
+            TypeRef(NoPrefix, b, _))) => { // for generic parameter
+            if (a.fullName != b.fullName) {
+              c.warning(c.enclosingPosition,
+                s"Type symbols are not compatible: $a != $b")
+
+              false
+            }
+            else conforms(types.tail)
+          }
+
+          case Some((a, b)) if (a.typeArgs.size != b.typeArgs.size) => {
+            c.warning(c.enclosingPosition,
+              s"Type parameters are not matching: $a != $b")
+
+            false
+          }
+
+          case Some((a, b)) if a.typeArgs.isEmpty =>
+            if (a =:= b) conforms(types.tail) else {
+              c.warning(c.enclosingPosition,
+                s"Types are not compatible: $a != $b")
+
+              false
+            }
+
+          case Some((a, b)) if (a.baseClasses != b.baseClasses) => {
+            c.warning(c.enclosingPosition,
+              s"Generic types are not compatible: $a != $b")
+
+            false
+          }
+
+          case Some((a, b)) =>
+            conforms((a.typeArgs, b.typeArgs).zipped ++: types.tail)
+
+          case _ => true
+        }
+
+      // The apply methods for the object
+      private val applies = companionType.decl(TermName("apply")) match {
         case NoSymbol => c.abort(c.enclosingPosition, "No apply function found")
-        case s => s.asTerm.alternatives.filter {
-          _.asMethod.paramLists.size == 1
+
+        case s => s.asTerm.alternatives.filter { apply =>
+          val ps = apply.asMethod.paramLists
+
+          if (ps.size == 1) true else ps.drop(1).forall {
+            case p :: _ => p.isImplicit
+            case _ => false
+          }
         }
       }
 
-    // Find an apply method that matches the unapply
-    val maybeApply = applies.collectFirst {
-      case (apply: MethodSymbol) if hasVarArgs && {
-        // Option[List[c.universe.Type]]
-        val someApplyTypes = apply.paramLists.headOption.map(_.map(_.asTerm.typeSignature))
-        val someInitApply = someApplyTypes.map(_.init)
-        val someApplyLast = someApplyTypes.map(_.last)
-        val someInitUnapply = unapplyReturnTypes.map(_.init)
-        val someUnapplyLast = unapplyReturnTypes.map(_.last)
-        val initsMatch = someInitApply == someInitUnapply
-        val lastMatch = (for {
-          lastApply <- someApplyLast
-          lastUnapply <- someUnapplyLast
-        } yield lastApply <:< lastUnapply).getOrElse(false)
-        initsMatch && lastMatch
-      } => apply
+      /* Find an apply method that matches the unapply */
+      val maybeApply: Option[MethodSymbol] = applies.collectFirst {
+        case (apply: MethodSymbol) if hasVarArgs && {
+          // Option[List[c.universe.Type]]
+          val someApplyTypes = apply.paramLists.headOption.
+            map(_.map(_.asTerm.typeSignature))
 
-      case (apply: MethodSymbol) if {
-        val applyParams = apply.paramLists.headOption.
-          toList.flatten.map(_.typeSignature)
-        val unapplyParams = unapplyReturnTypes.toList.flatten
+          val someInitApply = someApplyTypes.map(_.init)
+          val someApplyLast = someApplyTypes.map(_.last)
+          val someInitUnapply = unapplyReturnTypes.map(_.init)
+          val someUnapplyLast = unapplyReturnTypes.map(_.last)
+          val initsMatch = someInitApply == someInitUnapply
+          val lastMatch = (for {
+            lastApply <- someApplyLast
+            lastUnapply <- someUnapplyLast
+          } yield lastApply <:< lastUnapply).getOrElse(false)
 
-        def paramsMatch = (applyParams, unapplyParams).zipped.forall {
-          case (TypeRef(NoPrefix, applyParam, _),
-            TypeRef(NoPrefix, unapplyParam, _)) => // for generic parameter
-            applyParam.fullName == unapplyParam.fullName
+          initsMatch && lastMatch
+        } => apply
 
-          case (applyParam, unapplyParam) => applyParam =:= unapplyParam
-        }
+        case (apply: MethodSymbol) if {
+          val applyParams = apply.paramLists.headOption.
+            toList.flatten.map(_.typeSignature)
+          val unapplyParams = unapplyReturnTypes.toList.flatten
 
-        (applyParams.size == unapplyParams.size && paramsMatch)
-      } => apply
-    }
+          (applyParams.size == unapplyParams.size &&
+            conforms((applyParams, unapplyParams).zipped.toSeq))
 
-    val (tparams, params) = maybeApply match {
-      case Some(apply) => {
-        apply.typeParams -> apply.paramLists.head
-        // assume there is a single parameter group
+        } => apply
       }
 
-      case None => c.abort(c.enclosingPosition, "No apply function found matching unapply parameters")
-    }
+      // Parameters symbols -> Function tree
+      lazy val applyFunction: Option[(Tree, List[TypeSymbol], List[Symbol])] =
+        maybeApply.flatMap { app =>
+          app.paramLists.headOption.map { params =>
+            val tree = if (hasVarArgs) {
+              val applyParams = params.foldLeft(List.empty[Tree]) { (l, e) =>
+                l :+ Ident(TermName(e.name.encodedName.toString))
+              }
+              val vals = params.foldLeft(List.empty[Tree])((l, e) =>
+                // Let type inference infer the type by using the empty type
+                l :+ q"val ${TermName(e.name.encodedName.toString)}: ${TypeTree()}"
+              )
 
-    val TypeRef(_, _, tpeArgs) = atag.tpe
+              q"(..$vals) => $companionObject.apply(..${applyParams.init}, ${applyParams.last}: _*)"
+            } else if (tpeArgs.isEmpty) {
+              q"$companionObject.apply _"
+            } else q"$companionObject.apply[..$tpeArgs] _"
 
-    val boundTypes = tparams.zip(tpeArgs).map {
-      case (sym, ty) => sym.fullName -> ty
-    }.toMap
-
-    // Now we find all the implicits that we need
-    final case class Implicit(paramName: Name, paramType: Type, neededImplicit: Tree, isRecursive: Boolean, tpe: Type)
-
-    val createImplicit = { (name: Name, implType: c.universe.type#Type) =>
-      val ptype = boundTypes.lift(implType.typeSymbol.fullName).
-        getOrElse(implType)
-
-      val (isRecursive, tpe) = ptype match {
-        case TypeRef(_, t, args) => {
-          val isRec = args.exists(_.typeSymbol == companioned)
-          // Option[_] needs special treatment because we need to use XXXOpt
-          val tp = if (ptype.typeConstructor <:< typeOf[Option[_]].typeConstructor) args.head else ptype
-          (isRec, tp)
+            (tree, app.typeParams.map(_.asType), params)
+          }
         }
 
-        case TypeRef(_, t, _) => (false, ptype)
-      }
-
-      // builds M implicit from expected type
-      val neededImplicitType = appliedType(natag.tpe.typeConstructor, tpe :: Nil)
-      // infers implicit
-      val neededImplicit = c.inferImplicitValue(neededImplicitType)
-      Implicit(name, ptype, neededImplicit, isRecursive, tpe)
+      lazy val unapplyFunction: Tree = if (tpeArgs.isEmpty) {
+        q"$unlift($companionObject.$effectiveUnapply)"
+      } else q"$unlift($companionObject.$effectiveUnapply[..$tpeArgs])"
     }
 
-    val applyParamImplicits = params.map { param => createImplicit(param.name, param.typeSignature) }
-    val effectiveInferredImplicits = if (hasVarArgs) {
-      val varArgsImplicit = createImplicit(applyParamImplicits.last.paramName, unapplyReturnTypes.get.last)
-      applyParamImplicits.init :+ varArgsImplicit
-    } else applyParamImplicits
+    val (applyFunction, tparams, params) = ApplyUnapply.applyFunction match {
+      case Some(info) => info
 
-    // if any implicit is missing, abort
-    val missingImplicits = effectiveInferredImplicits.collect { case Implicit(_, t, impl, rec, _) if impl == EmptyTree && !rec => t }
-    if (missingImplicits.nonEmpty)
-      c.abort(c.enclosingPosition, s"No implicit format for ${missingImplicits.mkString(", ")} available.")
+      case _ => c.abort(c.enclosingPosition,
+        s"No apply function found matching unapply parameters")
+    }
 
-    var hasRec = false
+    // Utility for implicit resolution - can hardly be moved outside
+    // (due to dependent types)
+    object ImplicitResolver {
+      // Per each symbol of the type parameters, which type is bound to
+      private val boundTypes: Map[String, Type] = tparams.zip(tpeArgs).map {
+        case (sym, ty) => sym.fullName -> ty
+      }.toMap
+
+      // The placeholder type
+      private val PlaceholderType: Type = typeOf[Placeholder]
+
+      /* Refactor the input types, by replacing any type matching the `filter`,
+       * by the given `replacement`.
+       */
+      @annotation.tailrec
+      private def refactor(in: List[Type], base: TypeSymbol, out: List[Type], tail: List[(List[Type], TypeSymbol, List[Type])], filter: Type => Boolean, replacement: Type, altered: Boolean): (Type, Boolean) = in match {
+        case tpe :: ts =>
+          boundTypes.getOrElse(tpe.typeSymbol.fullName, tpe) match {
+            case t if (filter(t)) =>
+              refactor(ts, base, (replacement :: out), tail,
+                filter, replacement, true)
+
+            case TypeRef(_, sym, as) if as.nonEmpty =>
+              refactor(as, sym.asType, List.empty, (ts, base, out) :: tail,
+                filter, replacement, altered)
+
+            case t => refactor(ts, base, (t :: out), tail,
+              filter, replacement, altered)
+          }
+
+        case _ => {
+          val tpe = appliedType(base, out.reverse)
+
+          tail match {
+            case (x, y, more) :: ts =>
+              refactor(x, y, (tpe :: more), ts, filter, replacement, altered)
+
+            case _ => tpe -> altered
+          }
+        }
+      }
+
+      /**
+       * Replaces any reference to the type itself by the Placeholder type. 
+       * @return the normalized type + whether any self reference has been found
+       */
+      private def normalized(tpe: Type): (Type, Boolean) =
+        boundTypes.getOrElse(tpe.typeSymbol.fullName, tpe) match {
+          case t if (t =:= atag.tpe) => PlaceholderType -> true
+
+          case TypeRef(_, sym, args) if args.nonEmpty =>
+            refactor(args, sym.asType, List.empty, List.empty,
+              _ =:= atag.tpe, PlaceholderType, false)
+
+          case t => t -> false
+        }
+
+      /* Restores reference to the type itself when Placeholder is found. */
+      private def denormalized(ptype: Type): Type = ptype match {
+        case PlaceholderType => atag.tpe
+
+        case TypeRef(_, sym, args) if args.nonEmpty =>
+          refactor(args, sym.asType, List.empty, List.empty,
+            _ == PlaceholderType, atag.tpe, false)._1
+
+        case _ => ptype
+      }
+
+      val forwardName = TermName(c.freshName("forward"))
+
+      private object ImplicitTransformer extends Transformer {
+        override def transform(tree: Tree): Tree = tree match {
+          case tt: TypeTree =>
+            super.transform(TypeTree(denormalized(tt.tpe)))
+
+          case Select(Select(This(TypeName("JsMacroImpl")), t), sym) if (
+            t.toString == "Placeholder" && sym.toString == "Format"
+          ) => super.transform(q"$forwardName")
+
+          case _ => super.transform(tree)
+        }
+      }
+
+      private def createImplicit(name: Name, ptype: Type): Implicit = {
+        val tpe = ptype match {
+          case TypeRef(_, _, targ :: _) =>
+            // Option[_] needs special treatment because we need to use XXXOpt
+            if (ptype.typeConstructor <:< typeOf[Option[_]].typeConstructor) {
+              targ
+            } else ptype
+
+          case SingleType(_, _) | TypeRef(_, _, _) => ptype
+        }
+
+        val (ntpe, selfRef) = normalized(tpe)
+        val ptpe = boundTypes.get(ntpe.typeSymbol.fullName).getOrElse(ntpe)
+
+        // infers implicit
+        val neededImplicitType = appliedType(natag.tpe.typeConstructor, ptpe)
+        val neededImplicit = if (!selfRef) {
+          c.inferImplicitValue(neededImplicitType)
+        } else c.untypecheck(
+          // Reset the type attributes on the refactored tree for the implicit
+          ImplicitTransformer.transform(
+            c.inferImplicitValue(neededImplicitType))
+        )
+
+        Implicit(name, ptype, neededImplicit, tpe, selfRef)
+      }
+
+      // To print the implicit types in the compiler messages
+      private def prettyType(t: Type): String =
+        boundTypes.getOrElse(t.typeSymbol.fullName, t) match {
+          case TypeRef(_, base, args) if args.nonEmpty => s"""${base.asType.fullName}[${args.map(prettyType(_)).mkString(", ")}]"""
+
+          case t => t.typeSymbol.fullName
+        }
+
+      def apply(params: List[Symbol]): List[Implicit] = {
+        val resolvedImplicits = params.map { param =>
+          createImplicit(param.name, param.typeSignature)
+        }
+        val effectiveImplicits = if (ApplyUnapply.hasVarArgs) {
+          val varArgsImplicit = createImplicit(
+            resolvedImplicits.last.paramName,
+            ApplyUnapply.unapplyReturnTypes.get.last)
+
+          resolvedImplicits.init :+ varArgsImplicit
+        } else resolvedImplicits
+
+        // if any implicit is missing, abort
+        val missingImplicits = effectiveImplicits.collect {
+          case Implicit(_, t, EmptyTree/* ~= not found */, _, _) => t
+        }
+
+        if (missingImplicits.nonEmpty) {
+          c.abort(c.enclosingPosition,
+            s"No instance of ${natag.tpe.typeSymbol.fullName} is available for ${missingImplicits.map(prettyType(_)).mkString(", ")} in the implicit scope (Hint: if declared in the same file, make sure it's declared before)")
+        }
+
+        effectiveImplicits
+      }
+
+      // ---
+
+      // Now we find all the implicits that we need
+      final case class Implicit(
+        paramName: Name,
+        paramType: Type,
+        neededImplicit: Tree,
+        tpe: Type,
+        selfRef: Boolean
+      )
+    }
 
     // combines all reads into CanBuildX
-    val canBuild = effectiveInferredImplicits.map {
-      case Implicit(name, t, impl, rec, tpe) =>
+    val cfgName = TermName(c.freshName("config"))
+    val resolvedImplicits = ImplicitResolver(params)
+    val canBuild = resolvedImplicits.map {
+      case ImplicitResolver.Implicit(name, pt, impl, _, _) =>
         // Equivalent to __ \ "name", but uses a naming scheme
         // of (String) => (String) to find the correct "name"
-        val cn = c.Expr[String](q"implicitly[$json.JsonConfiguration].naming(${name.decodedName.toString})")
+        val cn = c.Expr[String](
+          q"$cfgName.naming(${name.decodedName.toString})")
+
         val jspathTree = q"""$JsPath \ $cn"""
 
         // If we're not recursive, simple, just invoke read/write/format
-        if (!rec) {
-          // If we're an option, invoke the nullable version
-          if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor) {
-            q"$jspathTree.$callNullable($impl)"
-          } else {
-            q"$jspathTree.$call($impl)"
-          }
+        // If we're an option, invoke the nullable version
+        if (pt.typeConstructor <:< typeOf[Option[_]].typeConstructor) {
+          q"$jspathTree.$callNullable($impl)"
         } else {
-          // Otherwise we have to invoke the lazy version
-          hasRec = true
-          if (t.typeConstructor <:< typeOf[Option[_]].typeConstructor) {
-            q"$jspathTree.$callNullable($JsPath.$lazyCall(this.lazyStuff))"
-          } else {
-            // If this is a list/set/seq/map, then we need to wrap the reads into that.
-            def readsWritesHelper(methodName: String): List[Tree] =
-              conditionalList(Reads, Writes).map(s => q"$s.${TermName(methodName)}(this.lazyStuff)")
-
-            val arg = if (tpe.typeConstructor <:< typeOf[List[_]].typeConstructor)
-              readsWritesHelper("list")
-            else if (tpe.typeConstructor <:< typeOf[Set[_]].typeConstructor)
-              readsWritesHelper("set")
-            else if (tpe.typeConstructor <:< typeOf[Seq[_]].typeConstructor)
-              readsWritesHelper("seq")
-            else if (tpe.typeConstructor <:< typeOf[Map[_, _]].typeConstructor)
-              readsWritesHelper("map")
-            else List(q"this.lazyStuff")
-
-            q"$jspathTree.$lazyCall(..$arg)"
-          }
+          q"$jspathTree.$call($impl)"
         }
     }.reduceLeft[Tree] { (acc, r) =>
       q"$acc.and($r)"
     }
 
-    val applyFunction = {
-      if (hasVarArgs) {
-
-        val applyParams = params.foldLeft(List[Tree]())((l, e) =>
-          l :+ Ident(TermName(e.name.encodedName.toString))
-        )
-        val vals = params.foldLeft(List[Tree]())((l, e) =>
-          // Let type inference infer the type by using the empty type, TypeTree()
-          l :+ q"val ${TermName(e.name.encodedName.toString)}: ${TypeTree()}"
-        )
-
-        q"(..$vals) => $companionObject.apply(..${applyParams.init}, ${applyParams.last}: _*)"
-      } else {
-        q"$companionObject.apply _"
-      }
-    }
-
-    val unapplyFunction = q"$unlift($companionObject.$effectiveUnapply)"
-
     val multiParam = params.length > 1
     // if case class has one single field, needs to use map/contramap/inmap on the Reads/Writes/Format instead of
     // canbuild.apply
     val applyOrMap = TermName(if (multiParam) "apply" else mapLikeMethod)
-    val syntaxImport = if(!multiParam && !writes) q"" else q"import $syntax._"
-    val finalTree = q"""
-      $syntaxImport
 
-      $canBuild.$applyOrMap(..${conditionalList(applyFunction, unapplyFunction)})
-    """
+    val syntaxImport = if (!multiParam && !writes) q"" else q"import $syntax._"
+    val canBuildCall = q"$canBuild.$applyOrMap(..${conditionalList(applyFunction, ApplyUnapply.unapplyFunction)})"
 
-    val lazyFinalTree = if (!hasRec) {
-      finalTree
-    } else {
-      // If we're recursive, we need to wrap the whole thing in a class that breaks the recursion using a
-      // lazy val
-      q"""
-        new $LazyHelper[${matag.tpe.typeSymbol}, ${atag.tpe.typeSymbol}] {
-          override lazy val lazyStuff: ${matag.tpe.typeSymbol}[${atag.tpe}] = $finalTree
-        }.lazyStuff
-       """
-    }
+    val finalTree =
+      if (!resolvedImplicits.exists(_.selfRef)) {
+        q"""
+        $syntaxImport
+
+        val $cfgName = implicitly[$json.JsonConfiguration]
+
+        $canBuildCall
+        """
+      } else {
+        // Has nested reference to the same type
+
+        val forward: Tree = methodName match {
+          case "read" =>
+            q"$json.Reads[${atag.tpe}](instance.reads(_))"
+
+          case "write" =>
+            q"$json.OWrites[${atag.tpe}](instance.writes(_))"
+
+          case _ =>
+            q"$json.OFormat[${atag.tpe}](instance.reads(_), instance.writes(_))"
+        }
+        val forwardCall =
+          q"private val ${ImplicitResolver.forwardName} = $forward"
+
+        val generated = TypeName(c.freshName("Generated"))
+
+        q"""
+        final class $generated()(implicit $cfgName: $json.JsonConfiguration) {
+          // wrap there for self reference
+
+          $syntaxImport
+
+          $forwardCall
+
+          def instance: ${matag.tpe.typeSymbol}[${atag.tpe}] = $canBuildCall
+        }
+
+        new $generated().instance
+        """
+      }
 
     if (debugEnabled) {
-      c.info(c.enclosingPosition, showCode(lazyFinalTree), force = true)
+      c.info(c.enclosingPosition, showCode(finalTree), force = true)
     }
 
-    c.Expr[M[A]](lazyFinalTree)
+    c.Expr[M[A]](finalTree)
   }
 
   private lazy val debugEnabled =
     Option(System.getProperty("play.json.macro.debug")).
-        filterNot(_.isEmpty).map(_.toLowerCase).exists { v =>
-      "true".equals(v) || v.substring(0, 1) == "y"
-    }
-
+      filterNot(_.isEmpty).map(_.toLowerCase).exists { v =>
+        "true".equals(v) || v.substring(0, 1) == "y"
+      }
 }
-
-

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/JsonConfiguration.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/JsonConfiguration.scala
@@ -33,8 +33,8 @@ object JsonNaming {
    * as is for its column (e.g. fooBar -> fooBar).
    */
   object Identity extends JsonNaming {
-
-    override def apply(property: String): String = property
+    def apply(property: String): String = property
+    override val toString = "Identity"
   }
 
   /**
@@ -42,7 +42,6 @@ object JsonNaming {
    * to name its column (e.g. fooBar -> foo_bar).
    */
   object SnakeCase extends JsonNaming {
-
     def apply(property: String): String = {
       val length = property.length
       val result = new StringBuilder(length * 2)
@@ -71,11 +70,11 @@ object JsonNaming {
       result.toString()
     }
 
-    /** Naming using a custom transformation function. */
-    def apply(transformation: String => String): JsonNaming =
-      new JsonNaming {
-        def apply(property: String): String = transformation(property)
-      }
+    override val toString = "SnakeCase"
   }
 
+  /** Naming using a custom transformation function. */
+  def apply(transformation: String => String): JsonNaming = new JsonNaming {
+    def apply(property: String): String = transformation(property)
+  }
 }

--- a/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
+++ b/framework/src/play-json/src/main/scala/play/api/libs/json/Writes.scala
@@ -102,7 +102,7 @@ object Writes extends PathWrites with ConstraintWrites with DefaultWrites {
 /**
  * Default Serializers.
  */
-trait DefaultWrites {
+trait DefaultWrites extends LowPriorityWrites {
   import scala.language.implicitConversions
 
   /**
@@ -187,13 +187,6 @@ trait DefaultWrites {
    */
   implicit def mapWrites[V: Writes]: OWrites[Map[String, V]] = OWrites[Map[String, V]] { ts =>
     JsObject(ts.mapValues(toJson(_)).toSeq)
-  }
-
-  /**
-   * Serializer for Traversables types.
-   */
-  implicit def traversableWrites[A: Writes] = Writes[Traversable[A]] { as =>
-    JsArray(as.map(toJson(_)).toSeq)
   }
 
   /**
@@ -433,4 +426,14 @@ trait DefaultWrites {
       case x => JsString(x.toString)
     }
   }
+}
+
+sealed trait LowPriorityWrites {
+  /**
+   * Serializer for Traversables types.
+   */
+  implicit def traversableWrites[A: Writes] = Writes[Traversable[A]] { as =>
+    JsArray(as.map(toJson(_)).toSeq)
+  } // Avoid resolution ambiguity with more specific Traversable Writes,
+  // such as OWrites.map
 }

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/MacroSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/MacroSpec.scala
@@ -1,0 +1,272 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.libs.json
+
+object TestFormats {
+  implicit def eitherReads[A: Reads, B: Reads] = Reads[Either[A, B]] { js =>
+    implicitly[Reads[A]].reads(js) match {
+      case JsSuccess(a, _) => JsSuccess(Left(a))
+      case _ => implicitly[Reads[B]].reads(js).map(Right(_))
+    }
+  }
+
+  implicit def eitherWrites[A: Writes, B: Writes] = Writes[Either[A, B]] {
+    case Left(a) => implicitly[Writes[A]].writes(a)
+    case Right(b) => implicitly[Writes[B]].writes(b)
+  }
+
+  implicit def tuple2Reads[A: Reads, B: Reads]: Reads[(A, B)] = Reads { js =>
+    for {
+      a <- (js \ "_1").validate[A]
+      b <- (js \ "_2").validate[B]
+    } yield a -> b
+  }
+
+  implicit def tuple2OWrites[A: Writes, B: Writes]: OWrites[(A, B)] =
+    OWrites {
+      case (a, b) => Json.obj("_1" -> a, "_2" -> b)
+    }
+}
+
+class MacroSpec extends org.specs2.mutable.Specification {
+  "JSON macros" title
+
+  "Reads" should {
+    "be generated for simple case class" in {
+      Json.reads[Simple].reads(Json.obj("bar" -> "lorem")).get must_== Simple("lorem")
+    }
+
+    "as Format for a simple generic case class" in {
+      val fmt = Json.format[Lorem[Double]]
+
+      fmt.reads(Json.obj("ipsum" -> 0.123D, "age" -> 1)).get must_== Lorem(
+        0.123D, 1)
+    }
+  }
+
+  "Writes" should {
+    "be generated for simple case class" in {
+      Json.writes[Simple].writes(Simple("lorem")) must_== Json.obj("bar" -> "lorem")
+    }
+
+    "as Format for a generic case class" in {
+      val fmt = Json.format[Lorem[Float]]
+
+      fmt.writes(Lorem(2.34F, 2)) must_== Json.obj(
+        "ipsum" -> 2.34F, "age" -> 2)
+    }
+  }
+
+  "Macro" should {
+    "handle case class with self type as nested type parameter" >> {
+      import TestFormats._
+
+      val jsonNoValue = Json.obj("id" -> 1L)
+      val jsonStrValue = Json.obj("id" -> 2L, "value" -> "str")
+      val jsonFooValue = Json.obj("id" -> 3L, "value" -> jsonStrValue)
+
+      val fooStrValue = Foo(2L, Some(Left("str")))
+      val fooFooValue = Foo(3L, Some(Right(fooStrValue)))
+
+      def readSpec(r: Reads[Foo]) = {
+        r.reads(jsonNoValue).get must_== Foo(1L, None) and {
+          r.reads(jsonStrValue).get must_== fooStrValue
+        } and {
+          r.reads(jsonFooValue).get must_== fooFooValue
+        } and {
+          r.reads(Json.obj("id" -> 4L, "value" -> jsonFooValue)).
+            get must_== Foo(4L, Some(Right(fooFooValue)))
+        }
+      }
+
+      def writeSpec(w: Writes[Foo]) = {
+        w.writes(Foo(1L, None)) must_== jsonNoValue and {
+          w.writes(fooStrValue) must_== jsonStrValue
+        } and {
+          w.writes(fooFooValue) must_== jsonFooValue
+        } and {
+          w.writes(Foo(4L, Some(Right(fooFooValue)))) must_== Json.
+            obj("id" -> 4L, "value" -> jsonFooValue)
+        }
+      }
+
+      "to generate Reads" in readSpec(Json.reads[Foo])
+
+      "to generate Writes" in writeSpec(Json.writes[Foo])
+
+      "to generate Format" in {
+        val f: OFormat[Foo] = Json.format[Foo]
+
+        readSpec(f) and writeSpec(f)
+      }
+    }
+
+    "handle generic case class with multiple generic parameters" >> {
+      val jsonNoOther = Json.obj("base" -> 1)
+      val jsonOther = Json.obj("base" -> 2, "other" -> 3)
+
+      val noOther = Interval(1, None)
+      val other = Interval(2, Some(3))
+
+      def readSpec(r: Reads[Interval[Int]]) =
+        r.reads(jsonNoOther).get must_== noOther and {
+          r.reads(jsonOther).get must_== other
+        }
+
+      def writeSpec(r: Writes[Interval[Int]]) =
+        r.writes(noOther) must_== jsonNoOther and {
+          r.writes(other) must_== jsonOther
+        }
+
+      "to generate Reads" in readSpec(Json.reads[Interval[Int]])
+
+      "to generate Writes" in writeSpec(Json.writes[Interval[Int]])
+
+      "to generate Format" in {
+        val f = Json.format[Interval[Int]]
+        readSpec(f) and writeSpec(f)
+      }
+    }
+
+    "handle case class with implicits" >> {
+      val json1 = Json.obj("pos" -> 2, "text" -> "str")
+      val json2 = Json.obj("ident" -> "id", "value" -> 23.456D)
+      val fixture1 = WithImplicit1(2, "str")
+      val fixture2 = WithImplicit2("id", 23.456D)
+
+      def readSpec1(r: Reads[WithImplicit1]) =
+        r.reads(json1).get must_== fixture1
+
+      def writeSpec2(w: OWrites[WithImplicit2[Double]]) =
+        w.writes(fixture2) must_== json2
+
+      "to generate Reads" in readSpec1(Json.reads[WithImplicit1])
+
+      "to generate Writes with type parameters" in writeSpec2(
+        Json.writes[WithImplicit2[Double]])
+
+      "to generate Format" in {
+        val f1 = Json.format[WithImplicit1]
+        val f2 = Json.format[WithImplicit2[Double]]
+
+        readSpec1(f1) and {
+          f1.writes(fixture1) must_== json1
+        } and writeSpec2(f2) and {
+          f2.reads(json2).get must_== fixture2
+        }
+      }
+    }
+
+    "handle generic case class with multiple generic parameters and self references" >> {
+      import TestFormats._
+
+      val nestedLeft = Json.obj("id" -> 2, "a" -> 0.2F, "b" -> 0.3F, "c" -> 3)
+
+      val nestedRight = Json.obj(
+        "id" -> 1, "a" -> 0.1F, "b" -> "right1", "c" -> 2)
+
+      val jsonRight = Json.obj(
+        "id" -> 3, "a" -> nestedRight, "b" -> "right2", "c" -> 0.4D)
+
+      val jsonLeft = Json.obj(
+        "id" -> 4, "a" -> nestedLeft, "b" -> nestedRight, "c" -> 0.5D)
+
+      val complexRight = Complex(3, Complex(1, 0.1F, Right("right1"), 2),
+        Right("right2"), 0.4D)
+
+      val complexLeft = Complex(4, Complex(2, 0.2F, Left(0.3F), 3),
+        Left(Complex(1, 0.1F, Right("right1"), 2)), 0.5D)
+
+      def readSpec(r: Reads[Complex[Complex[Float, Int], Double]]) = {
+        r.reads(jsonRight).get must_== complexRight and {
+          r.reads(jsonLeft).get must_== complexLeft
+        }
+      }
+
+      def writeSpec(r: Writes[Complex[Complex[Float, Int], Double]]) = {
+        r.writes(complexRight) must_== jsonRight and {
+          r.writes(complexLeft) must_== jsonLeft
+        }
+      }
+
+      "to generate Reads" in readSpec {
+        implicit val nested = Json.reads[Complex[Float, Int]]
+        Json.reads[Complex[Complex[Float, Int], Double]]
+      }
+
+      "to generate Writes" in writeSpec {
+        implicit val nested = Json.writes[Complex[Float, Int]]
+        Json.writes[Complex[Complex[Float, Int], Double]]
+      }
+
+      "to generate Writes" in {
+        implicit val nested = Json.format[Complex[Float, Int]]
+        val f = Json.format[Complex[Complex[Float, Int], Double]]
+
+        readSpec(f) and writeSpec(f)
+      }
+    }
+
+    "handle case class with collection types" >> {
+      import TestFormats._
+
+      val json = Json.obj(
+        "id" -> "foo",
+        "ls" -> List(1.2D, 23.45D),
+        "set" -> List(1, 3, 4, 7),
+        "seq" -> List(
+          Json.obj("_1" -> 2, "_2" -> "bar"),
+          Json.obj("_1" -> 4, "_2" -> "lorem"),
+          Json.obj("_2" -> "ipsum", "_1" -> 5)
+        ),
+        "scores" -> Json.obj("A1" -> 0.1F, "EF" -> 12.3F)
+      )
+      val withColl = WithColl(
+        id = "foo",
+        ls = List(1.2D, 23.45D),
+        set = Set(1, 3, 4, 7),
+        seq = Seq(2 -> "bar", 4 -> "lorem", 5 -> "ipsum"),
+        scores = Map("A1" -> 0.1F, "EF" -> 12.3F)
+      )
+
+      def readSpec(r: Reads[WithColl[Double, (Int, String)]]) =
+        r.reads(json).get must_== withColl
+
+      def writeSpec(w: Writes[WithColl[Double, (Int, String)]]) =
+        w.writes(withColl) must_== json
+
+      "to generated Reads" in readSpec {
+        Json.reads[WithColl[Double, (Int, String)]]
+      }
+
+      "to generated Writes" in writeSpec {
+        Json.writes[WithColl[Double, (Int, String)]]
+      }
+
+      "to generate Format" in {
+        val f = Json.format[WithColl[Double, (Int, String)]]
+        readSpec(f) and writeSpec(f)
+      }
+    }
+  }
+
+  // ---
+
+  case class Simple(bar: String)
+  case class Lorem[T](ipsum: T, age: Int)
+
+  case class Foo(id: Long, value: Option[Either[String, Foo]])
+  case class Interval[T](base: T, other: Option[T])
+  case class Complex[T, U](id: Int, a: T, b: Either[T, String], c: U)
+
+  case class WithImplicit1(pos: Int, text: String)(implicit x: Numeric[Int])
+  case class WithImplicit2[N: Numeric](ident: String, value: N)
+
+  case class WithColl[A: Numeric, B](
+    id: String,
+    ls: List[A],
+    set: Set[Int],
+    seq: Seq[B],
+    scores: Map[String, Float])
+}

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/ReadsSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/ReadsSpec.scala
@@ -17,6 +17,8 @@ import java.time.{
 import java.time.format.DateTimeFormatter
 import play.api.data.validation.ValidationError
 
+case class Ipsum(id: Long, value: Either[String, Ipsum])
+
 class ReadsSpec extends org.specs2.mutable.Specification {
 
   title("JSON Reads")
@@ -445,22 +447,4 @@ class ReadsSpec extends org.specs2.mutable.Specification {
       }
     }
   }
-
-  "Macro" should {
-    "generate Reads for simple case class" in {
-      Json.reads[Foo].reads(Json.obj("bar" -> "lorem")).get must_== Foo("lorem")
-    }
-
-    "generate Formats for a generic case class" in {
-      val fmt = Json.format[Lorem[Double]]
-
-      fmt.reads(Json.obj("ipsum" -> 0.123D, "age" -> 1)).get must_== Lorem(
-        0.123D, 1)
-    }
-  }
-
-  // ---
-
-  case class Foo(bar: String)
-  case class Lorem[T](ipsum: T, age: Int)
 }

--- a/framework/src/play-json/src/test/scala/play/api/libs/json/WritesSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/WritesSpec.scala
@@ -173,21 +173,5 @@ class WritesSpec extends org.specs2.mutable.Specification {
     }
   }
 
-  "Macro" should {
-    "generate Writes for simple case class" in {
-      Json.writes[Foo].writes(Foo("lorem")) must_== Json.obj("bar" -> "lorem")
-    }
-
-    "generate Formats for a generic case class" in {
-      val fmt = Json.format[Lorem[Float]]
-
-      fmt.writes(Lorem(2, 2.34F)) must_== Json.obj(
-        "value" -> 2, "ipsum" -> 2.34F)
-    }
-  }
-
-  // ---
-
   case class Foo(bar: String)
-  case class Lorem[A](value: Int, ipsum: A)
 }


### PR DESCRIPTION
I've come up with a partial solution to making the JSON macro more robust when handling recursive types. Rather than making a pull request, I wanted to discuss my findings here first, because I don't know how well they will be received.

Suppose we have: 
```
case class Foo(id: Long, value: Either[String, Foo])
```
and some:
```
implicit def eitherReads[A : Reads, B : Reads]: Reads[Either[A, B]] = ???
```
The following macro call will fail from a type-mismatch error:
```
implicit val reads = Json.reads[Foo]
```
After some digging, I found that if the macro determines that the structure is recursive (and not using a nullable call), it will eventually land [here](https://github.com/playframework/playframework/blob/f7e17a7880972b2e6a955e71a7035ae0f7903681/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala#L192-L200). This means that even if the [implicit found earlier in the macro](https://github.com/playframework/playframework/blob/f7e17a7880972b2e6a955e71a7035ae0f7903681/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala#L151) has type `Reads[Either[String, Foo]]`, the macro will insert the recursive call of type `Reads[Foo]` in the [`else` branch](https://github.com/playframework/playframework/blob/f7e17a7880972b2e6a955e71a7035ae0f7903681/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala#L200).

One idea I had was inspecting the implicit tree that was resolved, and carefully splicing in the call to `this.lazyStuff`. I see only a few possibilities for the structure of the implicit tree:

1.  An implicit method that likely has it's own implicit parameters, to handle generics. Such as `Reads.seq`, or the above `eitherReads`, etc.
2.  An implicit that can be typechecked to `N[A]` (an exact recursive call to the ident the macro result will be assigned to).
3.  Some other static tree, such as an implicit val, or object, which requires no recursion and can be left alone.

So I wrote a method to handle these cases:
```
def recursiveReplace(impl: Tree): List[Tree] = impl match {
  case q"$obj.$impldef[..$tparams](..$implparams)" => {
    val replaced = implparams.map(p => recursiveReplace(p))
    q"$obj.$impldef[..$tparams](..$replaced)"
  }
  case obj if (c.typecheck(obj).tpe <:< natag.tpe) => q"this.lazyStuff"
  case tree => tree
}
```
This will inspect a implicitly resolved tree and attempt to more carefully splice in the recursive calls. If the tree is a (1), it will extract the parameter trees and process them recursively with `recursiveReplace`. If it is a (2), it is replaced with the recursive call to the macro result `q"this.lazyStuff"`. If it is a (3) (for the moment), the tree is left alone.

I wrote a few tests for `Either` and replaced [this call](https://github.com/playframework/playframework/blob/f7e17a7880972b2e6a955e71a7035ae0f7903681/framework/src/play-json/src/main/scala/play/api/libs/json/JsMacroImpl.scala#L200) with a call to `recursiveReplace(impl)`. Theoretically, `recursiveReplace` should also work for the manually handled `Set`, `List`, `Map` and `Seq` helpers, so I tried removing them and the tests failed (rather, didn't compile). It was then I realized the fix wouldn't work without a type annotation on the macro result, and why the aforementioned types are being handled specially.

One [already existing test](https://github.com/playframework/playframework/blob/f7e17a7880972b2e6a955e71a7035ae0f7903681/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala#L416-L426) for example contains:
```
implicit val userReads = Json.reads[UserMap]
```

Where `UserMap` is: `case class UserMap(name: String, friends: Map[String, UserMap] = Map())`

It _would_ work with my patch if the test actually read: 
```
implicit val userReads: Reads[UserMap] = Json.reads[UserMap]
```
The problem lies in the implicit resolution. The type checker fails to find the implicit `Reads[Map[...]]` because it can't find the `Reads[UserMap]` that it depends on, because there is no type annotation:
```
/playframework/framework/src/play-json/src/test/scala/play/api/libs/json/JsonExtensionSpec.scala:465: json.this.Reads.mapReads is not a valid implicit value for play.api.libs.json.Reads[Map[String,play.api.libs.json.UserMap]] because:
[info] hasMatchingSymbol reported error: No Json deserializer found for type play.api.libs.json.UserMap. Try to implement an implicit Reads or Format for this type.
[info]       implicit val userReads = Json.reads[UserMap]
```
So the "needed implicit" is actually an empty tree.

It seems like the macro can be much more powerful than it currently is, to support any kind of recursive type (well, maybe not any, but many more). The obvious problem with the above solution is that it introduces a breaking change where client code must annotate `Reads`, `Writes` and `Format` generated by the macro (at least in the recursive case).

However:
* It is very rigid to only support `Set`, `List`, `Map` and `Seq`, and `Option` within recursive types, and adding more would make the code far more ugly.
* Isn't it good practice to explicitly annotate implicit result types anyway?
* Many user-defined recursive types are not supported by the macro because of this.

Or is needing to annotate the macro result unacceptable?