### PR TITLE
use jdk bundled xerces for 2.5 branch

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 import javax.xml.parsers.SAXParserFactory
-import org.apache.xerces.impl.Constants
+import play.libs.XML.Constants
 import javax.xml.XMLConstants
 
 /** Application mode, either `DEV`, `TEST`, or `PROD`. */
@@ -41,8 +41,7 @@ object Play {
    * no explicit doco stating this is the case. That said, there does not appear to be any other way than
    * declaring a factory in order to yield a parser of a specific type.
    */
-  private[play] val xercesSaxParserFactory =
-    SAXParserFactory.newInstance("org.apache.xerces.jaxp.SAXParserFactoryImpl", Play.getClass.getClassLoader)
+  private[play] val xercesSaxParserFactory = SAXParserFactory.newInstance()
   xercesSaxParserFactory.setFeature(Constants.SAX_FEATURE_PREFIX + Constants.EXTERNAL_GENERAL_ENTITIES_FEATURE, false)
   xercesSaxParserFactory.setFeature(Constants.SAX_FEATURE_PREFIX + Constants.EXTERNAL_PARAMETER_ENTITIES_FEATURE, false)
   xercesSaxParserFactory.setFeature(Constants.XERCES_FEATURE_PREFIX + Constants.DISALLOW_DOCTYPE_DECL_FEATURE, true)


### PR DESCRIPTION
Fixes #6939 

## Purpose

This pr backport #6342  to `2.5.x` branch and will fix #6939 

And avoid `ClassLoader.loadClass` locking  block each other

### apache xreces have lock while creating SAXParser

xerces
```java
public SAXParser(SymbolTable symbolTable, XMLGrammarPool grammarPool) {
    super((XMLParserConfiguration)ObjectFactory.createObject(
                "org.apache.xerces.xni.parser.XMLParserConfiguration",
               "org.apache.xerces.parsers.XIncludeAwareParserConfiguration"
       ));
```


In Java 8 
```java
public SAXParser(SymbolTable symbolTable, XMLGrammarPool grammarPool) {
        super(new XIncludeAwareParserConfiguration());
```

### Jdk bundled DocumentBuilderFactoryImpl.newDocumentBuilder also have lock

see [here](https://plumbr.eu/blog/locked-threads/classloading-and-locking)


