### PR TITLE
Migrate CSRF to request attributes

### DIFF
--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -34,6 +34,9 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
 
     private final CSRF.Token$ Token = CSRF.Token$.MODULE$;
 
+    private static final String CSRF_TOKEN = "CSRF_TOKEN";
+    private static final String CSRF_TOKEN_NAME = "CSRF_TOKEN_NAME";
+
     @Override
     public CompletionStage<Result> call(Http.Context ctx) {
 
@@ -47,8 +50,8 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
             String newToken = tokenProvider.generateToken();
 
             // Place this token into the context
-            ctx.args.put(Token.RequestTag(), newToken);
-            ctx.args.put(Token.NameRequestTag(), config.tokenName());
+            ctx.args.put(CSRF_TOKEN, newToken);
+            ctx.args.put(CSRF_TOKEN_NAME, config.tokenName());
 
             // Create a new Scala RequestHeader with the token
             request = csrfActionHelper.tagRequest(request, new CSRF.Token(config.tokenName(), newToken));

--- a/framework/src/play-filters-helpers/src/main/scala/views/html/helper/CSRF.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/views/html/helper/CSRF.scala
@@ -11,11 +11,16 @@ import play.twirl.api.{ Html, HtmlFormat }
  */
 object CSRF {
 
+  def getToken(implicit request: RequestHeader): play.filters.csrf.CSRF.Token =
+    play.filters.csrf.CSRF.getToken.getOrElse(
+      sys.error("No CSRF token was generated for this request! Is the CSRF filter installed?")
+    )
+
   /**
    * Add the CSRF token as a query String parameter to this reverse router request
    */
   def apply(call: Call)(implicit request: RequestHeader): Call = {
-    val token = play.filters.csrf.CSRF.getToken.getOrElse(sys.error("No CSRF token present!"))
+    val token = getToken
     new Call(
       call.method,
       s"${call.url}${if (call.url.contains("?")) "&" else "?"}${token.name}=${token.value}"
@@ -26,7 +31,7 @@ object CSRF {
    * Render a CSRF form field token
    */
   def formField(implicit request: RequestHeader): Html = {
-    val token = play.filters.csrf.CSRF.getToken.getOrElse(sys.error("No CSRF token present!"))
+    val token = getToken
     // probably not possible for an attacker to XSS with a CSRF token, but just to be on the safe side...
     Html(s"""<input type="hidden" name="${token.name}" value="${HtmlFormat.escape(token.value)}"/>""")
   }


### PR DESCRIPTION
This just migrates from using tags to attributes for storing the CSRF token info on the request.

All the existing tests still pass. I still have to look at what's happening with #6977.