### PR TITLE
Fix XHTML mime type

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -86,7 +86,8 @@ object CSRFConfig {
   private def defaultCreateIfNotFound(request: RequestHeader) = {
     // If the request isn't accepting HTML, then it won't be rendering a form, so there's no point in generating a
     // CSRF token for it.
-    (request.method == "GET" || request.method == "HEAD") && (request.accepts("text/html") || request.accepts("application/xml+xhtml"))
+    import play.api.http.MimeTypes._
+    (request.method == "GET" || request.method == "HEAD") && (request.accepts(HTML) || request.accepts(XHTML))
   }
 
   private[play] val HeaderNoCheck = "nocheck"

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -46,6 +46,9 @@ class CSRFFilterSpec extends CSRFCommonSpecs {
     "add a token to GET requests that accept HTML" in {
       buildCsrfAddToken()(_.withHeaders(ACCEPT -> "text/html").get())(_.status must_== OK)
     }
+    "add a token to GET requests that accept XHTML" in {
+      buildCsrfAddToken()(_.withHeaders(ACCEPT -> "application/xhtml+xml").get())(_.status must_== OK)
+    }
     "not add a token to HEAD requests that don't accept HTML" in {
       buildCsrfAddToken()(_.withHeaders(ACCEPT -> "application/json").head())(_.status must_== NOT_FOUND)
     }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -2285,7 +2285,7 @@ public class Http {
     }
 
     /** Common HTTP MIME types */
-    public static interface MimeTypes {
+    public interface MimeTypes {
 
         /**
          * Content-Type of text.
@@ -2306,6 +2306,11 @@ public class Http {
          * Content-Type of xml.
          */
         String XML = "application/xml";
+
+        /**
+         * Content-Type of xhtml.
+         */
+        String XHTML = "application/xhtml+xml";
 
         /**
          * Content-Type of css.

--- a/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
+++ b/framework/src/play/src/main/scala/play/api/http/StandardValues.scala
@@ -24,6 +24,11 @@ trait ContentTypes {
   def HTML(implicit codec: Codec) = withCharset(MimeTypes.HTML)
 
   /**
+   * Content-Type of xhtml.
+   */
+  def XHTML(implicit codec: Codec) = withCharset(MimeTypes.XHTML)
+
+  /**
    * Content-Type of xml.
    */
   def XML(implicit codec: Codec) = withCharset(MimeTypes.XML)
@@ -113,6 +118,11 @@ trait MimeTypes {
    * Content-Type of xml.
    */
   val XML = "application/xml"
+
+  /**
+   * Content-Type of xml.
+   */
+  val XHTML = "application/xhtml+xml"
 
   /**
    * Content-Type of css.


### PR DESCRIPTION
This fixes an incorrect mime type for XHTML, and adds constants for the XHTML mime type (`application/xhtml+xml`).