### PR TITLE
Remove access to global state while baking result cookies

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -277,7 +277,7 @@ case class Result(header: ResponseHeader, body: HttpEntity,
     requestHasFlash: Boolean = false): Result = {
 
     val allCookies = {
-      val setCookieCookies = Cookies.decodeSetCookieHeader(header.headers.getOrElse(SET_COOKIE, ""))
+      val setCookieCookies = cookieHeaderEncoding.decodeSetCookieHeader(header.headers.getOrElse(SET_COOKIE, ""))
       val session = newSession.map { data =>
         if (data.isEmpty) sessionBaker.discard.toCookie else sessionBaker.encodeAsCookie(data)
       }
@@ -292,7 +292,7 @@ case class Result(header: ResponseHeader, body: HttpEntity,
     if (allCookies.isEmpty) {
       this
     } else {
-      withHeaders(SET_COOKIE -> Cookies.encodeSetCookieHeader(allCookies))
+      withHeaders(SET_COOKIE -> cookieHeaderEncoding.encodeSetCookieHeader(allCookies))
     }
   }
 }


### PR DESCRIPTION
## Fixes

Fixes a problem happening in https://github.com/playframework/play-java-dagger2-example/pull/10.

## Purpose

Remove global state access from `Results.bakeCookie`.