### PR TITLE
Move encoding of cookies from Result to server implementation

### DIFF
--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaResults.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaResults.scala
@@ -54,8 +54,9 @@ package scalaguide.http.scalaresults {
 
       "Setting and discarding cookies" in {
         //#set-cookies
-        val result = Ok("Hello world").withCookies(
-          Cookie("theme", "blue"))
+        val result = Ok("Hello world")
+          .withCookies(Cookie("theme", "blue"))
+          .bakeCookies()
         //#set-cookies
         testHeader(result, SET_COOKIE, "theme=blue")
         //#discarding-cookies
@@ -67,7 +68,7 @@ package scalaguide.http.scalaresults {
         //#setting-discarding-cookies
         testHeader(result3, SET_COOKIE, "skin=;")
         testHeader(result3, SET_COOKIE, "theme=blue;")
-        
+
       }
 
       "Changing the charset for text based HTTP responses" in {
@@ -86,7 +87,8 @@ package scalaguide.http.scalaresults {
     }
 
     def testHeader(results: Result, key: String, value: String) = {
-      results.header.headers.get(key).get must contain(value)
+      results.bakeCookies() // bake cookies with default configuration
+        .header.headers.get(key).get must contain(value)
     }
 
     def testAction[A](action: Action[A], expectedResponse: Int = OK, request: Request[A] = FakeRequest()) = {
@@ -114,7 +116,7 @@ package scalaguide.http.scalaresults {
 
     }
     //#full-application-set-myCustomCharset
- 
+
 
   object CodeShow {
     //#Source-Code-HTML

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -456,8 +456,8 @@ object CSRFAction {
       CSRF.getToken(request).fold(
         config.cookieName.flatMap { cookie =>
           request.cookies.get(cookie).map { token =>
-            result.discardingCookies(DiscardingCookie(cookie, domain = Session.domain, path = Session.path,
-              secure = config.secureCookie))
+            result.discardingCookies(
+              DiscardingCookie(cookie, domain = Session.domain, path = Session.path, secure = config.secureCookie))
           }
         }.getOrElse {
           result.withSession(result.session(request) - config.tokenName)

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
@@ -3,29 +3,42 @@
  */
 package play.it.http
 
-import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.test._
-import play.api.mvc._
+import play.api.http.{ FlashConfiguration, SessionConfiguration }
 import play.api.mvc.Results._
+import play.api.mvc._
+import play.api.test._
+import play.api.Application
 
 class ScalaResultsSpec extends PlaySpecification {
 
-  "support session helper" in withApplication() {
+  def sessionBaker(implicit app: Application): CookieBaker[Session] = app.injector.instanceOf[SessionCookieBaker]
+  def flashBaker(implicit app: Application): CookieBaker[Flash] = app.injector.instanceOf[FlashCookieBaker]
 
-    Session.decode("  ").isEmpty must be_==(true)
+  def bake(result: Result)(implicit app: Application): Result = {
+    result.bakeCookies(sessionBaker, flashBaker)
+  }
+
+  def cookies(result: Result)(implicit app: Application): Seq[Cookie] = {
+    Cookies.decodeSetCookieHeader(bake(result).header.headers("Set-Cookie"))
+  }
+
+  "support session helper" in withApplication() { implicit app =>
+
+    sessionBaker.decode("  ").isEmpty must be_==(true)
 
     val data = Map("user" -> "kiki", "langs" -> "fr:en:de")
-    val encodedSession = Session.encode(data)
-    val decodedSession = Session.decode(encodedSession)
+    val encodedSession = sessionBaker.encode(data)
+    val decodedSession = sessionBaker.decode(encodedSession)
 
     decodedSession must_== Map("user" -> "kiki", "langs" -> "fr:en:de")
-    val Result(ResponseHeader(_, headers, _), _) =
+    val Result(ResponseHeader(_, headers, _), _, _, _, _) = bake {
       Ok("hello").as("text/html")
         .withSession("user" -> "kiki", "langs" -> "fr:en:de")
         .withCookies(Cookie("session", "items"), Cookie("preferences", "blue"))
         .discardingCookies(DiscardingCookie("logged"))
         .withSession("user" -> "kiki", "langs" -> "fr:en:de")
         .withCookies(Cookie("lang", "fr"), Cookie("session", "items2"))
+    }
 
     val setCookies = Cookies.decodeSetCookieHeader(headers("Set-Cookie")).map(c => c.name -> c).toMap
     setCookies.size must be_==(5)
@@ -34,63 +47,63 @@ class ScalaResultsSpec extends PlaySpecification {
     setCookies("lang").value must be_==("fr")
     setCookies("logged").maxAge must beSome
     setCookies("logged").maxAge must beSome(0)
-    val playSession = Session.decodeFromCookie(setCookies.get(Session.COOKIE_NAME))
+    val playSession = sessionBaker.decodeFromCookie(setCookies.get(sessionBaker.COOKIE_NAME))
     playSession.data must_== Map("user" -> "kiki", "langs" -> "fr:en:de")
   }
 
-  "ignore session cookies that have been tampered with" in withApplication() {
+  "ignore session cookies that have been tampered with" in withApplication() { implicit app =>
     val data = Map("user" -> "alice")
-    val encodedSession = Session.encode(data)
+    val encodedSession = sessionBaker.encode(data)
     // Change a value in the session
     val maliciousSession = encodedSession.replaceFirst("user=alice", "user=mallory")
-    val decodedSession = Session.decode(maliciousSession)
+    val decodedSession = sessionBaker.decode(maliciousSession)
     decodedSession must beEmpty
   }
 
   "support a custom application context" in {
-    "set session on right path" in withFooPath {
-      Cookies.decodeSetCookieHeader(Ok.withSession("user" -> "alice").header.headers("Set-Cookie")).head.path must_== "/foo"
+    "set session on right path" in withFooPath { implicit app =>
+      cookies(Ok.withSession("user" -> "alice")).head.path must_== "/foo"
     }
 
-    "discard session on right path" in withFooPath {
-      Cookies.decodeSetCookieHeader(Ok.withNewSession.header.headers("Set-Cookie")).head.path must_== "/foo"
+    "discard session on right path" in withFooPath { implicit app =>
+      cookies(Ok.withNewSession).head.path must_== "/foo"
     }
 
-    "set flash on right path" in withFooPath {
-      Cookies.decodeSetCookieHeader(Ok.flashing("user" -> "alice").header.headers("Set-Cookie")).head.path must_== "/foo"
+    "set flash on right path" in withFooPath { implicit app =>
+      cookies(Ok.flashing("user" -> "alice")).head.path must_== "/foo"
     }
 
     // flash cookie is discarded in PlayDefaultUpstreamHandler
   }
 
   "support a custom session domain" in {
-    "set session on right domain" in withFooDomain {
-      Cookies.decodeSetCookieHeader(Ok.withSession("user" -> "alice").header.headers("Set-Cookie")).head.domain must beSome(".foo.com")
+    "set session on right domain" in withFooDomain { implicit app =>
+      cookies(Ok.withSession("user" -> "alice")).head.domain must beSome(".foo.com")
     }
 
-    "discard session on right domain" in withFooDomain {
-      Cookies.decodeSetCookieHeader(Ok.withNewSession.header.headers("Set-Cookie")).head.domain must beSome(".foo.com")
+    "discard session on right domain" in withFooDomain { implicit app =>
+      cookies(Ok.withNewSession).head.domain must beSome(".foo.com")
     }
   }
 
   "support a secure session" in {
-    "set session as secure" in withSecureSession {
-      Cookies.decodeSetCookieHeader(Ok.withSession("user" -> "alice").header.headers("Set-Cookie")).head.secure must_== true
+    "set session as secure" in withSecureSession { implicit app =>
+      cookies(Ok.withSession("user" -> "alice")).head.secure must_== true
     }
 
-    "discard session as secure" in withSecureSession {
-      Cookies.decodeSetCookieHeader(Ok.withNewSession.header.headers("Set-Cookie")).head.secure must_== true
+    "discard session as secure" in withSecureSession { implicit app =>
+      cookies(Ok.withNewSession).head.secure must_== true
     }
   }
 
-  def withApplication[T](config: (String, Any)*)(block: => T): T = running(
+  def withApplication[T](config: (String, Any)*)(block: Application => T): T = running(
     _.configure(Map(config: _*) + ("play.crypto.secret" -> "foo"))
-  )(_ => block)
+  )(block)
 
-  def withFooPath[T](block: => T) = withApplication("application.context" -> "/foo")(block)
+  def withFooPath[T](block: Application => T) = withApplication("application.context" -> "/foo")(block)
 
-  def withFooDomain[T](block: => T) = withApplication("session.domain" -> ".foo.com")(block)
+  def withFooDomain[T](block: Application => T) = withApplication("session.domain" -> ".foo.com")(block)
 
-  def withSecureSession[T](block: => T) = withApplication("session.secure" -> true)(block)
+  def withSecureSession[T](block: Application => T) = withApplication("session.secure" -> true)(block)
 
 }

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -61,6 +61,8 @@ trait Application {
 
   def configuration: Configuration
 
+  private[play] lazy val httpConfiguration = HttpConfiguration.fromConfiguration(configuration)
+
   /**
    * The default ActorSystem used by the application.
    */

--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -70,7 +70,10 @@ class BuiltinModule extends SimpleModule((env, conf) => {
     bind[CryptoConfig].toProvider[CryptoConfigParser],
     bind[CookieSigner].toProvider[CookieSignerProvider],
     bind[CSRFTokenSigner].toProvider[CSRFTokenSignerProvider],
-    bind[TemporaryFileCreator].to[DefaultTemporaryFileCreator]
+    bind[TemporaryFileCreator].to[DefaultTemporaryFileCreator],
+
+    bind[SessionCookieBaker].to[DefaultSessionCookieBaker],
+    bind[FlashCookieBaker].to[DefaultFlashCookieBaker]
 
   ) ++ dynamicBindings(
       HttpErrorHandler.bindingsFromConfiguration,

--- a/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
@@ -64,7 +64,7 @@ class MessagesSpec extends Specification {
     }
 
     "support setting the language on a result" in {
-      val cookie = Cookies.decodeSetCookieHeader(api.setLang(Results.Ok, Lang("en-AU")).header.headers("Set-Cookie")).head
+      val cookie = api.setLang(Results.Ok, Lang("en-AU")).newCookies.head
       cookie.name must_== "PLAY_LANG"
       cookie.value must_== "en-AU"
     }


### PR DESCRIPTION
This moves the actual encoding of cookies to the server implementation. The list of cookies as well as separate session and flash data structures are stored directly on the request. These are encoded when the request is sent.

This has two main advantages:
 1. Not having to encode and decode the cookies every time we change a small thing saves us unnecessary work and makes the implementation simpler
 2. Doing the encoding on the server instead of on the result itself makes it easier to remove the global state from results.

@richdougherty Do you think it makes sense to use attributes on the result rather than extra fields here for session and flash?