### PR TITLE
Change inlet/outlet stream names to improve debug

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/akka/http/play/WebSocketHandler.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/akka/http/play/WebSocketHandler.scala
@@ -52,8 +52,8 @@ object WebSocketHandler {
   private def aggregateFrames(bufferLimit: Int): GraphStage[FlowShape[FrameEvent, Either[Message, RawMessage]]] = {
     new GraphStage[FlowShape[FrameEvent, Either[Message, RawMessage]]] {
 
-      val in = Inlet[FrameEvent]("in")
-      val out = Outlet[Either[Message, RawMessage]]("out")
+      val in = Inlet[FrameEvent]("WebSocketHandler.aggregateFrames.in")
+      val out = Outlet[Either[Message, RawMessage]]("WebSocketHandler.aggregateFrames.out")
 
       override val shape = FlowShape.of(in, out)
 
@@ -161,8 +161,8 @@ object WebSocketHandler {
     AkkaStreams.bypassWith(Flow[Either[Message, RawMessage]].via(
       new GraphStage[FlowShape[Either[Message, RawMessage], Either[RawMessage, Message]]] {
 
-        val in = Inlet[Either[Message, RawMessage]]("in")
-        val out = Outlet[Either[RawMessage, Message]]("out")
+        val in = Inlet[Either[Message, RawMessage]]("WebSocketHandler.handleProtocolFailures.in")
+        val out = Outlet[Either[RawMessage, Message]]("WebSocketHandler.handleProtocolFailures.out")
 
         override val shape = FlowShape.of(in, out)
 

--- a/framework/src/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/WebSocketFlowHandler.scala
@@ -20,13 +20,14 @@ object WebSocketFlowHandler {
   def webSocketProtocol(bufferLimit: Int): BidiFlow[RawMessage, Message, Message, Message, NotUsed] = {
     BidiFlow.fromGraph(new GraphStage[BidiShape[RawMessage, Message, Message, Message]] {
       // The stream of incoming messages from the websocket connection
-      val remoteIn = Inlet[RawMessage]("WebSocketIn")
-      // The stream of websocket messages going to the application
-      val appOut = Outlet[Message]("WebSocketAppOut")
-      // The stream of websocket messages being produced by the application
-      val appIn = Inlet[Message]("WebSocketAppIn")
+      val remoteIn = Inlet[RawMessage]("WebSocketFlowHandler.remote.in")
       // The stream of websocket messages going out to the websocket connection
-      val remoteOut = Outlet[Message]("WebSocketOut")
+      val remoteOut = Outlet[Message]("WebSocketFlowHandler.remote.out")
+
+      // The stream of websocket messages being produced by the application
+      val appIn = Inlet[Message]("WebSocketFlowHandler.app.in")
+      // The stream of websocket messages going to the application
+      val appOut = Outlet[Message]("WebSocketFlowHandler.app.out")
 
       override def shape: BidiShape[RawMessage, Message, Message, Message] = new BidiShape(remoteIn, appOut, appIn, remoteOut)
 

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/AkkaStreams.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/AkkaStreams.scala
@@ -81,8 +81,8 @@ object AkkaStreams {
    */
   def ignoreAfterFinish[T]: Flow[T, T, _] = Flow[T].via(new GraphStage[FlowShape[T, T]] {
 
-    val in = Inlet[T]("in")
-    val out = Outlet[T]("out")
+    val in = Inlet[T]("AkkaStreams.in")
+    val out = Outlet[T]("AkkaStreams.out")
 
     override def shape: FlowShape[T, T] = FlowShape.of(in, out)
 

--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/Probes.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/Probes.scala
@@ -81,8 +81,8 @@ object Probes {
   def flowProbe[T](name: String, messageLogger: T => String = (t: T) => t.toString): Flow[T, T, _] = {
     Flow[T].via(new GraphStage[FlowShape[T, T]] with Probe {
 
-      val in = Inlet[T]("in")
-      val out = Outlet[T]("out")
+      val in = Inlet[T]("Probes.in")
+      val out = Outlet[T]("Probes.out")
 
       override def shape: FlowShape[T, T] = FlowShape.of(in, out)
 

--- a/framework/src/play/src/main/scala/play/core/formatters/Multipart.scala
+++ b/framework/src/play/src/main/scala/play/core/formatters/Multipart.scala
@@ -121,8 +121,8 @@ object Multipart {
 
     new GraphStage[FlowShape[MultipartFormData.Part[Source[ByteString, _]], Source[ByteString, Any]]] {
 
-      val in = Inlet[MultipartFormData.Part[Source[ByteString, _]]]("in")
-      val out = Outlet[Source[ByteString, Any]]("out")
+      val in = Inlet[MultipartFormData.Part[Source[ByteString, _]]]("CustomCharsetByteStringFormatter.in")
+      val out = Outlet[Source[ByteString, Any]]("CustomCharsetByteStringFormatter.out")
 
       override def shape = FlowShape.of(in, out)
 


### PR DESCRIPTION
## Purpose

This follows a suggestion made by @ktoso and give Akka Streams Inlet/Outlet because it is better for debugging purposes.