### PR TITLE
Allowing white spaces occurred in the start of each line in the routes file.

### DIFF
--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
@@ -182,7 +182,7 @@ private[routes] class RoutesFileParser extends JavaTokenParsers {
 
   def end: util.matching.Regex = """\s*""".r
 
-  def comment: Parser[Comment] = "#" ~> ".*".r ^^ {
+  def comment: Parser[Comment] = """\s*#""".r ~> ".*".r ^^ {
     case c => Comment(c)
   }
 
@@ -304,11 +304,11 @@ private[routes] class RoutesFileParser extends JavaTokenParsers {
     case parts => parts.mkString(".")
   }
 
-  def route = httpVerb ~! separator ~ path ~ separator ~ positioned(call) ~ ignoreWhiteSpace ^^ {
-    case v ~ _ ~ p ~ _ ~ c ~ _ => Route(v, p, c)
+  def route = """\s*""".r ~ httpVerb ~! separator ~ path ~ separator ~ positioned(call) ~ ignoreWhiteSpace ^^ {
+    case _ ~ v ~ _ ~ p ~ _ ~ c ~ _ => Route(v, p, c)
   }
 
-  def include = "->" ~! separator ~ path ~ separator ~ router ~ ignoreWhiteSpace ^^ {
+  def include = """\s*->""".r ~! separator ~ path ~ separator ~ router ~ ignoreWhiteSpace ^^ {
     case _ ~ _ ~ p ~ _ ~ r ~ _ => Include(p.toString, r)
   }
 

--- a/framework/src/routes-compiler/src/test/scala/play/routes/compiler/RoutesFileParserSpec.scala
+++ b/framework/src/routes-compiler/src/test/scala/play/routes/compiler/RoutesFileParserSpec.scala
@@ -131,6 +131,21 @@ class RoutesFileParserSpec extends Specification {
       parseRoute("# some comment\nGET /s p.c.m").comments must containTheSameElementsAs(Seq(Comment(" some comment")))
     }
 
+    "parse the HTTP method with white spaces occurred in the start of line" in {
+      parseRoute(" GET /s p.c.m").verb must_== HttpVerb("GET")
+    }
+
+    "parse an include with white spaces occurred in the start of line" in {
+      val rule = parseRule(" -> /s someFile")
+      rule must beAnInstanceOf[Include]
+      rule.asInstanceOf[Include].router must_== "someFile"
+      rule.asInstanceOf[Include].prefix must_== "s"
+    }
+
+    "parse a comment with white spaces occurred in the start of line" in {
+      parseRoute(" # some comment\nGET /s p.c.m").comments must containTheSameElementsAs(Seq(Comment(" some comment")))
+    }
+
     "throw an error for an unexpected line" in parseError("foo")
     "throw an error for an invalid path" in parseError("GET s p.c.m")
     "throw an error for no path" in parseError("GET")


### PR DESCRIPTION
It should allow white spaces occurred in the start of each line in the routes file. So we can adjust the indentation of each line to make it more prettier. 
Currently, if white spaces occurs in the start of lines: 
```
# Application
   GET    /index         controllers.Application.index
```
It will complain one error:
```
[error] D:\idea-projects\qizhi-cloud\conf\routes:5: Compilation error[string matching regex `\z' expected but `G' found]
```
With this pull request, the following routes passes the compilation:
```
# Application
  GET    /index         controllers.Application.index   
  GET    /login         controllers.Application.login
# GET    /test          controllers.Application.test
  GET    /logout        controllers.Application.logout

# Sub Routes   
  ->     /product       product.Routes
```
And it looks more prettier than before.