### PR TITLE
API to atomically move the files or fallback if not supported

### DIFF
--- a/framework/src/play/src/main/java/play/libs/Files.java
+++ b/framework/src/play/src/main/java/play/libs/Files.java
@@ -44,6 +44,18 @@ public final class Files {
         File file();
 
         TemporaryFileCreator temporaryFileCreator();
+
+        default TemporaryFile moveTo(File to) {
+            return moveTo(to, false);
+        }
+
+        TemporaryFile moveTo(File to, boolean replace);
+
+        default TemporaryFile atomicMoveWithFallback(File to) {
+            return atomicMoveWithFallback(to, false);
+        }
+
+        TemporaryFile atomicMoveWithFallback(File to, boolean replace);
     }
 
     /**
@@ -93,6 +105,11 @@ public final class Files {
             this.temporaryFileCreator = new DelegateTemporaryFileCreator(temporaryFile.temporaryFileCreator());
         }
 
+        private DelegateTemporaryFile(play.api.libs.Files.TemporaryFile temporaryFile, TemporaryFileCreator temporaryFileCreator) {
+            this.temporaryFile = temporaryFile;
+            this.temporaryFileCreator = temporaryFileCreator;
+        }
+
         @Override
         public Path path() {
             return temporaryFile.path();
@@ -106,6 +123,16 @@ public final class Files {
         @Override
         public TemporaryFileCreator temporaryFileCreator() {
             return temporaryFileCreator;
+        }
+
+        @Override
+        public TemporaryFile moveTo(File to, boolean replace) {
+            return new DelegateTemporaryFile(temporaryFile.moveTo(to, replace), this.temporaryFileCreator);
+        }
+
+        @Override
+        public TemporaryFile atomicMoveWithFallback(File to, boolean replace) {
+            return new DelegateTemporaryFile(temporaryFile.atomicMoveWithFallback(to.toPath(), replace), this.temporaryFileCreator);
         }
     }
 

--- a/framework/src/play/src/main/java/play/libs/Files.java
+++ b/framework/src/play/src/main/java/play/libs/Files.java
@@ -51,11 +51,7 @@ public final class Files {
 
         TemporaryFile moveTo(File to, boolean replace);
 
-        default TemporaryFile atomicMoveWithFallback(File to) {
-            return atomicMoveWithFallback(to, false);
-        }
-
-        TemporaryFile atomicMoveWithFallback(File to, boolean replace);
+        TemporaryFile atomicMoveWithFallback(File to);
     }
 
     /**
@@ -131,8 +127,8 @@ public final class Files {
         }
 
         @Override
-        public TemporaryFile atomicMoveWithFallback(File to, boolean replace) {
-            return new DelegateTemporaryFile(temporaryFile.atomicMoveWithFallback(to.toPath(), replace), this.temporaryFileCreator);
+        public TemporaryFile atomicMoveWithFallback(File to) {
+            return new DelegateTemporaryFile(temporaryFile.atomicMoveWithFallback(to.toPath()), this.temporaryFileCreator);
         }
     }
 

--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -131,8 +131,9 @@ object Files {
     private def moveToWithOptions(to: Path, replace: Boolean, additionalOptions: CopyOption*) = {
       if (replace)
         JFiles.move(path, to, additionalOptions :+ StandardCopyOption.REPLACE_EXISTING: _*)
-      else
+      else if (!to.toFile.exists())
         JFiles.move(path, to, additionalOptions: _*)
+      else to
     }
   }
 

--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -94,7 +94,11 @@ object Files {
      */
     def moveTo(to: Path, replace: Boolean): TemporaryFile = {
       try {
-        moveToWithOptions(to, replace)
+        if (replace)
+          JFiles.move(path, to, StandardCopyOption.REPLACE_EXISTING)
+        else if (!to.toFile.exists())
+          JFiles.move(path, to)
+        else to
       } catch {
         case ex: FileAlreadyExistsException => to
       }
@@ -105,20 +109,21 @@ object Files {
     /**
      * Attempts to move source to target atomically and falls back to a non-atomic move if it fails.
      *
+     * This always tries to replace existent files. Since it is platform dependent if atomic moves replaces
+     * existent files or not, considering that it will always replaces, makes the API more predictable.
+     *
      * @param to the path to the destination file
-     * @param replace true if an existing file should be replaced, false otherwise.
      */
     // see https://github.com/apache/kafka/blob/d345d53/clients/src/main/java/org/apache/kafka/common/utils/Utils.java#L608-L626
-    def atomicMoveWithFallback(to: Path, replace: Boolean): TemporaryFile = {
+    def atomicMoveWithFallback(to: Path): TemporaryFile = {
       try {
-        moveToWithOptions(to, replace, StandardCopyOption.ATOMIC_MOVE)
+        JFiles.move(path, to, StandardCopyOption.ATOMIC_MOVE)
       } catch {
         case outer: IOException =>
           try {
+            JFiles.move(path, to, StandardCopyOption.REPLACE_EXISTING)
             logger.debug(s"Non-atomic move of $path to $to succeeded after atomic move failed due to ${outer.getMessage}")
-            moveToWithOptions(to, replace)
           } catch {
-            case ex: FileAlreadyExistsException => to
             case inner: IOException =>
               inner.addSuppressed(outer)
               throw inner
@@ -126,14 +131,6 @@ object Files {
       }
 
       temporaryFileCreator.create(to)
-    }
-
-    private def moveToWithOptions(to: Path, replace: Boolean, additionalOptions: CopyOption*) = {
-      if (replace)
-        JFiles.move(path, to, additionalOptions :+ StandardCopyOption.REPLACE_EXISTING: _*)
-      else if (!to.toFile.exists())
-        JFiles.move(path, to, additionalOptions: _*)
-      else to
     }
   }
 

--- a/framework/src/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
@@ -99,7 +99,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       JFiles.exists(destination) must beTrue
     }
 
-    "move a file atomically without replacing" in new WithScope() {
+    "do not replace file when moving atomically with replace disabled" in new WithScope() {
       val lifecycle = new DefaultApplicationLifecycle
       val reaper = mock[TemporaryFileReaper]
       val creator = new DefaultTemporaryFileCreator(lifecycle, reaper)

--- a/framework/src/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/TemporaryFileCreatorSpec.scala
@@ -5,10 +5,8 @@ package play.api.libs
 
 import java.io.File
 import java.nio.charset.Charset
-import java.nio.file.{ FileSystems, Path, StandardWatchEventKinds, WatchEvent, Files => JFiles }
+import java.nio.file.{ Path, Files => JFiles }
 
-import akka.actor.ActorSystem
-import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mock.Mockito
 import org.specs2.mutable.{ After, Specification }
 import org.specs2.specification.Scope
@@ -22,7 +20,7 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
 
   sequential
 
-  val utf8 = Charset.forName("UTF8")
+  val utf8: Charset = Charset.forName("UTF8")
 
   "DefaultTemporaryFileCreator" should {
 
@@ -93,25 +91,10 @@ class TemporaryFileCreatorSpec extends Specification with Mockito {
       writeFile(file, "file to be moved")
 
       val destination = parentDirectory.resolve("destination.txt")
-      creator.create(file).atomicMoveWithFallback(destination, replace = true)
+      creator.create(file).atomicMoveWithFallback(destination)
 
       JFiles.exists(file) must beFalse
       JFiles.exists(destination) must beTrue
-    }
-
-    "do not replace file when moving atomically with replace disabled" in new WithScope() {
-      val lifecycle = new DefaultApplicationLifecycle
-      val reaper = mock[TemporaryFileReaper]
-      val creator = new DefaultTemporaryFileCreator(lifecycle, reaper)
-
-      val file = parentDirectory.resolve("do-not-replace.txt")
-      val destination = parentDirectory.resolve("already-exists.txt")
-
-      writeFile(file, "file that won't be replaced")
-      writeFile(destination, "already exists")
-
-      val to = creator.create(file).atomicMoveWithFallback(destination, replace = false)
-      new String(java.nio.file.Files.readAllBytes(to.toPath)) must contain("already exists")
     }
 
     "works when using compile time dependency injection" in {


### PR DESCRIPTION
## Fixes

Try to move files atomically if supported and, if not, fallback to regular moving. It was added as a new API to avoid breaking existent uses of `moveTo` which does not use atomic moves.

## References

This was adapted from Kafka: https://github.com/apache/kafka/blob/d345d53/clients/src/main/java/org/apache/kafka/common/utils/Utils.java#L608-L626