### PR TITLE
[WIP] Add Java Embedded Server with Akka HTTP

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/embedding/JavaEmbeddingPlayAkkaHttp.md
+++ b/documentation/manual/working/javaGuide/advanced/embedding/JavaEmbeddingPlayAkkaHttp.md
@@ -1,0 +1,2 @@
+<!--- Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com> -->
+#  Embedding a Play Server with Akka Http server in your application

--- a/documentation/manual/working/javaGuide/advanced/embedding/JavaEmbeddingPlayNetty.md
+++ b/documentation/manual/working/javaGuide/advanced/embedding/JavaEmbeddingPlayNetty.md
@@ -1,0 +1,26 @@
+<!--- Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com> -->
+#  Embedding a Netty server in your application
+
+While Play apps are most commonly used as their own container, you can also embed a Play server into your own existing application.  This can be used in conjunction with the Twirl template compiler and Play routes compiler, but these are of course not necessary, a common use case for embedding a Play application will be because you only have a few very simple routes.
+
+The simplest way to start an embedded Play server is to use the [`Server`](api/java/play/server/Server.html) factory methods.  If all you need to do is provide some straightforward routes, you may decide to use the [[Routing DSL|JavaRoutingDsl]], so you will need the following imports:
+
+@[imports](code/javaguide/advanced/embedding/JavaEmbeddingPlay.java)
+
+Then you can create a server using the `forRouter` method:
+
+@[simple](code/javaguide/advanced/embedding/JavaEmbeddingPlay.java)
+
+By default, this will start a server on a random port in test mode.  You can check the port using the `httpPort` method:
+
+@[http-port](code/javaguide/advanced/embedding/JavaEmbeddingPlay.java)
+
+You can configure the server by passing in a `port` and/or `mode`:
+
+@[config](code/javaguide/advanced/embedding/JavaEmbeddingPlay.java)
+
+To stop the server once you've started it, simply call the `stop` method:
+
+@[stop](code/javaguide/advanced/embedding/JavaEmbeddingPlay.java)
+
+> **Note:** Play requires an application secret to be configured in order to start.  This can be configured by providing an `application.conf` file in your application, or using the `play.http.secret.key` system property.

--- a/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaAkkaEmbeddingPlay.java
+++ b/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaAkkaEmbeddingPlay.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package javaguide.advanced.embedding;
+
+public class JavaAkkaEmbeddingPlay {
+
+}

--- a/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaNettyEmbeddingPlay.java
+++ b/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaNettyEmbeddingPlay.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 
 import org.junit.Test;
 
+import play.Mode;
+import play.core.server.NettyServer;
 import play.libs.ws.WSClient;
 import play.libs.ws.WSResponse;
 
@@ -23,7 +25,7 @@ import static play.mvc.Controller.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
-public class JavaEmbeddingPlay {
+public class JavaNettyEmbeddingPlay {
 
     @Test
     public void simple() throws Exception {
@@ -58,7 +60,7 @@ public class JavaEmbeddingPlay {
     @Test
     public void config() throws Exception {
         //#config
-        Server server = Server.forRouter((components) -> RoutingDsl.fromComponents(components)
+        Server server = Server.forRouter(Mode.TEST, (components) -> RoutingDsl.fromComponents(components)
                 .GET("/hello/:to").routeTo(to ->
                         ok("Hello " + to)
                 )

--- a/documentation/manual/working/javaGuide/advanced/embedding/index.toc
+++ b/documentation/manual/working/javaGuide/advanced/embedding/index.toc
@@ -1,1 +1,3 @@
 JavaEmbeddingPlay:Embedding Play
+JavaEmbeddingPlayAkkaHttp:Embedding Play with Akka HTTP Server
+JavaEmbeddingPlayNetty:Embedding Play with Netty Server

--- a/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlay.md
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlay.md
@@ -2,5 +2,5 @@
 
 While Play apps are most commonly used as their own container, you can also embed a Play server into your own existing application.  This can be used in conjunction with the Twirl template compiler and Play routes compiler, but these are of course not necessary, a common use case for embedding a Play application will be because you only have a few very simple routes.
 
-* [[Embedding Play with Akka HTTP Server|JavaEmbeddingPlayAkkaHttp]]
-* [[Embedding Play with Netty Server|JavaEmbeddingPlayNetty]]
+* [[Embedding Play with Akka HTTP Server|ScalaEmbeddingPlayAkkaHttp]]
+* [[Embedding Play with Netty Server|ScalaEmbeddingPlayNetty]]

--- a/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayNetty.md
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayNetty.md
@@ -1,7 +1,6 @@
 <!--- Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com> -->
 # Embedding a Netty server in your application
 
-While Play apps are most commonly used as their own container, you can also embed a Play server into your own existing application.  This can be used in conjunction with the Twirl template compiler and Play routes compiler, but these are of course not necessary, a common use case for embedding a Play application will be because you only have a few very simple routes.
 
 The simplest way to start an embedded Play server is to use the [`NettyServer`](api/scala/play/core/server/NettyServer$.html) factory methods.  If all you need to do is provide some straightforward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouter` method:
 

--- a/documentation/manual/working/scalaGuide/advanced/embedding/index.toc
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/index.toc
@@ -1,2 +1,3 @@
+ScalaEmbeddingPlay:Embedding Play
 ScalaEmbeddingPlayAkkaHttp:Embedding Play with Akka HTTP Server
 ScalaEmbeddingPlayNetty:Embedding Play with Netty Server


### PR DESCRIPTION
The Java API for creating a server uses the DefaultServerProvider, which is hardcoded to Netty.

This PR breaks up the Java API the same way as the Scala API, providing AkkaHttpServer / NettyServer options.