### PR TITLE
[WIP] Refactor MimeTypes to use Configuration

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/RangeResults.java
+++ b/framework/src/play/src/main/java/play/mvc/RangeResults.java
@@ -5,7 +5,7 @@ package play.mvc;
 
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
-import play.api.libs.MimeTypes;
+import play.api.libs.MimeTypes$;
 import play.core.j.JavaRangeResult;
 
 import java.io.File;
@@ -29,7 +29,7 @@ public class RangeResults {
     }
 
     private static Optional<String> mimeTypeFor(String fileName) {
-        Option<String> option = MimeTypes.forFileName(fileName);
+        Option<String> option = MimeTypes$.MODULE$.defaultMimeTypes().forFileName(fileName);
         return OptionConverters.toJava(option);
     }
 

--- a/framework/src/play/src/main/java/play/mvc/StatusHeader.java
+++ b/framework/src/play/src/main/java/play/mvc/StatusHeader.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import play.api.libs.MimeTypes;
+import play.api.libs.MimeTypes$;
 import play.http.HttpEntity;
 import play.libs.Json;
 import play.utils.UriEncoding;
@@ -275,10 +277,11 @@ public class StatusHeader extends Result {
                 (resourceName.isPresent() ? "; filename=\"" + resourceName.get() + "\"; filename*=utf-8''" + UriEncoding.encodePathSegment(resourceName.get(), UTF_8) : "")
         );
 
+        final MimeTypes mimeTypes = MimeTypes$.MODULE$.defaultMimeTypes();
         return new Result(status(), headers, new HttpEntity.Streamed(
                 data,
                 contentLength,
-                resourceName.map(name -> OptionConverters.toJava(play.api.libs.MimeTypes.forFileName(name))
+                resourceName.map(name -> OptionConverters.toJava(mimeTypes.forFileName(name))
                         .orElse(Http.MimeTypes.BINARY)
                 )
         ));

--- a/framework/src/play/src/test/scala/play/api/libs/MimeTypesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/MimeTypesSpec.scala
@@ -4,16 +4,40 @@
 package play.api.libs
 
 import org.specs2.mutable._
+import play.api.{ Configuration, Environment, Mode }
 
 class MimeTypesSpec extends Specification {
 
   "Mime types" should {
     "choose the correct mime type for file with lowercase extension" in {
-      MimeTypes.forFileName("image.png") must be equalTo Some("image/png")
+      val config = Configuration.load(Environment.simple(mode = Mode.Test))
+      val mimeTypes = MimeTypes.fromConfiguration(config)
+      mimeTypes.forFileName("image.png") must be equalTo Some("image/png")
     }
     "choose the correct mime type for file with uppercase extension" in {
-      MimeTypes.forFileName("image.PNG") must be equalTo Some("image/png")
+      val config = Configuration.load(Environment.simple(mode = Mode.Test))
+      val mimeTypes = MimeTypes.fromConfiguration(config)
+      mimeTypes.forFileName("image.PNG") must be equalTo Some("image/png")
     }
+
+    "choose JSON as text" in {
+      val config = Configuration.load(Environment.simple(mode = Mode.Test))
+      val mimeTypes = MimeTypes.fromConfiguration(config)
+      mimeTypes.isText("application/json") must beTrue
+    }
+
+    "choose text/* as text" in {
+      val config = Configuration.load(Environment.simple(mode = Mode.Test))
+      val mimeTypes = MimeTypes.fromConfiguration(config)
+      mimeTypes.isText("text/foo") must beTrue
+    }
+
+    "use additional types using syntax" in {
+      val config = Configuration.load(Environment.simple(mode = Mode.Test)) ++ Configuration("mimetype.foo" -> "image/bar")
+      val mimeTypes = MimeTypes.fromConfiguration(config)
+      mimeTypes.forFileName("image.foo") must be equalTo Some("image/bar")
+    }
+
   }
 
 }


### PR DESCRIPTION
DO NOT MERGE WORK IN PROGRESS

Removes another reference to `Play.current` by parsing the Configuration directly.

This isn't very efficient as it means parsing the config file twice, but it's unlikely that MIME types are going to be overridden.

Adding it to the API for the relevant methods (`sendResource` / `sendFile` etc) means having to add a `mimeTypes.findFileFor()` to the API.  So, add `(implicit mimeTypes: MimeTypes)` to the Scala methods and then inject `DefaultMimeTypes` through `AbstractController` and add it as `implicit val mimeTypes = components.mimeTypes`, meaning that from a user API perspective it should look the same.

The Java API changes can't be elided quite the same way with injection or implicits.  `RangeResults` especially is a completely static API which is no fun.