### PR TITLE
Fix Multipart form data parts with optional quotes

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -7,9 +7,9 @@ import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.Application
 import play.api.libs.Files.TemporaryFile
-import play.api.mvc.{ PlayBodyParsers, MultipartFormData, Result }
+import play.api.mvc.{ MultipartFormData, PlayBodyParsers, Result }
 import play.api.test._
-import play.core.parsers.Multipart.FileInfoMatcher
+import play.core.parsers.Multipart.{ FileInfoMatcher, PartInfoMatcher }
 import play.utils.PlayIO
 
 class MultipartFormDataParserSpec extends PlaySpecification {
@@ -24,6 +24,14 @@ class MultipartFormDataParserSpec extends PlaySpecification {
       |Content-Disposition: form-data; name="text2:colon"
       |
       |the second text field
+      |--aabbccddee
+      |Content-Disposition: form-data; name=noQuotesText1
+      |
+      |text field with unquoted name
+      |--aabbccddee
+      |Content-Disposition: form-data; name=noQuotesText1:colon
+      |
+      |text field with unquoted name and colon
       |--aabbccddee
       |Content-Disposition: form-data; name="file1"; filename="file1.txt"
       |Content-Type: text/plain
@@ -46,6 +54,8 @@ class MultipartFormDataParserSpec extends PlaySpecification {
       case parts =>
         parts.dataParts.get("text1") must_== Some(Seq("the first text field"))
         parts.dataParts.get("text2:colon") must_== Some(Seq("the second text field"))
+        parts.dataParts.get("noQuotesText1") must_== Some(Seq("text field with unquoted name"))
+        parts.dataParts.get("noQuotesText1:colon") must_== Some(Seq("text field with unquoted name and colon"))
         parts.files must haveLength(2)
         parts.file("file1") must beSome.like {
           case filePart => PlayIO.readFileAsString(filePart.ref.file) must_== "the first file\r\n"
@@ -140,10 +150,28 @@ class MultipartFormDataParserSpec extends PlaySpecification {
       result.get must equalTo(("document", """quotes"".jpg""", Option("image/jpeg")))
     }
 
-    "parse unquoted content disposition" in {
+    "parse unquoted content disposition with file matcher" in {
       val result = FileInfoMatcher.unapply(Map("content-disposition" -> """form-data; name=document; filename=hello.txt"""))
       result must not(beEmpty)
       result.get must equalTo(("document", "hello.txt", None))
+    }
+
+    "parse unquoted content disposition with part matcher" in {
+      val result = PartInfoMatcher.unapply(Map("content-disposition" -> """form-data; name=partName"""))
+      result must not(beEmpty)
+      result.get must equalTo("partName")
+    }
+
+    "parse unquoted content disposition with part matcher" in {
+      val result = PartInfoMatcher.unapply(Map("content-disposition" -> """form-data; name=partName"""))
+      result must not(beEmpty)
+      result.get must equalTo("partName")
+    }
+
+    "ignore extended name in content disposition" in {
+      val result = PartInfoMatcher.unapply(Map("content-disposition" -> """form-data; name=partName; name*=utf8'en'extendedName"""))
+      result must not(beEmpty)
+      result.get must equalTo("partName")
     }
 
     "ignore extended filename in content disposition" in {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -162,12 +162,6 @@ class MultipartFormDataParserSpec extends PlaySpecification {
       result.get must equalTo("partName")
     }
 
-    "parse unquoted content disposition with part matcher" in {
-      val result = PartInfoMatcher.unapply(Map("content-disposition" -> """form-data; name=partName"""))
-      result must not(beEmpty)
-      result.get must equalTo("partName")
-    }
-
     "ignore extended name in content disposition" in {
       val result = PartInfoMatcher.unapply(Map("content-disposition" -> """form-data; name=partName; name*=utf8'en'extendedName"""))
       result must not(beEmpty)

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -197,7 +197,7 @@ object Multipart {
   private[play] object PartInfoMatcher {
     def unapply(headers: Map[String, String]): Option[String] = {
 
-      val KeyValue = """^([a-zA-Z_0-9]+)="(.*)"$""".r
+      val KeyValue = """^([a-zA-Z_0-9]+)="?(.*)"?$""".r
 
       for {
         values <- headers.get("content-disposition").map(

--- a/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/Multipart.scala
@@ -197,7 +197,7 @@ object Multipart {
   private[play] object PartInfoMatcher {
     def unapply(headers: Map[String, String]): Option[String] = {
 
-      val KeyValue = """^([a-zA-Z_0-9]+)="?(.*)"?$""".r
+      val KeyValue = """^([a-zA-Z_0-9]+)="?(.*?)"?$""".r
 
       for {
         values <- headers.get("content-disposition").map(


### PR DESCRIPTION
##Fix
Multipart form data parts have optional quotes. This was already fixed for "filename" param, but not for regular parameters.

##References

I've also commented on this issue:
playframework#6275