### PR TITLE
Only add CSRF token if it has been rendered

### DIFF
--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
@@ -38,7 +38,8 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
     @Override
     public CompletionStage<Result> call(Http.Context ctx) {
 
-        CSRFActionHelper csrfActionHelper = new CSRFActionHelper(sessionConfiguration, config, tokenSigner);
+        CSRFActionHelper csrfActionHelper =
+            new CSRFActionHelper(sessionConfiguration, config, tokenSigner, tokenProvider);
 
         RequestHeader request = csrfActionHelper.tagRequestFromHeader(ctx._requestHeader());
         // Check for bypass

--- a/framework/src/play-filters-helpers/src/main/scala/play/api/test/CSRFTokenHelper.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/api/test/CSRFTokenHelper.scala
@@ -6,7 +6,6 @@ package play.api.test
 import play.api.http.{ SecretConfiguration, SessionConfiguration }
 import play.api.libs.crypto.{ CSRFTokenSigner, CSRFTokenSignerProvider, DefaultCookieSigner }
 import play.api.mvc.{ Request }
-import play.filters.csrf.CSRF.{ Token, TokenProvider, TokenProviderProvider }
 import play.filters.csrf.{ CSRFActionHelper, CSRFConfig }
 
 /**
@@ -26,8 +25,6 @@ object CSRFTokenHelper {
     tokenSigner = csrfTokenSigner
   )
 
-  private val tokenProvider: TokenProvider = new TokenProviderProvider(csrfConfig, csrfTokenSigner).get
-
   /**
    * Adds a CSRF token to the request, using the Scala Request API.
    *
@@ -36,16 +33,14 @@ object CSRFTokenHelper {
    * @return a request with a CSRF token attached.
    */
   def addCSRFToken[A](request: Request[A]): Request[A] = {
-    val newToken = tokenProvider.generateToken
-    csrfActionHelper.tagRequest(request, Token(csrfConfig.tokenName, newToken))
+    csrfActionHelper.tagRequestWithNewToken(request)
   }
 
   /**
    * Adds a CSRF token to the request, using the Java RequestBuilder API.
    */
   def addCSRFToken(requestBuilder: play.mvc.Http.RequestBuilder): play.mvc.Http.RequestBuilder = {
-    val newToken = tokenProvider.generateToken
-    csrfActionHelper.tagRequest(requestBuilder, Token(csrfConfig.tokenName, newToken))
+    csrfActionHelper.tagRequestWithNewToken(requestBuilder)
   }
 
   /**


### PR DESCRIPTION
This PR makes the `TokenInfo` class lazy, so we don't have to even generate the token if the page never chooses to render it. This is a performance optimization in the simple case of rendering a page that doesn't need a CSRF token.

This also performs some other refactoring of our CSRF utilities. There's still a lot of things that could be improved, but the main goal here was to move complexity to the `CSRFActionHelper` that's shared among all the CSRF utilities.

/cc @richdougherty 