### PR TITLE
Add a Java API for response headers

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/ResponseHeader.java
+++ b/framework/src/play/src/main/java/play/mvc/ResponseHeader.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.mvc;
+
+import scala.compat.java8.OptionConverters;
+
+import java.util.*;
+
+/**
+ * A simple HTTP response header, used for standard responses.
+ *
+ * @see play.mvc.Result
+ * @see play.api.mvc.ResponseHeader
+ */
+public class ResponseHeader {
+
+    private final int status;
+    private final String reasonPhrase;
+    private final Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+    public ResponseHeader(int status, Map<String, String> headers) {
+        this(status, headers, null);
+    }
+
+    public ResponseHeader(int status, Map<String, String> headers, String reasonPhrase) {
+        this.status = status;
+        this.reasonPhrase = reasonPhrase;
+        this.headers.putAll(headers);
+    }
+
+    public play.api.mvc.ResponseHeader asScala() {
+        return new play.api.mvc.ResponseHeader(status, headers, OptionConverters.toScala(Optional.ofNullable(reasonPhrase)));
+    }
+
+    public int status() {
+        return status;
+    }
+
+    public Optional<String> reasonPhrase() {
+        return Optional.ofNullable(reasonPhrase);
+    }
+
+    public Optional<String> getHeader(String headerName) {
+        return Optional.ofNullable(this.headers.get(headerName));
+    }
+
+    public Map<String, String> headers() {
+        return Collections.unmodifiableMap(headers);
+    }
+
+    public ResponseHeader withHeader(String name, String value) {
+        Map<String, String> updatedHeaders = copyCurrentHeaders();
+        updatedHeaders.put(name, value);
+        return new ResponseHeader(status, updatedHeaders, reasonPhrase);
+    }
+
+    public ResponseHeader withHeaders(Map<String, String> newHeaders) {
+        Map<String, String> updatedHeaders = copyCurrentHeaders();
+        updatedHeaders.putAll(newHeaders);
+        return new ResponseHeader(status, updatedHeaders, reasonPhrase);
+    }
+
+    private Map<String, String> copyCurrentHeaders() {
+        Map<String, String> updatedHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        updatedHeaders.putAll(this.headers);
+        return updatedHeaders;
+    }
+}

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -50,6 +50,10 @@ final class ResponseHeader(val status: Int, _headers: Map[String, String] = Map.
     case ResponseHeader(s, h, r) => (s, h, r).equals((status, headers, reasonPhrase))
     case _ => false
   }
