### PR TITLE
Update to Play-WS m3, add caching option

### DIFF
--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -276,7 +276,8 @@ public class JavaWS {
                     play.libs.ws.ahc.AhcWSClientConfigFactory.forConfig(
                             configuration.underlying(),
                             environment.classLoader()),
-                    materializer);
+                            null, // no HTTP caching
+                            materializer);
             // #ws-client
 
             org.slf4j.Logger logger = play.Logger.underlying();

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -250,7 +250,7 @@ object Dependencies {
       logback % Test
     ) ++ specsBuild.map(_ % Test)
 
-  val playWsStandaloneVersion = "1.0.0-M2"
+  val playWsStandaloneVersion = "1.0.0-M3"
   val playWsDeps = Seq(
     "com.typesafe.play" %% "play-ws-standalone" % playWsStandaloneVersion,
     logback % Test

--- a/framework/src/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSClient.java
+++ b/framework/src/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSClient.java
@@ -6,6 +6,8 @@ package play.libs.ws.ahc;
 
 import akka.stream.Materializer;
 import play.api.libs.ws.ahc.AhcWSClientConfig;
+import play.api.libs.ws.ahc.cache.EffectiveURIKey;
+import play.api.libs.ws.ahc.cache.ResponseEntry;
 import play.libs.ws.WSClient;
 import play.libs.ws.WSRequest;
 
@@ -14,7 +16,7 @@ import java.io.IOException;
 
 /**
  * A WS client backed by AsyncHttpClient implementation.
- *
+ * <p>
  * See https://www.playframework.com/documentation/latest/JavaWS for documentation.
  */
 public class AhcWSClient implements WSClient {
@@ -29,16 +31,19 @@ public class AhcWSClient implements WSClient {
     /**
      * Creates WS client manually from configuration, internally creating a new
      * instance of AsyncHttpClient and managing its own thread pool.
-     *
+     * <p>
      * This client is not managed as part of Play's lifecycle, and <b>must</b>
      * be closed by calling ws.close(), otherwise you will run into memory leaks.
      *
-     * @param config a config object, usually from AhcWSClientConfigFactory
+     * @param config       a config object, usually from AhcWSClientConfigFactory
+     * @param cache        if not null, provides HTTP caching.
      * @param materializer an Akka materializer
      * @return a new instance of AhcWSClient.
      */
-    public static AhcWSClient create(AhcWSClientConfig config, Materializer materializer) {
-        final StandaloneAhcWSClient client = StandaloneAhcWSClient.create(config, materializer);
+    public static AhcWSClient create(AhcWSClientConfig config,
+                                     javax.cache.Cache<EffectiveURIKey, ResponseEntry> cache,
+                                     Materializer materializer) {
+        final StandaloneAhcWSClient client = StandaloneAhcWSClient.create(config, cache, materializer);
         return new AhcWSClient(client);
     }
 

--- a/framework/src/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSClient.scala
+++ b/framework/src/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSClient.scala
@@ -1,6 +1,9 @@
 package play.api.libs.ws.ahc
 
+import javax.cache.Cache
+
 import akka.stream.Materializer
+import play.api.libs.ws.ahc.cache.{ EffectiveURIKey, ResponseEntry }
 import play.api.libs.ws.{ WSClient, WSRequest }
 
 /**
@@ -53,9 +56,12 @@ object AhcWSClient {
    *   }
    * }}}
    *
-   * @param config configuration settings
+   * @param config configuration settings, AhcWSClientConfig() by default
+   * @param cache enables HTTP cache-control, None by default
    */
-  def apply(config: AhcWSClientConfig = AhcWSClientConfig())(implicit materializer: Materializer): AhcWSClient = {
-    new AhcWSClient(StandaloneAhcWSClient(config))
+  def apply(
+    config: AhcWSClientConfig = AhcWSClientConfig(),
+    cache: Option[Cache[EffectiveURIKey, ResponseEntry]] = None)(implicit materializer: Materializer): AhcWSClient = {
+    new AhcWSClient(StandaloneAhcWSClient(config, cache))
   }
 }

--- a/framework/src/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSClientProvider.scala
+++ b/framework/src/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSClientProvider.scala
@@ -5,10 +5,10 @@ import javax.inject.{ Inject, Provider, Singleton }
 import akka.stream.Materializer
 import com.typesafe.sslconfig.ssl.SystemConfiguration
 import com.typesafe.sslconfig.ssl.debug.DebugConfiguration
-import play.shaded.ahc.org.asynchttpclient.{ AsyncHttpClient, DefaultAsyncHttpClient }
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.ws.{ WSClient, WSClientConfig, WSConfigParser }
 import play.api.{ Configuration, Environment }
+import play.shaded.ahc.org.asynchttpclient.{ AsyncHttpClient, DefaultAsyncHttpClient }
 
 import scala.concurrent.Future
 
@@ -60,5 +60,7 @@ class AsyncHttpClientProvider @Inject() (
 class WSClientProvider @Inject() (asyncHttpClient: AsyncHttpClient)(implicit materializer: Materializer)
     extends Provider[WSClient] {
 
-  lazy val get: WSClient = new AhcWSClient(new StandaloneAhcWSClient(asyncHttpClient))
+  lazy val get: WSClient = {
+    new AhcWSClient(new StandaloneAhcWSClient(asyncHttpClient))
+  }
 }


### PR DESCRIPTION
* Updates Play-WS dependency to M3 (which does not contain unshaded deps)
* Add option to create WSClient with HTTP caching (disabled by default)