### PR TITLE
Create ValidatorFactory just once

### DIFF
--- a/framework/src/play-java-forms/src/main/java/play/data/validation/ValidatorProvider.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/ValidatorProvider.java
@@ -9,21 +9,22 @@ import javax.inject.Singleton;
 import javax.validation.Validator;
 import javax.validation.Validation;
 import javax.validation.ConstraintValidatorFactory;
+import javax.validation.ValidatorFactory;
 
 @Singleton
 public class ValidatorProvider implements Provider<Validator> {
 
-    private ConstraintValidatorFactory constraintValidatorFactory;
+    private ValidatorFactory validatorFactory;
 
     @Inject
     public ValidatorProvider(ConstraintValidatorFactory constraintValidatorFactory) {
-        this.constraintValidatorFactory = constraintValidatorFactory;
+        this.validatorFactory = Validation.byDefaultProvider().configure()
+                .constraintValidatorFactory(constraintValidatorFactory)
+                .buildValidatorFactory();
     }
 
     public Validator get() {
-        return Validation.buildDefaultValidatorFactory().usingContext()
-            .constraintValidatorFactory(constraintValidatorFactory)
-            .getValidator();
+        return this.validatorFactory.getValidator();
     }
 
 }

--- a/framework/src/play-java-forms/src/main/java/play/data/validation/ValidatorProvider.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/ValidatorProvider.java
@@ -3,6 +3,8 @@
  */
 package play.data.validation;
 
+import java.util.concurrent.CompletableFuture;
+
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
@@ -11,16 +13,23 @@ import javax.validation.Validation;
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.ValidatorFactory;
 
+import play.inject.ApplicationLifecycle;
+
 @Singleton
 public class ValidatorProvider implements Provider<Validator> {
 
     private ValidatorFactory validatorFactory;
 
     @Inject
-    public ValidatorProvider(ConstraintValidatorFactory constraintValidatorFactory) {
+    public ValidatorProvider(ConstraintValidatorFactory constraintValidatorFactory, final ApplicationLifecycle lifecycle) {
         this.validatorFactory = Validation.byDefaultProvider().configure()
                 .constraintValidatorFactory(constraintValidatorFactory)
                 .buildValidatorFactory();
+
+        lifecycle.addStopHook(() -> {
+            this.validatorFactory.close();
+            return CompletableFuture.completedFuture(null);
+        });
     }
 
     public Validator get() {


### PR DESCRIPTION
Right now we create a `ValidatorFactory` **each time** we need a validator - which is quite often (for every constraint annotation for each request).
But we just need a single `ValidatorFactory` per app which delivers us the desired validator(s).

Also using `usingContext` isn't ideal here. What we do right now we create a `ValidationFactory` via `buildDefaultValidatorFactory` (which actually is just a shortcut for `.byDefaultProvider().configure().buildValidatorFactory()`) and then re-configure this just created factory via `usingContext()`. With my change we now immediately create the factory we want. 

This change will save some CPU cycles and heap space :laughing: 