### PR TITLE
Make play.Environment injectable

### DIFF
--- a/framework/src/play-java/src/main/java/play/inject/BuiltInModule.java
+++ b/framework/src/play-java/src/main/java/play/inject/BuiltInModule.java
@@ -18,12 +18,13 @@ public class BuiltInModule extends play.api.inject.Module {
     @Override
     public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
         return seq(
-          bind(ApplicationLifecycle.class).to(DelegateApplicationLifecycle.class),
-          bind(play.Configuration.class).toProvider(ConfigurationProvider.class),
-          bind(CSRFTokenSigner.class).to(DefaultCSRFTokenSigner.class),
-          bind(CookieSigner.class).to(HMACSHA1CookieSigner.class),
-          bind(Files.TemporaryFileCreator.class).to(Files.DelegateTemporaryFileCreator.class),
-          bind(FileMimeTypes.class).toSelf()
+            bind(ApplicationLifecycle.class).to(DelegateApplicationLifecycle.class),
+            bind(play.Environment.class).toSelf(),
+            bind(play.Configuration.class).toProvider(ConfigurationProvider.class),
+            bind(CSRFTokenSigner.class).to(DefaultCSRFTokenSigner.class),
+            bind(CookieSigner.class).to(HMACSHA1CookieSigner.class),
+            bind(Files.TemporaryFileCreator.class).to(Files.DelegateTemporaryFileCreator.class),
+            bind(FileMimeTypes.class).toSelf()
         );
     }
 }


### PR DESCRIPTION
Seems weird that play.Environment does not have a binding but play.api.Environment does.