### PR TITLE
Add joda forms module

### DIFF
--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -412,21 +412,27 @@ In order to make the default play distribution a bit smaller we removed some lib
 
 #### Joda-Time removal
 
-If you can, you could migrate all occurrences to Java8 `java.time`.
+We recommend using the `java.time` APIs, so we are removing joda-time support from the core of Play.
 
-If you can't and still need to use Joda-Time in Play Forms and Play-Json you can just add the `play-joda` project:
+Play's Scala forms library had some Joda formats. If you don't wish to migrate, you can add the `jodaForms` module in your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.typesafe.play" % "play-joda" % "1.0.0"
+libraryDependencies += jodaForms
 ```
 
-And then import the corresponding Object for Forms:
+And then import the corresponding object:
 
 ```scala
 import play.api.data.JodaForms._
 ```
 
-or for Play-Json
+If you need Joda support in play-json, you can add the following dependency:
+
+```scala
+libraryDependencies += "com.typesafe.play" % "play-json-joda" % playJsonVersion
+```
+
+where `playJsonVersion` is the play-json version you wish to use. Play 2.6.x should be compatible with play-json 2.6.x. Note that play-json is now a separate project (described later).
 
 ```scala
 import play.api.data.JodaWrites._

--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -46,6 +46,12 @@ lazy val PlayNettyUtilsProject = PlayNonCrossBuiltProject("Play-Netty-Utils", "p
       libraryDependencies ++= nettyUtilsDependencies
     )
 