+
+  def asJava: play.mvc.ResponseHeader = {
+    new play.mvc.ResponseHeader(status, headers.asJava, reasonPhrase.orNull)
+  }
 }
 object ResponseHeader {
   val basicDateFormatPattern = "EEE, dd MMM yyyy HH:mm:ss"
@@ -258,7 +262,7 @@ case class Result(header: ResponseHeader, body: HttpEntity,
   /**
    * Convert this result to a Java result.
    */
-  def asJava: play.mvc.Result = new play.mvc.Result(header, body.asJava,
+  def asJava: play.mvc.Result = new play.mvc.Result(header.asJava, body.asJava,
     newSession.map(_.asJava).orNull, newFlash.map(_.asJava).orNull, newCookies.map(_.asJava).asJava)
 
   /**

--- a/framework/src/play/src/main/scala/play/core/j/JavaResults.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaResults.scala
@@ -9,8 +9,10 @@ import play.api.http._
 import play.api.mvc._
 import play.mvc.Http.{ Cookie => JCookie, Cookies => JCookies, Flash => JFlash, Session => JSession }
 import play.mvc.{ Result => JResult }
+import play.mvc.{ ResponseHeader => JResponseHeader }
 
 import scala.annotation.varargs
+import scala.collection.JavaConverters
 import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters
 import scala.concurrent.Await
@@ -64,16 +66,14 @@ object JavaResultExtractor {
     Cookies.fromSetCookieHeader(responseHeader.headers.get(HeaderNames.SET_COOKIE)).get(Flash.COOKIE_NAME)
   ).data.asJava)
 
-  def withHeader(responseHeader: ResponseHeader, name: String, value: String): ResponseHeader =
-    responseHeader.copy(headers = responseHeader.headers + (name -> value))
-
   @varargs
-  def withHeader(responseHeader: ResponseHeader, nameValues: String*): ResponseHeader = {
+  def withHeader(responseHeader: JResponseHeader, nameValues: String*): JResponseHeader = {
+    import JavaConverters._
     if (nameValues.length % 2 != 0) {
       throw new IllegalArgumentException("Unmatched name - withHeaders must be invoked with an even number of string arguments")
     }
     val toAdd = nameValues.grouped(2).map(pair => pair(0) -> pair(1))
-    responseHeader.copy(headers = responseHeader.headers ++ toAdd)
+    responseHeader.withHeaders(toAdd.toMap.asJava)
   }
 
   def getBody(result: JResult, timeout: Long, materializer: Materializer): ByteString =

--- a/framework/src/play/src/test/scala/play/mvc/ResponseHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/mvc/ResponseHeaderSpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.mvc
+
+import org.specs2.mutable.Specification
+import scala.collection.JavaConverters._
+import scala.compat.java8.OptionConverters._
+
+class ResponseHeaderSpec extends Specification {
+
+  "ResponseHeader" should {
+
+    "create with status and headers" in {
+      val headers = Map("a" -> "b").asJava
+      val responseHeader = new ResponseHeader(Http.Status.OK, headers)
+      responseHeader.status() must beEqualTo(Http.Status.OK)
+      responseHeader.getHeader("a").asScala must beSome("b")
+    }
+
+    "create with status, headers and a reason phrase" in {
+      val headers = Map("a" -> "b").asJava
+      val responseHeader = new ResponseHeader(Http.Status.OK, headers, "Custom")
+      responseHeader.status() must beEqualTo(Http.Status.OK)
+      responseHeader.getHeader("a").asScala must beSome("b")
+      responseHeader.reasonPhrase().asScala must beSome("Custom")
+    }
+
+    "get all headers" in {
+      val headers = Map("a" -> "b", "c" -> "d").asJava
+      val responseHeader = new ResponseHeader(Http.Status.OK, headers)
+      responseHeader.headers().get("a") must beEqualTo("b")
+      responseHeader.headers().get("c") must beEqualTo("d")
+    }
+
+    "get a single header" in {
+      val headers = Map("a" -> "b").asJava
+      val responseHeader = new ResponseHeader(Http.Status.OK, headers)
+      responseHeader.getHeader("a").asScala must beSome("b")
+      responseHeader.getHeader("c").asScala must beNone
+    }
+
+    "add a single new header" in {
+      val headers = Map("a" -> "b").asJava
+      val responseHeader = new ResponseHeader(Http.Status.OK, headers)
+      val newResponseHeader = responseHeader.withHeader("c", "d")
+      newResponseHeader.headers().get("c") must beEqualTo("d")
+    }
+
+    "preserve existing headers when adding a single new header" in {
+      val headers = Map("a" -> "b").asJava
+      val responseHeader = new ResponseHeader(Http.Status.OK, headers)
+      val newResponseHeader = responseHeader.withHeader("c", "d")
+      newResponseHeader.headers().get("a") must beEqualTo("b")
+      newResponseHeader.headers().get("c") must beEqualTo("d")
+    }
+
+    "add multiple new headers" in {
+      val headers = Map("a" -> "b").asJava
+      val responseHeader = new ResponseHeader(Http.Status.OK, headers)
+      val newResponseHeader = responseHeader.withHeaders(Map("c" -> "d", "e" -> "f").asJava)
+      newResponseHeader.headers().get("c") must beEqualTo("d")
+      newResponseHeader.headers().get("e") must beEqualTo("f")
+    }
+
+    "be convertible to a Scala ResponseHeader" in {
+      val headers = Map("a" -> "b").asJava
+      val responseHeader = new ResponseHeader(Http.Status.OK, headers)
+      val scalaResponseHeader = responseHeader.asScala()
+      scalaResponseHeader.status must beEqualTo(Http.Status.OK)
+      scalaResponseHeader.headers.contains("a") must beTrue
+    }
+
+    "handle header names case insensitively" in {
+      "when adding a single header" in {
+        val headers = Map("Name" -> "Value").asJava
+        val responseHeader = new ResponseHeader(Http.Status.OK, headers).withHeader("NAME", "New Value")
+        responseHeader.headers().get("name") must beEqualTo("New Value")
+      }
+      "when adding multiple headers" in {
+        val headers = Map("Name" -> "Value").asJava
+        val responseHeader = new ResponseHeader(Http.Status.OK, headers)
+          .withHeaders(Map("NAME" -> "New Value", "Another" -> "Another Value").asJava)
+
+        responseHeader.headers().get("name") must beEqualTo("New Value")
+      }
+      "when getting the header" in {
+        val headers = Map("Name" -> "Value").asJava
+        val responseHeader = new ResponseHeader(Http.Status.OK, headers)
+        responseHeader.getHeader("NAME").asScala must beSome("Value")
+      }
+    }
+
+  }
+}

--- a/framework/src/play/src/test/scala/play/mvc/ResultSpec.scala
+++ b/framework/src/play/src/test/scala/play/mvc/ResultSpec.scala
@@ -1,20 +1,18 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-package play.test
+package play.mvc
 
 import java.nio.charset.StandardCharsets
 import java.util.Optional
 
 import akka.util.ByteString
 import org.specs2.mutable._
-
 import play.api.http.HttpEntity.Strict
-import play.api.mvc.{ Cookie, Results }
+import play.api.mvc.{ Cookie, Results => ScalaResults }
+import play.mvc.Http.HeaderNames
+import scala.compat.java8.OptionConverters._
 
-/**
- *
- */
 class ResultSpec extends Specification {
 
   "Result" should {
@@ -37,7 +35,7 @@ class ResultSpec extends Specification {
     // This is in Scala because building wrapped scala results is easier.
     "test for cookies" in {
 
-      val javaResult = Results.Ok("Hello world").withCookies(Cookie("name1", "value1")).asJava
+      val javaResult = ScalaResults.Ok("Hello world").withCookies(Cookie("name1", "value1")).asJava
 
       val cookies = javaResult.cookies()
       val cookie = cookies.iterator().next()
@@ -49,8 +47,13 @@ class ResultSpec extends Specification {
     "get charset correctly" in {
       val charset = StandardCharsets.ISO_8859_1.name()
       val contentType = s"text/plain;charset=$charset"
-      val javaResult = Results.Ok.sendEntity(new Strict(ByteString.fromString("foo", charset), Some(contentType))).asJava
+      val javaResult = ScalaResults.Ok.sendEntity(Strict(ByteString.fromString("foo", charset), Some(contentType))).asJava
       javaResult.charset() must_== Optional.of(charset)
+    }
+
+    "get the location header" in {
+      val javaResult = ScalaResults.Ok("Hello world").withHeaders(HeaderNames.LOCATION -> "/new-location").asJava
+      javaResult.redirectLocation().asScala must beSome("/new-location")
     }
   }
 }


### PR DESCRIPTION
## Fixes

Fixes #2178.

## Purpose

Add a Java API for response headers

## References

See #2178 and related issues.
