### PR TITLE
Fix path to activator in document

### DIFF
--- a/documentation/manual/gettingStarted/Installing.md
+++ b/documentation/manual/gettingStarted/Installing.md
@@ -61,10 +61,10 @@ Add to your login profile.  Usually, this is `$HOME/.profile`:
 export PATH=/path/to/activator-x.x.x/bin:$PATH
 ```
 
-Make sure that the `activator` script is executable. If it's not:
+Make sure that the `bin/activator` script is executable. If it's not:
 
 ```
-chmod u+x /path/to/activator-x.x.x/activator
+chmod u+x /path/to/activator-x.x.x/bin/activator
 ```
 
 #### Windows

--- a/documentation/manual/gettingStarted/Installing.md
+++ b/documentation/manual/gettingStarted/Installing.md
@@ -61,7 +61,7 @@ Add to your login profile.  Usually, this is `$HOME/.profile`:
 export PATH=/path/to/activator-x.x.x/bin:$PATH
 ```
 
-Make sure that the `bin/activator` script is executable. If it's not:
+Make sure that the `activator` script is executable. If it's not:
 
 ```
 chmod u+x /path/to/activator-x.x.x/bin/activator


### PR DESCRIPTION
This PR simply fixes 2 lines in documentation/manual/gettingStarted/Installing.md,
where the path to activator was wrong.