### PR TITLE
Serve pre deflated files direct from jar files

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -125,6 +125,7 @@ object Dependencies {
     jacksons ++
     Seq(
       "commons-codec" % "commons-codec" % "1.10",
+      "org.apache.commons" % "commons-compress" % "1.13",
 
       playJson,
 

--- a/framework/src/play/src/main/scala/play/api/mvc/RangeResult.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/RangeResult.scala
@@ -5,22 +5,15 @@ package play.api.mvc
 
 import java.nio.charset.StandardCharsets
 
-import akka.NotUsed
-import akka.stream.Attributes
-import akka.stream.FlowShape
-import akka.stream.Inlet
-import akka.stream.Outlet
 import akka.stream.scaladsl.FileIO
-import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 import akka.stream.scaladsl.StreamConverters
-import akka.stream.stage._
 import akka.util.ByteString
 import play.api.http.ContentTypes
 import play.api.http.HeaderNames._
 import play.api.http.HttpEntity
 import play.api.http.Status._
-import play.utils.UriEncoding
+import play.utils.{ StreamsUtils, UriEncoding }
 
 // Long should be good enough to represent even very large files
 // considering that Long.MAX_VALUE is 9223372036854775807 which
@@ -375,7 +368,7 @@ object RangeResult {
         val firstRange = rangeSet.first
         val byteRange = firstRange.byteRange
 
-        val entitySource = source.via(sliceBytesTransformer(byteRange.start, firstRange.length))
+        val entitySource = source.via(StreamsUtils.sliceBytesTransformer(byteRange.start, firstRange.length))
 
         Result(
           ResponseHeader(
@@ -419,41 +412,4 @@ object RangeResult {
     }
   }
 
-  // See https://github.com/akka/akka-http/blob/master/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala#L76
-  private def sliceBytesTransformer(start: Long, length: Option[Long]): Flow[ByteString, ByteString, NotUsed] = {
-    val transformer = new GraphStage[FlowShape[ByteString, ByteString]] {
-      val in: Inlet[ByteString] = Inlet("Slicer.in")
-      val out: Outlet[ByteString] = Outlet("Slicer.out")
-
-      override val shape: FlowShape[ByteString, ByteString] = FlowShape.of(in, out)
-      override def createLogic(inheritedAttributes: Attributes) =
-
-        new GraphStageLogic(shape) with InHandler with OutHandler {
-
-          var toSkip: Long = start
-          var remaining: Long = length.getOrElse(Int.MaxValue)
-
-          override def onPush(): Unit = {
-            val element = grab(in)
-            if (toSkip >= element.length)
-              pull(in)
-            else {
-              val data = element.drop(toSkip.toInt).take(math.min(remaining, Int.MaxValue).toInt)
-              remaining -= data.size
-              push(out, data)
-              if (remaining <= 0) completeStage()
-            }
-            toSkip -= element.length
-          }
-
-          override def onPull() = {
-            pull(in)
-          }
-
-          setHandlers(in, out, this)
-        }
-    }
-
-    Flow[ByteString].via(transformer).named("sliceBytes")
-  }
 }

--- a/framework/src/play/src/main/scala/play/utils/StreamsUtils.scala
+++ b/framework/src/play/src/main/scala/play/utils/StreamsUtils.scala
@@ -1,0 +1,50 @@
+package play.utils
+
+import akka.NotUsed
+import akka.stream.{ Attributes, FlowShape, Inlet, Outlet }
+import akka.stream.scaladsl.Flow
+import akka.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
+import akka.util.ByteString
+
+// Make private[play] once Play Assets controller is moved out of controllers package
+object StreamsUtils {
+
+  // See https://github.com/akka/akka-http/blob/master/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala#L76
+  def sliceBytesTransformer(start: Long, length: Option[Long]): Flow[ByteString, ByteString, NotUsed] = {
+    val transformer = new GraphStage[FlowShape[ByteString, ByteString]] {
+      val in: Inlet[ByteString] = Inlet("Slicer.in")
+      val out: Outlet[ByteString] = Outlet("Slicer.out")
+
+      override val shape: FlowShape[ByteString, ByteString] = FlowShape.of(in, out)
+      override def createLogic(inheritedAttributes: Attributes) =
+
+        new GraphStageLogic(shape) with InHandler with OutHandler {
+
+          var toSkip: Long = start
+          var remaining: Long = length.getOrElse(Int.MaxValue)
+
+          override def onPush(): Unit = {
+            val element = grab(in)
+            if (toSkip >= element.length)
+              pull(in)
+            else {
+              val data = element.drop(toSkip.toInt).take(math.min(remaining, Int.MaxValue).toInt)
+              remaining -= data.size
+              push(out, data)
+              if (remaining <= 0) completeStage()
+            }
+            toSkip -= element.length
+          }
+
+          override def onPull() = {
+            pull(in)
+          }
+
+          setHandlers(in, out, this)
+        }
+    }
+
+    Flow[ByteString].via(transformer).named("sliceBytes")
+  }
+
+}


### PR DESCRIPTION
Fixes #4855

This is an optimization that takes advantage of the fact that resources in jar files are already deflated, and hence can be served directly if deflate compression is requested. This means when the resource is read, it does not first need to be decompressed (as may need to be done when reading pre zipped files from the jar file). It also means no special sbt-web plugins need to be added to the pipeline to enable pre compressed assets in Play, since they are all compressed by virtue of being served directly from the jar file.