### PR TITLE
Add trait to keep Action idiom while creating routers

### DIFF
--- a/documentation/manual/working/scalaGuide/advanced/routing/code/SirdAppLoader.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/SirdAppLoader.scala
@@ -4,7 +4,6 @@
 import play.api.ApplicationLoader.Context
 import play.api._
 import play.api.mvc.Results._
-import play.api.mvc._
 import play.api.routing.Router
 import play.api.routing.sird._
 

--- a/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
@@ -67,9 +67,8 @@ import client._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import org.specs2.mutable.Specification
-import org.specs2.time.NoTimeConversions
 import play.api.routing.Router
-import play.api.{BuiltInComponents, BuiltInComponentsFromContext}
+import play.api.BuiltInComponentsFromContext
 import play.api.routing.sird._
 import play.filters.HttpFiltersComponents
 
@@ -105,8 +104,7 @@ class ScalaTestingWebServiceClients extends Specification {
       Server.withApplicationFromContext() { context =>
         new BuiltInComponentsFromContext(context) with HttpFiltersComponents {
           override def router: Router = Router.from {
-            case GET(p"/repositories") =>
-              this.defaultActionBuilder { req =>
+            case GET(p"/repositories") => Action { req =>
                 Results.Ok.sendResource("github/repositories.json")(fileMimeTypes)
               }
           }
@@ -128,10 +126,9 @@ class ScalaTestingWebServiceClients extends Specification {
 
       def withGitHubClient[T](block: GitHubClient => T): T = {
         Server.withApplicationFromContext() { context =>
-          new BuiltInComponentsFromContext(context) with HttpFiltersComponents{
+          new BuiltInComponentsFromContext(context) with HttpFiltersComponents {
             override def router: Router = Router.from {
-              case GET(p"/repositories") =>
-                this.defaultActionBuilder { req =>
+              case GET(p"/repositories") => Action { req =>
                   Results.Ok.sendResource("github/repositories.json")(fileMimeTypes)
                 }
             }

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -235,11 +235,11 @@ class DefaultApplication @Inject() (
     override val actorSystem: ActorSystem,
     override val materializer: Materializer) extends Application {
 
-  def path = environment.rootPath
+  override def path: File = environment.rootPath
 
-  def classloader = environment.classLoader
+  override def classloader: ClassLoader = environment.classLoader
 
-  def stop() = applicationLifecycle.stop()
+  override def stop(): Future[_] = applicationLifecycle.stop()
 }
 
 /**
@@ -316,6 +316,42 @@ trait BuiltInComponents extends I18nComponents {
   lazy val fileMimeTypes: FileMimeTypes = new DefaultFileMimeTypesProvider(httpConfiguration.fileMimeTypes).get
 
   lazy val javaContextComponents = JavaHelpers.createContextComponents(messagesApi, langs, fileMimeTypes, httpConfiguration)
+
+  /**
+   * This can be used to create Action for [[play.api.routing.Router]]s:
+   *
+   * {{{
+   * class MyComponents(context: Context) extends BuiltInComponentsFromContext(context) {
+   *    lazy val router = Router.from {
+   *      case GET(p"/hello/$to") => Action {
+   *        Ok(s"Hello $to")
+   *      }
+   *    }
+   * }
+   * }}}
+   *
+   * @return the action builder.
+   * @see [[ActionBuilder]]
+   */
+  def Action: ActionBuilder[Request, AnyContent] = defaultActionBuilder
+
+  /**
+   * Parsers that can be combined with Action builder to create [[play.api.mvc.Action]]s:
+   *
+   * {{{
+   * class MyComponents(context: Context) extends BuiltInComponentsFromContext(context) {
+   *    lazy val router = Router.from {
+   *      case GET(p"/hello/$to") => Action(parse.json) { request =>
+   *        Ok(request.body)
+   *      }
+   *    }
+   * }
+   * }}}
+   *
+   * @return the body parsers
+   * @see [[PlayBodyParsers]]
+   */
+  def parse: PlayBodyParsers = playBodyParsers
 }
 
 /**


### PR DESCRIPTION
This will enable users to avoid deprecated `Action` and use `ActionBuilder` while keeping the same idiom.