### PR TITLE
Refactor PlayBodyParsers

### DIFF
--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -53,7 +53,7 @@ class BuiltinModule extends SimpleModule((env, conf) => {
     bind[RequestFactory].to[DefaultRequestFactory],
     bind[TemporaryFileReaper].to[DefaultTemporaryFileReaper],
     bind[TemporaryFileCreator].to[DefaultTemporaryFileCreator],
-    bind[PlayBodyParsers].to[PlayBodyParsersImpl],
+    bind[PlayBodyParsers].to[DefaultPlayBodyParsers],
     bind[BodyParsers.Default].toSelf,
     bind[DefaultActionBuilder].to[DefaultActionBuilderImpl],
     bind[ControllerComponents].to[DefaultControllerComponents],

--- a/framework/src/play/src/test/scala/play/api/mvc/MaxLengthBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/MaxLengthBodyParserSpec.scala
@@ -30,7 +30,7 @@ class MaxLengthBodyParserSpec extends Specification with AfterAll {
   import system.dispatcher
   implicit val mat = ActorMaterializer()
   val tempFileCreator = SingletonTemporaryFileCreator
-  val parse = new PlayBodyParsersImpl(
+  val parse = new DefaultPlayBodyParsers(
     ParserConfiguration(), new DefaultHttpErrorHandler(Environment.simple(), Configuration.empty), mat, tempFileCreator)
 
   override def afterAll: Unit = {


### PR DESCRIPTION
Changes the naming of `PlayBodyParsersImpl` to `DefaultPlayBodyParsers`. Also removes the call by name parameters and creates a special case for `BodyParsers.parse`