### PR TITLE
	Specialized Headers impl backed by Akka Http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 logs
+*.iml
 target
 .idea
 .idea_modules

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -4,7 +4,9 @@
 package play.core.server.akkahttp
 
 import java.net.{ InetAddress, InetSocketAddress, URI }
+import java.util.Locale
 
+import akka.http.javadsl.model.headers.RawRequestURI
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.stream.Materializer
@@ -12,14 +14,16 @@ import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import play.api.Logger
 import play.api.http.HeaderNames._
-import play.api.http.{ HttpChunk, HttpErrorHandler, Status, HttpEntity => PlayHttpEntity }
+import play.api.http.{ HeaderNames, HttpChunk, HttpErrorHandler, Status, HttpEntity => PlayHttpEntity }
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc._
 import play.api.mvc.request.{ RemoteConnection, RequestTarget }
 import play.core.server.common.{ ForwardedHeaderHandler, ServerResultUtils }
+import play.core.utils.CaseInsensitiveOrdered
 
 import scala.collection.immutable
 import scala.collection.mutable.ListBuffer
+import scala.collection.immutable.TreeSet
 import scala.concurrent.Future
 
 /**
@@ -55,7 +59,7 @@ private[server] class AkkaModelConversion(
     secureProtocol: Boolean,
     request: HttpRequest): RequestHeader = {
 
-    val (headers, _uriString) = convertRequestHeaders(request)
+    val headers = convertRequestHeadersAkka(request)
     val remoteAddressArg = remoteAddress // Avoid clash between method arg and RequestHeader field
 
     new RequestHeaderImpl(
@@ -69,8 +73,8 @@ private[server] class AkkaModelConversion(
         headers),
       request.method.name,
       new RequestTarget {
-        override lazy val uri: URI = new URI(uriString)
-        override lazy val uriString: String = _uriString
+        override lazy val uri: URI = new URI(headers.uri)
+        override lazy val uriString: String = headers.uri
         override lazy val path: String = request.uri.path.toString
         override lazy val queryMap: Map[String, Seq[String]] = request.uri.query().toMultiMap
       },
@@ -83,37 +87,34 @@ private[server] class AkkaModelConversion(
   /**
    * Convert the request headers of an Akka `HttpRequest` to a Play `Headers` object.
    */
