### PR TITLE
Inject dependencies with functions

### DIFF
--- a/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
+++ b/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
@@ -4,13 +4,13 @@
 package play.api.inject
 package guice
 
-import com.google.inject.util.{Modules => GuiceModules, Providers => GuiceProviders}
-import com.google.inject.{Binder, CreationException, Guice, Provider, Stage, Module => GuiceModule}
+import com.google.inject.util.{ Modules => GuiceModules, Providers => GuiceProviders }
+import com.google.inject.{ Binder, CreationException, Guice, Provider, Stage, Module => GuiceModule }
 import java.io.File
 import javax.inject.Inject
 
-import play.api.inject.{Binding => PlayBinding, Injector => PlayInjector, Module => PlayModule}
-import play.api.{Configuration, Environment, Mode, PlayException}
+import play.api.inject.{ Binding => PlayBinding, Injector => PlayInjector, Module => PlayModule }
+import play.api.{ Configuration, Environment, Mode, PlayException }
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
@@ -368,7 +368,7 @@ trait GuiceableModuleConversions {
             case ProviderConstructionTarget(provider) => builder.toProvider(provider)
             case ConstructionTarget(implementation) => builder.to(implementation)
             case BindingKeyTarget(key) => builder.to(GuiceKey(key))
-            case ft@FunctionTarget(_, _) => builder.toProvider(functionProvider(ft))
+            case ft @ FunctionTarget(_, _) => builder.toProvider(functionProvider(ft))
           }
           (binding.scope, binding.eager) match {
             case (Some(scope), false) => builder.in(scope)

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -4,11 +4,13 @@
 package play.api
 
 import java.io._
+import java.time.Clock
 import javax.inject.Inject
 
 import akka.actor.ActorSystem
 import akka.stream.{ ActorMaterializer, Materializer }
 import javax.inject.Singleton
+
 import play.api.http._
 import play.api.inject.{ DefaultApplicationLifecycle, Injector, NewInstanceInjector, SimpleInjector }
 import play.api.libs.Files.{ DefaultTemporaryFileCreator, TemporaryFileCreator }
@@ -253,9 +255,9 @@ trait BuiltInComponents {
 
   lazy val cryptoConfig: CryptoConfig = new CryptoConfigParser(environment, configuration).get
 
-  lazy val cookieSigner: CookieSigner = new CookieSignerProvider(cryptoConfig).get
+  lazy val cookieSigner: CookieSigner = new HMACSHA1CookieSigner(cryptoConfig)
 
-  lazy val csrfTokenSigner: CSRFTokenSigner = new CSRFTokenSignerProvider(cookieSigner).get
+  lazy val csrfTokenSigner: CSRFTokenSigner = new DefaultCSRFTokenSigner(cookieSigner, Clock.systemUTC())
 
   lazy val tempFileCreator: TemporaryFileCreator = new DefaultTemporaryFileCreator(applicationLifecycle)
 }

--- a/framework/src/play/src/main/scala/play/api/inject/Binding.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Binding.scala
@@ -228,11 +228,11 @@ final case class BindingKey[T](clazz: Class[T], qualifier: Option[QualifierAnnot
    */
   def toSelf: Binding[T] = Binding(this, None, None, false, SourceLocator.source)
 
-  def toFunction[T1: ClassTag, R <: T: ClassTag](f: T1 => R): Binding[T] =
+  def toFunction[T1: ClassTag](f: T1 => T): Binding[T] =
     toFunction(implicitly[ClassTag[T1]].runtimeClass.asInstanceOf[Class[T1]])(f)
-  def toFunction[T1, R <: T](c1: Class[_ <: T1])(f: T1 => R): Binding[T] =
+  def toFunction[T1](c1: Class[_ <: T1])(f: T1 => T): Binding[T] =
     toFunction(BindingKey(c1))(f)
-  def toFunction[T1, R <: T](k1: BindingKey[T1])(f: T1 => R): Binding[T] =
+  def toFunction[T1](k1: BindingKey[T1])(f: T1 => T): Binding[T] =
     Binding(this, Some(FunctionTarget(Seq(k1), { case Seq(a1) => f(a1.asInstanceOf[T1]) })), None, false, SourceLocator.source)
 
 

--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -37,7 +37,7 @@ class BuiltinModule extends Module {
       bind[Environment] to env,
       bind[ConfigurationProvider].to(new ConfigurationProvider(configuration)),
       bind[Configuration].toProvider[ConfigurationProvider],
-      bind[Config].toFunction((c: Configuration) => c.underlying),
+      bind[Config].toProvider[ConfigProvider],
       bind[HttpConfiguration].toFunction((c: Configuration) => HttpConfiguration.fromConfiguration(c)),
 
       // Application lifecycle, bound both to the interface, and its implementation, so that Application can access it
@@ -73,6 +73,10 @@ class BuiltinModule extends Module {
 // This allows us to access the original configuration via this
 // provider while overriding the binding for Configuration itself.
 class ConfigurationProvider(val get: Configuration) extends Provider[Configuration]
+
+class ConfigProvider @Inject() (configuration: Configuration) extends Provider[Config] {
+  override def get() = configuration.underlying
+}
 
 @Singleton
 class RoutesProvider @Inject() (injector: Injector, environment: Environment, configuration: Configuration, httpConfig: HttpConfiguration) extends Provider[Router] {

--- a/framework/src/play/src/main/scala/play/api/libs/crypto/CSRFTokenSigner.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/crypto/CSRFTokenSigner.scala
@@ -145,8 +145,3 @@ object CSRFTokenSigner {
     MessageDigest.isEqual(a.getBytes(StandardCharsets.UTF_8), b.getBytes(StandardCharsets.UTF_8))
   }
 }
-
-@Singleton
-class CSRFTokenSignerProvider @Inject() (signer: CookieSigner) extends Provider[CSRFTokenSigner] {
-  lazy val get: CSRFTokenSigner = new DefaultCSRFTokenSigner(signer, Clock.systemUTC())
-}

--- a/framework/src/play/src/main/scala/play/api/libs/crypto/CookieSigner.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/crypto/CookieSigner.scala
@@ -41,11 +41,6 @@ trait CookieSigner {
   def sign(message: String): String
 }
 
-@Singleton
-class CookieSignerProvider @Inject() (config: CryptoConfig) extends Provider[CookieSigner] {
-  lazy val get: CookieSigner = new HMACSHA1CookieSigner(config)
-}
-
 /**
  * Uses an HMAC-SHA1 for signing cookies.
  */


### PR DESCRIPTION
Using a function is much easier than creating a Provider each time some simple binding logic is needed. It's particularly helpful when writing tests. I've inlined several of our existing one-liner Providers to show how it works.

The implementation is trivial in Guice. I need to check if it would be supported by other runtime DI frameworks.

- [ ] Check on mailing list that this can be supported from Guice, Dagger, etc
- [ ] Support more function arities
- [ ] Java API