+lazy val PlayJodaFormsProject = PlayCrossBuiltProject("Play-Joda-Forms", "play-joda-forms")
+    .settings(
+      libraryDependencies ++= joda
+    )
+    .dependsOn(PlayProject, PlaySpecs2Project % "test")
+
 lazy val PlayProject = PlayCrossBuiltProject("Play", "play")
     .enablePlugins(SbtTwirl)
     .settings(
@@ -301,6 +307,7 @@ lazy val publishedProjects = Seq[ProjectReference](
   PlayJdbcEvolutionsProject,
   PlayJavaProject,
   PlayJavaFormsProject,
+  PlayJodaFormsProject,
   PlayJavaJdbcProject,
   PlayJpaProject,
   PlayNettyUtilsProject,

--- a/framework/project/Dependencies.scala
+++ b/framework/project/Dependencies.scala
@@ -81,6 +81,11 @@ object Dependencies {
     "net.jodah" % "typetools" % "0.4.9"
   ) ++ specsBuild.map(_ % Test)
 
+  val joda = Seq(
+    "joda-time" % "joda-time" % "2.9.9",
+    "org.joda" % "joda-convert" % "1.8.1"
+  )
+
   val javaFormsDeps = Seq(
 
     "org.hibernate" % "hibernate-validator" % "5.4.1.Final",

--- a/framework/src/play-forms-joda/src/main/scala/play/api/data/JodaForms.scala
+++ b/framework/src/play-forms-joda/src/main/scala/play/api/data/JodaForms.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.data
+
+import play.api.data.format._
+
+object JodaForms {
+
+  import JodaFormats._
+
+  /**
+   * Constructs a simple mapping for a date field (mapped as `org.joda.time.DateTime type`).
+   *
+   * For example:
+   * {{{
+   *   Form("birthdate" -> jodaDate)
+   * }}}
+   */
+  val jodaDate: Mapping[org.joda.time.DateTime] = Forms.of[org.joda.time.DateTime]
+
+  /**
+   * Constructs a simple mapping for a date field (mapped as `org.joda.time.DateTime type`).
+   *
+   * For example:
+   * {{{
+   *   Form("birthdate" -> jodaDate("dd-MM-yyyy"))
+   * }}}
+   *
+   * @param pattern the date pattern, as defined in `org.joda.time.format.DateTimeFormat`
+   * @param timeZone the `org.joda.time.DateTimeZone` to use for parsing and formatting
+   */
+  def jodaDate(pattern: String, timeZone: org.joda.time.DateTimeZone = org.joda.time.DateTimeZone.getDefault): Mapping[org.joda.time.DateTime] = Forms.of[org.joda.time.DateTime] as jodaDateTimeFormat(pattern, timeZone)
+
+  /**
+   * Constructs a simple mapping for a date field (mapped as `org.joda.time.LocalDatetype`).
+   *
+   * For example:
+   * {{{
+   * Form("birthdate" -> jodaLocalDate)
+   * }}}
+   */
+  val jodaLocalDate: Mapping[org.joda.time.LocalDate] = Forms.of[org.joda.time.LocalDate]
+
+  /**
+   * Constructs a simple mapping for a date field (mapped as `org.joda.time.LocalDate type`).
+   *
+   * For example:
+   * {{{
+   * Form("birthdate" -> jodaLocalDate("dd-MM-yyyy"))
+   * }}}
+   *
+   * @param pattern the date pattern, as defined in `org.joda.time.format.DateTimeFormat`
+   */
+  def jodaLocalDate(pattern: String): Mapping[org.joda.time.LocalDate] = Forms.of[org.joda.time.LocalDate] as jodaLocalDateFormat(pattern)
+
+}

--- a/framework/src/play-forms-joda/src/main/scala/play/api/data/format/JodaFormats.scala
+++ b/framework/src/play-forms-joda/src/main/scala/play/api/data/format/JodaFormats.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.data.format
+
+import play.api.data._
+
+object JodaFormats {
+
+  /**
+   * Helper for formatters binders
+   * @param parse Function parsing a String value into a T value, throwing an exception in case of failure
+   * @param errArgs Error to set in case of parsing failure
+   * @param key Key name of the field to parse
+   * @param data Field data
+   */
+  private def parsing[T](parse: String => T, errMsg: String, errArgs: Seq[Any])(key: String, data: Map[String, String]): Either[Seq[FormError], T] = {
+    Formats.stringFormat.bind(key, data).right.flatMap { s =>
+      scala.util.control.Exception.allCatch[T]
+        .either(parse(s))
+        .left.map(e => Seq(FormError(key, errMsg, errArgs)))
+    }
+  }
+
+  /**
+   * Formatter for the `org.joda.time.DateTime` type.
+   *
+   * @param pattern a date pattern as specified in `org.joda.time.format.DateTimeFormat`.
+   * @param timeZone the `org.joda.time.DateTimeZone` to use for parsing and formatting
+   */
+  def jodaDateTimeFormat(pattern: String, timeZone: org.joda.time.DateTimeZone = org.joda.time.DateTimeZone.getDefault): Formatter[org.joda.time.DateTime] = new Formatter[org.joda.time.DateTime] {
+
+    val formatter = org.joda.time.format.DateTimeFormat.forPattern(pattern).withZone(timeZone)
+
+    override val format = Some(("format.date", Seq(pattern)))
+
+    def bind(key: String, data: Map[String, String]) = parsing(formatter.parseDateTime, "error.date", Nil)(key, data)
+
+    def unbind(key: String, value: org.joda.time.DateTime) = Map(key -> value.withZone(timeZone).toString(pattern))
+  }
+
+  /**
+   * Default formatter for `org.joda.time.DateTime` type with pattern `yyyy-MM-dd`.
+   */
+  implicit val jodaDateTimeFormat: Formatter[org.joda.time.DateTime] = jodaDateTimeFormat("yyyy-MM-dd")
+
+  /**
+   * Formatter for the `org.joda.time.LocalDate` type.
+   *
+   * @param pattern a date pattern as specified in `org.joda.time.format.DateTimeFormat`.
+   */
+  def jodaLocalDateFormat(pattern: String): Formatter[org.joda.time.LocalDate] = new Formatter[org.joda.time.LocalDate] {
+
+    import org.joda.time.LocalDate
+
+    val formatter = org.joda.time.format.DateTimeFormat.forPattern(pattern)
+    def jodaLocalDateParse(data: String) = LocalDate.parse(data, formatter)
+
+    override val format = Some(("format.date", Seq(pattern)))
+
+    def bind(key: String, data: Map[String, String]) = parsing(jodaLocalDateParse, "error.date", Nil)(key, data)
+
+    def unbind(key: String, value: LocalDate) = Map(key -> value.toString(pattern))
+  }
+
+  /**
+   * Default formatter for `org.joda.time.LocalDate` type with pattern `yyyy-MM-dd`.
+   */
+  implicit val jodaLocalDateFormat: Formatter[org.joda.time.LocalDate] = jodaLocalDateFormat("yyyy-MM-dd")
+
+}

--- a/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
+++ b/framework/src/sbt-plugin/src/main/scala/play/sbt/PlayImport.scala
@@ -35,6 +35,8 @@ object PlayImport {
 
   val javaForms = component("play-java-forms")
 
+  val jodaForms = component("play-joda-forms")
+
   val javaJdbc = component("play-java-jdbc")
 
   def javaEbean = movedExternal(


### PR DESCRIPTION
I'm going to remove https://github.com/playframework/play-joda. Since this is just a legacy support module that is unlikely to change, I don't think it makes sense to have a separate project. It's much easier if we have simple submodules (play-joda-forms, play-json-joda) that are associated with each project.