### PR TITLE
[WIP] Add blake2 as default cookie signer

### DIFF
--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -98,3 +98,9 @@ public class MyController extends Controller {
 ```
 
 Once the template is defined with its dependencies, then the controller can have the template injected into the controller, but the controller does not see `TemplateRenderingComponent`.
+
+## Message Authentication using Blake2b 
+
+In the wake of the [SHA-1 collision](https://security.googleblog.com/2017/02/announcing-first-sha1-collision.html?m=1), Play's cookie handling now uses [Blake2b](https://blake2.net/) by default for message authentication, instead of SHA-1 HMAC. 
+
+This should be transparent to most projects but if the previous cookie signing behavior is required, then  `play.http.secret.mac=HmacSHA1` should be set in `application.conf`.

--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -101,6 +101,6 @@ Once the template is defined with its dependencies, then the controller can have
 
 ## Message Authentication using Blake2b 
 
-In the wake of the [SHA-1 collision](https://security.googleblog.com/2017/02/announcing-first-sha1-collision.html?m=1), Play's cookie handling now uses [Blake2b](https://blake2.net/) by default for message authentication, instead of SHA-1 HMAC. 
+In the wake of the [SHA-1 collision](https://security.googleblog.com/2017/02/announcing-first-sha1-collision.html), Play's cookie handling now uses [Blake2b](https://blake2.net/) by default for message authentication, instead of SHA-1 HMAC. 
 
 This should be transparent to most projects but if the previous cookie signing behavior is required, then  `play.http.secret.mac=HmacSHA1` should be set in `application.conf`.

--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -103,4 +103,6 @@ Once the template is defined with its dependencies, then the controller can have
 
 In the wake of the [SHA-1 collision](https://security.googleblog.com/2017/02/announcing-first-sha1-collision.html), Play's cookie handling now uses [Blake2b](https://blake2.net/) by default for message authentication, instead of SHA-1 HMAC. 
 
-This should be transparent to most projects but if the previous cookie signing behavior is required, then  `play.http.secret.mac=HmacSHA1` should be set in `application.conf`.
+Because the session cookie is authenticated differently between Play 2.5.x and Play 2.6.x, this means that an upgrade from an existing Play 2.5.x application will result in sessions being invalidated as users rollover between servers. 
+
+If the previous cookie signing behavior is required, then `play.http.secret.mac=HmacSHA1` should be set in `application.conf`.

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -606,4 +606,6 @@ There are some configurations.  The old configuration paths will generally still
 
 In the wake of the [SHA-1 collision](https://security.googleblog.com/2017/02/announcing-first-sha1-collision.html), Play's cookie handling now uses [Blake2b](https://blake2.net/) by default for message authentication, instead of SHA-1 HMAC. 
 
+Because the session cookie is authenticated differently between Play 2.5.x and Play 2.6.x, this means that an upgrade from an existing Play 2.5.x application will result in sessions being invalidated as users rollover between servers. 
+
 This should be transparent to most projects but if the previous cookie signing behavior is required, then  `play.http.secret.mac=HmacSHA1` should be set in `application.conf`.

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -604,6 +604,6 @@ There are some configurations.  The old configuration paths will generally still
 
 ## Message Authentication using Blake2b 
 
-In the wake of the [SHA-1 collision](https://security.googleblog.com/2017/02/announcing-first-sha1-collision.html?m=1), Play's cookie handling now uses [Blake2b](https://blake2.net/) by default for message authentication, instead of SHA-1 HMAC. 
+In the wake of the [SHA-1 collision](https://security.googleblog.com/2017/02/announcing-first-sha1-collision.html), Play's cookie handling now uses [Blake2b](https://blake2.net/) by default for message authentication, instead of SHA-1 HMAC. 
 
 This should be transparent to most projects but if the previous cookie signing behavior is required, then  `play.http.secret.mac=HmacSHA1` should be set in `application.conf`.

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -600,3 +600,10 @@ There are some configurations.  The old configuration paths will generally still
 | ------------------------- | ---------------------------------- |
 | `play.crypto.secret`      | `play.http.secret.key`             |
 | `play.crypto.provider`    | `play.http.secret.provider`        |
+
+
+## Message Authentication using Blake2b 
+
+In the wake of the [SHA-1 collision](https://security.googleblog.com/2017/02/announcing-first-sha1-collision.html?m=1), Play's cookie handling now uses [Blake2b](https://blake2.net/) by default for message authentication, instead of SHA-1 HMAC. 
+
+This should be transparent to most projects but if the previous cookie signing behavior is required, then  `play.http.secret.mac=HmacSHA1` should be set in `application.conf`.

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -114,6 +114,9 @@ object Dependencies {
     "com.google.inject.extensions" % "guice-assistedinject" % guiceVersion
   )
 
+  val scryptoVersion = "1.2.0-RC3"
+  val scrypto = "org.consensusresearch" %% "scrypto" % scryptoVersion
+
   def runtime(scalaVersion: String) =
     slf4j ++
     Seq("akka-actor", "akka-slf4j").map("com.typesafe.akka" %% _ % akkaVersion) ++
@@ -125,6 +128,7 @@ object Dependencies {
       playJson,
 
       guava,
+      scrypto,
 
       "org.apache.commons" % "commons-lang3" % "3.5",
 

--- a/framework/src/play-java/src/main/java/play/inject/BuiltInModule.java
+++ b/framework/src/play-java/src/main/java/play/inject/BuiltInModule.java
@@ -10,7 +10,7 @@ import play.libs.Files;
 import play.libs.crypto.CSRFTokenSigner;
 import play.libs.crypto.CookieSigner;
 import play.libs.crypto.DefaultCSRFTokenSigner;
-import play.libs.crypto.HMACSHA1CookieSigner;
+import play.libs.crypto.DelegateCookieSigner;
 import play.mvc.FileMimeTypes;
 import scala.collection.Seq;
 
@@ -21,7 +21,7 @@ public class BuiltInModule extends play.api.inject.Module {
           bind(ApplicationLifecycle.class).to(DelegateApplicationLifecycle.class),
           bind(play.Configuration.class).toProvider(ConfigurationProvider.class),
           bind(CSRFTokenSigner.class).to(DefaultCSRFTokenSigner.class),
-          bind(CookieSigner.class).to(HMACSHA1CookieSigner.class),
+          bind(CookieSigner.class).to(DelegateCookieSigner.class),
           bind(Files.TemporaryFileCreator.class).to(Files.DelegateTemporaryFileCreator.class),
           bind(FileMimeTypes.class).toSelf()
         );

--- a/framework/src/play/src/main/java/play/libs/crypto/DelegateCookieSigner.java
+++ b/framework/src/play/src/main/java/play/libs/crypto/DelegateCookieSigner.java
@@ -4,23 +4,20 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**
- * Authenticates a cookie by creating a  message authentication code using HMAC-SHA1.
+ * Delegates to a Scala CookieSigner.
  */
 @Singleton
-public class HMACSHA1CookieSigner implements CookieSigner {
+public class DelegateCookieSigner implements CookieSigner {
 
     private final play.api.libs.crypto.CookieSigner signer;
 
     @Inject
-    public HMACSHA1CookieSigner(play.api.libs.crypto.CookieSigner signer) {
+    public DelegateCookieSigner(play.api.libs.crypto.CookieSigner signer) {
         this.signer = signer;
     }
 
     /**
-     * Signs the given String with HMAC-SHA1 using the application's secret key.
-     * <br>
-     * By default this uses the platform default JSSE provider.  This can be overridden by defining
-     * <code>application.crypto.provider</code> in <code>application.conf</code>.
+     * Signs the cookie with the default key.
      *
      * @param message The message to sign.
      * @return A hexadecimal encoded signature.
@@ -30,10 +27,7 @@ public class HMACSHA1CookieSigner implements CookieSigner {
     }
 
     /**
-     * Signs the given String with HMAC-SHA1 using the given key.
-     * <br>
-     * By default this uses the platform default JSSE provider.  This can be overridden by defining
-     * <code>application.crypto.provider</code> in <code>application.conf</code>.
+     * Signs the cookie with the given key.
      *
      * @param message The message to sign.
      * @param key     The private key to sign with.

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -174,6 +174,9 @@ play {
 
       # The JCE provider to use. If null, uses the platform default.
       provider = null
+
+      # The algorithm to use for message authentication.  Use "HmacSHA1" to revert back to pre-2.6.x behavior.
+      mac = "blake2b"
     }
 
     fileMimeTypes = """

--- a/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -57,9 +57,9 @@ case class HttpConfiguration(
  *
  * To achieve 4, using the location of application.conf to generate the secret should ensure this.
  *
- * @param secret   the application secret\
+ * @param secret   the application secret
  * @param provider the JCE provider to use. If null, uses the platform default
- * @param mac the MAC to use for message authentication.
+ * @param mac the algorithm to use for message authentication.
  */
 case class SecretConfiguration(secret: String = "changeme", provider: Option[String] = None, mac: Option[String] = None)
 

--- a/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpConfiguration.scala
@@ -57,10 +57,11 @@ case class HttpConfiguration(
  *
  * To achieve 4, using the location of application.conf to generate the secret should ensure this.
  *
- * @param secret   the application secre
+ * @param secret   the application secret\
  * @param provider the JCE provider to use. If null, uses the platform default
+ * @param mac the MAC to use for message authentication.
  */
-case class SecretConfiguration(secret: String = "changeme", provider: Option[String] = None)
+case class SecretConfiguration(secret: String = "changeme", provider: Option[String] = None, mac: Option[String] = None)
 
 /**
  * The cookies configuration
@@ -219,7 +220,9 @@ object HttpConfiguration {
 
     val provider = config.getDeprecated[Option[String]]("play.http.secret.provider", "play.crypto.provider")
 
-    SecretConfiguration(String.valueOf(secret), provider)
+    val mac = config.getOptional[String]("play.http.secret.mac")
+
+    SecretConfiguration(String.valueOf(secret), provider, mac)
   }
 
   /**

--- a/framework/src/play/src/main/scala/play/api/libs/crypto/CSRFTokenSigner.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/crypto/CSRFTokenSigner.scala
@@ -97,6 +97,9 @@ class DefaultCSRFTokenSigner @Inject() (signer: CookieSigner, clock: Clock) exte
    * @return The verified raw token, or None if the token isn't valid.
    */
   def extractSignedToken(token: String): Option[String] = {
+    val Array(signature, nonce, raw) = token.split("-", 3)
+    println(signer.sign(nonce + "-" + raw))
+
     token.split("-", 3) match {
       case Array(signature, nonce, raw) if isEqual(signature, signer.sign(nonce + "-" + raw)) => Some(raw)
       case _ => None

--- a/framework/src/play/src/main/scala/play/api/libs/crypto/CookieSigner.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/crypto/CookieSigner.scala
@@ -57,7 +57,7 @@ class DefaultCookieSigner(secretConfiguration: SecretConfiguration) extends Cook
    *
    * @param message The message to sign.
    * @param key The private key to sign with.
-   * @return A encoded signature.
+   * @return An encoded signature.
    */
   def sign(message: String, key: Array[Byte]): String = {
     mac match {
@@ -76,7 +76,7 @@ class DefaultCookieSigner(secretConfiguration: SecretConfiguration) extends Cook
    * Signs the given String using the application’s secret key.
    *
    * @param message The message to sign.
-   * @return A encoded signature.
+   * @return An encoded signature.
    */
   def sign(message: String): String = {
     sign(message, secretConfiguration.secret.getBytes(StandardCharsets.UTF_8))

--- a/framework/src/play/src/main/scala/play/api/libs/crypto/CookieSigner.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/crypto/CookieSigner.scala
@@ -8,6 +8,7 @@ import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 import javax.inject.{ Inject, Provider, Singleton }
 
+import ove.crypto.digest.Blake2b
 import play.api.http.SecretConfiguration
 import play.api.libs.Codecs
 
@@ -21,9 +22,6 @@ trait CookieSigner {
   /**
    * Signs (MAC) the given String using the given secret key.
    *
-   * By default this uses the platform default JCE provider.  This can be overridden by defining
-   * `play.http.secret.provider` in `application.conf`.
-   *
    * @param message The message to sign.
    * @param key     The private key to sign with.
    * @return A hexadecimal encoded signature.
@@ -32,9 +30,6 @@ trait CookieSigner {
 
   /**
    * Signs (MAC) the given String using the application’s secret key.
-   *
-   * By default this uses the platform default JCE provider.  This can be overridden by defining
-   * `play.http.secret.provider` in `application.conf`.
    *
    * @param message The message to sign.
    * @return A hexadecimal encoded signature.
@@ -48,36 +43,40 @@ class CookieSignerProvider @Inject() (secretConfiguration: SecretConfiguration) 
 }
 
 /**
- * Uses an HMAC-SHA1 for signing cookies.
+ * The default cookie signer.
+ *
+ * This is configured for <a href="https://blake2.net/">BLAKE2b in keyed mode</a> out of the
+ * box if secretConfiguration.mac is "blake2b" or None, but will use JCA algorithm with a Mac otherwise.
  */
-class DefaultCookieSigner @Inject() (secretConfiguration: SecretConfiguration) extends CookieSigner {
+class DefaultCookieSigner(secretConfiguration: SecretConfiguration) extends CookieSigner {
 
-  private lazy val HmacSHA1 = "HmacSHA1"
+  def mac: String = secretConfiguration.mac.getOrElse("blake2b")
 
   /**
-   * Signs the given String with HMAC-SHA1 using the given key.
-   *
-   * By default this uses the platform default JSSE provider.  This can be overridden by defining
-   * `play.http.secret.provider` in `application.conf`.
+   * Signs the given String using the given key and the provided algorithm.
    *
    * @param message The message to sign.
    * @param key The private key to sign with.
-   * @return A hexadecimal encoded signature.
+   * @return A encoded signature.
    */
   def sign(message: String, key: Array[Byte]): String = {
-    val mac = secretConfiguration.provider.fold(Mac.getInstance(HmacSHA1))(p => Mac.getInstance(HmacSHA1, p))
-    mac.init(new SecretKeySpec(key, HmacSHA1))
-    Codecs.toHexString(mac.doFinal(message.getBytes(StandardCharsets.UTF_8)))
+    mac match {
+      case "blake2b" =>
+        val mac = Blake2b.Mac.newInstance(key)
+        Codecs.toHexString(mac.digest(message.getBytes(StandardCharsets.UTF_8)))
+
+      case algorithm =>
+        val mac = secretConfiguration.provider.fold(Mac.getInstance(algorithm))(p => Mac.getInstance(algorithm, p))
+        mac.init(new SecretKeySpec(key, algorithm))
+        Codecs.toHexString(mac.doFinal(message.getBytes(StandardCharsets.UTF_8)))
+    }
   }
 
   /**
-   * Signs the given String with HMAC-SHA1 using the application’s secret key.
-   *
-   * By default this uses the platform default JSSE provider.  This can be overridden by defining
-   * `play.http.secret.provider` in `application.conf`.
+   * Signs the given String using the application’s secret key.
    *
    * @param message The message to sign.
-   * @return A hexadecimal encoded signature.
+   * @return A encoded signature.
    */
   def sign(message: String): String = {
     sign(message, secretConfiguration.secret.getBytes(StandardCharsets.UTF_8))

--- a/framework/src/play/src/test/scala/play/api/libs/crypto/CSRFTokenSignerSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/crypto/CSRFTokenSignerSpec.scala
@@ -11,7 +11,7 @@ import play.api.http.SecretConfiguration
 class CSRFTokenSignerSpec extends Specification {
 
   val key = "0123456789abcdef"
-  val secretConfiguration = SecretConfiguration(key, Some("HmacSHA1"))
+  val secretConfiguration = SecretConfiguration(key)
   val clock = Clock.fixed(Instant.ofEpochMilli(0L), ZoneId.systemDefault)
   val signer = new DefaultCookieSigner(secretConfiguration)
   val tokenSigner = new DefaultCSRFTokenSigner(signer, clock)
@@ -28,14 +28,14 @@ class CSRFTokenSignerSpec extends Specification {
       val token: String = "0FFFFFFFFFFFFFFFFFFFFF24"
       token.length must be_==(24)
       val signedToken = tokenSigner.signToken(token)
-      signedToken must beEqualTo("77adb3c3dfe5ee567556b259549a4ddfa6797c05-0-0FFFFFFFFFFFFFFFFFFFFF24")
+      signedToken must beEqualTo("169b4bd49930f3a91232fe14e38952bfe3840022c387b12e25aad7e8603d2ba356a99732a2151c25178d3bcf68fb99acd63f2e47717bbf2ee564e1f8cda3fc82-0-0FFFFFFFFFFFFFFFFFFFFF24")
     }
   }
 
   "tokenSigner.compareSignedTokens" should {
     "be successful" in {
-      val token1: String = "b3ba23c672b5e115b0c44335544dbf42934f70f5-1445022964749-0FFFFFFFFFFFFFFFFFFFFF24"
-      val token2: String = "b3ba23c672b5e115b0c44335544dbf42934f70f5-1445022964749-0FFFFFFFFFFFFFFFFFFFFF24"
+      val token1: String = "cddd64086f143c0c0d4f5a934533efe01744a183b2a30cc6f26bac1635023674f935e292838383a0b0ccc777e3874ba910756c67f6fc48654a169226b370bf26-1445022964749-0FFFFFFFFFFFFFFFFFFFFF24"
+      val token2: String = "cddd64086f143c0c0d4f5a934533efe01744a183b2a30cc6f26bac1635023674f935e292838383a0b0ccc777e3874ba910756c67f6fc48654a169226b370bf26-1445022964749-0FFFFFFFFFFFFFFFFFFFFF24"
       val actual = tokenSigner.compareSignedTokens(token1, token2)
       actual must beTrue
     }

--- a/framework/src/play/src/test/scala/play/api/libs/crypto/CSRFTokenSignerSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/crypto/CSRFTokenSignerSpec.scala
@@ -11,7 +11,7 @@ import play.api.http.SecretConfiguration
 class CSRFTokenSignerSpec extends Specification {
 
   val key = "0123456789abcdef"
-  val secretConfiguration = SecretConfiguration(key, None)
+  val secretConfiguration = SecretConfiguration(key, Some("HmacSHA1"))
   val clock = Clock.fixed(Instant.ofEpochMilli(0L), ZoneId.systemDefault)
   val signer = new DefaultCookieSigner(secretConfiguration)
   val tokenSigner = new DefaultCSRFTokenSigner(signer, clock)

--- a/framework/src/play/src/test/scala/play/api/libs/crypto/CookieSignerSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/crypto/CookieSignerSpec.scala
@@ -11,10 +11,34 @@ class CookieSignerSpec extends Specification {
 
   "signer.sign" should {
 
+    "be able to sign input using Blake2b using the config secret" in {
+      val text = "Play Framework 2.0"
+      val key = "0123456789abcdef"
+      val secretConfiguration = SecretConfiguration(key)
+      val signer = new DefaultCookieSigner(secretConfiguration)
+      signer.sign(text) must be_==("7328db687e45025bacb3e137edea4f6152dda6081964b267f9d92042bbaacf5ebb0103cb74446597a1a9735d5d81999ad5a43141f9e2621ad3def7180ebc055d")
+    }
+
+    "be able to sign input using Blake2b using an explicitly passed in key" in {
+      val text = "Play Framework 2.0"
+      val key = "different key"
+      val secretConfiguration = SecretConfiguration(key)
+      val signer = new DefaultCookieSigner(secretConfiguration)
+      signer.sign(text, key.getBytes("UTF-8")) must be_==("279857b7d26b4ca9d942aa24efa4b760a9abd3b35129d1794c22bb56c01642259b55bff0d782786285052ea47f80be388f6224e020746c9a2fc7f07f63f79d54")
+    }
+
+    "be able to sign input using Blake2b using an explicitly passed in key (same as secret)" in {
+      val text = "Play Framework 2.0"
+      val key = "0123456789abcdef"
+      val secretConfiguration = SecretConfiguration(key)
+      val signer = new DefaultCookieSigner(secretConfiguration)
+      signer.sign(text, key.getBytes("UTF-8")) must be_==("7328db687e45025bacb3e137edea4f6152dda6081964b267f9d92042bbaacf5ebb0103cb74446597a1a9735d5d81999ad5a43141f9e2621ad3def7180ebc055d")
+    }
+
     "be able to sign input using HMAC-SHA1 using the config secret" in {
       val text = "Play Framework 2.0"
       val key = "0123456789abcdef"
-      val secretConfiguration = SecretConfiguration(key, None)
+      val secretConfiguration = SecretConfiguration(key, mac = Some("HmacSHA1"))
       val signer = new DefaultCookieSigner(secretConfiguration)
       signer.sign(text) must be_==("94f63b1470ee74e15dc15fd704e26b0df36ef848")
     }
@@ -22,7 +46,7 @@ class CookieSignerSpec extends Specification {
     "be able to sign input using HMAC-SHA1 using an explicitly passed in key" in {
       val text = "Play Framework 2.0"
       val key = "different key"
-      val secretConfiguration = SecretConfiguration(key, None)
+      val secretConfiguration = SecretConfiguration(key, mac = Some("HmacSHA1"))
       val signer = new DefaultCookieSigner(secretConfiguration)
       signer.sign(text, key.getBytes("UTF-8")) must be_==("470037631bddcbd13bb85d80d531c97a340f836f")
     }
@@ -30,7 +54,7 @@ class CookieSignerSpec extends Specification {
     "be able to sign input using HMAC-SHA1 using an explicitly passed in key (same as secret)" in {
       val text = "Play Framework 2.0"
       val key = "0123456789abcdef"
-      val secretConfiguration = SecretConfiguration(key, None)
+      val secretConfiguration = SecretConfiguration(key, mac = Some("HmacSHA1"))
       val signer = new DefaultCookieSigner(secretConfiguration)
       signer.sign(text, key.getBytes("UTF-8")) must be_==("94f63b1470ee74e15dc15fd704e26b0df36ef848")
     }


### PR DESCRIPTION
## Purpose

Adds blake2 as the default MAC algorithm for cookie signing, adds a "mac" configuration property.

## Background Context

With a SHA-1 collision already found on http://security.googleblog.com/2017/02/announcing-first-sha1-collision.html it's clear it's time to migrate everything off SHA-1 based algorithms.  SHA1 HMAC is not implicated, but the trend is inexorable http://valerieaurora.org/hash.html and with 2.6.x coming out, it's a good time to change the default.  Blake2b is faster than SHA-1 https://blake2.net/ and is perfectly suited for MAC.

This should not affect most projects, but it is possible that projects which poke into the session handling cookie may break.  

There may be a problem with rolling upgrades, because session cookies will not validate as users roll between servers.  Maybe it'd be better to have fallback behavior, but that would be something you'd only want during the rollover.

The old behavior is still available if projects need it, by setting `play.http.secret.mac=HmacSHA1` in application.conf.

WIP: Needs notes in Migration26.md, possibly add this to Highlights26.md