### PR TITLE
Honors the expiration time in DefaultSyncCacheApi

### DIFF
--- a/framework/src/play-cache/src/main/java/play/cache/AsyncCacheApi.java
+++ b/framework/src/play-cache/src/main/java/play/cache/AsyncCacheApi.java
@@ -25,7 +25,6 @@ public interface AsyncCacheApi {
      *
      * @param <T> the type of the stored object
      * @param key the key to look up
-     * @return the object or null
      * @return a CompletionStage containing the value
      */
     <T> CompletionStage<T> get(String key);

--- a/framework/src/play-cache/src/main/java/play/cache/DefaultSyncCacheApi.java
+++ b/framework/src/play-cache/src/main/java/play/cache/DefaultSyncCacheApi.java
@@ -14,7 +14,7 @@ import javax.inject.Inject;
  */
 public class DefaultSyncCacheApi implements SyncCacheApi, CacheApi {
 
-    private AsyncCacheApi cacheApi;
+    private final AsyncCacheApi cacheApi;
 
     protected long awaitTimeoutMillis = 5000;
 
@@ -48,7 +48,7 @@ public class DefaultSyncCacheApi implements SyncCacheApi, CacheApi {
 
     @Override
     public <T> T getOrElseUpdate(String key, Callable<T> block, int expiration) {
-        return blocking(cacheApi.getOrElseUpdate(key, () -> CompletableFuture.completedFuture(block.call())));
+        return blocking(cacheApi.getOrElseUpdate(key, () -> CompletableFuture.completedFuture(block.call()), expiration));
     }
 
     @Override

--- a/framework/src/play-cache/src/test/scala/play/api/cache/CacheApiSpec.scala
+++ b/framework/src/play-cache/src/test/scala/play/api/cache/CacheApiSpec.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.api.cache
 
 import javax.inject.{ Inject, Provider }
@@ -51,4 +54,4 @@ class CustomCacheManagerProvider @Inject() (cacheManagerProvider: CacheManagerPr
 }
 
 class NamedCacheController @Inject() (
-  @NamedCache("custom") val cache: CacheApi)
+  @NamedCache("custom") val cache: SyncCacheApi)

--- a/framework/src/play-cache/src/test/scala/play/api/cache/CachedSpec.scala
+++ b/framework/src/play-cache/src/test/scala/play/api/cache/CachedSpec.scala
@@ -164,9 +164,7 @@ class CachedSpec extends PlaySpecification {
   }
 
   val dummyAction = Action { request: Request[_] =>
-    Results.Ok {
-      Random.nextInt().toString
-    }
+    Results.Ok(Random.nextInt().toString)
   }
 
   val notFoundAction = Action { request: Request[_] =>

--- a/framework/src/play-cache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
+++ b/framework/src/play-cache/src/test/scala/play/api/cache/JavaCacheApiSpec.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.cache
+
+import java.util.concurrent.{ Callable, CompletableFuture, CompletionStage }
+
+import org.specs2.concurrent.ExecutionEnv
+
+import scala.concurrent.duration._
+import scala.compat.java8.FutureConverters._
+import play.cache.{ AsyncCacheApi => JavaAsyncCacheApi, SyncCacheApi => JavaSyncCacheApi }
+import play.api.test.{ PlaySpecification, WithApplication }
+
+import scala.concurrent.Await
+
+class JavaCacheApiSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
+
+  sequential
+
+  "Java AsyncCacheApi" should {
+    "set cache values" in new WithApplication {
+      val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+      Await.result(cacheApi.set("foo", "bar").toScala, 1.second)
+      cacheApi.get[String]("foo").toScala must beEqualTo("bar").await
+    }
+    "set cache values with an expiration time" in new WithApplication {
+      val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+      Await.result(cacheApi.set("foo", "bar", 1 /* second */ ).toScala, 1.second)
+
+      Thread.sleep(2.seconds.toMillis)
+      cacheApi.get[String]("foo").toScala must beNull.await
+    }
+    "get or update" should {
+      "get value when it exists" in new WithApplication {
+        val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+        Await.result(cacheApi.set("foo", "bar").toScala, 1.second)
+        cacheApi.get[String]("foo").toScala must beEqualTo("bar").await
+      }
+      "update cache when value does not exists" in new WithApplication {
+        val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+        val future = cacheApi.getOrElseUpdate[String]("foo", new Callable[CompletionStage[String]] {
+          override def call() = CompletableFuture.completedFuture[String]("bar")
+        }).toScala
+
+        future must beEqualTo("bar").await
+        cacheApi.get[String]("foo").toScala must beEqualTo("bar").await
+      }
+      "update cache with an expiration time when value does not exists" in new WithApplication {
+        val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+        val future = cacheApi.getOrElseUpdate[String]("foo", new Callable[CompletionStage[String]] {
+          override def call() = CompletableFuture.completedFuture[String]("bar")
+        }, 1 /* second */ ).toScala
+
+        future must beEqualTo("bar").await
+
+        Thread.sleep(2.seconds.toMillis)
+        cacheApi.get[String]("foo").toScala must beNull.await
+      }
+    }
+    "remove values from cache" in new WithApplication {
+      val cacheApi = app.injector.instanceOf[JavaAsyncCacheApi]
+      Await.result(cacheApi.set("foo", "bar").toScala, 1.second)
+      cacheApi.get[String]("foo").toScala must beEqualTo("bar").await
+
+      Await.result(cacheApi.remove("foo").toScala, 1.second)
+      cacheApi.get[String]("foo").toScala must beNull.await
+    }
+  }
+
+  "Java SyncCacheApi" should {
+    "set cache values" in new WithApplication {
+      val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+      cacheApi.set("foo", "bar")
+      cacheApi.get[String]("foo") must beEqualTo("bar")
+    }
+    "set cache values with an expiration time" in new WithApplication {
+      val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+      cacheApi.set("foo", "bar", 1 /* second */ )
+
+      Thread.sleep(2.seconds.toMillis)
+      cacheApi.get[String]("foo") must beNull
+    }
+    "get or update" should {
+      "get value when it exists" in new WithApplication {
+        val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+        cacheApi.set("foo", "bar")
+        cacheApi.get[String]("foo") must beEqualTo("bar")
+      }
+      "update cache when value does not exists" in new WithApplication {
+        val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+        val value = cacheApi.getOrElseUpdate[String]("foo", new Callable[String] {
+          override def call() = "bar"
+        })
+
+        value must beEqualTo("bar")
+        cacheApi.get[String]("foo") must beEqualTo("bar")
+      }
+      "update cache with an expiration time when value does not exists" in new WithApplication {
+        val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+        val future = cacheApi.getOrElseUpdate[String]("foo", new Callable[String] {
+          override def call() = "bar"
+        }, 1 /* second */ )
+
+        future must beEqualTo("bar")
+
+        Thread.sleep(2.seconds.toMillis)
+        cacheApi.get[String]("foo") must beNull
+      }
+    }
+    "remove values from cache" in new WithApplication {
+      val cacheApi = app.injector.instanceOf[JavaSyncCacheApi]
+      cacheApi.set("foo", "bar")
+      cacheApi.get[String]("foo") must beEqualTo("bar")
+
+      cacheApi.remove("foo")
+      cacheApi.get[String]("foo") must beNull
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

The main change here is to solve a small bug at `DefaultSyncCacheApi.getOrElseUpdate` which was ignoring the `expiration` parameter.

Tests were added to the Java version of Cache APIs and other small improvements were made.

## References

After merging, #4972 could be closed.
