### PR TITLE
Add Scala configuration changes to highlights and migration guide

### DIFF
--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -170,6 +170,12 @@ For more information, please see [[ScalaLogging]] or [[JavaLogging]].
 
 For more information about using Markers in logging, see [TurboFilters](https://logback.qos.ch/manual/filters.html#TurboFilter) and [marker based triggering](https://logback.qos.ch/manual/appenders.html#OnMarkerEvaluator) sections in the Logback manual.
 
+## Configuration improvements
+
+In the Java API, we have moved to the standard `Config` object from Lightbend's Config library instead of `play.Configuration`. This brings the behavior in line with standard config behavior, as the methods now expect all keys to exist. See [[the Java config migration guide|JavaConfigMigration26]] for migration details.
+
+In the Scala API, we have introduced new methods to the `play.api.Configuration` class to simplify the API and allow loading of custom types. You can now use an implicit `ConfigLoader` to load any custom type you want. Like the `Config` API, the new `Configuration#get[T]` expects the key to exist by default and returns a value of type `T`, but there is also a `ConfigLoader[Option[T]]` that allows `null` config values. See the [[Scala configuration docs|ScalaConfig]] for more details.
+
 ## Security Logging
 
 A security marker has been added for security related operations in Play, and failed security checks now log  at WARN level, with the security marker set.  This ensures that developers always know why a particular request is failing, which is important now that security filters are enabled by default in Play.
@@ -272,7 +278,7 @@ public class JavaLog4JLoggerConfigurator implements LoggerConfigurator {
 
 ## Java Compile Time Components
 
-Just as Scala, Play now has components to enable [[Java Compile Time Dependency Injection|JavaCompileTimeDependencyInjection]]. The components were created as interfaces that you should `implements` and they provide default implementations. There are components for all the types that could be injected when using [[Runtime Dependency Injection|JavaDependencyInjection]]. To create an application using Compile Time Dependency Injection, you just need to provide an implementation of `play.ApplicationLoader` that uses a custom implementation of `play.BuiltInComponents`, for example:
+Just as in Scala, Play now has components to enable [[Java Compile Time Dependency Injection|JavaCompileTimeDependencyInjection]]. The components were created as interfaces that you should `implements` and they provide default implementations. There are components for all the types that could be injected when using [[Runtime Dependency Injection|JavaDependencyInjection]]. To create an application using Compile Time Dependency Injection, you just need to provide an implementation of `play.ApplicationLoader` that uses a custom implementation of `play.BuiltInComponents`, for example:
 
 ```java
 import play.routing.Router;

--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -15,7 +15,7 @@ Update the Play version number in project/plugins.sbt to upgrade Play:
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.x")
 ```
 
-Where the "x" in `2.6.x` is the minor version of Play you want to use, per instance `2.6.0`.
+Where the "x" in `2.6.x` is the minor version of Play you want to use, for instance `2.6.0`.
 
 ### sbt upgrade to 0.13.15
 
@@ -315,6 +315,29 @@ See [[Cache APIs Migration|CacheMigration26]].
 ## Java Configuration API Migration Notes
 
 See [[Java Configuration Migration|JavaConfigMigration26]].
+
+## Scala Configuration API
+
+The Scala `play.api.Configuration` API now has new methods that allow loading any type using a `ConfigLoader`. These new methods expect configuration keys to exist in the configuration file. For example, the following old code:
+
+```scala
+val myConfig: String = configuration.getString("my.config.key").getOrElse("default")
+```
+should be changed to
+```scala
+val myConfig: String = configuration.get[String]("my.config.key")
+```
+and the value "default" should be set in configuration as `my.config.key = default`.
+
+Alternatively, if custom logic is required in the code to obtain the default value, you can set the default to null in your config file (`my.config.key = null`), and read an `Option[T]`:
+```scala
+val myConfigOption: Option[String] = configuration.get[Option[String]]("my.config.key")
+val myConfig: String = myConfigOption.getOrElse(computeDefaultValue())
+```
+
+Also, there are several methods in the old `Configuration` that return Java types, like `getBooleanList`. We recommend using the Scala version `get[Seq[Boolean]]` instead if possible. If that is not possible, you can access the `underlying` Config object and call `getBooleanList` from it.
+
+The deprecation messages on the existing methods also explain how to migrate each method. See [[the Scala Configuration docs|ScalaConfig]] for more details on the proper use of `play.api.Configuration`.
 
 ## Removed APIs
 

--- a/documentation/manual/working/scalaGuide/main/config/ScalaConfig.md
+++ b/documentation/manual/working/scalaGuide/main/config/ScalaConfig.md
@@ -31,4 +31,4 @@ Then you can use `config.get` as we did above:
 
 ### Optional configuration keys
 
-Play's `Configuration` supports getting optional configuration keys using the `getOptional[A]` method. It works just like `get[A]` but will return `None` if the key does not exist. Instead of using this method, we recommend setting optional keys to `null` in your configuration file and using `get[Option[A]]`. But we provide this method for convenience in case you need to interface with libraries that use `Config` in a non-standard way.
+Play's `Configuration` supports getting optional configuration keys using the `getOptional[A]` method. It works just like `get[A]` but will return `None` if the key does not exist. Instead of using this method, we recommend setting optional keys to `null` in your configuration file and using `get[Option[A]]`. But we provide this method for convenience in case you need to interface with libraries that use configuration in a non-standard way.


### PR DESCRIPTION
This makes sure the new Configuration API is mentioned in the highlights and migration guide. I included a small amount of detail and refer to the Scala configuration docs for more information.