### PR TITLE
[2.5.x]: Fix empty query string parse

### DIFF
--- a/framework/src/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/framework/src/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -10,9 +10,10 @@ import akka.util.ByteString
 import play.api.test.Helpers._
 import play.api.mvc.Results._
 import play.twirl.api.Content
-import scala.concurrent.Future
 
+import scala.concurrent.Future
 import org.specs2.mutable._
+import play.api.mvc.AnyContentAsEmpty
 
 class HelpersSpec extends Specification {
 
@@ -92,6 +93,20 @@ class HelpersSpec extends Specification {
       (contentAsJson(jsonContent) \ "play").as[List[String]] must_== List("java", "scala")
     }
 
+  }
+
+  "Fakes" in {
+    "FakeRequest" should {
+      "parse query strings" in {
+        val request = FakeRequest("GET", "/uri?q1=1&q2=2", FakeHeaders(), AnyContentAsEmpty)
+        request.queryString.get("q1") must beSome.which(_.contains("1"))
+        request.queryString.get("q2") must beSome.which(_.contains("2"))
+      }
+      "return an empty map when there is no query string parameters" in {
+        val request = FakeRequest("GET", "/uri", FakeHeaders(), AnyContentAsEmpty)
+        request.queryString must beEmpty
+      }
+    }
   }
 
 }

--- a/framework/src/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
+++ b/framework/src/play/src/main/scala/play/core/parsers/FormUrlEncodedParser.scala
@@ -74,11 +74,16 @@ object FormUrlEncodedParser {
    * @return The sequence of key/value pairs
    */
   private def parseToPairs(data: String, encoding: String): Seq[(String, String)] = {
-    parameterDelimiter.split(data).map { param =>
-      val parts = param.split("=", -1)
-      val key = URLDecoder.decode(parts(0), encoding)
-      val value = URLDecoder.decode(parts.lift(1).getOrElse(""), encoding)
-      key -> value
+    val split = parameterDelimiter.split(data)
+    if (split.length == 1 && split(0).isEmpty) {
+      Seq.empty
+    } else {
+      split.map { param =>
+        val parts = param.split("=", -1)
+        val key = URLDecoder.decode(parts(0), encoding)
+        val value = URLDecoder.decode(parts.lift(1).getOrElse(""), encoding)
+        key -> value
+      }
     }
   }
 }

--- a/framework/src/play/src/test/scala/play/core/parsers/FormUrlEncodedParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/parsers/FormUrlEncodedParserSpec.scala
@@ -29,6 +29,12 @@ object FormUrlEncodedParserSpec extends Specification {
     "decode fields with no value" in {
       FormUrlEncodedParser.parse("foo=bar&baz") must_== Map("foo" -> List("bar"), "baz" -> List(""))
     }
+    "decode single field with no value" in {
+      FormUrlEncodedParser.parse("foo") must_== Map("foo" -> List(""))
+    }
+    "decode when there are no fields" in {
+      FormUrlEncodedParser.parse("") must beEmpty
+    }
     "ensure field order is retained, when requested" in {
       val url_encoded = "Zero=zero&One=one&Two=two&Three=three&Four=four&Five=five&Six=six&Seven=seven"
       val result: Map[String, Seq[String]] = FormUrlEncodedParser.parse(url_encoded)

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/build.sbt
@@ -40,7 +40,7 @@ checkStartScript := {
   }
 }
 
-def retry[B](max: Int = 10, sleep: Long = 500, current: Int = 1)(block: => B): B = {
+def retry[B](max: Int = 20, sleep: Long = 500, current: Int = 1)(block: => B): B = {
   try {
     block
   } catch {


### PR DESCRIPTION
## Purpose

Returns an empty Map when parsing URIs with empty query string.

## Fixes

Fixes #7028.