### PR TITLE
[2.4.x] 204/304 response should also trigger onDoneEnumerating for the body

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/ModelConversion.scala
@@ -181,6 +181,8 @@ private[akkahttp] class ModelConversion(forwardedHeaderHandler: ForwardedHeaderH
               data = dataSource(enum)
             ))
           case ServerResultUtils.StreamWithNoBody =>
+            // Ensure that the body is consumed in case any onDoneEnumerating handlers are registered
+            result.body |>>> Iteratee.ignore
             valid(HttpEntity.Empty)
           case ServerResultUtils.StreamWithKnownLength(enum) =>
             convertedHeaders.contentLength.get match {

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyResultStreamer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyResultStreamer.scala
@@ -86,6 +86,8 @@ object NettyResultStreamer {
             case ServerResultUtils.StreamWithKnownLength(enum) =>
               streamEnum(enum)
             case ServerResultUtils.StreamWithNoBody =>
+              // Ensure that the body is consumed in case any onDoneEnumerating handlers are registered
+              result.body |>>> Iteratee.ignore
               // `StreamWithNoBody` won't add the Content-Length entity-header to the response (if not already present)
               sendContent()
             case ServerResultUtils.StreamWithStrictBody(body) =>


### PR DESCRIPTION
Fixes the issue of "204/304 response didn't trigger onDoneEnumerating for the body", which @bbarkley has reported.

When the response status is 204 or 304, the response doesn't send out with a body. The case of StreamWithNoBody in both Netty server and Akka HTTP server didn't consume the response's empty Enumerator body, thus the onDoneEnumerating hook couldn't be triggered.

Added tests, which fail without the fix.

Create this pull request on behalf of @bbarkley.