### PR TITLE
Update HikariCP to version 2.6.1

### DIFF
--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -784,7 +784,7 @@ If you were using the FluentLenium library you might have to change some syntax 
 
 ### HikariCP
 
-HikariCP was update and a new configuration was introduced: `initializationFailTimeout`. This new configuration should be used to replace `initializationFailFast` which is now deprecated. See [HikariCP changelog](https://github.com/brettwooldridge/HikariCP/blob/dev/CHANGES) and [documentation for `initializationFailTimeout`](https://github.com/brettwooldridge/HikariCP#infrequently-used) to better understand how to use this new configuration.
+HikariCP was updated and a new configuration was introduced: `initializationFailTimeout`. This new configuration should be used to replace `initializationFailFast` which is now deprecated. See [HikariCP changelog](https://github.com/brettwooldridge/HikariCP/blob/dev/CHANGES) and [documentation for `initializationFailTimeout`](https://github.com/brettwooldridge/HikariCP#infrequently-used) to better understand how to use this new configuration.
 
 ## Other Configuration changes
 

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -782,6 +782,10 @@ And if you are, for some reason, directly using Netty classes, you should [adapt
 The FluentLenium library was updated to version 3.1.1 and as a result the underlying Selenium version changed to [3.0.1](https://seleniumhq.wordpress.com/2016/10/13/selenium-3-0-out-now/). If you were using Selenium's WebDriver API before, there shouldn't be anything to do. Please check [this](https://seleniumhq.wordpress.com/2016/10/04/selenium-3-is-coming/) announcement for further information.
 If you were using the FluentLenium library you might have to change some syntax to get your tests working again. Please see FluentLenium's [Migration Guide](http://fluentlenium.org/migration/from-0.13.2-to-1.0-or-3.0/) for more details about how to adapt your code.
 
+### HikariCP
+
+HikariCP was update and a new configuration was introduced: `initializationFailTimeout`. This new configuration should be used to replace `initializationFailFast` which is now deprecated. See [HikariCP changelog](https://github.com/brettwooldridge/HikariCP/blob/dev/CHANGES) and [documentation for `initializationFailTimeout`](https://github.com/brettwooldridge/HikariCP#infrequently-used) to better understand how to use this new configuration.
+
 ## Other Configuration changes
 
 There are some configurations.  The old configuration paths will generally still work, but a deprecation warning will be output at runtime if you use them.  Here is a summary of the changed keys:

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -46,7 +46,7 @@ object Dependencies {
 
   val jdbcDeps = Seq(
     "com.jolbox" % "bonecp" % "0.8.0.RELEASE",
-    "com.zaxxer" % "HikariCP" % "2.5.1",
+    "com.zaxxer" % "HikariCP" % "2.6.1",
     "com.googlecode.usc" % "jdbcdslog" % "1.0.6.2",
     h2database % Test,
     acolyte % Test,

--- a/framework/src/play-jdbc/src/main/resources/reference.conf
+++ b/framework/src/play-jdbc/src/main/resources/reference.conf
@@ -87,6 +87,19 @@ play {
         # If non null, sets the name of the connection pool. Primarily used for stats reporting.
         poolName = null
 
+        # This property controls whether the pool will "fail fast" if the pool cannot be seeded with
+        # an initial connection successfully.
+        # 1. Any positive number is taken to be the number of milliseconds to attempt to acquire an initial connection;
+        #    the application thread will be blocked during this period. If a connection cannot be acquired before this
+        #    timeout occurs, an exception will be thrown. This timeout is applied after the connectionTimeout period.
+        # 2. If the value is zero (0), HikariCP will attempt to obtain and validate a connection. If a connection
+        #    is obtained, but fails validation, an exception will be thrown and the pool not started. However, if
+        #    a connection cannot be obtained, the pool will start, but later efforts to obtain a connection may fail.
+        # 3. A value less than zero will bypass any initial connection attempt, and the pool will start immediately
+        #    while trying to obtain connections in the background. Consequently, later efforts to obtain a connection
+        #    may fail.
+        initializationFailTimeout = 1
+
         # Sets whether or not construction of the pool should fail if the minimum number of connections
         # couldn't be created.
         initializationFailFast = true

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
@@ -120,6 +120,7 @@ private[db] class HikariCPConfig(dbConfig: DatabaseConfig, configuration: Config
     config.get[Option[String]]("poolName").foreach(hikariConfig.setPoolName)
 
     // Infrequently used
+    hikariConfig.setInitializationFailTimeout(config.get[Long]("initializationFailTimeout"))
     hikariConfig.setInitializationFailFast(config.get[Boolean]("initializationFailFast"))
     hikariConfig.setIsolateInternalQueries(config.get[Boolean]("isolateInternalQueries"))
     hikariConfig.setAllowPoolSuspension(config.get[Boolean]("allowPoolSuspension"))

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
@@ -120,8 +120,8 @@ private[db] class HikariCPConfig(dbConfig: DatabaseConfig, configuration: Config
     config.get[Option[String]]("poolName").foreach(hikariConfig.setPoolName)
 
     // Infrequently used
-    hikariConfig.setInitializationFailTimeout(config.get[Long]("initializationFailTimeout"))
     hikariConfig.setInitializationFailFast(config.get[Boolean]("initializationFailFast"))
+    hikariConfig.setInitializationFailTimeout(config.get[Long]("initializationFailTimeout"))
     hikariConfig.setIsolateInternalQueries(config.get[Boolean]("isolateInternalQueries"))
     hikariConfig.setAllowPoolSuspension(config.get[Boolean]("allowPoolSuspension"))
     hikariConfig.setReadOnly(config.get[Boolean]("readOnly"))

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
@@ -73,6 +73,10 @@ class HikariCPConfigSpec extends Specification {
         new HikariCPConfig(dbConfig, reference).toHikariConfig.isInitializationFailFast must beTrue
       }
 
+      "initializationFailTimeout to 1" in new Configs {
+        new HikariCPConfig(dbConfig, reference).toHikariConfig.getInitializationFailTimeout must beEqualTo(1)
+      }
+
       "isolateInternalQueries to false" in new Configs {
         new HikariCPConfig(dbConfig, reference).toHikariConfig.isIsolateInternalQueries must beFalse
       }
@@ -131,6 +135,11 @@ class HikariCPConfigSpec extends Specification {
       "maximumPoolSize" in new Configs {
         val config = from("hikaricp.maximumPoolSize" -> "20")
         new HikariCPConfig(dbConfig, config).toHikariConfig.getMaximumPoolSize must beEqualTo(20)
+      }
+
+      "initializationFailTimeout" in new Configs {
+        val config = from("hikaricp.initializationFailTimeout" -> "10")
+        new HikariCPConfig(dbConfig, config).toHikariConfig.getInitializationFailTimeout must beEqualTo(10)
       }
 
       "initializationFailFast" in new Configs {

--- a/framework/src/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
+++ b/framework/src/play-jdbc/src/test/scala/play/api/db/HikariCPConfigSpec.scala
@@ -143,7 +143,7 @@ class HikariCPConfigSpec extends Specification {
       }
 
       "initializationFailFast" in new Configs {
-        val config = from("hikaricp.initializationFailFast" -> "false")
+        val config = from("hikaricp.initializationFailFast" -> "false", "hikaricp.initializationFailTimeout" -> "-1")
         new HikariCPConfig(dbConfig, config).toHikariConfig.isInitializationFailFast must beFalse
       }
 


### PR DESCRIPTION
## Purpose

Updates HikariCP to its new version.

## References

See HikariCP changelog for 2.6.0 and 2.6.1 to better understand what changed for this update:

https://github.com/brettwooldridge/HikariCP/blob/dev/CHANGES
