### PR TITLE
Correctly compare signed tokens

### DIFF
--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/JavaCSRFActionSpec.scala
@@ -82,9 +82,9 @@ class JavaCSRFActionSpec extends CSRFCommonSpecs {
     )) { implicit app =>
       { case _ => javaAction[JavaCSRFActionSpec.MyAction]("getToken", myAction.getToken) }
     } { ws =>
-      lazy val token = crypto.generateSignedToken
+      lazy val token = signedTokenProvider.generateToken
       val returned = await(ws.url("http://localhost:" + testServerPort).withSession(TokenName -> token).get()).body
-      crypto.compareSignedTokens(token, returned) must beTrue
+      signedTokenProvider.compareTokens(token, returned) must beTrue
     }
   }
 


### PR DESCRIPTION
Fixes #6977 

This fixes the `SignedTokenProvider` so it correctly compares signed tokens. It also fixes the CSRF tests so they correctly catch this type of error.