### PR TITLE
Align the BuildLink interface with Lagom

### DIFF
--- a/framework/src/build-link/src/main/java/play/core/Build.java
+++ b/framework/src/build-link/src/main/java/play/core/Build.java
@@ -14,7 +14,7 @@ public class Build {
     List<String> list = new ArrayList<String>();
     list.add(play.core.BuildLink.class.getName());
     list.add(play.core.BuildDocHandler.class.getName());
-    list.add(play.core.server.ServerWithStop.class.getName());
+    list.add(play.core.server.ReloadableServer.class.getName());
     list.add(play.api.UsefulException.class.getName());
     list.add(play.api.PlayException.class.getName());
     list.add(play.api.PlayException.InterestingLines.class.getName());

--- a/framework/src/build-link/src/main/java/play/core/server/ReloadableServer.java
+++ b/framework/src/build-link/src/main/java/play/core/server/ReloadableServer.java
@@ -4,20 +4,25 @@
 package play.core.server;
 
 /**
- * A server that can be stopped.
+ * A server that can be reloaded or stopped.
  */
-public interface ServerWithStop {
+public interface ReloadableServer {
 
   /**
    * Stop the server.
    */
-  public void stop();
+  void stop();
+
+  /**
+   * Reload the server if necessary.
+   */
+  void reload();
 
   /**
    * Get the address of the server.
    *
    * @return The address of the server.
    */
-  public java.net.InetSocketAddress mainAddress(); 
+  java.net.InetSocketAddress mainAddress(); 
 
 }

--- a/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
+++ b/framework/src/play-docs-sbt-plugin/src/main/scala/com/typesafe/play/docs/sbtplugin/PlayDocsPlugin.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.Callable
 import com.typesafe.play.docs.sbtplugin.PlayDocsValidation.{ ValidationConfig, CodeSamplesReport, MarkdownRefReport }
 import play.core.BuildDocHandler
 import play.core.PlayVersion
-import play.core.server.ServerWithStop
+import play.core.server.ReloadableServer
 import play.routes.compiler.RoutesCompiler.RoutesCompilerTask
 import play.TemplateImports
 import play.sbt.Colors
@@ -230,8 +230,8 @@ object PlayDocsPlugin extends AutoPlugin {
       def call() = Project.runTask(translationCodeSamplesReport, state.value).get._2.toEither.right.get
     }
     val docServerStart = constructor.newInstance()
-    val server: ServerWithStop = startMethod.invoke(docServerStart, manualPath.value, buildDocHandler, translationReport, forceTranslationReport,
-      new java.lang.Integer(port)).asInstanceOf[ServerWithStop]
+    val server: ReloadableServer = startMethod.invoke(docServerStart, manualPath.value, buildDocHandler, translationReport, forceTranslationReport,
+      new java.lang.Integer(port)).asInstanceOf[ReloadableServer]
 
     println()
     println(Colors.green("Documentation server started, you can now view the docs by going to http://" + server.mainAddress()))

--- a/framework/src/play-docs/src/main/scala/play/docs/DocServerStart.scala
+++ b/framework/src/play-docs/src/main/scala/play/docs/DocServerStart.scala
@@ -22,7 +22,7 @@ import scala.util.Success
 class DocServerStart {
 
   def start(projectPath: File, buildDocHandler: BuildDocHandler, translationReport: Callable[File],
-    forceTranslationReport: Callable[File], port: java.lang.Integer): ServerWithStop = {
+    forceTranslationReport: Callable[File], port: java.lang.Integer): ReloadableServer = {
 
     val application: Application = {
       val environment = Environment(projectPath, this.getClass.getClassLoader, Mode.Test)

--- a/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -32,7 +32,7 @@ object DevServerStart {
   def mainDevOnlyHttpsMode(
     buildLink: BuildLink,
     httpsPort: Int,
-    httpAddress: String): ServerWithStop = {
+    httpAddress: String): ReloadableServer = {
     mainDev(buildLink, None, Some(httpsPort), httpAddress)
   }
 
@@ -45,7 +45,7 @@ object DevServerStart {
   def mainDevHttpMode(
     buildLink: BuildLink,
     httpPort: Int,
-    httpAddress: String): ServerWithStop = {
+    httpAddress: String): ReloadableServer = {
     mainDev(buildLink, Some(httpPort), Option(System.getProperty("https.port")).map(Integer.parseInt(_)), httpAddress)
   }
 
@@ -53,7 +53,7 @@ object DevServerStart {
     buildLink: BuildLink,
     httpPort: Option[Int],
     httpsPort: Option[Int],
-    httpAddress: String): ServerWithStop = {
+    httpAddress: String): ReloadableServer = {
     val classLoader = getClass.getClassLoader
     Threads.withContextClassLoader(classLoader) {
       try {
@@ -103,7 +103,10 @@ object DevServerStart {
           override def current: Option[Application] = lastState.toOption
 
           /**
-           * Returns a Try, which is either a Success with new application or Failure with exception.
+           * Calls the BuildLink to recompile the application if files have changed and constructs a new application
+           * using the new classloader. Returns the existing application if nothing has changed.
+           *
+           * @return a Try, which is either a Success containing the application or Failure with exception.
            * When a Failure is returned, the server handles it by returning an error page, so that the error
            * can be displayed in the user's browser. Failure is usually the result of a compilation error.
            */

--- a/framework/src/play-server/src/main/scala/play/core/server/ProdServerStart.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/ProdServerStart.scala
@@ -30,7 +30,7 @@ object ProdServerStart {
    * @param process The process (real or abstract) to use for starting the
    * server.
    */
-  def start(process: ServerProcess): ServerWithStop = {
+  def start(process: ServerProcess): ReloadableServer = {
     try {
 
       // Read settings

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -28,7 +28,7 @@ trait WebSocketable {
 /**
  * Provides generic server behaviour for Play applications.
  */
-trait Server extends ServerWithStop {
+trait Server extends ReloadableServer {
 
   def mode: Mode
 
@@ -82,7 +82,9 @@ trait Server extends ServerWithStop {
 
   def applicationProvider: ApplicationProvider
 
-  def stop() {
+  def reload(): Unit = applicationProvider.get
+
+  def stop(): Unit = {
     applicationProvider.current.foreach { app =>
       LoggerConfigurator(app.classloader).foreach(_.shutdown())
     }

--- a/framework/src/play-server/src/test/scala/play/core/server/ProdServerStartSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/ProdServerStartSpec.scala
@@ -36,7 +36,7 @@ class FakeServerProcess(
 
 // A family of fake servers for us to test
 
-class FakeServer(context: ServerProvider.Context) extends Server with ServerWithStop {
+class FakeServer(context: ServerProvider.Context) extends Server with ReloadableServer {
   def config = context.config
   def applicationProvider = context.appProvider
   def mode = config.mode

--- a/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
+++ b/framework/src/run-support/src/main/scala/play/runsupport/Reloader.scala
@@ -220,10 +220,10 @@ object Reloader {
         val mainClass = applicationLoader.loadClass(mainClassName)
         if (httpPort.isDefined) {
           val mainDev = mainClass.getMethod("mainDevHttpMode", classOf[BuildLink], classOf[Int], classOf[String])
-          mainDev.invoke(null, reloader, httpPort.get: java.lang.Integer, httpAddress).asInstanceOf[play.core.server.ServerWithStop]
+          mainDev.invoke(null, reloader, httpPort.get: java.lang.Integer, httpAddress).asInstanceOf[play.core.server.ReloadableServer]
         } else {
           val mainDev = mainClass.getMethod("mainDevOnlyHttpsMode", classOf[BuildLink], classOf[Int], classOf[String])
-          mainDev.invoke(null, reloader, httpsPort.get: java.lang.Integer, httpAddress).asInstanceOf[play.core.server.ServerWithStop]
+          mainDev.invoke(null, reloader, httpsPort.get: java.lang.Integer, httpAddress).asInstanceOf[play.core.server.ReloadableServer]
         }
       }
 


### PR DESCRIPTION
This change will allow us to delete Lagom's `build-link` project when Lagom is upgraded to Play 2.6