### PR TITLE
NonBlockingAction

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/EssentialAction.java
+++ b/framework/src/play/src/main/java/play/mvc/EssentialAction.java
@@ -6,12 +6,12 @@ package play.mvc;
 import java.util.function.Function;
 
 import akka.util.ByteString;
+import play.api.mvc.AbstractEssentialAction;
 import play.api.mvc.Handler;
 import play.core.Execution;
 import play.core.j.RequestHeaderImpl;
 import play.libs.streams.Accumulator;
 import play.mvc.Http.RequestHeader;
-import scala.runtime.AbstractFunction1;
 
 /**
  * Given a `RequestHeader`, an `EssentialAction` consumes the request body (a `ByteString`) and returns a `Result`.
@@ -21,9 +21,7 @@ import scala.runtime.AbstractFunction1;
  *
  * Unlike traditional method-based Java actions, EssentialAction does not use a context.
  */
-public abstract class EssentialAction
-    extends AbstractFunction1<play.api.mvc.RequestHeader, play.api.libs.streams.Accumulator<ByteString, play.api.mvc.Result>>
-    implements play.api.mvc.EssentialAction, Handler {
+public abstract class EssentialAction extends AbstractEssentialAction implements Handler {
 
     public static EssentialAction of(Function<RequestHeader, Accumulator<ByteString, Result>> action) {
         return new EssentialAction() {
@@ -41,15 +39,5 @@ public abstract class EssentialAction
         return apply(new RequestHeaderImpl(rh))
             .map(Result::asScala, Execution.trampoline())
             .asScala();
-    }
-
-    @Override
-    public play.api.mvc.EssentialAction apply() {
-        return this;
-    }
-
-    @Override
-    public EssentialAction asJava() {
-        return this;
     }
 }


### PR DESCRIPTION
Consider this situation:

1. Clients make requests, with one retry for failures. The load is steady, and the server has a capacity 80% more than the load.

2. A temporary slowdown happens: database issues, a burst of requests, CPU-stealing, whatever. During this time, clients time out, and their retry times out.

3. The source of the slowdown is removed.

The system never recovers because load is 160% of possible throughput and clients are always timing out. In fact no only does it not recover, but the queue of connections waiting responses increases indefinitely.

This can easily happens backend SOA where timeouts are lowish and clients retry. This happened frequently at Lucid Software (though usually taking the form of extended downtimes instead of interminable failure).

---

We implemented two solutions in a fork of Play which fixed the problem soundly: detect client TCP resets (#5973), and limit the queue of requests (this PR). Based on discussion (https://groups.google.com/forum/#!topic/play-framework-dev/TbGXrsWnVdU), the latter solution is appealing.

It could be implemented (a) in Play's core itself, or (b) in application code like this:

```scala
new EssentialFilter {
  private[this] val current = AtomicInteger
  private[this] val limit = 50
  def apply(next: EssentialAction) = {
    if (current.incrementAndGet > 50) { /* runs on Netty thread pool */
      EssentialAction(_ => Accumulator.done(Results.ServiceUnavailable) /* runs on Play default thread pool */)
    } else {
      next(request)
    }
  }
})
```

Application code allows flexibility to customize conditions, e.g. exclude specific controllers from the limit. The only issue with it is that an immediate response is not possible if Play's default thread pool is backed-up (which, if there is a slowdown, probably has happened).

This PR makes it possible to return a response without waiting in the Play thread pool.

```scala
new EssentialFilter {
  private[this] val current = AtomicInteger
  private[this] val limit = 50
  def apply(next: EssentialAction) = {
    if (current.incrementAndGet > 50) {
      NonBlockingAction(_ => Accumulator.done(Results.ServiceUnavailable))
    } else {
      next(request)
    }
  }
})
```

I realize that the ideal solution is to not block the Play thread pool in the first place. But considering that we are already running (potentially blocking) application code on Netty I/O thread pool, I thought this not a terrible solution.