### PR TITLE
POST, PUT, PATCH should ignore querystring params when building form

### DIFF
--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -131,7 +131,11 @@ Then in your template you can use `AssetsFinder#path` to find the final path of 
 
 You can still continue to use reverse routes with `Assets.versioned`, but some global state is required to convert the asset name you provide to the final asset name, which can be problematic if you want to run multiple applications at once.
 
-## Java Form Changes
+## Form changes
+
+Starting with Play 2.6 query string parameters will not be bound to a form instance anymore when using `.bindFromRequest()` in combination with `POST`, `PUT` or `PATCH` requests.
+
+### Java Form Changes
 
 The `.errors()` method of a `play.data.Form` instance is now deprecated. You should use `allErrors()` instead now which returns a simple `List<ValidationError>` instead of a `Map<String,List<ValidationError>>`. Where before Play 2.6 you called `.errors().get("key")` you can now simply call `.errors("key")`.
 

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -20,6 +20,7 @@ import static java.lang.annotation.RetentionPolicy.*;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.mvc.Http;
+import play.mvc.Http.HttpVerbs;
 
 import static play.libs.F.*;
 
@@ -220,7 +221,7 @@ public class Form<T> {
 
         jsonData.forEach(data::put);
 
-        if(!request.method().equals("POST") && !request.method().equals("PUT") && !request.method().equals("PATCH")) {
+        if(!request.method().equalsIgnoreCase(HttpVerbs.POST) && !request.method().equalsIgnoreCase(HttpVerbs.PUT) && !request.method().equalsIgnoreCase(HttpVerbs.PATCH)) {
             fillDataWith(data, request.queryString());
         }
 

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -213,8 +213,6 @@ public class Form<T> {
             );
         }
 
-        Map<String,String[]> queryString = request.queryString();
-
         Map<String,String> data = new HashMap<>();
 
         fillDataWith(data, urlFormEncoded);
@@ -222,7 +220,9 @@ public class Form<T> {
 
         jsonData.forEach(data::put);
 
-        fillDataWith(data, queryString);
+        if(!request.method().equals("POST") && !request.method().equals("PUT") && !request.method().equals("PATCH")) {
+            fillDataWith(data, request.queryString());
+        }
 
         return data;
     }

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -53,6 +53,33 @@ class FormSpec extends Specification {
       val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
       myForm hasErrors () must beEqualTo(false)
     }
+    "query params ignored when using POST" in {
+      val req = FormSpec.dummyRequest(Map("name" -> Array("peter"), "dueDate" -> Array("15/12/2009")), "POST", "?name=michael&id=55555")
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+
+      val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
+      myForm hasErrors () must beEqualTo(false)
+      myForm.value().get().getName() must beEqualTo("peter")
+      myForm.value().get().getId() must beEqualTo(null)
+    }
+    "query params ignored when using PUT" in {
+      val req = FormSpec.dummyRequest(Map("name" -> Array("peter"), "dueDate" -> Array("15/12/2009")), "PUT", "?name=michael&id=55555")
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+
+      val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
+      myForm hasErrors () must beEqualTo(false)
+      myForm.value().get().getName() must beEqualTo("peter")
+      myForm.value().get().getId() must beEqualTo(null)
+    }
+    "query params ignored when using PATCH" in {
+      val req = FormSpec.dummyRequest(Map("name" -> Array("peter"), "dueDate" -> Array("15/12/2009")), "PATCH", "?name=michael&id=55555")
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+
+      val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
+      myForm hasErrors () must beEqualTo(false)
+      myForm.value().get().getName() must beEqualTo("peter")
+      myForm.value().get().getId() must beEqualTo(null)
+    }
     "have an error due to badly formatted date" in new WithApplication() {
       val contextComponents = app.injector.instanceOf[JavaContextComponents]
       val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))
