### PR TITLE
Moves/Renames akka-http related files to be on par with netty and changes gzip decoder

### DIFF
--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -58,7 +58,7 @@ lazy val main = Project("Play-Documentation", file(".")).enablePlugins(PlayDocsP
       playProject("Play-JDBC") % "test",
       playProject("Play-Logback") % "test",
       playProject("Play-Java-JDBC") % "test",
-      playProject("Play-Akka-Http-Server-Experimental") % "test"
+      playProject("Play-Akka-Http-Server") % "test"
     )
 
 lazy val playDocs = playProject("Play-Docs")

--- a/documentation/manual/experimental/AkkaHttpServer.md
+++ b/documentation/manual/experimental/AkkaHttpServer.md
@@ -35,7 +35,7 @@ Now Play should automatically select the Akka HTTP server for running in dev mod
 If for some reason you have both the Akka HTTP server and the Netty HTTP server on your classpath, you'll need to manually select it.  This can be done using the `play.server.provider` system property, for example, in dev mode:
 
 ```
-run -Dplay.server.provider=play.core.server.akkahttp.AkkaHttpServerProvider
+run -Dplay.server.provider=play.core.server.AkkaHttpServerProvider
 ```
 
 ### Verifying that the Akka HTTP server is running
@@ -57,7 +57,7 @@ The Akka HTTP server is configured with Typesafe Config, like the rest of Play. 
 play {
 
   # The server provider class name
-  server.provider = "play.core.server.akkahttp.AkkaHttpServerProvider"
+  server.provider = "play.core.server.AkkaHttpServerProvider"
 
   akka {
     # How long to wait when binding to the listening socket

--- a/documentation/manual/experimental/AkkaHttpServer.md
+++ b/documentation/manual/experimental/AkkaHttpServer.md
@@ -108,7 +108,7 @@ akka {
 
 ## Embedded Usage
 
-Play Akka HTTP server is also configurable as a embedded Play server. The simplest way to start an Play Akka HTTP Server is to use the [`AkkaHttpServer`](api/scala/play/core/server/akkahttp/AkkaHttpServer$.html) factory methods. If all you need to do is provide some straightforward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouter` method:
+Play Akka HTTP server is also configurable as a embedded Play server. The simplest way to start an Play Akka HTTP Server is to use the [`AkkaHttpServer`](api/scala/play/core/server/AkkaHttpServer$.html) factory methods. If all you need to do is provide some straightforward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouter` method:
 
 @[simple-akka-http](code/ScalaAkkaEmbeddingPlay.scala)
 
@@ -116,7 +116,7 @@ By default, this will start a server on port 9000 in prod mode.  You can configu
 
 @[config-akka-http](code/ScalaAkkaEmbeddingPlay.scala)
 
-You may want to customise some of the components that Play provides, for example, the HTTP error handler.  A simple way of doing this is by using Play's components traits, the [`AkkaServerComponents`](api/scala/play/core/server/akkahttp/AkkaServerComponents.html) trait is provided for this purpose, and can be conveniently combined with [`BuiltInComponents`](api/scala/play/api/BuiltInComponents.html) to build the application that it requires:
+You may want to customise some of the components that Play provides, for example, the HTTP error handler.  A simple way of doing this is by using Play's components traits, the [`AkkaServerComponents`](api/scala/play/core/server/AkkaServerComponents.html) trait is provided for this purpose, and can be conveniently combined with [`BuiltInComponents`](api/scala/play/api/BuiltInComponents.html) to build the application that it requires:
 
 @[components-akka-http](code/ScalaAkkaEmbeddingPlay.scala)
 

--- a/documentation/manual/experimental/code/ScalaAkkaEmbeddingPlay.scala
+++ b/documentation/manual/experimental/code/ScalaAkkaEmbeddingPlay.scala
@@ -14,7 +14,7 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
   "Embedding play with akka" should {
     "be very simple" in {
       //#simple-akka-http
-      import play.core.server.akkahttp.AkkaHttpServer
+      import play.core.server.AkkaHttpServer
       import play.api.routing.sird._
       import play.api.mvc._
 
@@ -37,7 +37,7 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
     "be configurable with akka" in {
       //#config-akka-http
       import play.core.server._
-      import play.core.server.akkahttp.AkkaHttpServer
+      import play.core.server.AkkaHttpServer
       import play.api.routing.sird._
       import play.api.mvc._
 
@@ -60,7 +60,7 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
 
     "allow overriding components" in {
       //#components-akka-http
-      import play.core.server.akkahttp.AkkaServerComponents
+      import play.core.server.AkkaServerComponents
       import play.api.routing.Router
       import play.api.routing.sird._
       import play.api.mvc._
@@ -97,7 +97,7 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
     "allow usage from a running application" in {
       //#application-akka-http
       import play.api.inject.guice.GuiceApplicationBuilder
-      import play.core.server.akkahttp.AkkaHttpServer
+      import play.core.server.AkkaHttpServer
       import play.core.server.ServerConfig
       import play.api.routing.sird._
       import play.api.routing.SimpleRouterImpl

--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -91,7 +91,7 @@ lazy val PlayNettyServerProject = PlayCrossBuiltProject("Play-Netty-Server", "pl
     .settings(libraryDependencies ++= netty)
     .dependsOn(PlayServerProject)
 
-lazy val PlayAkkaHttpServerProject = PlayCrossBuiltProject("Play-Akka-Http-Server-Experimental", "play-akka-http-server")
+lazy val PlayAkkaHttpServerProject = PlayCrossBuiltProject("Play-Akka-Http-Server", "play-akka-http-server")
     .settings(libraryDependencies ++= akkaHttp)
     // Include scripted tests here as well as in the SBT Plugin, because we
     // don't want the SBT Plugin to have a dependency on an experimental module.

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -151,7 +151,7 @@ object Dependencies {
   val nettyUtilsDependencies = slf4j
 
   val akkaHttp = Seq(
-    "com.typesafe.akka" %% "akka-http" % akkaHttpVersion
+    "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion
   )
 
   def routesCompilerDependencies(scalaVersion: String) = Seq(

--- a/framework/src/play-akka-http-server/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/reference.conf
@@ -7,7 +7,7 @@ play {
 
   server {
     # The server provider class name
-    provider = "play.core.server.akkahttp.AkkaHttpServerProvider"
+    provider = "play.core.server.AkkaHttpServerProvider"
 
     akka {
       # How long to wait when binding to the listening socket

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -3,9 +3,7 @@
  */
 package play.core.server.akkahttp
 
-import java.net.InetAddress
-import java.net.InetSocketAddress
-import java.net.URI
+import java.net.{ InetAddress, InetSocketAddress, URI }
 
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
@@ -14,17 +12,11 @@ import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.Logger
 import play.api.http.HeaderNames._
-import play.api.http.HttpChunk
-import play.api.http.HttpErrorHandler
-import play.api.http.Status
-import play.api.http.{ HttpEntity => PlayHttpEntity }
+import play.api.http.{ HttpChunk, HttpErrorHandler, Status, HttpEntity => PlayHttpEntity }
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc._
-import play.api.mvc.request.RemoteConnection
-import play.api.mvc.request.RequestAttrKey
-import play.api.mvc.request.RequestTarget
-import play.core.server.common.ForwardedHeaderHandler
-import play.core.server.common.ServerResultUtils
+import play.api.mvc.request.{ RemoteConnection, RequestAttrKey, RequestTarget }
+import play.core.server.common.{ ForwardedHeaderHandler, ServerResultUtils }
 
 import scala.collection.immutable
 import scala.concurrent.Future
@@ -32,7 +24,7 @@ import scala.concurrent.Future
 /**
  * Conversions between Akka's and Play's HTTP model objects.
  */
-private[akkahttp] class ModelConversion(
+private[server] class AkkaModelConversion(
     resultUtils: ServerResultUtils,
     forwardedHeaderHandler: ForwardedHeaderHandler) {
 

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/HttpRequestDecoder.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/HttpRequestDecoder.scala
@@ -3,19 +3,23 @@
  */
 package play.core.server.akkahttp
 
-import akka.http.scaladsl.coding.{ DataMapper, Decoder, Deflate, Gzip }
+import akka.NotUsed
 import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.headers.{ HttpEncodings, `Content-Encoding` }
+import akka.stream.scaladsl.{ Compression, Flow }
+import akka.util.ByteString
 
-object HttpRequestDecoder {
+private[server] object HttpRequestDecoder {
 
-  def decodeRequestWith(decoder: Decoder, request: HttpRequest): HttpRequest = {
-    decoder.decode(request)(DataMapper.mapRequest)
+  private def decodeRequestWith(decoderFlow: Flow[ByteString, ByteString, NotUsed], request: HttpRequest): HttpRequest = {
+    request.withEntity(request.entity.transformDataBytes(decoderFlow))
+      .withHeaders(request.headers.filter(_.isInstanceOf[`Content-Encoding`]))
   }
 
   def decodeRequest(request: HttpRequest): HttpRequest = {
     request.encoding match {
-      case Gzip.encoding => decodeRequestWith(Gzip, request)
-      case Deflate.encoding => decodeRequestWith(Deflate, request)
+      case HttpEncodings.gzip => decodeRequestWith(Compression.gunzip(), request)
+      case HttpEncodings.deflate => decodeRequestWith(Compression.inflate(), request)
       // Handle every undefined decoding as is
       case _ => request
     }

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/system-property/build.sbt
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/system-property/build.sbt
@@ -20,7 +20,7 @@ libraryDependencies ++= Seq(
 
 fork in Test := true
 
-javaOptions in Test += "-Dplay.server.provider=play.core.server.akkahttp.AkkaHttpServerProvider"
+javaOptions in Test += "-Dplay.server.provider=play.core.server.AkkaHttpServerProvider"
 
 PlayKeys.playInteractionMode := play.sbt.StaticPlayNonBlockingInteractionMode
 

--- a/framework/src/play-akka-http-server/src/sbt-test/akka-http/system-property/test
+++ b/framework/src/play-akka-http-server/src/sbt-test/akka-http/system-property/test
@@ -4,7 +4,7 @@
 > playStop
 
 # Start dev mode with an overridden server - AkkaHttpServer
-> run -Dplay.server.provider=play.core.server.akkahttp.AkkaHttpServerProvider
+> run -Dplay.server.provider=play.core.server.AkkaHttpServerProvider
 > verifyResourceContains / 200 akka-http
 > playStop
 

--- a/framework/src/play-akka-http-server/src/test/scala/play/core/server/AkkaHttpServerSpec.scala
+++ b/framework/src/play-akka-http-server/src/test/scala/play/core/server/AkkaHttpServerSpec.scala
@@ -1,18 +1,17 @@
 /*
  * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
  */
-package play.core.server.akkahttp
+package play.core.server
 
+import akka.util.Timeout
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws._
-import play.api.mvc._
 import play.api.mvc.BodyParsers.parse
 import play.api.mvc.Results._
+import play.api.mvc._
 import play.api.test._
 
 import scala.concurrent.Future
-import akka.util.Timeout
-import play.core.server.AkkaHttpServer
 
 class AkkaHttpServerSpec extends PlaySpecification with WsTestClient {
   // Provide a flag to disable Akka HTTP tests

--- a/framework/src/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHttpServerSpec.scala
+++ b/framework/src/play-akka-http-server/src/test/scala/play/core/server/akkahttp/AkkaHttpServerSpec.scala
@@ -9,8 +9,10 @@ import play.api.mvc._
 import play.api.mvc.BodyParsers.parse
 import play.api.mvc.Results._
 import play.api.test._
+
 import scala.concurrent.Future
 import akka.util.Timeout
+import play.core.server.AkkaHttpServer
 
 class AkkaHttpServerSpec extends PlaySpecification with WsTestClient {
   // Provide a flag to disable Akka HTTP tests

--- a/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
@@ -9,7 +9,7 @@ import org.specs2.specification.AroundEach
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.core.server.{ NettyServer, ServerProvider }
-import play.core.server.akkahttp.AkkaHttpServer
+import play.core.server.AkkaHttpServer
 
 import scala.concurrent.duration._
 


### PR DESCRIPTION
actually this marks akka-http backend as non experimental
and changes the gzip decoder from akka-http to akka-stream so that we can
only depend on the akka-http-core model
AkkaHttpServer and ModelConversions were moved to play.core.server to be on par with the netty backend.