### PR TITLE
Initialize Http.RequestBuilder with localhost

### DIFF
--- a/framework/src/play-test/src/main/java/play/test/Helpers.java
+++ b/framework/src/play-test/src/main/java/play/test/Helpers.java
@@ -136,7 +136,7 @@ public class Helpers implements play.mvc.Http.Status, play.mvc.Http.HeaderNames 
      * @return the request builder.
      */
     public static RequestBuilder fakeRequest(String method, String uri) {
-        return new RequestBuilder().host("localhost").method(method).uri(uri);
+        return new RequestBuilder().method(method).uri(uri);
     }
 
     /**

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -809,6 +809,8 @@ public class Http {
          */
         public RequestBuilder() {
             this(new DefaultRequestFactory(HttpConfiguration.createWithDefaults()));
+            // Add a host of "localhost" to validate against the AllowedHostsFilter.
+            this.host("localhost");
         }
 
         /**


### PR DESCRIPTION
The RequestBuilder has a remote connection of 127.0.0.1 but does not pass the AllowedHostsFilter as it does not have a Host header.  This PR adds the Host header directly to the RequestBuilder constructor.

Note that `Helpers.fakeRequest()` does contain the appropriate host header, but in testing it's just as valid to call `new Http.RequestBuilder()` as it is to call `Headers.fakeRequest()`.