### PR TITLE
Removes microbenchmark from travis build

### DIFF
--- a/framework/bin/travis
+++ b/framework/bin/travis
@@ -15,7 +15,7 @@
 # we can run the tasks serially.
 set -ev
 
-declare -a TASKS=(checkCodeStyle test testSbtPlugins testDocumentation rehearseMicrobenchmarks)
+declare -a TASKS=(checkCodeStyle test testSbtPlugins testDocumentation)
 
 for TASK in "${TASKS[@]}" 
 do  


### PR DESCRIPTION
Travis CI could use some speeding up, and microbenchmarks only work when we know what hardware we're running on.