### PR TITLE
Add slack notification for travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,5 @@ notifications:
       - https://webhooks.gitter.im/e/d2c8a242a2615f659595
     on_success: always
     on_failure: always
+  slack:
+    secure: LIYWP1YF6DEXh4gBQ0DlaQP+kenerp7Q1AC3y/+egJYUu1g2TWmBlkcpXOcdHzrgTIUX/LYnSlhowIpsW7/YwcyLn3rOJI6SJM00DrDPRm6X1586P9DcR4XiX7MChewzbnmebx6KISt6bFtfvcd67J2cinmShwXQh2AmwvuT3Tc=


### PR DESCRIPTION
Adds Travis build notification into #play-buzz.

See https://blog.travis-ci.com/2014-03-13-slack-notifications/ for more details.