### PR TITLE
Remove unused runSbtTask

### DIFF
--- a/framework/src/build-link/src/main/java/play/core/BuildLink.java
+++ b/framework/src/build-link/src/main/java/play/core/BuildLink.java
@@ -78,18 +78,4 @@ public interface BuildLink {
      * @return The settings.
      */
     public Map<String,String> settings();
-
-    /**
-     * Run a task in the build tool.
-     *
-     * This can be used by Play plugins, for example, by a test fixture plugin to run tests.  The format of the passed
-     * in task and the return value are build tool specific.
-     *
-     * For the default SBT implementation, it's a standard SBT task, and the result is the return value of that task.
-     * Note that if the return value is anything but JDK classes, the only way to access it will be using reflection.
-     *
-     * @param task The name of the task to run.
-     * @return The result of running the task.
-     */
-    public Object runTask(String task);
 }

--- a/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -5,8 +5,9 @@ package play.runsupport
 
 import java.io.{ Closeable, File }
 import java.net.{ URL, URLClassLoader }
-import java.security.{ PrivilegedAction, AccessController }
+import java.security.{ AccessController, PrivilegedAction }
 import java.util.jar.JarFile
+
 import play.api.PlayException
 import play.core.{ Build, BuildLink, BuildDocHandler }
 import play.dev.filewatch.FileWatchService
@@ -143,7 +144,7 @@ object Reloader {
     docsClasspath: Classpath, docsJar: Option[File],
     defaultHttpPort: Int, defaultHttpAddress: String, projectPath: File,
     devSettings: Seq[(String, String)], args: Seq[String],
-    runSbtTask: String => AnyRef, mainClassName: String): PlayDevServer = {
+    mainClassName: String): PlayDevServer = {
 
     val (properties, httpPort, httpsPort, httpAddress) = filterArgs(args, defaultHttpPort, defaultHttpAddress, devSettings)
     val systemProperties = extractSystemProperties(javaOptions)
@@ -213,7 +214,7 @@ object Reloader {
     lazy val applicationLoader = dependencyClassLoader("PlayDependencyClassLoader", urls(dependencyClasspath), delegatingLoader)
     lazy val assetsLoader = assetsClassLoader(applicationLoader)
 
-    lazy val reloader = new Reloader(reloadCompile, reloaderClassLoader, assetsLoader, projectPath, devSettings, monitoredFiles, fileWatchService, generatedSourceHandlers, runSbtTask)
+    lazy val reloader = new Reloader(reloadCompile, reloaderClassLoader, assetsLoader, projectPath, devSettings, monitoredFiles, fileWatchService, generatedSourceHandlers)
 
     try {
       // Now we're about to start, let's call the hooks:
@@ -295,8 +296,7 @@ class Reloader(
     devSettings: Seq[(String, String)],
     monitoredFiles: Seq[File],
     fileWatchService: FileWatchService,
-    generatedSourceHandlers: Map[String, GeneratedSourceMapping],
-    runSbtTask: String => AnyRef) extends BuildLink {
+    generatedSourceHandlers: Map[String, GeneratedSourceMapping]) extends BuildLink {
 
   // The current classloader for the application
   @volatile private var currentApplicationClassLoader: Option[ClassLoader] = None
@@ -408,8 +408,6 @@ class Reloader(
       }
     }.orNull
   }
-
-  def runTask(task: String): AnyRef = runSbtTask(task)
 
   def close() = {
     currentApplicationClassLoader = None

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -77,13 +77,6 @@ object PlayRun {
       () => Project.runTask(streamsManager in scope, state).map(_._2).get.toEither.right.toOption
     )
 
-    val runSbtTask: String => AnyRef = (task: String) => {
-      val parser = Act.scopedKeyParser(state)
-      val Right(sk) = complete.DefaultParsers.result(parser, task)
-      val result = Project.runTask(sk.asInstanceOf[Def.ScopedKey[Task[AnyRef]]], state).map(_._2)
-      result.flatMap(_.toEither.right.toOption).orNull
-    }
-
     lazy val devModeServer = Reloader.startDevMode(
       runHooks.value,
       (javaOptions in Runtime).value,
@@ -103,7 +96,6 @@ object PlayRun {
       baseDirectory.value,
       devSettings.value,
       args,
-      runSbtTask,
       (mainClass in (Compile, Keys.run)).value.get
     )
 


### PR DESCRIPTION
I'd like to refactor more of the Reloader into reusable components if possible. There's a bit of code that's shared between here and Lagom and it'd be nice to have it be an easily callable library.

I couldn't find anything that was using this. Lagom doesn't support it, so it brings the two reloaders a little closer. It also simplifies the code by not needing to support unused functionality. Let me know if there's some external project that depends on it somehow. I did some searches and couldn't find any.