### PR TITLE
Using EnumMap for mapping enums.

### DIFF
--- a/framework/src/play-server/src/main/java/play/server/Server.java
+++ b/framework/src/play-server/src/main/java/play/server/Server.java
@@ -10,7 +10,7 @@ import play.core.j.JavaModeConverter;
 import play.core.server.JavaServerHelper;
 
 import java.net.InetSocketAddress;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -246,7 +246,7 @@ public class Server {
      * to serving TEST mode over HTTP on a random available port.
      */
     public static class Builder {
-        private Server.Config _config = new Server.Config(new HashMap<>(), Mode.TEST);
+        private Server.Config _config = new Server.Config(new EnumMap<>(Protocol.class), Mode.TEST);
 
         /**
          * Instruct the server to serve HTTP on a particular port.
@@ -324,7 +324,7 @@ public class Server {
         }
 
         private Builder _protocol(Protocol protocol, int port) {
-            Map<Protocol, Integer> newPorts = new HashMap<>();
+            Map<Protocol, Integer> newPorts = new EnumMap<>(Protocol.class);
             newPorts.putAll(_config.ports());
             newPorts.put(protocol, port);
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?

# Helpful things

Going over some more code, I noticed an opportunity for EnumMap to be used.

EnumMap documentation: https://docs.oracle.com/javase/8/docs/api/java/util/EnumMap.html

EnumMap is basically a Map specifically implemented for when the Map's key is an Enum. It's faster and has a smaller memory footprint than a HashMap. Extremely compact and performant.

I made this little bit of code with some HashMap vs EnumMap loops, for people who want to test it: https://ideone.com/y5mT3d

I scanned the entirety of the playframework github project for use of Maps, this instance is the only one in the entire project that has an Enum for a key, far as I call tell.

EDIT: XmlBodyParser unit test failed for Scala version 2.11.8, something else for 2.12.1. Not sure how it's related.