### PR TITLE
Remove deprecated config settings from tests

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
@@ -100,10 +100,10 @@ class ScalaResultsSpec extends PlaySpecification {
     _.configure(Map(config: _*) + ("play.crypto.secret" -> "foo"))
   )(block)
 
-  def withFooPath[T](block: Application => T) = withApplication("application.context" -> "/foo")(block)
+  def withFooPath[T](block: Application => T) = withApplication("play.http.context" -> "/foo")(block)
 
-  def withFooDomain[T](block: Application => T) = withApplication("session.domain" -> ".foo.com")(block)
+  def withFooDomain[T](block: Application => T) = withApplication("play.http.session.domain" -> ".foo.com")(block)
 
-  def withSecureSession[T](block: Application => T) = withApplication("session.secure" -> true)(block)
+  def withSecureSession[T](block: Application => T) = withApplication("play.http.session.secure" -> true)(block)
 
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/mvc/FiltersSpec.scala
@@ -162,7 +162,7 @@ trait FiltersSpec extends Specification with ServerIntegrationSpecification {
       }
     }
 
-    "Filters are not applied when the request is outside the application.context" in withServer(
+    "Filters are not applied when the request is outside play.http.context" in withServer(
       Map("play.http.context" -> "/foo"))(ErrorHandlingFilter, ThrowExceptionFilter) { ws =>
         val response = Await.result(ws.url("/ok").post(expectedOkText), Duration.Inf)
         response.status must_== 200


### PR DESCRIPTION
Fixes ScalaResultsSpec to use the non-deprecated config settings.