### PR TITLE
LoggerConfigurator should work with empty app config

### DIFF
--- a/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/components/CompileTimeDependencyInjection.java
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/components/CompileTimeDependencyInjection.java
@@ -57,7 +57,7 @@ public class CompileTimeDependencyInjection {
             LoggerConfigurator.apply(context.environment().classLoader())
                 .ifPresent(loggerConfigurator ->
                     loggerConfigurator.configure(
-                        context.environment().asScala(),
+                        context.environment(),
                         context.initialConfig()
                     )
                 );

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/components/CompileTimeDependencyInjection.java
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/components/CompileTimeDependencyInjection.java
@@ -56,7 +56,10 @@ public class CompileTimeDependencyInjection {
 
             LoggerConfigurator.apply(context.environment().classLoader())
                 .ifPresent(loggerConfigurator ->
-                        loggerConfigurator.configure(context.environment().asScala())
+                    loggerConfigurator.configure(
+                        context.environment().asScala(),
+                        context.initialConfig()
+                    )
                 );
 
             return new MyComponents(context).application();

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
@@ -65,7 +65,7 @@ class MyComponents(context: Context)
 class MyApplicationLoaderWithInitialization extends ApplicationLoader {
   def load(context: Context) = {
     LoggerConfigurator(context.environment.classLoader).foreach {
-      _.configure(context.environment)
+      _.configure(context.environment, context.initialConfiguration)
     }
     new MyComponents(context).application
   }

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
@@ -65,7 +65,7 @@ class MyComponents(context: Context)
 class MyApplicationLoaderWithInitialization extends ApplicationLoader {
   def load(context: Context) = {
     LoggerConfigurator(context.environment.classLoader).foreach {
-      _.configure(context.environment, context.initialConfiguration)
+      _.configure(context.environment, context.initialConfiguration, Map.empty)
     }
     new MyComponents(context).application
   }

--- a/framework/src/play/src/main/java/play/LoggerConfigurator.java
+++ b/framework/src/play/src/main/java/play/LoggerConfigurator.java
@@ -13,6 +13,7 @@ import scala.compat.java8.OptionConverters;
 
 import java.io.File;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional ;
 
@@ -43,6 +44,21 @@ public interface LoggerConfigurator extends play.api.LoggerConfigurator {
 
     /**
      * Configures the logger with the environment and the application configuration.
+     * <p>
+     * This is what full applications will run, and the place to put extra properties,
+     * either through optionalProperties or by setting configuration properties and
+     * having "play.logger.includeConfigProperties=true" in the config.
+     *
+     * @param env                the application environment
+     * @param configuration      the application's configuration
+     */
+    default void configure(Environment env, Config configuration) {
+        configure(env, configuration, Collections.emptyMap());
+    }
+
+    /**
+     * Configures the logger with the environment, the application configuration and
+     * additional properties.
      * <p>
      * This is what full applications will run, and the place to put extra properties,
      * either through optionalProperties or by setting configuration properties and

--- a/framework/src/play/src/main/scala/play/api/LoggerConfigurator.scala
+++ b/framework/src/play/src/main/scala/play/api/LoggerConfigurator.scala
@@ -35,7 +35,7 @@ trait LoggerConfigurator {
    * @param configuration the application's configuration
    * @param optionalProperties any optional properties (you can use Map.empty otherwise)
    */
-  def configure(env: Environment, configuration: Configuration, optionalProperties: Map[String, String] = Map.empty): Unit
+  def configure(env: Environment, configuration: Configuration, optionalProperties: Map[String, String]): Unit
 
   /**
    * Configures the logger with a list of properties and an optional URL.

--- a/framework/src/play/src/main/scala/play/api/LoggerConfigurator.scala
+++ b/framework/src/play/src/main/scala/play/api/LoggerConfigurator.scala
@@ -35,7 +35,7 @@ trait LoggerConfigurator {
    * @param configuration the application's configuration
    * @param optionalProperties any optional properties (you can use Map.empty otherwise)
    */
-  def configure(env: Environment, configuration: Configuration, optionalProperties: Map[String, String]): Unit
+  def configure(env: Environment, configuration: Configuration, optionalProperties: Map[String, String] = Map.empty): Unit
 
   /**
    * Configures the logger with a list of properties and an optional URL.

--- a/framework/src/play/src/main/scala/play/api/LoggerConfigurator.scala
+++ b/framework/src/play/src/main/scala/play/api/LoggerConfigurator.scala
@@ -73,7 +73,7 @@ object LoggerConfigurator {
     val mutableMap = new scala.collection.mutable.HashMap[String, String]()
     mutableMap.put("application.home", env.rootPath.getAbsolutePath)
 
-    if (config.get[Boolean]("play.logger.includeConfigProperties")) {
+    if (config.getOptional[Boolean]("play.logger.includeConfigProperties").contains(true)) {
       val entrySet = config.underlying.entrySet.asScala
       for (entry <- entrySet) {
         val value = entry.getValue

--- a/framework/src/play/src/test/scala/play/api/LoggerConfiguratorSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/LoggerConfiguratorSpec.scala
@@ -80,6 +80,13 @@ class LoggerConfiguratorSpec extends Specification {
       properties must havePair("some.property" -> "BBB")
     }
 
+    "generate empty properties when configuration is empty" in {
+      val env = Environment.simple()
+      val config = Configuration.empty
+      val properties = LoggerConfigurator.generateProperties(env, config, Map.empty)
+      properties must size(1)
+    }
+
   }
 
 }


### PR DESCRIPTION
This is useful mainly for test purpose and is also supported (and documented) by Play 2.5.x.