### PR TITLE
Remove Netty dependency from play-openid

### DIFF
--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -216,7 +216,6 @@ lazy val PlayAhcWsProject = PlayCrossBuiltProject("Play-AHC-WS", "play-ahc-ws")
 
 lazy val PlayOpenIdProject = PlayCrossBuiltProject("Play-OpenID", "play-openid")
   .settings(
-    libraryDependencies ++= playOpenIdDeps,
     parallelExecution in Test := false,
     // quieten deprecation warnings in tests
     scalacOptions in Test := (scalacOptions in Test).value diff Seq("-deprecation")

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -256,11 +256,6 @@ object Dependencies {
     (specsBuild :+ specsMatcherExtra).map(_ % Test) :+
     mockitoAll % Test
 
-  val playOpenIdDeps = Seq(
-    // import org.jboss.netty.handler.codec.http.QueryStringDecoder in package.scala
-    "io.netty" % "netty" % "3.10.6.Final" % Test
-  )
-
   val playDocsSbtPluginDependencies = Seq(
     "com.typesafe.play" %% "play-doc" % playDocVersion
   )

--- a/framework/src/play-openid/src/test/scala/play/api/libs/openid/package.scala
+++ b/framework/src/play-openid/src/test/scala/play/api/libs/openid/package.scala
@@ -4,7 +4,7 @@
 package play.api.libs
 
 import scala.io.Source
-import org.jboss.netty.handler.codec.http.QueryStringDecoder
+import io.netty.handler.codec.http.QueryStringDecoder
 import java.net.{ MalformedURLException, URL }
 import util.control.Exception._
 import collection.JavaConverters._
@@ -27,7 +27,7 @@ package object openid {
   def parseQueryString(url: String): Params = {
     catching(classOf[MalformedURLException]) opt new URL(url) map {
       url =>
-        new QueryStringDecoder(url.toURI.getRawQuery, false).getParameters.asScala.mapValues(_.asScala.toSeq).toMap
+        new QueryStringDecoder(url.toURI.getRawQuery, false).parameters().asScala.mapValues(_.asScala.toSeq).toMap
     } getOrElse Map()
   }
 


### PR DESCRIPTION
Removes the 3.5.x Netty dependency on QueryStringDecoder from Play-OpenId project by moving to the Netty 4.x version.
