### PR TITLE
Deprecate methods using global state in test Helpers

### DIFF
--- a/framework/src/play-integration-test/src/test/java/play/routing/AbstractRoutingDslTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/routing/AbstractRoutingDslTest.java
@@ -4,6 +4,7 @@
 package play.routing;
 
 import org.junit.Test;
+import play.Application;
 import play.mvc.PathBindable;
 import play.mvc.Result;
 
@@ -20,6 +21,8 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
  * This class is in the integration tests so that we have the right helper classes to build a request with to test it.
  */
 public abstract class AbstractRoutingDslTest {
+
+    abstract Application application();
 
     abstract RoutingDsl routingDsl();
 
@@ -298,7 +301,7 @@ public abstract class AbstractRoutingDslTest {
     }
 
     private String makeRequest(Router router, String method, String path) {
-        Result result = routeAndCall(router, fakeRequest(method, path));
+        Result result = routeAndCall(application(), router, fakeRequest(method, path));
         if (result == null) {
             return null;
         } else {

--- a/framework/src/play-integration-test/src/test/java/play/routing/CompileTimeInjectionRoutingDslTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/routing/CompileTimeInjectionRoutingDslTest.java
@@ -4,21 +4,33 @@
 package play.routing;
 
 import org.junit.BeforeClass;
+import play.Application;
+import play.DefaultApplication;
 import play.api.ApplicationLoader;
+import play.inject.DelegateInjector;
+import play.inject.Injector;
 
 public class CompileTimeInjectionRoutingDslTest extends AbstractRoutingDslTest {
 
     private static TestComponents components;
+    private static Application application;
 
     @BeforeClass
     public static void startApp() {
         play.api.ApplicationLoader.Context context = play.ApplicationLoader.create(play.Environment.simple()).underlying();
         components = new TestComponents(context);
+        Injector injector = new DelegateInjector(components.injector());
+        application = new DefaultApplication(components.application(), injector);
     }
 
     @Override
     RoutingDsl routingDsl() {
         return components.routingDsl();
+    }
+
+    @Override
+    Application application() {
+        return application;
     }
 
     private static class TestComponents extends RoutingDslComponentsFromContext {

--- a/framework/src/play-integration-test/src/test/java/play/routing/DependencyInjectedRoutingDslTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/routing/DependencyInjectedRoutingDslTest.java
@@ -20,6 +20,11 @@ public class DependencyInjectedRoutingDslTest extends AbstractRoutingDslTest {
     }
 
     @Override
+    Application application() {
+        return app;
+    }
+
+    @Override
     RoutingDsl routingDsl() {
         return app.injector().instanceOf(RoutingDsl.class);
     }

--- a/framework/src/play-integration-test/src/test/java/play/routing/GlobalStateRoutingDslTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/routing/GlobalStateRoutingDslTest.java
@@ -23,6 +23,11 @@ public class GlobalStateRoutingDslTest extends AbstractRoutingDslTest {
     }
 
     @Override
+    Application application() {
+        return app;
+    }
+
+    @Override
     RoutingDsl routingDsl() {
         return new RoutingDsl();
     }


### PR DESCRIPTION
## Purpose

Deprecated test helpers methods that were using global state.