### PR TITLE
Better HSTS behavior in RedirectHttpsFilter

### DIFF
--- a/documentation/manual/working/commonGuide/filters/RedirectHttpsFilter.md
+++ b/documentation/manual/working/commonGuide/filters/RedirectHttpsFilter.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com> -->
 # Redirect HTTPS Filter
 
-Play provides a filter which will redirect HTTP requests to HTTP requests.
+Play provides a filter which will redirect all HTTP requests to HTTPS automatically.
 
 ## Enabling the HTTPS filter
 
@@ -13,15 +13,19 @@ play.filters.enabled += play.filters.https.RedirectHttpsFilter
 
 ## Determining Secure Requests
 
-The filter evaluates a request to be secure if `request.secure` is true.  
+The filter evaluates a request to be secure if `request.secure` is true.
 
 This logic is set by the [[trusted proxies|HTTPServer#configuring-trusted-proxies]] configured for Play's HTTP engine.  Internally, `play.core.server.common.ForwardedHeaderHandler` and `play.api.mvc.request.RemoteConnection` determine between them whether an incoming request meets the criteria to be "secure", meaning that the request has gone through HTTPS at some point.
 
 A request that is not secure is redirected according to the redirect code determined through configuration.
 
-## Strict Transport Security 
+## Strict Transport Security
 
-The [Strict Transport Security](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) header is used to indicate when HTTPS should always be used, and is added to a secure request.  The default is null, since HSTS can interfere with development if you are working on multiple projects.  To set HSTS, add the following to `application.conf`:
+The [Strict Transport Security](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) header is used to indicate when HTTPS should always be used, and is added to a secure request.
+
+This header is only enabled in production, since HSTS can cause problems in development by forcing the browser to always assume https://localhost:9000 for the application -- this is especially an issue when working with multiple projects.
+
+The default is "max-age=31536000; includeSubDomains", and can be set explicitly by adding the following to `application.conf`:
 
 ```
 play.filters.https.strictTransportSecurity="max-age=31536000; includeSubDomains"
@@ -33,7 +37,7 @@ The filter redirects using HTTP code 308, which is a permanent redirect that doe
 
 ```
 play.filters.https.redirectStatusCode = 301
-``` 
+```
 
 ## Custom HTTPS Port
 

--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -179,10 +179,8 @@ play.filters {
   https {
 
     # The Strict-Transport-Security header is used to signal to browsers to always use https.
-    # Set to null for development purposes, since HSTS causes problems on localhost:9000
-    # Use the following in a production context:
-    # strictTransportSecurity = "max-age=31536000; includeSubDomains"
-    strictTransportSecurity = null
+    # This header is only enabled in production, since HSTS causes problems on localhost:9000 for development
+    strictTransportSecurity = "max-age=31536000; includeSubDomains"
 
     # Configures the redirect status code used if the request is not secure.
     # By default, uses HTTP status code 308, which is a permanent redirect that does

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
@@ -5,15 +5,11 @@ package play.filters.https
 
 import javax.inject.{ Inject, Provider }
 
-import play.api.{ Configuration, Environment, Mode }
 import play.api.http.HeaderNames._
-import play.api.http.Status
 import play.api.http.Status._
 import play.api.inject.SimpleModule
-import play.api.libs.streams.Accumulator
 import play.api.mvc._
-
-import scala.concurrent.ExecutionContext
+import play.api.{ Configuration, Environment, Mode }
 
 /**
  * A filter that redirects HTTP requests to https requests.
@@ -24,21 +20,20 @@ import scala.concurrent.ExecutionContext
  * For documentation on configuring this filter, please see the Play documentation at
  * https://www.playframework.com/documentation/latest/RedirectHttpsFilter
  */
-class RedirectHttpsFilter @Inject() (config: RedirectHttpsConfiguration, environment: Environment)
+class RedirectHttpsFilter @Inject() (config: RedirectHttpsConfiguration)
     extends EssentialFilter {
 
   override def apply(next: EssentialAction): EssentialAction = EssentialAction { req =>
+    import play.api.libs.streams.Accumulator
     import play.core.Execution.Implicits.trampoline
     if (req.secure) {
       next(req).map { result =>
-        config.strictTransportSecurity.map { sts =>
-          environment.mode match {
-            case Mode.Prod =>
-              result.withHeaders(STRICT_TRANSPORT_SECURITY -> sts)
-            case other =>
-              result
-          }
-        }.getOrElse(result)
+        config.strictTransportSecurity match {
+          case Some(sts) if config.hstsEnabled =>
+            result.withHeaders(STRICT_TRANSPORT_SECURITY -> sts)
+          case other =>
+            result
+        }
       }
     } else {
       Accumulator.done(Results.Redirect(createHttpsRedirectUrl(req), config.redirectStatusCode))
@@ -59,10 +54,11 @@ class RedirectHttpsFilter @Inject() (config: RedirectHttpsConfiguration, environ
 case class RedirectHttpsConfiguration(
   strictTransportSecurity: Option[String] = Some("max-age=31536000; includeSubDomains"),
   redirectStatusCode: Int = PERMANENT_REDIRECT,
-  sslPort: Option[Int] = None // should match up to ServerConfig.sslPort
+  sslPort: Option[Int] = None, // should match up to ServerConfig.sslPort
+  hstsEnabled: Boolean = false
 )
 
-class RedirectHttpsConfigurationProvider @Inject() (c: Configuration)
+class RedirectHttpsConfigurationProvider @Inject() (c: Configuration, e: Environment)
     extends Provider[RedirectHttpsConfiguration] {
   private val stsPath = "play.filters.https.strictTransportSecurity"
   private val statusCodePath = "play.filters.https.redirectStatusCode"
@@ -71,12 +67,12 @@ class RedirectHttpsConfigurationProvider @Inject() (c: Configuration)
   lazy val get: RedirectHttpsConfiguration = {
     val strictTransportSecurityMaxAge = c.get[Option[String]](stsPath)
     val redirectStatusCode = c.get[Int](statusCodePath)
-    if (!Status.isRedirect(redirectStatusCode)) {
+    if (!isRedirect(redirectStatusCode)) {
       throw c.reportError(statusCodePath, s"Status Code $redirectStatusCode is not a Redirect status code!")
     }
     val port = c.getOptional[Int](portPath)
 
-    RedirectHttpsConfiguration(strictTransportSecurityMaxAge, redirectStatusCode, port)
+    RedirectHttpsConfiguration(strictTransportSecurityMaxAge, redirectStatusCode, port, e.mode == Mode.Prod)
   }
 }
 

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
@@ -6,7 +6,6 @@ package play.filters.https
 import javax.inject.Inject
 
 import com.typesafe.config.ConfigFactory
-import org.specs2.concurrent.ExecutionEnv
 import play.api.Mode.Mode
 import play.api._
 import play.api.http.HttpFilters
@@ -21,13 +20,14 @@ private[https] class TestFilters @Inject() (redirectPlainFilter: RedirectHttpsFi
   override def filters: Seq[EssentialFilter] = Seq(redirectPlainFilter)
 }
 
-class RedirectHttpsFilterSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
+class RedirectHttpsFilterSpec extends PlaySpecification {
 
   "RedirectHttpsConfigurationProvider" should {
 
     "throw configuration error on invalid redirect status code" in {
       val configuration = Configuration.from(Map("play.filters.https.redirectStatusCode" -> "200"))
-      val configProvider = new RedirectHttpsConfigurationProvider(configuration)
+      val environment = Environment.simple()
+      val configProvider = new RedirectHttpsConfigurationProvider(configuration, environment)
 
       {
         configProvider.get

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
@@ -6,20 +6,22 @@ package play.filters.https
 import javax.inject.Inject
 
 import com.typesafe.config.ConfigFactory
-import play.api.{ Application, Configuration, PlayException }
+import org.specs2.concurrent.ExecutionEnv
+import play.api.Mode.Mode
+import play.api._
 import play.api.http.HttpFilters
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.mvc.request.RemoteConnection
-import play.api.test._
+import play.api.test.{ WithApplication, _ }
 
 private[https] class TestFilters @Inject() (redirectPlainFilter: RedirectHttpsFilter) extends HttpFilters {
   override def filters: Seq[EssentialFilter] = Seq(redirectPlainFilter)
 }
 
-class RedirectHttpsFilterSpec extends PlaySpecification {
+class RedirectHttpsFilterSpec(implicit ee: ExecutionEnv) extends PlaySpecification {
 
   "RedirectHttpsConfigurationProvider" should {
 
@@ -61,22 +63,35 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
       status(result) must_== OK
     }
 
-    "contain HSTS header if configured" in new WithApplication(buildApp(
-      """
-        |play.filters.https.strictTransportSecurity="max-age=31536000; includeSubDomains"
-      """.stripMargin)) {
+    "redirect to custom HTTPS port if configured" in new WithApplication(buildApp("play.filters.https.port = 9443")) {
+      val result = route(app, request("/please/dont?remove=this&foo=bar")).get
+
+      header(LOCATION, result) must_== Some("https://playframework.com:9443/please/dont?remove=this&foo=bar")
+    }
+
+    "not contain default HSTS header if secure in test" in new WithApplication(buildApp()) {
+      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = true, clientCertificateChain = None)
+      val result = route(app, request().withConnection(secure)).get
+
+      header(STRICT_TRANSPORT_SECURITY, result) must_== None
+    }
+
+    "contain default HSTS header if secure in production" in new WithApplication(buildApp(mode = Mode.Prod)) {
       val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = true, clientCertificateChain = None)
       val result = route(app, request().withConnection(secure)).get
 
       header(STRICT_TRANSPORT_SECURITY, result) must_== Some("max-age=31536000; includeSubDomains")
     }
 
-    "Redirect to custom HTTPS port if configured" in new WithApplication(buildApp("play.filters.https.port = 9443")) {
-      val result = route(app, request("/please/dont?remove=this&foo=bar")).get
+    "contain custom HSTS header if configured explicitly in prod" in new WithApplication(buildApp(
+      """
+        |play.filters.https.strictTransportSecurity="max-age=12345; includeSubDomains"
+      """.stripMargin, mode = Mode.Prod)) {
+      val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = true, clientCertificateChain = None)
+      val result = route(app, request().withConnection(secure)).get
 
-      header(LOCATION, result) must_== Some("https://playframework.com:9443/please/dont?remove=this&foo=bar")
+      header(STRICT_TRANSPORT_SECURITY, result) must_== Some("max-age=12345; includeSubDomains")
     }
-
   }
 
   private def request(uri: String = "/") = {
@@ -84,7 +99,7 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
       .withHeaders(HOST -> "playframework.com")
   }
 
-  private def buildApp(config: String = "") = new GuiceApplicationBuilder()
+  private def buildApp(config: String = "", mode: Mode = Mode.Test) = GuiceApplicationBuilder(Environment.simple(mode = mode))
     .configure(Configuration(ConfigFactory.parseString(config)))
     .appRoutes(app => {
       case ("GET", "/") =>


### PR DESCRIPTION
This PR provides a reasonable default for Strict-Transport-Security, but only enables it in production.mode.  

This means that applications only have to enable the filter, and don't have to also explicitly configure HSTS.