### PR TITLE
documentation: clarify how the child actor get its name

### DIFF
--- a/documentation/manual/working/javaGuide/main/akka/JavaAkka.md
+++ b/documentation/manual/working/javaGuide/main/akka/JavaAkka.md
@@ -78,7 +78,7 @@ Now, the actor that depends on this can extend [`InjectedActorSupport`](api/java
 
 @[injectedparent](code/javaguide/akka/ParentActor.java)
 
-It uses the `injectedChild` to create and get a reference to the child actor, passing in the key.
+It uses the `injectedChild` to create and get a reference to the child actor, passing in the key. The second parameter (`key` in this example) will be used as the child actor's name.
 
 Finally, we need to bind our actors.  In our module, we use the `bindActorFactory` method to bind the parent actor, and also bind the child factory to the child implementation:
 

--- a/documentation/manual/working/scalaGuide/main/akka/ScalaAkka.md
+++ b/documentation/manual/working/scalaGuide/main/akka/ScalaAkka.md
@@ -78,7 +78,7 @@ Now, the actor that depends on this can extend [`InjectedActorSupport`](api/scal
 
 @[injectedparent](code/ScalaAkka.scala)
 
-It uses the `injectedChild` to create and get a reference to the child actor, passing in the key.
+It uses the `injectedChild` to create and get a reference to the child actor, passing in the key. The second parameter (`key` in this example) will be used as the child actor's name.
 
 Finally, we need to bind our actors.  In our module, we use the `bindActorFactory` method to bind the parent actor, and also bind the child factory to the child implementation:
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

It adds a tiny bit to the akka documentation clarifying how the child actor gets its name, because in the existing example the `key` parameter is used both as a parameter to the factory as well as the actor's name.

## References

Are there any relevant issues / PRs / mailing lists discussions?

  - this confused me a lot when I saw that the key is passed twice.