### PR TITLE
Replaced tail recursion in java-test with loop.

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/TestBrowser.java
+++ b/framework/src/play-test/src/main/java/play/test/TestBrowser.java
@@ -83,7 +83,7 @@ public class TestBrowser extends FluentAdapter {
      * @return the return value.
      */
     public <T>T waitUntil(Function<WebDriver, T> f) {
-        FluentWait<WebDriver> wait = fluentWait().withTimeout(3000, TimeUnit.MILLISECONDS);
+        FluentWait<WebDriver> wait = fluentWait().withTimeout(3000L, TimeUnit.MILLISECONDS);
         return waitUntil(wait,f);
     }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you checked that both Scala and Java APIs are updated?

Not sure if there's an equivalent Scala part that requires updating.

# Helpful things

## Purpose

Code analysis turned up this `tail recursion`, where the very last statement of a piece of code calls the same method again. Can be replaced by a loop, which is stated to be considerably faster.

## Background Context

It is both easier to read and avoids method calls. The analysis stated that some JVMs perform this change at compilation time and others don't. In either case, having it in place anyway makes for more readable code.