### PR TITLE
polished the akka-http backend

### DIFF
--- a/documentation/manual/experimental/AkkaHttpServer.md
+++ b/documentation/manual/experimental/AkkaHttpServer.md
@@ -14,9 +14,9 @@ In future versions of Play we may implement a production quality Akka HTTP backe
 
 ## Known issues
 
-* Slow. There is a lot more copying in the Akka HTTP backend because the Play and Akka HTTP APIs are not naturally compatible. A lot of extra copying is needed to translate the objects.
 * Server shutdown is a bit rough. HTTP server actors are just killed.
 * The implementation contains code duplicated from the Netty backend.
+* Currently some Exception could not be handled by the HttpErrorHandler (Header Parsing Errors, Request Timeout).
 
 ## Usage
 
@@ -61,7 +61,37 @@ play {
 
   akka {
     # How long to wait when binding to the listening socket
-    http-bind-timeout = 5 seconds
+    bind-timeout = 5 seconds
+    
+    # Enables/disables automatic handling of HEAD requests.
+    # If this setting is enabled the server dispatches HEAD requests as GET
+    # requests to the application and automatically strips off all message
+    # bodies from outgoing responses.
+    # Note that, even when this setting is off the server will never send
+    # out message bodies on responses to HEAD requests.
+    transparent-head-requests = on
+
+    # How long a request takes until it times out
+    # request-timeout = 240 seconds
+    # If this setting is empty the server only accepts requests that carry a
+    # non-empty `Host` header. Otherwise it responds with `400 Bad Request`.
+    # Set to a non-empty value to be used in lieu of a missing or empty `Host`
+    # header to make the server accept such requests.
+    # Note that the server will never accept HTTP/1.1 request without a `Host`
+    # header, i.e. this setting only affects HTTP/1.1 requests with an empty
+    # `Host` header as well as HTTP/1.0 requests.
+    # Examples: `www.spray.io` or `example.com:8080`
+    default-host-header = ""
+
+    # Enables/disables the addition of a `Remote-Address` header
+    # holding the clients (remote) IP address.
+    remote-address-header = off
+
+    # The default value of the `Server` header to produce if no
+    # explicit `Server`-header was included in a response.
+    # If this value is the empty string and no header was included in
+    # the request, no `Server` header will be rendered at all.
+    server-header = ""
   }
 
 }

--- a/framework/src/play-akka-http-server/src/main/resources/play/reference-overrides.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/play/reference-overrides.conf
@@ -18,9 +18,6 @@ akka {
   http.server {
     # Disable Akka-HTTP's transparent HEAD handling. so that play's HEAD handling can take action
     transparent-head-requests = false
-
-    # Enable Raw-Request-URI header to get actual request URI
-    raw-request-uri-header = true
   }
 
 }

--- a/framework/src/play-akka-http-server/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/reference.conf
@@ -12,6 +12,37 @@ play {
     akka {
       # How long to wait when binding to the listening socket
       bindTimeout = 5 seconds
+
+      # How long a request takes until it times out
+      # request-timeout = 240 seconds
+
+      # Enables/disables automatic handling of HEAD requests.
+      # If this setting is enabled the server dispatches HEAD requests as GET
+      # requests to the application and automatically strips off all message
+      # bodies from outgoing responses.
+      # Note that, even when this setting is off the server will never send
+      # out message bodies on responses to HEAD requests.
+      transparent-head-requests = on
+
+      # If this setting is empty the server only accepts requests that carry a
+      # non-empty `Host` header. Otherwise it responds with `400 Bad Request`.
+      # Set to a non-empty value to be used in lieu of a missing or empty `Host`
+      # header to make the server accept such requests.
+      # Note that the server will never accept HTTP/1.1 request without a `Host`
+      # header, i.e. this setting only affects HTTP/1.1 requests with an empty
+      # `Host` header as well as HTTP/1.0 requests.
+      # Examples: `www.spray.io` or `example.com:8080`
+      default-host-header = ""
+
+      # Enables/disables the addition of a `Remote-Address` header
+      # holding the clients (remote) IP address.
+      remote-address-header = off
+
+      # The default value of the `Server` header to produce if no
+      # explicit `Server`-header was included in a response.
+      # If this value is the empty string and no header was included in
+      # the request, no `Server` header will be rendered at all.
+      server-header = ""
     }
   }
 

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -59,10 +59,8 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
       // We could get NettyServer to send a similar tag, but for the moment
       // let's not, just in case it slows NettyServer down a bit.
       override val tags = Map("HTTP_SERVER" -> "akka-http")
-      // Note: Akka HTTP doesn't provide a direct way to get the raw URI
-      // This will only work properly if
-      override def uri = request.header[`Raw-Request-URI`].map(_.value) getOrElse {
-        logger.warn("Can't get raw request URI. Please set akka.http.server.raw-request-uri-header = true")
+      override def uri = request.header[`Raw-Request-URI`].map(_.uri).getOrElse {
+        logger.warn("Can't get raw request URI.")
         request.uri.toString
       }
       override def path = request.uri.path.toString


### PR DESCRIPTION
currently the raw-request-uri-header was never set, even after changing the configuration
since we construct the initial-settings manually, so it always raised "Can't get raw request URI. Please set...'
Unfortunatly the user can't set it by himself
