### PR TITLE
[2.5.x Backport] Update to Akka 2.4.14, materializer is not public API and changed a bit (#6767)

### DIFF
--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -406,7 +406,12 @@ object PlayBuild extends Build {
   lazy val PlayTestProject = PlayCrossBuiltProject("Play-Test", "play-test")
     .settings(
       libraryDependencies ++= testDependencies,
-      parallelExecution in Test := false
+      parallelExecution in Test := false,
+      binaryIssueFilters := Seq(
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.test.NoMaterializer.withNamePrefix"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.test.NoMaterializer.executionContext"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.test.NoMaterializer.materialize")
+      )
     ).dependsOn(PlayNettyServerProject)
 
   lazy val PlaySpecs2Project = PlayCrossBuiltProject("Play-Specs2", "play-specs2")

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -6,8 +6,8 @@ import buildinfo.BuildInfo
 
 object Dependencies {
 
-  val akkaVersion = "2.4.12"
-  val akkaHttpVersion = "2.4.11"
+  val akkaVersion = "2.4.14"
+  val akkaHttpVersion = "10.0.0"
 
   val specsVersion = "3.6.6"
   val specsBuild = Seq(

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -4,7 +4,7 @@
 package play.api.test
 
 import akka.actor.Cancellable
-import akka.stream.{ ClosedShape, Graph, Materializer }
+import akka.stream._
 import akka.stream.scaladsl.Source
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.mvc.Http.RequestBody
@@ -25,7 +25,7 @@ import org.openqa.selenium.htmlunit._
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-
+import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.Future
 import akka.util.{ ByteString, Timeout }
 
@@ -397,12 +397,19 @@ object Helpers extends PlayRunners
  * a default one that simply throws an exception if used.
  */
 private[play] object NoMaterializer extends Materializer {
-  def withNamePrefix(name: String) = throw new UnsupportedOperationException("NoMaterializer cannot be named")
-  implicit def executionContext = throw new UnsupportedOperationException("NoMaterializer does not have an execution context")
-  def materialize[Mat](runnable: Graph[ClosedShape, Mat]) =
-    throw new UnsupportedOperationException("No materializer was provided, probably when attempting to extract a response body, but that body is a streamed body and so requires a materializer to extract it.")
-  override def scheduleOnce(delay: FiniteDuration, task: Runnable): Cancellable =
-    throw new UnsupportedOperationException("NoMaterializer can't schedule tasks")
-  override def schedulePeriodically(initialDelay: FiniteDuration, interval: FiniteDuration, task: Runnable): Cancellable =
-    throw new UnsupportedOperationException("NoMaterializer can't schedule tasks")
+  override def withNamePrefix(name: String): Materializer =
+    throw new UnsupportedOperationException("NoMaterializer cannot be named")
+  override def materialize[Mat](runnable: Graph[ClosedShape, Mat]): Mat =
+    throw new UnsupportedOperationException("NoMaterializer cannot materialize")
+  override def materialize[Mat](runnable: Graph[ClosedShape, Mat], initialAttributes: Attributes): Mat =
+    throw new UnsupportedOperationException("NoMaterializer cannot materialize")
+
+  override def executionContext: ExecutionContextExecutor =
+    throw new UnsupportedOperationException("NoMaterializer does not provide an ExecutionContext")
+
+  def scheduleOnce(delay: FiniteDuration, task: Runnable): Cancellable =
+    throw new UnsupportedOperationException("NoMaterializer cannot schedule a single event")
+
+  def schedulePeriodically(initialDelay: FiniteDuration, interval: FiniteDuration, task: Runnable): Cancellable =
+    throw new UnsupportedOperationException("NoMaterializer cannot schedule a repeated event")
 }


### PR DESCRIPTION
Backport of https://github.com/playframework/playframework/pull/6767

I'm unsure about `akka-http`  but since we still have the experimental marker on it I guess it's fine to use 10.0.0?