### PR TITLE
[WIP] Document new stubs and test helpers

### DIFF
--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -480,3 +480,43 @@ public class JPAPersonRepository implements PersonRepository {
     ...
 }
 ```
+
+## Testing Improvements
+
+Some utility classes have been added to the `play.api.test` package to make functional testing easier with dependency injected components.  
+
+### Injecting
+
+There are methods defined in [ScalaTestingWithGuice](ScalaTestingWithGuice##Overriding-bindings-in-a-functional-test) to override bindings, but there are times when it's easier to use the injector directly through the implicit `app`:
+
+```scala
+"test" in new WithApplication() {
+  val executionContext = app.injector.instanceOf[ExecutionContext]
+  ...
+}
+```
+
+Now with the [`Injecting`](api/scala/play/api/test/Injecting.html) trait, you can elide this:
+
+```scala
+"test" in new WithApplication() with Injecting {
+  val executionContext = inject[ExecutionContext]
+  ...
+}
+```
+
+### StubControllerComponents
+
+The [`StubControllerComponentsFactory`](api/scala/play/api/test/StubControllerComponentsFactory.html) creates a stub [`ControllerComponents`](api/scala/play/api/mvc/ControllerComponents.html) that can be used for unit testing a controller:
+
+```scala
+val controller = new MyController(stubControllerComponents())
+```
+
+### StubBodyParser
+
+The [`StubBodyParserFactory`](api/scala/play/api/test/StubBodyParserFactory.html) creates a stub [`BodyParser`](api/scala/play/api/mvc/BodyParser.html) that can be used for unit testing content:
+
+```
+val stubParser = stubBodyParser(AnyContent("hello"))
+```


### PR DESCRIPTION
## Purpose

https://www.playframework.com/documentation/2.6.x/JavaTest / https://www.playframework.com/documentation/2.6.x/ScalaTestingYourApplication needs to be updated to be current with the changes made to the MVC framework.  Particularly the Java Http.Context changes, which used to be global and now rely on injected components.

Started off with highlights, but there's probably more that need documenting.

Should also mention Scalatest's [ScalaFutures](http://doc.scalatest.org/3.0.0/index.html#org.scalatest.concurrent.ScalaFutures) and [AsyncTestSuite support](http://www.scalatest.org/user_guide/async_testing) which does not rely on a blocking `whenReady`.  Play's own `FutureAwaits` could also use a pointer to the Async support.
