### PR TITLE
[doc]: remove some deprecated API usages

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/code/detailedtopics/ThreadPoolsJava.java
+++ b/documentation/manual/working/commonGuide/configuration/code/detailedtopics/ThreadPoolsJava.java
@@ -4,7 +4,6 @@
 package detailedtopics;
 
 import org.junit.Test;
-import play.Play;
 import play.Application;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -16,17 +15,15 @@ public class ThreadPoolsJava {
     @Test
     public void usingAppClassLoader() throws Exception {
         final Application app = fakeApplication();
-        running(app, new Runnable() {
-            public void run() {
-                String myClassName = "java.lang.String";
-                try {
-                    //#using-app-classloader
-                    Class myClass = app.classloader().loadClass(myClassName);
-                    //#using-app-classloader
-                    assertThat(myClass, notNullValue());
-                } catch (ClassNotFoundException e) {
-                    throw new RuntimeException(e);
-                }
+        running(app, () -> {
+            String myClassName = "java.lang.String";
+            try {
+                //#using-app-classloader
+                Class myClass = app.classloader().loadClass(myClassName);
+                //#using-app-classloader
+                assertThat(myClass, notNullValue());
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
             }
         });
     }

--- a/documentation/manual/working/javaGuide/code/MockJavaAction.scala
+++ b/documentation/manual/working/javaGuide/code/MockJavaAction.scala
@@ -7,35 +7,14 @@ import java.util.concurrent.{CompletableFuture, CompletionStage}
 
 import play.api.mvc.{Action, Request}
 import play.core.j._
-import play.http.DefaultActionCreator
 import play.mvc.{Controller, Http, Result}
-import play.api.http.HttpConfiguration
 import play.api.test.Helpers
-import play.i18n.{Langs => JLangs, MessagesApi => JMessagesApi}
-import play.mvc.{FileMimeTypes => JFileMimeTypes}
 import java.lang.reflect.Method
 
 import akka.stream.Materializer
 
-abstract class MockJavaAction extends Controller with Action[Http.RequestBody] {
+abstract class MockJavaAction(handlerComponents: JavaHandlerComponents) extends Controller with Action[Http.RequestBody] {
   self =>
-
-  private lazy val app = play.api.Play.current
-
-  private lazy val contextComponents = new DefaultJavaContextComponents(
-    app.injector.instanceOf(classOf[JMessagesApi]),
-    app.injector.instanceOf(classOf[JLangs]),
-    app.injector.instanceOf(classOf[JFileMimeTypes]),
-    HttpConfiguration()
-  )
-
-  private lazy val handlerComponents = new DefaultJavaHandlerComponents(
-    app.injector,
-    new DefaultActionCreator,
-    HttpConfiguration(),
-    this.executionContext,
-    contextComponents
-  )
 
   private lazy val action = new JavaAction(handlerComponents) {
     val annotations = new JavaActionAnnotations(controller, method, handlerComponents.httpConfiguration.actionComposition)
@@ -118,8 +97,8 @@ object MockJavaActionJavaMocker {
  */
 package play {
 
-object HandlerInvokerFactoryAccessor {
-  val javaBodyParserToScala = play.core.routing.HandlerInvokerFactory.javaBodyParserToScala _
-}
+  object HandlerInvokerFactoryAccessor {
+    val javaBodyParserToScala = play.core.routing.HandlerInvokerFactory.javaBodyParserToScala _
+  }
 
 }

--- a/documentation/manual/working/javaGuide/code/MockJavaAction.scala
+++ b/documentation/manual/working/javaGuide/code/MockJavaAction.scala
@@ -81,7 +81,9 @@ object MockJavaActionHelper {
  */
 object MockJavaActionJavaMocker {
   def findActionMethod(obj: AnyRef): Method = {
-    val maybeMethod = obj.getClass.getDeclaredMethods.find(!_.isSynthetic)
+    val maybeMethod = obj.getClass.getDeclaredMethods.find { method =>
+      !method.isSynthetic && method.getParameterCount == 0
+    }
     val theMethod = maybeMethod.getOrElse(
       throw new RuntimeException("MockJavaAction must declare at least one non synthetic method")
     )

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaComet.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaComet.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 //#comet-imports
 import akka.stream.javadsl.Source;
+import play.core.j.JavaHandlerComponents;
 import play.libs.Comet;
 import play.libs.Json;
 import play.mvc.Http;
@@ -19,6 +20,7 @@ import play.mvc.Result;
 import play.test.WithApplication;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
@@ -28,6 +30,11 @@ import static play.test.Helpers.fakeRequest;
 public class JavaComet extends WithApplication {
 
     public static class Controller1 extends MockJavaAction {
+
+        Controller1(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         //#comet-string
         public static Result index() {
             final Source source = Source.from(Arrays.asList("kiki", "foo", "bar"));
@@ -37,11 +44,16 @@ public class JavaComet extends WithApplication {
     }
 
     public static class Controller2 extends MockJavaAction {
+
+        Controller2(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         //#comet-json
         public static Result index() {
             final ObjectNode objectNode = Json.newObject();
             objectNode.put("foo", "bar");
-            final Source source = Source.from(Arrays.asList(objectNode));
+            final Source source = Source.from(Collections.singletonList(objectNode));
             return ok().chunked(source.via(Comet.json("parent.cometMessage"))).as(Http.MimeTypes.HTML);
         }
         //#comet-json
@@ -49,10 +61,16 @@ public class JavaComet extends WithApplication {
 
     @Test
     public void foreverIframe() {
-        String content = contentAsString(MockJavaActionHelper.call(new Controller1(), fakeRequest(), mat), mat);
+        String content = contentAsString(MockJavaActionHelper.call(new Controller1(app.injector().instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat), mat);
         assertThat(content, containsString("<script type=\"text/javascript\">parent.cometMessage('kiki');</script>"));
         assertThat(content, containsString("<script type=\"text/javascript\">parent.cometMessage('foo');</script>"));
         assertThat(content, containsString("<script type=\"text/javascript\">parent.cometMessage('bar');</script>"));
+    }
+
+    @Test
+    public void foreverIframeWithJson() {
+        String content = contentAsString(MockJavaActionHelper.call(new Controller2(app.injector().instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat), mat);
+        assertThat(content, containsString("<script type=\"text/javascript\">parent.cometMessage({\"foo\":\"bar\"});</script>"));
     }
 
 }

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaStream.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaStream.java
@@ -10,15 +10,16 @@ import akka.stream.OverflowStrategy;
 import akka.NotUsed;
 
 import javaguide.testhelpers.MockJavaAction;
-import javaguide.testhelpers.MockJavaActionHelper;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
+import play.core.j.JavaHandlerComponents;
 import play.mvc.Result;
 import play.test.WithApplication;
 
 import java.io.*;
 import java.util.Optional;
 
+import static javaguide.testhelpers.MockJavaActionHelper.call;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static play.test.Helpers.*;
@@ -27,10 +28,15 @@ public class JavaStream extends WithApplication {
 
     @Test
     public void byDefault() {
-        assertThat(contentAsString(MockJavaActionHelper.call(new Controller1(), fakeRequest(), mat)), equalTo("Hello World"));
+        assertThat(contentAsString(call(new Controller1(instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat)), equalTo("Hello World"));
     }
 
     public static class Controller1 extends MockJavaAction {
+
+        Controller1(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         //#by-default
         public Result index() {
             return ok("Hello World");
@@ -45,13 +51,18 @@ public class JavaStream extends WithApplication {
         try (OutputStream os = new FileOutputStream(file)) {
             IOUtils.write("hi", os, "UTF-8");
         }
-        Result result = MockJavaActionHelper.call(new Controller2(), fakeRequest(), mat);
+        Result result = call(new Controller2(instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat);
         assertThat(contentAsString(result, mat), equalTo("hi"));
         assertThat(result.body().contentLength(), equalTo(Optional.of(2L)));
         file.delete();
     }
 
     public static class Controller2 extends MockJavaAction {
+
+        Controller2(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         //#serve-file
         public Result index() {
             return ok(new java.io.File("/tmp/fileToServe.pdf"));
@@ -61,7 +72,7 @@ public class JavaStream extends WithApplication {
 
     @Test
     public void inputStream() {
-        String content = contentAsString(MockJavaActionHelper.call(new Controller3(), fakeRequest(), mat), mat);
+        String content = contentAsString(call(new Controller3(instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat), mat);
         // Wait until results refactoring is merged, then this will work
         // assertThat(content, containsString("hello"));
     }
@@ -71,6 +82,11 @@ public class JavaStream extends WithApplication {
     }
 
     public static class Controller3 extends MockJavaAction {
+
+        Controller3(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         //#input-stream
         public Result index() {
             InputStream is = getDynamicStreamSomewhere();
@@ -81,11 +97,16 @@ public class JavaStream extends WithApplication {
 
     @Test
     public void chunked() {
-        String content = contentAsString(MockJavaActionHelper.call(new Controller4(), fakeRequest(), mat), mat);
+        String content = contentAsString(call(new Controller4(instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat), mat);
         assertThat(content, equalTo("kikifoobar"));
     }
 
     public static class Controller4 extends MockJavaAction {
+
+        Controller4(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         //#chunked
         public Result index() {
             // Prepare a chunked text stream

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaForms.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaForms.java
@@ -6,6 +6,7 @@ package javaguide.forms;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import play.Application;
+import play.core.j.JavaHandlerComponents;
 import play.data.DynamicForm;
 import play.data.Form;
 import play.data.FormFactory;
@@ -16,15 +17,12 @@ import play.mvc.*;
 import play.test.WithApplication;
 
 import javaguide.testhelpers.MockJavaAction;
-import javaguide.testhelpers.MockJavaActionHelper;
 import javaguide.forms.u1.User;
 
-import java.text.ParseException;
 import java.time.LocalTime;
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
+import static javaguide.testhelpers.MockJavaActionHelper.call;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static play.test.Helpers.*;
@@ -46,7 +44,7 @@ public class JavaForms extends WithApplication {
         //#create
 
         //#bind
-        Map<String,String> anyData = new HashMap();
+        Map<String,String> anyData = new HashMap<>();
         anyData.put("email", "bob@gmail.com");
         anyData.put("password", "secret");
 
@@ -59,12 +57,17 @@ public class JavaForms extends WithApplication {
 
     @Test
     public void bindFromRequest() {
-        Result result = MockJavaActionHelper.call(new Controller1(),
+        Result result = call(new Controller1(instanceOf(JavaHandlerComponents.class)),
                 fakeRequest("POST", "/").bodyForm(ImmutableMap.of("email", "e", "password", "p")), mat);
         assertThat(contentAsString(result), equalTo("e"));
     }
 
     public class Controller1 extends MockJavaAction {
+
+        Controller1(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         public Result index() {
             Form<User> userForm = formFactory().form(User.class);
             //#bind-from-request
@@ -83,7 +86,7 @@ public class JavaForms extends WithApplication {
 
     @Test
     public void adhocValidation() {
-        Result result = MockJavaActionHelper.call(new U3UserController(), fakeRequest("POST", "/")
+        Result result = call(new U3UserController(instanceOf(JavaHandlerComponents.class)), fakeRequest("POST", "/")
                 .bodyForm(ImmutableMap.of("email", "e", "password", "p")), mat);
 
         // Run it through the template
@@ -91,6 +94,10 @@ public class JavaForms extends WithApplication {
     }
 
     public class U3UserController extends MockJavaAction {
+
+        U3UserController(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
 
         public Result index() {
             Form<javaguide.forms.u3.User> userForm = formFactory().form(javaguide.forms.u3.User.class).bindFromRequest();
@@ -110,7 +117,7 @@ public class JavaForms extends WithApplication {
 
     @Test
     public void listValidation() {
-        Result result = MockJavaActionHelper.call(new ListValidationController(), fakeRequest("POST", "/")
+        Result result = call(new ListValidationController(instanceOf(JavaHandlerComponents.class)), fakeRequest("POST", "/")
                 .bodyForm(ImmutableMap.of("email", "e")), mat);
 
         // Run it through the template
@@ -147,6 +154,10 @@ public class JavaForms extends WithApplication {
 
     public class ListValidationController extends MockJavaAction {
 
+        ListValidationController(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         public Result index() {
             Form<UserForm> userForm = formFactory().form(UserForm.class).bindFromRequest();
 
@@ -161,7 +172,7 @@ public class JavaForms extends WithApplication {
 
     @Test
     public void handleErrors() {
-        Result result = MockJavaActionHelper.call(new Controller2(), fakeRequest("POST", "/")
+        Result result = call(new Controller2(instanceOf(JavaHandlerComponents.class)), fakeRequest("POST", "/")
             .bodyForm(ImmutableMap.of("email", "e")), mat);
         assertThat(contentAsString(result), startsWith("Got user"));
     }
@@ -178,6 +189,10 @@ public class JavaForms extends WithApplication {
             String render(Form<?> form) {
                 return "rendered";
             }
+        }
+
+        Controller2(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
         }
 
         public Result index() {
@@ -212,13 +227,18 @@ public class JavaForms extends WithApplication {
 
     @Test
     public void dynamicForm() {
-        Result result = MockJavaActionHelper.call(new Controller3(),
+        Result result = call(new Controller3(instanceOf(JavaHandlerComponents.class)),
                 fakeRequest("POST", "/").bodyForm(ImmutableMap.of("firstname", "a", "lastname", "b")), mat);
         assertThat(contentAsString(result), equalTo("Hello a b"));
     }
 
     public class Controller3 extends MockJavaAction {
         FormFactory formFactory = formFactory();
+
+        Controller3(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         //#dynamic
         public Result hello() {
             DynamicForm requestData = formFactory.form().bindFromRequest();

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActions.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActions.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.junit.Test;
+import play.core.j.JavaHandlerComponents;
 import play.mvc.Controller;
 import play.mvc.Result;
 
@@ -22,7 +23,7 @@ import static javaguide.testhelpers.MockJavaActionHelper.call;
 public class JavaActions extends WithApplication {
     @Test
     public void simpleAction() {
-        assertThat(call(new MockJavaAction() {
+        assertThat(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             //#simple-action
             public Result index() {
                 return ok("Got request " + request() + "!");
@@ -33,7 +34,7 @@ public class JavaActions extends WithApplication {
 
     @Test
     public void fullController() {
-        assertThat(call(new MockJavaAction() {
+        assertThat(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             public Result index() {
                 return new javaguide.http.full.Application().index();
             }
@@ -42,7 +43,7 @@ public class JavaActions extends WithApplication {
 
     @Test
     public void withParams() {
-        Result result = call(new MockJavaAction() {
+        Result result = call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             //#params-action
             public Result index(String name) {
                 return ok("Hello " + name);
@@ -59,7 +60,7 @@ public class JavaActions extends WithApplication {
 
     @Test
     public void simpleResult() {
-        assertThat(call(new MockJavaAction() {
+        assertThat(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             //#simple-result
             public Result index() {
                 return ok("Hello world!");
@@ -104,7 +105,7 @@ public class JavaActions extends WithApplication {
 
     @Test
     public void redirectAction() {
-        Result result = call(new MockJavaAction() {
+        Result result = call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             //#redirect-action
             public Result index() {
                 return redirect("/user/home");
@@ -117,7 +118,7 @@ public class JavaActions extends WithApplication {
 
     @Test
     public void temporaryRedirectAction() {
-        Result result = call(new MockJavaAction() {
+        Result result = call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             //#temporary-redirect-action
             public Result index() {
                 return temporaryRedirect("/user/home");

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaBodyParsers.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaBodyParsers.java
@@ -3,10 +3,9 @@
  */
 package javaguide.http;
 
-import akka.stream.Materializer;
 import akka.util.ByteString;
-import org.junit.Before;
 import org.junit.Test;
+import play.core.j.JavaHandlerComponents;
 import play.http.HttpErrorHandler;
 import play.libs.F;
 import play.libs.Json;
@@ -24,8 +23,6 @@ import play.mvc.Http.*;
 import java.util.concurrent.Executor;
 import java.util.concurrent.CompletionStage;
 
-import scala.compat.java8.FutureConverters;
-
 import java.util.*;
 
 import static javaguide.testhelpers.MockJavaActionHelper.*;
@@ -37,7 +34,7 @@ public class JavaBodyParsers extends WithApplication {
 
     @Test
     public void accessRequestBody() {
-        assertThat(contentAsString(call(new MockJavaAction() {
+        assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             //#access-json-body
             public Result index() {
                 JsonNode json = request().body().asJson();
@@ -49,7 +46,7 @@ public class JavaBodyParsers extends WithApplication {
 
     @Test
     public void particularBodyParser() {
-        assertThat(contentAsString(call(new MockJavaAction() {
+        assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     //#particular-body-parser
                     @BodyParser.Of(BodyParser.Text.class)
                     public Result index() {
@@ -109,7 +106,7 @@ public class JavaBodyParsers extends WithApplication {
 
     @Test
     public void composingBodyParser() {
-        assertThat(contentAsString(call(new MockJavaAction() {
+        assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                 //#composing-access
                 @BodyParser.Of(UserBodyParser.class)
                 public Result save() {
@@ -129,11 +126,16 @@ public class JavaBodyParsers extends WithApplication {
         for (int i = 0; i < 1100; i++) {
             body.append("1234567890");
         }
-        assertThat(callWithStringBody(new MaxLengthAction(), fakeRequest(), body.toString(), mat).status(),
+        assertThat(callWithStringBody(new MaxLengthAction(instanceOf(JavaHandlerComponents.class)), fakeRequest(), body.toString(), mat).status(),
                 equalTo(413));
     }
 
     public static class MaxLengthAction extends MockJavaAction {
+
+        MaxLengthAction(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         //#max-length
         // Accept only 10KB of data.
         public static class Text10Kb extends BodyParser.Text {
@@ -213,7 +215,7 @@ public class JavaBodyParsers extends WithApplication {
 
     @Test
     public void testCsv() {
-        assertThat(contentAsString(call(new MockJavaAction() {
+        assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                 @BodyParser.Of(CsvBodyParser.class)
                 public Result uploadCsv() {
                     String value = ((List<List<String>>) request().body().as(List.class)).get(1).get(2);

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaContentNegotiation.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaContentNegotiation.java
@@ -4,12 +4,13 @@
 package javaguide.http;
 
 import org.junit.Test;
+import play.core.j.JavaHandlerComponents;
 import play.libs.Json;
 import play.test.WithApplication;
 import javaguide.testhelpers.MockJavaAction;
 import play.mvc.*;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static javaguide.testhelpers.MockJavaActionHelper.*;
@@ -21,7 +22,7 @@ public class JavaContentNegotiation extends WithApplication {
 
     @Test
     public void negotiateContent() {
-        assertThat(contentAsString(call(new MockJavaAction() {
+        assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     //#negotiate-content
                     public Result list() {
                         List<Item> items = Item.find.all();
@@ -48,7 +49,7 @@ public class JavaContentNegotiation extends WithApplication {
 
     static class Find {
         List<Item> all() {
-            return Arrays.asList(new Item("foo"));
+            return Collections.singletonList(new Item("foo"));
         }
     }
 

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import javaguide.testhelpers.MockJavaAction;
 import org.junit.Test;
 import play.core.j.JavaContextComponents;
+import play.core.j.JavaHandlerComponents;
 import play.i18n.Langs;
 import play.i18n.MessagesApi;
 import play.libs.Json;
@@ -60,7 +61,7 @@ public class JavaResponse extends WithApplication {
 
     @Test
     public void responseHeaders() {
-        Map<String, String> headers = call(new MockJavaAction() {
+        Map<String, String> headers = call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             //#response-headers
             public Result index() {
                 response().setHeader(CACHE_CONTROL, "max-age=3600");
@@ -127,7 +128,7 @@ public class JavaResponse extends WithApplication {
 
     @Test
     public void charset() {
-        assertThat(call(new MockJavaAction() {
+        assertThat(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     //#charset
                     public Result index() {
                         return ok("<h1>Hello World!</h1>", "iso-8859-1").as("text/html; charset=iso-8859-1");

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaRouting.scala
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaRouting.scala
@@ -5,16 +5,17 @@ package javaguide.http
 
 import java.util.concurrent.CompletableFuture
 
-import play.api.Application
 import akka.stream.ActorMaterializer
 import org.specs2.mutable.Specification
 import play.api.mvc.{EssentialAction, RequestHeader}
 import play.api.routing.Router
 import javaguide.http.routing._
+
 import play.api.test.Helpers._
 import play.api.test.FakeRequest
 import javaguide.testhelpers.MockJavaAction
-import play.libs.F
+
+import play.core.j.JavaHandlerComponents
 
 class JavaRouting extends Specification {
 
@@ -61,7 +62,7 @@ class JavaRouting extends Specification {
     "support reverse routing" in {
       running() { app =>
         implicit val mat = ActorMaterializer()(app.actorSystem)
-        header("Location", call(new MockJavaAction {
+        header("Location", call(new MockJavaAction(app.injector.instanceOf[JavaHandlerComponents]) {
           override def invocation = CompletableFuture.completedFuture(new javaguide.http.routing.controllers.Application().index())
         }, FakeRequest())) must beSome("/hello/Bob")
       }
@@ -87,42 +88,38 @@ class JavaRouting extends Specification {
       })
     }
   }
-
 }
 
 package routing.query.controllers {
+  import play.api.mvc.{ AbstractController, ControllerComponents }
 
-import play.api.mvc.{Controller, Action}
-
-class Application extends Controller {
-  def show(page: String) = Action {
-    Ok("showing page " + page)
+  class Application @javax.inject.Inject() (components: ControllerComponents) extends AbstractController(components) {
+    def show(page: String) = Action {
+      Ok("showing page " + page)
+    }
   }
-}
 }
 
 package routing.fixed.controllers {
+  import play.api.mvc.{ AbstractController, ControllerComponents }
 
-import play.api.mvc.{Controller, Action}
-
-class Application extends Controller {
-  def show(page: String) = Action {
-    Ok("showing page " + page)
+  class Application @javax.inject.Inject() (components: ControllerComponents) extends AbstractController(components) {
+    def show(page: String) = Action {
+      Ok("showing page " + page)
+    }
   }
-}
 }
 
 package routing.defaultvalue.controllers {
+  import play.api.mvc.{ AbstractController, ControllerComponents }
 
-import play.api.mvc.{Controller, Action}
-
-class Clients extends Controller {
-  def list(page: Int) = Action {
-    Ok("clients page " + page)
+  class Clients @javax.inject.Inject() (components: ControllerComponents) extends AbstractController(components) {
+    def list(page: Int) = Action {
+      Ok("clients page " + page)
+    }
   }
-}
 }
 
 package routing.defaultcontroller.controllers {
-class Default extends _root_.controllers.Default
+  class Default extends _root_.controllers.Default
 }

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaSessionFlash.java
@@ -3,10 +3,8 @@
  */
 package javaguide.http;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.*;
-import play.Application;
-import play.libs.Json;
+import play.core.j.JavaHandlerComponents;
 import play.test.WithApplication;
 import javaguide.testhelpers.MockJavaAction;
 
@@ -24,7 +22,7 @@ public class JavaSessionFlash extends WithApplication {
 
     @Test
     public void readSession() {
-        assertThat(contentAsString(call(new MockJavaAction() {
+        assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     //#read-session
                     public Result index() {
                         String user = session("connected");
@@ -41,7 +39,7 @@ public class JavaSessionFlash extends WithApplication {
 
     @Test
     public void storeSession() {
-        Session session = call(new MockJavaAction() {
+        Session session = call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             //#store-session
             public Result login() {
                 session("connected", "user@gmail.com");
@@ -54,7 +52,7 @@ public class JavaSessionFlash extends WithApplication {
 
     @Test
     public void removeFromSession() {
-        Session session = call(new MockJavaAction() {
+        Session session = call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             //#remove-from-session
             public Result logout() {
                 session().remove("connected");
@@ -67,7 +65,7 @@ public class JavaSessionFlash extends WithApplication {
 
     @Test
     public void discardWholeSession() {
-        Session session = call(new MockJavaAction() {
+        Session session = call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             //#discard-whole-session
             public Result logout() {
                 session().clear();
@@ -80,7 +78,7 @@ public class JavaSessionFlash extends WithApplication {
 
     @Test
     public void readFlash() {
-        assertThat(contentAsString(call(new MockJavaAction() {
+        assertThat(contentAsString(call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     //#read-flash
                     public Result index() {
                         String message = flash("success");
@@ -96,7 +94,7 @@ public class JavaSessionFlash extends WithApplication {
 
     @Test
     public void storeFlash() {
-        Flash flash = call(new MockJavaAction() {
+        Flash flash = call(new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             //#store-flash
             public Result save() {
                 flash("success", "The item has been created");
@@ -109,7 +107,7 @@ public class JavaSessionFlash extends WithApplication {
 
     @Test
     public void accessFlashInTemplate() {
-        MockJavaAction index = new MockJavaAction() {
+        MockJavaAction index = new MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
             public Result index() {
                 return ok(javaguide.http.views.html.index.render());
             }

--- a/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/JavaI18N.java
+++ b/documentation/manual/working/javaGuide/main/i18n/code/javaguide/i18n/JavaI18N.java
@@ -4,7 +4,6 @@
 package javaguide.i18n;
 
 import org.junit.Test;
-import org.junit.Before;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
@@ -13,6 +12,7 @@ import javaguide.testhelpers.MockJavaActionHelper;
 import javaguide.i18n.html.hellotemplate;
 import javaguide.i18n.html.helloscalatemplate;
 import play.Application;
+import play.core.j.JavaHandlerComponents;
 import play.mvc.Http;
 import play.mvc.Result;
 import play.test.WithApplication;
@@ -58,11 +58,16 @@ public class JavaI18N extends WithApplication {
 
     @Test
     public void checkDefaultHello() {
-        Result result = MockJavaActionHelper.call(new DefaultLangController(), fakeRequest("GET", "/"), mat);
+        Result result = MockJavaActionHelper.call(new DefaultLangController(instanceOf(JavaHandlerComponents.class)), fakeRequest("GET", "/"), mat);
         assertThat(contentAsString(result), containsString("hello"));
     }
 
     public static class DefaultLangController extends MockJavaAction {
+
+        DefaultLangController(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         //#default-lang-render
         public Result index() {
             return ok(hellotemplate.render()); // "hello"
@@ -72,11 +77,16 @@ public class JavaI18N extends WithApplication {
 
     @Test
     public void checkDefaultScalaHello() {
-        Result result = MockJavaActionHelper.call(new DefaultScalaLangController(), fakeRequest("GET", "/"), mat);
+        Result result = MockJavaActionHelper.call(new DefaultScalaLangController(instanceOf(JavaHandlerComponents.class)), fakeRequest("GET", "/"), mat);
         assertThat(contentAsString(result), containsString("hello"));
     }
 
     public static class DefaultScalaLangController extends MockJavaAction {
+
+        DefaultScalaLangController(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         public Result index() {
             return ok(helloscalatemplate.render()); // "hello"
         }
@@ -84,7 +94,7 @@ public class JavaI18N extends WithApplication {
 
     @Test
     public void checkChangeLangHello() {
-        Result result = MockJavaActionHelper.call(new ChangeLangController(), fakeRequest("GET", "/"), mat);
+        Result result = MockJavaActionHelper.call(new ChangeLangController(instanceOf(JavaHandlerComponents.class)), fakeRequest("GET", "/"), mat);
         assertThat(contentAsString(result), containsString("bonjour"));
     }
 
@@ -96,6 +106,11 @@ public class JavaI18N extends WithApplication {
     }
 
     public static class ChangeLangController extends MockJavaAction {
+
+        ChangeLangController(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         //#change-lang-render
         public Result index() {
             ctx().changeLang("fr");
@@ -106,11 +121,9 @@ public class JavaI18N extends WithApplication {
 
     public static class ContextMessagesController extends MockJavaAction {
 
-        private final MessagesApi messagesApi;
-
         @javax.inject.Inject
-        public ContextMessagesController(MessagesApi messagesApi) {
-            this.messagesApi = messagesApi;
+        public ContextMessagesController(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
         }
 
         //#show-context-messages
@@ -124,11 +137,16 @@ public class JavaI18N extends WithApplication {
 
     @Test
     public void checkSetTransientLangHello() {
-        Result result = MockJavaActionHelper.call(new SetTransientLangController(), fakeRequest("GET", "/"), mat);
+        Result result = MockJavaActionHelper.call(new SetTransientLangController(instanceOf(JavaHandlerComponents.class)), fakeRequest("GET", "/"), mat);
         assertThat(contentAsString(result), containsString("howdy"));
     }
 
     public static class SetTransientLangController extends MockJavaAction {
+
+        SetTransientLangController(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         //#set-transient-lang-render
         public Result index() {
             ctx().setTransientLang("en-US");

--- a/documentation/manual/working/javaGuide/main/json/code/javaguide/json/JavaJsonActions.java
+++ b/documentation/manual/working/javaGuide/main/json/code/javaguide/json/JavaJsonActions.java
@@ -6,11 +6,10 @@ package javaguide.json;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
+import play.core.j.JavaHandlerComponents;
 import play.mvc.Result;
 import play.libs.Json;
 
@@ -21,7 +20,6 @@ import play.test.WithApplication;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.*;
-import static play.mvc.Results.ok;
 import static play.test.Helpers.*;
 import static javaguide.testhelpers.MockJavaActionHelper.call;
 
@@ -67,32 +65,37 @@ public class JavaJsonActions extends WithApplication {
     @Test
     public void requestAsAnyContentAction() {
         assertThat(contentAsString(
-            call(new JsonRequestAsJsonAction(), fakeRequest().bodyJson(Json.parse("{\"name\":\"Greg\"}")), mat)
+            call(new JsonRequestAsAnyContentAction(instanceOf(JavaHandlerComponents.class)), fakeRequest().bodyJson(Json.parse("{\"name\":\"Greg\"}")), mat)
         ), equalTo("Hello Greg"));
     }
 
     @Test
     public void requestAsJsonAction() {
         assertThat(contentAsString(
-            call(new JsonRequestAsJsonAction(), fakeRequest().bodyJson(Json.parse("{\"name\":\"Greg\"}")), mat)
+            call(new JsonRequestAsJsonAction(instanceOf(JavaHandlerComponents.class)), fakeRequest().bodyJson(Json.parse("{\"name\":\"Greg\"}")), mat)
         ), equalTo("Hello Greg"));
     }
 
     @Test
     public void responseAction() {
         assertThat(contentAsString(
-            call(new JsonResponseAction(), fakeRequest(), mat)
+            call(new JsonResponseAction(instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat)
         ), equalTo("{\"exampleField1\":\"foobar\",\"exampleField2\":\"Hello world!\"}"));
     }
 
     @Test
     public void responseDaoAction() {
         assertThat(contentAsString(
-            call(new JsonResponseDaoAction(), fakeRequest(), mat)
+            call(new JsonResponseDaoAction(instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat)
         ), equalTo("[{\"firstName\":\"Foo\",\"lastName\":\"Bar\",\"age\":30}]"));
     }
 
     static class JsonRequestAsAnyContentAction extends MockJavaAction {
+
+        JsonRequestAsAnyContentAction(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         //#json-request-as-anycontent
         public Result sayHello() {
             JsonNode json = request().body().asJson();
@@ -111,6 +114,11 @@ public class JavaJsonActions extends WithApplication {
     }
 
     static class JsonRequestAsJsonAction extends MockJavaAction {
+
+        JsonRequestAsJsonAction(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         //#json-request-as-json
         @BodyParser.Of(BodyParser.Json.class)
         public Result sayHello() {
@@ -126,6 +134,10 @@ public class JavaJsonActions extends WithApplication {
     }
 
     static class JsonResponseAction extends MockJavaAction {
+        JsonResponseAction(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         //#json-response
         public Result sayHello() {
             ObjectNode result = Json.newObject();
@@ -137,9 +149,13 @@ public class JavaJsonActions extends WithApplication {
     }
 
     static class JsonResponseDaoAction extends MockJavaAction {
+        JsonResponseDaoAction(JavaHandlerComponents javaHandlerComponents) {
+            super(javaHandlerComponents);
+        }
+
         static class PersonDao {
             public List<Person> findAll() {
-                List<Person> people = new ArrayList<Person>();
+                List<Person> people = new ArrayList<>();
 
                 Person person = new Person();
                 person.firstName = "Foo";

--- a/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
+++ b/documentation/manual/working/javaGuide/main/upload/code/JavaFileUpload.java
@@ -8,6 +8,7 @@ import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 import org.junit.Test;
+import play.core.j.JavaHandlerComponents;
 import play.core.parsers.Multipart;
 import play.libs.streams.Accumulator;
 import play.mvc.BodyParser;
@@ -124,7 +125,7 @@ public class JavaFileUpload extends WithApplication {
         play.libs.Files.TemporaryFileCreator tfc = play.libs.Files.singletonTemporaryFileCreator();
         Source source = FileIO.fromPath(Files.createTempFile("temp", "txt"));
         Http.MultipartFormData.FilePart dp = new Http.MultipartFormData.FilePart<Source>("name", "filename", "text/plain", source);
-        assertThat(contentAsString(call(new javaguide.testhelpers.MockJavaAction() {
+        assertThat(contentAsString(call(new javaguide.testhelpers.MockJavaAction(instanceOf(JavaHandlerComponents.class)) {
                     @BodyParser.Of(MultipartFormDataWithFileBodyParser.class)
                     public Result uploadCustomMultiPart() throws Exception {
                         final Http.MultipartFormData<File> formData = request().body().asMultipartFormData();

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -7,7 +7,9 @@ import javaguide.testhelpers.MockJavaAction;
 
 // #ws-imports
 import org.slf4j.Logger;
+import play.Application;
 import play.api.Configuration;
+import play.core.j.JavaHandlerComponents;
 import play.libs.ws.*;
 
 import java.util.Arrays;
@@ -21,15 +23,12 @@ import play.libs.Json;
 // #json-imports
 
 // #multipart-imports
-import play.libs.ws.ahc.*;
 import play.mvc.Http.MultipartFormData.*;
 // #multipart-imports
 
 import java.io.*;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.*;
 
 import org.w3c.dom.Document;
@@ -51,8 +50,15 @@ public class JavaWS {
 
     public static class Controller0 extends MockJavaAction {
 
-        private WSClient ws;
-        private Materializer materializer;
+        private final WSClient ws;
+        private final Materializer materializer;
+
+        @Inject
+        Controller0(JavaHandlerComponents javaHandlerComponents, WSClient ws, Materializer materializer) {
+            super(javaHandlerComponents);
+            this.ws = ws;
+            this.materializer = materializer;
+        }
 
         public void requestExamples() {
             // #ws-holder
@@ -298,8 +304,13 @@ public class JavaWS {
 
     public static class Controller1 extends MockJavaAction {
 
+        private final WSClient ws;
+
         @Inject
-        private WSClient ws;
+        public Controller1(JavaHandlerComponents javaHandlerComponents, WSClient client) {
+            super(javaHandlerComponents);
+            this.ws = client;
+        }
 
         // #ws-action
         public CompletionStage<Result> index() {
@@ -312,8 +323,13 @@ public class JavaWS {
 
     public static class Controller2 extends MockJavaAction {
 
+        private final WSClient ws;
+
         @Inject
-        private WSClient ws;
+        public Controller2(JavaHandlerComponents javaHandlerComponents, WSClient ws) {
+            super(javaHandlerComponents);
+            this.ws = ws;
+        }
 
         // #composed-call
         public CompletionStage<Result> index() {
@@ -326,14 +342,24 @@ public class JavaWS {
 
     public static class Controller3 extends MockJavaAction {
 
+        private final WSClient ws;
+        private Logger logger;
+
         @Inject
-        private WSClient ws;
+        public Controller3(JavaHandlerComponents javaHandlerComponents, WSClient ws) {
+            super(javaHandlerComponents);
+            this.ws = ws;
+            this.logger = org.slf4j.LoggerFactory.getLogger("testLogger");
+        }
+
+        public void setLogger(Logger logger) {
+            this.logger = logger;
+        }
 
         // #ws-request-filter
         public CompletionStage<Result> index() {
-            Logger logger = org.slf4j.LoggerFactory.getLogger("testLogger");
             WSRequestFilter filter = executor -> request -> {
-                logger.debug("url = {}", request.getUrl());
+                logger.debug("url = " + request.getUrl());
                 return executor.apply(request);
             };
 

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWSSpec.scala
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWSSpec.scala
@@ -5,22 +5,24 @@ package javaguide.ws
 
 import org.specs2.mutable._
 import play.api.test._
-
 import play.api.mvc._
 import play.api.libs.json._
-
 import play.test.Helpers._
-
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsObject
 import javaguide.testhelpers.MockJavaActionHelper
-import play.api.http.Status
+import javaguide.ws.JavaWS.Controller3
 
-object JavaWSSpec extends Specification with Results with Status {
+import org.slf4j.Logger
+import org.specs2.mock.Mockito
+import play.api.http.Status
+import play.api.{Application => PlayApplication}
+
+object JavaWSSpec extends Specification with Results with Status with Mockito {
   // It's much easier to test this in Scala because we need to set up a
   // fake application with routes.
 
-  def fakeApplication = GuiceApplicationBuilder().routes {
+  def fakeApplication: PlayApplication = GuiceApplicationBuilder().routes {
     case ("GET", "/feed") =>
       Action {
         val obj: JsObject = Json.obj(
@@ -54,6 +56,17 @@ object JavaWSSpec extends Specification with Results with Status {
 
       result.status() must equalTo(OK)
       contentAsString(result) must beEqualTo("Number of comments: 10")
+    }
+
+    "call WS with a filter" in new WithServer(app = fakeApplication, port = 3333) {
+      val controller = app.injector.instanceOf[Controller3]
+      val logger = mock[Logger]
+      controller.setLogger(logger)
+
+      val result = MockJavaActionHelper.call(controller, fakeRequest())
+
+      result.status() must equalTo(OK)
+      there was one(logger).debug("url = http://localhost:3333/feed")
     }
   }
 

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
@@ -50,9 +50,9 @@ class ScalaWebSockets extends PlaySpecification {
       }
 
       "allow cleaning up" in new WithApplication() {
-        val closed = Promise[Unit]()
+        val closed = Promise[Boolean]()
         val someResource = new Closeable() {
-          def close() = closed.success(())
+          def close() = closed.success(true)
         }
         class MyActor extends Actor {
           def receive = PartialFunction.empty
@@ -69,7 +69,7 @@ class ScalaWebSockets extends PlaySpecification {
         runWebSocket(
           WebSocket.accept[String, String](req => ActorFlow.actorRef(out => Props(new MyActor))), Source.empty, 0
         ) must beRight[List[Message]]
-        await(closed.future) must_== ()
+        await(closed.future) must_== true
       }
 
       "allow closing the WebSocket" in new WithApplication() {

--- a/documentation/project/plugins.sbt
+++ b/documentation/project/plugins.sbt
@@ -11,4 +11,4 @@ lazy val playDocsPlugin = ProjectRef(Path.fileProperty("user.dir").getParentFile
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
 
 // Required for PlayEnhancer.md
-addSbtPlugin("com.typesafe.sbt" % "sbt-play-enhancer" % "1.1.0-RC2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-play-enhancer" % "1.1.0")

--- a/framework/src/play-test/src/main/java/play/test/WithApplication.java
+++ b/framework/src/play-test/src/main/java/play/test/WithApplication.java
@@ -38,8 +38,21 @@ public class WithApplication {
      * @param <T> the type to return, using `app.injector.instanceOf`
      * @return an instance of type T.
      */
-    <T> T inject(Class<T> clazz) {
+    protected <T> T instanceOf(Class<T> clazz) {
         return app.injector().instanceOf(clazz);
+    }
+
+    /**
+     * Provides an instance from the application.
+     *
+     * @param clazz the type's class.
+     * @param <T> the type to return, using `app.injector.instanceOf`
+     * @return an instance of type T.
+     *
+     * @deprecated As of 2.6.0. Use {@link #instanceOf(Class)}.
+     */
+    <T> T inject(Class<T> clazz) {
+        return instanceOf(clazz);
     }
 
     @Before


### PR DESCRIPTION
## Purpose

Refactoring docs code to avoid some usages of deprecated APIs. Also add some missing tests.

## Background Context

We have deprecated a lot of APIs but they are still being used by some documentation code. I don't want to remove them all at once to avoid big pull requests (which are harder to review). Some of the changes are just mechanical and some could add new methods to production code (like https://github.com/playframework/playframework/pull/6916/commits/5f36597c5abe761e9159da854a7ba298fca320b3 at this PR).