### PR TITLE
Remove docs from dev mode

### DIFF
--- a/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -31,10 +31,9 @@ object DevServerStart {
    */
   def mainDevOnlyHttpsMode(
     buildLink: BuildLink,
-    buildDocHandler: BuildDocHandler,
     httpsPort: Int,
     httpAddress: String): ServerWithStop = {
-    mainDev(buildLink, buildDocHandler, None, Some(httpsPort), httpAddress)
+    mainDev(buildLink, None, Some(httpsPort), httpAddress)
   }
 
   /**
@@ -45,15 +44,13 @@ object DevServerStart {
    */
   def mainDevHttpMode(
     buildLink: BuildLink,
-    buildDocHandler: BuildDocHandler,
     httpPort: Int,
     httpAddress: String): ServerWithStop = {
-    mainDev(buildLink, buildDocHandler, Some(httpPort), Option(System.getProperty("https.port")).map(Integer.parseInt(_)), httpAddress)
+    mainDev(buildLink, Some(httpPort), Option(System.getProperty("https.port")).map(Integer.parseInt(_)), httpAddress)
   }
 
   private def mainDev(
     buildLink: BuildLink,
-    buildDocHandler: BuildDocHandler,
     httpPort: Option[Int],
     httpsPort: Option[Int],
     httpAddress: String): ServerWithStop = {
@@ -197,10 +194,7 @@ object DevServerStart {
           }
 
           override def handleWebCommand(request: play.api.mvc.RequestHeader): Option[Result] = {
-            buildDocHandler.maybeHandleDocRequest(request).asInstanceOf[Option[Result]].orElse(
-              currentWebCommands.flatMap(_.handleWebCommand(request, buildLink, path))
-            )
-
+            currentWebCommands.flatMap(_.handleWebCommand(request, buildLink, path))
           }
 
         }

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -89,8 +89,6 @@ object PlayRun {
       playMonitoredFiles.value,
       fileWatchService.value,
       generatedSourceHandlers,
-      (managedClasspath in DocsApplication).value.files,
-      playDocsJar.value,
       playDefaultPort.value,
       playDefaultAddress.value,
       baseDirectory.value,


### PR DESCRIPTION
Reasons why:
* Removing makes it easier to share code with Lagom and other projects
* Doesn't work if you have a compile error in project
* Docs are not searchable, so are hard to navigate compared to web
* It's undocumented, so few know it exists
* Required if we want to move to Paradox

The main benefit to the feature is that it makes the docs available offline, but we should be able to add a downloadable link to the docs artifact to fulfill this purpose