### PR TITLE
Only call entityManagerContext.pop if the EntityManager is set

### DIFF
--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/DefaultJPAApi.java
@@ -153,8 +153,8 @@ public class DefaultJPAApi implements JPAApi {
             }
             throw t;
         } finally {
-            entityManagerContext.pop(true);
             if (entityManager != null) {
+                entityManagerContext.pop(true);
                 entityManager.close();
             }
         }


### PR DESCRIPTION
Fixes https://github.com/playframework/playframework/issues/6041 and https://github.com/playframework/playframework/issues/7037