### PR TITLE
Deprecate form.reject() and form.discardErrors()

### DIFF
--- a/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/DynamicForm.java
@@ -120,7 +120,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      */
     public DynamicForm fill(Map<String, Object> value) {
         Form<Dynamic> form = super.fill(new Dynamic(value));
-        return new DynamicForm(new HashMap<>(form.rawData()), new ArrayList<>(form.allErrors()), form.value(), messagesApi, formatters, validator);
+        return new DynamicForm(form.rawData(), form.allErrors(), form.value(), messagesApi, formatters, validator);
     }
 
     /**
@@ -160,7 +160,7 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
         }
         
         Form<Dynamic> form = super.bind(data, allowedFields);
-        return new DynamicForm(new HashMap<>(form.rawData()), new ArrayList<>(form.allErrors()), form.value(), messagesApi, formatters, validator);
+        return new DynamicForm(form.rawData(), form.allErrors(), form.value(), messagesApi, formatters, validator);
     }
     
     /**
@@ -201,19 +201,48 @@ public class DynamicForm extends Form<DynamicForm.Dynamic> {
      * @param key the error key
      * @param error the error message
      * @param args the error arguments
+     * 
+     * @deprecated Deprecated as of 2.6.0. Use {@link #withError(String, String, List)} instead.
      */
     public void reject(String key, String error, List<Object> args) {
         super.reject(asDynamicKey(key), error, args);
     }
 
     /**
+     * @param key the error key
+     * @param error the error message
+     * @param args the error arguments
+     * 
+     * @return a copy of this form with the given error added.
+     */
+    @Override
+    public DynamicForm withError(final String key, final String error, final List<Object> args) {
+        final Form<Dynamic> form = super.withError(asDynamicKey(key), error, args);
+        return new DynamicForm(this.rawData, form.allErrors(), form.value(), this.messagesApi, this.formatters, this.validator);
+    }
+    
+    /**
      * Adds an error to this form.
      *
      * @param key the error key
      * @param error the error message
+     * 
+     * @deprecated Deprecated as of 2.6.0. Use {@link #withError(String, String)} instead.
      */    
+    @Deprecated
     public void reject(String key, String error) {
         super.reject(asDynamicKey(key), error);
+    }
+    
+    /**
+     * @param key the error key
+     * @param error the error message
+     * 
+     * @return a copy of this form with the given error added.
+     */
+    @Override
+    public DynamicForm withError(final String key, final String error) {
+        return withError(key, error, new ArrayList<>());
     }
 
     // -- tools

--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -161,8 +161,8 @@ public class Form<T> {
     public Form(String rootName, Class<T> clazz, Map<String,String> data, List<ValidationError> errors, Optional<T> value, Class<?>[] groups, MessagesApi messagesApi, Formatters formatters, javax.validation.Validator validator) {
         this.rootName = rootName;
         this.backedType = clazz;
-        this.data = data != null ? data : new HashMap<>();
-        this.errors = errors != null ? errors : new ArrayList<>();
+        this.data = data != null ? new HashMap<>(data) : new HashMap<>();
+        this.errors = errors != null ? new ArrayList<>(errors) : new ArrayList<>();
         this.value = value;
         this.groups = groups;
         this.messagesApi = messagesApi;
@@ -539,7 +539,7 @@ public class Form<T> {
             }
             return new Form<>(rootName, backedType, data, errors, Optional.ofNullable((T)result.getTarget()), groups, messagesApi, formatters, this.validator);
         }
-        return new Form<>(rootName, backedType, new HashMap<>(data), errors, Optional.ofNullable((T)result.getTarget()), groups, messagesApi, formatters, this.validator);
+        return new Form<>(rootName, backedType, data, errors, Optional.ofNullable((T)result.getTarget()), groups, messagesApi, formatters, this.validator);
     }
 
     /**
@@ -767,7 +767,10 @@ public class Form<T> {
      * Adds an error to this form.
      *
      * @param error the <code>ValidationError</code> to add.
+     * 
+     * @deprecated Deprecated as of 2.6.0. Use {@link #withError(ValidationError)} instead.
      */
