### PR TITLE
Allow multiple withCookies calls in Java API

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -51,12 +51,13 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
 
     "add cookies in Result" in makeRequest(new MockController {
       def action = {
-        Results.ok("Hello world").withCookies(
-          new Http.Cookie("bar", "KitKat", 1000, "/", "example.com", false, true)
-        )
+        Results.ok("Hello world")
+          .withCookies(new Http.Cookie("bar", "KitKat", 1000, "/", "example.com", false, true))
+          .withCookies(new Http.Cookie("framework", "Play", 1000, "/", "example.com", false, true))
       }
     }) { response =>
-      response.header("Set-Cookie").get must contain("bar=KitKat;")
+      response.allHeaders("Set-Cookie") must contain((s: String) => s.startsWith("bar=KitKat;"))
+      response.allHeaders("Set-Cookie") must contain((s: String) => s.startsWith("framework=Play;"))
       response.body must_== "Hello world"
     }
 

--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -3,6 +3,7 @@
  */
 package play.mvc;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -261,11 +262,13 @@ public class Result {
 
     /**
      * Returns a copy of this result with the given cookies.
-     * @param cookies the cookies to add to the result.
+     * @param newCookies the cookies to add to the result.
      * @return the transformed copy.
      */
-    public Result withCookies(Cookie... cookies) {
-        return new Result(header, body, session, flash, Arrays.asList(cookies));
+    public Result withCookies(Cookie... newCookies) {
+        List<Cookie> finalCookies = new ArrayList<>(cookies);
+        finalCookies.addAll(Arrays.asList(newCookies));
+        return new Result(header, body, session, flash, finalCookies);
     }
 
     /**


### PR DESCRIPTION
This actually fixes a bug introduced on the master branch. We need to append the provided list of cookies to the existing list.