### PR TITLE
changes the basic http client to use a case insensitive tree map

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BasicHttpClient.scala
@@ -12,6 +12,9 @@ import javax.net.ssl.X509TrustManager
 import org.apache.commons.io.IOUtils
 import play.api.test.Helpers._
 import play.core.server.common.ServerResultUtils
+import play.core.utils.CaseInsensitiveOrdered
+
+import scala.collection.immutable.TreeMap
 
 object BasicHttpClient {
 
@@ -190,7 +193,7 @@ class BasicHttpClient(port: Int, secure: Boolean) {
           parsed :: readHeaders
         }
       }
-      val headers = readHeaders.toMap
+      val headers = TreeMap(readHeaders: _*)(CaseInsensitiveOrdered)
 
       def readCompletely(length: Int): String = {
         if (length == 0) {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -4,7 +4,8 @@
 package play.it.http
 
 import java.util.Locale.ENGLISH
-import java.util.concurrent.{ LinkedBlockingQueue }
+import java.util.concurrent.LinkedBlockingQueue
+
 import akka.stream.scaladsl.Source
 import akka.util.{ ByteString, Timeout }
 import play.api._
@@ -19,9 +20,13 @@ import play.api.libs.ws._
 import play.api.libs.EventSource
 import play.core.server.common.ServerResultException
 import play.it._
+
 import scala.util.Try
 import scala.concurrent.Future
-import play.api.http.{ HttpEntity, HttpChunk, Status }
+import play.api.http.{ HttpChunk, HttpEntity, Status }
+import play.core.utils.CaseInsensitiveOrdered
+
+import scala.collection.immutable.TreeMap
 
 class NettyScalaResultsHandlingSpec extends ScalaResultsHandlingSpec with NettyIntegrationSpecification
 class AkkaHttpScalaResultsHandlingSpec extends ScalaResultsHandlingSpec with AkkaHttpIntegrationSpecification
@@ -443,7 +448,7 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
           BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
         ).head
         response.status must_== 500
-        (response.headers -- Set(CONNECTION, CONTENT_LENGTH, DATE, SERVER)) must be(Map.empty)
+        (response.headers -- Set(CONNECTION, CONTENT_LENGTH, DATE, SERVER)) must be empty
       }
 
     "return a 500 response if an error occurs during the onError" in withServer(
@@ -460,7 +465,7 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
           BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
         ).head
         response.status must_== 500
-        (response.headers -- Set(CONNECTION, CONTENT_LENGTH, DATE, SERVER)) must be(Map.empty)
+        (response.headers -- Set(CONNECTION, CONTENT_LENGTH, DATE, SERVER)) must be empty
       }
   }
 


### PR DESCRIPTION
actually on netty 4.1 some headers will be sent lowercased,
however our current basic http test client wasn't inlined with the current rfc
and handled headers in a case sensitive fashion.

This actually will enable netty-reactive-streams 2.0.0-SNAPSHOT, async-http-client 2.1.0-alpha1 and netty 4.1.5 to run the play test suite.