### PR TITLE
Fix documentation error (usage of noop setContentType)

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
@@ -63,10 +63,9 @@ public class JavaResponse extends WithApplication {
         Map<String, String> headers = call(new MockJavaAction() {
             //#response-headers
             public Result index() {
-                response().setContentType("text/html");
                 response().setHeader(CACHE_CONTROL, "max-age=3600");
                 response().setHeader(ETAG, "xxx");
-                return ok("<h1>Hello World!</h1>");
+                return ok("<h1>Hello World!</h1>").as("text/html");
             }
             //#response-headers
         }, fakeRequest(), mat).headers();


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #6707

## Purpose

Fixes a documentation error that made people use the noop `setContentType` of `play.mvc.Http.Response`

## Background Context

Cleaning up an issue that had no real priority but gave backlog.

## References

https://github.com/playframework/playframework/issues/6707