### PR TITLE
Connect docs to external apidoc where possible

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -29,6 +29,7 @@ import interplay.PlayBuildBase.autoImport._
 
 import scala.util.control.NonFatal
 
+
 object BuildSettings {
 
   // Argument for setting size of permgen space or meta space for all forked processes
@@ -49,29 +50,114 @@ object BuildSettings {
   /**
    * These settings are used by all projects
    */
-  def playCommonSettings: Seq[Setting[_]] = scalariformSettings ++ Seq(
+  def playCommonSettings: Seq[Setting[_]] = {
+    import scala.util.matching.Regex
+    import scala.util.matching.Regex.Match
+
+    val javaApiUrl = "http://docs.oracle.com/javase/8/docs/api/index.html"
+    val javaxInjectUrl = "https://javax-inject.github.io/javax-inject/api/index.html"
+    var externalJavadocLinks = Set(
+      javaApiUrl,
+      javaxInjectUrl
+    )
+
+    scalariformSettings ++ Seq(
       ScalariformKeys.preferences := ScalariformKeys.preferences.value
         .setPreference(SpacesAroundMultiImports, true)
         .setPreference(SpaceInsideParentheses, false)
         .setPreference(DanglingCloseParenthesis, Preserve)
-        .setPreference(PreserveSpaceBeforeArguments, true)        
+        .setPreference(PreserveSpaceBeforeArguments, true)
         .setPreference(DoubleIndentClassDeclaration, true)
     ) ++ Seq(
-    homepage := Some(url("https://playframework.com")),
-    ivyLoggingLevel := UpdateLogging.DownloadOnly,
-    resolvers ++= Seq(
-      Resolver.typesafeRepo("releases"),
-      Resolver.typesafeIvyRepo("releases")
-    ),
-    fork in Test := true,
-    parallelExecution in Test := false,
-    testListeners in (Test,test) := Nil,
-    javaOptions in Test ++= Seq(maxMetaspace, "-Xmx512m", "-Xms128m"),
-    testOptions += Tests.Argument(TestFrameworks.JUnit, "-v"),
-    bintrayPackage := "play-sbt-plugin",
-    autoAPIMappings := true,
-    apiMappings += scalaInstance.value.libraryJar -> url( raw"""http://scala-lang.org/files/archive/api/${scalaInstance.value.actualVersion}/index.html""")
-  )
+      homepage := Some(url("https://playframework.com")),
+      ivyLoggingLevel := UpdateLogging.DownloadOnly,
+      resolvers ++= Seq(
+        Resolver.typesafeRepo("releases"),
+        Resolver.typesafeIvyRepo("releases")
+      ),
+      fork in Test := true,
+      parallelExecution in Test := false,
+      testListeners in (Test,test) := Nil,
+      javaOptions in Test ++= Seq(maxMetaspace, "-Xmx512m", "-Xms128m"),
+      testOptions += Tests.Argument(TestFrameworks.JUnit, "-v"),
+      bintrayPackage := "play-sbt-plugin",
+      autoAPIMappings := true,
+      apiMappings += scalaInstance.value.libraryJar -> url(raw"""http://scala-lang.org/files/archive/api/${scalaInstance.value.actualVersion}/index.html"""),
+      apiMappings += {
+        // Maps JDK 1.8 jar into apidoc.
+        val rtJar: String = System.getProperty("sun.boot.class.path").split(java.io.File.pathSeparator).collectFirst {
+          case str: String if str.endsWith(java.io.File.separator + "rt.jar") => str
+        }.get // fail hard if not found
+        file(rtJar) -> url(javaApiUrl)
+      },
+      apiMappings ++= {
+        // Finds appropriate scala apidoc from dependencies when autoAPIMappings are insufficient.
+        // See the following:
+        //
+        // http://stackoverflow.com/questions/19786841/can-i-use-sbts-apimappings-setting-for-managed-dependencies/20919304#20919304
+        // http://www.scala-sbt.org/release/docs/Howto-Scaladoc.html#Enable+manual+linking+to+the+external+Scaladoc+of+managed+dependencies
+        // https://github.com/ThoughtWorksInc/sbt-api-mappings/blob/master/src/main/scala/com/thoughtworks/sbtApiMappings/ApiMappings.scala#L34
+
+        val ScalaLibraryRegex = """^.*[/\\]scala-library-([\d\.]+)\.jar$""".r
+
+        val IvyRegex = """^.*[/\\]([\.\-_\w]+)[/\\]([\.\-_\w]+)[/\\](?:jars|bundles)[/\\]([\.\-_\w]+)\.jar$""".r
+
+        (for {
+          jar <- (dependencyClasspath in Compile in doc).value.toSet ++ (dependencyClasspath in Test in doc).value
+          fullyFile = jar.data
+          urlOption = fullyFile.getCanonicalPath match {
+            case ScalaLibraryRegex(v) =>
+              Some(url(raw"""http://scala-lang.org/files/archive/api/$v/index.html"""))
+
+            case IvyRegex(organization, name, jarBaseFile) if jarBaseFile.startsWith(s"$name-") =>
+              val version = jarBaseFile.substring(name.length + 1, jarBaseFile.length)
+              organization match {
+                case "com.typesafe.akka" =>
+                  Some(url(raw"http://doc.akka.io/api/akka/$version/"))
+
+                case "javax.inject" =>
+                  Some(url(javaxInjectUrl))
+
+                case _ =>
+                  val link = raw"""https://oss.sonatype.org/service/local/repositories/public/archive/${organization.replace('.', '/')}/$name/$version/$jarBaseFile-javadoc.jar/!/index.html"""
+                  externalJavadocLinks += link
+                  Some(url(link))
+              }
+
+            case other =>
+              None
+
+          }
+          url <- urlOption
+        } yield (fullyFile -> url))(collection.breakOut(Map.canBuildFrom))
+      },      
+      doc in Compile <<= (doc in Compile) map { target: File =>
+          // Maps to Javadoc references in Scaladoc, and fixes the link so that it uses query parameters in
+          // Javadoc style to link directly to the referenced class.        
+          // http://stackoverflow.com/questions/16934488/how-to-link-classes-from-jdk-into-scaladoc-generated-doc/
+
+          def javadocLinkRegex(javadocURL: String): Regex = ("""\"(\Q""" + javadocURL + """\E)#([^"]*)\"""").r
+
+          def hasJavadocLink(f: File): Boolean = externalJavadocLinks exists {
+            javadocURL: String =>
+              (javadocLinkRegex(javadocURL) findFirstIn IO.read(f)).nonEmpty
+          }
+
+          val fixJavaLinks: Match => String = m =>
+            m.group(1) + "?" + m.group(2).replace(".", "/") + ".html"
+
+          (target ** "*.html").get.filter(hasJavadocLink).foreach { f =>
+            val newContent: String = externalJavadocLinks.foldLeft(IO.read(f)) {
+              case (oldContent: String, javadocURL: String) =>
+                //logger.debug(s"Fixing $f with $javadocURL")
+                javadocLinkRegex(javadocURL).replaceAllIn(oldContent, fixJavaLinks)
+            }
+            IO.write(f, newContent)
+          }
+          target
+      }
+    )
+  }
 
   /**
    * These settings are used by all projects that are part of the runtime, as opposed to development, mode of Play.

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -103,9 +103,10 @@ object Dependencies {
     mockitoAll
   ).map(_ % Test)
 
+  val guiceVersion = "4.0"
   val guiceDeps = Seq(
-    "com.google.inject" % "guice" % "4.0",
-    "com.google.inject.extensions" % "guice-assistedinject" % "4.0"
+    "com.google.inject" % "guice" % guiceVersion,
+    "com.google.inject.extensions" % "guice-assistedinject" % guiceVersion
   )
 
   def runtime(scalaVersion: String) =
@@ -267,14 +268,16 @@ object Dependencies {
     logback % Test
   ) ++ guiceDeps
 
+  val ehcacheVersion = "2.6.11"
   val playCacheDeps = Seq(
-      "net.sf.ehcache" % "ehcache-core" % "2.6.11",
+      "net.sf.ehcache" % "ehcache-core" % ehcacheVersion,
       logback % Test
     ) ++ specsBuild.map(_ % Test)
 
+  val asyncHttpClientVersion = "2.0.11"
   val playWsDeps = Seq(
     guava,
-    "org.asynchttpclient" % "async-http-client" % "2.0.11",
+    "org.asynchttpclient" % "async-http-client" % asyncHttpClientVersion,
     logback % Test
   ) ++
     Seq("signpost-core", "signpost-commonshttp4").map("oauth.signpost" % _  % "1.2.1.2") ++

--- a/framework/project/Docs.scala
+++ b/framework/project/Docs.scala
@@ -81,6 +81,7 @@ object Docs {
       }
     )
 
+  // This is a specialized task that does not replace "sbt doc" but packages all the doc at once.
   def apiDocsTask = Def.task {
 
     val targetDir = new File(target.value, "scala-" + CrossVersion.binaryScalaVersion(scalaVersion.value))
@@ -99,6 +100,7 @@ object Docs {
       val javaCache = new File(targetDir, "javaapidocs.cache")
 
       val label = "Play " + version
+      // Use the apiMappings value from the "doc" command
       val apiMappings = Keys.apiMappings.value
       val externalDocsScalacOption = Opts.doc.externalAPI(apiMappings).head.replace("-doc-external-doc:", "")
 
@@ -109,8 +111,7 @@ object Docs {
         // Hence it needs to be the base directory for the build, not the base directory for the play-docs project.
         "-sourcepath", (baseDirectory in ThisBuild).value.getAbsolutePath,
         "-doc-source-url", "https://github.com/playframework/playframework/tree/" + sourceTree + "/framework€{FILE_PATH}.scala",
-        "-doc-external-doc", externalDocsScalacOption)
-
+        s"-doc-external-doc:${externalDocsScalacOption}")
 
       val compilers = Keys.compilers.value
       val useCache = apiDocsUseCache.value
@@ -140,8 +141,60 @@ object Docs {
       javadoc(apiDocsJavaSources.value, classpath, apiTarget / "java", javadocOptions, 10, streams.value.log)
     }
 
+    // Known Java libraries in non-standard locations...
+    // All the external Javadoc URLs that must be fixed.
+    val externalJavadocLinks = Set(
+      javaApiUrl,
+      javaxInjectUrl,
+      ehCacheUrl,
+      guiceUrl,
+      ahcUrl
+    ) ++ Dependencies.slf4j.map(moduleIDToJavadoc)
+
+    import scala.util.matching.Regex
+    import scala.util.matching.Regex.Match
+
+    def javadocLinkRegex(javadocURL: String): Regex = ("""\"(\Q""" + javadocURL + """\E)#([^"]*)\"""").r
+
+    def hasJavadocLink(f: File): Boolean = externalJavadocLinks exists { javadocURL: String =>
+      (javadocLinkRegex(javadocURL) findFirstIn IO.read(f)).nonEmpty
+    }
+
+    val fixJavaLinks: Match => String = m =>
+      m.group(1) + "?" + m.group(2).replace(".", "/") + ".html"
+
+    // Maps to Javadoc references in Scaladoc, and fixes the link so that it uses query parameters in
+    // Javadoc style to link directly to the referenced class.
+    // http://stackoverflow.com/questions/16934488/how-to-link-classes-from-jdk-into-scaladoc-generated-doc/
+    (apiTarget ** "*.html").get.filter(hasJavadocLink).foreach { f =>
+      val newContent: String = externalJavadocLinks.foldLeft(IO.read(f)) {
+        case (oldContent: String, javadocURL: String) =>
+          javadocLinkRegex(javadocURL).replaceAllIn(oldContent, fixJavaLinks)
+      }
+      IO.write(f, newContent)
+    }
     apiTarget
   }
+
+  // Converts an artifact into a Javadoc URL.
+  def artifactToJavadoc(organization: String, name: String, apiVersion:String, jarBaseFile: String) = {
+    val slashedOrg = organization.replace('.', '/')
+    raw"""https://oss.sonatype.org/service/local/repositories/public/archive/$slashedOrg/$name/$apiVersion/$jarBaseFile-javadoc.jar/!/index.html"""
+  }
+
+  // Converts an SBT module into a Javadoc URL.
+  def moduleIDToJavadoc(id: ModuleID): String = {
+    artifactToJavadoc(id.organization, id.name, id.revision, s"${id.name}-${id.revision}")
+  }
+
+  val javaApiUrl = "http://docs.oracle.com/javase/8/docs/api/index.html"
+  val javaxInjectUrl = "https://javax-inject.github.io/javax-inject/api/index.html"
+  // ehcache has 2.6.11 as version, but latest is only 2.6.9 on the site!
+  val ehCacheUrl = raw"http://www.ehcache.org/apidocs/2.6.9/index.html"
+  // nonstandard guice location
+  val guiceUrl = raw"http://google.github.io/guice/api-docs/${Dependencies.guiceVersion}/javadoc/index.html"
+  // non standard ahc location
+  val ahcUrl = raw"http://static.javadoc.io/org.asynchttpclient/async-http-client/${Dependencies.asyncHttpClientVersion}/index.html"
 
   def allConfsTask(projectRef: ProjectRef, structure: BuildStructure): Task[Seq[(String, File)]] = {
     val projects = allApiProjects(projectRef.build, structure)


### PR DESCRIPTION
Connects Play apidoc with Akka, Java and Scaladocs.  

This means that https://www.playframework.com/documentation/2.5.x/api/scala/index.html#play.api.package will have links to the scala-lang site, java.lang.String, Akka, and so forth.

This is naturally difficult to test, but here's how you run through this:

```
cd framework
sbt apiDocs
cd ../documentation
sbt run
```

The external javadoc links were broken because of a missing ":", meaning the apiMappings were not applied previously in 2.5.x.  This PR contains the following fix:

```
      val options = Seq(
        // Note, this is used by the doc-source-url feature to determine the relative path of a given source file.
        // If it's not a prefix of a the absolute path of the source file, the absolute path of that file will be put
        // into the FILE_SOURCE variable below, which is definitely not what we want.
        // Hence it needs to be the base directory for the build, not the base directory for the play-docs project.
        "-sourcepath", (baseDirectory in ThisBuild).value.getAbsolutePath,
        "-doc-source-url", "https://github.com/playframework/playframework/tree/" + sourceTree + "/framework€{FILE_PATH}.scala",
        s"-doc-external-doc:${externalDocsScalacOption}")
```

Note that while `sbt apiDocs` looks like `sbt doc`, it's actually targeting the root and doing some additional logic.  The additional links to external javadoc are fiddly and have to be done by hand, as AHC / Guice / EhCache do not have a standard position for their docs.  The work done here is incomplete, but is at least a basis.