### PR TITLE
Configurable websocket frame max length

### DIFF
--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -1058,7 +1058,8 @@ HikariCP was updated and a new configuration was introduced: `initializationFail
 
 There are some configurations.  The old configuration paths will generally still work, but a deprecation warning will be output at runtime if you use them.  Here is a summary of the changed keys:
 
-| Old key                   | New key                            |
-| ------------------------- | ---------------------------------- |
-| `play.crypto.secret`      | `play.http.secret.key`             |
-| `play.crypto.provider`    | `play.http.secret.provider`        |
+| Old key                       | New key                                 |
+|-------------------------------|-----------------------------------------|
+| `play.crypto.secret`          | `play.http.secret.key`                  |
+| `play.crypto.provider`        | `play.http.secret.provider`             |
+| `play.websocket.buffer.limit` | `play.server.websocket.frame.maxLength` |

--- a/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaWebSockets.md
@@ -88,3 +88,13 @@ Let’s write another example that discards the input data and closes the socket
 Here is another example in which the input data is logged to standard out and then sent back to the client using a mapped flow:
 
 @[streams3](code/javaguide/async/JavaWebSockets.java)
+
+## Configuring WebSocket Frame Length
+
+You can configure the max length for [WebSocket data frames](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#Format) using `play.server.websocket.frame.maxLength` or passing `-Dwebsocket.frame.maxLength` system property when running your application. For example:
+
+```
+sbt -Dwebsocket.frame.maxLength=64k run
+```
+
+This configuration gives you more control of WebSocket frame length and can be adjusted to your application requirements. It may also reduce denial of service attacks using long data frames.

--- a/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaWebSockets.md
@@ -92,3 +92,13 @@ Let’s write another example that discards the input data and closes the socket
 Here is another example in which the input data is logged to standard out and then sent back to the client using a mapped flow:
 
 @[streams3](code/ScalaWebSockets.scala)
+
+## Configuring WebSocket Frame Length
+
+You can configure the max length for [WebSocket data frames](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#Format) using `play.server.websocket.frame.maxLength` or passing `-Dwebsocket.frame.maxLength` system property when running your application. For example:
+
+```
+sbt -Dwebsocket.frame.maxLength=64k run
+```
+
+This configuration gives you more control of WebSocket frame length and can be adjusted to your application requirements. It may also reduce denial of service attacks using long data frames.

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/netty/PlayRequestHandler.scala
@@ -110,7 +110,7 @@ private[play] class PlayRequestHandler(val server: NettyServer) extends ChannelI
 
         val wsProtocol = if (requestHeader.secure) "wss" else "ws"
         val wsUrl = s"$wsProtocol://${requestHeader.host}${requestHeader.path}"
-        val bufferLimit = app.configuration.getOptional[ConfigMemorySize]("play.websocket.buffer.limit").map(_.toBytes).getOrElse(65536L).asInstanceOf[Int]
+        val bufferLimit = app.configuration.getDeprecated[ConfigMemorySize]("play.server.websocket.frame.maxLength", "play.websocket.buffer.limit").toBytes.toInt
         val factory = new WebSocketServerHandshakerFactory(wsUrl, "*", true, bufferLimit)
 
         val executed = Future(ws(requestHeader))(app.actorSystem.dispatcher)

--- a/framework/src/play-server/src/main/resources/reference.conf
+++ b/framework/src/play-server/src/main/resources/reference.conf
@@ -79,6 +79,13 @@ play {
     # If set to "/dev/null" then no pid file will be created.
     pidfile.path = ${play.server.dir}/RUNNING_PID
     pidfile.path = ${?pidfile.path}
+
+    websocket {
+      # Maximum allowable frame payload length. Setting this value to your application's
+      # requirement may reduce denial of service attacks using long data frames.
+      frame.maxLength = 64k
+      frame.maxLength = ${?websocket.frame.maxLength}
+    }
   }
 
   editor = ${?PLAY_EDITOR}


### PR DESCRIPTION
## Fixes

Fixes #7335.

## Purpose

Configurable websocket buffer limit. Also add a reference value, which was hardcoded for both Akka and Netty servers.

This should be backported to 2.5.x.