### PR TITLE
Make Action#executionContext abstract

### DIFF
--- a/documentation/manual/working/javaGuide/code/MockJavaAction.scala
+++ b/documentation/manual/working/javaGuide/code/MockJavaAction.scala
@@ -18,7 +18,10 @@ abstract class MockJavaAction extends Controller with Action[Http.RequestBody] {
   self =>
 
   private lazy val components = new DefaultJavaHandlerComponents(
-    play.api.Play.current.injector, new DefaultActionCreator, HttpConfiguration()
+    play.api.Play.current.injector,
+    new DefaultActionCreator,
+    HttpConfiguration(),
+    this.executionContext
   )
 
   private lazy val action = new JavaAction(components) {
@@ -39,6 +42,8 @@ abstract class MockJavaAction extends Controller with Action[Http.RequestBody] {
 
   private val controller = this.getClass
   private val method = MockJavaActionJavaMocker.findActionMethod(this)
+
+  def executionContext = play.api.libs.concurrent.Execution.defaultContext
 
   def invocation = {
     method.invoke(this) match {

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -80,6 +80,7 @@ class ScalaActionsCompositionSpec extends Specification with Controller {
         }
 
         lazy val parser = action.parser
+        lazy val executionContext = action.executionContext
       }
       //#actions-class-wrapping
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -476,6 +476,7 @@ case class CSRFCheck @Inject() (config: CSRFConfig, tokenSigner: CSRFTokenSigner
 
   private class CSRFCheckAction[A](tokenProvider: TokenProvider, errorHandler: ErrorHandler, wrapped: Action[A]) extends Action[A] {
     def parser = wrapped.parser
+    def executionContext = wrapped.executionContext
     def apply(untaggedRequest: Request[A]) = {
       val request = CSRFAction.tagRequestFromHeader(untaggedRequest, config, tokenSigner)
 
@@ -531,6 +532,7 @@ case class CSRFAddToken @Inject() (config: CSRFConfig, crypto: CSRFTokenSigner) 
 
   private class CSRFAddTokenAction[A](config: CSRFConfig, tokenProvider: TokenProvider, wrapped: Action[A]) extends Action[A] {
     def parser = wrapped.parser
+    def executionContext = wrapped.executionContext
     def apply(untaggedRequest: Request[A]) = {
       val request = CSRFAction.tagRequestFromHeader(untaggedRequest, config, crypto)
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -101,7 +101,7 @@ trait Action[A] extends EssentialAction {
    *
    * @return The execution context to run the action in
    */
-  protected def executionContext: ExecutionContext = play.core.Execution.internalContext
+  def executionContext: ExecutionContext
 
   /**
    * Returns itself, for better support in the routes file.
@@ -412,6 +412,7 @@ trait ActionBuilder[+R[_], B] extends ActionFunction[Request, R] {
    * @return an action
    */
   final def async[A](bodyParser: BodyParser[A])(block: R[A] => Future[Result]): Action[A] = composeAction(new Action[A] {
+    def executionContext = self.executionContext
     def parser = composeParser(bodyParser)
     def apply(request: Request[A]) = try {
       invokeBlock(request, block)

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -58,6 +58,8 @@ abstract class JavaAction(val components: JavaHandlerComponents) extends Action[
   def invocation: CompletionStage[JResult]
   val annotations: JavaActionAnnotations
 
+  val executionContext: ExecutionContext = components.executionContext
+
   def apply(req: Request[play.mvc.Http.RequestBody]): Future[Result] = {
 
     val javaContext: JContext = createJavaContext(req)
@@ -131,6 +133,7 @@ trait JavaHandlerComponents {
   def getAction[A <: JAction[_]](actionClass: Class[A]): A
   def actionCreator: play.http.ActionCreator
   def httpConfiguration: HttpConfiguration
+  def executionContext: ExecutionContext
 }
 
 /**
@@ -139,7 +142,8 @@ trait JavaHandlerComponents {
 class DefaultJavaHandlerComponents @Inject() (
     injector: Injector,
     val actionCreator: play.http.ActionCreator,
-    val httpConfiguration: HttpConfiguration
+    val httpConfiguration: HttpConfiguration,
+    val executionContext: ExecutionContext
 ) extends JavaHandlerComponents {
   def getBodyParser[A <: JBodyParser[_]](parserClass: Class[A]): A = injector.instanceOf(parserClass)
   def getAction[A <: JAction[_]](actionClass: Class[A]): A = injector.instanceOf(actionClass)


### PR DESCRIPTION
This makes the `executionContext` method of `Action` abstract. Previously we defaulted to Play's default execution context obtained using global state.

This shouldn't have much effect on our users, since Actions are generally created using `ActionBuilder`.