### PR TITLE
Use List instead of Map to manage java-form errors

### DIFF
--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -129,6 +129,10 @@ Then in your template you can use `AssetsFinder#path` to find the final path of 
 
 You can still continue to use reverse routes with `Assets.versioned`, but some global state is required to convert the asset name you provide to the final asset name, which can be problematic if you want to run multiple applications at once.
 
+## Java Form Changes
+
+The `.errors()` method of a `play.data.Form` instance now returns a simple `List<ValidationError>` instead of a `Map<String,List<ValidationError>>`. Where before Play 2.6 you called `.errors().get("key")` you can now simply call `.errors("key")`.
+
 ## JPA Migration Notes
 
 See [[JPA migration notes|JPAMigration26]].

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -131,7 +131,7 @@ You can still continue to use reverse routes with `Assets.versioned`, but some g
 
 ## Java Form Changes
 
-The `.errors()` method of a `play.data.Form` instance now returns a simple `List<ValidationError>` instead of a `Map<String,List<ValidationError>>`. Where before Play 2.6 you called `.errors().get("key")` you can now simply call `.errors("key")`.
+The `.errors()` method of a `play.data.Form` instance is now deprecated. You should use `allErrors()` instead now which returns a simple `List<ValidationError>` instead of a `Map<String,List<ValidationError>>`. Where before Play 2.6 you called `.errors().get("key")` you can now simply call `.errors("key")`.
 
 ## JPA Migration Notes
 

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaForms.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/JavaForms.java
@@ -221,8 +221,8 @@ public class JavaForms extends WithApplication {
         //#fill
         userForm = userForm.fill(new User("bob@gmail.com", "secret"));
         //#fill
-        assertThat(userForm.field("email").value(), equalTo("bob@gmail.com"));
-        assertThat(userForm.field("password").value(), equalTo("secret"));
+        assertThat(userForm.field("email").getValue().get(), equalTo("bob@gmail.com"));
+        assertThat(userForm.field("password").getValue().get(), equalTo("secret"));
     }
 
     @Test
@@ -258,7 +258,7 @@ public class JavaForms extends WithApplication {
         Form<WithLocalTime> form = application.injector().instanceOf(FormFactory.class).form(WithLocalTime.class);
         WithLocalTime obj = form.bind(ImmutableMap.of("time", "23:45")).get();
         assertThat(obj.getTime(), equalTo(LocalTime.of(23, 45)));
-        assertThat(form.fill(obj).field("time").value(), equalTo("23:45"));
+        assertThat(form.fill(obj).field("time").getValue().get(), equalTo("23:45"));
     }
 
     public static class WithLocalTime {

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -150,9 +150,19 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
 
     /**
      * Retrieve an error by key.
+     * 
+     * @deprecated Deprecated as of 2.6.0. Use {@link #getError(String)} instead.
      */
+    @Deprecated
     public ValidationError error(String key) {
         return super.error(asDynamicKey(key));
+    }
+
+    /**
+     * Retrieve an error by key.
+     */
+    public Optional<ValidationError> getError(String key) {
+        return super.getError(asDynamicKey(key));
     }
 
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -102,7 +102,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      */
     public DynamicForm fill(Map<String, Object> value) {
         Form<Dynamic> form = super.fill(new Dynamic(value));
-        return new DynamicForm(form.data(), form.errors(), form.value(), messagesApi, formatters, validator);
+        return new DynamicForm(form.data(), form.allErrors(), form.value(), messagesApi, formatters, validator);
     }
 
     /**
@@ -142,7 +142,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         }
         
         Form<Dynamic> form = super.bind(data, allowedFields);
-        return new DynamicForm(form.data(), form.errors(), form.value(), messagesApi, formatters, validator);
+        return new DynamicForm(form.data(), form.allErrors(), form.value(), messagesApi, formatters, validator);
     }
     
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -102,7 +102,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      */
     public DynamicForm fill(Map<String, Object> value) {
         Form<Dynamic> form = super.fill(new Dynamic(value));
-        return new DynamicForm(form.data(), form.allErrors(), form.value(), messagesApi, formatters, validator);
+        return new DynamicForm(new HashMap<>(form.data()), new ArrayList<>(form.allErrors()), form.value(), messagesApi, formatters, validator);
     }
 
     /**
@@ -142,7 +142,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         }
         
         Form<Dynamic> form = super.bind(data, allowedFields);
-        return new DynamicForm(form.data(), form.allErrors(), form.value(), messagesApi, formatters, validator);
+        return new DynamicForm(new HashMap<>(form.data()), new ArrayList<>(form.allErrors()), form.value(), messagesApi, formatters, validator);
     }
     
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -6,6 +6,7 @@ package play.data;
 import javax.validation.Validator;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import play.data.validation.*;
 import play.data.format.Formatters;
@@ -40,13 +41,28 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      * @param formatters     the formatters component.
      * @param validator      the validator component.
      */
-    public DynamicForm(Map<String,String> data, Map<String,List<ValidationError>> errors, Optional<Dynamic> value, MessagesApi messagesApi, Formatters formatters, Validator validator) {
+    public DynamicForm(Map<String,String> data, List<ValidationError> errors, Optional<Dynamic> value, MessagesApi messagesApi, Formatters formatters, Validator validator) {
         super(null, DynamicForm.Dynamic.class, data, errors, value, messagesApi, formatters, validator);
         rawData = new HashMap<>();
         for (Map.Entry<String, String> e : data.entrySet()) {
             rawData.put(asNormalKey(e.getKey()), e.getValue());
         }
 
+    }
+
+    /**
+     * @deprecated Deprecated as of 2.6.0. Replace the parameter {@code Map<String,List<ValidationError>>} with a simple {@code List<ValidationError>}.
+     */
+    @Deprecated
+    public DynamicForm(Map<String,String> data, Map<String,List<ValidationError>> errors, Optional<Dynamic> value, MessagesApi messagesApi, Formatters formatters, Validator validator) {
+        this(
+                data,
+                errors != null ? errors.values().stream().flatMap(v -> v.stream()).collect(Collectors.toList()) : new ArrayList<>(),
+                value,
+                messagesApi,
+                formatters,
+                validator
+        );
     }
     
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -92,7 +92,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
 
     @Override
     public Map<String, String> data() {
-        return rawData;
+        return Collections.unmodifiableMap(rawData);
     }
 
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -66,7 +66,10 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     }
     
     /**
-     * Gets the concrete value if the submission was a success.
+     * Gets the concrete value only if the submission was a success.
+     * If the form is invalid because of validation errors this method will return null.
+     * If you want to retrieve the value even when the form is invalid use {@link #value(String)} instead.
+     * 
      * @param key the string key.
      * @return the value, or null if there is no match.
      */
@@ -76,6 +79,15 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         } catch(Exception e) {
             return null;
         }
