### PR TITLE
Add security marker context, tag filter failures

### DIFF
--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -101,13 +101,13 @@ Once the template is defined with its dependencies, then the controller can have
 
 ## Filters Enhancements
 
-Play now comes with a default set of enabled filters, defined through configuration.
+Play now comes with a default set of enabled filters, defined through configuration.  This provides a "secure by default" experience for new Play applications, and tightens security on existing Play applications.
 
-* `play.filters.csrf.CSRFFilter`
-* `play.filters.headers.SecurityHeadersFilter`
-* `play.filters.hosts.AllowedHostsFilter`
+The following filters are enabled by default:
 
-This means that on new projects, CSRF protection ([[ScalaCsrf]] / [[JavaCsrf]]), [[SecurityHeaders]] and [[AllowedHostsFilter]] are all defined automatically.  This provides a "secure by default" experience for new Play applications, and tightens security on existing Play applications.
+* `play.filters.csrf.CSRFFilter` prevents CSRF attacks, see [[ScalaCsrf]] / [[JavaCsrf]]
+* `play.filters.headers.SecurityHeadersFilter` prevents XSS and frame origin attacks, see [[SecurityHeaders]]
+* `play.filters.hosts.AllowedHostsFilter` prevents DNS rebinding attacks, see [[AllowedHostsFilter]]
 
 In addition, filters can now be configured through `application.conf`.  To append to the defaults list, use the `+=`:
 
