### PR TITLE
Add bindings for Java i18n classes

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
@@ -14,13 +14,17 @@ class MessagesSpec extends PlaySpecification with Controller {
   implicit val lang = Lang("en-US")
 
   "Messages" should {
-    "provide default messages" in new WithApplication() {
+    "provide default messages" in new WithApplication(_.requireExplicitBindings()) {
       val messagesApi = app.injector.instanceOf[MessagesApi]
+      val javaMessagesApi = app.injector.instanceOf[play.i18n.MessagesApi]
+
       val msg = messagesApi("constraint.email")
+      val javaMsg = javaMessagesApi.get(new play.i18n.Lang(lang), "constraint.email")
 
       msg must ===("Email")
+      msg must ===(javaMsg)
     }
-    "permit default override" in new WithApplication() {
+    "permit default override" in new WithApplication(_.requireExplicitBindings()) {
       val messagesApi = app.injector.instanceOf[MessagesApi]
       val msg = messagesApi("constraint.required")
 

--- a/framework/src/play/src/main/scala/play/api/i18n/I18nModule.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/I18nModule.scala
@@ -10,7 +10,9 @@ class I18nModule extends Module {
   def bindings(environment: Environment, configuration: Configuration) = {
     Seq(
       bind[Langs].to[DefaultLangs],
-      bind[MessagesApi].to[DefaultMessagesApi]
+      bind[MessagesApi].to[DefaultMessagesApi],
+      bind[play.i18n.MessagesApi].toSelf,
+      bind[play.i18n.Langs].toSelf
     )
   }
 }

--- a/framework/src/play/src/main/scala/play/utils/Reflect.scala
+++ b/framework/src/play/src/main/scala/play/utils/Reflect.scala
@@ -53,13 +53,17 @@ object Reflect {
       case Some(Left(direct)) =>
         Seq(
           bind[ScalaTrait].to(direct),
-          bind[JavaInterface].to[JavaDelegate]
+          bind[JavaInterface].to[JavaDelegate],
+          bind[JavaDelegate].toSelf,
+          BindingKey(direct).toSelf
         )
       // Implements the java interface
       case Some(Right(java)) =>
         Seq(
           bind[ScalaTrait].to[JavaAdapter],
-          bind[JavaInterface].to(java)
+          bind[JavaAdapter].toSelf,
+          bind[JavaInterface].to(java),
+          BindingKey(java).toSelf
         )
 
       case None => Nil


### PR DESCRIPTION
I noticed I couldn't find the bindings for the Java versions of these anywhere. I think we inadvertently removed them.