### PR TITLE
Update to play-ws M4

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -250,7 +250,7 @@ object Dependencies {
       logback % Test
     ) ++ specsBuild.map(_ % Test)
 
-  val playWsStandaloneVersion = "1.0.0-M3"
+  val playWsStandaloneVersion = "1.0.0-M4"
   val playWsDeps = Seq(
     "com.typesafe.play" %% "play-ws-standalone" % playWsStandaloneVersion,
     logback % Test

--- a/framework/src/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSModule.java
+++ b/framework/src/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSModule.java
@@ -4,6 +4,7 @@
 package play.libs.ws.ahc;
 
 import akka.stream.Materializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import play.api.Configuration;
 import play.api.Environment;
 import play.api.inject.Binding;
@@ -37,8 +38,8 @@ public class AhcWSModule extends Module {
         private final AhcWSClient client;
 
         @Inject
-        public AhcWSClientProvider(AsyncHttpClient asyncHttpClient, Materializer materializer) {
-            client = new AhcWSClient(new StandaloneAhcWSClient(asyncHttpClient, materializer));
+        public AhcWSClientProvider(AsyncHttpClient asyncHttpClient, Materializer materializer, ObjectMapper objectMapper) {
+            client = new AhcWSClient(new StandaloneAhcWSClient(asyncHttpClient, materializer, objectMapper));
         }
 
         @Override

--- a/framework/src/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSClient.scala
+++ b/framework/src/play-ahc-ws/src/main/scala/play/api/libs/ws/ahc/AhcWSClient.scala
@@ -27,7 +27,9 @@ class AhcWSClient(underlyingClient: StandaloneAhcWSClient) extends WSClient {
    *
    * @param url The base URL to make HTTP requests to.
    * @return a request
+   * @throws IllegalArgumentException if the URL is invalid.
    */
+  @throws[IllegalArgumentException]
   override def url(url: String): WSRequest = {
     AhcWSRequest(underlyingClient.url(url).asInstanceOf[StandaloneAhcWSRequest])
   }


### PR DESCRIPTION
Updates Play to use Play-WS 1.0.0-M4 and updates the Java provider to use the injected ObjectMapper.