### PR TITLE
Rename MessagesAction to MessagesActionBuilder

### DIFF
--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -356,10 +356,10 @@ In the past, putting together a form in Play has required [multiple steps](https
 
 In addition, it was inconvenient to have a `Messages` instance passed through all template fragments when form handling was required, and `Messages` implicit support was provided directly through the controller trait.  The I18N API has been refined with the addition of a `MessagesProvider` trait, implicits that are tied directly to requests, and the forms documentation has been improved.
 
-The [`MessagesAction`](api/scala/play/api/mvc/MessagesAction.html) has been added.  This action exposes a [`MessagesRequest`](api/scala/play/api/mvc/MessagesRequest.html), which is a [`WrappedRequest`](api/scala/play/api/mvc/WrappedRequest.html) that extends [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html), only a single implicit parameter needs to be made available to templates, and you don't need to extend `Controller` with `I18nSupport`.  This is also useful because to use [[CSRF|ScalaCsrf]] with forms, both a `Request` (technically a `RequestHeader`) and a `Messages` object must be available to the template.
+The [`MessagesActionBuilder`](api/scala/play/api/mvc/MessagesActionBuilder.html) has been added.  This action builder provides a [`MessagesRequest`](api/scala/play/api/mvc/MessagesRequest.html), which is a [`WrappedRequest`](api/scala/play/api/mvc/WrappedRequest.html) that extends [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html), only a single implicit parameter needs to be made available to templates, and you don't need to extend `Controller` with `I18nSupport`.  This is also useful because to use [[CSRF|ScalaCsrf]] with forms, both a `Request` (technically a `RequestHeader`) and a `Messages` object must be available to the template.
 
 ```scala
-class FormController @Inject()(messagesAction: MessagesAction, components: ControllerComponents)
+class FormController @Inject()(messagesAction: MessagesActionBuilder, components: ControllerComponents)
   extends AbstractController(components) {
 
   import play.api.data.Form
@@ -394,7 +394,7 @@ where `displayForm.scala.html` is defined as:
 }
 ```
 
-For more information, please see [[ScalaI18N]] or [[JavaI18N]].
+For more information, please see [[ScalaI18N]].
 
 ## Future Timeout and Delayed Support
 

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
@@ -171,7 +171,7 @@ The first way is to make the controller extend [`play.api.i18n.I18nSupport`](api
 
 @[messages-controller](code/ScalaForms.scala)
 
-The second way is to dependency inject a [`MessagesAction`](api/scala/play/api/mvc/MessagesAction.html).  
+The second way is to dependency inject a [`MessagesActionBuilder`](api/scala/play/api/mvc/MessagesActionBuilder.html), which provides a [`MessagesRequest`](api/scala/play/api/mvc/MessagesRequest.html):
 
 @[messages-request-controller](code/ScalaForms.scala)
 

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -567,7 +567,7 @@ class MessagesController @Inject()(cc: ControllerComponents)
 
 //#messages-request-controller
 // Example form that uses a MessagesRequest, which is also a MessagesProvider
-class FormController @Inject()(messagesAction: MessagesAction, components: ControllerComponents)
+class FormController @Inject()(messagesAction: MessagesActionBuilder, components: ControllerComponents)
   extends AbstractController(components) {
 
   import play.api.data.Form


### PR DESCRIPTION
## Purpose

Renames MessagesAction to MessagesActionBuilder.

## Background Context

Should be inline with the other action builders.