### PR TITLE
Update ScalaForms documentation with options example

### DIFF
--- a/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
@@ -210,17 +210,24 @@ When you use this with a view helper, the value of the element will be filled wi
 @helper.inputText(filledForm("name")) @* will render value="Bob" *@
 ```
 
-Fill is especially helpful for helpers that need lists or maps of values, such as the [`select`](api/scala/views/html/helper/select$.html) and [`inputRadioGroup`](api/scala/views/html/helper/inputRadioGroup$.html) helpers.  Use [`options`](api/scala/views/html/helper/options$.html) to value these helpers with lists, maps and pairs.
+Fill is especially helpful for helpers that need lists or maps of values, such as the [`select`](api/scala/views/html/helper/select$.html) and [`inputRadioGroup`](api/scala/views/html/helper/inputRadioGroup$.html) helpers.  Use [`options`](api/scala/views/html/helper/options$.html) to value these helpers with lists, maps and pairs:
 
-```html
-@valueLabels = @{List("A" -> "Ardvark", "B" -> "Banana")}
-@helper.select(filledForm("alphabet"), options(valueLabels)) 
-@* The above will render a select element with options that
-   have values and display values like 
-   <option value="A">Ardvark</option> 
-   <option value="B">Banana</option>
-*@
-```
+A single valued form mapping can set the selected options in a select
+dropdown:
+
+@[addressSelectForm-constraint](code/ScalaForms.scala)
+
+@[addressSelectForm-filled](code/ScalaForms.scala)
+
+And when this is used in a template that sets the options to a list of pairs
+
+@[select-form-define](code/scalaguide/forms/scalaforms/views/select.scala.html)
+
+@[addressSelectForm-options-usage](code/scalaguide/forms/scalaforms/views/select.scala.html)
+
+The filled value will be selected in the dropdown based on the first value of the pair.
+In this case, the U.K. Office will be displayed in the select and the option's value 
+will be London.
 
 ### Nested values
 

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
@@ -212,6 +212,16 @@ When you use this with a view helper, the value of the element will be filled wi
 
 Fill is especially helpful for helpers that need lists or maps of values, such as the [`select`](api/scala/views/html/helper/select$.html) and [`inputRadioGroup`](api/scala/views/html/helper/inputRadioGroup$.html) helpers.  Use [`options`](api/scala/views/html/helper/options$.html) to value these helpers with lists, maps and pairs.
 
+```html
+@valueLabels = @{List("A" -> "Ardvark", "B" -> "Banana")}
+@helper.select(filledForm("alphabet"), options(valueLabels)) 
+@* The above will render a select element with options that
+   have values and display values like 
+   <option value="A">Ardvark</option> 
+   <option value="B">Banana</option>
+*@
+```
+
 ### Nested values
 
 A form mapping can define nested values by using [`Forms.mapping`](api/scala/play/api/data/Forms$.html) inside an existing mapping:

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -127,6 +127,12 @@ class ScalaFormsSpec extends Specification with Controller {
       emailValue must beEqualTo("bob@example.com")
     }
 
+    "fill selects with options and set their defaults" in {
+      val boundForm = controllers.Application.filledAddressSelectForm
+      val html = views.html.select(boundForm)
+      html.body must contain("option value=\"London\" selected")
+    }
+
   }
 }
 
@@ -263,6 +269,23 @@ class Application extends Controller {
     //#userForm-filled
 
     user.name
+  }
+
+  //#addressSelectForm-constraint
+  val addressSelectForm: Form[AddressData] = Form(
+    mapping(
+      "street" -> text,
+      "city" -> text
+    )(AddressData.apply)(AddressData.unapply)
+  )
+  //#addressSelectForm-constraint
+
+  val filledAddressSelectForm = {
+    //#addressSelectForm-filled
+    val selectedFormValues = AddressData(street = "Main St", city = "London")
+    val filledForm = addressSelectForm.fill(selectedFormValues)
+    //#addressSelectForm-filled
+    filledForm
   }
 
   //#userForm-verify

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/select.scala.html
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/select.scala.html
@@ -1,0 +1,16 @@
+@* #select-form-define *@
+@(
+addressData: Form[AddressData], 
+cityOptions: List[(String, String)] = List("New York" -> "U.S. Office", "London" -> "U.K. Office", "Brussels" -> "E.U. Office")
+)(implicit messages: Messages)
+@* #select-form-define *@
+
+@import scalaguide.forms.scalaforms.controllers._
+@import scalaguide.forms.scalaforms.controllers.routes
+
+@helper.form(action = routes.Application.submit) {
+    @* #addressSelectForm-options-usage *@
+    @helper.select(addressData("city"), options = cityOptions) @* Will render the selected city to be the filled value *@
+    @helper.inputText(addressData("street"))
+    @* #addressSelectForm-options-usage *@
+})


### PR DESCRIPTION
This PR adds an example and clarifies how the `options` helper actually converts the list/pairs given to it into values/displays for a `select` helper. 

Previously, it wasn't clear to people who weren't comfortable looking at the source code of the helpers that the first value of the pair would become the value of an input and the second would become the text displayed to the user.

Signed the CLA via the github application. 
