### PR TITLE
De-emphasize activator in docs and refer to sample templates

### DIFF
--- a/documentation/manual/about/Philosophy.md
+++ b/documentation/manual/about/Philosophy.md
@@ -51,7 +51,7 @@ Existing Java build systems, however, were not flexible enough to support this n
 
 Meanwhile, developers using Play for more enterprise-scale projects, which require build process customization and integration with their existing company build systems, were a bit lost. The Python scripts we provided with Play 1.x are in no way a fully-featured build system and are not easily customizable. That’s why we’ve decided to go for a more powerful build system for Play 2.
 
-Since we need a modern build tool, flexible enough to support Play original conventions and able to build Java and Scala projects, we have chosen to integrate [sbt](http://www.scala-sbt.org/) in Play 2. This, however, should not scare existing Play users who are happy with the simplicity of the original Play build. We are using [Activator](https://www.lightbend.com/get-started) to provide simple commands like `activator new`, `run`, `start` on top of an extensible model and if you need to change the way your application is built and deployed, the fact that a Play project is a standard sbt project gives you all the power you need to customize and adapt it.
+Since we need a modern build tool, flexible enough to support Play original conventions and able to build Java and Scala projects, we have chosen to integrate [sbt](http://www.scala-sbt.org/) in Play 2. SBT is the de facto build tool for Scala and is increasingly accepted in the Java community as well.
 
 This also means better integration with Maven projects out of the box, the ability to package and publish your project as a simple set of JAR files to any repository, and especially live compiling and reloading at development time of any depended project, even for standard Java or Scala library projects.
 

--- a/documentation/manual/gettingStarted/IDE.md
+++ b/documentation/manual/gettingStarted/IDE.md
@@ -61,7 +61,7 @@ You then need to import the application into your Workspace with the **File/Impo
 
 [[images/eclipse.png]]
 
-To debug, start your application with `activator -jvm-debug 9999 run` and in Eclipse right-click on the project and select **Debug As**, **Debug Configurations**. In the **Debug Configurations** dialog, right-click on **Remote Java Application** and select **New**. Change **Port** to 9999 and click **Apply**. From now on you can click on **Debug** to connect to the running application. Stopping the debugging session will not stop the server.
+To debug, start your application with `sbt -jvm-debug 9999 run` and in Eclipse right-click on the project and select **Debug As**, **Debug Configurations**. In the **Debug Configurations** dialog, right-click on **Remote Java Application** and select **New**. Change **Port** to 9999 and click **Apply**. From now on you can click on **Debug** to connect to the running application. Stopping the debugging session will not stop the server.
 
 > **Tip**: You can run your application using `~run` to enable direct compilation on file change. This way scala template files are auto discovered when you create a new template in `view` and auto compiled when the file changes. If you use normal `run` then you have to hit `Refresh` on your browser each time.
 
@@ -161,10 +161,10 @@ Edit your project/plugins.sbt file, and add the following line (you should first
 addSbtPlugin("org.ensime" % "ensime-sbt" % "0.2.3")
 ```
 
-Start Play:
+Start SBT:
 
 ```bash
-$ activator
+$ sbt
 ```
 
 Enter 'gen-ensime' at the play console. The plugin should generate a .ensime file in the root of your Play project.

--- a/documentation/manual/gettingStarted/Installing.md
+++ b/documentation/manual/gettingStarted/Installing.md
@@ -3,6 +3,8 @@
 
 This page shows how to download, install and run a Play application.  There's a built in tutorial that shows you around, so running this Play application will show you how Play itself works!
 
+Play is a series of libraries available in [Maven Repository](https://mvnrepository.com/artifact/com.typesafe.play), so you can use any Java build tool to build a Play project. However, much of the development experience Play is known for (routes, templates compilation and auto-reloading) is provided by SBT. In this guide we describe how to install Play with SBT. We also describe how to use Activator, an SBT wrapper that provides a graphical interface.
+
 ## Prerequisites
 
 Play requires Java 1.8.  To check that you have the latest JDK, please run:
@@ -13,9 +15,19 @@ java -version
 
 If you don't have the JDK, you have to install it from [Oracle's JDK Site](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
 
-## Installing Play
+## Installing Play with SBT
 
-Play is a series of libraries available in [Maven Repository](http://mvnrepository.com/artifact/com.typesafe.play), so you can use any Java build tool to build a Play project.
+We provide a number of sample projects that have an `./sbt` launcher in the local directory. These can be found on our [download page](https://playframework.com/download#examples). This launcher will automatically download dependencies without you having to install SBT ahead of time.
+
+Refer to the [SBT download page](https://www.scala-sbt.org/download.html) to install the SBT launcher on your system, which provides the `sbt` command. Otherwise you can use the SBT launcher located in your example project's directory.
+
+### Running Play with SBT
+
+SBT provides all the necessary commands to run your application. You can use `sbt run` to run your app. For more details on running Play from the command line, refer to the [[new application documentation|NewApplication]] for more details.
+
+## Installing Play with Activator
+
+Activator is a wrapper for SBT that provides a nice graphical user interface and access to a library of third-party templates. Some new users prefer this interface to just using SBT. Note that since Activator is a wrapper for SBT, any commands referencing the `sbt` command can also be used with the `activator` command.
 
 For getting started, we'll install Play through [Lightbend Activator](https://www.lightbend.com/activator/docs).
 
@@ -65,7 +77,7 @@ setx PATH=%PATH%;"C:\path\to\activator-x.x.x\bin"
 
 Note that [setx](https://technet.microsoft.com/en-us/library/cc755104.aspx) is only available on Windows 8 or later -- before that, and you will have to use the [System Properties dialog](https://java.com/en/download/help/path.xml).
 
-## Create a Project
+### Create a Project
 
 Activator comes with a couple of different "seeds" that can be used to start off a Play project: `play-java` and `play-scala`.  You can create a project based off a template either from Activator's Web Interface, or directly from the command line.
 
@@ -79,13 +91,13 @@ Follow the arrows to create a new project:
 
 You can read the [Activator documentation](https://www.lightbend.com/activator/docs) for more information on how to use the Web Interface.
 
-## Accessing the Built-in Tutorial
+### Accessing the Built-in Tutorial
 
 Activator's Web Interface contains a built in tutorial section that will walk you through your new application:
 
 [[images/webTutorial.png]]
 
-## Running Play
+### Running Play
 
 Play has an easy to use "development mode" that will let you make changes to code and see your results immediate on the page.
 

--- a/documentation/manual/gettingStarted/NewApplication.md
+++ b/documentation/manual/gettingStarted/NewApplication.md
@@ -1,7 +1,30 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
 # Creating a new application
 
-## Create a new application with the activator command
+## Create a new application
+
+## Create a new application using an existing example project
+
+We provide a number of [sample projects](https://playframework.com/download#examples) that provide good starting points for a new application. These applications already have an SBT launcher included so you don't need to manually install SBT on your system.
+
+To use an example project, download and extract the project you're interested in. Edit the `build.sbt` to customize it for your project:
+
+```scala
+name := "play-scala" // <- Your project's name. Used for generated binaries.
+
+version := "1.0-SNAPSHOT" // <- project version
+```
+
+Then you can run SBT
+```bash
+$ ./sbt
+```
+
+This will load your project and fetch dependencies. You can use the `run` command to run your application.
+
+Next, you can learn about [using the console](https://www.playframework.com/documentation/2.5.x/PlayConsole) provided by SBT.
+
+## Create a new application with Activator
 
 The `activator` command can be used to create a new Play application.  Activator allows you to select a template that your new application should be based off.  For vanilla Play projects, the names of these templates are `play-scala` for Scala based Play applications, and `play-java` for Java based Play applications.
 
@@ -32,19 +55,9 @@ $ cd my-first-app
 $ activator
 ```
 
-## Create a new application with the Activator UI
+## Create a new application using SBT
 
-New Play applications can also be created with the Activator UI.  To use the Activator UI, run:
-
-```bash
-$ activator ui
-```
-
-You can read the documentation for using the Activator UI [here](https://lightbend.com/activator/docs).
-
-## Create a new application without Activator
-
-It is also possible to create a new Play application without installing Activator, using sbt directly.
+It is also possible to create a new Play application using sbt directly.
 
 > First install [sbt](http://www.scala-sbt.org/) if needed.
 

--- a/documentation/manual/gettingStarted/PlayConsole.md
+++ b/documentation/manual/gettingStarted/PlayConsole.md
@@ -1,15 +1,15 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
-# Using the Play console
+# Using the SBT console
 
 ## Launching the console
 
-The Play console is a development console based on sbt that allows you to manage a Play application’s complete development cycle.
+The SBT console is a development console based on sbt that allows you to manage a Play application’s complete development cycle.
 
-To launch the Play console, change to the directory of your project, and run Activator:
+To launch the Play console, change to the directory of your project, and run SBT (or `activator` in place of the `sbt` command):
 
 ```bash
 $ cd my-first-app
-$ activator
+$ sbt
 ```
 
 [[images/console.png]]
@@ -70,11 +70,11 @@ To start application inside scala console (e.g. to access database):
 
 @[consoleapp](code/PlayConsole.scala)
 
-[[images/consoleEval.png]] 
+[[images/consoleEval.png]]
 
 ## Debugging
 
-You can ask Play to start a **JPDA** debug port when starting the console. You can then connect using Java debugger. Use the `activator -jvm-debug <port>` command to do that:
+You can ask Play to start a **JPDA** debug port when starting the console. You can then connect using Java debugger. Use the `sbt -jvm-debug <port>` command to do that:
 
 ```bash
 $ activator -jvm-debug 9999
@@ -88,7 +88,7 @@ Listening for transport dt_socket at address: 9999
 
 ## Using sbt features
 
-The Play console is just a normal sbt console, so you can use sbt features such as **triggered execution**. 
+You can use sbt features such as **triggered execution**.
 
 For example, using `~ compile`:
 
@@ -114,10 +114,10 @@ You can also do the same for `~ test`, to continuously test your project each ti
 
 ## Using the play commands directly
 
-You can also run commands directly without entering the Play console. For example, enter `activator run`:
+You can also run commands directly without entering the Play console. For example, enter `sbt run`:
 
 ```bash
-$ activator run
+$ sbt run
 [info] Loading project definition from /Users/jroper/tmp/my-first-app/project
 [info] Set current project to my-first-app (in build file:/Users/jroper/tmp/my-first-app/)
 
@@ -131,5 +131,5 @@ $ activator run
 The application starts directly. When you quit the server using `Ctrl+D`, you will come back to your OS prompt. Of course, the **triggered execution** is available here as well:
 
 ```bash
-$ activator ~run
+$ sbt ~run
 ```

--- a/documentation/manual/gettingStarted/Tutorials.md
+++ b/documentation/manual/gettingStarted/Tutorials.md
@@ -20,7 +20,7 @@ Finally, the core Play templates are available as git repositories on Github und
 In general, whenever you see a template, you can download the template by using the Github project name.  For example, if you have an example Play project on Github called "some-awesome-play-template", you can download and use the template by typing
 
 ```
-activator new my-local-project-directory some-awesome-play-template 
+activator new my-local-project-directory some-awesome-play-template
 ```
 
 If you do not have activator installed or would prefer to use git, you can always clone the project the old fashioned way:
@@ -35,12 +35,16 @@ Creating new projects is covered in more detail in [[Creating a new application|
 
 This section covers the core tutorials and examples from Play.  These are maintained by the core Play team, and so will be based on the latest Play release.
 
-### Creating a Seed Template
+### Downloading an example template from the web
+
+Many of these templates are provided without a dependency on Activator from our [download page](https://www.playframework.com/download#examples)
+
+### Creating a Seed Template from Activator
 
 If you are starting off a new Play project and don't want any extras, you can use the seed templates by typing the following at the command prompt:
 
 ``` shell
-activator new my-scala-project play-scala 
+activator new my-scala-project play-scala
 ```
 
 or
@@ -106,7 +110,7 @@ This is an example template showing how to encrypt and sign data securely with [
 
 ### Compile Time Dependency Injection
 
-[[Compile time dependency injection|ScalaCompileTimeDependencyInjection]] can be done in Play in a number of different DI frameworks.  
+[[Compile time dependency injection|ScalaCompileTimeDependencyInjection]] can be done in Play in a number of different DI frameworks.
 
 There are two examples shown here, but there are other compile time DI frameworks such as Scaldi, which has [Play integration](http://scaldi.org/learn/#play-integration) built in, and [Dagger 2](https://google.github.io/dagger/), which is written in Java.
 

--- a/documentation/manual/hacking/BuildingFromSource.md
+++ b/documentation/manual/hacking/BuildingFromSource.md
@@ -5,7 +5,7 @@ If you want to use some unreleased changes for Play, or you want to contribute t
 
 ## Prerequisites
 
-To build Play, you need to have [sbt](http://www.scala-sbt.org/) installed.  Activator (which is just a wrapper around sbt) is also fine.
+To build Play, you need to have [sbt](http://www.scala-sbt.org/) installed.
 
 ## Grab the source
 
@@ -64,7 +64,7 @@ You can run basic tests from the sbt console using the `test` task:
 
 Like with publishing, you can prefix the command with `+` to run the tests against all supported Scala versions.
 
-The Play PR validation runs a few more tests than just the basic tests, including scripted tests, testing the documentation code samples, and testing the Play activator templates.  The scripts that are run by the PR validation can be found in the `framework/bin` directory, you can run each of these to run the same tests that the PR validation runs.
+The Play PR validation runs a few more tests than just the basic tests, including scripted tests, testing the documentation code samples, and testing the Play templates.  The scripts that are run by the PR validation can be found in the `framework/bin` directory, you can run each of these to run the same tests that the PR validation runs.
 
 ## Use in projects
 
@@ -81,7 +81,7 @@ Once you have done this, you can start the console and interact with your projec
 
 ```bash
 $ cd <projectdir>
-$ activator
+$ sbt
 ```
 
 ## Using Code in Eclipse

--- a/documentation/manual/hacking/Translations.md
+++ b/documentation/manual/hacking/Translations.md
@@ -9,7 +9,7 @@ In addition to this, Play also provides facilities for validating the integrity 
 
 ## Prerequisites
 
-You need to have `activator` or `sbt` installed.  It will also be very useful to have a clone of the Play repository, with the branch that you're translating checked out, so that you have something to copy to start with.
+You need to have `sbt` (or `activator`) installed.  It will also be very useful to have a clone of the Play repository, with the branch that you're translating checked out, so that you have something to copy to start with.
 
 If you're translating an unreleased version of the Play documentation, then you'll need to build that version of Play and publish it locally on your machine first.  This can be done by running:
 
@@ -58,7 +58,7 @@ Now you're ready to start translating!
 
 ## Translating documentation
 
-First off, start the documentation server.  The documentation server will serve your documentation up for you so you can see what it looks like as you're going.  To do this you'll need `sbt` or `activator` installed, either one is fine, in the examples here we'll be using `sbt`:
+First off, start the documentation server.  The documentation server will serve your documentation up for you so you can see what it looks like as you're going.
 
 ```bash
 $ sbt run

--- a/documentation/manual/working/commonGuide/assets/AssetsOverview.md
+++ b/documentation/manual/working/commonGuide/assets/AssetsOverview.md
@@ -18,7 +18,7 @@ If you follow this structure it will be simpler to get started, but nothing stop
 
 ## WebJars
 
-[WebJars](http://www.webjars.org/) provide a convenient and conventional packaging mechanism that is a part of Activator and sbt. For example you can declare that you will be using the popular [Bootstrap library](http://getbootstrap.com/) simply by adding the following dependency in your build file:
+[WebJars](http://www.webjars.org/) provide a convenient and conventional packaging mechanism that is a part of SBT. For example you can declare that you will be using the popular [Bootstrap library](http://getbootstrap.com/) simply by adding the following dependency in your build file:
 
 ```scala
 libraryDependencies += "org.webjars" % "bootstrap" % "3.3.6"
@@ -120,7 +120,7 @@ pipelineStages := Seq(rjs, digest, gzip)
 
 The above will order the RequireJs optimizer ([sbt-rjs](https://github.com/sbt/sbt-rjs)), the digester ([sbt-digest](https://github.com/sbt/sbt-digest)) and then compression ([sbt-gzip](https://github.com/sbt/sbt-gzip)). Unlike many sbt tasks, these tasks will execute in the order declared, one after the other.
 
-In essence asset fingerprinting permits your static assets to be served with aggressive caching instructions to a browser. This will result in an improved experience for your users given that subsequent visits to your site will result in less assets requiring to be downloaded. Rails also describes the benefits of [asset fingerprinting](http://guides.rubyonrails.org/asset_pipeline.html#what-is-fingerprinting-and-why-should-i-care-questionmark). 
+In essence asset fingerprinting permits your static assets to be served with aggressive caching instructions to a browser. This will result in an improved experience for your users given that subsequent visits to your site will result in less assets requiring to be downloaded. Rails also describes the benefits of [asset fingerprinting](http://guides.rubyonrails.org/asset_pipeline.html#what-is-fingerprinting-and-why-should-i-care-questionmark).
 
 The above declaration of `pipelineStages` and the requisite `addSbtPlugin` declarations in your `plugins.sbt` for the plugins you require are your start point. You must then declare to Play what assets are to be versioned. The following routes file entry declares that all assets are to be versioned:
 

--- a/documentation/manual/working/commonGuide/build/BuildOverview.md
+++ b/documentation/manual/working/commonGuide/build/BuildOverview.md
@@ -13,7 +13,7 @@ The documentation here describes Play's usage of sbt at a very high level.  As y
 
 ## Play application directory structure
 
-Most people get started with Play using the `activator new` command which produces a directory structure like this:
+Most people get started with Play using on of our [example templates](https://playframework.com/download#examples), or with the `activator new` command, which generally produce a directory structure like this:
 
 - `/`: The root folder of your application
 - `/README`: A text file describing your application that will get deployed with it.
@@ -28,11 +28,11 @@ For now, we are going to concern ourselves with the `/build.sbt` file and the `/
 
 ## The `/build.sbt` file.
 
-When you use the `activator new foo` command, the build description file, `/build.sbt`, will be generated like this:
+An SBT build file for Play generally looks something like this:
 
 @[default](code/build.sbt)
 
-The `name` line defines the name of your application and it will be the same as the name of your application's root directory, `/`, which is derived from the argument that you gave to the `activator new` command.
+The `name` line defines the name of your application and it will be the same as the name of your application's root directory, `/`. In Activator this is derived from the argument that you gave to the `activator new` command.
 
 The `version` line provides  the version of your application which is used as part of the name for the artifacts your build will produce.
 
@@ -42,7 +42,7 @@ You should use the `PlayJava` or `PlayScala` plugin to configure sbt for Java or
 
 ### Using scala for building
 
-Activator is also able to construct the build requirements from scala files inside your project's `project` folder. The recommended practice is to use `build.sbt` but there are times when using scala directly is required. If you find yourself, perhaps because you're migrating an older project, then here are a few useful imports:
+SBT is also able to construct the build requirements from scala files inside your project's `project` folder. The recommended practice is to use `build.sbt` but there are times when using scala directly is required. If you find yourself, perhaps because you're migrating an older project, then here are a few useful imports:
 
 ```scala
 import sbt._

--- a/documentation/manual/working/commonGuide/build/SBTCookbook.md
+++ b/documentation/manual/working/commonGuide/build/SBTCookbook.md
@@ -3,7 +3,7 @@
 
 ## Hooking into Play's dev mode
 
-When Play runs in dev mode, that is, when using `activator run`, it's often useful to hook into this to start up additional processes that are required for development.  This can be done by defining a `PlayRunHook`, which is a trait with the following methods:
+When Play runs in dev mode, that is, when using `sbt run`, it's often useful to hook into this to start up additional processes that are required for development.  This can be done by defining a `PlayRunHook`, which is a trait with the following methods:
 
  * `beforeStarted(): Unit` - called before the play application is started, but after all "before run" tasks have been completed.
  * `afterStarted(addr: InetSocketAddress): Unit` - called after the play application has been started.
@@ -17,13 +17,13 @@ Now you can register this hook in `build.sbt`:
 
 @[grunt-build-sbt](code/runhook.sbt)
 
-This will execute the `grunt dist` command in `baseDirectory` before the application is started whenever you run `activator run`.
+This will execute the `grunt dist` command in `baseDirectory` before the application is started whenever you run `sbt run`.
 
 Now we want to modify our run hook to execute the `grunt watch` command to observe changes and rebuild the Web application when they happen, so we'll modify the `Grunt.scala` file we created before:
 
 @[grunt-watch](code/runhook.sbt)
 
-Now when the application is started using `activator run`, `grunt watch` will be executed to rerun the grunt build whenever files change.
+Now when the application is started using `sbt run`, `grunt watch` will be executed to rerun the grunt build whenever files change.
 
 ## Add compiler options
 

--- a/documentation/manual/working/commonGuide/production/Deploying.md
+++ b/documentation/manual/working/commonGuide/production/Deploying.md
@@ -11,7 +11,7 @@ Before you run your application in production mode, you need to generate an appl
 
 ## Using the dist task
 
-The dist task builds a binary version of your application that you can deploy to a server without any dependency on sbt or activator, the only thing the server needs is a Java installation.
+The dist task builds a binary version of your application that you can deploy to a server without any dependency on SBT or Activator, the only thing the server needs is a Java installation.
 
 In the Play console, simply type `dist`:
 
@@ -47,7 +47,7 @@ For a full description of usage invoke the start script with a `-h` option.
 > Alternatively a tar.gz file can be produced instead. Tar files retain permissions. Invoke the `universal:packageZipTarball` task instead of the `dist` task:
 >
 > ```bash
-> activator universal:packageZipTarball
+> sbt universal:packageZipTarball
 > ```
 
 By default, the `dist` task will include the API documentation in the generated package. If this is not necessary, add these lines in `build.sbt`:
@@ -153,10 +153,10 @@ Then in the Play console, use the `publish` task:
 
 ## Running a production server in place
 
-In some circumstances, you may not want to create a full distribution, you may in fact want to run your application from your project's source directory.  This requires an sbt or activator installation on the server, and can be done using the `stage` task.
+In some circumstances, you may not want to create a full distribution, you may in fact want to run your application from your project's source directory.  This requires an SBT installation on the server, and can be done using the `stage` task.
 
 ```bash
-$ activator clean stage
+$ sbt clean stage
 ```
 
 [[images/stage.png]]
@@ -201,7 +201,7 @@ Now add the following configuration to your `build.sbt`:
 
 @[assembly](code/assembly.sbt)
 
-Now you can build the artifact by running `activator assembly`, and run your application by running:
+Now you can build the artifact by running `sbt assembly`, and run your application by running:
 
 ```
 $ java -jar target/scala-2.XX/<yourprojectname>-assembly-<version>.jar -Dplay.crypto.secret=abcdefghijk

--- a/documentation/manual/working/commonGuide/production/cloud/Deploying-Boxfuse.md
+++ b/documentation/manual/working/commonGuide/production/cloud/Deploying-Boxfuse.md
@@ -15,7 +15,7 @@ As Boxfuse works with your AWS account, it first needs the necessary permissions
 
 ## Build your Application
 
-Package your app using the Lightbend Activator by typing the `activator dist` command in your project directory.
+Package your app using the `sbt dist` command in your project directory.
 
 ## Deploy your Application
 

--- a/documentation/manual/working/javaGuide/main/tests/JavaTest.md
+++ b/documentation/manual/working/javaGuide/main/tests/JavaTest.md
@@ -7,7 +7,7 @@ Writing tests for your application can be an involved process. Play supports [JU
 
 The location for tests is in the "test" folder. There are two sample test files created in the test folder which can be used as templates.
 
-You can run tests from the Activator console.
+You can run tests from the SBT console.
 
 * To run all tests, run `test`.
 * To run only one test class, run `testOnly` followed by the name of the class i.e. `testOnly my.namespace.MyTest`.


### PR DESCRIPTION
 - Mention SBT as the build tool except for the few areas we talk about features exclusive to Activator.
 - Clarify that Activator is just a wrapper for SBT
 - Refer to the sample template downloads being added to the Play website: https://github.com/playframework/playframework.com/pull/97