### PR TITLE
Fix PlayJava after extracting Java forms

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/Play.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/Play.scala
@@ -52,14 +52,14 @@ object PlayMinimalJava extends AutoPlugin {
  * via sbt's enablePlugins mechanism e.g.:
  *
  * {{{
- *   lazy val root = project.in(file(".")).enablePlugins(PlayFormsJava)
+ *   lazy val root = project.in(file(".")).enablePlugins(PlayJava)
  * }}}
  */
 object PlayJava extends AutoPlugin {
   override def requires = Play
   override def projectSettings =
     PlaySettings.defaultJavaSettings ++
-      Seq(libraryDependencies += PlayImport.javaCore)
+      Seq(libraryDependencies += PlayImport.javaForms)
 }
 
 /**

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -33,6 +33,8 @@ object PlayImport {
 
   val javaCore = component("play-java")
 
+  val javaForms = component("play-java-forms")
+
   val javaJdbc = component("play-java-jdbc")
 
   def javaEbean = movedExternal(


### PR DESCRIPTION
I think this should have been done in #6559 but was overlooked.

I tried to run a very simple play java project with current `master` but I got this error when compiling the twirl templates:

```
[info] Compiling 6 Scala sources and 3 Java sources to play-java-seed/target/scala-2.12/classes...
[error] play-java-seed/app/views/index.scala.html:1: object data is not a member of package play
[error] @()
[error] ^
[error] play-java-seed/app/views/main.scala.html:1: object data is not a member of package play
[error] @*
[error] ^
[error] two errors found
[error] (compile:compileIncremental) Compilation failed
```

Changing the plugin settings fixed the problem - it should have been like this in first place already I think.