### PR TITLE
Add failing test for `dist` task with invalid docs

### DIFF
--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-invalid-api/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-invalid-api/app/controllers/Application.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package controllers
+
+import play.api._
+import play.api.mvc._
+
+import javax.inject.Inject
+
+/**
+ * @see [[invalid link]]
+ */
+class Application @Inject() extends Controller {
+  def index = TODO
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-invalid-api/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-invalid-api/build.sbt
@@ -1,0 +1,15 @@
+//
+// Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+//
+
+name := "dist-sample"
+version := "1.0-SNAPSHOT"
+
+lazy val root = (project in file(".")).enablePlugins(PlayScala)
+
+libraryDependencies += guice
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.8")
+scalacOptions +="-Xfatal-warnings"
+
+routesGenerator := InjectedRoutesGenerator

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-invalid-api/conf/routes
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-invalid-api/conf/routes
@@ -1,0 +1,9 @@
+# Routes
+# This file defines all application routes (Higher priority routes first)
+# ~~~~
+
+# Home page
+GET        /                    controllers.Application.index
+
+# Map static resources from the /public folder to the /assets URL path
+GET        /assets/*file        controllers.Assets.at(path="/public", file)

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-invalid-api/project/build.properties
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-invalid-api/project/build.properties
@@ -1,0 +1,4 @@
+#
+# Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+#
+sbt.version=0.13.11

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-invalid-api/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-invalid-api/project/plugins.sbt
@@ -1,0 +1,7 @@
+//
+// Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+//
+
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.0")

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-invalid-api/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-invalid-api/test
@@ -1,0 +1,7 @@
+# Build the distribution and ensure that the files we expect are indeed there
+> stage
+$ exists target/universal/stage/README
+$ exists target/universal/stage/SomeFile.txt
+$ exists target/universal/stage/SomeFolder/SomeOtherFile.txt
+$ exists target/universal/stage/lib/dist-sample.dist-sample-1.0-SNAPSHOT-sans-externalized.jar
+-$ exists target/universal/stage/lib/dist-sample.dist-sample-1.0-SNAPSHOT.jar


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

This is a failing test for #6688.

I suggested an `AutoPlugin` in the ticket to extract [this behaviour](https://github.com/playframework/playframework/blob/2.5.x/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala#L219-L227) and make in configurable.

## Fixes

Fixes #6688

## Purpose

Provides a failing test, when the API documentation can't be built. We currently can't workaround
the [simulacrum](https://github.com/mpilquist/simulacrum) generated docs.
