### PR TITLE
Create SimpleModule helper for creating Play modules

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
@@ -6,9 +6,9 @@ package play.filters.cors
 import javax.inject.{ Inject, Provider }
 
 import akka.stream.Materializer
+import play.api.Configuration
 import play.api.http.HttpErrorHandler
-import play.api.{ Environment, Configuration }
-import play.api.inject.Module
+import play.api.inject._
 
 /**
  * Provider for CORSConfig.
@@ -31,12 +31,10 @@ class CORSFilterProvider @Inject() (configuration: Configuration, errorHandler: 
 /**
  * CORS module.
  */
-class CORSModule extends Module {
-  def bindings(environment: Environment, configuration: Configuration) = Seq(
-    bind[CORSConfig].toProvider[CORSConfigProvider],
-    bind[CORSFilter].toProvider[CORSFilterProvider]
-  )
-}
+class CORSModule extends SimpleModule(
+  bind[CORSConfig].toProvider[CORSConfigProvider],
+  bind[CORSFilter].toProvider[CORSFilterProvider]
+)
 
 /**
  * Components for the CORS Filter

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -5,21 +5,22 @@ package play.filters.gzip
 
 import java.util.function.BiFunction
 import java.util.zip.GZIPOutputStream
-import javax.inject.{ Provider, Inject, Singleton }
+import javax.inject.{ Inject, Provider, Singleton }
 
-import akka.stream.{ OverflowStrategy, FlowShape, Materializer }
 import akka.stream.scaladsl._
+import akka.stream.{ FlowShape, Materializer, OverflowStrategy }
 import akka.util.ByteString
 import com.typesafe.config.ConfigMemorySize
-import play.api.inject.Module
+import play.api.Configuration
+import play.api.http.{ HttpChunk, HttpEntity, Status }
+import play.api.inject._
 import play.api.libs.streams.GzipFlow
-import play.api.{ Environment, Configuration }
+import play.api.mvc.RequestHeader.acceptHeader
 import play.api.mvc._
 import play.core.j
-import scala.concurrent.Future
-import play.api.mvc.RequestHeader.acceptHeader
-import play.api.http.{ HttpChunk, HttpEntity, Status }
+
 import scala.compat.java8.FunctionConverters._
+import scala.concurrent.Future
 
 /**
  * A gzip filter.
@@ -219,12 +220,10 @@ class GzipFilterConfigProvider @Inject() (config: Configuration) extends Provide
 /**
  * The gzip filter module.
  */
-class GzipFilterModule extends Module {
-  def bindings(environment: Environment, configuration: Configuration) = Seq(
-    bind[GzipFilterConfig].toProvider[GzipFilterConfigProvider],
-    bind[GzipFilter].toSelf
-  )
-}
+class GzipFilterModule extends SimpleModule(
+  bind[GzipFilterConfig].toProvider[GzipFilterConfigProvider],
+  bind[GzipFilter].toSelf
+)
 
 /**
  * The gzip filter components.

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/headers/SecurityHeadersFilter.scala
@@ -3,11 +3,11 @@
  */
 package play.filters.headers
 
-import javax.inject.{ Singleton, Inject, Provider }
+import javax.inject.{ Inject, Provider, Singleton }
 
-import play.api.inject.Module
+import play.api.Configuration
+import play.api.inject._
 import play.api.mvc._
-import play.api.{ Environment, Configuration }
 
 /**
  * This class sets a number of common security headers on the HTTP request.
@@ -79,8 +79,9 @@ case class SecurityHeadersConfig(
     this(frameOptions = Some("DENY"))
   }
 
-  import scala.compat.java8.OptionConverters._
   import java.{ util => ju }
+
+  import scala.compat.java8.OptionConverters._
 
   def withFrameOptions(frameOptions: ju.Optional[String]): SecurityHeadersConfig =
     copy(frameOptions = frameOptions.asScala)
@@ -163,12 +164,10 @@ class SecurityHeadersConfigProvider @Inject() (configuration: Configuration) ext
 /**
  * The security headers module.
  */
