### PR TITLE
Retry the websocket spec

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
@@ -26,11 +26,12 @@ trait ServerIntegrationSpecification extends PendingUntilFixed with AroundEach {
   parent =>
   implicit def integrationServerProvider: ServerProvider
 
-  /**
-   * Retry up to 3 times.
-   */
+  def aroundEventually[R: AsResult](r: => R) = {
+    EventuallyResults.eventually[R](1, 20.milliseconds)(r)
+  }
+
   def around[R: AsResult](r: => R) = {
-    AsResult(EventuallyResults.eventually(1, 20.milliseconds)(r))
+    AsResult(aroundEventually(r))
   }
 
   implicit class UntilAkkaHttpFixed[T: AsResult](t: => T) {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -9,7 +9,9 @@ import java.util.concurrent.atomic.AtomicReference
 import akka.actor.{ Actor, Props, Status }
 import akka.stream.scaladsl._
 import akka.util.ByteString
+import org.specs2.execute.{ AsResult, EventuallyResults }
 import org.specs2.matcher.Matcher
+import org.specs2.specification.AroundEach
 import play.api.Application
 import play.api.http.websocket._
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -78,6 +80,14 @@ trait WebSocketSpec extends PlaySpecification
     with ServerIntegrationSpecification
     with WebSocketSpecMethods
     with PingWebSocketSpec {
+
+  /*
+   * This is the flakiest part of the test suite -- the CI server will timeout websockets
+   * and fail tests seemingly at random.
+   */
+  override def aroundEventually[R: AsResult](r: => R) = {
+    EventuallyResults.eventually[R](5, 100.milliseconds)(r)
+  }
 
   sequential
 
@@ -190,7 +200,7 @@ trait WebSocketSpec extends PlaySpecification
             closeFrame(1003)
           ))
         }
-      }.skipUntilNettyHttpFixed
+      }
 
     }
 


### PR DESCRIPTION
The websocket integration test is flaky, and will sometimes fail.  

Add some code to retry only websocket specs up to 5 times, with 100 msec delay.