### PR TITLE
Add Java version for LoggerConfigurator

### DIFF
--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -71,6 +71,35 @@ libraryDependencies += "com.typesafe.play" %% "play-iteratees-reactive-streams" 
 
 Finally, Play Iteratees has a separate versioning scheme, so the version no longer is in sync with the Play version.
 
+## Scala `Mode` changes
+
+Scala [`Mode`](api/scala/play/api/Mode.html) was refactored from an Enumeration to a hierarchy of case objects. Most of the Scala code won't change because of this refactoring. But, if you are accessing the Scala `Mode` values in your Java code, you will need to change it from:
+
+```java
+// Consider this Java code
+play.api.Mode.Mode scalaMode = play.api.Mode.Test();
+```
+
+Must be rewritten to:
+
+```java
+// Consider this Java code
+play.api.Mode.Mode scalaMode = play.api.Mode.test();
+```
+
+Notice the lowercase in `test` call. It is also easier to convert between Java and Scala modes:
+
+```java
+// In your Java code
+play.api.Mode.Mode scalaMode = play.Mode.TEST.asScala();
+```
+
+Or in your Scala code:
+
+```scala
+play.Mode javaMode = play.api.Mode.Dev.asJava
+```
+
 ## `Writeable[JsValue]` changes
 
 Previously, the default Scala `Writeable[JsValue]` allowed you to define an implicit `Codec`, which would allow you to write using a different charset. This could be a problem since `application/json` does not act like text-based content types. It only allows Unicode charsets (`UTF-8`, `UTF-16` and `UTF-32`) and does not define a `charset` parameter like many text-based content types.

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -73,25 +73,25 @@ Finally, Play Iteratees has a separate versioning scheme, so the version no long
 
 ## Scala `Mode` changes
 
-Scala [`Mode`](api/scala/play/api/Mode$.html) was refactored from an Enumeration to a hierarchy of case objects. Most of the Scala code won't change because of this refactoring. But, if you are accessing the Scala `Mode` values in your Java code, you will need to change it from:
+Scala [`Mode`](api/scala/play/api/Mode.html) was refactored from an Enumeration to a hierarchy of case objects. Most of the Scala code won't change because of this refactoring. But, if you are accessing the Scala `Mode` values in your Java code, you will need to change it from:
 
 ```java
 // Consider this Java code
-play.api.Mode.Mode scalaMode = play.api.Mode.Test();
+play.api.Mode scalaMode = play.api.Mode.Test();
 ```
 
 Must be rewritten to:
 
 ```java
 // Consider this Java code
-play.api.Mode.Mode scalaMode = play.api.Mode.test();
+play.api.Mode scalaMode = play.Mode.TEST.asScala();
 ```
 
-Notice the lowercase in `test` call. It is also easier to convert between Java and Scala modes:
+It is also easier to convert between Java and Scala modes:
 
 ```java
 // In your Java code
-play.api.Mode.Mode scalaMode = play.Mode.TEST.asScala();
+play.api.Mode scalaMode = play.Mode.DEV.asScala();
 ```
 
 Or in your Scala code:
@@ -99,6 +99,8 @@ Or in your Scala code:
 ```scala
 play.Mode javaMode = play.api.Mode.Dev.asJava
 ```
+
+Also, `play.api.Mode.Mode` is now deprecated and you should use `play.api.Mode` instead. 
 
 ## `Writeable[JsValue]` changes
 

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -73,7 +73,7 @@ Finally, Play Iteratees has a separate versioning scheme, so the version no long
 
 ## Scala `Mode` changes
 
