### PR TITLE
Remove FileInputStream/FileOutputStream

### DIFF
--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaStream.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaStream.java
@@ -48,7 +48,7 @@ public class JavaStream extends WithApplication {
     public void serveFile() throws Exception {
         File file = new File("/tmp/fileToServe.pdf");
         file.deleteOnExit();
-        try (OutputStream os = new FileOutputStream(file)) {
+        try (OutputStream os = java.nio.file.Files.newOutputStream(file.toPath())) {
             IOUtils.write("hi", os, "UTF-8");
         }
         Result result = call(new Controller2(instanceOf(JavaHandlerComponents.class)), fakeRequest(), mat);

--- a/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
+++ b/documentation/manual/working/javaGuide/main/ws/code/javaguide/ws/JavaWS.java
@@ -176,7 +176,7 @@ public class JavaWS {
             String url = "http://example.com";
             //#stream-to-file
             File file = File.createTempFile("stream-to-file-", ".txt");
-            FileOutputStream outputStream = new FileOutputStream(file);
+            OutputStream outputStream = java.nio.file.Files.newOutputStream(file.toPath());
 
             // Make the request
             CompletionStage<? extends StreamedResponse> futureResponse =

--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -359,7 +359,7 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
 
           val downloadedFile: Future[File] = futureResponse.flatMap {
             res =>
-              val outputStream = new FileOutputStream(file)
+              val outputStream = java.nio.file.Files.newOutputStream(file.toPath)
 
               // The sink that writes to the output stream
               val sink = Sink.foreach[ByteString] { bytes =>

--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/EvolutionsApi.scala
@@ -3,7 +3,7 @@
  */
 package play.api.db.evolutions
 
-import java.io.{ FileInputStream, InputStream }
+import java.io.InputStream
 import java.sql._
 import javax.inject.{ Inject, Singleton }
 
@@ -480,7 +480,7 @@ abstract class ResourceEvolutionsReader extends EvolutionsReader {
 class EnvironmentEvolutionsReader @Inject() (environment: Environment) extends ResourceEvolutionsReader {
 
   def loadResource(db: String, revision: Int) = {
-    environment.getExistingFile(Evolutions.fileName(db, revision)).map(new FileInputStream(_)).orElse {
+    environment.getExistingFile(Evolutions.fileName(db, revision)).map(f => java.nio.file.Files.newInputStream(f.toPath)).orElse {
       environment.resourceAsStream(Evolutions.resourceName(db, revision))
     }
   }

--- a/framework/src/play-server/src/main/scala/play/core/server/ProdServerStart.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ProdServerStart.scala
@@ -128,7 +128,7 @@ object ProdServerStart {
       }
 
       val pid = process.pid getOrElse (throw ServerStartException("Couldn't determine current process's pid"))
-      val out = new FileOutputStream(pidFile)
+      val out = java.nio.file.Files.newOutputStream(pidFile.toPath)
       try out.write(pid.getBytes) finally out.close()
 
       Some(pidFile)

--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/DefaultSSLEngineProvider.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/DefaultSSLEngineProvider.scala
@@ -9,7 +9,7 @@ import play.core.ApplicationProvider
 import javax.net.ssl.{ TrustManager, KeyManagerFactory, SSLEngine, SSLContext, X509TrustManager }
 import java.security.KeyStore
 import java.security.cert.X509Certificate
-import java.io.{ FileInputStream, File }
+import java.io.File
 import play.api.Logger
 import scala.util.control.NonFatal
 import play.utils.PlayIO
@@ -38,7 +38,7 @@ class DefaultSSLEngineProvider(serverConfig: ServerConfig, appProvider: Applicat
       val algorithm = if (keyStoreConfig.hasPath("algorithm")) keyStoreConfig.getString("algorithm") else KeyManagerFactory.getDefaultAlgorithm
       val file = new File(path)
       if (file.isFile) {
-        val in = new FileInputStream(file)
+        val in = java.nio.file.Files.newInputStream(file.toPath)
         try {
           keyStore.load(in, password)
           logger.debug("Using HTTPS keystore at " + file.getAbsolutePath)

--- a/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ssl/FakeKeyStore.scala
@@ -9,7 +9,7 @@ import sun.security.x509._
 import java.util.Date
 import java.math.BigInteger
 import java.security.cert.X509Certificate
-import java.io.{ File, FileInputStream, FileOutputStream }
+import java.io.File
 import javax.net.ssl.KeyManagerFactory
 import scala.util.Properties.isJavaAtLeast
 import play.utils.PlayIO
@@ -34,7 +34,7 @@ object FakeKeyStore {
 
     // Should regenerate if we find an unacceptably weak key in there.
     val store = KeyStore.getInstance("JKS")
-    val in = new FileInputStream(keyStoreFile)
+    val in = java.nio.file.Files.newInputStream(keyStoreFile.toPath)
     try {
       store.load(in, "".toCharArray)
     } finally {
@@ -69,14 +69,14 @@ object FakeKeyStore {
       keyStore.load(null, "".toCharArray)
       keyStore.setKeyEntry("playgenerated", keyPair.getPrivate, "".toCharArray, Array(cert))
       keyStore.setCertificateEntry("playgeneratedtrusted", cert)
-      val out = new FileOutputStream(keyStoreFile)
+      val out = java.nio.file.Files.newOutputStream(keyStoreFile.toPath)
       try {
         keyStore.store(out, "".toCharArray)
       } finally {
         PlayIO.closeQuietly(out)
       }
     } else {
-      val in = new FileInputStream(keyStoreFile)
+      val in = java.nio.file.Files.newInputStream(keyStoreFile.toPath)
       try {
         keyStore.load(in, "".toCharArray)
       } finally {

--- a/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.api.mvc
 
-import java.io.{ File, FileOutputStream, InputStream }
+import java.io.{ File, InputStream }
 import java.nio.file.Path
 
 import akka.actor.ActorSystem
@@ -455,7 +455,7 @@ class RangeResultSpec extends Specification {
   private def createFile(path: Path): File = {
     if (!java.nio.file.Files.exists(path)) {
       java.nio.file.Files.createFile(path)
-      val fos = new FileOutputStream(path.toFile)
+      val fos = java.nio.file.Files.newOutputStream(path)
       try {
         fos.write("The file content".getBytes)
       } finally {

--- a/framework/src/play/src/test/scala/play/libs/XMLSpec.scala
+++ b/framework/src/play/src/test/scala/play/libs/XMLSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.libs
 
-import java.io.{ FileOutputStream, File }
+import java.io.File
 
 import org.specs2.mutable.Specification
 import org.xml.sax.SAXException
@@ -17,7 +17,7 @@ class XMLSpec extends Specification {
     }
 
     def writeStringToFile(file: File, text: String) = {
-      val out = new FileOutputStream(file)
+      val out = java.nio.file.Files.newOutputStream(file.toPath)
       try {
         out.write(text.getBytes("utf-8"))
       } finally {

--- a/framework/src/play/src/test/scala/play/utils/ResourcesSpec.scala
+++ b/framework/src/play/src/test/scala/play/utils/ResourcesSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.utils
 
-import java.io.{ FileInputStream, BufferedInputStream, File, FileOutputStream }
+import java.io.{ BufferedInputStream, File }
 import java.net.{ URL, URLConnection, URLStreamHandler }
 import java.util.zip.{ ZipEntry, ZipOutputStream }
 import org.specs2.mutable.Specification
@@ -174,7 +174,7 @@ class ResourcesSpec extends Specification {
   }
 
   private def createZip(zip: File, files: Seq[File]) = {
-    val zipOutputStream = new ZipOutputStream(new FileOutputStream(zip))
+    val zipOutputStream = new ZipOutputStream(java.nio.file.Files.newOutputStream(zip.toPath))
     files.foreach(f => addFileToZip(zipOutputStream, f))
     zipOutputStream.close()
   }
@@ -187,7 +187,7 @@ class ResourcesSpec extends Specification {
     zip.putNextEntry(new ZipEntry(entryName))
 
     if (!file.isDirectory) {
-      val in = new BufferedInputStream(new FileInputStream(file))
+      val in = new BufferedInputStream(java.nio.file.Files.newInputStream(file.toPath))
       var b = in.read()
       while (b > -1) {
         zip.write(b)


### PR DESCRIPTION
Replaces instances of "new FileInputStream" and "new FileOutputStream" with Files.newInputStream and Files.newOutputStream, respectively.

See https://www.cloudbees.com/blog/fileinputstream-fileoutputstream-considered-harmful for the extended version -- the basic idea is that it reduces GC pauses.