### PR TITLE
WebSocket endpoints returning 400 for HEAD requests

### DIFF
--- a/framework/src/play-akka-http-server/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/reference.conf
@@ -27,7 +27,7 @@ play {
       # bodies from outgoing responses.
       # Note that, even when this setting is off the server will never send
       # out message bodies on responses to HEAD requests.
-      transparent-head-requests = on
+      transparent-head-requests = off
 
       # If this setting is empty the server only accepts requests that carry a
       # non-empty `Host` header. Otherwise it responds with `400 Bad Request`.

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -26,7 +26,6 @@ import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.api.routing.Router
 import play.core.{ ApplicationProvider, DefaultWebCommands, SourceMapper, WebCommands }
-import play.core.server._
 import play.core.server.akkahttp.{ AkkaModelConversion, HttpRequestDecoder }
 import play.core.server.common.{ ForwardedHeaderHandler, ServerResultUtils }
 import play.core.server.ssl.ServerSSLEngine

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
@@ -7,13 +7,11 @@ package play.it.action
 import akka.stream.scaladsl.Source
 import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders
 import org.specs2.mutable.Specification
-import play.api.Play
 import play.api.http.HeaderNames._
 import play.api.http.Status._
 import play.api.libs.ws.{ WSClient, WSResponse }
 import play.api.mvc._
 import play.api.routing.Router.Routes
-import play.api.routing.Router.Tags._
 import play.api.routing.sird._
 import play.api.test._
 import play.core.server.Server
@@ -24,17 +22,22 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import play.shaded.ahc.org.asynchttpclient.netty.NettyResponse
 import play.api.libs.typedmap.TypedKey
 
+import scala.concurrent.Future
+
 class NettyHeadActionSpec extends HeadActionSpec with NettyIntegrationSpecification
 class AkkaHttpHeadActionSpec extends HeadActionSpec with AkkaHttpIntegrationSpecification
 
 trait HeadActionSpec extends Specification with FutureAwaits with DefaultAwaitTimeout with ServerIntegrationSpecification {
 
-  private def route(verb: String, path: String)(handler: EssentialAction): PartialFunction[(String, String), Handler] = {
-    case (v, p) if v == verb && p == path => handler
-  }
   sequential
 
   "HEAD requests" should {
+
+    def webSocketResponse(implicit Action: DefaultActionBuilder): Routes = {
+      case GET(p"/ws") => WebSocket.acceptOrResult[String, String] { request =>
+        Future.successful(Left(Results.Forbidden))
+      }
+    }
 
     def chunkedResponse(implicit Action: DefaultActionBuilder): Routes = {
       case GET(p"/chunked") =>
@@ -51,6 +54,7 @@ trait HeadActionSpec extends Specification with FutureAwaits with DefaultAwaitTi
         .orElse(delete) // DELETE /delete
         .orElse(stream) // GET /stream/0
         .orElse(chunkedResponse) // GET /chunked
+        .orElse(webSocketResponse) // GET /ws
 
     def withServer[T](block: WSClient => T): T = {
       // Routes from HttpBinApplication
@@ -65,6 +69,11 @@ trait HeadActionSpec extends Specification with FutureAwaits with DefaultAwaitTi
       } { implicit port =>
         WsTestClient.withClient(block)
       }
+    }
+
+    "return 400 in response to a HEAD in a WebSocket handler" in withServer { client =>
+      val result = await(client.url("/ws").head())
+      result.status must_== BAD_REQUEST
     }
 
     "return 200 in response to a URL with a GET handler" in withServer { client =>


### PR DESCRIPTION
## Fixes

Fixes #4878.

## Purpose

As suggested by @gmethvin (https://github.com/playframework/playframework/issues/4878#issuecomment-125174212), `HEAD` request against ws endpoints will now respond with a Bad Request (`400`).

## References

See #7057 and #7059.
