### PR TITLE
Fix akka server empty response body

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -183,7 +183,7 @@ class AkkaHttpServer(
 
     val upgradeToWebSocket = request.header[UpgradeToWebSocket]
 
-    // Get the app's HttpErroHandler or fallback to a default value
+    // Get the app's HttpErrorHandler or fallback to a default value
     val errorHandler: HttpErrorHandler = tryApp match {
       case Success(app) => app.errorHandler
       case Failure(_) => DefaultHttpErrorHandler

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -229,6 +229,9 @@ private[server] class AkkaModelConversion(
       case PlayHttpEntity.Strict(data, _) =>
         HttpEntity.Strict(contentType, data)
 
+      case PlayHttpEntity.Streamed(data, Some(contentLength), _) if contentLength == 0 =>
+        HttpEntity.Strict(contentType, ByteString.empty)
+
       case PlayHttpEntity.Streamed(data, Some(contentLength), _) =>
         HttpEntity.Default(contentType, contentLength, data)
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -5,17 +5,13 @@ package play.it.http
 
 import java.nio.file.{ Files => JFiles }
 import java.util.Locale.ENGLISH
-import java.util.concurrent.LinkedBlockingQueue
 
 import akka.stream.scaladsl.Source
-import akka.util.{ ByteString, Timeout }
-import play.api._
+import akka.util.ByteString
 import play.api.http._
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
-import play.api.mvc.Results._
-import play.api.routing.Router
 import play.api.test._
 import play.api.libs.ws._
 import play.api.libs.EventSource
@@ -24,10 +20,7 @@ import play.it._
 
 import scala.util.Try
 import scala.concurrent.Future
-import play.api.http.{ HttpChunk, HttpEntity, Status }
-import play.core.utils.CaseInsensitiveOrdered
-
-import scala.collection.immutable.TreeMap
+import play.api.http.{ HttpChunk, HttpEntity }
 
 class NettyScalaResultsHandlingSpec extends ScalaResultsHandlingSpec with NettyIntegrationSpecification
 class AkkaHttpScalaResultsHandlingSpec extends ScalaResultsHandlingSpec with AkkaHttpIntegrationSpecification
@@ -67,14 +60,13 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       response.body must_== "Hello world"
     }
 
-    // todo might not need this after all though - it's indicative of a lower level behaviour of akka http
-    "not fail when sending an empty entity with a known size zero" in makeRequest(
-      Results.Ok.sendEntity(HttpEntity.Streamed(Source.empty[ByteString], Some(0), None))
-    ) {
-        response =>
-          response.status must_== 200
-          response.header(CONTENT_LENGTH) must beSome("0") or beNone
-      }
+    def emptyStreamedEntity = Results.Ok.sendEntity(HttpEntity.Streamed(Source.empty[ByteString], Some(0), None))
+
+    "not fail when sending an empty entity with a known size zero" in makeRequest(emptyStreamedEntity) {
+      response =>
+        response.status must_== 200
+        response.header(CONTENT_LENGTH) must beSome("0") or beNone
+    }
 
     "not fail when sending an empty file" in {
       val emptyPath = JFiles.createTempFile("empty", ".txt")

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -67,12 +67,13 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       response.body must_== "Hello world"
     }
 
-    "not fail when sending an empty entity" in makeRequest(
-      Results.Ok.sendEntity(HttpEntity.Streamed(Source.empty[ByteString], None, None))
+    // todo might not need this after all though - it's indicative of a lower level behaviour of akka http
+    "not fail when sending an empty entity with a known size zero" in makeRequest(
+      Results.Ok.sendEntity(HttpEntity.Streamed(Source.empty[ByteString], Some(0), None))
     ) {
         response =>
           response.status must_== 200
-          response.header(CONTENT_LENGTH) must beSome(0)
+          response.header(CONTENT_LENGTH) must beSome("0") or beNone
       }
 
     "not fail when sending an empty file" in {
@@ -89,7 +90,7 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
       ) {
           response =>
             response.status must_== 200
-            response.header(CONTENT_LENGTH) must beSome(0)
+            response.header(CONTENT_LENGTH) must beSome("0")
         } finally JFiles.delete(emptyPath)
     }
 


### PR DESCRIPTION
## Fixes

Fixes #7194.

## Purpose

Fix Akka Server version to correctly deliver empty files.

## References

See issue #7194. Tests were added by @ScalaWilliam in #7195 and cherry-picked here.