### PR TITLE
Better MessagesProvider implicitNotFound

### DIFF
--- a/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaForms.md
@@ -161,15 +161,23 @@ The generic `input` helper mentioned above will let you code the desired HTML re
 
 For complex form elements, you can also create your own custom view helpers (using scala classes in the `views` package) and [[custom field constructors|ScalaCustomFieldConstructors]].
 
-### Passing Messages to Form Helpers
+### Passing MessagesProvider to Form Helpers
 
 The form helpers above -- [`input`](api/scala/views/html/helper/input$.html), [`checkbox`](api/scala/views/html/helper/checkbox$.html), and so on -- all take [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) as an implicit parameter.  The form handlers need to take [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) because they need to provide error messages mapped to the language defined in the request.  You can see more about [`Messages`](api/scala/play/api/i18n/Messages.html) in the [[Internationalization with Messages|ScalaI18N]] page.
 
-There are two ways to pass in the [`Messages`](api/scala/play/api/i18n/Messages.html) object required.
-  
-The first way is to make the controller extend [`play.api.i18n.I18nSupport`](api/scala/play/api/i18n/I18nSupport.html), which makes use of an injected [`MessagesApi`](api/scala/play/api/i18n/MessagesApi.html), and use an implicit conversion from an implicit request to [`Messages`](api/scala/play/api/i18n/Messages.html):
+There are two ways to pass in the [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html) object required.
+
+#### Option One: Implicitly Convert Request to Messages
+
+The first way is to make the controller extend [`play.api.i18n.I18nSupport`](api/scala/play/api/i18n/I18nSupport.html), which makes use of an injected [`MessagesApi`](api/scala/play/api/i18n/MessagesApi.html), and will implicitly convert an implicit request to an implicit [`Messages`](api/scala/play/api/i18n/Messages.html):
 
 @[messages-controller](code/ScalaForms.scala)
+
+This means that the following form template will be resolved:
+
+@[form-define](code/scalaguide/forms/scalaforms/views/implicitMessages.scala.html)
+
+#### Option Two: Use MessagesRequest
 
 The second way is to dependency inject a [`MessagesActionBuilder`](api/scala/play/api/mvc/MessagesActionBuilder.html), which provides a [`MessagesRequest`](api/scala/play/api/mvc/MessagesRequest.html):
 
