### PR TITLE
[WIP] Akka HTTP performance improvement for strict requests

### DIFF
--- a/framework/src/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
+++ b/framework/src/play-streams/src/main/scala/play/api/libs/streams/Accumulator.scala
@@ -3,6 +3,9 @@
  */
 package play.api.libs.streams
 
+import java.util.Optional
+import java.util.concurrent.CompletionStage
+
 import akka.stream.Materializer
 import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
 
@@ -12,6 +15,7 @@ import scala.compat.java8.FutureConverters._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
+import scala.compat.java8.OptionConverters._
 
 /**
  * An accumulator of elements into a future of a result.
@@ -68,6 +72,11 @@ sealed trait Accumulator[-E, +A] {
    * Run this accumulator by feeding nothing into it.
    */
   def run()(implicit materializer: Materializer): Future[A]
+
+  /**
+   * Run this accumulator by feeding a single element into it.
+   */
+  def run(elem: E)(implicit materializer: Materializer): Future[A]
 
   /**
    * Right associative operator alias for run.
@@ -130,6 +139,10 @@ private class SinkAccumulator[-E, +A](wrappedSink: => Sink[E, Future[A]]) extend
     run(Source.empty)
   }
 
+  def run(elem: E)(implicit materializer: Materializer): Future[A] = {
+    run(Source.single(elem))
+  }
+
   def toSink: Sink[E, Future[A]] = sink
 
   import scala.annotation.unchecked.{ uncheckedVariance => uV }
@@ -139,21 +152,22 @@ private class SinkAccumulator[-E, +A](wrappedSink: => Sink[E, Future[A]]) extend
   }
 }
 
-/**
- * An accumulator that ignores the body passed in, and is immediately available.
- */
-private class DoneAccumulator[+A](future: Future[A]) extends Accumulator[Any, A] {
+private class StrictAccumulator[-E, +A](handler: Option[E] => Future[A], val toSink: Sink[E, Future[A]]) extends Accumulator[E, A] {
 
-  def map[B](f: A => B)(implicit executor: ExecutionContext): Accumulator[Any, B] =
-    new DoneAccumulator(
+  private def mapMat[B](f: Future[A] => Future[B])(implicit executor: ExecutionContext): StrictAccumulator[E, B] = {
+    new StrictAccumulator(handler.andThen(f), toSink.mapMaterializedValue(f))
+  }
+
+  override def map[B](f: A => B)(implicit executor: ExecutionContext): Accumulator[E, B] =
+    mapMat { future =>
       future.value match {
         case Some(Success(a)) => Future.fromTry(Try(f(a))) // optimize already completed case
         case _ => future.map(f)
       }
-    )
+    }
 
-  def mapFuture[B](f: A => Future[B])(implicit executor: ExecutionContext): Accumulator[Any, B] =
-    new DoneAccumulator(
+  def mapFuture[B](f: A => Future[B])(implicit executor: ExecutionContext): Accumulator[E, B] =
+    mapMat { future =>
       future.value match {
         // optimize already completed case
         case Some(Success(a)) =>
@@ -163,35 +177,48 @@ private class DoneAccumulator[+A](future: Future[A]) extends Accumulator[Any, A]
           }
         case _ => future.flatMap(f)
       }
-    )
-
-  def recover[B >: A](pf: PartialFunction[Throwable, B])(implicit executor: ExecutionContext): Accumulator[Any, B] =
-    future.value match {
-      case Some(Success(a)) => this // optimize already completed case
-      case _ => new DoneAccumulator(future.recover(pf))
     }
 
-  def recoverWith[B >: A](pf: PartialFunction[Throwable, Future[B]])(implicit executor: ExecutionContext): Accumulator[Any, B] =
-    future.value match {
-      case Some(Success(a)) => this // optimize already completed case
-      case _ => new DoneAccumulator(future.recoverWith(pf))
+  def recover[B >: A](pf: PartialFunction[Throwable, B])(implicit executor: ExecutionContext): Accumulator[E, B] =
+    mapMat { future =>
+      future.value match {
+        case Some(Success(a)) => future // optimize already completed case
+        case _ => future.recover(pf)
+      }
     }
 
-  def through[F](flow: Flow[F, Any, _]): Accumulator[F, A] = this
+  def recoverWith[B >: A](pf: PartialFunction[Throwable, Future[B]])(implicit executor: ExecutionContext): Accumulator[E, B] =
+    mapMat { future =>
+      future.value match {
+        case Some(Success(a)) => future // optimize already completed case
+        case _ => future.recoverWith(pf)
+      }
+    }
 
-  def run(source: Source[Any, _])(implicit materializer: Materializer): Future[A] = {
-    source.toMat(Sink.cancelled)((_, _) => future).run()
+  override def through[F](flow: Flow[F, E, _]): Accumulator[F, A] = {
+    new SinkAccumulator(flow.toMat(toSink)(Keep.right))
   }
 
-  def run()(implicit materializer: Materializer): Future[A] = future
+  override def run(source: Source[E, _])(implicit materializer: Materializer): Future[A] = {
+    source.runWith(toSink)
+  }
 
-  def toSink: Sink[Any, Future[A]] = Sink.cancelled.mapMaterializedValue(_ => future)
+  override def run()(implicit materializer: Materializer): Future[A] = {
+    handler(None)
+  }
+
+  override def run(elem: E)(implicit materializer: Materializer): Future[A] = {
+    handler(Some(elem))
+  }
 
   import scala.annotation.unchecked.{ uncheckedVariance => uV }
 
-  def asJava: play.libs.streams.Accumulator[Any @uV, A @uV] = {
-    play.libs.streams.Accumulator.done(future.toJava)
-  }
+  override def asJava: play.libs.streams.Accumulator[E @uV, A @uV] = play.libs.streams.Accumulator.strict(
+    new java.util.function.Function[Optional[E], CompletionStage[A]] {
+      override def apply(t: Optional[E]) = handler(t.asScala).toJava
+    },
+    toSink.mapMaterializedValue(FutureConverters.toJava).asJava
+  )
 }
 
 private class FlattenedAccumulator[-E, +A](future: Future[Accumulator[E, A]])(implicit materializer: Materializer)
@@ -231,7 +258,7 @@ object Accumulator {
    * The underlying sink will cancel as soon as its onSubscribe method is called, and the materialized value will be
    * an immediately available future of `a`.
    */
-  def done[A](a: A): Accumulator[Any, A] = new DoneAccumulator[A](Future.successful(a))
+  def done[A](a: A): Accumulator[Any, A] = done(Future.successful(a))
 
   /**
    * Create a done accumulator.
@@ -239,7 +266,18 @@ object Accumulator {
    * The underlying sink will cancel as soon as its onSubscribe method is called, and the materialized value will be
    * the passed in future.
    */
-  def done[A](a: Future[A]): Accumulator[Any, A] = new DoneAccumulator(a)
+  def done[A](a: Future[A]): Accumulator[Any, A] =
+    new StrictAccumulator[Any, A](_ => a, Sink.cancelled.mapMaterializedValue(_ => a))
+
+  /**
+   * Create an accumulator that is capable of handling the stream as a single, possibly empty, element, with a sink
+   * provided as a fallback if the stream can't be expressed as a single element.
+   *
+   * This is intended to be able to be used to avoid a stream materialization for strict entities.
+   */
+  def strict[E, A](strictHandler: Option[E] => Future[A], toSink: Sink[E, Future[A]]): Accumulator[E, A] = {
+    new StrictAccumulator(strictHandler, toSink)
+  }
 
   /**
    * Create an accumulator that forwards the stream fed into it to the source it produces.

--- a/framework/src/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/api/libs/streams/AccumulatorSpec.scala
@@ -27,7 +27,6 @@ class AccumulatorSpec extends Specification {
     }
   }
 
-  def sum: Accumulator[Int, Int] = Accumulator(Sink.fold[Int, Int](0)(_ + _))
   def source = Source(1 to 3)
   def await[T](f: Future[T]) = Await.result(f, 10.seconds)
   def error[T](any: Any): T = throw sys.error("error")
@@ -40,7 +39,9 @@ class AccumulatorSpec extends Specification {
     }
   })
 
-  "an accumulator" should {
+  "a sink accumulator" should {
+    def sum: Accumulator[Int, Int] = Accumulator(Sink.fold[Int, Int](0)(_ + _))
+
     "provide map" in withMaterializer { implicit m =>
       await(sum.map(_ + 10).run(source)) must_== 16
     }
@@ -57,7 +58,7 @@ class AccumulatorSpec extends Specification {
         }.run(source)) must_== 20
       }
 
-      "when the exception comes from the stream" in withMaterializer { implicit m =>
+      "when the exception comes fom the stream" in withMaterializer { implicit m =>
         await(sum.recover {
           case e => 20
         }.run(errorSource)) must_== 20
@@ -113,4 +114,133 @@ class AccumulatorSpec extends Specification {
       }
     }
   }
+
+  "a strict accumulator" should {
+    def sum: Accumulator[Int, Int] = Accumulator.strict[Int, Int](e => Future.successful(e.getOrElse(0)), Sink.fold[Int, Int](0)(_ + _))
+
+    "run with a stream" in {
+
+      "provide map" in withMaterializer { implicit m =>
+        await(sum.map(_ + 10).run(source)) must_== 16
+      }
+
+      "provide mapFuture" in withMaterializer { implicit m =>
+        await(sum.mapFuture(r => Future(r + 10)).run(source)) must_== 16
+      }
+
+      "be recoverable" in {
+
+        "when the exception is introduced in the materialized value" in withMaterializer { implicit m =>
+          await(sum.map(error[Int]).recover {
+            case e => 20
+          }.run(source)) must_== 20
+        }
+
+        "when the exception comes fom the stream" in withMaterializer { implicit m =>
+          await(sum.recover {
+            case e => 20
+          }.run(errorSource)) must_== 20
+        }
+      }
+
+      "be recoverable with a future" in {
+
+        "when the exception is introduced in the materialized value" in withMaterializer { implicit m =>
+          await(sum.map(error[Int]).recoverWith {
+            case e => Future(20)
+          }.run(source)) must_== 20
+        }
+
+        "when the exception comes from the stream" in withMaterializer { implicit m =>
+          await(sum.recoverWith {
+            case e => Future(20)
+          }.run(errorSource)) must_== 20
+        }
+      }
+
+      "be able to be composed with a flow" in withMaterializer { implicit m =>
+        await(sum.through(Flow[Int].map(_ * 2)).run(source)) must_== 12
+      }
+
+      "be able to be composed in a left to right associate way" in withMaterializer { implicit m =>
+        await(source ~>: Flow[Int].map(_ * 2) ~>: sum) must_== 12
+      }
+
+      "be flattenable from a future of itself" in {
+
+        "for a successful future" in withMaterializer { implicit m =>
+          await(Accumulator.flatten(Future(sum)).run(source)) must_== 6
+        }
+
+        "for a failed future" in withMaterializer { implicit m =>
+          val result = Accumulator.flatten[Int, Int](Future.failed(new RuntimeException("failed"))).run(source)
+          await(result) must throwA[RuntimeException]("failed")
+        }
+
+        "for a failed stream" in withMaterializer { implicit m =>
+          await(Accumulator.flatten(Future(sum)).run(errorSource)) must throwA[RuntimeException]("error")
+        }
+      }
+
+      "be compatible with Java accumulator" in {
+        "Java asScala" in withMaterializer { implicit m =>
+          await(play.libs.streams.Accumulator.fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava).asScala().run(source)) must_== 6
+        }
+
+        "Scala asJava" in withMaterializer { implicit m =>
+          await(FutureConverters.toScala(sum.asJava.run(source.asJava, m))) must_== 6
+        }
+      }
+    }
+
+    "run with a single element" in {
+
+      "provide map" in withMaterializer { implicit m =>
+        await(sum.map(_ + 10).run(6)) must_== 16
+      }
+
+      "provide mapFuture" in withMaterializer { implicit m =>
+        await(sum.mapFuture(r => Future(r + 10)).run(6)) must_== 16
+      }
+
+      "be recoverable" in {
+        "when the exception is introduced in the materialized value" in withMaterializer { implicit m =>
+          await(sum.map(error[Int]).recover {
+            case e => 20
+          }.run(6)) must_== 20
+        }
+      }
+
+      "be recoverable with a future" in {
+        "when the exception is introduced in the materialized value" in withMaterializer { implicit m =>
+          await(sum.map(error[Int]).recoverWith {
+            case e => Future(20)
+          }.run(6)) must_== 20
+        }
+      }
+
+      "be able to be composed with a flow" in withMaterializer { implicit m =>
+        await(sum.through(Flow[Int].map(_ * 2)).run(6)) must_== 12
+      }
+
+      "be flattenable from a future of itself" in {
+
+        "for a successful future" in withMaterializer { implicit m =>
+          await(Accumulator.flatten(Future(sum)).run(6)) must_== 6
+        }
+      }
+
+      "be compatible with Java accumulator" in {
+        "Java asScala" in withMaterializer { implicit m =>
+          await(play.libs.streams.Accumulator.fromSink(sum.toSink.mapMaterializedValue(FutureConverters.toJava).asJava).asScala().run(6)) must_== 6
+        }
+
+        "Scala asJava" in withMaterializer { implicit m =>
+          await(FutureConverters.toScala(sum.asJava.run(6, m))) must_== 6
+        }
+      }
+    }
+
+  }
+
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -841,19 +841,32 @@ trait PlayBodyParsers extends BodyParserUtils {
     BodyParser(name + ", maxLength=" + maxLength) { request =>
       import play.core.Execution.Implicits.trampoline
 
-      enforceMaxLength(request, maxLength, Accumulator(
-        Sink.fold[ByteString, ByteString](ByteString.empty)((state, bs) => state ++ bs)
-      ) mapFuture { bytes =>
-          try {
-            Future.successful(Right(parser(request, bytes)))
-          } catch {
-            case NonFatal(e) =>
-              logger.debug(errorMessage, e)
-              createBadResult(errorMessage + ": " + e.getMessage)(request).map(Left(_))
-          }
-        })
-    }
+      def parseBody(bytes: ByteString): Future[Either[Result, A]] = {
+        try {
+          Future.successful(Right(parser(request, bytes)))
+        } catch {
+          case NonFatal(e) =>
+            logger.debug(errorMessage, e)
+            createBadResult(errorMessage + ": " + e.getMessage)(request).map(Left(_))
+        }
+      }
 
+      Accumulator.strict[ByteString, Either[Result, A]](
+        // If the body was strict
+        {
+          case Some(bytes) if bytes.size <= maxLength =>
+            parseBody(bytes)
+          case None =>
+            parseBody(ByteString.empty)
+          case _ =>
+            createBadResult("Request Entity Too Large", REQUEST_ENTITY_TOO_LARGE)(request).map(Left.apply)
+        },
+        // Otherwise, use an enforce max length accumulator on a folding sink
+        enforceMaxLength(request, maxLength, Accumulator(
+          Sink.fold[ByteString, ByteString](ByteString.empty)((state, bs) => state ++ bs)
+        ).mapFuture(parseBody)).toSink
+      )
+    }
 }
 
 /**


### PR DESCRIPTION
Background:

Akka HTTP buffers request bodies as "strict" entities in certain
situations. These bodies are available immediately, and don't need
stream materialization to handle them.

Play's action design requires that all request bodies be handled as
streams, since an action is defined to be a Sink that materializes to a
future of the response, so the only way to pass a body into a Play
action is to feed a Source of the body into that Sink. Even if that body
is a 100 byte body that has already been buffered by Akka HTTP as a
strict entity, and even if actions handling is to simply fold all the
byte strings received together, Play's design still requires that this
in memory body be wrapped in a Source.single, and then fed into a
Sink.fold(_ ++ _). No matter how much Akka streams improves the
performance of its materialization, this materialization will always be
unnecessarily done and a burden on Play's performance.

Play has already added a fast path for when there is no request body,
and the action is not interested in consuming a request body (such as
for GET requests), in the form of a DoneAccumulator, which both the
Netty and Akka HTTP server implementations use by invoking this fast
path when there is no body.

Fix:

This change adds a StrictAccumulator implementation of Accumulator, which
allows an accumulator to specify a fast path that avoids using streams
(and hence materialization) for when there is just one or zero elements to
handle. It deletes the DoneAccumulator, and replaces its usage with
StrictAccumulator, since StrictAccumulator can achieve everything that
the DoneAccumulator can. Both of these classes are private
implementation details of accumulator, there is no public API that has
been broken to make these changes, the factory methods for creating a
done accumulator still exist, just implemented using the struct
accumulator.

The body parsers that buffer the full body have been modified to use the
new strict accumulator, and the Akka HTTP server implementation has been
modified to take advantage of the new run method that has been added to
Accumulator which triggers the StrictAccumulator fast path.

The Netty server implementation hasn't been modified at all - there's no
point, since it does not yet support buffering small bodies in a single
message, and can only be handled with streams.

Still to be done:

* Tests for the Java accumulator have yet to be written
* The Java body parsers do not yet use this.