### PR TITLE
Update Fluentlenium to latest version

### DIFF
--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -522,7 +522,11 @@ Or get a custom one:
 ```scala
 val fileMimeTypes = new DefaultFileMimeTypesProvider(FileMimeTypesConfiguration(Map("foo" -> "text/bar"))).get
 ```
+## Updated libraries
 
+### Fluentlenium
+The Fluentlenium library was updated to version 3.1.1 and as a result the underlying Selenium version changed to [3.0.1](https://seleniumhq.wordpress.com/2016/10/13/selenium-3-0-out-now/). If you were using Selenium's WebDriver API before, there shouldn't be anything to do. Please check [this](https://seleniumhq.wordpress.com/2016/10/04/selenium-3-is-coming/) announcement for further information.
+If you were using the Fluentlenium library you might have to change some syntax to get your tests working again. Please see Fluentlenium's [Migration Guide](http://fluentlenium.org/migration/from-0.13.2-to-1.0-or-3.0/)
 
 ## Other Configuration changes
 

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/BrowserFunctionalTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/BrowserFunctionalTest.java
@@ -22,7 +22,7 @@ public class BrowserFunctionalTest extends WithBrowser {
     @Test
     public void runInBrowser() {
         browser.goTo("/");
-        assertNotNull(browser.$("title").getText());
+        assertNotNull(browser.$("title").text());
     }
 
 }

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/FunctionalTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/FunctionalTest.java
@@ -78,9 +78,9 @@ public class FunctionalTest extends WithApplication {
     public void runInBrowser() {
         running(testServer(), HTMLUNIT, browser -> {
             browser.goTo("/");
-            assertEquals("Welcome to Play!", browser.$("#title").getText());
+            assertEquals("Welcome to Play!", browser.$("#title").text());
             browser.$("a").click();
-            assertEquals("/login", browser.url());
+            assertEquals("login", browser.url());
         });
     }
     //#test-browser

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ScalaFunctionalTestSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ScalaFunctionalTestSpec.scala
@@ -107,12 +107,12 @@ class ScalaFunctionalTestSpec extends ExampleSpecification {
       browser.goTo("/")
 
       // Check the page
-      browser.$("#title").getTexts.get(0) must equalTo("Hello Guest")
+      browser.$("#title").text() must equalTo("Hello Guest")
 
       browser.$("a").click()
 
-      browser.url must equalTo("/login")
-      browser.$("#title").getTexts.get(0) must equalTo("Hello Coco")
+      browser.url must equalTo("login")
+      browser.$("#title").text() must equalTo("Hello Coco")
     }
     // #scalafunctionaltest-testwithbrowser
 

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -235,9 +235,12 @@ object Dependencies {
     junitInterface,
     guava,
     findBugs,
-    "net.sourceforge.htmlunit" % "htmlunit" % "2.20", // adds support for jQuery 2.20; can be removed as soon as fluentlenium has it in it's own dependencies
-    ("org.fluentlenium" % "fluentlenium-core" % "0.10.9")
+    ("org.fluentlenium" % "fluentlenium-core" % "3.1.1")
       .exclude("org.jboss.netty", "netty"),
+    "net.sourceforge.htmlunit" % "htmlunit" % "2.23",
+    "org.seleniumhq.selenium" % "htmlunit-driver" % "2.23.2",
+    "org.seleniumhq.selenium" % "selenium-firefox-driver" % "3.0.1",
+    "org.seleniumhq.selenium" % "selenium-support" % "3.0.1",
     logback % Test
   ) ++ guiceDeps
 

--- a/framework/src/play-test/src/main/java/play/test/TestBrowser.java
+++ b/framework/src/play-test/src/main/java/play/test/TestBrowser.java
@@ -3,12 +3,10 @@
  */
 package play.test;
 
-import org.openqa.selenium.*;
-import org.openqa.selenium.support.ui.*;
-
-import org.fluentlenium.core.*;
-
 import com.google.common.base.Function;
+import org.fluentlenium.adapter.FluentAdapter;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.FluentWait;
 
 import java.util.concurrent.TimeUnit;
 
@@ -36,8 +34,8 @@ public class TestBrowser extends FluentAdapter {
      * @param baseUrl The base url to use for relative requests.
      */
     public TestBrowser(WebDriver webDriver, String baseUrl) {
-        super(webDriver);
-        withDefaultUrl(baseUrl);
+        super.initFluent(webDriver);
+        super.getConfiguration().setBaseUrl(baseUrl);
     }
 
     /**
@@ -97,5 +95,15 @@ public class TestBrowser extends FluentAdapter {
      */
     public WebDriver.Options manage() {
         return super.getDriver().manage();
+    }
+
+    /**
+     * Quits and releases the {@link WebDriver}
+     */
+    void quit() {
+        if (getDriver() != null) {
+            getDriver().quit();
+        }
+        releaseFluent();
     }
 }

--- a/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Selenium.scala
@@ -3,14 +3,14 @@
  */
 package play.api.test
 
+import java.util.concurrent.TimeUnit
+
+import com.google.common.base.Function
+import org.fluentlenium.adapter.FluentAdapter
+import org.fluentlenium.core.domain.{ FluentList, FluentWebElement }
 import org.openqa.selenium._
 import org.openqa.selenium.firefox._
 import org.openqa.selenium.htmlunit._
-
-import org.fluentlenium.core._
-
-import java.util.concurrent.TimeUnit
-import com.google.common.base.Function
 import org.openqa.selenium.support.ui.FluentWait
 
 /**
@@ -18,9 +18,9 @@ import org.openqa.selenium.support.ui.FluentWait
  *
  * @param webDriver The WebDriver instance to use.
  */
-case class TestBrowser(webDriver: WebDriver, baseUrl: Option[String]) extends FluentAdapter(webDriver) {
-
-  baseUrl.map(baseUrl => withDefaultUrl(baseUrl))
+case class TestBrowser(webDriver: WebDriver, baseUrl: Option[String]) extends FluentAdapter() {
+  super.initFluent(webDriver)
+  baseUrl.foreach(baseUrl => super.getConfiguration.setBaseUrl(baseUrl))
 
   /**
    * Submits a form with the given field values
@@ -32,12 +32,12 @@ case class TestBrowser(webDriver: WebDriver, baseUrl: Option[String]) extends Fl
    *   )
    * }}}
    */
-  def submit(selector: String, fields: (String, String)*): Fluent = {
+  def submit(selector: String, fields: (String, String)*): FluentList[FluentWebElement] = {
     fields.foreach {
       case (fieldName, fieldValue) =>
-        fill(s"${selector} *[name=${fieldName}]").`with`(fieldValue)
+        $(s"$selector *[name=$fieldName]").fill.`with`(fieldValue)
     }
-    super.submit(selector)
+    $(selector).submit()
   }
 
   /**
@@ -75,6 +75,11 @@ case class TestBrowser(webDriver: WebDriver, baseUrl: Option[String]) extends Fl
    * to set cookies, manage timeouts among other things
    */
   def manage: WebDriver.Options = super.getDriver.manage
+
+  def quit() {
+    Option(super.getDriver).foreach(_.quit())
+    releaseFluent()
+  }
 }
 
 /**


### PR DESCRIPTION
Bumps fluentlenium version to 3.1.1 and adjusts classes accordingly. This seems fit since scalatestplus-play already uses Selenium 3 while the current fluentlenium version 0.10.9 still uses Selenium 2
