### PR TITLE
Use the Akka ExecutionContext to execute actions

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -194,6 +194,18 @@ trait FiltersSpec extends Specification with ServerIntegrationSpecification {
       response.body must_== ThrowExceptionFilter.expectedText
     }
 
+    object ThreadNameFilter extends EssentialFilter {
+      def apply(next: EssentialAction): EssentialAction = EssentialAction { req =>
+        Accumulator.done(Results.Ok(Thread.currentThread().getName))
+      }
+    }
+
+    "Filters should use the Akka ExecutionContext" in withServer()(ThreadNameFilter) { ws =>
+      val result = Await.result(ws.url("/ok").get(), Duration.Inf)
+      val threadName = result.body
+      threadName must startWith("application-akka.actor.default-dispatcher-")
+    }
+
     val filterAddedHeaderKey = "CUSTOM_HEADER"
     val filterAddedHeaderVal = "custom header val"
 

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -257,10 +257,10 @@ private[play] class PlayRequestHandler(val server: NettyServer) extends ChannelI
     import play.core.Execution.Implicits.trampoline
 
     for {
+      bodyParser <- Future(action(requestHeader))(mat.executionContext)
       // Execute the action and get a result
       actionResult <- {
         val body = modelConversion.convertRequestBody(request)
-        val bodyParser = action(requestHeader)
         (body match {
           case None => bodyParser.run()
           case Some(source) => bodyParser.run(source)


### PR DESCRIPTION
This makes sure the Netty server always uses Akka's ExecutionContext to execute actions (like we did in 2.4.x), rather than using the Netty thread.

/cc @jroper 