### PR TITLE
Fixes #6688 adds a includeDocumentation variable

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -119,5 +119,7 @@ object PlayImport {
 
     val playMonitoredFiles = TaskKey[Seq[File]]("playMonitoredFiles")
     val fileWatchService = SettingKey[FileWatchService]("fileWatchService", "The watch service Play uses to watch for file changes")
+
+    val includeDocumentation = SettingKey[Boolean]("includeDocumentation", "Determines if a documentation should be generated on stage/dist tasks.")
   }
 }

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -120,6 +120,6 @@ object PlayImport {
     val playMonitoredFiles = TaskKey[Seq[File]]("playMonitoredFiles")
     val fileWatchService = SettingKey[FileWatchService]("fileWatchService", "The watch service Play uses to watch for file changes")
 
-    val includeDocumentation = SettingKey[Boolean]("includeDocumentation", "Determines if a documentation should be generated on stage/dist tasks.")
+    val includeDocumentationInBinary = SettingKey[Boolean]("includeDocumentationInBinary", "Includes the Documentation inside the distribution binary.")
   }
 }

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -60,6 +60,8 @@ object PlaySettings {
 
     externalizeResources := true,
 
+    includeDocumentation := true,
+
     javacOptions in (Compile, doc) := List("-encoding", "utf8"),
 
     libraryDependencies += {
@@ -225,15 +227,24 @@ object PlaySettings {
       }
     }.value,
 
-    mappings in Universal ++= {
-      val docDirectory = (doc in Compile).value
-      val docDirectoryLen = docDirectory.getCanonicalPath.length
-      val pathFinder = docDirectory ** "*"
-      pathFinder.get map {
-        docFile: File =>
-          docFile -> ("share/doc/api/" + docFile.getCanonicalPath.substring(docDirectoryLen))
+    mappings in Universal ++= Def.taskDyn {
+      // the documentation will only be included if includeDocumentation is true (see: http://www.scala-sbt.org/1.0/docs/Tasks.html#Dynamic+Computations+with)
+      if (includeDocumentation.value) {
+        Def.task{
+          val docDirectory = (doc in Compile).value
+          val docDirectoryLen = docDirectory.getCanonicalPath.length
+          val pathFinder = docDirectory ** "*"
+          pathFinder.get map {
+            docFile: File =>
+              docFile -> ("share/doc/api/" + docFile.getCanonicalPath.substring(docDirectoryLen))
+          }
+        }
+      } else {
+        Def.task {
+          Seq[(sbt.File, String)]()
+        }
       }
-    },
+    }.value,
 
     mappings in Universal ++= {
       val pathFinder = baseDirectory.value * "README*"

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -60,7 +60,7 @@ object PlaySettings {
 
     externalizeResources := true,
 
-    includeDocumentation := true,
+    includeDocumentationInBinary := true,
 
     javacOptions in (Compile, doc) := List("-encoding", "utf8"),
 
@@ -229,7 +229,7 @@ object PlaySettings {
 
     mappings in Universal ++= Def.taskDyn {
       // the documentation will only be included if includeDocumentation is true (see: http://www.scala-sbt.org/1.0/docs/Tasks.html#Dynamic+Computations+with)
-      if (includeDocumentation.value) {
+      if (includeDocumentationInBinary.value) {
         Def.task{
           val docDirectory = (doc in Compile).value
           val docDirectoryLen = docDirectory.getCanonicalPath.length

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/README
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/README
@@ -1,0 +1,4 @@
+This is your new Play application
+=====================================
+
+This file will be packaged with your application, when using `play dist`.

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/app/controllers/Application.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package controllers
+
+import play.api._
+import play.api.mvc._
+import scala.collection.JavaConverters._
+
+import javax.inject.Inject
+
+/**
+ * i will fail since I check for a undefined class [[Documentation]]
+ */
+class Application @Inject() (action: DefaultActionBuilder) extends Controller {
+
+  def index = action {
+    Ok
+  }
+
+}

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/build.sbt
@@ -1,0 +1,20 @@
+//
+// Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+//
+
+name := "dist-no-documentation-sample"
+
+// actually it should fail on any warning so that we can check that packageBin won't include any documentation
+scalacOptions in Compile := Seq("-Xfatal-warnings", "-deprecation")
+
+version := "1.0-SNAPSHOT"
+
+lazy val root = (project in file(".")).enablePlugins(PlayScala)
+
+libraryDependencies += guice
+
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.8")
+
+play.sbt.PlayImport.PlayKeys.includeDocumentation := false
+
+packageDoc in Compile := { new File(".") }

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/build.sbt
@@ -15,6 +15,6 @@ libraryDependencies += guice
 
 scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.8")
 
-play.sbt.PlayImport.PlayKeys.includeDocumentation := false
+play.sbt.PlayImport.PlayKeys.includeDocumentationInBinary := false
 
 packageDoc in Compile := { new File(".") }

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/conf/application.conf
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/conf/application.conf
@@ -1,0 +1,3 @@
+play.crypto.secret=";1[WE]JmK;XMCxV=S2P6kYl?A<^YcKYW3aui[SmusaQlkjq97A`M8l_S:iV?OmDh"
+play.i18n.langs = [ "en" ]
+some.config="foo"

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/conf/routes
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/conf/routes
@@ -1,0 +1,1 @@
+GET        /                    controllers.Application.index

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/project/build.properties
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/project/build.properties
@@ -1,0 +1,4 @@
+#
+# Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+#
+sbt.version=0.13.13

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/project/plugins.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/project/plugins.sbt
@@ -1,0 +1,5 @@
+//
+// Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+//
+
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % sys.props("project.version"))

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/test
@@ -1,0 +1,6 @@
+# Build the distribution and ensure that there is no documentation
+> stage
+$ absent target/universal/stage/share
+
+# Build the documentation which should fail
+-> compile:doc

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/test
@@ -2,5 +2,4 @@
 > stage
 $ absent target/universal/stage/share
 
-# Build the documentation which should fail
 -> compile:doc


### PR DESCRIPTION
# Helpful things

## Fixes

Fixes #6688

## Purpose

Fixes #6688 adds a includeDocumentation variable to remove the java/scala-doc from the distribution

## Background Context

Actually to really stop it from generating the documentation would mean to actually set `packageDoc` to new `File(".")`, see https://github.com/playframework/playframework/pull/6723/files#diff-69b29e5ccdf04d73ef169d932b4e2dbcR20.

Another way would be creating a `AutoPlugin` to remove the `mappings` but even that can't remove the `packageDoc` call.

/cc @muuki88 