### PR TITLE
Update to Akka 2.4.14, materializer is not public API and changed a bit

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -6,7 +6,7 @@ import buildinfo.BuildInfo
 
 object Dependencies {
 
-  val akkaVersion = "2.4.12"
+  val akkaVersion = "2.4.14"
   val akkaHttpVersion = "10.0.0"
 
   val specsVersion = "3.8.6"

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -5,7 +5,7 @@ package play.api.test
 
 import akka.actor.Cancellable
 import akka.stream.scaladsl.Source
-import akka.stream.{ ClosedShape, Graph, Materializer }
+import akka.stream._
 import akka.util.{ ByteString, Timeout }
 import org.openqa.selenium._
 import org.openqa.selenium.firefox._
@@ -20,6 +20,7 @@ import play.mvc.Http.RequestBody
 import play.twirl.api.Content
 
 import scala.concurrent.{ Await, Future }
+import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
 import scala.language.reflectiveCalls
 import scala.reflect.ClassTag
@@ -466,12 +467,19 @@ trait Injecting {
  * a default one that simply throws an exception if used.
  */
 private[play] object NoMaterializer extends Materializer {
-  def withNamePrefix(name: String) = throw new UnsupportedOperationException("NoMaterializer cannot be named")
-  implicit def executionContext = throw new UnsupportedOperationException("NoMaterializer does not have an execution context")
-  def materialize[Mat](runnable: Graph[ClosedShape, Mat]) =
-    throw new UnsupportedOperationException("No materializer was provided, probably when attempting to extract a response body, but that body is a streamed body and so requires a materializer to extract it.")
-  override def scheduleOnce(delay: FiniteDuration, task: Runnable): Cancellable =
-    throw new UnsupportedOperationException("NoMaterializer can't schedule tasks")
-  override def schedulePeriodically(initialDelay: FiniteDuration, interval: FiniteDuration, task: Runnable): Cancellable =
-    throw new UnsupportedOperationException("NoMaterializer can't schedule tasks")
+  override def withNamePrefix(name: String): Materializer =
+    throw new UnsupportedOperationException("NoMaterializer cannot be named")
+  override def materialize[Mat](runnable: Graph[ClosedShape, Mat]): Mat =
+    throw new UnsupportedOperationException("NoMaterializer cannot materialize")
+  override def materialize[Mat](runnable: Graph[ClosedShape, Mat], initialAttributes: Attributes): Mat =
+    throw new UnsupportedOperationException("NoMaterializer cannot materialize")
+
+  override def executionContext: ExecutionContextExecutor =
+    throw new UnsupportedOperationException("NoMaterializer does not provide an ExecutionContext")
+
+  def scheduleOnce(delay: FiniteDuration, task: Runnable): Cancellable =
+    throw new UnsupportedOperationException("NoMaterializer cannot schedule a single event")
+
+  def schedulePeriodically(initialDelay: FiniteDuration, interval: FiniteDuration, task: Runnable): Cancellable =
+    throw new UnsupportedOperationException("NoMaterializer cannot schedule a repeated event")
 }


### PR DESCRIPTION
Hi there,
this brings Play onto 2.4.14 - it's fully binary compatible otherwise - just extending the materializer is "gray zone" so this needed to change. 