### PR TITLE
added httpcore dependency

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -309,7 +309,8 @@ object Dependencies {
     "oauth.signpost" % "signpost-commonshttp4" % "1.2.1.2" excludeAll(
       ExclusionRule(organization = "org.apache.httpcomponents")
       ),
-    "org.apache.httpcomponents" % "httpclient" % "4.5.2"
+    "org.apache.httpcomponents" % "httpclient" % "4.5.2",
+    "org.apache.httpcomponents" % "httpcore" % "4.4.4"
   ) ++ (specsBuild :+ specsMatcherExtra).map(_ % Test) :+
     mockitoAll % Test
 


### PR DESCRIPTION
Hi, 

After upgrading to 2.5.11 I was getting runtime exceptions when using a class from ` "org.apache.httpcomponents" % "httpclient"`. 
`httpclient` has a dependency on `httpcore`, but `httpcore` is excluded by 
`ExclusionRule(organization = "org.apache.httpcomponents")`
I could fix this by adding it to my app dependencies, but maybe it's better to have this dependency in the framework.
[Here is a forum user who also had this problem.](https://groups.google.com/d/msg/play-framework/E2fnsC0sbSg/B9Rd2kPCAAAJ)

thanks
Simon