### PR TITLE
Add HTTP/2 support module and documentation

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
@@ -2,10 +2,14 @@
 
 By default, Play uses the [[Akka HTTP server backend|AkkaHttpServer]].
 
-like the rest of Play, the Akka HTTP server backend is configured with Typesafe Config.
+Like the rest of Play, the Akka HTTP server backend is configured with Typesafe Config.
 
 @[](/confs/play-akka-http-server/reference.conf)
 
 You can read more about the configuration settings in the [Akka HTTP documentation](http://doc.akka.io/docs/akka-http/current/scala/http/configuration.html).
+
+There is also a separate configuration file for the HTTP/2 support in Akka HTTP, if you have enabled the `AkkaHttp2Support` plugin:
+
+@[](/confs/play-akka-http2-support/reference.conf)
 
 > **Note:** In dev mode, when you use the `run` command, your `application.conf` settings will not be picked up by the server. This is because in dev mode the server starts before the application classpath is available. There are several [[other options|Configuration#Using-with-the-run-command]] you'll need to use instead.

--- a/documentation/manual/working/commonGuide/server/AkkaHttpServer.md
+++ b/documentation/manual/working/commonGuide/server/AkkaHttpServer.md
@@ -19,4 +19,36 @@ Please configure any work with blocking APIs off the main rendering thread, usin
 
 ## Configuring Akka HTTP
 
-You can configure the Akka HTTP server settings through [[application.conf|SettingsAkkaHttp]].
+You can configure the Akka HTTP server settings through [[application.conf|SettingsAkkaHttp]]. That also describes how to enable the HTTP/2 support.
+
+## HTTP/2 support (experimental)
+
+Play's Akka HTTP server also supports HTTP/2. This feature is labeled "experimental" because the API may change in the future, and it has not been thoroughly tested in the wild. However, if you'd like to help Play improve please do test out HTTP/2 support and give us feedback about your experience.
+
+To add support for HTTP/2, add the `PlayAkkaHttp2Support` plugin. You can do this in an `enablePlugins` call for your project in `build.sbt`:
+
+```
+lazy val root = (project in file("."))
+  .enablePlugins(PlayScala, PlayAkkaHttp2Support)
+```
+
+Adding the plugin will do multiple things:
+
+ - It will add the `play-akka-http2-support` module, which provides extra configuration for HTTP/2 and depends on the `akka-http2-support` module. By default HTTP/2 is enabled. It can be disabled by passing the `http2.enabled` system property, e.g. `play "start -Dhttp2.enabled=no"`.
+ - Configures the [Jetty ALPN agent](https://github.com/jetty-project/jetty-alpn-agent) as a Java agent using [sbt-javaagent](https://github.com/sbt/sbt-javaagent), and automatically adds the `-javaagent` argument for `start`, `stage` and `dist` tasks (i.e. production mode). This adds ALPN support to the JDK, allowing Akka HTTP to negotiate the protocol with the client. It *does not* configure for run mode. In JDK 9 this will not be an issue, since ALPN support is provided by default.
+
+### Using HTTP/2 in `run` mode
+
+If you need to use HTTP/2 in dev mode, you need to add a `-javaagent` argument for the Jetty ALPN agent to the Java options used to execute SBT
+
+```
+export SBT_OPTS="$SBT_OPTS -javaagent:$AGENT"
+```
+
+where `$AGENT` is the path to your Java agent. If you've already run `sbt stage`, you can find the path to the agent in your `target` directory:
+
+```
+export AGENT=$(pwd)/$(find target -name 'jetty-alpn-agent-*.jar' | head -1)
+```
+
+You also may want to write a simple script to run your app with the needed options, as demonstrated the `./play` script in the [play-scala-tls-example](https://github.com/playframework/play-scala-tls-example/blob/2.5.x/play)

--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -89,12 +89,19 @@ lazy val PlayNettyServerProject = PlayCrossBuiltProject("Play-Netty-Server", "pl
 
 import AkkaDependency._
 lazy val PlayAkkaHttpServerProject = PlayCrossBuiltProject("Play-Akka-Http-Server", "play-akka-http-server")
-    // Include scripted tests here as well as in the SBT Plugin, because we
-    // don't want the SBT Plugin to have a dependency on an experimental module.
-    //.settings(ScriptedPlugin.scriptedSettings ++ playScriptedSettings)
     .dependsOn(PlayServerProject, StreamsProject)
     .dependsOn(PlayGuiceProject % "test")
+    .settings(
+      resolvers += "Akka Snapshot Repository" at "http://repo.akka.io/snapshots/"
+    )
     .addAkkaModuleDependency("akka-http-core")
+
+lazy val PlayAkkaHttp2SupportProject = PlayCrossBuiltProject("Play-Akka-Http2-Support", "play-akka-http2-support")
+    .dependsOn(PlayAkkaHttpServerProject)
+    .settings(
+      resolvers += "Akka Snapshot Repository" at "http://repo.akka.io/snapshots/"
+    )
+    .addAkkaModuleDependency("akka-http2-support")
 
 lazy val PlayJdbcApiProject = PlayCrossBuiltProject("Play-JDBC-Api", "play-jdbc-api")
     .dependsOn(PlayProject)
@@ -286,6 +293,7 @@ lazy val publishedProjects = Seq[ProjectReference](
   RoutesCompilerProject,
   SbtRoutesCompilerProject,
   PlayAkkaHttpServerProject,
+  PlayAkkaHttp2SupportProject,
   PlayCacheProject,
   PlayEhcacheProject,
   PlayJdbcApiProject,

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -9,7 +9,7 @@ import buildinfo.BuildInfo
 object Dependencies {
 
   val akkaVersion = "2.5.1"
-  val akkaHttpVersion = "10.0.6"
+  val akkaHttpVersion = "10.0.6+7-e2ba6752"
   val playJsonVersion = "2.6.0-M7"
 
   val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
@@ -190,6 +190,7 @@ object Dependencies {
 
       sbtDep("com.typesafe.sbt" % "sbt-native-packager" % BuildInfo.sbtNativePackagerVersion),
 
+      sbtDep("com.lightbend.sbt" % "sbt-javaagent" % "0.1.2"),
       sbtDep("com.typesafe.sbt" % "sbt-web" % "1.4.0"),
       sbtDep("com.typesafe.sbt" % "sbt-js-engine" % "1.2.0")
     ) ++ specsBuild.map(_ % Test)

--- a/framework/src/play-akka-http-server/src/main/resources/play/reference-overrides.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/play/reference-overrides.conf
@@ -17,7 +17,21 @@ akka {
 
   http.server {
     # Disable Akka-HTTP's transparent HEAD handling. so that play's HEAD handling can take action
-    transparent-head-requests = false
+    transparent-head-requests = off
+
+    # doesn't work when we set .withRemoteAddressHeader(true) for some reason
+    remote-address-header = on
   }
 
+}
+
+# separate config for dev mode
+play.akka.dev-mode {
+  akka {
+    log-dead-letters = off
+    http.server {
+      transparent-head-requests = off
+      remote-address-header = on
+    }
+  }
 }

--- a/framework/src/play-akka-http-server/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/reference.conf
@@ -39,10 +39,6 @@ play {
       # Examples: `www.spray.io` or `example.com:8080`
       default-host-header = ""
 
-      # Enables/disables the addition of a `Remote-Address` header
-      # holding the clients (remote) IP address.
-      remote-address-header = off
-
       # The default value of the `Server` header to produce if no
       # explicit `Server`-header was included in a response.
       # If this value is the empty string and no header was included in

--- a/framework/src/play-akka-http2-support/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http2-support/src/main/resources/reference.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+#
+
+# Determines whether HTTP2 is enabled.
+play.server.akka.http2 {
+  enabled = true
+  enabled = ${?http2.enabled}
+}

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/Play.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/Play.scala
@@ -5,7 +5,6 @@ package play.sbt
 
 import com.typesafe.sbt.jse.SbtJsTask
 import com.typesafe.sbt.packager.archetypes.JavaServerAppPackaging
-import play.sbt.PlayAkkaHttpServer.allRequirements
 import play.sbt.PlayImport.PlayKeys
 import play.sbt.routes.RoutesCompiler
 import play.twirl.sbt.SbtTwirl
@@ -102,5 +101,18 @@ object PlayAkkaHttpServer extends AutoPlugin {
 
   override def projectSettings = Seq(
     libraryDependencies += "com.typesafe.play" %% "play-akka-http-server" % play.core.PlayVersion.current
+  )
+}
+
+object PlayAkkaHttp2Support extends AutoPlugin {
+  import com.lightbend.sbt.javaagent.JavaAgent
+
+  override def requires = PlayAkkaHttpServer && JavaAgent
+
+  import JavaAgent.JavaAgentKeys._
+
+  override def projectSettings = Seq(
+    libraryDependencies += "com.typesafe.play" %% "play-akka-http2-support" % play.core.PlayVersion.current,
+    javaAgents += "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.6" % "compile;test"
   )
 }


### PR DESCRIPTION
To enable HTTP/2, you can enable the `PlayAkkaHttp2Support` module on your project. This will add the `play-akka-http2-support` module and add the Java agent for ALPN support.

See also playframework/play-scala-tls-example#30

To work in dev mode, the user has to manually add a Java agent for ALPN support. I hope to improve the user experience for this in the future.