### PR TITLE
[UFR] Remove `Execution.internalContext` references

### DIFF
--- a/framework/src/play-java-ws/src/main/java/play/libs/openid/DefaultOpenIdClient.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/openid/DefaultOpenIdClient.java
@@ -3,11 +3,11 @@
  */
 package play.libs.openid;
 
-import play.core.Execution;
 import play.libs.Scala;
 import play.mvc.Http;
 import scala.collection.JavaConversions;
 import scala.compat.java8.FutureConverters;
+import scala.concurrent.ExecutionContext;
 import scala.runtime.AbstractFunction1;
 
 import javax.inject.Inject;
@@ -18,10 +18,12 @@ import java.util.concurrent.CompletionStage;
 public class DefaultOpenIdClient implements OpenIdClient {
 
     private final play.api.libs.openid.OpenIdClient client;
+    private final ExecutionContext executionContext;
 
     @Inject
-    public DefaultOpenIdClient(play.api.libs.openid.OpenIdClient client) {
+    public DefaultOpenIdClient(play.api.libs.openid.OpenIdClient client, ExecutionContext executionContext) {
         this.client = client;
+        this.executionContext = executionContext;
     }
 
     @Override
@@ -60,7 +62,7 @@ public class DefaultOpenIdClient implements OpenIdClient {
                     public UserInfo apply(play.api.libs.openid.UserInfo scalaUserInfo) {
                         return new UserInfo(scalaUserInfo.id(), JavaConversions.mapAsJavaMap(scalaUserInfo.attributes()));
                     }
-                }, Execution.internalContext());
+                }, executionContext);
         return FutureConverters.toJava(scalaPromise);
     }
 

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -111,7 +111,7 @@ private[play] class PlayRequestHandler(val server: NettyServer) extends ChannelI
         val bufferLimit = app.configuration.getBytes("play.websocket.buffer.limit").getOrElse(65536L).asInstanceOf[Int]
         val factory = new WebSocketServerHandshakerFactory(wsUrl, "*", true, bufferLimit)
 
-        val executed = Future(ws(requestHeader))(play.core.Execution.internalContext)
+        val executed = Future(ws(requestHeader))(app.actorSystem.dispatcher)
 
         import play.core.Execution.Implicits.trampoline
         executed.flatMap(identity).flatMap {

--- a/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -114,7 +114,7 @@ object DevServerStart {
               //
               // Because we are on DEV mode here, it doesn't really matter
               // but it's more coherent with the way it works in PROD mode.
-              implicit val ec = play.core.Execution.internalContext
+              implicit val ec = scala.concurrent.ExecutionContext.global
               Await.result(scala.concurrent.Future {
 
                 val reloaded = buildLink.reload match {

--- a/framework/src/play/src/main/scala/play/core/Execution.scala
+++ b/framework/src/play/src/main/scala/play/core/Execution.scala
@@ -12,6 +12,11 @@ import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
  */
 private[play] object Execution {
 
+  /**
+   * @deprecated Use the application execution context.
+   * @return the actorsystem's execution context
+   */
+  @deprecated("Use an injected execution context", "2.6.0")
   def internalContext: ExecutionContextExecutor = {
     Play.privateMaybeApplication match {
       case None => common


### PR DESCRIPTION
The `Execution.internalContext` methods are static, so they all depend on Play.privateMaybeApplication.  They can be replaced with generic thread pool references that don't go through the same pathway.