### PR TITLE
Make it possible to disable the reverse router

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesGenerator.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesGenerator.scala
@@ -54,6 +54,8 @@ object StaticRoutesGenerator extends RoutesGenerator {
     val sourceInfo = RoutesSourceInfo(task.file.getCanonicalPath.replace(File.separator, "/"), new java.util.Date().toString)
     val routes = rules.collect { case r: Route => r }
 
+    val routesPrefixFiles = Seq(folder + RoutesPrefixFile -> generateRoutesPrefix(sourceInfo, namespace))
+
     val forwardsRoutesFiles = if (task.forwardsRouter) {
       Seq(folder + ForwardsRoutesFile -> generateRouter(sourceInfo, namespace, task.additionalImports, rules))
     } else {
@@ -61,15 +63,14 @@ object StaticRoutesGenerator extends RoutesGenerator {
     }
 
     val reverseRoutesFiles = if (task.reverseRouter) {
-      Seq(folder + RoutesPrefixFile -> generateRoutesPrefix(sourceInfo, namespace)) ++
-        generateReverseRouters(sourceInfo, namespace, task.additionalImports, routes, task.namespaceReverseRouter) ++
+      generateReverseRouters(sourceInfo, namespace, task.additionalImports, routes, task.namespaceReverseRouter) ++
         generateJavaScriptReverseRouters(sourceInfo, namespace, task.additionalImports, routes, task.namespaceReverseRouter) ++
         generateJavaWrappers(sourceInfo, namespace, rules, task.namespaceReverseRouter)
     } else {
       Nil
     }
 
-    forwardsRoutesFiles ++ reverseRoutesFiles
+    routesPrefixFiles ++ forwardsRoutesFiles ++ reverseRoutesFiles
   }
 
   private def generateRouter(sourceInfo: RoutesSourceInfo, namespace: Option[String], additionalImports: Seq[String], rules: List[Rule]) =
@@ -151,6 +152,8 @@ object InjectedRoutesGenerator extends RoutesGenerator {
     val sourceInfo = RoutesSourceInfo(task.file.getCanonicalPath.replace(File.separator, "/"), new java.util.Date().toString)
     val routes = rules.collect { case r: Route => r }
 
+    val routesPrefixFiles = Seq(folder + RoutesPrefixFile -> generateRoutesPrefix(sourceInfo, namespace))
+
     val forwardsRoutesFiles = if (task.forwardsRouter) {
       Seq(folder + ForwardsRoutesFile -> generateRouter(sourceInfo, namespace, task.additionalImports, rules))
     } else {
@@ -158,15 +161,14 @@ object InjectedRoutesGenerator extends RoutesGenerator {
     }
 
     val reverseRoutesFiles = if (task.reverseRouter) {
-      Seq(folder + RoutesPrefixFile -> generateRoutesPrefix(sourceInfo, namespace)) ++
-        generateReverseRouters(sourceInfo, namespace, task.additionalImports, routes, task.namespaceReverseRouter) ++
+      generateReverseRouters(sourceInfo, namespace, task.additionalImports, routes, task.namespaceReverseRouter) ++
         generateJavaScriptReverseRouters(sourceInfo, namespace, task.additionalImports, routes, task.namespaceReverseRouter) ++
         generateJavaWrappers(sourceInfo, namespace, rules, task.namespaceReverseRouter)
     } else {
       Nil
     }
 
-    forwardsRoutesFiles ++ reverseRoutesFiles
+    routesPrefixFiles ++ forwardsRoutesFiles ++ reverseRoutesFiles
   }
 
   private def generateRouter(sourceInfo: RoutesSourceInfo, namespace: Option[String], additionalImports: Seq[String], rules: List[Rule]) = {

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/test
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/test
@@ -18,19 +18,19 @@ $ exists common/target/routes/main/controllers/c/routes.java
 -$ exists common/target/routes/main/b/Routes.scala
 -$ exists common/target/routes/main/c/Routes.scala
 
--$ exists a/target/routes/main/a/RoutesPrefix.scala
+$ exists a/target/routes/main/a/RoutesPrefix.scala
 -$ exists a/target/routes/main/controllers/a/ReverseRoutes.scala
 -$ exists a/target/routes/main/controllers/a/javascript/JavaScriptReverseRoutes.scala
 -$ exists a/target/routes/main/controllers/a/routes.java
 $ exists a/target/routes/main/a/Routes.scala
 
--$ exists b/target/routes/main/b/RoutesPrefix.scala
+$ exists b/target/routes/main/b/RoutesPrefix.scala
 -$ exists b/target/routes/main/controllers/b/ReverseRoutes.scala
 -$ exists b/target/routes/main/controllers/b/javascript/JavaScriptReverseRoutes.scala
 -$ exists b/target/routes/main/controllers/b/routes.java
 $ exists b/target/routes/main/b/Routes.scala
 
--$ exists c/target/routes/main/c/RoutesPrefix.scala
+$ exists c/target/routes/main/c/RoutesPrefix.scala
 -$ exists c/target/routes/main/controllers/c/ReverseRoutes.scala
 -$ exists c/target/routes/main/controllers/c/javascript/JavaScriptReverseRoutes.scala
 -$ exists c/target/routes/main/controllers/c/routes.java


### PR DESCRIPTION
Fixes #7185. Makes sure RoutesPrefix is generated regardless of whether reverse routes are enabled, since it is used in the generated forwards router.

One of the scripted tests was failing for me locally but it wasn't clear why. Maybe someone more familiar with those tests can help.