### PR TITLE
Upgrade spec2 and twirl for 2.12

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
 
   val akkaVersion = "2.4.10"
 
-  val specsVersion = "3.8.4"
+  val specsVersion = "3.8.5"
   val specsBuild = Seq(
     "specs2-core",
     "specs2-junit",
@@ -184,6 +184,7 @@ object Dependencies {
   def sbtRcClient(scalaBinaryVersion: String): ModuleID = CrossVersion.partialVersion(scalaBinaryVersion) match {
     case Some((2, 10)) => "com.typesafe.sbtrc" % "client-2-10" % sbtRcVersion
     case Some((2, 11)) => "com.typesafe.sbtrc" % "client-2-11" % sbtRcVersion
+    case Some((2, 12)) => "com.typesafe.sbtrc" % "client-2-12" % sbtRcVersion
     case _ => sys.error(s"Unsupported scala version: $scalaBinaryVersion")
   }
 
@@ -196,6 +197,7 @@ object Dependencies {
   def sbtRcActorClient(scalaBinaryVersion: String): ModuleID = CrossVersion.partialVersion(scalaBinaryVersion) match {
     case Some((2, 10)) => "com.typesafe.sbtrc" % "actor-client-2-10" % sbtRcVersion
     case Some((2, 11)) => "com.typesafe.sbtrc" % "actor-client-2-11" % sbtRcVersion
+    case Some((2, 12)) => "com.typesafe.sbtrc" % "actor-client-2-12" % sbtRcVersion
     case _ => sys.error(s"Unsupported scala version: $scalaBinaryVersion")
   }
 

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -5,7 +5,7 @@ buildInfoSettings
 sourceGenerators in Compile <+= buildInfo
 
 val sbtNativePackagerVersion = "1.1.1"
-val sbtTwirlVersion = sys.props.getOrElse("twirl.version", "1.1.1")
+val sbtTwirlVersion = sys.props.getOrElse("twirl.version", "1.2.0")
 
 buildInfoKeys := Seq[BuildInfoKey](
   "sbtNativePackagerVersion" -> sbtNativePackagerVersion,


### PR DESCRIPTION
Upgrades specs2 and twirl versions to 3.8.5 and Twirl 1.2.0, to be better suited for Scala 2.12, for https://github.com/playframework/playframework/issues/6110

See https://github.com/etorreborre/specs2/issues/504 and 