### PR TITLE
Experimental/WIP: field injection of components in controllers

### DIFF
--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -11,12 +11,11 @@ import akka.stream.ActorMaterializer
 import play.api.http._
 import play.api.test._
 import play.api.test.Helpers._
-import play.api.mvc.BodyParsers
 import org.specs2.mutable.Specification
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import play.api.Logger
-import play.api.mvc.Controller
+import play.api.mvc.Results._
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
@@ -29,7 +28,7 @@ object User {
 }
 
 @RunWith(classOf[JUnitRunner])
-class ScalaActionsCompositionSpec extends Specification with Controller {
+class ScalaActionsCompositionSpec extends Specification {
 
   "an action composition" should {
 
@@ -92,7 +91,7 @@ class ScalaActionsCompositionSpec extends Specification with Controller {
         override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
           block(request)
         }
-        override def composeAction[A](action: Action[A]) = new Logging(action)
+        override def composeAction[A](action: Action[A]) = Logging(action)
       }
       //#actions-wrapping-builder
 

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
@@ -7,6 +7,7 @@ import akka.stream.ActorMaterializer
 import play.api.http.Writeable
 import play.api.libs.json.{Json, JsValue}
 import play.api.mvc._
+import play.api.mvc.Results._
 import play.api.test._
 import play.api.test.Helpers._
 import org.specs2.mutable.Specification
@@ -17,7 +18,7 @@ import java.io.File
 import org.specs2.execute.AsResult
 
   @RunWith(classOf[JUnitRunner])
-  class ScalaBodyParsersSpec extends Specification with Controller {
+class ScalaBodyParsersSpec extends Specification {
 
     def helloRequest = FakeRequest("POST", "/").withJsonBody(Json.obj("name" -> "foo"))
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/ContentNegotiationSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/ContentNegotiationSpec.scala
@@ -6,15 +6,16 @@ package play.it.action
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import play.api.mvc._
+import play.api.mvc.Results._
 import play.api.test.{ FakeRequest, PlaySpecification }
 
 import scala.concurrent.Future
 
-class ContentNegotiationSpec extends PlaySpecification with BaseController {
+class ContentNegotiationSpec extends PlaySpecification with Controller {
 
   implicit val system = ActorSystem()
   implicit val mat = ActorMaterializer()
-  val Action = ActionBuilder.ignoringBody
+  override val Action = ActionBuilder.ignoringBody
 
   "rendering" should {
     "work with simple results" in {

--- a/framework/src/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/framework/src/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -19,7 +19,7 @@ import scala.language.reflectiveCalls
 class HelpersSpec extends Specification {
 
   val ctrl = new Controller {
-    private val Action = ActionBuilder.ignoringBody
+    override val Action = ActionBuilder.ignoringBody
     def abcAction: EssentialAction = Action {
       Ok("abc").as("text/plain")
     }

--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -431,12 +431,12 @@ package controllers {
   @Singleton
   class Assets @Inject() (errorHandler: HttpErrorHandler, meta: AssetsMetadata) extends AssetsBuilder(errorHandler, meta)
 
-  class AssetsBuilder(errorHandler: HttpErrorHandler, meta: AssetsMetadata) extends BaseController {
+  class AssetsBuilder(errorHandler: HttpErrorHandler, meta: AssetsMetadata) extends Controller {
 
     import meta._
     import Assets._
 
-    private val Action = new ActionBuilder.IgnoringBody()(Execution.trampoline)
+    override val Action = new ActionBuilder.IgnoringBody()(Execution.trampoline)
 
     private def maybeNotModified(request: RequestHeader, assetInfo: AssetInfo, aggressiveCaching: Boolean): Option[Result] = {
       // First check etag. Important, if there is an If-None-Match header, we MUST not check the

--- a/framework/src/play/src/main/scala/play/api/controllers/Default.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Default.scala
@@ -23,7 +23,7 @@ object Default extends Default
  */
 class Default @Inject() () extends Controller {
 
-  private val Action = new ActionBuilder.IgnoringBody()(controllers.Execution.trampoline)
+  override val Action = new ActionBuilder.IgnoringBody()(controllers.Execution.trampoline)
 
   /**
    * Returns a 501 NotImplemented response.

--- a/framework/src/play/src/main/scala/play/api/controllers/ExternalAssets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/ExternalAssets.scala
@@ -33,7 +33,7 @@ class ExternalAssets @Inject() (environment: Environment)(implicit ec: Execution
 
   val AbsolutePath = """^(/|[a-zA-Z]:\\).*""".r
 
-  private val Action = new ActionBuilder.IgnoringBody()(_root_.controllers.Execution.trampoline)
+  override val Action = new ActionBuilder.IgnoringBody()(_root_.controllers.Execution.trampoline)
 
   /**
    * Generates an `Action` that serves a static resource from an external folder


### PR DESCRIPTION
I'm marking this as experimental because this is to be discussed before evolving or even discarding later.

Basically, while removing deprecated code from our docs, most of them were related to remove usage of the Action object. It is being used by most of the controllers and the actual solution is to migrate away from play.api.mvc.Controller and use play.api.mvc.AbstractController, which is more verbose. That means that user code, in order to avoid deprecation warnings, have to be rewritten from:

    class MyController extends Controller

to:

    class MyController(components: ControllerComponents) extends AbstractController(components)

This PR uses Guice field injection to maintain the former syntax while partially avoiding global state. The drawbacks here are:

1. Mixing constructor and field injection, which could be unclear
2. Test code that manually instantiate controllers will need to call setControllerComponents to avoid the warning message.
3. Compile Time DI code needs to call setControllerComponents.