### PR TITLE
(compile in Test) should also be a default in sbt-eclipse preTasks

### DIFF
--- a/documentation/manual/gettingStarted/IDE.md
+++ b/documentation/manual/gettingStarted/IDE.md
@@ -9,17 +9,17 @@ However, using a modern Java or Scala IDE provides cool productivity features li
 
 ### Setup sbteclipse
 
-Integration with Eclipse requires [sbteclipse](https://github.com/typesafehub/sbteclipse) 4.0.0 or newer.
+Integration with Eclipse requires [sbteclipse](https://github.com/typesafehub/sbteclipse). Make sure to always use the [most recent available version](https://github.com/typesafehub/sbteclipse/releases).
 
 ```scala
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "4.0.0")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.1.0")
 ```
 
 You must `compile` your project before running the `eclipse` command. You can force compilation to happen when the `eclipse` command is run by adding the following setting:
 
 ```scala
 // Compile the project before generating Eclipse files, so that generated .scala or .class files for views and routes are present
-EclipseKeys.preTasks := Seq(compile in Compile)
+EclipseKeys.preTasks := Seq(compile in Compile, compile in Test)
 ```
 
 If you have Scala sources in your project, you will need to install [Scala IDE](http://scala-ide.org/).


### PR DESCRIPTION
So it matches the `sbt-eclipse` default `managedClassDirectories` setting:
https://github.com/typesafehub/sbteclipse/blob/v5.1.0/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala#L48
@benmccann [agrees with me on this change](https://github.com/typesafehub/sbteclipse/pull/327#issuecomment-268654889)