### PR TITLE
Add legacy cookie support

### DIFF
--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -24,7 +24,7 @@ class Attrs {
 // Get the User object from the request
 User user = req.attrs().get(Attrs.USER);
 // Put a User object into the request
-Request newReq = req.withAttrs(req.attrs().put(Attrs.USER, newUser));
+Request newReq = req.addAttr(Attrs.USER, newUser);
 ```
 
 Scala:
@@ -37,7 +37,7 @@ object Attrs {
 // Get the User object from the request
 val user: User = req.attrs(Attrs.User)
 // Put a User object into the request
-val newReq = req.withAttrs(req.attrs.updated(Attrs.User, newUser))
+val newReq = req.addAttr(Attrs.User, newUser)
 ```
 
 Attributes are stored in a `TypedMap`. You can read more about attributes in the `TypedMap` documentation: [Javadoc](api/java/play/libs/typedmap/TypedMap.html), [Scaladoc](api/scala/play/api/libs/typedmap/TypedMap.html).

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -444,7 +444,7 @@ object Attrs {
 val userName: String = req.attrs(Attrs.UserName)
 val optUserName: [String] = req.attrs.get(Attrs.UserName)
 // Setting an attribute on a Request or RequestHeader
-val newReq = req.withAttrs(req.attrs.updated(Attrs.UserName, newName))
+val newReq = req.addAttr(Attrs.UserName, newName)
 ```
 
 However, if appropriate, we recommend you convert your `String` tags into attributes with non-`String` values. Converting your tags into non-`String` objects has several benefits. First, you will make your code more type-safe. This will increase your code's reliability and make it easier to understand. Second, the objects you store in attributes can contain multiple properties, allowing you to aggregate multiple tags into a single value. Third, converting tags into attributes means you don't need to encode and decode values from `String`s, which may increase performance.

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -871,7 +871,7 @@ Play's cookie encoding uses a "fallback" cookie encoding mechanism that reads in
 Using JWT encoded cookies should be seamless, but if you want, you can revert back to URL encoded cookie encoding by switching to `play.api.mvc.LegacyCookiesModule` in application.conf file:
 
 ```
-play.modules.disabled+="play.api.mvc.DefaultCookiesModule"
+play.modules.disabled+="play.api.mvc.CookiesModule"
 play.modules.enabled+="play.api.mvc.LegacyCookiesModule"
 ```
 
@@ -880,7 +880,7 @@ play.modules.enabled+="play.api.mvc.LegacyCookiesModule"
 If you have custom cookies being used in Play, using the `CookieBaker[T]` trait, then you will need to specify what kind of encoding you want for your custom cookie baker.
 
 The `encode` and `decode` methods that `Map[String, String]` to and from the format found in the browser have been extracted into `CookieDataCodec`.  There are three implementations: `FallbackCookieDataCodec`, `JWTCookieDataCodec`, or `UrlEncodedCookieDataCodec`, which respectively represent URL-encoded with an HMAC, or a JWT, or a "read signed or JWT, write JWT" codec.
-  
+
 
 and then provide a `JWTConfiguration` case class, using the `JWTConfigurationParser` with the path to your configuration, or use `JWTConfiguration()` for the defaults.
 

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -858,33 +858,54 @@ class MyComponents(context: ApplicationLoader.Context)
 
 ## JWT Support
 
-Play's session cookie encoding has been switched to use JSON Web Token (JWT) under the hood.  JWT comes with a number of advantages, notably automatic signing with HMAC-SHA-256, and support for automatic "not before" and "expires after" date checks which ensure the session cookie cannot be reused outside of a given time window.
+Play's cookie encoding has been switched to use JSON Web Token (JWT) under the hood.  JWT comes with a number of advantages, notably automatic signing with HMAC-SHA-256, and support for automatic "not before" and "expires after" date checks which ensure the session cookie cannot be reused outside of a given time window.
 
-More information is available under [[Configuring the Session Cookie|SettingsSession]] page. 
+More information is available under [[Configuring the Session Cookie|SettingsSession]] page.
+
+### Fallback Cookie Support
+
+Play's cookie encoding uses a "fallback" cookie encoding mechanism that reads in JWT encoded cookies, then attempts reading a URL encoded cookie if the JWT parsing fails, so you can safely migrate existing session cookies to JWT.  This functionality is in the `FallbackCookieDataCodec` trait and leveraged by `DefaultSessionCookieBaker` and `DefaultFlashCookieBaker`.
 
 ### Legacy Support
 
-Play's `DefaultSessionCookieBaker` has fallback support for reading session cookies in the old url encoded format, so migrations will not be affected.
+Using JWT encoded cookies should be seamless, but if you want, you can revert back to URL encoded cookie encoding by switching to `play.api.mvc.LegacyCookiesModule` in application.conf file:
 
-To use the previous behavior, bind `SessionCookieBaker` to `LegacySessionCookieBaker` in your module:
-
-```scala
-bind[SessionCookieBaker].to[LegacySessionCookieBaker]
+```
+play.modules.disabled+="play.api.mvc.DefaultCookiesModule"
+play.modules.enabled+="play.api.mvc.LegacyCookiesModule"
 ```
 
 ### Custom CookieBakers
 
 If you have custom cookies being used in Play, using the `CookieBaker[T]` trait, then you will need to specify what kind of encoding you want for your custom cookie baker.
 
-The `encode` and `decode` methods that `Map[String, String]` to and from the format found in the browser have been extracted into `CookieDataCodec`.  There are three implementations: `SignedCookieDataCodec`, `JWTCookieDataCodec`, and `FallbackCookieDataCodec`, which respectively represent URL-encoded with an HMAC, or a JWT, or a "read signed or JWT, write JWT" codec.
+The `encode` and `decode` methods that `Map[String, String]` to and from the format found in the browser have been extracted into `CookieDataCodec`.  There are three implementations: `FallbackCookieDataCodec`, `JWTCookieDataCodec`, or `UrlEncodedCookieDataCodec`, which respectively represent URL-encoded with an HMAC, or a JWT, or a "read signed or JWT, write JWT" codec.
   
-To use an implementation, add it to your class:  
+
+and then provide a `JWTConfiguration` case class, using the `JWTConfigurationParser` with the path to your configuration, or use `JWTConfiguration()` for the defaults.
+
 
 ```scala
-class MyCookieBaker[T](val secretConfiguration: SecretConfiguration, val jwtConfiguration: JWTConfiguration) extends CookieBaker[T] with JWTCookieDataCodec
-```
+@Singleton
+class UserInfoCookieBaker @Inject()(service: UserInfoService,
+                                    val secretConfiguration: SecretConfiguration)
+  extends CookieBaker[UserInfo] with JWTCookieDataCodec {
 
-and then provide a `JWTConfiguration` case class, using the `JWTConfigurationParser` with the path to your configuration.
+  override val COOKIE_NAME: String = "userInfo"
+
+  override val isSigned = true
+
+  override def emptyCookie: UserInfo = new UserInfo()
+
+  override protected def serialize(userInfo: UserInfo): Map[String, String] = service.encrypt(userInfo)
+
+  override protected def deserialize(data: Map[String, String]): UserInfo = service.decrypt(data)
+
+  override val path: String = "/"
+
+  override val jwtConfiguration: JWTConfiguration = JWTConfigurationParser()
+}
+```
 
 ## Updated libraries
 

--- a/documentation/manual/working/commonGuide/configuration/SettingsSession.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsSession.md
@@ -10,14 +10,14 @@ When a session cookie is created, the "issued at" `iat` and "not before" `nbf` c
 
 ## Session Timeout / Expiration
 
-By default, there is no technical timeout for the Session. It expires when the user closes the web browser. If you need a functional timeout for a specific application, you set the maximum age of the session cookie by configuring the key `play.http.session.maxAge` in `application.conf`, and this will also set `play.http.session.jwt.expiresAfter` to the same value.  The `maxAge` property will remove the cookie from the browser, and the JWT `exp` claim will be set in the cookie, and will make it invalid after the given duration. 
+By default, there is no technical timeout for the Session. It expires when the user closes the web browser. If you need a functional timeout for a specific application, you set the maximum age of the session cookie by configuring the key `play.http.session.maxAge` in `application.conf`, and this will also set `play.http.session.jwt.expiresAfter` to the same value.  The `maxAge` property will remove the cookie from the browser, and the JWT `exp` claim will be set in the cookie, and will make it invalid after the given duration.
 
 ## URL Encoded Cookie Encoding
 
 The session cookie uses the JWT cookie encoding.  If you want, you can revert back to URL encoded cookie encoding by switching to `play.api.mvc.LegacyCookiesModule` in the application.conf file:
 
 ```
-play.modules.disabled+="play.api.mvc.DefaultCookiesModule"
+play.modules.disabled+="play.api.mvc.CookiesModule"
 play.modules.enabled+="play.api.mvc.LegacyCookiesModule"
 ```
 

--- a/documentation/manual/working/commonGuide/configuration/SettingsSession.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsSession.md
@@ -4,13 +4,22 @@ Play stores the session using a session cookie in the browser.  When you are pro
 
 Session and flash cookies are stored in [JSON Web Token](https://tools.ietf.org/html/rfc7519) (JWT) format.  The encoding is transparent to Play, but there some useful properties of JWT which can be leveraged for session cookies, and can be configured through `application.conf`.  Note that JWT is typically used in an HTTP header value, which is not what is active here -- in addition, the JWT is signed using the secret, but is not encrypted by Play.
 
-### Not Before Support
+## Not Before Support
 
 When a session cookie is created, the "issued at" `iat` and "not before" `nbf` claims in JWT will be set to the time of cookie creation, which prevents a cookie from being accepted before the current time.
 
-### Session Timeout / Expiration
+## Session Timeout / Expiration
 
 By default, there is no technical timeout for the Session. It expires when the user closes the web browser. If you need a functional timeout for a specific application, you set the maximum age of the session cookie by configuring the key `play.http.session.maxAge` in `application.conf`, and this will also set `play.http.session.jwt.expiresAfter` to the same value.  The `maxAge` property will remove the cookie from the browser, and the JWT `exp` claim will be set in the cookie, and will make it invalid after the given duration. 
+
+## URL Encoded Cookie Encoding
+
+The session cookie uses the JWT cookie encoding.  If you want, you can revert back to URL encoded cookie encoding by switching to `play.api.mvc.LegacyCookiesModule` in the application.conf file:
+
+```
+play.modules.disabled+="play.api.mvc.DefaultCookiesModule"
+play.modules.enabled+="play.api.mvc.LegacyCookiesModule"
+```
 
 ## Session Configuration
 

--- a/documentation/manual/working/javaGuide/main/tests/code/tests/guice/JavaGuiceApplicationBuilderTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/tests/guice/JavaGuiceApplicationBuilderTest.java
@@ -52,7 +52,7 @@ public class JavaGuiceApplicationBuilderTest {
         ClassLoader classLoader = new URLClassLoader(new URL[0]);
         // #set-environment
         Application application = new GuiceApplicationBuilder()
-            .load(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule(), new play.api.i18n.I18nModule()) // ###skip
+            .load(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule(), new play.api.i18n.I18nModule(), new play.api.mvc.CookiesModule()) // ###skip
             .loadConfig(ConfigFactory.defaultReference()) // ###skip
             .configure("play.http.filters", "play.api.http.NoHttpFilters") // ###skip
             .in(new Environment(new File("path/to/app"), classLoader, Mode.TEST))
@@ -69,7 +69,7 @@ public class JavaGuiceApplicationBuilderTest {
         ClassLoader classLoader = new URLClassLoader(new URL[0]);
         // #set-environment-values
         Application application = new GuiceApplicationBuilder()
-            .load(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule(), new play.api.i18n.I18nModule()) // ###skip
+            .load(new play.api.inject.BuiltinModule(), new play.inject.BuiltInModule(), new play.api.i18n.I18nModule(), new play.api.mvc.CookiesModule()) // ###skip
             .loadConfig(ConfigFactory.defaultReference()) // ###skip
             .configure("play.http.filters", "play.api.http.NoHttpFilters") // ###skip
             .in(new File("path/to/app"))
@@ -149,6 +149,7 @@ public class JavaGuiceApplicationBuilderTest {
                 Guiceable.modules(
                     new play.api.inject.BuiltinModule(),
                     new play.api.i18n.I18nModule(),
+                    new play.api.mvc.CookiesModule(),
                     new play.inject.BuiltInModule()
                 ),
                 Guiceable.bindings(

--- a/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/ScalaGuiceApplicationBuilderSpec.scala
@@ -28,7 +28,7 @@ class ScalaGuiceApplicationBuilderSpec extends PlaySpecification {
       val classLoader = new URLClassLoader(Array.empty)
       // #set-environment
       val application = new GuiceApplicationBuilder()
-        .load(new play.api.inject.BuiltinModule, new play.api.i18n.I18nModule) // ###skip
+        .load(new play.api.inject.BuiltinModule, new play.api.i18n.I18nModule, new play.api.mvc.CookiesModule) // ###skip
         .loadConfig(Configuration.reference) // ###skip
         .configure("play.http.filters" -> "play.api.http.NoHttpFilters") // ###skip
         .in(Environment(new File("path/to/app"), classLoader, Mode.Test))
@@ -44,7 +44,7 @@ class ScalaGuiceApplicationBuilderSpec extends PlaySpecification {
       val classLoader = new URLClassLoader(Array.empty)
       // #set-environment-values
       val application = new GuiceApplicationBuilder()
-        .load(new play.api.inject.BuiltinModule, new play.api.i18n.I18nModule) // ###skip
+        .load(new play.api.inject.BuiltinModule, new play.api.i18n.I18nModule, new play.api.mvc.CookiesModule) // ###skip
         .loadConfig(Configuration.reference) // ###skip
         .configure("play.http.filters" -> "play.api.http.NoHttpFilters") // ###skip
         .in(new File("path/to/app"))
@@ -119,6 +119,7 @@ class ScalaGuiceApplicationBuilderSpec extends PlaySpecification {
         .load(
           new play.api.inject.BuiltinModule,
           new play.api.i18n.I18nModule,
+          new play.api.mvc.CookiesModule,
           bind[Component].to[DefaultComponent]
         ).injector()
       // #load-modules

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -387,7 +387,7 @@ class CSRFActionHelper(
         // vulnerability
         val newTokenValue = tokenSigner.extractSignedToken(token.value).map(tokenSigner.signToken)
         newTokenValue.fold(newReq)(tv =>
-          newReq.withAttrs(newReq.attrs + (Token.InfoAttr -> TokenInfo(token, tv)))
+          newReq.addAttr(Token.InfoAttr, TokenInfo(token, tv))
         )
       } else {
         newReq
@@ -400,7 +400,7 @@ class CSRFActionHelper(
   }
 
   def tagRequest(request: RequestHeader, token: Token): RequestHeader = {
-    request.withAttrs(request.attrs + (Token.InfoAttr -> TokenInfo(token)))
+    request.addAttr(Token.InfoAttr, TokenInfo(token))
   }
 
   def tagRequest[A](request: Request[A], token: Token): Request[A] = {

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -282,14 +282,13 @@ object CSRF {
  * The CSRF module.
  */
 class CSRFModule extends Module {
-  def bindings(environment: Environment, configuration: Configuration) = {
-    Seq(
-      bind[CSRFTokenSigner].toProvider[CSRFTokenSignerProvider],
-      bind[CSRFConfig].toProvider[CSRFConfigProvider],
-      bind[CSRF.TokenProvider].toProvider[CSRF.TokenProviderProvider],
-      bind[CSRFFilter].toSelf
-    ) ++ ErrorHandler.bindingsFromConfiguration(environment, configuration)
-  }
+  def bindings(environment: Environment, configuration: Configuration) = Seq(
+    bind[play.libs.crypto.CSRFTokenSigner].to(classOf[play.libs.crypto.DefaultCSRFTokenSigner]),
+    bind[CSRFTokenSigner].toProvider[CSRFTokenSignerProvider],
+    bind[CSRFConfig].toProvider[CSRFConfigProvider],
+    bind[CSRF.TokenProvider].toProvider[CSRF.TokenProviderProvider],
+    bind[CSRFFilter].toSelf
+  ) ++ ErrorHandler.bindingsFromConfiguration(environment, configuration)
 }
 
 /**

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -10,8 +10,8 @@ import akka.stream.Materializer
 import com.typesafe.config.ConfigMemorySize
 import play.api._
 import play.api.http.{ HttpConfiguration, HttpErrorHandler }
-import play.api.inject.{ Binding, Module }
-import play.api.libs.crypto.CSRFTokenSigner
+import play.api.inject.{ Binding, Module, bind }
+import play.api.libs.crypto.{ CSRFTokenSigner, CSRFTokenSignerProvider }
 import play.api.libs.typedmap.TypedKey
 import play.api.mvc.Results._
 import play.api.mvc._
@@ -284,6 +284,7 @@ object CSRF {
 class CSRFModule extends Module {
   def bindings(environment: Environment, configuration: Configuration) = {
     Seq(
+      bind[CSRFTokenSigner].toProvider[CSRFTokenSignerProvider],
       bind[CSRFConfig].toProvider[CSRFConfigProvider],
       bind[CSRF.TokenProvider].toProvider[CSRF.TokenProviderProvider],
       bind[CSRFFilter].toSelf

--- a/framework/src/play-guice/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
+++ b/framework/src/play-guice/src/test/java/play/inject/guice/GuiceApplicationBuilderTest.java
@@ -82,7 +82,7 @@ public class GuiceApplicationBuilderTest {
     public void setModuleLoader() {
         Injector injector = new GuiceApplicationBuilder()
             .withModuleLoader((env, conf) -> ImmutableList.of(
-                Guiceable.modules(new play.api.inject.BuiltinModule(), new play.api.i18n.I18nModule()),
+                Guiceable.modules(new play.api.inject.BuiltinModule(), new play.api.i18n.I18nModule(), new play.api.mvc.CookiesModule()),
                 Guiceable.bindings(bind(A.class).to(A1.class))))
             .injector();
 
@@ -93,7 +93,7 @@ public class GuiceApplicationBuilderTest {
     public void setLoadedModulesDirectly() {
         Injector injector = new GuiceApplicationBuilder()
             .load(
-                Guiceable.modules(new play.api.inject.BuiltinModule(), new play.api.i18n.I18nModule()),
+                Guiceable.modules(new play.api.inject.BuiltinModule(), new play.api.i18n.I18nModule(), new play.api.mvc.CookiesModule()),
                 Guiceable.bindings(bind(A.class).to(A1.class)))
             .injector();
 

--- a/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
@@ -4,12 +4,13 @@
 package play.api.inject
 package guice
 
-import javax.inject.{ Inject, Provider, Singleton }
+import javax.inject.{Inject, Provider, Singleton}
 
-import com.google.inject.{ CreationException, ProvisionException }
+import com.google.inject.{CreationException, ProvisionException}
 import org.specs2.mutable.Specification
 import play.api.i18n.I18nModule
-import play.api.{ Configuration, Environment }
+import play.api.mvc.CookiesModule
+import play.api.{Configuration, Environment}
 
 class GuiceApplicationBuilderSpec extends Specification {
 
@@ -58,7 +59,7 @@ class GuiceApplicationBuilderSpec extends Specification {
 
     "set module loader" in {
       val injector = new GuiceApplicationBuilder()
-        .load((env, conf) => Seq(new BuiltinModule, new I18nModule, bind[GuiceApplicationBuilderSpec.A].to[GuiceApplicationBuilderSpec.A1]))
+        .load((env, conf) => Seq(new BuiltinModule, new I18nModule, new CookiesModule, bind[GuiceApplicationBuilderSpec.A].to[GuiceApplicationBuilderSpec.A1]))
         .injector()
 
       injector.instanceOf[GuiceApplicationBuilderSpec.A] must beAnInstanceOf[GuiceApplicationBuilderSpec.A1]
@@ -66,7 +67,7 @@ class GuiceApplicationBuilderSpec extends Specification {
 
     "set loaded modules directly" in {
       val injector = new GuiceApplicationBuilder()
-        .load(new BuiltinModule, new I18nModule, bind[GuiceApplicationBuilderSpec.A].to[GuiceApplicationBuilderSpec.A1])
+        .load(new BuiltinModule, new I18nModule, new CookiesModule, bind[GuiceApplicationBuilderSpec.A].to[GuiceApplicationBuilderSpec.A1])
         .injector()
 
       injector.instanceOf[GuiceApplicationBuilderSpec.A] must beAnInstanceOf[GuiceApplicationBuilderSpec.A1]
@@ -74,14 +75,14 @@ class GuiceApplicationBuilderSpec extends Specification {
 
     "eagerly load singletons" in {
       new GuiceApplicationBuilder()
-        .load(new BuiltinModule, new I18nModule, bind[GuiceApplicationBuilderSpec.C].to[GuiceApplicationBuilderSpec.C1])
+        .load(new BuiltinModule, new I18nModule, new CookiesModule, bind[GuiceApplicationBuilderSpec.C].to[GuiceApplicationBuilderSpec.C1])
         .eagerlyLoaded()
         .injector() must throwA[CreationException]
     }
 
     "work with built in modules and requireAtInjectOnConstructors" in {
       new GuiceApplicationBuilder()
-        .load(new BuiltinModule, new I18nModule)
+        .load(new BuiltinModule, new I18nModule, new CookiesModule)
         .requireAtInjectOnConstructors()
         .eagerlyLoaded()
         .injector() must not(throwA[CreationException])
@@ -89,7 +90,7 @@ class GuiceApplicationBuilderSpec extends Specification {
 
     "set lazy load singletons" in {
       val builder = new GuiceApplicationBuilder()
-        .load(new BuiltinModule, new I18nModule, bind[GuiceApplicationBuilderSpec.C].to[GuiceApplicationBuilderSpec.C1])
+        .load(new BuiltinModule, new I18nModule, new CookiesModule, bind[GuiceApplicationBuilderSpec.C].to[GuiceApplicationBuilderSpec.C1])
 
       builder.injector() must throwAn[CreationException].not
       builder.injector().instanceOf[GuiceApplicationBuilderSpec.C] must throwAn[ProvisionException]

--- a/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationBuilderSpec.scala
@@ -4,13 +4,13 @@
 package play.api.inject
 package guice
 
-import javax.inject.{Inject, Provider, Singleton}
+import javax.inject.{ Inject, Provider, Singleton }
 
-import com.google.inject.{CreationException, ProvisionException}
+import com.google.inject.{ CreationException, ProvisionException }
 import org.specs2.mutable.Specification
 import play.api.i18n.I18nModule
 import play.api.mvc.CookiesModule
-import play.api.{Configuration, Environment}
+import play.api.{ Configuration, Environment }
 
 class GuiceApplicationBuilderSpec extends Specification {
 

--- a/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
@@ -7,12 +7,12 @@ import org.specs2.mutable.Specification
 import com.google.inject.AbstractModule
 import com.typesafe.config.Config
 import play.api.i18n.I18nModule
-import play.{Environment => JavaEnvironment}
-import play.api.{ApplicationLoader, Configuration, Environment}
-import play.api.inject.{BuiltinModule, DefaultApplicationLifecycle}
+import play.{ Environment => JavaEnvironment }
+import play.api.{ ApplicationLoader, Configuration, Environment }
+import play.api.inject.{ BuiltinModule, DefaultApplicationLifecycle }
 import play.api.mvc.CookiesModule
 
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
 class GuiceApplicationLoaderSpec extends Specification {

--- a/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
+++ b/framework/src/play-guice/src/test/scala/play/api/inject/guice/GuiceApplicationLoaderSpec.scala
@@ -7,11 +7,12 @@ import org.specs2.mutable.Specification
 import com.google.inject.AbstractModule
 import com.typesafe.config.Config
 import play.api.i18n.I18nModule
-import play.{ Environment => JavaEnvironment }
-import play.api.{ ApplicationLoader, Configuration, Environment }
-import play.api.inject.{ BuiltinModule, DefaultApplicationLifecycle }
+import play.{Environment => JavaEnvironment}
+import play.api.{ApplicationLoader, Configuration, Environment}
+import play.api.inject.{BuiltinModule, DefaultApplicationLifecycle}
+import play.api.mvc.CookiesModule
 
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 class GuiceApplicationLoaderSpec extends Specification {
@@ -31,7 +32,7 @@ class GuiceApplicationLoaderSpec extends Specification {
     }
 
     "allow replacing automatically loaded modules" in {
-      val builder = new GuiceApplicationBuilder().load(new BuiltinModule, new I18nModule, new ManualTestModule)
+      val builder = new GuiceApplicationBuilder().load(new BuiltinModule, new I18nModule, new CookiesModule, new ManualTestModule)
       val loader = new GuiceApplicationLoader(builder)
       val app = loader.load(fakeContext)
       app.injector.instanceOf[Foo] must beAnInstanceOf[ManualFoo]

--- a/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionOrderTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/it/http/ActionCompositionOrderTest.java
@@ -54,7 +54,7 @@ public class ActionCompositionOrderTest {
     static class WithUsernameAction extends Action<WithUsername> {
         @Override
         public CompletionStage<Result> call(Http.Context ctx) {
-            return delegate.call(ctx.withRequest(ctx.request().withAttrs(ctx.request().attrs().put(Security.USERNAME, configuration.value()))));
+            return delegate.call(ctx.withRequest(ctx.request().addAttr(Security.USERNAME, configuration.value())));
         }
     }
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
@@ -133,7 +133,7 @@ trait HeadActionSpec extends Specification with FutureAwaits with DefaultAwaitTi
     val CustomAttr = TypedKey[String]("CustomAttr")
     def addCustomTagAndAttr(r: RequestHeader): RequestHeader = {
       val withTags = r.copy(tags = Map("CustomTag" -> "x"))
-      val withAttrs = withTags.withAttrs(withTags.attrs.updated(CustomAttr, "y"))
+      val withAttrs = withTags.addAttr(CustomAttr, "y")
       withAttrs
     }
     val tagAndAttrAction = ActionBuilder.ignoringBody { rh: RequestHeader =>

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaHttpHandlerSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaHttpHandlerSpec.scala
@@ -37,7 +37,7 @@ trait JavaHttpHandlerSpec extends PlaySpecification with WsTestClient with Serve
       response.body must beEqualTo("None")
     }
     "route a modified request to a JavaHandler's Action" in handlerResponse(
-      Handler.Stage.modifyRequest(req => req.withAttrs(req.attrs.updated(TestAttr, "Hello!")), javaHandler)
+      Handler.Stage.modifyRequest(req => req.addAttr(TestAttr, "Hello!"), javaHandler)
     ) { response =>
         response.body must beEqualTo("Some(Hello!)")
       }

--- a/framework/src/play-java/src/main/java/play/inject/BuiltInModule.java
+++ b/framework/src/play-java/src/main/java/play/inject/BuiltInModule.java
@@ -7,10 +7,8 @@ import play.api.Configuration;
 import play.api.Environment;
 import play.api.inject.Binding;
 import play.libs.Files;
-import play.libs.crypto.CSRFTokenSigner;
 import play.libs.crypto.CookieSigner;
-import play.libs.crypto.DefaultCSRFTokenSigner;
-import play.libs.crypto.HMACSHA1CookieSigner;
+import play.libs.crypto.DefaultCookieSigner;
 import play.mvc.FileMimeTypes;
 import scala.collection.Seq;
 
@@ -21,8 +19,7 @@ public class BuiltInModule extends play.api.inject.Module {
             bind(ApplicationLifecycle.class).to(DelegateApplicationLifecycle.class),
             bind(play.Environment.class).toSelf(),
             bind(play.Configuration.class).toProvider(ConfigurationProvider.class),
-            bind(CSRFTokenSigner.class).to(DefaultCSRFTokenSigner.class),
-            bind(CookieSigner.class).to(HMACSHA1CookieSigner.class),
+            bind(CookieSigner.class).to(DefaultCookieSigner.class),
             bind(Files.TemporaryFileCreator.class).to(Files.DelegateTemporaryFileCreator.class),
             bind(FileMimeTypes.class).toSelf()
         );

--- a/framework/src/play-java/src/test/java/play/mvc/AttributesTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/AttributesTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.mvc;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import play.core.j.RequestHeaderImpl;
+import play.libs.typedmap.TypedKey;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public final class AttributesTest {
+
+	@Parameters
+	public static Collection<Http.RequestHeader> targets() {
+		return Arrays.asList(new Http.RequestBuilder().build(),
+				new RequestHeaderImpl(new Http.RequestBuilder().build().asScala()));
+	}
+
+	private Http.RequestHeader requestHeader;
+
+	public AttributesTest(final Http.RequestHeader requestHeader) {
+		this.requestHeader = requestHeader;
+	}
+
+	@Test
+	public void testRequestHeader_addSingleAttribute() {
+		final TypedKey<String> color = TypedKey.create("color");
+
+		final Http.RequestHeader newRequestHeader = requestHeader.addAttr(color, "red");
+
+		assertTrue(newRequestHeader.attrs().containsKey(color));
+		assertEquals("red", newRequestHeader.attrs().get(color));
+	}
+
+	@Test
+	public void testRequestHeader_KeepCurrentAttributesWhenAddingANewOne() {
+		final TypedKey<Long> number = TypedKey.create("number");
+		final TypedKey<String> color = TypedKey.create("color");
+
+		Http.RequestHeader newRequestHeader = requestHeader.addAttr(color, "red")
+				.addAttr(number, 5L);
+
+		assertTrue(newRequestHeader.attrs().containsKey(number));
+		assertTrue(newRequestHeader.attrs().containsKey(color));
+		assertEquals(((Long) 5L), newRequestHeader.attrs().get(number));
+		assertEquals("red", newRequestHeader.attrs().get(color));
+	}
+
+	@Test
+	public void testRequestHeader_OverrideExistingValue() {
+		final TypedKey<Long> number = TypedKey.create("number");
+		final TypedKey<String> color = TypedKey.create("color");
+
+		Http.RequestHeader newRequestHeader = requestHeader
+				.addAttr(color, "red")
+				.addAttr(number, 5L)
+				.addAttr(color, "white");
+
+		assertTrue(newRequestHeader.attrs().containsKey(number));
+		assertTrue(newRequestHeader.attrs().containsKey(color));
+		assertEquals(((Long) 5L), newRequestHeader.attrs().get(number));
+		assertEquals("white", newRequestHeader.attrs().get(color));
+	}
+
+}

--- a/framework/src/play-java/src/test/java/play/mvc/RequestBuilderTest.java
+++ b/framework/src/play-java/src/test/java/play/mvc/RequestBuilderTest.java
@@ -4,16 +4,16 @@
 package play.mvc;
 
 import akka.stream.javadsl.Source;
+import org.junit.Test;
 import play.api.Application;
 import play.api.Play;
 import play.api.inject.guice.GuiceApplicationBuilder;
 import play.core.j.JavaContextComponents;
+import play.libs.Files.TemporaryFileCreator;
 import play.libs.typedmap.TypedKey;
-import play.libs.Files.*;
 import play.mvc.Http.Context;
 import play.mvc.Http.Request;
 import play.mvc.Http.RequestBuilder;
-import org.junit.Test;
 
 import java.io.File;
 import java.util.Collections;
@@ -132,7 +132,7 @@ public class RequestBuilderTest {
     public void testUsername() {
         final Request req1 =
             new RequestBuilder().uri("http://playframework.com/").build();
-        final Request req2 = req1.withAttrs(req1.attrs().put(Security.USERNAME, "user2"));
+        final Request req2 = req1.addAttr(Security.USERNAME, "user2");
         final Request req3 = req1.withUsername("user3");
         final Request req4 =
                 new RequestBuilder().uri("http://playframework.com/").username("user4").build();

--- a/framework/src/play/src/main/java/play/libs/crypto/DefaultCookieSigner.java
+++ b/framework/src/play/src/main/java/play/libs/crypto/DefaultCookieSigner.java
@@ -7,23 +7,20 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**
- * Authenticates a cookie by creating a  message authentication code using HMAC-SHA1.
+ * This class delegates to the Scala CookieSigner.
  */
 @Singleton
-public class HMACSHA1CookieSigner implements CookieSigner {
+public class DefaultCookieSigner implements CookieSigner {
 
     private final play.api.libs.crypto.CookieSigner signer;
 
     @Inject
-    public HMACSHA1CookieSigner(play.api.libs.crypto.CookieSigner signer) {
+    public DefaultCookieSigner(play.api.libs.crypto.CookieSigner signer) {
         this.signer = signer;
     }
 
     /**
-     * Signs the given String with HMAC-SHA1 using the application's secret key.
-     * <br>
-     * By default this uses the platform default JSSE provider.  This can be overridden by defining
-     * <code>application.crypto.provider</code> in <code>application.conf</code>.
+     * Signs the given String using the application's secret key.
      *
      * @param message The message to sign.
      * @return A hexadecimal encoded signature.
@@ -34,10 +31,8 @@ public class HMACSHA1CookieSigner implements CookieSigner {
     }
 
     /**
-     * Signs the given String with HMAC-SHA1 using the given key.
+     * Signs the given String using the given key.
      * <br>
-     * By default this uses the platform default JSSE provider.  This can be overridden by defining
-     * <code>application.crypto.provider</code> in <code>application.conf</code>.
      *
      * @param message The message to sign.
      * @param key     The private key to sign with.

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -540,6 +540,15 @@ public class Http {
         RequestHeader withAttrs(TypedMap newAttrs);
 
         /**
+         * Create a new versions of this object with the given attribute attached to it.
+         *
+         * @param key The new attribute key.
+         * @param value  The attribute value.
+         * @return The new version of this object with the new attribute.
+         */
+        <A> RequestHeader addAttr(TypedKey<A> key, A value);
+
+        /**
          * Attach a body to this header.
          *
          * @param body The body to attach.
@@ -698,6 +707,9 @@ public class Http {
 
         // Override return type
         Request withAttrs(TypedMap newAttrs);
+
+        // Override return type
+        <A> Request addAttr(TypedKey<A> key, A value);
 
         /**
          * The user name for this request, if defined.
@@ -1047,7 +1059,7 @@ public class Http {
          * @return the request builder with extra attribute
          */
         public <T> RequestBuilder attr(TypedKey<T> key, T value) {
-            req = req.withAttrs(req.attrs().updated(key.underlying(), value));
+            req = req.addAttr(key.underlying(), value);
             return this;
         }
 

--- a/framework/src/play/src/main/java/play/mvc/Security.java
+++ b/framework/src/play/src/main/java/play/mvc/Security.java
@@ -5,12 +5,16 @@ package play.mvc;
 
 import play.inject.Injector;
 import play.libs.typedmap.TypedKey;
-import play.mvc.Http.*;
+import play.mvc.Http.Context;
+import play.mvc.Http.Request;
 
-import java.lang.annotation.*;
+import javax.inject.Inject;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import javax.inject.Inject;
 
 /**
  * Defines several security helpers.
@@ -51,7 +55,7 @@ public class Security {
                 Result unauthorized = authenticator.onUnauthorized(ctx);
                 return CompletableFuture.completedFuture(unauthorized);
             } else {
-                Request usernameReq = ctx.request().withAttrs(ctx.request().attrs().put(USERNAME, username));
+                Request usernameReq = ctx.request().addAttr(USERNAME, username);
                 Context usernameCtx = ctx.withRequest(usernameReq);
                 return delegate.call(usernameCtx);
             }

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -809,6 +809,7 @@ play {
     # The enabled modules that should be automatically loaded.
     enabled += "play.api.inject.BuiltinModule"
     enabled += "play.api.i18n.I18nModule"
+    enabled += "play.api.mvc.DefaultCookiesModule"
     enabled += "controllers.AssetsModule"
 
     # A way to disable modules that are automatically enabled

--- a/framework/src/play/src/main/resources/reference.conf
+++ b/framework/src/play/src/main/resources/reference.conf
@@ -809,7 +809,7 @@ play {
     # The enabled modules that should be automatically loaded.
     enabled += "play.api.inject.BuiltinModule"
     enabled += "play.api.i18n.I18nModule"
-    enabled += "play.api.mvc.DefaultCookiesModule"
+    enabled += "play.api.mvc.CookiesModule"
     enabled += "controllers.AssetsModule"
 
     # A way to disable modules that are automatically enabled

--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -15,7 +15,6 @@ import play.api.http._
 import play.api.libs.Files.TemporaryFileReaperConfiguration.TemporaryFileReaperConfigurationProvider
 import play.api.libs.Files._
 import play.api.libs.concurrent.{ ActorSystemProvider, ExecutionContextProvider, MaterializerProvider }
-import play.api.libs.crypto._
 import play.api.mvc._
 import play.api.mvc.request.{ DefaultRequestFactory, RequestFactory }
 import play.api.routing.Router
@@ -74,13 +73,6 @@ class BuiltinModule extends SimpleModule((env, conf) => {
     bind[ExecutionContext].to[ExecutionContextExecutor],
     bind[Executor].to[ExecutionContextExecutor],
     bind[HttpExecutionContext].toSelf,
-
-    bind[CookieSigner].toProvider[CookieSignerProvider],
-    bind[CSRFTokenSigner].toProvider[CSRFTokenSignerProvider],
-
-    bind[CookieHeaderEncoding].to[DefaultCookieHeaderEncoding],
-    bind[SessionCookieBaker].to[DefaultSessionCookieBaker],
-    bind[FlashCookieBaker].to[DefaultFlashCookieBaker],
 
     bind[FileMimeTypes].toProvider[DefaultFileMimeTypesProvider]
   ) ++ dynamicBindings(

--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -49,6 +49,7 @@ class BuiltinModule extends SimpleModule((env, conf) => {
     bind[SecretConfiguration].toProvider[SecretConfigurationProvider],
     bind[TemporaryFileReaperConfiguration].toProvider[TemporaryFileReaperConfigurationProvider],
 
+    bind[CookieHeaderEncoding].to[DefaultCookieHeaderEncoding],
     bind[RequestFactory].to[DefaultRequestFactory],
     bind[TemporaryFileReaper].to[DefaultTemporaryFileReaper],
     bind[TemporaryFileCreator].to[DefaultTemporaryFileCreator],

--- a/framework/src/play/src/main/scala/play/api/libs/crypto/CookieSigner.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/crypto/CookieSigner.scala
@@ -6,10 +6,12 @@ package play.api.libs.crypto
 import java.nio.charset.StandardCharsets
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
-import javax.inject.{ Inject, Provider, Singleton }
+import javax.inject.{Inject, Provider, Singleton}
 
 import play.api.http.SecretConfiguration
 import play.api.libs.Codecs
+import play.libs.crypto
+import play.libs.crypto.DefaultCookieSigner
 
 /**
  * Authenticates a cookie by returning a message authentication code (MAC).
@@ -45,7 +47,7 @@ trait CookieSigner {
    * @return the Java version for this cookie signer.
    */
   def asJava: play.libs.crypto.CookieSigner = {
-    new play.libs.crypto.HMACSHA1CookieSigner(this)
+    new crypto.DefaultCookieSigner(this)
   }
 }
 

--- a/framework/src/play/src/main/scala/play/api/libs/crypto/CookieSigner.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/crypto/CookieSigner.scala
@@ -6,7 +6,7 @@ package play.api.libs.crypto
 import java.nio.charset.StandardCharsets
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
-import javax.inject.{Inject, Provider, Singleton}
+import javax.inject.{ Inject, Provider, Singleton }
 
 import play.api.http.SecretConfiguration
 import play.api.libs.Codecs

--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -739,10 +739,9 @@ case class DefaultJWTCookieDataCodec @Inject() (
 /**
  * A cookie module that uses JWT as the cookie encoding, falling back to URL encoding.
  */
-class DefaultCookiesModule extends SimpleModule((env, conf) => {
+class CookiesModule extends SimpleModule((env, conf) => {
   Seq(
     bind[CookieSigner].toProvider[CookieSignerProvider],
-    bind[CookieHeaderEncoding].to[DefaultCookieHeaderEncoding],
     bind[SessionCookieBaker].to[DefaultSessionCookieBaker],
     bind[FlashCookieBaker].to[DefaultFlashCookieBaker]
   )
@@ -754,7 +753,6 @@ class DefaultCookiesModule extends SimpleModule((env, conf) => {
 class LegacyCookiesModule extends SimpleModule((env, conf) => {
   Seq(
     bind[CookieSigner].toProvider[CookieSignerProvider],
-    bind[CookieHeaderEncoding].to[DefaultCookieHeaderEncoding],
     bind[SessionCookieBaker].to[LegacySessionCookieBaker],
     bind[FlashCookieBaker].to[LegacyFlashCookieBaker]
   )

--- a/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
@@ -100,6 +100,14 @@ class DefaultFlashCookieBaker @Inject() (
   override val signedCodec: UrlEncodedCookieDataCodec = DefaultUrlEncodedCookieDataCodec(isSigned, cookieSigner)
 }
 
+class LegacyFlashCookieBaker @Inject() (
+  val config: FlashConfiguration,
+  val secretConfiguration: SecretConfiguration,
+  val cookieSigner: CookieSigner)
+    extends FlashCookieBaker with UrlEncodedCookieDataCodec {
+  def this() = this(FlashConfiguration(), SecretConfiguration(), new CookieSignerProvider(SecretConfiguration()).get)
+}
+
 @deprecated("Inject [[play.api.mvc.FlashCookieBaker]] instead", "2.6.0")
 object Flash extends FlashCookieBaker with UrlEncodedCookieDataCodec {
   def config: FlashConfiguration = HttpConfiguration.current.flash

--- a/framework/src/play/src/main/scala/play/api/mvc/Request.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Request.scala
@@ -54,6 +54,8 @@ trait Request[+A] extends RequestHeader {
     new RequestImpl[A](connection, method, target, version, newHeaders, attrs, body)
   override def withAttrs(newAttrs: TypedMap): Request[A] =
     new RequestImpl[A](connection, method, target, version, headers, newAttrs, body)
+  override def addAttr[B](key: TypedKey[B], value: B): Request[A] =
+    withAttrs(attrs.updated(key, value))
 }
 
 object Request {

--- a/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -7,7 +7,7 @@ import java.security.cert.X509Certificate
 
 import play.api.http.{ HeaderNames, MediaRange, MediaType }
 import play.api.i18n.Lang
-import play.api.libs.typedmap.{ TypedEntry, TypedMap }
+import play.api.libs.typedmap.{ TypedEntry, TypedKey, TypedMap }
 import play.api.mvc.request._
 
 import scala.annotation.implicitNotFound
@@ -140,6 +140,17 @@ trait RequestHeader {
    */
   def withAttrs(newAttrs: TypedMap): RequestHeader =
     new RequestHeaderImpl(connection, method, target, version, headers, newAttrs)
+
+  /**
+   * Create a new versions of this object with the given attribute attached to it.
+   *
+   * @param key The new attribute key.
+   * @param value  The attribute value.
+   * @tparam A The type of value.
+   * @return The new version of this object with the new attribute.
+   */
+  def addAttr[A](key: TypedKey[A], value: A): RequestHeader =
+    withAttrs(attrs.updated(key, value))
 
   // -- Computed
 
@@ -288,10 +299,10 @@ trait RequestHeader {
 
     // We only need to modify the request when an argument is non-null.
     if (id != null) {
-      newHeader = newHeader.withAttrs(newHeader.attrs.updated(RequestAttrKey.Id, (id: Long)))
+      newHeader = newHeader.addAttr(RequestAttrKey.Id, (id: Long))
     }
     if (tags != null) {
-      newHeader = newHeader.withAttrs(newHeader.attrs.updated(RequestAttrKey.Tags, tags))
+      newHeader = newHeader.addAttr(RequestAttrKey.Tags, tags)
     }
     if (uri != null) {
       newHeader = newHeader.withTarget(newHeader.target.withUriString(uri))

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -14,7 +14,7 @@ import play.api.mvc._
 import play.api.{ Configuration, Environment }
 import play.api.mvc.request.{ RemoteConnection, RequestTarget }
 import play.core.Execution.Implicits.trampoline
-import play.libs.typedmap.TypedMap
+import play.libs.typedmap.{ TypedKey, TypedMap }
 import play.mvc.Http.{ RequestBody, Context => JContext, Cookie => JCookie, Cookies => JCookies, Request => JRequest, RequestHeader => JRequestHeader, RequestImpl => JRequestImpl }
 import play.mvc.{ Security, Result => JResult }
 
@@ -307,6 +307,8 @@ class RequestHeaderImpl(header: RequestHeader) extends JRequestHeader {
   override def attrs: TypedMap = new TypedMap(header.attrs)
   override def withAttrs(newAttrs: TypedMap): JRequestHeader =
     new RequestHeaderImpl(header.withAttrs(newAttrs.underlying()))
+  override def addAttr[A](key: TypedKey[A], value: A): JRequestHeader =
+    withAttrs(attrs.put(key, value))
 
   def withBody(body: RequestBody): JRequest = new JRequestImpl(header.withBody(body))
 
@@ -374,11 +376,14 @@ class RequestImpl(request: Request[RequestBody]) extends RequestHeaderImpl(reque
   override def attrs: TypedMap = new TypedMap(asScala.attrs)
   override def withAttrs(newAttrs: TypedMap): JRequest =
     new RequestImpl(request.withAttrs(newAttrs.underlying()))
+  override def addAttr[A](key: TypedKey[A], value: A): JRequest =
+    withAttrs(attrs.put(key, value))
 
   override def body: RequestBody = request.body
   override def hasBody: Boolean = request.hasBody
   override def withBody(body: RequestBody): JRequest = new RequestImpl(request.withBody(body))
 
   override def username: String = attrs().getOptional(Security.USERNAME).orElse(null)
-  override def withUsername(username: String): JRequest = withAttrs(attrs.put(Security.USERNAME, username))
+  override def withUsername(username: String): JRequest = addAttr(Security.USERNAME, username)
+
 }

--- a/framework/src/play/src/main/scala/play/core/routing/GeneratedRouter.scala
+++ b/framework/src/play/src/main/scala/play/core/routing/GeneratedRouter.scala
@@ -240,7 +240,7 @@ abstract class GeneratedRouter extends Router {
     val modifyRequestFunc: RequestHeader => RequestHeader = { rh: RequestHeader =>
       val newTags = if (rh.tags.isEmpty) tags else rh.tags ++ tags
       val rh2 = rh.copy(tags = newTags)
-      val rh3 = rh2.withAttrs(rh2.attrs.updated(play.api.routing.Router.Attrs.HandlerDef, handlerDef))
+      val rh3 = rh2.addAttr(play.api.routing.Router.Attrs.HandlerDef, handlerDef)
       rh3
     }
 

--- a/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -11,7 +11,6 @@ import play.api.http.HttpConfiguration
 import play.api.i18n.Lang
 import play.api.libs.typedmap.{ TypedKey, TypedMap }
 import play.api.mvc.request.{ DefaultRequestFactory, RemoteConnection, RequestTarget }
-
 class RequestHeaderSpec extends Specification {
 
   "request header" should {
@@ -33,6 +32,25 @@ class RequestHeaderSpec extends Specification {
       "getting a nonexistent attribute should be None" in {
         val x = TypedKey[Int]("x")
         dummyRequestHeader().attrs.get(x) must beNone
+      }
+      "can add single attribute" in {
+        val x = TypedKey[Int]("x")
+        dummyRequestHeader().addAttr(x, 3).attrs(x) must_== 3
+      }
+      "keep current attributes when adding a new one" in {
+        val x = TypedKey[Int]
+        val y = TypedKey[String]
+        dummyRequestHeader().withAttrs(TypedMap(y -> "hello")).addAttr(x, 3).attrs(y) must_== "hello"
+      }
+      "overrides current attribute value" in {
+        val x = TypedKey[Int]
+        val y = TypedKey[String]
+        val requestHeader = dummyRequestHeader().withAttrs(TypedMap(y -> "hello"))
+          .addAttr(x, 3)
+          .addAttr(y, "white")
+
+        requestHeader.attrs(y) must_== "white"
+        requestHeader.attrs(x) must_== 3
       }
     }
 

--- a/framework/src/play/src/test/scala/play/api/mvc/RequestSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RequestSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.mvc
+
+import org.specs2.mutable.Specification
+import play.api.http.HttpConfiguration
+import play.api.libs.typedmap.{ TypedKey, TypedMap }
+import play.api.mvc.request.{ DefaultRequestFactory, RemoteConnection, RequestTarget }
+import play.mvc.Http.RequestBody
+
+class RequestSpec extends Specification {
+
+  "request" should {
+    "have typed attributes" in {
+      "can add single attribute" in {
+        val x = TypedKey[Int]("x")
+        dummyRequest().addAttr(x, 3).attrs(x) must_== 3
+      }
+      "keep current attributes when adding a new one" in {
+        val x = TypedKey[Int]
+        val y = TypedKey[String]
+        dummyRequest().withAttrs(TypedMap(y -> "hello")).addAttr(x, 3).attrs(y) must_== "hello"
+      }
+      "overrides current attribute value" in {
+        val x = TypedKey[Int]
+        val y = TypedKey[String]
+        val request = dummyRequest().withAttrs(TypedMap(y -> "hello"))
+          .addAttr(x, 3)
+          .addAttr(y, "white")
+
+        request.attrs(y) must_== "white"
+        request.attrs(x) must_== 3
+      }
+    }
+  }
+
+  private def dummyRequest(
+    requestMethod: String = "GET",
+    requestUri: String = "/",
+    headers: Headers = Headers()) = {
+    new DefaultRequestFactory(HttpConfiguration()).createRequest(
+      connection = RemoteConnection("", false, None),
+      method = "GET",
+      target = RequestTarget(requestUri, "", Map.empty),
+      version = "",
+      headers = headers,
+      attrs = TypedMap.empty,
+      new RequestBody(null)
+    )
+  }
+
+}

--- a/framework/src/play/src/test/scala/play/core/test/Fakes.scala
+++ b/framework/src/play/src/test/scala/play/core/test/Fakes.scala
@@ -10,7 +10,7 @@ import akka.util.ByteString
 import play.api.http.HttpConfiguration
 import play.api.libs.Files.{ SingletonTemporaryFileCreator, TemporaryFile }
 import play.api.libs.json.JsValue
-import play.api.libs.typedmap.TypedMap
+import play.api.libs.typedmap.{ TypedKey, TypedMap }
 import play.api.mvc._
 import play.api.mvc.request._
 import play.core.parsers.FormUrlEncodedParser
@@ -52,6 +52,8 @@ class FakeRequest[A](request: Request[A]) extends Request[A] {
     new FakeRequest(request.withHeaders(newHeaders))
   override def withAttrs(attrs: TypedMap): FakeRequest[A] =
     new FakeRequest(request.withAttrs(attrs))
+  override def addAttr[B](key: TypedKey[B], value: B): FakeRequest[A] =
+    withAttrs(attrs.updated(key, value))
   override def withBody[B](body: B): FakeRequest[B] =
     new FakeRequest(request.withBody(body))
 
@@ -86,7 +88,7 @@ class FakeRequest[A](request: Request[A]) extends Request[A] {
    */
   def withFlash(data: (String, String)*): FakeRequest[A] = {
     val newFlash = new Flash(flash.data ++ data)
-    withAttrs(attrs.updated(RequestAttrKey.Flash, Cell(newFlash)))
+    addAttr(RequestAttrKey.Flash, Cell(newFlash))
   }
 
   /**
@@ -94,7 +96,7 @@ class FakeRequest[A](request: Request[A]) extends Request[A] {
    */
   def withCookies(cookies: Cookie*): FakeRequest[A] = {
     val newCookies: Cookies = Cookies(CookieHeaderMerging.mergeCookieHeaderCookies(this.cookies ++ cookies))
-    withAttrs(attrs.updated(RequestAttrKey.Cookies, Cell(newCookies)))
+    addAttr(RequestAttrKey.Cookies, Cell(newCookies))
   }
 
   /**
@@ -102,7 +104,7 @@ class FakeRequest[A](request: Request[A]) extends Request[A] {
    */
   def withSession(newSessions: (String, String)*): FakeRequest[A] = {
     val newSession = Session(this.session.data ++ newSessions)
-    withAttrs(attrs.updated(RequestAttrKey.Session, Cell(newSession)))
+    addAttr(RequestAttrKey.Session, Cell(newSession))
   }
 
   /**


### PR DESCRIPTION
## Fixes

Cookie encoding behavior was not modularized before.  This PR breaks out cookie support into modules and documents clearly how to replace cookie encoding functionality so that users have the option to fallback to URL encoded cookies.

Also moves the CSRFTokenSigner to the CSRF module, as it is not in the core functionality.