### PR TITLE
Use JavaConverters instead of deprecated JavaConversions

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/routing/code/GuiceAppLoader.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/GuiceAppLoader.java
@@ -6,7 +6,6 @@ import play.api.inject.BindingKey;
 import play.api.inject.guice.GuiceableModule;
 import play.api.inject.guice.GuiceableModule$;
 import play.inject.guice.GuiceApplicationLoader;
-import scala.collection.JavaConversions;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/framework/src/play-cache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
+++ b/framework/src/play-cache/src/main/scala/play/api/cache/ehcache/EhCacheApi.scala
@@ -45,10 +45,10 @@ trait EhCacheComponents {
  */
 class EhCacheModule extends SimpleModule((environment, configuration) => {
 
-  import scala.collection.JavaConversions._
+  import scala.collection.JavaConverters._
 
   val defaultCacheName = configuration.underlying.getString("play.cache.defaultCache")
-  val bindCaches = configuration.underlying.getStringList("play.cache.bindCaches").toSeq
+  val bindCaches = configuration.underlying.getStringList("play.cache.bindCaches").asScala
   val createBoundCaches = configuration.underlying.getBoolean("play.cache.createBoundCaches")
 
   // Creates a named cache qualifier

--- a/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsValidation.scala
+++ b/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsValidation.scala
@@ -236,9 +236,9 @@ object PlayDocsValidation {
   val generateUpstreamCodeSamplesTask = Def.task {
     docsJarFile.value match {
       case Some(jarFile) =>
-        import scala.collection.JavaConversions._
+        import scala.collection.JavaConverters._
         val jar = new JarFile(jarFile)
-        val parsedFiles = jar.entries().toIterator.collect {
+        val parsedFiles = jar.entries().asScala.collect {
           case entry if entry.getName.endsWith(".md") && entry.getName.startsWith("play/docs/content/manual") =>
             val fileName = entry.getName.stripPrefix("play/docs/content")
             val contents = IO.readStream(jar.getInputStream(entry))

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaRequestsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaRequestsSpec.scala
@@ -29,13 +29,13 @@ class JavaRequestsSpec extends PlaySpecification with Mockito {
     }
 
     "create a request with a helper that can do cookies" in {
-      import scala.collection.JavaConversions._
+      import scala.collection.JavaConverters._
 
       val cookie1 = Cookie("name1", "value1")
       val requestHeader: RequestHeader = FakeRequest().withCookies(cookie1)
       val javaRequest: Http.Request = new RequestImpl(requestHeader)
 
-      val iterator: Iterator[Http.Cookie] = javaRequest.cookies().iterator()
+      val iterator: Iterator[Http.Cookie] = javaRequest.cookies().asScala.toIterator
       val cookieList = iterator.toList
 
       cookieList.size must be equalTo 1
@@ -44,7 +44,7 @@ class JavaRequestsSpec extends PlaySpecification with Mockito {
     }
 
     "create a context with a helper that can do cookies" in {
-      import scala.collection.JavaConversions._
+      import scala.collection.JavaConverters._
 
       val cookie1 = Cookie("name1", "value1")
 
@@ -52,7 +52,7 @@ class JavaRequestsSpec extends PlaySpecification with Mockito {
       val javaContext: Context = JavaHelpers.createJavaContext(requestHeader, JavaHelpers.createContextComponents())
       val javaRequest = javaContext.request()
 
-      val iterator: Iterator[Http.Cookie] = javaRequest.cookies().iterator()
+      val iterator: Iterator[Http.Cookie] = javaRequest.cookies().asScala.toIterator
       val cookieList = iterator.toList
 
       cookieList.size must be equalTo 1

--- a/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -12,7 +12,7 @@ import play.data.format.Formatters
 import views.html.helper.FieldConstructor.defaultField
 import views.html.helper.inputText
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 /**
  * Specs for Java dynamic forms
@@ -65,17 +65,17 @@ class DynamicFormSpec extends Specification {
     }
 
     "allow access to the property when filled" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validator).fill(Map("foo" -> "bar"))
+      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validator).fill(Map("foo" -> "bar").asJava)
       form.get("foo") must_== "bar"
     }
 
     "allow access to the equivalent of the raw data when filled" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validator).fill(Map("foo" -> "bar"))
+      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validator).fill(Map("foo" -> "bar").asJava)
       form("foo").value() must_== "bar"
     }
 
     "don't throw NullPointerException when all components of form are null" in {
-      val form = new DynamicForm(null, null, null).fill(Map("foo" -> "bar"))
+      val form = new DynamicForm(null, null, null).fill(Map("foo" -> "bar").asJava)
       form("foo").value() must_== "bar"
     }
 

--- a/framework/src/play-openid/src/main/java/play/libs/openid/DefaultOpenIdClient.java
+++ b/framework/src/play-openid/src/main/java/play/libs/openid/DefaultOpenIdClient.java
@@ -5,10 +5,9 @@ package play.libs.openid;
 
 import play.libs.Scala;
 import play.mvc.Http;
-import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
 import scala.compat.java8.FutureConverters;
 import scala.concurrent.ExecutionContext;
-import scala.runtime.AbstractFunction1;
 
 import javax.inject.Inject;
 import java.util.HashMap;
@@ -49,21 +48,16 @@ public class DefaultOpenIdClient implements OpenIdClient {
         if (axOptional == null) axOptional = new HashMap<>();
         return FutureConverters.toJava(client.redirectURL(openID,
                 callbackURL,
-                JavaConversions.mapAsScalaMap(axRequired).toSeq(),
-                JavaConversions.mapAsScalaMap(axOptional).toSeq(),
+                JavaConverters.mapAsScalaMap(axRequired).toSeq(),
+                JavaConverters.mapAsScalaMap(axOptional).toSeq(),
                 Scala.Option(realm)));
     }
 
     @Override
     public CompletionStage<UserInfo> verifiedId(Http.RequestHeader request) {
-        scala.concurrent.Future<UserInfo> scalaPromise = client.verifiedId(request.queryString()).map(
-                new AbstractFunction1<play.api.libs.openid.UserInfo, UserInfo>() {
-                    @Override
-                    public UserInfo apply(play.api.libs.openid.UserInfo scalaUserInfo) {
-                        return new UserInfo(scalaUserInfo.id(), JavaConversions.mapAsJavaMap(scalaUserInfo.attributes()));
-                    }
-                }, executionContext);
-        return FutureConverters.toJava(scalaPromise);
+        return FutureConverters
+                .toJava(client.verifiedId(request.queryString()))
+                .thenApply(userInfo -> new UserInfo(userInfo.id(), JavaConverters.mapAsJavaMap(userInfo.attributes())));
     }
 
     @Override

--- a/framework/src/play-openid/src/main/scala/play/api/libs/openid/OpenIdClient.scala
+++ b/framework/src/play-openid/src/main/scala/play/api/libs/openid/OpenIdClient.scala
@@ -120,8 +120,8 @@ class WsOpenIdClient @Inject() (ws: WSClient, discovery: Discovery)(implicit ec:
    * For internal use
    */
   def verifiedId(queryString: java.util.Map[String, Array[String]]): Future[UserInfo] = {
-    import scala.collection.JavaConversions._
-    verifiedId(queryString.toMap.mapValues(_.toSeq))
+    import scala.collection.JavaConverters._
+    verifiedId(queryString.asScala.toMap.mapValues(_.toSeq))
   }
 
   private def verifiedId(queryString: Map[String, Seq[String]]): Future[UserInfo] = {

--- a/framework/src/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
@@ -14,14 +14,14 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.compat.java8.FutureConverters
 
 import akka.actor.ActorSystem
-import akka.stream.javadsl.{ Flow, Source, Sink }
+import akka.stream.javadsl.{ Source, Sink }
 import akka.stream.{ ActorMaterializer, Materializer }
 import akka.japi.function.{ Function => JFn, Function2 => JFn2 }
 
 import org.reactivestreams.{ Subscription, Subscriber, Publisher }
 
 class AccumulatorSpec extends org.specs2.mutable.Specification {
-  import scala.collection.JavaConversions.asJavaIterable
+  import scala.collection.JavaConverters.asJavaIterable
 
   def withMaterializer[T](block: Materializer => T) = {
     val system = ActorSystem("test")

--- a/framework/src/play/src/main/java/play/i18n/Langs.java
+++ b/framework/src/play/src/main/java/play/i18n/Langs.java
@@ -3,7 +3,7 @@
  */
 package play.i18n;
 
-import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -23,8 +23,8 @@ public class Langs {
     @Inject
     public Langs(play.api.i18n.Langs langs) {
         this.langs = langs;
-        List<Lang> availables = new ArrayList<Lang>();
-        for (play.api.i18n.Lang lang : JavaConversions.asJavaIterable(langs.availables())) {
+        List<Lang> availables = new ArrayList<>();
+        for (play.api.i18n.Lang lang : JavaConverters.asJavaIterable(langs.availables())) {
             availables.add(new Lang(lang));
         }
         this.availables = Collections.unmodifiableList(availables);
@@ -55,6 +55,6 @@ public class Langs {
      * @return The preferred language
      */
     public Lang preferred(Collection<Lang> candidates) {
-        return new Lang(langs.preferred((scala.collection.Seq) JavaConversions.collectionAsScalaIterable(candidates).toSeq()));
+        return new Lang(langs.preferred((scala.collection.Seq) JavaConverters.collectionAsScalaIterable(candidates).toSeq()));
     }
 }

--- a/framework/src/play/src/main/java/play/i18n/MessagesApi.java
+++ b/framework/src/play/src/main/java/play/i18n/MessagesApi.java
@@ -5,7 +5,7 @@ package play.i18n;
 
 import org.apache.commons.lang3.ArrayUtils;
 import play.mvc.Http;
-import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
 import scala.collection.Seq;
 import scala.collection.mutable.Buffer;
 
@@ -115,7 +115,7 @@ public class MessagesApi {
      * @return the most appropriate Messages instance given the candidate languages
      */
     public Messages preferred(Collection<Lang> candidates) {
-        Seq<Lang> cs = JavaConversions.collectionAsScalaIterable(candidates).toSeq();
+        Seq<Lang> cs = JavaConverters.collectionAsScalaIterable(candidates).toSeq();
         play.api.i18n.Messages msgs = messages.preferred((Seq) cs);
         return new MessagesImpl(new Lang(msgs.lang()), this);
     }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -28,7 +28,7 @@ import play.libs.Json;
 import play.libs.XML;
 import play.libs.typedmap.TypedKey;
 import play.libs.typedmap.TypedMap;
-import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
 import scala.collection.Seq;
 import scala.collection.immutable.Map$;
 import scala.compat.java8.OptionConverters;
@@ -106,10 +106,10 @@ public class Http {
             this.header = request._underlyingHeader();
             this.id = header.id();
             this.response = new Response();
-            this.session = new Session(JavaConversions.mapAsJavaMap(header.session().data()));
-            this.flash = new Flash(JavaConversions.mapAsJavaMap(header.flash().data()));
+            this.session = new Session(JavaConverters.mapAsJavaMap(header.session().data()));
+            this.flash = new Flash(JavaConverters.mapAsJavaMap(header.flash().data()));
             this.args = new HashMap<String,Object>();
-            this.args.putAll(JavaConversions.mapAsJavaMap(header.tags()));
+            this.args.putAll(JavaConverters.mapAsJavaMap(header.tags()));
             this.components = components;
         }
 
@@ -1052,7 +1052,7 @@ public class Http {
          * @deprecated Use typed attributes, i.e. <code>attrs()</code>, instead.
          */
         public Map<String, String> tags() {
-            return JavaConversions.mapAsJavaMap(req.tags());
+            return JavaConverters.mapAsJavaMap(req.tags());
         }
 
         /**
@@ -1284,7 +1284,7 @@ public class Http {
          * @return the cookies in a Java map
          */
         public Map<String,String> flash() {
-          return JavaConversions.mapAsJavaMap(req.flash().data());
+          return JavaConverters.mapAsJavaMap(req.flash().data());
         }
 
         /**
@@ -1316,7 +1316,7 @@ public class Http {
          * @return the sessions in the request
          */
         public Map<String,String> session() {
-            return JavaConversions.mapAsJavaMap(req.session().data());
+            return JavaConverters.mapAsJavaMap(req.session().data());
         }
 
         /**
@@ -1370,7 +1370,7 @@ public class Http {
         public Optional<List<X509Certificate>> clientCertificateChain() {
             return OptionConverters.toJava(
                     req.connection().clientCertificateChain()).map(
-                            list -> new ArrayList<X509Certificate>(JavaConversions.asJavaCollection(list)));
+                            list -> new ArrayList<X509Certificate>(JavaConverters.asJavaCollection(list)));
         }
 
         /**
@@ -1382,7 +1382,7 @@ public class Http {
             req = req.withConnection(RemoteConnection$.MODULE$.apply(
                     req.connection().remoteAddress(),
                     req.connection().secure(),
-                    OptionConverters.toScala(Optional.ofNullable(JavaConversions.asScalaBuffer(clientCertificateChain).toList()))
+                    OptionConverters.toScala(Optional.ofNullable(JavaConverters.asScalaBuffer(clientCertificateChain).toList()))
             ));
             return this;
         }
@@ -1390,7 +1390,7 @@ public class Http {
         protected static scala.collection.immutable.Map<String,Seq<String>> mapListToScala(Map<String,List<String>> data) {
             Map<String,Seq<String>> seqs = new HashMap<>();
             for (String key: data.keySet()) {
-                seqs.put(key, JavaConversions.asScalaBuffer(data.get(key)));
+                seqs.put(key, JavaConverters.asScalaBuffer(data.get(key)));
             }
             return asScala(seqs);
         }

--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -15,7 +15,7 @@ import play.core.j.JavaHelpers$;
 import play.core.j.JavaResultExtractor;
 import play.http.HttpEntity;
 import play.libs.Scala;
-import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
 import scala.compat.java8.OptionConverters;
 
 import static play.mvc.Http.Cookie;
@@ -178,7 +178,7 @@ public class Result {
      * @return the immutable map of headers
      */
     public Map<String, String> headers() {
-        return Collections.unmodifiableMap(JavaConversions.mapAsJavaMap(this.header.headers()));
+        return Collections.unmodifiableMap(JavaConverters.mapAsJavaMap(this.header.headers()));
     }
 
     /**

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -30,7 +30,7 @@ import scala.concurrent.ExecutionContext
  */
 final class ResponseHeader(val status: Int, _headers: Map[String, String] = Map.empty, val reasonPhrase: Option[String] = None) {
   private[play] def this(status: Int, _headers: java.util.Map[String, String], reasonPhrase: Option[String]) =
-    this(status, collection.JavaConversions.mapAsScalaMap(_headers).toMap, reasonPhrase)
+    this(status, collection.JavaConverters.mapAsScalaMap(_headers).toMap, reasonPhrase)
 
   val headers: Map[String, String] = TreeMap[String, String]()(CaseInsensitiveOrdered) ++ _headers
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -17,7 +17,7 @@ import play.libs.typedmap.TypedMap
 import play.mvc.Http.{ RequestBody, Context => JContext, Cookie => JCookie, Cookies => JCookies, Request => JRequest, RequestHeader => JRequestHeader, RequestImpl => JRequestImpl }
 import play.mvc.{ Security, Result => JResult }
 
-import scala.collection.{ JavaConversions, mutable }
+import scala.collection.{ JavaConverters, mutable }
 import scala.collection.JavaConverters._
 import scala.compat.java8.{ FutureConverters, OptionConverters }
 import scala.concurrent.Future
@@ -64,7 +64,7 @@ trait JavaHelpers {
 
   def javaMapOfArraysToScalaSeqOfPairs(m: java.util.Map[String, Array[String]]): Seq[(String, String)] = {
     for {
-      (k, arr) <- JavaConversions.mapAsScalaMap(m).to[Vector]
+      (k, arr) <- JavaConverters.mapAsScalaMap(m).to[Vector]
       el <- arr
     } yield (k, el)
   }

--- a/framework/src/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
@@ -12,7 +12,7 @@ class HttpConfigurationSpec extends Specification {
 
   "HttpConfiguration" should {
 
-    import scala.collection.JavaConversions._
+    import scala.collection.JavaConverters._
 
     def properties = {
       Map(
@@ -34,7 +34,7 @@ class HttpConfigurationSpec extends Specification {
       )
     }
 
-    val configuration = new Configuration(ConfigFactory.parseMap(properties))
+    val configuration = new Configuration(ConfigFactory.parseMap(properties.asJava))
 
     "configure a context" in {
       val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
@@ -43,13 +43,13 @@ class HttpConfigurationSpec extends Specification {
 
     "throw an error when context does not starts with /" in {
       val config = properties + ("play.http.context" -> "something")
-      val wrongConfiguration = Configuration(ConfigFactory.parseMap(config))
+      val wrongConfiguration = Configuration(ConfigFactory.parseMap(config.asJava))
       new HttpConfiguration.HttpConfigurationProvider(wrongConfiguration).get must throwA[PlayException]
     }
 
     "throw an error when context includes a mimetype config setting" in {
       val config = properties + ("mimetype" -> "something")
-      val wrongConfiguration = Configuration(ConfigFactory.parseMap(config))
+      val wrongConfiguration = Configuration(ConfigFactory.parseMap(config.asJava))
       new HttpConfiguration.HttpConfigurationProvider(wrongConfiguration).get must throwA[PlayException]
     }
 

--- a/framework/src/run-support/src/main/scala/play/runsupport/FileWatchService.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/FileWatchService.scala
@@ -277,9 +277,9 @@ private[play] class JDK7FileWatchService(logger: LoggerProxy) extends FileWatchS
 
             val events = watchKey.pollEvents()
 
-            import scala.collection.JavaConversions._
+            import scala.collection.JavaConverters._
             // If a directory has been created, we must watch it and its sub directories
-            events.foreach { event =>
+            events.asScala.foreach { event =>
 
               if (event.kind == ENTRY_CREATE) {
                 val file = watchKey.watchable.asInstanceOf[Path].resolve(event.context.asInstanceOf[Path]).toFile


### PR DESCRIPTION
## Purpose

JavaConversions was deprecated in Scala 2.12. This PR replaces it with JavaConverters.