### PR TITLE
Fix MultipartFormData typo mdf -> mfd

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
@@ -52,8 +52,8 @@ object HttpBinApplication {
             // Anything else
             case m: play.api.mvc.AnyContentAsMultipartFormData @unchecked =>
               Json.obj(
-                "form" -> m.mdf.dataParts.map { case (k, v) => k -> JsString(v.mkString) },
-                "file" -> JsString(m.mdf.file("upload").map(v => FileUtils.readFileToString(v.ref.file)).getOrElse(""))
+                "form" -> m.mfd.dataParts.map { case (k, v) => k -> JsString(v.mkString) },
+                "file" -> JsString(m.mfd.file("upload").map(v => FileUtils.readFileToString(v.ref.file)).getOrElse(""))
               )
             case b =>
               Json.obj("data" -> JsString(b.toString))
@@ -355,4 +355,3 @@ object HttpBinApplication {
   }
 
 }
-

--- a/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala
@@ -114,7 +114,7 @@ case class AnyContentAsJson(json: JsValue) extends AnyContent
 /**
  * AnyContent - Multipart form data body
  */
-case class AnyContentAsMultipartFormData(mdf: MultipartFormData[TemporaryFile]) extends AnyContent
+case class AnyContentAsMultipartFormData(mfd: MultipartFormData[TemporaryFile]) extends AnyContent
 
 /**
  * Multipart form data body.


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Purpose

This PR fixes a typo in `MultipartFormData` where `mdf` should most likely be abbreviated as `mfd`

