### PR TITLE
upgrade to latest MiMa (0.1.12)

### DIFF
--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -5,7 +5,7 @@
 import BuildSettings._
 import Dependencies._
 import Generators._
-import com.typesafe.tools.mima.plugin.MimaKeys.{ previousArtifacts, reportBinaryIssues }
+import com.typesafe.tools.mima.plugin.MimaKeys.{ mimaPreviousArtifacts, mimaReportBinaryIssues }
 import interplay.PlayBuildBase.autoImport._
 import sbt.ScriptedPlugin._
 import sbt._
@@ -230,7 +230,7 @@ lazy val PlayIntegrationTestProject = PlayCrossBuiltProject("Play-Integration-Te
     .settings(
       libraryDependencies += h2database % Test,
       parallelExecution in Test := false,
-      previousArtifacts := Set.empty
+      mimaPreviousArtifacts := Set.empty
     )
     .dependsOn(PlayProject % "test->test", PlayLogback % "test->test", PlayWsProject, PlayWsJavaProject, PlaySpecs2Project)
     .dependsOn(PlayFiltersHelpersProject)
@@ -243,7 +243,7 @@ lazy val PlayMicrobenchmarkProject = PlayCrossBuiltProject("Play-Microbenchmark"
     .enablePlugins(JmhPlugin)
     .settings(
       parallelExecution in Test := false,
-      previousArtifacts := Set.empty
+      mimaPreviousArtifacts := Set.empty
     )
     .dependsOn(PlayProject % "test->test", PlayLogback % "test->test", PlayWsProject, PlayWsJavaProject, PlaySpecs2Project)
     .dependsOn(PlayFiltersHelpersProject)
@@ -312,7 +312,7 @@ lazy val PlayFramework = Project("Play-Framework", file("."))
       libraryDependencies ++= (runtime(scalaVersion.value) ++ jdbcDeps),
       Docs.apiDocsInclude := false,
       Docs.apiDocsIncludeManaged := false,
-      reportBinaryIssues := (),
+      mimaReportBinaryIssues := (),
       commands += Commands.quickPublish
     ).settings(Release.settings: _*)
     .aggregate(publishedProjects: _*)

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -7,7 +7,7 @@ import sbt.ScriptedPlugin._
 import sbt._
 import Keys._
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
-import com.typesafe.tools.mima.plugin.MimaKeys.previousArtifacts
+import com.typesafe.tools.mima.plugin.MimaKeys.mimaPreviousArtifacts
 
 import scalariform.formatter.preferences._
 import com.typesafe.sbt.SbtScalariform.scalariformSettings
@@ -128,7 +128,7 @@ object BuildSettings {
    * These settings are used by all projects that are part of the runtime, as opposed to development, mode of Play.
    */
   def playRuntimeSettings: Seq[Setting[_]] = playCommonSettings ++ mimaDefaultSettings ++ Seq(
-    previousArtifacts := {
+    mimaPreviousArtifacts := {
       // Binary compatibility is tested against these versions
       val previousVersions = {
         val VersionPattern = """^(\d+).(\d+).(\d+)(-.*)?""".r

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -18,7 +18,7 @@ scalacOptions ++= Seq("-deprecation", "-language:_")
 
 addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "1.3.0"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % sbtTwirlVersion)
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.8")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.12")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.16")
 


### PR DESCRIPTION
the newest version supports Scala 2.12 properly and is capable of
detecting a variety of compatibility issues older versions missed