### PR TITLE
Upgrade play-file-watch to 1.0.1

### DIFF
--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -164,7 +164,7 @@ object Dependencies {
   }
 
   val runSupportDependencies = Seq(
-    "com.lightbend.play" %% "play-file-watch" % "1.0.0"
+    "com.lightbend.play" %% "play-file-watch" % "1.0.1"
   ) ++ specsBuild.map(_ % Test)
 
   // use partial version so that non-standard scala binary versions from dbuild also work


### PR DESCRIPTION
`play-file-watch` was having issues with cross-compilation, 1.0.1 is published so we can upgrade to it.