### PR TITLE
Add Injecting trait to WithApplication

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/WithApplication.java
+++ b/framework/src/play-test/src/main/java/play/test/WithApplication.java
@@ -31,6 +31,17 @@ public class WithApplication {
         return Helpers.fakeApplication();
     }
 
+    /**
+     * Provides an instance from the application.
+     *
+     * @param clazz the type's class.
+     * @param <T> the type to return, using `app.injector.instanceOf`
+     * @return an instance of type T.
+     */
+    <T> T inject(Class<T> clazz) {
+        return app.injector().instanceOf(clazz);
+    }
+
     @Before
     public void startPlay() {
         app = provideApplication();

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -22,6 +22,7 @@ import play.twirl.api.Content
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 import scala.language.reflectiveCalls
+import scala.reflect.ClassTag
 
 /**
  * Helper functions to run tests.
@@ -440,6 +441,24 @@ object Helpers extends PlayRunners
   with EssentialActionCaller
   with RouteInvokers
   with FutureAwaits
+
+/**
+ * A trait declared on a class that contains an `def app: Application`, and can provide
+ * instances of a class.  Useful in integration tests.
+ */
+trait Injecting {
+  self: HasApp =>
+
+  /**
+   * Given an application, provides an instance from the application.
+   *
+   * @tparam T the type to return, using `app.injector.instanceOf`
+   * @return an instance of type T.
+   */
+  def inject[T: ClassTag]: T = {
+    self.app.injector.instanceOf
+  }
+}
 
 /**
  * In 99% of cases, when running tests against the result body, you don't actually need a materializer since it's a

--- a/framework/src/play-test/src/main/scala/play/api/test/package.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/package.scala
@@ -11,4 +11,12 @@ package object test {
    * Provided as an implicit by WithServer and WithBrowser.
    */
   type Port = Int
+
+  /**
+   * A structural type indicating there is an application.
+   */
+  type HasApp = {
+    def app: Application
+  }
+
 }

--- a/framework/src/play-test/src/test/java/play/test/WithApplicationTest.java
+++ b/framework/src/play-test/src/test/java/play/test/WithApplicationTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.test;
+
+import org.junit.Test;
+import play.i18n.MessagesApi;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests WithApplication functionality.
+ */
+public class WithApplicationTest extends WithApplication {
+
+    @Test
+    public void withInject() {
+        MessagesApi messagesApi = inject(MessagesApi.class);
+        assertNotNull(messagesApi);
+    }
+}

--- a/framework/src/play-test/src/test/scala/play/api/test/InjectingSpec.scala
+++ b/framework/src/play-test/src/test/scala/play/api/test/InjectingSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.test
+
+import org.specs2.mock.Mockito
+import org.specs2.mutable._
+import play.api.Application
+import play.api.inject.Injector
+
+import scala.language.reflectiveCalls
+
+class InjectingSpec extends Specification with Mockito {
+
+  class Foo
+
+  class AppContainer(val app: Application)
+
+  "Injecting trait" should {
+
+    "provide an instance when asked for a class" in {
+      val injector = mock[Injector]
+      val app = mock[Application]
+      app.injector returns injector
+      val expected = new Foo
+      injector.instanceOf[Foo] returns expected
+
+      val appContainer = new AppContainer(app) with Injecting
+      val actual: Foo = appContainer.inject[Foo]
+      actual must_== expected
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Adds a `Providing` trait to make access to components in functional testing a bit easier.

## Background Context

Using `app.injector.instanceOf[Foo]` all the time is not all that fun, and this provides a more direct experience to the end user, who really shouldn't have to care about the injector per se.
