### PR TITLE
Better return type on method, to avoid cast when overriding handleRead()

### DIFF
--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -147,7 +147,7 @@ class NettyServer(
   /**
    * Create a new PlayRequestHandler.
    */
-  protected[this] def newRequestHandler(): ChannelHandler = new PlayRequestHandler(this)
+  protected[this] def newRequestHandler(): ChannelInboundHandler = new PlayRequestHandler(this)
 
   /**
    * Create a sink for the incoming connection channels.


### PR DESCRIPTION
See title.

The previous return type was overly ambitious for no real gain.
All tests in `Play-Netty-Server` still pass.