### PR TITLE
Typo in ScalaJsonCombinators.md

### DIFF
--- a/documentation/manual/working/scalaGuide/main/json/ScalaJsonCombinators.md
+++ b/documentation/manual/working/scalaGuide/main/json/ScalaJsonCombinators.md
@@ -32,7 +32,7 @@ You will require these imports to create `Reads`:
 `JsPath` has methods to create special `Reads` that apply another `Reads` to a `JsValue` at a specified path:
 
 - `JsPath.read[T](implicit r: Reads[T]): Reads[T]` - Creates a `Reads[T]` that will apply the implicit argument `r` to the `JsValue` at this path.
-- `JsPath.readNullable[T](implicit r: Reads[T]): Reads[Option[T]]readNullable` - Use for paths that may be missing or can contain a null value.
+- `JsPath.readNullable[T](implicit r: Reads[T]): Reads[Option[T]]` - Use for paths that may be missing or can contain a null value.
 
 > Note: The JSON library provides implicit `Reads` for basic types such as `String`, `Int`, `Double`, etc.
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Purpose

Removes a typo:

`Reads[Option[T]]readNullable` -> `Reads[Option[T]]`