### PR TITLE
[UFR] Define MessageApi configuration in a provider.

### DIFF
--- a/documentation/manual/working/scalaGuide/advanced/extending/code/ScalaExtendingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/extending/code/ScalaExtendingPlay.scala
@@ -26,6 +26,10 @@ class MyMessagesApi extends MessagesApi {
   override def translate(key: String, args: Seq[Any])(implicit lang: Lang): Option[String] = ???
 }
 
+class MyMessagesApiProvider extends javax.inject.Provider[MyMessagesApi] {
+  override def get(): MyMessagesApi = new MyMessagesApi
+}
+
 // #module-definition
 class MyCode {
   // add functionality here
@@ -42,8 +46,8 @@ class MyModule extends play.api.inject.Module {
 class MyI18nModule extends play.api.inject.Module {
   def bindings(environment: Environment, configuration: Configuration) = {
     Seq(
-      bind[Langs].to[DefaultLangs],
-      bind[MessagesApi].to[MyMessagesApi]
+      bind[Langs].toProvider[DefaultLangsProvider],
+      bind[MessagesApi].toProvider[MyMessagesApiProvider]
     )
   }
 }

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaFieldConstructor.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaFieldConstructor.scala
@@ -4,13 +4,17 @@
 package scalaguide.forms.scalafieldconstructor {
 
 import org.specs2.mutable.Specification
-import play.api.{Environment, Configuration}
-import play.api.i18n.{DefaultLangs, DefaultMessagesApi, Messages}
+import play.api.http.HttpConfiguration
+import play.api.{Configuration, Environment}
+import play.api.i18n._
 
 class ScalaFieldConstructorSpec extends Specification {
 
   val conf = Configuration.reference
-  implicit val messages: Messages = new DefaultMessagesApi(Environment.simple(), conf, new DefaultLangs(conf)).preferred(Seq.empty)
+  val langs = new DefaultLangsProvider(conf).get
+  val httpConfiguration = HttpConfiguration.fromConfiguration(conf)
+  val messagesApi = new DefaultMessagesApiProvider(Environment.simple(), conf, langs, httpConfiguration).get
+  implicit val messages: Messages = messagesApi.preferred(Seq.empty)
 
   "field constructors" should {
 

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -11,6 +11,7 @@ import play.api.i18n._
 import scalaguide.forms.scalaforms.controllers.routes
 import play.api.mvc._
 import play.api.test.{WithApplication, _}
+import play.api.test._
 import org.specs2.mutable.Specification
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
@@ -29,8 +30,8 @@ import play.api.data.validation.Constraints._
 @RunWith(classOf[JUnitRunner])
 class ScalaFormsSpec extends Specification with Controller {
 
-  val conf = Configuration.reference
-  implicit val messages: Messages = new DefaultMessagesApi(Environment.simple(), conf, new DefaultLangs(conf)).preferred(Seq.empty)
+  val messagesApi = new DefaultMessagesApi()
+  implicit val messages: Messages = messagesApi.preferred(Seq.empty)
 
   "A scala forms" should {
 

--- a/documentation/manual/working/scalaGuide/main/i18n/code/ScalaI18N.scala
+++ b/documentation/manual/working/scalaGuide/main/i18n/code/ScalaI18N.scala
@@ -5,6 +5,7 @@ package scalaguide.i18n.scalai18n {
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import play.api._
+import play.api.http.HttpConfiguration
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
 import play.api.test._
@@ -69,8 +70,9 @@ class ScalaI18nSpec extends PlaySpecification with Controller {
 
   "A Scala translation" should {
 
-    val langs = new DefaultLangs(conf)
-    val messagesApi = new DefaultMessagesApi(Environment.simple(), conf, langs)
+    val langs = new DefaultLangsProvider(conf).get
+    val httpConfiguration = HttpConfiguration.fromConfiguration(conf)
+    val messagesApi = new DefaultMessagesApiProvider(Environment.simple(), conf, langs, httpConfiguration).get
 
     implicit val lang = Lang("en")
 

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
@@ -139,17 +139,15 @@ You can test it like:
 
 @[scalatest-examplecontrollerspec](code/specs2/ExampleControllerSpec.scala)
 
-Using [`play.api.test.FakeRequest`]()
+## Unit Testing Forms
 
-To unit test form processing and render validation errors, you will want a [`MessagesApi`](api/scala/play/api/i18n/MessagesApi.html).
+Forms are also just regular classes, and can unit tested using Play's Test Helpers. Using [`play.api.test.FakeRequest`](api/scala/play/api/test/FakeRequest.html), you can call `form.bindFromRequest` and test for errors against any custom constraints.
 
-The default implementation of [`MessagesApi`](api/scala/play/api/i18n/MessagesApi.html) is [`DefaultMessagesApi`](api/scala/play/api/i18n/DefaultMessagesApi.html).  For unit testing purposes,  [`DefaultMessagesApi`](api/scala/play/api/i18n/DefaultMessagesApi.html) can be instantiated without arguments, and will take a raw map.
+To unit test form processing and render validation errors, you will want a [`MessagesApi`](api/scala/play/api/i18n/MessagesApi.html) instance in implicit scope.  The default implementation of [`MessagesApi`](api/scala/play/api/i18n/MessagesApi.html) is [`DefaultMessagesApi`](api/scala/play/api/i18n/DefaultMessagesApi.html).  For unit testing purposes, [`DefaultMessagesApi`](api/scala/play/api/i18n/DefaultMessagesApi.html) can be instantiated without arguments, and will take a raw map.
   
-```scala
-import play.api.i18n.DefaultMessagesApi
-implicit val messagesApi = new DefaultMessagesApi(Map("en" -> Map("hello.world" -> "hello world!")))
-```
+You can test it like:
 
+@[scalatest-exampleformspec](code/specs2/ExampleControllerSpec.scala)
 
 ## Unit Testing EssentialAction
 

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
@@ -139,6 +139,18 @@ You can test it like:
 
 @[scalatest-examplecontrollerspec](code/specs2/ExampleControllerSpec.scala)
 
+Using [`play.api.test.FakeRequest`]()
+
+To unit test form processing and render validation errors, you will want a [`MessagesApi`](api/scala/play/api/i18n/MessagesApi.html).
+
+The default implementation of [`MessagesApi`](api/scala/play/api/i18n/MessagesApi.html) is [`DefaultMessagesApi`](api/scala/play/api/i18n/DefaultMessagesApi.html).  For unit testing purposes,  [`DefaultMessagesApi`](api/scala/play/api/i18n/DefaultMessagesApi.html) can be instantiated without arguments, and will take a raw map.
+  
+```scala
+import play.api.i18n.DefaultMessagesApi
+implicit val messagesApi = new DefaultMessagesApi(Map("en" -> Map("hello.world" -> "hello world!")))
+```
+
+
 ## Unit Testing EssentialAction
 
 Testing [`Action`](api/scala/play/api/mvc/Action.html) or [`Filter`](api/scala/play/api/mvc/Filter.html) can require to test an [`EssentialAction`](api/scala/play/api/mvc/EssentialAction.html) ([[more information about what an EssentialAction is|ScalaEssentialAction]])

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleControllerSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleControllerSpec.scala
@@ -4,8 +4,11 @@
 package scalaguide.tests.specs2
 
 // #scalatest-examplecontrollerspec
+import javax.inject.Inject
+
 import play.api.mvc._
 import play.api.test._
+
 import scala.concurrent.Future
 
 class ExampleControllerSpec extends PlaySpecification with Results {
@@ -20,6 +23,41 @@ class ExampleControllerSpec extends PlaySpecification with Results {
   }
 }
 // #scalatest-examplecontrollerspec
+
+// #scalatest-exampleform
+class ExampleFormSpec extends PlaySpecification with Results {
+
+  import play.api.data._
+  import play.api.data.Forms._
+
+  case class UserData(name: String, age: Int)
+
+  val form = Form(
+    mapping(
+      "name" -> text,
+      "age" -> number(min = 0)
+    )(UserData.apply)(UserData.unapply)
+  )
+
+  "Form" should {
+    "be valid" in {
+      import play.api.i18n.DefaultMessagesApi
+      implicit val messagesApi = new DefaultMessagesApi(Map("en" -> Map("constraint.min" -> "minimum!")))
+
+      def errorFunc(badForm: Form[UserData]) = {
+        BadRequest(badForm.errorsAsJson)
+      }
+      def successFunc(userData: UserData) = {
+        Redirect("/").flashing("success" -> "success form!")
+      }
+
+      implicit val request = FakeRequest("POST", "/").withFormUrlEncodedBody("name" -> "Play", "age" -> "-1")
+      val result: Result = form.bindFromRequest().fold(errorFunc, successFunc)
+      result.header.status must be 307
+    }
+  }
+}
+// #scalatest-exampleform
 
 // #scalatest-examplecontroller
 class ExampleController extends Controller {

--- a/framework/src/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.CompletableFuture
 
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.specs2.mutable.Specification
-import play.api.i18n.DefaultMessagesApi
+import play.api.i18n.{ DefaultMessagesApi, DefaultMessagesApiProvider }
 import play.api.inject.BindingKey
 import play.api.mvc.{ RequestHeader, Results }
 import play.api.routing._
@@ -73,11 +73,11 @@ class HttpErrorHandlerSpec extends Specification {
       .withFallback(ConfigFactory.defaultReference())
     val configuration = Configuration(config)
     val env = Environment.simple(mode = mode)
-    val langs = new play.api.i18n.DefaultLangs(configuration)
-    val messagesApi = new DefaultMessagesApi(env, configuration, langs)
+    val httpConfiguration = HttpConfiguration.fromConfiguration(configuration)
+    val langs = new play.api.i18n.DefaultLangsProvider(configuration).get
+    val messagesApi = new DefaultMessagesApiProvider(env, configuration, langs, httpConfiguration).get
     val jLangs = new play.i18n.Langs(langs)
     val jMessagesApi = new play.i18n.MessagesApi(messagesApi)
-    val httpConfiguration = HttpConfiguration.fromConfiguration(configuration)
     Fakes.injectorFromBindings(HttpErrorHandler.bindingsFromConfiguration(env, configuration)
       ++ Seq(
         BindingKey(classOf[Router]).to(Router.empty),

--- a/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -3,22 +3,23 @@
  */
 package play.data
 
+import javax.validation.Validation
+
 import org.specs2.mutable.Specification
-import play.api.{ Configuration, Environment }
-import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
-import play.data.format.Formatters
-import views.html.helper.inputText
+import play.api.i18n.DefaultMessagesApi
 import play.core.j.PlayFormsMagicForJava.javaFieldtoScalaField
+import play.data.format.Formatters
 import views.html.helper.FieldConstructor.defaultField
+import views.html.helper.inputText
 
 import scala.collection.JavaConversions._
-import javax.validation.Validation
 
 /**
  * Specs for Java dynamic forms
  */
 class DynamicFormSpec extends Specification {
-  val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
+
+  val messagesApi = new DefaultMessagesApi()
   implicit val messages = messagesApi.preferred(Seq.empty)
   val jMessagesApi = new play.i18n.MessagesApi(messagesApi)
   val validator = Validation.buildDefaultValidatorFactory().getValidator()

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -5,32 +5,32 @@ package play.data
 
 import java.util
 import java.util.Optional
+import javax.validation.Validation
+import javax.validation.groups.Default
 
 import org.specs2.mutable.Specification
-import play.mvc.Http.{ Context, Request, RequestBuilder }
-
-import scala.collection.JavaConverters._
-import scala.beans.BeanProperty
-import play.api.{ Configuration, Environment }
-import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
+import play.api.http.HttpConfiguration
+import play.api.i18n._
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.WithApplication
+import play.api.{ Configuration, Environment }
+import play.core.j.{ JavaContextComponents, JavaHelpers }
 import play.data.format.Formatters
+import play.mvc.Http.{ Context, Request, RequestBuilder }
 import play.twirl.api.Html
-import javax.validation.groups.Default
-import javax.validation.Validation
 
-import play.api.http.HttpConfiguration
-import play.core.j.{ DefaultJavaContextComponents, JavaContextComponents, JavaHelpers }
+import scala.beans.BeanProperty
+import scala.collection.JavaConverters._
 
 class FormSpec extends Specification {
 
   val environment = Environment.simple()
   val config = Configuration.load(environment)
-  val langs = new DefaultLangs(config)
-  val messagesApi = new DefaultMessagesApi(environment, config, langs)
-  val jMessagesApi = new play.i18n.MessagesApi(messagesApi)
   val httpConfiguration = HttpConfiguration.fromConfiguration(config)
+  val langs = new DefaultLangsProvider(config).get
+  val messagesApi = new DefaultMessagesApiProvider(environment, config, langs, httpConfiguration).get
+
+  val jMessagesApi = new play.i18n.MessagesApi(messagesApi)
   val defaultContextComponents = JavaHelpers.createContextComponents(messagesApi, langs, httpConfiguration)
   val formFactory = new FormFactory(jMessagesApi, new Formatters(jMessagesApi), Validation.buildDefaultValidatorFactory().getValidator())
 

--- a/framework/src/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
@@ -3,18 +3,20 @@
  */
 package play.data
 
-import validation.Constraints.{ MaxLength, Required }
-import beans.BeanProperty
-import org.specs2.mutable.Specification
-import scala.collection.JavaConverters._
-import play.api.{ Configuration, Environment }
-import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
-import play.data.format.Formatters
 import javax.validation.Validation
+
+import org.specs2.mutable.Specification
+import play.api.i18n._
+import play.data.format.Formatters
+import play.data.validation.Constraints.{ MaxLength, Required }
+
+import scala.beans.BeanProperty
+import scala.collection.JavaConverters._
 
 class PartialValidationSpec extends Specification {
 
-  val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
+  val messagesApi = new DefaultMessagesApi()
+
   val jMessagesApi = new play.i18n.MessagesApi(messagesApi)
   val formFactory = new FormFactory(jMessagesApi, new Formatters(jMessagesApi), Validation.buildDefaultValidatorFactory().getValidator())
 

--- a/framework/src/play/src/main/scala/play/api/i18n/I18nModule.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/I18nModule.scala
@@ -3,14 +3,15 @@
  */
 package play.api.i18n
 
+import play.api.http.HttpConfiguration
 import play.api.{ Configuration, Environment }
 import play.api.inject.Module
 
 class I18nModule extends Module {
   def bindings(environment: Environment, configuration: Configuration) = {
     Seq(
-      bind[Langs].to[DefaultLangs],
-      bind[MessagesApi].to[DefaultMessagesApi],
+      bind[Langs].toProvider[DefaultLangsProvider],
+      bind[MessagesApi].toProvider[DefaultMessagesApiProvider],
       bind[play.i18n.MessagesApi].toSelf,
       bind[play.i18n.Langs].toSelf
     )
@@ -24,8 +25,9 @@ trait I18nComponents {
 
   def environment: Environment
   def configuration: Configuration
+  def httpConfiguration: HttpConfiguration
 
-  lazy val messagesApi: MessagesApi = new DefaultMessagesApi(environment, configuration, langs)
-  lazy val langs: Langs = new DefaultLangs(configuration)
+  lazy val langs: Langs = new DefaultLangsProvider(configuration).get
+  lazy val messagesApi: MessagesApi = new DefaultMessagesApiProvider(environment, configuration, langs, httpConfiguration).get
 
 }

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.CompletionStage
 
 import play.api.{ Configuration, Environment }
 import play.api.http.HttpConfiguration
-import play.api.i18n.{ DefaultLangs, DefaultMessagesApi, Langs, MessagesApi }
+import play.api.i18n._
 import play.api.libs.typedmap.{ TypedEntry, TypedKey }
 import play.api.mvc._
 import play.core.Execution.Implicits.trampoline
@@ -129,9 +129,9 @@ trait JavaHelpers {
    * @return an instance of JavaContextComponents with default messagesApi and langs.
    */
   def createContextComponents(configuration: Configuration, env: Environment): JavaContextComponents = {
-    val langs = new DefaultLangs(configuration)
-    val messagesApi = new DefaultMessagesApi(env, configuration, langs)
     val httpConfiguration = HttpConfiguration.fromConfiguration(configuration)
+    val langs = new DefaultLangsProvider(configuration).get
+    val messagesApi = new DefaultMessagesApiProvider(env, configuration, langs, httpConfiguration).get
     createContextComponents(messagesApi, langs, httpConfiguration)
   }
 

--- a/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
@@ -7,9 +7,10 @@ import play.api.{ Configuration, Environment }
 import play.api.data.Forms._
 import play.api.data.validation.Constraints._
 import play.api.data.format.Formats._
-import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
+import play.api.i18n._
 import play.api.libs.json.Json
 import org.specs2.mutable.Specification
+import play.api.http.HttpConfiguration
 
 class FormSpec extends Specification {
   "A form" should {
@@ -268,7 +269,11 @@ class FormSpec extends Specification {
   }
 
   "correctly lookup error messages when using errorsAsJson" in {
-    val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
+    val messagesApi: MessagesApi = {
+      val config = Configuration.reference
+      val langs = new DefaultLangsProvider(config).get
+      new DefaultMessagesApiProvider(Environment.simple(), config, langs, HttpConfiguration()).get
+    }
     implicit val messages = messagesApi.preferred(Seq.empty)
 
     val form = Form(single("foo" -> Forms.text), Map.empty, Seq(FormError("foo", "error.custom", Seq("error.customarg"))), None)

--- a/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/i18n/MessagesSpec.scala
@@ -6,9 +6,10 @@ package play.api.i18n
 import java.io.File
 
 import org.specs2.mutable._
-import play.api.mvc.{ Cookie, Cookies, Results }
-import play.api.{ PlayException, Mode, Environment, Configuration }
+import play.api.http.HttpConfiguration
 import play.api.i18n.Messages.MessageSource
+import play.api.mvc.{ Cookie, Results }
+import play.api.{ Configuration, Environment, Mode, PlayException }
 import play.core.test.FakeRequest
 
 class MessagesSpec extends Specification {
@@ -22,11 +23,11 @@ class MessagesSpec extends Specification {
       "foo" -> "foo francais"),
     "fr-CH" -> Map(
       "title" -> "Titre suisse"))
-  val api = new DefaultMessagesApi(
-    new Environment(new File("."), this.getClass.getClassLoader, Mode.Dev),
-    Configuration.reference, new DefaultLangs(Configuration.reference ++ Configuration.from(Map("play.i18n.langs" -> Seq("en", "fr", "fr-CH"))))
-  ) {
-    override protected def loadAllMessages = testMessages
+  val api = {
+    val env = new Environment(new File("."), this.getClass.getClassLoader, Mode.Dev)
+    val config = Configuration.reference ++ Configuration.from(Map("play.i18n.langs" -> Seq("en", "fr", "fr-CH")))
+    val langs = new DefaultLangsProvider(config).get
+    new DefaultMessagesApi(testMessages, langs)
   }
 
   def translate(msg: String, lang: String, reg: String): Option[String] = {
@@ -90,10 +91,10 @@ class MessagesSpec extends Specification {
     }
 
     "report error for invalid lang" in {
-      new DefaultMessagesApi(
-        new Environment(new File("."), this.getClass.getClassLoader, Mode.Dev),
-        Configuration.reference, new DefaultLangs(Configuration.reference ++ Configuration.from(Map("play.i18n.langs" -> Seq("invalid_language"))))
-      ) must throwA[PlayException]
+      {
+        val langs = new DefaultLangsProvider(Configuration.reference ++ Configuration.from(Map("play.i18n.langs" -> Seq("invalid_language")))).get
+        val messagesApi = new DefaultMessagesApiProvider(new Environment(new File("."), this.getClass.getClassLoader, Mode.Dev), Configuration.reference, langs, HttpConfiguration()).get
+      } must throwA[PlayException]
     }
   }
 

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -14,10 +14,10 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Sink
 import org.specs2.mutable._
 import play.api.http.HeaderNames._
-import play.api.http.{ FlashConfiguration, SessionConfiguration }
+import play.api.http.{ FlashConfiguration, HttpConfiguration, SessionConfiguration }
 import play.api.http.Status._
-import play.api.i18n.{ DefaultLangs, DefaultMessagesApi }
-import play.api.{ Configuration, Environment, Play }
+import play.api.i18n._
+import play.api.{ Application, Configuration, Environment, Play }
 import play.core.test._
 
 import scala.concurrent.Await
@@ -155,9 +155,9 @@ class ResultsSpec extends Specification {
         Some(Set(preferencesCookie, sessionCookie)))
     }
 
-    "support clearing a language cookie using clearingLang" in withApplication {
-      implicit val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
-      val cookie = Cookies.decodeSetCookieHeader(bake { Ok.clearingLang }.header.headers("Set-Cookie")).head
+    "support clearing a language cookie using clearingLang" in withApplication { app: Application =>
+      implicit val messagesApi = app.injector.instanceOf[MessagesApi]
+      val cookie = Cookies.decodeSetCookieHeader(bake(Ok.clearingLang).header.headers("Set-Cookie")).head
       cookie.name must_== Play.langCookieName
       cookie.value must_== ""
     }

--- a/framework/src/play/src/test/scala/play/core/test/package.scala
+++ b/framework/src/play/src/test/scala/play/core/test/package.scala
@@ -3,7 +3,7 @@
  */
 package play.core
 
-import play.api.{ ApplicationLoader, BuiltInComponentsFromContext, Environment, Play }
+import play.api._
 
 package object test {
 
@@ -17,6 +17,18 @@ package object test {
     Play.start(app)
     try {
       block
+    } finally {
+      Play.stop(app)
+    }
+  }
+
+  def withApplication[T](block: Application => T): T = {
+    val app = new BuiltInComponentsFromContext(ApplicationLoader.createContext(Environment.simple())) {
+      def router = play.api.routing.Router.empty
+    }.application
+    Play.start(app)
+    try {
+      block(app)
     } finally {
       Play.stop(app)
     }

--- a/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
+++ b/framework/src/play/src/test/scala/views/html/helper/HelpersSpec.scala
@@ -7,15 +7,18 @@ import org.specs2.mutable.Specification
 import play.api.{ Configuration, Environment }
 import play.api.data.Forms._
 import play.api.data._
+import play.api.http.HttpConfiguration
 import play.api.i18n._
 import play.twirl.api.Html
 
-import scala.beans.BeanProperty
-
 class HelpersSpec extends Specification {
   import FieldConstructor.defaultField
-  val messagesApi = new DefaultMessagesApi(Environment.simple(), Configuration.reference, new DefaultLangs(Configuration.reference))
-  implicit val messages = messagesApi.preferred(Seq.empty)
+
+  val conf = Configuration.reference
+  val langs = new DefaultLangsProvider(conf).get
+  val httpConfiguration = HttpConfiguration.fromConfiguration(conf)
+  val messagesApi = new DefaultMessagesApiProvider(Environment.simple(), conf, langs, httpConfiguration).get
+  implicit val messages: Messages = messagesApi.preferred(Seq.empty)
 
   "@inputText" should {
 


### PR DESCRIPTION
## Purpose

This PR breaks out the construction of a `DefaultMessagesApi` from configuration using a `javax.inject.Provider`.  It removes a hardcoded reference to HttpConfiguration and allows for other instances of `DefaultMessagesApi` to be passed back with just a Map backing and default arguments instead of the entire environment / configuration etc.

This also makes it much easier to supply a MessagesApi object to FakeRequest, etc.

Docs added: unit testing a form by passing a `DefaultMessagesApi` in.