### PR TITLE
Ensure akka-http has valid reference.conf

### DIFF
--- a/framework/src/play-akka-http-server/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/reference.conf
@@ -13,8 +13,13 @@ play {
       # How long to wait when binding to the listening socket
       bindTimeout = 5 seconds
 
+      # The idle timeout for an open connection after which it will be closed
+      # Set to null to disable the timeout
+      https.idleTimeout = 75 seconds
+      http.idleTimeout = 75 seconds
+
       # How long a request takes until it times out
-      # request-timeout = 240 seconds
+      requestTimeout = null
 
       # Enables/disables automatic handling of HEAD requests.
       # If this setting is enabled the server dispatches HEAD requests as GET


### PR DESCRIPTION
The reference.conf refers to `request-timeout` but the code refers to `requestTimeout`

The idleTimeout settings are left undefined and not in AkkaHttp.

See https://groups.google.com/d/msg/play-framework/imf51EsYU08/tDk0sEfPCgAJ for user experience

Documentation at https://github.com/playframework/playframework/blob/master/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md could also use some love

@ktoso and @jrudolph are looking at akka-http already, so not going to go into cleaning up the `.getOptional` calls...