### PR TITLE
Add immutable header to aggressiveCacheControl

### DIFF
--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -821,7 +821,7 @@ play {
 
     defaultCache = "public, max-age=3600"
 
-    aggressiveCache = "public, max-age=31536000"
+    aggressiveCache = "public, max-age=31536000, immutable"
 
     digest.algorithm = "md5"
 

--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -107,7 +107,7 @@ package controllers {
     enableCacheControl: Boolean = false,
     configuredCacheControl: Map[String, Option[String]] = Map.empty,
     defaultCacheControl: String = "public, max-age=3600",
-    aggressiveCacheControl: String = "public, max-age=31536000",
+    aggressiveCacheControl: String = "public, max-age=31536000, immutable",
     digestAlgorithm: String = "md5",
     checkForMinified: Boolean = true,
     textContentTypes: Set[String] = Set("application/json", "application/javascript"))


### PR DESCRIPTION
## Purpose

Per [Mozilla](https://hacks.mozilla.org/2017/01/using-immutable-caching-to-speed-up-the-web/) and [Patrick McManus](https://bitsup.blogspot.com/2016/05/cache-control-immutable.html) we can add the "immutable" property to versioned, fingerprinted assets in Prod mode to make sure that Firefox and Chrome speed up reloads of assets.

## References

[Chromium Issue](https://bugs.chromium.org/p/chromium/issues/detail?id=611416)
[Mozilla Issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1267474)