### PR TITLE
[WIP]: Remove global state for Cookies, Sessions and Flash

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
@@ -3,7 +3,6 @@
  */
 package play.it.http
 
-import play.api.http.{ FlashConfiguration, SessionConfiguration }
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.test._
@@ -101,10 +100,16 @@ class ScalaResultsSpec extends PlaySpecification {
     _.configure(Map(config: _*) + ("play.crypto.secret" -> "foo"))
   )(block)
 
-  def withFooPath[T](block: Application => T) = withApplication("play.http.context" -> "/foo")(block)
-
   def withFooDomain[T](block: Application => T) = withApplication("play.http.session.domain" -> ".foo.com")(block)
 
   def withSecureSession[T](block: Application => T) = withApplication("play.http.session.secure" -> true)(block)
 
+  def withFooPath[T](block: Application => T) = {
+    val path = "/foo"
+    withApplication(
+      "play.http.context" -> path,
+      "play.http.session.path" -> path,
+      "play.http.flash.path" -> path
+    )(block)
+  }
 }

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -144,6 +144,10 @@ play {
       # The domain to set on the session cookie
       # If null, does not set a domain on the session cookie.
       domain = null
+
+      # The session path
+      # Must start with /.
+      path = ${play.http.context}
     }
 
     # Flash configuration
