### PR TITLE
[doc] Move the unreliable network section

### DIFF
--- a/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaWS.md
@@ -23,8 +23,6 @@ Now any component that wants to use WS will have to declare a dependency on the 
 
 @[dependency](code/ScalaWSSpec.scala)
 
-> If you are calling out to an [unreliable network](https://queue.acm.org/detail.cfm?id=2655736) or doing any blocking work, including any kind of DNS work such as calling [`java.util.URL.equals()`](https://docs.oracle.com/javase/8/docs/api/java/net/URL.html#equals-java.lang.Object-), then you should use a custom execution context as described in [[ThreadPools]].  You should size the pool to leave a safety margin large enough to account for timeouts, and consider using `play.api.libs.concurrent.Timeout` and a [Failsafe Circuit Breaker](https://github.com/jhalterman/failsafe#circuit-breakers).
-
 We've called the `WSClient` instance `ws`, all the following examples will assume this name.
 
 To build an HTTP request, you start with `ws.url()` to specify the URL.
@@ -213,6 +211,10 @@ When making a request from a controller, you can map the response to a `Future[R
 ### Using WSClient with Future Timeout
 
 If a chain of WS calls does not complete in time, it may be useful to wrap the result in a timeout block, which will return a failed Future if the chain does not complete in time.  The best way to do this is with Play's [[non-blocking Timeout feature|ScalaAsync]], using [`play.api.libs.concurrent.Timeout`](api/scala/play/api/libs/concurrent/Timeout.html).
+
+### Using WSClient with unreliable networks
+
+If you are calling out to an [unreliable network](https://queue.acm.org/detail.cfm?id=2655736) or doing any blocking work, including any kind of DNS work such as calling [`java.util.URL.equals()`](https://docs.oracle.com/javase/8/docs/api/java/net/URL.html#equals-java.lang.Object-), then you should use a custom execution context as described in [[ThreadPools]], preferably through [`play.api.libs.concurrent.CustomExecutionContext`](api/scala/play/api/libs/concurrent/CustomExecutionContext.html).  You should size the pool to leave a safety margin large enough to account for timeouts, and consider using [`play.api.libs.concurrent.Timeout`](api/scala/play/api/libs/concurrent/Timeout.html) and a [Failsafe Circuit Breaker](https://github.com/jhalterman/failsafe#circuit-breakers).
 
 ## Directly creating WSClient
 


### PR DESCRIPTION
## Purpose

Moves the note about unreliable networks in WS documentation down to patterns and adds `CustomExecutionContext` as a class.

## Background Context

The note is situated too high, where it can be skipped over as an introduction, rather than as a general pattern.

This needs an example and also needs a Java section that is equivalent.