### PR TITLE
Update ScalaResults.scala replacing obsolete test classes.  Update Sc…

### DIFF
--- a/documentation/manual/working/scalaGuide/main/http/ScalaResults.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaResults.md
@@ -9,11 +9,11 @@ For example:
 
 @[content-type_text](code/ScalaResults.scala)
 
-Will automatically set the `Content-Type` header to `text/plain`, while:
+Will automatically set the `Content-Type` header to `text/plain; charset=utf-8`, while:
 
 @[content-type_xml](code/ScalaResults.scala)
 
-will set the Content-Type header to `application/xml`.
+will set the Content-Type header to `application/xml; charset=utf-8`.
 
 > **Tip:** this is done via the `play.api.http.ContentTypeOf` type class.
 


### PR DESCRIPTION
…alaResults.md to reflect default charsets.

# Pull Request Checklist

* [X ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ X] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ X] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [ Y] Have you added copyright headers to new files?
* [ Y] Have you checked that both Scala and Java APIs are updated?
* [ Y] Have you updated the documentation for both Scala and Java sections?
* [ Y] Have you added tests for any changed functionality?

# Helpful things

## Fixes
Use PlaySpec instead of the obsolete PlaySpecification trait in ScalaResults.scala.  The default content-type has charset set to utf-8, where before it left charset unset.   The defaults documented in ScalaResults.md are changed to reflect the new defaults.

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
