### PR TITLE
Add InjectedController and refactor controller hierarchy

### DIFF
--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -30,7 +30,7 @@ import play.api.data.validation.Constraints._
 // #validation-imports
 
 @RunWith(classOf[JUnitRunner])
-class ScalaFormsSpec extends Specification with Controller {
+class ScalaFormsSpec extends Specification with ControllerHelpers {
 
   val messagesApi = new DefaultMessagesApi()
   implicit val messages: Messages = messagesApi.preferred(Seq.empty)
@@ -104,12 +104,12 @@ class ScalaFormsSpec extends Specification with Controller {
     "display global errors user template" in new WithApplication {
       val controller = app.injector.instanceOf[controllers.Application]
       val userForm = controller.userFormConstraintsAdHoc
-      
+
       implicit val request = FakeRequest().withFormUrlEncodedBody("name" -> "Johnny Utah", "age" -> "25")
-      
+
       val boundForm = userForm.bindFromRequest
       boundForm.hasGlobalErrors must beTrue
-      
+
       val html = views.html.user(boundForm)
       html.body must contain("Failed form constraints!")
     }
@@ -531,7 +531,7 @@ class Application @Inject()(components: ControllerComponents) extends AbstractCo
     Ok(views.html.contact.form(contactForm.fill(existingContact)))
   }
   // #contact-edit
-  
+
   // #contact-save
   def saveContact = Action { implicit request =>
     contactForm.bindFromRequest.fold(
@@ -545,7 +545,7 @@ class Application @Inject()(components: ControllerComponents) extends AbstractCo
     )
   }
   // #contact-save
-  
+
   def showContact(id: Int) = Action {
     Ok("Contact id: " + id)
   }

--- a/documentation/manual/working/scalaGuide/main/http/ScalaActions.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaActions.md
@@ -3,7 +3,7 @@
 
 ## What is an Action?
 
-Most of the requests received by a Play application are handled by an `Action`. 
+Most of the requests received by a Play application are handled by an `Action`.
 
 A `play.api.mvc.Action` is basically a `(play.api.mvc.Request => play.api.mvc.Result)` function that handles a request and generates a result to be sent to the client.
 
@@ -13,13 +13,13 @@ An action returns a `play.api.mvc.Result` value, representing the HTTP response 
 
 ## Building an Action
 
-The `play.api.mvc.Action` companion object offers several helper methods to construct an Action value. 
+Within any controller extending `BaseController`, the `Action` value is the default action builder. This action builder contains several helpers for creating `Action`s.
 
 The first simplest one just takes as argument an expression block returning a `Result`:
 
 @[zero-arg-action](code/ScalaActions.scala)
 
-This is the simplest way to create an Action, but we don't get a reference to the incoming request. It is often useful to access the HTTP request calling this Action. 
+This is the simplest way to create an Action, but we don't get a reference to the incoming request. It is often useful to access the HTTP request calling this Action.
 
 So there is another Action builder that takes as an argument a function `Request => Result`:
 
@@ -37,7 +37,7 @@ Body parsers will be covered later in this manual.  For now you just need to kno
 
 ## Controllers are action generators
 
-A `Controller` is nothing more than an object that generates `Action` values. Controllers can be defined as classes to take advantage of [[Dependency Injection|ScalaDependencyInjection]] or as objects.
+A controller in Play is nothing more than an object that generates `Action` values. Controllers are typically defined as classes to take advantage of [[Dependency Injection|ScalaDependencyInjection]].
 
 > **Note:** Keep in mind that defining controllers as objects will not be supported in future versions of Play. Using classes is the recommended approach.
 

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
@@ -109,7 +109,8 @@ import org.specs2.execute.AsResult
         import scala.concurrent.ExecutionContext
         import akka.util.ByteString
 
-        class MyController @Inject() (ws: WSClient)(implicit ec: ExecutionContext) {
+        class MyController @Inject() (ws: WSClient, val controllerComponents: ControllerComponents)
+            (implicit ec: ExecutionContext) extends BaseController {
 
           def forward(request: WSRequest): BodyParser[WSResponse] = BodyParser { req =>
             Accumulator.source[ByteString].mapFuture { source =>
@@ -132,7 +133,7 @@ import org.specs2.execute.AsResult
       "parse the body as csv" in new WithApplication() {
         import scala.concurrent.ExecutionContext.Implicits.global
         //#csv
-        import play.api.mvc._
+        import play.api.mvc.BodyParser
         import play.api.libs.streams._
         import akka.util.ByteString
         import akka.stream.scaladsl._
@@ -216,4 +217,4 @@ import org.specs2.execute.AsResult
     }
   }
 }
- 
+

--- a/framework/src/play-guice/src/main/scala/play/api/libs/concurrent/AkkaGuiceSupport.scala
+++ b/framework/src/play-guice/src/main/scala/play/api/libs/concurrent/AkkaGuiceSupport.scala
@@ -25,7 +25,8 @@ import scala.reflect._
  *
  * Then to use the above actor in your application, add a qualified injected dependency, like so:
  * {{{
- *   class MyController @Inject() (@Named("myActor") myActor: ActorRef) extends Controller {
+ *   class MyController @Inject() (@Named("myActor") myActor: ActorRef, val controllerComponents: ControllerComponents)
+ *       extends BaseController {
  *     ...
  *   }
  * }}}

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/ContentNegotiationSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/ContentNegotiationSpec.scala
@@ -10,7 +10,7 @@ import play.api.test.{ FakeRequest, PlaySpecification }
 
 import scala.concurrent.Future
 
-class ContentNegotiationSpec extends PlaySpecification with BaseController {
+class ContentNegotiationSpec extends PlaySpecification with ControllerHelpers {
 
   implicit val system = ActorSystem()
   implicit val mat = ActorMaterializer()

--- a/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/i18n/MessagesSpec.scala
@@ -4,10 +4,10 @@
 package play.it.i18n
 
 import play.api.test.{ PlaySpecification, WithApplication }
-import play.api.mvc.Controller
+import play.api.mvc.ControllerHelpers
 import play.api.i18n._
 
-class MessagesSpec extends PlaySpecification with Controller {
+class MessagesSpec extends PlaySpecification with ControllerHelpers {
 
   sequential
 

--- a/framework/src/play-test/src/test/scala/play/api/test/HelpersSpec.scala
+++ b/framework/src/play-test/src/test/scala/play/api/test/HelpersSpec.scala
@@ -9,18 +9,16 @@ import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import org.specs2.mutable._
 import play.api.mvc.Results._
-import play.api.mvc.{ ActionBuilder, Controller, EssentialAction }
+import play.api.mvc._
 import play.api.test.Helpers._
 import play.twirl.api.Content
 
 import scala.concurrent.Future
 import scala.language.reflectiveCalls
-import org.specs2.mutable._
-import play.api.mvc.AnyContentAsEmpty
 
 class HelpersSpec extends Specification {
 
-  val ctrl = new Controller {
+  val ctrl = new ControllerHelpers {
     private val Action = ActionBuilder.ignoringBody
     def abcAction: EssentialAction = Action {
       Ok("abc").as("text/plain")

--- a/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Assets.scala
@@ -614,7 +614,7 @@ package controllers {
   @Singleton
   class Assets @Inject() (errorHandler: HttpErrorHandler, meta: AssetsMetadata) extends AssetsBuilder(errorHandler, meta)
 
-  class AssetsBuilder(errorHandler: HttpErrorHandler, meta: AssetsMetadata) extends BaseController {
+  class AssetsBuilder(errorHandler: HttpErrorHandler, meta: AssetsMetadata) extends ControllerHelpers {
 
     import meta._
     import Assets._

--- a/framework/src/play/src/main/scala/play/api/controllers/Default.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/Default.scala
@@ -6,6 +6,7 @@ package controllers
 import javax.inject.Inject
 
 import play.api.mvc._
+import play.twirl.api.Html
 
 @deprecated("Use Default class instead", "2.6.0")
 object Default extends Default
@@ -21,7 +22,7 @@ object Default extends Default
  * GET   /xxx             controllers.Default.error
  * }}}
  */
-class Default @Inject() () extends Controller {
+class Default @Inject() () extends ControllerHelpers {
 
   private val Action = new ActionBuilder.IgnoringBody()(controllers.Execution.trampoline)
 

--- a/framework/src/play/src/main/scala/play/api/controllers/ExternalAssets.scala
+++ b/framework/src/play/src/main/scala/play/api/controllers/ExternalAssets.scala
@@ -29,7 +29,8 @@ import scala.concurrent.{ ExecutionContext, Future }
  * }}}
  *
  */
-class ExternalAssets @Inject() (environment: Environment)(implicit ec: ExecutionContext, fileMimeTypes: FileMimeTypes) extends Controller {
+class ExternalAssets @Inject() (environment: Environment)(implicit ec: ExecutionContext, fileMimeTypes: FileMimeTypes)
+    extends ControllerHelpers {
 
   val AbsolutePath = """^(/|[a-zA-Z]:\\).*""".r
 

--- a/framework/src/play/src/main/scala/play/api/http/FileMimeTypes.scala
+++ b/framework/src/play/src/main/scala/play/api/http/FileMimeTypes.scala
@@ -34,13 +34,13 @@ import scala.annotation.implicitNotFound
  * }
  * }}}
  *
- * or, if [[play.api.mvc.AbstractController]] is extended, then
+ * or, if [[play.api.mvc.BaseController]] is extended, then
  * an implicit fileMimeTypes instance is already made available from
  * [[play.api.mvc.ControllerComponents]], meaning that no explicit import is required:
  *
  * {{{
- * class MyController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
- *    def sendFile() = ...
+ * class MyController @Inject()(val controllerComponents: ControllerComponents) extends BaseController {
+ *   def sendFile() = ...
  * }
  * }}}
  */

--- a/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala
@@ -58,7 +58,8 @@ object Akka {
    *
    * Then to use the above actor in your application, add a qualified injected dependency, like so:
    * {{{
-   *   class MyController @Inject() (@Named("myActor") myActor: ActorRef) extends Controller {
+   *   class MyController @Inject() (@Named("myActor") myActor: ActorRef,
+   *      val controllerComponents: ControllerComponents) extends BaseController {
    *     ...
    *   }
    * }}}

--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -491,7 +491,8 @@ class DefaultActionBuilderImpl(parser: BodyParser[AnyContent])(implicit ec: Exec
 /**
  * Helper object to create `Action` values.
  */
-@deprecated("Inject an ActionBuilder (e.g. DefaultActionBuilder) or use AbstractController instead", "2.6.0")
+@deprecated("Inject an ActionBuilder (e.g. DefaultActionBuilder)" +
+  " or extend BaseController/AbstractController/InjectedController", "2.6.0")
 object Action extends DefaultActionBuilder {
   override def executionContext: ExecutionContext = play.core.Execution.internalContext
   override def parser: BodyParser[AnyContent] = BodyParsers.parse.default

--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -123,7 +123,7 @@ trait QueryStringBindable[A] {
  *   // GET  /show/:user      controllers.Application.show(user)
  *   // For example: /show/42
  *
- *   object Application extends Controller {
+ *   class HomeController @Inject() (val controllerComponents: ControllerComponents) extends BaseController {
  *     def show(user: User) = Action {
  *       ...
  *     }

--- a/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -303,7 +303,7 @@ case class RawBuffer(memoryThreshold: Int, temporaryFileCreator: TemporaryFileCr
  * Legacy body parsers trait. Basically all this does is define a "parse" member with a PlayBodyParsers instance
  * constructed from the running app's settings. If no app is running, we create parsers using default settings and an
  * internally-created materializer. This is done to support legacy behavior. Instead of using this trait, we suggest
- * injecting an instance of PlayBodyParsers (either directly or through AbstractController).
+ * injecting an instance of PlayBodyParsers (either directly or through [[BaseController]] or one of its subclasses).
  */
 trait BodyParsers {
 

--- a/framework/src/play/src/main/scala/play/api/mvc/package.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/package.scala
@@ -8,7 +8,7 @@ package play.api
  *
  * For example, a typical controller:
  * {{{
- * object Application extends Controller {
+ * class HomeController @Inject() (val controllerComponents: ControllerComponents) extends BaseController {
  *
  *   def index = Action {
  *     Ok("It works!")

--- a/framework/src/play/src/test/scala/play/api/libs/CometSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/CometSpec.scala
@@ -18,7 +18,7 @@ import scala.concurrent.{ Await, Future }
 
 class CometSpec extends Specification {
 
-  class MockController(val materializer: Materializer, action: ActionBuilder[Request, AnyContent]) extends Controller {
+  class MockController(val materializer: Materializer, action: ActionBuilder[Request, AnyContent]) extends ControllerHelpers {
 
     //#comet-string
     def cometString = action {

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/dev-mode/app/controllers/Application.scala
@@ -4,8 +4,9 @@
 package controllers
 
 import play.api.mvc._
+import javax.inject.Inject
 
-class Application extends Controller {
+class Application @Inject() (c: ControllerComponents) extends AbstractController(c) {
   def index = Action {
     Ok("original")
   }

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution-without-documentation/app/controllers/Application.scala
@@ -12,7 +12,7 @@ import javax.inject.Inject
 /**
  * i will fail since I check for a undefined class [[Documentation]]
  */
-class Application @Inject() (action: DefaultActionBuilder) extends Controller {
+class Application @Inject() (action: DefaultActionBuilder) extends ControllerHelpers {
 
   def index = action {
     Ok

--- a/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/play-sbt-plugin/distribution/app/controllers/Application.scala
@@ -9,7 +9,7 @@ import scala.collection.JavaConverters._
 
 import javax.inject.Inject
 
-class Application @Inject() (env: Environment, configuration: Configuration) extends Controller {
+class Application @Inject() (env: Environment, configuration: Configuration, c: ControllerComponents) extends AbstractController(c) {
 
   def index = Action {
     Ok(views.html.index("Your new application is ready."))

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/a/app/controllers/a/A.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/a/app/controllers/a/A.scala
@@ -4,8 +4,9 @@
 package controllers.a
 
 import play.api.mvc._
+import javax.inject.Inject
 
-class A extends Controller {
+class A @Inject()(c: ControllerComponents) extends AbstractController(c) {
 
   def index = Action {
     controllers.a.routes.A.index

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/b/app/controllers/b/B.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/b/app/controllers/b/B.scala
@@ -4,8 +4,9 @@
 package controllers.b
 
 import play.api.mvc._
+import javax.inject.Inject
 
-class B extends Controller {
+class B @Inject()(c: ControllerComponents) extends AbstractController(c) {
 
   def index = Action {
     controllers.a.routes.A.index

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/c/app/controllers/c/C.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/aggregate-reverse-routes/c/app/controllers/c/C.scala
@@ -4,8 +4,9 @@
 package controllers.c
 
 import play.api.mvc._
+import javax.inject.Inject
 
-class C extends Controller {
+class C @Inject()(c: ControllerComponents) extends AbstractController(c) {
 
   def index = Action {
     controllers.a.routes.A.index()

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/source-mapping/Application.scala
@@ -4,7 +4,8 @@
 package controllers
 
 import play.api.mvc._
+import javax.inject.Inject
 
-class Application extends Controller {
+class Application @Inject()(c: ControllerComponents) extends AbstractController(c) {
   def index = Action(Ok)
 }


### PR DESCRIPTION
This provides a new controller `InjectedController` that uses method injection. It also refactors the controller hierarchy to remove duplication, makes `BaseController` the actual base controller trait with abstract `ControllerComponents`, and adds additional information to the migration guide.