### PR TITLE
Remove injector from Java compile time dependency injection components

### DIFF
--- a/documentation/manual/working/javaGuide/main/forms/JavaFormHelpers.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaFormHelpers.md
@@ -37,7 +37,7 @@ A rendered field does not only consist of an `<input>` tag, but may also need a 
     
 All input helpers take an implicit `FieldConstructor` that handles this part. The default one (used if there are no other field constructors available in the scope), generates HTML like:
 
-```
+```html
 <dl class="error" id="email_field">
     <dt><label for="email">Email:</label></dt>
     <dd><input type="text" name="email" id="email" value=""></dd>

--- a/documentation/manual/working/javaGuide/main/forms/JavaForms.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaForms.md
@@ -189,10 +189,9 @@ Using a group sequence is especially a good practice when you have a `validate` 
 
 Sometimes you need more sophisticated validation processes. E.g. when a user signs up you want to check if his email address already exists in the database and if so validation should fail.
 
-Because constraints support [[Dependency Injection|JavaDependencyInjection]] we can easily create our own custom (class-level) constraint which gets a `Database` object injected - which we can use later in the validation process. (Actually you could also inject other components like `MessagesApi`, `JPAApi`, etc.)
+Because constraints support both [[runtime Dependency Injection|JavaDependencyInjection]] and [[|JavaCompileTimeDependencyInjection]], we can easily create our own custom (class-level) constraint which gets a `Database` object injected - which we can use later in the validation process. Of course you can also inject other components like `MessagesApi`, `JPAApi`, etc.
 
-> You only need to create one class-level constraint for each cross concern.
-**For example:** The constraint we will create in this section is reusable and can be used for all validation processes where you need to access the database. The reason why Play doesn't provide any generic class-level constraints with dependency injected components is because Play doesn't know which components you might have enabled in your project.
+> **Note:** You only need to create one class-level constraint for each cross concern. For example, the constraint we will create in this section is reusable and can be used for all validation processes where you need to access the database. The reason why Play doesn't provide any generic class-level constraints with dependency injected components is because Play doesn't know which components you might have enabled in your project.
 
 First let's set up the interface with the `validate` method we will implement in our form later. You can see the method gets passed a `Database` object (Checkout the [[database docs|JavaDatabase]]):
 
@@ -206,7 +205,13 @@ Finally this is how our constraint implementation looks like:
 
 @[constraint](code/javaguide/forms/customconstraint/ValidateWithDBValidator.java)
 
-As you can see we inject the `Database` object into the constraint's constructor and use it later when calling `validate`.
+As you can see we inject the `Database` object into the constraint's constructor and use it later when calling `validate`. When using runtime Dependency Injection, Guice will automatically inject the `Database` object, but for compile-time Dependency Injection you need to do that by yourself:
+
+@[constraint-compile-timed-di](code/javaguide/forms/customconstraint/ValidateWithDBComponents.java)
+
+> **Note**: you don't need to create the `database` instance by yourself, it is already defined in the implemented interfaces.
+
+This way, your validator will be available when necessary.
 
 When writing your own class-level constraints you can pass following objects to the `reportValidationStatus` method: A `ValidationError`, a `List<ValidationError>` or a `String` (handled as global error). Any other objects will be ignored by Play.
 

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/customconstraint/ValidateWithDBComponents.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/customconstraint/ValidateWithDBComponents.java
@@ -27,11 +27,6 @@ public class ValidateWithDBComponents extends BuiltInComponentsFromContext
     }
 
     @Override
