### PR TITLE
Added dependency on play.db.DBApi to play.db.jpa.DefaultJPAApi.JPAApiProvider to ensure that data sources are initialised and bound to JNDI before they are accessed

### DIFF
--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -3,6 +3,7 @@
  */
 package play.db.jpa;
 
+import play.db.DBApi;
 import play.inject.ApplicationLifecycle;
 
 import java.util.*;
@@ -36,7 +37,7 @@ public class DefaultJPAApi implements JPAApi {
         private final JPAApi jpaApi;
 
         @Inject
-        public JPAApiProvider(JPAConfig jpaConfig, JPAEntityManagerContext context, ApplicationLifecycle lifecycle) {
+        public JPAApiProvider(JPAConfig jpaConfig, JPAEntityManagerContext context, ApplicationLifecycle lifecycle, DBApi dbApi) {
             // dependency on db api ensures that the databases are initialised
             jpaApi = new DefaultJPAApi(jpaConfig, context);
             lifecycle.addStopHook(() -> {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #6792

## Purpose

Adds dependency on play.db.DBApi to play.db.jpa.DefaultJPAApi.JPAApiProvider to ensure that data sources are initialised and bound to JNDI before they are accessed.

## Background Context

The implementations of JPAApi and DBApi do not have any dependencies that would ensure the order in which they are both created, so there is no guarantee that the data source is bound to JNDI by HikariCPConnectionPool before it is accessed by DefaultJPAApi. By adding a dependency on play.db.DBApi to play.db.jpa.DefaultJPAApi.JPAApiProvider data sources are always initialised and bound to JNDI before they are accessed.

## References
