### PR TITLE
Update netty to version 4.1.8.final

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -139,7 +139,7 @@ object Dependencies {
     specsBuild.map(_ % Test) ++
     javaTestDeps
 
-  val nettyVersion = "4.1.7.Final"
+  val nettyVersion = "4.1.8.Final"
 
   val netty = Seq(
     "com.typesafe.netty" % "netty-reactive-streams-http" % "2.0.0-M1",

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -5,7 +5,6 @@ package play.core.server
 
 import java.io.IOException
 import java.net.InetSocketAddress
-import java.util.concurrent.TimeUnit
 
 import akka.Done
 import akka.actor.ActorSystem

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala
@@ -319,16 +319,6 @@ private[server] class NettyModelConversion(
     new DefaultHttpContent(byteStringToByteBuf(bytes))
   }
 
-  private def clientCertificatesFromSslEngine(sslEngine: Option[SSLEngine]): Option[Seq[X509Certificate]] = {
-    try {
-      sslEngine.map { engine =>
-        engine.getSession.getPeerCertificates.toSeq.collect { case x509: X509Certificate => x509 }
-      }
-    } catch {
-      case e: SSLPeerUnverifiedException => None
-    }
-  }
-
   // cache the date header of the last response so we only need to compute it every second
   private var cachedDateHeader: (Long, String) = (Long.MinValue, null)
   private def dateHeader: String = {


### PR DESCRIPTION
## Purpose

Updates Netty and remove deprecated API calls.

## References

http://netty.io/news/2017/01/30/4-0-44-Final-4-1-8-Final.html