### PR TITLE
fixes some problems with query strings

### DIFF
--- a/framework/src/play-netty-server/src/main/java/play/core/server/netty/QueryStringDecoder.java
+++ b/framework/src/play-netty-server/src/main/java/play/core/server/netty/QueryStringDecoder.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package play.core.server.netty;
+
+import java.nio.charset.Charset;
+
+import io.netty.util.CharsetUtil;
+import io.netty.handler.codec.http.HttpConstants;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Splits an HTTP query string into a path string and key-value parameter pairs.
+ * This decoder is for one time use only.  Create a new instance for each URI:
+ * <pre>
+ * {@link QueryStringDecoder} decoder = new {@link QueryStringDecoder}("/hello?recipient=world&x=1;y=2");
+ * assert decoder.path().equals("/hello");
+ * assert decoder.parameters().get("recipient").get(0).equals("world");
+ * assert decoder.parameters().get("x").get(0).equals("1");
+ * assert decoder.parameters().get("y").get(0).equals("2");
+ * </pre>
+ *
+ * This decoder can also decode the content of an HTTP POST request whose
+ * content type is <tt>application/x-www-form-urlencoded</tt>:
+ * <pre>
+ * {@link QueryStringDecoder} decoder = new {@link QueryStringDecoder}("recipient=world&x=1;y=2", false);
+ * ...
+ * </pre>
+ *
+ * <h3>HashDOS vulnerability fix</h3>
+ *
+ * As a workaround to the <a href="http://netty.io/s/hashdos">HashDOS</a> vulnerability, the decoder
+ * limits the maximum number of decoded key-value parameter pairs, up to {@literal 1024} by
+ * default, and you can configure it when you construct the decoder by passing an additional
+ * integer parameter.
+ *
+ */
+public class QueryStringDecoder {
+
+    private static final int DEFAULT_MAX_PARAMS = 1024;
+
+    private final Charset charset;
+    private final String uri;
+    private final boolean hasPath;
+    private final int maxParams;
+    private String path;
+    private Map<String, List<String>> params;
+    private int nParams;
+
+    /**
+     * Creates a new decoder that decodes the specified URI. The decoder will
+     * assume that the query string is encoded in UTF-8.
+     */
+    public QueryStringDecoder(String uri) {
+        this(uri, HttpConstants.DEFAULT_CHARSET);
+    }
+
+    /**
+     * Creates a new decoder that decodes the specified URI encoded in the
+     * specified charset.
+     */
+    public QueryStringDecoder(String uri, boolean hasPath) {
+        this(uri, HttpConstants.DEFAULT_CHARSET, hasPath);
+    }
+
+    /**
+     * Creates a new decoder that decodes the specified URI encoded in the
+     * specified charset.
+     */
+    public QueryStringDecoder(String uri, Charset charset) {
+        this(uri, charset, true);
+    }
+
+    /**
+     * Creates a new decoder that decodes the specified URI encoded in the
+     * specified charset.
+     */
+    public QueryStringDecoder(String uri, Charset charset, boolean hasPath) {
+        this(uri, charset, hasPath, DEFAULT_MAX_PARAMS);
+    }
+
+    /**
+     * Creates a new decoder that decodes the specified URI encoded in the
+     * specified charset.
+     */
+    public QueryStringDecoder(String uri, Charset charset, boolean hasPath, int maxParams) {
+        if (uri == null) {
+            throw new NullPointerException("getUri");
+        }
+        if (charset == null) {
+            throw new NullPointerException("charset");
+        }
+        if (maxParams <= 0) {
+            throw new IllegalArgumentException(
+                    "maxParams: " + maxParams + " (expected: a positive integer)");
+        }
+
+        this.uri = uri;
+        this.charset = charset;
+        this.maxParams = maxParams;
+        this.hasPath = hasPath;
+    }
+
+    /**
+     * Creates a new decoder that decodes the specified URI. The decoder will
+     * assume that the query string is encoded in UTF-8.
+     */
+    public QueryStringDecoder(URI uri) {
+        this(uri, HttpConstants.DEFAULT_CHARSET);
+    }
+
+    /**
+     * Creates a new decoder that decodes the specified URI encoded in the
+     * specified charset.
+     */
+    public QueryStringDecoder(URI uri, Charset charset) {
+        this(uri, charset, DEFAULT_MAX_PARAMS);
+    }
+
+    /**
+     * Creates a new decoder that decodes the specified URI encoded in the
+     * specified charset.
+     */
+    public QueryStringDecoder(URI uri, Charset charset, int maxParams) {
+        if (uri == null) {
+            throw new NullPointerException("getUri");
+        }
+        if (charset == null) {
+            throw new NullPointerException("charset");
+        }
+        if (maxParams <= 0) {
+            throw new IllegalArgumentException(
+                    "maxParams: " + maxParams + " (expected: a positive integer)");
+        }
+
+        String rawPath = uri.getRawPath();
+        if (rawPath != null) {
+            hasPath = true;
+        } else {
+            rawPath = "";
+            hasPath = false;
+        }
+        // Also take care of cut of things like "http://localhost"
+        this.uri = rawPath + (uri.getRawQuery() == null? "" : '?' + uri.getRawQuery());
+
+        this.charset = charset;
+        this.maxParams = maxParams;
+    }
+
+    /**
+     * Returns the uri used to initialize this {@link QueryStringDecoder}.
+     */
+    public String uri() {
+        return uri;
+    }
+
+    /**
+     * Returns the decoded path string of the URI.
+     */
+    public String path() {
+        if (path == null) {
+            if (!hasPath) {
+                path = "";
+            } else {
+                int pathEndPos = uri.indexOf('?');
+                path = decodeComponent(pathEndPos < 0 ? uri : uri.substring(0, pathEndPos), this.charset);
+            }
+        }
+        return path;
+    }
+
+    /**
+     * Returns the decoded key-value parameter pairs of the URI.
+     */
+    public Map<String, List<String>> parameters() {
+        if (params == null) {
+            if (hasPath) {
+                int pathEndPos = uri.indexOf('?');
+                if (pathEndPos >= 0 && pathEndPos < uri.length() - 1) {
+                    decodeParams(uri.substring(pathEndPos + 1));
+                } else {
+                    params = Collections.emptyMap();
+                }
+            } else {
+                if (uri.isEmpty()) {
+                    params = Collections.emptyMap();
+                } else {
+                    decodeParams(uri);
+                }
+            }
+        }
+        return params;
+    }
+
+    private void decodeParams(String s) {
+        Map<String, List<String>> params = this.params = new LinkedHashMap<String, List<String>>();
+        nParams = 0;
+        String name = null;
+        int pos = 0; // Beginning of the unprocessed region
+        int i;       // End of the unprocessed region
+        char c;  // Current character
+        for (i = 0; i < s.length(); i++) {
+            c = s.charAt(i);
+            if (c == '=' && name == null) {
+                if (pos != i) {
+                    name = decodeComponent(s.substring(pos, i), charset);
+                }
+                pos = i + 1;
+                // http://www.w3.org/TR/html401/appendix/notes.html#h-B.2.2
+            } else if (c == ',' && name != null) {
+                // if there is a comma we need to add a param
+                addParam(params, name, decodeComponent(s.substring(pos, i), charset));
+                pos = i +1;
+            } else if (c == '&' || c == ';') {
+                if (name == null && pos != i) {
+                    // We haven't seen an `=' so far but moved forward.
+                    // Must be a param of the form '&a&' so add it with
+                    // an empty value.
+                    if (!addParam(params, decodeComponent(s.substring(pos, i), charset), "")) {
+                        return;
+                    }
+                } else if (name != null) {
+                    if (!addParam(params, name, decodeComponent(s.substring(pos, i), charset))) {
+                        return;
+                    }
+                    name = null;
+                }
+                pos = i + 1;
+            }
+        }
+
+        if (pos != i) {  // Are there characters we haven't dealt with?
+            if (name == null) {     // Yes and we haven't seen any `='.
+                addParam(params, decodeComponent(s.substring(pos, i), charset), "");
+            } else {                // Yes and this must be the last value.
+                addParam(params, name, decodeComponent(s.substring(pos, i), charset));
+            }
+        } else if (name != null) {  // Have we seen a name without value?
+            addParam(params, name, "");
+        }
+    }
+
+    private boolean addParam(Map<String, List<String>> params, String name, String value) {
+        if (nParams >= maxParams) {
+            return false;
+        }
+
+        List<String> values = params.get(name);
+        if (values == null) {
+            values = new ArrayList<String>(1);  // Often there's only 1 value.
+            params.put(name, values);
+        }
+        values.add(value);
+        nParams ++;
+        return true;
+    }
+
+    /**
+     * Decodes a bit of an URL encoded by a browser.
+     * <p>
+     * This is equivalent to calling {@link #decodeComponent(String, Charset)}
+     * with the UTF-8 charset (recommended to comply with RFC 3986, Section 2).
+     * @param s The string to decode (can be empty).
+     * @return The decoded string, or {@code s} if there's nothing to decode.
+     * If the string to decode is {@code null}, returns an empty string.
+     * @throws IllegalArgumentException if the string contains a malformed
+     * escape sequence.
+     */
+    public static String decodeComponent(final String s) {
+        return decodeComponent(s, HttpConstants.DEFAULT_CHARSET);
+    }
+
+    /**
+     * Decodes a bit of an URL encoded by a browser.
+     * <p>
+     * The string is expected to be encoded as per RFC 3986, Section 2.
+     * This is the encoding used by JavaScript functions {@code encodeURI}
+     * and {@code encodeURIComponent}, but not {@code escape}.  For example
+     * in this encoding, &eacute; (in Unicode {@code U+00E9} or in UTF-8
+     * {@code 0xC3 0xA9}) is encoded as {@code %C3%A9} or {@code %c3%a9}.
+     * <p>
+     * This is essentially equivalent to calling
+     *   {@link URLDecoder#decode(String, String) URLDecoder.decode(s, charset.name())}
+     * except that it's over 2x faster and generates less garbage for the GC.
+     * Actually this function doesn't allocate any memory if there's nothing
+     * to decode, the argument itself is returned.
+     * @param s The string to decode (can be empty).
+     * @param charset The charset to use to decode the string (should really
+     * be {@link CharsetUtil#UTF_8}.
+     * @return The decoded string, or {@code s} if there's nothing to decode.
+     * If the string to decode is {@code null}, returns an empty string.
+     * @throws IllegalArgumentException if the string contains a malformed
+     * escape sequence.
+     */
+    public static String decodeComponent(final String s, final Charset charset) {
+        if (s == null) {
+            return "";
+        }
+        final int size = s.length();
+        boolean modified = false;
+        for (int i = 0; i < size; i++) {
+            final char c = s.charAt(i);
+            if (c == '%' || c == '+') {
+                modified = true;
+                break;
+            }
+        }
+        if (!modified) {
+            return s;
+        }
+        final byte[] buf = new byte[size];
+        int pos = 0;  // position in `buf'.
+        for (int i = 0; i < size; i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '+':
+                    buf[pos++] = ' ';  // "+" -> " "
+                    break;
+                case '%':
+                    if (i == size - 1) {
+                        throw new IllegalArgumentException("unterminated escape"
+                                + " sequence at end of string: " + s);
+                    }
+                    c = s.charAt(++i);
+                    if (c == '%') {
+                        buf[pos++] = '%';  // "%%" -> "%"
+                        break;
+                    }
+                    if (i == size - 1) {
+                        throw new IllegalArgumentException("partial escape"
+                                + " sequence at end of string: " + s);
+                    }
+                    c = decodeHexNibble(c);
+                    final char c2 = decodeHexNibble(s.charAt(++i));
+                    if (c == Character.MAX_VALUE || c2 == Character.MAX_VALUE) {
+                        throw new IllegalArgumentException(
+                                "invalid escape sequence `%" + s.charAt(i - 1)
+                                        + s.charAt(i) + "' at index " + (i - 2)
+                                        + " of: " + s);
+                    }
+                    c = (char) (c * 16 + c2);
+                    // Fall through.
+                default:
+                    buf[pos++] = (byte) c;
+                    break;
+            }
+        }
+        return new String(buf, 0, pos, charset);
+    }
+
+    /**
+     * Helper to decode half of a hexadecimal number from a string.
+     * @param c The ASCII character of the hexadecimal number to decode.
+     * Must be in the range {@code [0-9a-fA-F]}.
+     * @return The hexadecimal value represented in the ASCII character
+     * given, or {@link Character#MAX_VALUE} if the character is invalid.
+     */
+    private static char decodeHexNibble(final char c) {
+        if ('0' <= c && c <= '9') {
+            return (char) (c - '0');
+        } else if ('a' <= c && c <= 'f') {
+            return (char) (c - 'a' + 10);
+        } else if ('A' <= c && c <= 'F') {
+            return (char) (c - 'A' + 10);
+        } else {
+            return Character.MAX_VALUE;
+        }
+    }
+}

