### PR TITLE
Remove global state from play.api.mvc.Security

### DIFF
--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -269,7 +269,22 @@ Now that cookies are stored in request attributes updating the cookie will chang
 
 If you still need the old behavior you can still use `Cookies.encodeCookieHeader` to convert the `Cookie` objects into an HTTP header then store the header with `FakeRequest.withHeaders`.
 
-#### Request Security username property is now an attribute
+#### play.api.mvc.Security.username (Scala API), session.username config key and dependent actions helpers are deprecated
+
+`Security.username` just retrieves the `session.username` key from configuration, which defined the session key used to get the username. It was removed since it required statics to work, and it's fairly easy to implement the same or similar behavior yourself.
+
+You can read the username session key from configuration yourself using `configuration.get[String]("session.username")`.
+
+If you're using the `Authenticated(String => EssentialAction)` method, you can easily create your own action to do something similar:
+
+```scala
+  def AuthenticatedWithUsername(action: String => EssentialAction) =
+    WithAuthentication[String](_.session.get(UsernameKey))(action)
+```
+
+where `UsernameKey` represents the session key you want to use for the username.
+
+#### Request Security (Java API) username property is now an attribute
 
 The Java Request object contains a `username` property which is set when the `Security.Authenticated` annotation is added to a Java action. In Play 2.6 the username property has been deprecated. The username property methods have been updated to store the username in the `Security.USERNAME` attribute. You should update your code to use the `Security.USERNAME` attribute directly. In a future version of Play we will remove the username property.
 

--- a/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
+++ b/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
@@ -204,10 +204,10 @@ class Application1 @Inject() (cached: Cached)(implicit ec: ExecutionContext) ext
   }
   //#cached-action
 
-  import play.api.mvc.Security.Authenticated
+  import play.api.mvc.Security._
 
   //#composition-cached-action
-  def userProfile = Authenticated { userId =>
+  def userProfile = WithAuthentication(_.session.get("username")) { userId =>
     cached(req => "profile." + userId) {
       Action.async {
         User.find(userId).map { user =>

--- a/framework/src/play/src/main/scala/play/api/mvc/Security.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Security.scala
@@ -16,6 +16,13 @@ import scala.language.reflectiveCalls
  */
 object Security {
 
+  private val logger = Logger(getClass)
+
+  /**
+   * The default error response for an unauthorized request; used multiple places here
+   */
+  private val DefaultUnauthorized: RequestHeader => Result = _ => Unauthorized(views.html.defaultpages.unauthorized())
+
   /**
    * Wraps another action, allowing only authenticated HTTP requests.
    * Furthermore, it lets users to configure where to retrieve the user info from
@@ -44,7 +51,8 @@ object Security {
    */
   def Authenticated[A](
     userinfo: RequestHeader => Option[A],
-    onUnauthorized: RequestHeader => Result)(action: A => EssentialAction): EssentialAction = {
+    onUnauthorized: RequestHeader => Result
+  )(action: A => EssentialAction): EssentialAction = {
 
     EssentialAction { request =>
       userinfo(request).map { user =>
@@ -56,11 +64,26 @@ object Security {
 
   }
 
+  def WithAuthentication[A](
+    userinfo: RequestHeader => Option[A]
+  )(action: A => EssentialAction): EssentialAction = {
+    Authenticated(userinfo, DefaultUnauthorized)(action)
+  }
+
   /**
    * Key of the username attribute stored in session.
    */
-  lazy val username: String =
-    Play.privateMaybeApplication.flatMap(_.configuration.getOptional[String]("session.username")) getOrElse "username"
+  @deprecated("Security.username is deprecated.", "2.6.0")
+  lazy val username: String = {
+    Play.privateMaybeApplication.flatMap(_.configuration.getOptional[String]("session.username")) match {
+      case Some(usernameKey) =>
+        logger.warn("The session.username configuration key is no longer supported.")
+        logger.warn("Inject Configuration into your controller or component and call get[String](\"session.username\")")
+        usernameKey
+      case None =>
+        "username"
+    }
+  }
 
   /**
    * Wraps another action, allowing only authenticated HTTP requests.
@@ -84,9 +107,10 @@ object Security {
    *
    * @param action the action to wrap
    */
+  @deprecated("Use Authenticated(RequestHeader => Option[String])(String => EssentialAction)", "2.6.0")
   def Authenticated(action: String => EssentialAction): EssentialAction = Authenticated(
     req => req.session.get(username),
-    _ => Unauthorized(views.html.defaultpages.unauthorized()))(action)
+    DefaultUnauthorized)(action)
 
   /**
    * An authenticated request
@@ -197,13 +221,17 @@ object Security {
     def apply[U](
       userinfo: RequestHeader => Option[U],
       defaultParser: BodyParser[AnyContent],
-      onUnauthorized: RequestHeader => Result = _ => Unauthorized(views.html.defaultpages.unauthorized()))(implicit ec: ExecutionContext): AuthenticatedBuilder[U] = {
+      onUnauthorized: RequestHeader => Result = DefaultUnauthorized
+    )(implicit ec: ExecutionContext): AuthenticatedBuilder[U] = {
       new AuthenticatedBuilder(userinfo, defaultParser, onUnauthorized)
     }
 
     /**
      * Simple authenticated action builder that looks up the username from the session
      */
+    @deprecated(
+      "Use AuthenticatedBuilder(RequestHeader => Option[String], BodyParser[AnyContent]); the first argument gets the username",
+      "2.6.0")
     def apply(defaultParser: BodyParser[AnyContent])(implicit ec: ExecutionContext): AuthenticatedBuilder[String] = {
       apply[String](req => req.session.get(username), defaultParser)
     }


### PR DESCRIPTION
I don't believe this helper is used that often, since typically we recommend a third-party library for handling authentication/authorization, so I've just deprecated the code that reads from configuration.