### PR TITLE
Make Formats.parsing method non-private

### DIFF
--- a/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
@@ -306,20 +306,29 @@ You can populate a form with initial values using [`Form#fill`](api/scala/play/a
 
 Or you can define a default mapping on the number using [`Forms.default`](api/scala/play/api/data/Forms$.html):
 
-```
-Form(
-  mapping(
-    "name" -> default(text, "Bob")
-    "age" -> default(number, 18)
-  )(User.apply)(User.unapply)
-)
-```
+@[userForm-default](code/ScalaForms.scala)
 
 ### Ignored values
 
 If you want a form to have a static value for a field, use [`Forms.ignored`](api/scala/play/api/data/Forms$.html):
 
 @[userForm-static-value](code/ScalaForms.scala)
+
+### Custom binders for form mappings
+
+Each form mapping uses an implicitly provided [`Formatter[T]`](api/scala/play/api/data/format/Formatter.html) binder object that performs the conversion of incoming `String` form data to/from the target data type.
+
+@[userData-custom-datatype](code/ScalaForms.scala)
+
+To bind to a custom type like java.net.URL in the example above, define a form mapping like this:
+
+@[userForm-custom-datatype](code/ScalaForms.scala)
+
+For this to work you will need to make an implicit `Formatter[java.net.URL]` available to perform the data binding/unbinding.
+
+@[userForm-custom-formatter](code/ScalaForms.scala)
+
+Note the [`Formats.parsing`](api/scala/play/api/data/format/Formats$.html) function is used to capture any exceptions thrown in the act of converting a `String` to target type `T` and registers a [`FormError`](api/scala/play/api/data/FormError.html) on the form field binding.
 
 ## Putting it all together
 

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -5,6 +5,8 @@ package scalaguide.forms.scalaforms {
 
 import javax.inject.Inject
 
+import java.net.URL
+
 import play.api.{Configuration, Environment}
 import play.api.i18n._
 
@@ -436,7 +438,7 @@ class Application extends Controller with I18nSupport {
     mapping(
       "name" -> default(text, "Bob"),
       "age" -> default(number, 18)
-    )(User.apply)(User.unapply)
+    )(UserData.apply)(UserData.unapply)
   )
   //#userForm-default
 
@@ -463,6 +465,7 @@ class Application extends Controller with I18nSupport {
   //#userForm-custom-datatype
 
   //#userForm-custom-formatter
+  import play.api.data.format.Formatter
   import play.api.data.format.Formats._
   implicit object UrlFormatter extends Formatter[URL] {
     override val format = Some(("format.url", Nil))

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -434,7 +434,7 @@ class Application extends Controller with I18nSupport {
   //#userForm-default
   Form(
     mapping(
-      "name" -> default(text, "Bob")
+      "name" -> default(text, "Bob"),
       "age" -> default(number, 18)
     )(User.apply)(User.unapply)
   )

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -169,6 +169,10 @@ case class UserListData(name: String, emails: List[String])
 case class UserOptionalData(name: String, email: Option[String])
 // #userData-optional
 
+// #userData-custom-datatype
+case class UserCustomData(name:String, website: java.net.URL)
+// #userData-custom-datatype
+
 //#messages-request
 class MessagesRequest[A](request: Request[A], val messages: Messages)
   extends WrappedRequest(request) with play.api.i18n.MessagesProvider {
@@ -198,8 +202,6 @@ case class ContactInformation(label: String,
 }
 
 package controllers {
-
-import play.api.i18n.{I18nSupport, Lang}
 
 import views.html._
 import views.html.contact._
@@ -429,6 +431,16 @@ class Application extends Controller with I18nSupport {
     user.email
   }
 
+  //#userForm-default
+  Form(
+    mapping(
+      "name" -> default(text, "Bob")
+      "age" -> default(number, 18)
+    )(User.apply)(User.unapply)
+  )
+  //#userForm-default
+
+
   case class UserStaticData(id: Long, name: String, email: Option[String])
 
   //#userForm-static-value
@@ -440,6 +452,25 @@ class Application extends Controller with I18nSupport {
     )(UserStaticData.apply)(UserStaticData.unapply)
   )
   //#userForm-static-value
+
+  //#userForm-custom-datatype
+  val userFormCustom = Form(
+    mapping(
+      "name" -> text,
+      "website" ->  of[URL]
+    )(UserCustomData.apply)(UserCustomData.unapply)
+  )
+  //#userForm-custom-datatype
+
+  //#userForm-custom-formatter
+  import play.api.data.format.Formats._
+  implicit object UrlFormatter extends Formatter[URL] {
+    override val format = Some(("format.url", Nil))
+    override def bind(key: String, data: Map[String, String]) = parsing(new URL(_), "error.url", Nil)(key, data)
+    override def unbind(key: String, value: URL) = Map(key -> value.toString)
+  }
+  //#userForm-custom-formatter
+
 
   val userFormStaticId = {
     val anyData = Map("id" -> "1", "name" -> "bob")

--- a/framework/src/play/src/main/scala/play/api/data/format/Format.scala
+++ b/framework/src/play/src/main/scala/play/api/data/format/Format.scala
@@ -84,7 +84,7 @@ object Formats {
    * @param key Key name of the field to parse
    * @param data Field data
    */
-  private def parsing[T](parse: String => T, errMsg: String, errArgs: Seq[Any])(key: String, data: Map[String, String]): Either[Seq[FormError], T] = {
+  def parsing[T](parse: String => T, errMsg: String, errArgs: Seq[Any])(key: String, data: Map[String, String]): Either[Seq[FormError], T] = {
     stringFormat.bind(key, data).right.flatMap { s =>
       scala.util.control.Exception.allCatch[T]
         .either(parse(s))

--- a/framework/src/play/src/test/scala/play/api/data/format/FormatSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/format/FormatSpec.scala
@@ -120,4 +120,38 @@ class FormatSpec extends Specification {
     }
   }
 
+  "String parsing utility function" should {
+
+    val errorMessage = "error.parsing"
+
+    def parsingFunction[T](fu: String => T) = Formats.parsing(fu, errorMessage, Nil) _
+
+    val intParse: String => Int = Integer.parseInt
+
+    val testField = "field"
+    val testNumber = 1234
+
+    "parse an integer from a string" in {
+      parsingFunction(intParse)(testField, Map(testField -> testNumber.toString)).fold(
+        errors => "The parsing should not fail" must equalTo("Error"),
+        parsedInt => parsedInt mustEqual testNumber
+      )
+    }
+
+    "register a field error if string not parseable into an Int" in {
+      parsingFunction(intParse)(testField, Map(testField -> "notParseable")).fold(
+        errors => errors should containTheSameElementsAs(Seq(FormError(testField, errorMessage))),
+        parsedInt => "The parsing should fail" must equalTo("Error")
+      )
+    }
+
+    "register a field error if unexpected exception encountered during parsing" in {
+      parsingFunction(_ => throw new AssertionError)(testField, Map(testField -> testNumber.toString)).fold(
+        errors => errors should containTheSameElementsAs(Seq(FormError(testField, errorMessage))),
+        parsedInt => "The parsing should fail" must equalTo("Error")
+      )
+    }
+
+  }
+
 }


### PR DESCRIPTION
For users developing their own `Formatter`s wanting to re-use the logic in the `parsing` method, please make this method non-private.

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
