### PR TITLE
[2.5.x] Fix XHTML mime type

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -82,7 +82,8 @@ object CSRFConfig {
   private def defaultCreateIfNotFound(request: RequestHeader) = {
     // If the request isn't accepting HTML, then it won't be rendering a form, so there's no point in generating a
     // CSRF token for it.
-    (request.method == "GET" || request.method == "HEAD") && (request.accepts("text/html") || request.accepts("application/xml+xhtml"))
+    (request.method == "GET" || request.method == "HEAD") &&
+      (request.accepts("text/html") || request.accepts("application/xhtml+xml"))
   }
 
   private[play] val HeaderNoCheck = "nocheck"

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/csrf/CSRFFilterSpec.scala
@@ -46,6 +46,9 @@ object CSRFFilterSpec extends CSRFCommonSpecs {
     "add a token to GET requests that accept HTML" in {
       buildCsrfAddToken()(_.withHeaders(ACCEPT -> "text/html").get())(_.status must_== OK)
     }
+    "add a token to GET requests that accept XHTML" in {
+      buildCsrfAddToken()(_.withHeaders(ACCEPT -> "application/xhtml+xml").get())(_.status must_== OK)
+    }
     "not add a token to HEAD requests that don't accept HTML" in {
       buildCsrfAddToken()(_.withHeaders(ACCEPT -> "application/json").head())(_.status must_== NOT_FOUND)
     }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -2301,7 +2301,7 @@ public class Http {
     }
 
     /** Common HTTP MIME types */
-    public static interface MimeTypes {
+    public interface MimeTypes {
 
         /**
          * Content-Type of text.
@@ -2322,6 +2322,11 @@ public class Http {
          * Content-Type of xml.
          */
         String XML = "application/xml";
+
+        /**
+         * Content-Type of xhtml.
+         */
+        String XHTML = "application/xhtml+xml";
 
         /**
          * Content-Type of css.


### PR DESCRIPTION
Backport of #7026

(I decided not to add some of the constants in traits for binary compatibility reasons.)