### PR TITLE
List enabled filters on startup

### DIFF
--- a/framework/src/play/src/main/scala/play/api/http/HttpFilters.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpFilters.scala
@@ -60,7 +60,6 @@ object HttpFilters {
  * @param injector finds an instance of filter by the class name
  */
 class EnabledFilters @Inject() (env: Environment, configuration: Configuration, injector: Injector, webCommands: WebCommands) extends HttpFilters {
-
   private val enabledKey = "play.filters.enabled"
   private val disabledKey = "play.filters.disabled"
 
@@ -120,12 +119,18 @@ class JavaHttpFiltersDelegate @Inject() (delegate: HttpFilters)
  * Web command handler for listing filters on application start.
  */
 class EnabledFiltersWebCommands @Inject() (enabledFilters: EnabledFilters) extends HandleWebCommandSupport {
-  private val logger = play.api.Logger("application")
+  private val logger = play.api.Logger("play.api.http.EnabledFilters")
+
+  private var enabled = true
 
   def handleWebCommand(request: play.api.mvc.RequestHeader, buildLink: play.core.BuildLink, path: java.io.File): Option[play.api.mvc.Result] = {
-    logger.info("Enabled Filters: ")
-    for (f <- enabledFilters.filters) {
-      logger.info(s"  ${f.getClass.toString}")
+    if (enabled) {
+      enabled = false
+      val b = new StringBuffer()
+      b.append("Enabled Filters: ")
+      enabledFilters.filters.foreach(f => b.append(s"  ${f.getClass.getCanonicalName}\n"))
+      b.append("Play comes with filters enabled by default for security: https://www.playframework.com/documentation/latest/Filters\n")
+      logger.info(b.toString)
     }
     None
   }

--- a/framework/src/play/src/main/scala/play/api/http/HttpFilters.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpFilters.scala
@@ -100,9 +100,8 @@ class EnabledFilters @Inject() (env: Environment, configuration: Configuration, 
   private def printMessageInDevMode(): Unit = {
     if (env.mode == play.api.Mode.Dev) {
       val b = new StringBuffer()
-      b.append("Enabled Filters: ")
-      filters.foreach(f => b.append(s"  ${f.getClass.getCanonicalName}\n"))
-      b.append(s"Play comes with filters enabled by default for security: $url\n")
+      b.append(s"Enabled Filters (see <$url>):\n\n")
+      filters.foreach(f => b.append(s"    ${f.getClass.getCanonicalName}\n"))
       logger.info(b.toString)
     }
   }

--- a/framework/src/play/src/main/scala/play/api/http/HttpFilters.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpFilters.scala
@@ -7,9 +7,8 @@ import javax.inject.Inject
 
 import com.typesafe.config.ConfigException
 import play.api.inject.{ Binding, BindingKey, Injector }
-import play.api.{ Configuration, Environment }
+import play.api.{ Configuration, Environment, Logger }
 import play.api.mvc.EssentialFilter
-import play.core.{ HandleWebCommandSupport, WebCommands }
 import play.utils.Reflect
 
 /**
@@ -53,45 +52,63 @@ object HttpFilters {
 }
 
 /**
- * This class pulls in a list of filters through configuration property, binding them to a list of classes.
+ * This class provides filters that are "automatically" enabled through `play.filters.enabled`.
+ * A list of default filters are defined in reference.conf.
+ *
+ * See https://www.playframework.com/documentation/latest/Filters for more information.
  *
  * @param env the environment (classloader is used from here)
  * @param configuration the configuration
  * @param injector finds an instance of filter by the class name
  */
-class EnabledFilters @Inject() (env: Environment, configuration: Configuration, injector: Injector, webCommands: WebCommands) extends HttpFilters {
+class EnabledFilters @Inject() (env: Environment, configuration: Configuration, injector: Injector) extends HttpFilters {
+
+  private val url = "https://www.playframework.com/documentation/latest/Filters"
+
+  private val logger = Logger(this.getClass)
+
   private val enabledKey = "play.filters.enabled"
+
   private val disabledKey = "play.filters.disabled"
 
-  private val defaultBindings: Seq[BindingKey[EssentialFilter]] = {
-    try {
-      val disabledSet = configuration.get[Seq[String]](disabledKey).toSet
-      val enabledList = configuration.get[Seq[String]](enabledKey).filterNot(disabledSet.contains)
+  override val filters: Seq[EssentialFilter] = {
+    val bindings: Seq[BindingKey[EssentialFilter]] = {
+      try {
+        val disabledSet = configuration.get[Seq[String]](disabledKey).toSet
+        val enabledList = configuration.get[Seq[String]](enabledKey).filterNot(disabledSet.contains)
 
-      for (filterClassName <- enabledList) yield {
-        try {
-          val filterClass: Class[EssentialFilter] = env.classLoader.loadClass(filterClassName).asInstanceOf[Class[EssentialFilter]]
-          BindingKey(filterClass)
-        } catch {
-          case e: ClassNotFoundException =>
-            throw configuration.reportError(enabledKey, s"Cannot load class $filterClassName", Some(e))
+        for (filterClassName <- enabledList) yield {
+          try {
+            val filterClass: Class[EssentialFilter] = env.classLoader.loadClass(filterClassName).asInstanceOf[Class[EssentialFilter]]
+            BindingKey(filterClass)
+          } catch {
+            case e: ClassNotFoundException =>
+              throw configuration.reportError(enabledKey, s"Cannot load class $filterClassName", Some(e))
+          }
         }
+      } catch {
+        case e: ConfigException.Null =>
+          Nil
+        case e: ConfigException.Missing =>
+          Nil
       }
-    } catch {
-      case e: ConfigException.Null =>
-        Nil
-      case e: ConfigException.Missing =>
-        Nil
+    }
+
+    bindings.map(injector.instanceOf(_))
+  }
+
+  private def printMessageInDevMode(): Unit = {
+    if (env.mode == play.api.Mode.Dev) {
+      val b = new StringBuffer()
+      b.append("Enabled Filters: ")
+      filters.foreach(f => b.append(s"  ${f.getClass.getCanonicalName}\n"))
+      b.append(s"Play comes with filters enabled by default for security: $url\n")
+      logger.info(b.toString)
     }
   }
 
-  /**
-   * Return the filters that should filter every request
-   */
-  override lazy val filters: Seq[EssentialFilter] = defaultBindings.map(injector.instanceOf(_))
-
   def start(): Unit = {
-    webCommands.addHandler(new EnabledFiltersWebCommands(this))
+    printMessageInDevMode()
   }
 
   start() // on construction
@@ -114,24 +131,3 @@ class JavaHttpFiltersAdapter @Inject() (underlying: play.http.HttpFilters)
 
 class JavaHttpFiltersDelegate @Inject() (delegate: HttpFilters)
   extends play.http.DefaultHttpFilters(delegate.filters: _*)
-
-/**
- * Web command handler for listing filters on application start.
- */
-class EnabledFiltersWebCommands @Inject() (enabledFilters: EnabledFilters) extends HandleWebCommandSupport {
-  private val logger = play.api.Logger("play.api.http.EnabledFilters")
-
-  private var enabled = true
-
-  def handleWebCommand(request: play.api.mvc.RequestHeader, buildLink: play.core.BuildLink, path: java.io.File): Option[play.api.mvc.Result] = {
-    if (enabled) {
-      enabled = false
-      val b = new StringBuffer()
-      b.append("Enabled Filters: ")
-      enabledFilters.filters.foreach(f => b.append(s"  ${f.getClass.getCanonicalName}\n"))
-      b.append("Play comes with filters enabled by default for security: https://www.playframework.com/documentation/latest/Filters\n")
-      logger.info(b.toString)
-    }
-    None
-  }
-}

--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -15,9 +15,7 @@ import akka.actor.{ ActorSystem, Cancellable }
 import com.google.common.base.{ FinalizablePhantomReference, FinalizableReferenceQueue }
 import com.google.common.collect.Sets
 import play.api.Configuration
-import play.api.http.HttpConfiguration
 import play.api.inject.ApplicationLifecycle
-import play.libs.Files
 
 import scala.concurrent.Future
 import scala.concurrent.duration.{ Duration, FiniteDuration }

--- a/framework/src/play/src/test/scala/play/api/http/EnabledFiltersSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/EnabledFiltersSpec.scala
@@ -7,7 +7,6 @@ import org.specs2.mutable.Specification
 import play.api.inject.{ Injector, NewInstanceInjector }
 import play.api.mvc.{ EssentialAction, EssentialFilter }
 import play.api.{ Configuration, Environment, PlayException }
-import play.core.DefaultWebCommands
 
 /**
  * Unit tests for default filter spec functionality
@@ -23,8 +22,7 @@ class EnabledFiltersSpec extends Specification {
         "play.filters.disabled.0" -> ""
       ))
       val injector: Injector = NewInstanceInjector
-      val webCommands = new DefaultWebCommands
-      val defaultFilters = new EnabledFilters(env, conf, injector, webCommands)
+      val defaultFilters = new EnabledFilters(env, conf, injector)
 
       defaultFilters.filters must haveLength(1)
       defaultFilters.filters.head must beAnInstanceOf[MyTestFilter]
@@ -34,8 +32,7 @@ class EnabledFiltersSpec extends Specification {
       val env: Environment = Environment.simple()
       val conf: Configuration = Configuration.from(Map("play.filters.enabled" -> null))
       val injector: Injector = NewInstanceInjector
-      val webCommands = new DefaultWebCommands
-      val defaultFilters = new EnabledFilters(env, conf, injector, webCommands)
+      val defaultFilters = new EnabledFilters(env, conf, injector)
 
       defaultFilters.filters must haveLength(0)
     }
@@ -44,8 +41,7 @@ class EnabledFiltersSpec extends Specification {
       val env: Environment = Environment.simple()
       val conf: Configuration = Configuration.from(Map())
       val injector: Injector = NewInstanceInjector
-      val webCommands = new DefaultWebCommands
-      val defaultFilters = new EnabledFilters(env, conf, injector, webCommands)
+      val defaultFilters = new EnabledFilters(env, conf, injector)
 
       defaultFilters.filters must haveLength(0)
     }
@@ -57,10 +53,9 @@ class EnabledFiltersSpec extends Specification {
         "play.filters.disabled.0" -> ""
       ))
       val injector: Injector = NewInstanceInjector
-      val webCommands = new DefaultWebCommands
 
       {
-        new EnabledFilters(env, conf, injector, webCommands)
+        new EnabledFilters(env, conf, injector)
       } must throwAn[PlayException.ExceptionSource]
     }
 
@@ -72,8 +67,7 @@ class EnabledFiltersSpec extends Specification {
         "play.filters.disabled.0" -> "play.api.http.MyTestFilter"
       ))
       val injector: Injector = NewInstanceInjector
-      val webCommands = new DefaultWebCommands
-      val defaultFilters = new EnabledFilters(env, conf, injector, webCommands)
+      val defaultFilters = new EnabledFilters(env, conf, injector)
 
       defaultFilters.filters must haveLength(1)
       defaultFilters.filters.head must beAnInstanceOf[MyTestFilter2]

--- a/framework/src/play/src/test/scala/play/api/http/EnabledFiltersSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/EnabledFiltersSpec.scala
@@ -7,6 +7,7 @@ import org.specs2.mutable.Specification
 import play.api.inject.{ Injector, NewInstanceInjector }
 import play.api.mvc.{ EssentialAction, EssentialFilter }
 import play.api.{ Configuration, Environment, PlayException }
+import play.core.DefaultWebCommands
 
 /**
  * Unit tests for default filter spec functionality
@@ -22,7 +23,8 @@ class EnabledFiltersSpec extends Specification {
         "play.filters.disabled.0" -> ""
       ))
       val injector: Injector = NewInstanceInjector
-      val defaultFilters = new EnabledFilters(env, conf, injector)
+      val webCommands = new DefaultWebCommands
+      val defaultFilters = new EnabledFilters(env, conf, injector, webCommands)
 
       defaultFilters.filters must haveLength(1)
       defaultFilters.filters.head must beAnInstanceOf[MyTestFilter]
@@ -32,7 +34,8 @@ class EnabledFiltersSpec extends Specification {
       val env: Environment = Environment.simple()
       val conf: Configuration = Configuration.from(Map("play.filters.enabled" -> null))
       val injector: Injector = NewInstanceInjector
-      val defaultFilters = new EnabledFilters(env, conf, injector)
+      val webCommands = new DefaultWebCommands
+      val defaultFilters = new EnabledFilters(env, conf, injector, webCommands)
 
       defaultFilters.filters must haveLength(0)
     }
@@ -41,7 +44,8 @@ class EnabledFiltersSpec extends Specification {
       val env: Environment = Environment.simple()
       val conf: Configuration = Configuration.from(Map())
       val injector: Injector = NewInstanceInjector
-      val defaultFilters = new EnabledFilters(env, conf, injector)
+      val webCommands = new DefaultWebCommands
+      val defaultFilters = new EnabledFilters(env, conf, injector, webCommands)
 
       defaultFilters.filters must haveLength(0)
     }
@@ -53,9 +57,10 @@ class EnabledFiltersSpec extends Specification {
         "play.filters.disabled.0" -> ""
       ))
       val injector: Injector = NewInstanceInjector
+      val webCommands = new DefaultWebCommands
 
       {
-        new EnabledFilters(env, conf, injector)
+        new EnabledFilters(env, conf, injector, webCommands)
       } must throwAn[PlayException.ExceptionSource]
     }
 
@@ -67,7 +72,8 @@ class EnabledFiltersSpec extends Specification {
         "play.filters.disabled.0" -> "play.api.http.MyTestFilter"
       ))
       val injector: Injector = NewInstanceInjector
-      val defaultFilters = new EnabledFilters(env, conf, injector)
+      val webCommands = new DefaultWebCommands
+      val defaultFilters = new EnabledFilters(env, conf, injector, webCommands)
 
       defaultFilters.filters must haveLength(1)
       defaultFilters.filters.head must beAnInstanceOf[MyTestFilter2]


### PR DESCRIPTION
It should be clear to people what filters are enabled on server startup in development, and this is not obvious from the logs.  

This PR ensures that filters are printed out to the log on the first URL request, using a webcommand hook.

This is one of a series of "filter visibility" PRs, see https://github.com/playframework/playframework/issues/7148 as well