### PR TITLE
Remove incorrect occurrence of ".admin." in HTTP Routing docs

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/JavaRouting.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaRouting.md
@@ -157,7 +157,7 @@ You can then reverse the URL to the `hello` action method, by using the `control
 
 @[reverse-redirect](code/javaguide/http/routing/controllers/Application.java)
 
-> **Note:** There is a `routes` subpackage for each controller package. So the action `controllers.admin.Application.hello` can be reversed via `controllers.admin.routes.Application.hello` (as long as there is no other route before it in the routes file that happens to match the generated path).
+> **Note:** There is a `routes` subpackage for each controller package. So the action `controllers.Application.hello` can be reversed via `controllers.routes.Application.hello` (as long as there is no other route before it in the routes file that happens to match the generated path).
 
 The reverse action method works quite simply: it takes your parameters and substitutes them back into the route pattern.  In the case of path segments (`:foo`), the value is encoded before the substitution is done.  For regex and wildcard patterns the string is substituted in raw form, since the value may span multiple segments.  Make sure you escape those components as desired when passing them to the reverse route, and avoid passing unvalidated user input.
 

--- a/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
@@ -160,7 +160,7 @@ You can then reverse the URL to the `hello` action method, by using the `control
 
 @[reverse-router](code/ScalaRouting.scala)
 
-> **Note:** There is a `routes` subpackage for each controller package. So the action `controllers.admin.Application.hello` can be reversed via `controllers.admin.routes.Application.hello` (as long as there is no other route before it in the routes file that happens to match the generated path).
+> **Note:** There is a `routes` subpackage for each controller package. So the action `controllers.Application.hello` can be reversed via `controllers.routes.Application.hello` (as long as there is no other route before it in the routes file that happens to match the generated path).
 
 The reverse action method works quite simply: it takes your parameters and substitutes them back into the route pattern.  In the case of path segments (`:foo`), the value is encoded before the substitution is done.  For regex and wildcard patterns the string is substituted in raw form, since the value may span multiple segments.  Make sure you escape those components as desired when passing them to the reverse route, and avoid passing unvalidated user input.
 


### PR DESCRIPTION
The source code above the text I've changed refers to `controllers.routes.Application` and `controllers.Application`, and not `controllers.admin.routes.Application` and `controllers.admin.Application`.

I therefore removed the `.admin` - which is otherwise inconsistent with the preceding code.

Introducing a different namespace placement of the Application in this paragraph could confuse the reader.

One can see the rendering of the code and document here, for review:

https://playframework.com/documentation/2.5.6/ScalaRouting#reverse-routing

https://playframework.com/documentation/2.5.6/JavaRouting#reverse-routing
