### PR TITLE
More explicit MarkerContext examples

### DIFF
--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -14,7 +14,9 @@ lazy val main = Project("Play-Documentation", file(".")).enablePlugins(PlayDocsP
       version := PlayVersion.current,
       libraryDependencies ++= Seq(
         "com.h2database" % "h2" % "1.4.191" % Test,
-        "org.mockito" % "mockito-core" % "1.9.5" % "test"
+        "org.mockito" % "mockito-core" % "1.9.5" % "test",
+        // https://github.com/logstash/logstash-logback-encoder/tree/logstash-logback-encoder-4.9#including
+        "net.logstash.logback" % "logstash-logback-encoder" % "4.9" % "test"
       ),
 
       PlayDocsKeys.docsJarFile := Some((packageBin in(playDocs, Compile)).value),


### PR DESCRIPTION
This documentation change adds more examples of MarkerContext usage to Highlights and logging.

This was previously https://github.com/playframework/playframework/pull/7269 but that PR was misfiled as a playframework branch instead of a wsargent branch.