### PR TITLE
Remove unused classloader settings

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala
@@ -125,10 +125,6 @@ object PlaySettings {
 
     playCommonClassloader := PlayCommands.playCommonClassloaderTask.value,
 
-    playDependencyClassLoader := PlayRun.createURLClassLoader,
-
-    playReloaderClassLoader := PlayRun.createDelegatedResourcesClassLoader,
-
     playCompileEverything := PlayCommands.playCompileEverythingTask.value,
 
     playReload := PlayCommands.playReloadTask.value,

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -41,15 +41,12 @@ object PlayRun {
    */
   val DocsApplication = config("docs").hide
 
-  val createURLClassLoader: ClassLoaderCreator = Reloader.createURLClassLoader
-  val createDelegatedResourcesClassLoader: ClassLoaderCreator = Reloader.createDelegatedResourcesClassLoader
-
   val twirlSourceHandler = new TwirlSourceMapping()
 
   val generatedSourceHandlers = SbtTwirl.defaultFormats.map{ case (k, v) => ("scala." + k, twirlSourceHandler) }
 
-  val playDefaultRunTask = playRunTask(playRunHooks, playDependencyClasspath, playDependencyClassLoader,
-    playReloaderClasspath, playReloaderClassLoader, playAssetsClassLoader)
+  val playDefaultRunTask = playRunTask(playRunHooks, playDependencyClasspath,
+    playReloaderClasspath, playAssetsClassLoader)
 
   /**
    * This method is public API, used by sbt-echo, which is used by Activator:
@@ -61,8 +58,8 @@ object PlayRun {
    */
   def playRunTask(
     runHooks: TaskKey[Seq[play.sbt.PlayRunHook]],
-    dependencyClasspath: TaskKey[Classpath], dependencyClassLoader: TaskKey[ClassLoaderCreator],
-    reloaderClasspath: TaskKey[Classpath], reloaderClassLoader: TaskKey[ClassLoaderCreator],
+    dependencyClasspath: TaskKey[Classpath],
+    reloaderClasspath: TaskKey[Classpath],
     assetsClassLoader: TaskKey[ClassLoader => ClassLoader]): Def.Initialize[InputTask[Unit]] = Def.inputTask {
 
     val args = Def.spaceDelimited().parsed
@@ -80,12 +77,10 @@ object PlayRun {
     lazy val devModeServer = Reloader.startDevMode(
       runHooks.value,
       (javaOptions in Runtime).value,
-      dependencyClasspath.value.files,
-      dependencyClassLoader.value,
-      reloadCompile,
-      reloaderClassLoader.value,
-      assetsClassLoader.value,
       playCommonClassloader.value,
+      dependencyClasspath.value.files,
+      reloadCompile,
+      assetsClassLoader.value,
       playMonitoredFiles.value,
       fileWatchService.value,
       generatedSourceHandlers,


### PR DESCRIPTION
As far as I can tell these settings have never been used and just add extra complication. These are not present in the Lagom reloader, which is a little cleaner

I also reordered to parameters to `startDevMode` to match the ordering in Lagom, which I think was nicer, as it makes it easier for me to follow the logic across the two

After this is merged, I have just one or maybe two changes left to the reload functionality and we will then be able to use the same reloader for Play and Lagom. After the cleanup is done it may make sense to have this be a separate project with its own lifecycle