+    }
+
+    /**
+     * Gets the concrete value
+     * @param key the string key.
+     * @return the value
+     */
+    public Optional<Object> value(String key) {
+        return super.value().map(v -> v.getData().get(asNormalKey(key)));
     }
 
     @Override
@@ -88,7 +100,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      * @param value    the map of values to fill in the form.
      * @return the modified form.
      */
-    public DynamicForm fill(Map value) {
+    public DynamicForm fill(Map<String, Object> value) {
         Form<Dynamic> form = super.fill(new Dynamic(value));
         return new DynamicForm(form.data(), form.errors(), form.value(), messagesApi, formatters, validator);
     }
@@ -209,22 +221,21 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
     /**
      * Simple data structure used by <code>DynamicForm</code>.
      */
-    @SuppressWarnings("rawtypes")
     public static class Dynamic {
 
-        private Map data = new HashMap();
+        private Map<String, Object> data = new HashMap<>();
 
         public Dynamic() {
         }
 
-        public Dynamic(Map data) {
+        public Dynamic(Map<String, Object> data) {
             this.data = data;
         }
 
         /**
          * @return the data.
          */
-        public Map getData() {
+        public Map<String, Object> getData() {
             return data;
         }
 
@@ -232,7 +243,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
          * Sets the new data.
          * @param data    the map of data.
          */
-        public void setData(Map data) {
+        public void setData(Map<String, Object> data) {
             this.data = data;
         }
 

--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -156,7 +156,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         // javadoc cannot find the static inner class.
         Field field = super.field(asDynamicKey(key));
         return new Field(this, key, field.constraints(), field.format(), field.errors(),
-            field.value() == null ? get(key) : field.value()
+            field.getValue().orElse((String)value(key).orElse(null))
         );
     }
 

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -753,7 +753,7 @@ public class Form<T> {
                             }
                             attributes.add(attrValue);
                         }
-                        format = Tuple(d.name(), attributes);
+                        format = Tuple(d.name(), Collections.unmodifiableList(attributes));
                     }
                 }
             }
