### PR TITLE
Simplify wrapping of PlayRequestHandler.

### DIFF
--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -145,6 +145,11 @@ class NettyServer(
   }
 
   /**
+   * Create a new PlayRequestHandler.
+   */
+  protected[this] def newRequestHandler(): ChannelHandler = new PlayRequestHandler(this)
+
+  /**
    * Create a sink for the incoming connection channels.
    */
   private def channelSink(port: Int, secure: Boolean): Sink[Channel, Future[Done]] = {
@@ -191,7 +196,7 @@ class NettyServer(
           pipeline.addLast("idle-handler", new IdleStateHandler(0, 0, timeout, timeUnit))
       }
 
-      val requestHandler = new PlayRequestHandler(this)
+      val requestHandler = newRequestHandler()
 
       // Use the streams handler to close off the connection.
       pipeline.addLast("http-handler", new HttpStreamsServerHandler(Seq[ChannelHandler](requestHandler).asJava))


### PR DESCRIPTION
Expose the PlayRequestHandler class, and make it simple to override this
in a NettyServer subclass.  This will make it possible to use
lightweight wrappers around the request handler's `handle()` method.