### PR TITLE
[WIP] Set up cross-compile for sbt 1.0.0-M5

### DIFF
--- a/framework/project/build.properties
+++ b/framework/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=0.13.16-M1


### PR DESCRIPTION
DO NOT MERGE WORK IN PROGRESS

This is a running PR for cross compatibility for sbt 1.0.0-M5.  It looks like sbt-twirl et al need to have 1.0.0-M5 cross compiles first before we can do this, so it might be a stretch.

Fixes https://github.com/playframework/playframework/issues/7261

See https://github.com/sbt/sbt/releases/tag/v0.13.16-M1

Set up for http://developer.lightbend.com/blog/2017-04-18-sbt-1-0-roadmap-and-beta1/#cross-building-sbt-1-0-plugin-from-sbt-0-13

Apparently https://github.com/sbt/sbt-pgp/blob/master/CONTRIBUTING.md is related somehow.

* Depends on Twirl: https://github.com/playframework/twirl/pull/138