### PR TITLE
Add Scalate as a library for Play support

### DIFF
--- a/documentation/manual/ModuleDirectory.md
+++ b/documentation/manual/ModuleDirectory.md
@@ -178,6 +178,11 @@ To create your own public module or to migrate from a `play.api.Plugin`, please 
 * **Documentation:** <https://github.com/loicdescotte/Play2-HTML5Tags/blob/master/README.md>
 * **Short description:** These tags add client side validation capabilities, based on model constraints (e.g required, email pattern, max|min length...) and specific input fields (date, telephone number, url...) to Play templates
 
+### Scalate
+* **Website:** <https://github.com/scalate/play-scalate>
+* **Documentation:** <https://scalate.github.io/scalate/documentation/index.html>
+* **Short description:** Alternatives to Twirl HTML template support for Jade (like Haml), Mustache, Scaml (also like Haml), SSP (like Velocity), and Scuery (CSS3 selector language)
+
 ### PDF module (Java)
 
 * **Website:** <https://github.com/innoveit/play2-pdf>


### PR DESCRIPTION
## Purpose

Adds Scalate as a library module to the module directory.  This gives HAML and Velocity type support as an alternative to Twirl.