### PR TITLE
Remove sourceclear from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,3 @@ notifications:
     on_failure: always
   slack:
     secure: LIYWP1YF6DEXh4gBQ0DlaQP+kenerp7Q1AC3y/+egJYUu1g2TWmBlkcpXOcdHzrgTIUX/LYnSlhowIpsW7/YwcyLn3rOJI6SJM00DrDPRm6X1586P9DcR4XiX7MChewzbnmebx6KISt6bFtfvcd67J2cinmShwXQh2AmwvuT3Tc=
-addons:
-  srcclr: true


### PR DESCRIPTION
## Purpose

Removes sourceclear from the build because it errors and doesn't work with sbt in any case :-/
