### PR TITLE
Parse IPv4-mapped IPv6 addresses in forward headers

### DIFF
--- a/framework/src/play-server/src/main/scala/play/core/server/common/NodeIdentifierParser.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/NodeIdentifierParser.scala
@@ -3,12 +3,14 @@
  */
 package play.core.server.common
 
-import java.net.{ Inet6Address, InetAddress, Inet4Address }
+import java.net.{ Inet4Address, Inet6Address, InetAddress }
+
+import com.google.common.net.InetAddresses
+import play.core.server.common.ForwardedHeaderHandler.{ ForwardedHeaderVersion, Rfc7239, Xforwarded }
+import play.core.server.common.NodeIdentifierParser._
+
 import scala.util.Try
 import scala.util.parsing.combinator.RegexParsers
-
-import ForwardedHeaderHandler.{ ForwardedHeaderVersion, Rfc7239, Xforwarded }
-import NodeIdentifierParser._
 
 /**
  * The NodeIdentifierParser object can parse node identifiers described in RFC 7239.
@@ -49,7 +51,7 @@ private[common] class NodeIdentifierParser(version: ForwardedHeaderVersion) exte
 
   private lazy val ipv4Address = regex("[\\d\\.]{7,15}".r) ^? inetAddress
 
-  private lazy val ipv6Address = regex("[\\da-fA-F:]+".r) ^? inetAddress
+  private lazy val ipv6Address = regex("[\\da-fA-F:\\.]+".r) ^? inetAddress
 
   private lazy val obfnode = regex("_[\\p{Alnum}\\._-]+".r)
 
@@ -65,8 +67,8 @@ private[common] class NodeIdentifierParser(version: ForwardedHeaderVersion) exte
   private def obfport = regex("_[\\p{Alnum}\\._-]+".r)
 
   private def inetAddress = new PartialFunction[String, InetAddress] {
-    def isDefinedAt(s: String) = Try { InetAddress.getByName(s) }.isSuccess
-    def apply(s: String) = Try { InetAddress.getByName(s) }.get
+    def isDefinedAt(s: String) = Try { InetAddresses.forString(s) }.isSuccess
+    def apply(s: String) = Try { InetAddresses.forString(s) }.get
   }
 }
 

--- a/framework/src/play-server/src/main/scala/play/core/server/common/Subnet.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/Subnet.scala
@@ -5,6 +5,8 @@ package play.core.server.common
 
 import java.net.InetAddress
 
+import com.google.common.net.InetAddresses
+
 private[common] case class Subnet(ip: InetAddress, cidr: Option[Int] = None) {
 
   private def remainderOfMask = for {
@@ -31,8 +33,8 @@ private[common] case class Subnet(ip: InetAddress, cidr: Option[Int] = None) {
 
 private[common] object Subnet {
   def apply(s: String): Subnet = s.split("/") match {
-    case Array(ip, subnet) => Subnet(InetAddress.getByName(ip), Some(subnet.toInt))
-    case Array(ip) => Subnet(InetAddress.getByName(ip))
+    case Array(ip, subnet) => Subnet(InetAddresses.forString(ip), Some(subnet.toInt))
+    case Array(ip) => Subnet(InetAddresses.forString(ip))
     case _ => throw new IllegalArgumentException(s"$s contains more than one '/'.")
   }
 

--- a/framework/src/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ForwardedHeaderHandlerSpec.scala
@@ -4,10 +4,11 @@
 package play.core.server.common
 
 import java.net.InetAddress
+
+import com.google.common.net.InetAddresses
 import org.specs2.mutable.Specification
-import org.specs2.specification.Scope
 import play.api.mvc.Headers
-import play.api.{ PlayException, Configuration }
+import play.api.{ Configuration, PlayException }
 import play.core.server.common.ForwardedHeaderHandler._
 
 class ForwardedHeaderHandlerSpec extends Specification {
@@ -26,9 +27,10 @@ class ForwardedHeaderHandlerSpec extends Specification {
           |Forwarded: for=192.0.2.43, for=198.51.100.17, for=127.0.0.1
           |Forwarded: for=192.0.2.61;proto=https
           |Forwarded: for=unknown
-        """.stripMargin
+          |Forwarded: For="[::ffff:192.168.0.9]";proto=https
+          """.stripMargin
       ))
-      results.length must_== 8
+      results.length must_== 9
       results(0)._1 must_== ForwardedEntry(Some("_gazonk"), None)
       results(0)._2 must beLeft
       results(0)._3 must beNone
@@ -53,16 +55,19 @@ class ForwardedHeaderHandlerSpec extends Specification {
       results(7)._1 must_== ForwardedEntry(Some("unknown"), None)
       results(7)._2 must beLeft
       results(7)._3 must beNone
+      results(8)._1 must_== ForwardedEntry(Some("[::ffff:192.168.0.9]"), Some("https"))
+      results(8)._2 must beRight(ConnectionInfo(addr("::ffff:192.168.0.9"), true))
+      results(8)._3 must beSome(false)
     }
 
     "parse x-forwarded entries" in {
       val results = processHeaders(version("x-forwarded") ++ trustedProxies("2001:db8:cafe::17"), headers(
         """
-          |X-Forwarded-For: 192.168.1.1, ::1, [2001:db8:cafe::17], 127.0.0.1
-          |X-Forwarded-Proto: https, http, https, http
+          |X-Forwarded-For: 192.168.1.1, ::1, [2001:db8:cafe::17], 127.0.0.1, ::ffff:123.123.123.123
+          |X-Forwarded-Proto: https, http, https, http, https
         """.stripMargin
       ))
-      results.length must_== 4
+      results.length must_== 5
       results(0)._1 must_== ForwardedEntry(Some("192.168.1.1"), Some("https"))
       results(0)._2 must beRight(ConnectionInfo(addr("192.168.1.1"), true))
       results(0)._3 must beSome(false)
@@ -75,6 +80,9 @@ class ForwardedHeaderHandlerSpec extends Specification {
       results(3)._1 must_== ForwardedEntry(Some("127.0.0.1"), Some("http"))
       results(3)._2 must beRight(ConnectionInfo(addr("127.0.0.1"), false))
       results(3)._3 must beSome(false)
+      results(4)._1 must_== ForwardedEntry(Some("::ffff:123.123.123.123"), Some("https"))
+      results(4)._2 must beRight(ConnectionInfo(addr("::ffff:123.123.123.123"), true))
+      results(4)._3 must beSome(false)
     }
 
     "default to trusting IPv4 and IPv6 localhost with rfc7239 when there is config with default settings" in {
@@ -156,6 +164,14 @@ class ForwardedHeaderHandlerSpec extends Specification {
         """
           |Forwarded: For="[2001:db8:cafe::17]:4711"
         """.stripMargin)) mustEqual ConnectionInfo(addr("2001:db8:cafe::17"), false)
+    }
+
+    "handle quoted IPv4-mapped IPv6 addresses with rfc7239" in {
+      handler(version("rfc7239") ++ trustedProxies("fe80::1", "::ffff:123.123.123.123")).remoteConnection(addr("fe80::1"), false, headers(
+        """
+          |Forwarded: For="[::ffff:99.99.99.99]:4711"
+          |Forwarded: For="[::ffff:123.123.123.123]"
+        """.stripMargin)) mustEqual ConnectionInfo(addr("::ffff:99.99.99.99"), false)
     }
 
     "ignore obfuscated addresses with rfc7239" in {
@@ -415,7 +431,7 @@ class ForwardedHeaderHandlerSpec extends Specification {
     }
   }
 
-  def addr(ip: String): InetAddress = InetAddress.getByName(ip)
+  def addr(ip: String): InetAddress = InetAddresses.forString(ip)
 
   val localhost: InetAddress = addr("127.0.0.1")
 

--- a/framework/src/play-server/src/test/scala/play/core/server/common/NodeIdentifierParserSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/NodeIdentifierParserSpec.scala
@@ -3,11 +3,10 @@
  */
 package play.core.server.common
 
