### PR TITLE
More generic handling of generated sources

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -169,7 +169,6 @@ object Dependencies {
   def runSupportDependencies(sbtVersion: String, scalaVersion: String) = Seq(
     sbtIO(sbtVersion, scalaVersion),
     "com.lightbend.play" %% "play-file-watch" % "1.0.0",
-    "com.typesafe.play" %% "twirl-compiler" % BuildInfo.sbtTwirlVersion,
     logback % Test
   ) ++ specsBuild.map(_ % Test)
 


### PR DESCRIPTION
This makes it so that:
* Reloader no longer depends on Twirl and is more generic
* We don't try to parse a source file as Twirl unless the extension matches
* It's easier to support other generated sources in the future