-    public ConnectionPool connectionPool() {
-        return null;
-    }
-
-    @Override
     public StaticConstraintValidatorFactory constraintValidatorFactory() {
         return new StaticConstraintValidatorFactory()
                 .addConstraintValidator(

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/customconstraint/ValidateWithDBComponents.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/customconstraint/ValidateWithDBComponents.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package javaguide.forms.customconstraint;
+
+// #constraint-compile-timed-di
+import play.ApplicationLoader;
+import play.BuiltInComponentsFromContext;
+import play.data.FormFactoryComponents;
+import play.data.validation.StaticConstraintValidatorFactory;
+import play.db.ConnectionPool;
+import play.db.DBComponents;
+import play.db.HikariCPComponents;
+import play.filters.components.NoHttpFiltersComponents;
+import play.routing.Router;
+
+public class ValidateWithDBComponents extends BuiltInComponentsFromContext
+        implements FormFactoryComponents, DBComponents, HikariCPComponents, NoHttpFiltersComponents {
+
+    public ValidateWithDBComponents(ApplicationLoader.Context context) {
+        super(context);
+    }
+
+    @Override
+    public Router router() {
+        return Router.empty();
+    }
+
+    @Override
+    public ConnectionPool connectionPool() {
+        return null;
+    }
+
+    @Override
+    public StaticConstraintValidatorFactory constraintValidatorFactory() {
+        return new StaticConstraintValidatorFactory()
+                .addConstraintValidator(
+                        ValidateWithDBValidator.class,
+                        new ValidateWithDBValidator(database("default"))
+                );
+    }
+}
+
+// #constraint-compile-timed-di

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/customconstraint/ValidateWithDBComponents.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/customconstraint/ValidateWithDBComponents.java
@@ -7,8 +7,7 @@ package javaguide.forms.customconstraint;
 import play.ApplicationLoader;
 import play.BuiltInComponentsFromContext;
 import play.data.FormFactoryComponents;
-import play.data.validation.StaticConstraintValidatorFactory;
-import play.db.ConnectionPool;
+import play.data.validation.MappedConstraintValidatorFactory;
 import play.db.DBComponents;
 import play.db.HikariCPComponents;
 import play.filters.components.NoHttpFiltersComponents;
@@ -27,8 +26,8 @@ public class ValidateWithDBComponents extends BuiltInComponentsFromContext
     }
 
     @Override
-    public StaticConstraintValidatorFactory constraintValidatorFactory() {
-        return new StaticConstraintValidatorFactory()
+    public MappedConstraintValidatorFactory constraintValidatorFactory() {
+        return new MappedConstraintValidatorFactory()
                 .addConstraintValidator(
                         ValidateWithDBValidator.class,
                         new ValidateWithDBValidator(database("default"))

--- a/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/customconstraint/ValidateWithDBValidator.java
+++ b/documentation/manual/working/javaGuide/main/forms/code/javaguide/forms/customconstraint/ValidateWithDBValidator.java
@@ -15,7 +15,7 @@ import play.db.Database;
 
 public class ValidateWithDBValidator implements PlayConstraintValidator<ValidateWithDB, ValidatableWithDB<?>> {
 
-    private Database db;
+    private final Database db;
 
     @Inject
     public ValidateWithDBValidator(final Database db) {

--- a/documentation/manual/working/javaGuide/main/http/JavaActionsComposition.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaActionsComposition.md
@@ -61,7 +61,11 @@ Then in an action you can get the arg like this:
 
 ## Using Dependency Injection
 
-You can use [[Dependency Injection|JavaDependencyInjection]] together with action composition. For example, if you want to define your own result cache solution, first define the annotation:
+You can use [[runtime Dependency Injection|JavaDependencyInjection]] or [[compile-time Dependency Injection|JavaCompileTimeDependencyInjection]]together with action composition. 
+
+### Runtime Dependency Injection
+
+For example, if you want to define your own result cache solution, first define the annotation:
 
 @[action-composition-dependency-injection-annotation](code/javaguide/http/JavaActionsComposition.java)
 
@@ -69,4 +73,12 @@ And then you can define your action with the dependencies injected:
 
 @[action-composition-dependency-injection](code/javaguide/http/JavaActionsComposition.java)
 
-As stated above, every request **must** be served by a distinct instance of your `play.mvc.Action` and you **must not** annotate your action as a `@Singleton`.
+> **Note:** As stated above, every request **must** be served by a distinct instance of your `play.mvc.Action` and you **must not** annotate your action as a `@Singleton`.
+
+### Compile-time Dependency Injection
+
+When using [[compile-time Dependency Injection|JavaCompileTimeDependencyInjection]], you need to manually add your actions or an Action supplier to [`JavaHandlerComponents`](api/scala/play/core/j/JavaHandlerComponents.html). You do that by overriding method `javaHandlerComponents` in [`BuiltInComponents`](api/java/play/BuiltInComponents.html):
+
+@[action-composition-compile-time-di](code/javaguide/http/JavaActionsComposition.java)
+
+> **Note:** As stated above, every request **must** be served by a distinct instance of your `play.mvc.Action` and that is why you add a `java.util.function.Supplier<Action>` instead of the instance itself. Of course, you can have a `Supplier` returning the same instance every time, but this is not encouraged.

--- a/documentation/manual/working/javaGuide/main/http/JavaActionsComposition.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaActionsComposition.md
@@ -77,7 +77,7 @@ And then you can define your action with the dependencies injected:
 
 ### Compile-time Dependency Injection
 
-When using [[compile-time Dependency Injection|JavaCompileTimeDependencyInjection]], you need to manually add your actions or an Action supplier to [`JavaHandlerComponents`](api/scala/play/core/j/JavaHandlerComponents.html). You do that by overriding method `javaHandlerComponents` in [`BuiltInComponents`](api/java/play/BuiltInComponents.html):
+When using [[compile-time Dependency Injection|JavaCompileTimeDependencyInjection]], you need to manually add your `Action` supplier to [`JavaHandlerComponents`](api/scala/play/core/j/JavaHandlerComponents.html). You do that by overriding method `javaHandlerComponents` in [`BuiltInComponents`](api/java/play/BuiltInComponents.html):
 
 @[action-composition-compile-time-di](code/javaguide/http/JavaActionsComposition.java)
 

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActionsComposition.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActionsComposition.java
@@ -3,11 +3,17 @@
  */
 package javaguide.http;
 
+import play.ApplicationLoader;
+import play.BuiltInComponentsFromContext;
 import play.Logger;
 import play.cache.AsyncCacheApi;
 import play.cache.Cached;
+import play.cache.ehcache.EhCacheComponents;
+import play.core.j.StaticJavaHandlerComponents;
+import play.filters.components.NoHttpFiltersComponents;
 import play.libs.Json;
 import play.mvc.*;
+import play.routing.Router;
 
 import javax.inject.Inject;
 import java.lang.annotation.ElementType;
@@ -16,6 +22,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
 
 public class JavaActionsComposition extends Controller {
 
@@ -125,4 +132,27 @@ public class JavaActionsComposition extends Controller {
     }
     // #action-composition-dependency-injection
 
+    // #action-composition-compile-time-di
+    public class MyComponents extends BuiltInComponentsFromContext
+            implements NoHttpFiltersComponents, EhCacheComponents {
+
+        public MyComponents(ApplicationLoader.Context context) {
+            super(context);
+        }
+
+        @Override
+        public Router router() {
+            return Router.empty();
+        }
+
+        @Override
+        public StaticJavaHandlerComponents javaHandlerComponents() {
+            return super.javaHandlerComponents()
+                    // Add action that does not depends on any other component
+                    .addAction(VerboseAction.class, VerboseAction::new)
+                    // Add action that depends on the cache api
+                    .addAction(MyOwnCachedAction.class, () -> new MyOwnCachedAction(defaultCacheApi()));
+        }
+    }
+    // #action-composition-compile-time-di
 }

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActionsComposition.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActionsComposition.java
@@ -9,7 +9,7 @@ import play.Logger;
 import play.cache.AsyncCacheApi;
 import play.cache.Cached;
 import play.cache.ehcache.EhCacheComponents;
-import play.core.j.StaticJavaHandlerComponents;
+import play.core.j.MappedJavaHandlerComponents;
 import play.filters.components.NoHttpFiltersComponents;
 import play.libs.Json;
 import play.mvc.*;
@@ -22,7 +22,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import java.util.concurrent.CompletionStage;
-import java.util.function.Supplier;
 
 public class JavaActionsComposition extends Controller {
 
@@ -146,7 +145,7 @@ public class JavaActionsComposition extends Controller {
         }
 
         @Override
-        public StaticJavaHandlerComponents javaHandlerComponents() {
+        public MappedJavaHandlerComponents javaHandlerComponents() {
             return super.javaHandlerComponents()
                     // Add action that does not depends on any other component
                     .addAction(VerboseAction.class, VerboseAction::new)

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
@@ -8,8 +8,6 @@ import javaguide.testhelpers.MockJavaAction;
 import org.junit.Test;
 import play.core.j.JavaContextComponents;
 import play.core.j.JavaHandlerComponents;
-import play.i18n.Langs;
-import play.i18n.MessagesApi;
 import play.libs.Json;
 import play.mvc.Http.Cookie;
 import play.mvc.Result;

--- a/framework/src/play-ehcache/src/test/scala/play/api/cache/ehcache/EhCacheApiSpec.scala
+++ b/framework/src/play-ehcache/src/test/scala/play/api/cache/ehcache/EhCacheApiSpec.scala
@@ -49,7 +49,7 @@ class EhCacheApiSpec extends PlaySpecification {
 class CustomCacheManagerProvider @Inject() (cacheManagerProvider: CacheManagerProvider) extends Provider[CacheManager] {
   lazy val get = {
     val mgr = cacheManagerProvider.get
-    mgr.removalAll()
+    mgr.removeAllCaches()
     mgr.addCache("custom")
     mgr
   }

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/components/CSRFComponents.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/components/CSRFComponents.java
@@ -5,7 +5,6 @@ package play.filters.components;
 
 import play.components.*;
 import play.filters.csrf.*;
-import play.inject.Injector;
 
 /**
  * The Java CSRF components.
@@ -15,8 +14,6 @@ public interface CSRFComponents extends ConfigurationComponents,
         HttpConfigurationComponents,
         HttpErrorHandlerComponents,
         AkkaComponents {
-
-    Injector injector();
 
     default CSRFConfig csrfConfig() {
         return CSRFConfig$.MODULE$.fromConfiguration(configuration());
@@ -41,7 +38,7 @@ public interface CSRFComponents extends ConfigurationComponents,
                 sessionConfiguration(),
                 csrfTokenProvider(),
                 csrfTokenSigner().asScala(),
-                injector()
+                csrfErrorHandler()
         );
     }
 

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
@@ -4,8 +4,8 @@
 package play.filters.csrf;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 import javax.inject.Inject;
 
@@ -25,25 +25,23 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
     private final SessionConfiguration sessionConfiguration;
     private final CSRF.TokenProvider tokenProvider;
     private final CSRFTokenSigner tokenSigner;
-
-    private CSRFErrorHandler errorHandler;
-    private Injector injector;
+    private Function<RequireCSRFCheck, CSRFErrorHandler> configurator;
 
     @Inject
     public RequireCSRFCheckAction(CSRFConfig config, SessionConfiguration sessionConfiguration, CSRF.TokenProvider tokenProvider, CSRFTokenSigner csrfTokenSigner, Injector injector) {
-        this.config = config;
-        this.sessionConfiguration = sessionConfiguration;
-        this.tokenProvider = tokenProvider;
-        this.tokenSigner = csrfTokenSigner;
-        this.injector = injector;
+        this(config, sessionConfiguration, tokenProvider, csrfTokenSigner, configAnnotation -> injector.instanceOf(configAnnotation.error()));
     }
 
     public RequireCSRFCheckAction(CSRFConfig config, SessionConfiguration sessionConfiguration, CSRF.TokenProvider tokenProvider, CSRFTokenSigner csrfTokenSigner, CSRFErrorHandler errorHandler) {
+        this(config, sessionConfiguration, tokenProvider, csrfTokenSigner, configAnnotation -> errorHandler);
+    }
+
+    public RequireCSRFCheckAction(CSRFConfig config, SessionConfiguration sessionConfiguration, CSRF.TokenProvider tokenProvider, CSRFTokenSigner csrfTokenSigner, Function<RequireCSRFCheck, CSRFErrorHandler> configurator) {
         this.config = config;
         this.sessionConfiguration = sessionConfiguration;
         this.tokenProvider = tokenProvider;
         this.tokenSigner = csrfTokenSigner;
-        this.errorHandler = errorHandler;
+        this.configurator = configurator;
     }
 
     @Override
@@ -110,10 +108,7 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
             }
         }
 
-        CSRFErrorHandler handler = Optional
-                .ofNullable(injector)
-                .map(injctr -> (CSRFErrorHandler)injctr.instanceOf(configuration.error()))
-                .orElse(this.errorHandler);
+        CSRFErrorHandler handler = configurator.apply(this.configuration);
         return handler.handle(new play.core.j.RequestHeaderImpl(request), msg);
     }
 }

--- a/framework/src/play-integration-test/src/test/java/play/BuiltInComponentsFromContextTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/BuiltInComponentsFromContextTest.java
@@ -7,14 +7,11 @@ import org.junit.Before;
 import org.junit.Test;
 import play.api.http.HttpConfiguration;
 import play.components.BodyParserComponents;
-import play.core.j.JavaContextComponents;
 import play.filters.components.HttpFiltersComponents;
-import play.i18n.Langs;
-import play.i18n.MessagesApi;
-import play.libs.Files;
-import play.libs.crypto.CSRFTokenSigner;
-import play.libs.crypto.CookieSigner;
-import play.mvc.*;
+import play.mvc.EssentialFilter;
+import play.mvc.Http;
+import play.mvc.Result;
+import play.mvc.Results;
 import play.routing.Router;
 import play.routing.RoutingDsl;
 import play.test.Helpers;
@@ -191,79 +188,5 @@ public class BuiltInComponentsFromContextTest {
     @Test
     public void temporaryFileCreatorMustBeASingleton() {
         assertThat(this.componentsFromContext.tempFileCreator(), sameInstance(this.componentsFromContext.tempFileCreator()));
-    }
-
-    // Injector tests
-
-    @Test
-    public void shouldBeAbleToInjectHttpConfiguration() {
-        assertThat(this.componentsFromContext.injector().instanceOf(HttpConfiguration.class), notNullValue());
-    }
-
-    @Test
-    public void shouldBeAbleToInjectJavaContextComponents() {
-        assertThat(this.componentsFromContext.injector().instanceOf(JavaContextComponents.class), notNullValue());
-    }
-
-
-    @Test
-    public void shouldBeAbleToInjectCookieSigner() {
-        assertThat(this.componentsFromContext.injector().instanceOf(CookieSigner.class), notNullValue());
-    }
-
-    @Test
-    public void shouldBeAbleToInjectCSRFTokenSigner() {
-        assertThat(this.componentsFromContext.injector().instanceOf(CSRFTokenSigner.class), notNullValue());
-    }
-
-    @Test
-    public void shouldBeAbleToInjectTemporaryFileCreator() {
-        assertThat(this.componentsFromContext.injector().instanceOf(Files.TemporaryFileCreator.class), notNullValue());
-    }
-
-    @Test
-    public void shouldBeAbleToInjectFileMimeTypes() {
-        assertThat(this.componentsFromContext.injector().instanceOf(FileMimeTypes.class), notNullValue());
-    }
-
-    @Test
-    public void shouldBeAbleToInjectMessagesApi() {
-        assertThat(this.componentsFromContext.injector().instanceOf(MessagesApi.class), notNullValue());
-    }
-
-    @Test
-    public void shouldBeAbleToInjectLangs() {
-        assertThat(this.componentsFromContext.injector().instanceOf(Langs.class), notNullValue());
-    }
-
-
-    @Test
-    public void shouldBeAbleToInjectScalaVersionOfCookieSigner() {
-        assertThat(this.componentsFromContext.injector().instanceOf(play.api.libs.crypto.CookieSigner.class), notNullValue());
-    }
-
-    @Test
-    public void shouldBeAbleToInjectScalaVersionOfCSRFTokenSigner() {
-        assertThat(this.componentsFromContext.injector().instanceOf(play.api.libs.crypto.CSRFTokenSigner.class), notNullValue());
-    }
-
-    @Test
-    public void shouldBeAbleToInjectScalaVersionOfTemporaryFileCreator() {
-        assertThat(this.componentsFromContext.injector().instanceOf(play.api.libs.Files.TemporaryFileCreator.class), notNullValue());
-    }
-
-    @Test
-    public void shouldBeAbleToInjectScalaVersionOfFileMimeTypes() {
-        assertThat(this.componentsFromContext.injector().instanceOf(play.api.http.FileMimeTypes.class), notNullValue());
-    }
-
-    @Test
-    public void shouldBeAbleToInjectScalaVersionOfMessagesApi() {
-        assertThat(this.componentsFromContext.injector().instanceOf(play.api.i18n.MessagesApi.class), notNullValue());
-    }
-
-    @Test
-    public void shouldBeAbleToInjectScalaVersionOfLangs() {
-        assertThat(this.componentsFromContext.injector().instanceOf(play.api.i18n.Langs.class), notNullValue());
     }
 }

--- a/framework/src/play-integration-test/src/test/java/play/BuiltInComponentsFromContextTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/BuiltInComponentsFromContextTest.java
@@ -7,7 +7,13 @@ import org.junit.Before;
 import org.junit.Test;
 import play.api.http.HttpConfiguration;
 import play.components.BodyParserComponents;
+import play.core.j.JavaContextComponents;
 import play.filters.components.HttpFiltersComponents;
+import play.i18n.Langs;
+import play.i18n.MessagesApi;
+import play.libs.Files;
+import play.libs.crypto.CSRFTokenSigner;
+import play.libs.crypto.CookieSigner;
 import play.mvc.*;
 import play.routing.Router;
 import play.routing.RoutingDsl;
@@ -149,41 +155,115 @@ public class BuiltInComponentsFromContextTest {
 
     @Test
     public void actorSystemMustBeASingleton() {
-        assertThat(this.componentsFromContext.actorSystem(), equalTo(this.componentsFromContext.actorSystem()));
+        assertThat(this.componentsFromContext.actorSystem(), sameInstance(this.componentsFromContext.actorSystem()));
     }
 
     @Test
     public void applicationMustBeASingleton() {
-        assertThat(this.componentsFromContext.application(), equalTo(this.componentsFromContext.application()));
+        assertThat(this.componentsFromContext.application(), sameInstance(this.componentsFromContext.application()));
     }
 
     @Test
     public void langsMustBeASingleton() {
-        assertThat(this.componentsFromContext.langs(), equalTo(this.componentsFromContext.langs()));
+        assertThat(this.componentsFromContext.langs(), sameInstance(this.componentsFromContext.langs()));
     }
 
     @Test
     public void fileMimeTypesMustBeASingleton() {
-        assertThat(this.componentsFromContext.fileMimeTypes(), equalTo(this.componentsFromContext.fileMimeTypes()));
+        assertThat(this.componentsFromContext.fileMimeTypes(), sameInstance(this.componentsFromContext.fileMimeTypes()));
     }
 
     @Test
     public void httpRequestHandlerMustBeASingleton() {
-        assertThat(this.componentsFromContext.httpRequestHandler(), equalTo(this.componentsFromContext.httpRequestHandler()));
+        assertThat(this.componentsFromContext.httpRequestHandler(), sameInstance(this.componentsFromContext.httpRequestHandler()));
     }
 
     @Test
     public void cookieSignerMustBeASingleton() {
-        assertThat(this.componentsFromContext.cookieSigner(), equalTo(this.componentsFromContext.cookieSigner()));
+        assertThat(this.componentsFromContext.cookieSigner(), sameInstance(this.componentsFromContext.cookieSigner()));
     }
 
     @Test
     public void csrfTokenSignerMustBeASingleton() {
-        assertThat(this.componentsFromContext.csrfTokenSigner(), equalTo(this.componentsFromContext.csrfTokenSigner()));
+        assertThat(this.componentsFromContext.csrfTokenSigner(), sameInstance(this.componentsFromContext.csrfTokenSigner()));
     }
 
     @Test
     public void temporaryFileCreatorMustBeASingleton() {
-        assertThat(this.componentsFromContext.tempFileCreator(), equalTo(this.componentsFromContext.tempFileCreator()));
+        assertThat(this.componentsFromContext.tempFileCreator(), sameInstance(this.componentsFromContext.tempFileCreator()));
+    }
+
+    // Injector tests
+
+    @Test
+    public void shouldBeAbleToInjectHttpConfiguration() {
+        assertThat(this.componentsFromContext.injector().instanceOf(HttpConfiguration.class), notNullValue());
+    }
+
+    @Test
+    public void shouldBeAbleToInjectJavaContextComponents() {
+        assertThat(this.componentsFromContext.injector().instanceOf(JavaContextComponents.class), notNullValue());
+    }
+
+
+    @Test
+    public void shouldBeAbleToInjectCookieSigner() {
+        assertThat(this.componentsFromContext.injector().instanceOf(CookieSigner.class), notNullValue());
+    }
+
+    @Test
+    public void shouldBeAbleToInjectCSRFTokenSigner() {
+        assertThat(this.componentsFromContext.injector().instanceOf(CSRFTokenSigner.class), notNullValue());
+    }
+
+    @Test
+    public void shouldBeAbleToInjectTemporaryFileCreator() {
+        assertThat(this.componentsFromContext.injector().instanceOf(Files.TemporaryFileCreator.class), notNullValue());
+    }
+
+    @Test
+    public void shouldBeAbleToInjectFileMimeTypes() {
+        assertThat(this.componentsFromContext.injector().instanceOf(FileMimeTypes.class), notNullValue());
+    }
+
+    @Test
+    public void shouldBeAbleToInjectMessagesApi() {
+        assertThat(this.componentsFromContext.injector().instanceOf(MessagesApi.class), notNullValue());
+    }
+
+    @Test
+    public void shouldBeAbleToInjectLangs() {
+        assertThat(this.componentsFromContext.injector().instanceOf(Langs.class), notNullValue());
+    }
+
+
+    @Test
+    public void shouldBeAbleToInjectScalaVersionOfCookieSigner() {
+        assertThat(this.componentsFromContext.injector().instanceOf(play.api.libs.crypto.CookieSigner.class), notNullValue());
+    }
+
+    @Test
+    public void shouldBeAbleToInjectScalaVersionOfCSRFTokenSigner() {
+        assertThat(this.componentsFromContext.injector().instanceOf(play.api.libs.crypto.CSRFTokenSigner.class), notNullValue());
+    }
+
+    @Test
+    public void shouldBeAbleToInjectScalaVersionOfTemporaryFileCreator() {
+        assertThat(this.componentsFromContext.injector().instanceOf(play.api.libs.Files.TemporaryFileCreator.class), notNullValue());
+    }
+
+    @Test
+    public void shouldBeAbleToInjectScalaVersionOfFileMimeTypes() {
+        assertThat(this.componentsFromContext.injector().instanceOf(play.api.http.FileMimeTypes.class), notNullValue());
+    }
+
+    @Test
+    public void shouldBeAbleToInjectScalaVersionOfMessagesApi() {
+        assertThat(this.componentsFromContext.injector().instanceOf(play.api.i18n.MessagesApi.class), notNullValue());
+    }
+
+    @Test
+    public void shouldBeAbleToInjectScalaVersionOfLangs() {
+        assertThat(this.componentsFromContext.injector().instanceOf(play.api.i18n.Langs.class), notNullValue());
     }
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JAction.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JAction.scala
@@ -27,6 +27,9 @@ import play.mvc.{ Http, Result }
 object JAction {
   def apply(app: Application, c: AbstractMockController): EssentialAction = {
     val handlerComponents = app.injector.instanceOf[JavaHandlerComponents]
+    apply(app, c, handlerComponents)
+  }
+  def apply(app: Application, c: AbstractMockController, handlerComponents: JavaHandlerComponents): EssentialAction = {
     new JavaAction(handlerComponents) {
       val annotations = new JavaActionAnnotations(c.getClass, c.getClass.getMethod("action"), handlerComponents.httpConfiguration.actionComposition)
       val parser = HandlerInvokerFactory.javaBodyParserToScala(handlerComponents.getBodyParser(annotations.parser))

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -56,7 +56,7 @@ class BuiltInComponentsJavaActionCompositionSpec extends JavaActionCompositionSp
 
       override def router(): JRouter = {
         Router.from {
-          case _ => JAction(application().asScala(), controller)
+          case _ => JAction(application().asScala(), controller, javaHandlerComponents())
         }.asJava
       }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -7,13 +7,13 @@ import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.WSResponse
 import play.api.routing.Router
-import play.api.test.{ PlaySpecification, TestServer, WsTestClient }
-import play.core.j.StaticJavaHandlerComponents
-import play.http.{ ActionCreator, DefaultActionCreator }
-import play.it.http.ActionCompositionOrderTest.{ ActionAnnotation, ControllerAnnotation, WithUsername }
-import play.mvc.{ EssentialFilter, Result, Results }
+import play.api.test.{PlaySpecification, TestServer, WsTestClient}
+import play.core.j.MappedJavaHandlerComponents
+import play.http.{ActionCreator, DefaultActionCreator}
+import play.it.http.ActionCompositionOrderTest.{ActionAnnotation, ControllerAnnotation, WithUsername}
+import play.mvc.{EssentialFilter, Result, Results}
 import play.mvc.Http.Cookie
-import play.routing.{ Router => JRouter }
+import play.routing.{Router => JRouter}
 
 class GuiceJavaActionCompositionSpec extends JavaActionCompositionSpec {
   override def makeRequest[T](controller: MockController, configuration: Map[String, AnyRef] = Map.empty)(block: WSResponse => T): T = {
@@ -40,7 +40,7 @@ class BuiltInComponentsJavaActionCompositionSpec extends JavaActionCompositionSp
     implicit val port = testServerPort
     val components = new play.BuiltInComponentsFromContext(context(configuration)) {
 
-      override def javaHandlerComponents(): StaticJavaHandlerComponents = {
+      override def javaHandlerComponents(): MappedJavaHandlerComponents = {
         import java.util.function.{ Supplier => JSupplier }
         super.javaHandlerComponents()
           .addAction(classOf[ActionCompositionOrderTest.ActionComposition], new JSupplier[ActionCompositionOrderTest.ActionComposition] {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -6,16 +6,17 @@ package play.it.http
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.WSResponse
+import play.api.routing.Router
 import play.api.test.{ PlaySpecification, TestServer, WsTestClient }
+import play.core.j.StaticJavaHandlerComponents
+import play.http.{ ActionCreator, DefaultActionCreator }
 import play.it.http.ActionCompositionOrderTest.{ ActionAnnotation, ControllerAnnotation, WithUsername }
-import play.mvc.{ Result, Results }
+import play.mvc.{ EssentialFilter, Result, Results }
 import play.mvc.Http.Cookie
+import play.routing.{ Router => JRouter }
 
-class JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
-
-  sequential
-
-  def makeRequest[T](controller: MockController, configuration: Map[String, _ <: Any] = Map.empty)(block: WSResponse => T) = {
+class GuiceJavaActionCompositionSpec extends JavaActionCompositionSpec {
+  override def makeRequest[T](controller: MockController, configuration: Map[String, AnyRef] = Map.empty)(block: WSResponse => T): T = {
     implicit val port = testServerPort
     lazy val app: Application = GuiceApplicationBuilder().configure(configuration).routes {
       case _ => JAction(app, controller)
@@ -26,6 +27,59 @@ class JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
       block(response)
     }
   }
+}
+
+class BuiltInComponentsJavaActionCompositionSpec extends JavaActionCompositionSpec {
+
+  def context(initialSettings: Map[String, AnyRef]): play.ApplicationLoader.Context = {
+    import scala.collection.JavaConverters._
+    play.ApplicationLoader.create(play.Environment.simple(), initialSettings.asJava)
+  }
+
+  override def makeRequest[T](controller: MockController, configuration: Map[String, AnyRef])(block: (WSResponse) => T): T = {
+    implicit val port = testServerPort
+    val components = new play.BuiltInComponentsFromContext(context(configuration)) {
+
+      override def javaHandlerComponents(): StaticJavaHandlerComponents = {
+        import java.util.function.{ Supplier => JSupplier }
+        super.javaHandlerComponents()
+          .addAction(classOf[ActionCompositionOrderTest.ActionComposition], new JSupplier[ActionCompositionOrderTest.ActionComposition] {
+            override def get(): ActionCompositionOrderTest.ActionComposition = new ActionCompositionOrderTest.ActionComposition()
+          })
+          .addAction(classOf[ActionCompositionOrderTest.ControllerComposition], new JSupplier[ActionCompositionOrderTest.ControllerComposition] {
+          override def get(): ActionCompositionOrderTest.ControllerComposition = new ActionCompositionOrderTest.ControllerComposition()
+        })
+          .addAction(classOf[ActionCompositionOrderTest.WithUsernameAction], new JSupplier[ActionCompositionOrderTest.WithUsernameAction] {
+          override def get(): ActionCompositionOrderTest.WithUsernameAction = new ActionCompositionOrderTest.WithUsernameAction()
+        })
+      }
+
+      override def router(): JRouter = {
+        Router.from {
+          case _ => JAction(application().asScala(), controller)
+        }.asJava
+      }
+
+      override def httpFilters(): Array[EssentialFilter] = Array.empty
+
+      override def actionCreator(): ActionCreator = {
+        configuration.get[Option[String]]("play.http.actionCreator")
+          .map(Class.forName)
+          .map(c => c.newInstance().asInstanceOf[ActionCreator])
+          .getOrElse(new DefaultActionCreator)
+      }
+    }
+
+    running(TestServer(port, components.application().asScala())) {
+      val response = await(wsUrl("/").get())
+      block(response)
+    }
+  }
+}
+
+trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
+
+  def makeRequest[T](controller: MockController, configuration: Map[String, AnyRef] = Map.empty)(block: WSResponse => T): T
 
   "When action composition is configured to invoke controller first" should {
     "execute controller composition before action composition" in makeRequest(new ComposedController {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -7,13 +7,13 @@ import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.WSResponse
 import play.api.routing.Router
-import play.api.test.{PlaySpecification, TestServer, WsTestClient}
+import play.api.test.{ PlaySpecification, TestServer, WsTestClient }
 import play.core.j.MappedJavaHandlerComponents
-import play.http.{ActionCreator, DefaultActionCreator}
-import play.it.http.ActionCompositionOrderTest.{ActionAnnotation, ControllerAnnotation, WithUsername}
-import play.mvc.{EssentialFilter, Result, Results}
+import play.http.{ ActionCreator, DefaultActionCreator }
+import play.it.http.ActionCompositionOrderTest.{ ActionAnnotation, ControllerAnnotation, WithUsername }
+import play.mvc.{ EssentialFilter, Result, Results }
 import play.mvc.Http.Cookie
-import play.routing.{Router => JRouter}
+import play.routing.{ Router => JRouter }
 
 class GuiceJavaActionCompositionSpec extends JavaActionCompositionSpec {
   override def makeRequest[T](controller: MockController, configuration: Map[String, AnyRef] = Map.empty)(block: WSResponse => T): T = {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -47,11 +47,11 @@ class BuiltInComponentsJavaActionCompositionSpec extends JavaActionCompositionSp
             override def get(): ActionCompositionOrderTest.ActionComposition = new ActionCompositionOrderTest.ActionComposition()
           })
           .addAction(classOf[ActionCompositionOrderTest.ControllerComposition], new JSupplier[ActionCompositionOrderTest.ControllerComposition] {
-          override def get(): ActionCompositionOrderTest.ControllerComposition = new ActionCompositionOrderTest.ControllerComposition()
-        })
+            override def get(): ActionCompositionOrderTest.ControllerComposition = new ActionCompositionOrderTest.ControllerComposition()
+          })
           .addAction(classOf[ActionCompositionOrderTest.WithUsernameAction], new JSupplier[ActionCompositionOrderTest.WithUsernameAction] {
-          override def get(): ActionCompositionOrderTest.WithUsernameAction = new ActionCompositionOrderTest.WithUsernameAction()
-        })
+            override def get(): ActionCompositionOrderTest.WithUsernameAction = new ActionCompositionOrderTest.WithUsernameAction()
+          })
       }
 
       override def router(): JRouter = {

--- a/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/Constraints.java
@@ -77,10 +77,17 @@ public class Constraints {
             map(c -> c.getAnnotation()).
             collect(Collectors.<Annotation>toList());
 
-        return Stream.of(orderedAnnotations).filter(constraintAnnot::contains) // only use annotations for which we actually have a constraint
-            .filter(a -> a.annotationType().isAnnotationPresent(Display.class)).map(a -> 
-                displayableConstraint(constraints.parallelStream().filter(c -> c.getAnnotation().equals(a)).findFirst().get())
-        ).collect(Collectors.toList());
+        return Stream
+                .of(orderedAnnotations)
+                .filter(constraintAnnot::contains) // only use annotations for which we actually have a constraint
+                .filter(a -> a.annotationType().isAnnotationPresent(Display.class))
+                .map(a -> displayableConstraint(
+                        constraints.parallelStream()
+                                .filter(c -> c.getAnnotation().equals(a))
+                                .findFirst()
+                                .get()
+                        )
+                ).collect(Collectors.toList());
     }
     
     /**
@@ -103,7 +110,7 @@ public class Constraints {
     @Retention(RUNTIME)
     @Constraint(validatedBy = RequiredValidator.class)
     @play.data.Form.Display(name="constraint.required")
-    public static @interface Required {
+    public @interface Required {
         String message() default RequiredValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
@@ -157,7 +164,7 @@ public class Constraints {
     @Retention(RUNTIME)
     @Constraint(validatedBy = MinValidator.class)
     @play.data.Form.Display(name="constraint.min", attributes={"value"})
-    public static @interface Min {
+    public @interface Min {
         String message() default MinValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
@@ -215,7 +222,7 @@ public class Constraints {
     @Retention(RUNTIME)
     @Constraint(validatedBy = MaxValidator.class)
     @play.data.Form.Display(name="constraint.max", attributes={"value"})
-    public static @interface Max {
+    public @interface Max {
         String message() default MaxValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
@@ -273,7 +280,7 @@ public class Constraints {
     @Retention(RUNTIME)
     @Constraint(validatedBy = MinLengthValidator.class)
     @play.data.Form.Display(name="constraint.minLength", attributes={"value"})
-    public static @interface MinLength {
+    public @interface MinLength {
         String message() default MinLengthValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
@@ -299,7 +306,7 @@ public class Constraints {
         }
 
         public boolean isValid(String object) {
-            if(object == null || object.length() == 0) {
+            if(object == null || object.isEmpty()) {
                 return true;
             }
 
@@ -330,7 +337,7 @@ public class Constraints {
     @Retention(RUNTIME)
     @Constraint(validatedBy = MaxLengthValidator.class)
     @play.data.Form.Display(name="constraint.maxLength", attributes={"value"})
-    public static @interface MaxLength {
+    public @interface MaxLength {
         String message() default MaxLengthValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
@@ -356,7 +363,7 @@ public class Constraints {
         }
 
         public boolean isValid(String object) {
-            if(object == null || object.length() == 0) {
+            if(object == null || object.isEmpty()) {
                 return true;
             }
 
@@ -387,7 +394,7 @@ public class Constraints {
     @Retention(RUNTIME)
     @Constraint(validatedBy = EmailValidator.class)
     @play.data.Form.Display(name="constraint.email", attributes={})
-    public static @interface Email {
+    public @interface Email {
         String message() default EmailValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
@@ -404,17 +411,20 @@ public class Constraints {
 
         public EmailValidator() {}
 
+        @Override
         public void initialize(Email constraintAnnotation) {
         }
 
+        @Override
         public boolean isValid(String object) {
-            if(object == null || object.length() == 0) {
+            if (object == null || object.isEmpty()) {
                 return true;
             }
 
             return regex.matcher(object).matches();
         }
 
+        @Override
         public Tuple<String, Object[]> getErrorMessageKey() {
             return Tuple(message, new Object[] {});
         }
@@ -438,7 +448,7 @@ public class Constraints {
     @Retention(RUNTIME)
     @Constraint(validatedBy = PatternValidator.class)
     @play.data.Form.Display(name="constraint.pattern", attributes={"value"})
-    public static @interface Pattern {
+    public @interface Pattern {
         String message() default PatternValidator.message;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
@@ -459,18 +469,21 @@ public class Constraints {
             this.regex = java.util.regex.Pattern.compile(regex);
         }
 
+        @Override
         public void initialize(Pattern constraintAnnotation) {
             regex = java.util.regex.Pattern.compile(constraintAnnotation.value());
         }
 
+        @Override
         public boolean isValid(String object) {
-            if(object == null || object.length() == 0) {
+            if (object == null || object.isEmpty()) {
                 return true;
             }
 
             return regex.matcher(object).matches();
         }
 
+        @Override
         public Tuple<String, Object[]> getErrorMessageKey() {
             return Tuple(message, new Object[] { regex });
         }
@@ -495,7 +508,7 @@ public class Constraints {
     @Retention(RUNTIME)
     @Constraint(validatedBy = ValidateWithValidator.class)
     @play.data.Form.Display(name="constraint.validatewith", attributes={})
-    public static @interface ValidateWith {
+    public @interface ValidateWith {
         String message() default ValidateWithValidator.defaultMessage;
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
@@ -556,14 +569,14 @@ public class Constraints {
     @Target({TYPE, ANNOTATION_TYPE})
     @Retention(RUNTIME)
     @Constraint(validatedBy = ValidateValidator.class)
-    public static @interface Validate {
+    public @interface Validate {
         String message() default "error.invalid";
         Class<?>[] groups() default {};
         Class<? extends Payload>[] payload() default {};
     }
 
-    public static interface Validatable<T> {
-        public T validate();
+    public interface Validatable<T> {
+        T validate();
     }
 
     public static class ValidateValidator implements PlayConstraintValidator<Validate, Validatable<?>> {

--- a/framework/src/play-java-forms/src/main/java/play/data/validation/MappedConstraintValidatorFactory.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/MappedConstraintValidatorFactory.java
@@ -12,7 +12,7 @@ import java.util.function.Supplier;
 /**
  * ConstraintValidatorFactory to be used with compile-time Dependency Injection.
  */
-public class StaticConstraintValidatorFactory implements ConstraintValidatorFactory {
+public class MappedConstraintValidatorFactory implements ConstraintValidatorFactory {
 
     // This is a Map<Class, Supplier> so that we can have both
     // singletons and non-singletons validators.
@@ -24,9 +24,9 @@ public class StaticConstraintValidatorFactory implements ConstraintValidatorFact
      * @param key the constraint validator type
      * @param constraintValidator the constraint validator instance
      * @param <T> the type of constraint validator implementation
-     * @return {@link StaticConstraintValidatorFactory} with the given constraint validator added.
+     * @return {@link MappedConstraintValidatorFactory} with the given constraint validator added.
      */
-    public <T extends ConstraintValidator<?, ?>> StaticConstraintValidatorFactory addConstraintValidator(Class<T> key, T constraintValidator) {
+    public <T extends ConstraintValidator<?, ?>> MappedConstraintValidatorFactory addConstraintValidator(Class<T> key, T constraintValidator) {
         validators.put(key, () -> constraintValidator);
         return this;
     }
@@ -37,9 +37,9 @@ public class StaticConstraintValidatorFactory implements ConstraintValidatorFact
      * @param key the constraint validator type
      * @param constraintValidator the constraint validator instance
      * @param <T> the type of constraint validator implementation
-     * @return {@link StaticConstraintValidatorFactory} with the given constraint validator added.
+     * @return {@link MappedConstraintValidatorFactory} with the given constraint validator added.
      */
-    public <T extends ConstraintValidator<?, ?>> StaticConstraintValidatorFactory addConstraintValidator(Class<T> key, Supplier<T> constraintValidator) {
+    public <T extends ConstraintValidator<?, ?>> MappedConstraintValidatorFactory addConstraintValidator(Class<T> key, Supplier<T> constraintValidator) {
         validators.put(key, constraintValidator::get);
         return this;
     }

--- a/framework/src/play-java-forms/src/main/java/play/data/validation/StaticConstraintValidatorFactory.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/StaticConstraintValidatorFactory.java
@@ -47,7 +47,7 @@ public class StaticConstraintValidatorFactory implements ConstraintValidatorFact
     @Override
     @SuppressWarnings("unchecked")
     public <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key) {
-        return (T) validators.computeIfAbsent(key, clazz -> () -> newInstance(clazz));
+        return (T) validators.computeIfAbsent(key, clazz -> () -> newInstance(clazz)).get();
     }
 
     @Override

--- a/framework/src/play-java-forms/src/main/java/play/data/validation/StaticConstraintValidatorFactory.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/StaticConstraintValidatorFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.data.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorFactory;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * ConstraintValidatorFactory to be used with compile-time Dependency Injection.
+ */
+public class StaticConstraintValidatorFactory implements ConstraintValidatorFactory {
+
+    // This is a Map<Class, Supplier> so that we can have both
+    // singletons and non-singletons validators.
+    private final Map<Class<? extends ConstraintValidator>, Supplier<ConstraintValidator>> validators = new HashMap<>();
+
+    /**
+     * Adds validator as a singleton.
+     *
+     * @param key the constraint validator type
+     * @param constraintValidator the constraint validator instance
+     * @param <T> the type of constraint validator implementation
+     * @return {@link StaticConstraintValidatorFactory} with the given constraint validator added.
+     */
+    public <T extends ConstraintValidator<?, ?>> StaticConstraintValidatorFactory addConstraintValidator(Class<T> key, T constraintValidator) {
+        validators.put(key, () -> constraintValidator);
+        return this;
+    }
+
+    /**
+     * Adds validator as a non-singleton.
+     *
+     * @param key the constraint validator type
+     * @param constraintValidator the constraint validator instance
+     * @param <T> the type of constraint validator implementation
+     * @return {@link StaticConstraintValidatorFactory} with the given constraint validator added.
+     */
+    public <T extends ConstraintValidator<?, ?>> StaticConstraintValidatorFactory addConstraintValidator(Class<T> key, Supplier<T> constraintValidator) {
+        validators.put(key, constraintValidator::get);
+        return this;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key) {
+        return (T) validators.computeIfAbsent(key, clazz -> () -> newInstance(clazz));
+    }
+
+    @Override
+    public void releaseInstance(ConstraintValidator<?, ?> instance) {
+        validators.clear();
+    }
+
+    // This is a fallback to avoid that users needs to create every single
+    // validator instance, which are usually very simple. We then create the
+    // constraint validators automatically, even for compile-time dependency
+    // injection, but we enable users to register their own instances if they
+    // need to do so.
+    private <T extends ConstraintValidator<?, ?>> T newInstance(Class<T> key) {
+        try {
+            return key.newInstance();
+        } catch (InstantiationException | RuntimeException | IllegalAccessException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/framework/src/play-java-forms/src/main/java/play/data/validation/ValidatorsComponents.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/ValidatorsComponents.java
@@ -14,12 +14,10 @@ import javax.validation.Validator;
  */
 public interface ValidatorsComponents {
 
-    Injector injector();
-
     ApplicationLifecycle applicationLifecycle();
 
     default ConstraintValidatorFactory constraintValidatorFactory() {
-        return new DefaultConstraintValidatorFactory(injector());
+        return new StaticConstraintValidatorFactory();
     }
 
     default Validator validator() {

--- a/framework/src/play-java-forms/src/main/java/play/data/validation/ValidatorsComponents.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/validation/ValidatorsComponents.java
@@ -4,7 +4,6 @@
 package play.data.validation;
 
 import play.inject.ApplicationLifecycle;
-import play.inject.Injector;
 
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.Validator;
@@ -17,7 +16,7 @@ public interface ValidatorsComponents {
     ApplicationLifecycle applicationLifecycle();
 
     default ConstraintValidatorFactory constraintValidatorFactory() {
-        return new StaticConstraintValidatorFactory();
+        return new MappedConstraintValidatorFactory();
     }
 
     default Validator validator() {

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -34,7 +34,7 @@ class RuntimeDependencyInjectionFormSpec extends FormSpec {
   override def application: Application = GuiceApplicationBuilder().build()
 }
 
-class CompileTimeDependencyInjection extends FormSpec {
+class CompileTimeDependencyInjectionFormSpec extends FormSpec {
 
   class MyComponents(context: ApplicationLoader.Context) extends BuiltInComponentsFromContext(context)
       with FormFactoryComponents {

--- a/framework/src/play-java-jdbc/src/main/java/play/db/DBComponents.java
+++ b/framework/src/play-java-jdbc/src/main/java/play/db/DBComponents.java
@@ -7,7 +7,7 @@ import play.Environment;
 import play.api.db.DBApiProvider;
 import play.components.ConfigurationComponents;
 import play.inject.ApplicationLifecycle;
-import play.inject.Injector;
+import scala.Option;
 
 import java.util.List;
 
@@ -31,8 +31,6 @@ import java.util.List;
  * @see ConnectionPoolComponents
  */
 public interface DBComponents extends ConfigurationComponents, ConnectionPoolComponents {
-
-    Injector injector();
 
     Environment environment();
 
@@ -63,7 +61,7 @@ public interface DBComponents extends ConfigurationComponents, ConnectionPoolCom
             configuration(),
             connectionPool().asScala(),
             applicationLifecycle().asScala(),
-            injector().asScala()
+            Option.empty()
         ).get();
         return new DefaultDBApi(scalaDbApi);
     }

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/ConnectionPool.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/ConnectionPool.scala
@@ -48,6 +48,18 @@ object ConnectionPool {
     }
   }
 
+  /**
+   * Load a connection pool from a configured connection pool. This is intended to be used with compile-time
+   * dependency injection and then it does not accepts an Injector.
+   */
+  def fromConfig(config: String, environment: Environment, default: ConnectionPool): ConnectionPool = {
+    config match {
+      case "bonecp" => new BoneConnectionPool(environment)
+      case "hikaricp" => new HikariCPConnectionPool(environment)
+      case _ => default
+    }
+  }
+
   private val PostgresFullUrl = "^postgres://([a-zA-Z0-9_]+):([^@]+)@([^/]+)/([^\\s]+)$".r
   private val MysqlFullUrl = "^mysql://([a-zA-Z0-9_]+):([^@]+)@([^/]+)/([^\\s]+)$".r
   private val MysqlCustomProperties = ".*\\?(.*)".r

--- a/framework/src/play-jdbc/src/main/scala/play/api/db/DefaultDBApi.scala
+++ b/framework/src/play-jdbc/src/main/scala/play/api/db/DefaultDBApi.scala
@@ -41,7 +41,7 @@ class DefaultDBApi(
   def connect(logConnection: Boolean = false): Unit = {
     databases foreach { db =>
       try {
-        db.getConnection.close()
+        db.getConnection().close()
         if (logConnection) logger.info(s"Database [${db.name}] connected at ${db.url}")
       } catch {
         case NonFatal(e) =>

--- a/framework/src/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
@@ -23,7 +23,7 @@ import org.reactivestreams.{ Subscription, Subscriber, Publisher }
 class AccumulatorSpec extends org.specs2.mutable.Specification {
   // JavaConversions is required because JavaConverters.asJavaIterable only exists in 2.12
   // and we cross compile for 2.11
-  import scala.collection.JavaConversions.asJavaIterable
+  import scala.collection.JavaConverters._
 
   def withMaterializer[T](block: Materializer => T) = {
     val system = ActorSystem("test")
@@ -40,7 +40,7 @@ class AccumulatorSpec extends org.specs2.mutable.Specification {
       0,
       new JFn2[Int, Int, Int] { def apply(a: Int, b: Int) = a + b }))
 
-  def source = Source from asJavaIterable(1 to 3)
+  def source = Source from (1 to 3).asJava
   def sawait[T](f: Future[T]) = Await.result(f, 10.seconds)
   def await[T](f: CompletionStage[T]) =
     f.toCompletableFuture.get(10, TimeUnit.SECONDS)

--- a/framework/src/play/src/main/java/play/BuiltInComponents.java
+++ b/framework/src/play/src/main/java/play/BuiltInComponents.java
@@ -3,22 +3,15 @@
  */
 package play;
 
-import play.api.OptionalSourceMapper;
 import play.api.http.HttpConfiguration;
 import play.api.i18n.DefaultMessagesApiProvider;
-import play.api.inject.RoutesProvider;
 import play.components.*;
 import play.core.j.JavaContextComponents;
 import play.core.j.JavaHelpers$;
 import play.http.ActionCreator;
 import play.http.DefaultActionCreator;
-import play.http.DefaultHttpErrorHandler;
-import play.http.HttpErrorHandler;
 import play.i18n.I18nComponents;
 import play.i18n.MessagesApi;
-import scala.compat.java8.OptionConverters;
-
-import javax.inject.Provider;
 
 /**
  * Helper to provide the Play built in components.
@@ -64,21 +57,5 @@ public interface BuiltInComponents extends
     @Override
     default HttpConfiguration httpConfiguration() {
         return HttpConfiguration.fromConfiguration(configuration(), environment().asScala());
-    }
-
-    @Override
-    default HttpErrorHandler httpErrorHandler() {
-        Provider<play.api.routing.Router> provider = new RoutesProvider(
-                injector().asScala(),
-                environment().asScala(),
-                configuration(),
-                httpConfiguration()
-        );
-        return new DefaultHttpErrorHandler(
-                config(),
-                environment(),
-                new OptionalSourceMapper(OptionConverters.toScala(sourceMapper())),
-                provider
-        );
     }
 }

--- a/framework/src/play/src/main/java/play/BuiltInComponentsFromContext.java
+++ b/framework/src/play/src/main/java/play/BuiltInComponentsFromContext.java
@@ -62,7 +62,7 @@ public abstract class BuiltInComponentsFromContext implements BuiltInComponents 
     private final Supplier<Files.TemporaryFileCreator> _tempFileCreator = lazy(this::createTempFileCreator);
 
     private final Supplier<HttpErrorHandler> _httpErrorHandler = lazy(this::createHttpErrorHandler);
-    private final Supplier<StaticJavaHandlerComponents> _javaHandlerComponents = lazy(this::createJavaHandlerComponents);
+    private final Supplier<MappedJavaHandlerComponents> _javaHandlerComponents = lazy(this::createJavaHandlerComponents);
 
     public BuiltInComponentsFromContext(ApplicationLoader.Context context) {
         this.context = context;
@@ -130,12 +130,12 @@ public abstract class BuiltInComponentsFromContext implements BuiltInComponents 
     }
 
     @Override
-    public StaticJavaHandlerComponents javaHandlerComponents() {
+    public MappedJavaHandlerComponents javaHandlerComponents() {
         return this._javaHandlerComponents.get();
     }
 
-    private StaticJavaHandlerComponents createJavaHandlerComponents() {
-        StaticJavaHandlerComponents javaHandlerComponents = new StaticJavaHandlerComponents(
+    private MappedJavaHandlerComponents createJavaHandlerComponents() {
+        MappedJavaHandlerComponents javaHandlerComponents = new MappedJavaHandlerComponents(
                 actionCreator(),
                 httpConfiguration(),
                 executionContext(),

--- a/framework/src/play/src/main/java/play/components/BaseComponents.java
+++ b/framework/src/play/src/main/java/play/components/BaseComponents.java
@@ -24,6 +24,4 @@ public interface BaseComponents extends ConfigurationComponents {
     ApplicationLifecycle applicationLifecycle();
 
     Router router();
-
-    Injector injector();
 }

--- a/framework/src/play/src/main/java/play/components/HttpComponents.java
+++ b/framework/src/play/src/main/java/play/components/HttpComponents.java
@@ -3,6 +3,7 @@
  */
 package play.components;
 
+import play.core.j.JavaHandlerComponents;
 import play.http.ActionCreator;
 import play.http.HttpRequestHandler;
 import play.mvc.EssentialFilter;
@@ -60,6 +61,8 @@ public interface HttpComponents extends HttpConfigurationComponents {
      * @see EssentialFilter
      */
     EssentialFilter[] httpFilters();
+
+    JavaHandlerComponents javaHandlerComponents();
 
     HttpRequestHandler httpRequestHandler();
 }

--- a/framework/src/play/src/main/java/play/core/j/MappedJavaHandlerComponents.java
+++ b/framework/src/play/src/main/java/play/core/j/MappedJavaHandlerComponents.java
@@ -20,7 +20,7 @@ import java.util.function.Supplier;
  * {@link play.mvc.BodyParser} must be added here manually. This is way we avoid mixing runtime dependency
  * injector components with compile time injected ones.
  */
-public class StaticJavaHandlerComponents implements JavaHandlerComponents {
+public class MappedJavaHandlerComponents implements JavaHandlerComponents {
 
     private final ActionCreator actionCreator;
     private final HttpConfiguration httpConfiguration;
@@ -30,7 +30,7 @@ public class StaticJavaHandlerComponents implements JavaHandlerComponents {
     private final Map<Class<? extends Action<?>>, Supplier<Action<?>>> actions = new HashMap<>();
     private final Map<Class<? extends BodyParser<?>>, Supplier<BodyParser<?>>> bodyPasers = new HashMap<>();
 
-    public StaticJavaHandlerComponents(ActionCreator actionCreator, HttpConfiguration httpConfiguration, ExecutionContext executionContext, JavaContextComponents contextComponents) {
+    public MappedJavaHandlerComponents(ActionCreator actionCreator, HttpConfiguration httpConfiguration, ExecutionContext executionContext, JavaContextComponents contextComponents) {
         this.actionCreator = actionCreator;
         this.httpConfiguration = httpConfiguration;
         this.executionContext = executionContext;
@@ -67,12 +67,12 @@ public class StaticJavaHandlerComponents implements JavaHandlerComponents {
         return this.contextComponents;
     }
 
-    public <A extends Action<?>> StaticJavaHandlerComponents addAction(Class<A> clazz, Supplier<A> actionSupplier) {
+    public <A extends Action<?>> MappedJavaHandlerComponents addAction(Class<A> clazz, Supplier<A> actionSupplier) {
         this.actions.put(clazz, (Supplier<Action<?>>) actionSupplier);
         return this;
     }
 
-    public <B extends BodyParser<?>> StaticJavaHandlerComponents addBodyParser(Class<B> clazz, Supplier<B> bodyParserSupplier) {
+    public <B extends BodyParser<?>> MappedJavaHandlerComponents addBodyParser(Class<B> clazz, Supplier<B> bodyParserSupplier) {
         this.bodyPasers.put(clazz, (Supplier<BodyParser<?>>) bodyParserSupplier);
         return this;
     }

--- a/framework/src/play/src/main/java/play/core/j/StaticJavaHandlerComponents.java
+++ b/framework/src/play/src/main/java/play/core/j/StaticJavaHandlerComponents.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.core.j;
 
 import play.api.http.HttpConfiguration;

--- a/framework/src/play/src/main/java/play/core/j/StaticJavaHandlerComponents.java
+++ b/framework/src/play/src/main/java/play/core/j/StaticJavaHandlerComponents.java
@@ -1,0 +1,77 @@
+package play.core.j;
+
+import play.api.http.HttpConfiguration;
+import play.http.ActionCreator;
+import play.mvc.Action;
+import play.mvc.BodyParser;
+import scala.concurrent.ExecutionContext;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * The components necessary to handle a Java handler.
+ *
+ * But this implementation does not uses an Injector. Instead, the necessary {@link play.mvc.Action} and
+ * {@link play.mvc.BodyParser} must be added here manually. This is way we avoid mixing runtime dependency
+ * injector components with compile time injected ones.
+ */
+public class StaticJavaHandlerComponents implements JavaHandlerComponents {
+
+    private final ActionCreator actionCreator;
+    private final HttpConfiguration httpConfiguration;
+    private final ExecutionContext executionContext;
+    private final JavaContextComponents contextComponents;
+
+    private final Map<Class<? extends Action<?>>, Supplier<Action<?>>> actions = new HashMap<>();
+    private final Map<Class<? extends BodyParser<?>>, Supplier<BodyParser<?>>> bodyPasers = new HashMap<>();
+
+    public StaticJavaHandlerComponents(ActionCreator actionCreator, HttpConfiguration httpConfiguration, ExecutionContext executionContext, JavaContextComponents contextComponents) {
+        this.actionCreator = actionCreator;
+        this.httpConfiguration = httpConfiguration;
+        this.executionContext = executionContext;
+        this.contextComponents = contextComponents;
+    }
+
+    @Override @SuppressWarnings("unchecked")
+    public <A extends BodyParser<?>> A getBodyParser(Class<A> parserClass) {
+        return (A) this.bodyPasers.get(parserClass).get();
+    }
+
+    @Override @SuppressWarnings("unchecked")
+    public <A extends Action<?>> A getAction(Class<A> actionClass) {
+        return (A) this.actions.get(actionClass).get();
+    }
+
+    @Override
+    public ActionCreator actionCreator() {
+        return this.actionCreator;
+    }
+
+    @Override
+    public HttpConfiguration httpConfiguration() {
+        return this.httpConfiguration;
+    }
+
+    @Override
+    public ExecutionContext executionContext() {
+        return this.executionContext;
+    }
+
+    @Override
+    public JavaContextComponents contextComponents() {
+        return this.contextComponents;
+    }
+
+    public <A extends Action<?>> StaticJavaHandlerComponents addAction(Class<A> clazz, Supplier<A> actionSupplier) {
+        this.actions.put(clazz, (Supplier<Action<?>>) actionSupplier);
+        return this;
+    }
+
+    public <B extends BodyParser<?>> StaticJavaHandlerComponents addBodyParser(Class<B> clazz, Supplier<B> bodyParserSupplier) {
+        this.bodyPasers.put(clazz, (Supplier<BodyParser<?>>) bodyParserSupplier);
+        return this;
+    }
+
+}

--- a/framework/src/play/src/main/scala/play/api/inject/Injector.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Injector.scala
@@ -99,6 +99,13 @@ class SimpleInjector(fallback: Injector, components: Map[Class[_], Any] = Map.em
   /**
    * Add a component to the injector.
    */
-  def +[T](component: T)(implicit ct: ClassTag[T]) =
+  def +[T](component: T)(implicit ct: ClassTag[T]): SimpleInjector =
     new SimpleInjector(fallback, components + (ct.runtimeClass -> component))
+
+  /**
+   * Add a component to the injector.
+   */
+  def add[T](clazz: Class[T], component: T): SimpleInjector =
+    new SimpleInjector(fallback, components + (clazz -> component))
+
 }

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -3,6 +3,7 @@
  */
 package play.core.j
 
+import java.lang.annotation.Annotation
 import java.util.concurrent.CompletionStage
 import javax.inject.Inject
 
@@ -19,6 +20,8 @@ import play.mvc.Http.{ Context => JContext }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
+import java.util.function.{ Supplier => JSupplier }
+
 /**
  * Retains and evaluates what is otherwise expensive reflection work on call by call basis.
  *
@@ -31,11 +34,11 @@ class JavaActionAnnotations(val controller: Class[_], val method: java.lang.refl
       .filterNot(_ == null)
       .headOption.map(_.value).getOrElse(classOf[JBodyParser.Default])
 
-  val controllerAnnotations = play.api.libs.Collections.unfoldLeft[Seq[java.lang.annotation.Annotation], Option[Class[_]]](Option(controller)) { clazz =>
+  val controllerAnnotations: Seq[Annotation] = play.api.libs.Collections.unfoldLeft[Seq[java.lang.annotation.Annotation], Option[Class[_]]](Option(controller)) { clazz =>
     clazz.map(c => (Option(c.getSuperclass), c.getDeclaredAnnotations.toSeq))
   }.flatten
 
-  val actionMixins = {
+  val actionMixins: Seq[(Annotation, Class[_ <: JAction[_]])] = {
     val allDeclaredAnnotations: Seq[java.lang.annotation.Annotation] = if (config.controllerAnnotationsFirst) {
       controllerAnnotations ++ method.getDeclaredAnnotations
     } else {
@@ -169,4 +172,3 @@ class DefaultJavaHandlerComponents @Inject() (
   def getBodyParser[A <: JBodyParser[_]](parserClass: Class[A]): A = injector.instanceOf(parserClass)
   def getAction[A <: JAction[_]](actionClass: Class[A]): A = injector.instanceOf(actionClass)
 }
-

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayInteractionMode.scala
@@ -54,7 +54,7 @@ object PlayConsoleInteractionMode extends PlayInteractionMode {
 
   private def withConsoleReader[T](f: ConsoleReader => T): T = {
     val consoleReader = new ConsoleReader
-    try f(consoleReader) finally consoleReader.shutdown()
+    try f(consoleReader) finally consoleReader.close()
   }
   private def waitForKey(): Unit = {
     withConsoleReader { consoleReader =>


### PR DESCRIPTION
## Purpose

The main point here is to reduce the dependency on `Injector` for Java components at the same time that makes is more on par with what we have for Scala compile-time DI. So we have a new implementation of `JavaHandlerComponents` which does not depend on the `Injector` anymore.

We will then have components added to the injector (Java and some Scala which are eventually needed by Java delegates/wrappers).