### PR TITLE
Make Result#withCookies override existing cookies with the same name

### DIFF
--- a/framework/src/play/src/main/java/play/mvc/Result.java
+++ b/framework/src/play/src/main/java/play/mvc/Result.java
@@ -10,6 +10,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import play.core.j.JavaHelpers$;
 import play.core.j.JavaResultExtractor;
@@ -290,8 +292,12 @@ public class Result {
      * @return the transformed copy.
      */
     public Result withCookies(Cookie... newCookies) {
-        List<Cookie> finalCookies = new ArrayList<>(cookies);
-        finalCookies.addAll(Arrays.asList(newCookies));
+        List<Cookie> finalCookies = Stream.concat(cookies.stream().filter(cookie -> {
+            for (Cookie newCookie : newCookies) {
+                if (cookie.name().equals(newCookie.name())) return false;
+            }
+            return true;
+        }), Stream.of(newCookies)).collect(Collectors.toList());
         return new Result(header, body, session, flash, finalCookies);
     }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -104,8 +104,8 @@ case class Result(header: ResponseHeader, body: HttpEntity,
   }
 
   /**
-   * Adds cookies to this result. If the result already contains
-   * cookies then the new cookies will be merged with the old cookies.
+   * Adds cookies to this result. If the result already contains cookies then cookies with the same name in the new
+   * list will override existing ones.
    *
    * For example:
    * {{{
@@ -116,7 +116,8 @@ case class Result(header: ResponseHeader, body: HttpEntity,
    * @return the new result
    */
   def withCookies(cookies: Cookie*): Result = {
-    if (cookies.isEmpty) this else copy(newCookies = newCookies ++ cookies)
+    val filteredCookies = newCookies.filter(cookie => !cookies.exists(_.name == cookie.name))
+    if (cookies.isEmpty) this else copy(newCookies = filteredCookies ++ cookies)
   }
 
   /**
@@ -131,7 +132,7 @@ case class Result(header: ResponseHeader, body: HttpEntity,
    * @return the new result
    */
   def discardingCookies(cookies: DiscardingCookie*): Result = {
-    withCookies(newCookies ++ cookies.map(_.toCookie): _*)
+    withCookies(cookies.map(_.toCookie): _*)
   }
 
   /**

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -17,7 +17,7 @@ import play.api.http.HeaderNames._
 import play.api.http._
 import play.api.http.Status._
 import play.api.i18n._
-import play.api.{ Application, Configuration, Environment, Play }
+import play.api.{ Application, Play }
 import play.core.test._
 
 import scala.concurrent.Await
@@ -120,6 +120,21 @@ class ResultsSpec extends Specification {
       setCookies("preferences").value must be_==("blue")
       setCookies("lang").value must be_==("fr")
       setCookies("logged").maxAge must beSome(Cookie.DiscardedMaxAge)
+    }
+
+    "properly add and discard cookies" in {
+      val result = Ok("hello").as("text/html")
+        .withCookies(Cookie("session", "items"), Cookie("preferences", "blue"))
+        .withCookies(Cookie("lang", "fr"), Cookie("session", "items2"))
+        .discardingCookies(DiscardingCookie("logged"))
+
+      result.newCookies.length must_== 4
+      result.newCookies.find(_.name == "logged").map(_.value) must beSome("")
+
+      val resultDiscarded = result.discardingCookies(DiscardingCookie("preferences"), DiscardingCookie("lang"))
+      resultDiscarded.newCookies.length must_== 4
+      resultDiscarded.newCookies.find(_.name == "preferences").map(_.value) must beSome("")
+      resultDiscarded.newCookies.find(_.name == "lang").map(_.value) must beSome("")
     }
 
     "provide convenience method for setting cookie header" in withApplication {


### PR DESCRIPTION
Fixes #7174. Basically, this makes sure if we add new cookies, any existing cookies with the same name are removed from the list.