### PR TITLE
[doc] make combined-body-parser example compile

### DIFF
--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaBodyParsers.scala
@@ -181,11 +181,10 @@ import org.specs2.execute.AsResult
   import play.api.mvc._
 
     object Application extends Controller {
-      def file(to: File) = parse.file(to)
       //#body-parser-combining
       val storeInUserFile = parse.using { request =>
         request.session.get("username").map { user =>
-          file(to = new File("/tmp/" + user + ".upload"))
+          parse.file(to = new File("/tmp/" + user + ".upload"))
         }.getOrElse {
           sys.error("You don't have the right to upload here")
         }
@@ -217,4 +216,3 @@ import org.specs2.execute.AsResult
     }
   }
 }
-


### PR DESCRIPTION
## Fixes

The example code for [Combining body parsers](https://www.playframework.com/documentation/2.5.x/ScalaBodyParsers#Combining-body-parsers) does not compile when copied into another Controller, because it uses a `file` method that is not part of the example. 
Since the method is a one-liner and not used elsewhere I inlined it in the example.