### PR TITLE
Improve Java app loader/provider

### DIFF
--- a/framework/src/play-server/src/test/scala/play/core/server/ssl/ServerSSLEngineSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/ssl/ServerSSLEngineSpec.scala
@@ -11,9 +11,11 @@ import org.specs2.mock.Mockito
 import org.specs2.specification.Scope
 import play.core.ApplicationProvider
 import play.core.server.ServerConfig
+
 import scala.util.Failure
 import java.io.File
 import javax.net.ssl.SSLEngine
+
 import play.server.api.SSLEngineProvider
 
 class WrongSSLEngineProvider {}
@@ -61,9 +63,13 @@ class ServerSSLEngineSpec extends Specification with Mockito {
   }
 
   def createEngine(engineProvider: Option[String], tempDir: Option[File] = None) = {
-    val app = mock[ApplicationProvider]
-    app.get returns Failure(new Exception("no app"))
-    ServerSSLEngine.createSSLEngineProvider(serverConfig(tempDir.getOrElse(new File(".")), engineProvider), app)
+    val app = mock[play.api.Application]
+    app.classloader returns this.getClass.getClassLoader
+    app.asJava returns mock[play.Application]
+
+    val appProvider = mock[ApplicationProvider]
+    appProvider.get returns scala.util.Success(app) // Failure(new Exception("no app"))
+    ServerSSLEngine.createSSLEngineProvider(serverConfig(tempDir.getOrElse(new File(".")), engineProvider), appProvider)
       .createSSLEngine()
   }
 

--- a/framework/src/play/src/main/java/play/ApplicationLoader.java
+++ b/framework/src/play/src/main/java/play/ApplicationLoader.java
@@ -34,6 +34,16 @@ import scala.compat.java8.OptionConverters;
  */
 public interface ApplicationLoader {
 
+    static ApplicationLoader apply(Context context) {
+        final play.api.ApplicationLoader loader = play.api.ApplicationLoader$.MODULE$.apply(context.asScala());
+        return new ApplicationLoader() {
+            @Override
+            public Application load(Context context) {
+                return loader.load(context.asScala()).asJava();
+            }
+        };
+    }
+
     /**
      * Load an application given the context.
      *

--- a/framework/src/play/src/main/java/play/server/ApplicationProvider.java
+++ b/framework/src/play/src/main/java/play/server/ApplicationProvider.java
@@ -4,7 +4,11 @@
 package play.server;
 
 import play.Application;
+import play.mvc.Http;
+import play.mvc.Result;
+import scala.compat.java8.OptionConverters;
 
+import java.util.Optional;
 
 /**
  * Provides information about a Play Application running inside a Play server.
@@ -12,13 +16,43 @@ import play.Application;
 public class ApplicationProvider {
 
     private final Application application;
+    private final play.core.ApplicationProvider underlying;
 
     public ApplicationProvider(Application application) {
         this.application = application;
+        this.underlying = play.core.ApplicationProvider$.MODULE$.apply(application.asScala());
     }
 
+    /**
+     * @return The Scala version of this application provider.
+     */
+    public play.core.ApplicationProvider asScala() {
+        return underlying;
+    }
+
+    /**
+     * @return the application.
+     *
+     * @deprecated Deprecated as of 2.6.0. Use {@link #get()} instead.
+     */
     public Application getApplication() {
         return application;
     }
 
+    /**
+     * @return Returns an Optional with the application, if available.
+     */
+    public Optional<Application> get() {
+        return Optional.ofNullable(application);
+    }
+
+    /**
+     * Handle a request directly, without using the application.
+     * @param requestHeader the request made.
+     */
+    public Optional<Result> handleWebCommand(Http.RequestHeader requestHeader) {
+        return OptionConverters
+                .toJava(this.underlying.handleWebCommand(requestHeader.asScala()))
+                .map(play.api.mvc.Result::asJava);
+    }
 }

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -85,7 +85,7 @@ object ApplicationLoader {
           override def load(context: ApplicationLoader.Context): Application = {
             val javaContext = new play.ApplicationLoader.Context(context)
             val javaApplication = javaApplicationLoader.load(javaContext)
-            javaApplication.getWrappedApplication
+            javaApplication.asScala()
           }
         }
         new JavaApplicationLoaderAdapter


### PR DESCRIPTION
## Purpose

While this API is internal and wouldn’t be used by users creating application, it could be useful to people integrating with Play.

It will helps us to move from this code:

```java
public class Foo {
    public static void main(String[] args) {
        play.Environment env = play.Environment.simple();
        play.ApplicationLoader.Context context = play.ApplicationLoader.create(env);

        play.api.ApplicationLoader loader = play.api.ApplicationLoader$.MODULE$.apply(context.underlying());

        play.api.Application application = loader.load(context.underlying());
        play.core.ApplicationProvider applicationProvider = play.core.ApplicationProvider$.MODULE$.apply(application);

        scala.Option<play.api.mvc.Result> resultOption = applicationProvider.handleWebCommand(someKindOfRequestTranslation());
        
        if (resultOption.isDefined()) {
            // application was able to handle the result
            play.api.mvc.Result result = resultOption.get();
        } else {
            // no handler was found
            play.api.mvc.Result result = play.api.mvc.Results$.MODULE$.NotFound();
        }
    }

    private static play.api.mvc.RequestHeader someKindOfRequestTranslation() {
        return ...;
    }
}
```

To this new version using only Java APIs:

```java
public class Foo {
    public static void main(String[] args) {
        play.Environment env = play.Environment.simple();
        play.ApplicationLoader.Context context = play.ApplicationLoader.create(env);

        play.ApplicationLoader loader = play.ApplicationLoader.apply(context);

        play.Application application = loader.load(context);
        play.server.ApplicationProvider applicationProvider = new play.server.ApplicationProvider(application);

        play.mvc.Result result = applicationProvider
                .handleWebCommand(someKindOfRequestTranslation())
                .orElse(play.mvc.Results.notFound());
    }

    // This would translate from AWS Lambda request to a Play request.
    private static play.mvc.Http.RequestHeader someKindOfRequestTranslation() {
        return ...;
    }
}
```

## References

See discussion here: https://twitter.com/sapessi/status/859450726551924736