@@ -498,9 +525,10 @@ class FormSpec extends Specification {
 
 object FormSpec {
 
-  def dummyRequest(data: Map[String, Array[String]]): Request = {
+  def dummyRequest(data: Map[String, Array[String]], method: String = "POST", query: String = ""): Request = {
     new RequestBuilder()
-      .uri("http://localhost/test")
+      .method(method)
+      .uri("http://localhost/test" + query)
       .bodyFormArrayValues(data.asJava)
       .build()
   }

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -5,6 +5,7 @@ package play.data
 
 import java.util
 import java.util.Optional
+import java.time.{ LocalDate, ZoneId }
 import javax.validation.{ Validation, Validator, Configuration => vConfiguration }
 import javax.validation.groups.Default
 
@@ -80,6 +81,48 @@ class FormSpec extends Specification {
       myForm.value().get().getName() must beEqualTo("peter")
       myForm.value().get().getId() must beEqualTo(null)
     }
+
+    "query params NOT ignored when using GET" in {
+      val req = FormSpec.dummyRequest(Map("name" -> Array("peter"), "dueDate" -> Array("15/12/2009")), "GET", "?name=michael&id=55555")
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+
+      val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
+      myForm hasErrors () must beEqualTo(false)
+      myForm.value().get().getDueDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate() must beEqualTo(LocalDate.of(2009, 12, 15)) // we also parse the body for GET requests
+      myForm.value().get().getName() must beEqualTo("michael") // but query param overwrites body when using GET
+      myForm.value().get().getId() must beEqualTo(55555)
+    }
+    "query params NOT ignored when using DELETE" in {
+      val req = FormSpec.dummyRequest(Map("name" -> Array("peter"), "dueDate" -> Array("15/12/2009")), "DELETE", "?name=michael&id=55555")
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+
+      val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
+      myForm hasErrors () must beEqualTo(false)
+      myForm.value().get().getDueDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate() must beEqualTo(LocalDate.of(2009, 12, 15)) // we also parse the body for DELETE requests
+      myForm.value().get().getName() must beEqualTo("michael") // but query param overwrites body when using DELETE
+      myForm.value().get().getId() must beEqualTo(55555)
+    }
+    "query params NOT ignored when using HEAD" in {
+      val req = FormSpec.dummyRequest(Map("name" -> Array("peter"), "dueDate" -> Array("15/12/2009")), "HEAD", "?name=michael&id=55555")
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+
+      val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
+      myForm hasErrors () must beEqualTo(false)
+      myForm.value().get().getDueDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate() must beEqualTo(LocalDate.of(2009, 12, 15)) // we also parse the body for HEAD requests
+      myForm.value().get().getName() must beEqualTo("michael") // but query param overwrites body when using HEAD
+      myForm.value().get().getId() must beEqualTo(55555)
+    }
+    "query params NOT ignored when using OPTIONS" in {
+      val req = FormSpec.dummyRequest(Map("name" -> Array("peter"), "dueDate" -> Array("15/12/2009")), "OPTIONS", "?name=michael&id=55555")
+      Context.current.set(new Context(666, null, req, Map.empty.asJava, Map.empty.asJava, Map.empty.asJava, defaultContextComponents))
+
+      val myForm = formFactory.form(classOf[play.data.Task]).bindFromRequest()
+      myForm hasErrors () must beEqualTo(false)
+      myForm.value().get().getDueDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate() must beEqualTo(LocalDate.of(2009, 12, 15)) // we also parse the body for OPTIONS requests
+      myForm.value().get().getName() must beEqualTo("michael") // but query param overwrites body when using OPTIONS
+      myForm.value().get().getId() must beEqualTo(55555)
+    }
+
     "have an error due to badly formatted date" in new WithApplication() {
       val contextComponents = app.injector.instanceOf[JavaContextComponents]
       val req = FormSpec.dummyRequest(Map("id" -> Array("1234567891"), "name" -> Array("peter"), "dueDate" -> Array("2009/11e/11")))

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -2342,4 +2342,17 @@ public class Http {
          */
         String BINARY = "application/octet-stream";
     }
+
+    /**
+     * Standard HTTP Verbs
+     */
+    public static interface HttpVerbs {
+        String GET = "GET";
+        String POST = "POST";
+        String PUT = "PUT";
+        String PATCH = "PATCH";
+        String DELETE = "DELETE";
+        String HEAD = "HEAD";
+        String OPTIONS = "OPTIONS";
+    }
 }

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -7,6 +7,7 @@ import scala.language.existentials
 
 import format._
 import play.api.data.validation._
+import play.api.http.HttpVerbs
 
 /**
  * Helper to manage HTML form description, submission and validation.
@@ -83,7 +84,7 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
         case body: play.api.mvc.MultipartFormData[_] => body.asFormUrlEncoded
         case body: play.api.libs.json.JsValue => FormUtils.fromJson(js = body).mapValues(Seq(_))
         case _ => Map.empty[String, Seq[String]]
-      }) ++ (if (request.method != "POST" && request.method != "PUT" && request.method != "PATCH") { request.queryString } else { Nil })
+      }) ++ (if (!request.method.equalsIgnoreCase(HttpVerbs.POST) && !request.method.equalsIgnoreCase(HttpVerbs.PUT) && !request.method.equalsIgnoreCase(HttpVerbs.PATCH)) { request.queryString } else { Nil })
     }
   }
 

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -83,7 +83,7 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
         case body: play.api.mvc.MultipartFormData[_] => body.asFormUrlEncoded
         case body: play.api.libs.json.JsValue => FormUtils.fromJson(js = body).mapValues(Seq(_))
         case _ => Map.empty[String, Seq[String]]
-      }) ++ request.queryString
+      }) ++ (if (request.method != "POST" && request.method != "PUT" && request.method != "PATCH") { request.queryString } else { Nil })
     }
   }
 

--- a/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
@@ -62,6 +62,38 @@ class FormSpec extends Specification {
       f1.get must equalTo((Some("michael@jackson.com"), None))
     }
 
+    "query params NOT ignored when using GET" in {
+      implicit val request = FakeRequest(method = "GET", "/?email=bob%40marley.com&name=john").withFormUrlEncodedBody("email" -> "michael@jackson.com")
+
+      val f1 = ScalaForms.updateForm.bindFromRequest()
+      f1.errors must beEmpty
+      f1.get must equalTo((Some("bob@marley.com"), Some("john")))
+    }
+
+    "query params NOT ignored when using DELETE" in {
+      implicit val request = FakeRequest(method = "DELETE", "/?email=bob%40marley.com&name=john").withFormUrlEncodedBody("email" -> "michael@jackson.com")
+
+      val f1 = ScalaForms.updateForm.bindFromRequest()
+      f1.errors must beEmpty
+      f1.get must equalTo((Some("bob@marley.com"), Some("john")))
+    }
+
+    "query params NOT ignored when using HEAD" in {
+      implicit val request = FakeRequest(method = "HEAD", "/?email=bob%40marley.com&name=john").withFormUrlEncodedBody("email" -> "michael@jackson.com")
+
+      val f1 = ScalaForms.updateForm.bindFromRequest()
+      f1.errors must beEmpty
+      f1.get must equalTo((Some("bob@marley.com"), Some("john")))
+    }
+
+    "query params NOT ignored when using OPTIONS" in {
+      implicit val request = FakeRequest(method = "OPTIONS", "/?email=bob%40marley.com&name=john").withFormUrlEncodedBody("email" -> "michael@jackson.com")
+
+      val f1 = ScalaForms.updateForm.bindFromRequest()
+      f1.errors must beEmpty
+      f1.get must equalTo((Some("bob@marley.com"), Some("john")))
+    }
+
     "support mapping 22 fields" in {
       val form = Form(
         tuple(

--- a/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
@@ -11,6 +11,7 @@ import play.api.i18n._
 import play.api.libs.json.Json
 import org.specs2.mutable.Specification
 import play.api.http.HttpConfiguration
+import play.core.test.FakeRequest
 
 class FormSpec extends Specification {
   "A form" should {
@@ -35,6 +36,30 @@ class FormSpec extends Specification {
       f9.errors must beEmpty
 
       ScalaForms.emailForm.fillAndValidate(("o'flynn@example.com", "O'Flynn")).errors must beEmpty
+    }
+
+    "query params ignored when using POST" in {
+      implicit val request = FakeRequest(method = "POST", "/?email=bob%40marley.com&name=john").withFormUrlEncodedBody("email" -> "michael@jackson.com")
+
+      val f1 = ScalaForms.updateForm.bindFromRequest()
+      f1.errors must beEmpty
+      f1.get must equalTo((Some("michael@jackson.com"), None))
+    }
+
+    "query params ignored when using PUT" in {
+      implicit val request = FakeRequest(method = "PUT", "/?email=bob%40marley.com&name=john").withFormUrlEncodedBody("email" -> "michael@jackson.com")
+
+      val f1 = ScalaForms.updateForm.bindFromRequest()
+      f1.errors must beEmpty
+      f1.get must equalTo((Some("michael@jackson.com"), None))
+    }
+
+    "query params ignored when using PATCH" in {
+      implicit val request = FakeRequest(method = "PATCH", "/?email=bob%40marley.com&name=john").withFormUrlEncodedBody("email" -> "michael@jackson.com")
+
+      val f1 = ScalaForms.updateForm.bindFromRequest()
+      f1.errors must beEmpty
+      f1.get must equalTo((Some("michael@jackson.com"), None))
     }
 
     "support mapping 22 fields" in {
@@ -396,6 +421,13 @@ object ScalaForms {
     tuple(
       "email" -> email,
       "name" -> of[String]
+    )
+  )
+
+  val updateForm = Form(
+    tuple(
+      "email" -> optional(text),
+      "name" -> optional(text)
     )
   )
 


### PR DESCRIPTION
Fixes #7070