@@ -207,12 +207,27 @@ For more information, please see [[ScalaLogging]] or [[JavaLogging]].
 
 For more information about using Markers in logging, see [TurboFilters](https://logback.qos.ch/manual/filters.html#TurboFilter) and [marker based triggering](https://logback.qos.ch/manual/appenders.html#OnMarkerEvaluator) sections in the Logback manual.
 
+## Security Logging
+
+A security marker has been added for security related operations in Play, and failed security checks now log  at WARN level, with the security marker set.  This ensures that developers always know why a particular request is failing, which is important now that security filters are enabled by default in Play.
+
+The security marker also allows security failures to be triggered or filtered distinct from normal logging.  For example, to disable all logging with the SECURITY marker set, add the following lines to the `logback.xml` file:
+
+```xml
+<turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
+    <Marker>SECURITY</Marker>
+    <OnMatch>DENY</OnMatch>
+</turboFilter>
+```
+
+In addition, log events using the security marker can also trigger a message to a Security Information & Event Management (SEIM) engine for further processing.
+
 ## Improved Form Handling I18N support
 
-The `MessagesApi` and `Lang` classes are used for internationalization in Play, and are required to display error messages in forms. 
- 
- In the past, putting together a form in Play has required [multiple steps](https://www.theguardian.com/info/developer-blog/2015/dec/30/how-to-add-a-form-to-a-play-application), and the creation of a `Messages` instance from a request was not discussed in the context of form handling. 
-  
+The `MessagesApi` and `Lang` classes are used for internationalization in Play, and are required to display error messages in forms.
+
+In the past, putting together a form in Play has required [multiple steps](https://www.theguardian.com/info/developer-blog/2015/dec/30/how-to-add-a-form-to-a-play-application), and the creation of a `Messages` instance from a request was not discussed in the context of form handling. 
+
 In addition, it was inconvenient to have a `Messages` instance passed through all template fragments when form handling was required, and `Messages` implicit support was provided directly through the controller trait.  The I18N API has been refined with the addition of a `MessagesProvider` trait, implicits that are tied directly to requests, and the forms documentation has been improved.
 
 For more information, please see [[ScalaI18N]] or [[JavaI18N]].

--- a/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
@@ -45,6 +45,20 @@ Add the necessary appender(s) to the root:
 </root>
 ```
 
+## Security Logging
+
+A security marker has been added for security related operations in Play, and failed security checks now log  at WARN level, with the security marker set.  This ensures that developers always know why a particular request is failing, which is important now that security filters are enabled by default in Play.
+
+The security marker also allows security failures to be triggered or filtered distinct from normal logging.  For example, to disable all logging with the SECURITY marker set, add the following lines to the `logback.xml` file:
+
+```xml
+<turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
+    <Marker>SECURITY</Marker>
+    <OnMatch>DENY</OnMatch>
+</turboFilter>
+```
+
+In addition, log events using the security marker can also trigger a message to a Security Information & Event Management (SEIM) engine for further processing.
 
 ## Using a custom application loader
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
@@ -7,12 +7,12 @@ import java.util.Locale
 
 import scala.collection.immutable
 import scala.concurrent.Future
-
 import java.net.{ URI, URISyntaxException }
 
 import play.api.LoggerLike
-import play.api.http.{ HttpErrorHandler, HeaderNames, HttpVerbs }
-import play.api.mvc.{ RequestHeader, Results, Result }
+import play.api.MarkerContexts.SecurityMarkerContext
+import play.api.http.{ HeaderNames, HttpErrorHandler, HttpVerbs }
+import play.api.mvc.{ RequestHeader, Result, Results }
 
 /**
  * An abstraction for providing [[play.api.mvc.Action]]s and [[play.api.mvc.Filter]]s that support Cross-Origin
@@ -302,7 +302,7 @@ private[cors] trait AbstractCORSPolicy {
   }
 
   private def handleInvalidCORSRequest(request: RequestHeader): Future[Result] = {
-    logger.trace(s"""Invalid CORS request;Origin=${request.headers.get(HeaderNames.ORIGIN)};Method=${request.method};${HeaderNames.ACCESS_CONTROL_REQUEST_HEADERS}=${request.headers.get(HeaderNames.ACCESS_CONTROL_REQUEST_HEADERS)}""")
+    logger.warn(s"""Invalid CORS request;Origin=${request.headers.get(HeaderNames.ORIGIN)};Method=${request.method};${HeaderNames.ACCESS_CONTROL_REQUEST_HEADERS}=${request.headers.get(HeaderNames.ACCESS_CONTROL_REQUEST_HEADERS)}""")(SecurityMarkerContext)
     Future.successful(Results.Forbidden)
   }
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -158,7 +158,7 @@ class CSRFConfigProvider @Inject() (config: Configuration) extends Provider[CSRF
 
 object CSRF {
 
-  private[csrf] val filterLogger = play.api.Logger("play.filters")
+  private[csrf] val filterLogger = play.api.Logger("play.filters.CSRF")
 
   /**
    * A CSRF token

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/hosts/AllowedHostsFilter.scala
@@ -5,7 +5,8 @@ package play.filters.hosts
 
 import javax.inject.{ Inject, Provider, Singleton }
 
-import play.api.Configuration
+import play.api.MarkerContexts.SecurityMarkerContext
+import play.api.{ Configuration, Logger }
 import play.api.http.{ HttpErrorHandler, Status }
 import play.api.inject._
 import play.api.libs.streams.Accumulator
@@ -18,6 +19,8 @@ import play.core.j.{ JavaContextComponents, JavaHttpErrorHandlerAdapter }
 case class AllowedHostsFilter @Inject() (config: AllowedHostsConfig, errorHandler: HttpErrorHandler)
     extends EssentialFilter {
 
+  private val logger = Logger(this.getClass)
+
   // Java API
   def this(config: AllowedHostsConfig, errorHandler: play.http.HttpErrorHandler, contextComponents: JavaContextComponents) {
     this(config, new JavaHttpErrorHandlerAdapter(errorHandler, contextComponents))
@@ -29,6 +32,7 @@ case class AllowedHostsFilter @Inject() (config: AllowedHostsConfig, errorHandle
     if (hostMatchers.exists(_(req.host))) {
       next(req)
     } else {
+      logger.warn(s"Host not allowed: ${req.host}")(SecurityMarkerContext)
       Accumulator.done(errorHandler.onClientError(req, Status.BAD_REQUEST, s"Host not allowed: ${req.host}"))
     }
   }

--- a/framework/src/play/src/main/scala/play/api/Logger.scala
+++ b/framework/src/play/src/main/scala/play/api/Logger.scala
@@ -400,7 +400,7 @@ trait LowPriorityMarkerContextImplicits {
 /**
  * A default marker context.  This is used by `MarkerContext.apply`, but can also be used to provide
  * explicit typing for markers.  For example, to define a SecurityContext marker, you can define a case
- * object extending DefaultMarkerContext
+ * object extending DefaultMarkerContext:
  *
  * {{{
  * case object SecurityMarkerContext extends DefaultMarkerContext(MarkerFactory.getMarker("SECURITY"))
@@ -410,4 +410,10 @@ trait LowPriorityMarkerContextImplicits {
  */
 class DefaultMarkerContext(someMarker: Marker) extends MarkerContext {
   def marker: Option[Marker] = Option(someMarker)
+}
+
+object MarkerContexts {
+
+  case object SecurityMarkerContext extends DefaultMarkerContext(org.slf4j.MarkerFactory.getMarker("SECURITY"))
+
 }


### PR DESCRIPTION
This PR adds a security marker context, and adds warning log messages tagged with an SLF4J marker when a request fails a security filter.

This serves several purposes:

1. Make people aware why a particular request is failing and why they're getting a 400 code
2. Allow security failures to be marked out distinct from normal Play logging
3. Allow developers to disable security messages with a turbo filter.

May need to add some documentation to show how to turn off the warnings -- essentially in logback.xml you add:

```xml
<turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
    <Marker>SECURITY</Marker>
    <OnMatch>DENY</OnMatch>
  </turboFilter>
```

or triggering an email if you're in production (see https://roman-ivanov.blogspot.com/2015/03/neutral-filters-and-evaluator-ordering.html for a good example)