### PR TITLE
Remove custom Java installer for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
-scala: 
-  - 2.11.8
-sudo: false
+# Trusty VM has 1.8u101
+# https://github.com/travis-ci/travis-ci/issues/3259#issuecomment-243534696
+sudo: required
 jdk:
   - oraclejdk8
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: scala
 # Trusty VM has 1.8u101
 # https://github.com/travis-ci/travis-ci/issues/3259#issuecomment-243534696
-sudo: required
+dist: trusty
+sudo: false
+group: beta
 jdk:
   - oraclejdk8
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: scala
+scala: 
+  - 2.11.8
 sudo: false
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,5 @@
 language: scala
 sudo: false
-# This is needed as long as the travis build environment is JDK 1.8.0 < u40 (at time of writing it is u31)
-# Otherwise, FSpec fails due to deadlocks caused by CompletableFuture.thenCompose blocking in the trampoline 
-# executor.
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
 jdk:
   - oraclejdk8
 script:


### PR DESCRIPTION
The master build seems to be failing and we don't need to use a custom java installer now that Travis CI has upgraded past the u31 bug...

https://travis-ci.org/playframework/playframework/builds/174834911

```
Using worker: worker-linux-docker-d5c5f82d.prod.travis-ci.org:travis-linux-3

Build system information
Build language: scala
Build group: stable
Build dist: precise
Build id: 174834911
Job id: 174834912
travis-build version: 628c8d2e6
Build image provisioning date and time
Thu Feb  5 15:09:33 UTC 2015
Operating System Details
Distributor ID:	Ubuntu
Description:	Ubuntu 12.04.5 LTS
Release:	12.04
Codename:	precise
Linux Version
3.13.0-29-generic
Cookbooks Version
a68419e https://github.com/travis-ci/travis-cookbooks/tree/a68419e
GCC version
gcc (Ubuntu/Linaro 4.6.3-1ubuntu5) 4.6.3
Copyright (C) 2011 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

LLVM version
clang version 3.4 (tags/RELEASE_34/final)
Target: x86_64-unknown-linux-gnu
Thread model: posix
Pre-installed Ruby versions
ruby-1.9.3-p551
Pre-installed Node.js versions
v0.10.36
Pre-installed Go versions
1.4.1
Redis version
redis-server 2.8.19
riak version
2.0.2
MongoDB version
MongoDB 2.4.12
CouchDB version
couchdb 1.6.1
Neo4j version
1.9.4
RabbitMQ Version
3.4.3
ElasticSearch version
1.4.0
Installed Sphinx versions
2.0.10
2.1.9
2.2.6
Default Sphinx version
2.2.6
Installed Firefox version
firefox 31.0esr
PhantomJS version
1.9.8
ant -version
Apache Ant(TM) version 1.8.2 compiled on December 3 2011
mvn -version
Apache Maven 3.2.5 (12a6b3acb947671f09b81f49094c53f426d8cea1; 2014-12-14T17:29:23+00:00)
Maven home: /usr/local/maven
Java version: 1.7.0_76, vendor: Oracle Corporation
Java home: /usr/lib/jvm/java-7-oracle/jre
Default locale: en_US, platform encoding: ANSI_X3.4-1968
OS name: "linux", version: "3.13.0-29-generic", arch: "amd64", family: "unix"

$ export DEBIAN_FRONTEND=noninteractive
W: Size of file /var/lib/apt/lists/us.archive.ubuntu.com_ubuntu_dists_precise-updates_restricted_binary-amd64_Packages.gz is not what the server reported 19576 20785
W: Size of file /var/lib/apt/lists/us.archive.ubuntu.com_ubuntu_dists_precise-updates_restricted_binary-i386_Packages.gz is not what the server reported 19521 20707
W: Size of file /var/lib/apt/lists/us.archive.ubuntu.com_ubuntu_dists_precise-backports_multiverse_source_Sources.gz is not what the server reported 5886 5888
W: Size of file /var/lib/apt/lists/ppa.launchpad.net_travis-ci_zero-mq_ubuntu_dists_precise_main_binary-amd64_Packages.gz is not what the server reported 832 1195
W: Size of file /var/lib/apt/lists/ppa.launchpad.net_ubuntugis_ppa_ubuntu_dists_precise_main_binary-amd64_Packages.gz is not what the server reported 33653 36677
W: Size of file /var/lib/apt/lists/ppa.launchpad.net_ubuntugis_ppa_ubuntu_dists_precise_main_binary-i386_Packages.gz is not what the server reported 33699 36733
W: Size of file /var/lib/apt/lists/security.ubuntu.com_ubuntu_dists_precise-security_restricted_binary-amd64_Packages.gz is not what the server reported 13782 14904
W: Size of file /var/lib/apt/lists/security.ubuntu.com_ubuntu_dists_precise-security_restricted_binary-i386_Packages.gz is not what the server reported 13751 14885
Reading package lists...
Building dependency tree...
Reading state information...
The following extra packages will be installed:
  libc-bin libc-dev-bin libc6-dev
Suggested packages:
  glibc-doc
The following packages will be upgraded:
  libc-bin libc-dev-bin libc6 libc6-dev
4 upgraded, 0 newly installed, 0 to remove and 263 not upgraded.
Need to get 8,840 kB of archives.
After this operation, 14.3 kB disk space will be freed.
Get:1 http://us.archive.ubuntu.com/ubuntu/ precise-updates/main libc6-dev amd64 2.15-0ubuntu10.15 [2,943 kB]
Get:2 http://us.archive.ubuntu.com/ubuntu/ precise-updates/main libc-dev-bin amd64 2.15-0ubuntu10.15 [84.7 kB]
Get:3 http://us.archive.ubuntu.com/ubuntu/ precise-updates/main libc-bin amd64 2.15-0ubuntu10.15 [1,177 kB]
Get:4 http://us.archive.ubuntu.com/ubuntu/ precise-updates/main libc6 amd64 2.15-0ubuntu10.15 [4,636 kB]
Fetched 8,840 kB in 0s (27.1 MB/s)
Preconfiguring packages ...
(Reading database ... 72019 files and directories currently installed.)
Preparing to replace libc6-dev 2.15-0ubuntu10.10 (using .../libc6-dev_2.15-0ubuntu10.15_amd64.deb) ...
Unpacking replacement libc6-dev ...
Preparing to replace libc-dev-bin 2.15-0ubuntu10.10 (using .../libc-dev-bin_2.15-0ubuntu10.15_amd64.deb) ...
Unpacking replacement libc-dev-bin ...
Preparing to replace libc-bin 2.15-0ubuntu10.10 (using .../libc-bin_2.15-0ubuntu10.15_amd64.deb) ...
Unpacking replacement libc-bin ...
Processing triggers for man-db ...
Setting up libc-bin (2.15-0ubuntu10.15) ...
(Reading database ... 72018 files and directories currently installed.)
Preparing to replace libc6 2.15-0ubuntu10.10 (using .../libc6_2.15-0ubuntu10.15_amd64.deb) ...
Unpacking replacement libc6 ...
Setting up libc6 (2.15-0ubuntu10.15) ...
Setting up libc-dev-bin (2.15-0ubuntu10.15) ...
Setting up libc6-dev (2.15-0ubuntu10.15) ...
Processing triggers for libc-bin ...
ldconfig deferred processing now taking place
Updating sbt
$ git clone --depth=50 --branch=master https://github.com/playframework/playframework.git playframework/playframework
Cloning into 'playframework/playframework'...
remote: Counting objects: 4218, done.
remote: Compressing objects: 100% (2667/2667), done.
Receiving objects: 100% (4218/4218), 4.88 MiB | 0 bytes/s, done.
remote: Total 4218 (delta 906), reused 2841 (delta 701), pack-reused 0
Resolving deltas: 100% (906/906), done.
Checking connectivity... done.

$ cd playframework/playframework
$ git checkout -qf 22582318c2d42e30a33267c858451715879e9669
Installing APT Packages (BETA)
$ export DEBIAN_FRONTEND=noninteractive
$ sudo -E apt-get -yq update &>> ~/apt-get-update.log

$ sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install oracle-java8-installer
Reading package lists...
Building dependency tree...
Reading state information...
Suggested packages:
  binfmt-support visualvm ttf-baekmuk ttf-unfonts ttf-unfonts-core
  ttf-kochi-gothic ttf-sazanami-gothic ttf-kochi-mincho ttf-sazanami-mincho
  ttf-arphic-uming
Recommended packages:
  oracle-java8-set-default
The following packages will be upgraded:
  oracle-java8-installer
1 upgraded, 0 newly installed, 0 to remove and 262 not upgraded.
Need to get 23.5 kB of archives.
After this operation, 128 kB disk space will be freed.
Get:1 http://ppa.launchpad.net/webupd8team/java/ubuntu/ precise/main oracle-java8-installer all 8u111+8u111arm-1~webupd8~0 [23.5 kB]
Fetched 23.5 kB in 0s (101 kB/s)
Preconfiguring packages ...
(Reading database ... 72018 files and directories currently installed.)
Preparing to replace oracle-java8-installer 8u31+8u33arm-1~webupd8~1 (using .../oracle-java8-installer_8u111+8u111arm-1~webupd8~0_all.deb) ...
oracle-license-v1-1 license has already been accepted
Unpacking replacement oracle-java8-installer ...
Processing triggers for shared-mime-info ...
Setting up oracle-java8-installer (8u111+8u111arm-1~webupd8~0) ...
No /var/cache/oracle-jdk8-installer/wgetrc file found.
Creating /var/cache/oracle-jdk8-installer/wgetrc and
using default oracle-java8-installer wgetrc settings for it.
Downloading Oracle Java 8...
--2016-11-10 17:09:15--  http://download.oracle.com/otn-pub/java/jdk/8u111-b14/jdk-8u111-linux-x64.tar.gz
Resolving download.oracle.com (download.oracle.com)... 104.96.220.152, 104.96.220.162
Connecting to download.oracle.com (download.oracle.com)|104.96.220.152|:80... connected.
HTTP request sent, awaiting response... 302 Moved Temporarily
Location: https://edelivery.oracle.com/otn-pub/java/jdk/8u111-b14/jdk-8u111-linux-x64.tar.gz [following]
--2016-11-10 17:09:15--  https://edelivery.oracle.com/otn-pub/java/jdk/8u111-b14/jdk-8u111-linux-x64.tar.gz
Resolving edelivery.oracle.com (edelivery.oracle.com)... 104.96.237.225, 2600:1408:10:185::2d3e, 2600:1408:10:184::2d3e
Connecting to edelivery.oracle.com (edelivery.oracle.com)|104.96.237.225|:443... connected.
HTTP request sent, awaiting response... 302 Moved Temporarily
Location: https://www.oracle.com/splash/edelivery/index.html [following]
--2016-11-10 17:09:15--  https://www.oracle.com/splash/edelivery/index.html
Resolving www.oracle.com (www.oracle.com)... 104.96.237.225, 2600:1408:10:184::2d3e, 2600:1408:10:185::2d3e
Connecting to www.oracle.com (www.oracle.com)|104.96.237.225|:443... connected.
HTTP request sent, awaiting response... 503 Service Unavailable
2016-11-10 17:09:15 ERROR 503: Service Unavailable.

download failed
Oracle JDK 8 is NOT installed.
dpkg: error processing oracle-java8-installer (--configure):
 subprocess installed post-installation script returned error exit status 1
Errors were encountered while processing:
 oracle-java8-installer
E: Sub-process /usr/bin/dpkg returned an error code (1)

apt-get install failed
$ cat ~/apt-get-update.log
Get:1 http://downloads-distro.mongodb.org dist Release.gpg [490 B]
Get:2 http://downloads-distro.mongodb.org dist Release [2,040 B]
Get:3 http://downloads-distro.mongodb.org dist/10gen amd64 Packages [30.9 kB]
Get:4 http://downloads-distro.mongodb.org dist/10gen i386 Packages [30.5 kB]
Hit http://us.archive.ubuntu.com precise Release.gpg
Get:5 http://us.archive.ubuntu.com precise-updates Release.gpg [198 B]
Get:6 http://us.archive.ubuntu.com precise-backports Release.gpg [198 B]
Hit http://us.archive.ubuntu.com precise Release
Get:7 http://us.archive.ubuntu.com precise-updates Release [55.4 kB]
Get:8 http://us.archive.ubuntu.com precise-backports Release [55.5 kB]
Hit http://us.archive.ubuntu.com precise/main Sources
Hit http://us.archive.ubuntu.com precise/restricted Sources
Hit http://us.archive.ubuntu.com precise/universe Sources
Hit http://us.archive.ubuntu.com precise/multiverse Sources
Hit http://us.archive.ubuntu.com precise/main amd64 Packages
Hit http://us.archive.ubuntu.com precise/restricted amd64 Packages
Hit http://us.archive.ubuntu.com precise/universe amd64 Packages
Hit http://us.archive.ubuntu.com precise/multiverse amd64 Packages
Hit http://us.archive.ubuntu.com precise/main i386 Packages
Hit http://us.archive.ubuntu.com precise/restricted i386 Packages
Hit http://us.archive.ubuntu.com precise/universe i386 Packages
Hit http://us.archive.ubuntu.com precise/multiverse i386 Packages
Get:9 http://us.archive.ubuntu.com precise-updates/main Sources [613 kB]
Get:10 http://us.archive.ubuntu.com precise-updates/restricted Sources [9,183 B]
Get:11 http://us.archive.ubuntu.com precise-updates/universe Sources [163 kB]
Get:12 http://us.archive.ubuntu.com precise-updates/multiverse Sources [11.0 kB]
Get:13 http://us.archive.ubuntu.com precise-updates/main amd64 Packages [1,334 kB]
Hit http://ppa.launchpad.net precise Release.gpg
Hit http://ppa.launchpad.net precise Release.gpg
Get:14 http://ppa.launchpad.net precise Release.gpg [316 B]
Get:15 http://ppa.launchpad.net precise Release.gpg [316 B]
Get:16 http://ppa.launchpad.net precise Release.gpg [316 B]
Get:17 http://security.ubuntu.com precise-security Release.gpg [198 B]
Get:18 http://us.archive.ubuntu.com precise-updates/restricted amd64 Packages [19.6 kB]
Get:19 http://us.archive.ubuntu.com precise-updates/universe amd64 Packages [365 kB]
Get:20 http://us.archive.ubuntu.com precise-updates/multiverse amd64 Packages [19.4 kB]
Get:21 http://ppa.launchpad.net precise Release.gpg [316 B]
Hit http://ppa.launchpad.net precise Release
Hit http://ppa.launchpad.net precise Release
Get:22 http://ppa.launchpad.net precise Release [12.9 kB]
Get:23 http://us.archive.ubuntu.com precise-updates/main i386 Packages [1,425 kB]
Get:24 http://apt.postgresql.org precise-pgdg Release.gpg [819 B]
Get:25 http://ppa.launchpad.net precise Release [12.9 kB]
Get:26 http://us.archive.ubuntu.com precise-updates/restricted i386 Packages [19.5 kB]
Get:27 http://us.archive.ubuntu.com precise-updates/universe i386 Packages [375 kB]
Get:28 http://us.archive.ubuntu.com precise-updates/multiverse i386 Packages [19.6 kB]
Get:29 http://us.archive.ubuntu.com precise-backports/main Sources [6,057 B]
Get:30 http://us.archive.ubuntu.com precise-backports/restricted Sources [40 B]
Get:31 http://us.archive.ubuntu.com precise-backports/universe Sources [52.3 kB]
Get:32 http://us.archive.ubuntu.com precise-backports/multiverse Sources [5,886 B]
Get:33 http://us.archive.ubuntu.com precise-backports/main amd64 Packages [6,727 B]
Get:34 http://us.archive.ubuntu.com precise-backports/restricted amd64 Packages [40 B]
Get:35 http://us.archive.ubuntu.com precise-backports/universe amd64 Packages [57.6 kB]
Get:36 http://us.archive.ubuntu.com precise-backports/multiverse amd64 Packages [5,459 B]
Get:37 http://us.archive.ubuntu.com precise-backports/main i386 Packages [6,719 B]
Get:38 http://us.archive.ubuntu.com precise-backports/restricted i386 Packages [40 B]
Get:39 http://us.archive.ubuntu.com precise-backports/universe i386 Packages [57.4 kB]
Get:40 http://us.archive.ubuntu.com precise-backports/multiverse i386 Packages [5,437 B]
Get:41 http://security.ubuntu.com precise-security Release [55.5 kB]
Get:42 http://ppa.launchpad.net precise Release [12.9 kB]
Get:43 http://ppa.launchpad.net precise Release [13.0 kB]
Get:44 http://apt.postgresql.org precise-pgdg Release [40.1 kB]
Hit http://ppa.launchpad.net precise/main amd64 Packages
Hit http://ppa.launchpad.net precise/main i386 Packages
Hit http://ppa.launchpad.net precise/main amd64 Packages
Get:45 http://security.ubuntu.com precise-security/main Sources [183 kB]
Get:46 http://apt.postgresql.org precise-pgdg/main amd64 Packages [115 kB]
Hit http://ppa.launchpad.net precise/main i386 Packages
Get:47 http://ppa.launchpad.net precise/main amd64 Packages [612 B]
Get:48 http://ppa.launchpad.net precise/main i386 Packages [612 B]
Get:49 http://ppa.launchpad.net precise/main amd64 Packages [832 B]
Get:50 http://ppa.launchpad.net precise/main i386 Packages [828 B]
Get:51 http://ppa.launchpad.net precise/main amd64 Packages [33.7 kB]
Get:52 http://ppa.launchpad.net precise/main i386 Packages [33.7 kB]
Get:53 http://security.ubuntu.com precise-security/restricted Sources [4,548 B]
Get:54 http://security.ubuntu.com precise-security/universe Sources [63.2 kB]
Get:55 http://security.ubuntu.com precise-security/multiverse Sources [2,902 B]
Get:56 http://security.ubuntu.com precise-security/main amd64 Packages [834 kB]
Get:57 http://ppa.launchpad.net precise/main amd64 Packages [3,110 B]
Get:58 http://ppa.launchpad.net precise/main i386 Packages [3,110 B]
Get:59 http://apt.postgresql.org precise-pgdg/main i386 Packages [115 kB]
Get:60 http://security.ubuntu.com precise-security/restricted amd64 Packages [13.8 kB]
Get:61 http://security.ubuntu.com precise-security/universe amd64 Packages [179 kB]
Get:62 http://security.ubuntu.com precise-security/multiverse amd64 Packages [3,215 B]
Get:63 http://security.ubuntu.com precise-security/main i386 Packages [923 kB]
Get:64 http://security.ubuntu.com precise-security/restricted i386 Packages [13.8 kB]
Get:65 http://security.ubuntu.com precise-security/universe i386 Packages [188 kB]
Get:66 http://security.ubuntu.com precise-security/multiverse i386 Packages [3,374 B]
Fetched 7,621 kB in 7s (1,035 kB/s)
Reading package lists...
Hit http://downloads-distro.mongodb.org dist Release.gpg
Hit http://downloads-distro.mongodb.org dist Release
Hit http://downloads-distro.mongodb.org dist/10gen amd64 Packages
Hit http://downloads-distro.mongodb.org dist/10gen i386 Packages
Hit http://security.ubuntu.com precise-security Release.gpg
Hit http://us.archive.ubuntu.com precise Release.gpg
Hit http://us.archive.ubuntu.com precise-updates Release.gpg
Hit http://us.archive.ubuntu.com precise-backports Release.gpg
Hit http://security.ubuntu.com precise-security Release
Hit http://us.archive.ubuntu.com precise Release
Hit http://us.archive.ubuntu.com precise-updates Release
Hit http://us.archive.ubuntu.com precise-backports Release
Hit http://security.ubuntu.com precise-security/main Sources
Hit http://us.archive.ubuntu.com precise/main Sources
Hit http://us.archive.ubuntu.com precise/restricted Sources
Hit http://us.archive.ubuntu.com precise/universe Sources
Hit http://us.archive.ubuntu.com precise/multiverse Sources
Hit http://us.archive.ubuntu.com precise/main amd64 Packages
Hit http://us.archive.ubuntu.com precise/restricted amd64 Packages
Hit http://us.archive.ubuntu.com precise/universe amd64 Packages
Hit http://security.ubuntu.com precise-security/restricted Sources
Hit http://security.ubuntu.com precise-security/universe Sources
Hit http://security.ubuntu.com precise-security/multiverse Sources
Hit http://security.ubuntu.com precise-security/main amd64 Packages
Hit http://security.ubuntu.com precise-security/restricted amd64 Packages
Hit http://security.ubuntu.com precise-security/universe amd64 Packages
Hit http://security.ubuntu.com precise-security/multiverse amd64 Packages
Hit http://security.ubuntu.com precise-security/main i386 Packages
Hit http://security.ubuntu.com precise-security/restricted i386 Packages
Hit http://security.ubuntu.com precise-security/universe i386 Packages
Hit http://us.archive.ubuntu.com precise/multiverse amd64 Packages
Hit http://us.archive.ubuntu.com precise/main i386 Packages
Hit http://us.archive.ubuntu.com precise/restricted i386 Packages
Hit http://us.archive.ubuntu.com precise/universe i386 Packages
Hit http://security.ubuntu.com precise-security/multiverse i386 Packages
Hit http://us.archive.ubuntu.com precise/multiverse i386 Packages
Hit http://us.archive.ubuntu.com precise-updates/main Sources
Hit http://us.archive.ubuntu.com precise-updates/restricted Sources
Hit http://us.archive.ubuntu.com precise-updates/universe Sources
Hit http://us.archive.ubuntu.com precise-updates/multiverse Sources
Hit http://us.archive.ubuntu.com precise-updates/main amd64 Packages
Hit http://us.archive.ubuntu.com precise-updates/restricted amd64 Packages
Hit http://us.archive.ubuntu.com precise-updates/universe amd64 Packages
Hit http://us.archive.ubuntu.com precise-updates/multiverse amd64 Packages
Hit http://us.archive.ubuntu.com precise-updates/main i386 Packages
Hit http://us.archive.ubuntu.com precise-updates/restricted i386 Packages
Hit http://us.archive.ubuntu.com precise-updates/universe i386 Packages
Hit http://us.archive.ubuntu.com precise-updates/multiverse i386 Packages
Hit http://us.archive.ubuntu.com precise-backports/main Sources
Hit http://us.archive.ubuntu.com precise-backports/restricted Sources
Hit http://us.archive.ubuntu.com precise-backports/universe Sources
Hit http://us.archive.ubuntu.com precise-backports/multiverse Sources
Hit http://us.archive.ubuntu.com precise-backports/main amd64 Packages
Hit http://us.archive.ubuntu.com precise-backports/restricted amd64 Packages
Hit http://us.archive.ubuntu.com precise-backports/universe amd64 Packages
Hit http://ppa.launchpad.net precise Release.gpg
Hit http://ppa.launchpad.net precise Release.gpg
Hit http://ppa.launchpad.net precise Release.gpg
Hit http://ppa.launchpad.net precise Release.gpg
Hit http://ppa.launchpad.net precise Release.gpg
Hit http://ppa.launchpad.net precise Release.gpg
Hit http://us.archive.ubuntu.com precise-backports/multiverse amd64 Packages
Hit http://us.archive.ubuntu.com precise-backports/main i386 Packages
Hit http://us.archive.ubuntu.com precise-backports/restricted i386 Packages
Hit http://us.archive.ubuntu.com precise-backports/universe i386 Packages
Hit http://us.archive.ubuntu.com precise-backports/multiverse i386 Packages
Hit http://apt.postgresql.org precise-pgdg Release.gpg
Hit http://ppa.launchpad.net precise Release
Hit http://ppa.launchpad.net precise Release
Hit http://ppa.launchpad.net precise Release
Hit http://ppa.launchpad.net precise Release
Hit http://ppa.launchpad.net precise Release
Hit http://ppa.launchpad.net precise Release
Hit http://ppa.launchpad.net precise/main amd64 Packages
Hit http://ppa.launchpad.net precise/main i386 Packages
Hit http://ppa.launchpad.net precise/main amd64 Packages
Hit http://ppa.launchpad.net precise/main i386 Packages
Hit http://ppa.launchpad.net precise/main amd64 Packages
Hit http://ppa.launchpad.net precise/main i386 Packages
Hit http://ppa.launchpad.net precise/main amd64 Packages
Hit http://ppa.launchpad.net precise/main i386 Packages
Hit http://ppa.launchpad.net precise/main amd64 Packages
Hit http://apt.postgresql.org precise-pgdg Release
Hit http://ppa.launchpad.net precise/main i386 Packages
Hit http://ppa.launchpad.net precise/main amd64 Packages
Hit http://ppa.launchpad.net precise/main i386 Packages
Hit http://apt.postgresql.org precise-pgdg/main amd64 Packages
Hit http://apt.postgresql.org precise-pgdg/main i386 Packages
Reading package lists...

The command "sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install oracle-java8-installer" failed and exited with 100 during .

Your build has been stopped.
```