### PR TITLE
Add cookie SameSite attribute and use for session and flash

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
@@ -16,6 +16,7 @@ import play.mvc.Result;
 import play.test.WithApplication;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static javaguide.testhelpers.MockJavaActionHelper.*;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -78,10 +79,7 @@ public class JavaResponse extends WithApplication {
     public void setCookie() {
         setContext(fakeRequest(), contextComponents());
         //#set-cookie
-        response().setCookie(new Cookie(
-            "theme", "blue",
-            null, null, null, false, false
-        ));
+        response().setCookie(Cookie.builder("theme", "blue").build());
         //#set-cookie
         Cookie cookie = response().cookies().iterator().next();
         assertThat(cookie.name(), equalTo("theme"));
@@ -93,15 +91,16 @@ public class JavaResponse extends WithApplication {
     public void detailedSetCookie() {
         setContext(fakeRequest(), contextComponents());
         //#detailed-set-cookie
-        response().setCookie(new Cookie(
-                "theme",        // name
-                "blue",         // value
-                3600,           // maximum age
-                "/some/path",   // path
-                ".example.com", // domain
-                false,          // secure
-                true            // http only
-        ));
+        response().setCookie(
+            Cookie.builder("theme", "blue")
+                .withMaxAge(3600)
+                .withPath("/some/path")
+                .withDomain(".example.com")
+                .withSecure(false)
+                .withHttpOnly(true)
+                .withSameSite(Cookie.SameSite.STRICT)
+                .build()
+        );
         //#detailed-set-cookie
         Cookie cookie = response().cookies().iterator().next();
         assertThat(cookie.name(), equalTo("theme"));
@@ -111,6 +110,8 @@ public class JavaResponse extends WithApplication {
         assertThat(cookie.domain(), equalTo(".example.com"));
         assertThat(cookie.secure(), equalTo(false));
         assertThat(cookie.httpOnly(), equalTo(true));
+        assertThat(cookie.sameSite(),
+            equalTo(Optional.of(Cookie.SameSite.STRICT)));
         removeContext();
     }
 

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/AddCSRFTokenAction.java
@@ -60,7 +60,7 @@ public class AddCSRFTokenAction extends Action<AddCSRFToken> {
             if (config.cookieName().isDefined()) {
                 scala.Option<String> domain = Session.domain();
                 Http.Cookie cookie = new Http.Cookie(config.cookieName().get(), newToken, null, Session.path(),
-                        domain.isDefined() ? domain.get() : null, config.secureCookie(), config.httpOnlyCookie());
+                        domain.isDefined() ? domain.get() : null, config.secureCookie(), config.httpOnlyCookie(), null);
                 ctx.response().setCookie(cookie);
             } else {
                 ctx.session().put(config.tokenName(), newToken);

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -52,8 +52,8 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
     "add cookies in Result" in makeRequest(new MockController {
       def action = {
         Results.ok("Hello world")
-          .withCookies(new Http.Cookie("bar", "KitKat", 1000, "/", "example.com", false, true))
-          .withCookies(new Http.Cookie("framework", "Play", 1000, "/", "example.com", false, true))
+          .withCookies(new Http.Cookie("bar", "KitKat", 1000, "/", "example.com", false, true, null))
+          .withCookies(new Http.Cookie("framework", "Play", 1000, "/", "example.com", false, true, null))
       }
     }) { response =>
       response.allHeaders("Set-Cookie") must contain((s: String) => s.startsWith("bar=KitKat;"))
@@ -63,7 +63,7 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
 
     "add cookies in Response" in makeRequest(new MockController {
       def action = {
-        response.setCookie(new Http.Cookie("foo", "1", 1000, "/", "example.com", false, true))
+        response.setCookie(new Http.Cookie("foo", "1", 1000, "/", "example.com", false, true, null))
         Results.ok("Hello world")
       }
     }) { response =>
@@ -73,9 +73,9 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
 
     "add cookies in both Response and Result" in makeRequest(new MockController {
       def action = {
-        response.setCookie(new Http.Cookie("foo", "1", 1000, "/", "example.com", false, true))
+        response.setCookie(new Http.Cookie("foo", "1", 1000, "/", "example.com", false, true, null))
         Results.ok("Hello world").withCookies(
-          new Http.Cookie("bar", "KitKat", 1000, "/", "example.com", false, true)
+          new Http.Cookie("bar", "KitKat", 1000, "/", "example.com", false, true, null)
         )
       }
     }) { response =>

--- a/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
+++ b/framework/src/play-java-forms/src/test/java/play/mvc/HttpFormsTest.java
@@ -273,7 +273,7 @@ public class HttpFormsTest {
             data.put("id", "1234567891");
             data.put("name", "peter");
             data.put("dueDate", "2009/11e/11");
-            Cookie frCookie = new Cookie("PLAY_LANG", "fr", 0, "/", null, false, false);
+            Cookie frCookie = new Cookie("PLAY_LANG", "fr", 0, "/", null, false, false, null);
             rb = new RequestBuilder().cookie(frCookie).uri("http://localhost/test").bodyForm(data);
             ctx = new Context(rb, contextComponents(app));
             Context.current.set(ctx);

--- a/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/HttpTest.java
@@ -151,7 +151,7 @@ public class HttpTest {
         withApplication((app) -> {
             JavaContextComponents contextComponents = app.injector().instanceOf(JavaContextComponents.class);
 
-            Cookie frCookie = new Cookie("PLAY_LANG", "fr", null, "/", null, false, false);
+            Cookie frCookie = new Cookie("PLAY_LANG", "fr", null, "/", null, false, false, null);
             RequestBuilder rb = new RequestBuilder().cookie(frCookie);
             Context ctx = new Context(rb, contextComponents);
             // Start off as 'en' with no cookie set

--- a/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/ClientCookieDecoder.java
+++ b/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/ClientCookieDecoder.java
@@ -157,6 +157,7 @@ public final class ClientCookieDecoder extends CookieDecoder {
         private String expires;
         private boolean secure;
         private boolean httpOnly;
+        private String sameSite;
 
         public CookieBuilder(DefaultCookie cookie) {
             this.cookie = cookie;
@@ -182,6 +183,7 @@ public final class ClientCookieDecoder extends CookieDecoder {
             cookie.setMaxAge(mergeMaxAgeAndExpire(maxAge, expires));
             cookie.setSecure(secure);
             cookie.setHttpOnly(httpOnly);
+            cookie.setSameSite(sameSite);
             return cookie;
         }
 
@@ -255,7 +257,13 @@ public final class ClientCookieDecoder extends CookieDecoder {
         private void parse8(String header, int nameStart, String value) {
             if (header.regionMatches(true, nameStart, CookieHeaderNames.HTTPONLY, 0, 8)) {
                 httpOnly = true;
+            } else if (header.regionMatches(true, nameStart, CookieHeaderNames.SAMESITE, 0, 8)) {
+                setSameSite(value);
             }
+        }
+
+        private void setSameSite(String value) {
+            sameSite = value;
         }
     }
 }

--- a/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/Cookie.java
+++ b/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/Cookie.java
@@ -94,6 +94,13 @@ public interface Cookie extends Comparable<Cookie> {
     int maxAge();
 
     /**
+     * Returns the SameSite attribute of this cookie as a String
+     *
+     * @return The SameSite attribute of the cookie
+     */
+    String sameSite();
+
+    /**
      * Sets the maximum age of this {@link Cookie} in seconds.
      * If an age of {@code 0} is specified, this {@link Cookie} will be
      * automatically removed by browser because it will expire immediately.

--- a/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/CookieHeaderNames.java
+++ b/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/CookieHeaderNames.java
@@ -28,6 +28,8 @@ final class CookieHeaderNames {
 
     public static final String HTTPONLY = "HTTPOnly";
 
+    public static final String SAMESITE = "SameSite";
+
     private CookieHeaderNames() {
         // Unused.
     }

--- a/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/DefaultCookie.java
+++ b/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/DefaultCookie.java
@@ -30,6 +30,7 @@ public class DefaultCookie implements Cookie {
     private int maxAge = Integer.MIN_VALUE;
     private boolean secure;
     private boolean httpOnly;
+    private String sameSite;
 
     /**
      * Creates a new cookie with the specified name and value.
@@ -103,6 +104,14 @@ public class DefaultCookie implements Cookie {
         this.secure = secure;
     }
 
+    public String sameSite() {
+        return sameSite;
+    }
+
+    public void setSameSite(String sameSite) {
+        this.sameSite = sameSite;
+    }
+
     public boolean isHttpOnly() {
         return httpOnly;
     }
@@ -149,6 +158,16 @@ public class DefaultCookie implements Cookie {
             return false;
         } else {
             return domain().equalsIgnoreCase(that.domain());
+        }
+
+        if (sameSite() == null) {
+            if (that.sameSite() != null) {
+                return false;
+            }
+        } else if (that.sameSite() == null) {
+            return false;
+        } else {
+            return sameSite().equalsIgnoreCase(that.sameSite());
         }
 
         return true;
@@ -223,6 +242,9 @@ public class DefaultCookie implements Cookie {
         }
         if (isHttpOnly()) {
             buf.append(", HTTPOnly");
+        }
+        if (sameSite() != null) {
+            buf.append(", SameSite=" + sameSite);
         }
         return buf.toString();
     }

--- a/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/ServerCookieEncoder.java
+++ b/framework/src/play-netty-utils/src/main/java/play/core/netty/utils/ServerCookieEncoder.java
@@ -90,6 +90,10 @@ public final class ServerCookieEncoder extends CookieEncoder {
             add(buf, CookieHeaderNames.EXPIRES, HttpHeaderDateFormat.get().format(expires));
         }
 
+        if (cookie.sameSite() != null) {
+            add(buf, CookieHeaderNames.SAMESITE, cookie.sameSite());
+        }
+
         if (cookie.path() != null) {
             add(buf, CookieHeaderNames.PATH, cookie.path());
         }

--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -304,7 +304,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * @param requestBuilder the request builder
      * @param timeout the timeout
-     * @deprecated Deprecated as in 2.6.0. Use {@link #routeAndCall(Application, RequestBuilder, long)}.
+     * @deprecated as of 2.6.0. Use {@link routeAndCall(Application, RequestBuilder, long)}.
      * @see GuiceApplicationBuilder
      * @return the result
      */
@@ -337,7 +337,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * @param router the router
      * @param requestBuilder the request builder
      * @param timeout the timeout
-     * @deprecated Deprecated as in 2.6.0. Use {@link #routeAndCall(Application, Class, RequestBuilder, long)}.
+     * @deprecated as of 2.6.0. Use {@link #routeAndCall(Application, Class, RequestBuilder, long)}.
      * @see GuiceApplicationBuilder
      * @return the result
      */
@@ -373,7 +373,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * @param router the router
      * @param requestBuilder the request builder
-     * @deprecated Deprecated as in 2.6.0. Use {@link #routeAndCall(Application, Router, RequestBuilder)}.
+     * @deprecated as of 2.6.0. Use {@link #routeAndCall(Application, Router, RequestBuilder)}.
      * @see GuiceApplicationBuilder
      * @return the result
      */
@@ -399,7 +399,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * @param router the router
      * @param requestBuilder the request builder
      * @param timeout the timeout
-     * @deprecated Deprecated as in 2.6.0. Use {@link #routeAndCall(Application, RequestBuilder, long)}.
+     * @deprecated as of 2.6.0. Use {@link #routeAndCall(Application, RequestBuilder, long)}.
      * @see GuiceApplicationBuilder
      * @return the result
      */
@@ -434,7 +434,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      *
      * @param call the call to route
-     * @deprecated Deprecated as in 2.6.0. Use {@link #route(Application, Call)}.
+     * @deprecated as of 2.6.0. Use {@link #route(Application, Call)}.
      * @see GuiceApplicationBuilder
      * @return the result
      */
@@ -450,7 +450,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * @param call the call to route
      * @param timeout the time out
-     * @deprecated Deprecated as in 2.6.0. Use {@link #route(Application, Call, long)}.
+     * @deprecated as of 2.6.0. Use {@link #route(Application, Call, long)}.
      * @see GuiceApplicationBuilder
      * @return the result
      */
@@ -465,7 +465,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
 
     /**
      * @param requestBuilder the request builder the request builder
-     * @deprecated Deprecated as in 2.6.0. Use {@link #route(Application, RequestBuilder)}.
+     * @deprecated as of 2.6.0. Use {@link #route(Application, RequestBuilder)}.
      * @see GuiceApplicationBuilder
      * @return the result
      */
@@ -488,7 +488,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
     /**
      * @param requestBuilder the request builder
      * @param timeout the timeout
-     * @deprecated Deprecated as in 2.6.0. Use {@link #route(Application, RequestBuilder, long)}.
+     * @deprecated as of 2.6.0. Use {@link #route(Application, RequestBuilder, long)}.
      * @see GuiceApplicationBuilder
      * @return the result
      */

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -142,6 +142,9 @@ play {
       # Whether the HTTP only attribute of the cookie should be set to true
       httpOnly = true
 
+      # The value of the SameSite attribute of the cookie. Set to null for no SameSite attribute.
+      sameSite = "lax"
+
       # The domain to set on the session cookie
       # If null, does not set a domain on the session cookie.
       domain = null
@@ -161,6 +164,9 @@ play {
 
       # Whether the HTTP only attribute of the cookie should be set to true
       httpOnly = true
+
+      # The value of the SameSite attribute of the cookie. Set to null for no SameSite attribute.
+      sameSite = "lax"
 
       # The flash path
       # Must start with /.
@@ -737,7 +743,7 @@ play {
   filters {
     # List of enabled filters as fully qualified class names
     # enabled = []
-    
+
     # List of disabled filters as fully qualified class names
     disabled = []
   }

--- a/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
@@ -81,6 +81,7 @@ trait FlashCookieBaker extends CookieBaker[Flash] {
   override def secure = config.secure
   override def httpOnly = config.httpOnly
   override def domain = sessionConfig.domain
+  override def sameSite = config.sameSite
 
   def deserialize(data: Map[String, String]) = new Flash(data)
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Session.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Session.scala
@@ -82,6 +82,7 @@ trait SessionCookieBaker extends CookieBaker[Session] {
   override def httpOnly = config.httpOnly
   override def path = config.path
   override def domain = config.domain
+  override def sameSite = config.sameSite
 
   def deserialize(data: Map[String, String]) = new Session(data)
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaResults.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaResults.scala
@@ -26,22 +26,11 @@ object JavaResultExtractor {
       private val cookies = Cookies.fromSetCookieHeader(responseHeader.headers.get(HeaderNames.SET_COOKIE))
 
       def get(name: String): JCookie = {
-        cookies.get(name).map(makeJavaCookie).orNull
-      }
-
-      private def makeJavaCookie(cookie: Cookie): JCookie = {
-        new JCookie(
-          cookie.name,
-          cookie.value,
-          cookie.maxAge.map(i => new Integer(i)).orNull,
-          cookie.path,
-          cookie.domain.orNull,
-          cookie.secure,
-          cookie.httpOnly)
+        cookies.get(name).map(_.asJava).orNull
       }
 
       def iterator: java.util.Iterator[JCookie] = {
-        cookies.toIterator.map(makeJavaCookie).asJava
+        cookies.toIterator.map(_.asJava).asJava
       }
     }
 

--- a/framework/src/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/HttpConfigurationSpec.scala
@@ -8,6 +8,7 @@ import java.io.File
 import com.typesafe.config.ConfigFactory
 import org.specs2.mutable.Specification
 import play.api.{ Configuration, Environment, Mode, PlayException }
+import play.api.mvc.Cookie.SameSite
 import play.core.netty.utils.{ ClientCookieDecoder, ClientCookieEncoder, ServerCookieDecoder, ServerCookieEncoder }
 
 class HttpConfigurationSpec extends Specification {
@@ -30,10 +31,12 @@ class HttpConfigurationSpec extends Specification {
         "play.http.session.httpOnly" -> "true",
         "play.http.session.domain" -> "playframework.com",
         "play.http.session.path" -> "/session",
+        "play.http.session.sameSite" -> "lax",
         "play.http.flash.cookieName" -> "PLAY_FLASH",
         "play.http.flash.secure" -> "true",
         "play.http.flash.httpOnly" -> "true",
         "play.http.flash.path" -> "/flash",
+        "play.http.flash.sameSite" -> "lax",
         "play.http.fileMimeTypes" -> "foo=text/foo",
         "play.http.secret.key" -> "mysecret",
         "play.http.secret.provider" -> "HmacSHA1"
@@ -124,6 +127,11 @@ class HttpConfigurationSpec extends Specification {
         val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration, environment).get
         httpConfiguration.session.domain must beEqualTo(Some("playframework.com"))
       }
+
+      "cookie samesite" in {
+        val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration, environment).get
+        httpConfiguration.session.sameSite must beSome(SameSite.Lax)
+      }
     }
 
     "configure flash should set" in {
@@ -141,6 +149,11 @@ class HttpConfigurationSpec extends Specification {
       "cookie httpOnly" in {
         val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration, environment).get
         httpConfiguration.flash.httpOnly must beTrue
+      }
+
+      "cookie samesite" in {
+        val httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(configuration, environment).get
+        httpConfiguration.flash.sameSite must beSome(SameSite.Lax)
       }
     }
 


### PR DESCRIPTION
Fixes #7086 

This adds the [`SameSite`](https://tools.ietf.org/html/draft-west-first-party-cookies-07) attribute to the cookie models, and sets it to `Lax` by default for the session and flash cookies.