### PR TITLE
Make (spring) locale of current request available in validate()

### DIFF
--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -312,13 +312,14 @@ public class Form<T> {
         dataBinder.setConversionService(formatters.conversion);
         dataBinder.setAutoGrowNestedPaths(true);
         final Map<String, String> objectDataFinal = objectData;
-        withRequestLocale(() -> { dataBinder.bind(new MutablePropertyValues(objectDataFinal)); return null; });
-        Set<ConstraintViolation<Object>> validationErrors;
-        if (groups != null) {
-            validationErrors = validator.validate(dataBinder.getTarget(), groups);
-        } else {
-            validationErrors = validator.validate(dataBinder.getTarget());
-        }
+        Set<ConstraintViolation<Object>> validationErrors = withRequestLocale(() -> {
+            dataBinder.bind(new MutablePropertyValues(objectDataFinal));
+            if (groups != null) {
+                return validator.validate(dataBinder.getTarget(), groups);
+            } else {
+                return validator.validate(dataBinder.getTarget());
+            }
+        });
 
         BindingResult result = dataBinder.getBindingResult();
 

--- a/framework/src/play-java-forms/src/test/java/play/data/validation/TestConstraints.java
+++ b/framework/src/play-java-forms/src/test/java/play/data/validation/TestConstraints.java
@@ -13,9 +13,12 @@ import javax.validation.Constraint;
 import javax.validation.ConstraintValidator;
 import javax.validation.Payload;
 
+import play.api.i18n.Lang;
 import play.data.validation.Constraints.Validator;
 import play.i18n.MessagesApi;
 import play.mvc.Http;
+
+import org.springframework.context.i18n.LocaleContextHolder;
 
 public class TestConstraints {
 
@@ -59,6 +62,55 @@ public class TestConstraints {
             }
 
             return Pattern.compile(this.messagesApi.get(Http.Context.current.get().lang(), this.msgKey)).matcher(object).matches();
+        }
+
+        @Override
+        public Tuple<String, Object[]> getErrorMessageKey() {
+            return Tuple(message, new Object[] { this.msgKey });
+        }
+
+    }
+
+    /**
+     * Defines another I18N constraint for a string field.
+     */
+    @Target({FIELD})
+    @Retention(RUNTIME)
+    @Constraint(validatedBy = AnotherI18NConstraintValidator.class)
+    @play.data.Form.Display(name="constraint.anotheri18nconstraint", attributes={"value"})
+    public static @interface AnotherI18NConstraint {
+        String message() default AnotherI18NConstraintValidator.message;
+        Class<?>[] groups() default {};
+        Class<? extends Payload>[] payload() default {};
+        String value();
+    }
+
+    /**
+     * Validator for <code>@AnotherI18NConstraint</code> fields.
+     */
+    public static class AnotherI18NConstraintValidator extends Validator<String> implements ConstraintValidator<AnotherI18NConstraint, String> {
+
+        String msgKey;
+
+        final static public String message = "error.anotheri18nconstraint";
+
+        @Inject
+        private MessagesApi messagesApi;
+
+        public AnotherI18NConstraintValidator() {}
+
+        @Override
+        public void initialize(AnotherI18NConstraint constraintAnnotation) {
+            this.msgKey = constraintAnnotation.value();
+        }
+
+        @Override
+        public boolean isValid(String object) {
+            if(object == null || object.length() == 0) {
+                return true;
+            }
+
+            return Pattern.compile(this.messagesApi.get(new Lang(LocaleContextHolder.getLocale()), this.msgKey)).matcher(object).matches();
         }
 
         @Override

--- a/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -309,6 +309,7 @@ public class HttpFormsTest {
             data.put("name", "peter");
             data.put("dueDate", "11/11/2009");
             data.put("zip", "1234");
+            data.put("anotherZip", "1234");
             RequestBuilder rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
             Context ctx = new Context(rb, contextComponents(app));
             Context.current.set(ctx);
@@ -324,6 +325,7 @@ public class HttpFormsTest {
             data.put("name", "peter");
             data.put("dueDate", "11/11/2009");
             data.put("zip", "567");
+            data.put("anotherZip", "567");
             rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
             ctx = new Context(rb, contextComponents(app));
             Context.current.set(ctx);
@@ -340,6 +342,7 @@ public class HttpFormsTest {
             data.put("name", "peter");
             data.put("dueDate", "11/11/2009");
             data.put("zip", "1234");
+            data.put("anotherZip", "1234");
             rb = new RequestBuilder().uri("http://localhost/test").bodyForm(data);
             ctx = new Context(rb, contextComponents(app));
             Context.current.set(ctx);
@@ -351,6 +354,8 @@ public class HttpFormsTest {
             myForm.data().clear();
             assertThat(myForm.error("zip").messages().size()).isEqualTo(1);
             assertThat(myForm.error("zip").message()).isEqualTo("error.i18nconstraint");
+            assertThat(myForm.error("anotherZip").messages().size()).isEqualTo(1);
+            assertThat(myForm.error("anotherZip").message()).isEqualTo("error.anotheri18nconstraint");
         });
     }
 

--- a/framework/src/play-java-forms/src/test/scala/play/data/Task.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/Task.scala
@@ -12,6 +12,7 @@ class Task {
   type Min = play.data.validation.Constraints.Min @field
   type Required = play.data.validation.Constraints.Required @field
   type I18NConstraint = play.data.validation.TestConstraints.I18Constraint @field
+  type AnotherI18NConstraint = play.data.validation.TestConstraints.AnotherI18NConstraint @field
   type DateTime = play.data.format.Formats.DateTime @field
 
   @Min(10)
@@ -36,6 +37,10 @@ class Task {
   @BeanProperty
   @I18NConstraint(value = "patterns.zip")
   var zip: String = _
+
+  @BeanProperty
+  @AnotherI18NConstraint(value = "patterns.zip")
+  var anotherZip: String = _
 
 }
 


### PR DESCRIPTION
Just a simple addition to #5565 so that the `withRequestLocale` lambda also spans across the `validator.validate(...)` method - just to make sure spring's `LocaleContextHolder.getLocale()` is set inside the validate logic if needed by spring (or by user code). Actually I thought I did this in the original PR already...