### PR TITLE
[doc] Update WS timeout with examples

### DIFF
--- a/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/ws/code/ScalaWSSpec.scala
@@ -3,10 +3,6 @@
  */
 package scalaguide.ws.scalaws
 
-import akka.Done
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import play.api.{Environment, Mode}
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.ahc._
 import play.api.test._
@@ -16,8 +12,6 @@ import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import org.specs2.specification.AfterAll
 import play.api.libs.concurrent.Futures
-
-import scala.concurrent.TimeoutException
 
 //#dependency
 import javax.inject.Inject
@@ -507,17 +501,20 @@ class ScalaWSSpec extends PlaySpecification with Results with AfterAll {
     }
 
     "allow timeout" in new WithServer() with Injecting {
-      val futures = inject[Futures]
-      val ws = inject[WSClient]
       //#ws-futures-timeout
-      val result = futures.timeout(1 second) {
-        ws.url(url).get().map { response =>
+      implicit val futures = inject[Futures]
+      val ws = inject[WSClient]
+
+      // Adds withTimeout as type enrichment on Future[WSResponse]
+      import play.api.libs.concurrent.Futures._
+
+      val result =
+        ws.url(url).get().withTimeout(1 second).map { response =>
           Ok(response.body)
+        }.recover {
+          case e: scala.concurrent.TimeoutException =>
+            GatewayTimeout
         }
-      }.recover {
-        case e: scala.concurrent.TimeoutException =>
-          GatewayTimeout
-      }
       //#ws-futures-timeout
       status(result) must_== OK
     }


### PR DESCRIPTION
## Purpose

Adds documentation example to WS on timeout for futures.

## References

Futures functionality needs example.