-Scala [`Mode`](api/scala/play/api/Mode.html) was refactored from an Enumeration to a hierarchy of case objects. Most of the Scala code won't change because of this refactoring. But, if you are accessing the Scala `Mode` values in your Java code, you will need to change it from:
+Scala [`Mode`](api/scala/play/api/Mode$.html) was refactored from an Enumeration to a hierarchy of case objects. Most of the Scala code won't change because of this refactoring. But, if you are accessing the Scala `Mode` values in your Java code, you will need to change it from:
 
 ```java
 // Consider this Java code

--- a/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
@@ -230,7 +230,13 @@ play.logger.configurator=Log4J2LoggerConfigurator
 
 And then extend LoggerConfigurator with any customizations:
 
-@[log4j2-import](code/Log4j2LoggerConfigurator.scala)
+Java
+: @[log4j2-import](code/JavaLog4JLoggerConfigurator.java)
+Scala
+: @[log4j2-import](code/Log4j2LoggerConfigurator.scala)
 
-@[log4j2-class](code/Log4j2LoggerConfigurator.scala)
 
+Java
+: @[log4j2-class](code/JavaLog4JLoggerConfigurator.java)
+Scala
+: @[log4j2-class](code/Log4j2LoggerConfigurator.scala)

--- a/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
@@ -231,12 +231,7 @@ play.logger.configurator=Log4J2LoggerConfigurator
 And then extend LoggerConfigurator with any customizations:
 
 Java
-: @[log4j2-import](code/JavaLog4JLoggerConfigurator.java)
-Scala
-: @[log4j2-import](code/Log4j2LoggerConfigurator.scala)
-
-
-Java
 : @[log4j2-class](code/JavaLog4JLoggerConfigurator.java)
+
 Scala
 : @[log4j2-class](code/Log4j2LoggerConfigurator.scala)

--- a/documentation/manual/working/commonGuide/configuration/code/JavaLog4JLoggerConfigurator.java
+++ b/documentation/manual/working/commonGuide/configuration/code/JavaLog4JLoggerConfigurator.java
@@ -49,6 +49,7 @@ public class JavaLog4JLoggerConfigurator implements LoggerConfigurator {
 
     @Override
     public void configure(Environment env, Config configuration, Map<String, String> optionalProperties) {
+        // LoggerConfigurator.generateProperties enables play.logger.includeConfigProperties=true
         Map<String, String> properties = LoggerConfigurator.generateProperties(env, configuration, optionalProperties);
         URL resourceUrl = env.resource("log4j2.xml");
         configure(properties, Optional.ofNullable(resourceUrl));

--- a/documentation/manual/working/commonGuide/configuration/code/JavaLog4JLoggerConfigurator.java
+++ b/documentation/manual/working/commonGuide/configuration/code/JavaLog4JLoggerConfigurator.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+// #log4j2-import
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.slf4j.ILoggerFactory;
+import play.Environment;
+import play.LoggerConfigurator;
+import play.Mode;
+import play.api.PlayException;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+//###skip: 1
+/*
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.*;
+import org.apache.logging.log4j.core.config.Configurator;
+// #log4j2-import
+*/
+
+//#log4j2-class
+public class JavaLog4JLoggerConfigurator implements LoggerConfigurator {
+
+    private ILoggerFactory factory;
+
+    @Override
+    public void init(File rootPath, Mode mode) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("application.home", rootPath.getAbsolutePath());
+
+        String resourceName = "log4j2.xml";
+        URL resourceUrl = this.getClass().getClassLoader().getResource(resourceName);
+        configure(properties, Optional.ofNullable(resourceUrl));
+    }
+
+    @Override
+    public void configure(Environment env) {
+        Map<String, String> properties = LoggerConfigurator.generateProperties(env, ConfigFactory.empty(), Collections.emptyMap());
+        URL resourceUrl = env.resource("log4j2.xml");
+        configure(properties, Optional.ofNullable(resourceUrl));
+    }
+
+    @Override
+    public void configure(Environment env, Config configuration, Map<String, String> optionalProperties) {
+        Map<String, String> properties = LoggerConfigurator.generateProperties(env, configuration, optionalProperties);
+        URL resourceUrl = env.resource("log4j2.xml");
+        configure(properties, Optional.ofNullable(resourceUrl));
+    }
+
+    @Override
+    public void configure(Map<String, String> properties, Optional<URL> config) {
+        try {
+            LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
+            loggerContext.setConfigLocation(config.get().toURI());
+
+            factory = org.slf4j.impl.StaticLoggerBinder.getSingleton().getLoggerFactory();
+        } catch (URISyntaxException ex) {
+            throw new PlayException(
+                "log4j2.xml resource was not found",
+                "Could not parse the location for log4j2.xml resource",
+                ex
+            );
+        }
+    }
+
+    @Override
+    public ILoggerFactory loggerFactory() {
+        return factory;
+    }
+
+    @Override
+    public void shutdown() {
+        LoggerContext loggerContext = (LoggerContext) LogManager.getContext();
+        Configurator.shutdown(loggerContext);
+    }
+}
+//#log4j2-class

--- a/documentation/manual/working/commonGuide/configuration/code/JavaLog4JLoggerConfigurator.java
+++ b/documentation/manual/working/commonGuide/configuration/code/JavaLog4JLoggerConfigurator.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-// #log4j2-import
+//#log4j2-class
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.slf4j.ILoggerFactory;
@@ -23,10 +23,9 @@ import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.*;
 import org.apache.logging.log4j.core.config.Configurator;
-// #log4j2-import
+//###skip: 1
 */
 
-//#log4j2-class
 public class JavaLog4JLoggerConfigurator implements LoggerConfigurator {
 
     private ILoggerFactory factory;

--- a/documentation/manual/working/commonGuide/configuration/code/Log4j2LoggerConfigurator.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/Log4j2LoggerConfigurator.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 import java.io.File
 import java.net.{URI, URL}
 

--- a/documentation/manual/working/commonGuide/configuration/code/Log4j2LoggerConfigurator.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/Log4j2LoggerConfigurator.scala
@@ -24,7 +24,7 @@ class Log4J2LoggerConfigurator extends LoggerConfigurator {
 
   private var factory: ILoggerFactory = _
 
-  override def init(rootPath: File, mode: Mode.Mode): Unit = {
+  override def init(rootPath: File, mode: Mode): Unit = {
     val properties = Map("application.home" -> rootPath.getAbsolutePath)
     val resourceName = "log4j2.xml"
     val resourceUrl = Option(this.getClass.getClassLoader.getResource(resourceName))

--- a/documentation/manual/working/commonGuide/configuration/code/Log4j2LoggerConfigurator.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/Log4j2LoggerConfigurator.scala
@@ -1,11 +1,12 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
+//#log4j2-class
 import java.io.File
-import java.net.{URI, URL}
+import java.net.{ URI, URL }
 
+//###skip: 1
 /*
-// #log4j2-import
 import play.api.{Mode, Configuration, Environment, LoggerConfigurator}
 
 import org.slf4j.ILoggerFactory
@@ -13,13 +14,12 @@ import org.slf4j.ILoggerFactory
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.core._
 import org.apache.logging.log4j.core.config.Configurator
-// #log4j2-import
+//###skip: 1
 */
 
-import play.api.{Mode, Configuration, Environment, LoggerConfigurator}
+import play.api.{ Mode, Configuration, Environment, LoggerConfigurator }
 import org.slf4j.ILoggerFactory
 
-//#log4j2-class
 class Log4J2LoggerConfigurator extends LoggerConfigurator {
 
   private var factory: ILoggerFactory = _

--- a/documentation/manual/working/commonGuide/configuration/code/Log4j2LoggerConfigurator.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/Log4j2LoggerConfigurator.scala
@@ -66,9 +66,9 @@ object Configurator {
 }
 
 object LogManager {
-  def getContext() = ???
+  def getContext(): LoggerContext = ???
 
-  def getContext(b: Boolean) = ???
+  def getContext(b: Boolean): LoggerContext = ???
 
 }
 

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaErrorHandling.scala
@@ -29,11 +29,11 @@ class ScalaErrorHandling extends PlaySpecification with WsTestClient {
       import play.api._
       import play.api.routing._
       import javax.inject.Provider
-      def errorHandler(mode: Mode.Mode) = new default.ErrorHandler(
+      def errorHandler(mode: Mode) = new default.ErrorHandler(
         Environment.simple(mode = mode), Configuration.empty, new OptionalSourceMapper(None),
         new Provider[Router] { def get = Router.empty }
       )
-      def errorContent(mode: Mode.Mode) =
+      def errorContent(mode: Mode) =
         contentAsString(errorHandler(mode).onServerError(FakeRequest(), new RuntimeException("foo")))
 
       errorContent(Mode.Prod) must startWith("A server error occurred: ")

--- a/framework/bin/travis
+++ b/framework/bin/travis
@@ -17,11 +17,14 @@ set -ev
 
 declare -a TASKS=(checkCodeStyle checkFileHeaders test testSbtPlugins testDocumentation)
 
+# Use travis scala version or defaults to 2.12.1 which is the `scalaVersion` configured in build.sbt
+SCALA_VERSION=${TRAVIS_SCALA_VERSION:-"2.12.1"}
+
 for TASK in "${TASKS[@]}"
 do
   # We have multi-threaded tests and see concurrent modification when starting logback,
   # so always run tests sequentially.
   # Use sbt-doge for building code https://github.com/sbt/sbt-doge#strict-aggregation
-  framework/bin/$TASK +++$TRAVIS_SCALA_VERSION "set concurrentRestrictions in Global += Tags.limitAll(1)"
+  framework/bin/$TASK +++$SCALA_VERSION "set concurrentRestrictions in Global += Tags.limitAll(1)"
 done
 

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -222,15 +222,23 @@ object Dependencies {
     guava % Test
   ) ++ specsBuild.map(_ % Test)
 
+  val seleniumVersion = "3.3.1"
   val testDependencies = Seq(junit) ++ specsBuild.map(_ % Test) ++ Seq(
     junitInterface,
     guava,
     findBugs,
-    ("org.fluentlenium" % "fluentlenium-core" % "3.1.1")
-      .exclude("org.jboss.netty", "netty"),
-    "org.seleniumhq.selenium" % "htmlunit-driver" % "2.25",
-    "org.seleniumhq.selenium" % "selenium-firefox-driver" % "3.3.1",
-    "org.seleniumhq.selenium" % "selenium-support" % "3.3.1"
+    "org.fluentlenium" % "fluentlenium-core" % "3.1.1" exclude("org.jboss.netty", "netty"),
+    // htmlunit-driver uses an open range to selenium dependencies. This is slightly
+    // slowing down the build. So the open range deps were removed and we can re-add
+    // them using a specific version. Using an open range is also not good for the
+    // local cache.
+    "org.seleniumhq.selenium" % "htmlunit-driver" % "2.26" excludeAll(
+      ExclusionRule("org.seleniumhq.selenium", "selenium-api"),
+      ExclusionRule("org.seleniumhq.selenium", "selenium-support")
+    ),
+    "org.seleniumhq.selenium" % "selenium-api" % seleniumVersion,
+    "org.seleniumhq.selenium" % "selenium-support" % seleniumVersion,
+    "org.seleniumhq.selenium" % "selenium-firefox-driver" % seleniumVersion
   ) ++ guiceDeps
 
   val ehcacheVersion = "2.6.11"

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
@@ -6,7 +6,6 @@ package play.filters.https
 import javax.inject.Inject
 
 import com.typesafe.config.ConfigFactory
-import play.api.Mode.Mode
 import play.api._
 import play.api.http.HttpFilters
 import play.api.inject.bind
@@ -42,7 +41,7 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
       val result = route(app, req).get
 
       status(result) must_== PERMANENT_REDIRECT
-      header(LOCATION, result) must_== Some("https://playframework.com/please/dont?remove=this&foo=bar")
+      header(LOCATION, result) must beSome("https://playframework.com/please/dont?remove=this&foo=bar")
     }
 
     "redirect with custom redirect status code if configured" in new WithApplication(buildApp(
@@ -59,28 +58,28 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
       val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = true, clientCertificateChain = None)
       val result = route(app, request().withConnection(secure)).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must_== None
+      header(STRICT_TRANSPORT_SECURITY, result) must beNone
       status(result) must_== OK
     }
 
     "redirect to custom HTTPS port if configured" in new WithApplication(buildApp("play.filters.https.port = 9443")) {
       val result = route(app, request("/please/dont?remove=this&foo=bar")).get
 
-      header(LOCATION, result) must_== Some("https://playframework.com:9443/please/dont?remove=this&foo=bar")
+      header(LOCATION, result) must beSome("https://playframework.com:9443/please/dont?remove=this&foo=bar")
     }
 
     "not contain default HSTS header if secure in test" in new WithApplication(buildApp()) {
       val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = true, clientCertificateChain = None)
       val result = route(app, request().withConnection(secure)).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must_== None
+      header(STRICT_TRANSPORT_SECURITY, result) must beNone
     }
 
     "contain default HSTS header if secure in production" in new WithApplication(buildApp(mode = Mode.Prod)) {
       val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = true, clientCertificateChain = None)
       val result = route(app, request().withConnection(secure)).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must_== Some("max-age=31536000; includeSubDomains")
+      header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=31536000; includeSubDomains")
     }
 
     "contain custom HSTS header if configured explicitly in prod" in new WithApplication(buildApp(
@@ -90,7 +89,7 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
       val secure = RemoteConnection(remoteAddressString = "127.0.0.1", secure = true, clientCertificateChain = None)
       val result = route(app, request().withConnection(secure)).get
 
-      header(STRICT_TRANSPORT_SECURITY, result) must_== Some("max-age=12345; includeSubDomains")
+      header(STRICT_TRANSPORT_SECURITY, result) must beSome("max-age=12345; includeSubDomains")
     }
   }
 

--- a/framework/src/play-guice/src/main/java/play/inject/guice/GuiceBuilder.java
+++ b/framework/src/play-guice/src/main/java/play/inject/guice/GuiceBuilder.java
@@ -38,7 +38,7 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
      * @return a copy of this builder with the new environment
      */
     public final Self in(Environment env) {
-        return newBuilder(delegate.in(env.underlying()));
+        return newBuilder(delegate.in(env.asScala()));
     }
 
     /**
@@ -58,7 +58,7 @@ public abstract class GuiceBuilder<Self, Delegate extends play.api.inject.guice.
      * @return a copy of this build configured with this mode
      */
     public final Self in(Mode mode) {
-        return newBuilder(delegate.in(play.api.Mode.apply(mode.ordinal())));
+        return newBuilder(delegate.in(mode.asScala()));
     }
 
     /**

--- a/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
+++ b/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceInjectorBuilder.scala
@@ -44,7 +44,7 @@ abstract class GuiceBuilder[Self] protected (
   /**
    * Set the environment mode.
    */
-  final def in(mode: Mode.Mode): Self =
+  final def in(mode: Mode): Self =
     copyBuilder(environment = environment.copy(mode = mode))
 
   /**

--- a/framework/src/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/http/HttpErrorHandlerSpec.scala
@@ -70,7 +70,7 @@ class HttpErrorHandlerSpec extends Specification {
 
   }
 
-  def handler(handlerClass: String, mode: Mode.Mode): HttpErrorHandler = {
+  def handler(handlerClass: String, mode: Mode): HttpErrorHandler = {
     val properties = Map(
       "play.http.errorHandler" -> handlerClass,
       "play.http.secret.key" -> "mysecret"

--- a/framework/src/play-guice/src/test/scala/play/api/inject/ModulesSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/inject/ModulesSpec.scala
@@ -50,7 +50,7 @@ class ModulesSpec extends Specification {
       located.size must_== 1
       located.head must beLike {
         case mod: JavaGuiceConfigurationModule =>
-          mod.environment.underlying must_== env
+          mod.environment.asScala() must_== env
           mod.configuration.underlying must_== conf.underlying
       }
     }
@@ -64,7 +64,7 @@ class ModulesSpec extends Specification {
       located.size must_== 1
       located.head must beLike {
         case mod: JavaGuiceConfigModule =>
-          mod.environment.underlying must_== env
+          mod.environment.asScala() must_== env
           mod.config must_== conf.underlying
       }
     }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/ConnectionPool.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/ConnectionPool.scala
@@ -58,7 +58,7 @@ object ConnectionPool {
    *
    * Supports shortcut URLs for postgres and mysql, and also adds various default parameters as appropriate.
    */
-  def extractUrl(maybeUrl: Option[String], mode: Mode.Mode): (Option[String], Option[(String, String)]) = {
+  def extractUrl(maybeUrl: Option[String], mode: Mode): (Option[String], Option[(String, String)]) = {
 
     maybeUrl match {
       case Some(PostgresFullUrl(username, password, host, dbname)) =>

--- a/framework/src/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
+++ b/framework/src/play-logback/src/main/scala/play/api/libs/logback/LogbackLoggerConfigurator.scala
@@ -24,7 +24,7 @@ class LogbackLoggerConfigurator extends LoggerConfigurator {
   /**
    * Initialize the Logger when there's no application ClassLoader available.
    */
-  def init(rootPath: java.io.File, mode: Mode.Mode): Unit = {
+  def init(rootPath: java.io.File, mode: Mode): Unit = {
     // Set the global application mode for logging
     play.api.Logger.setApplicationMode(mode)
 

--- a/framework/src/play-logback/src/test/scala/play/api/ModeSpecificLoggerSpec.scala
+++ b/framework/src/play-logback/src/test/scala/play/api/ModeSpecificLoggerSpec.scala
@@ -7,7 +7,7 @@ class ModeSpecificLoggerSpec extends Specification {
 
   sequential
 
-  case class ModeLoggerTest(mode: Mode.Mode*) {
+  case class ModeLoggerTest(mode: Mode*) {
     private val logger = Logger(getClass).forMode(mode: _*)
 
     logger.info("This is info")
@@ -32,7 +32,7 @@ class ModeSpecificLoggerSpec extends Specification {
     }
   }
 
-  private def withLoggerMode[T](mode: Mode.Mode)(block: => T): T = {
+  private def withLoggerMode[T](mode: Mode)(block: => T): T = {
     Logger.setApplicationMode(mode)
     val result = block
     Logger.unsetApplicationMode()

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -30,7 +30,7 @@ trait WebSocketable {
  */
 trait Server extends ServerWithStop {
 
-  def mode: Mode.Mode
+  def mode: Mode
 
   /**
    * Try to get the handler for a request and return it as a `Right`. If we
@@ -223,13 +223,13 @@ object Server {
 }
 
 private[play] object JavaServerHelper {
-  def forRouter(router: Router, mode: Mode.Mode, httpPort: Option[Integer], sslPort: Option[Integer]): Server = {
+  def forRouter(router: Router, mode: Mode, httpPort: Option[Integer], sslPort: Option[Integer]): Server = {
     forRouter(mode, httpPort, sslPort)(new JFunction[BuiltInComponents, Router] {
       override def apply(components: BuiltInComponents): Router = router
     })
   }
 
-  def forRouter(mode: Mode.Mode, httpPort: Option[Integer], sslPort: Option[Integer])(block: JFunction[BuiltInComponents, Router]): Server = {
+  def forRouter(mode: Mode, httpPort: Option[Integer], sslPort: Option[Integer])(block: JFunction[BuiltInComponents, Router]): Server = {
     val context = ApplicationLoader.Context(
       Environment.simple(mode = mode),
       None, new DefaultWebCommands(), Configuration(ConfigFactory.load()),

--- a/framework/src/play-server/src/main/scala/play/core/server/ServerConfig.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ServerConfig.scala
@@ -26,7 +26,7 @@ case class ServerConfig(
     port: Option[Int],
     sslPort: Option[Int],
     address: String,
-    mode: Mode.Mode,
+    mode: Mode,
     properties: Properties,
     configuration: Configuration) {
   // Some basic validation of config
@@ -41,7 +41,7 @@ object ServerConfig {
     port: Option[Int] = Some(9000),
     sslPort: Option[Int] = None,
     address: String = "0.0.0.0",
-    mode: Mode.Mode = Mode.Prod,
+    mode: Mode = Mode.Prod,
     properties: Properties = System.getProperties): ServerConfig = {
     ServerConfig(
       rootDir = rootDir,

--- a/framework/src/play-test/src/main/java/play/test/TestServer.java
+++ b/framework/src/play-test/src/main/java/play/test/TestServer.java
@@ -4,7 +4,7 @@
 package play.test;
 
 import play.Application;
-import play.api.Mode;
+import play.Mode;
 import play.core.server.ServerConfig;
 import play.core.server.ServerProvider;
 import scala.Option;
@@ -43,7 +43,7 @@ public class TestServer extends play.api.test.TestServer {
     private static ServerConfig createServerConfig(Optional<Integer> port, Optional<Integer> sslPort) {
         return ServerConfig.apply(TestServer.class.getClassLoader(), new File("."),
                 (Option) OptionConverters.toScala(port), (Option) OptionConverters.toScala(sslPort), "0.0.0.0",
-                Mode.test(), System.getProperties());
+                Mode.TEST.asScala(), System.getProperties());
     }
 
 }

--- a/framework/src/play-test/src/main/java/play/test/TestServer.java
+++ b/framework/src/play-test/src/main/java/play/test/TestServer.java
@@ -43,7 +43,7 @@ public class TestServer extends play.api.test.TestServer {
     private static ServerConfig createServerConfig(Optional<Integer> port, Optional<Integer> sslPort) {
         return ServerConfig.apply(TestServer.class.getClassLoader(), new File("."),
                 (Option) OptionConverters.toScala(port), (Option) OptionConverters.toScala(sslPort), "0.0.0.0",
-                Mode.Test(), System.getProperties());
+                Mode.test(), System.getProperties());
     }
 
 }

--- a/framework/src/play/src/main/java/play/Configuration.java
+++ b/framework/src/play/src/main/java/play/Configuration.java
@@ -21,7 +21,7 @@ import javax.inject.Singleton;
 /**
  * The current application configuration.
  *
- * @deprecated Use Config instead.
+ * @deprecated As of release 2.6.0. Use {@link Config} instead.
  */
 @Singleton
 @Deprecated

--- a/framework/src/play/src/main/java/play/DelegateLoggerConfigurator.java
+++ b/framework/src/play/src/main/java/play/DelegateLoggerConfigurator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play;
+
+import com.typesafe.config.Config;
+import org.slf4j.ILoggerFactory;
+import play.libs.Scala;
+import scala.compat.java8.OptionConverters;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.net.URL;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Java delegator to encapsulates a {@link play.api.LoggerConfigurator}.
+ */
+class DelegateLoggerConfigurator implements LoggerConfigurator {
+
+    private final play.api.LoggerConfigurator delegate;
+
+    @Inject
+    public DelegateLoggerConfigurator(play.api.LoggerConfigurator delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void init(File rootPath, Mode mode) {
+        delegate.init(rootPath, mode.asScala());
+    }
+
+    @Override
+    public void configure(Environment env) {
+        delegate.configure(env.asScala());
+    }
+
+    @Override
+    public void configure(Environment env, Config configuration, Map<String, String> optionalProperties) {
+        delegate.configure(
+            env.asScala(),
+            new play.api.Configuration(configuration),
+            Scala.asScala(optionalProperties)
+        );
+    }
+
+    @Override
+    public void configure(Map<String, String> properties, Optional<URL> config) {
+        delegate.configure(
+            Scala.asScala(properties),
+            OptionConverters.toScala(config)
+        );
+    }
+
+    @Override
+    public ILoggerFactory loggerFactory() {
+        return delegate.loggerFactory();
+    }
+
+    @Override
+    public void shutdown() {
+        delegate.shutdown();
+    }
+}

--- a/framework/src/play/src/main/java/play/Environment.java
+++ b/framework/src/play/src/main/java/play/Environment.java
@@ -26,7 +26,7 @@ public class Environment {
     }
 
     public Environment(File rootPath, ClassLoader classLoader, Mode mode) {
-        this(new play.api.Environment(rootPath, classLoader, play.api.Mode.apply(mode.ordinal())));
+        this(new play.api.Environment(rootPath, classLoader, mode.asScala()));
     }
 
     public Environment(File rootPath, Mode mode) {
@@ -65,13 +65,7 @@ public class Environment {
      * @return the mode
      */
     public Mode mode() {
-        if (env.mode().equals(play.api.Mode.Prod())) {
-            return Mode.PROD;
-        } else if (env.mode().equals(play.api.Mode.Dev())) {
-            return Mode.DEV;
-        } else {
-            return Mode.TEST;
-        }
+        return env.mode().asJava();
     }
 
     /**

--- a/framework/src/play/src/main/java/play/LoggerConfigurator.java
+++ b/framework/src/play/src/main/java/play/LoggerConfigurator.java
@@ -8,7 +8,6 @@ import org.slf4j.ILoggerFactory;
 import play.api.Configuration;
 import play.api.LoggerConfigurator$;
 import play.libs.Scala;
-import scala.Enumeration;
 import scala.Option;
 import scala.compat.java8.OptionConverters;
 
@@ -104,8 +103,18 @@ public interface LoggerConfigurator extends play.api.LoggerConfigurator {
                 if (loggerConfigurator instanceof LoggerConfigurator) {
                     return (LoggerConfigurator)loggerConfigurator;
                 } else {
+                    // Avoid failing if using a Scala logger configurator
                     return new DelegateLoggerConfigurator(loggerConfigurator);
                 }
             });
+    }
+
+    static Map<String, String> generateProperties(Environment env, Config config, Map<String, String> optionalProperties) {
+        scala.collection.immutable.Map<String, String> generateProperties = LoggerConfigurator$.MODULE$.generateProperties(
+                env.asScala(),
+                new Configuration(config),
+                Scala.asScala(optionalProperties)
+        );
+        return Scala.asJava(generateProperties);
     }
 }

--- a/framework/src/play/src/main/java/play/LoggerConfigurator.java
+++ b/framework/src/play/src/main/java/play/LoggerConfigurator.java
@@ -27,14 +27,8 @@ public interface LoggerConfigurator extends play.api.LoggerConfigurator {
     void init(File rootPath, Mode mode);
 
     @Override
-    default void init(File rootPath, play.api.Mode.Mode mode) {
-        Mode javaMode = Mode.TEST;
-        if (mode.equals(play.api.Mode.dev())) {
-            javaMode = Mode.DEV;
-        } else if (mode.equals(play.api.Mode.prod())) {
-            javaMode = Mode.PROD;
-        }
-        init(rootPath, javaMode);
+    default void init(File rootPath, play.api.Mode mode) {
+        init(rootPath, mode.asJava());
     }
 
     /**

--- a/framework/src/play/src/main/java/play/Mode.java
+++ b/framework/src/play/src/main/java/play/Mode.java
@@ -3,5 +3,18 @@
  */
 package play;
 
-/** Application mode, either `DEV`, `TEST`, or `PROD`. */
-public enum Mode { DEV, TEST, PROD }
+/**
+ * Application mode, either `DEV`, `TEST`, or `PROD`.
+ */
+public enum Mode {
+    DEV, TEST, PROD;
+
+    public play.api.Mode.Mode asScala() {
+        if (this == DEV) {
+            return play.api.Mode.dev();
+        } else if (this == PROD) {
+            return play.api.Mode.prod();
+        }
+        return play.api.Mode.test();
+    }
+}

--- a/framework/src/play/src/main/java/play/Mode.java
+++ b/framework/src/play/src/main/java/play/Mode.java
@@ -9,12 +9,12 @@ package play;
 public enum Mode {
     DEV, TEST, PROD;
 
-    public play.api.Mode.Mode asScala() {
+    public play.api.Mode asScala() {
         if (this == DEV) {
-            return play.api.Mode.dev();
+            return play.api.Mode.Dev$.MODULE$;
         } else if (this == PROD) {
-            return play.api.Mode.prod();
+            return play.api.Mode.Prod$.MODULE$;
         }
-        return play.api.Mode.test();
+        return play.api.Mode.Test$.MODULE$;
     }
 }

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -14,7 +14,7 @@ play {
 
   logger {
     # This is a boolean configuration.
-    # If true, the configuration properties setted will be used when configuring the logger.
+    # If true, the configuration properties will be used when configuring the logger.
     includeConfigProperties = false
   }
 

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -12,6 +12,12 @@ play {
   # Defines whether the global application is allowed
   allowGlobalApplication = true
 
+  logger {
+    # This is a boolean configuration.
+    # If true, the configuration properties setted will be used when configuring the logger.
+    includeConfigProperties = false
+  }
+
   http {
 
     # The application context.

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -57,7 +57,7 @@ trait Application {
   /**
    * `Dev`, `Prod` or `Test`
    */
-  def mode: Mode.Mode = environment.mode
+  def mode: Mode = environment.mode
 
   /**
    * The application's environment

--- a/framework/src/play/src/main/scala/play/api/Environment.scala
+++ b/framework/src/play/src/main/scala/play/api/Environment.scala
@@ -17,7 +17,7 @@ import java.io.{ InputStream, File }
 case class Environment(
     rootPath: File,
     classLoader: ClassLoader,
-    mode: Mode.Mode) {
+    mode: Mode) {
 
   /**
    * Retrieves a file relative to the application root path.
@@ -104,5 +104,5 @@ object Environment {
    * Uses the same classloader that the environment classloader is defined in, and the current working directory as the
    * path.
    */
-  def simple(path: File = new File("."), mode: Mode.Mode = Mode.Test) = Environment(path, Environment.getClass.getClassLoader, mode)
+  def simple(path: File = new File("."), mode: Mode = Mode.Test) = Environment(path, Environment.getClass.getClassLoader, mode)
 }

--- a/framework/src/play/src/main/scala/play/api/Logger.scala
+++ b/framework/src/play/src/main/scala/play/api/Logger.scala
@@ -252,12 +252,12 @@ class Logger private (val logger: Slf4jLogger, isEnabled: => Boolean) extends Lo
    *
    * If the global application mode has not been set (by calling Logger.setApplicationMode), this has no effect.
    */
-  def forMode(mode: Mode.Mode*): Logger = {
+  def forMode(mode: Mode*): Logger = {
     modeLoggerCache.getOrElseUpdate(mode, new Logger(logger, Logger.applicationMode.forall(mode.contains)))
   }
 
-  private[this] val modeLoggerCache: mutable.Map[Seq[Mode.Mode], Logger] =
-    new ConcurrentHashMap[Seq[Mode.Mode], Logger]().asScala
+  private[this] val modeLoggerCache: mutable.Map[Seq[Mode], Logger] =
+    new ConcurrentHashMap[Seq[Mode], Logger]().asScala
 }
 
 /**
@@ -277,18 +277,18 @@ object Logger extends Logger(LoggerFactory.getLogger("application")) {
 
   private[this] val log: Slf4jLogger = LoggerFactory.getLogger(getClass)
 
-  private[this] var _mode: Option[Mode.Mode] = None
+  private[this] var _mode: Option[Mode] = None
   private[this] val _appsRunning: AtomicInteger = new AtomicInteger(0)
 
   /**
    * The global application mode currently being used by the logging API.
    */
-  def applicationMode: Option[Mode.Mode] = _mode
+  def applicationMode: Option[Mode] = _mode
 
   /**
    * Set the global application mode used for logging. Used when the Play application starts.
    */
-  def setApplicationMode(mode: Mode.Mode): Unit = {
+  def setApplicationMode(mode: Mode): Unit = {
     val appsRunning = _appsRunning.incrementAndGet()
     applicationMode foreach { currentMode =>
       if (currentMode != mode) {

--- a/framework/src/play/src/main/scala/play/api/LoggerConfigurator.scala
+++ b/framework/src/play/src/main/scala/play/api/LoggerConfigurator.scala
@@ -73,7 +73,7 @@ object LoggerConfigurator {
     val mutableMap = new scala.collection.mutable.HashMap[String, String]()
     mutableMap.put("application.home", env.rootPath.getAbsolutePath)
 
-    if (config.getOptional[Boolean]("play.logger.includeConfigProperties").contains(true)) {
+    if (config.get[Boolean]("play.logger.includeConfigProperties")) {
       val entrySet = config.underlying.entrySet.asScala
       for (entry <- entrySet) {
         val value = entry.getValue

--- a/framework/src/play/src/main/scala/play/api/LoggerConfigurator.scala
+++ b/framework/src/play/src/main/scala/play/api/LoggerConfigurator.scala
@@ -73,14 +73,14 @@ object LoggerConfigurator {
     val mutableMap = new scala.collection.mutable.HashMap[String, String]()
     mutableMap.put("application.home", env.rootPath.getAbsolutePath)
 
-    if (config.getBoolean("play.logger.includeConfigProperties").contains(true)) {
+    if (config.getOptional[Boolean]("play.logger.includeConfigProperties").contains(true)) {
       val entrySet = config.underlying.entrySet.asScala
       for (entry <- entrySet) {
         val value = entry.getValue
         value.valueType() match {
           case ConfigValueType.STRING =>
             mutableMap.put(entry.getKey, value.unwrapped().asInstanceOf[String])
-          case other =>
+          case _ =>
             mutableMap.put(entry.getKey, value.render())
         }
       }

--- a/framework/src/play/src/main/scala/play/api/LoggerConfigurator.scala
+++ b/framework/src/play/src/main/scala/play/api/LoggerConfigurator.scala
@@ -17,7 +17,7 @@ trait LoggerConfigurator {
   /**
    * Initialize the Logger when there's no application ClassLoader available.
    */
-  def init(rootPath: java.io.File, mode: Mode.Mode): Unit
+  def init(rootPath: java.io.File, mode: Mode): Unit
 
   /**
    * This is a convenience method that adds no extra properties.

--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -11,13 +11,40 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 import javax.xml.parsers.SAXParserFactory
+
 import play.libs.XML.Constants
 import javax.xml.XMLConstants
 
-/** Application mode, either `DEV`, `TEST`, or `PROD`. */
-object Mode extends Enumeration {
-  type Mode = Value
-  val Dev, Test, Prod = Value
+/**
+ * Application mode, either `Dev`, `Test`, or `Prod`.
+ *
+ * @see [[play.Mode]]
+ */
+
+object Mode {
+
+  sealed trait Mode {
+    def asJava: play.Mode
+  }
+
+  case object Dev extends Mode {
+    override def asJava: play.Mode = play.Mode.DEV
+  }
+
+  case object Test extends Mode {
+    override def asJava: play.Mode = play.Mode.TEST
+  }
+
+  case object Prod extends Mode {
+    override def asJava: play.Mode = play.Mode.PROD
+  }
+
+  // Made the modes accessible in Java code.
+  def dev() = Dev
+  def test() = Test
+  def prod() = Prod
+
+  def modes() = Seq(Dev, Test, Prod)
 }
 
 /**

--- a/framework/src/play/src/main/scala/play/api/Play.scala
+++ b/framework/src/play/src/main/scala/play/api/Play.scala
@@ -20,31 +20,21 @@ import javax.xml.XMLConstants
  *
  * @see [[play.Mode]]
  */
+sealed abstract class Mode(val asJava: play.Mode)
 
 object Mode {
 
-  sealed trait Mode {
-    def asJava: play.Mode
-  }
+  @deprecated("Use play.api.Mode instead of play.api.Mode.Mode", "2.6.0")
+  type Mode = play.api.Mode
 
-  case object Dev extends Mode {
-    override def asJava: play.Mode = play.Mode.DEV
-  }
+  @deprecated("Use play.api.Mode instead of play.api.Mode.Value", "2.6.0")
+  type Value = play.api.Mode
 
-  case object Test extends Mode {
-    override def asJava: play.Mode = play.Mode.TEST
-  }
+  case object Dev extends play.api.Mode(play.Mode.DEV)
+  case object Test extends play.api.Mode(play.Mode.TEST)
+  case object Prod extends play.api.Mode(play.Mode.PROD)
 
-  case object Prod extends Mode {
-    override def asJava: play.Mode = play.Mode.PROD
-  }
-
-  // Made the modes accessible in Java code.
-  def dev() = Dev
-  def test() = Test
-  def prod() = Prod
-
-  def modes() = Seq(Dev, Test, Prod)
+  lazy val values: Set[play.api.Mode] = Set(Dev, Test, Prod)
 }
 
 /**

--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -181,7 +181,7 @@ package controllers {
   }
 
   object AssetsConfiguration {
-    def fromConfiguration(c: Configuration, mode: Mode.Mode = Mode.Test): AssetsConfiguration = {
+    def fromConfiguration(c: Configuration, mode: Mode = Mode.Test): AssetsConfiguration = {
       AssetsConfiguration(
         path = c.get[String]("play.assets.path"),
         urlPrefix = c.get[String]("play.assets.urlPrefix"),

--- a/framework/src/play/src/main/scala/play/api/libs/crypto/CookieSigner.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/crypto/CookieSigner.scala
@@ -11,7 +11,6 @@ import javax.inject.{ Inject, Provider, Singleton }
 import play.api.http.SecretConfiguration
 import play.api.libs.Codecs
 import play.libs.crypto
-import play.libs.crypto.DefaultCookieSigner
 
 /**
  * Authenticates a cookie by returning a message authentication code (MAC).

--- a/framework/src/play/src/main/scala/play/core/j/JavaModeConverter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaModeConverter.scala
@@ -9,6 +9,6 @@ import scala.language.implicitConversions
  * Converter for Java Mode enum from Scala Mode
  */
 object JavaModeConverter {
-  implicit def asJavaMode(mode: play.api.Mode.Mode): play.Mode = mode.asJava
-  implicit def asScalaMode(mode: play.Mode): play.api.Mode.Mode = mode.asScala()
+  implicit def asJavaMode(mode: play.api.Mode): play.Mode = mode.asJava
+  implicit def asScalaMode(mode: play.Mode): play.api.Mode = mode.asScala()
 }

--- a/framework/src/play/src/main/scala/play/core/j/JavaModeConverter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaModeConverter.scala
@@ -9,14 +9,6 @@ import scala.language.implicitConversions
  * Converter for Java Mode enum from Scala Mode
  */
 object JavaModeConverter {
-  implicit def asJavaMode(mode: play.api.Mode.Mode): play.Mode = mode match {
-    case play.api.Mode.Dev => play.Mode.DEV
-    case play.api.Mode.Test => play.Mode.TEST
-    case play.api.Mode.Prod => play.Mode.PROD
-  }
-  implicit def asScalaMode(mode: play.Mode): play.api.Mode.Mode = mode match {
-    case play.Mode.DEV => play.api.Mode.Dev
-    case play.Mode.TEST => play.api.Mode.Test
-    case play.Mode.PROD => play.api.Mode.Prod
-  }
+  implicit def asJavaMode(mode: play.api.Mode.Mode): play.Mode = mode.asJava
+  implicit def asScalaMode(mode: play.Mode): play.api.Mode.Mode = mode.asScala()
 }

--- a/framework/src/play/src/test/java/play/mvc/ResultsTest.java
+++ b/framework/src/play/src/test/java/play/mvc/ResultsTest.java
@@ -186,7 +186,7 @@ public class ResultsTest {
   }
 
   private void mockRegularFileTypes() {
-    HttpConfiguration httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(Configuration.reference(), play.api.Environment.simple(new File("."), Mode.Test())).get();
+    HttpConfiguration httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(Configuration.reference(), play.api.Environment.simple(new File("."), Mode.test())).get();
     final DefaultFileMimeTypes defaultFileMimeTypes = new DefaultFileMimeTypesProvider(httpConfiguration.fileMimeTypes()).get();
     final FileMimeTypes fileMimeTypes = new FileMimeTypes(defaultFileMimeTypes);
     when(this.ctx.fileMimeTypes()).thenReturn(fileMimeTypes);

--- a/framework/src/play/src/test/java/play/mvc/ResultsTest.java
+++ b/framework/src/play/src/test/java/play/mvc/ResultsTest.java
@@ -3,8 +3,6 @@
  */
 package play.mvc;
 
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import org.junit.*;
 
 import java.io.File;
@@ -13,11 +11,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.util.HashMap;
-import java.util.Map;
 
+import play.Mode;
 import play.api.Configuration;
-import play.api.Mode;
 import play.api.http.DefaultFileMimeTypes;
 import play.api.http.DefaultFileMimeTypesProvider;
 import play.api.http.HttpConfiguration;
@@ -186,7 +182,7 @@ public class ResultsTest {
   }
 
   private void mockRegularFileTypes() {
-    HttpConfiguration httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(Configuration.reference(), play.api.Environment.simple(new File("."), Mode.test())).get();
+    HttpConfiguration httpConfiguration = new HttpConfiguration.HttpConfigurationProvider(Configuration.reference(), play.api.Environment.simple(new File("."), Mode.TEST.asScala())).get();
     final DefaultFileMimeTypes defaultFileMimeTypes = new DefaultFileMimeTypesProvider(httpConfiguration.fileMimeTypes()).get();
     final FileMimeTypes fileMimeTypes = new FileMimeTypes(defaultFileMimeTypes);
     when(this.ctx.fileMimeTypes()).thenReturn(fileMimeTypes);

--- a/framework/src/play/src/test/scala/play/api/ConfigurationSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/ConfigurationSpec.scala
@@ -118,7 +118,7 @@ class ConfigurationSpec extends Specification {
     }
 
     "fail if application.conf is not found" in {
-      def load(mode: Mode.Mode) = {
+      def load(mode: Mode) = {
         // system classloader should not have an application.conf
         Configuration.load(Environment(new File("."), ClassLoader.getSystemClassLoader, mode))
       }

--- a/framework/src/play/src/test/scala/play/api/LoggerConfiguratorSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/LoggerConfiguratorSpec.scala
@@ -7,11 +7,13 @@ import org.specs2.mutable.Specification
 
 class LoggerConfiguratorSpec extends Specification {
 
+  private lazy val referenceConfig = Configuration.reference
+
   "generateProperties" should {
 
     "generate in the simplest case" in {
       val env = Environment.simple()
-      val config = Configuration.empty
+      val config = referenceConfig
       val properties = LoggerConfigurator.generateProperties(env, config, Map.empty)
       properties.size must beEqualTo(1)
       properties must havePair("application.home" -> env.rootPath.getAbsolutePath)
@@ -19,7 +21,7 @@ class LoggerConfiguratorSpec extends Specification {
 
     "generate in the case of including string config property" in {
       val env = Environment.simple()
-      val config = Configuration(
+      val config = referenceConfig ++ Configuration(
         "play.logger.includeConfigProperties" -> true,
         "my.string.in.application.conf" -> "hello"
       )
@@ -29,7 +31,7 @@ class LoggerConfiguratorSpec extends Specification {
 
     "generate in the case of including integer config property" in {
       val env = Environment.simple()
-      val config = Configuration(
+      val config = referenceConfig ++ Configuration(
         "play.logger.includeConfigProperties" -> true,
         "my.number.in.application.conf" -> 1
       )
@@ -39,7 +41,7 @@ class LoggerConfiguratorSpec extends Specification {
 
     "generate in the case of including null config property" in {
       val env = Environment.simple()
-      val config = Configuration(
+      val config = referenceConfig ++ Configuration(
         "play.logger.includeConfigProperties" -> true,
         "my.null.in.application.conf" -> null
       )
@@ -51,7 +53,7 @@ class LoggerConfiguratorSpec extends Specification {
 
     "generate in the case of direct properties" in {
       val env = Environment.simple()
-      val config = Configuration.empty
+      val config = referenceConfig
       val optProperties = Map("direct.map.property" -> "goodbye")
       val properties = LoggerConfigurator.generateProperties(env, config, optProperties)
 
@@ -62,7 +64,7 @@ class LoggerConfiguratorSpec extends Specification {
 
     "generate a null using direct properties" in {
       val env = Environment.simple()
-      val config = Configuration.empty
+      val config = referenceConfig
       val optProperties = Map("direct.null.property" -> null)
       val properties = LoggerConfigurator.generateProperties(env, config, optProperties)
 
@@ -71,7 +73,7 @@ class LoggerConfiguratorSpec extends Specification {
 
     "override config property with direct properties" in {
       val env = Environment.simple()
-      val config = Configuration("some.property" -> "AAA")
+      val config = referenceConfig ++ Configuration("some.property" -> "AAA")
       val optProperties = Map("some.property" -> "BBB")
       val properties = LoggerConfigurator.generateProperties(env, config, optProperties)
 

--- a/framework/src/play/src/test/scala/play/api/ModeSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/ModeSpec.scala
@@ -17,15 +17,6 @@ class ModeSpec extends Specification {
     "convert Prod mode to Java play.Mode.PROD" in {
       Mode.Prod.asJava must beEqualTo(play.Mode.PROD)
     }
-    "get test mode" in {
-      Mode.test() must beEqualTo(Mode.Test)
-    }
-    "get dev mode" in {
-      Mode.dev() must beEqualTo(Mode.Dev)
-    }
-    "get prod mode" in {
-      Mode.prod() must beEqualTo(Mode.Prod)
-    }
   }
 
   "Java Mode" should {

--- a/framework/src/play/src/test/scala/play/api/ModeSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/ModeSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api
+
+import org.specs2.mutable.Specification
+
+class ModeSpec extends Specification {
+
+  "Scala Mode" should {
+    "convert Dev mode to Java play.Mode.DEV" in {
+      Mode.Dev.asJava must beEqualTo(play.Mode.DEV)
+    }
+    "convert Test mode to Java play.Mode.TEST" in {
+      Mode.Test.asJava must beEqualTo(play.Mode.TEST)
+    }
+    "convert Prod mode to Java play.Mode.PROD" in {
+      Mode.Prod.asJava must beEqualTo(play.Mode.PROD)
+    }
+    "get test mode" in {
+      Mode.test() must beEqualTo(Mode.Test)
+    }
+    "get dev mode" in {
+      Mode.dev() must beEqualTo(Mode.Dev)
+    }
+    "get prod mode" in {
+      Mode.prod() must beEqualTo(Mode.Prod)
+    }
+  }
+
+  "Java Mode" should {
+    "convert play.Mode.DEV to Scala Dev" in {
+      play.Mode.DEV.asScala() must beEqualTo(Mode.Dev)
+    }
+    "convert play.Mode.TEST to Scala Test" in {
+      play.Mode.TEST.asScala() must beEqualTo(Mode.Test)
+    }
+    "convert play.Mode.PROD to Scala Prod" in {
+      play.Mode.PROD.asScala() must beEqualTo(Mode.Prod)
+    }
+  }
+}

--- a/framework/src/play/src/test/scala/play/api/PlayCoreTestApplication.scala
+++ b/framework/src/play/src/test/scala/play/api/PlayCoreTestApplication.scala
@@ -17,7 +17,7 @@ import play.api.mvc.request.DefaultRequestFactory
 private[play] case class PlayCoreTestApplication(
     config: Map[String, Any] = Map(),
     path: File = new File("."),
-    override val mode: Mode.Mode = Mode.Test) extends Application {
+    override val mode: Mode = Mode.Test) extends Application {
 
   def this() = this(config = Map())
 

--- a/framework/src/play/src/test/scala/play/api/http/SecretConfigurationParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/SecretConfigurationParserSpec.scala
@@ -13,7 +13,7 @@ class ActualKeySecretConfigurationParserSpec extends SecretConfigurationParserSp
 class DeprecatedKeySecretConfigurationParserSpec extends SecretConfigurationParserSpec {
   override def secretKey: String = "play.crypto.secret"
 
-  override def parseSecret(mode: Mode.Mode, secret: Option[String] = None) = {
+  override def parseSecret(mode: Mode, secret: Option[String] = None) = {
     HttpConfiguration.fromConfiguration(
       Configuration.reference ++ Configuration.from(
         secret.map(secretKey -> _).toMap ++ Map(
@@ -32,7 +32,7 @@ trait SecretConfigurationParserSpec extends Specification {
 
   val Secret = "abcdefghijklmnopqrs"
 
-  def parseSecret(mode: Mode.Mode, secret: Option[String] = None): String = {
+  def parseSecret(mode: Mode, secret: Option[String] = None): String = {
     HttpConfiguration.fromConfiguration(
       Configuration.reference ++ Configuration.from(
         secret.map(secretKey -> _).toMap


### PR DESCRIPTION
## Fixes

Fixes #6045.

## Purpose

This adds the Java version for LoggerConfigurator. This becomes more evident while documenting #7170.

## Background Context

This will enable Java users to both implement their LoggerConfigurators using Java and have a Java API to access Scala LoggerConfigurators. In fact, the Java version of LoggerConfigurator inherits from the Scala version.

## References

This is part of #7170.