### PR TITLE
Component lifecycle clarification in DI chapter of doc

### DIFF
--- a/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
@@ -59,7 +59,20 @@ To enable the injected routes generator specifically, add the following to your 
 
 @[content](code/injected.sbt)
 
-When using the injected routes generator, prefixing the action with an `@` symbol takes on a special meaning, it means instead of the controller being injected directly, a `Provider` of the controller will be injected.  This allows, for example, prototype controllers, as well as an option for breaking cyclic dependencies.
+There are two ways of defining routes when this routes generator is used:
+
+1. Defining actions without using the `@` symbol
+
+    For those routes, all controllers and their related components are **effectively singletons** due to router being a singleton, but keep in mind that if you inject a controller into a non-singleton component then its lifecycle will be determined by that parent component (not a general pattern but possible).
+
+    The major difference between this approach and static controllers is that all dependencies are determined at runtime.
+
+2. Prefixing actions with the `@` symbol
+
+    This means instead of the controller being injected directly, a `Provider` of the controller will be injected. Doing this means:
+
+    1. A new controller instance and its corresponding components will be used to handle each incoming request, unless it's explicitly declared singleton.
+    2. This allows for breaking cyclic dependencies, e.g. injecting `Application` into controllers.
 
 ### Static routes generator
 

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
@@ -63,9 +63,7 @@ There are two ways of defining routes when this routes generator is used:
 
 1. Defining actions without using the `@` symbol
 
-    For those routes, all controllers and their related components are **effectively singletons** due to router being a singleton, but keep in mind that if you inject a controller into a non-singleton component then its lifecycle will be determined by that parent component (not a general pattern but possible).
-
-    The major difference between this approach and static controllers is that all dependencies are determined at runtime.
+    For those routes, all controllers and their related components are **effectively singletons** due to router being a singleton with Play's default application loader, but keep in mind that if you inject a controller into a non-singleton component then its lifecycle will be determined by that parent component (not a general pattern but possible).
 
 2. Prefixing actions with the `@` symbol
 

--- a/documentation/manual/working/javaGuide/main/http/JavaRouting.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaRouting.md
@@ -28,7 +28,7 @@ routesGenerator := StaticRoutesGenerator
 
 The code samples in Play's documentation assume that you are using the injected routes generator. If you are not using this, you can trivially adapt the code samples for the static routes generator by declaring each of your action methods as `static`.
 
-For difference between the routes generator and advanced usage, see [[dependency injecting controllers|JavaDependencyInjection#dependency-injecting-controllers]].
+For difference between the routes generator and advanced usage, see [[dependency injecting controllers|JavaDependencyInjection#dependency-injecting-controllers]] for more details about the routes file syntax.
 
 ## The routes file syntax
 

--- a/documentation/manual/working/javaGuide/main/http/JavaRouting.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaRouting.md
@@ -26,7 +26,9 @@ If you need to use static controllers, you can switch to the static routes gener
 routesGenerator := StaticRoutesGenerator
 ```
 
-The code samples in Play's documentation assume that you are using the injected routes generator. If you are not using this, you can trivially adapt the code samples for the static routes generator, either by prefixing the controller invocation part of the route with an `@` symbol, or by declaring each of your action methods as `static`.
+The code samples in Play's documentation assume that you are using the injected routes generator. If you are not using this, you can trivially adapt the code samples for the static routes generator by declaring each of your action methods as `static`.
+
+For difference between the routes generator and advanced usage, see [[dependency injecting controllers|JavaDependencyInjection#dependency-injecting-controllers]].
 
 ## The routes file syntax
 

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaDependencyInjection.md
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaDependencyInjection.md
@@ -55,9 +55,7 @@ There are two ways of defining routes when this routes generator is used:
 
 1. Defining actions without using the `@` symbol
 
-    For those routes, all controllers and their related components are **effectively singletons** due to router being a singleton, but keep in mind that if you inject a controller into a non-singleton component then its lifecycle will be determined by that parent component (not a general pattern but possible).
-
-    The major difference between this approach and static controllers is that all dependencies are determined at runtime.
+    For those routes, all controllers and their related components are **effectively singletons** due to router being a singleton with Play's default application loader, but keep in mind that if you inject a controller into a non-singleton component then its lifecycle will be determined by that parent component (not a general pattern but possible).
 
 2. Prefixing actions with the `@` symbol
 

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaDependencyInjection.md
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/ScalaDependencyInjection.md
@@ -47,12 +47,24 @@ There are two ways to make Play use dependency injected controllers.
 
 By default (since 2.5.0), Play will generate a router that will declare all the controllers that it routes to as dependencies, allowing your controllers to be dependency injected themselves.
 
-
 To enable the injected routes generator specifically, add the following to your build settings in `build.sbt`:
 
 @[content](code/injected.sbt)
 
-When using the injected routes generator, prefixing the action with an `@` symbol takes on a special meaning, it means instead of the controller being injected directly, a `Provider` of the controller will be injected.  This allows, for example, prototype controllers, as well as an option for breaking cyclic dependencies.
+There are two ways of defining routes when this routes generator is used:
+
+1. Defining actions without using the `@` symbol
+
+    For those routes, all controllers and their related components are **effectively singletons** due to router being a singleton, but keep in mind that if you inject a controller into a non-singleton component then its lifecycle will be determined by that parent component (not a general pattern but possible).
+
+    The major difference between this approach and static controllers is that all dependencies are determined at runtime.
+
+2. Prefixing actions with the `@` symbol
+
+    This means instead of the controller being injected directly, a `Provider` of the controller will be injected. Doing this means:
+
+    1. A new controller instance and its corresponding components will be used to handle each incoming request, unless it's explicitly declared singleton.
+    2. This allows for breaking cyclic dependencies, e.g. injecting `Application` into controllers.
 
 ### Static routes generator
 

--- a/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
@@ -26,7 +26,9 @@ If you need to use static controllers, you can switch to the static routes gener
 routesGenerator := StaticRoutesGenerator
 ```
 
-The code samples in Play's documentation assumes that you are using the injected routes generator. If you are not using this, you can trivially adapt the code samples for the static routes generator, either by prefixing the controller invocation part of the route with an `@` symbol, or by declaring each of your controllers as an `object` rather than a `class`.
+The code samples in Play's documentation assumes that you are using the injected routes generator. If you are not using this, you can trivially adapt the code samples for the static routes generator by declaring each of your controllers as an `object` rather than a `class`.
+
+For difference between the routes generator and advanced usage, see [[dependency injecting controllers|ScalaDependencyInjection#dependency-injecting-controllers]].
 
 ## The routes file syntax
 

--- a/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
@@ -28,7 +28,7 @@ routesGenerator := StaticRoutesGenerator
 
 The code samples in Play's documentation assumes that you are using the injected routes generator. If you are not using this, you can trivially adapt the code samples for the static routes generator by declaring each of your controllers as an `object` rather than a `class`.
 
-For difference between the routes generator and advanced usage, see [[dependency injecting controllers|ScalaDependencyInjection#dependency-injecting-controllers]].
+For difference between the routes generator and advanced usage, see [[dependency injecting controllers|ScalaDependencyInjection#dependency-injecting-controllers]] for more details about the routes file syntax.
 
 ## The routes file syntax
 


### PR DESCRIPTION
## Background Context

It's not clear in current documentation how controllers are allocated
during request handling. Also the current words "prototype controller"
are not clear to general developers as that's a spring specific term.
This change is to make things explicit.
