### PR TITLE
Add a CORS config param to allow pass-through of forbidden origins.

### DIFF
--- a/documentation/manual/working/commonGuide/filters/CorsFilter.md
+++ b/documentation/manual/working/commonGuide/filters/CorsFilter.md
@@ -38,6 +38,7 @@ The available options include:
 * `play.filters.cors.exposedHeaders` - set custom HTTP headers to be exposed in the response (by default no headers are exposed)
 * `play.filters.cors.supportsCredentials` - disable/enable support for credentials (by default credentials support is enabled)
 * `play.filters.cors.preflightMaxAge` - set how long the results of a preflight request can be cached in a preflight result cache (by default 1 hour)
+* `play.filters.cors.serveForbiddenOrigins` - enable/disable serving requests with origins not in whitelist as non-CORS requests (by default they are forbidden)
 
 For example:
 

--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -150,6 +150,9 @@ play.filters {
 
     # The maximum amount of time the CORS meta data should be cached by the client
     preflightMaxAge = 1 hour
+
+    # Whether to serve forbidden origins as non-CORS requests
+    serveForbiddenOrigins = false
   }
 
   # GZip filter configuration

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
@@ -49,7 +49,10 @@ private[cors] trait AbstractCORSPolicy {
          * If the value of the Origin header is not a case-sensitive match for any of the values in list of origins, do
          * not set any additional headers and terminate this set of steps.
          */
-        handleInvalidCORSRequest(request)
+        if (corsConfig.serveForbiddenOrigins)
+          next(request)
+        else
+          handleInvalidCORSRequest(request)
       case (Some(originHeader), _) if isSameOrigin(originHeader, request) =>
         // Same-origin request
         next(request)

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
@@ -24,6 +24,7 @@ import play.api.mvc.{ Filter, RequestHeader, Result }
  *  - set custom HTTP headers to be exposed in the response (by default no headers are exposed)
  *  - disable/enable support for credentials (by default credentials support is enabled)
  *  - set how long (in seconds) the results of a preflight request can be cached in a preflight result cache (by default 3600 seconds, 1 hour)
+ *  - enable/disable serving requests with origins not in whitelist as non-CORS requests (by default they are forbidden)
  *
  * @param  corsConfig  configuration of the CORS policy
  * @param  pathPrefixes  whitelist of path prefixes to restrict the filter

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSCommonSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/cors/CORSCommonSpec.scala
@@ -56,6 +56,29 @@ trait CORSCommonSpec extends PlaySpecification {
       }
     }
 
+    val serveForbidden = Map(
+      "play.filters.cors.allowedOrigins" -> Seq("http://example.org"),
+      "play.filters.cors.serveForbiddenOrigins" -> "true")
+
+    "pass through requests with serve forbidden origins on and an origin header that is" in {
+      "invalid" in withApplication(conf = serveForbidden) { app =>
+        val result = route(app, fakeRequest().withHeaders(
+          ORIGIN -> "file://"
+        )).get
+
+        status(result) must_== OK
+        mustBeNoAccessControlResponseHeaders(result)
+      }
+      "forbidden" in withApplication(conf = serveForbidden) { app =>
+        val result = route(app, fakeRequest().withHeaders(
+          ORIGIN -> "http://www.example.com"
+        )).get
+
+        status(result) must_== OK
+        mustBeNoAccessControlResponseHeaders(result)
+      }
+    }
+
     "not consider sub domains to be the same origin" in withApplication() { app =>
       val result = route(app, fakeRequest().withHeaders(
         ORIGIN -> "http://www.example.com",


### PR DESCRIPTION
# Pull Request Checklist
- [X] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
- [X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
- [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
- [X] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
- [X] Have you added copyright headers to new files?
- [X] Have you checked that both Scala and Java APIs are updated?
- [X] Have you updated the documentation for both Scala and Java sections?
- [X] Have you added tests for any changed functionality?
# Helpful things
## Fixes

Fixes #5193 
## Purpose

This patch adds support to conditionally handle requests from non-whitelisted origins as non-CORS requests, ie let them to pass through. The default behavior is not changed, unallowed origins are forbidden. Please note that serving forbidden origins as non-CORS requests doesn't lower the security, given that browsers check the access control headers and block the response anyway.
## Background Context

Not all requests with an `Origin` header are CORS requests generated by browsers. Other clients can set the `Origin` header, don't send preflight calls, and don't expect to receive CORS access control headers in the answer. A common client of such type is a Cordova application, that always sends the `Origin: file://` header.
