### PR TITLE
[doc] Remove object controller references

### DIFF
--- a/documentation/manual/hacking/Documentation.md
+++ b/documentation/manual/hacking/Documentation.md
@@ -62,7 +62,7 @@ package foo.bar.controllers
 
 import play.api.mvc._
 
-object Application extends Controller {
+class HomeController extends Controller {
   ...
 }
 //#controller

--- a/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonHttpSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonHttpSpec.scala
@@ -185,7 +185,7 @@ import play.api.mvc._
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
-object Application extends Controller {
+class HomeController extends Controller {
 
 }
 //#controller

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
@@ -57,7 +57,7 @@ You can call any `Action` code by providing a [`FakeRequest`](api/scala/play/api
 
 @[scalafunctionaltest-functionalexamplecontrollerspec](code/specs2/FunctionalExampleControllerSpec.scala)
 
-Technically, you don't need [`WithApplication`](api/scala/play/api/test/WithApplication.html) here, although it wouldn't hurt anything to have it.
+Technically, you don't need [`WithApplication`](api/scala/play/api/test/WithApplication.html) here, because you can instantiate the controller directly -- however, direct controller instantiation is more of a unit test of the controller than a functional test.
 
 ## Testing the router
 

--- a/documentation/manual/working/scalaGuide/main/tests/code/controllers/Application.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/controllers/Application.scala
@@ -7,7 +7,7 @@ package controllers
 
 import play.api.mvc._
 
-object Application extends Controller {
+class Application extends Controller {
   def index() = Action {
     Ok("Hello Bob") as("text/plain")
   }

--- a/documentation/manual/working/scalaGuide/main/tests/code/controllers/HomeController.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/controllers/HomeController.scala
@@ -7,7 +7,7 @@ package controllers
 
 import play.api.mvc._
 
-class Application extends Controller {
+class HomeController extends Controller {
   def index() = Action {
     Ok("Hello Bob") as("text/plain")
   }

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/FunctionalExampleControllerSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/FunctionalExampleControllerSpec.scala
@@ -10,8 +10,9 @@ import play.api.test._
 class FunctionalExampleControllerSpec extends PlaySpecification {
 
   // #scalafunctionaltest-functionalexamplecontrollerspec
-  "respond to the index Action" in {
-    val result = controllers.Application.index()(FakeRequest())
+  "respond to the index Action" in new WithApplication {
+    val controller = app.injector.instanceOf[scalaguide.tests.controllers.HomeController]
+    val result = controller.index()(FakeRequest())
 
     status(result) must equalTo(OK)
     contentType(result) must beSome("text/plain")

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOAuthSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOAuthSpec.scala
@@ -17,7 +17,7 @@ import play.api.data.Forms._
 import play.api.libs.oauth._
 import play.api.libs.ws._
 
-class Application @Inject()(wsClient:WSClient) extends Controller {
+class HomeController @Inject()(wsClient:WSClient) extends Controller {
 
 }
 //#dependency


### PR DESCRIPTION
Scrubs some more "object Application" references in the documentation.