### PR TITLE
Fix cross build compilation and publishing

### DIFF
--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -4,29 +4,37 @@ buildInfoSettings
 
 sourceGenerators in Compile += Def.task(buildInfo.value).taskValue
 
-val sbtNativePackagerVersion = "1.1.1"
-val sbtTwirlVersion = sys.props.getOrElse("twirl.version", "1.3.0")
+val Versions = new {
+  val sbtNativePackager = "1.1.1"
+  val mima = "0.1.12"
+  val sbtScalariform = "1.6.0"
+  val sbtJmh = "0.2.16"
+  val sbtDoge = "0.1.5"
+  val webjarsLocatorCore = "0.26"
+  val sbtTwirl: String = sys.props.getOrElse("twirl.version", "1.3.0")
+  val interplay: String = sys.props.getOrElse("interplay.version", "1.3.4")
+}
 
 buildInfoKeys := Seq[BuildInfoKey](
-  "sbtNativePackagerVersion" -> sbtNativePackagerVersion,
-  "sbtTwirlVersion" -> sbtTwirlVersion
+  "sbtNativePackagerVersion" -> Versions.sbtNativePackager,
+  "sbtTwirlVersion" -> Versions.sbtTwirl
 )
 
 logLevel := Level.Warn
 
 scalacOptions ++= Seq("-deprecation", "-language:_")
 
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "1.3.4"))
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % sbtTwirlVersion)
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.12")
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.16")
+addSbtPlugin("com.typesafe.play" % "interplay" % Versions.interplay)
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % Versions.sbtTwirl)
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % Versions.mima)
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % Versions.sbtScalariform)
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % Versions.sbtJmh)
 
 libraryDependencies ++= Seq(
   "org.scala-sbt" % "scripted-plugin" % sbtVersion.value,
-  "org.webjars" % "webjars-locator-core" % "0.26"
+  "org.webjars" % "webjars-locator-core" % Versions.webjarsLocatorCore
 )
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
+addSbtPlugin("com.eed3si9n" % "sbt-doge" % Versions.sbtDoge)

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -16,7 +16,7 @@ logLevel := Level.Warn
 
 scalacOptions ++= Seq("-deprecation", "-language:_")
 
-addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "1.3.1"))
+addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.version", "1.3.4"))
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % sbtTwirlVersion)
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.12")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")

--- a/framework/src/play/src/main/java/play/i18n/Langs.java
+++ b/framework/src/play/src/main/java/play/i18n/Langs.java
@@ -3,7 +3,7 @@
  */
 package play.i18n;
 
