### PR TITLE
Use Java version of BuiltInComponents in Server.forRouter

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaEmbeddingPlay.java
+++ b/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaEmbeddingPlay.java
@@ -28,7 +28,7 @@ public class JavaEmbeddingPlay {
     @Test
     public void simple() throws Exception {
         //#simple
-        Server server = Server.forRouter((components) -> new RoutingDsl(components.defaultScalaParser(), components.javaContextComponents())
+        Server server = Server.forRouter((components) -> RoutingDsl.fromComponents(components)
                 .GET("/hello/:to").routeTo(to ->
                         ok("Hello " + to)
                 )
@@ -58,7 +58,7 @@ public class JavaEmbeddingPlay {
     @Test
     public void config() throws Exception {
         //#config
-        Server server = Server.forRouter((components) -> new RoutingDsl(components.defaultScalaParser(), components.javaContextComponents())
+        Server server = Server.forRouter((components) -> RoutingDsl.fromComponents(components)
                 .GET("/hello/:to").routeTo(to ->
                         ok("Hello " + to)
                 )

--- a/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaEmbeddingPlay.java
+++ b/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaEmbeddingPlay.java
@@ -28,7 +28,7 @@ public class JavaEmbeddingPlay {
     @Test
     public void simple() throws Exception {
         //#simple
-        Server server = Server.forRouter((components) -> new RoutingDsl(components.defaultBodyParser(), components.javaContextComponents())
+        Server server = Server.forRouter((components) -> new RoutingDsl(components.defaultScalaParser(), components.javaContextComponents())
                 .GET("/hello/:to").routeTo(to ->
                         ok("Hello " + to)
                 )
@@ -58,7 +58,7 @@ public class JavaEmbeddingPlay {
     @Test
     public void config() throws Exception {
         //#config
-        Server server = Server.forRouter((components) -> new RoutingDsl(components.defaultBodyParser(), components.javaContextComponents())
+        Server server = Server.forRouter((components) -> new RoutingDsl(components.defaultScalaParser(), components.javaContextComponents())
                 .GET("/hello/:to").routeTo(to ->
                         ok("Hello " + to)
                 )

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/GitHubClientTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/GitHubClientTest.java
@@ -26,7 +26,7 @@ public class GitHubClientTest {
 
     @Before
     public void setup() {
-        server = Server.forRouter((components) -> new RoutingDsl(components.defaultScalaParser(), components.javaContextComponents())
+        server = Server.forRouter((components) -> RoutingDsl.fromComponents(components)
                 .GET("/repositories").routeTo(() -> {
                     ArrayNode repos = Json.newArray();
                     ObjectNode repo = Json.newObject();

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/GitHubClientTest.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/GitHubClientTest.java
@@ -26,7 +26,7 @@ public class GitHubClientTest {
 
     @Before
     public void setup() {
-        server = Server.forRouter((components) -> new RoutingDsl(components.defaultBodyParser(), components.javaContextComponents())
+        server = Server.forRouter((components) -> new RoutingDsl(components.defaultScalaParser(), components.javaContextComponents())
                 .GET("/repositories").routeTo(() -> {
                     ArrayNode repos = Json.newArray();
                     ObjectNode repo = Json.newObject();

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/JavaTestingWebServiceClients.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/JavaTestingWebServiceClients.java
@@ -22,7 +22,7 @@ public class JavaTestingWebServiceClients {
     @Test
     public void mockService() {
         //#mock-service
-        Server server = Server.forRouter((components) -> new RoutingDsl(components.defaultScalaParser(), components.javaContextComponents())
+        Server server = Server.forRouter((components) -> RoutingDsl.fromComponents(components)
                 .GET("/repositories").routeTo(() -> {
                     ArrayNode repos = Json.newArray();
                     ObjectNode repo = Json.newObject();
@@ -39,7 +39,7 @@ public class JavaTestingWebServiceClients {
     @Test
     public void sendResource() throws Exception {
         //#send-resource
-        Server server = Server.forRouter((components) -> new RoutingDsl(components.defaultScalaParser(), components.javaContextComponents())
+        Server server = Server.forRouter((components) -> RoutingDsl.fromComponents(components)
                 .GET("/repositories").routeTo(() ->
                         ok().sendResource("github/repositories.json")
                 )

--- a/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/JavaTestingWebServiceClients.java
+++ b/documentation/manual/working/javaGuide/main/tests/code/javaguide/tests/JavaTestingWebServiceClients.java
@@ -22,7 +22,7 @@ public class JavaTestingWebServiceClients {
     @Test
     public void mockService() {
         //#mock-service
-        Server server = Server.forRouter((components) -> new RoutingDsl(components.defaultBodyParser(), components.javaContextComponents())
+        Server server = Server.forRouter((components) -> new RoutingDsl(components.defaultScalaParser(), components.javaContextComponents())
                 .GET("/repositories").routeTo(() -> {
                     ArrayNode repos = Json.newArray();
                     ObjectNode repo = Json.newObject();
@@ -39,7 +39,7 @@ public class JavaTestingWebServiceClients {
     @Test
     public void sendResource() throws Exception {
         //#send-resource
-        Server server = Server.forRouter((components) -> new RoutingDsl(components.defaultBodyParser(), components.javaContextComponents())
+        Server server = Server.forRouter((components) -> new RoutingDsl(components.defaultScalaParser(), components.javaContextComponents())
                 .GET("/repositories").routeTo(() ->
                         ok().sendResource("github/repositories.json")
                 )

--- a/framework/src/play-integration-test/src/test/java/play/BuiltInComponentsFromContextTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/BuiltInComponentsFromContextTest.java
@@ -31,7 +31,7 @@ public class BuiltInComponentsFromContextTest {
 
         @Override
         public Router router() {
-            return new RoutingDsl(defaultScalaParser(), javaContextComponents())
+            return new RoutingDsl(defaultScalaBodyParser(), javaContextComponents())
                     .GET("/").routeTo(() -> Results.ok("index"))
                     .build();
         }

--- a/framework/src/play-integration-test/src/test/scala/play/it/routing/ServerSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/routing/ServerSpec.scala
@@ -68,7 +68,7 @@ class ServerSpec extends Specification with BeforeAll {
       "with the given router" in {
         withServer(
           Server.forRouter(JavaMode.DEV, asJavaFunction { components: JBuiltInComponents =>
-            new RoutingDsl(components.defaultScalaParser(), components.javaContextComponents)
+            RoutingDsl.fromComponents(components)
               .GET("/something").routeTo(
                 new Supplier[Result] {
                   override def get() = Results.ok("You got something")

--- a/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
+++ b/framework/src/play-java/src/main/java/play/routing/RoutingDsl.java
@@ -4,6 +4,7 @@
 package play.routing;
 
 import net.jodah.typetools.TypeResolver;
+import play.BuiltInComponents;
 import play.Logger;
 import play.api.Application;
 import play.api.mvc.AnyContent;
@@ -123,6 +124,10 @@ public class RoutingDsl {
     public RoutingDsl(PlayBodyParsers bodyParsers, JavaContextComponents contextComponents) {
         this.bodyParser = bodyParsers.defaultBodyParser();
         this.contextComponents = contextComponents;
+    }
+
+    public static RoutingDsl fromComponents(BuiltInComponents components) {
+        return new RoutingDsl(components.defaultScalaBodyParser(), components.javaContextComponents());
     }
 
     private Application app() {

--- a/framework/src/play-java/src/main/java/play/routing/RoutingDslComponents.java
+++ b/framework/src/play-java/src/main/java/play/routing/RoutingDslComponents.java
@@ -32,7 +32,7 @@ import play.components.BodyParserComponents;
 public interface RoutingDslComponents extends BodyParserComponents {
 
     default RoutingDsl routingDsl() {
-        return new RoutingDsl(defaultScalaParser(), javaContextComponents());
+        return new RoutingDsl(defaultScalaBodyParser(), javaContextComponents());
     }
 
 }

--- a/framework/src/play-server/src/main/java/play/server/Server.java
+++ b/framework/src/play-server/src/main/java/play/server/Server.java
@@ -4,7 +4,7 @@
 package play.server;
 
 import play.Mode;
-import play.api.BuiltInComponents;
+import play.BuiltInComponents;
 import play.routing.Router;
 import play.core.j.JavaModeConverter;
 import play.core.server.JavaServerHelper;
@@ -303,10 +303,10 @@ public class Server {
             Server.Config config = _buildConfig();
             return new Server(
                     JavaServerHelper.forRouter(
-                            JavaModeConverter.asScalaMode(config.mode()),
-                            OptionConverters.toScala(config.maybeHttpPort()),
-                            OptionConverters.toScala(config.maybeHttpsPort()),
-                            (components) -> block.apply(components).asScala()
+                        JavaModeConverter.asScalaMode(config.mode()),
+                        OptionConverters.toScala(config.maybeHttpPort()),
+                        OptionConverters.toScala(config.maybeHttpsPort()),
+                        block
                     )
             );
         }

--- a/framework/src/play/src/main/java/play/ApplicationLoader.java
+++ b/framework/src/play/src/main/java/play/ApplicationLoader.java
@@ -81,7 +81,8 @@ public interface ApplicationLoader {
                     environment.asScala(),
                     scala.Option.empty(),
                     new play.core.DefaultWebCommands(),
-                    play.api.Configuration.load(environment.asScala(), play.libs.Scala.asScala(initialSettings)),
+                    play.api.Configuration.load(environment.asScala(),
+                    play.libs.Scala.asScala(initialSettings)),
                     new DefaultApplicationLifecycle());
         }
 

--- a/framework/src/play/src/main/java/play/BuiltInComponents.java
+++ b/framework/src/play/src/main/java/play/BuiltInComponents.java
@@ -23,15 +23,17 @@ import javax.inject.Provider;
 /**
  * Helper to provide the Play built in components.
  */
-public interface BuiltInComponents extends BaseComponents,
-        ApplicationComponents,
+public interface BuiltInComponents extends
         AkkaComponents,
+        ApplicationComponents,
+        BaseComponents,
+        BodyParserComponents,
         ConfigurationComponents,
+        CryptoComponents,
+        FileMimeTypesComponents,
         HttpComponents,
         HttpErrorHandlerComponents,
-        FileMimeTypesComponents,
         I18nComponents,
-        CryptoComponents,
         TemporaryFileComponents {
 
     @Override

--- a/framework/src/play/src/main/java/play/components/BodyParserComponents.java
+++ b/framework/src/play/src/main/java/play/components/BodyParserComponents.java
@@ -18,7 +18,7 @@ public interface BodyParserComponents extends HttpErrorHandlerComponents,
         AkkaComponents,
         TemporaryFileComponents {
 
-    default PlayBodyParsers scalaParsers() {
+    default PlayBodyParsers scalaBodyParsers() {
         return PlayBodyParsers$.MODULE$.apply(
                 httpConfiguration().parser(),
                 scalaHttpErrorHandler(),
@@ -27,8 +27,8 @@ public interface BodyParserComponents extends HttpErrorHandlerComponents,
         );
     }
 
-    default play.api.mvc.BodyParser<AnyContent> defaultScalaParser() {
-        return scalaParsers().defaultBodyParser();
+    default play.api.mvc.BodyParser<AnyContent> defaultScalaBodyParser() {
+        return scalaBodyParsers().defaultBodyParser();
     }
 
     /**
@@ -36,11 +36,11 @@ public interface BodyParserComponents extends HttpErrorHandlerComponents,
      *
      * @see BodyParser.Default
      */
-    default BodyParser.Default defaultParser() {
+    default BodyParser.Default defaultBodyParser() {
         return new BodyParser.Default(
                 httpErrorHandler(),
                 httpConfiguration(),
-                scalaParsers()
+                scalaBodyParsers()
         );
     }
 
@@ -49,11 +49,11 @@ public interface BodyParserComponents extends HttpErrorHandlerComponents,
      *
      * @see BodyParser.AnyContent
      */
-    default BodyParser.AnyContent anyContentParser() {
+    default BodyParser.AnyContent anyContentBodyParser() {
         return new BodyParser.AnyContent(
                 httpErrorHandler(),
                 httpConfiguration(),
-                scalaParsers()
+                scalaBodyParsers()
         );
     }
 
@@ -62,7 +62,7 @@ public interface BodyParserComponents extends HttpErrorHandlerComponents,
      *
      * @see BodyParser.Json
      */
-    default BodyParser.Json jsonParser() {
+    default BodyParser.Json jsonBodyParser() {
         return new BodyParser.Json(
                 httpConfiguration(),
                 httpErrorHandler()
@@ -74,7 +74,7 @@ public interface BodyParserComponents extends HttpErrorHandlerComponents,
      *
      * @see BodyParser.TolerantJson
      */
-    default BodyParser.TolerantJson tolerantJsonParser() {
+    default BodyParser.TolerantJson tolerantJsonBodyParser() {
         return new BodyParser.TolerantJson(
                 httpConfiguration(),
                 httpErrorHandler()
@@ -86,11 +86,11 @@ public interface BodyParserComponents extends HttpErrorHandlerComponents,
      *
      * @see BodyParser.Xml
      */
-    default BodyParser.Xml xmlParser() {
+    default BodyParser.Xml xmlBodyParser() {
         return new BodyParser.Xml(
                 httpConfiguration(),
                 httpErrorHandler(),
-                scalaParsers()
+                scalaBodyParsers()
         );
     }
 
@@ -99,7 +99,7 @@ public interface BodyParserComponents extends HttpErrorHandlerComponents,
      *
      * @see BodyParser.TolerantXml
      */
-    default BodyParser.TolerantXml tolerantXmlParser() {
+    default BodyParser.TolerantXml tolerantXmlBodyParser() {
         return new BodyParser.TolerantXml(
                 httpConfiguration(),
                 httpErrorHandler()
@@ -111,7 +111,7 @@ public interface BodyParserComponents extends HttpErrorHandlerComponents,
      *
      * @see BodyParser.Text
      */
-    default BodyParser.Text textParser() {
+    default BodyParser.Text textBodyParser() {
         return new BodyParser.Text(
                 httpConfiguration(),
                 httpErrorHandler()
@@ -123,7 +123,7 @@ public interface BodyParserComponents extends HttpErrorHandlerComponents,
      *
      * @see BodyParser.TolerantText
      */
-    default BodyParser.TolerantText tolerantTextParser() {
+    default BodyParser.TolerantText tolerantTextBodyParser() {
         return new BodyParser.TolerantText(
                 httpConfiguration(),
                 httpErrorHandler()
@@ -135,7 +135,7 @@ public interface BodyParserComponents extends HttpErrorHandlerComponents,
      *
      * @see BodyParser.Bytes
      */
-    default BodyParser.Bytes bytesParser() {
+    default BodyParser.Bytes bytesBodyParser() {
         return new BodyParser.Bytes(
                 httpConfiguration(),
                 httpErrorHandler()
@@ -147,8 +147,8 @@ public interface BodyParserComponents extends HttpErrorHandlerComponents,
      *
      * @see BodyParser.Raw
      */
-    default BodyParser.Raw rawParser() {
-        return new BodyParser.Raw(scalaParsers());
+    default BodyParser.Raw rawBodyParser() {
+        return new BodyParser.Raw(scalaBodyParsers());
     }
 
     /**
@@ -156,7 +156,7 @@ public interface BodyParserComponents extends HttpErrorHandlerComponents,
      *
      * @see BodyParser.FormUrlEncoded
      */
-    default BodyParser.FormUrlEncoded formUrlEncodedParser() {
+    default BodyParser.FormUrlEncoded formUrlEncodedBodyParser() {
         return new BodyParser.FormUrlEncoded(
                 httpConfiguration(),
                 httpErrorHandler()
@@ -168,8 +168,8 @@ public interface BodyParserComponents extends HttpErrorHandlerComponents,
      *
      * @see BodyParser.MultipartFormData
      */
-    default BodyParser.MultipartFormData multipartFormDataParser() {
-        return new BodyParser.MultipartFormData(scalaParsers());
+    default BodyParser.MultipartFormData multipartFormDataBodyParser() {
+        return new BodyParser.MultipartFormData(scalaBodyParsers());
     }
 
     /**
@@ -177,7 +177,7 @@ public interface BodyParserComponents extends HttpErrorHandlerComponents,
      *
      * @see BodyParser.Empty
      */
-    default BodyParser.Empty emptyParser() {
+    default BodyParser.Empty emptyBodyParser() {
         return new BodyParser.Empty();
     }
 }


### PR DESCRIPTION
## Purpose

Instead of using Scala `BuiltInComponents` in `Server.forRouter`, now uses the Java version.

## References

See #7170.
