### PR TITLE
Improve global application configuration and handling

### DIFF
--- a/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
+++ b/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationBuilder.scala
@@ -35,6 +35,12 @@ final case class GuiceApplicationBuilder(
   def this() = this(environment = Environment.simple())
 
   /**
+   * Sets the configuration key to enable/disable global application state
+   */
+  def globalApp(enabled: Boolean): GuiceApplicationBuilder =
+    configure(Play.GlobalAppConfigKey -> enabled)
+
+  /**
    * Set the initial configuration loader.
    * Overrides the default or any previously configured values.
    */

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/AnyContentBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/AnyContentBodyParserSpec.scala
@@ -3,30 +3,31 @@
  */
 package play.it.http.parsing
 
-import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import play.api.Application
 import play.api.mvc._
 import play.api.test._
 
 class AnyContentBodyParserSpec extends PlaySpecification {
 
   "The anyContent body parser" should {
-
-    def parse(method: String, contentType: Option[String], body: ByteString)(implicit mat: Materializer) = {
+    def parse(method: String, contentType: Option[String], body: ByteString)(implicit app: Application) = {
+      implicit val mat = app.materializer
+      val parsers = app.injector.instanceOf[PlayBodyParsers]
       val request = FakeRequest(method, "/x").withHeaders(contentType.map(CONTENT_TYPE -> _).toSeq: _*)
-      await(BodyParsers.parse.anyContent(request).run(Source.single(body)))
+      await(parsers.anyContent(request).run(Source.single(body)))
     }
 
-    "parse text bodies for DELETE requests" in new WithApplication() {
+    "parse text bodies for DELETE requests" in new WithApplication(_.globalApp(false)) {
       parse("DELETE", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
     }
 
-    "parse text bodies for GET requests" in new WithApplication() {
+    "parse text bodies for GET requests" in new WithApplication(_.globalApp(false)) {
       parse("GET", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
     }
 
-    "parse empty bodies as raw for GET requests" in new WithApplication() {
+    "parse empty bodies as raw for GET requests" in new WithApplication(_.globalApp(false)) {
       parse("PUT", None, ByteString.empty) must beRight.like {
         case AnyContentAsRaw(rawBuffer) => rawBuffer.asBytes() must beSome.like {
           case outBytes => outBytes must beEmpty
@@ -34,29 +35,29 @@ class AnyContentBodyParserSpec extends PlaySpecification {
       }
     }
 
-    "parse text bodies for HEAD requests" in new WithApplication() {
+    "parse text bodies for HEAD requests" in new WithApplication(_.globalApp(false)) {
       parse("HEAD", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
     }
 
-    "parse text bodies for OPTIONS requests" in new WithApplication() {
+    "parse text bodies for OPTIONS requests" in new WithApplication(_.globalApp(false)) {
       parse("OPTIONS", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
     }
 
-    "parse XML bodies for PATCH requests" in new WithApplication() {
+    "parse XML bodies for PATCH requests" in new WithApplication(_.globalApp(false)) {
       parse("POST", Some("text/xml"), ByteString("<bar></bar>")) must beRight(AnyContentAsXml(<bar></bar>))
     }
 
-    "parse text bodies for POST requests" in new WithApplication() {
+    "parse text bodies for POST requests" in new WithApplication(_.globalApp(false)) {
       parse("POST", Some("text/plain"), ByteString("bar")) must beRight(AnyContentAsText("bar"))
     }
 
-    "parse JSON bodies for PUT requests" in new WithApplication() {
+    "parse JSON bodies for PUT requests" in new WithApplication(_.globalApp(false)) {
       parse("PUT", Some("application/json"), ByteString("""{"foo":"bar"}""")) must beRight.like {
         case AnyContentAsJson(json) => (json \ "foo").as[String] must_== "bar"
       }
     }
 
-    "parse unknown bodies as raw for PUT requests" in new WithApplication() {
+    "parse unknown bodies as raw for PUT requests" in new WithApplication(_.globalApp(false)) {
       parse("PUT", None, ByteString.empty) must beRight.like {
         case AnyContentAsRaw(rawBuffer) => rawBuffer.asBytes() must beSome.like {
           case outBytes => outBytes must beEmpty

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -10,7 +10,7 @@ promise.akka.actor.typed.timeout=5s
 
 play {
   # Defines whether the global application is allowed
-  globalApplication = true
+  allowGlobalApplication = true
 
   http {
 

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -181,6 +181,15 @@ trait Application {
    * @return The injector.
    */
   def injector: Injector = NewInstanceInjector
+
+  /**
+   * Returns true if the global application is enabled for this app. If set to false, this changes the behavior of
+   * Play.start, Play.current, and Play.maybeApplication to disallow access to the global application instance,
+   * also affecting the deprecated Play APIs that use these.
+   */
+  lazy val globalApplicationEnabled: Boolean = {
+    configuration.getOptional[Boolean](Play.GlobalAppConfigKey).getOrElse(true)
+  }
 }
 
 object Application {

--- a/framework/src/play/src/test/scala/play/api/PlayGlobalAppSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/PlayGlobalAppSpec.scala
@@ -1,0 +1,77 @@
+package play.api
+
+import org.specs2.mutable.Specification
+
+class PlayGlobalAppSpec extends Specification {
+
+  sequential
+
+  def testApp(allowGlobalApp: Boolean): PlayCoreTestApplication =
+    PlayCoreTestApplication(Map("play.allowGlobalApplication" -> allowGlobalApp))
+
+  "play.api.Play" should {
+    "start apps with global state enabled" in {
+      val app = testApp(true)
+      Play.start(app)
+      Play.privateMaybeApplication must beSome(app)
+      Play.stop(app)
+      success
+    }
+    "start apps with global state disabled" in {
+      val app = testApp(false)
+      Play.start(app)
+      Play.privateMaybeApplication must throwA[RuntimeException]
+      Play.stop(app)
+      success
+    }
+    "shut down the first app when starting a second app with global state enabled" in {
+      val app1 = testApp(true)
+      Play.start(app1)
+      val app2 = testApp(true)
+      Play.start(app2)
+      app1.isTerminated must beTrue
+      app2.isTerminated must beFalse
+      Play.privateMaybeApplication must beSome(app2)
+      Play.current must_== app2
+      Play.stop(app1)
+      Play.stop(app2)
+      success
+    }
+    "start one app with global state after starting another without global state" in {
+      val app1 = testApp(false)
+      Play.start(app1)
+      val app2 = testApp(true)
+      Play.start(app2)
+      app1.isTerminated must beFalse
+      app2.isTerminated must beFalse
+      Play.privateMaybeApplication must beSome(app2)
+      Play.stop(app1)
+      Play.stop(app2)
+      success
+    }
+    "start one app without global state after starting another with global state" in {
+      val app1 = testApp(true)
+      Play.start(app1)
+      val app2 = testApp(false)
+      Play.start(app2)
+      app1.isTerminated must beFalse
+      app2.isTerminated must beFalse
+      Play.privateMaybeApplication must beSome(app1)
+      Play.stop(app1)
+      Play.stop(app2)
+      success
+    }
+    "start multiple apps with global state disabled" in {
+      val app1 = testApp(false)
+      Play.start(app1)
+      val app2 = testApp(false)
+      Play.start(app2)
+      app1.isTerminated must beFalse
+      app2.isTerminated must beFalse
+      Play.privateMaybeApplication must throwA[RuntimeException]
+      Play.stop(app1)
+      Play.stop(app2)
+      success
+    }
+  }
+}


### PR DESCRIPTION
 - Add `globalApplicationEnabled` lazy val to Application to make it easier to determine or set if the global app is enabled.
 - Change `Play.start` to only call `Play.stop` on the current app if we need to replace the existing global application instance.
 - Add `GuiceApplicationBuilder#globalApp(Boolean)` to make it easy to enable or disable global state in a test.
 - Change a test as a proof of concept.