### PR TITLE
akka-http header should not be parsed to be on par with netty

### DIFF
--- a/framework/src/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHttpServerSpec.scala
+++ b/framework/src/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHttpServerSpec.scala
@@ -50,7 +50,7 @@ class AkkaHttpServerSpec extends PlaySpecification with WsTestClient {
         case ("GET", "/hello") => Action(Ok("greetings"))
       } { response =>
         response.status must_== 200
-        response.header(CONTENT_TYPE) must_== Some("text/plain; charset=UTF-8")
+        response.header(CONTENT_TYPE) must_== Some("text/plain; charset=utf-8")
         response.header(CONTENT_LENGTH) must_== Some("9")
         response.header(TRANSFER_ENCODING) must_== None
         response.body must_== "greetings"
@@ -66,7 +66,7 @@ class AkkaHttpServerSpec extends PlaySpecification with WsTestClient {
         }
       } { response =>
         response.status must_== 200
-        response.header(CONTENT_TYPE) must_== Some("text/plain; charset=UTF-8")
+        response.header(CONTENT_TYPE) must_== Some("text/plain; charset=utf-8")
         response.header(CONTENT_LENGTH) must_== Some("9")
         response.header(TRANSFER_ENCODING) must_== None
         response.body must_== "greetings"

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
@@ -63,7 +63,7 @@ trait AssetsSpec extends PlaySpecification
       result.header(VARY) must beNone
       result.header(CONTENT_ENCODING) must beNone
       result.header(CACHE_CONTROL) must_== defaultCacheControl
-    }.skipUntilAkkaHttpFixed
+    }
 
     "serve an asset in a subdirectory" in withServer { client =>
       val result = await(client.url("/subdir/baz.txt").get())


### PR DESCRIPTION
Well this is a controversial one, however netty allows **every** content-type (even `Content-Type: wsargent/gmethvin`), not just arbitary ones.
This PR allows actually Setting non RFC like Content-Types.

Well in Future Play Versions we should probably Parse everything **and** disallow such things, however as seen in the AssetsSpec some people actually need non compliance (a big one is probably adding a charset to json, which is invalid by the specification, but is actually used in many many frameworks/applications)
Also the parsing should've been done a level higher, so I guess even if we have typed headers we would need to convert them and I guess this is the most straightforwarded way since it tricks `akka-http`.