-  private def convertRequestHeaders(request: HttpRequest): (Headers, String) = {
-    var requestUri: String = null
-    val headerBuffer = new ListBuffer[(String, String)]()
-    headerBuffer += CONTENT_TYPE -> request.entity.contentType.value
+  private def convertRequestHeadersAkka(request: HttpRequest): AkkaHeadersWrapper = {
+    var knownContentLength: Option[String] = None
+    var isChunked: Option[String] = None
 
     request.entity match {
-      case HttpEntity.Strict(contentType, data) =>
-        if (request.method.requestEntityAcceptance == RequestEntityAcceptance.Expected || data.nonEmpty)
-          headerBuffer += CONTENT_LENGTH -> data.length.toString
-
-      case HttpEntity.Default(contentType, contentLength, _) =>
-        if (request.method.requestEntityAcceptance == RequestEntityAcceptance.Expected || contentLength > 0)
-          headerBuffer += CONTENT_LENGTH -> contentLength.toString
-
-      case _: HttpEntity.Chunked =>
-        headerBuffer += TRANSFER_ENCODING -> play.api.http.HttpProtocol.CHUNKED
+      case HttpEntity.Strict(_, data) =>
+        if (request.method.requestEntityAcceptance == RequestEntityAcceptance.Expected || data.nonEmpty) {
+          knownContentLength = Some(data.length.toString)
+        }
+      case HttpEntity.Default(_, cLength, _) =>
+        if (request.method.requestEntityAcceptance == RequestEntityAcceptance.Expected || cLength > 0) {
+          knownContentLength = Some(cLength.toString)
+        }
+      case e: HttpEntity.Chunked =>
+        isChunked = Some(TransferEncodings.chunked.value)
     }
-    request.headers
-      .foreach {
-        case `Raw-Request-URI`(uri) => requestUri = uri
-        case header => headerBuffer += header.name -> header.value
-      }
 
-    val uri =
-      if (requestUri == null) {
-        logger.warn("Can't get raw request URI. Raw-Request-URI was missing.")
-        request.uri.toString
-      } else
-        requestUri
+    var requestUri: String = null
+    request.headers.foreach {
+      case `Raw-Request-URI`(u) =>
+        requestUri = u
+      case e: `Transfer-Encoding` =>
+        isChunked = Some(e.value())
+      case _ => // continue
+    }
+    if (requestUri eq null) requestUri = request.uri.toString() // fallback value
 
-    (new Headers(headerBuffer.result()), uri)
+    new AkkaHeadersWrapper(request, knownContentLength, request.headers, isChunked, requestUri)
   }
 
   /**
@@ -256,5 +257,69 @@ private[server] class AkkaModelConversion(
         accum.copy(misc = accum.misc :+ miscHeader)
     }
   }
+
+}
+
+final case class AkkaHeadersWrapper(
+    request: HttpRequest,
+    knownContentLength: Option[String],
+    hs: immutable.Seq[HttpHeader],
+    isChunked: Option[String],
+    uri: String
+) extends Headers(null) {
+
+  override def headers: Seq[(String, String)] =
+    if (_headers ne null) _headers
+    else {
+      _headers = hs.map(h => h.name() -> h.value) // TODO should we mark _headers volatile? It's harmless to re-gen them again
+      _headers
+    }
+
+  // note that these are rarely used, mostly just in tests
+  override def add(headers: (String, String)*): AkkaHeadersWrapper =
+    copy(hs = this.hs ++ raw(headers))
+
+  override def apply(key: String): String =
+    get(key).getOrElse(throw new RuntimeException(s"Header with name ${key} not found!"))
+
+  override def get(key: String): Option[String] =
+    key match {
+      case HeaderNames.CONTENT_LENGTH => knownContentLength
+      case HeaderNames.TRANSFER_ENCODING => isChunked
+      case HeaderNames.CONTENT_TYPE => Option(request.entity.contentType.value)
+      case _ =>
+        val lower = key.toLowerCase(Locale.ROOT)
+        hs.collectFirst({ case h if h.lowercaseName == lower => h.value })
+    }
+
+  // note that these are rarely used, mostly just in tests
+  override def getAll(key: String): immutable.Seq[String] =
+    hs.collect({ case h if h.is(key) => h.value })
+
+  override lazy val keys: immutable.Set[String] =
+    hs.map(_.name).toSet
+
+  // note that these are rarely used, mostly just in tests
+  override def remove(keys: String*): Headers =
+    copy(hs = hs.filterNot(keys.contains))
+
+  // note that these are rarely used, mostly just in tests
+  override def replace(headers: (String, String)*): Headers = {
+    val replaced = hs.filterNot(h => headers.exists(rm => h.is(rm._1))) ++ raw(headers)
+    copy(hs = replaced)
+  }
+
+  override def equals(other: Any): Boolean = {
+    other match {
+      case that: AkkaHeadersWrapper => that.request == this.request
+      case _ => false
+    }
+  }
+
+  private def raw(headers: Seq[(String, String)]): Seq[RawHeader] =
+    headers.map(t => RawHeader(t._1, t._2))
+
+  override def hashCode: Int =
+    request.hashCode()
 
 }

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -269,7 +269,7 @@ final case class AkkaHeadersWrapper(
 ) extends Headers(null) {
 
   override lazy val headers: Seq[(String, String)] =
-    hs.map(h => h.name() -> h.value) 
+    hs.map(h => h.name() -> h.value)
 
   // note that these are rarely used, mostly just in tests
   override def add(headers: (String, String)*): AkkaHeadersWrapper =
@@ -282,7 +282,7 @@ final case class AkkaHeadersWrapper(
     key match {
       case HeaderNames.CONTENT_LENGTH => knownContentLength
       case HeaderNames.TRANSFER_ENCODING => isChunked
-      case HeaderNames.CONTENT_TYPE => Option(request.entity.contentType.value)
+      case HeaderNames.CONTENT_TYPE => Some(request.entity.contentType.value)
       case _ =>
         val lower = key.toLowerCase(Locale.ROOT)
         hs.collectFirst({ case h if h.lowercaseName == lower => h.value })

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -74,7 +74,7 @@ private[server] class AkkaModelConversion(
       request.method.name,
       new RequestTarget {
         override lazy val uri: URI = new URI(headers.uri)
-        override lazy val uriString: String = headers.uri
+        override def uriString: String = headers.uri
         override lazy val path: String = request.uri.path.toString
         override lazy val queryMap: Map[String, Seq[String]] = request.uri.query().toMultiMap
       },

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -268,12 +268,8 @@ final case class AkkaHeadersWrapper(
     uri: String
 ) extends Headers(null) {
 
-  override def headers: Seq[(String, String)] =
-    if (_headers ne null) _headers
-    else {
-      _headers = hs.map(h => h.name() -> h.value) // TODO should we mark _headers volatile? It's harmless to re-gen them again
-      _headers
-    }
+  override lazy val headers: Seq[(String, String)] =
+    hs.map(h => h.name() -> h.value) 
 
   // note that these are rarely used, mostly just in tests
   override def add(headers: (String, String)*): AkkaHeadersWrapper =

--- a/framework/src/play/src/main/scala/play/api/mvc/Headers.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Headers.scala
@@ -17,7 +17,7 @@ import scala.collection.immutable.{ TreeMap, TreeSet }
  * since subclasses might initially set it to a `null` value and then initialize
  * it lazily.
  */
-class Headers(protected var _headers: Seq[(String, String)]) {
+class Headers(protected var headers: Seq[(String, String)]) {
 
   // TODO expose the actual Long content length? esp.since available in Akka HTTP backend easily
   //  /** INTERNAL API: Content-Length or -1 if not known. */

--- a/framework/src/play/src/main/scala/play/api/mvc/Headers.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Headers.scala
@@ -6,7 +6,6 @@ package play.api.mvc
 import java.util.Locale
 
 import play.core.utils.CaseInsensitiveOrdered
-import play.mvc.Http.HeaderNames
 
 import scala.collection.immutable.{ TreeMap, TreeSet }
 
@@ -17,12 +16,7 @@ import scala.collection.immutable.{ TreeMap, TreeSet }
  * since subclasses might initially set it to a `null` value and then initialize
  * it lazily.
  */
-class Headers(protected var headers: Seq[(String, String)]) {
-
-  // TODO expose the actual Long content length? esp.since available in Akka HTTP backend easily
-  //  /** INTERNAL API: Content-Length or -1 if not known. */
-  //  private[play] def contentLength: Long =
-  //    get(HeaderNames.CONTENT_LENGTH).map(_.toLong).getOrElse(-1)
+class Headers(protected var _headers: Seq[(String, String)]) {
 
   /**
    * The headers as a sequence of name-value pairs.

--- a/framework/src/play/src/main/scala/play/api/mvc/Headers.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Headers.scala
@@ -6,6 +6,7 @@ package play.api.mvc
 import java.util.Locale
 
 import play.core.utils.CaseInsensitiveOrdered
+import play.mvc.Http.HeaderNames
 
 import scala.collection.immutable.{ TreeMap, TreeSet }
 
@@ -17,6 +18,11 @@ import scala.collection.immutable.{ TreeMap, TreeSet }
  * it lazily.
  */
 class Headers(protected var _headers: Seq[(String, String)]) {
+
+  // TODO expose the actual Long content length? esp.since available in Akka HTTP backend easily
+  //  /** INTERNAL API: Content-Length or -1 if not known. */
+  //  private[play] def contentLength: Long =
+  //    get(HeaderNames.CONTENT_LENGTH).map(_.toLong).getOrElse(-1)
 
   /**
    * The headers as a sequence of name-value pairs.

--- a/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -160,9 +160,8 @@ trait RequestHeader {
    */
   def hasBody: Boolean = {
     import HeaderNames._
-    headers.get(CONTENT_LENGTH).exists(_gtZero) || headers.get(TRANSFER_ENCODING).isDefined
+    headers.get(CONTENT_LENGTH).exists(RequestHeader._gtZero) || headers.get(TRANSFER_ENCODING).isDefined
   }
-  private val _gtZero: String => Boolean = _.toLong > 0
 
   /**
    * The HTTP host (domain, optionally port). This value is derived from the request target, if a hostname is present.
@@ -187,7 +186,7 @@ trait RequestHeader {
    */
   lazy val acceptLanguages: Seq[play.api.i18n.Lang] = {
     val langs = RequestHeader.acceptHeader(headers, HeaderNames.ACCEPT_LANGUAGE).map(item => (item._1, Lang.get(item._2)))
-    langs.sortWith((a, b) => a._1 > b._1).map(_._2).flatten
+    langs.sortWith((a, b) => a._1 > b._1).flatMap(_._2)
   }
 
   /**
@@ -203,7 +202,7 @@ trait RequestHeader {
    * @return true if `mimeType` matches the Accept header, otherwise false
    */
   def accepts(mimeType: String): Boolean = {
-    acceptedTypes.isEmpty || acceptedTypes.find(_.accepts(mimeType)).isDefined
+    acceptedTypes.isEmpty || acceptedTypes.exists(_.accepts(mimeType))
   }
 
   /**
@@ -334,6 +333,8 @@ trait RequestHeader {
 object RequestHeader {
   // “The first "q" parameter (if any) separates the media-range parameter(s) from the accept-params.”
   val qPattern = ";\\s*q=([0-9.]+)".r
+
+  private val _gtZero: String => Boolean = _.toLong > 0
 
   /**
    * @return The items of an Accept* header, with their q-value.

--- a/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -39,12 +39,6 @@ trait RequestHeader {
   @deprecated("Use typed attributes instead, see `attrs`", "2.6.0")
   final def tags: Map[String, String] = attrs.get(RequestAttrKey.Tags).getOrElse(Map.empty)
 
-  // TODO we could do it here instead in Headers, would be cleaner
-  //  /**
-  //   * Content lenght of contained entity. `0` if no entity is present.
-  //   */
-  //  def contentLength: Long 
-
   /**
    * The HTTP method.
    */

--- a/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -39,6 +39,12 @@ trait RequestHeader {
   @deprecated("Use typed attributes instead, see `attrs`", "2.6.0")
   final def tags: Map[String, String] = attrs.get(RequestAttrKey.Tags).getOrElse(Map.empty)
 
+  // TODO we could do it here instead in Headers, would be cleaner
+  //  /**
+  //   * Content lenght of contained entity. `0` if no entity is present.
+  //   */
+  //  def contentLength: Long 
+
   /**
    * The HTTP method.
    */
@@ -160,8 +166,9 @@ trait RequestHeader {
    */
   def hasBody: Boolean = {
     import HeaderNames._
-    headers.get(CONTENT_LENGTH).isDefined || headers.get(TRANSFER_ENCODING).isDefined
+    headers.get(CONTENT_LENGTH).exists(_gtZero) || headers.get(TRANSFER_ENCODING).isDefined
   }
+  private val _gtZero: String => Boolean = _.toLong > 0
 
   /**
    * The HTTP host (domain, optionally port). This value is derived from the request target, if a hostname is present.


### PR DESCRIPTION
Two optimisations.

One: to check that if contentLength is given but only if > 0 then we need to materialize things
Two: To avoid copying all headers into strings all the time but only when really we have to.
The special cased ContentLength, ContentType and uri help a bit too.

I got a few failures locally but did not think they're related, so want to check on travis too while I look into those.