### PR TITLE
Use trampoline ExecutionContext in Java EssentialAction

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/EssentialAction.java
+++ b/framework/src/play/src/main/java/play/mvc/EssentialAction.java
@@ -39,7 +39,7 @@ public abstract class EssentialAction
     @Override
     public play.api.libs.streams.Accumulator<ByteString, play.api.mvc.Result> apply(play.api.mvc.RequestHeader rh) {
         return apply(new RequestHeaderImpl(rh))
-            .map(Result::asScala, Execution.internalContext())
+            .map(Result::asScala, Execution.trampoline())
             .asScala();
     }
 


### PR DESCRIPTION
This eliminates the global state in `EssentialAction` by running the `Result::asScala` in the same thread.