-import java.net.InetAddress.getByName
 import org.specs2.mutable.Specification
-
 import ForwardedHeaderHandler.{ ForwardedHeaderVersion, Rfc7239, Xforwarded }
 import NodeIdentifierParser._
+import com.google.common.net.InetAddresses
 
 class NodeIdentifierParserSpec extends Specification {
 
@@ -16,10 +15,12 @@ class NodeIdentifierParserSpec extends Specification {
     parser.parseNode(str)
   }
 
+  private def ip(s: String): Ip = Ip(InetAddresses.forString(s))
+
   "NodeIdentifierParser" should {
 
     "parse an ip v6 address with port" in {
-      parseNode(Rfc7239, "[8F:F3B::FF]:9000") must beRight(Ip(getByName("8F:F3B::FF")) -> Some(PortNumber(9000)))
+      parseNode(Rfc7239, "[8F:F3B::FF]:9000") must beRight(ip("8F:F3B::FF") -> Some(PortNumber(9000)))
     }
 
     "not parse unescaped ip v6 address in rfc7239 header" in {
@@ -27,19 +28,19 @@ class NodeIdentifierParserSpec extends Specification {
     }
 
     "parse unescaped ip v6 address in x-forwarded-for header" in {
-      parseNode(Xforwarded, "8F:F3B::FF") must beRight(Ip(getByName("8F:F3B::FF")) -> None)
+      parseNode(Xforwarded, "8F:F3B::FF") must beRight(ip("8F:F3B::FF") -> None)
     }
 
     "parse an ip v6 address with obfuscated port" in {
-      parseNode(Rfc7239, "[::FF]:_obf") must beRight(Ip(getByName("::FF")) -> Some(ObfuscatedPort("_obf")))
+      parseNode(Rfc7239, "[::FF]:_obf") must beRight(ip("::FF") -> Some(ObfuscatedPort("_obf")))
     }
 
     "parse an ip v4 address with port" in {
-      parseNode(Rfc7239, "127.0.0.1:8080") must beRight(Ip(getByName("127.0.0.1")) -> Some(PortNumber(8080)))
+      parseNode(Rfc7239, "127.0.0.1:8080") must beRight(ip("127.0.0.1") -> Some(PortNumber(8080)))
     }
 
     "parse an ip v4 address without port" in {
-      parseNode(Rfc7239, "192.168.0.1") must beRight(Ip(getByName("192.168.0.1")) -> None)
+      parseNode(Rfc7239, "192.168.0.1") must beRight(ip("192.168.0.1") -> None)
     }
 
     "parse an unknown ip address without port" in {

--- a/framework/src/play-server/src/test/scala/play/core/server/common/SubnetSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/SubnetSpec.scala
@@ -3,8 +3,7 @@
  */
 package play.core.server.common
 
-import java.net.InetAddress
-
+import com.google.common.net.InetAddresses
 import org.specs2.matcher.DataTables
 import org.specs2.mutable.Specification
 
@@ -22,7 +21,7 @@ class SubnetSpec extends Specification with DataTables {
         "2001:dbfe::/31" !! "2001:dbff::" ! true |
         "2001:db8:cafe::17" !! "2001:db8:cafe::17" ! true |>
         {
-          (a, b, c) => Subnet(a).isInRange(InetAddress.getByName(b)) mustEqual c
+          (a, b, c) => Subnet(a).isInRange(InetAddresses.forString(b)) mustEqual c
         }
     }
   }


### PR DESCRIPTION
Fixes #6629.

I also changed to use Guava's IP address parser instead of the standard Java parser. The Java parser will make DNS lookups for non-IP addresses. I don't think we need DNS lookups so the Guava parser is probably better.

Cc @swoopster-sb.