### PR TITLE
Add additional @Targets to constraints

### DIFF
--- a/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java
@@ -97,7 +97,7 @@ public class Constraints {
     /**
      * Defines a field as required.
      */
-    @Target({FIELD})
+    @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = RequiredValidator.class)
     @play.data.Form.Display(name="constraint.required")
@@ -151,7 +151,7 @@ public class Constraints {
     /**
      * Defines a minimum value for a numeric field.
      */
-    @Target({FIELD})
+    @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = MinValidator.class)
     @play.data.Form.Display(name="constraint.min", attributes={"value"})
@@ -209,7 +209,7 @@ public class Constraints {
     /**
      * Defines a maximum value for a numeric field.
      */
-    @Target({FIELD})
+    @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = MaxValidator.class)
     @play.data.Form.Display(name="constraint.max", attributes={"value"})
@@ -267,7 +267,7 @@ public class Constraints {
     /**
      * Defines a minimum length for a string field.
      */
-    @Target({FIELD})
+    @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = MinLengthValidator.class)
     @play.data.Form.Display(name="constraint.minLength", attributes={"value"})
@@ -324,7 +324,7 @@ public class Constraints {
     /**
      * Defines a maximum length for a string field.
      */
-    @Target({FIELD})
+    @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = MaxLengthValidator.class)
     @play.data.Form.Display(name="constraint.maxLength", attributes={"value"})
@@ -381,7 +381,7 @@ public class Constraints {
     /**
      * Defines a email constraint for a string field.
      */
-    @Target({FIELD})
+    @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = EmailValidator.class)
     @play.data.Form.Display(name="constraint.email", attributes={})
@@ -432,7 +432,7 @@ public class Constraints {
     /**
      * Defines a pattern constraint for a string field.
      */
-    @Target({FIELD})
+    @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = PatternValidator.class)
     @play.data.Form.Display(name="constraint.pattern", attributes={"value"})
@@ -487,7 +487,7 @@ public class Constraints {
      /**
      * Defines a custom validator.
      */
-    @Target({FIELD})
+    @Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = ValidateWithValidator.class)
     @play.data.Form.Display(name="constraint.validatewith", attributes={})

--- a/framework/src/play-java-forms/src/test/java/play/data/ListForm.java
+++ b/framework/src/play-java-forms/src/test/java/play/data/ListForm.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.data;
+
+import play.data.validation.Constraints;
+
+import java.util.List;
+
+import javax.validation.Valid;
+
+public class ListForm {
+
+    @Valid
+    private List<@Constraints.Min(0) Integer> values;
+
+    public List<Integer> getValues() {
+        return values;
+    }
+
+    public void setValues(final List<Integer> values) {
+        this.values = values;
+    }
+}

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -248,6 +248,15 @@ class FormSpec extends Specification {
 
     }
 
+    "support type arguments constraints" in {
+      val listForm = formFactory.form(classOf[ListForm]).bindFromRequest(FormSpec.dummyRequest(Map("values[0]" -> Array("4"), "values[1]" -> Array("-3"), "values[2]" -> Array("6"))))
+
+      listForm.hasErrors must beEqualTo(true)
+      listForm.allErrors().size() must beEqualTo(1)
+      listForm.errors("values[1]").get(0).messages().size() must beEqualTo(1)
+      listForm.errors("values[1]").get(0).messages().get(0) must beEqualTo("error.min")
+    }
+
     "work with the @repeat helper" in {
       val form = formFactory.form(classOf[JavaForm])
 


### PR DESCRIPTION
Just had this case: When validating a form I want to make sure that all integers [inside a list submitted by the user](https://www.playframework.com/documentation/2.5.x/JavaFormHelpers#Handling-repeated-values) are positiv. This can be done with Hibernate validator via:

```java
import play.data.validation.Constraints.Min;

@Valid
private List<@Min(0) Integer> values;
```

Unfortunataly all our constraints defined in [`play.data.validation.Constraints`](https://github.com/playframework/playframework/blob/2.6.0-M1/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java) are only allowed  on fields currently. **So right now this doesn't work in Play.**
However Hibernate validator allows you to put constraints on type arguments (`TYPE_USE`) like needed in the case above. For other purposes you could put constraints on methods, constructors and other annotations as well which is all described in the hibernate validator docs.
[All](https://github.com/hibernate/hibernate-validator/tree/master/engine/src/main/java/org/hibernate/validator/constraints) the built-in Hibernate validator constraints use [these](https://github.com/hibernate/hibernate-validator/blob/master/engine/src/main/java/org/hibernate/validator/constraints/NotEmpty.java#L38) set of `@Targets` by default - I was actually wondering why Play doesn't.