### PR TITLE
Fix documentation code NPE

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/models/AgeRange.java
+++ b/documentation/manual/working/javaGuide/advanced/routing/code/javaguide/binder/models/AgeRange.java
@@ -27,7 +27,7 @@ public Optional<AgeRange> bind(String key, Map<String, String[]> data) {
 		return Optional.of(this);
 		
 	} catch (Exception e){ // no parameter match return None
-		return Optional.of(null);
+		return Optional.empty();
 	}
 }
 


### PR DESCRIPTION
The documentation code was using 
return Optional.of(null); instead of Optional.empty();
of(null) would throw a NullPointerException

//cc @marcospereira #6966
