### PR TITLE
Factor out global state from Http.Context

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaEmbeddingPlay.java
+++ b/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaEmbeddingPlay.java
@@ -10,19 +10,16 @@ import org.junit.Test;
 
 import play.libs.ws.WSClient;
 import play.libs.ws.WSResponse;
-import play.libs.ws.ahc.AhcWSClient;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 
 //#imports
-import play.api.Play;
 import play.Mode;
 import play.routing.RoutingDsl;
 import play.server.Server;
 import static play.mvc.Controller.*;
-import akka.stream.Materializer;
 //#imports
 
 import static org.hamcrest.CoreMatchers.*;

--- a/documentation/manual/working/javaGuide/code/MockJavaAction.scala
+++ b/documentation/manual/working/javaGuide/code/MockJavaAction.scala
@@ -35,7 +35,7 @@ abstract class MockJavaAction extends Controller with Action[Http.RequestBody] {
     contextComponents
   )
 
-  private lazy val action = new JavaAction(handlerComponents, contextComponents) {
+  private lazy val action = new JavaAction(handlerComponents) {
     val annotations = new JavaActionAnnotations(controller, method, handlerComponents.httpConfiguration.actionComposition)
 
     def parser = {

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
@@ -4,23 +4,30 @@
 package javaguide.http;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.junit.*;
-import play.libs.Json;
-import play.test.WithApplication;
 import javaguide.testhelpers.MockJavaAction;
-
-import play.mvc.*;
-import play.mvc.Http.*;
+import org.junit.Test;
+import play.core.j.JavaContextComponents;
+import play.i18n.Langs;
+import play.i18n.MessagesApi;
+import play.libs.Json;
+import play.mvc.Http.Cookie;
+import play.mvc.Result;
+import play.test.WithApplication;
 
 import java.util.Map;
 
 import static javaguide.testhelpers.MockJavaActionHelper.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
 import static play.mvc.Controller.*;
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
-import static play.test.Helpers.*;
+import static play.test.Helpers.fakeRequest;
 
 public class JavaResponse extends WithApplication {
+
+    JavaContextComponents contextComponents() {
+        return app.injector().instanceOf(JavaContextComponents.class);
+    }
 
     @Test
     public void textContentType() {
@@ -69,7 +76,7 @@ public class JavaResponse extends WithApplication {
 
     @Test
     public void setCookie() {
-        setContext(fakeRequest());
+        setContext(fakeRequest(), contextComponents());
         //#set-cookie
         response().setCookie("theme", "blue");
         //#set-cookie
@@ -81,7 +88,7 @@ public class JavaResponse extends WithApplication {
 
     @Test
     public void detailedSetCookie() {
-        setContext(fakeRequest());
+        setContext(fakeRequest(), contextComponents());
         //#detailed-set-cookie
         response().setCookie(
                 "theme",        // name
@@ -106,7 +113,7 @@ public class JavaResponse extends WithApplication {
 
     @Test
     public void discardCookie() {
-        setContext(fakeRequest());
+        setContext(fakeRequest(), contextComponents());
         //#discard-cookie
         response().discardCookie("theme");
         //#discard-cookie

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/SimpleHttpRequestHandler.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/SimpleHttpRequestHandler.java
@@ -5,6 +5,8 @@ package javaguide.advanced.httprequesthandlers;
 
 //#simple
 import javax.inject.Inject;
+
+import play.core.j.JavaContextComponents;
 import play.routing.Router;
 import play.api.mvc.Handler;
 import play.http.*;
@@ -15,12 +17,12 @@ import play.core.j.JavaHandlerComponents;
 
 public class SimpleHttpRequestHandler implements HttpRequestHandler {
     private final Router router;
-    private final JavaHandlerComponents components;
+    private final JavaHandlerComponents handlerComponents;
 
     @Inject
     public SimpleHttpRequestHandler(Router router, JavaHandlerComponents components) {
         this.router = router;
-        this.components = components;
+        this.handlerComponents = components;
     }
 
     public HandlerForRequest handlerForRequest(Http.RequestHeader request) {
@@ -28,7 +30,7 @@ public class SimpleHttpRequestHandler implements HttpRequestHandler {
             EssentialAction.of(req -> Accumulator.done(Results.notFound()))
         );
         if (handler instanceof JavaHandler) {
-            handler = ((JavaHandler)handler).withComponents(components);
+            handler = ((JavaHandler)handler).withComponents(handlerComponents);
         }
         return new HandlerForRequest(request, handler);
     }

--- a/documentation/manual/working/javaGuide/main/tests/code/tests/guice/JavaGuiceApplicationBuilderTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/tests/guice/JavaGuiceApplicationBuilderTest.java
@@ -53,7 +53,7 @@ public class JavaGuiceApplicationBuilderTest {
         ClassLoader classLoader = new URLClassLoader(new URL[0]);
         // #set-environment
         Application application = new GuiceApplicationBuilder()
-            .load(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule()) // ###skip
+            .load(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule(), new play.api.i18n.I18nModule()) // ###skip
             .loadConfig(Configuration.reference()) // ###skip
             .in(new Environment(new File("path/to/app"), classLoader, Mode.TEST))
             .build();
@@ -69,7 +69,7 @@ public class JavaGuiceApplicationBuilderTest {
         ClassLoader classLoader = new URLClassLoader(new URL[0]);
         // #set-environment-values
         Application application = new GuiceApplicationBuilder()
-            .load(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule()) // ###skip
+            .load(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule(), new play.api.i18n.I18nModule()) // ###skip
             .loadConfig(Configuration.reference()) // ###skip
             .in(new File("path/to/app"))
             .in(Mode.TEST)
@@ -145,6 +145,7 @@ public class JavaGuiceApplicationBuilderTest {
             .load(
                 Guiceable.modules(
                     new play.api.inject.BuiltinModule(),
+                    new play.api.i18n.I18nModule(),
                     new play.inject.BuiltInModule()
                 ),
                 Guiceable.bindings(

--- a/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala
@@ -29,7 +29,7 @@ class ScalaGuiceApplicationBuilderSpec extends PlaySpecification {
       val classLoader = new URLClassLoader(Array.empty)
       // #set-environment
       val application = new GuiceApplicationBuilder()
-        .load(new play.api.inject.BuiltinModule) // ###skip
+        .load(new play.api.inject.BuiltinModule, new play.api.i18n.I18nModule) // ###skip
         .loadConfig(Configuration.reference) // ###skip
         .in(Environment(new File("path/to/app"), classLoader, Mode.Test))
         .build
@@ -44,7 +44,7 @@ class ScalaGuiceApplicationBuilderSpec extends PlaySpecification {
       val classLoader = new URLClassLoader(Array.empty)
       // #set-environment-values
       val application = new GuiceApplicationBuilder()
-        .load(new play.api.inject.BuiltinModule) // ###skip
+        .load(new play.api.inject.BuiltinModule, new play.api.i18n.I18nModule) // ###skip
         .loadConfig(Configuration.reference) // ###skip
         .in(new File("path/to/app"))
         .in(Mode.Test)
@@ -114,6 +114,7 @@ class ScalaGuiceApplicationBuilderSpec extends PlaySpecification {
       val injector = new GuiceApplicationBuilder()
         .load(
           new play.api.inject.BuiltinModule,
+          new play.api.i18n.I18nModule,
           bind[Component].to[DefaultComponent]
         ).injector
       // #load-modules

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
@@ -5,7 +5,7 @@ package play.filters.cors
 
 import akka.stream.Materializer
 import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
-import play.core.j.JavaHttpErrorHandlerAdapter
+import play.core.j.{ JavaContextComponents, JavaHttpErrorHandlerAdapter }
 
 import scala.concurrent.Future
 
@@ -39,8 +39,8 @@ class CORSFilter(
     private val pathPrefixes: Seq[String] = Seq("/"))(override implicit val mat: Materializer) extends Filter with AbstractCORSPolicy {
 
   // Java constructor
-  def this(corsConfig: CORSConfig, errorHandler: play.http.HttpErrorHandler, pathPrefixes: java.util.List[String])(mat: Materializer) = {
-    this(corsConfig, new JavaHttpErrorHandlerAdapter(errorHandler), Seq(pathPrefixes.toArray.asInstanceOf[Array[String]]: _*))(mat)
+  def this(corsConfig: CORSConfig, errorHandler: play.http.HttpErrorHandler, pathPrefixes: java.util.List[String], contextComponents: JavaContextComponents)(mat: Materializer) = {
+    this(corsConfig, new JavaHttpErrorHandlerAdapter(errorHandler, contextComponents), Seq(pathPrefixes.toArray.asInstanceOf[Array[String]]: _*))(mat)
   }
 
   override protected val logger = Logger(classOf[CORSFilter])

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
@@ -3,13 +3,12 @@
  */
 package play.filters.csrf
 
-import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
 import javax.inject.{ Inject, Provider }
 
 import akka.stream.Materializer
 import play.api.libs.crypto.CSRFTokenSigner
 import play.api.mvc._
+import play.core.j.JavaContextComponents
 import play.filters.csrf.CSRF._
 
 /**
@@ -36,8 +35,8 @@ class CSRFFilter(
   }
 
   // Java constructor for manually constructing the filter
-  def this(config: CSRFConfig, tokenSigner: play.libs.crypto.CSRFTokenSigner, tokenProvider: TokenProvider, errorHandler: CSRFErrorHandler)(mat: Materializer) = {
-    this(config, tokenSigner.asScala, tokenProvider, new JavaCSRFErrorHandlerAdapter(errorHandler))(mat)
+  def this(config: CSRFConfig, tokenSigner: play.libs.crypto.CSRFTokenSigner, tokenProvider: TokenProvider, errorHandler: CSRFErrorHandler, contextComponents: JavaContextComponents)(mat: Materializer) = {
+    this(config, tokenSigner.asScala, tokenProvider, new JavaCSRFErrorHandlerAdapter(errorHandler, contextComponents))(mat)
   }
 
   def apply(next: EssentialAction): EssentialAction = new CSRFAction(next, config, tokenSigner, tokenProvider, errorHandler)

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -10,7 +10,7 @@ import play.api.http.{ HttpErrorHandler, Status }
 import play.api.inject._
 import play.api.libs.streams.Accumulator
 import play.api.mvc.{ EssentialAction, EssentialFilter }
-import play.core.j.JavaHttpErrorHandlerAdapter
+import play.core.j.{ JavaContextComponents, JavaHttpErrorHandlerAdapter }
 
 /**
  * A filter that denies requests by hosts that do not match a configured list of allowed hosts.
@@ -19,8 +19,8 @@ case class AllowedHostsFilter @Inject() (config: AllowedHostsConfig, errorHandle
     extends EssentialFilter {
 
   // Java API
-  def this(config: AllowedHostsConfig, errorHandler: play.http.HttpErrorHandler) {
-    this(config, new JavaHttpErrorHandlerAdapter(errorHandler))
+  def this(config: AllowedHostsConfig, errorHandler: play.http.HttpErrorHandler, contextComponents: JavaContextComponents) {
+    this(config, new JavaHttpErrorHandlerAdapter(errorHandler, contextComponents))
   }
 
   private val hostMatchers: Seq[HostMatcher] = config.allowed map HostMatcher.apply

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFCommonSpecs.scala
@@ -5,12 +5,11 @@ package play.filters.csrf
 
 import org.specs2.matcher.MatchResult
 import org.specs2.mutable.Specification
-import play.api.Application
 import play.api.http.{ ContentTypeOf, ContentTypes, Writeable }
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.crypto.CSRFTokenSigner
 import play.api.libs.ws._
-import play.api.mvc.{ DefaultActionBuilder, ControllerComponents, Handler, Session }
+import play.api.mvc.{ DefaultActionBuilder, Handler, Session }
 import play.api.test.{ PlaySpecification, TestServer }
 
 import scala.concurrent.Future

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
@@ -25,7 +25,7 @@ class JavaCSRFActionSpec extends CSRFCommonSpecs {
   def javaContextComponents = Play.privateMaybeApplication.get.injector.instanceOf[JavaContextComponents]
   def myAction = Play.privateMaybeApplication.get.injector.instanceOf[JavaCSRFActionSpec.MyAction]
 
-  def javaAction[T: ClassTag](method: String, inv: => Result) = new JavaAction(javaHandlerComponents, javaContextComponents) {
+  def javaAction[T: ClassTag](method: String, inv: => Result) = new JavaAction(javaHandlerComponents) {
     val clazz = implicitly[ClassTag[T]].runtimeClass
     def parser = HandlerInvokerFactory.javaBodyParserToScala(javaHandlerComponents.getBodyParser(annotations.parser))
     def invocation = CompletableFuture.completedFuture(inv)

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.CompletableFuture
 import play.api.Play
 import play.api.libs.ws._
 import play.api.mvc.Session
-import play.core.j.{ JavaAction, JavaActionAnnotations, JavaHandlerComponents }
+import play.core.j.{ JavaAction, JavaActionAnnotations, JavaContextComponents, JavaHandlerComponents }
 import play.core.routing.HandlerInvokerFactory
 import play.mvc.Http.{ Context, RequestHeader }
 import play.mvc.{ Controller, Result, Results }
@@ -22,13 +22,14 @@ import scala.reflect.ClassTag
 class JavaCSRFActionSpec extends CSRFCommonSpecs {
 
   def javaHandlerComponents = Play.privateMaybeApplication.get.injector.instanceOf[JavaHandlerComponents]
+  def javaContextComponents = Play.privateMaybeApplication.get.injector.instanceOf[JavaContextComponents]
   def myAction = Play.privateMaybeApplication.get.injector.instanceOf[JavaCSRFActionSpec.MyAction]
 
-  def javaAction[T: ClassTag](method: String, inv: => Result) = new JavaAction(javaHandlerComponents) {
+  def javaAction[T: ClassTag](method: String, inv: => Result) = new JavaAction(javaHandlerComponents, javaContextComponents) {
     val clazz = implicitly[ClassTag[T]].runtimeClass
     def parser = HandlerInvokerFactory.javaBodyParserToScala(javaHandlerComponents.getBodyParser(annotations.parser))
     def invocation = CompletableFuture.completedFuture(inv)
-    val annotations = new JavaActionAnnotations(clazz, clazz.getMethod(method), components.httpConfiguration.actionComposition)
+    val annotations = new JavaActionAnnotations(clazz, clazz.getMethod(method), handlerComponents.httpConfiguration.actionComposition)
   }
 
   def buildCsrfCheckRequest(sendUnauthorizedResult: Boolean, configuration: (String, String)*) = new CsrfTester {

--- a/framework/src/play-guice/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
+++ b/framework/src/play-guice/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
@@ -69,16 +69,6 @@ public class GuiceApplicationBuilderTest {
     }
 
     @Test
-    public void disableLoadedModules() {
-        Injector injector = new GuiceApplicationBuilder()
-            .disable(play.api.i18n.I18nModule.class)
-            .injector();
-
-        exception.expect(com.google.inject.ConfigurationException.class);
-        injector.instanceOf(play.api.i18n.Langs.class);
-    }
-
-    @Test
     public void setInitialConfigurationLoader() {
         Config extra = ConfigFactory.parseMap(ImmutableMap.of("a", 1));
         Application app = new GuiceApplicationBuilder()
@@ -92,7 +82,7 @@ public class GuiceApplicationBuilderTest {
     public void setModuleLoader() {
         Injector injector = new GuiceApplicationBuilder()
             .withModuleLoader((env, conf) -> ImmutableList.of(
-                Guiceable.modules(new play.api.inject.BuiltinModule()),
+                Guiceable.modules(new play.api.inject.BuiltinModule(), new play.api.i18n.I18nModule()),
                 Guiceable.bindings(bind(A.class).to(A1.class))))
             .injector();
 
@@ -103,7 +93,7 @@ public class GuiceApplicationBuilderTest {
     public void setLoadedModulesDirectly() {
         Injector injector = new GuiceApplicationBuilder()
             .load(
-                Guiceable.modules(new play.api.inject.BuiltinModule()),
+                Guiceable.modules(new play.api.inject.BuiltinModule(), new play.api.i18n.I18nModule()),
                 Guiceable.bindings(bind(A.class).to(A1.class)))
             .injector();
 

--- a/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
@@ -41,11 +41,9 @@ class GuiceApplicationBuilderSpec extends Specification {
     "disable modules" in {
       val injector = new GuiceApplicationBuilder()
         .bindings(new GuiceApplicationBuilderSpec.AModule)
-        .disable[play.api.i18n.I18nModule]
         .disable(classOf[GuiceApplicationBuilderSpec.AModule])
         .injector()
 
-      injector.instanceOf[play.api.i18n.Langs] must throwA[com.google.inject.ConfigurationException]
       injector.instanceOf[GuiceApplicationBuilderSpec.A] must throwA[com.google.inject.ConfigurationException]
     }
 
@@ -60,7 +58,7 @@ class GuiceApplicationBuilderSpec extends Specification {
 
     "set module loader" in {
       val injector = new GuiceApplicationBuilder()
-        .load((env, conf) => Seq(new BuiltinModule, bind[GuiceApplicationBuilderSpec.A].to[GuiceApplicationBuilderSpec.A1]))
+        .load((env, conf) => Seq(new BuiltinModule, new I18nModule, bind[GuiceApplicationBuilderSpec.A].to[GuiceApplicationBuilderSpec.A1]))
         .injector()
 
       injector.instanceOf[GuiceApplicationBuilderSpec.A] must beAnInstanceOf[GuiceApplicationBuilderSpec.A1]
@@ -68,7 +66,7 @@ class GuiceApplicationBuilderSpec extends Specification {
 
     "set loaded modules directly" in {
       val injector = new GuiceApplicationBuilder()
-        .load(new BuiltinModule, bind[GuiceApplicationBuilderSpec.A].to[GuiceApplicationBuilderSpec.A1])
+        .load(new BuiltinModule, new I18nModule, bind[GuiceApplicationBuilderSpec.A].to[GuiceApplicationBuilderSpec.A1])
         .injector()
 
       injector.instanceOf[GuiceApplicationBuilderSpec.A] must beAnInstanceOf[GuiceApplicationBuilderSpec.A1]
@@ -76,7 +74,7 @@ class GuiceApplicationBuilderSpec extends Specification {
 
     "eagerly load singletons" in {
       new GuiceApplicationBuilder()
-        .load(new BuiltinModule, bind[GuiceApplicationBuilderSpec.C].to[GuiceApplicationBuilderSpec.C1])
+        .load(new BuiltinModule, new I18nModule, bind[GuiceApplicationBuilderSpec.C].to[GuiceApplicationBuilderSpec.C1])
         .eagerlyLoaded()
         .injector() must throwA[CreationException]
     }
@@ -91,7 +89,7 @@ class GuiceApplicationBuilderSpec extends Specification {
 
     "set lazy load singletons" in {
       val builder = new GuiceApplicationBuilder()
-        .load(new BuiltinModule, bind[GuiceApplicationBuilderSpec.C].to[GuiceApplicationBuilderSpec.C1])
+        .load(new BuiltinModule, new I18nModule, bind[GuiceApplicationBuilderSpec.C].to[GuiceApplicationBuilderSpec.C1])
 
       builder.injector() must throwAn[CreationException].not
       builder.injector().instanceOf[GuiceApplicationBuilderSpec.C] must throwAn[ProvisionException]

--- a/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
@@ -5,6 +5,7 @@ package play.api.inject.guice
 
 import org.specs2.mutable.Specification
 import com.google.inject.AbstractModule
+import play.api.i18n.I18nModule
 import play.{ Configuration => JavaConfiguration, Environment => JavaEnvironment }
 import play.api.{ ApplicationLoader, Configuration, Environment }
 import play.api.inject.{ BuiltinModule, DefaultApplicationLifecycle }
@@ -29,7 +30,7 @@ class GuiceApplicationLoaderSpec extends Specification {
     }
 
     "allow replacing automatically loaded modules" in {
-      val builder = new GuiceApplicationBuilder().load(new BuiltinModule, new ManualTestModule)
+      val builder = new GuiceApplicationBuilder().load(new BuiltinModule, new I18nModule, new ManualTestModule)
       val loader = new GuiceApplicationLoader(builder)
       val app = loader.load(fakeContext)
       app.injector.instanceOf[Foo] must beAnInstanceOf[ManualFoo]

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JAction.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JAction.scala
@@ -28,8 +28,7 @@ import play.mvc.{ Http, Result }
 object JAction {
   def apply(app: Application, c: AbstractMockController): EssentialAction = {
     val handlerComponents = app.injector.instanceOf[JavaHandlerComponents]
-    val contextComponents = app.injector.instanceOf[JavaContextComponents]
-    new JavaAction(handlerComponents, contextComponents) {
+    new JavaAction(handlerComponents) {
       val annotations = new JavaActionAnnotations(c.getClass, c.getClass.getMethod("action"), handlerComponents.httpConfiguration.actionComposition)
       val parser = HandlerInvokerFactory.javaBodyParserToScala(handlerComponents.getBodyParser(annotations.parser))
       def invocation = c.invocation

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JAction.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JAction.scala
@@ -3,11 +3,11 @@
  */
 package play.it.http
 
-import java.util.concurrent.{ CompletionStage, CompletableFuture }
+import java.util.concurrent.{ CompletableFuture, CompletionStage }
 
 import play.api._
 import play.api.mvc.EssentialAction
-import play.core.j.{ JavaHandlerComponents, JavaActionAnnotations, JavaAction }
+import play.core.j.{ JavaAction, JavaActionAnnotations, JavaContextComponents, JavaHandlerComponents }
 import play.core.routing.HandlerInvokerFactory
 import play.mvc.{ Http, Result }
 
@@ -27,10 +27,11 @@ import play.mvc.{ Http, Result }
  */
 object JAction {
   def apply(app: Application, c: AbstractMockController): EssentialAction = {
-    val components = app.injector.instanceOf[JavaHandlerComponents]
-    new JavaAction(components) {
-      val annotations = new JavaActionAnnotations(c.getClass, c.getClass.getMethod("action"), components.httpConfiguration.actionComposition)
-      val parser = HandlerInvokerFactory.javaBodyParserToScala(components.getBodyParser(annotations.parser))
+    val handlerComponents = app.injector.instanceOf[JavaHandlerComponents]
+    val contextComponents = app.injector.instanceOf[JavaContextComponents]
+    new JavaAction(handlerComponents, contextComponents) {
+      val annotations = new JavaActionAnnotations(c.getClass, c.getClass.getMethod("action"), handlerComponents.httpConfiguration.actionComposition)
+      val parser = HandlerInvokerFactory.javaBodyParserToScala(handlerComponents.getBodyParser(annotations.parser))
       def invocation = c.invocation
     }
   }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaRequestsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaRequestsSpec.scala
@@ -49,7 +49,7 @@ class JavaRequestsSpec extends PlaySpecification with Mockito {
       val cookie1 = Cookie("name1", "value1")
 
       val requestHeader: Request[Http.RequestBody] = Request[Http.RequestBody](FakeRequest().withCookies(cookie1), new RequestBody(null))
-      val javaContext: Context = JavaHelpers.createJavaContext(requestHeader)
+      val javaContext: Context = JavaHelpers.createJavaContext(requestHeader, JavaHelpers.createContextComponents())
       val javaRequest = javaContext.request()
 
       val iterator: Iterator[Http.Cookie] = javaRequest.cookies().iterator()
@@ -62,7 +62,7 @@ class JavaRequestsSpec extends PlaySpecification with Mockito {
 
     "create a request without a body" in {
       val requestHeader: Request[Http.RequestBody] = Request[Http.RequestBody](FakeRequest(), new RequestBody(null))
-      val javaContext: Context = JavaHelpers.createJavaContext(requestHeader)
+      val javaContext: Context = JavaHelpers.createJavaContext(requestHeader, JavaHelpers.createContextComponents())
       val javaRequest = javaContext.request()
 
       requestHeader.hasBody must beFalse
@@ -71,7 +71,7 @@ class JavaRequestsSpec extends PlaySpecification with Mockito {
 
     "create a request with a body" in {
       val requestHeader: Request[Http.RequestBody] = Request[Http.RequestBody](FakeRequest(), new RequestBody("foo"))
-      val javaContext: Context = JavaHelpers.createJavaContext(requestHeader)
+      val javaContext: Context = JavaHelpers.createJavaContext(requestHeader, JavaHelpers.createContextComponents())
       val javaRequest = javaContext.request()
 
       requestHeader.hasBody must beTrue

--- a/framework/src/play-integration-test/src/test/scala/play/it/libs/JavaFormSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/libs/JavaFormSpec.scala
@@ -4,9 +4,9 @@
 package play.it.libs
 
 import play.api.test._
-import play.core.j.JavaHelpers
-import play.data.Form
+import play.core.j.{ JavaContextComponents, JavaHelpers }
 import play.data.validation.Constraints.Required
+
 import scala.annotation.meta.field
 import scala.beans.BeanProperty
 import scala.collection.JavaConverters._
@@ -16,7 +16,8 @@ class JavaFormSpec extends PlaySpecification {
   "A Java form" should {
 
     "throw a meaningful exception when get is called on an invalid form" in new WithApplication() {
-      JavaHelpers.withContext(FakeRequest()) { _ =>
+      val components = app.injector.instanceOf[JavaContextComponents]
+      JavaHelpers.withContext(FakeRequest(), components) { _ =>
         val formFactory = app.injector.instanceOf[play.data.FormFactory]
         val myForm = formFactory.form(classOf[FooForm]).bind(Map("id" -> "1234567891").asJava)
         myForm.hasErrors must beEqualTo(true)

--- a/framework/src/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
+++ b/framework/src/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
@@ -6,9 +6,9 @@ package play.routing
 import java.util.concurrent.CompletionStage
 
 import play.api.Play
-import play.api.http.{ HttpConfiguration, JavaHttpErrorHandlerDelegate, ParserConfiguration }
-import play.api.mvc.{ ActionBuilder, PlayBodyParsers, Results }
-import play.core.j.JavaHelpers
+import play.api.http.{HttpConfiguration, JavaHttpErrorHandlerDelegate, ParserConfiguration}
+import play.api.mvc.{ActionBuilder, PlayBodyParsers, Results}
+import play.core.j.{JavaContextComponents, JavaHelpers}
 import play.core.routing.HandlerInvokerFactory
 import play.mvc.Http.Context
 import play.mvc.Result
@@ -61,19 +61,20 @@ private[routing] object RouterBuilderHelper {
             val action = maybeParams match {
               case Left(error) => ActionBuilder.ignoringBody(Results.BadRequest(error))
               case Right(params) =>
+                // If testing an embedded application we may not have a Guice injector, therefore we can't rely on
+                // it to instantiate the default body parser, we have to instantiate it ourselves.
+                val app = Play.privateMaybeApplication.get // throw exception if no current app
 
                 // Convert to a Scala action
                 val parser = HandlerInvokerFactory.javaBodyParserToScala {
-                  // If testing an embedded application we may not have a Guice injector, therefore we can't rely on
-                  // it to instantiate the default body parser, we have to instantiate it ourselves.
-                  val app = Play.privateMaybeApplication.get // throw exception if no current app
                   val bp = PlayBodyParsers(ParserConfiguration(), app.errorHandler, app.materializer)
                   new play.mvc.BodyParser.Default(
                     new JavaHttpErrorHandlerDelegate(app.errorHandler),
                     app.injector.instanceOf[HttpConfiguration], bp)
                 }
                 ActionBuilder.ignoringBody.async(parser) { request =>
-                  val ctx = JavaHelpers.createJavaContext(request)
+                  val contextComponents = app.injector.instanceOf[JavaContextComponents]
+                  val ctx = JavaHelpers.createJavaContext(request, contextComponents)
                   try {
                     Context.current.set(ctx)
                     route.actionMethod.invoke(route.action, params: _*) match {

--- a/framework/src/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
+++ b/framework/src/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
@@ -6,9 +6,9 @@ package play.routing
 import java.util.concurrent.CompletionStage
 
 import play.api.Play
-import play.api.http.{HttpConfiguration, JavaHttpErrorHandlerDelegate, ParserConfiguration}
-import play.api.mvc.{ActionBuilder, PlayBodyParsers, Results}
-import play.core.j.{JavaContextComponents, JavaHelpers}
+import play.api.http.{ HttpConfiguration, JavaHttpErrorHandlerDelegate, ParserConfiguration }
+import play.api.mvc.{ ActionBuilder, PlayBodyParsers, Results }
+import play.core.j.{ JavaContextComponents, JavaHelpers }
 import play.core.routing.HandlerInvokerFactory
 import play.mvc.Http.Context
 import play.mvc.Result

--- a/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import play.Application;
 import play.Environment;
 import play.Play;
+import play.core.j.JavaContextComponents;
 import play.data.Birthday;
 import play.data.Form;
 import play.data.FormFactory;
@@ -76,7 +77,9 @@ public class HttpTest {
     @Test
     public void testChangeLang() {
         withApplication((app) -> {
-            Context ctx = new Context(new RequestBuilder());
+            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+
+            Context ctx = new Context(new RequestBuilder(), contextComponents);
             // Start off as 'en' with no cookie set
             assertThat(ctx.lang().code()).isEqualTo("en");
             assertThat(responseLangCookie(ctx)).isNull();
@@ -93,7 +96,9 @@ public class HttpTest {
     @Test
     public void testChangeLangFailure() {
         withApplication((app) -> {
-            Context ctx = new Context(new RequestBuilder());
+            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+
+            Context ctx = new Context(new RequestBuilder(), contextComponents);
             // Start off as 'en' with no cookie set
             assertThat(ctx.lang().code()).isEqualTo("en");
             assertThat(responseLangCookie(ctx)).isNull();
@@ -108,7 +113,9 @@ public class HttpTest {
     @Test
     public void testClearLang() {
         withApplication((app) -> {
-            Context ctx = new Context(new RequestBuilder());
+            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+
+            Context ctx = new Context(new RequestBuilder(), contextComponents);
             // Set 'fr' as our initial language
             assertThat(ctx.changeLang("fr")).isTrue();
             assertThat(ctx.lang().code()).isEqualTo("fr");
@@ -124,7 +131,9 @@ public class HttpTest {
     @Test
     public void testSetTransientLang() {
         withApplication((app) -> {
-            Context ctx = new Context(new RequestBuilder());
+            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+
+            Context ctx = new Context(new RequestBuilder(), contextComponents);
             // Start off as 'en' with no cookie set
             assertThat(ctx.lang().code()).isEqualTo("en");
             assertThat(responseLangCookie(ctx)).isNull();
@@ -141,7 +150,9 @@ public class HttpTest {
     @Test(expected=IllegalArgumentException.class)
     public void testSetTransientLangFailure() {
         withApplication((app) -> {
-            Context ctx = new Context(new RequestBuilder());
+            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+
+            Context ctx = new Context(new RequestBuilder(), contextComponents);
             // Start off as 'en' with no cookie set
             assertThat(ctx.lang().code()).isEqualTo("en");
             assertThat(responseLangCookie(ctx)).isNull();
@@ -153,9 +164,11 @@ public class HttpTest {
     @Test
     public void testClearTransientLang() {
         withApplication((app) -> {
+            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+
             Cookie frCookie = new Cookie("PLAY_LANG", "fr", null, "/", null, false, false);
             RequestBuilder rb = new RequestBuilder().cookie(frCookie);
-            Context ctx = new Context(rb);
+            Context ctx = new Context(rb, contextComponents);
             // Start off as 'en' with no cookie set
             assertThat(ctx.lang().code()).isEqualTo("fr");
             assertThat(responseLangCookie(ctx)).isNull();
@@ -175,6 +188,8 @@ public class HttpTest {
     @Test
     public void testLangDataBinder() {
         withApplication((app) -> {
+            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+
             FormFactory formFactory = app.injector().instanceOf(FormFactory.class);
             Formatters formatters = app.injector().instanceOf(Formatters.class);
 
@@ -185,7 +200,7 @@ public class HttpTest {
             Map<String, String> data = new HashMap<>();
             data.put("amount", "1234567,89");
             RequestBuilder rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            Context ctx = new Context(rb);
+            Context ctx = new Context(rb, contextComponents);
             Context.current.set(ctx);
             // Parse french input with french formatter
             ctx.changeLang("fr");
@@ -210,7 +225,7 @@ public class HttpTest {
             data = new HashMap<>();
             data.put("amount", "1234567.89");
             rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            ctx = new Context(rb);
+            ctx = new Context(rb, contextComponents);
             Context.current.set(ctx);
             // Parse english input with french formatter
             ctx.changeLang("fr");
@@ -241,11 +256,13 @@ public class HttpTest {
     public void testLangErrorsAsJson() {
         withApplication((app) -> {
             MessagesApi messagesApi = app.injector().instanceOf(MessagesApi.class);
+            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+
             Formatters formatters = app.injector().instanceOf(Formatters.class);
             Validator validator = app.injector().instanceOf(Validator.class);
 
             RequestBuilder rb = new RequestBuilder();
-            Context ctx = new Context(rb);
+            Context ctx = new Context(rb, contextComponents);
             Context.current.set(ctx);
 
             List<Object> args = new ArrayList<>();
@@ -264,12 +281,13 @@ public class HttpTest {
     public void testLangAnnotationDateDataBinder() {
         withApplication((app) -> {
             FormFactory formFactory = app.injector().instanceOf(FormFactory.class);
+            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
 
             // Prepare Request and Context
             Map<String, String> data = new HashMap<>();
             data.put("date", "3/10/1986");
             RequestBuilder rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            Context ctx = new Context(rb);
+            Context ctx = new Context(rb, contextComponents);
             Context.current.set(ctx);
             // Parse date input with pattern from the default messages file
             Form<Birthday> myForm = formFactory.form(Birthday.class).bindFromRequest();
@@ -284,7 +302,7 @@ public class HttpTest {
             data = new HashMap<>();
             data.put("date", "16.2.2001");
             rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            ctx = new Context(rb);
+            ctx = new Context(rb, contextComponents);
             Context.current.set(ctx);
             // Parse french date input with pattern from the french messages file
             ctx.changeLang("fr");
@@ -300,7 +318,7 @@ public class HttpTest {
             data = new HashMap<>();
             data.put("date", "8-31-1950");
             rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            ctx = new Context(rb);
+            ctx = new Context(rb, contextComponents);
             Context.current.set(ctx);
             // Parse english date input with pattern from the en-US messages file
             ctx.changeLang("en-US");
@@ -318,12 +336,13 @@ public class HttpTest {
     public void testLangDateDataBinder() {
         withApplication((app) -> {
             FormFactory formFactory = app.injector().instanceOf(FormFactory.class);
+            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
 
             // Prepare Request and Context
             Map<String, String> data = new HashMap<>();
             data.put("alternativeDate", "1982-5-7");
             RequestBuilder rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            Context ctx = new Context(rb);
+            Context ctx = new Context(rb, contextComponents);
             Context.current.set(ctx);
             // Parse date input with pattern from Play's default messages file
             Form<Birthday> myForm = formFactory.form(Birthday.class).bindFromRequest();
@@ -338,7 +357,7 @@ public class HttpTest {
             data = new HashMap<>();
             data.put("alternativeDate", "10_4_2005");
             rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            ctx = new Context(rb);
+            ctx = new Context(rb, contextComponents);
             Context.current.set(ctx);
             // Parse french date input with pattern from the french messages file
             ctx.changeLang("fr");
@@ -354,7 +373,7 @@ public class HttpTest {
             data = new HashMap<>();
             data.put("alternativeDate", "3/12/1962");
             rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            ctx = new Context(rb);
+            ctx = new Context(rb, contextComponents);
             Context.current.set(ctx);
             // Parse english date input with pattern from the en-US messages file
             ctx.changeLang("en-US");
@@ -372,6 +391,7 @@ public class HttpTest {
     public void testInvalidMessages() {
         withApplication((app) -> {
             FormFactory formFactory = app.injector().instanceOf(FormFactory.class);
+            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
 
             // Prepare Request and Context
             Map<String, String> data = new HashMap<>();
@@ -379,7 +399,7 @@ public class HttpTest {
             data.put("name", "peter");
             data.put("dueDate", "2009/11e/11");
             RequestBuilder rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            Context ctx = new Context(rb);
+            Context ctx = new Context(rb, contextComponents);
             Context.current.set(ctx);
             // Parse date input with pattern from the default messages file
             Form<Task> myForm = formFactory.form(Task.class).bindFromRequest();
@@ -398,7 +418,7 @@ public class HttpTest {
             data.put("dueDate", "2009/11e/11");
             Cookie frCookie = new Cookie("PLAY_LANG", "fr", null, "/", null, false, false);
             rb = new RequestBuilder().cookie(frCookie).uri("http://localhost/test").bodyForm(data);
-            ctx = new Context(rb);
+            ctx = new Context(rb, contextComponents);
             Context.current.set(ctx);
             // Parse date input with pattern from the french messages file
             myForm = formFactory.form(Task.class).bindFromRequest();
@@ -417,6 +437,7 @@ public class HttpTest {
     public void testConstraintWithInjectedMessagesApi() {
         withApplication((app) -> {
             FormFactory formFactory = app.injector().instanceOf(FormFactory.class);
+            JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
 
             // Prepare Request and Context
             Map<String, String> data = new HashMap<>();
@@ -425,7 +446,7 @@ public class HttpTest {
             data.put("dueDate", "11/11/2009");
             data.put("zip", "1234");
             RequestBuilder rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            Context ctx = new Context(rb);
+            Context ctx = new Context(rb, contextComponents);
             Context.current.set(ctx);
             // Parse input with pattern from the default messages file
             Form<Task> myForm = formFactory.form(Task.class).bindFromRequest();
@@ -440,7 +461,7 @@ public class HttpTest {
             data.put("dueDate", "11/11/2009");
             data.put("zip", "567");
             rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            ctx = new Context(rb);
+            ctx = new Context(rb, contextComponents);
             Context.current.set(ctx);
             // Parse input with pattern from the french messages file
             ctx.changeLang("fr");
@@ -456,7 +477,7 @@ public class HttpTest {
             data.put("dueDate", "11/11/2009");
             data.put("zip", "1234");
             rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
-            ctx = new Context(rb);
+            ctx = new Context(rb, contextComponents);
             Context.current.set(ctx);
             // Parse WRONG input with pattern from the french messages file
             ctx.changeLang("fr");

--- a/framework/src/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -9,6 +9,7 @@ import play.api.Play;
 import play.api.inject.guice.GuiceApplicationBuilder;
 import play.api.libs.typedmap.TypedKey;
 import play.api.libs.typedmap.TypedKeyFactory;
+import play.core.j.JavaContextComponents;
 import play.mvc.Http.Context;
 import play.mvc.Http.Request;
 import play.mvc.Http.RequestBuilder;
@@ -102,7 +103,10 @@ public class RequestBuilderTest {
 
     @Test
     public void testFlash() {
-        Context ctx = new Context(new RequestBuilder().flash("a","1").flash("b","1").flash("b","2"));
+        Application app = new GuiceApplicationBuilder().build();
+        Play.start(app);
+        JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+        Context ctx = new Context(new RequestBuilder().flash("a","1").flash("b","1").flash("b","2"), contextComponents);
         assertEquals("1", ctx.flash().get("a"));
         assertEquals("2", ctx.flash().get("b"));
     }
@@ -111,7 +115,8 @@ public class RequestBuilderTest {
     public void testSession() {
         Application app = new GuiceApplicationBuilder().build();
         Play.start(app);
-        Context ctx = new Context(new RequestBuilder().session("a","1").session("b","1").session("b","2"));
+        JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
+        Context ctx = new Context(new RequestBuilder().session("a","1").session("b","1").session("b","2"), contextComponents);
         assertEquals("1", ctx.session().get("a"));
         assertEquals("2", ctx.session().get("b"));
         Play.stop(app);

--- a/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala
+++ b/framework/src/play-specs2/src/main/scala/play/api/test/Specs.scala
@@ -9,6 +9,7 @@ import org.specs2.mutable.Around
 import org.specs2.specification.Scope
 import play.api.inject.guice.{ GuiceApplicationBuilder, GuiceApplicationLoader }
 import play.api.{ Application, ApplicationLoader, Environment, Mode }
+import play.core.j.JavaContextComponents
 import play.core.server.ServerProvider
 
 // NOTE: Do *not* put any initialisation code in the below classes, otherwise delayedInit() gets invoked twice

--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -12,6 +12,7 @@ import play.routing.Router;
 import play.api.test.PlayRunners$;
 import play.core.j.JavaHandler;
 import play.core.j.JavaHandlerComponents;
+import play.core.j.JavaContextComponents;
 import play.http.HttpEntity;
 import play.mvc.*;
 import play.api.test.Helpers$;
@@ -62,8 +63,9 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
             return wrapScalaResult(action.apply(requestBuilder._underlyingRequest()), timeout);
         } else if (handler instanceof JavaHandler) {
             final play.api.inject.Injector injector = play.api.Play.current().injector();
+            final JavaHandlerComponents handlerComponents = injector.instanceOf(JavaHandlerComponents.class);
             return invokeHandler(
-                    ((JavaHandler) handler).withComponents(injector.instanceOf(JavaHandlerComponents.class)),
+                    ((JavaHandler) handler).withComponents(handlerComponents),
                     requestBuilder, timeout
             );
         } else {
@@ -95,9 +97,9 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Calls a Callable which invokes a Controller or some other method with a Context
      */
-    public static <V> V invokeWithContext(RequestBuilder requestBuilder, Callable<V> callable) {
+    public static <V> V invokeWithContext(RequestBuilder requestBuilder, JavaContextComponents contextComponents, Callable<V> callable) {
         try {
-            Context.current.set(new Context(requestBuilder));
+            Context.current.set(new Context(requestBuilder, contextComponents));
             return callable.call();
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/framework/src/play/src/main/java/play/http/HttpErrorHandler.java
+++ b/framework/src/play/src/main/java/play/http/HttpErrorHandler.java
@@ -3,6 +3,7 @@
  */
 package play.http;
 
+import play.core.j.JavaContextComponents;
 import play.mvc.Http.RequestHeader;
 import play.mvc.Result;
 

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -3,9 +3,11 @@
  */
 package play.api
 
+import play.api.i18n.{ I18nComponents, I18nModule }
 import play.core.{ DefaultWebCommands, SourceMapper, WebCommands }
 import play.utils.Reflect
-import play.api.inject.DefaultApplicationLifecycle
+import play.api.inject.{ DefaultApplicationLifecycle, Injector, NewInstanceInjector, SimpleInjector }
+import play.core.j.{ DefaultJavaContextComponents, JavaHelpers }
 
 /**
  * Loads an application.  This is responsible for instantiating an application given a context.
@@ -118,11 +120,14 @@ object ApplicationLoader {
 /**
  * Helper that provides all the built in components dependencies from the application loader context
  */
-abstract class BuiltInComponentsFromContext(context: ApplicationLoader.Context) extends BuiltInComponents {
+abstract class BuiltInComponentsFromContext(context: ApplicationLoader.Context) extends BuiltInComponents with I18nComponents {
   lazy val environment = context.environment
   lazy val sourceMapper = context.sourceMapper
   lazy val webCommands = context.webCommands
   lazy val configuration = context.initialConfiguration
   lazy val applicationLifecycle: DefaultApplicationLifecycle = context.lifecycle
+
+  lazy val javaContextComponents = JavaHelpers.createContextComponents(messagesApi, langs, httpConfiguration)
+  override lazy val injector: Injector = new SimpleInjector(NewInstanceInjector) + router + cookieSigner + csrfTokenSigner + httpConfiguration + tempFileCreator + javaContextComponents
 }
 

--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -6,7 +6,7 @@ package play.api.http
 import javax.inject._
 
 import play.api._
-import play.api.inject.Binding
+import play.api.inject.{ Binding, BindingKey }
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.http.Status._
@@ -51,8 +51,12 @@ object HttpErrorHandler {
    * Get the bindings for the error handler from the configuration
    */
   def bindingsFromConfiguration(environment: Environment, configuration: Configuration): Seq[Binding[_]] = {
-    Reflect.bindingsFromConfiguration[HttpErrorHandler, play.http.HttpErrorHandler, JavaHttpErrorHandlerAdapter, JavaHttpErrorHandlerDelegate, DefaultHttpErrorHandler](environment, configuration,
+    val fromConfiguration = Reflect.bindingsFromConfiguration[HttpErrorHandler, play.http.HttpErrorHandler, JavaHttpErrorHandlerAdapter, JavaHttpErrorHandlerDelegate, DefaultHttpErrorHandler](environment, configuration,
       "play.http.errorHandler", "ErrorHandler")
+
+    val javaContextComponentsBindings = Seq(BindingKey(classOf[play.core.j.JavaContextComponents]).to[play.core.j.DefaultJavaContextComponents])
+
+    fromConfiguration ++ javaContextComponentsBindings
   }
 }
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -53,9 +53,7 @@ class JavaActionAnnotations(val controller: Class[_], val method: java.lang.refl
 /*
  * An action that's handling Java requests
  */
-abstract class JavaAction(
-  val handlerComponents: JavaHandlerComponents,
-  val contextComponents: JavaContextComponents)
+abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
     extends Action[play.mvc.Http.RequestBody] with JavaHelpers {
   private def config: ActionCompositionConfiguration = handlerComponents.httpConfiguration.actionComposition
 
@@ -65,7 +63,7 @@ abstract class JavaAction(
   val executionContext: ExecutionContext = handlerComponents.executionContext
 
   def apply(req: Request[play.mvc.Http.RequestBody]): Future[Result] = {
-
+    val contextComponents = handlerComponents.contextComponents
     val javaContext: JContext = createJavaContext(req, contextComponents)
 
     val rootAction = new JAction[Any] {

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -11,11 +11,12 @@ import play.api.inject.Injector
 
 import scala.compat.java8.FutureConverters
 import scala.language.existentials
-
 import play.core.Execution.Implicits.trampoline
 import play.api.mvc._
-import play.mvc.{ Action => JAction, Result => JResult, BodyParser => JBodyParser }
+import play.mvc.{ Action => JAction, BodyParser => JBodyParser, Result => JResult }
+import play.i18n.{ Langs => JLangs, MessagesApi => JMessagesApi }
 import play.mvc.Http.{ Context => JContext }
+
 import scala.concurrent.{ ExecutionContext, Future }
 
 /**
@@ -52,17 +53,20 @@ class JavaActionAnnotations(val controller: Class[_], val method: java.lang.refl
 /*
  * An action that's handling Java requests
  */
-abstract class JavaAction(val components: JavaHandlerComponents) extends Action[play.mvc.Http.RequestBody] with JavaHelpers {
-  private def config: ActionCompositionConfiguration = components.httpConfiguration.actionComposition
+abstract class JavaAction(
+  val handlerComponents: JavaHandlerComponents,
+  val contextComponents: JavaContextComponents)
+    extends Action[play.mvc.Http.RequestBody] with JavaHelpers {
+  private def config: ActionCompositionConfiguration = handlerComponents.httpConfiguration.actionComposition
 
   def invocation: CompletionStage[JResult]
   val annotations: JavaActionAnnotations
 
-  val executionContext: ExecutionContext = components.executionContext
+  val executionContext: ExecutionContext = handlerComponents.executionContext
 
   def apply(req: Request[play.mvc.Http.RequestBody]): Future[Result] = {
 
-    val javaContext: JContext = createJavaContext(req)
+    val javaContext: JContext = createJavaContext(req, contextComponents)
 
     val rootAction = new JAction[Any] {
       def call(ctx: JContext): CompletionStage[JResult] = {
@@ -77,7 +81,7 @@ abstract class JavaAction(val components: JavaHandlerComponents) extends Action[
       }
     }
 
-    val baseAction = components.actionCreator.createAction(javaContext.request, annotations.method)
+    val baseAction = handlerComponents.actionCreator.createAction(javaContext.request, annotations.method)
 
     val endOfChainAction = if (config.executeActionCreatorActionFirst) {
       rootAction
@@ -88,13 +92,13 @@ abstract class JavaAction(val components: JavaHandlerComponents) extends Action[
 
     val finalUserDeclaredAction = annotations.actionMixins.foldLeft[JAction[_ <: Any]](endOfChainAction) {
       case (delegate, (annotation, actionClass)) =>
-        val action = components.getAction(actionClass).asInstanceOf[play.mvc.Action[Object]]
+        val action = handlerComponents.getAction(actionClass).asInstanceOf[play.mvc.Action[Object]]
         action.configuration = annotation
         action.delegate = delegate
         action
     }
 
-    val finalAction = components.actionCreator.wrapAction(if (config.executeActionCreatorActionFirst) {
+    val finalAction = handlerComponents.actionCreator.wrapAction(if (config.executeActionCreatorActionFirst) {
       baseAction.delegate = finalUserDeclaredAction
       baseAction
     } else {
@@ -125,8 +129,23 @@ trait JavaHandler extends Handler {
   /**
    * Return a Handler that has the necessary components supplied to execute it.
    */
-  def withComponents(components: JavaHandlerComponents): Handler
+  def withComponents(handlerComponents: JavaHandlerComponents): Handler
 }
+
+trait JavaContextComponents {
+  def messagesApi: JMessagesApi
+  def langs: JLangs
+  def httpConfiguration: HttpConfiguration
+}
+
+/**
+ * The components necessary to handle a play.mvc.Http.Context object.
+ */
+class DefaultJavaContextComponents @Inject() (
+  val messagesApi: JMessagesApi,
+  val langs: JLangs,
+  val httpConfiguration: HttpConfiguration
+) extends JavaContextComponents
 
 trait JavaHandlerComponents {
   def getBodyParser[A <: JBodyParser[_]](parserClass: Class[A]): A
@@ -134,6 +153,7 @@ trait JavaHandlerComponents {
   def actionCreator: play.http.ActionCreator
   def httpConfiguration: HttpConfiguration
   def executionContext: ExecutionContext
+  def contextComponents: JavaContextComponents
 }
 
 /**
@@ -143,7 +163,8 @@ class DefaultJavaHandlerComponents @Inject() (
     injector: Injector,
     val actionCreator: play.http.ActionCreator,
     val httpConfiguration: HttpConfiguration,
-    val executionContext: ExecutionContext
+    val executionContext: ExecutionContext,
+    val contextComponents: JavaContextComponents
 ) extends JavaHandlerComponents {
   def getBodyParser[A <: JBodyParser[_]](parserClass: Class[A]): A = injector.instanceOf(parserClass)
   def getAction[A <: JAction[_]](actionClass: Class[A]): A = injector.instanceOf(actionClass)

--- a/framework/src/play/src/main/scala/play/core/j/JavaHttpErrorHandlerAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHttpErrorHandlerAdapter.scala
@@ -12,13 +12,13 @@ import play.http.{ HttpErrorHandler => JHttpErrorHandler }
 /**
  * Adapter from a Java HttpErrorHandler to a Scala HttpErrorHandler
  */
-class JavaHttpErrorHandlerAdapter @Inject() (underlying: JHttpErrorHandler) extends HttpErrorHandler {
+class JavaHttpErrorHandlerAdapter @Inject() (underlying: JHttpErrorHandler, contextComponents: JavaContextComponents) extends HttpErrorHandler {
 
   def onClientError(request: RequestHeader, statusCode: Int, message: String) = {
-    JavaHelpers.invokeWithContext(request, req => underlying.onClientError(req, statusCode, message))
+    JavaHelpers.invokeWithContext(request, contextComponents, req => underlying.onClientError(req, statusCode, message))
   }
 
   def onServerError(request: RequestHeader, exception: Throwable) = {
-    JavaHelpers.invokeWithContext(request, req => underlying.onServerError(req, exception))
+    JavaHelpers.invokeWithContext(request, contextComponents, req => underlying.onServerError(req, exception))
   }
 }

--- a/framework/src/play/src/main/scala/play/core/routing/HandlerInvoker.scala
+++ b/framework/src/play/src/main/scala/play/core/routing/HandlerInvoker.scala
@@ -100,7 +100,7 @@ object HandlerInvokerFactory {
 
       override def call(call: => A): Handler = new JavaHandler {
         def withComponents(handlerComponents: JavaHandlerComponents): Handler = {
-          new play.core.j.JavaAction(handlerComponents, handlerComponents.contextComponents) {
+          new play.core.j.JavaAction(handlerComponents) {
             override val annotations = cachedAnnotations(handlerComponents.httpConfiguration.actionComposition)
             override val parser = {
               val javaParser = handlerComponents.getBodyParser(annotations.parser)


### PR DESCRIPTION
## Purpose

Extract currentApp() from Http.Context, and inject MessagesApi and Langs from outside using JavaContextComponents.

## Background Context

Http.Context() contains a `messages()` method, so it must be provided from somewhere in the app.  JavaHandlerComponents are used in JavaAction, so DI can be merged in from that point.