### PR TITLE
[Doc] Adding 'StreamedBody' example to `forward-body`

### DIFF
--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
@@ -113,8 +113,7 @@ import org.specs2.execute.AsResult
           def forward(request: WSRequest): BodyParser[WSResponse] = BodyParser { req =>
             Accumulator.source[ByteString].mapFuture { source =>
               request
-                // TODO: stream body when support is implemented
-                // .withBody(source)
+                .withBody(StreamedBody(source))
                 .execute()
                 .map(Right.apply)
             }


### PR DESCRIPTION
# Pull Request Checklist
- [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
- [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
- [ ] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
- [ ] Have you added copyright headers to new files?
- [x] Have you checked that both Scala and Java APIs are updated?
- [-] Have you updated the documentation for both Scala and Java sections?
- [ ] Have you added tests for any changed functionality?
## Background Context

Since Accumulator gives us `source: Source[ByteString,_]` we should be able to stream body as described here https://www.playframework.com/documentation/2.5.x/ScalaWS#streaming-data

If it is feasible we might also need to check java docs too.
