### PR TITLE
Upgrade to interplay 1.3.1

### DIFF
--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -16,7 +16,7 @@ logLevel := Level.Warn
 
 scalacOptions ++= Seq("-deprecation", "-language:_")
 
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "1.3.0"))
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "1.3.1"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % sbtTwirlVersion)
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.12")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")


### PR DESCRIPTION
This change makes Play depend on Interplay 1.3.1, which uses the Scala 2.12.1 compiler explicitly.

This fixes the javadoc stackoverflow bug and ensures downstream Play projects don't run into odd issues.

Notably, the sbt-twirl download error in https://github.com/playframework/playframework/issues/6782 was being caused by a misapplied scalaVersion looking for a 2.12 version of sbt-twirl, when all SBT projects should be on 2.10.