### PR TITLE
[WIP] Adds an Injectable trait to PlaySpecification

### DIFF
--- a/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
+++ b/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
@@ -32,7 +32,7 @@ class ScalaCacheSpec extends PlaySpecification with Controller {
 
     "be injectable" in {
       running() { app =>
-        app.injector.instanceOf[inject.Application]
+        app.injector.instanceOf[injected.Application]
         ok
       }
     }
@@ -159,7 +159,7 @@ object html {
 
 }
 
-package inject {
+package injected {
 //#inject
 import play.api.cache._
 import play.api.mvc._

--- a/framework/src/play-specs2/src/main/scala/play/api/test/PlaySpecification.scala
+++ b/framework/src/play-specs2/src/main/scala/play/api/test/PlaySpecification.scala
@@ -22,5 +22,6 @@ trait PlaySpecification extends Specification
     with Writeables
     with RouteInvokers
     with FutureAwaits
-    with HttpVerbs {
+    with HttpVerbs
+    with Injectable {
 }

--- a/framework/src/play-test/src/test/scala/play/api/test/InjectingSpec.scala
+++ b/framework/src/play-test/src/test/scala/play/api/test/InjectingSpec.scala
@@ -10,15 +10,14 @@ import play.api.inject.Injector
 
 import scala.language.reflectiveCalls
 
-class InjectingSpec extends Specification with Mockito {
+class InjectingSpec extends Specification with Mockito with Injectable {
 
   class Foo
 
   class AppContainer(val app: Application)
 
   "Injecting trait" should {
-
-    "provide an instance when asked for a class" in {
+    "provide an instance when using inject" in {
       val injector = mock[Injector]
       val app = mock[Application]
       app.injector returns injector
@@ -27,6 +26,42 @@ class InjectingSpec extends Specification with Mockito {
 
       val appContainer = new AppContainer(app) with Injecting
       val actual: Foo = appContainer.inject[Foo]
+      actual must_== expected
+    }
+
+    "provide an instance when using injecting" in {
+      val injector = mock[Injector]
+      val app = mock[Application]
+      app.injector returns injector
+      val expected = new Foo
+      injector.instanceOf[Foo] returns expected
+
+      val appContainer = new AppContainer(app) with Injecting
+      val actual: Foo = appContainer.injecting { foo: Foo => foo }
+      actual must_== expected
+    }
+  }
+
+  "Injectable trait" should {
+    "provide an instance when using inject" in {
+      val injector = mock[Injector]
+      implicit val app = mock[Application] // must be implicit
+      app.injector returns injector
+      val expected = new Foo
+      injector.instanceOf[Foo] returns expected
+
+      val actual: Foo = inject[Foo]
+      actual must_== expected
+    }
+
+    "provide an instance when using injecting" in {
+      val injector = mock[Injector]
+      implicit val app = mock[Application] // must be implicit
+      app.injector returns injector
+      val expected = new Foo
+      injector.instanceOf[Foo] returns expected
+
+      val actual: Foo = injecting { foo: Foo => foo }
       actual must_== expected
     }
   }


### PR DESCRIPTION
WIP DO NOT MERGE NEEDS DOCS AND FEEDBACK

Adds an `Injectable` trait that takes an implicit `Application` to resolve the type.  

This is different than `Injecting` because it requires an implicit val in scope.  Given that `WithApplication` and `WithServer` declare `implicit val app: Application`, having two of them may be redundant.