### PR TITLE
Remove deprecated lang methods

### DIFF
--- a/framework/src/play/src/main/java/play/i18n/Lang.java
+++ b/framework/src/play/src/main/java/play/i18n/Lang.java
@@ -4,10 +4,11 @@
 package play.i18n;
 
 import java.util.*;
+import java.util.stream.Stream;
 
 import play.Application;
-import play.api.Play;
 import play.libs.*;
+import scala.collection.immutable.Seq;
 
 import static java.util.stream.Collectors.toList;
 
@@ -83,39 +84,13 @@ public class Lang extends play.api.i18n.Lang {
     /**
      * Retrieve Lang availables from the application configuration.
      *
-     * @return the available languages
-     * @deprecated Please use Lang.availables(app), since 2.5.0
-     */
-    @Deprecated
-    public static List<Lang> availables() {
-        Application current = play.Play.application();
-        return availables(current);
-    }
-
-    /**
-     * Retrieve Lang availables from the application configuration.
-     *
      * @param app the current application.
      * @return the list of available Lang.
      */
     public static List<Lang> availables(Application app) {
-        List<play.api.i18n.Lang> langs = Scala.asJava(play.api.i18n.Lang.availables(app.getWrappedApplication()));
-        return langs.stream().map(Lang::new).collect(toList());
-    }
-
-    /**
-     * Guess the preferred lang in the langs set passed as argument.
-     * The first Lang that matches an available Lang wins, otherwise returns the first Lang available in this application.
-     *
-     * @param langs the set of langs from which to guess the preferred
-     * @return the preferred lang.
-     * @deprecated Please use preferred(app, langs).  Deprecated since 2.5.0.
-     */
-    @Deprecated
-    public static Lang preferred(List<Lang> langs) {
-        play.api.Application app = Play.current();
-        List<play.api.i18n.Lang> result = langs.stream().collect(toList());
-        return new Lang(play.api.i18n.Lang.preferred(Scala.toSeq(result), app));
+        play.api.i18n.Langs langs = app.injector().instanceOf(play.api.i18n.Langs.class);
+        List<play.api.i18n.Lang> availableLangs = Scala.asJava(langs.availables());
+        return availableLangs.stream().map(Lang::new).collect(toList());
     }
 
     /**
@@ -123,11 +98,13 @@ public class Lang extends play.api.i18n.Lang {
      * The first Lang that matches an available Lang wins, otherwise returns the first Lang available in this application.
      *
      * @param app the currept application
-     * @param langs the set of langs from which to guess the preferred
+     * @param availableLangs the set of langs from which to guess the preferred
      * @return the preferred lang.
      */
-    public static Lang preferred(Application app, List<Lang> langs) {
-        List<play.api.i18n.Lang> result = langs.stream().collect(toList());
-        return new Lang(play.api.i18n.Lang.preferred(Scala.toSeq(result), app.getWrappedApplication()));
+    public static Lang preferred(Application app, List<Lang> availableLangs) {
+        play.api.i18n.Langs langs = app.injector().instanceOf(play.api.i18n.Langs.class);
+        Stream<Lang> stream = availableLangs.stream();
+        List<play.api.i18n.Lang> langSeq = stream.map(l -> new play.api.i18n.Lang(l.toLocale())).collect(toList());
+        return new Lang(langs.preferred(Scala.toSeq(langSeq)));
     }
 }

--- a/framework/src/play/src/main/scala/play/api/i18n/Langs.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Langs.scala
@@ -113,28 +113,6 @@ object Lang {
   def get(code: String): Option[Lang] = Try(apply(code)).toOption
 
   private val langsCache = Application.instanceCache[Langs]
-
-  /**
-   * Retrieve Lang availables from the application configuration.
-   *
-   * {{{
-   * play.i18n.langs = ["fr", "en", "de"]
-   * }}}
-   */
-  @deprecated("Inject Langs into your component", "2.5.0")
-  def availables(implicit app: Application): Seq[Lang] = {
-    langsCache(app).availables
-  }
-
-  /**
-   * Guess the preferred lang in the langs set passed as argument.
-   * The first Lang that matches an available Lang wins, otherwise returns the first Lang available in this application.
-   */
-  @deprecated("Inject Langs into your component", "2.5.0")
-  def preferred(langs: Seq[Lang])(implicit app: Application): Lang = {
-    langsCache(app).preferred(langs)
-  }
-
 }
 
 /**


### PR DESCRIPTION
There were some 2.5.x deprecated Lang methods still hanging around.

This PR removes them.  Note that the 2.5.x deprecated Play.current() accessors are still around.