### PR TITLE
Remove Play.current from scaladoc header

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -22,12 +22,6 @@ object Mode extends Enumeration {
 
 /**
  * High-level API to access Play global features.
- *
- * Note that this API depends on a running application.
- * You can import the currently running application in a scope using:
- * {{{
- * import play.api.Play.current
- * }}}
  */
 object Play {
 


### PR DESCRIPTION
Removes deprecated example from scaladoc.