### PR TITLE
Reference to play-redis module in Module directory in the documentation

### DIFF
--- a/documentation/manual/ModuleDirectory.md
+++ b/documentation/manual/ModuleDirectory.md
@@ -108,6 +108,11 @@ To create your own public module or to migrate from a `play.api.Plugin`, please 
 * **Website:** <https://github.com/scalikejdbc/scalikejdbc-play-support>
 * **Short description:** Provides yet another database access API for Play
 
+### Redis Cache Plugin (Java and Scala)
+
+* **Website:** <https://github.com/KarelCemus/play-redis>
+* **Short description:** Provides both blocking and asynchronous redis based cache implementation. It implements common Play's CacheApi for both Java and Scala plus provides a few more Scala APIs implementing various Redis commands including the support of collections.
+
 
 
 ## Deployment


### PR DESCRIPTION
## Purpose

This PR updates the documentation. It adds reference to [play-redis](https://github.com/KarelCemus/play-redis) module implementing a redis based cache. It implements common `CacheAPI` and some additional redis commands including the support of collections. The API is implemented in both blocking and asynchronous manner.
