### PR TITLE
[2.3.x] Update Http.scala to support different properties

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Http.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Http.scala
@@ -575,7 +575,7 @@ package play.api.mvc {
       .flatMap(_.configuration.getMilliseconds("session.maxAge")
         .map(Duration(_, MILLISECONDS).toSeconds.toInt))
     override val httpOnly = Play.maybeApplication.flatMap(_.configuration.getBoolean("session.httpOnly")).getOrElse(true)
-    override def path = Play.maybeApplication.flatMap(_.configuration.getString("application.context")).getOrElse("/")
+    override def path = Play.maybeApplication.flatMap(_.configuration.getString("session.path")).getOrElse(Play.maybeApplication.flatMap(_.configuration.getString("application.context")).getOrElse("/"))
     override def domain = Play.maybeApplication.flatMap(_.configuration.getString("session.domain"))
 
     def deserialize(data: Map[String, String]) = new Session(data)


### PR DESCRIPTION


## Fixes

The capability of having a session path which does not depend in the property application.context

## Purpose

Support a separate property for path: **session.path**


## References

https://github.com/playframework/playframework/issues/6694

Support a separate property for path: session.path

Added by request: https://github.com/playframework/playframework/issues/6694