### PR TITLE
Fix incorrect level header (#6585)

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/JavaWS.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaWS.md
@@ -221,7 +221,7 @@ There are 3 different timeouts in WS. Reaching a timeout causes the WS request t
 
 The request timeout can be overridden for a specific connection with `setTimeout()` (see "Making a Request" section).
 
-## Configuring WS with SSL
+### Configuring WS with SSL
 
 To configure WS for use with HTTP over SSL/TLS (HTTPS), please see [[Configuring WS SSL|WsSSL]].
 


### PR DESCRIPTION
As in ScalaWS.md, the `## Configuring WS with SSL` should be a level 3 header under `Configuring WS`