### PR TITLE
Un-interpolated error messages allows removal of javax.el

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -81,7 +81,6 @@ object Dependencies {
   val javaFormsDeps = Seq(
 
     "org.hibernate" % "hibernate-validator" % "5.2.4.Final",
-    "javax.el"      % "javax.el-api"        % "3.0.0", // required by hibernate-validator
 
     ("org.springframework" % "spring-context" % springFrameworkVersion)
       .exclude("org.springframework", "spring-aop")

--- a/framework/src/play-java-forms/src/main/java/play/data/validation/ValidatorProvider.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/ValidatorProvider.java
@@ -15,6 +15,8 @@ import javax.validation.ValidatorFactory;
 
 import play.inject.ApplicationLifecycle;
 
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+
 @Singleton
 public class ValidatorProvider implements Provider<Validator> {
 
@@ -24,6 +26,7 @@ public class ValidatorProvider implements Provider<Validator> {
     public ValidatorProvider(ConstraintValidatorFactory constraintValidatorFactory, final ApplicationLifecycle lifecycle) {
         this.validatorFactory = Validation.byDefaultProvider().configure()
                 .constraintValidatorFactory(constraintValidatorFactory)
+                .messageInterpolator(new ParameterMessageInterpolator())
                 .buildValidatorFactory();
 
         lifecycle.addStopHook(() -> {

--- a/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -22,7 +22,7 @@ class DynamicFormSpec extends Specification {
   val messagesApi = new DefaultMessagesApi()
   implicit val messages = messagesApi.preferred(Seq.empty)
   val jMessagesApi = new play.i18n.MessagesApi(messagesApi)
-  val validator = Validation.buildDefaultValidatorFactory().getValidator()
+  val validator = FormSpec.validator()
 
   "a dynamic form" should {
 

--- a/framework/src/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
@@ -18,7 +18,7 @@ class PartialValidationSpec extends Specification {
   val messagesApi = new DefaultMessagesApi()
 
   val jMessagesApi = new play.i18n.MessagesApi(messagesApi)
-  val formFactory = new FormFactory(jMessagesApi, new Formatters(jMessagesApi), Validation.buildDefaultValidatorFactory().getValidator())
+  val formFactory = new FormFactory(jMessagesApi, new Formatters(jMessagesApi), FormSpec.validator())
 
   "partial validation" should {
     "not fail when fields not in the same group fail validation" in {


### PR DESCRIPTION
Hibernate validator *itself* will by default interpolate the error messages you define in a constraint (e.g. `@Required(message="I will be interpolated")`). See the [docs](https://docs.jboss.org/hibernate/validator/5.2/reference/en-US/html_single/#validator-gettingstarted-uel):
> Hibernate Validator requires an implementation of the Unified Expression Language (JSR 341) for evaluating dynamic expressions **in constraint violation messages**

So you *could* [use expressions like](https://docs.jboss.org/hibernate/validator/5.2/reference/en-US/html_single/#_examples) `${validatedValue}` and `${formatter.format('%1$.2f', validatedValue)}` or [reference the attribute values of the constraint](https://docs.jboss.org/hibernate/validator/5.2/reference/en-US/html_single/#section-interpolation-with-message-expressions).

So for this message interpolation we did include the `javax.el` dependency: Otherwise we would get `ClassNotFoundExceptions` as soon a Play app (containing constraints) starts up - even when we never ever use these interpolation feature(s). **And that's the point:**
As it turns out Play cooks it's own soup on how to handle constraint error messages. Play's concept completely bypasses the way Hibernate validator retrieves error messages. Play uses the constraint message only to "transport" message keys of it's `conf/messages` file. What happens is that after a form got validated, Play builds it's own `ValidationError` objects containing the message key (and it's arguments) which it [retrieved (interpolated already) from Hibernate validator](https://github.com/playframework/playframework/blob/2.5.10/framework/src/play-java/src/main/java/play/data/Form.java#L320) and uses these objects for further processing ([rendering the error messages (by looking up in the `conf/messages`)](https://www.playframework.com/documentation/2.5.x/JavaForms#handling-binding-failure), etc.).

Giving this, I don't see the need for interpolation these constraint messages (keys) before passing it to Play. [By providing](https://docs.jboss.org/hibernate/validator/5.2/reference/en-US/html_single/#section-validator-factory-message-interpolator) Hibernate Validator our own simple custom `MessageInterpolater` you see in this PR, we can just pass the message keys through. (May also improve performance).

Sure, someone could just write plain error messages into constraint's `message` attributes (instead of message keys) and *may* want to interpolate them the Hibernate validator way, but I think this is not what Play enforces you to do (giving all the documention is based on the message key concept - plus think of the `ValidationError` object concept). Also bad for i18n.