### PR TITLE
Use FastFuture in Akka Http backend result processing

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -15,6 +15,7 @@ import akka.http.scaladsl.model.headers.Expect
 import akka.http.scaladsl.model.ws.UpgradeToWebSocket
 import akka.http.scaladsl.settings.ServerSettings
 import akka.http.scaladsl.{ ConnectionContext, Http }
+import akka.http.scaladsl.util.FastFuture._
 import akka.stream.Materializer
 import akka.stream.scaladsl._
 import akka.util.ByteString
@@ -242,7 +243,7 @@ class AkkaHttpServer(
       case None => actionAccumulator.run()
       case Some(s) => actionAccumulator.run(s)
     }
-    val responseFuture: Future[HttpResponse] = resultFuture.flatMap { result =>
+    val responseFuture: Future[HttpResponse] = resultFuture.fast.flatMap { result =>
       val cleanedResult: Result = resultUtils.prepareCookies(taggedRequestHeader, result)
       modelConversion.convertResult(taggedRequestHeader, cleanedResult, request.protocol, errorHandler)
     }

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -7,6 +7,7 @@ import java.net.{ InetAddress, InetSocketAddress, URI }
 
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.util.FastFuture._
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
@@ -182,7 +183,7 @@ private[server] class AkkaModelConversion(
 
     resultUtils.resultConversionWithErrorHandling(requestHeaders, unvalidated, errorHandler) { unvalidated =>
       // Convert result
-      resultUtils.validateResult(requestHeaders, unvalidated, errorHandler).map { validated: Result =>
+      resultUtils.validateResult(requestHeaders, unvalidated, errorHandler).fast.map { validated: Result =>
         val convertedHeaders: AkkaHttpHeaders = convertResponseHeaders(validated.header.headers)
         val entity = convertResultBody(requestHeaders, convertedHeaders, validated, protocol)
         val connectionHeader = resultUtils.determineConnectionHeader(requestHeaders, validated)


### PR DESCRIPTION
For simple requests all the Futures are already completed so avoiding any
overhead of using ExecutionContext brings a ~ 4% improvement.