### PR TITLE
Fix cookie max-age computation

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsSpec.scala
@@ -46,7 +46,7 @@ class ScalaResultsSpec extends PlaySpecification {
     setCookies("preferences").value must be_==("blue")
     setCookies("lang").value must be_==("fr")
     setCookies("logged").maxAge must beSome
-    setCookies("logged").maxAge must beSome(0)
+    setCookies("logged").maxAge must beSome(Cookie.DiscardedMaxAge)
     val playSession = sessionBaker.decodeFromCookie(setCookies.get(sessionBaker.COOKIE_NAME))
     playSession.data must_== Map("user" -> "kiki", "langs" -> "fr:en:de")
   }

--- a/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/ClientCookieDecoder.java
+++ b/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/ClientCookieDecoder.java
@@ -238,7 +238,7 @@ public final class ClientCookieDecoder extends CookieDecoder {
 
         private void setMaxAge(String value) {
             try {
-                maxAge = Math.max(Integer.valueOf(value), 0);
+                maxAge = Integer.valueOf(value);
             } catch (NumberFormatException e1) {
                 // ignore failure to parse -> treat as session cookie
             }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -1829,7 +1829,7 @@ public class Http {
          * @param secure Whether the cookie to discard is secure
          */
         public void discardCookie(String name, String path, String domain, boolean secure) {
-            cookies.add(new Cookie(name, "", -86400, path, domain, secure, false));
+            cookies.add(new Cookie(name, "", play.api.mvc.Cookie.DiscardedMaxAge(), path, domain, secure, false));
         }
 
         public Collection<Cookie> cookies() {

--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -34,6 +34,16 @@ case class Cookie(name: String, value: String, maxAge: Option[Int] = None, path:
   }
 }
 
+object Cookie {
+  import scala.concurrent.duration._
+
+  /**
+   * The cookie's max age, in seconds, when we expire the cookie. This is also used to determine Expires. It's set
+   * to one day ago to work for clients that only support Expires and have a clock that is slightly behind.
+   */
+  val DiscardedMaxAge: Int = -1.day.toSeconds.toInt
+}
+
 /**
  * A cookie to be discarded.  This contains only the data necessary for discarding a cookie.
  *
@@ -43,7 +53,7 @@ case class Cookie(name: String, value: String, maxAge: Option[Int] = None, path:
  * @param secure whether this cookie is secured
  */
 case class DiscardingCookie(name: String, path: String = "/", domain: Option[String] = None, secure: Boolean = false) {
-  def toCookie = Cookie(name, "", Some(-86400), path, domain, secure)
+  def toCookie = Cookie(name, "", Some(Cookie.DiscardedMaxAge), path, domain, secure)
 }
 
 /**

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -119,7 +119,7 @@ class ResultsSpec extends Specification {
       setCookies("session").maxAge must beNone
       setCookies("preferences").value must be_==("blue")
       setCookies("lang").value must be_==("fr")
-      setCookies("logged").maxAge must beSome(0)
+      setCookies("logged").maxAge must beSome(Cookie.DiscardedMaxAge)
     }
 
     "provide convenience method for setting cookie header" in withApplication {


### PR DESCRIPTION
Fixes #6888 by reading the raw max-age value from the cookie and setting that directly instead of using `Math.max(maxAge, 0)`. It's valid to have negative `Max-Age` values, and this is needed to properly set `Expires` since `maxAge` is used to set both.

Needs backport to 2.5.x.