### PR TITLE
Add stub helpers into documentation

### DIFF
--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -499,3 +499,43 @@ public class JPAPersonRepository implements PersonRepository {
     ...
 }
 ```
+
+## Testing Improvements
+
+Some utility classes have been added to the `play.api.test` packagein 2.6.x to make functional testing easier with dependency injected components.  
+
+### Injecting
+
+There are many functional tests that use the injector directly through the implicit `app`:
+
+```scala
+"test" in new WithApplication() {
+  val executionContext = app.injector.instanceOf[ExecutionContext]
+  ...
+}
+```
+
+Now with the [`Injecting`](api/scala/play/api/test/Injecting.html) trait, you can elide this:
+
+```scala
+"test" in new WithApplication() with Injecting {
+  val executionContext = inject[ExecutionContext]
+  ...
+}
+```
+
+### StubControllerComponents
+
+The [`StubControllerComponentsFactory`](api/scala/play/api/test/StubControllerComponentsFactory.html) creates a stub [`ControllerComponents`](api/scala/play/api/mvc/ControllerComponents.html) that can be used for unit testing a controller:
+
+```scala
+val controller = new MyController(stubControllerComponents())
+```
+
+### StubBodyParser
+
+The [`StubBodyParserFactory`](api/scala/play/api/test/StubBodyParserFactory.html) creates a stub [`BodyParser`](api/scala/play/api/mvc/BodyParser.html) that can be used for unit testing content:
+
+```
+val stubParser = stubBodyParser(AnyContent("hello"))
+```

--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -502,7 +502,7 @@ public class JPAPersonRepository implements PersonRepository {
 
 ## Testing Improvements
 
-Some utility classes have been added to the `play.api.test` packagein 2.6.x to make functional testing easier with dependency injected components.  
+Some utility classes have been added to the `play.api.test` package in 2.6.x to make functional testing easier with dependency injected components.  
 
 ### Injecting
 

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithSpecs2.md
@@ -39,6 +39,16 @@ If you want to test your application using a browser, you can use [Selenium WebD
 
 @[scalafunctionaltest-testwithbrowser](code/specs2/ScalaFunctionalTestSpec.scala)
 
+## Injecting
+
+There are many functional tests that use the injector directly through the implicit `app`:
+
+@[scalafunctionaltest-noinjecting](code/specs2/ExampleHelpersSpec.scala)
+
+With the [`Injecting`](api/scala/play/api/test/Injecting.html) trait, you can elide this:
+
+@[scalafunctionaltest-injecting](code/specs2/ExampleHelpersSpec.scala)
+
 ## PlaySpecification
 
 [`PlaySpecification`](api/scala/play/api/test/PlaySpecification.html) is an extension of [`Specification`](https://etorreborre.github.io/specs2/api/SPECS2-3.6.6/index.html#org.specs2.mutable.Specification) that excludes some of the mixins provided in the default specs2 specification that clash with Play helpers methods.  It also mixes in the Play test helpers and types for convenience.

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingWithSpecs2.md
@@ -139,6 +139,18 @@ You can test it like:
 
 @[scalatest-examplecontrollerspec](code/specs2/ExampleControllerSpec.scala)
 
+### StubControllerComponents
+
+The [`StubControllerComponentsFactory`](api/scala/play/api/test/StubControllerComponentsFactory.html) creates a stub [`ControllerComponents`](api/scala/play/api/mvc/ControllerComponents.html) that can be used for unit testing a controller:
+
+@[scalatest-stubcontrollercomponents](code/specs2/ExampleHelpersSpec.scala)
+
+### StubBodyParser
+
+The [`StubBodyParserFactory`](api/scala/play/api/test/StubBodyParserFactory.html) creates a stub [`BodyParser`](api/scala/play/api/mvc/BodyParser.html) that can be used for unit testing content:
+
+@[scalatest-stubbodyparser](code/specs2/ExampleHelpersSpec.scala)
+
 ## Unit Testing Forms
 
 Forms are also just regular classes, and can unit tested using Play's Test Helpers. Using [`play.api.test.FakeRequest`](api/scala/play/api/test/FakeRequest.html), you can call `form.bindFromRequest` and test for errors against any custom constraints.

--- a/documentation/manual/working/scalaGuide/main/tests/ScalaTestingYourApplication.md
+++ b/documentation/manual/working/scalaGuide/main/tests/ScalaTestingYourApplication.md
@@ -4,7 +4,9 @@
 Writing tests for your application can be an involved process. Play offers integration with both [ScalaTest](http://www.scalatest.org) and [specs2](https://etorreborre.github.io/specs2/) and provides helpers and application stubs to make testing your application as easy as possible. For the details of using your preferred test framework with Play, see the pages on [[ScalaTest|ScalaTestingWithScalaTest]] or [[specs2|ScalaTestingWithSpecs2]].
 
 * [[Testing your Application with ScalaTest|ScalaTestingWithScalaTest]]
+* [[Writing functional tests with ScalaTest|ScalaFunctionalTestingWithScalaTest]]
 * [[Testing your Application with specs2|ScalaTestingWithSpecs2]]
+* [[Writing functional tests with specs2|ScalaFunctionalTestingWithSpecs2]]
 
 ## Advanced testing
 
@@ -12,3 +14,4 @@ Play provides a number of helpers for testing specific parts of an application.
 
 * [[Testing using Guice dependency injection|ScalaTestingWithGuice]]
 * [[Testing with databases|ScalaTestingWithDatabases]]
+* [[Testing with Web Service Clients|ScalaTestingWebServiceClients]]

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleControllerSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleControllerSpec.scala
@@ -4,6 +4,8 @@
 package scalaguide.tests.specs2
 
 // #scalatest-examplecontrollerspec
+import javax.inject.Inject
+
 import play.api.mvc._
 import play.api.test._
 
@@ -13,7 +15,7 @@ class ExampleControllerSpec extends PlaySpecification with Results {
 
   "Example Page#index" should {
     "should be valid" in {
-      val controller = new ExampleController()
+      val controller = new ExampleController(Helpers.stubControllerComponents())
       val result: Future[Result] = controller.index().apply(FakeRequest())
       val bodyText: String = contentAsString(result)
       bodyText must be equalTo "ok"
@@ -68,7 +70,8 @@ class ExampleFormSpec extends PlaySpecification with Results {
 // #scalatest-exampleformspec
 
 // #scalatest-examplecontroller
-class ExampleController extends Controller {
+class ExampleController @Inject()(cc: ControllerComponents)
+  extends AbstractController(cc) {
   def index() = Action {
     Ok("ok")
   }

--- a/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleHelpersSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/specs2/ExampleHelpersSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package specs2
+
+import play.api.mvc.{AbstractController, AnyContent, ControllerComponents}
+import play.api.test.{Helpers, Injecting, PlaySpecification, WithApplication}
+
+import scala.concurrent.ExecutionContext
+
+/**
+ * Snippets to show off test helpers
+ */
+class ExampleHelpersSpec extends PlaySpecification {
+
+  // #scalafunctionaltest-noinjecting
+  "test" in new WithApplication() {
+    val executionContext = app.injector.instanceOf[ExecutionContext]
+    executionContext must beAnInstanceOf[ExecutionContext]
+  }
+  // #scalafunctionaltest-noinjecting
+
+  // #scalafunctionaltest-injecting
+  "test" in new WithApplication() with play.api.test.Injecting {
+    val executionContext = inject[ExecutionContext]
+    executionContext must beAnInstanceOf[ExecutionContext]
+  }
+  // #scalafunctionaltest-injecting
+
+  // #scalatest-stubbodyparser
+  val stubParser = Helpers.stubBodyParser(AnyContent("hello"))
+  // #scalatest-stubbodyparser
+
+  // #scalatest-stubcontrollercomponents
+  val controller = new MyController(
+    Helpers.stubControllerComponents(bodyParser = stubParser)
+  )
+  // #scalatest-stubcontrollercomponents
+
+  class MyController(cc: ControllerComponents) extends AbstractController(cc) {
+
+  }
+}


### PR DESCRIPTION
Adds the stub helpers so that AbstractController is documented.

Also add a couple of missing pages from the testing overview page and add it to the highlights.

Note that this doesn't cover scalatestplus-play as the documentation is in nother repository, and it doesn't cover changes in the Java test helpers (if any)...