### PR TITLE
Remove references to `play` command

### DIFF
--- a/documentation/manual/gettingStarted/IDE.md
+++ b/documentation/manual/gettingStarted/IDE.md
@@ -51,7 +51,7 @@ If you want to grab the available source jars (this will take longer and it's po
 EclipseKeys.skipParents in ThisBuild := false
 ```
 
-or from the play console, type:
+or from the [sbt shell](http://www.scala-sbt.org/0.13/docs/Howto-Interactive-Mode.html), type:
 
 ```bash
 [my-first-app] $ eclipse skip-parents=false
@@ -168,7 +168,7 @@ Start SBT:
 $ sbt
 ```
 
-Enter 'gen-ensime' at the play console. The plugin should generate a .ensime file in the root of your Play project.
+Enter 'gen-ensime' at the [sbt shell](http://www.scala-sbt.org/0.13/docs/Howto-Interactive-Mode.html). The plugin should generate a .ensime file in the root of your Play project.
 
 ```bash
 [MYPROJECT] $ gen-ensime

--- a/documentation/manual/working/commonGuide/configuration/ConfigFile.md
+++ b/documentation/manual/working/commonGuide/configuration/ConfigFile.md
@@ -415,6 +415,6 @@ For powers of two, exactly these strings are supported:
 
 ## Conventional override by system properties
 
-Java system properties override settings found in the `application.conf` and `reference.conf` files. This supports specifying config options on the command line. ie. `play -Dkey=value run`
+Java system properties override settings found in the `application.conf` and `reference.conf` files. This supports specifying config options on the command line, for example `sbt -Dkey=value run`.
 
-Note : Play forks the JVM for tests - and so to use command line overrides in tests you must add `Keys.fork in Test := false` in `build.sbt` before you can use them for a test.
+> **Note**: Play forks the JVM for tests - and so to use command line overrides in tests you must add `Keys.fork in Test := false` in `build.sbt` before you can use them for a test.

--- a/documentation/manual/working/commonGuide/database/Developing-with-the-H2-Database.md
+++ b/documentation/manual/working/commonGuide/database/Developing-with-the-H2-Database.md
@@ -74,7 +74,7 @@ H2, by default, creates tables with upper case names. Sometimes you don't want t
 
 ## H2 Browser
 
-You can browse the contents of your database by typing `h2-browser` at the play console.  An SQL browser will run in your web browser.
+You can browse the contents of your database by typing `h2-browser` at the [sbt shell](http://www.scala-sbt.org/0.13/docs/Howto-Interactive-Mode.html).  An SQL browser will run in your web browser.
 
 ## H2 Documentation
 


### PR DESCRIPTION
Replaces with references to sbt and sbt shell.

Fixes #7268.