--- a/framework/src/play-netty-server/src/main/java/play/core/server/netty/QueryStringDecoder.java
+++ b/framework/src/play-netty-server/src/main/java/play/core/server/netty/QueryStringDecoder.java
@@ -30,20 +30,19 @@ import java.util.Map;
 /**
  * Splits an HTTP query string into a path string and key-value parameter pairs.
  * This decoder is for one time use only.  Create a new instance for each URI:
- * <pre>
+ * <pre>{@code
  * {@link QueryStringDecoder} decoder = new {@link QueryStringDecoder}("/hello?recipient=world&x=1;y=2");
  * assert decoder.path().equals("/hello");
  * assert decoder.parameters().get("recipient").get(0).equals("world");
  * assert decoder.parameters().get("x").get(0).equals("1");
  * assert decoder.parameters().get("y").get(0).equals("2");
- * </pre>
+ * }</pre>
  *
  * This decoder can also decode the content of an HTTP POST request whose
  * content type is <tt>application/x-www-form-urlencoded</tt>:
- * <pre>
+ * <pre>{@code
  * {@link QueryStringDecoder} decoder = new {@link QueryStringDecoder}("recipient=world&x=1;y=2", false);
- * ...
- * </pre>
+ * }</pre>
  *
  * <h3>HashDOS vulnerability fix</h3>
  *

--- a/framework/src/play-netty-server/src/test/java/play/core/server/netty/QueryStringDecoderTest.java
+++ b/framework/src/play-netty-server/src/test/java/play/core/server/netty/QueryStringDecoderTest.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package play.core.server.netty;
+
+import io.netty.util.CharsetUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class QueryStringDecoderTest {
+
+    @Test
+    public void testBasicUris() throws URISyntaxException {
+        QueryStringDecoder d = new QueryStringDecoder(new URI("http://localhost/path"));
+        Assert.assertEquals(0, d.parameters().size());
+    }
+
+    @Test
+    public void testBasic() throws Exception {
+        QueryStringDecoder d;
+
+        d = new QueryStringDecoder("/foo");
+        Assert.assertEquals("/foo", d.path());
+        Assert.assertEquals(0, d.parameters().size());
+
+        d = new QueryStringDecoder("/foo%20bar");
+        Assert.assertEquals("/foo bar", d.path());
+        Assert.assertEquals(0, d.parameters().size());
+
+        d = new QueryStringDecoder("/foo?a=b=c");
+        Assert.assertEquals("/foo", d.path());
+        Assert.assertEquals(1, d.parameters().size());
+        Assert.assertEquals(1, d.parameters().get("a").size());
+        Assert.assertEquals("b=c", d.parameters().get("a").get(0));
+
+        d = new QueryStringDecoder("/foo?a=1&a=2");
+        Assert.assertEquals("/foo", d.path());
+        Assert.assertEquals(1, d.parameters().size());
+        Assert.assertEquals(2, d.parameters().get("a").size());
+        Assert.assertEquals("1", d.parameters().get("a").get(0));
+        Assert.assertEquals("2", d.parameters().get("a").get(1));
+
+        d = new QueryStringDecoder("/foo%20bar?a=1&a=2");
+        Assert.assertEquals("/foo bar", d.path());
+        Assert.assertEquals(1, d.parameters().size());
+        Assert.assertEquals(2, d.parameters().get("a").size());
+        Assert.assertEquals("1", d.parameters().get("a").get(0));
+        Assert.assertEquals("2", d.parameters().get("a").get(1));
+
+        d = new QueryStringDecoder("/foo?a=&a=2");
+        Assert.assertEquals("/foo", d.path());
+        Assert.assertEquals(1, d.parameters().size());
+        Assert.assertEquals(2, d.parameters().get("a").size());
+        Assert.assertEquals("", d.parameters().get("a").get(0));
+        Assert.assertEquals("2", d.parameters().get("a").get(1));
+
+        d = new QueryStringDecoder("/foo?a=1&a=");
+        Assert.assertEquals("/foo", d.path());
+        Assert.assertEquals(1, d.parameters().size());
+        Assert.assertEquals(2, d.parameters().get("a").size());
+        Assert.assertEquals("1", d.parameters().get("a").get(0));
+        Assert.assertEquals("", d.parameters().get("a").get(1));
+
+        d = new QueryStringDecoder("/foo?a=1&a=&a=");
+        Assert.assertEquals("/foo", d.path());
+        Assert.assertEquals(1, d.parameters().size());
+        Assert.assertEquals(3, d.parameters().get("a").size());
+        Assert.assertEquals("1", d.parameters().get("a").get(0));
+        Assert.assertEquals("", d.parameters().get("a").get(1));
+        Assert.assertEquals("", d.parameters().get("a").get(2));
+
+        d = new QueryStringDecoder("/foo?a=1=&a==2");
+        Assert.assertEquals("/foo", d.path());
+        Assert.assertEquals(1, d.parameters().size());
+        Assert.assertEquals(2, d.parameters().get("a").size());
+        Assert.assertEquals("1=", d.parameters().get("a").get(0));
+        Assert.assertEquals("=2", d.parameters().get("a").get(1));
+
+        d = new QueryStringDecoder("/dynatable/?queries%5Bsearch%5D=%7B%22condition%22%3A%22AND%22%2C%22rules%22%3A%5B%5D%7D&page=1&perPage=10&offset=0");
+        Assert.assertEquals("/dynatable/", d.path());
+        Assert.assertEquals(4, d.parameters().size());
+        Assert.assertEquals(1, d.parameters().get("queries[search]").size());
+        Assert.assertEquals("{\"condition\":\"AND\",\"rules\":[]}", d.parameters().get("queries[search]").get(0));
+        Assert.assertEquals("1", d.parameters().get("page").get(0));
+        Assert.assertEquals("10", d.parameters().get("perPage").get(0));
+        Assert.assertEquals("0", d.parameters().get("offset").get(0));
+
+        d = new QueryStringDecoder("/foo?filter=a=b,c");
+        Assert.assertEquals("/foo", d.path());
+        Assert.assertEquals(1, d.parameters().size());
+        Assert.assertEquals(2, d.parameters().get("filter").size());
+        Assert.assertEquals("a=b", d.parameters().get("filter").get(0));
+        Assert.assertEquals("c", d.parameters().get("filter").get(1));
+
+        d = new QueryStringDecoder("/foo?filter=a=b,c,d,f");
+        Assert.assertEquals("/foo", d.path());
+        Assert.assertEquals(1, d.parameters().size());
+        Assert.assertEquals(4, d.parameters().get("filter").size());
+        Assert.assertEquals("a=b", d.parameters().get("filter").get(0));
+        Assert.assertEquals("c", d.parameters().get("filter").get(1));
+        Assert.assertEquals("d", d.parameters().get("filter").get(2));
+        Assert.assertEquals("f", d.parameters().get("filter").get(3));
+
+        d = new QueryStringDecoder("/foo?filter=a=b,c,d,f&hello=demo,tag&filter=x");
+        Assert.assertEquals("/foo", d.path());
+        Assert.assertEquals(2, d.parameters().size());
+        Assert.assertEquals(5, d.parameters().get("filter").size());
+        Assert.assertEquals("a=b", d.parameters().get("filter").get(0));
+        Assert.assertEquals("c", d.parameters().get("filter").get(1));
+        Assert.assertEquals("d", d.parameters().get("filter").get(2));
+        Assert.assertEquals("f", d.parameters().get("filter").get(3));
+        Assert.assertEquals("x", d.parameters().get("filter").get(4));
+        Assert.assertEquals(2, d.parameters().get("hello").size());
+        Assert.assertEquals("demo", d.parameters().get("hello").get(0));
+        Assert.assertEquals("tag", d.parameters().get("hello").get(1));
+    }
+
+    @Test
+    public void testExotic() throws Exception {
+        assertQueryString("", "");
+        assertQueryString("foo", "foo");
+        assertQueryString("foo", "foo?");
+        assertQueryString("/foo", "/foo?");
+        assertQueryString("/foo", "/foo");
+        assertQueryString("?a=", "?a");
+        assertQueryString("foo?a=", "foo?a");
+        assertQueryString("/foo?a=", "/foo?a");
+        assertQueryString("/foo?a=", "/foo?a&");
+        assertQueryString("/foo?a=", "/foo?&a");
+        assertQueryString("/foo?a=", "/foo?&a&");
+        assertQueryString("/foo?a=", "/foo?&=a");
+        assertQueryString("/foo?a=", "/foo?=a&");
+        assertQueryString("/foo?a=", "/foo?a=&");
+        assertQueryString("/foo?a=b&c=d", "/foo?a=b&&c=d");
+        assertQueryString("/foo?a=b&c=d", "/foo?a=b&=&c=d");
+        assertQueryString("/foo?a=b&c=d", "/foo?a=b&==&c=d");
+        assertQueryString("/foo?a=b&c=&x=y", "/foo?a=b&c&x=y");
+        assertQueryString("/foo?a=", "/foo?a=");
+        assertQueryString("/foo?a=", "/foo?&a=");
+        assertQueryString("/foo?a=b&c=d", "/foo?a=b&c=d");
+        assertQueryString("/foo?a=1&a=&a=", "/foo?a=1&a&a=");
+    }
+
+    @Test
+    public void testHashDos() throws Exception {
+        StringBuilder buf = new StringBuilder();
+        buf.append('?');
+        for (int i = 0; i < 65536; i ++) {
+            buf.append('k');
+            buf.append(i);
+            buf.append("=v");
+            buf.append(i);
+            buf.append('&');
+        }
+        Assert.assertEquals(1024, new QueryStringDecoder(buf.toString()).parameters().size());
+    }
+
+    @Test
+    public void testHasPath() throws Exception {
+        QueryStringDecoder decoder = new QueryStringDecoder("1=2", false);
+        Assert.assertEquals("", decoder.path());
+        Map<String, List<String>> params = decoder.parameters();
+        Assert.assertEquals(1, params.size());
+        Assert.assertTrue(params.containsKey("1"));
+        List<String> param = params.get("1");
+        Assert.assertNotNull(param);
+        Assert.assertEquals(1, param.size());
+        Assert.assertEquals("2", param.get(0));
+    }
+
+    @Test
+    public void testUrlDecoding() throws Exception {
+        final String caffe = new String(
+                // "Caffé" but instead of putting the literal E-acute in the
+                // source file, we directly use the UTF-8 encoding so as to
+                // not rely on the platform's default encoding (not portable).
+                new byte[] {'C', 'a', 'f', 'f', (byte) 0xC3, (byte) 0xA9},
+                "UTF-8");
+        final String[] tests = {
+                // Encoded   ->   Decoded or error message substring
+                "",               "",
+                "foo",            "foo",
+                "f%%b",           "f%b",
+                "f+o",            "f o",
+                "f++",            "f  ",
+                "fo%",            "unterminated escape sequence",
+                "%42",            "B",
+                "%5f",            "_",
+                "f%4",            "partial escape sequence",
+                "%x2",            "invalid escape sequence `%x2' at index 0 of: %x2",
+                "%4x",            "invalid escape sequence `%4x' at index 0 of: %4x",
+                "Caff%C3%A9",     caffe,
+        };
+        for (int i = 0; i < tests.length; i += 2) {
+            final String encoded = tests[i];
+            final String expected = tests[i + 1];
+            try {
+                final String decoded = QueryStringDecoder.decodeComponent(encoded);
+                Assert.assertEquals(expected, decoded);
+            } catch (IllegalArgumentException e) {
+                Assert.assertTrue("String \"" + e.getMessage() + "\" does"
+                                + " not contain \"" + expected + '"',
+                        e.getMessage().contains(expected));
+            }
+        }
+    }
+
+    private static void assertQueryString(String expected, String actual) {
+        QueryStringDecoder ed = new QueryStringDecoder(expected, CharsetUtil.UTF_8);
+        QueryStringDecoder ad = new QueryStringDecoder(actual, CharsetUtil.UTF_8);
+        Assert.assertEquals(ed.path(), ad.path());
+        Assert.assertEquals(ed.parameters(), ad.parameters());
+    }
+
+    // See #189
+    @Test
+    public void testURI() {
+        URI uri = URI.create("http://localhost:8080/foo?param1=value1&param2=value2&param3=value3");
+        QueryStringDecoder decoder = new QueryStringDecoder(uri);
+        Assert.assertEquals("/foo", decoder.path());
+        Map<String, List<String>> params =  decoder.parameters();
+        Assert.assertEquals(3, params.size());
+        Iterator<Entry<String, List<String>>> entries = params.entrySet().iterator();
+
+        Entry<String, List<String>> entry = entries.next();
+        Assert.assertEquals("param1", entry.getKey());
+        Assert.assertEquals(1, entry.getValue().size());
+        Assert.assertEquals("value1", entry.getValue().get(0));
+
+        entry = entries.next();
+        Assert.assertEquals("param2", entry.getKey());
+        Assert.assertEquals(1, entry.getValue().size());
+        Assert.assertEquals("value2", entry.getValue().get(0));
+
+        entry = entries.next();
+        Assert.assertEquals("param3", entry.getKey());
+        Assert.assertEquals(1, entry.getValue().size());
+        Assert.assertEquals("value3", entry.getValue().get(0));
+
+        Assert.assertFalse(entries.hasNext());
+    }
+
+    // See #189
+    @Test
+    public void testURISlashPath() {
+        URI uri = URI.create("http://localhost:8080/?param1=value1&param2=value2&param3=value3");
+        QueryStringDecoder decoder = new QueryStringDecoder(uri);
+        Assert.assertEquals("/", decoder.path());
+        Map<String, List<String>> params =  decoder.parameters();
+        Assert.assertEquals(3, params.size());
+        Iterator<Entry<String, List<String>>> entries = params.entrySet().iterator();
+
+        Entry<String, List<String>> entry = entries.next();
+        Assert.assertEquals("param1", entry.getKey());
+        Assert.assertEquals(1, entry.getValue().size());
+        Assert.assertEquals("value1", entry.getValue().get(0));
+
+        entry = entries.next();
+        Assert.assertEquals("param2", entry.getKey());
+        Assert.assertEquals(1, entry.getValue().size());
+        Assert.assertEquals("value2", entry.getValue().get(0));
+
+        entry = entries.next();
+        Assert.assertEquals("param3", entry.getKey());
+        Assert.assertEquals(1, entry.getValue().size());
+        Assert.assertEquals("value3", entry.getValue().get(0));
+
+        Assert.assertFalse(entries.hasNext());
+    }
+
+    // See #189
+    @Test
+    public void testURINoPath() {
+        URI uri = URI.create("http://localhost:8080?param1=value1&param2=value2&param3=value3");
+        QueryStringDecoder decoder = new QueryStringDecoder(uri);
+        Assert.assertEquals("", decoder.path());
+        Map<String, List<String>> params =  decoder.parameters();
+        Assert.assertEquals(3, params.size());
+        Iterator<Entry<String, List<String>>> entries = params.entrySet().iterator();
+
+        Entry<String, List<String>> entry = entries.next();
+        Assert.assertEquals("param1", entry.getKey());
+        Assert.assertEquals(1, entry.getValue().size());
+        Assert.assertEquals("value1", entry.getValue().get(0));
+
+        entry = entries.next();
+        Assert.assertEquals("param2", entry.getKey());
+        Assert.assertEquals(1, entry.getValue().size());
+        Assert.assertEquals("value2", entry.getValue().get(0));
+
+        entry = entries.next();
+        Assert.assertEquals("param3", entry.getKey());
+        Assert.assertEquals(1, entry.getValue().size());
+        Assert.assertEquals("value3", entry.getValue().get(0));
+
+        Assert.assertFalse(entries.hasNext());
+    }
+
+    // See https://github.com/netty/netty/issues/1833
+    @Test
+    public void testURI2() {
+        URI uri = URI.create("http://foo.com/images;num=10?query=name;value=123");
+        QueryStringDecoder decoder = new QueryStringDecoder(uri);
+        Assert.assertEquals("/images;num=10", decoder.path());
+        Map<String, List<String>> params =  decoder.parameters();
+        Assert.assertEquals(2, params.size());
+        Iterator<Entry<String, List<String>>> entries = params.entrySet().iterator();
+
+        Entry<String, List<String>> entry = entries.next();
+        Assert.assertEquals("query", entry.getKey());
+        Assert.assertEquals(1, entry.getValue().size());
+        Assert.assertEquals("name", entry.getValue().get(0));
+
+        entry = entries.next();
+        Assert.assertEquals("value", entry.getKey());
+        Assert.assertEquals(1, entry.getValue().size());
+        Assert.assertEquals("123", entry.getValue().get(0));
+
+        Assert.assertFalse(entries.hasNext());
+    }
+}


### PR DESCRIPTION
## Fixes

Fixes #6551
Fixes #6549

@gmethvin @wsargent This is a Backport of QueryStringDecoder which I proposed here:
https://github.com/netty/netty/pull/5820

This needs a backport against 2.5.x
After this we can also merge: https://github.com/playframework/playframework/pull/6543

I will delay scala-uri WIP for master since I got some questions after working with it the last couple of days.