### PR TITLE
Upgrade sbt-native-packager to latest stable version

### DIFF
--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -5,7 +5,7 @@ buildInfoSettings
 sourceGenerators in Compile += Def.task(buildInfo.value).taskValue
 
 val Versions = new {
-  val sbtNativePackager = "1.1.1"
+  val sbtNativePackager = "1.1.5"
   val mima = "0.1.12"
   val sbtScalariform = "1.6.0"
   val sbtJmh = "0.2.20"


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Could not tag a docker image as the latest using `docker:publish`/`docker:publishLocal` due to old `sbt-native-packager` version.

## Purpose

Updates `sbt-native-packager` to the latest stable version. 

## Background Context

I tried to use `dockerUpdateLatest in Docker := true`, but it was broken in the `sbt-native-packager` used in Play 2.5.12

## References

https://github.com/sbt/sbt-native-packager/releases/tag/v1.1.5
https://github.com/sbt/sbt-native-packager/releases/tag/v1.1.3
sbt/sbt-native-packager#845
sbt/sbt-native-packager#818
sbt/sbt-native-packager#838

## Other

I want this in the next 2.5.x release too, is that possible? How would I go about doing that (open a PR against the `2.5.x` branch?)?