### PR TITLE
Simplify timestamp checking and fix dev-mode tests

### DIFF
--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/test
@@ -156,40 +156,40 @@ $ sleep 1000
 > verifyReloads 1
 
 # Change a scala file
-$ copy-file changes/Application.scala.1 app/controllers/Application.scala
 $ sleep 1000
+$ copy-file changes/Application.scala.1 app/controllers/Application.scala
 > verifyResourceContains / 200 first
 > verifyReloads 2
 
 # Change a static asset
-$ copy-file changes/some.css.1 public/css/some.css
 $ sleep 1000
+$ copy-file changes/some.css.1 public/css/some.css
 > verifyResourceContains /assets/css/some.css 200 first
 # No reloads should have happened
 > verifyReloads 2
 
 # Change a compiled asset
-$ copy-file changes/main.less.1 app/assets/main.less
 $ sleep 1000
+$ copy-file changes/main.less.1 app/assets/main.less
 > verifyResourceContains /assets/main.css 200 first
 # No reloads should have happened
 > verifyReloads 2
 
 # Introduce a compile error
-$ copy-file changes/Application.scala.2 app/controllers/Application.scala
 $ sleep 1000
+$ copy-file changes/Application.scala.2 app/controllers/Application.scala
 > verifyResourceContains / 500
 > verifyReloads 2
 
 # Fix the compile error
-$ copy-file changes/Application.scala.3 app/controllers/Application.scala
 $ sleep 1000
+$ copy-file changes/Application.scala.3 app/controllers/Application.scala
 > verifyResourceContains / 200 second
 > verifyReloads 3
 
 # Change a resource (also introduces a startup failure)
-$ copy-file changes/application.conf.1 conf/application.conf
 $ sleep 1000
+$ copy-file changes/application.conf.1 conf/application.conf
 > verifyResourceContains / 500
 > verifyReloads 4
 


### PR DESCRIPTION
`SourceModificationWatch` internally is quite a bit more complicated than what we really are using it for. It calls `sleep` internally, tracks a quiet waiting period, etc. and really all we want to know is have any files been updated.

Once I simplified this implementation it became much clearer to walk through the test and see why it was failing. The issue is that the sleep statements need to be in between compiling and modifying the file.

I'm wondering if a better solution though wouldn't be to setup a second watcher for the classpath using the file watch service. Do we really want the expected behavior of the user modifying `application.conf` within 1s of a compilation to be that the modification is ignored?