### PR TITLE
Make initializationFailFast optional

### DIFF
--- a/framework/src/play-jdbc/src/main/resources/reference.conf
+++ b/framework/src/play-jdbc/src/main/resources/reference.conf
@@ -100,10 +100,6 @@ play {
         #    may fail.
         initializationFailTimeout = 1
 
-        # Sets whether or not construction of the pool should fail if the minimum number of connections
-        # couldn't be created.
-        initializationFailFast = true
-
         # Sets whether internal queries should be isolated
         isolateInternalQueries = false
 

--- a/framework/src/play-jdbc/src/main/resources/reference.conf
+++ b/framework/src/play-jdbc/src/main/resources/reference.conf
@@ -100,6 +100,12 @@ play {
         #    may fail.
         initializationFailTimeout = 1
 
+        # Sets whether or not construction of the pool should fail if the minimum number of connections
+        # couldn't be created.
+        # Deprecated value in HikariCP, initializationFailTimeout should be used instead.
+        # This configuration value is optional, so commenting it out removes the runtime warning from HikariCP.
+        #initializationFailFast = true
+
         # Sets whether internal queries should be isolated
         isolateInternalQueries = false
 

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
@@ -120,7 +120,7 @@ private[db] class HikariCPConfig(dbConfig: DatabaseConfig, configuration: Config
     config.get[Option[String]]("poolName").foreach(hikariConfig.setPoolName)
 
     // Infrequently used
-    hikariConfig.setInitializationFailFast(config.get[Boolean]("initializationFailFast"))
+    config.getOptional[Boolean]("initializationFailFast").map(hikariConfig.setInitializationFailFast)
     hikariConfig.setInitializationFailTimeout(config.get[Long]("initializationFailTimeout"))
     hikariConfig.setIsolateInternalQueries(config.get[Boolean]("isolateInternalQueries"))
     hikariConfig.setAllowPoolSuspension(config.get[Boolean]("allowPoolSuspension"))

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/HikariCPModule.scala
@@ -120,7 +120,8 @@ private[db] class HikariCPConfig(dbConfig: DatabaseConfig, configuration: Config
     config.get[Option[String]]("poolName").foreach(hikariConfig.setPoolName)
 
     // Infrequently used
-    config.getOptional[Boolean]("initializationFailFast").map(hikariConfig.setInitializationFailFast)
+    // Use getOptional here so the runtime warning is only triggered if it is not null
+    config.getOptional[Boolean]("initializationFailFast").foreach(hikariConfig.setInitializationFailFast)
     hikariConfig.setInitializationFailTimeout(config.get[Long]("initializationFailTimeout"))
     hikariConfig.setIsolateInternalQueries(config.get[Boolean]("isolateInternalQueries"))
     hikariConfig.setAllowPoolSuspension(config.get[Boolean]("allowPoolSuspension"))


### PR DESCRIPTION
If `hikariConfig.setInitializationFailFast` is called from code, it spits out a runtime warning which is awkward, considering it's in `reference.conf` and therefore always called.

This PR makes the `hikaricp.initializationFailFast` property optional and removes it from configuration, so that there is no warning from HikariCP by default.