@@ -887,7 +887,7 @@ public class Form<T> {
          * @return The errors associated with this field.
          */
         public List<ValidationError> errors() {
-            return errors;
+            return Collections.unmodifiableList(errors);
         }
 
         /**
@@ -896,7 +896,7 @@ public class Form<T> {
          * @return The constraints associated with this field.
          */
         public List<Tuple<String,List<Object>>> constraints() {
-            return constraints;
+            return Collections.unmodifiableList(constraints);
         }
 
         /**
@@ -914,9 +914,9 @@ public class Form<T> {
         @SuppressWarnings("rawtypes")
         public List<Integer> indexes() {
             if(form == null) {
-                return new ArrayList<>(0);
+                return Collections.emptyList();
             }
-            return form.value().map((Function<Object, List<Integer>>) value -> {
+            return Collections.unmodifiableList(form.value().map((Function<Object, List<Integer>>) value -> {
                 BeanWrapper beanWrapper = new BeanWrapperImpl(value);
                 beanWrapper.setAutoGrowNestedPaths(true);
                 String objectKey = name;
@@ -949,7 +949,7 @@ public class Form<T> {
                 List<Integer> sortedResult = new ArrayList<>(result);
                 Collections.sort(sortedResult);
                 return sortedResult;
-            });
+            }));
         }
 
         /**

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -13,7 +13,6 @@ import java.util.function.Supplier;
 import java.lang.annotation.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
@@ -538,9 +537,7 @@ public class Form<T> {
      */
     @Deprecated
     public Map<String,List<ValidationError>> errors() {
-        return Collections.unmodifiableMap(this.errors.stream().collect(Collectors.toMap(e -> e.key(), e -> Collections.unmodifiableList(Arrays.asList(e)), (v1, v2) ->
-            Collections.unmodifiableList(Stream.of(v1, v2).flatMap(Collection::stream).collect(Collectors.toList()))
-        )));
+        return Collections.unmodifiableMap(this.errors.stream().collect(Collectors.groupingBy(error -> error.key())));
     }
 
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -882,6 +882,13 @@ public class Form<T> {
         }
 
         /**
+        * @return The field name.
+        */
+        public Optional<String> getName() {
+            return Optional.ofNullable(name);
+        }
+
+        /**
          * Returns the field value, if defined.
          *
          * @return The field value, if defined.
@@ -895,6 +902,13 @@ public class Form<T> {
                 return or;
             }
             return value;
+        }
+
+        /**
+        * @return The field value, if defined.
+        */
+        public Optional<String> getValue() {
+            return Optional.ofNullable(value);
         }
 
         /**

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -560,7 +560,7 @@ public class Form<T> {
         if(key == null) {
             return Collections.emptyList();
         }
-        return errors.stream().filter(error -> error.key().equals(key)).collect(Collectors.toList());
+        return Collections.unmodifiableList(errors.stream().filter(error -> error.key().equals(key)).collect(Collectors.toList()));
     }
 
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -138,7 +138,7 @@ public class Form<T> {
     public Form(String rootName, Class<T> clazz, Map<String,String> data, List<ValidationError> errors, Optional<T> value, Class<?>[] groups, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
         this.rootName = rootName;
         this.backedType = clazz;
-        this.data = data;
+        this.data = data != null ? data : new HashMap<>();
         this.errors = errors != null ? errors : new ArrayList<>();
         this.value = value;
         this.groups = groups;
@@ -850,9 +850,9 @@ public class Form<T> {
         public Field(Form<?> form, String name, List<Tuple<String,List<Object>>> constraints, Tuple<String,List<Object>> format, List<ValidationError> errors, String value) {
             this.form = form;
             this.name = name;
-            this.constraints = constraints;
+            this.constraints = constraints != null ? constraints : new ArrayList<>();
             this.format = format;
-            this.errors = errors;
+            this.errors = errors != null ? errors : new ArrayList<>();
             this.value = value;
         }
 

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -876,7 +876,10 @@ public class Form<T> {
          * Returns the field name.
          *
          * @return The field name.
+         * 
+         * @deprecated Deprecated as of 2.6.0. Use {@link #getName()} instead.
          */
+        @Deprecated
         public String name() {
             return name;
         }
@@ -892,11 +895,18 @@ public class Form<T> {
          * Returns the field value, if defined.
          *
          * @return The field value, if defined.
+         * 
+         * @deprecated Deprecated as of 2.6.0. Use {@link #getValue()} instead.
          */
+        @Deprecated
         public String value() {
             return value;
         }
 
+        /**
+         * @deprecated Deprecated as of 2.6.0. Use {@link #getValue()} instead.
+         */
+        @Deprecated
         public String valueOr(String or) {
             if (value == null) {
                 return or;

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -519,13 +519,21 @@ public class Form<T> {
      * Retrieves the first global error (an error without any key), if it exists.
      *
      * @return An error or <code>null</code>.
+     * 
+     * @deprecated Deprecated as of 2.6.0. Use {@link #getGlobalError()} instead.
      */
+    @Deprecated
     public ValidationError globalError() {
-        List<ValidationError> errors = globalErrors();
-        if (errors.isEmpty()) {
-            return null;
-        }
-        return errors.get(0);
+        return this.getGlobalError().orElse(null);
+    }
+
+    /**
+     * Retrieves the first global error (an error without any key), if it exists.
+     *
+     * @return An error.
+     */
+    public Optional<ValidationError> getGlobalError() {
+        return globalErrors().stream().findFirst();
     }
 
     /**
@@ -563,9 +571,20 @@ public class Form<T> {
     /**
      * @param key    the field name associated with the error.
      * @return an error by key, or null.
+     * 
+     * @deprecated Deprecated as of 2.6.0. Use {@link #getError(String)} instead.
      */
+    @Deprecated
     public ValidationError error(String key) {
-        return errors(key).stream().findFirst().orElse(null);
+        return this.getError(key).orElse(null);
+    }
+
+    /**
+     * @param key    the field name associated with the error.
+     * @return an error by key
+     */
+    public Optional<ValidationError> getError(String key) {
+        return errors(key).stream().findFirst();
     }
 
     /**

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -430,7 +430,7 @@ public class Form<T> {
                 } else if (globalError instanceof List) {
                     errors.addAll((List<ValidationError>) globalError);
                 } else if (globalError instanceof Map) {
-                    errors.addAll(((Map<String,List<ValidationError>>)globalError).values().stream().flatMap(v -> v.stream()).collect(Collectors.toList()));
+                    ((Map<String,List<ValidationError>>)globalError).forEach((key, values) -> errors.addAll(values));
                 }
                 return new Form(rootName, backedType, data, errors, Optional.ofNullable((T)result.getTarget()), groups, messagesApi, formatters, this.validator);
             }

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -634,7 +634,7 @@ public class Form<T> {
     /**
      * Gets the concrete value only if the submission was a success.
      * If the form is invalid because of validation errors this method will throw an exception.
-     * If you want to retrieve the value even when the form is invalid use <code>value()</code> instead.
+     * If you want to retrieve the value even when the form is invalid use {@link #value()} instead.
      *
      * @throws IllegalStateException if there are errors binding the form, including the errors as JSON in the message
      * @return the concrete value.

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -455,7 +455,7 @@ public class Form<T> {
      * @return the actual form data.
      */
     public Map<String,String> data() {
-        return data;
+        return Collections.unmodifiableMap(data);
     }
 
     public String name() {

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -409,7 +409,7 @@ public class Form<T> {
                 errors.addAll(globalErrors);
             }
 
-            return new Form(rootName, backedType, data, errors, Optional.ofNullable((T)result.getTarget()), groups, messagesApi, formatters, this.validator);
+            return new Form<>(rootName, backedType, data, errors, Optional.ofNullable((T)result.getTarget()), groups, messagesApi, formatters, this.validator);
         } else {
             Object globalError = null;
             if (result.getTarget() != null) {
@@ -425,15 +425,15 @@ public class Form<T> {
             if (globalError != null) {
                 final List<ValidationError> errors = new ArrayList<>();
                 if (globalError instanceof String) {
-                    errors.add(new ValidationError("", (String)globalError, new ArrayList()));
+                    errors.add(new ValidationError("", (String)globalError, new ArrayList<>()));
                 } else if (globalError instanceof List) {
                     errors.addAll((List<ValidationError>) globalError);
                 } else if (globalError instanceof Map) {
                     ((Map<String,List<ValidationError>>)globalError).forEach((key, values) -> errors.addAll(values));
                 }
-                return new Form(rootName, backedType, data, errors, Optional.ofNullable((T)result.getTarget()), groups, messagesApi, formatters, this.validator);
+                return new Form<>(rootName, backedType, data, errors, Optional.ofNullable((T)result.getTarget()), groups, messagesApi, formatters, this.validator);
             }
-            return new Form(rootName, backedType, new HashMap<>(data), errors, Optional.ofNullable((T)result.getTarget()), groups, messagesApi, formatters, this.validator);
+            return new Form<>(rootName, backedType, new HashMap<>(data), errors, Optional.ofNullable((T)result.getTarget()), groups, messagesApi, formatters, this.validator);
         }
     }
 
@@ -474,12 +474,11 @@ public class Form<T> {
      * @param value existing value of type <code>T</code> used to fill this form
      * @return a copy of this form filled with the new data
      */
-    @SuppressWarnings("unchecked")
     public Form<T> fill(T value) {
         if (value == null) {
             throw new RuntimeException("Cannot fill a form with a null value");
         }
-        return new Form(
+        return new Form<>(
                 rootName,
                 backedType,
                 new HashMap<>(),
@@ -951,7 +950,6 @@ public class Form<T> {
         /**
          * @return the indexes available for this field (for repeated fields and List)
          */
-        @SuppressWarnings("rawtypes")
         public List<Integer> indexes() {
             if(form == null) {
                 return Collections.emptyList();
@@ -968,7 +966,7 @@ public class Form<T> {
                 if (beanWrapper.isReadableProperty(objectKey)) {
                     Object value1 = beanWrapper.getPropertyValue(objectKey);
                     if (value1 instanceof Collection) {
-                        for (int i = 0; i<((Collection) value1).size(); i++) {
+                        for (int i = 0; i<((Collection<?>) value1).size(); i++) {
                             result.add(i);
                         }
                     }

--- a/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java
@@ -89,7 +89,7 @@ public class Constraints {
      */
     public static Tuple<String,List<Object>> displayableConstraint(ConstraintDescriptor<?> constraint) {
         final Display displayAnnotation = constraint.getAnnotation().annotationType().getAnnotation(Display.class);
-        return Tuple(displayAnnotation.name(), Stream.of(displayAnnotation.attributes()).map(attr -> constraint.getAttributes().get(attr)).collect(Collectors.toList()));
+        return Tuple(displayAnnotation.name(), Collections.unmodifiableList(Stream.of(displayAnnotation.attributes()).map(attr -> constraint.getAttributes().get(attr)).collect(Collectors.toList())));
     }
 
     // --- Required

--- a/framework/src/play-java-forms/src/main/scala/play/core/PlayFormsMagicForJava.scala
+++ b/framework/src/play-java-forms/src/main/scala/play/core/PlayFormsMagicForJava.scala
@@ -7,6 +7,7 @@ package play.core.j
 object PlayFormsMagicForJava {
 
   import scala.collection.JavaConverters._
+  import scala.compat.java8.OptionConverters
   import scala.language.implicitConversions
 
   /**
@@ -15,7 +16,7 @@ object PlayFormsMagicForJava {
   implicit def javaFieldtoScalaField(jField: play.data.Form.Field): play.api.data.Field = {
     new play.api.data.Field(
       null,
-      jField.name,
+      jField.getName.orElse(null),
       Option(jField.constraints).map(c => c.asScala.map { jT =>
         jT._1 -> jT._2.asScala
       }).getOrElse(Nil),
@@ -26,7 +27,7 @@ object PlayFormsMagicForJava {
           jE.messages.asScala,
           jE.arguments.asScala)
       }).getOrElse(Nil),
-      Option(jField.value)) {
+      OptionConverters.toScala(jField.getValue)) {
 
       override def apply(key: String) = {
         javaFieldtoScalaField(jField.sub(key))

--- a/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -57,6 +57,11 @@ public class HttpFormsTest {
         return app.injector().instanceOf(JavaContextComponents.class);
     }
 
+    private <T> Form<T> copyFormWithoutRawData(final Form<T> formToCopy, final Application app) {
+        return new Form<T>(formToCopy.name(), formToCopy.getBackedType(), null, formToCopy.allErrors(), formToCopy.value(),
+            (Class[])null, app.injector().instanceOf(MessagesApi.class), app.injector().instanceOf(Formatters.class), app.injector().instanceOf(Validator.class));
+    }
+
     @Test
     public void testLangDataBinder() {
         withApplication((app) -> {
@@ -77,19 +82,17 @@ public class HttpFormsTest {
             Form<Money> myForm = formFactory.form(Money.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            myForm.data().clear();
             Money money = myForm.get();
             assertThat(money.getAmount()).isEqualTo(new BigDecimal("1234567.89"));
-            assertThat(myForm.field("amount").value()).isEqualTo("1 234 567,89");
+            assertThat(copyFormWithoutRawData(myForm, app).field("amount").value()).isEqualTo("1 234 567,89");
             // Parse french input with english formatter
             ctx.changeLang("en");
             myForm = formFactory.form(Money.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            myForm.data().clear();
             money = myForm.get();
             assertThat(money.getAmount()).isEqualTo(new BigDecimal("123456789"));
-            assertThat(myForm.field("amount").value()).isEqualTo("123,456,789");
+            assertThat(copyFormWithoutRawData(myForm, app).field("amount").value()).isEqualTo("123,456,789");
 
             // Prepare Request and Context with english number
             data = new HashMap<>();
@@ -102,19 +105,17 @@ public class HttpFormsTest {
             myForm = formFactory.form(Money.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            myForm.data().clear();
             money = myForm.get();
             assertThat(money.getAmount()).isEqualTo(new BigDecimal("1234567"));
-            assertThat(myForm.field("amount").value()).isEqualTo("1 234 567");
+            assertThat(copyFormWithoutRawData(myForm, app).field("amount").value()).isEqualTo("1 234 567");
             // Parse english input with english formatter
             ctx.changeLang("en");
             myForm = formFactory.form(Money.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            myForm.data().clear();
             money = myForm.get();
             assertThat(money.getAmount()).isEqualTo(new BigDecimal("1234567.89"));
-            assertThat(myForm.field("amount").value()).isEqualTo("1,234,567.89");
+            assertThat(copyFormWithoutRawData(myForm, app).field("amount").value()).isEqualTo("1,234,567.89");
 
             // Clean up (Actually not really necassary because formatters are not global anyway ;-)
             formatters.conversion.removeConvertible(BigDecimal.class, String.class); // removes print conversion
@@ -158,9 +159,8 @@ public class HttpFormsTest {
             Form<Birthday> myForm = formFactory.form(Birthday.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            myForm.data().clear();
             Birthday birthday = myForm.get();
-            assertThat(myForm.field("date").value()).isEqualTo("03/10/1986");
+            assertThat(copyFormWithoutRawData(myForm, app).field("date").value()).isEqualTo("03/10/1986");
             assertThat(birthday.getDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(1986, 10, 3));
 
             // Prepare Request and Context
@@ -174,9 +174,8 @@ public class HttpFormsTest {
             myForm = formFactory.form(Birthday.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            myForm.data().clear();
             birthday = myForm.get();
-            assertThat(myForm.field("date").value()).isEqualTo("16.02.2001");
+            assertThat(copyFormWithoutRawData(myForm, app).field("date").value()).isEqualTo("16.02.2001");
             assertThat(birthday.getDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(2001, 2, 16));
 
             // Prepare Request and Context
@@ -190,9 +189,8 @@ public class HttpFormsTest {
             myForm = formFactory.form(Birthday.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            myForm.data().clear();
             birthday = myForm.get();
-            assertThat(myForm.field("date").value()).isEqualTo("08-31-1950");
+            assertThat(copyFormWithoutRawData(myForm, app).field("date").value()).isEqualTo("08-31-1950");
             assertThat(birthday.getDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(1950, 8, 31));
         });
     }
@@ -212,9 +210,8 @@ public class HttpFormsTest {
             Form<Birthday> myForm = formFactory.form(Birthday.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            myForm.data().clear();
             Birthday birthday = myForm.get();
-            assertThat(myForm.field("alternativeDate").value()).isEqualTo("1982-05-07");
+            assertThat(copyFormWithoutRawData(myForm, app).field("alternativeDate").value()).isEqualTo("1982-05-07");
             assertThat(birthday.getAlternativeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(1982, 5, 7));
 
             // Prepare Request and Context
@@ -228,9 +225,8 @@ public class HttpFormsTest {
             myForm = formFactory.form(Birthday.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            myForm.data().clear();
             birthday = myForm.get();
-            assertThat(myForm.field("alternativeDate").value()).isEqualTo("10_04_2005");
+            assertThat(copyFormWithoutRawData(myForm, app).field("alternativeDate").value()).isEqualTo("10_04_2005");
             assertThat(birthday.getAlternativeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(2005, 10, 4));
 
             // Prepare Request and Context
@@ -244,9 +240,8 @@ public class HttpFormsTest {
             myForm = formFactory.form(Birthday.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            myForm.data().clear();
             birthday = myForm.get();
-            assertThat(myForm.field("alternativeDate").value()).isEqualTo("03/12/1962");
+            assertThat(copyFormWithoutRawData(myForm, app).field("alternativeDate").value()).isEqualTo("03/12/1962");
             assertThat(birthday.getAlternativeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(1962, 12, 3));
         });
     }
@@ -268,7 +263,6 @@ public class HttpFormsTest {
             Form<Task> myForm = formFactory.form(Task.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isTrue();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            myForm.data().clear();
             assertThat(myForm.error("dueDate").messages().size()).isEqualTo(2);
             assertThat(myForm.error("dueDate").messages().get(0)).isEqualTo("error.invalid");
             assertThat(myForm.error("dueDate").messages().get(1)).isEqualTo("error.invalid.java.util.Date");
@@ -287,7 +281,6 @@ public class HttpFormsTest {
             myForm = formFactory.form(Task.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isTrue();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            myForm.data().clear();
             assertThat(myForm.error("dueDate").messages().size()).isEqualTo(3);
             assertThat(myForm.error("dueDate").messages().get(0)).isEqualTo("error.invalid");
             assertThat(myForm.error("dueDate").messages().get(1)).isEqualTo("error.invalid.java.util.Date");
@@ -315,7 +308,6 @@ public class HttpFormsTest {
             Form<Task> myForm = formFactory.form(Task.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            myForm.data().clear();
 
             // Prepare Request and Context
             data = new HashMap<>();
@@ -332,7 +324,6 @@ public class HttpFormsTest {
             myForm = formFactory.form(Task.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            myForm.data().clear();
 
             // Prepare Request and Context
             data = new HashMap<>();
@@ -349,7 +340,6 @@ public class HttpFormsTest {
             myForm = formFactory.form(Task.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isTrue();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            myForm.data().clear();
             assertThat(myForm.error("zip").messages().size()).isEqualTo(1);
             assertThat(myForm.error("zip").message()).isEqualTo("error.i18nconstraint");
             assertThat(myForm.error("anotherZip").messages().size()).isEqualTo(1);

--- a/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -84,7 +84,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasGlobalErrors()).isFalse();
             Money money = myForm.get();
             assertThat(money.getAmount()).isEqualTo(new BigDecimal("1234567.89"));
-            assertThat(copyFormWithoutRawData(myForm, app).field("amount").value()).isEqualTo("1 234 567,89");
+            assertThat(copyFormWithoutRawData(myForm, app).field("amount").getValue().get()).isEqualTo("1 234 567,89");
             // Parse french input with english formatter
             ctx.changeLang("en");
             myForm = formFactory.form(Money.class).bindFromRequest();
@@ -92,7 +92,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasGlobalErrors()).isFalse();
             money = myForm.get();
             assertThat(money.getAmount()).isEqualTo(new BigDecimal("123456789"));
-            assertThat(copyFormWithoutRawData(myForm, app).field("amount").value()).isEqualTo("123,456,789");
+            assertThat(copyFormWithoutRawData(myForm, app).field("amount").getValue().get()).isEqualTo("123,456,789");
 
             // Prepare Request and Context with english number
             data = new HashMap<>();
@@ -107,7 +107,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasGlobalErrors()).isFalse();
             money = myForm.get();
             assertThat(money.getAmount()).isEqualTo(new BigDecimal("1234567"));
-            assertThat(copyFormWithoutRawData(myForm, app).field("amount").value()).isEqualTo("1 234 567");
+            assertThat(copyFormWithoutRawData(myForm, app).field("amount").getValue().get()).isEqualTo("1 234 567");
             // Parse english input with english formatter
             ctx.changeLang("en");
             myForm = formFactory.form(Money.class).bindFromRequest();
@@ -115,7 +115,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasGlobalErrors()).isFalse();
             money = myForm.get();
             assertThat(money.getAmount()).isEqualTo(new BigDecimal("1234567.89"));
-            assertThat(copyFormWithoutRawData(myForm, app).field("amount").value()).isEqualTo("1,234,567.89");
+            assertThat(copyFormWithoutRawData(myForm, app).field("amount").getValue().get()).isEqualTo("1,234,567.89");
 
             // Clean up (Actually not really necassary because formatters are not global anyway ;-)
             formatters.conversion.removeConvertible(BigDecimal.class, String.class); // removes print conversion
@@ -160,7 +160,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
             Birthday birthday = myForm.get();
-            assertThat(copyFormWithoutRawData(myForm, app).field("date").value()).isEqualTo("03/10/1986");
+            assertThat(copyFormWithoutRawData(myForm, app).field("date").getValue().get()).isEqualTo("03/10/1986");
             assertThat(birthday.getDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(1986, 10, 3));
 
             // Prepare Request and Context
@@ -175,7 +175,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
             birthday = myForm.get();
-            assertThat(copyFormWithoutRawData(myForm, app).field("date").value()).isEqualTo("16.02.2001");
+            assertThat(copyFormWithoutRawData(myForm, app).field("date").getValue().get()).isEqualTo("16.02.2001");
             assertThat(birthday.getDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(2001, 2, 16));
 
             // Prepare Request and Context
@@ -190,7 +190,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
             birthday = myForm.get();
-            assertThat(copyFormWithoutRawData(myForm, app).field("date").value()).isEqualTo("08-31-1950");
+            assertThat(copyFormWithoutRawData(myForm, app).field("date").getValue().get()).isEqualTo("08-31-1950");
             assertThat(birthday.getDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(1950, 8, 31));
         });
     }
@@ -211,7 +211,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
             Birthday birthday = myForm.get();
-            assertThat(copyFormWithoutRawData(myForm, app).field("alternativeDate").value()).isEqualTo("1982-05-07");
+            assertThat(copyFormWithoutRawData(myForm, app).field("alternativeDate").getValue().get()).isEqualTo("1982-05-07");
             assertThat(birthday.getAlternativeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(1982, 5, 7));
 
             // Prepare Request and Context
@@ -226,7 +226,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
             birthday = myForm.get();
-            assertThat(copyFormWithoutRawData(myForm, app).field("alternativeDate").value()).isEqualTo("10_04_2005");
+            assertThat(copyFormWithoutRawData(myForm, app).field("alternativeDate").getValue().get()).isEqualTo("10_04_2005");
             assertThat(birthday.getAlternativeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(2005, 10, 4));
 
             // Prepare Request and Context
@@ -241,7 +241,7 @@ public class HttpFormsTest {
             assertThat(myForm.hasErrors()).isFalse();
             assertThat(myForm.hasGlobalErrors()).isFalse();
             birthday = myForm.get();
-            assertThat(copyFormWithoutRawData(myForm, app).field("alternativeDate").value()).isEqualTo("03/12/1962");
+            assertThat(copyFormWithoutRawData(myForm, app).field("alternativeDate").getValue().get()).isEqualTo("03/12/1962");
             assertThat(birthday.getAlternativeDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()).isEqualTo(LocalDate.of(1962, 12, 3));
         });
     }

--- a/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -135,10 +135,8 @@ public class HttpFormsTest {
 
             List<Object> args = new ArrayList<>();
             args.add("error.customarg");
-            List<ValidationError> error = new ArrayList<>();
-            error.add(new ValidationError("key", "error.custom", args));
-            Map<String,List<ValidationError>> errors = new HashMap<>();
-            errors.put("foo", error);
+            List<ValidationError> errors = new ArrayList<>();
+            errors.add(new ValidationError("foo", "error.custom", args));
             Form<Money> form = new Form<>(null, Money.class, new HashMap<>(), errors, Optional.empty(), messagesApi, formatters, validator);
 
             assertThat(form.errorsAsJson().get("foo").toString()).isEqualTo("[\"It looks like something was not correct\"]");

--- a/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -263,10 +263,10 @@ public class HttpFormsTest {
             Form<Task> myForm = formFactory.form(Task.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isTrue();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            assertThat(myForm.error("dueDate").messages().size()).isEqualTo(2);
-            assertThat(myForm.error("dueDate").messages().get(0)).isEqualTo("error.invalid");
-            assertThat(myForm.error("dueDate").messages().get(1)).isEqualTo("error.invalid.java.util.Date");
-            assertThat(myForm.error("dueDate").message()).isEqualTo("error.invalid.java.util.Date");
+            assertThat(myForm.getError("dueDate").get().messages().size()).isEqualTo(2);
+            assertThat(myForm.getError("dueDate").get().messages().get(0)).isEqualTo("error.invalid");
+            assertThat(myForm.getError("dueDate").get().messages().get(1)).isEqualTo("error.invalid.java.util.Date");
+            assertThat(myForm.getError("dueDate").get().message()).isEqualTo("error.invalid.java.util.Date");
 
             // Prepare Request and Context
             data = new HashMap<>();
@@ -281,11 +281,11 @@ public class HttpFormsTest {
             myForm = formFactory.form(Task.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isTrue();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            assertThat(myForm.error("dueDate").messages().size()).isEqualTo(3);
-            assertThat(myForm.error("dueDate").messages().get(0)).isEqualTo("error.invalid");
-            assertThat(myForm.error("dueDate").messages().get(1)).isEqualTo("error.invalid.java.util.Date");
-            assertThat(myForm.error("dueDate").messages().get(2)).isEqualTo("error.invalid.dueDate");
-            assertThat(myForm.error("dueDate").message()).isEqualTo("error.invalid.dueDate");
+            assertThat(myForm.getError("dueDate").get().messages().size()).isEqualTo(3);
+            assertThat(myForm.getError("dueDate").get().messages().get(0)).isEqualTo("error.invalid");
+            assertThat(myForm.getError("dueDate").get().messages().get(1)).isEqualTo("error.invalid.java.util.Date");
+            assertThat(myForm.getError("dueDate").get().messages().get(2)).isEqualTo("error.invalid.dueDate");
+            assertThat(myForm.getError("dueDate").get().message()).isEqualTo("error.invalid.dueDate");
         });
     }
 
@@ -340,10 +340,10 @@ public class HttpFormsTest {
             myForm = formFactory.form(Task.class).bindFromRequest();
             assertThat(myForm.hasErrors()).isTrue();
             assertThat(myForm.hasGlobalErrors()).isFalse();
-            assertThat(myForm.error("zip").messages().size()).isEqualTo(1);
-            assertThat(myForm.error("zip").message()).isEqualTo("error.i18nconstraint");
-            assertThat(myForm.error("anotherZip").messages().size()).isEqualTo(1);
-            assertThat(myForm.error("anotherZip").message()).isEqualTo("error.anotheri18nconstraint");
+            assertThat(myForm.getError("zip").get().messages().size()).isEqualTo(1);
+            assertThat(myForm.getError("zip").get().message()).isEqualTo("error.i18nconstraint");
+            assertThat(myForm.getError("anotherZip").get().messages().size()).isEqualTo(1);
+            assertThat(myForm.getError("anotherZip").get().message()).isEqualTo("error.anotheri18nconstraint");
         });
     }
 

--- a/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -73,12 +73,12 @@ class DynamicFormSpec extends Specification {
 
     "allow access to the equivalent of the raw data when filled" in {
       val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validator).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
-      form("foo").value() must_== "bar"
+      form("foo").getValue().get() must_== "bar"
     }
 
     "don't throw NullPointerException when all components of form are null" in {
       val form = new DynamicForm(null, null, null).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
-      form("foo").value() must_== "bar"
+      form("foo").getValue().get() must_== "bar"
     }
 
     "convert jField to scala Field when all components of jField are null" in {

--- a/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -29,6 +29,7 @@ class DynamicFormSpec extends Specification {
     "bind values from a request" in {
       val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validator).bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
       form.get("foo") must_== "bar"
+      form.value("foo").get must_== "bar"
     }
 
     "allow access to raw data values from request" in {
@@ -65,17 +66,18 @@ class DynamicFormSpec extends Specification {
     }
 
     "allow access to the property when filled" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validator).fill(Map("foo" -> "bar").asJava)
+      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validator).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
       form.get("foo") must_== "bar"
+      form.value("foo").get must_== "bar"
     }
 
     "allow access to the equivalent of the raw data when filled" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validator).fill(Map("foo" -> "bar").asJava)
+      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validator).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
       form("foo").value() must_== "bar"
     }
 
     "don't throw NullPointerException when all components of form are null" in {
-      val form = new DynamicForm(null, null, null).fill(Map("foo" -> "bar").asJava)
+      val form = new DynamicForm(null, null, null).fill(Map("foo" -> "bar").asInstanceOf[Map[String, Object]].asJava)
       form("foo").value() must_== "bar"
     }
 

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -17,6 +17,7 @@ import play.api.test.WithApplication
 import play.api.{ Configuration, Environment }
 import play.core.j.{ JavaContextComponents, JavaHelpers }
 import play.data.format.Formatters
+import play.data.validation.ValidationError
 import play.mvc.Http.{ Context, Request, RequestBuilder }
 import play.twirl.api.Html
 
@@ -59,10 +60,10 @@ class FormSpec extends Specification {
 
       val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(true)
-      myForm.errors.get("dueDate").get(0).messages().size() must beEqualTo(2)
-      myForm.errors.get("dueDate").get(0).messages().get(1) must beEqualTo("error.invalid.java.util.Date")
-      myForm.errors.get("dueDate").get(0).messages().get(0) must beEqualTo("error.invalid")
-      myForm.errors.get("dueDate").get(0).message() must beEqualTo("error.invalid.java.util.Date")
+      myForm.errors("dueDate").get(0).messages().size() must beEqualTo(2)
+      myForm.errors("dueDate").get(0).messages().get(1) must beEqualTo("error.invalid.java.util.Date")
+      myForm.errors("dueDate").get(0).messages().get(0) must beEqualTo("error.invalid")
+      myForm.errors("dueDate").get(0).message() must beEqualTo("error.invalid.java.util.Date")
 
       // make sure we can access the values of an invalid form
       myForm.value().get().getId() must beEqualTo(1234567891)
@@ -95,11 +96,11 @@ class FormSpec extends Specification {
 
       val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(true)
-      myForm.errors.get("dueDate").get(0).messages().size() must beEqualTo(3)
-      myForm.errors.get("dueDate").get(0).messages().get(2) must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
-      myForm.errors.get("dueDate").get(0).messages().get(1) must beEqualTo("error.invalid.java.util.Date") // is defined in play's default messages file
-      myForm.errors.get("dueDate").get(0).messages().get(0) must beEqualTo("error.invalid") // is defined in play's default messages file
-      myForm.errors.get("dueDate").get(0).message() must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
+      myForm.errors("dueDate").get(0).messages().size() must beEqualTo(3)
+      myForm.errors("dueDate").get(0).messages().get(2) must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
+      myForm.errors("dueDate").get(0).messages().get(1) must beEqualTo("error.invalid.java.util.Date") // is defined in play's default messages file
+      myForm.errors("dueDate").get(0).messages().get(0) must beEqualTo("error.invalid") // is defined in play's default messages file
+      myForm.errors("dueDate").get(0).message() must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
     }
     "have an error due to badly formatted date after using changeLang" in new WithApplication(GuiceApplicationBuilder().configure("play.i18n.langs" -> Seq("en", "en-US", "fr")).build()) {
       val contextComponents = app.injector.instanceOf[JavaContextComponents]
@@ -111,11 +112,11 @@ class FormSpec extends Specification {
 
       val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(true)
-      myForm.errors.get("dueDate").get(0).messages().size() must beEqualTo(3)
-      myForm.errors.get("dueDate").get(0).messages().get(2) must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
-      myForm.errors.get("dueDate").get(0).messages().get(1) must beEqualTo("error.invalid.java.util.Date") // is defined in play's default messages file
-      myForm.errors.get("dueDate").get(0).messages().get(0) must beEqualTo("error.invalid") // is defined in play's default messages file
-      myForm.errors.get("dueDate").get(0).message() must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
+      myForm.errors("dueDate").get(0).messages().size() must beEqualTo(3)
+      myForm.errors("dueDate").get(0).messages().get(2) must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
+      myForm.errors("dueDate").get(0).messages().get(1) must beEqualTo("error.invalid.java.util.Date") // is defined in play's default messages file
+      myForm.errors("dueDate").get(0).messages().get(0) must beEqualTo("error.invalid") // is defined in play's default messages file
+      myForm.errors("dueDate").get(0).message() must beEqualTo("error.invalid.dueDate") // is ONLY defined in messages.fr
     }
     "have an error due to missing required value" in new WithApplication() {
       val contextComponents = app.injector.instanceOf[JavaContextComponents]
@@ -125,7 +126,7 @@ class FormSpec extends Specification {
 
       val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(true)
-      myForm.errors.get("dueDate").get(0).messages().asScala must contain("error.required")
+      myForm.errors("dueDate").get(0).messages().asScala must contain("error.required")
     }
     "have an error due to bad value in Id field" in new WithApplication() {
       val contextComponents = app.injector.instanceOf[JavaContextComponents]
@@ -135,7 +136,7 @@ class FormSpec extends Specification {
 
       val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(true)
-      myForm.errors.get("id").get(0).messages().asScala must contain("error.invalid")
+      myForm.errors("id").get(0).messages().asScala must contain("error.invalid")
     }
     "be valid with default date binder" in {
       val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("15/12/2009"), "endDate" -> Array("2008-11-21")))
@@ -152,7 +153,7 @@ class FormSpec extends Specification {
 
       val myForm = formFactory.form(classOf[play.data.models.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(true)
-      myForm.errors.get("endDate").get(0).messages().asScala must contain("error.invalid.java.util.Date")
+      myForm.errors("endDate").get(0).messages().asScala must contain("error.invalid.java.util.Date")
     }
 
     "support repeated values for Java binding" in {
@@ -229,8 +230,8 @@ class FormSpec extends Specification {
         val form = formFactory.form(classOf[MyBlueUser]).bind(
           Map("name" -> "Shrek", "skinColor" -> "green", "hairColor" -> "blue").asJava)
         form.hasErrors must beEqualTo(true)
-        form.errors().get("hairColor") must beNull
-        val validationErrors = form.errors().get("skinColor")
+        form.errors("hairColor").asScala must beEmpty
+        val validationErrors = form.errors("skinColor")
         validationErrors.size() must beEqualTo(1)
         validationErrors.get(0).message must beEqualTo("notblue")
       }
@@ -238,9 +239,9 @@ class FormSpec extends Specification {
       "that returns customized message in annotation when validator fails" in {
         val form = formFactory.form(classOf[MyBlueUser]).bind(
           Map("name" -> "Smurf", "skinColor" -> "blue", "hairColor" -> "white").asJava)
-        form.errors().get("skinColor") must beNull
+        form.errors("skinColor").asScala must beEmpty
         form.hasErrors must beEqualTo(true)
-        val validationErrors = form.errors().get("hairColor")
+        val validationErrors = form.errors("hairColor")
         validationErrors.size() must beEqualTo(1)
         validationErrors.get(0).message must beEqualTo("i-am-blue")
       }
@@ -265,7 +266,7 @@ class FormSpec extends Specification {
         // Don't use bind, the point here is to have a form with data that isn't bound, otherwise the mapping indexes
         // used come from the form, not the input data
         new Form[JavaForm](null, classOf[JavaForm], map.asJava,
-          Map.empty.asJava, Optional.empty[JavaForm], null, null, FormSpec.validator())
+          List.empty.asJava.asInstanceOf[java.util.List[ValidationError]], Optional.empty[JavaForm], null, null, FormSpec.validator())
       }
 
       "render the right number of fields if there's multiple sub fields at a given index when filled from a value" in {

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -212,9 +212,9 @@ class FormSpec extends Specification {
 
     "support email validation" in {
       val userEmail = formFactory.form(classOf[UserEmail])
-      userEmail.bind(Map("email" -> "john@example.com").asJava).errors().asScala must beEmpty
-      userEmail.bind(Map("email" -> "o'flynn@example.com").asJava).errors().asScala must beEmpty
-      userEmail.bind(Map("email" -> "john@ex'ample.com").asJava).errors().asScala must not(beEmpty)
+      userEmail.bind(Map("email" -> "john@example.com").asJava).allErrors().asScala must beEmpty
+      userEmail.bind(Map("email" -> "o'flynn@example.com").asJava).allErrors().asScala must beEmpty
+      userEmail.bind(Map("email" -> "john@ex'ample.com").asJava).allErrors().asScala must not(beEmpty)
     }
 
     "support custom validators" in {

--- a/framework/src/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/PartialValidationSpec.scala
@@ -23,7 +23,7 @@ class PartialValidationSpec extends Specification {
   "partial validation" should {
     "not fail when fields not in the same group fail validation" in {
       val form = formFactory.form(classOf[SomeForm], classOf[Partial]).bind(Map("prop2" -> "Hello", "prop3" -> "abc").asJava)
-      form.errors().asScala must beEmpty
+      form.allErrors().asScala must beEmpty
     }
 
     "fail when a field in the group fails validation" in {


### PR DESCRIPTION
Right now we use a `Map<String,List<ValidationError>>` to store validation errors inside a `play.data.Form` instance.
But this absolutely doesn't make any sense at all and makes the code just very confusing. A `Map` entry's key will always be the same as the keys of the `ValidationError`s the `Map` entry stores anyway. It seemed the only "sense" to store the `ValidationError`s in a map was to access it "more easy" via `.get("somekey")` - but since we are using Java >= 8 we can simple use stream methods (`filter`, `findFirst` , etc.) to access the desired error(s).

Also it turns out the use of a `Map` here is a leftover from one of Play 2 first commits ever - where a `ValidationError` [didn't have a `key` field yet](https://github.com/playframework/playframework/commit/8d644fe0f629bb5213f0dbcd393d419329fba664#diff-5ca281da229236db4cc36a9058ce1238) (so using a map back than seems reasonable).

Plus: The Scala `Form` uses [a simple `List`](https://github.com/playframework/playframework/blob/2.6.0-M1/framework/src/play/src/main/scala/play/api/data/Form.scala#L35) as well - so we just bring [the Java implemention on par with it](https://github.com/playframework/playframework/blob/2.6.0-M1/framework/src/play/src/main/scala/play/api/data/Form.scala#L174).