### PR TITLE
[2.5.x] use Json.mapper().getFactory() instead of creating a new JsonFactory …

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -121,6 +121,7 @@ object Dependencies {
   def runtime(scalaVersion: String) =
     slf4j ++
     Seq("akka-actor", "akka-slf4j").map("com.typesafe.akka" %% _ % akkaVersion) ++
+    Seq("akka-testkit").map("com.typesafe.akka" %% _ % akkaVersion % Test) ++
     jacksons ++
     Seq(
       "org.scala-stm" %% "scala-stm" % "0.7",

--- a/framework/src/play/src/main/java/play/mvc/StatusHeader.java
+++ b/framework/src/play/src/main/java/play/mvc/StatusHeader.java
@@ -20,7 +20,6 @@ import akka.util.ByteString;
 import akka.util.ByteString$;
 import akka.util.ByteStringBuilder;
 import com.fasterxml.jackson.core.JsonEncoding;
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -353,7 +352,7 @@ public class StatusHeader extends Result {
         ByteStringBuilder builder = ByteString$.MODULE$.newBuilder();
 
         try {
-            JsonGenerator jgen = new JsonFactory(mapper).createGenerator(builder.asOutputStream(), encoding);
+            JsonGenerator jgen = mapper.getFactory().createGenerator(builder.asOutputStream(), encoding);
 
             mapper.writeValue(jgen, json);
             String contentType = "application/json; charset=" + encoding.getJavaName();

--- a/framework/src/play/src/test/scala/play/mvc/StatusHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/mvc/StatusHeaderSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.mvc
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Sink
+import akka.testkit.TestKit
+import com.fasterxml.jackson.core.io.{ CharacterEscapes, SerializedString }
+import com.fasterxml.jackson.core.JsonEncoding
+import org.specs2.mutable.SpecificationLike
+import org.specs2.specification.BeforeAfterAll
+import play.libs.Json
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+
+class StatusHeaderSpec extends TestKit(ActorSystem("StatusHeaderSpec")) with SpecificationLike with BeforeAfterAll {
+
+  override def beforeAll(): Unit = {}
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    Json.mapper.getFactory.setCharacterEscapes(null)
+  }
+
+  "StatusHeader" should {
+
+    "use factory attached to Json.mapper() when serializing Json" in {
+      val materializer = ActorMaterializer()
+
+      Json.mapper.getFactory.setCharacterEscapes(new CharacterEscapes {
+        override def getEscapeSequence(ch: Int) = new SerializedString(f"\\u$ch%04x")
+
+        override def getEscapeCodesForAscii: Array[Int] =
+          CharacterEscapes.standardAsciiEscapesForJSON.zipWithIndex.map {
+            case (_, code) if !(Character.isAlphabetic(code) || Character.isDigit(code)) => CharacterEscapes.ESCAPE_CUSTOM
+            case (escape, _) => escape
+          }
+      })
+
+      val jsonNode = Json.mapper.createObjectNode
+      jsonNode.put("field", "value&")
+
+      val statusHeader = new StatusHeader(Http.Status.OK)
+      val result = statusHeader.sendJson(jsonNode, JsonEncoding.UTF8)
+
+      val content = Await.result(for {
+        byteString <- result.body.dataStream.runWith(Sink.head, materializer)
+      } yield byteString.decodeString("UTF-8"), Duration.Inf)
+
+      content must_== "{\"field\":\"value\\u0026\"}"
+    }
+  }
+}


### PR DESCRIPTION
Backport of #6843 to 2.5.x
Fixes ##6828