### PR TITLE
OS X/Java build error

### DIFF
--- a/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java
@@ -69,7 +69,11 @@ public class Constraints {
      * The order of the returned constraints corresponds to the order of the {@code orderedAnnotations parameter}. 
      */
     public static List<Tuple<String,List<Object>>> displayableConstraint(Set<ConstraintDescriptor<?>> constraints, Annotation[] orderedAnnotations) {
-        return Stream.of(orderedAnnotations).filter(constraints.stream().map(c -> c.getAnnotation()).collect(Collectors.toList())::contains) // only use annotations for which we actually have a constraint
+        final List<Annotation> constraintAnnot = constraints.stream().
+            map(c -> c.getAnnotation()).
+            collect(Collectors.<Annotation>toList());
+
+        return Stream.of(orderedAnnotations).filter(constraintAnnot::contains) // only use annotations for which we actually have a constraint
             .filter(a -> a.annotationType().isAnnotationPresent(Display.class)).map(a -> 
                 displayableConstraint(constraints.parallelStream().filter(c -> c.getAnnotation().equals(a)).findFirst().get())
         ).collect(Collectors.toList());


### PR DESCRIPTION
```
[error] /Users/cchantep/Projects/playframework/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java:72: no suitable method found for collect(java.util.stream.Collector<java.lang.Object,capture#1 of ?,java.util.List<java.lang.Object>>)
[error]     method java.util.stream.Stream.<R>collect(java.util.function.Supplier<R>,java.util.function.BiConsumer<R,? super capture#2 of ?>,java.util.function.BiConsumer<R,R>) is not applicable
[error]       (cannot infer type-variable(s) R
[error]         (actual and formal argument lists differ in length))
[error]     method java.util.stream.Stream.<R,A>collect(java.util.stream.Collector<? super capture#2 of ?,A,R>) is not applicable
[error]       (cannot infer type-variable(s) R,A,capture#3 of ?,T
[error]         (argument mismatch; java.util.stream.Collector<capture#2 of ?,capture#4 of ?,java.util.List<capture#2 of ?>> cannot be converted to java.util.stream.Collector<? super capture#2 of ?,capture#4 of ?,java.util.List<capture#2 of ?>>))
[error] constraints.stream().map(c -> c.getAnnotation()).collect
```