### PR TITLE
Redirect plain http to https filter

### DIFF
--- a/documentation/manual/working/commonGuide/filters/Filters.md
+++ b/documentation/manual/working/commonGuide/filters/Filters.md
@@ -7,3 +7,4 @@ Play provides several standard filters that can modify the HTTP behavior of your
 - [[Configuring security headers|SecurityHeaders]]
 - [[Configuring CORS|CorsFilter]]
 - [[Configuring allowed hosts|AllowedHostsFilter]]
+- [[Configuring redirect plain filter|RedirectPlainFilter]]

--- a/documentation/manual/working/commonGuide/filters/RedirectPlainFilter.md
+++ b/documentation/manual/working/commonGuide/filters/RedirectPlainFilter.md
@@ -1,0 +1,24 @@
+<!--- Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com> -->
+# Redirect plain filter
+
+Play provides a filter which will redirect plain requests to secure requests.
+
+## Enabling the redirect plain filter
+
+To enable the filter, add the Play filters project to your `libraryDependencies` in `build.sbt`:
+
+@[content](code/filters.sbt)
+
+Now add the filter to your filters, which is typically done by creating a `Filters` class in the root of your project:
+
+Scala
+: @[filters](code/RedirectPlainFilter.scala)
+
+Java
+: @[filters](code/detailedtopics/configuration/redirectplain/Filters.java)
+
+## Configuring the redirect plain filter
+
+The only thing you can configure is the `Strict-Transport-Security` header value:
+
+`play.filters.redirectplain.strict-transport-security.max-age = 86400`

--- a/documentation/manual/working/commonGuide/filters/SecurityHeaders.md
+++ b/documentation/manual/working/commonGuide/filters/SecurityHeaders.md
@@ -48,5 +48,5 @@ Security headers may be overridden in specific actions using `withHeaders` on th
 @[allowActionSpecificHeaders](code/SecurityHeaders.scala)
 
 Any security headers not mentioned in `withHeaders` will use the usual configured values
-(if present) or the defaults.  Action-specific security headers are ignored unless 
+(if present) or the defaults.  Action-specific security headers are ignored unless
 `play.filters.headers.allowActionSpecificHeaders` is set to `true` in the configuration.

--- a/documentation/manual/working/commonGuide/filters/code/RedirectPlainFilter.scala
+++ b/documentation/manual/working/commonGuide/filters/code/RedirectPlainFilter.scala
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package detailedtopics.configuration.allowedhosts.sapi
+
+//#filters
+import javax.inject.Inject
+
+import play.api.http.DefaultHttpFilters
+import play.filters.redirectplain.RedirectPlainFilter
+
+class Filters @Inject() (redirectPlainFilter: RedirectPlainFilter)
+  extends DefaultHttpFilters(redirectPlainFilter)
+//#filters

--- a/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/redirectplain/Filters.java
+++ b/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/redirectplain/Filters.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package detailedtopics.configuration.hosts;
+
+//#filters
+import play.mvc.EssentialFilter;
+import play.filters.redirectplain.RedirectPlainFilter;
+import play.http.DefaultHttpFilters;
+
+import javax.inject.Inject;
+
+public class Filters extends DefaultHttpFilters {
+    @Inject public Filters(RedirectPlainFilter redirectPlainFilter) {
+        super(redirectPlainFilter);
+    }
+}
+//#filters

--- a/documentation/manual/working/commonGuide/filters/index.toc
+++ b/documentation/manual/working/commonGuide/filters/index.toc
@@ -3,3 +3,4 @@ GzipEncoding:Configuring gzip encoding
 SecurityHeaders:Configuring security headers
 CorsFilter:Configuring CORS
 AllowedHostsFilter:Configuring allowed hosts
+RedirectPlainFilter:Redirect plain http requests

