### PR TITLE
Empty body result failing testcase

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -67,12 +67,13 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       response.body must_== "Hello world"
     }
 
-    "not fail when sending an empty entity" in makeRequest(
-      Results.Ok.sendEntity(HttpEntity.Streamed(Source.empty[ByteString], None, None))
+    // todo might not need this after all though - it's indicative of a lower level behaviour of akka http
+    "not fail when sending an empty entity with a known size zero" in makeRequest(
+      Results.Ok.sendEntity(HttpEntity.Streamed(Source.empty[ByteString], Some(0), None))
     ) {
         response =>
           response.status must_== 200
-          response.header(CONTENT_LENGTH) must beSome(0)
+          response.header(CONTENT_LENGTH) must beSome("0") or beNone
       }
 
     "not fail when sending an empty file" in {
@@ -89,7 +90,7 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       ) {
           response =>
             response.status must_== 200
-            response.header(CONTENT_LENGTH) must beSome(0)
+            response.header(CONTENT_LENGTH) must beSome("0")
         } finally JFiles.delete(emptyPath)
     }
 


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [ ] Have you checked that both Scala and Java APIs are updated?

This is not final, as I need feedback before making it nice. Feel free to also fork this. 

# Helpful things

## Purpose

Exposes Issue https://github.com/playframework/playframework/issues/7194 

## Background Context

I found the place where both Netty and Akka HTTP are tested. But I am not sure this is the right place for this.

I'm just adding this as an automated test case for reference as my time is somewhat limited to go much further but yet I'd like this problem not to appear in the 2.6.0 release.

## References

#7194
