### PR TITLE
Use Enter key to stop play run command (#2671)

### DIFF
--- a/documentation/manual/gettingStarted/PlayConsole.md
+++ b/documentation/manual/gettingStarted/PlayConsole.md
@@ -125,10 +125,10 @@ $ sbt run
 
 [info] play - Listening for HTTP on /0:0:0:0:0:0:0:0:9000
 
-(Server started, use Ctrl+D to stop and go back to the console...)
+(Server started, use Enter to stop and go back to the console...)
 ```
 
-The application starts directly. When you quit the server using `Ctrl+D`, you will come back to your OS prompt. Of course, the **triggered execution** is available here as well:
+The application starts directly. When you quit the server using `Enter`, you will come back to your OS prompt. Of course, the **triggered execution** is available here as well:
 
 ```bash
 $ sbt ~run

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala
@@ -60,9 +60,9 @@ object PlayConsoleInteractionMode extends PlayInteractionMode {
     withConsoleReader { consoleReader =>
       def waitEOF(): Unit = {
         consoleReader.readCharacter() match {
-          case 4 | -1 =>
+          case 4 | 13 | -1 =>
           // Note: we have to listen to -1 for jline2, for some reason...
-          // STOP on Ctrl-D or EOF.
+          // STOP on Ctrl-D, Enter or EOF.
           case 11 =>
             consoleReader.clearScreen(); waitEOF()
           case 10 =>

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -100,7 +100,7 @@ object PlayRun {
         devModeServer
 
         println()
-        println(Colors.green("(Server started, use Ctrl+D to stop and go back to the console...)"))
+        println(Colors.green("(Server started, use Enter to stop and go back to the console...)"))
         println()
 
         // If we have both Watched.Configuration and Watched.ContinuousState


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [n/a] Have you added copyright headers to new files? No new files
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [n/a] Have you added tests for any changed functionality? AFAIK, sbt scripted test plugin doesn't allow to have test the reading key stroke from the console, i guess that's the reason why there is no existing tests for this part of the plugin.

# Helpful things

## Fixes

Fixes #2671

## Purpose

What does this PR do?

This PR allows the use if the key Enter to stop the play run command.

## Background Context

Using Ctrl-D for stopping the run command is risky since Ctrl-D is also used for terminating SBT. I regularly terminate SBT when I only mean to stop the run command.

We should allow Enter to be used to stop the run command. SBT already uses Enter to terminate other interactive commands, such as ~compile, ~test, etc. To make the transition easy for users we can still support Ctrl-D in addition to Enter, but I suggest we only advertise Enter to new users.

Why did you take this approach?

## References
https://github.com/playframework/playframework/issues/2671
