### PR TITLE
Add @unchecked to type match case.

### DIFF
--- a/framework/src/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
+++ b/framework/src/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala
@@ -78,7 +78,7 @@ private[routing] object RouterBuilderHelper {
                     Context.current.set(ctx)
                     route.actionMethod.invoke(route.action, params: _*) match {
                       case result: Result => Future.successful(result.asScala)
-                      case promise: CompletionStage[Result] => FutureConverters.toScala(promise).map(_.asScala)
+                      case promise: CompletionStage[Result @unchecked] => FutureConverters.toScala(promise).map(_.asScala)
                     }
                   } finally {
                     Context.current.remove()

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -237,7 +237,7 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
 
   private def translateMsgArg(msgArg: Any)(implicit messages: play.api.i18n.Messages) = msgArg match {
     case key: String => messages(key)
-    case keys: Seq[String] => keys.map(key => messages(key))
+    case keys: Seq[String @unchecked] => keys.map(key => messages(key))
     case _ => msgArg
   }
 

--- a/framework/src/play/src/main/scala/views/helper/Helpers.scala
+++ b/framework/src/play/src/main/scala/views/helper/Helpers.scala
@@ -53,7 +53,7 @@ package views.html.helper {
 
     private def translateMsgArg(msgArg: Any) = msgArg match {
       case key: String => messages(key)
-      case keys: Seq[String] => keys.map(key => messages(key))
+      case keys: Seq[String @unchecked] => keys.map(key => messages(key))
       case _ => msgArg
     }
 

--- a/framework/src/play/src/main/scala/views/helper/select.scala.html
+++ b/framework/src/play/src/main/scala/views/helper/select.scala.html
@@ -35,7 +35,7 @@
             }
             @options.map { case (k, v) =>
                 @defining( selectedValues.contains(k) ) { selected =>
-                @defining( args.toMap.get('_disabled).exists { case s: Seq[String] => s.contains(k) }){ disabled =>
+                @defining( args.toMap.get('_disabled).exists { case s: Seq[String@unchecked] => s.contains(k) }){ disabled =>
                 <option value="@k"@if(selected){ selected="selected"}@if(disabled){ disabled}>@v</option>
             }}}
         </select>


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

I added @unchecked annotation to match expression.

## Purpose

To resolve warnings caused by type erasure in match expression.
This warnings occurred at compile.

```scala
  private def translateMsgArg(msgArg: Any)(implicit messages: play.api.i18n.Messages) = msgArg match {
    ... 
    case keys: Seq[String] => keys.map(key => messages(key))
    ...
  }
```
```
[warn] /Users/wada.yusuke/Documents/playframework/framework/src/play/src/main/scala/play/api/data/Form.scala:240: non-variable type argument String in type pattern Seq[String] (the underlying of Seq[String]) is unchecked since it is eliminated by erasure
```


## Background Context

To solve type wiping warnings, it is possible to

1. Assign `@unchecked` 
2. Create a new collection type corresponding to type parameters

In order to minimize the influence on existing code, I choice 1.


At compile time, other warnings were issued, but only the warnings of type erasure was resolved. I have not fixed any other warnings.


## References

* Type Erasure (The Java™ Tutorials > Learning the Java Language > Generics (Updated)) https://docs.oracle.com/javase/tutorial/java/generics/erasure.html