--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -4,6 +4,7 @@ play.modules {
   enabled += "play.filters.headers.SecurityHeadersModule"
   enabled += "play.filters.hosts.AllowedHostsModule"
   enabled += "play.filters.gzip.GzipFilterModule"
+  enabled += "play.filters.redirectplain.RedirectPlainModule"
 }
 
 play.filters {
@@ -165,5 +166,11 @@ play.filters {
     # to chunked encoding.
     chunkedThreshold = 100k
 
+  }
+
+  redirectplain {
+    strict-transport-security {
+      max-age = 86400
+    }
   }
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/redirectplain/RedirectPlainFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/redirectplain/RedirectPlainFilter.scala
@@ -42,11 +42,11 @@ class RedirectPlainConfigProvider @Inject() (configuration: Configuration)
     extends Provider[RedirectPlainConfig] {
 
   lazy val enabled: Boolean = configuration
-    .getOptional[Boolean]("filters.redirectplain.enabled")
+    .getOptional[Boolean]("play.filters.redirectplain.enabled")
     .getOrElse(false)
 
   lazy val strictTransportSecurityMaxAge = configuration
-    .getOptional[Long]("filters.redirectplain.strict-transport-security.max-age")
+    .getOptional[Long]("play.filters.redirectplain.strict-transport-security.max-age")
     .getOrElse(31536000l)
 
   lazy val get = RedirectPlainConfig(enabled, strictTransportSecurityMaxAge)

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/redirectplain/RedirectPlainFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/redirectplain/RedirectPlainFilter.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.filters.redirectplain
 
 import javax.inject.{ Inject, Provider }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/redirectplain/RedirectPlainFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/redirectplain/RedirectPlainFilter.scala
@@ -1,0 +1,55 @@
+package play.filters.redirectplain
+
+import javax.inject.{ Inject, Provider }
+
+import akka.stream.Materializer
+import play.api.Configuration
+import play.api.http.HeaderNames._
+import play.api.inject.SimpleModule
+import play.api.mvc._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+/**
+ * A filter that redirects plain request to https requests
+ * based on X-Forwarded-Protocol and security request security
+ */
+case class RedirectPlainFilter @Inject() (val mat: Materializer, config: RedirectPlainConfig)
+    extends Filter {
+
+  override def apply(nextFilter: RequestHeader => Future[Result])(req: RequestHeader): Future[Result] = {
+    if (config.enabled) {
+      (req.headers.get(X_FORWARDED_PROTO) match {
+        case Some(value) => (value == "https")
+        case None => req.secure
+      }) match {
+        case true => nextFilter(req).map(_.withHeaders(STRICT_TRANSPORT_SECURITY -> s"max-age=${config.strictTransportSecurityMaxAge}"))
+        case false => Future(Results.Redirect(s"https://${req.host}${req.uri}", 301))
+      }
+    } else {
+      nextFilter(req)
+    }
+  }
+}
+
+case class RedirectPlainConfig(enabled: Boolean, strictTransportSecurityMaxAge: Long)
+
+class RedirectPlainConfigProvider @Inject() (configuration: Configuration)
+    extends Provider[RedirectPlainConfig] {
+
+  lazy val enabled: Boolean = configuration
+    .getOptional[Boolean]("filters.redirectplain.enabled")
+    .getOrElse(false)
+
+  lazy val strictTransportSecurityMaxAge = configuration
+    .getOptional[Long]("filters.redirectplain.strict-transport-security.max-age")
+    .getOrElse(31536000l)
+
+  lazy val get = RedirectPlainConfig(enabled, strictTransportSecurityMaxAge)
+
+}
+
+class RedirectPlainModule extends SimpleModule {
+  bind[RedirectPlainConfig].toProvider[RedirectPlainConfigProvider]
+}

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/redirectplain/RedirectPlainFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/redirectplain/RedirectPlainFilter.scala
@@ -6,7 +6,7 @@ package play.filters.redirectplain
 import javax.inject.{ Inject, Provider }
 
 import akka.stream.Materializer
-import com.typesafe.config.{ Config, ConfigFactory }
+import play.api.Configuration
 import play.api.http.HeaderNames._
 import play.api.inject.SimpleModule
 import play.api.mvc._
@@ -38,21 +38,16 @@ case class RedirectPlainFilter @Inject() (val mat: Materializer, config: Redirec
 
 case class RedirectPlainConfig(enabled: Boolean, strictTransportSecurityMaxAge: Long)
 
-class RedirectPlainConfigProvider @Inject() (config: Config)
+class RedirectPlainConfigProvider @Inject() (configuration: Configuration)
     extends Provider[RedirectPlainConfig] {
 
-  // Set default values to use
-  lazy val configWithFallback = config.withFallback(ConfigFactory.parseString(
-    """
-      |play.filters.redirectplain.enabled=false
-      |play.filters.redirectplain.strict-transport-security.max-age=31536000
-    """.stripMargin))
+  lazy val enabled: Boolean = configuration
+    .getOptional[Boolean]("play.filters.redirectplain.enabled")
+    .getOrElse(false)
 
-  lazy val enabled: Boolean = configWithFallback
-    .getBoolean("play.filters.redirectplain.enabled")
-
-  lazy val strictTransportSecurityMaxAge = configWithFallback
-    .getLong("play.filters.redirectplain.strict-transport-security.max-age")
+  lazy val strictTransportSecurityMaxAge = configuration
+    .getOptional[Long]("play.filters.redirectplain.strict-transport-security.max-age")
+    .getOrElse(31536000l)
 
   lazy val get = RedirectPlainConfig(enabled, strictTransportSecurityMaxAge)
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/redirectplain/RedirectPlainFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/redirectplain/RedirectPlainFilter.scala
@@ -8,11 +8,52 @@ import javax.inject.{ Inject, Provider }
 import akka.stream.Materializer
 import play.api.Configuration
 import play.api.http.HeaderNames._
+import play.api.http.Status._
 import play.api.inject.SimpleModule
 import play.api.mvc._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+
+object RedirectPlainFilter {
+
+  /**
+   * Create https redirect url for given request
+   *
+   * @param req  Request to create https request url for
+   * @return
+   */
+  def createHttpsRedirectUrl(req: RequestHeader): String = s"https://${req.host}${req.uri}"
+
+  /**
+   * Checks both the X_FORWARDED_PROTO and FORWARDED headers
+   *
+   * @see {play.filters.redirectplain.RedirectPlainFilter#isSecureForwarded}
+   * @param req  Request to check if it is secure
+   * @return
+   */
+  def isRequestSecure(req: RequestHeader): Boolean = req.secure || isSecureForwarded(req)
+
+  /**
+   * Checks to see if either the X_FORWARDED_PROTO or FORWARDED headers
+   * contains a https proxy. If either one of them contains https
+   * the request is assumed secure.
+   *
+   * @param req  Request to check if it is forwarded securely
+   * @return
+   */
+  def isSecureForwarded(req: RequestHeader): Boolean = {
+    // First check the X_FORWARDED_PROTO
+    req.headers.get(X_FORWARDED_PROTO) match {
+      case Some(value) => value.contains("https")
+      // If X_FORWARDED_PROTO header not found check the forwarded headers
+      case None => req.headers.get(FORWARDED) match {
+        case Some(value) => value.contains("https")
+        case None => false
+      }
+    }
+  }
+}
 
 /**
  * A filter that redirects plain request to https requests
@@ -20,36 +61,29 @@ import scala.concurrent.Future
  */
 case class RedirectPlainFilter @Inject() (val mat: Materializer, config: RedirectPlainConfig)
     extends Filter {
+  import RedirectPlainFilter._
+
+  lazy val strictMaxAge = s"max-age=${config.strictTransportSecurityMaxAge}"
 
   override def apply(nextFilter: RequestHeader => Future[Result])(req: RequestHeader): Future[Result] = {
-    if (config.enabled) {
-      (req.headers.get(X_FORWARDED_PROTO) match {
-        case Some(value) => (value == "https")
-        case None => req.secure
-      }) match {
-        case true => nextFilter(req).map(_.withHeaders(STRICT_TRANSPORT_SECURITY -> s"max-age=${config.strictTransportSecurityMaxAge}"))
-        case false => Future(Results.Redirect(s"https://${req.host}${req.uri}", 301))
-      }
-    } else {
-      nextFilter(req)
-    }
+    if (isRequestSecure(req))
+      nextFilter(req).map(_.withHeaders(STRICT_TRANSPORT_SECURITY -> strictMaxAge))
+    else
+      Future(Results.Redirect(createHttpsRedirectUrl(req), PERMANENT_REDIRECT))
   }
+
 }
 
-case class RedirectPlainConfig(enabled: Boolean, strictTransportSecurityMaxAge: Long)
+case class RedirectPlainConfig(strictTransportSecurityMaxAge: Long)
 
 class RedirectPlainConfigProvider @Inject() (configuration: Configuration)
     extends Provider[RedirectPlainConfig] {
-
-  lazy val enabled: Boolean = configuration
-    .getOptional[Boolean]("play.filters.redirectplain.enabled")
-    .getOrElse(false)
 
   lazy val strictTransportSecurityMaxAge = configuration
     .getOptional[Long]("play.filters.redirectplain.strict-transport-security.max-age")
     .getOrElse(31536000l)
 
-  lazy val get = RedirectPlainConfig(enabled, strictTransportSecurityMaxAge)
+  lazy val get = RedirectPlainConfig(strictTransportSecurityMaxAge)
 
 }
 

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/redirectplain/RedirectPlainFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/redirectplain/RedirectPlainFilterSpec.scala
@@ -6,17 +6,16 @@ package play.filters.redirectplain
 import javax.inject.Inject
 
 import com.typesafe.config.ConfigFactory
-import play.api.{ Application, Configuration }
 import play.api.http.HttpFilters
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.ws.WSClient
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.routing.Router
 import play.api.test._
+import play.api.{ Application, Configuration }
 
-class TestFilters @Inject() (redirectPlainFilter: RedirectPlainFilter) extends HttpFilters {
+private[redirectplain] class TestFilters @Inject() (redirectPlainFilter: RedirectPlainFilter) extends HttpFilters {
   override def filters: Seq[EssentialFilter] = Seq(redirectPlainFilter)
 }
 
@@ -25,7 +24,7 @@ class RedirectPlainFilterSpec extends PlaySpecification {
   private def request(app: Application, xForwardedProto: String, uri: String = "/", headers: Seq[(String, String)] = Seq()) = {
     val req = FakeRequest(method = "GET", path = uri)
       .withHeaders(headers: _*)
-      .withHeaders(HOST -> "localhost")
+      .withHeaders(HOST -> "playframework.com")
       .withHeaders(X_FORWARDED_PROTO -> xForwardedProto)
     route(app, req).get
   }
@@ -45,32 +44,36 @@ class RedirectPlainFilterSpec extends PlaySpecification {
     running(app)(block(app))
   }
 
-  val TestServerPort = 8192
-  def withServer[T](config: String)(block: WSClient => T): T = {
-    val app = buildApp(config)
-    running(TestServer(TestServerPort, app))(block(app.injector.instanceOf[WSClient]))
-  }
-
   "RedirectPlainFilter" should {
 
-    "do nothing when not explicitly enabled" in withApplication("") { app =>
-      status(request(app, "http")) must_== OK
+    "correctly determine X-Forwarded-Proto security" in {
+      RedirectPlainFilter.isSecureForwarded(FakeRequest().withHeaders(X_FORWARDED_PROTO -> "http")) must_== false
+      RedirectPlainFilter.isSecureForwarded(FakeRequest().withHeaders(X_FORWARDED_PROTO -> "https")) must_== true
     }
 
-    "redirect when not on https" in withApplication("play.filters.redirectplain.enabled=true") { app =>
-      status(request(app, "http")) must_== MOVED_PERMANENTLY
-      header(LOCATION, request(app, "http", "/test/123?foo=bar&bar=baz")) must_== Some ("https://localhost/test/123?foo=bar&bar=baz")
+    "correctly determine Forwarded security" in {
+      RedirectPlainFilter.isSecureForwarded(FakeRequest().withHeaders(FORWARDED -> "for=192.0.2.60;proto=http;by=203.0.113.43")) must_== false
+      RedirectPlainFilter.isSecureForwarded(FakeRequest().withHeaders(FORWARDED -> "for=192.0.2.60;proto=https;by=203.0.113.43")) must_== true
     }
 
-    "not redirect when on https" in withApplication("play.filters.redirectplain.enabled=true") { app =>
+    "create a proper redirect url" in {
+      val request = FakeRequest(GET, "/please/dont?remove=this&foo=bar").withHeaders("Host" -> "playframework.com")
+
+      RedirectPlainFilter.createHttpsRedirectUrl(request) must_== "https://playframework.com/please/dont?remove=this&foo=bar"
+    }
+
+    "redirect when not on https including the path and url query parameters" in withApplication("") { app =>
+      val req = request(app, "http", "/please/dont?remove=this&foo=bar")
+
+      status(req) must_== PERMANENT_REDIRECT
+      header(LOCATION, req) must_== Some("https://playframework.com/please/dont?remove=this&foo=bar")
+    }
+
+    "not redirect when on https" in withApplication("") { app =>
       status(request(app, "https")) must_== OK
     }
 
-    "add strict transport security headers on https" in withApplication(
-      """
-        |play.filters.redirectplain.enabled=true
-        |play.filters.redirectplain.strict-transport-security.max-age=12345
-      """.stripMargin) { app =>
+    "add strict transport security headers on https" in withApplication("play.filters.redirectplain.strict-transport-security.max-age=12345") { app =>
       header(STRICT_TRANSPORT_SECURITY, request(app, "https")) must_== Some ("max-age=12345")
     }
   }

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/redirectplain/RedirectPlainFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/redirectplain/RedirectPlainFilterSpec.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.filters.redirectplain
 
 import javax.inject.Inject

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/redirectplain/RedirectPlainFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/redirectplain/RedirectPlainFilterSpec.scala
@@ -1,0 +1,75 @@
+package play.filters.redirectplain
+
+import javax.inject.Inject
+
+import com.typesafe.config.ConfigFactory
+import play.api.{ Application, Configuration }
+import play.api.http.HttpFilters
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws.WSClient
+import play.api.mvc.Results._
+import play.api.mvc._
+import play.api.routing.Router
+import play.api.test._
+
+class TestFilters @Inject() (redirectPlainFilter: RedirectPlainFilter) extends HttpFilters {
+  override def filters: Seq[EssentialFilter] = Seq(redirectPlainFilter)
+}
+
+class RedirectPlainFilterSpec extends PlaySpecification {
+
+  private def request(app: Application, xForwardedProto: String, uri: String = "/", headers: Seq[(String, String)] = Seq()) = {
+    val req = FakeRequest(method = "GET", path = uri)
+      .withHeaders(headers: _*)
+      .withHeaders(HOST -> "localhost")
+      .withHeaders(X_FORWARDED_PROTO -> xForwardedProto)
+    route(app, req).get
+  }
+
+  def buildApp(config: String) = new GuiceApplicationBuilder()
+    .configure(Configuration(ConfigFactory.parseString(config)))
+    .overrides(
+      bind[Router].to(Router.from {
+        case _ => Action(Ok(""))
+      }),
+      bind[RedirectPlainConfig].toProvider[RedirectPlainConfigProvider],
+      bind[HttpFilters].to[TestFilters]
+    ).build
+
+  def withApplication[T](config: String)(block: Application => T): T = {
+    val app = buildApp(config)
+    running(app)(block(app))
+  }
+
+  val TestServerPort = 8192
+  def withServer[T](config: String)(block: WSClient => T): T = {
+    val app = buildApp(config)
+    running(TestServer(TestServerPort, app))(block(app.injector.instanceOf[WSClient]))
+  }
+
+  "RedirectPlainFilter" should {
+
+    "do nothing when not explicitly enabled" in withApplication("") { app =>
+      status(request(app, "http")) must_== OK
+    }
+
+    "redirect when not on https" in withApplication("filters.redirectplain.enabled=true") { app =>
+      status(request(app, "http")) must_== MOVED_PERMANENTLY
+      header(LOCATION, request(app, "http", "/test/123?foo=bar&bar=baz")) must_== Some ("https://localhost/test/123?foo=bar&bar=baz")
+    }
+
+    "not redirect when on https" in withApplication("filters.redirectplain.enabled=true") { app =>
+      status(request(app, "https")) must_== OK
+    }
+
+    "add strict transport security headers on https" in withApplication(
+      """
+        |filters.redirectplain.enabled=true
+        |filters.redirectplain.strict-transport-security.max-age=12345
+      """.stripMargin) { app =>
+      header(STRICT_TRANSPORT_SECURITY, request(app, "https")) must_== Some ("max-age=12345")
+    }
+  }
+
+}

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/redirectplain/RedirectPlainFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/redirectplain/RedirectPlainFilterSpec.scala
@@ -57,19 +57,19 @@ class RedirectPlainFilterSpec extends PlaySpecification {
       status(request(app, "http")) must_== OK
     }
 
-    "redirect when not on https" in withApplication("filters.redirectplain.enabled=true") { app =>
+    "redirect when not on https" in withApplication("play.filters.redirectplain.enabled=true") { app =>
       status(request(app, "http")) must_== MOVED_PERMANENTLY
       header(LOCATION, request(app, "http", "/test/123?foo=bar&bar=baz")) must_== Some ("https://localhost/test/123?foo=bar&bar=baz")
     }
 
-    "not redirect when on https" in withApplication("filters.redirectplain.enabled=true") { app =>
+    "not redirect when on https" in withApplication("play.filters.redirectplain.enabled=true") { app =>
       status(request(app, "https")) must_== OK
     }
 
     "add strict transport security headers on https" in withApplication(
       """
-        |filters.redirectplain.enabled=true
-        |filters.redirectplain.strict-transport-security.max-age=12345
+        |play.filters.redirectplain.enabled=true
+        |play.filters.redirectplain.strict-transport-security.max-age=12345
       """.stripMargin) { app =>
       header(STRICT_TRANSPORT_SECURITY, request(app, "https")) must_== Some ("max-age=12345")
     }

--- a/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
@@ -307,7 +307,7 @@ trait HeaderNames {
   val ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method"
   val ACCESS_CONTROL_REQUEST_HEADERS = "Access-Control-Request-Headers"
 
-  val STRICT_TRANSPORT_SECURITY = "Strict-Tranpsort-Security"
+  val STRICT_TRANSPORT_SECURITY = "Strict-Transport-Security"
 }
 
 /**

--- a/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
@@ -306,6 +306,8 @@ trait HeaderNames {
   val ORIGIN = "Origin"
   val ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method"
   val ACCESS_CONTROL_REQUEST_HEADERS = "Access-Control-Request-Headers"
+
+  val STRICT_TRANSPORT_SECURITY = "Strict-Tranpsort-Security"
 }
 
 /**


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Purpose

This filter redirects http to https based on the `X-Forwarded-Proto` header and `request.secure`

## Background Context

I found myself writing this filter over and over so I thought it might be nice to have it in a core module.

I am willing to write some documentation for the changes I made but thought I'd wait for some feedback first.
