### PR TITLE
[2.5.x] Add explicit binding for JPAEntityManagerContext

### DIFF
--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAEntityManagerContext.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAEntityManagerContext.java
@@ -2,6 +2,7 @@ package play.db.jpa;
 
 import play.mvc.Http;
 
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -9,6 +10,9 @@ import java.util.Deque;
 public class JPAEntityManagerContext extends ThreadLocal<Deque<EntityManager>> {
 
     private static final String CURRENT_ENTITY_MANAGER = "entityManagerContext";
+
+    @Inject
+    public JPAEntityManagerContext() {}
 
     @Override
     public Deque<EntityManager> initialValue() {

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAModule.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPAModule.java
@@ -18,7 +18,8 @@ public class JPAModule extends Module {
     public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
         return seq(
             bind(JPAApi.class).toProvider(DefaultJPAApi.JPAApiProvider.class),
-            bind(JPAConfig.class).toProvider(DefaultJPAConfig.JPAConfigProvider.class)
+            bind(JPAConfig.class).toProvider(DefaultJPAConfig.JPAConfigProvider.class),
+            bind(JPAEntityManagerContext.class).toSelf()
         );
     }
 


### PR DESCRIPTION
I came across this while testing out the Spring application loader. It's actually not a problem in master because we don't use DI for the JPAEntityManagerContext.