-import scala.collection.JavaConverters;
+import play.libs.Scala;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -24,7 +24,7 @@ public class Langs {
     public Langs(play.api.i18n.Langs langs) {
         this.langs = langs;
         List<Lang> availables = new ArrayList<>();
-        for (play.api.i18n.Lang lang : JavaConverters.asJavaIterable(langs.availables())) {
+        for (play.api.i18n.Lang lang : Scala.asJava(langs.availables())) {
             availables.add(new Lang(lang));
         }
         this.availables = Collections.unmodifiableList(availables);
@@ -55,6 +55,6 @@ public class Langs {
      * @return The preferred language
      */
     public Lang preferred(Collection<Lang> candidates) {
-        return new Lang(langs.preferred((scala.collection.Seq) JavaConverters.collectionAsScalaIterable(candidates).toSeq()));
+        return new Lang(langs.preferred((scala.collection.Seq) Scala.asScala(candidates).toSeq()));
     }
 }

--- a/framework/src/play/src/main/java/play/i18n/MessagesApi.java
+++ b/framework/src/play/src/main/java/play/i18n/MessagesApi.java
@@ -4,8 +4,8 @@
 package play.i18n;
 
 import org.apache.commons.lang3.ArrayUtils;
+import play.libs.Scala;
 import play.mvc.Http;
-import scala.collection.JavaConverters;
 import scala.collection.Seq;
 import scala.collection.mutable.Buffer;
 
@@ -115,7 +115,7 @@ public class MessagesApi {
      * @return the most appropriate Messages instance given the candidate languages
      */
     public Messages preferred(Collection<Lang> candidates) {
-        Seq<Lang> cs = JavaConverters.collectionAsScalaIterable(candidates).toSeq();
+        Seq<Lang> cs = Scala.asScala(candidates);
         play.api.i18n.Messages msgs = messages.preferred((Seq) cs);
         return new MessagesImpl(new Lang(msgs.lang()), this);
     }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -25,10 +25,10 @@ import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.libs.Files;
 import play.libs.Json;
+import play.libs.Scala;
 import play.libs.XML;
 import play.libs.typedmap.TypedKey;
 import play.libs.typedmap.TypedMap;
-import scala.collection.JavaConverters;
 import scala.collection.Seq;
 import scala.collection.immutable.Map$;
 import scala.compat.java8.OptionConverters;
@@ -106,10 +106,10 @@ public class Http {
             this.header = request._underlyingHeader();
             this.id = header.id();
             this.response = new Response();
-            this.session = new Session(JavaConverters.mapAsJavaMap(header.session().data()));
-            this.flash = new Flash(JavaConverters.mapAsJavaMap(header.flash().data()));
-            this.args = new HashMap<String,Object>();
-            this.args.putAll(JavaConverters.mapAsJavaMap(header.tags()));
+            this.session = new Session(Scala.asJava(header.session().data()));
+            this.flash = new Flash(Scala.asJava(header.flash().data()));
+            this.args = new HashMap<>();
+            this.args.putAll(Scala.asJava(header.tags()));
             this.components = components;
         }
 
@@ -131,7 +131,7 @@ public class Http {
             this.response = new Response();
             this.session = new Session(sessionData);
             this.flash = new Flash(flashData);
-            this.args = new HashMap<String,Object>(args);
+            this.args = new HashMap<>(args);
             this.components = components;
         }
 
@@ -1052,7 +1052,7 @@ public class Http {
          * @deprecated Use typed attributes, i.e. <code>attrs()</code>, instead.
          */
         public Map<String, String> tags() {
-            return JavaConverters.mapAsJavaMap(req.tags());
+            return Scala.asJava(req.tags());
         }
 
         /**
@@ -1284,7 +1284,7 @@ public class Http {
          * @return the cookies in a Java map
          */
         public Map<String,String> flash() {
-          return JavaConverters.mapAsJavaMap(req.flash().data());
+          return Scala.asJava(req.flash().data());
         }
 
         /**
@@ -1316,7 +1316,7 @@ public class Http {
          * @return the sessions in the request
          */
         public Map<String,String> session() {
-            return JavaConverters.mapAsJavaMap(req.session().data());
+            return Scala.asJava(req.session().data());
         }
 
         /**
@@ -1370,7 +1370,7 @@ public class Http {
         public Optional<List<X509Certificate>> clientCertificateChain() {
             return OptionConverters.toJava(
                     req.connection().clientCertificateChain()).map(
-                            list -> new ArrayList<X509Certificate>(JavaConverters.asJavaCollection(list)));
+                            list -> new ArrayList<>(Scala.asJava(list)));
         }
 
         /**
@@ -1382,17 +1382,9 @@ public class Http {
             req = req.withConnection(RemoteConnection$.MODULE$.apply(
                     req.connection().remoteAddress(),
                     req.connection().secure(),
-                    OptionConverters.toScala(Optional.ofNullable(JavaConverters.asScalaBuffer(clientCertificateChain).toList()))
+                    OptionConverters.toScala(Optional.ofNullable(Scala.asScala(clientCertificateChain)))
             ));
             return this;
-        }
-
-        protected static scala.collection.immutable.Map<String,Seq<String>> mapListToScala(Map<String,List<String>> data) {
-            Map<String,Seq<String>> seqs = new HashMap<>();
-            for (String key: data.keySet()) {
-                seqs.put(key, JavaConverters.asScalaBuffer(data.get(key)));
-            }
-            return asScala(seqs);
         }
     }
 
@@ -1464,7 +1456,7 @@ public class Http {
             }
         }
 
-        public static interface Part<A> {
+        public interface Part<A> {
 
         }
 

--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -15,7 +15,6 @@ import play.core.j.JavaHelpers$;
 import play.core.j.JavaResultExtractor;
 import play.http.HttpEntity;
 import play.libs.Scala;
-import scala.collection.JavaConverters;
 import scala.compat.java8.OptionConverters;
 
 import static play.mvc.Http.Cookie;
@@ -178,7 +177,7 @@ public class Result {
      * @return the immutable map of headers
      */
     public Map<String, String> headers() {
-        return Collections.unmodifiableMap(JavaConverters.mapAsJavaMap(this.header.headers()));
+        return Collections.unmodifiableMap(Scala.asJava(this.header.headers()));
     }
 
     /**

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -30,7 +30,7 @@ import scala.concurrent.ExecutionContext
  */
 final class ResponseHeader(val status: Int, _headers: Map[String, String] = Map.empty, val reasonPhrase: Option[String] = None) {
   private[play] def this(status: Int, _headers: java.util.Map[String, String], reasonPhrase: Option[String]) =
-    this(status, collection.JavaConverters.mapAsScalaMap(_headers).toMap, reasonPhrase)
+    this(status, _headers.asScala.toMap, reasonPhrase)
 
   val headers: Map[String, String] = TreeMap[String, String]()(CaseInsensitiveOrdered) ++ _headers
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -17,7 +17,6 @@ import play.libs.typedmap.TypedMap
 import play.mvc.Http.{ RequestBody, Context => JContext, Cookie => JCookie, Cookies => JCookies, Request => JRequest, RequestHeader => JRequestHeader, RequestImpl => JRequestImpl }
 import play.mvc.{ Security, Result => JResult }
 
-import scala.collection.{ JavaConverters, mutable }
 import scala.collection.JavaConverters._
 import scala.compat.java8.{ FutureConverters, OptionConverters }
 import scala.concurrent.Future
@@ -63,7 +62,7 @@ trait JavaHelpers {
 
   def javaMapOfArraysToScalaSeqOfPairs(m: java.util.Map[String, Array[String]]): Seq[(String, String)] = {
     for {
-      (k, arr) <- JavaConverters.mapAsScalaMap(m).to[Vector]
+      (k, arr) <- m.asScala.to[Vector]
       el <- arr
     } yield (k, el)
   }


### PR DESCRIPTION
## Fixes

Fixes #6782.

## Purpose

1. Uses JavaConverters' methods compatible with both Scala 2.11 and 2.12.
2. Update interplay to ensure that proper `crossScalaVersions` is used in sbt plugins

## References

See playframework/interplay#22 and playframework/interplay#23.