@@ -177,9 +185,13 @@ The second way is to dependency inject a [`MessagesActionBuilder`](api/scala/pla
 
 This is useful because to use [[CSRF|ScalaCsrf]] with forms, both a `Request` (technically a `RequestHeader`) and a [`Messages`](api/scala/play/api/i18n/Messages.html) object must be available to the template.  By using a [`MessagesRequest`](api/scala/play/api/mvc/MessagesRequest.html), which is a [`WrappedRequest`](api/scala/play/api/mvc/WrappedRequest.html) that extends [`MessagesProvider`](api/scala/play/api/i18n/MessagesProvider.html), only a single implicit parameter needs to be made available to templates.
 
+Because you typically don't need the body of the request, you can pass [`MessagesRequestHeader`](api/scala/play/api/mvc/MessagesRequestHeader.html), rather than typing `MessagesRequest[_]`:
+
 @[form-define](code/scalaguide/forms/scalaforms/views/messages.scala.html)
 
-You can always use [[action composition|ScalaActionsComposition]] and extend [AbstractController](api/scala/play/api/mvc/AbstractController.html) to incorporate form processing into your controllers.
+Rather than inject [`MessagesActionBuilder`](api/scala/play/api/mvc/MessagesActionBuilder.html) into your controller, you can also make [`MessagesActionBuilder`](api/scala/play/api/mvc/MessagesActionBuilder.html) be the default `Action` by extending [MessagesAbstractController](api/scala/play/api/mvc/MessagesAbstractController.html) to incorporate form processing into your controllers.
+
+@[messages-abstract-controller](code/ScalaForms.scala)
 
 ### Displaying errors in a view template
 

--- a/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
+++ b/documentation/manual/working/scalaGuide/main/forms/code/ScalaForms.scala
@@ -566,7 +566,7 @@ class MessagesController @Inject()(cc: ControllerComponents)
 //#messages-controller
 
 //#messages-request-controller
-// Example form that uses a MessagesRequest, which is also a MessagesProvider
+// Example form injecting a messagesAction
 class FormController @Inject()(messagesAction: MessagesActionBuilder, components: ControllerComponents)
   extends AbstractController(components) {
 
@@ -587,6 +587,30 @@ class FormController @Inject()(messagesAction: MessagesActionBuilder, components
   def post() = TODO
 }
 //#messages-request-controller
+
+
+  //#messages-abstract-controller
+  // Form with Action extending MessagesAbstractController
+  class MessagesFormController @Inject()(components: MessagesControllerComponents)
+    extends MessagesAbstractController(components) {
+
+    import play.api.data.Form
+    import play.api.data.Forms._
+
+    val userForm = Form(
+      mapping(
+        "name" -> text,
+        "age" -> number
+      )(views.html.UserData.apply)(views.html.UserData.unapply)
+    )
+
+    def index = Action { implicit request: MessagesRequest[AnyContent] =>
+      Ok(views.html.messages(userForm))
+    }
+
+    def post() = TODO
+  }
+  //#messages-abstract-controller
 
 }
 

--- a/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/implicitMessages.scala.html
+++ b/documentation/manual/working/scalaGuide/main/forms/code/scalaguide/forms/scalaforms/views/implicitMessages.scala.html
@@ -1,0 +1,18 @@
+@import scalaguide.forms.scalaforms._
+@import scalaguide.forms.scalaforms.controllers.routes
+
+@* #form-define *@
+@(userForm: Form[UserData])(implicit request: RequestHeader, messagesProvider: MessagesProvider)
+
+@import helper._
+
+@helper.form(action = routes.FormController.post()) {
+@CSRF.formField                     @* <- takes a RequestHeader    *@
+@helper.inputText(userForm("name")) @* <- takes a MessagesProvider *@
+@helper.inputText(userForm("age"))  @* <- takes a MessagesProvider *@
+}
+@* #form-define *@<!--
+  ~ /*
+  ~  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+  ~  */
+  -->

--- a/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/Messages.scala
@@ -12,6 +12,7 @@ import play.api.mvc._
 import play.mvc.Http
 import play.utils.{ PlayIO, Resources }
 
+import scala.annotation.implicitNotFound
 import scala.io.Codec
 import scala.language._
 import scala.util.parsing.combinator._
@@ -249,6 +250,7 @@ case class MessagesImpl(lang: Lang, messagesApi: MessagesApi) extends Messages {
  * extend Product and does not expose MessagesApi as part of
  * its interface.
  */
+@implicitNotFound("An implicit Messages instance was not found.  Please see https://www.playframework.com/documentation/latest/ScalaI18N")
 trait Messages extends MessagesProvider {
 
   /**
@@ -310,6 +312,7 @@ trait Messages extends MessagesProvider {
 /**
  * This trait is used to indicate when a Messages instance can be produced.
  */
+@implicitNotFound("An implicit MessagesProvider instance was not found.  Please see https://www.playframework.com/documentation/latest/ScalaForms#passing-messages-to-form-helpers")
 trait MessagesProvider {
   def messages: Messages
 }


### PR DESCRIPTION
Add messages implicit not found and more forms documentation.

This gives an error message like the following:

```
   [play-scala-seed] $ compile
    [info] Compiling 10 Scala sources and 1 Java source to
   /home/wsargent/work/play-scala-seed/target/scala-2.12/classes...
    [error]
    /home/wsargent/work/play-scala-seed/app/views/user/form.scala.html:9: An
   implicit MessagesProvider instance was not found.  Please see
    https://www.playframework.com/documentation/latest/ScalaForms#passing-messages-to-form-helpers
    [error]   @helper.inputText(userForm("name"))
    [error]                    ^
    [error]
    /home/wsargent/work/play-scala-seed/app/views/user/form.scala.html:10: An
    implicit MessagesProvider instance was not found.  Please see
    https://www.playframework.com/documentation/latest/ScalaForms#passing-messages-to-form-helpers
    [error]   @helper.inputText(userForm("age"))
    [error]                    ^
    [error] two errors found
    [error] (compile:compileIncremental) Compilation failed
    [error] Total time: 0 s, completed May 16, 2017 4:29:00 PM
```