@@ -156,6 +160,10 @@ play {
 
       # Whether the HTTP only attribute of the cookie should be set to true
       httpOnly = true
+
+      # The flash path
+      # Must start with /.
+      path = ${play.http.context}
     }
 
     fileMimeTypes = """

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -457,7 +457,7 @@ class DefaultMessagesApi @Inject() (
 
   override def setLang(result: Result, lang: Lang): Result = {
     result.withCookies(Cookie(langCookieName, lang.code,
-      path = httpConfiguration.context,
+      path = httpConfiguration.session.path,
       domain = httpConfiguration.session.domain,
       secure = langCookieSecure,
       httpOnly = langCookieHttpOnly))
@@ -466,7 +466,7 @@ class DefaultMessagesApi @Inject() (
   override def clearLang(result: Result): Result = {
     result.discardingCookies(DiscardingCookie(
       langCookieName,
-      path = httpConfiguration.context,
+      path = httpConfiguration.session.path,
       domain = httpConfiguration.session.domain,
       secure = langCookieSecure))
   }

--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -65,6 +65,7 @@ trait Cookies extends Traversable[Cookie] {
 /**
  * Helper utilities to encode Cookies.
  */
+@deprecated("Inject [[play.api.mvc.CookieHeaderEncoding]] instead", "2.6.0")
 object Cookies extends CookieHeaderEncoding {
 
   // Use global state for cookie header configuration
@@ -325,7 +326,7 @@ trait CookieBaker[T <: AnyRef] {
   /**
    *  The cookie path.
    */
-  def path = "/"
+  def path: String
 
   /**
    * The cookie signer.

--- a/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
@@ -76,7 +76,7 @@ trait FlashCookieBaker extends CookieBaker[Flash] {
 
   lazy val emptyCookie = new Flash
 
-  override def path = HttpConfiguration.current.context
+  override def path = config.path
   override def secure = config.secure
   override def httpOnly = config.httpOnly
   override def domain = sessionConfig.domain
@@ -94,8 +94,10 @@ class DefaultFlashCookieBaker @Inject() (val config: FlashConfiguration, val ses
   def this() = this(FlashConfiguration(), SessionConfiguration())
 }
 
+@deprecated("Inject [[play.api.mvc.FlashCookieBaker]] instead", "2.6.0")
 object Flash extends FlashCookieBaker {
   def config = HttpConfiguration.current.flash
   def sessionConfig = HttpConfiguration.current.session
   def fromJavaFlash(javaFlash: play.mvc.Http.Flash): Flash = new Flash(javaFlash.asScala.toMap)
+  override def path = HttpConfiguration.current.context
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/Session.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Session.scala
@@ -79,7 +79,7 @@ trait SessionCookieBaker extends CookieBaker[Session] {
   override def secure = config.secure
   override def maxAge = config.maxAge.map(_.toSeconds.toInt)
   override def httpOnly = config.httpOnly
-  override def path = HttpConfiguration.current.context
+  override def path = config.path
   override def domain = config.domain
   override def cookieSigner = play.api.libs.Crypto.cookieSigner
 
@@ -92,7 +92,9 @@ class DefaultSessionCookieBaker @Inject() (val config: SessionConfiguration) ext
   def this() = this(SessionConfiguration())
 }
 
+@deprecated("Inject [[play.api.mvc.SessionCookieBaker]] instead", "2.6.0")
 object Session extends SessionCookieBaker {
   def config = HttpConfiguration.current.session
   def fromJavaSession(javaSession: play.mvc.Http.Session): Session = new Session(javaSession.asScala.toMap)
+  override def path = HttpConfiguration.current.context
 }

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -29,12 +29,11 @@ import scala.concurrent.Future
 trait JavaHelpers {
 
   def cookieToScalaCookie(c: play.mvc.Http.Cookie): Cookie = {
-    Cookie(c.name, c.value,
-      if (c.maxAge == null) None else Some(c.maxAge), c.path, Option(c.domain), c.secure, c.httpOnly)
+    Cookie(c.name, c.value, Option(c.maxAge), c.path, Option(c.domain), c.secure, c.httpOnly)
   }
 
   def cookiesToScalaCookies(cookies: java.lang.Iterable[play.mvc.Http.Cookie]): Seq[Cookie] = {
-    cookies.asScala.toSeq.map(cookieToScalaCookie(_))
+    cookies.asScala.toSeq.map(cookieToScalaCookie)
   }
 
   def cookiesToJavaCookies(cookies: Cookies) = {

--- a/framework/src/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
@@ -27,9 +27,11 @@ class HttpConfigurationSpec extends Specification {
         "play.http.session.maxAge" -> "10s",
         "play.http.session.httpOnly" -> "true",
         "play.http.session.domain" -> "playframework.com",
+        "play.http.session.path" -> "/session",
         "play.http.flash.cookieName" -> "PLAY_FLASH",
         "play.http.flash.secure" -> "true",
         "play.http.flash.httpOnly" -> "true",
+        "play.http.flash.path" -> "/flash",
         "play.http.fileMimeTypes" -> "foo=text/foo"
       )
     }
@@ -43,6 +45,28 @@ class HttpConfigurationSpec extends Specification {
 
     "throw an error when context does not starts with /" in {
       val config = properties + ("play.http.context" -> "something")
+      val wrongConfiguration = Configuration(ConfigFactory.parseMap(config.asJava))
+      new HttpConfiguration.HttpConfigurationProvider(wrongConfiguration).get must throwA[PlayException]
+    }
+
+    "configure a session path" in {
+      val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
+      httpConfiguration.session.path must beEqualTo("/session")
+    }
+
+    "throw an error when session path does not starts with /" in {
+      val config = properties + ("play.http.session.path" -> "something")
+      val wrongConfiguration = Configuration(ConfigFactory.parseMap(config.asJava))
+      new HttpConfiguration.HttpConfigurationProvider(wrongConfiguration).get must throwA[PlayException]
+    }
+
+    "configure a flash path" in {
+      val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration).get
+      httpConfiguration.flash.path must beEqualTo("/flash")
+    }
+
+    "throw an error when flash path does not starts with /" in {
+      val config = properties + ("play.http.flash.path" -> "something")
       val wrongConfiguration = Configuration(ConfigFactory.parseMap(config.asJava))
       new HttpConfiguration.HttpConfigurationProvider(wrongConfiguration).get must throwA[PlayException]
     }


### PR DESCRIPTION
## Status:

This is a working in progress PR. There is still work to be done regarding the `CookieSigner`.

## Fixes

Fixes #6694 and invalidates #6753.

## Purpose

Remove the global state access made at Cookies, Flash, Sessions and related classes.

## References

#6753  PR was made agains branch 2.3.x, so maybe we can backport part of this PR to branch 2.5. Basically, these two new configurations:

1. play.http.session.path: defaults to play.http.context
2. play.http.flash.path: defaults to play.http.context