### PR TITLE
Update to interplay 1.3.2

### DIFF
--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -5,7 +5,7 @@ buildInfoSettings
 sourceGenerators in Compile += Def.task(buildInfo.value).taskValue
 
 val sbtNativePackagerVersion = "1.1.1"
-val sbtTwirlVersion = sys.props.getOrElse("twirl.version", "1.3.0")
+val sbtTwirlVersion = sys.props.getOrElse("twirl.version", "1.3.2")
 
 buildInfoKeys := Seq[BuildInfoKey](
   "sbtNativePackagerVersion" -> sbtNativePackagerVersion,


### PR DESCRIPTION
Fixes the case where sbt plugin projects were not found because they were looking for 2.12 versions.

```
[warn]     :: com.typesafe.sbt#sbt-twirl;1.3.0: not found
[warn]     :: com.typesafe.sbt#sbt-native-packager;1.1.1: not found
[warn]     :: com.typesafe.sbt#sbt-web;1.3.0: not found
[warn]     :: com.typesafe.sbt#sbt-js-engine;1.1.3: not found
```

Interplay 1.3.2 contains https://github.com/playframework/interplay/pull/22
