### PR TITLE
publishLocal fails due to -no-java-comments not getting applied, since we override the scala version

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -58,10 +58,9 @@ object BuildSettings {
       ),
       scalacOptions in(Compile, doc) := {
         // disable the new scaladoc feature for scala 2.12.0, might be removed in 2.12.0-1 (https://github.com/scala/scala-dev/issues/249)
-        if (scalaVersion.value == "2.12.0") {
-          Seq("-no-java-comments")
-        } else {
-          Seq()
+        CrossVersion.partialVersion(scalaVersion.value) match {
+          case Some((2, 12)) => Seq("-no-java-comments")
+          case _ => Seq()
         }
       },
       fork in Test := true,


### PR DESCRIPTION
Actually we need to set `no-java-comments` for 2.12 unfortunatly that does not get applied for play-java since it overrides the scala version. I also made it future proof since 2.12.1 would not include the fix for it.