### PR TITLE
Removes global state from CSRF components

### DIFF
--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -37,7 +37,7 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
         play.api.mvc.Request<RequestBody> request =
             CSRFAction.tagRequestFromHeader(ctx.request()._underlyingRequest(), config, tokenSigner);
 
-        if (CSRFAction.getTokenToValidate(request, config, tokenSigner).isEmpty()) {
+        if (CSRFAction.getTokenToValidate(request).isEmpty()) {
             // No token in header and we have to create one if not found, so create a new token
             String newToken = tokenProvider.generateToken();
 

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -40,7 +40,7 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
         CSRFActionHelper csrfActionHelper = new CSRFActionHelper(sessionConfiguration, config, tokenSigner);
 
         play.api.mvc.Request<RequestBody> request =
-                csrfActionHelper.tagRequestFromHeader(ctx.request()._underlyingRequest(), config, tokenSigner);
+                csrfActionHelper.tagRequestFromHeader(ctx.request()._underlyingRequest());
 
         if (csrfActionHelper.getTokenToValidate(request).isEmpty()) {
             // No token in header and we have to create one if not found, so create a new token

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletionStage;
 
 import javax.inject.Inject;
 
+import play.api.http.SessionConfiguration;
 import play.api.libs.crypto.CSRFTokenSigner;
 import play.api.mvc.Session;
 import play.mvc.Action;
@@ -19,25 +20,29 @@ import play.mvc.Result;
 public class AddCSRFTokenAction extends Action<AddCSRFToken> {
 
     private final CSRFConfig config;
+    private final SessionConfiguration sessionConfiguration;
     private final CSRF.TokenProvider tokenProvider;
     private final CSRFTokenSigner tokenSigner;
 
     @Inject
-    public AddCSRFTokenAction(CSRFConfig config, CSRF.TokenProvider tokenProvider, CSRFTokenSigner tokenSigner) {
+    public AddCSRFTokenAction(CSRFConfig config, SessionConfiguration sessionConfiguration, CSRF.TokenProvider tokenProvider, CSRFTokenSigner tokenSigner) {
         this.config = config;
+        this.sessionConfiguration = sessionConfiguration;
         this.tokenProvider = tokenProvider;
         this.tokenSigner = tokenSigner;
     }
 
     private final CSRF.Token$ Token = CSRF.Token$.MODULE$;
-    private final CSRFAction$ CSRFAction = CSRFAction$.MODULE$;
 
     @Override
     public CompletionStage<Result> call(Http.Context ctx) {
-        play.api.mvc.Request<RequestBody> request =
-            CSRFAction.tagRequestFromHeader(ctx.request()._underlyingRequest(), config, tokenSigner);
 
-        if (CSRFAction.getTokenToValidate(request).isEmpty()) {
+        CSRFActionHelper csrfActionHelper = new CSRFActionHelper(sessionConfiguration, config, tokenSigner);
+
+        play.api.mvc.Request<RequestBody> request =
+                csrfActionHelper.tagRequestFromHeader(ctx.request()._underlyingRequest(), config, tokenSigner);
+
+        if (csrfActionHelper.getTokenToValidate(request).isEmpty()) {
             // No token in header and we have to create one if not found, so create a new token
             String newToken = tokenProvider.generateToken();
 
@@ -46,7 +51,7 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
             ctx.args.put(Token.NameRequestTag(), config.tokenName());
 
             // Create a new Scala RequestHeader with the token
-            request = CSRFAction.tagRequest(request, new CSRF.Token(config.tokenName(), newToken));
+            request = csrfActionHelper.tagRequest(request, new CSRF.Token(config.tokenName(), newToken));
 
             // Also add it to the response
             if (config.cookieName().isDefined()) {

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
@@ -42,7 +42,7 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
             return delegate.call(ctx);
         } else {
             // Get token from cookie/session
-            Option<String> headerToken = CSRFAction.getTokenToValidate(request, config, crypto);
+            Option<String> headerToken = CSRFAction.getTokenToValidate(request);
             if (headerToken.isDefined()) {
                 String tokenToCheck = null;
 

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
@@ -40,9 +40,9 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
 
         CSRFActionHelper csrfActionHelper = new CSRFActionHelper(sessionConfiguration, config, tokenSigner);
 
-        RequestHeader request = csrfActionHelper.tagRequestFromHeader(ctx._requestHeader(), config, tokenSigner);
+        RequestHeader request = csrfActionHelper.tagRequestFromHeader(ctx._requestHeader());
         // Check for bypass
-        if (!csrfActionHelper.requiresCsrfCheck(request, config)) {
+        if (!csrfActionHelper.requiresCsrfCheck(request)) {
             return delegate.call(ctx);
         } else {
             // Get token from cookie/session
@@ -51,7 +51,7 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
                 String tokenToCheck = null;
 
                 // Get token from query string
-                Option<String> queryStringToken = csrfActionHelper.getHeaderToken(request, config);
+                Option<String> queryStringToken = csrfActionHelper.getHeaderToken(request);
                 if (queryStringToken.isDefined()) {
                     tokenToCheck = queryStringToken.get();
                 } else {

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -11,10 +11,9 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import akka.stream.stage.{ DetachedContext, DetachedStage }
 import akka.util.ByteString
-import play.api.Play
 import play.api.http.HeaderNames._
-import play.api.http.{ HttpConfiguration, SecretConfiguration, SessionConfiguration }
-import play.api.libs.crypto.{ CSRFTokenSigner, CSRFTokenSignerProvider, CookieSignerProvider }
+import play.api.http.SessionConfiguration
+import play.api.libs.crypto.CSRFTokenSigner
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.core.parsers.Multipart
@@ -364,22 +363,6 @@ private class BodyHandler(config: CSRFConfig, checkBody: ByteString => Boolean) 
 }
 
 private[csrf] object NoTokenInBody extends RuntimeException(null, null, false, false)
-
-@deprecated("This has no public API and will be removed in the future", "2.6.0")
-object CSRFAction extends CSRFActionHelper(
-  HttpConfiguration.current.session,
-  Play.maybeApplication match {
-    case Some(app) => app.injector.instanceOf[CSRFConfig]
-    case None => CSRFConfig()
-  },
-  Play.maybeApplication match {
-    case Some(app) =>
-      app.injector.instanceOf[CSRFTokenSigner]
-    case None =>
-      val cookieSignerProvider = new CookieSignerProvider(SecretConfiguration())
-      new CSRFTokenSignerProvider(cookieSignerProvider.get).get
-  }
-)
 
 private[csrf] class CSRFActionHelper(
     sessionConfiguration: SessionConfiguration,

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFFilter.scala
@@ -6,6 +6,7 @@ package play.filters.csrf
 import javax.inject.{ Inject, Provider }
 
 import akka.stream.Materializer
+import play.api.http.SessionConfiguration
 import play.api.libs.crypto.CSRFTokenSigner
 import play.api.mvc._
 import play.core.j.JavaContextComponents
@@ -26,19 +27,20 @@ import play.filters.csrf.CSRF._
 class CSRFFilter(
     config: => CSRFConfig,
     tokenSigner: => CSRFTokenSigner,
+    sessionConfiguration: => SessionConfiguration,
     val tokenProvider: TokenProvider,
     val errorHandler: ErrorHandler = CSRF.DefaultErrorHandler)(implicit mat: Materializer) extends EssentialFilter {
 
   @Inject
-  def this(config: Provider[CSRFConfig], tokenSignerProvider: Provider[CSRFTokenSigner], tokenProvider: TokenProvider, errorHandler: ErrorHandler)(mat: Materializer) = {
-    this(config.get, tokenSignerProvider.get, tokenProvider, errorHandler)(mat)
+  def this(config: Provider[CSRFConfig], tokenSignerProvider: Provider[CSRFTokenSigner], sessionConfiguration: SessionConfiguration, tokenProvider: TokenProvider, errorHandler: ErrorHandler)(mat: Materializer) = {
+    this(config.get, tokenSignerProvider.get, sessionConfiguration, tokenProvider, errorHandler)(mat)
   }
 
   // Java constructor for manually constructing the filter
-  def this(config: CSRFConfig, tokenSigner: play.libs.crypto.CSRFTokenSigner, tokenProvider: TokenProvider, errorHandler: CSRFErrorHandler, contextComponents: JavaContextComponents)(mat: Materializer) = {
-    this(config, tokenSigner.asScala, tokenProvider, new JavaCSRFErrorHandlerAdapter(errorHandler, contextComponents))(mat)
+  def this(config: CSRFConfig, tokenSigner: play.libs.crypto.CSRFTokenSigner, sessionConfiguration: SessionConfiguration, tokenProvider: TokenProvider, errorHandler: CSRFErrorHandler, contextComponents: JavaContextComponents)(mat: Materializer) = {
+    this(config, tokenSigner.asScala, sessionConfiguration, tokenProvider, new JavaCSRFErrorHandlerAdapter(errorHandler, contextComponents))(mat)
   }
 
-  def apply(next: EssentialAction): EssentialAction = new CSRFAction(next, config, tokenSigner, tokenProvider, errorHandler)
+  def apply(next: EssentialAction): EssentialAction = new CSRFAction(next, config, tokenSigner, tokenProvider, sessionConfiguration, errorHandler)
 
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -9,7 +9,7 @@ import javax.inject.{ Inject, Provider, Singleton }
 import akka.stream.Materializer
 import com.typesafe.config.ConfigMemorySize
 import play.api._
-import play.api.http.HttpErrorHandler
+import play.api.http.{ HttpConfiguration, HttpErrorHandler }
 import play.api.inject.{ Binding, Module }
 import play.api.libs.crypto.CSRFTokenSigner
 import play.api.mvc.Results._
@@ -279,16 +279,18 @@ class CSRFModule extends Module {
  * The CSRF components.
  */
 trait CSRFComponents {
+  def environment: Environment
   def configuration: Configuration
   def csrfTokenSigner: CSRFTokenSigner
   def httpErrorHandler: HttpErrorHandler
+  def httpConfiguration: HttpConfiguration
   implicit def materializer: Materializer
 
   lazy val csrfConfig: CSRFConfig = CSRFConfig.fromConfiguration(configuration)
   lazy val csrfTokenProvider: CSRF.TokenProvider = new CSRF.TokenProviderProvider(csrfConfig, csrfTokenSigner).get
   lazy val csrfErrorHandler: CSRF.ErrorHandler = new CSRFHttpErrorHandler(httpErrorHandler)
-  lazy val csrfFilter: CSRFFilter = new CSRFFilter(csrfConfig, csrfTokenSigner, csrfTokenProvider, csrfErrorHandler)
-  lazy val csrfCheck: CSRFCheck = new CSRFCheck(csrfConfig, csrfTokenSigner)
-  lazy val csrfAddToken: CSRFAddToken = new CSRFAddToken(csrfConfig, csrfTokenSigner)
+  lazy val csrfFilter: CSRFFilter = new CSRFFilter(csrfConfig, csrfTokenSigner, httpConfiguration.session, csrfTokenProvider, csrfErrorHandler)
+  lazy val csrfCheck: CSRFCheck = CSRFCheck(csrfConfig, csrfTokenSigner, httpConfiguration.session)
+  lazy val csrfAddToken: CSRFAddToken = CSRFAddToken(csrfConfig, csrfTokenSigner, httpConfiguration.session)
 
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -279,7 +279,6 @@ class CSRFModule extends Module {
  * The CSRF components.
  */
 trait CSRFComponents {
-  def environment: Environment
   def configuration: Configuration
   def csrfTokenSigner: CSRFTokenSigner
   def httpErrorHandler: HttpErrorHandler


### PR DESCRIPTION
## Purpose

It stills keep some global state to keep some compatibility.

The remaining global state usage was marked as deprecated and should be removed later.