### PR TITLE
Add builtin controller components

### DIFF
--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -133,6 +133,6 @@ abstract class BuiltInComponentsFromContext(context: ApplicationLoader.Context) 
   )
 
   override lazy val injector: Injector = new SimpleInjector(NewInstanceInjector) + router + cookieSigner +
-    csrfTokenSigner + httpConfiguration + tempFileCreator + messagesApi + langs + javaContextComponents + fileMimeTypes + controllerComponents
+    csrfTokenSigner + httpConfiguration + tempFileCreator + messagesApi + langs + javaContextComponents + fileMimeTypes
 }
 

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -3,12 +3,12 @@
  */
 package play.api
 
-import play.api.i18n.{I18nComponents, I18nModule}
-import play.core.{DefaultWebCommands, SourceMapper, WebCommands}
+import play.api.i18n.{ I18nComponents, I18nModule }
+import play.core.{ DefaultWebCommands, SourceMapper, WebCommands }
 import play.utils.Reflect
-import play.api.inject.{DefaultApplicationLifecycle, Injector, NewInstanceInjector, SimpleInjector}
-import play.api.mvc.{ControllerComponents, DefaultControllerComponents}
-import play.core.j.{DefaultJavaContextComponents, JavaHelpers}
+import play.api.inject.{ DefaultApplicationLifecycle, Injector, NewInstanceInjector, SimpleInjector }
+import play.api.mvc.{ ControllerComponents, DefaultControllerComponents }
+import play.core.j.{ DefaultJavaContextComponents, JavaHelpers }
 
 /**
  * Loads an application.  This is responsible for instantiating an application given a context.

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -3,11 +3,12 @@
  */
 package play.api
 
-import play.api.i18n.{ I18nComponents, I18nModule }
-import play.core.{ DefaultWebCommands, SourceMapper, WebCommands }
+import play.api.i18n.{I18nComponents, I18nModule}
+import play.core.{DefaultWebCommands, SourceMapper, WebCommands}
 import play.utils.Reflect
-import play.api.inject.{ DefaultApplicationLifecycle, Injector, NewInstanceInjector, SimpleInjector }
-import play.core.j.{ DefaultJavaContextComponents, JavaHelpers }
+import play.api.inject.{DefaultApplicationLifecycle, Injector, NewInstanceInjector, SimpleInjector}
+import play.api.mvc.{ControllerComponents, DefaultControllerComponents}
+import play.core.j.{DefaultJavaContextComponents, JavaHelpers}
 
 /**
  * Loads an application.  This is responsible for instantiating an application given a context.
@@ -127,7 +128,11 @@ abstract class BuiltInComponentsFromContext(context: ApplicationLoader.Context) 
   lazy val configuration = context.initialConfiguration
   lazy val applicationLifecycle: DefaultApplicationLifecycle = context.lifecycle
 
+  lazy val controllerComponents: ControllerComponents = DefaultControllerComponents(
+    defaultActionBuilder, playBodyParsers, messagesApi, langs, fileMimeTypes, executionContext
+  )
+
   override lazy val injector: Injector = new SimpleInjector(NewInstanceInjector) + router + cookieSigner +
-    csrfTokenSigner + httpConfiguration + tempFileCreator + messagesApi + langs + javaContextComponents + fileMimeTypes
+    csrfTokenSigner + httpConfiguration + tempFileCreator + messagesApi + langs + javaContextComponents + fileMimeTypes + controllerComponents
 }
 


### PR DESCRIPTION
## Fixes

Adds controller components to BuiltInComponentsFromContext

## Purpose

Makes it easier to use in compile time DI.

## Background Context

This is important because any compile time DI that uses AbstractController depends on it:

```
class MyComponents(context: ApplicationLoader.Context) 
  extends BuiltInComponentsFromContext(context)
  with AhcWSComponents
  with _root_.controllers.AssetsComponents {

  lazy val parsers: PlayBodyParsers = playBodyParsers
  lazy val actionBuilder: ActionBuilder[Request, AnyContent] = defaultActionBuilder

  lazy val homeController = new _root_.controllers.HomeController(controllerComponents)

  lazy val router: Router = new _root_.router.Routes(httpErrorHandler, homeController, assets)
}
```
