### PR TITLE
Fixed JNDI initial context initialisation

### DIFF
--- a/framework/src/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
+++ b/framework/src/play-java-jdbc/src/test/java/play/db/DatabaseTest.java
@@ -7,7 +7,6 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
-import javax.naming.InitialContext;
 import javax.sql.DataSource;
 
 import com.google.common.collect.ImmutableMap;
@@ -17,6 +16,8 @@ import org.jdbcdslog.LogSqlDataSource;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.junit.Test;
+
+import play.api.libs.JNDI;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
@@ -48,6 +49,7 @@ public class DatabaseTest {
         Database db = Databases.createFrom("test", "org.h2.Driver", "jdbc:h2:mem:test", config);
         assertThat(db.getName(), equalTo("test"));
         assertThat(db.getUrl(), equalTo("jdbc:h2:mem:test"));
+        assertThat(JNDI.initialContext().lookup("DefaultDS"), equalTo(db.getDataSource()));
         db.shutdown();
     }
 
@@ -90,7 +92,7 @@ public class DatabaseTest {
         Database db = Databases.inMemoryWith("jndiName", "DefaultDS");
         assertThat(db.getName(), equalTo("default"));
         assertThat(db.getUrl(), equalTo("jdbc:h2:mem:default"));
-        assertThat(new InitialContext().lookup("DefaultDS"), equalTo(db.getDataSource()));
+        assertThat(JNDI.initialContext().lookup("DefaultDS"), equalTo(db.getDataSource()));
         db.shutdown();
     }
 
@@ -192,7 +194,7 @@ public class DatabaseTest {
         Map<String, String> config = ImmutableMap.of("jndiName", "DefaultDS", "logSql", "true");
         Database db = Databases.createFrom("test", "org.h2.Driver", "jdbc:h2:mem:test", config);
         assertThat(db.getDataSource(), instanceOf(LogSqlDataSource.class));
-        assertThat(new InitialContext().lookup("DefaultDS"), instanceOf(LogSqlDataSource.class));
+        assertThat(JNDI.initialContext().lookup("DefaultDS"), instanceOf(LogSqlDataSource.class));
         db.shutdown();
     }
 }

--- a/framework/src/play-jdbc/src/main/resources/jndi.properties
+++ b/framework/src/play-jdbc/src/main/resources/jndi.properties
@@ -1,2 +1,0 @@
-java.naming.provider.url=/
-java.naming.factory.initial=tyrex.naming.MemoryContextFactory

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/BoneCPModule.scala
@@ -5,12 +5,13 @@ package play.api.db
 
 import java.sql.{ Connection, Statement }
 import javax.inject.{ Inject, Singleton }
-import javax.naming.InitialContext
 import javax.sql.DataSource
 
 import com.typesafe.config.Config
 import play.api._
 import play.api.inject._
+import play.api.libs.JNDI
+
 import com.jolbox.bonecp._
 import com.jolbox.bonecp.hooks._
 
@@ -121,7 +122,7 @@ class BoneConnectionPool @Inject() (environment: Environment) extends Connection
 
     // Bind in JNDI
     dbConfig.jndiName foreach { jndiName =>
-      new InitialContext().rebind(jndiName, wrappedDataSource)
+      JNDI.initialContext.rebind(jndiName, wrappedDataSource)
       logger.info(s"""datasource [$name] bound to JNDI as $jndiName""")
     }
 

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
@@ -4,13 +4,13 @@
 package play.api.db
 
 import javax.inject.{ Inject, Singleton }
-import javax.naming.InitialContext
 import javax.sql.DataSource
 
 import com.typesafe.config.Config
 import com.zaxxer.hikari.{ HikariConfig, HikariDataSource }
 import play.api._
 import play.api.inject._
+import play.api.libs.JNDI
 
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.util.{ Failure, Success, Try }
@@ -53,7 +53,7 @@ class HikariCPConnectionPool @Inject() (environment: Environment) extends Connec
 
       // Bind in JNDI
       dbConfig.jndiName.foreach { jndiName =>
-        new InitialContext().rebind(jndiName, wrappedDataSource)
+        JNDI.initialContext.rebind(jndiName, wrappedDataSource)
         logger.info(s"datasource [$name] bound to JNDI as $jndiName")
       }
 

--- a/framework/src/play/src/main/scala/play/api/libs/JNDI.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/JNDI.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.libs
+
+import play.api._
+
+import javax.naming._
+import javax.naming.Context._
+
+/**
+ * JNDI Helpers.
+ */
+object JNDI {
+
+  private val IN_MEMORY_JNDI = "tyrex.naming.MemoryContextFactory"
+  private val IN_MEMORY_URL = "/"
+
+  /**
+   * An in memory JNDI implementation.
+   */
+  lazy val initialContext = {
+
+    val env = new java.util.Hashtable[String, String]
+
+    env.put(INITIAL_CONTEXT_FACTORY, {
+      Play.privateMaybeApplication.flatMap(_.configuration.getOptional[String](INITIAL_CONTEXT_FACTORY)).getOrElse {
+        System.setProperty(INITIAL_CONTEXT_FACTORY, IN_MEMORY_JNDI)
+        IN_MEMORY_JNDI
+      }
+    })
+
+    env.put(PROVIDER_URL, {
+      Play.privateMaybeApplication.flatMap(_.configuration.getOptional[String](PROVIDER_URL)).getOrElse {
+        System.setProperty(PROVIDER_URL, IN_MEMORY_URL)
+        IN_MEMORY_URL
+      }
+    })
+
+    new InitialContext(env)
+
+  }
+
+}

--- a/framework/src/play/src/main/scala/play/api/libs/JNDI.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/JNDI.scala
@@ -1,9 +1,7 @@
 /*
- * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
 package play.api.libs
-
-import play.api._
 
 import javax.naming._
 import javax.naming.Context._
@@ -24,16 +22,22 @@ object JNDI {
     val env = new java.util.Hashtable[String, String]
 
     env.put(INITIAL_CONTEXT_FACTORY, {
-      Play.privateMaybeApplication.flatMap(_.configuration.getOptional[String](INITIAL_CONTEXT_FACTORY)).getOrElse {
+      val initialContextFactory = System.getProperty(INITIAL_CONTEXT_FACTORY)
+      if (initialContextFactory != null) {
         System.setProperty(INITIAL_CONTEXT_FACTORY, IN_MEMORY_JNDI)
         IN_MEMORY_JNDI
+      } else {
+        initialContextFactory
       }
     })
 
     env.put(PROVIDER_URL, {
-      Play.privateMaybeApplication.flatMap(_.configuration.getOptional[String](PROVIDER_URL)).getOrElse {
+      val providerUrl = System.getProperty(PROVIDER_URL)
+      if (providerUrl != null) {
         System.setProperty(PROVIDER_URL, IN_MEMORY_URL)
         IN_MEMORY_URL
+      } else {
+        providerUrl
       }
     })
 


### PR DESCRIPTION
Fixes #7262

This reverts commit 4e67bd27dbf31d1a12826a7e1e26719704ecf7d8, ensuring that the right in memory URL is used, by setting it as a system property. It removes the dependence on Play's global state by using an already set system property if detected - this means the JNDI provider can still be customised using system properties.