### PR TITLE
Add MessagesAbstractController

### DIFF
--- a/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/BuiltinModule.scala
@@ -57,6 +57,8 @@ class BuiltinModule extends SimpleModule((env, conf) => {
     bind[BodyParsers.Default].toSelf,
     bind[DefaultActionBuilder].to[DefaultActionBuilderImpl],
     bind[ControllerComponents].to[DefaultControllerComponents],
+    bind[MessagesActionBuilder].to[DefaultMessagesActionBuilderImpl],
+    bind[MessagesControllerComponents].to[DefaultMessagesControllerComponents],
     bind[Futures].to[DefaultFutures],
 
     // Application lifecycle, bound both to the interface, and its implementation, so that Application can access it


### PR DESCRIPTION
This PR adds a BaseControllerHelpers trait that wires everything in ControllerHelpers to ControllerComponents.

Then, it redefines BaseController as BaseControllerHelpers with the Action trait.

Finally, it adds a MessagesAbstractController that extends BaseControllerHelpers, and a MessagesControllerComponents.  

This means that if you want to use MessagesRequest as the base type with an abstract controller, you can do it without interfering with BaseController inheritance or rewiring ControllerHelpers from the ground up.