### PR TITLE
Add type ascription in play.api.test.Fakes.scala, and remove useless method

### DIFF
--- a/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Fakes.scala
@@ -112,8 +112,6 @@ class FakeRequest[A](request: Request[A]) extends Request[A] {
     withBody(body = AnyContentAsFormUrlEncoded(play.utils.OrderPreserving.groupBy(data.toSeq)(_._1)))
   }
 
-  def certs = Future.successful(IndexedSeq.empty)
-
   /**
    * Adds a JSON body to the request.
    */
@@ -146,7 +144,7 @@ class FakeRequest[A](request: Request[A]) extends Request[A] {
   /**
    * Adds a multipart form data body to the request
    */
-  def withMultipartFormDataBody(form: MultipartFormData[TemporaryFile]) = {
+  def withMultipartFormDataBody(form: MultipartFormData[TemporaryFile]): FakeRequest[AnyContentAsMultipartFormData] = {
     withBody(body = AnyContentAsMultipartFormData(form))
   }
 
@@ -216,7 +214,7 @@ class FakeRequestFactory(requestFactory: RequestFactory) {
       new RequestTarget {
         override lazy val uri: URI = new URI(uriString)
         override def uriString: String = _uri
-        override lazy val path = uriString.split('?').take(1).mkString
+        override lazy val path: String = uriString.split('?').take(1).mkString
         override lazy val queryMap: Map[String, Seq[String]] = FormUrlEncodedParser.parse(queryString)
       },
       version,


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Purpose

This adds type ascription to `path` and `withMultipartFormDateBody` method  in `play.api.test.FakeRequest` and `play.api.test.RequestTarget`. 
And remove useless method.
