### PR TITLE
Reuse AbsoluteUri for parsing host in RequestHeader #7229

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -177,7 +177,7 @@ trait RequestHeader {
    * empty string is returned.
    */
   lazy val host: String = {
-    val AbsoluteUri = """(?is)^(https?)://([^/]+)(/.*|$)""".r
+    import RequestHeader.AbsoluteUri
     uri match {
       case AbsoluteUri(proto, hostPort, rest) => hostPort
       case _ => headers.get(HeaderNames.HOST).getOrElse("")
@@ -339,6 +339,8 @@ trait RequestHeader {
 }
 
 object RequestHeader {
+  private val AbsoluteUri = """(?is)^(https?)://([^/]+)(/.*|$)""".r
+
   // “The first "q" parameter (if any) separates the media-range parameter(s) from the accept-params.”
   val qPattern = ";\\s*q=([0-9.]+)".r
 


### PR DESCRIPTION
RequestHeaderSpec will cover this change because it runs concurrently.

Fixes #7229