### PR TITLE
Reduce usage of deprecated play.Configuration class

### DIFF
--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/ConfiguredActor.java
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/ConfiguredActor.java
@@ -5,16 +5,16 @@ package javaguide.akka;
 
 //#injected
 import akka.actor.UntypedActor;
-import play.Configuration;
+import com.typesafe.config.Config;
 
 import javax.inject.Inject;
 
 public class ConfiguredActor extends UntypedActor {
 
-    private Configuration configuration;
+    private Config configuration;
 
     @Inject
-    public ConfiguredActor(Configuration configuration) {
+    public ConfiguredActor(Config configuration) {
         this.configuration = configuration;
     }
 

--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/ConfiguredChildActor.java
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/ConfiguredChildActor.java
@@ -6,17 +6,17 @@ package javaguide.akka;
 //#injectedchild
 import akka.actor.UntypedActor;
 import com.google.inject.assistedinject.Assisted;
-import play.Configuration;
+import com.typesafe.config.Config;
 
 import javax.inject.Inject;
 
 public class ConfiguredChildActor extends UntypedActor {
 
-    private final Configuration configuration;
+    private final Config configuration;
     private final String key;
 
     @Inject
-    public ConfiguredChildActor(Configuration configuration, @Assisted String key) {
+    public ConfiguredChildActor(Config configuration, @Assisted String key) {
         this.configuration = configuration;
         this.key = key;
     }

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/guice/CustomApplicationLoader.java
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/guice/CustomApplicationLoader.java
@@ -4,21 +4,20 @@
 package javaguide.di.guice;
 
 //#custom-application-loader
-import play.Application;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import play.ApplicationLoader;
-import play.Configuration;
 import play.inject.guice.GuiceApplicationBuilder;
 import play.inject.guice.GuiceApplicationLoader;
-import play.libs.Scala;
 
 public class CustomApplicationLoader extends GuiceApplicationLoader {
 
     @Override
     public GuiceApplicationBuilder builder(ApplicationLoader.Context context) {
-        Configuration extra = new Configuration("a = 1");
+        Config extra = ConfigFactory.parseString("a = 1");
         return initialBuilder
             .in(context.environment())
-            .loadConfig(extra.withFallback(context.initialConfiguration()))
+            .loadConfig(extra.withFallback(context.initialConfig()))
             .overrides(overrides(context));
     }
 

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/guice/dynamic/Module.java
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/guice/dynamic/Module.java
@@ -3,23 +3,22 @@
  */
 package javaguide.di.guice.configured;
 
+import com.typesafe.config.Config;
 import javaguide.di.*;
 
 //#dynamic-guice-module
 import com.google.inject.AbstractModule;
-import com.google.inject.ConfigurationException;
 import com.google.inject.name.Names;
-import play.Configuration;
 import play.Environment;
 
 public class Module extends AbstractModule {
 
     private final Environment environment;
-    private final Configuration configuration;
+    private final Config configuration;
 
     public Module(
           Environment environment,
-          Configuration configuration) {
+          Config configuration) {
         this.environment = environment;
         this.configuration = configuration;
     }
@@ -28,23 +27,24 @@ public class Module extends AbstractModule {
         // Expect configuration like:
         // hello.en = "myapp.EnglishHello"
         // hello.de = "myapp.GermanHello"
-        Configuration helloConf = configuration.getConfig("hello");
+        final Config helloConf = configuration.getConfig("hello");
         // Iterate through all the languages and bind the
         // class associated with that language. Use Play's
         // ClassLoader to load the classes.
-        for (String l: helloConf.subKeys()) {
+        helloConf.entrySet().forEach(entry -> {
             try {
-                String bindingClassName = helloConf.getString(l);
-                Class<? extends Hello> bindingClass =
-                  environment.classLoader().loadClass(bindingClassName)
-                  .asSubclass(Hello.class);
+                String name = entry.getKey();
+                Class<? extends Hello> bindingClass = environment
+                        .classLoader()
+                        .loadClass(entry.getValue().toString())
+                        .asSubclass(Hello.class);
                 bind(Hello.class)
-                        .annotatedWith(Names.named(l))
+                        .annotatedWith(Names.named(name))
                         .to(bindingClass);
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException(e);
+            } catch (ClassNotFoundException ex) {
+              throw new RuntimeException(ex);
             }
-        }
+        });
     }
 }
 //#dynamic-guice-module

--- a/documentation/manual/working/javaGuide/main/tests/code/tests/guice/JavaGuiceApplicationBuilderTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/tests/guice/JavaGuiceApplicationBuilderTest.java
@@ -3,6 +3,7 @@
  */
 package javaguide.tests.guice;
 
+import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
@@ -12,12 +13,10 @@ import java.util.Map;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.junit.Test;
-import play.api.inject.Binding;
-import play.Configuration;
 import play.Environment;
 import play.Mode;
+import play.api.Configuration;
 import play.mvc.Result;
-import scala.collection.Seq;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
@@ -54,7 +53,7 @@ public class JavaGuiceApplicationBuilderTest {
         // #set-environment
         Application application = new GuiceApplicationBuilder()
             .load(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule(), new play.api.i18n.I18nModule()) // ###skip
-            .loadConfig(Configuration.reference()) // ###skip
+            .loadConfig(ConfigFactory.defaultReference()) // ###skip
             .in(new Environment(new File("path/to/app"), classLoader, Mode.TEST))
             .build();
         // #set-environment
@@ -70,7 +69,7 @@ public class JavaGuiceApplicationBuilderTest {
         // #set-environment-values
         Application application = new GuiceApplicationBuilder()
             .load(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule(), new play.api.i18n.I18nModule()) // ###skip
-            .loadConfig(Configuration.reference()) // ###skip
+            .loadConfig(ConfigFactory.defaultReference()) // ###skip
             .in(new File("path/to/app"))
             .in(Mode.TEST)
             .in(classLoader)
@@ -85,7 +84,7 @@ public class JavaGuiceApplicationBuilderTest {
     @Test
     public void addConfiguration() {
         // #add-configuration
-        Configuration extraConfig = new Configuration(ImmutableMap.of("a", 1));
+        Config extraConfig = ConfigFactory.parseMap(ImmutableMap.of("a", 1));
         Map<String, Object> configMap = ImmutableMap.of("b", 2, "c", "three");
 
         Application application = new GuiceApplicationBuilder()
@@ -95,10 +94,10 @@ public class JavaGuiceApplicationBuilderTest {
             .build();
         // #add-configuration
 
-        assertThat(application.configuration().getInt("a"), equalTo(1));
-        assertThat(application.configuration().getInt("b"), equalTo(2));
-        assertThat(application.configuration().getString("c"), equalTo("three"));
-        assertThat(application.configuration().getString("key"), equalTo("value"));
+        assertThat(application.config().getInt("a"), equalTo(1));
+        assertThat(application.config().getInt("b"), equalTo(2));
+        assertThat(application.config().getString("c"), equalTo("three"));
+        assertThat(application.config().getString("key"), equalTo("value"));
     }
 
     @Test

--- a/framework/src/play-guice/src/main/java/play/inject/guice/GuiceBuilder.java
+++ b/framework/src/play-guice/src/main/java/play/inject/guice/GuiceBuilder.java
@@ -6,6 +6,7 @@ package play.inject.guice;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Module;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import play.Configuration;
 import play.Environment;
 import play.Mode;
@@ -98,7 +99,7 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
      * @return a copy of this builder configured with the supplied configuration
      */
     public final Self configure(Map<String, Object> conf) {
-        return configure(new Configuration(conf));
+        return configure(ConfigFactory.parseMap(conf));
     }
 
     /**

--- a/framework/src/play-guice/src/test/java/play/inject/guice/GuiceApplicationLoaderTest.java
+++ b/framework/src/play-guice/src/test/java/play/inject/guice/GuiceApplicationLoaderTest.java
@@ -11,7 +11,11 @@ import org.junit.rules.ExpectedException;
 import play.Application;
 import play.ApplicationLoader;
 import play.Environment;
+import play.api.Configuration;
 
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -55,7 +59,24 @@ public class GuiceApplicationLoaderTest {
         assertThat(app.config().getInt("a"), is(1));
     }
 
-    public static interface A {}
+    @Test
+    public void usingAdditionalConfiguration() {
+        Properties properties = new Properties();
+        properties.setProperty("play.http.context", "/tests");
+
+        Config config = ConfigFactory.parseProperties(properties)
+                .withFallback(ConfigFactory.defaultReference());
+
+        GuiceApplicationBuilder builder = new GuiceApplicationBuilder();
+        ApplicationLoader loader = new GuiceApplicationLoader(builder);
+        ApplicationLoader.Context context = ApplicationLoader.Context.create(Environment.simple())
+                .withConfig(config);
+        Application app = loader.load(context);
+
+        assertThat(app.getWrappedApplication().httpConfiguration().context(), equalTo("/tests"));
+    }
+
+    public interface A {}
     public static class A1 implements A {}
 
     public static class AModule extends com.google.inject.AbstractModule {
@@ -64,7 +85,7 @@ public class GuiceApplicationLoaderTest {
         }
     }
 
-    public static interface B {}
+    public interface B {}
     public static class B1 implements B {}
 
 }

--- a/framework/src/play-guice/src/test/scala/play/api/inject/ModulesSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/inject/ModulesSpec.scala
@@ -4,6 +4,7 @@
 package play.api.inject
 
 import com.google.inject.AbstractModule
+import com.typesafe.config.Config
 import org.specs2.matcher.BeEqualTypedValueCheck
 import org.specs2.mutable.Specification
 import play.api.{ Configuration, Environment }
@@ -43,14 +44,28 @@ class ModulesSpec extends Specification {
     "load Guice modules that take a Java Environment and Configuration" in {
       val env = Environment.simple()
       val conf = Configuration("play.modules.enabled" -> Seq(
-        classOf[JavaGuiceModule].getName
+        classOf[JavaGuiceConfigurationModule].getName
       ))
       val located: Seq[Any] = Modules.locate(env, conf)
       located.size must_== 1
       located.head must beLike {
-        case mod: JavaGuiceModule =>
+        case mod: JavaGuiceConfigurationModule =>
           mod.environment.underlying must_== env
           mod.configuration.underlying must_== conf.underlying
+      }
+    }
+
+    "load Guice modules that take a Java Environment and Config" in {
+      val env = Environment.simple()
+      val conf = Configuration("play.modules.enabled" -> Seq(
+        classOf[JavaGuiceConfigModule].getName
+      ))
+      val located: Seq[Any] = Modules.locate(env, conf)
+      located.size must_== 1
+      located.head must beLike {
+        case mod: JavaGuiceConfigModule =>
+          mod.environment.underlying must_== env
+          mod.config must_== conf.underlying
       }
     }
 
@@ -68,7 +83,13 @@ class ScalaGuiceModule(
   def configure(): Unit = ()
 }
 
-class JavaGuiceModule(
+class JavaGuiceConfigModule(
+    val environment: JavaEnvironment,
+    val config: Config) extends AbstractModule {
+  def configure(): Unit = ()
+}
+
+class JavaGuiceConfigurationModule(
     val environment: JavaEnvironment,
     val configuration: JavaConfiguration) extends AbstractModule {
   def configure(): Unit = ()

--- a/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
@@ -5,8 +5,9 @@ package play.api.inject.guice
 
 import org.specs2.mutable.Specification
 import com.google.inject.AbstractModule
+import com.typesafe.config.Config
 import play.api.i18n.I18nModule
-import play.{ Configuration => JavaConfiguration, Environment => JavaEnvironment }
+import play.{ Environment => JavaEnvironment }
 import play.api.{ ApplicationLoader, Configuration, Environment }
 import play.api.inject.{ BuiltinModule, DefaultApplicationLifecycle }
 
@@ -100,7 +101,7 @@ class ScalaConfiguredModule(
 }
 class JavaConfiguredModule(
     environment: JavaEnvironment,
-    configuration: JavaConfiguration) extends AbstractModule {
+    config: Config) extends AbstractModule {
   def configure(): Unit = {
     bind(classOf[Foo]) to classOf[JavaConfiguredFoo]
   }

--- a/framework/src/play/src/main/java/play/ApplicationLoader.java
+++ b/framework/src/play/src/main/java/play/ApplicationLoader.java
@@ -30,151 +30,185 @@ import play.libs.Scala;
  */
 public interface ApplicationLoader {
 
-  /**
-   * Load an application given the context.
-   *
-   * @param context the context the apps hould be loaded into
-   * @return the loaded application
-   */
-  Application load(ApplicationLoader.Context context);
-
-  /**
-   * The context for loading an application.
-   */
-  final static class Context {
-
-    private final play.api.ApplicationLoader.Context underlying;
-
-  /**
-   * The context for loading an application.
-   *
-   * @param underlying The Scala context that is being wrapped.
-   */
-    public Context(play.api.ApplicationLoader.Context underlying) {
-        this.underlying = underlying;
-    }
-
-  /**
-   * The context for loading an application.
-   *
-   * @param environment the application environment
-   */
-    public Context(Environment environment) {
-        this(environment, new HashMap<>());
-    }
-
-  /**
-   * The context for loading an application.
-   *
-   * @param environment the application environment
-   * @param initialSettings the initial settings. These settings are merged with the settings from the loaded
-   *                        configuration files, and together form the initialConfiguration provided by the context.  It
-   *                        is intended for use in dev mode, to allow the build system to pass additional configuration
-   *                        into the application.
-   */
-    public Context(Environment environment, Map<String,Object> initialSettings) {
-        this.underlying = new play.api.ApplicationLoader.Context(
-           environment.underlying(),
-           scala.Option.empty(),
-           new play.core.DefaultWebCommands(),
-           play.api.Configuration.load(environment.underlying(), play.libs.Scala.asScala(initialSettings)),
-           new DefaultApplicationLifecycle());
-    }
+    /**
+     * Load an application given the context.
+     *
+     * @param context the context the apps hould be loaded into
+     * @return the loaded application
+     */
+    Application load(ApplicationLoader.Context context);
 
     /**
-     * Get the wrapped Scala context.
-     *
-     * @return the wrapped scala context
+     * The context for loading an application.
      */
-    public play.api.ApplicationLoader.Context underlying() {
-        return underlying;
-    }
+    final static class Context {
 
-    /**
-     * Get the environment from the context.
-     *
-     * @return the environment
-     */
-    public Environment environment() {
-        return new Environment(underlying.environment());
-    }
+        private final play.api.ApplicationLoader.Context underlying;
 
-    /**
-     * Get the configuration from the context. This configuration is not necessarily the same
-     * configuration used by the application, as the ApplicationLoader may, through it's own
-     * mechanisms, modify it or completely ignore it.
-     *
-     * @return the initial configuration
-     */
-    @Deprecated
-    public Configuration initialConfiguration() {
-        return new Configuration(underlying.initialConfiguration());
-    }
+        /**
+         * The context for loading an application.
+         *
+         * @param underlying The Scala context that is being wrapped.
+         */
+        public Context(play.api.ApplicationLoader.Context underlying) {
+            this.underlying = underlying;
+        }
 
-    /**
-     * Get the configuration from the context. This configuration is not necessarily the same
-     * configuration used by the application, as the ApplicationLoader may, through it's own
-     * mechanisms, modify it or completely ignore it.
-     *
-     * @return the initial configuration
-     */
-    public Config initialConfig() {
-      return underlying.initialConfiguration().underlying();
-    }
+        /**
+         * The context for loading an application.
+         *
+         * @param environment the application environment
+         */
+        public Context(Environment environment) {
+            this(environment, new HashMap<>());
+        }
 
-    /**
-     * Create a new context with a different environment.
-     *
-     * @param environment the environment this context should use
-     * @return a context using the specified environment
-     */
-    public Context withEnvironment(Environment environment) {
-        play.api.ApplicationLoader.Context scalaContext = new play.api.ApplicationLoader.Context(
-           environment.underlying(),
-           underlying.sourceMapper(),
-           underlying.webCommands(),
-           underlying.initialConfiguration(),
-           new DefaultApplicationLifecycle());
-        return new Context(scalaContext);
-    }
+        /**
+         * The context for loading an application.
+         *
+         * @param environment     the application environment
+         * @param initialSettings the initial settings. These settings are merged with the settings from the loaded
+         *                        configuration files, and together form the initialConfiguration provided by the context.  It
+         *                        is intended for use in dev mode, to allow the build system to pass additional configuration
+         *                        into the application.
+         */
+        public Context(Environment environment, Map<String, Object> initialSettings) {
+            this.underlying = new play.api.ApplicationLoader.Context(
+                    environment.underlying(),
+                    scala.Option.empty(),
+                    new play.core.DefaultWebCommands(),
+                    play.api.Configuration.load(environment.underlying(), play.libs.Scala.asScala(initialSettings)),
+                    new DefaultApplicationLifecycle());
+        }
 
-    /**
-     * Create a new context with a different configuration.
-     *
-     * @param initialConfiguration the configuration to use in the created context
-     * @return the created context
-     */
-    @Deprecated
-    public Context withConfiguration(Configuration initialConfiguration) {
-        play.api.ApplicationLoader.Context scalaContext = new play.api.ApplicationLoader.Context(
-           underlying.environment(),
-           underlying.sourceMapper(),
-           underlying.webCommands(),
-           initialConfiguration.getWrappedConfiguration(),
-           new DefaultApplicationLifecycle());
-        return new Context(scalaContext);
-    }
+        /**
+         * Get the wrapped Scala context.
+         *
+         * @return the wrapped scala context
+         */
+        public play.api.ApplicationLoader.Context underlying() {
+            return underlying;
+        }
 
-    /**
-     * Create a new context with a different configuration.
-     *
-     * @param initialConfiguration the configuration to use in the created context
-     * @return the created context
-     */
-    public Context withConfig(Config initialConfiguration) {
-      play.api.ApplicationLoader.Context scalaContext = new play.api.ApplicationLoader.Context(
-          underlying.environment(),
-          underlying.sourceMapper(),
-          underlying.webCommands(),
-          new play.api.Configuration(initialConfiguration),
-          new DefaultApplicationLifecycle());
-      return new Context(scalaContext);
-    }
+        /**
+         * Get the environment from the context.
+         *
+         * @return the environment
+         */
+        public Environment environment() {
+            return new Environment(underlying.environment());
+        }
 
-    // The following static methods are on the Context inner class rather
-    // than the ApplicationLoader interface because https://issues.scala-lang.org/browse/SI-8852
-    // wasn't fixed until Scala 2.11.3, and at the time of writing we need
-    // to support Scala 2.10.
+        /**
+         * Get the configuration from the context. This configuration is not necessarily the same
+         * configuration used by the application, as the ApplicationLoader may, through it's own
+         * mechanisms, modify it or completely ignore it.
+         *
+         * @return the initial configuration
+         */
+        @Deprecated
+        public Configuration initialConfiguration() {
+            return new Configuration(underlying.initialConfiguration());
+        }
+
+        /**
+         * Get the configuration from the context. This configuration is not necessarily the same
+         * configuration used by the application, as the ApplicationLoader may, through it's own
+         * mechanisms, modify it or completely ignore it.
+         *
+         * @return the initial configuration
+         */
+        public Config initialConfig() {
+            return underlying.initialConfiguration().underlying();
+        }
+
+        /**
+         * Create a new context with a different environment.
+         *
+         * @param environment the environment this context should use
+         * @return a context using the specified environment
+         */
+        public Context withEnvironment(Environment environment) {
+            play.api.ApplicationLoader.Context scalaContext = new play.api.ApplicationLoader.Context(
+                    environment.underlying(),
+                    underlying.sourceMapper(),
+                    underlying.webCommands(),
+                    underlying.initialConfiguration(),
+                    new DefaultApplicationLifecycle());
+            return new Context(scalaContext);
+        }
+
+        /**
+         * Create a new context with a different configuration.
+         *
+         * @param initialConfiguration the configuration to use in the created context
+         * @return the created context
+         */
+        @Deprecated
+        public Context withConfiguration(Configuration initialConfiguration) {
+            play.api.ApplicationLoader.Context scalaContext = new play.api.ApplicationLoader.Context(
+                    underlying.environment(),
+                    underlying.sourceMapper(),
+                    underlying.webCommands(),
+                    initialConfiguration.getWrappedConfiguration(),
+                    new DefaultApplicationLifecycle());
+            return new Context(scalaContext);
+        }
+
+        /**
+         * Create a new context with a different configuration.
+         *
+         * @param initialConfiguration the configuration to use in the created context
+         * @return the created context
+         */
+        public Context withConfig(Config initialConfiguration) {
+            play.api.ApplicationLoader.Context scalaContext = new play.api.ApplicationLoader.Context(
+                    underlying.environment(),
+                    underlying.sourceMapper(),
+                    underlying.webCommands(),
+                    new play.api.Configuration(initialConfiguration),
+                    new DefaultApplicationLifecycle());
+            return new Context(scalaContext);
+        }
+
+        // The following static methods are on the Context inner class rather
+        // than the ApplicationLoader interface because https://issues.scala-lang.org/browse/SI-8852
+        // wasn't fixed until Scala 2.11.3, and at the time of writing we need
+        // to support Scala 2.10.
+
+        /**
+         * Create an application loading context.
+         * <p>
+         * Locates and loads the necessary configuration files for the application.
+         *
+         * @param environment     The application environment.
+         * @param initialSettings The initial settings. These settings are merged with the settings from the loaded
+         *                        configuration files, and together form the initialConfiguration provided by the context.  It
+         *                        is intended for use in dev mode, to allow the build system to pass additional configuration
+         *                        into the application.
+         * @return the created context
+         * @deprecated as of 2.6.0. Use {@link ApplicationLoader#create(Environment, Map)}.
+         */
+        @Deprecated
+        public static Context create(Environment environment, Map<String, Object> initialSettings) {
+            return ApplicationLoader.create(environment, initialSettings);
+        }
+
+        /**
+         * Create an application loading context.
+         * <p>
+         * Locates and loads the necessary configuration files for the application.
+         *
+         * @param environment The application environment.
+         * @return a context created with the provided underlying environment
+         * @deprecated as of 2.6.0. Use {@link ApplicationLoader#create(Environment)}.
+         */
+        @Deprecated
+        public static Context create(Environment environment) {
+            return ApplicationLoader.create(environment);
+        }
+
+    }
 
     /**
      * Create an application loading context.
@@ -188,13 +222,13 @@ public interface ApplicationLoader {
      *                        into the application.
      * @return the created context
      */
-    public static Context create(Environment environment, Map<String, Object> initialSettings) {
+    static Context create(Environment environment, Map<String, Object> initialSettings) {
         play.api.ApplicationLoader.Context scalaContext = play.api.ApplicationLoader$.MODULE$.createContext(
-            environment.underlying(),
-            Scala.asScala(initialSettings),
-            Scala.<SourceMapper>None(),
-            new DefaultWebCommands(),
-            new DefaultApplicationLifecycle());
+                environment.underlying(),
+                Scala.asScala(initialSettings),
+                Scala.<SourceMapper>None(),
+                new DefaultWebCommands(),
+                new DefaultApplicationLifecycle());
         return new Context(scalaContext);
     }
 
@@ -206,10 +240,8 @@ public interface ApplicationLoader {
      * @param environment The application environment.
      * @return a context created with the provided underlying environment
      */
-    public static Context create(Environment environment) {
+    static Context create(Environment environment) {
         return create(environment, Collections.emptyMap());
     }
-
-  }
 
 }

--- a/framework/src/play/src/main/scala/play/api/inject/Module.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Module.scala
@@ -5,7 +5,10 @@ package play.api.inject
 
 import java.lang.reflect.Constructor
 import play.{ Configuration => JavaConfiguration, Environment => JavaEnvironment }
+
+import org.apache.commons.lang3.reflect.ConstructorUtils
 import play.api._
+
 import scala.annotation.varargs
 import scala.reflect.ClassTag
 
@@ -130,14 +133,14 @@ object Modules {
       val moduleClass = loadModuleClass()
 
       def tryConstruct(args: AnyRef*): Option[T] = {
-        val ctor: Option[Constructor[T]] = try {
+        val constructor: Option[Constructor[T]] = try {
           val argTypes = args.map(_.getClass)
-          Some(moduleClass.getConstructor(argTypes: _*))
+          Option(ConstructorUtils.getMatchingAccessibleConstructor(moduleClass, argTypes: _*))
         } catch {
           case _: NoSuchMethodException => None
           case _: SecurityException => None
         }
-        ctor.map(_.newInstance(args: _*))
+        constructor.map(_.newInstance(args: _*))
       }
 
       {


### PR DESCRIPTION
## Purpose

Removes `play.Configuration` in favor of using the `Config` class, from Typesafe Config lib.

