### PR TITLE
Add note about modularized OpenID support to 2.6 migration guide.

### DIFF
--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -35,6 +35,14 @@ In Play 2.6, the core Play module no longer includes Guice. You will need to con
 libraryDependencies += guice
 ```
 
+### OpenID support moved to separate module
+
+In Play 2.6, the core Play module no longer includes the OpenID support in `play.api.libs.openid` (Scala) and `play.libs.openid` (Java). To use these packages add `openId` to your `libraryDependencies`:
+
+```scala
+libraryDependencies += openId
+```
+
 ### Play JSON moved to separate project
 
 Play JSON has been moved to a separate library hosted at https://github.com/playframework/play-json. Since Play JSON has no depependencies on the rest of Play, the main change is that the `json` value from `PlayImport` will no longer work in your SBT build. Instead, you'll have to specify the library manually:

--- a/documentation/manual/working/javaGuide/main/ws/JavaOpenID.md
+++ b/documentation/manual/working/javaGuide/main/ws/JavaOpenID.md
@@ -14,9 +14,9 @@ Step 1 may be omitted if all your users are using the same OpenID provider (for 
 
 ## Usage
 
-To use OpenID, first add `openid` to your `build.sbt` file:
+To use OpenID, first add `openId` to your `build.sbt` file:
 
-@[javaws-sbt-dependencies](code/javaws.sbt)
+@[javaopenid-sbt-dependencies](code/javaopenid.sbt)
 
 Now any controller or component that wants to use OpenID will have to declare a dependency on the [OpenIdClient](api/java/play/libs/openid/OpenIdClient.html).
 

--- a/documentation/manual/working/javaGuide/main/ws/code/javaopenid.sbt
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaopenid.sbt
@@ -1,0 +1,9 @@
+//
+// Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+//
+
+//#javaopenid-sbt-dependencies
+libraryDependencies ++= Seq(
+  openId
+)
+//#javaopenid-sbt-dependencies

--- a/documentation/manual/working/scalaGuide/main/ws/ScalaOpenID.md
+++ b/documentation/manual/working/scalaGuide/main/ws/ScalaOpenID.md
@@ -18,7 +18,7 @@ To use OpenID, first add `openid`  to your `build.sbt` file:
 
 ```scala
 libraryDependencies ++= Seq(
-  openid
+  openId
 )
 ```
 


### PR DESCRIPTION
Additionally, fix case of `openId` import in the OpenID documentation, and add a Java sbt import snippet.