### PR TITLE
Rename package from java to javaguide

### DIFF
--- a/documentation/manual/working/commonGuide/production/ConfiguringHttps.md
+++ b/documentation/manual/working/commonGuide/production/ConfiguringHttps.md
@@ -30,11 +30,11 @@ Another alternative to configure the SSL certificates is to provide a custom [SS
 
 #### in Java, an implementation must be provided for [`play.server.SSLEngineProvider`](api/java/play/server/SSLEngineProvider.html)
 
-@[javaexample](code/java/CustomSSLEngineProvider.java)
+@[javaexample](code/javaguide/CustomSSLEngineProvider.java)
 
 #### in Scala, an implementation must be provided for [`play.server.api.SSLEngineProvider`](api/scala/play/server/api/SSLEngineProvider.html)
 
-@[scalaexample](code/scala/CustomSSLEngineProvider.scala)
+@[scalaexample](code/scalaguide/CustomSSLEngineProvider.scala)
 
 Having created an implementation for `play.server.SSLEngineProvider` or `play.server.api.SSLEngineProvider`, the following system property configures Play to use it:
 

--- a/documentation/manual/working/commonGuide/production/HTTPServer.md
+++ b/documentation/manual/working/commonGuide/production/HTTPServer.md
@@ -7,7 +7,7 @@ You can easily deploy your application as a stand-alone server by setting the ap
 $ /path/to/bin/<project-name> -Dhttp.port=80
 ```
 
-> Note that you probably need root permissions to bind a process on this port.
+> **Note**: you probably need root permissions to bind a process on this port.
 
 However, if you plan to host several applications in the same server or load balance several instances of your application for scalability or fault tolerance, you can use a front end HTTP server.
 
@@ -103,7 +103,7 @@ http {
 }
 ```
 
-> *Note* Make sure you are using version 1.2 or greater of Nginx otherwise chunked responses won't work properly.
+> **Note**: make sure you are using version 1.2 or greater of Nginx otherwise chunked responses won't work properly.
 
 ## Set up with Apache
 
@@ -186,7 +186,7 @@ Apache also provides a way to view the status of your cluster. Simply point your
 
 Because Play is completely stateless you don’t have to manage sessions between the 2 clusters. You can actually easily scale to more than 2 Play instances.
 
-To use websockets, you must use [mod_proxy_wstunnel](http://httpd.apache.org/docs/2.4/mod/mod_proxy_wstunnel.html), which was introduced in Apache 2.4.
+To use WebSockets, you must use [mod_proxy_wstunnel](http://httpd.apache.org/docs/2.4/mod/mod_proxy_wstunnel.html), which was introduced in Apache 2.4.
 
 Note that [ProxyPassReverse might rewrite incorrectly headers](https://issues.apache.org/bugzilla/show_bug.cgi?id=51982) adding an extra / to the URIs, so you may wish to use this workaround:
 ```

--- a/documentation/manual/working/commonGuide/production/code/javaguide/CustomSSLEngineProvider.java
+++ b/documentation/manual/working/commonGuide/production/code/javaguide/CustomSSLEngineProvider.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-package java;
+package javaguide;
 
 // #javaexample
 import play.server.ApplicationProvider;

--- a/documentation/manual/working/commonGuide/production/code/scalaguide/CustomSSLEngineProvider.scala
+++ b/documentation/manual/working/commonGuide/production/code/scalaguide/CustomSSLEngineProvider.scala
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-package scala
+package scalaguide
 
 // #scalaexample
 import javax.net.ssl._


### PR DESCRIPTION
## Purpose

This will both keeps better consistency with other sections of our documentation but also avoid an annoying warning that I’ve noticed while writing #7346. Here is an example of this warning in our build:

https://travis-ci.org/playframework/playframework/jobs/232592636#L3259