### PR TITLE
Refactoring play-jpa - Got rid of ThreadLocal

### DIFF
--- a/documentation/manual/working/commonGuide/build/SBTDependencies.md
+++ b/documentation/manual/working/commonGuide/build/SBTDependencies.md
@@ -34,7 +34,7 @@ Multiple dependencies can be added either by multiple declarations like the abov
 ```scala
 libraryDependencies ++= Seq(
   "org.apache.derby" % "derby" % "10.11.1.1",
-  "org.hibernate" % "hibernate-entitymanager" % "4.3.9.Final"
+  "org.hibernate" % "hibernate-core" % "5.2.5.Final"
 )
 ```
 

--- a/documentation/manual/working/javaGuide/main/sql/code/controllers/JPAController.java
+++ b/documentation/manual/working/javaGuide/main/sql/code/controllers/JPAController.java
@@ -30,6 +30,9 @@ public class JPAController extends Controller {
     //#jpa-controller-transactional-action
     @Transactional
     public Result index() {
+        EntityManager em = play.db.jpa.JPA.em(ctx());
+        // do something with the entity manager, per instance
+        // save, update or query model objects.
         return ok("A Transactional action");
     }
     //#jpa-controller-transactional-action
@@ -37,34 +40,33 @@ public class JPAController extends Controller {
     //#jpa-controller-transactional-readonly
     @Transactional(readOnly = true)
     public Result list() {
-        return ok("A Transactional action");
+        EntityManager em = play.db.jpa.JPA.em(ctx());
+        // query model objects with the entity manager
+        return ok("A Transactional read-only action");
     }
     //#jpa-controller-transactional-readonly
 
-    //#jpa-access-entity-manager
-    public void upadateSomething() {
-        EntityManager em = jpaApi.em();
-        // do something with the entity manager, per instance
-        // save, update or query model objects.
-    }
-    //#jpa-access-entity-manager
-
-    public void runningWithTransaction() {
-        //#jpa-withTransaction-function
+    //#jpa-withTransaction-function
+    // No @Transactional annotation
+    public Result querySomething() {
         // lambda is an instance of Function<EntityManager, Long>
-        jpaApi.withTransaction(entityManager -> {
+        final Long maxAge = jpaApi.withTransaction(entityManager -> {
             Query query = entityManager.createNativeQuery("select max(age) from people");
             return (Long) query.getSingleResult();
         });
-        //#jpa-withTransaction-function
+        return ok("Max age: " + maxAge);
+    }
+    //#jpa-withTransaction-function
 
-        //#jpa-withTransaction-runnable
-        // lambda is an instance of Runnable
-        jpaApi.withTransaction(() -> {
-            EntityManager em = jpaApi.em();
-            Query query = em.createNativeQuery("update people set active = 1 where age > 18");
+    //#jpa-withTransaction-consumer
+    // No @Transactional annotation
+    public Result updateSomething() {
+        // lambda is an instance of Consumer<EntityManager>
+        jpaApi.withTransaction(entityManager -> {
+            Query query = entityManager.createNativeQuery("update people set active = 1 where age > 18");
             query.executeUpdate();
         });
-        //#jpa-withTransaction-runnable
+        return ok("Sucessfully updated");
     }
+    //#jpa-withTransaction-consumer
 }

--- a/documentation/manual/working/javaGuide/main/sql/code/jpa.sbt
+++ b/documentation/manual/working/javaGuide/main/sql/code/jpa.sbt
@@ -5,7 +5,7 @@
 //#jpa-sbt-dependencies
 libraryDependencies ++= Seq(
   javaJpa,
-  "org.hibernate" % "hibernate-entitymanager" % "5.1.0.Final" // replace by your jpa implementation
+  "org.hibernate" % "hibernate-core" % "5.2.5.Final" // replace by your jpa implementation
 )
 //#jpa-sbt-dependencies
 

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -52,7 +52,7 @@ object Dependencies {
 
   val jpaDeps = Seq(
     "org.hibernate.javax.persistence" % "hibernate-jpa-2.1-api" % "1.0.0.Final",
-    "org.hibernate" % "hibernate-entitymanager" % "5.1.0.Final" % "test"
+    "org.hibernate" % "hibernate-core" % "5.2.5.Final" % "test"
   )
 
   val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0"

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
@@ -3,14 +3,14 @@
  */
 package play.db.jpa;
 
+import play.mvc.Http;
+
 import javax.persistence.EntityManager;
 
 /**
  * JPA Helpers.
  */
 public class JPA {
-
-    static JPAEntityManagerContext entityManagerContext = new JPAEntityManagerContext();
 
     /**
      * Create a default JPAApi with the given persistence unit configuration.
@@ -21,7 +21,7 @@ public class JPA {
      * @return the configured JPAApi
      */
     public static JPAApi createFor(String name, String unitName) {
-        return new DefaultJPAApi(DefaultJPAConfig.of(name, unitName), entityManagerContext).start();
+        return new DefaultJPAApi(DefaultJPAConfig.of(name, unitName)).start();
     }
 
     /**
@@ -32,27 +32,30 @@ public class JPA {
      * @return the configured JPAApi
      */
     public static JPAApi createFor(String unitName) {
-        return new DefaultJPAApi(DefaultJPAConfig.of("default", unitName), entityManagerContext).start();
+        return new DefaultJPAApi(DefaultJPAConfig.of("default", unitName)).start();
     }
 
     /**
-     * Get the default EntityManager for this thread.
+     * Get the default EntityManager from the current Http.Context.
      *
-     * @throws RuntimeException if no EntityManager is bound to the current Http.Context or the current Thread.
+     * @throws RuntimeException if no EntityManager is bound to the current Http.Context.
+     * @return the EntityManager
+     * 
+     * @deprecated Use {@link #em(play.mvc.Http.Context)} instead
+     */
+    @Deprecated
+    public static EntityManager em() {
+        return JPAEntityManagerContext.em();
+    }
+
+    /**
+     * Get the default EntityManager from the given Http.Context.
+     *
+     * @throws RuntimeException if no EntityManager is bound to the given Http.Context.
      * @return the EntityManager
      */
-    public static EntityManager em() {
-        return entityManagerContext.em();
-    }
-
-    /**
-     * Bind an EntityManager to the current HTTP context.
-     * If no HTTP context is available the EntityManager gets bound to the current thread instead.
-     *
-     * @param em the EntityManager to bind to this HTTP context.
-     */
-    public static void bindForSync(EntityManager em) {
-        entityManagerContext.pushOrPopEm(em, true);
+    public static EntityManager em(Http.Context ctx) {
+        return JPAEntityManagerContext.em(ctx);
     }
 
 }

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAApi.java
@@ -3,8 +3,10 @@
  */
 package play.db.jpa;
 
+import play.mvc.Http;
+
+import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import javax.persistence.EntityManager;
 
@@ -21,7 +23,7 @@ public interface JPAApi {
     public JPAApi start();
 
     /**
-     * Get the EntityManager for the specified persistence unit name.
+     * Get a newly created EntityManager for the specified persistence unit name.
      *
      * @param name The persistence unit name
      * @return EntityManager for the specified persistence unit name
@@ -29,14 +31,7 @@ public interface JPAApi {
     public EntityManager em(String name);
 
     /**
-     * Get the EntityManager for a particular persistence unit for this thread.
-     *
-     * @return EntityManager for the specified persistence unit name
-     */
-    public EntityManager em();
-
-    /**
-     * Run a block of code with a given EntityManager.
+     * Run a block of code with a newly created EntityManager.
      *
      * @param block Block of code to execute
      * @param <T> type of result
@@ -45,7 +40,7 @@ public interface JPAApi {
     public <T> T withTransaction(Function<EntityManager, T> block);
 
     /**
-     * Run a block of code with a given EntityManager.
+     * Run a block of code with a newly created EntityManager for the named Persistence Unit.
      *
      * @param name The persistence unit name
      * @param block Block of code to execute
@@ -55,7 +50,7 @@ public interface JPAApi {
     public <T> T withTransaction(String name, Function<EntityManager, T> block);
 
     /**
-     * Run a block of code with a given EntityManager.
+     * Run a block of code with a newly created EntityManager for the named Persistence Unit.
      *
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
@@ -66,31 +61,54 @@ public interface JPAApi {
     public <T> T withTransaction(String name, boolean readOnly, Function<EntityManager, T> block);
 
     /**
-     * Run a block of code in a JPA transaction.
+     * Run a block of code with a newly created EntityManager for the named Persistence Unit.
      *
+     * @param name The persistence unit name
+     * @param readOnly Is the transaction read-only?
+     * @param ctx Store the entity manager in this context?
      * @param block Block of code to execute
      * @param <T> type of result
      * @return code execution result
      */
-    public <T> T withTransaction(Supplier<T> block);
+    public <T> T withTransaction(String name, boolean readOnly, Http.Context ctx, Function<EntityManager, T> block);
+    
+    /**
+     * Run a block of code with a newly created EntityManager for the named Persistence Unit.
+     *
+     * @param name The persistence unit name
+     * @param readOnly Is the transaction read-only?
+     * @param ctx Store the entity manager in this context?
+     * @param keepTransactionOpen Don't commit nor rollback transaction. Also keeps the active entity manager stored in the given ctx (if supplied).
+     * @param block Block of code to execute
+     * @param <T> type of result
+     * @return code execution result
+     */
+    public <T> T withTransaction(String name, boolean readOnly, Http.Context ctx, boolean keepTransactionOpen, Function<EntityManager, T> block);
+
 
     /**
-     * Run a block of code in a JPA transaction.
+     * Run a block of code with a newly created EntityManager.
      *
      * @param block Block of code to execute
      */
-    public void withTransaction(Runnable block);
+    public void withTransaction(Consumer<EntityManager> block);
 
     /**
-     * Run a block of code in a JPA transaction.
+     * Run a block of code with a newly created EntityManager for the named Persistence Unit.
+     *
+     * @param name The persistence unit name
+     * @param block Block of code to execute
+     */
+    public void withTransaction(String name, Consumer<EntityManager> block);
+
+    /**
+     * Run a block of code with a newly created EntityManager for the named Persistence Unit.
      *
      * @param name The persistence unit name
      * @param readOnly Is the transaction read-only?
      * @param block Block of code to execute
-     * @param <T> type of result
-     * @return code execution result
      */
-    public <T> T withTransaction(String name, boolean readOnly, Supplier<T> block);
+    public void withTransaction(String name, boolean readOnly, Consumer<EntityManager> block);
 
     /**
      * Close all entity manager factories.

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/TransactionalAction.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/TransactionalAction.java
@@ -21,11 +21,14 @@ public class TransactionalAction extends Action<Transactional> {
         this.jpaApi = jpaApi;
     }
 
+    @Override
     public CompletionStage<Result> call(final Context ctx) {
         return jpaApi.withTransaction(
             configuration.value(),
             configuration.readOnly(),
-            () -> delegate.call(ctx)
+            ctx,
+            true, // keepTransactionOpen?
+            em -> delegate.call(ctx).whenComplete((result, error) -> JPAEntityManagerContext.closeAllTransactionsAndEntityManagers(ctx, error != null))
         );
     }
 

--- a/framework/src/play-java-jpa/src/test/java/play/db/jpa/TestEntity.java
+++ b/framework/src/play-java-jpa/src/test/java/play/db/jpa/TestEntity.java
@@ -16,21 +16,21 @@ public class TestEntity {
 
     public String name;
 
-    public void save() {
-        JPA.em().persist(this);
+    public void save(final EntityManager em) {
+        em.persist(this);
     }
 
-    public void delete() {
-        JPA.em().remove(this);
+    public void delete(final EntityManager em) {
+        em.remove(this);
     }
 
-    public static TestEntity find(Long id) {
-        return JPA.em().find(TestEntity.class, id);
+    public static TestEntity find(final EntityManager em, Long id) {
+        return em.find(TestEntity.class, id);
     }
 
-    public static List<String> allNames() {
+    public static List<String> allNames(final EntityManager em) {
         @SuppressWarnings("unchecked")
-        List<TestEntity> results = JPA.em().createQuery("from TestEntity order by name").getResultList();
+        List<TestEntity> results = em.createQuery("from TestEntity order by name").getResultList();
         return results.stream().map(entity -> entity.name).collect(toList());
     }
 


### PR DESCRIPTION
Replaces #6013

As we know to run code within a JPA transaction the preferred way is to call
```java
// inject jpaApi
jpaApi.withTransaction(em -> ...)
```
With this PR an entity manager now **always** gets passed to all the various `withTransaction` methods. The em doesn't get stored in a `ThreadLocal` anymore.

Only when using `@Transactional` the entity manager still will be stored in the `Http.Context` so we can access and (re-)use it later from within the controller's action methods. But I did change how this happens. Instead of just accessing `Http.Context.current()` you now have to explicitly pass the `context` in which the em should get stored to `withTransaction` (happens in `TransactionalAction.java`).
Eventually, to retrieve the em we now have to pass a context to `JPA.em(ctx)`.

With this changes `JPAEntityManagerContext` is becoming "just" a simple helper class which just makes it easier to store and read entity managers from a http context.

In future we can remove `JPA.em()` (it's deprecated now) in favor of `JPA.em(ctx)` - actually it's just a shortcut for `JPAEntityManagerContext.em(ctx)`.

This should make `play-jpa` ready for the removal of the http context threadlocal which I think is targeted for a future play version. (It should work nicely with the changes in #6473 done by @gmethvin)

One more thing:
In `@TransactionalAction` we tell `withTransaction` to keep the em and transaction open so it doesn't get closed immediately but only after the future has completed. I am not entirely sure if this should be managed here or if I should add a `withTransaction` that returns a `CompletionStage<T>` and manage it there. Related to #6489