### PR TITLE
Enable sharing Reloader with Lagom

### DIFF
--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayReload.scala
@@ -8,7 +8,7 @@ import sbt.Keys._
 
 import play.api.PlayException
 import play.sbt.PlayExceptions._
-import play.runsupport.Reloader.{ CompileResult, CompileSuccess, CompileFailure, Source, SourceMap }
+import play.runsupport.Reloader.{ CompileResult, CompileSuccess, CompileFailure, Source }
 
 object PlayReload {
 
@@ -24,7 +24,7 @@ object PlayReload {
       }.fold(identity, identity)
   }
 
-  def sourceMap(analysis: sbt.inc.Analysis): SourceMap = {
+  def sourceMap(analysis: sbt.inc.Analysis): Map[String, Source] = {
     analysis.apis.internal.foldLeft(Map.empty[String, Source]) {
       case (sourceMap, (file, source)) => sourceMap ++ {
         source.api.definitions map { d => d.name -> Source(file, originalSource(file)) }

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/run/PlayRun.scala
@@ -89,7 +89,8 @@ object PlayRun {
       baseDirectory.value,
       devSettings.value,
       args,
-      (mainClass in (Compile, Keys.run)).value.get
+      (mainClass in (Compile, Keys.run)).value.get,
+      PlayRun
     )
 
     interaction match {


### PR DESCRIPTION
Copies in changes from https://github.com/lagom/lagom/pull/137

Lagom should be able to use this Reloader instead of having its own after this change

This should help for adding Maven support to Play as well because it will be easier to copy what Lagom is doing by aligning the codebases a bit more

I'd appreciate a new milestone release after this is merged if that's not too hard. Lagom is already working on upgrading to Play 2.6 and that would make it slightly easier for me to test out some of these changes with Lagom