### PR TITLE
Refactor some singleton access

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -132,10 +132,10 @@ trait Cookies extends Traversable[Cookie] {
 /**
  * Helper utilities to encode Cookies.
  */
-@deprecated("Inject play.api.mvc.CookieHeaderEncoding instead", "2.6.0")
 object Cookies extends CookieHeaderEncoding {
 
   // Use global state for cookie header configuration
+  @deprecated("Inject play.api.mvc.CookieHeaderEncoding instead", "2.6.0")
   override protected def config: CookiesConfiguration = HttpConfiguration.current.cookies
 
   def apply(cookies: Seq[Cookie]): Cookies = new Cookies {

--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -132,7 +132,7 @@ trait Cookies extends Traversable[Cookie] {
 /**
  * Helper utilities to encode Cookies.
  */
-@deprecated("Inject [[play.api.mvc.CookieHeaderEncoding]] instead", "2.6.0")
+@deprecated("Inject play.api.mvc.CookieHeaderEncoding instead", "2.6.0")
 object Cookies extends CookieHeaderEncoding {
 
   // Use global state for cookie header configuration

--- a/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
@@ -80,7 +80,7 @@ trait FlashCookieBaker extends CookieBaker[Flash] with CookieDataCodec {
   override def secure: Boolean = config.secure
   override def httpOnly: Boolean = config.httpOnly
   override def domain: Option[String] = config.domain
-  override def sameSite = config.sameSite
+  override def sameSite: Option[Cookie.SameSite] = config.sameSite
 
   def deserialize(data: Map[String, String]): Flash = new Flash(data)
 
@@ -108,16 +108,46 @@ class LegacyFlashCookieBaker @Inject() (
   def this() = this(FlashConfiguration(), SecretConfiguration(), new CookieSignerProvider(SecretConfiguration()).get)
 }
 
-object Flash extends FlashCookieBaker with UrlEncodedCookieDataCodec {
+object Flash extends CookieBaker[Flash] with UrlEncodedCookieDataCodec {
+
+  val emptyCookie = new Flash
+
+  def fromJavaFlash(javaFlash: play.mvc.Http.Flash): Flash = new Flash(javaFlash.asScala.toMap)
+
+  @deprecated("Inject play.api.mvc.FlashCookieBaker instead", "2.6.0")
+  override val isSigned: Boolean = false
 
   @deprecated("Inject play.api.mvc.FlashCookieBaker instead", "2.6.0")
   def config: FlashConfiguration = HttpConfiguration.current.flash
-
-  def fromJavaFlash(javaFlash: play.mvc.Http.Flash): Flash = new Flash(javaFlash.asScala.toMap)
 
   @deprecated("Inject play.api.mvc.FlashCookieBaker instead", "2.6.0")
   override def path: String = HttpConfiguration.current.context
 
   @deprecated("Inject play.api.mvc.FlashCookieBaker instead", "2.6.0")
   override def cookieSigner: CookieSigner = play.api.libs.Crypto.cookieSigner
+
+  @deprecated("Inject play.api.mvc.FlashCookieBaker instead", "2.6.0")
+  override def COOKIE_NAME: String = config.cookieName
+
+  @deprecated("Inject play.api.mvc.FlashCookieBaker instead", "2.6.0")
+  override def secure: Boolean = config.secure
+
+  @deprecated("Inject play.api.mvc.FlashCookieBaker instead", "2.6.0")
+  override def maxAge = None
+
+  @deprecated("Inject play.api.mvc.FlashCookieBaker instead", "2.6.0")
+  override def httpOnly: Boolean = config.httpOnly
+
+  @deprecated("Inject play.api.mvc.FlashCookieBaker instead", "2.6.0")
+  override def domain: Option[String] = config.domain
+
+  @deprecated("Inject play.api.mvc.FlashCookieBaker instead", "2.6.0")
+  override def sameSite: Option[Cookie.SameSite] = config.sameSite
+
+  @deprecated("Inject play.api.mvc.FlashCookieBaker instead", "2.6.0")
+  override def deserialize(data: Map[String, String]): Flash = new Flash(data)
+
+  @deprecated("Inject play.api.mvc.FlashCookieBaker instead", "2.6.0")
+  override def serialize(flash: Flash): Map[String, String] = flash.data
+
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Flash.scala
@@ -108,10 +108,16 @@ class LegacyFlashCookieBaker @Inject() (
   def this() = this(FlashConfiguration(), SecretConfiguration(), new CookieSignerProvider(SecretConfiguration()).get)
 }
 
-@deprecated("Inject [[play.api.mvc.FlashCookieBaker]] instead", "2.6.0")
 object Flash extends FlashCookieBaker with UrlEncodedCookieDataCodec {
+
+  @deprecated("Inject play.api.mvc.FlashCookieBaker instead", "2.6.0")
   def config: FlashConfiguration = HttpConfiguration.current.flash
+
   def fromJavaFlash(javaFlash: play.mvc.Http.Flash): Flash = new Flash(javaFlash.asScala.toMap)
+
+  @deprecated("Inject play.api.mvc.FlashCookieBaker instead", "2.6.0")
   override def path: String = HttpConfiguration.current.context
+
+  @deprecated("Inject play.api.mvc.FlashCookieBaker instead", "2.6.0")
   override def cookieSigner: CookieSigner = play.api.libs.Crypto.cookieSigner
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/Session.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Session.scala
@@ -114,12 +114,19 @@ class LegacySessionCookieBaker @Inject() (val config: SessionConfiguration, val 
   def this() = this(SessionConfiguration(), new CookieSignerProvider(SecretConfiguration()).get)
 }
 
-@deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
 object Session extends SessionCookieBaker with FallbackCookieDataCodec {
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
   def config: SessionConfiguration = HttpConfiguration.current.session
+
   def fromJavaSession(javaSession: play.mvc.Http.Session): Session = new Session(javaSession.asScala.toMap)
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
   override def path: String = HttpConfiguration.current.context
 
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
   override lazy val jwtCodec = DefaultJWTCookieDataCodec(HttpConfiguration.current.secret, config.jwt)
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
   override lazy val signedCodec = DefaultUrlEncodedCookieDataCodec(isSigned, play.api.libs.Crypto.cookieSigner)
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/Session.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Session.scala
@@ -114,19 +114,48 @@ class LegacySessionCookieBaker @Inject() (val config: SessionConfiguration, val 
   def this() = this(SessionConfiguration(), new CookieSignerProvider(SecretConfiguration()).get)
 }
 
-object Session extends SessionCookieBaker with FallbackCookieDataCodec {
+object Session extends CookieBaker[Session] with FallbackCookieDataCodec {
 
-  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
-  def config: SessionConfiguration = HttpConfiguration.current.session
+  lazy val emptyCookie = new Session
 
   def fromJavaSession(javaSession: play.mvc.Http.Session): Session = new Session(javaSession.asScala.toMap)
 
   @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
-  override def path: String = HttpConfiguration.current.context
+  def config: SessionConfiguration = HttpConfiguration.current.session
 
   @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
   override lazy val jwtCodec = DefaultJWTCookieDataCodec(HttpConfiguration.current.secret, config.jwt)
 
   @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
   override lazy val signedCodec = DefaultUrlEncodedCookieDataCodec(isSigned, play.api.libs.Crypto.cookieSigner)
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
+  override val isSigned: Boolean = true
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
+  override def COOKIE_NAME: String = config.cookieName
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
+  override def secure: Boolean = config.secure
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
+  override def maxAge: Option[Int] = config.maxAge.map(_.toSeconds.toInt)
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
+  override def httpOnly: Boolean = config.httpOnly
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
+  override def path: String = HttpConfiguration.current.context
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
+  override def domain: Option[String] = config.domain
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
+  override def sameSite: Option[Cookie.SameSite] = config.sameSite
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
+  override def deserialize(data: Map[String, String]) = new Session(data)
+
+  @deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
+  override def serialize(session: Session): Map[String, String] = session.data
 }

--- a/framework/src/play/src/main/scala/play/api/mvc/Session.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Session.scala
@@ -114,7 +114,7 @@ class LegacySessionCookieBaker @Inject() (val config: SessionConfiguration, val 
   def this() = this(SessionConfiguration(), new CookieSignerProvider(SecretConfiguration()).get)
 }
 
-@deprecated("Inject [[play.api.mvc.SessionCookieBaker]] instead", "2.6.0")
+@deprecated("Inject play.api.mvc.SessionCookieBaker instead", "2.6.0")
 object Session extends SessionCookieBaker with FallbackCookieDataCodec {
   def config: SessionConfiguration = HttpConfiguration.current.session
   def fromJavaSession(javaSession: play.mvc.Http.Session): Session = new Session(javaSession.asScala.toMap)


### PR DESCRIPTION
Remove some deprecated singleton access in the Helpers.

Interestingly enough, even if I call `new Session()` the singleton object deprecation warning still is triggered by the compiler.

Think this is bug.