### PR TITLE
Deprecate play.cache.CacheApi

### DIFF
--- a/documentation/manual/working/javaGuide/main/cache/JavaCache.md
+++ b/documentation/manual/working/javaGuide/main/cache/JavaCache.md
@@ -19,7 +19,7 @@ The cache API is defined by the [AsyncCacheApi](api/java/play/cache/AsyncCacheAp
 
 @[inject](code/javaguide/cache/inject/Application.java)
 
-> **Note:** The API is intentionally minimal to allow various implementations to be plugged in. If you need a more specific API, use the one provided by your Cache plugin.
+> **Note:** The API is intentionally minimal to allow various implementations to be plugged in. If you need a more specific API, use the one provided by your Cache library.
 
 Using this simple API you can store data in the cache:
 
@@ -63,7 +63,7 @@ Now to access these different caches, when you inject them, use the [NamedCache]
 
 You can easily create a smart cached action using standard `Action` composition.
 
-> **Note:** Play HTTP `Result` instances are safe to cache and reuse later.
+> **Tip:** Play HTTP `Result` instances are safe to cache and reuse later.
 
 Play provides a default built-in helper for the standard case:
 

--- a/documentation/manual/working/javaGuide/main/cache/code/javaguide/cache/qualified/Application.java
+++ b/documentation/manual/working/javaGuide/main/cache/code/javaguide/cache/qualified/Application.java
@@ -11,7 +11,7 @@ import javax.inject.Inject;
 
 public class Application extends Controller {
 
-    @Inject @NamedCache("session-cache") CacheApi cache;
+    @Inject @NamedCache("session-cache") SyncCacheApi cache;
 
     // ...
 }

--- a/framework/src/play-cache/src/main/java/play/cache/CacheApi.java
+++ b/framework/src/play-cache/src/main/java/play/cache/CacheApi.java
@@ -7,7 +7,10 @@ import java.util.concurrent.Callable;
 
 /**
  * The Cache API.
+ *
+ * @deprecated Deprecated as of 2.6.0. Use {@link SyncCacheApi} or {@link AsyncCacheApi}.
  */
+@Deprecated
 public interface CacheApi {
     /**
      * Retrieves an object by key.


### PR DESCRIPTION
Users should now use play.cache.SyncCacheApi or play.cache.AsynCacheApi.

## References

https://github.com/playframework/playframework/pull/6865#pullrequestreview-17119846
