### PR TITLE
Trim digest of asset after reading it. fixes #6538

### DIFF
--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -259,7 +259,7 @@ object Assets extends AssetsBuilder(LazyHttpErrorHandler) {
   private[controllers] def digest(path: String): Option[String] = {
     digestCache.getOrElse(path, {
       val maybeDigestUrl: Option[URL] = resource(path + "." + digestAlgorithm)
-      val maybeDigest: Option[String] = maybeDigestUrl.map(scala.io.Source.fromURL(_).mkString)
+      val maybeDigest: Option[String] = maybeDigestUrl.map(scala.io.Source.fromURL(_).mkString.trim)
       if (!isDev && maybeDigest.isDefined) digestCache.put(path, maybeDigest)
       maybeDigest
     })


### PR DESCRIPTION
If using external tools to generate the digest of an asset (e.g. md5sum main.css > main.css.md5), it may happen that the tool adds non printable characters (like \n) after the digest.

This results in URLs generated like:
/assets/styles/dc5672cb5071cd31a6fb6d670807161c
-main.css

instead of 
/assets/styles/dc5672cb5071cd31a6fb6d670807161c-main.css

Proposed solution: Trim the digest read from the digest file.