### PR TITLE
New transformations for JSON writers

### DIFF
--- a/framework/src/play-json/src/test/scala/play/api/libs/json/WritesSpec.scala
+++ b/framework/src/play-json/src/test/scala/play/api/libs/json/WritesSpec.scala
@@ -162,6 +162,29 @@ class WritesSpec extends org.specs2.mutable.Specification {
       written must_== Json.obj("bar" -> "Lorem", "time" -> time)
     }
 
+    "be transformed with a value transformation" in {
+      val transformed: Writes[Foo] = Writes.transform(writes) {
+        case (foo, obj @ JsObject(_)) =>
+          obj ++ Json.obj("hash" -> foo.hashCode)
+
+        case (_, v) => v
+      }
+      val foo = Foo("Lorem")
+      val written: JsValue = transformed.writes(foo)
+
+      written must_== Json.obj("bar" -> "Lorem", "hash" -> foo.hashCode)
+    }
+
+    "be transformed with an object transformation" in {
+      val transformed: OWrites[Foo] = OWrites.transform(writes) { (foo, obj) =>
+        obj ++ Json.obj("hash" -> foo.hashCode)
+      }
+      val foo = Foo("Lorem")
+      val written: JsObject = transformed.writes(foo)
+
+      written must_== Json.obj("bar" -> "Lorem", "hash" -> foo.hashCode)
+    }
+
     "be transformed with another OWrites" in {
       val transformed: OWrites[Foo] =
         writes.transform(OWrites[JsObject] { obj =>


### PR DESCRIPTION
### Play Version (2.5.x / etc)

Play 2.5.x

### API (Scala / Java / Neither / Both)

Scala

### Operating System (Ubuntu 15.10 / MacOS 10.10 / Windows 10)

- Any 
- Darwin leto.local 15.6.0 Darwin Kernel Version 15.6.0: Thu Sep  1 15:01:16 PDT 2016; root:xnu-3248.60.11~2/RELEASE_X86_64 x86_64

### JDK (Oracle 1.8.0_72, OpenJDK 1.8.x, Azul Zing)

- Any
- java version "1.8.0_25" 

### Expected Behavior

Allow to enrich/rewrite an existing JSON writer, with a function given the initial input and the intermediary JSON output.

```scala
val transformed: OWrites[Foo] = OWrites.transform(writes) { (foo, obj) =>
  obj ++ Json.obj("hash" -> foo.hashCode)
}
val foo = Foo("Lorem")
val written: JsObject = transformed.writes(foo)
```