### PR TITLE
Upgrade to Scala 2.12

### DIFF
--- a/documentation/manual/working/commonGuide/assets/code/assets/controllers/RangeRequestController.scala
+++ b/documentation/manual/working/commonGuide/assets/code/assets/controllers/RangeRequestController.scala
@@ -4,10 +4,11 @@
 package assets.controllers
 
 import java.io.File
+import javax.inject.Inject
 
 import play.api.mvc._
 
-class RangeRequestController extends Controller {
+class RangeRequestController @Inject()(c: ControllerComponents) extends AbstractController(c) {
 
   // #range-request
   def video(videoId: Long) = Action { implicit request =>

--- a/documentation/manual/working/commonGuide/configuration/code/ThreadPools.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/ThreadPools.scala
@@ -16,7 +16,6 @@ import scala.concurrent.{ExecutionContext, Future, TimeoutException}
 import org.specs2.execute.AsResult
 
 class ThreadPoolsSpec extends PlaySpecification {
-  import scala.concurrent.ExecutionContext.Implicits.global
 
   "Play's thread pools" should {
 

--- a/documentation/manual/working/commonGuide/filters/SecurityHeaders.md
+++ b/documentation/manual/working/commonGuide/filters/SecurityHeaders.md
@@ -25,7 +25,7 @@ play.http.filters = "filters.MyFilters"
 
 ## Configuring the security headers
 
-Scaladoc is available in the [play.filters.headers](api/scala/play/filters/headers/package.html) package.
+Scaladoc is available in the [play.filters.headers](api/scala/play/filters/headers/) package.
 
 The filter will set headers in the HTTP response automatically.  The settings can be configured through the following settings in `application.conf`
 

--- a/documentation/manual/working/commonGuide/filters/code/GzipEncoding.scala
+++ b/documentation/manual/working/commonGuide/filters/code/GzipEncoding.scala
@@ -5,7 +5,6 @@ package detailedtopics.configuration.gzipencoding
 
 import akka.stream.ActorMaterializer
 import play.api.test._
-import detailedtopics.configuration.gzipencoding.CustomFilters
 
 class GzipEncoding extends PlaySpecification {
 

--- a/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/gzipencoding/CustomFilters.java
+++ b/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/gzipencoding/CustomFilters.java
@@ -8,8 +8,11 @@ import play.mvc.EssentialFilter;
 import play.filters.gzip.GzipFilter;
 import play.filters.gzip.GzipFilterConfig;
 import play.http.HttpFilters;
+import play.mvc.Http;
+import play.mvc.Result;
 
 import javax.inject.Inject;
+import java.util.function.BiFunction;
 
 public class CustomFilters implements HttpFilters {
 
@@ -18,8 +21,9 @@ public class CustomFilters implements HttpFilters {
     @Inject
     public CustomFilters(Materializer materializer) {
         //#gzip-filter
+        GzipFilterConfig gzipFilterConfig = new GzipFilterConfig();
         GzipFilter gzipFilter = new GzipFilter(
-          new GzipFilterConfig().withShouldGzip((req, res) ->
+          gzipFilterConfig.withShouldGzip((BiFunction<Http.RequestHeader, Result, Object>) (req, res) ->
             res.body().contentType().orElse("").startsWith("text/html")
           ), materializer
         );

--- a/documentation/manual/working/scalaGuide/advanced/routing/ScalaSirdRouter.md
+++ b/documentation/manual/working/scalaGuide/advanced/routing/ScalaSirdRouter.md
@@ -5,7 +5,7 @@ Play provides a DSL for defining embedded routers called the *String Interpolati
 
 Sird is based on a string interpolated extractor object.  Just as Scala supports interpolating parameters into strings for building strings (and any object for that matter), such as `s"Hello $to"`, the same mechanism can also be used to extract parameters out of strings, for example in case statements.
 
-The DSL lives in the [`play.api.routing.sird`](api/scala/play/api/routing/sird/package.html) package. Typically, you will want to import this package, as well as a few other packages:
+The DSL lives in the [`play.api.routing.sird`](api/scala/play/api/routing/sird/) package. Typically, you will want to import this package, as well as a few other packages:
 
 @[imports](code/ScalaSirdRouter.scala)
 

--- a/documentation/manual/working/scalaGuide/main/akka/code/ScalaAkka.scala
+++ b/documentation/manual/working/scalaGuide/main/akka/code/ScalaAkka.scala
@@ -9,7 +9,6 @@ import org.specs2.runner.JUnitRunner
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
 import play.api.test._
 import java.io.File
 
@@ -43,7 +42,7 @@ class ScalaAkkaSpec extends PlaySpecification {
       import play.api.mvc.Results._
       import actors.HelloActor.SayHello
 
-
+      import scala.concurrent.ExecutionContext.Implicits.global
       //#ask
       import scala.concurrent.duration._
       import akka.pattern.ask
@@ -79,6 +78,7 @@ class ScalaAkkaSpec extends PlaySpecification {
       import akka.pattern.ask
       implicit val timeout: Timeout = 5.seconds
 
+      import scala.concurrent.ExecutionContext.Implicits.global
       val actor = app.injector.instanceOf(bind[ActorRef].qualifiedWith("parent-actor"))
       val futureConfig = for {
         child <- (actor ? actors.ParentActor.GetChild("my.config")).mapTo[ActorRef]
@@ -95,6 +95,7 @@ class ScalaAkkaSpec extends PlaySpecification {
       //#schedule-actor
       import scala.concurrent.duration._
 
+      import scala.concurrent.ExecutionContext.Implicits.global
       val cancellable = system.scheduler.schedule(
         0.microseconds, 300.microseconds, testActor, "tick")
       //#schedule-actor
@@ -104,6 +105,7 @@ class ScalaAkkaSpec extends PlaySpecification {
     "actor scheduler" in withActorSystem { system =>
       val file = new File("/tmp/nofile")
       file.mkdirs()
+      import scala.concurrent.ExecutionContext.Implicits.global
       //#schedule-callback
       system.scheduler.scheduleOnce(10.milliseconds) {
         file.delete()

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaCustomValidations.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaCustomValidations.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
 # Using Custom Validations
 
-The [validation package](api/scala/play/api/data/validation/package.html) allows you to create ad-hoc constraints using the `verifying` method.  However, Play gives you the option of creating your own custom constraints, using the [`Constraint`](api/scala/play/api/data/validation/Constraint.html) case class.
+The [validation package](api/scala/play/api/data/validation/) allows you to create ad-hoc constraints using the `verifying` method.  However, Play gives you the option of creating your own custom constraints, using the [`Constraint`](api/scala/play/api/data/validation/Constraint.html) case class.
 
 Here, we'll implement a simple password strength constraint that uses regular expressions to check the password is not all letters or all numbers.  A [`Constraint`](api/scala/play/api/data/validation/Constraint.html) takes a function which returns a [`ValidationResult`](api/scala/play/api/data/validation/ValidationResult.html), and we use that function to return the results of the password check:
 

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
@@ -84,7 +84,7 @@ The out of the box constraints are defined on the [Forms object](api/scala/play/
 
 ### Defining ad-hoc constraints
 
-You can define your own ad-hoc constraints on the case classes using the [validation package](api/scala/play/api/data/validation/package.html).
+You can define your own ad-hoc constraints on the case classes using the [validation package](api/scala/play/api/data/validation/).
 
 @[userForm-constraints](code/ScalaForms.scala)
 
@@ -130,7 +130,7 @@ The first thing is to be able to create the [form tag](api/scala/views/html/help
 
 @[form-user](code/scalaguide/forms/scalaforms/views/user.scala.html)
 
-You can find several input helpers in the [`views.html.helper`](api/scala/views/html/helper/package.html) package. You feed them with a form field, and they display the corresponding HTML input, setting the value, constraints and displaying errors when a form binding fails.
+You can find several input helpers in the [`views.html.helper`](api/scala/views/html/helper/) package. You feed them with a form field, and they display the corresponding HTML input, setting the value, constraints and displaying errors when a form binding fails.
 
 > **Note:** You can use `@import helper._` in the template to avoid prefixing helpers with `@helper.`
 

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -266,7 +266,6 @@ class ScalaActionsCompositionSpec extends Specification with Controller {
         }
       //#item-action-use
 
-      import scala.concurrent.ExecutionContext.Implicits.global
       testAction(tagItem("foo", "bar"), expectedResponse = FORBIDDEN)
     }
 

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
@@ -18,13 +18,13 @@ import org.specs2.execute.AsResult
 
   @RunWith(classOf[JUnitRunner])
   class ScalaBodyParsersSpec extends Specification with Controller {
-    import scala.concurrent.ExecutionContext.Implicits.global
 
     def helloRequest = FakeRequest("POST", "/").withJsonBody(Json.obj("name" -> "foo"))
 
     "A scala body parser" should {
 
       "parse request as json" in {
+        import scala.concurrent.ExecutionContext.Implicits.global
         //#access-json-body
         def save = Action { request =>
           val body: AnyContent = request.body
@@ -130,7 +130,7 @@ import org.specs2.execute.AsResult
       }
 
       "parse the body as csv" in new WithApplication() {
-
+        import scala.concurrent.ExecutionContext.Implicits.global
         //#csv
         import play.api.mvc._
         import play.api.libs.streams._

--- a/documentation/manual/working/scalaGuide/main/json/ScalaJson.md
+++ b/documentation/manual/working/scalaGuide/main/json/ScalaJson.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
 # JSON basics
 
-Modern web applications often need to parse and generate data in the JSON (JavaScript Object Notation) format. Play supports this via its [JSON library](api/scala/play/api/libs/json/package.html).
+Modern web applications often need to parse and generate data in the JSON (JavaScript Object Notation) format. Play supports this via its [JSON library](api/scala/play/api/libs/json/).
 
 JSON is a lightweight data-interchange format and looks like this:
 
@@ -28,7 +28,7 @@ JSON is a lightweight data-interchange format and looks like this:
 
 ## The Play JSON library
 
-The [`play.api.libs.json`](api/scala/play/api/libs/json/package.html) package contains data structures for representing JSON data and utilities for converting between these data structures and other data representations. Some of the features of this package are:
+The [`play.api.libs.json`](api/scala/play/api/libs/json/) package contains data structures for representing JSON data and utilities for converting between these data structures and other data representations. Some of the features of this package are:
 
  - [[Automatic conversion|ScalaJsonAutomated]] to and from case classes with minimal boilerplate. If you want to get up and running quickly with minimal code, this is probably the place to start.
  - [[Custom validation|ScalaJsonCombinators#Validation-with-Reads]] while parsing.

--- a/documentation/manual/working/scalaGuide/main/json/ScalaJsonCombinators.md
+++ b/documentation/manual/working/scalaGuide/main/json/ScalaJsonCombinators.md
@@ -15,7 +15,7 @@ The examples on this page will use this `JsValue` structure and corresponding mo
 
 @[jspath-define](code/ScalaJsonCombinatorsSpec.scala)
 
-The [`play.api.libs.json`](api/scala/play/api/libs/json/package.html) package defines an alias for `JsPath`: `__` (double underscore). You can use this if you prefer:
+The [`play.api.libs.json`](api/scala/play/api/libs/json/) package defines an alias for `JsPath`: `__` (double underscore). You can use this if you prefer:
 
 @[jspath-define-alias](code/ScalaJsonCombinatorsSpec.scala)
 

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
 # Writing functional tests with specs2
 
-Play provides a number of classes and convenience methods that assist with functional testing.  Most of these can be found either in the [`play.api.test`](api/scala/play/api/test/package.html) package or in the [`Helpers`](api/scala/play/api/test/Helpers$.html) object.
+Play provides a number of classes and convenience methods that assist with functional testing.  Most of these can be found either in the [`play.api.test`](api/scala/play/api/test/) package or in the [`Helpers`](api/scala/play/api/test/Helpers$.html) object.
 
 You can add these methods and classes by importing the following:
 

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com> -->
 # The Play WS API
 
-Sometimes we would like to call other HTTP services from within a Play application. Play supports this via its [WS library](api/scala/play/api/libs/ws/package.html), which provides a way to make asynchronous HTTP calls through a WSClient instance.
+Sometimes we would like to call other HTTP services from within a Play application. Play supports this via its [WS library](api/scala/play/api/libs/ws/), which provides a way to make asynchronous HTTP calls through a WSClient instance.
 
 There are two important parts to using the WSClient: making a request, and processing the response.  We'll discuss how to make both GET and POST HTTP requests first, and then show how to process the response from WSClient.  Finally, we'll discuss some common use cases.
 

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOAuthSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOAuthSpec.scala
@@ -5,21 +5,20 @@ package scalaguide.ws.scalaoauth
 
 import play.api.test._
 
+import scala.concurrent.ExecutionContext
+
 //#dependency
 import javax.inject.Inject
 import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
 
-import play.api._
 import play.api.mvc._
-import play.api.data._
-import play.api.data.Forms._
 import play.api.libs.oauth._
 import play.api.libs.ws._
 
-class HomeController @Inject()(wsClient:WSClient) extends Controller {
-
-}
+class HomeController @Inject()(val wsClient: WSClient,
+                               c: ControllerComponents)
+                              (implicit val ec: ExecutionContext)
+  extends AbstractController(c)
 //#dependency
 
 
@@ -30,70 +29,67 @@ object routes {
   }
 }
 
-
 class ScalaOAuthSpec extends PlaySpecification {
 
   "Scala OAuth" should {
-    "be injectable" in new WithApplication() {
-      app.injector.instanceOf[Application] must beAnInstanceOf[Application]
-    }
-  }
+    "be injectable" in new WithApplication() with Injecting {
+      val controller = new HomeController(inject[WSClient], inject[ControllerComponents])(inject[ExecutionContext]) {
+        //#flow
+        val KEY = ConsumerKey("xxxxx", "xxxxx")
 
-  def wsClient: WSClient = null
+        val oauth = OAuth(ServiceInfo(
+          "https://api.twitter.com/oauth/request_token",
+          "https://api.twitter.com/oauth/access_token",
+          "https://api.twitter.com/oauth/authorize", KEY),
+          true)
 
-  import play.api.mvc.Results._
-  //#flow
-  val KEY = ConsumerKey("xxxxx", "xxxxx")
-
-  val oauth = OAuth(ServiceInfo(
-    "https://api.twitter.com/oauth/request_token",
-    "https://api.twitter.com/oauth/access_token",
-    "https://api.twitter.com/oauth/authorize", KEY),
-    true)
-
-  def sessionTokenPair(implicit request: RequestHeader): Option[RequestToken] = {
-    for {
-      token <- request.session.get("token")
-      secret <- request.session.get("secret")
-    } yield {
-      RequestToken(token, secret)
-    }
-  }
-
-  def authenticate = Action { request =>
-    request.getQueryString("oauth_verifier").map { verifier =>
-      val tokenPair = sessionTokenPair(request).get
-      // We got the verifier; now get the access token, store it and back to index
-      oauth.retrieveAccessToken(tokenPair, verifier) match {
-        case Right(t) => {
-          // We received the authorized tokens in the OAuth object - store it before we proceed
-          Redirect(routes.Application.index).withSession("token" -> t.token, "secret" -> t.secret)
+        def sessionTokenPair(implicit request: RequestHeader): Option[RequestToken] = {
+          for {
+            token <- request.session.get("token")
+            secret <- request.session.get("secret")
+          } yield {
+            RequestToken(token, secret)
+          }
         }
-        case Left(e) => throw e
-      }
-    }.getOrElse(
-      oauth.retrieveRequestToken("https://localhost:9000/auth") match {
-        case Right(t) => {
-          // We received the unauthorized tokens in the OAuth object - store it before we proceed
-          Redirect(oauth.redirectUrl(t.token)).withSession("token" -> t.token, "secret" -> t.secret)
-        }
-        case Left(e) => throw e
-      })
-  }
-  //#flow
 
-  //#extended
-  def timeline = Action.async { implicit request =>
-    sessionTokenPair match {
-      case Some(credentials) => {
-        wsClient.url("https://api.twitter.com/1.1/statuses/home_timeline.json")
-          .sign(OAuthCalculator(KEY, credentials))
-          .get
-          .map(result => Ok(result.json))
+        def authenticate = Action { request: Request[AnyContent] =>
+          request.getQueryString("oauth_verifier").map { verifier =>
+            val tokenPair = sessionTokenPair(request).get
+            // We got the verifier; now get the access token, store it and back to index
+            oauth.retrieveAccessToken(tokenPair, verifier) match {
+              case Right(t) => {
+                // We received the authorized tokens in the OAuth object - store it before we proceed
+                Redirect(routes.Application.index).withSession("token" -> t.token, "secret" -> t.secret)
+              }
+              case Left(e) => throw e
+            }
+          }.getOrElse(
+            oauth.retrieveRequestToken("https://localhost:9000/auth") match {
+              case Right(t) => {
+                // We received the unauthorized tokens in the OAuth object - store it before we proceed
+                Redirect(oauth.redirectUrl(t.token)).withSession("token" -> t.token, "secret" -> t.secret)
+              }
+              case Left(e) => throw e
+            })
+        }
+        //#flow
+
+        //#extended
+        def timeline = Action.async { implicit request: Request[AnyContent] =>
+          sessionTokenPair match {
+            case Some(credentials) => {
+              wsClient.url("https://api.twitter.com/1.1/statuses/home_timeline.json")
+                .sign(OAuthCalculator(KEY, credentials))
+                .get
+                .map(result => Ok(result.json))
+            }
+            case _ => Future.successful(Redirect(routes.Application.authenticate))
+          }
+        }
+        //#extended
       }
-      case _ => Future.successful(Redirect(routes.Application.authenticate))
+      controller must beAnInstanceOf[HomeController]
     }
   }
-  //#extended
 
 }

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaOpenIdSpec.scala
@@ -5,10 +5,11 @@ package scalaguide.ws.scalaopenid
 
 import play.api.test._
 
+import scala.concurrent.ExecutionContext
+
 //#dependency
 import javax.inject.Inject
 import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
 
 import play.api._
 import play.api.mvc._
@@ -16,60 +17,58 @@ import play.api.data._
 import play.api.data.Forms._
 import play.api.libs.openid._
 
-class Application @Inject() (openIdClient: OpenIdClient) extends Controller {
-
-}
+class IdController @Inject() (val openIdClient: OpenIdClient,
+                              c: ControllerComponents)
+                             (implicit val ec: ExecutionContext)
+  extends AbstractController(c)
 //#dependency
 
 
 class ScalaOpenIdSpec extends PlaySpecification {
 
   "Scala OpenId" should {
-    "be injectable" in new WithApplication() {
-      app.injector.instanceOf[Application] must beAnInstanceOf[Application]
+    "be injectable" in new WithApplication() with Injecting {
+      val controller = new IdController(inject[OpenIdClient], inject[ControllerComponents])(inject[ExecutionContext]) {
+        //#flow
+        def login = Action {
+          Ok(views.html.login())
+        }
+
+        def loginPost = Action.async { implicit request =>
+          Form(single(
+            "openid" -> nonEmptyText
+          )).bindFromRequest.fold({ error =>
+            Logger.info(s"bad request ${error.toString}")
+            Future.successful(BadRequest(error.toString))
+          }, { openId =>
+            openIdClient.redirectURL(openId, routes.Application.openIdCallback.absoluteURL())
+              .map(url => Redirect(url))
+              .recover { case t: Throwable => Redirect(routes.Application.login)}
+          })
+        }
+
+        def openIdCallback = Action.async { implicit request: Request[AnyContent] =>
+          openIdClient.verifiedId(request).map(info => Ok(info.id + "\n" + info.attributes))
+            .recover {
+              case t: Throwable =>
+                // Here you should look at the error, and give feedback to the user
+                Redirect(routes.Application.login)
+            }
+        }
+        //#flow
+
+        def extended(openId: String)(implicit request: RequestHeader) = {
+          //#extended
+          openIdClient.redirectURL(
+            openId,
+            routes.Application.openIdCallback.absoluteURL(),
+            Seq("email" -> "http://schema.openid.net/contact/email")
+          )
+          //#extended
+        }
+      }
+      controller must beAnInstanceOf[IdController]
     }
-  }
-
-  def openIdClient: OpenIdClient = null
-
-  import play.api.mvc.Results._
-
-  //#flow
-  def login = Action {
-    Ok(views.html.login())
-  }
-
-  def loginPost = Action.async { implicit request =>
-    Form(single(
-      "openid" -> nonEmptyText
-    )).bindFromRequest.fold({ error =>
-      Logger.info(s"bad request ${error.toString}")
-      Future.successful(BadRequest(error.toString))
-    }, { openId =>
-      openIdClient.redirectURL(openId, routes.Application.openIdCallback.absoluteURL())
-        .map(url => Redirect(url))
-        .recover { case t: Throwable => Redirect(routes.Application.login)}
-    })
-  }
-
-  def openIdCallback = Action.async { implicit request =>
-    openIdClient.verifiedId(request).map(info => Ok(info.id + "\n" + info.attributes))
-      .recover {
-      case t: Throwable =>
-        // Here you should look at the error, and give feedback to the user
-        Redirect(routes.Application.login)
-    }
-  }
-  //#flow
-
-  def extended(openId: String)(implicit request: RequestHeader) = {
-    //#extended
-    openIdClient.redirectURL(
-      openId,
-      routes.Application.openIdCallback.absoluteURL(),
-      Seq("email" -> "http://schema.openid.net/contact/email")
-    )
-    //#extended
   }
 }
 

--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -104,7 +104,7 @@ lazy val PlayAkkaHttpServerProject = PlayCrossBuiltProject("Play-Akka-Http-Serve
     .settings(libraryDependencies ++= akkaHttp)
     // Include scripted tests here as well as in the SBT Plugin, because we
     // don't want the SBT Plugin to have a dependency on an experimental module.
-    .settings(playFullScriptedSettings: _*)
+    //.settings(ScriptedPlugin.scriptedSettings ++ playScriptedSettings)
     .dependsOn(PlayServerProject, StreamsProject)
     .dependsOn(PlaySpecs2Project % "test", PlayWsProject % "test")
 

--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -150,6 +150,13 @@ lazy val PlaySpecs2Project = PlayCrossBuiltProject("Play-Specs2", "play-specs2")
 
 lazy val PlayJavaProject = PlayCrossBuiltProject("Play-Java", "play-java")
     .settings(libraryDependencies ++= javaDeps ++ javaTestDeps)
+    .settings(
+      // work around the stackoverflow bug in 2.12.0
+      resolvers += "nightlies" at
+        "https://scala-ci.typesafe.com/artifactory/scala-release-temp/",
+      scalaVersion := "2.12.1-371bc2c-nightly",
+      scalaBinaryVersion := "2.12"
+    )
     .dependsOn(
       PlayProject % "compile;test->test",
       PlayTestProject % "test",

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -56,6 +56,14 @@ object BuildSettings {
         Resolver.typesafeRepo("releases"),
         Resolver.typesafeIvyRepo("releases")
       ),
+      scalacOptions in(Compile, doc) := {
+        // disable the new scaladoc feature for scala 2.12.0, might be removed in 2.12.0-1 (https://github.com/scala/scala-dev/issues/249)
+        if (scalaVersion.value == "2.12.0") {
+          Seq("-no-java-comments")
+        } else {
+          Seq()
+        }
+      },
       fork in Test := true,
       parallelExecution in Test := false,
       testListeners in (Test,test) := Nil,
@@ -193,7 +201,7 @@ object BuildSettings {
     scriptedLaunchOpts ++= Seq(
       "-Xmx768m",
       maxMetaspace,
-      "-Dscala.version=" + sys.props.get("scripted.scala.version").getOrElse(sys.props.get("scala.version").getOrElse("2.11.8"))
+      "-Dscala.version=" + sys.props.get("scripted.scala.version").getOrElse(sys.props.get("scala.version").getOrElse("2.12.0"))
     )
   )
 

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -7,7 +7,7 @@ import buildinfo.BuildInfo
 object Dependencies {
 
   val akkaVersion = "2.4.12"
-  val akkaHttpVersion = "10.0.0-RC2"
+  val akkaHttpVersion = "10.0.0"
 
   val specsVersion = "3.8.6"
   val specsBuild = Seq(

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -7,7 +7,7 @@ import buildinfo.BuildInfo
 object Dependencies {
 
   val akkaVersion = "2.4.12"
-  val akkaHttpVersion = "2.4.11"
+  val akkaHttpVersion = "10.0.0-RC2"
 
   val specsVersion = "3.8.6"
   val specsBuild = Seq(
@@ -55,7 +55,7 @@ object Dependencies {
     "org.hibernate" % "hibernate-entitymanager" % "5.1.0.Final" % "test"
   )
 
-  val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0-RC7"
+  val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0"
   def scalaParserCombinators(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, major)) if major >= 11 => Seq("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4")
     case _ => Nil
@@ -145,8 +145,7 @@ object Dependencies {
   val nettyUtilsDependencies = slf4j
 
   val akkaHttp = Seq(
-    "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion,
-    "com.typesafe.akka" %% "akka-http-experimental" % akkaHttpVersion
+    "com.typesafe.akka" %% "akka-http" % akkaHttpVersion
   )
 
   def routesCompilerDependencies(scalaVersion: String) = Seq(
@@ -203,8 +202,9 @@ object Dependencies {
     "org.webjars" % "prettify" % "4-Mar-2013" % "webjars"
   )
 
+  val playDocVersion = "1.7.0"
   val playDocsDependencies = Seq(
-    "com.typesafe.play" %% "play-doc" % "1.6.0"
+    "com.typesafe.play" %% "play-doc" % playDocVersion
   ) ++ playdocWebjarDependencies
 
   val streamsDependencies = Seq(
@@ -257,7 +257,7 @@ object Dependencies {
     mockitoAll % Test
 
   val playDocsSbtPluginDependencies = Seq(
-    "com.typesafe.play" %% "play-doc" % "1.3.0"
+    "com.typesafe.play" %% "play-doc" % playDocVersion
   )
 
 }

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -5,7 +5,7 @@ buildInfoSettings
 sourceGenerators in Compile += Def.task(buildInfo.value).taskValue
 
 val sbtNativePackagerVersion = "1.1.1"
-val sbtTwirlVersion = sys.props.getOrElse("twirl.version", "1.2.0")
+val sbtTwirlVersion = sys.props.getOrElse("twirl.version", "1.3.0")
 
 buildInfoKeys := Seq[BuildInfoKey](
   "sbtNativePackagerVersion" -> sbtNativePackagerVersion,
@@ -16,7 +16,7 @@ logLevel := Level.Warn
 
 scalacOptions ++= Seq("-deprecation", "-language:_")
 
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "1.1.2"))
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "1.3.0"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % sbtTwirlVersion)
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.8")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/build.sbt
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/build.sbt
@@ -8,7 +8,7 @@ lazy val root = (project in file("."))
 
 name := "compiled-class"
 
-scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.8")
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.12.0")
 
 // Change our tests directory because the usual "test" directory clashes
 // with the scripted "test" file.

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/project/MediatorWorkaround.scala
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/play-akka-http-plugin/project/MediatorWorkaround.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+// Track https://github.com/sbt/sbt/issues/2786
+object MediatorWorkaround extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+  override def projectSettings =
+    Seq(
+      ivyScala := { ivyScala.value map {_.copy(overrideScalaVersion = sbtPlugin.value)} }
+    )
+}

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/system-property/build.sbt
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/system-property/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 name := "system-property"
 
-scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.8")
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.12.0")
 
 // because the "test" directory clashes with the scripted test file
 scalaSource in Test := (baseDirectory.value / "tests")

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/system-property/project/MediatorWorkaround.scala
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/system-property/project/MediatorWorkaround.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+// Track https://github.com/sbt/sbt/issues/2786
+object MediatorWorkaround extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+  override def projectSettings =
+    Seq(
+      ivyScala := { ivyScala.value map {_.copy(overrideScalaVersion = sbtPlugin.value)} }
+    )
+}

--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -122,7 +122,8 @@ trait Action[A] extends EssentialAction {
  * @tparam A the body content type
  */
 trait BodyParser[+A] extends (RequestHeader => Accumulator[ByteString, Either[Result, A]]) {
-  self =>
+  // "with Any" because we need to prevent 2.12 SAM inference here
+  self: BodyParser[A] with Any =>
 
   /**
    * Uses the provided function to transform the BodyParser's computed result
@@ -367,7 +368,7 @@ trait ActionBuilder[+R[_], B] extends ActionFunction[Request, R] {
    * For example:
    * {{{
    * val hello = Action.async {
-   *   WS.url("http://www.playframework.com").get().map { r =>
+   *   ws.url("http://www.playframework.com").get().map { r =>
    *     if (r.status == 200) Ok("The website is up") else NotFound("The website is down")
    *   }
    * }
@@ -385,7 +386,7 @@ trait ActionBuilder[+R[_], B] extends ActionFunction[Request, R] {
    * For example:
    * {{{
    * val hello = Action.async { request =>
-   *   WS.url(request.getQueryString("url").get).get().map { r =>
+   *   ws.url(request.getQueryString("url").get).get().map { r =>
    *     if (r.status == 200) Ok("The website is up") else NotFound("The website is down")
    *   }
    * }
@@ -402,7 +403,7 @@ trait ActionBuilder[+R[_], B] extends ActionFunction[Request, R] {
    * For example:
    * {{{
    * val hello = Action.async { request =>
-   *   WS.url(request.getQueryString("url").get).get().map { r =>
+   *   ws.url(request.getQueryString("url").get).get().map { r =>
    *     if (r.status == 200) Ok("The website is up") else NotFound("The website is down")
    *   }
    * }

--- a/framework/src/run-support/src/main/scala/play/runsupport/FileWatchService.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/FileWatchService.scala
@@ -3,19 +3,16 @@
  */
 package play.runsupport
 
+import java.io.File
 import java.net.URLClassLoader
-import java.util.List
 import java.util.Locale
 
-import sbt._
 import sbt.Path._
+import sbt._
 
-import scala.collection.JavaConversions
 import scala.reflect.ClassTag
-import scala.util.{ Properties, Try }
 import scala.util.control.NonFatal
-import java.io.File
-import java.util.concurrent.Callable
+import scala.util.{ Properties, Try }
 
 /**
  * A service that can watch files
@@ -29,17 +26,6 @@ trait FileWatchService {
    * @return A watcher
    */
   def watch(filesToWatch: Seq[File], onChange: () => Unit): FileWatcher
-
-  /**
-   * Watch the given sequence of files or directories.
-   *
-   * @param filesToWatch The files to watch.
-   * @param onChange A callback that is executed whenever something changes.
-   * @return A watcher
-   */
-  def watch(filesToWatch: List[File], onChange: Callable[Void]): FileWatcher = {
-    watch(JavaConversions.asScalaBuffer(filesToWatch), () => { onChange.call })
-  }
 
 }
 
@@ -150,7 +136,7 @@ private[play] class JNotifyFileWatchService(delegate: JNotifyFileWatchService.JN
 
 private object JNotifyFileWatchService {
 
-  import java.lang.reflect.{ Method, InvocationHandler, Proxy }
+  import java.lang.reflect.{ InvocationHandler, Method, Proxy }
 
   /**
    * Captures all the reflection invocations in one place.
@@ -349,10 +335,10 @@ private[play] class OptionalFileWatchServiceDelegate(val watchService: Try[FileW
  * mbean operation, so that the value can be retrieved.
  */
 private[runsupport] object GlobalStaticVar {
-  import javax.management._
-  import javax.management.modelmbean._
   import java.lang.management._
   import java.util.concurrent.atomic.AtomicReference
+  import javax.management._
+  import javax.management.modelmbean._
 
   private def objectName(name: String) = {
     new ObjectName(":type=GlobalStaticVar,name=" + name)

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 libraryDependencies += guice
 
-scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.8")
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.12.0")
 
 PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode
 

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/MediatorWorkaround.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/project/MediatorWorkaround.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+// Track https://github.com/sbt/sbt/issues/2786
+object MediatorWorkaround extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+  override def projectSettings =
+    Seq(
+      ivyScala := { ivyScala.value map {_.copy(overrideScalaVersion = sbtPlugin.value)} }
+    )
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/project/MediatorWorkaround.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/project/MediatorWorkaround.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+// Track https://github.com/sbt/sbt/issues/2786
+object MediatorWorkaround extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+  override def projectSettings =
+    Seq(
+      ivyScala := { ivyScala.value map {_.copy(overrideScalaVersion = sbtPlugin.value)} }
+    )
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
@@ -10,7 +10,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 libraryDependencies += guice
 
-scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.8")
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.12.0")
 
 routesGenerator := InjectedRoutesGenerator
 

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/project/MediatorWorkaround.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/project/MediatorWorkaround.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+// Track https://github.com/sbt/sbt/issues/2786
+object MediatorWorkaround extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+  override def projectSettings =
+    Seq(
+      ivyScala := { ivyScala.value map {_.copy(overrideScalaVersion = sbtPlugin.value)} }
+    )
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 lazy val module = (project in file("module")).enablePlugins(PlayScala)
 
-scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.8")
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.12.0")
 
 TaskKey[Unit]("unzipAssetsJar") := {
   IO.unzip(target.value / "universal" / "stage" / "lib" / s"${organization.value}.${normalizedName.value}-${version.value}-assets.jar", target.value / "assetsJar")

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/module/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/module/build.sbt
@@ -6,7 +6,7 @@ name := "assets-module-sample"
 
 version := "1.0-SNAPSHOT"
 
-scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.8")
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.12.0")
 
 includeFilter in (Assets, LessKeys.less) := "*.less"
 

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/project/MediatorWorkaround.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject-assets/project/MediatorWorkaround.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+// Track https://github.com/sbt/sbt/issues/2786
+object MediatorWorkaround extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+  override def projectSettings =
+    Seq(
+      ivyScala := { ivyScala.value map {_.copy(overrideScalaVersion = sbtPlugin.value)} }
+    )
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/build.sbt
@@ -23,7 +23,7 @@ lazy val nonplaymodule = (project in file("nonplaymodule"))
   .settings(common: _*)
 
 def common: Seq[Setting[_]] = Seq(
-  scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.8"),
+  scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.12.0"),
   libraryDependencies += guice
 )
 

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/project/MediatorWorkaround.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/multiproject/project/MediatorWorkaround.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+// Track https://github.com/sbt/sbt/issues/2786
+object MediatorWorkaround extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+  override def projectSettings =
+    Seq(
+      ivyScala := { ivyScala.value map {_.copy(overrideScalaVersion = sbtPlugin.value)} }
+    )
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/nested-secret/project/MediatorWorkaround.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/nested-secret/project/MediatorWorkaround.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+// Track https://github.com/sbt/sbt/issues/2786
+object MediatorWorkaround extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+  override def projectSettings =
+    Seq(
+      ivyScala := { ivyScala.value map {_.copy(overrideScalaVersion = sbtPlugin.value)} }
+    )
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/Build.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/Build.scala
@@ -55,7 +55,7 @@ object ApplicationBuild extends Build {
         bufferLogger +: currentFunction(key)
       }
     },
-    scalaVersion := sys.props.get("scala.version").getOrElse("2.11.8"),
+    scalaVersion := sys.props.get("scala.version").getOrElse("2.12.0"),
     checkLogContainsTask,
     compileIgnoreErrorsTask
   )

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/MediatorWorkaround.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/play-position-mapper/project/MediatorWorkaround.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+// Track https://github.com/sbt/sbt/issues/2786
+object MediatorWorkaround extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+  override def projectSettings =
+    Seq(
+      ivyScala := { ivyScala.value map {_.copy(overrideScalaVersion = sbtPlugin.value)} }
+    )
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/project/MediatorWorkaround.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/secret/project/MediatorWorkaround.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+// Track https://github.com/sbt/sbt/issues/2786
+object MediatorWorkaround extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+  override def projectSettings =
+    Seq(
+      ivyScala := { ivyScala.value map {_.copy(overrideScalaVersion = sbtPlugin.value)} }
+    )
+}

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/build.sbt
@@ -9,7 +9,7 @@ lazy val root = (project in file("."))
   .aggregate(common, a, b, c, nonplay)
 
 def commonSettings: Seq[Setting[_]] = Seq(
-  scalaVersion := sys.props.get("scala.version").getOrElse("2.11.8"),
+  scalaVersion := sys.props.get("scala.version").getOrElse("2.12.0"),
   libraryDependencies += guice,
   routesGenerator := play.routes.compiler.InjectedRoutesGenerator,
   // This makes it possible to run tests on the output regardless of scala version

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/project/MediatorWorkaround.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/project/MediatorWorkaround.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+// Track https://github.com/sbt/sbt/issues/2786
+object MediatorWorkaround extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+  override def projectSettings =
+    Seq(
+      ivyScala := { ivyScala.value map {_.copy(overrideScalaVersion = sbtPlugin.value)} }
+    )
+}

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/incremental-compilation/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/incremental-compilation/build.sbt
@@ -3,7 +3,7 @@
 //
 lazy val root = (project in file(".")).enablePlugins(RoutesCompiler)
 
-scalaVersion := sys.props.get("scala.version").getOrElse("2.11.8")
+scalaVersion := sys.props.get("scala.version").getOrElse("2.12.0")
 
 sources in (Compile, routes) := Seq(baseDirectory.value / "a.routes", baseDirectory.value / "b.routes")
 

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/incremental-compilation/project/MediatorWorkaround.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/incremental-compilation/project/MediatorWorkaround.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+// Track https://github.com/sbt/sbt/issues/2786
+object MediatorWorkaround extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+  override def projectSettings =
+    Seq(
+      ivyScala := { ivyScala.value map {_.copy(overrideScalaVersion = sbtPlugin.value)} }
+    )
+}

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/controllers/Application.scala
@@ -4,7 +4,7 @@
 package controllers
 
 import play.api.mvc._
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import javax.inject.Inject
 
 class Application @Inject() (c: ControllerComponents) extends AbstractController(c) {
@@ -36,7 +36,7 @@ class Application @Inject() (c: ControllerComponents) extends AbstractController
     Ok(`b[]`mkString(",") + " " + `b%%`)
   }
   def takeJavaList(x: java.util.List[Integer]) = Action {
-    Ok(x.mkString(","))
+    Ok(x.asScala.mkString(","))
   }
   def urlcoding(dynamic: String, static: String, query: String) = Action {
     Ok(s"dynamic=$dynamic static=$static query=$query")

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 libraryDependencies ++= Seq(guice, specs2 % Test)
 
-scalaVersion := sys.props.get("scala.version").getOrElse("2.11.8")
+scalaVersion := sys.props.get("scala.version").getOrElse("2.12.0")
 
 // can't use test directory since scripted calls its script "test"
 sourceDirectory in Test := baseDirectory.value / "tests"

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/project/MediatorWorkaround.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/project/MediatorWorkaround.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+// Track https://github.com/sbt/sbt/issues/2786
+object MediatorWorkaround extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+  override def projectSettings =
+    Seq(
+      ivyScala := { ivyScala.value map {_.copy(overrideScalaVersion = sbtPlugin.value)} }
+    )
+}

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/controllers/Application.scala
@@ -5,7 +5,7 @@ package controllers
 
 import play.api.mvc._
 import javax.inject.Inject
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 class Application @Inject() (c: ControllerComponents) extends AbstractController(c) {
   def index = Action {
@@ -30,7 +30,7 @@ class Application @Inject() (c: ControllerComponents) extends AbstractController
     Ok(x.mkString(","))
   }
   def takeJavaList(x: java.util.List[Integer]) = Action {
-    Ok(x.mkString(","))
+    Ok(x.asScala.mkString(","))
   }
   def urlcoding(dynamic: String, static: String, query: String) = Action {
     Ok(s"dynamic=$dynamic static=$static query=$query")

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 libraryDependencies ++= Seq(guice, specs2 % Test)
 
-scalaVersion := sys.props.get("scala.version").getOrElse("2.11.8")
+scalaVersion := sys.props.get("scala.version").getOrElse("2.12.0")
 
 // can't use test directory since scripted calls its script "test"
 sourceDirectory in Test := baseDirectory.value / "tests"

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/project/MediatorWorkaround.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/project/MediatorWorkaround.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+// Track https://github.com/sbt/sbt/issues/2786
+object MediatorWorkaround extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+  override def projectSettings =
+    Seq(
+      ivyScala := { ivyScala.value map {_.copy(overrideScalaVersion = sbtPlugin.value)} }
+    )
+}

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 libraryDependencies += guice
 
-scalaVersion := sys.props.get("scala.version").getOrElse("2.11.8")
+scalaVersion := sys.props.get("scala.version").getOrElse("2.12.0")
 
 sources in (Compile, routes) := Seq(baseDirectory.value / "routes")
 

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/project/MediatorWorkaround.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/project/MediatorWorkaround.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+// Track https://github.com/sbt/sbt/issues/2786
+object MediatorWorkaround extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+  override def projectSettings =
+    Seq(
+      ivyScala := { ivyScala.value map {_.copy(overrideScalaVersion = sbtPlugin.value)} }
+    )
+}


### PR DESCRIPTION
Sets up a Play version that works against 2.12.0 by default and does a cross-build to 2.11.8.

All the dependencies have been worked through, so if this builds, we should be good.