### PR TITLE
fix failed evolutions with query parameter

### DIFF
--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/ApplicationEvolutions.scala
@@ -397,7 +397,7 @@ case class InvalidDatabaseRevision(db: String, script: String) extends PlayExcep
   def content = script
 
   private val javascript = """
-        window.location = window.location.href.replace(/\/@evolutions.*$|\/$/, '') + '/@evolutions/apply/%s?redirect=' + encodeURIComponent(location)
+        window.location = window.location.href.split(/[?#]/)[0].replace(/\/@evolutions.*$|\/$/, '') + '/@evolutions/apply/%s?redirect=' + encodeURIComponent(location)
     """.format(db).trim
 
   def htmlDescription = {

--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -553,7 +553,7 @@ case class InconsistentDatabase(db: String, script: String, error: String, rev: 
   private val resolvePathJavascript =
     if (autocommit) s"'/@evolutions/resolve/$db/$rev?redirect=' + encodeURIComponent(window.location)"
     else "'/@evolutions'"
-  private val redirectJavascript = s"""window.location = window.location.href.replace(/\\/@evolutions.*$$|\\/$$/, '') + $resolvePathJavascript"""
+  private val redirectJavascript = s"""window.location = window.location.href.split(/[?#]/)[0].replace(/\\/@evolutions.*$$|\\/$$/, '') + $resolvePathJavascript"""
 
   private val sentenceEnd = if (autocommit) " before marking it as resolved." else "."
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [ ] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

## Purpose

Evolutions doesn't work with query parameter.

> http://localhost:9000/search?q=aaa

When url already has query parameters on Evolution, Play can't catch a redirect parameter as a query parameter in apply button.

> http://localhost:9000/search?q=aaa/@evolutions/apply/default?redirect=http%3A%2F%2Flocalhost%3A8484%2Fsearch%3Fq%3Daaa

Because `?` character is duplicated in redirect url.

My PR removes the search query from url in apply button for Evolution.

> http://localhost:9000/search/@evolutions/apply/default?redirect=http%3A%2F%2Flocalhost%3A8484%2Fsearch%3Fq%3Daaa