### PR TITLE
[2.5.x] Update Typesafe Config to 1.3.1

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -220,7 +220,7 @@ object Dependencies {
     sbtPluginDep(sbtVersion, scalaVersion, "org.scala-sbt" % "sbt-core-next" % sbtCoreNextVersion)
   )
 
-  val typesafeConfig = "com.typesafe" % "config" % "1.3.0"
+  val typesafeConfig = "com.typesafe" % "config" % "1.3.1"
 
   def sbtDependencies(sbtVersion: String, scalaVersion: String) = {
     def sbtDep(moduleId: ModuleID) = sbtPluginDep(sbtVersion, scalaVersion, moduleId)


### PR DESCRIPTION
This includes new features like the `include required("foo")` syntax. Should be compatible with 1.3.0.