### PR TITLE
Change CookieBuilder#withMaxAge to accept Duration

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
@@ -78,7 +78,10 @@ public class JavaResponse extends WithApplication {
     public void setCookie() {
         setContext(fakeRequest(), contextComponents());
         //#set-cookie
-        response().setCookie("theme", "blue");
+        response().setCookie(new Cookie(
+            "theme", "blue",
+            null, null, null, false, false
+        ));
         //#set-cookie
         Cookie cookie = response().cookies().iterator().next();
         assertThat(cookie.name(), equalTo("theme"));
@@ -90,7 +93,7 @@ public class JavaResponse extends WithApplication {
     public void detailedSetCookie() {
         setContext(fakeRequest(), contextComponents());
         //#detailed-set-cookie
-        response().setCookie(
+        response().setCookie(new Cookie(
                 "theme",        // name
                 "blue",         // value
                 3600,           // maximum age
@@ -98,7 +101,7 @@ public class JavaResponse extends WithApplication {
                 ".example.com", // domain
                 false,          // secure
                 true            // http only
-        );
+        ));
         //#detailed-set-cookie
         Cookie cookie = response().cookies().iterator().next();
         assertThat(cookie.name(), equalTo("theme"));


### PR DESCRIPTION
Fixes #6626

Also remove several deprecated methods for Java cookies (these have been deprecated since 2.5.0 and are easily rewritten).