+    @Deprecated
     public void reject(ValidationError error) {
         if (error == null) {
             throw new NullPointerException("Can't reject null-values");
@@ -776,14 +779,17 @@ public class Form<T> {
     }
 
     /**
-     * Adds an error to this form.
-     *
-     * @param key the error key
-     * @param error the error message
-     * @param args the error arguments
+     * @param error the <code>ValidationError</code> to add to the returned form.
+     * 
+     * @return a copy of this form with the given error added.
      */
-    public void reject(String key, String error, List<Object> args) {
-        reject(new ValidationError(key, error, args));
+    public Form<T> withError(final ValidationError error) {
+        if (error == null) {
+            throw new NullPointerException("Can't reject null-values");
+        }
+        final List<ValidationError> copiedErrors = new ArrayList<>(this.errors);
+        copiedErrors.add(error);
+        return new Form<T>(this.rootName, this.backedType, this.data, copiedErrors, this.value, this.groups, this.messagesApi, this.formatters, this.validator);
     }
 
     /**
@@ -791,9 +797,47 @@ public class Form<T> {
      *
      * @param key the error key
      * @param error the error message
+     * @param args the error arguments
+     * 
+     * @deprecated Deprecated as of 2.6.0. Use {@link #withError(String, String, List)} instead.
      */
+    @Deprecated
+    public void reject(String key, String error, List<Object> args) {
+        reject(new ValidationError(key, error, args));
+    }
+
+    /**
+     * @param key the error key
+     * @param error the error message
+     * @param args the error arguments
+     * 
+     * @return a copy of this form with the given error added.
+     */
+    public Form<T> withError(final String key, final String error, final List<Object> args) {
+        return withError(new ValidationError(key, error, args != null ? new ArrayList<>(args) : new ArrayList<>()));
+    }
+
+    /**
+     * Adds an error to this form.
+     *
+     * @param key the error key
+     * @param error the error message
+     * 
+     * @deprecated Deprecated as of 2.6.0. Use {@link #withError(String, String)} instead.
+     */
+    @Deprecated
     public void reject(String key, String error) {
         reject(key, error, new ArrayList<>());
+    }
+
+    /**
+     * @param key the error key
+     * @param error the error message
+     * 
+     * @return a copy of this form with the given error added.
+     */
+    public Form<T> withError(final String key, final String error) {
+        return withError(key, error, new ArrayList<>());
     }
 
     /**
@@ -801,25 +845,60 @@ public class Form<T> {
      *
      * @param error the error message
      * @param args the error arguments
+     * 
+     * @deprecated Deprecated as of 2.6.0. Use {@link #withGlobalError(String, List)} instead.
      */
+    @Deprecated
     public void reject(String error, List<Object> args) {
         reject(new ValidationError("", error, args));
+    }
+
+    /**
+     * @param error the global error message
+     * @param args the global error arguments
+     * 
+     * @return a copy of this form with the given global error added.
+     */
+    public Form<T> withGlobalError(final String error, final List<Object> args) {
+        return withError("", error, args);
     }
 
     /**
      * Adds a global error to this form.
      *
      * @param error the error message.
+     * 
+     * @deprecated Deprecated as of 2.6.0. Use {@link #withGlobalError(String)} instead.
      */
+    @Deprecated
     public void reject(String error) {
         reject("", error, new ArrayList<>());
     }
 
     /**
-     * Discards errors of this form
+     * @param error the global error message
+     * 
+     * @return a copy of this form with the given global error added.
      */
+    public Form<T> withGlobalError(final String error) {
+        return withGlobalError(error, new ArrayList<>());
+    }
+
+    /**
+     * Discards errors of this form
+     * 
+     * @deprecated Deprecated as of 2.6.0. Use {@link #discardingErrors()} instead.
+     */
+    @Deprecated
     public void discardErrors() {
         errors.clear();
+    }
+
+    /**
+     * @return a copy of this form but with the errors discarded.
+     */
+    public Form<T> discardingErrors() {
+        return new Form<T>(this.rootName, this.backedType, this.data, new ArrayList<>(), this.value, this.groups, this.messagesApi, this.formatters, this.validator);
     }
 
     /**
@@ -983,9 +1062,9 @@ public class Form<T> {
         public Field(Form<?> form, String name, List<Tuple<String,List<Object>>> constraints, Tuple<String,List<Object>> format, List<ValidationError> errors, String value) {
             this.form = form;
             this.name = name;
-            this.constraints = constraints != null ? constraints : new ArrayList<>();
+            this.constraints = constraints != null ? new ArrayList<>(constraints) : new ArrayList<>();
             this.format = format;
-            this.errors = errors != null ? errors : new ArrayList<>();
+            this.errors = errors != null ? new ArrayList<>(errors) : new ArrayList<>();
             this.value = value;
         }
 

--- a/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/DynamicFormSpec.scala
@@ -52,15 +52,15 @@ class DynamicFormSpec extends Specification {
     }
 
     "display errors in template helpers" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validator).bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
-      form.reject("foo", "There was an error")
+      var form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validator).bindFromRequest(FormSpec.dummyRequest(Map("foo" -> Array("bar"))))
+      form = form.withError("foo", "There was an error")
       val html = inputText(form("foo")).body
       html must contain("There was an error")
     }
 
     "display errors when a field is not present" in {
-      val form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validator).bindFromRequest(FormSpec.dummyRequest(Map()))
-      form.reject("foo", "Foo is required")
+      var form = new DynamicForm(jMessagesApi, new Formatters(jMessagesApi), validator).bindFromRequest(FormSpec.dummyRequest(Map()))
+      form = form.withError("foo", "Foo is required")
       val html = inputText(form("foo")).body
       html must contain("Foo is required")
     }


### PR DESCRIPTION
Replaces #6964 because most of the work was done in my previous pull requests regarding Java Forms already anyway.