-class SecurityHeadersModule extends Module {
-  def bindings(environment: Environment, configuration: Configuration) = Seq(
-    bind[SecurityHeadersConfig].toProvider[SecurityHeadersConfigProvider],
-    bind[SecurityHeadersFilter].toSelf
-  )
-}
+class SecurityHeadersModule extends SimpleModule(
+  bind[SecurityHeadersConfig].toProvider[SecurityHeadersConfigProvider],
+  bind[SecurityHeadersFilter].toSelf
+)
 
 /**
  * The security headers components.

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -5,11 +5,11 @@ package play.filters.hosts
 
 import javax.inject.{ Inject, Provider, Singleton }
 
+import play.api.Configuration
 import play.api.http.{ HttpErrorHandler, Status }
-import play.api.inject.Module
+import play.api.inject._
 import play.api.libs.streams.Accumulator
 import play.api.mvc.{ EssentialAction, EssentialFilter }
-import play.api.{ Configuration, Environment }
 import play.core.j.JavaHttpErrorHandlerAdapter
 
 /**
@@ -83,12 +83,10 @@ class AllowedHostsConfigProvider @Inject() (configuration: Configuration) extend
   lazy val get = AllowedHostsConfig.fromConfiguration(configuration)
 }
 
-class AllowedHostsModule extends Module {
-  def bindings(environment: Environment, configuration: Configuration) = Seq(
-    bind[AllowedHostsConfig].toProvider[AllowedHostsConfigProvider],
-    bind[AllowedHostsFilter].toSelf
-  )
-}
+class AllowedHostsModule extends SimpleModule(
+  bind[AllowedHostsConfig].toProvider[AllowedHostsConfigProvider],
+  bind[AllowedHostsFilter].toSelf
+)
 
 trait AllowedHostsComponents {
   def configuration: Configuration

--- a/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
@@ -133,11 +133,7 @@ object GuiceApplicationBuilderSpec {
   class A1 extends A
   class A2 extends A
 
-  class AModule extends Module {
-    def bindings(env: Environment, conf: Configuration) = Seq(
-      bind[A].to[A1]
-    )
-  }
+  class AModule extends SimpleModule(bind[A].to[A1])
 
   trait B
   class B1 extends B

--- a/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceInjectorBuilderSpec.scala
@@ -4,10 +4,12 @@
 package play.api.inject
 package guice
 
-import com.google.inject.AbstractModule
 import java.io.File
 import java.net.URLClassLoader
+
+import com.google.inject.AbstractModule
 import org.specs2.mutable.Specification
+import play.api.inject._
 import play.api.{ Configuration, Environment, Mode }
 
 class GuiceInjectorBuilderSpec extends Specification {
@@ -135,17 +137,9 @@ class GuiceInjectorBuilderSpec extends Specification {
 
 object GuiceInjectorBuilderSpec {
 
-  class EnvironmentModule extends Module {
-    def bindings(env: Environment, conf: Configuration) = Seq(
-      bind[Environment] to env
-    )
-  }
+  class EnvironmentModule extends SimpleModule((env, _) => Seq(bind[Environment] to env))
 
-  class ConfigurationModule extends Module {
-    def bindings(env: Environment, conf: Configuration) = Seq(
-      bind[Configuration] to conf
-    )
-  }
+  class ConfigurationModule extends SimpleModule((_, conf) => Seq(bind[Configuration] to conf))
 
   class SetConfigurationModule(conf: Configuration) extends AbstractModule {
     def configure() = bind(classOf[Configuration]) toInstance conf

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/ahc/AhcWSModule.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/ahc/AhcWSModule.java
@@ -7,6 +7,7 @@ import play.api.Configuration;
 import play.api.Environment;
 import play.api.inject.Binding;
 import play.api.inject.Module;
+import play.api.inject.SimpleModule;
 import play.libs.ws.WSAPI;
 import play.libs.ws.WSClient;
 import scala.collection.Seq;

--- a/framework/src/play-java/src/main/scala/play/core/ObjectMapperModule.scala
+++ b/framework/src/play-java/src/main/scala/play/core/ObjectMapperModule.scala
@@ -18,12 +18,9 @@ import scala.concurrent.Future
  * This solves the issue of the ObjectMapper cache from holding references to the application class loader between
  * reloads.
  */
