### PR TITLE
Upgrade Netty to version 4.0.43.Final

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -139,7 +139,7 @@ object Dependencies {
     specsBuild.map(_ % Test) ++
     javaTestDeps
 
-  val nettyVersion = "4.0.42.Final"
+  val nettyVersion = "4.0.43.Final"
 
   val netty = Seq(
     "com.typesafe.netty" % "netty-reactive-streams-http" % "1.0.8",
@@ -247,7 +247,7 @@ object Dependencies {
       logback % Test
     ) ++ specsBuild.map(_ % Test)
 
-  val asyncHttpClientVersion = "2.0.24"
+  val asyncHttpClientVersion = "2.0.26"
   val playAhcWsDeps = Seq(
     guava,
     "org.asynchttpclient" % "async-http-client" % asyncHttpClientVersion,


### PR DESCRIPTION
The async-http-client library needs to be upgraded too, as it used an internal Netty API
which has been removed in 4.0.43.Final, see [1].

[1]: https://github.com/AsyncHttpClient/async-http-client/pull/1317

## Purpose

The Netty team released a bug-fix-release on 12th Jan 2017. See http://netty.io/news/2017/01/12/4-0-43-Final-4-1-7-Final.html
