### PR TITLE
corrected the sonatype repository

### DIFF
--- a/documentation/manual/hacking/Repositories.md
+++ b/documentation/manual/hacking/Repositories.md
@@ -15,12 +15,11 @@ resolvers += Resolver.typesafeRepo("releases")
 
 ## Accessing snapshots
 
-Snapshots are published daily from our [[Continuous Integration Server|ThirdPartyTools]] to the Typesafe snapshots repository at <https://oss.sonatype.org/content/repositories/snapshots/>.
+Snapshots are published daily from our [[Continuous Integration Server|ThirdPartyTools]] to the Sonatype snapshots repository at <https://oss.sonatype.org/content/repositories/snapshots/>.
 
 > **Note:** it's an ivy style repository.
 
 ```scala
-// The Typesafe snapshots repository
-resolvers += Resolver.url("Typesafe Ivy Snapshots Repository", url("https://oss.sonatype.org/content/repositories/snapshots/"))(Resolver.ivyStylePatterns)
+resolvers += Resolver.sonatypeRepo("snapshots")
 ```
 


### PR DESCRIPTION
well sonatype is a maven style repo so the ivy style would be wrong, was probably wrong since the transition from typesafe to sonatype repo.