-class ObjectMapperModule extends Module {
-
-  def bindings(environment: Environment, configuration: Configuration) = Seq(
-    bind[ObjectMapper].toProvider[ObjectMapperProvider].eagerly()
-  )
-}
+class ObjectMapperModule extends SimpleModule(
+  bind[ObjectMapper].toProvider[ObjectMapperProvider].eagerly
+)
 
 @Singleton
 class ObjectMapperProvider @Inject() (lifecycle: ApplicationLifecycle) extends Provider[ObjectMapper] {

--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsModule.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsModule.scala
@@ -6,23 +6,19 @@ package play.api.db.evolutions
 import javax.inject._
 
 import play.api.db.DBApi
-import play.api.inject.{ Injector, Module }
+import play.api.inject._
 import play.api.{ Configuration, Environment }
 import play.core.WebCommands
 
 /**
  * Default module for evolutions API.
  */
-class EvolutionsModule extends Module {
-  def bindings(environment: Environment, configuration: Configuration) = {
-    Seq(
-      bind[EvolutionsConfig].toProvider[DefaultEvolutionsConfigParser],
-      bind[EvolutionsReader].to[EnvironmentEvolutionsReader],
-      bind[EvolutionsApi].to[DefaultEvolutionsApi],
-      bind[ApplicationEvolutions].toProvider[ApplicationEvolutionsProvider].eagerly
-    )
-  }
-}
+class EvolutionsModule extends SimpleModule(
+  bind[EvolutionsConfig].toProvider[DefaultEvolutionsConfigParser],
+  bind[EvolutionsReader].to[EnvironmentEvolutionsReader],
+  bind[EvolutionsApi].to[DefaultEvolutionsApi],
+  bind[ApplicationEvolutions].toProvider[ApplicationEvolutionsProvider].eagerly
+)
 
 /**
  * Components for default implementation of the evolutions API.

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
@@ -9,7 +9,7 @@ import javax.sql.DataSource
 
 import com.typesafe.config.Config
 import play.api._
-import play.api.inject.Module
+import play.api.inject._
 import play.api.libs.JNDI
 
 import com.jolbox.bonecp._
@@ -20,13 +20,7 @@ import scala.concurrent.duration.FiniteDuration
 /**
  * BoneCP runtime inject module.
  */
-class BoneCPModule extends Module {
-  def bindings(environment: Environment, configuration: Configuration) = {
-    Seq(
-      bind[ConnectionPool].to[BoneConnectionPool]
-    )
-  }
-}
+class BoneCPModule extends SimpleModule(bind[ConnectionPool].to[BoneConnectionPool])
 
 /**
  * BoneCP components (for compile-time injection).

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
@@ -7,25 +7,18 @@ import javax.inject.{ Inject, Singleton }
 import javax.sql.DataSource
 
 import com.typesafe.config.Config
-import play.api.libs.JNDI
-import play.api.inject.Module
+import com.zaxxer.hikari.{ HikariConfig, HikariDataSource }
 import play.api._
+import play.api.inject._
+import play.api.libs.JNDI
 
-import scala.concurrent.duration.{ FiniteDuration, Duration }
-import scala.util.{ Success, Try, Failure }
-
-import com.zaxxer.hikari.{ HikariDataSource, HikariConfig }
+import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.util.{ Failure, Success, Try }
 
 /**
  * HikariCP runtime inject module.
  */
-class HikariCPModule extends Module {
-  def bindings(environment: Environment, configuration: Configuration) = {
-    Seq(
-      bind[ConnectionPool].to[HikariCPConnectionPool]
-    )
-  }
-}
+class HikariCPModule extends SimpleModule(bind[ConnectionPool].to[HikariCPConnectionPool])
 
 /**
  * HikariCP components (for compile-time injection).

--- a/framework/src/play-ws/src/main/scala/play/api/libs/openid/OpenIdClient.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/openid/OpenIdClient.scala
@@ -3,21 +3,18 @@
  */
 package play.api.libs.openid
 
+import java.net._
 import javax.inject.{ Inject, Singleton }
 
-import play.api.{ Application, Configuration, Environment }
-import play.api.inject.Module
+import play.api.http.HeaderNames
+import play.api.inject._
+import play.api.libs.ws._
+import play.api.mvc.RequestHeader
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.control.Exception._
 import scala.util.matching.Regex
-import play.api.http.HeaderNames
-import play.api.libs.ws._
-import java.net._
-
-import play.api.mvc.{ Request, RequestHeader }
-
-import xml.Node
+import scala.xml.Node
 
 case class OpenIDServer(protocolVersion: String, url: String, delegate: Option[String])
 
@@ -282,14 +279,10 @@ private[openid] object Discovery {
 /**
  * The OpenID module
  */
-class OpenIDModule extends Module {
-  def bindings(environment: Environment, configuration: Configuration) = {
-    Seq(
-      bind[OpenIdClient].to[WsOpenIdClient],
-      bind[Discovery].to[WsDiscovery]
-    )
-  }
-}
+class OpenIDModule extends SimpleModule(
+  bind[OpenIdClient].to[WsOpenIdClient],
+  bind[Discovery].to[WsDiscovery]
+)
 
 /**
  * OpenID components

--- a/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcWS.scala
+++ b/framework/src/play-ws/src/main/scala/play/api/libs/ws/ahc/AhcWS.scala
@@ -3,31 +3,31 @@
  */
 package play.api.libs.ws.ahc
 
-import akka.stream.Materializer
-import akka.util.ByteString
-import org.asynchttpclient.{ Response => AHCResponse, _ }
-import org.asynchttpclient.proxy.{ ProxyServer => AHCProxyServer }
-import org.asynchttpclient.Realm
-import org.asynchttpclient.cookie.{ Cookie => AHCCookie }
-import org.asynchttpclient.util.HttpUtils
-import java.io.IOException
-import java.io.UnsupportedEncodingException
+import java.io.{ IOException, UnsupportedEncodingException }
 import java.nio.charset.{ Charset, StandardCharsets }
 import javax.inject.{ Inject, Provider, Singleton }
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.Sink
+import akka.util.ByteString
 import io.netty.handler.codec.http.HttpHeaders
+import org.asynchttpclient.Realm.AuthScheme
+import org.asynchttpclient.cookie.{ Cookie => AHCCookie }
+import org.asynchttpclient.proxy.{ ProxyServer => AHCProxyServer }
+import org.asynchttpclient.util.HttpUtils
+import org.asynchttpclient.{ Realm, Response => AHCResponse, _ }
 import play.api._
-import play.api.inject.{ ApplicationLifecycle, Module }
+import play.api.inject.{ bind, _ }
 import play.api.libs.ws._
 import play.api.libs.ws.ssl._
 import play.api.libs.ws.ssl.debug._
 import play.core.parsers.FormUrlEncodedParser
 import play.core.utils.CaseInsensitiveOrdered
+
 import scala.collection.JavaConverters._
 import scala.collection.immutable.TreeMap
-import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration.Duration
-import akka.stream.scaladsl.Sink
-import org.asynchttpclient.Realm.AuthScheme
+import scala.concurrent.{ Future, Promise }
 
 /**
  * A WS client backed by an AsyncHttpClient.
@@ -370,16 +370,12 @@ case class AhcWSRequest(
 
 }
 
-class AhcWSModule extends Module {
-  def bindings(environment: Environment, configuration: Configuration) = {
-    Seq(
-      bind[WSAPI].to[AhcWSAPI],
-      bind[AhcWSClientConfig].toProvider[AhcWSClientConfigParser].in[Singleton],
-      bind[WSClientConfig].toProvider[WSConfigParser].in[Singleton],
-      bind[WSClient].toProvider[WSClientProvider].in[Singleton]
-    )
-  }
-}
+class AhcWSModule extends SimpleModule(
+  bind[WSAPI].to[AhcWSAPI],
+  bind[AhcWSClientConfig].toProvider[AhcWSClientConfigParser].in[Singleton],
+  bind[WSClientConfig].toProvider[WSConfigParser].in[Singleton],
+  bind[WSClient].toProvider[WSClientProvider].in[Singleton]
+)
 
 class WSClientProvider @Inject() (wsApi: WSAPI) extends Provider[WSClient] {
   def get() = wsApi.client

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -8,7 +8,7 @@ import java.util.Locale
 import javax.inject.{ Inject, Singleton }
 
 import play.api._
-import play.api.inject.Module
+import play.api.inject._
 import play.api.mvc.{ Cookie, DiscardingCookie, RequestHeader, Result, Session }
 import play.mvc.Http
 import play.utils.{ PlayIO, Resources }
@@ -558,14 +558,10 @@ class DefaultMessagesApi @Inject() (environment: Environment, config: Configurat
 
 }
 
-class I18nModule extends Module {
-  def bindings(environment: Environment, configuration: Configuration) = {
-    Seq(
-      bind[Langs].to[DefaultLangs],
-      bind[MessagesApi].to[DefaultMessagesApi]
-    )
-  }
-}
+class I18nModule extends SimpleModule(
+  bind[Langs].to[DefaultLangs],
+  bind[MessagesApi].to[DefaultMessagesApi]
+)
 
 /**
  * Injection helper for i18n components

--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -28,59 +28,57 @@ import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
  * Provides all the core components of a Play application. This is typically automatically enabled by Play for an
  * application.
  */
-class BuiltinModule extends Module {
-  def bindings(env: Environment, configuration: Configuration): Seq[Binding[_]] = {
-    def dynamicBindings(factories: ((Environment, Configuration) => Seq[Binding[_]])*) = {
-      factories.flatMap(_(env, configuration))
-    }
-
-    Seq(
-      bind[Environment] to env,
-      bind[ConfigurationProvider].to(new ConfigurationProvider(configuration)),
-      bind[Configuration].toProvider[ConfigurationProvider],
-      bind[Config].toProvider[ConfigProvider],
-      bind[HttpConfiguration].toProvider[HttpConfigurationProvider],
-      bind[ParserConfiguration].toProvider[ParserConfigurationProvider],
-      bind[CookiesConfiguration].toProvider[CookiesConfigurationProvider],
-      bind[FlashConfiguration].toProvider[FlashConfigurationProvider],
-      bind[SessionConfiguration].toProvider[SessionConfigurationProvider],
-      bind[ActionCompositionConfiguration].toProvider[ActionCompositionConfigurationProvider],
-
-      bind[PlayBodyParsers].to[PlayBodyParsersImpl],
-      bind[BodyParsers.Default].toSelf,
-      bind[DefaultActionBuilder].to[DefaultActionBuilderImpl],
-      bind[ControllerComponents].to[DefaultControllerComponents],
-
-      // Application lifecycle, bound both to the interface, and its implementation, so that Application can access it
-      // to shut it down.
-      bind[DefaultApplicationLifecycle].toSelf,
-      bind[ApplicationLifecycle].to(bind[DefaultApplicationLifecycle]),
-
-      bind[Application].to[DefaultApplication],
-      bind[play.Application].to[play.DefaultApplication],
-
-      bind[Router].toProvider[RoutesProvider],
-      bind[play.routing.Router].to[JavaRouterAdapter],
-      bind[ActorSystem].toProvider[ActorSystemProvider],
-      bind[Materializer].toProvider[MaterializerProvider],
-      bind[ExecutionContextExecutor].toProvider[ExecutionContextProvider],
-      bind[ExecutionContext].to[ExecutionContextExecutor],
-      bind[Executor].to[ExecutionContextExecutor],
-      bind[HttpExecutionContext].toSelf,
-
-      bind[CryptoConfig].toProvider[CryptoConfigParser],
-      bind[CookieSigner].toProvider[CookieSignerProvider],
-      bind[CSRFTokenSigner].toProvider[CSRFTokenSignerProvider],
-      bind[TemporaryFileCreator].to[DefaultTemporaryFileCreator]
-
-    ) ++ dynamicBindings(
-        HttpErrorHandler.bindingsFromConfiguration,
-        HttpFilters.bindingsFromConfiguration,
-        HttpRequestHandler.bindingsFromConfiguration,
-        ActionCreator.bindingsFromConfiguration
-      )
+class BuiltinModule extends SimpleModule((env, conf) => {
+  def dynamicBindings(factories: ((Environment, Configuration) => Seq[Binding[_]])*) = {
+    factories.flatMap(_ (env, conf))
   }
-}
+
+  Seq(
+    bind[Environment] to env,
+    bind[ConfigurationProvider].to(new ConfigurationProvider(conf)),
+    bind[Configuration].toProvider[ConfigurationProvider],
+    bind[Config].toProvider[ConfigProvider],
+    bind[HttpConfiguration].toProvider[HttpConfigurationProvider],
+    bind[ParserConfiguration].toProvider[ParserConfigurationProvider],
+    bind[CookiesConfiguration].toProvider[CookiesConfigurationProvider],
+    bind[FlashConfiguration].toProvider[FlashConfigurationProvider],
+    bind[SessionConfiguration].toProvider[SessionConfigurationProvider],
+    bind[ActionCompositionConfiguration].toProvider[ActionCompositionConfigurationProvider],
+
+    bind[PlayBodyParsers].to[PlayBodyParsersImpl],
+    bind[BodyParsers.Default].toSelf,
+    bind[DefaultActionBuilder].to[DefaultActionBuilderImpl],
+    bind[ControllerComponents].to[DefaultControllerComponents],
+
+    // Application lifecycle, bound both to the interface, and its implementation, so that Application can access it
+    // to shut it down.
+    bind[DefaultApplicationLifecycle].toSelf,
+    bind[ApplicationLifecycle].to(bind[DefaultApplicationLifecycle]),
+
+    bind[Application].to[DefaultApplication],
+    bind[play.Application].to[play.DefaultApplication],
+
+    bind[Router].toProvider[RoutesProvider],
+    bind[play.routing.Router].to[JavaRouterAdapter],
+    bind[ActorSystem].toProvider[ActorSystemProvider],
+    bind[Materializer].toProvider[MaterializerProvider],
+    bind[ExecutionContextExecutor].toProvider[ExecutionContextProvider],
+    bind[ExecutionContext].to[ExecutionContextExecutor],
+    bind[Executor].to[ExecutionContextExecutor],
+    bind[HttpExecutionContext].toSelf,
+
+    bind[CryptoConfig].toProvider[CryptoConfigParser],
+    bind[CookieSigner].toProvider[CookieSignerProvider],
+    bind[CSRFTokenSigner].toProvider[CSRFTokenSignerProvider],
+    bind[TemporaryFileCreator].to[DefaultTemporaryFileCreator]
+
+  ) ++ dynamicBindings(
+      HttpErrorHandler.bindingsFromConfiguration,
+      HttpFilters.bindingsFromConfiguration,
+      HttpRequestHandler.bindingsFromConfiguration,
+      ActionCreator.bindingsFromConfiguration
+    )
+})
 
 // This allows us to access the original configuration via this
 // provider while overriding the binding for Configuration itself.

--- a/framework/src/play/src/main/scala/play/api/inject/Module.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Module.scala
@@ -76,6 +76,15 @@ abstract class Module {
 }
 
 /**
+ * A simple Play module, which can be configured by passing a function or a list of bindings.
+ */
+class SimpleModule(bindingsFunc: (Environment, Configuration) => Seq[Binding[_]]) extends Module {
+  def this(bindings: Binding[_]*) = this((_, _) => bindings)
+
+  override final def bindings(environment: Environment, configuration: Configuration) = bindingsFunc(environment, configuration)
+}
+
+/**
  * Locates and loads modules from the Play environment.
  */
 object Modules {


### PR DESCRIPTION
This creates a `SimpleModule` class that makes it slightly easier to define Play DI modules. It allows the syntax:

```scala
class FooModule extends SimpleModule(
  bind[Foo].to[FooImpl],
  bind[Bar].to[BarImpl]
)
```
or passing a function:
```scala
class BazModule extends SimpleModule((env, conf) => Seq(
  bind[Environment] to env,
  bind[Configuration] to conf
))
```

This is mainly intended to clean up our internal code but it could also be useful to external module developers.