### PR TITLE
Fix more missing javadoc

### DIFF
--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheck.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheck.java
@@ -19,9 +19,10 @@ import java.lang.annotation.Target;
 public @interface RequireCSRFCheck {
 
     /**
-     * Call a implementation class for handling the CSRF error.
+     * Calls a implementation class for handling the CSRF error.
      *
      * @see play.filters.csrf.CSRFErrorHandler
+     * @return the subtype of CSRFErrorHandler
      */
     Class<? extends CSRFErrorHandler> error() default CSRFErrorHandler.DefaultCSRFErrorHandler.class;
 

--- a/framework/src/play-guice/src/main/java/play/libs/akka/AkkaGuiceSupport.java
+++ b/framework/src/play-guice/src/main/java/play/libs/akka/AkkaGuiceSupport.java
@@ -42,6 +42,7 @@ public interface AkkaGuiceSupport {
      * bind the returned ActorRef for the actor will be bound, qualified with the passed in name, so that it can be
      * injected into other components.
      *
+     * @param <T> the actor type.
      * @param actorClass The class that implements the actor.
      * @param name The name of the actor.
      * @param props A function to provide props for the actor. The props passed in will just describe how to create the
@@ -62,6 +63,7 @@ public interface AkkaGuiceSupport {
      * bind the returned ActorRef for the actor will be bound, qualified with the passed in name, so that it can be
      * injected into other components.
      *
+     * @param <T> the actor type.
      * @param actorClass The class that implements the actor.
      * @param name The name of the actor.
      */
@@ -130,6 +132,7 @@ public interface AkkaGuiceSupport {
      * }
      * </pre>
      *
+     * @param <T> the actor type.
      * @param actorClass The class that implements the actor.
      * @param factoryClass The factory interface for creating the actor.
      */

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -20,6 +20,10 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     
     /**
      * Creates a new empty dynamic form.
+     *
+     * @param messagesApi    the messagesApi component.
+     * @param formatters     the formatters component.
+     * @param validator      the validator component.
      */
     public DynamicForm(MessagesApi messagesApi, Formatters formatters, Validator validator) {
         super(DynamicForm.Dynamic.class, messagesApi, formatters, validator);
@@ -32,6 +36,9 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      * @param data the current form data (used to display the form)
      * @param errors the collection of errors associated with this form
      * @param value optional concrete value if the form submission was successful
+     * @param messagesApi    the messagesApi component.
+     * @param formatters     the formatters component.
+     * @param validator      the validator component.
      */
     public DynamicForm(Map<String,String> data, Map<String,List<ValidationError>> errors, Optional<Dynamic> value, MessagesApi messagesApi, Formatters formatters, Validator validator) {
         super(null, DynamicForm.Dynamic.class, data, errors, value, messagesApi, formatters, validator);
@@ -44,6 +51,8 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     
     /**
      * Gets the concrete value if the submission was a success.
+     * @param key the string key.
+     * @return the value, or null if there is no match.
      */
     public String get(String key) {
         try {
@@ -59,7 +68,9 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     }
 
     /**
-     * Fille with existing data.
+     * Fills the form with existing data.
+     * @param value    the map of values to fill in the form.
+     * @return the modified form.
      */
     public DynamicForm fill(Map value) {
         Form<Dynamic> form = super.fill(new Dynamic(value));
@@ -185,7 +196,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         }
 
         /**
-         * Retrieves the data.
+         * @return the data.
          */
         public Map getData() {
             return data;
@@ -193,6 +204,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
 
         /**
          * Sets the new data.
+         * @param data    the map of data.
          */
         public void setData(Map data) {
             this.data = data;

--- a/framework/src/play-java-forms/src/main/java/play/data/FormFactory.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/FormFactory.java
@@ -29,35 +29,47 @@ public class FormFactory {
     }
     
     /**
-     * Instantiates a dynamic form.
+     * @return a dynamic form.
      */
     public DynamicForm form() {
         return new DynamicForm(messagesApi, formatters, validator);
     }
     
     /**
-     * Instantiates a new form that wraps the specified class.
+     * @param clazz    the class to map to a form.
+     * @param <T>   the type of value in the form.
+     * @return a new form that wraps the specified class.
      */
     public <T> Form<T> form(Class<T> clazz) {
         return new Form<>(clazz, messagesApi, formatters, validator);
     }
     
     /**
-     * Instantiates a new form that wraps the specified class.
+     * @param <T>   the type of value in the form.
+     * @param name the form's name.
+     * @param clazz the class to map to a form.
+     * @return a new form that wraps the specified class.
      */
     public <T> Form<T> form(String name, Class<T> clazz) {
         return new Form<>(name, clazz, messagesApi, formatters, validator);
     }
     
     /**
-     * Instantiates a new form that wraps the specified class.
+     * @param <T>   the type of value in the form.
+     * @param name the form's name
+     * @param clazz the class to map to a form.
+     * @param groups the classes of groups.
+     * @return a new form that wraps the specified class.
      */
     public <T> Form<T> form(String name, Class<T> clazz, Class<?>... groups) {
         return new Form<>(name, clazz, groups, messagesApi, formatters, validator);
     }
 
     /**
-     * Instantiates a new form that wraps the specified class.
+     * @param <T>   the type of value in the form.
+     * @param clazz the class to map to a form.
+     * @param groups the classes of groups.
+     * @return a new form that wraps the specified class.
      */
     public <T> Form<T> form(Class<T> clazz, Class<?>... groups) {
         return new Form<>(null, clazz, groups, messagesApi, formatters, validator);

--- a/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java
@@ -31,15 +31,13 @@ public class Constraints {
     public static abstract class Validator<T> {
 
         /**
-         * Returns {@code true} if this value is valid.
-         *
+         * @param object    the value to test.
          * @return {@code true} if this value is valid.
          */
         public abstract boolean isValid(T object);
 
         /**
-         * Returns {@code true} if this value is valid for the given constraint.
-         *
+         * @param object            the object to check
          * @param constraintContext The JSR-303 validation context.
          * @return {@code true} if this value is valid for the given constraint.
          */
@@ -57,6 +55,7 @@ public class Constraints {
      *
      * This method calls {@code displayableConstraint} under the hood.
      *
+     * @param constraints    the set of constraint descriptors.
      * @return a list of pairs of tuples assembled from displayableConstraint.
      */
     public static List<Tuple<String,List<Object>>> displayableConstraint(Set<ConstraintDescriptor<?>> constraints) {
@@ -66,7 +65,10 @@ public class Constraints {
     /**
      * Converts a set of constraints to human-readable values in guaranteed order.
      * Only constraints that have an annotation that intersect with the {@code orderedAnnotations} parameter will be considered.
-     * The order of the returned constraints corresponds to the order of the {@code orderedAnnotations parameter}. 
+     * The order of the returned constraints corresponds to the order of the {@code orderedAnnotations parameter}.
+     * @param constraints           the set of constraint descriptors.
+     * @param orderedAnnotations    the array of annotations
+     * @return a list of tuples showing readable constraints.
      */
     public static List<Tuple<String,List<Object>>> displayableConstraint(Set<ConstraintDescriptor<?>> constraints, Annotation[] orderedAnnotations) {
         final List<Annotation> constraintAnnot = constraints.stream().
@@ -82,6 +84,7 @@ public class Constraints {
     /**
      * Converts a constraint to a human-readable value.
      *
+     * @param constraint    the constraint descriptor.
      * @return A tuple containing the constraint's display name and the constraint attributes.
      */
     public static Tuple<String,List<Object>> displayableConstraint(ConstraintDescriptor<?> constraint) {
@@ -137,6 +140,7 @@ public class Constraints {
 
     /**
      * Constructs a 'required' validator.
+     * @return the RequiredValidator
      */
     public static Validator<Object> required() {
         return new RequiredValidator();
@@ -308,6 +312,8 @@ public class Constraints {
 
     /**
      * Constructs a 'minLength' validator.
+     * @param value    the minimum length value.
+     * @return the MinLengthValidator
      */
     public static Validator<String> minLength(long value) {
         return new MinLengthValidator(value);
@@ -363,6 +369,8 @@ public class Constraints {
 
     /**
      * Constructs a 'maxLength' validator.
+     * @param value    the max length
+     * @return the MaxLengthValidator
      */
     public static Validator<String> maxLength(long value) {
         return new MaxLengthValidator(value);
@@ -413,6 +421,7 @@ public class Constraints {
 
     /**
      * Constructs a 'email' validator.
+     * @return the EmailValidator
      */
     public static Validator<String> email() {
         return new EmailValidator();
@@ -468,6 +477,8 @@ public class Constraints {
 
     /**
      * Constructs a 'pattern' validator.
+     * @param regex    the regular expression to match.
+     * @return the PatternValidator.
      */
     public static Validator<String> pattern(String regex) {
         return new PatternValidator(regex);

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSRequest.java
@@ -229,8 +229,9 @@ public interface WSRequest {
     //-------------------------------------------------------------------------
 
     /**
-     * Set the HTTP method this request should use, where the no args execute() method is invoked.
+     * Sets the HTTP method this request should use, where the no args execute() method is invoked.
      *
+     * @param method    the HTTP method.
      * @return the modified WSRequest.
      */
     WSRequest setMethod(String method);
@@ -238,13 +239,14 @@ public interface WSRequest {
     /**
      * Set the body this request should use.
      *
+     * @param body    the body of the request.
      * @return the modified WSRequest.
      */
     WSRequest setBody(String body);
 
     /**
      * Set the body this request should use.
-     *
+     * @param body    the body of the request.
      * @return the modified WSRequest.
      */
     WSRequest setBody(JsonNode body);
@@ -262,17 +264,22 @@ public interface WSRequest {
     /**
      * Set the body this request should use.
      *
+     * @param body    the body of the request.
      * @return the modified WSRequest.
      */
     WSRequest setBody(File body);
 
     /**
      * Set the body this request should use.
+     * @param body    the body of the request.
+     * @return the modified WSRequest.
      */
     WSRequest setBody(Source<ByteString,?> body);
 
     /**
      * Set the multipart body this request should use.
+     * @param body    the body of the request.
+     * @return the modified WSRequest.
      */
     WSRequest setMultipartBody(Source<? super Http.MultipartFormData.Part<Source<ByteString, ?>>, ?> body);
 
@@ -317,6 +324,7 @@ public interface WSRequest {
      *
      * @param username the basic auth username
      * @param password the basic auth password
+     * @return the modified WSRequest.
      */
     WSRequest setAuth(String username, String password);
 
@@ -326,6 +334,7 @@ public interface WSRequest {
      * @param username the username
      * @param password the password
      * @param scheme   authentication scheme
+     * @return the modified WSRequest.
      */
     WSRequest setAuth(String username, String password, WSAuthScheme scheme);
 

--- a/framework/src/play-java-ws/src/main/java/play/libs/ws/WSResponse.java
+++ b/framework/src/play-java-ws/src/main/java/play/libs/ws/WSResponse.java
@@ -17,67 +17,69 @@ import java.util.Map;
 public interface WSResponse {
 
     /**
-     * Gets all the headers from the response.
+     * @return all the headers from the response.
      */
     Map<String, List<String>> getAllHeaders();
 
     /**
-     * Gets a single header from the response.
+     * @param key    the header's name
+     * @return a single header value from the response.
      */
     String getHeader(String key);
 
     /**
-     * Gets the underlying implementation response object, if any.
+     * @return the underlying implementation response object, if any.
      */
     Object getUnderlying();
 
     /**
-     * Returns the HTTP status code from the response.
+     * @return the HTTP status code from the response.
      */
     int getStatus();
 
     /**
-     * Returns the text associated with the status code.
+     * @return the text associated with the status code.
      */
     String getStatusText();
 
     /**
-     * Gets all the cookies from the response.
+     * @return all the cookies from the response.
      */
     List<WSCookie> getCookies();
 
     /**
-     * Gets a single cookie from the response, if any.
+     * @param name    the cookie name
+     * @return a single cookie from the response, if any.
      */
     WSCookie getCookie(String name);
 
     /**
-     * Gets the body as a string.
+     * @return the body as a string.
      */
     String getBody();
 
     /**
-     * Gets the body as XML.
+     * @return the body as XML.
      */
     Document asXml();
 
     /**
-     * Gets the body as JSON node.
+     * @return the body as JSON node.
      */
     JsonNode asJson();
 
     /**
-     * Gets the body as a stream.
+     * @return the body as a stream.
      */
     InputStream getBodyAsStream();
 
     /**
-     * Gets the body as an array of bytes.
+     * @return the body as an array of bytes.
      */
     byte[] asByteArray();
 
     /**
-     * Gets the URI of the response.
+     * @return the URI of the response.
      */
     URI getUri();
 }

--- a/framework/src/play-java/src/main/java/play/libs/Classpath.java
+++ b/framework/src/play-java/src/main/java/play/libs/Classpath.java
@@ -21,6 +21,7 @@ public class Classpath {
      * <p>
      * Note that it is better to specify a very specific package to avoid expensive searches.
      *
+     * @param app         the Play application
      * @param packageName the root package to scan
      * @return a set of types names satisfying the condition
      */
@@ -36,6 +37,7 @@ public class Classpath {
      * <p>
      * Note that it is better to specify a very specific package to avoid expensive searches.
      *
+     * @param app         the play application.
      * @param packageName the root package to scan
      * @param annotation annotation class
      * @return a set of types names statifying the condition
@@ -60,6 +62,7 @@ public class Classpath {
      * <p>
      * Note that it is better to specify a very specific package to avoid expensive searches.
      *
+     * @param env         the Play environment.
      * @param packageName the root package to scan
      * @return a set of types names satisfying the condition
      */
@@ -75,6 +78,7 @@ public class Classpath {
      * <p>
      * Note that it is better to specify a very specific package to avoid expensive searches.
      *
+     * @param env         the Play environment.
      * @param packageName the root package to scan
      * @param annotation annotation class
      * @return a set of types names statifying the condition

--- a/framework/src/play-java/src/main/java/play/libs/EventSource.java
+++ b/framework/src/play-java/src/main/java/play/libs/EventSource.java
@@ -35,9 +35,8 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 public class EventSource {
 
-
     /**
-     * Creates a flow of EventSource.Event to ByteString.
+     * @return a flow of EventSource.Event to ByteString.
      */
     public static Flow<EventSource.Event, ByteString, ?> flow() {
         Flow<Event, Event, NotUsed> flow = Flow.of(Event.class);

--- a/framework/src/play-java/src/main/java/play/libs/Time.java
+++ b/framework/src/play-java/src/main/java/play/libs/Time.java
@@ -105,12 +105,12 @@ public class Time {
 
     /**
      * Thanks to Quartz project, https://quartz.dev.java.net
-     * <P>
+     *  
      * Provides a parser and evaluator for unix-like cron expressions. Cron 
      * expressions provide the ability to specify complex time combinations such as
      * &quot;At 8:00am every Monday through Friday&quot; or &quot;At 1:30am every 
      * last Friday of the month&quot;. 
-     * <P>
+     *  
      * Cron expressions are comprised of 6 required fields and one optional field
      * separated by white space. The fields respectively are described as follows:
      * 
@@ -172,21 +172,21 @@ public class Time {
      * <td align="left"><code>, - * /</code></td>
      * </tr>
      * </table>
-     * <P>
+     *  
      * The '*' character is used to specify all values. For example, &quot;*&quot; 
      * in the minute field means &quot;every minute&quot;.
-     * <P>
+     *  
      * The '?' character is allowed for the day-of-month and day-of-week fields. It
      * is used to specify 'no specific value'. This is useful when you need to
      * specify something in one of the two fields, but not the other.
-     * <P>
+     *  
      * The '-' character is used to specify ranges For example &quot;10-12&quot; in
      * the hour field means &quot;the hours 10, 11 and 12&quot;.
-     * <P>
+     *  
      * The ',' character is used to specify additional values. For example
      * &quot;MON,WED,FRI&quot; in the day-of-week field means &quot;the days Monday,
      * Wednesday, and Friday&quot;.
-     * <P>
+     *  
      * The '/' character is used to specify increments. For example &quot;0/15&quot;
      * in the seconds field means &quot;the seconds 0, 15, 30, and 45&quot;. And 
      * &quot;5/15&quot; in the seconds field means &quot;the seconds 5, 20, 35, and
@@ -198,7 +198,7 @@ public class Time {
      * on every &quot;nth&quot; value in the given set. Thus &quot;7/6&quot; in the
      * month field only turns on month &quot;7&quot;, it does NOT mean every 6th 
      * month, please note that subtlety.  
-     * <P>
+     * 
      * The 'L' character is allowed for the day-of-month and day-of-week fields.
      * This character is short-hand for &quot;last&quot;, but it has different 
      * meaning in each of the two fields. For example, the value &quot;L&quot; in 
@@ -210,7 +210,7 @@ public class Time {
      * means &quot;the last friday of the month&quot;. When using the 'L' option, it
      * is important not to specify lists, or ranges of values, as you'll get 
      * confusing results.
-     * <P>
+     * 
      * The 'W' character is allowed for the day-of-month field.  This character 
      * is used to specify the weekday (Monday-Friday) nearest the given day.  As an 
      * example, if you were to specify &quot;15W&quot; as the value for the 
@@ -222,11 +222,11 @@ public class Time {
      * 1st is a Saturday, the trigger will fire on Monday the 3rd, as it will not 
      * 'jump' over the boundary of a month's days.  The 'W' character can only be 
      * specified when the day-of-month is a single day, not a range or list of days.
-     * <P>
+     * 
      * The 'L' and 'W' characters can also be combined for the day-of-month 
      * expression to yield 'LW', which translates to &quot;last weekday of the 
      * month&quot;.
-     * <P>
+     * 
      * The '#' character is allowed for the day-of-week field. This character is
      * used to specify &quot;the nth&quot; xxx day of the month. For example, the 
      * value of &quot;6#3&quot; in the day-of-week field means the third Friday of 
@@ -235,7 +235,7 @@ public class Time {
      * &quot;4#5&quot; = the fifth Wednesday of the month. Note that if you specify
      * &quot;#5&quot; and there is not 5 of the given day-of-week in the month, then
      * no firing will occur that month.
-     * <P>
+     *
      * <!--The 'C' character is allowed for the day-of-month and day-of-week fields.
      * This character is short-hand for "calendar". This means values are
      * calculated against the associated calendar, if any. If no calendar is
@@ -243,11 +243,10 @@ public class Time {
      * value of "5C" in the day-of-month field means "the first day included by the
      * calendar on or after the 5th". A value of "1C" in the day-of-week field
      * means "the first day included by the calendar on or after sunday".-->
-     * <P>
+     *
      * The legal characters and the names of months and days of the week are not
      * case sensitive.
      * 
-     * <p>
      * <b>NOTES:</b>
      * <ul>
      * <li>Support for specifying both a day-of-week and a day-of-month value is
@@ -418,6 +417,7 @@ public class Time {
         /**
          * Returns the time zone for which this <code>CronExpression</code> 
          * will be resolved.
+         * @return timezone
          */
         public TimeZone getTimeZone() {
             if (timeZone == null) {
@@ -430,6 +430,7 @@ public class Time {
         /**
          * Sets the time zone for which  this <code>CronExpression</code> 
          * will be resolved.
+         * @param timeZone    the time zone.
          */
         public void setTimeZone(TimeZone timeZone) {
             this.timeZone = timeZone;
@@ -1498,8 +1499,8 @@ public class Time {
          * Advance the calendar to the particular hour paying particular attention
          * to daylight saving problems.
          * 
-         * @param cal
-         * @param hour
+         * @param cal     calendar
+         * @param hour      hour of day.
          */
         protected void setCalendarHour(Calendar cal, int hour) {
             cal.set(java.util.Calendar.HOUR_OF_DAY, hour);
@@ -1511,6 +1512,8 @@ public class Time {
         /**
          * NOT YET IMPLEMENTED: Returns the time before the given time
          * that the <code>CronExpression</code> matches.
+         * @param endTime    end time
+         * @return date
          */
         protected Date getTimeBefore(Date endTime) {
             throw new UnsupportedOperationException();
@@ -1519,6 +1522,7 @@ public class Time {
         /**
          * NOT YET IMPLEMENTED: Returns the final time that the 
          * <code>CronExpression</code> will match.
+         * @return date
          */
         public Date getFinalFireTime() {
             throw new UnsupportedOperationException();

--- a/framework/src/play-java/src/main/java/play/libs/XPath.java
+++ b/framework/src/play-java/src/main/java/play/libs/XPath.java
@@ -137,9 +137,10 @@ public class XPath {
     }
 
     /**
-     * Return the text of a node, or the value of an attribute
      * @param path the XPath to execute
      * @param node the node, node-set or Context object for evaluation. This value can be null.
+     * @param namespaces    the XML namespaces map
+     * @return the text of a node, or the value of an attribute
      */
     public static String selectText(String path, Object node, Map<String, String> namespaces) {
         try {
@@ -159,9 +160,9 @@ public class XPath {
     }
 
     /**
-     * Return the text of a node, or the value of an attribute
      * @param path the XPath to execute
      * @param node the node, node-set or Context object for evaluation. This value can be null.
+     * @return the text of a node, or the value of an attribute
      */
     public static String selectText(String path, Object node) {
         return selectText(path, node, null);

--- a/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
+++ b/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
@@ -304,6 +304,7 @@ public class RoutingDsl {
         /**
          * Route with one parameter.
          *
+         * @param <A1> the first type parameter
          * @param action The action to execute.
          * @return This router builder.
          */
@@ -314,6 +315,8 @@ public class RoutingDsl {
         /**
          * Route with two parameters.
          *
+         * @param <A1> the first type parameter
+         * @param <A2> the second type parameter
          * @param action The action to execute.
          * @return This router builder.
          */
@@ -324,6 +327,9 @@ public class RoutingDsl {
         /**
          * Route with three parameters.
          *
+         * @param <A1> the first type parameter
+         * @param <A2> the second type parameter
+         * @param <A3> the third type parameter
          * @param action The action to execute.
          * @return This router builder.
          */
@@ -344,6 +350,7 @@ public class RoutingDsl {
         /**
          * Route with one parameter.
          *
+         * @param <A1> the first type parameter
          * @param action The action to execute.
          * @return This router builder.
          */
@@ -354,6 +361,8 @@ public class RoutingDsl {
         /**
          * Route with two parameters.
          *
+         * @param <A1> the first type parameter
+         * @param <A2> the second type parameter
          * @param action The action to execute.
          * @return This router builder.
          */
@@ -364,6 +373,9 @@ public class RoutingDsl {
         /**
          * Route with three parameters.
          *
+         * @param <A1> the first type parameter
+         * @param <A2> the second type parameter
+         * @param <A3> the third type parameter
          * @param action The action to execute.
          * @return This router builder.
          */

--- a/framework/src/play-jdbc-api/src/main/java/play/db/DBApi.java
+++ b/framework/src/play-jdbc-api/src/main/java/play/db/DBApi.java
@@ -11,14 +11,13 @@ import java.util.List;
 public interface DBApi {
 
     /**
-     * All configured databases.
+     * @return all configured databases.
      */
     public List<Database> getDatabases();
 
     /**
-     * Get database with given configuration name.
-     *
      * @param name the configuration name of the database
+     * @return Get database with given configuration name.
      */
     public Database getDatabase(String name);
 

--- a/framework/src/play-jdbc-api/src/main/java/play/db/Database.java
+++ b/framework/src/play-jdbc-api/src/main/java/play/db/Database.java
@@ -12,17 +12,17 @@ import javax.sql.DataSource;
 public interface Database {
 
     /**
-     * The configuration name for this database.
+     * @return the configuration name for this database.
      */
     public String getName();
 
     /**
-     * The underlying JDBC data source for this database.
+     * @return the underlying JDBC data source for this database.
      */
     public DataSource getDataSource();
 
     /**
-     * The JDBC connection URL this database, i.e. `jdbc:...` Normally retrieved
+     * @return the JDBC connection URL this database, i.e. `jdbc:...` Normally retrieved
      * via a connection.
      */
     public String getUrl();
@@ -59,6 +59,7 @@ public interface Database {
      * Execute a block of code, providing a JDBC connection. The connection and
      * all created statements are automatically released.
      *
+     * @param <A> the return value's type
      * @param block code to execute
      * @return the result of the code block
      */
@@ -77,6 +78,7 @@ public interface Database {
      * Execute a block of code, providing a JDBC connection. The connection and
      * all created statements are automatically released.
      *
+     * @param <A> the return value's type
      * @param autocommit determines whether to autocommit the connection
      * @param block      code to execute
      * @return the result of the code block
@@ -97,6 +99,7 @@ public interface Database {
      * connection and all created statements are automatically released. The
      * transaction is automatically committed, unless an exception occurs.
      *
+     * @param <A> the return value's type
      * @param block code to execute
      * @return the result of the code block
      */
@@ -109,6 +112,7 @@ public interface Database {
 
     /**
      * Converts the given database to a Scala database
+     * @return the database for scala API.
      */
     public default play.api.db.Database toScala() {
         return new play.api.db.Database() {

--- a/framework/src/play-jdbc-evolutions/src/main/java/play/db/evolutions/Evolution.java
+++ b/framework/src/play-jdbc-evolutions/src/main/java/play/db/evolutions/Evolution.java
@@ -26,6 +26,7 @@ public final class Evolution {
 
     /**
      * Get the revision of the evolution.
+     * @return The revision of the evolution to create.
      */
     public int getRevision() {
         return revision;
@@ -33,6 +34,7 @@ public final class Evolution {
 
     /**
      * Get the SQL script for bringing the evolution up.
+     * @return the sql script.
      */
     public String getSqlUp() {
         return sqlUp;
@@ -40,6 +42,7 @@ public final class Evolution {
 
     /**
      * Get the SQL script for tearing the evolution down.
+     * @return the sql script.
      */
     public String getSqlDown() {
         return sqlDown;

--- a/framework/src/play-jdbc-evolutions/src/main/java/play/db/evolutions/Evolutions.java
+++ b/framework/src/play-jdbc-evolutions/src/main/java/play/db/evolutions/Evolutions.java
@@ -14,9 +14,10 @@ import java.util.*;
 public class Evolutions {
 
     /**
-     * Create an evolutions reader that reads evolution files from this classes own classloader.
+     * Create an evolutions reader that reads evolution files from this class's own classloader.
      *
      * Only useful in simple classloading environments, such as when the classloader structure is flat.
+     * @return the evolutions reader.
      */
     public static play.api.db.evolutions.EvolutionsReader fromClassLoader() {
         return fromClassLoader(Evolutions.class.getClassLoader());
@@ -26,6 +27,8 @@ public class Evolutions {
      * Create an evolutions reader that reads evolution files from a classloader.
      *
      * @param classLoader The classloader to read from.
+     *
+     * @return the evolutions reader.
      */
     public static play.api.db.evolutions.EvolutionsReader fromClassLoader(ClassLoader classLoader) {
         return fromClassLoader(classLoader, "");
@@ -37,6 +40,8 @@ public class Evolutions {
      * @param classLoader The classloader to read from.
      * @param prefix A prefix that gets added to the resource file names, for example, this could be used to namespace
      *               evolutions in different environments to work with different databases.
+     *
+     * @return  the evolutions reader.
      */
     public static play.api.db.evolutions.EvolutionsReader fromClassLoader(ClassLoader classLoader, String prefix) {
         return new play.api.db.evolutions.ClassLoaderEvolutionsReader(classLoader, prefix);
@@ -46,6 +51,7 @@ public class Evolutions {
      * Create an evolutions reader based on a simple map of database names to evolutions.
      *
      * @param evolutions The map of database names to evolutions.
+     * @return  the evolutions reader.
      */
     public static play.api.db.evolutions.EvolutionsReader fromMap(Map<String, List<Evolution>> evolutions) {
         return new SimpleEvolutionsReader(evolutions);
@@ -55,6 +61,7 @@ public class Evolutions {
      * Create an evolutions reader for the default database from a list of evolutions.
      *
      * @param evolutions The list of evolutions.
+     * @return the evolutions reader.
      */
     public static play.api.db.evolutions.EvolutionsReader forDefault(Evolution... evolutions) {
         Map<String, List<Evolution>> map = new HashMap<String, List<Evolution>>();

--- a/framework/src/play-json/src/main/java/play/libs/Json.java
+++ b/framework/src/play-json/src/main/java/play/libs/Json.java
@@ -32,7 +32,7 @@ public class Json {
     }
 
     /**
-     * Get the ObjectMapper used to serialize and deserialize objects to and from JSON values.
+     * Gets the ObjectMapper used to serialize and deserialize objects to and from JSON values.
      *
      * This can be set to a custom implementation using Json.setObjectMapper.
      *
@@ -62,9 +62,10 @@ public class Json {
     }
 
     /**
-     * Convert an object to JsonNode.
+     * Converts an object to JsonNode.
      *
      * @param data Value to convert in Json.
+     * @return the JSON node.
      */
     public static JsonNode toJson(final Object data) {
         try {
@@ -75,10 +76,12 @@ public class Json {
     }
 
     /**
-     * Convert a JsonNode to a Java value
+     * Converts a JsonNode to a Java value
      *
+     * @param <A> the type of the return value.
      * @param json Json value to convert.
      * @param clazz Expected Java value type.
+     * @return the return value.
      */
     public static <A> A fromJson(JsonNode json, Class<A> clazz) {
         try {
@@ -90,6 +93,7 @@ public class Json {
 
     /**
      * Creates a new empty ObjectNode.
+     * @return new empty ObjectNode.
      */
     public static ObjectNode newObject() {
         return mapper().createObjectNode();
@@ -97,34 +101,43 @@ public class Json {
 
     /**
      * Creates a new empty ArrayNode.
+     * @return a new empty ArrayNode.
      */
     public static ArrayNode newArray() {
         return mapper().createArrayNode();
     }
 
     /**
-     * Convert a JsonNode to its string representation.
+     * Converts a JsonNode to its string representation.
+     * @param json    the JSON node to convert.
+     * @return the string representation.
      */
     public static String stringify(JsonNode json) {
         return generateJson(json, false, false);
     }
 
     /**
-     * Convert a JsonNode to its string representation, escaping non-ascii characters.
+     * Converts a JsonNode to its string representation, escaping non-ascii characters.
+     * @param json    the JSON node to convert.
+     * @return the string representation with escaped non-ascii characters.
      */
     public static String asciiStringify(JsonNode json) {
         return generateJson(json, false, true);
     }
 
     /**
-     * Convert a JsonNode to its string representation.
+     * Converts a JsonNode to its string representation.
+     * @param json    the JSON node to convert.
+     * @return the string representation, pretty printed.
      */
     public static String prettyPrint(JsonNode json) {
         return generateJson(json, true, false);
     }
 
     /**
-     * Parse a String representing a json, and return it as a JsonNode.
+     * Parses a String representing a json, and return it as a JsonNode.
+     * @param src    the JSON string.
+     * @return the JSON node.
      */
     public static JsonNode parse(String src) {
         try {
@@ -135,7 +148,9 @@ public class Json {
     }
 
     /**
-     * Parse a InputStream representing a json, and return it as a JsonNode.
+     * Parses a InputStream representing a json, and return it as a JsonNode.
+     * @param src    the JSON input stream.
+     * @return the JSON node.
      */
     public static JsonNode parse(java.io.InputStream src) {
         try {
@@ -146,7 +161,9 @@ public class Json {
     }
 
     /**
-     * Parse a byte array representing a json, and return it as a JsonNode.
+     * Parses a byte array representing a json, and return it as a JsonNode.
+     * @param src    the JSON input bytes.
+     * @return the JSON node.
      */
     public static JsonNode parse(byte[] src) {
         try {
@@ -161,6 +178,7 @@ public class Json {
      *
      * This is intended to be used when Play starts up.  By default, Play will inject its own object mapper here,
      * but this mapper can be overridden either by a custom module.
+     * @param mapper    the object mapper.
      */
     public static void setObjectMapper(ObjectMapper mapper) {
         objectMapper = mapper;

--- a/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/ClientCookieDecoder.java
+++ b/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/ClientCookieDecoder.java
@@ -46,6 +46,7 @@ public final class ClientCookieDecoder extends CookieDecoder {
     /**
      * Decodes the specified Set-Cookie HTTP header value into a {@link Cookie}.
      *
+     * @param header    the Set-Cookie header.
      * @return the decoded {@link Cookie}
      */
     public Cookie decode(String header) {

--- a/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/DefaultCookie.java
+++ b/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/DefaultCookie.java
@@ -33,6 +33,8 @@ public class DefaultCookie implements Cookie {
 
     /**
      * Creates a new cookie with the specified name and value.
+     * @param name     The cookie's name
+     * @param value    The cookie's value.
      */
     public DefaultCookie(String name, String value) {
         if (name == null) {

--- a/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/ServerCookieDecoder.java
+++ b/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/ServerCookieDecoder.java
@@ -57,6 +57,7 @@ public final class ServerCookieDecoder extends CookieDecoder {
     /**
      * Decodes the specified Set-Cookie HTTP header value into a {@link Cookie}.
      *
+     * @param header    the Set-Cookie header.
      * @return the decoded {@link Cookie}
      */
     public Set<Cookie> decode(String header) {

--- a/framework/src/play-streams/src/main/java/play/libs/streams/Accumulator.java
+++ b/framework/src/play-streams/src/main/java/play/libs/streams/Accumulator.java
@@ -136,6 +136,7 @@ public abstract class Accumulator<E, A> {
      * If it isn't, this could lead to resource leaks and deadlocks upstream.
      *
      * @return An accumulator that forwards the stream to the produced source.
+     * @param <E> the "in" type of the parameter.
      */
     public static <E> Accumulator<E, Source<E, ?>> source() {
         // If Akka streams ever provides Sink.source(), we should use that instead.
@@ -148,6 +149,8 @@ public abstract class Accumulator<E, A> {
     /**
      * Create a done accumulator with the given value.
      *
+     * @param <E> the "in" type of the parameter.
+     * @param <A> the materialized result of the accumulator.
      * @param a The done value for the accumulator.
      * @return The accumulator.
      */
@@ -158,6 +161,8 @@ public abstract class Accumulator<E, A> {
     /**
      * Create a done accumulator with the given future.
      *
+     * @param <E> the "in" type of the parameter.
+     * @param <A> the materialized result of the accumulator.
      * @param a A future of the done value.
      * @return The accumulator.
      */
@@ -168,6 +173,8 @@ public abstract class Accumulator<E, A> {
     /**
      * Flatten a completion stage of an accumulator to an accumulator.
      *
+     * @param <E> the "in" type of the parameter.
+     * @param <A> the materialized result of the accumulator.
      * @param stage the CompletionStage (asynchronous) accumulator
      * @param materializer the stream materializer
      * @return The accumulator using the given completion stage

--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -96,7 +96,13 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     // --
 
     /**
-     * Calls a Callable which invokes a Controller or some other method with a Context
+     * Calls a Callable which invokes a Controller or some other method with a Context.
+     *
+     * @param requestBuilder    the request builder to invoke in this context.
+     * @param contextComponents the context components to run.
+     * @param callable the callable block to run.
+     * @param <V> the return type.
+     * @return the value from {@code callable}.
      */
     public static <V> V invokeWithContext(RequestBuilder requestBuilder, JavaContextComponents contextComponents, Callable<V> callable) {
         try {
@@ -110,21 +116,27 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     }
 
     /**
-     * Build a new GET / fake request.
+     * Builds a new "GET /" fake request.
+     * @return the request builder.
      */
     public static RequestBuilder fakeRequest() {
         return fakeRequest("GET", "/");
     }
 
     /**
-     * Build a new fake request.
+     * Builds a new fake request.
+     * @param method    the request method.
+     * @param uri the relative URL.
+     * @return the request builder.
      */
     public static RequestBuilder fakeRequest(String method, String uri) {
         return new RequestBuilder().method(method).uri(uri);
     }
 
     /**
-     * Build a new fake request corresponding to a given route call
+     * Builds a new fake request corresponding to a given route call.
+     * @param call    the route call.
+     * @return the request builder.
      */
     public static RequestBuilder fakeRequest(Call call) {
         return fakeRequest(call.method(), call.url());
@@ -151,6 +163,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Constructs a in-memory (h2) database configuration to add to a fake application.
      *
+     * @param name    the database name.
      * @return a map of String containing database config info.
      */
     public static Map<String, String> inMemoryDatabase(String name) {
@@ -160,6 +173,8 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Constructs a in-memory (h2) database configuration to add to a fake application.
      *
+     * @param name       the database name.
+     * @param options the database options.
      * @return a map of String containing database config info.
      */
     public static Map<String, String> inMemoryDatabase(String name, Map<String, String> options) {
@@ -167,7 +182,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     }
 
     /**
-     * Build a new fake application.  Uses GuiceApplicationBuilder
+     * Build a new fake application.  Uses GuiceApplicationBuilder.
      *
      * @param additionalConfiguration map containing config info for the app.
      * @return an application from the current path with additional configuration.
@@ -386,6 +401,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * Executes a block of code in a running application.
      *
      * @param application the application context.
+     * @param block       the block to run after the Play app is started.
      */
     public static void running(Application application, final Runnable block) {
         synchronized (PlayRunners$.MODULE$.mutex()) {
@@ -421,6 +437,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Creates a new Test server.
      *
+     * @param port    the port to run the server on.
      * @return the test server.
      */
     public static TestServer testServer(int port) {
@@ -430,6 +447,9 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Creates a new Test server.
      *
+     *
+     * @param port    the port to run the server on.
+     * @param app     the Play application.
      * @return the test server.
      */
     public static TestServer testServer(int port, Application app) {
@@ -438,6 +458,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
 
     /**
      * Starts a Test server.
+     * @param server    the test server to start.
      */
     public static void start(TestServer server) {
         server.start();
@@ -445,6 +466,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
 
     /**
      * Stops a Test server.
+     * @param server    the test server to stop.a
      */
     public static void stop(TestServer server) {
         server.stop();
@@ -452,6 +474,8 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
 
     /**
      * Executes a block of code in a running server.
+     * @param server    the server to start.
+     * @param block  the block of code to run after the server starts.
      */
     public static void running(TestServer server, final Runnable block) {
         synchronized (PlayRunners$.MODULE$.mutex()) {
@@ -514,6 +538,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Creates a Test Browser.
      *
+     * @param port    the local port.
      * @return the test browser.
      */
     public static TestBrowser testBrowser(int port) {
@@ -523,6 +548,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Creates a Test Browser.
      *
+     * @param webDriver    the class of webdriver.
      * @return the test browser.
      */
     public static TestBrowser testBrowser(Class<? extends WebDriver> webDriver) {
@@ -532,6 +558,8 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Creates a Test Browser.
      *
+     * @param webDriver    the class of webdriver.
+     * @param port  the local port to test against.
      * @return the test browser.
      */
     public static TestBrowser testBrowser(Class<? extends WebDriver> webDriver, int port) {
@@ -547,6 +575,8 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Creates a Test Browser.
      *
+     * @param of      the web driver to run the browser with.
+     * @param port    the port to run against http://localhost
      * @return the test browser.
      */
     public static TestBrowser testBrowser(WebDriver of, int port) {
@@ -556,6 +586,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * Creates a Test Browser.
      *
+     * @param of      the web driver to run the browser with.
      * @return the test browser.
      */
     public static TestBrowser testBrowser(WebDriver of) {

--- a/framework/src/play-test/src/main/java/play/test/TestBrowser.java
+++ b/framework/src/play-test/src/main/java/play/test/TestBrowser.java
@@ -22,6 +22,7 @@ public class TestBrowser extends FluentAdapter {
      *
      * @param webDriver The WebDriver instance to use.
      * @param baseUrl The base url to use for relative requests.
+     * @throws Exception if the webdriver cannot be created.
      */
     public TestBrowser(Class<? extends WebDriver> webDriver, String baseUrl) throws Exception {
         this(play.api.test.WebDriverFactory.apply(webDriver), baseUrl);
@@ -41,7 +42,9 @@ public class TestBrowser extends FluentAdapter {
 
     /**
      * Creates a generic {@code FluentWait<WebDriver>} instance
-     * using the underlying web driver
+     * using the underlying web driver.
+     *
+     * @return the webdriver contained in a fluent wait.
      */
     public FluentWait<WebDriver> fluentWait() {
         return new FluentWait<WebDriver>(super.getDriver());
@@ -56,8 +59,10 @@ public class TestBrowser extends FluentAdapter {
      * Useful in situations where FluentAdapter#await is too specific
      * (for example to check against page source)
      *
+     * @param <T> the return type
      * @param wait generic {@code FluentWait<WebDriver>} instance
      * @param f function to execute
+     * @return the return value
      */
     public <T>T waitUntil(FluentWait<WebDriver> wait, Function<WebDriver, T> f) {
         return wait.until(f);
@@ -65,14 +70,19 @@ public class TestBrowser extends FluentAdapter {
 
     /**
      * Repeatedly applies this instance's input value to the given function until one of the following occurs:
-     * the function returns neither null nor false,
-     * the function throws an unignored exception,
-     * the default timeout expires
+     *
+     * <ul>
+     *     <li> the function returns neither null nor false,</li>
+     *     <li> the function throws an unignored exception,</li>
+     *     <li> the default timeout expires</li>
+     * </ul>
      *
      * useful in situations where FluentAdapter#await is too specific
      * (for example to check against page source or title)
      *
      * @param f function to execute
+     * @param <T> the return type
+     * @return the return value.
      */
     public <T>T waitUntil(Function<WebDriver, T> f) {
         FluentWait<WebDriver> wait = fluentWait().withTimeout(3000, TimeUnit.MILLISECONDS);
@@ -80,8 +90,10 @@ public class TestBrowser extends FluentAdapter {
     }
 
     /**
-     * retrieves the underlying option interface that can be used
-     * to set cookies, manage timeouts among other things
+     * Retrieves the underlying option interface that can be used
+     * to set cookies, manage timeouts among other things.
+     *
+     * @return the web driver options.
      */
     public WebDriver.Options manage() {
         return super.getDriver().manage();

--- a/framework/src/play-test/src/main/java/play/test/WithBrowser.java
+++ b/framework/src/play-test/src/main/java/play/test/WithBrowser.java
@@ -17,6 +17,7 @@ public class WithBrowser extends WithServer {
     /**
      * Override this if you want to use a different browser
      *
+     * @param port    the port to run the browser against.
      * @return a new test browser
      */
     protected TestBrowser provideBrowser(int port) {

--- a/framework/src/play/src/main/java/play/Logger.java
+++ b/framework/src/play/src/main/java/play/Logger.java
@@ -521,6 +521,7 @@ public class Logger {
         /**
          * Logs a message with the INFO level.
          *
+         * @param marker the marker data specific to this log statement
          * @param message message to log
          */
         public void info(Marker marker, String message) {

--- a/framework/src/play/src/main/java/play/http/DefaultHttpErrorHandler.java
+++ b/framework/src/play/src/main/java/play/http/DefaultHttpErrorHandler.java
@@ -211,6 +211,7 @@ public class DefaultHttpErrorHandler implements HttpErrorHandler {
      *
      * @param request   The request that triggered the error.
      * @param exception The exception.
+     * @return a CompletionStage containing the Result.
      */
     protected CompletionStage<Result> onDevServerError(RequestHeader request, UsefulException exception) {
         return CompletableFuture.completedFuture(Results.internalServerError(views.html.defaultpages.devError.render(playEditor, exception)));

--- a/framework/src/play/src/main/java/play/http/HttpEntity.java
+++ b/framework/src/play/src/main/java/play/http/HttpEntity.java
@@ -24,35 +24,38 @@ public abstract class HttpEntity {
     private HttpEntity() {}
 
     /**
-     * The content type, if defined
+     * @return The content type, if defined
      */
     public abstract Optional<String> contentType();
 
     /**
-     * Whether the entity is known to be empty or not.
+     * @return  Whether the entity is known to be empty or not.
      */
     public abstract boolean isKnownEmpty();
 
     /**
-     * The content length, if known
+     * @return The content length, if known
      */
     public abstract Optional<Long> contentLength();
 
     /**
-     * The stream of data.
+     * @return The stream of data.
      */
     public abstract Source<ByteString, ?> dataStream();
 
     /**
-     * Return the entity as the given content type.
+     * @param contentType    the content type to use, i.e. "text/html".
+     * @return Return the entity as the given content type.
      */
     public abstract HttpEntity as(String contentType);
 
     /**
-     * Consume the data.
+     * Consumes the data.
      *
      * This method should be used carefully, since if the source represents an ephemeral stream, then the entity may
      * not be usable after this method is invoked.
+     * @param mat    the application's materializer.
+     * @return a CompletionStage holding the data
      */
     public CompletionStage<ByteString> consumeData(Materializer mat) {
         return dataStream().runFold(ByteString.empty(), ByteString::concat, mat);
@@ -70,6 +73,8 @@ public abstract class HttpEntity {
      *
      * @param content The content.
      * @param charset The charset.
+     *
+     * @return the HTTP entity.
      */
     public static final HttpEntity fromContent(Content content, String charset) {
         String body;
@@ -87,6 +92,7 @@ public abstract class HttpEntity {
      *
      * @param content The content.
      * @param charset The charset.
+     * @return the HTTP entity.
      */
     public static final HttpEntity fromString(String content, String charset) {
         return new Strict(ByteString.fromString(content, charset), Optional.of("text/plain; charset=" + charset));

--- a/framework/src/play/src/main/java/play/http/HttpFilters.java
+++ b/framework/src/play/src/main/java/play/http/HttpFilters.java
@@ -12,12 +12,12 @@ import play.mvc.EssentialFilter;
 public interface HttpFilters {
 
     /**
-     * Return the filters that should filter every request
+     * @return the filters that should filter every request
      */
     EssentialFilter[] filters();
 
     /**
-     * Get a Scala HttpFilters object
+     * @return a Scala HttpFilters object
      */
     default play.api.http.HttpFilters asScala() {
         return new JavaHttpFiltersAdapter(this);

--- a/framework/src/play/src/main/java/play/http/HttpRequestHandler.java
+++ b/framework/src/play/src/main/java/play/http/HttpRequestHandler.java
@@ -73,7 +73,7 @@ public interface HttpRequestHandler {
     }
 
     /**
-     * Adapt this to a Scala HttpRequestHandler
+     * @return a Scala HttpRequestHandler
      */
     default play.api.http.HttpRequestHandler asScala() {
         return new JavaHttpRequestHandlerAdapter(this);

--- a/framework/src/play/src/main/java/play/inject/ApplicationLifecycle.java
+++ b/framework/src/play/src/main/java/play/inject/ApplicationLifecycle.java
@@ -23,6 +23,7 @@ public interface ApplicationLifecycle {
      *
      * The stop hook should redeem the returned future when it is finished shutting down.  It is acceptable to stop
      * immediately and return a successful future.
+     * @param hook    the stop hook.
      */
     void addStopHook(Callable<? extends CompletionStage<?>> hook);
 }

--- a/framework/src/play/src/main/java/play/inject/Bindings.java
+++ b/framework/src/play/src/main/java/play/inject/Bindings.java
@@ -9,6 +9,9 @@ public class Bindings {
 
     /**
      * Create a binding key for the given class.
+     * @param <T> the type of the bound class
+     * @param clazz    the class to bind
+     * @return the binding key for the given class
      */
     public static final <T> BindingKey<T> bind(Class<T> clazz) {
         return new BindingKey(clazz);

--- a/framework/src/play/src/main/java/play/inject/Injector.java
+++ b/framework/src/play/src/main/java/play/inject/Injector.java
@@ -20,6 +20,7 @@ public interface Injector {
     /**
      * Get an instance of the given class from the injector.
      *
+     * @param <T> the type of the instance
      * @param clazz The class to get the instance of
      * @return The instance
      */
@@ -28,6 +29,7 @@ public interface Injector {
     /**
      * Get an instance of the given class from the injector.
      *
+     * @param <T> the type of the instance
      * @param key The key of the binding
      * @return The instance
      */

--- a/framework/src/play/src/main/java/play/inject/SourceProvider.java
+++ b/framework/src/play/src/main/java/play/inject/SourceProvider.java
@@ -47,6 +47,7 @@ public final class SourceProvider {
    * Returns a new instance that also skips {@code moreClassesToSkip}.
    *
    * @param moreClassesToSkip a list of classes to skip in from source provider.
+   * @return the source provider skipping {@code moreClassesToSkip}.
    */
   public SourceProvider plusSkippedClasses(Class... moreClassesToSkip) {
     Set<String> toSkip = new HashSet<String>(classNamesToSkip);

--- a/framework/src/play/src/main/java/play/libs/Akka.java
+++ b/framework/src/play/src/main/java/play/libs/Akka.java
@@ -27,6 +27,7 @@ public class Akka {
      * Typically, you will want to use this in combination with a named qualifier, so that multiple ActorRefs can be
      * bound, and the scope should be set to singleton or eager singleton.
      *
+     * @param <T> the type of the actor
      * @param actorClass The class that implements the actor.
      * @param name The name of the actor.
      * @param props A function to provide props for the actor. The props passed in will just describe how to create the
@@ -51,6 +52,7 @@ public class Akka {
      * Typically, you will want to use this in combination with a named qualifier, so that multiple ActorRefs can be
      * bound, and the scope should be set to singleton or eager singleton.
      *
+     * @param <T> the type of the actor
      * @param actorClass The class that implements the actor.
      * @param name The name of the actor.
      * @return A provider for the actor.

--- a/framework/src/play/src/main/java/play/libs/F.java
+++ b/framework/src/play/src/main/java/play/libs/F.java
@@ -56,6 +56,8 @@ public class F {
          * Constructs a left side of the disjoint union, as opposed to the Right side.
          *
          * @param value The value of the left side
+         * @param <L> the left type
+         * @param <R> the right type
          * @return A left sided disjoint union
          */
         public static <L, R> Either<L, R> Left(L value) {
@@ -66,6 +68,8 @@ public class F {
          * Constructs a right side of the disjoint union, as opposed to the Left side.
          *
          * @param value The value of the right side
+         * @param <L> the left type
+         * @param <R> the right type
          * @return A right sided disjoint union
          */
         public static <L, R> Either<L, R> Right(R value) {
@@ -124,6 +128,8 @@ public class F {
      *
      * @param a The a value
      * @param b The b value
+     * @param <A> a's type
+     * @param <B> b's type
      * @return The tuple
      */
     public static <A, B> Tuple<A, B> Tuple(A a, B b) {
@@ -182,6 +188,9 @@ public class F {
      * @param a The a value
      * @param b The b value
      * @param c The c value
+     * @param <A> a's type
+     * @param <B> b's type
+     * @param <C> c's type
      * @return The tuple
      */
     public static <A, B, C> Tuple3<A, B, C> Tuple3(A a, B b, C c) {
@@ -244,6 +253,10 @@ public class F {
      * @param b The b value
      * @param c The c value
      * @param d The d value
+     * @param <A> a's type
+     * @param <B> b's type
+     * @param <C> c's type
+     * @param <D> d's type
      * @return The tuple
      */
     public static <A, B, C, D> Tuple4<A, B, C, D> Tuple4(A a, B b, C c, D d) {
@@ -312,6 +325,11 @@ public class F {
      * @param c The c value
      * @param d The d value
      * @param e The e value
+     * @param <A> a's type
+     * @param <B> b's type
+     * @param <C> c's type
+     * @param <D> d's type
+     * @param <E> e's type
      * @return The tuple
      */
     public static <A, B, C, D, E> Tuple5<A, B, C, D, E> Tuple5(A a, B b, C c, D d, E e) {
@@ -320,6 +338,8 @@ public class F {
 
     /**
      * Converts the execution context to an executor, preparing it first.
+     * @param ec    the execution context.
+     * @return      the Java Executor.
      */
     private static Executor toExecutor(ExecutionContext ec) {
         ExecutionContext prepared = ec.prepare();

--- a/framework/src/play/src/main/java/play/libs/Scala.java
+++ b/framework/src/play/src/main/java/play/libs/Scala.java
@@ -4,14 +4,15 @@
 package play.libs;
 
 import akka.japi.JavaPartialFunction;
+import scala.compat.java8.FutureConverters;
 import scala.runtime.AbstractFunction0;
 
 import java.lang.reflect.Array;
-import java.util.*;
+import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
-import scala.compat.java8.FutureConverters;
 
 /**
  * Class that contains useful java &lt;-&gt; scala conversion helpers.
@@ -19,20 +20,29 @@ import scala.compat.java8.FutureConverters;
 public class Scala {
 
     /**
-     * Wrap a Scala Option, handling None as null.
+     * Wraps a Scala Option, handling None as null.
+     *
+     * @param opt the scala option.
+     * @param <T> the type in the Option.
+     * @return the value of the option, or null if opt.isDefined is false.
      */
     public static <T> T orNull(scala.Option<T> opt) {
-        if(opt.isDefined()) {
+        if (opt.isDefined()) {
             return opt.get();
         }
         return null;
     }
 
     /**
-     * Wrap a Scala Option, handling None by returning a defaultValue
+     * Wraps a Scala Option, handling None by returning a defaultValue
+     *
+     * @param opt          the scala option.
+     * @param defaultValue the default value if None is found.
+     * @param <T>          the type in the Option.
+     * @return the return value.
      */
     public static <T> T orElse(scala.Option<T> opt, T defaultValue) {
-        if(opt.isDefined()) {
+        if (opt.isDefined()) {
             return opt.get();
         }
         return defaultValue;
@@ -40,22 +50,36 @@ public class Scala {
 
     /**
      * Converts a Scala Map to Java.
+     *
+     * @param scalaMap the scala map.
+     * @param <K>      key type
+     * @param <V>      value type
+     * @return the java map.
      */
-    public static <K,V> java.util.Map<K,V> asJava(scala.collection.Map<K,V> scalaMap) {
+    public static <K, V> java.util.Map<K, V> asJava(scala.collection.Map<K, V> scalaMap) {
         return scala.collection.JavaConverters.mapAsJavaMapConverter(scalaMap).asJava();
     }
 
     /**
      * Converts a Java Map to Scala.
+     *
+     * @param javaMap the java map
+     * @param <K>     key type
+     * @param <V>     value type
+     * @return the scala map.
      */
-    public static <A,B> scala.collection.immutable.Map<A,B> asScala(Map<A,B> javaMap) {
+    public static <K, V> scala.collection.immutable.Map<K, V> asScala(Map<K, V> javaMap) {
         return play.utils.Conversions.newMap(
                 scala.collection.JavaConverters.mapAsScalaMapConverter(javaMap).asScala().toSeq()
-                );
+        );
     }
 
     /**
      * Converts a Java Collection to a Scala Seq.
+     *
+     * @param javaCollection the java collection
+     * @param <A>            the type of Seq element
+     * @return the scala Seq.
      */
     public static <A> scala.collection.immutable.Seq<A> asScala(Collection<A> javaCollection) {
         return scala.collection.JavaConverters.collectionAsScalaIterableConverter(javaCollection).asScala().toList();
@@ -63,6 +87,10 @@ public class Scala {
 
     /**
      * Converts a Java Callable to a Scala Function0.
+     *
+     * @param callable the java callable.
+     * @param <A>      the return type.
+     * @return the scala function.
      */
     public static <A> scala.Function0<A> asScala(final Callable<A> callable) {
         return new AbstractFunction0<A>() {
@@ -83,6 +111,10 @@ public class Scala {
 
     /**
      * Converts a Java Callable to a Scala Function0.
+     *
+     * @param callable the java callable.
+     * @param <A>      the return type.
+     * @return the scala function in a Scala Future.
      */
     public static <A> scala.Function0<scala.concurrent.Future<A>> asScalaWithFuture(final Callable<CompletionStage<A>> callable) {
         return new AbstractFunction0<scala.concurrent.Future<A>>() {
@@ -101,6 +133,10 @@ public class Scala {
 
     /**
      * Converts a Scala List to Java.
+     *
+     * @param scalaList    the scala list.
+     * @return the java list
+     * @param <T> the return type.
      */
     public static <T> java.util.List<T> asJava(scala.collection.Seq<T> scalaList) {
         return scala.collection.JavaConverters.seqAsJavaListConverter(scalaList).asJava();
@@ -108,6 +144,11 @@ public class Scala {
 
     /**
      * Converts a Scala List to an Array.
+     *
+     * @param clazz    the element class type
+     * @param scalaList the scala list.
+     * @param <T> the return type.
+     * @return the array
      */
     public static <T> T[] asArray(Class<T> clazz, scala.collection.Seq<T> scalaList) {
         T[] arr = (T[]) Array.newInstance(clazz, scalaList.length());
@@ -117,6 +158,10 @@ public class Scala {
 
     /**
      * Converts a Java List to Scala Seq.
+     *
+     * @param list    the java list.
+     * @return the converted Seq.
+     * @param <T> the element type.
      */
     public static <T> scala.collection.Seq<T> toSeq(java.util.List<T> list) {
         return scala.collection.JavaConverters.asScalaBufferConverter(list).asScala().toList();
@@ -124,6 +169,10 @@ public class Scala {
 
     /**
      * Converts a Java Array to Scala Seq.
+     *
+     * @param array    the java array.
+     * @return the converted Seq.
+     * @param <T> the element type.
      */
     public static <T> scala.collection.Seq<T> toSeq(T[] array) {
         return toSeq(java.util.Arrays.asList(array));
@@ -131,6 +180,10 @@ public class Scala {
 
     /**
      * Converts a Java varargs to Scala Seq.
+     *
+     * @param array    the java array.
+     * @return the converted Seq.
+     * @param <T> the element type.
      */
     public static <T> scala.collection.Seq<T> varargs(T... array) {
         return toSeq(java.util.Arrays.asList(array));
@@ -138,50 +191,70 @@ public class Scala {
 
     /**
      * Wrap a value into a Scala Option.
+     *
+     * @param t    the java value.
+     * @return the converted Option.
+     * @param <T> the element type.
      */
     public static <T> scala.Option<T> Option(T t) {
         return scala.Option.apply(t);
     }
 
     /**
-     * None
+     * @param <T> the type parameter
+     * @return a scala {@code None}.
      */
     public static <T> scala.Option<T> None() {
         return (scala.Option<T>) scala.None$.MODULE$;
     }
 
     /**
-     * Create a Scala Tuple2.
+     * Creates a Scala {@code Tuple2}.
+     *
+     * @param a element one of the tuple.
+     * @param b element two of the tuple.
+     * @param <A> input parameter type
+     * @param <B> return type.
+     * @return an instance of Tuple2 with the elements.
      */
     @SuppressWarnings("unchecked")
-    public static <A,B> scala.Tuple2<A,B> Tuple(A a, B b) {
+    public static <A, B> scala.Tuple2<A, B> Tuple(A a, B b) {
         return new scala.Tuple2<A, B>(a, b);
     }
 
     /**
-     *  Convert a scala Tuple2 to a java F.Tuple.
+     * Converts a scala {@code Tuple2} to a java F.Tuple.
+     *
+     * @param tuple the Scala Tuple.
+     * @param <A> input parameter type
+     * @param <B> return type.
+     * @return an instance of Tuple with the elements.
      */
     public static <A, B> F.Tuple<A, B> asJava(scala.Tuple2<A, B> tuple) {
         return F.Tuple(tuple._1(), tuple._2());
     }
 
     /**
-     * Creates an empty Scala Seq.
+     * @param <T> the type parameter
+     * @return an empty Scala Seq.
      */
     @SuppressWarnings("unchecked")
     public static <T> scala.collection.Seq<T> emptySeq() {
-        return (scala.collection.Seq<T>)toSeq(new Object[] {});
+        return (scala.collection.Seq<T>) toSeq(new Object[]{});
     }
 
     /**
-     * Creates an empty Scala Map.
+     * @return an empty Scala Map.
+     * @param <A> input parameter type
+     * @param <B> return type.
      */
-    public static <A,B> scala.collection.immutable.Map<A,B> emptyMap() {
-        return new scala.collection.immutable.HashMap<A,B>();
+    public static <A, B> scala.collection.immutable.Map<A, B> emptyMap() {
+        return new scala.collection.immutable.HashMap<A, B>();
     }
 
     /**
-     * Returns an any ClassTag typed according to the Java compiler as C.
+     * @param <C> the classtag's type.
+     * @return an any ClassTag typed according to the Java compiler as C.
      */
     public static <C> scala.reflect.ClassTag<C> classTag() {
         return (scala.reflect.ClassTag<C>) scala.reflect.ClassTag$.MODULE$.Any();
@@ -210,8 +283,10 @@ public class Scala {
      * The above code will convert a flow of String into a flow of Integer, dropping any strings that can't be parsed
      * as integers.
      *
-     * @param f The function to make a partial function from.
-     * @return A Scala PartialFunction.
+     * @param f   The function to make a partial function from.
+     * @param <A> input parameter type
+     * @param <B> return type.
+     * @return a Scala PartialFunction.
      */
     public static <A, B> scala.PartialFunction<A, B> partialFunction(Function<A, B> f) {
         return new JavaPartialFunction<A, B>() {

--- a/framework/src/play/src/main/java/play/libs/XML.java
+++ b/framework/src/play/src/main/java/play/libs/XML.java
@@ -29,7 +29,10 @@ import java.io.UnsupportedEncodingException;
 public class XML {
 
     /**
-     * Parse an XML string as DOM.
+     * Parses an XML string as DOM.
+     *
+     * @param xml the input XML string
+     * @return the parsed XML DOM root.
      */
     public static Document fromString(String xml) {
         try {
@@ -43,7 +46,10 @@ public class XML {
     }
 
     /**
-     * Parse an InputStream as DOM.
+     * Parses an InputStream as DOM.
+     * @param in          the inputstream to parse.
+     * @param encoding the encoding of the input stream, if not null.
+     * @return the parsed XML DOM.
      */
     public static Document fromInputStream(InputStream in, String encoding) {
         InputSource is = new InputSource(in);
@@ -55,7 +61,7 @@ public class XML {
     }
 
     /**
-     * Parse the input source as DOM.
+     * Parses the input source as DOM.
      *
      * @param source The source to parse.
      * @return The Document.
@@ -83,7 +89,7 @@ public class XML {
     }
 
     /**
-     * Convert the document to bytes.
+     * Converts the document to bytes.
      *
      * @param document The document to convert.
      * @return The ByteString representation of the document.

--- a/framework/src/play/src/main/java/play/libs/akka/InjectedActorSupport.java
+++ b/framework/src/play/src/main/java/play/libs/akka/InjectedActorSupport.java
@@ -43,6 +43,7 @@ public interface InjectedActorSupport {
 
     /**
      * Context method expected to be implemented by UntypedActor.
+     * @return the ActorContext.
      */
     ActorContext context();
 }

--- a/framework/src/play/src/main/java/play/libs/concurrent/Futures.java
+++ b/framework/src/play/src/main/java/play/libs/concurrent/Futures.java
@@ -27,6 +27,7 @@ public class Futures {
      * The sequencing operations are performed in the default ExecutionContext.
      *
      * @param promises The CompletionStages to combine
+     * @param <A> the type of the completion's result.
      * @return A single CompletionStage whose methods act on the list of redeemed CompletionStages
      */
     public static <A> CompletionStage<List<A>> sequence(Iterable<? extends CompletionStage<A>> promises) {
@@ -44,8 +45,8 @@ public class Futures {
      * Combine the given CompletionStages into a single CompletionStage for the list of results.
      *
      * The sequencing operations are performed in the default ExecutionContext.
-     *
      * @param promises The CompletionStages to combine
+     * @param <A> the type of the completion's result.
      * @return A single CompletionStage whose methods act on the list of redeemed CompletionStage
      */
     public static <A> CompletionStage<List<A>> sequence(CompletionStage<A>... promises) {
@@ -62,6 +63,7 @@ public class Futures {
      * @param value The result value to use to complete the CompletionStage.
      * @param delay The delay (expressed with the corresponding unit).
      * @param unit The time unit, i.e. java.util.concurrent.TimeUnit.MILLISECONDS
+     * @param <A> the type of the completion's result.
      * @return the CompletionStage wrapping the result value
      */
     public static <A> CompletionStage<A> timeout(A value, long delay, TimeUnit unit) {
@@ -89,9 +91,9 @@ public class Futures {
      * it unsuitable for composition.  Cast with {@code Futures.<Void>timeout} if
      * necessary.
      *
-     * @param <A> the given type (used when composing Futures)
      * @param delay The delay (expressed with the corresponding unit).
      * @param unit The time Unit.
+     * @param <A> the type of the completion's result.
      * @return a CompletionStage that failed exceptionally
      */
     public static <A> CompletionStage<A> timeout(final long delay, final TimeUnit unit) {
@@ -116,7 +118,7 @@ public class Futures {
      * @param delay The time to wait.
      * @param unit The units to use for the delay.
      * @param executor The executor to run the supplier in.
-     *
+     * @param <A> the type of the completion's result.
      * @return the delayed CompletionStage wrapping supplier.
      */
     public static <A> CompletionStage<A> delayed(Supplier<A> supplier, long delay, TimeUnit unit, Executor executor) {

--- a/framework/src/play/src/main/java/play/libs/concurrent/Timeout.java
+++ b/framework/src/play/src/main/java/play/libs/concurrent/Timeout.java
@@ -23,9 +23,10 @@ public interface Timeout {
      * the given completion stage will still complete, even though that completed value
      * is not returned.
      *
-     * @param <A> the completion stage that should be wrapped with a timeout.
+     * @param stage the input completion stage that may time out.
      * @param delay The delay (expressed with the corresponding unit).
      * @param unit The time Unit.
+     * @param <A> the completion's result type.
      * @return either the completed future, or a completion stage that failed with timeout.
      */
     default <A> CompletionStage<A> timeout(final CompletionStage<A> stage, final long delay, final TimeUnit unit) {
@@ -39,8 +40,9 @@ public interface Timeout {
     /**
      * An alias for timeout(stage, delay, unit) that uses a java.time.Duration.
      *
-     * @param <A> the completion stage that should be wrapped with a future.
+     * @param stage the input completion stage that may time out.
      * @param delay The delay (expressed with the corresponding unit).
+     * @param <A> the completion stage that should be wrapped with a future.
      * @return the completion stage, or a completion stage that failed with timeout.
      */
     default <A> CompletionStage<A> timeout(final CompletionStage<A> stage, final Duration delay) {

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -508,6 +508,7 @@ public interface BodyParser<A> {
 
         /**
          * Returns a FilePartHandler expressed as a Java function.
+         * @return a file part handler function.
          */
         public abstract Function<Multipart.FileInfo, play.libs.streams.Accumulator<ByteString, Http.MultipartFormData.FilePart<A>>> createFilePartHandler();
 

--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -40,6 +40,9 @@ public class Result {
      *
      * @param header the response header
      * @param body the response body.
+     * @param session    the session set on the response.
+     * @param flash      the flash object on the response.
+     * @param cookies    the cookies set on the response.
      */
     public Result(ResponseHeader header, HttpEntity body, Session session, Flash flash, List<Cookie> cookies) {
         this.header = header;


### PR DESCRIPTION
Fixes more javadoc with missing @params, apart from HttpExecution.java and CSRFTokenSigner.java (which are already handled in different PRs).

To reproduce -- add a broken javadoc tag like @deprecatedBlah and then run:

```
sbt apiDocs
```

You should see much reduced number of warnings.

