### PR TITLE
reference messages.default in ScalaI18N.md

### DIFF
--- a/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
+++ b/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
@@ -35,7 +35,7 @@ You can also make the language implicit rather than declare it:
 
 Play provides predefined messages for forms validation. 
 You can overwrite these messages either with the default message file or any language-specific message file.
-To see which messages can be overwritten, you can have a look at [`messages.default`](https://github.com/playframework/playframework/blob/2.5.x/framework/src/play/src/main/resources/messages.default)(you need to select the branch according to the version of play you are using).
+To see which messages can be overwritten, you can have a look at [`messages.default`](https://github.com/playframework/playframework/blob/%PLAY_VERSION%/framework/src/play/src/main/resources/messages.default).
 
 ## Using Messages and MessagesProvider
 

--- a/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
+++ b/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
@@ -35,7 +35,7 @@ You can also make the language implicit rather than declare it:
 
 Play provides predefined messages for forms validation. 
 You can overwrite these messages either with the default message file or any language-specific message file.
-To see which messages can be overwritten, you can have a look at [`messages.default`](../../../../../../framework/src/play/src/main/resources/messages.default).
+To see which messages can be overwritten, you can have a look at [`messages.default`](https://github.com/playframework/playframework/blob/2.5.x/framework/src/play/src/main/resources/messages.default)(you need to select the branch according to the version of play you are using).
 
 ## Using Messages and MessagesProvider
 

--- a/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
+++ b/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
@@ -33,6 +33,10 @@ You can also make the language implicit rather than declare it:
 
 @[use-implicit-lang](code/scalaguide/i18n/ScalaI18nService.scala)
 
+Play provides predefined messages for forms validation. 
+You can overwrite these messages either with the default message file or any language-specific message file.
+To see which messages can be overwritten, you can have a look at [`messages.default`](../../../../../../framework/src/play/src/main/resources/messages.default).
+
 ## Using Messages and MessagesProvider
 
 Because it's common to want to use messages without having to provide an argument, you can wrap a given `Lang` together with the [`MessagesApi`](api/scala/play/api/i18n/MessagesApi.html) to create a [`play.api.i18n.Messages`](api/scala/play/api/i18n/MessagesImpl.html) instance.  The [`play.api.i18n.MessagesImpl`](api/scala/play/api/i18n/MessagesImpl.html) case class implements the [`Messages`](api/scala/play/api/i18n/Messages.html) trait if you want to create one directly:

--- a/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
+++ b/documentation/manual/working/scalaGuide/main/i18n/ScalaI18N.md
@@ -33,9 +33,9 @@ You can also make the language implicit rather than declare it:
 
 @[use-implicit-lang](code/scalaguide/i18n/ScalaI18nService.scala)
 
-Play provides predefined messages for forms validation. 
-You can overwrite these messages either with the default message file or any language-specific message file.
-To see which messages can be overwritten, you can have a look at [`messages.default`](https://github.com/playframework/playframework/blob/%PLAY_VERSION%/framework/src/play/src/main/resources/messages.default).
+Play provides predefined messages for forms validation.  You can overwrite these messages either with the default message file or any language-specific message file. You can see below which messages can be overwritten:
+
+@[](/confs/play/messages.default)
 
 ## Using Messages and MessagesProvider
 

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -278,8 +278,12 @@ object Docs {
         .get(structure.data)
         .map(_.map { resources =>
           (for {
-            conf <- resources.filter(resource => resource.name == "reference.conf" || resource.name.endsWith(".xml"))
-            id   <- projectId.toSeq
+            conf <- resources.filter(
+              resource =>
+                resource.name == "reference.conf" || resource.name.endsWith(".xml") || resource.name
+                  .endsWith(".default")
+            )
+            id <- projectId.toSeq
           } yield id -> conf).distinct
         })
 


### PR DESCRIPTION
In messages.default the default messages for forms validation are defined. 
In order to overwrite the validation messages with language-specific messages, you need to know under which alias the messages are defined.
The reference might save users some time searching for the aliases that play uses.