### PR TITLE
Upgrade sbt-native-packager to latest stable version (2.5.x)

### DIFF
--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -4,7 +4,7 @@ buildInfoSettings
 
 sourceGenerators in Compile <+= buildInfo
 
-val sbtNativePackagerVersion = "1.0.3"
+val sbtNativePackagerVersion = "1.1.5"
 val sbtTwirlVersion = sys.props.getOrElse("twirl.version", "1.1.1")
 
 buildInfoKeys := Seq[BuildInfoKey](


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Could not tag a docker image as the latest using `docker:publish`/`docker:publishLocal` due to old `sbt-native-packager` version. This a backport of #6924 on master.

## Purpose

Updates `sbt-native-packager` to the latest stable version. 

## Background Context

I tried to use `dockerUpdateLatest in Docker := true`, but it was broken in the `sbt-native-packager` used in Play 2.5.12

## References

#6924
https://github.com/sbt/sbt-native-packager/releases/tag/v1.1.5
https://github.com/sbt/sbt-native-packager/releases/tag/v1.1.3
sbt/sbt-native-packager#845
sbt/sbt-native-packager#818
sbt/sbt-native-packager#838