### PR TITLE
Add route modifier tags and NOCSRF

### DIFF
--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -55,6 +55,38 @@ Attributes are stored in a `TypedMap`. You can read more about attributes in the
 
 Request tags have now been deprecated and you should migrate to use attributes instead. See the [[tags section|Migration26#Request-tags-deprecation]] in the migration docs for more information.
 
+## Route modifier tags
+
+The routes file syntax now allows you to add "modifiers" to each route that provide custom behavior. We have implemented one such tag in the CSRF filter, the "nocsrf" tag. By default, the following route will not have the CSRF filter applied.
+
+```
++ nocsrf # Don't CSRF protect this route 
+POST /api/foo/bar ApiController.foobar
+```
+
+You can also create your own modifiers: the `+` symbol can be followed by any number of whitespace-separated tags.
+
+These are made available in the `HandlerDef` request attribute (which also contains other metadata on the handler definition in the routes file):
+
+Java:
+```java
+import java.util.List;
+import play.routing.HandlerDef;
+import play.routing.Router;
+
+HandlerDef handler = req.attrs().get(Router.Attrs.HANDLER_DEF);
+List<String> modifiers = handler.getModifiers();
+```
+
+Scala:
+```scala
+import play.api.routing.{ HandlerDef, Router }
+import play.api.mvc.RequestHeader
+
+val handler = request.attrs(Router.Attrs.HandlerDef)
+val modifiers = handler.modifiers
+```
+
 ## Injectable Twirl Templates
 
 Twirl templates can now be created with a constructor annotation using `@this`.  The constructor annotation means that Twirl templates can be injected into templates directly and can manage their own dependencies, rather than the controller having to manage dependencies not only for itself, but also for the templates it has to render.

--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -92,6 +92,15 @@ play.filters {
       blackList = []
     }
 
+    routeModifiers {
+      # If non empty, then requests will be checked if the route does not have this modifier
+      whiteList = ["nocsrf"]
+
+      # If non empty, then requests will be checked if the route contains this modifier
+      # The black list is used only if the white list is empty
+      blackList = []
+    }
+
     # The error handler.
     # Used by Play's built in DI support to locate and bind a request handler.  Must be one of the following:
     # - A FQCN that implements play.filters.csrf.CSRF.ErrorHandler (Scala).

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketSpec.scala
@@ -304,7 +304,7 @@ trait WebSocketSpec extends PlaySpecification
       implicit def toHandler[J <: AnyRef](javaHandler: => J)(implicit factory: HandlerInvokerFactory[J], ct: ClassTag[J]): Handler = {
         val invoker = factory.createInvoker(
           javaHandler,
-          new HandlerDef(ct.runtimeClass.getClassLoader, "package", "controller", "method", Nil, "GET", "", "/stream")
+          HandlerDef(ct.runtimeClass.getClassLoader, "package", "controller", "method", Nil, "GET", "/stream")
         )
         invoker.call(javaHandler)
       }

--- a/framework/src/play/src/main/java/play/routing/HandlerDef.java
+++ b/framework/src/play/src/main/java/play/routing/HandlerDef.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.routing;
+
+import java.util.List;
+import scala.collection.Seq;
+
+import play.libs.Scala;
+
+public abstract class HandlerDef {
+  public abstract ClassLoader classLoader();
+  public abstract String routerPackage();
+  public abstract String controller();
+  public abstract String method();
+  protected abstract Seq<Class<?>> parameterTypes();
+  public abstract String verb();
+  public abstract String path();
+  public abstract String comments();
+  protected abstract Seq<String> modifiers();
+
+  public List<Class<?>> getParameterTypes() {
+    return Scala.asJava(parameterTypes());
+  }
+
+  public List<String> getModifiers() {
+    return Scala.asJava(modifiers());
+  }
+}

--- a/framework/src/play/src/main/scala/play/api/routing/HandlerDef.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/HandlerDef.scala
@@ -7,4 +7,14 @@ package play.api.routing
  * Information about a `Handler`, especially useful for loading the handler
  * with reflection.
  */
-case class HandlerDef(classLoader: ClassLoader, routerPackage: String, controller: String, method: String, parameterTypes: Seq[Class[_]], verb: String, comments: String, path: String)
+case class HandlerDef(
+  classLoader: ClassLoader,
+  routerPackage: String,
+  controller: String,
+  method: String,
+  parameterTypes: Seq[Class[_]],
+  verb: String,
+  path: String,
+  comments: String = "",
+  modifiers: Seq[String] = Seq.empty
+) extends play.routing.HandlerDef

--- a/framework/src/play/src/main/scala/play/api/routing/Router.scala
+++ b/framework/src/play/src/main/scala/play/api/routing/Router.scala
@@ -73,6 +73,25 @@ object Router {
     }
   }
 
+  object RequestImplicits {
+    import play.api.mvc.RequestHeader
+
+    implicit class WithHandlerDef(val request: RequestHeader) extends AnyVal {
+      /**
+       * The [[HandlerDef]] representing the routes file entry (if any) on this request.
+       */
+      def handlerDef: Option[HandlerDef] = request.attrs.get(Attrs.HandlerDef)
+
+      /**
+       * Check if the route for this request has the given modifier tag (case insensitive).
+       *
+       * This can be used by a filter to change behavior.
+       */
+      def hasRouteModifier(modifier: String): Boolean =
+        handlerDef.exists(_.modifiers.exists(modifier.equalsIgnoreCase))
+    }
+  }
+
   /**
    * Request attributes used by the router.
    */
@@ -80,7 +99,7 @@ object Router {
     /**
      * Key for the [[HandlerDef]] used to handle the request.
      */
-    val HandlerDef = TypedKey[HandlerDef]("HandlerDef")
+    val HandlerDef: TypedKey[HandlerDef] = TypedKey("HandlerDef")
   }
 
   /** Tags that are added to requests by the router. */

--- a/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaAction.scala
@@ -68,7 +68,7 @@ abstract class JavaAction(val handlerComponents: JavaHandlerComponents)
 
     val rootAction = new JAction[Any] {
       def call(ctx: JContext): CompletionStage[JResult] = {
-        // The context may have changed, set it again
+        // The context may have changed, set it again;
         val oldContext = JContext.current.get()
         try {
           JContext.current.set(ctx)

--- a/framework/src/play/src/test/scala/play/core/routing/GeneratedRouterSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/routing/GeneratedRouterSpec.scala
@@ -58,8 +58,9 @@ object GeneratedRouterSpec extends Specification {
         "handler",
         Nil,
         "GET",
+        "/",
         "Comment",
-        "/"
+        Seq("Tag")
       )
       val request = FakeRequest()
       routeToHandler(handler, handlerDef, request) { routedHandler: Handler =>
@@ -85,8 +86,9 @@ object GeneratedRouterSpec extends Specification {
         "index",
         Nil,
         "GET",
+        "/",
         "Comment",
-        "/"
+        Seq("Tag")
       )
       val request = FakeRequest()
       routeToHandler(controller.index, handlerDef, request) { routedHandler: Handler =>

--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesFileParser.scala
@@ -170,23 +170,24 @@ private[routes] class RoutesFileParser extends JavaTokenParsers {
 
   def ignoreWhiteSpace: Parser[Option[String]] = opt(whiteSpace)
 
-  // This won't be needed when we upgrade to Scala 2.11, we will then be able to use JavaTokenParser.ident:
-  // https://github.com/scala/scala/pull/1466
-  def javaIdent: Parser[String] = """\p{javaJavaIdentifierStart}\p{javaJavaIdentifierPart}*""".r
-
   def tickedIdent: Parser[String] = """`[^`]+`""".r
 
-  def identifier: Parser[String] = namedError(javaIdent, "Identifier expected")
+  def identifier: Parser[String] = namedError(ident, "Identifier expected")
 
   def tickedIdentifier: Parser[String] = namedError(tickedIdent, "Identifier expected")
 
   def end: util.matching.Regex = """\s*""".r
 
-  def comment: Parser[Comment] = "#" ~> ".*".r ^^ {
-    case c => Comment(c)
+  def comment: Parser[Comment] = "#" ~> ".*".r ^^ Comment.apply
+
+  def modifiers: Parser[List[Modifier]] =
+    "+" ~> ignoreWhiteSpace ~> repsep("""[^#\s]+""".r, separator) <~ ignoreWhiteSpace ^^ (_.map(Modifier.apply))
+
+  def modifiersWithComment: Parser[(List[Modifier], Option[Comment])] = modifiers ~ opt(comment) ^^ {
+    case m ~ c => (m, c)
   }
 
-  def newLine: Parser[String] = namedError((("\r"?) ~> "\n"), "End of line expected")
+  def newLine: Parser[String] = namedError(("\r"?) ~> "\n", "End of line expected")
 
   def blankLine: Parser[Unit] = ignoreWhiteSpace ~> newLine ^^ { case _ => () }
 
@@ -238,7 +239,7 @@ private[routes] class RoutesFileParser extends JavaTokenParsers {
     case _ ~ parts => PathPattern(parts)
   }
 
-  def space(s: String): Parser[String] = (ignoreWhiteSpace ~> s <~ ignoreWhiteSpace)
+  def space(s: String): Parser[String] = ignoreWhiteSpace ~> s <~ ignoreWhiteSpace
 
   def parameterType: Parser[String] = ":" ~> ignoreWhiteSpace ~> simpleType
 
@@ -284,7 +285,7 @@ private[routes] class RoutesFileParser extends JavaTokenParsers {
 
   // Absolute method consists of a series of Java identifiers representing the package name, controller and method.
   // Since the Scala parser is greedy, we can't easily extract this out, so just parse at least 3
-  def absoluteMethod: Parser[List[String]] = namedError(javaIdent ~ "." ~ javaIdent ~ "." ~ rep1sep(javaIdent, ".") ^^ {
+  def absoluteMethod: Parser[List[String]] = namedError(ident ~ "." ~ ident ~ "." ~ rep1sep(ident, ".") ^^ {
     case first ~ _ ~ second ~ _ ~ rest => first :: second :: rest
   }, "Controller method call expected")
 
@@ -295,7 +296,7 @@ private[routes] class RoutesFileParser extends JavaTokenParsers {
         val packageName = packageParts.mkString(".")
         val className = classAndMethod(0)
         val methodName = classAndMethod(1)
-        val dynamic = !instantiate.isEmpty
+        val dynamic = instantiate.isDefined
         HandlerCall(packageName, className, dynamic, methodName, parameters)
       }
   }
@@ -304,27 +305,35 @@ private[routes] class RoutesFileParser extends JavaTokenParsers {
     case parts => parts.mkString(".")
   }
 
-  def route = httpVerb ~! separator ~ path ~ separator ~ positioned(call) ~ ignoreWhiteSpace ^^ {
-    case v ~ _ ~ p ~ _ ~ c ~ _ => Route(v, p, c)
+  def route = httpVerb ~! separator ~ path ~ separator ~ positioned(call) ^^ {
+    case v ~ _ ~ p ~ _ ~ c => Route(v, p, c)
   }
 
-  def include = "->" ~! separator ~ path ~ separator ~ router ~ ignoreWhiteSpace ^^ {
-    case _ ~ _ ~ p ~ _ ~ r ~ _ => Include(p.toString, r)
+  def include = "->" ~! separator ~ path ~ separator ~ router ^^ {
+    case _ ~ _ ~ p ~ _ ~ r => Include(p.toString, r)
   }
 
-  def sentence: Parser[Product with Serializable] = namedError((comment | positioned(include) | positioned(route)), "HTTP Verb (GET, POST, ...), include (->) or comment (#) expected") <~ (newLine | EOF)
+  def sentence: Parser[Product] = ignoreWhiteSpace ~>
+    namedError(
+      comment | modifiersWithComment | positioned(include) | positioned(route),
+      "HTTP Verb (GET, POST, ...), include (->), comment (#), or modifier line (+) expected"
+    ) <~ ignoreWhiteSpace <~ (newLine | EOF)
 
   def parser: Parser[List[Rule]] = phrase((blankLine | sentence *) <~ end) ^^ {
     case routes =>
-      routes.reverse.foldLeft(List[(Option[Rule], List[Comment])]()) {
-        case (s, r @ Route(_, _, _, _)) => (Some(r), List()) :: s
-        case (s, i @ Include(_, _)) => (Some(i), List()) :: s
-        case (s, c @ ()) => (None, List()) :: s
-        case ((r, comments) :: others, c @ Comment(_)) => (r, c :: comments) :: others
+      routes.reverse.foldLeft(List[(Option[Rule], List[Comment], List[Modifier])]()) {
+        case (s, r @ Route(_, _, _, _, _)) => (Some(r), Nil, Nil) :: s
+        case (s, i @ Include(_, _)) => (Some(i), Nil, Nil) :: s
+        case (s, c @ ()) => (None, Nil, Nil) :: s
+        case ((r, comments, modifiers) :: others, c: Comment) =>
+          (r, c :: comments, modifiers) :: others
+        case ((r, comments, modifiers) :: others, (ms: List[Modifier], c: Option[Comment])) =>
+          (r, c.toList ::: comments, ms ::: modifiers) :: others
         case (s, _) => s
       }.collect {
-        case (Some(r @ Route(_, _, _, _)), comments) => r.copy(comments = comments).setPos(r.pos)
-        case (Some(i @ Include(_, _)), _) => i
+        case (Some(r @ Route(_, _, _, _, _)), comments, modifiers) =>
+          r.copy(comments = comments, modifiers = modifiers).setPos(r.pos)
+        case (Some(i @ Include(_, _)), _, _) => i
       }
   }
 

--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesModels.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/RoutesModels.scala
@@ -20,7 +20,8 @@ sealed trait Rule extends Positional
  * @param call The call to make
  * @param comments The comments above the route
  */
-case class Route(verb: HttpVerb, path: PathPattern, call: HandlerCall, comments: List[Comment] = List()) extends Rule
+case class Route(verb: HttpVerb, path: PathPattern, call: HandlerCall,
+  comments: Seq[Comment] = Seq.empty, modifiers: Seq[Modifier] = Seq.empty) extends Rule
 
 /**
  * An include for another router
@@ -69,6 +70,11 @@ case class Parameter(name: String, typeName: String, fixed: Option[String], defa
  * A comment from the routes file.
  */
 case class Comment(comment: String)
+
+/**
+ * A modifier tag in the routes file
+ */
+case class Modifier(value: String)
 
 /**
  * A part of the path

--- a/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
+++ b/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
@@ -41,8 +41,8 @@ class Routes(
 
   def documentation = List(@for((dep, index) <- rules.zipWithIndex) {
     @dep.rule match {
-      case Route(verb, path, call, _) if path.parts.isEmpty => {(@tq@verb@tq, this.prefix, @tq@call@tq)}
-      case Route(verb, path, call, _) => {(@tq@verb@tq, this.prefix + (if(this.prefix.endsWith("/")) "" else "/") + @encodeStringConstant(path.toString), @tq@call@tq)}
+      case Route(verb, path, call, _, _) if path.parts.isEmpty => {(@tq@verb@tq, this.prefix, @tq@call@tq)}
+      case Route(verb, path, call, _, _) => {(@tq@verb@tq, this.prefix + (if(this.prefix.endsWith("/")) "" else "/") + @encodeStringConstant(path.toString), @tq@call@tq)}
       case include: Include => {prefixed_@(dep.ident)_@(index).router.documentation}
   },}
     Nil
@@ -52,7 +52,7 @@ class Routes(
   }}
 
 @for((dep, index) <- rules.zipWithIndex){@dep.rule match {
-case route @ Route(verb, path, call, comments) => {
+case route @ Route(verb, path, call, comments, modifiers) => {
   @markLines(route)
   private[this] lazy val @routeIdentifier(route, index) = Route("@verb.value",
     PathPattern(List(StaticPart(this.prefix)@if(path.parts.nonEmpty) {, StaticPart(this.defaultPrefix), }@path.parts.map(_.toString).mkString(", ")))
@@ -65,8 +65,9 @@ case route @ Route(verb, path, call, comments) => {
       "@call.method",
       @call.parameters.filterNot(_.isEmpty).map(params => params.map("classOf[" + _.typeName + "]").mkString(", ")).map("Seq(" + _ + ")").getOrElse("Nil"),
       "@verb",
+      this.prefix + @encodeStringConstant(path.toString),
       @encodeStringConstant(comments.map(_.comment).mkString("\n")),
-      this.prefix + @encodeStringConstant(path.toString)
+      Seq(@modifiers.map(_.value).map(encodeStringConstant).mkString(", "))
     )
   )
 }
@@ -83,7 +84,7 @@ case include @ Include(path, router) => {
     @markLines(include)
     case prefixed_@(dep.ident)_@(index)(handler) => handler
   }
-  case route @ Route(_, _, _, _) => {
+  case route: Route => {
     @markLines(route)
     case @(routeIdentifier(route, index))(params) =>
       call@(routeBinding(route)) @ob @localNames(route)

--- a/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/forwardsRouter.scala.twirl
+++ b/framework/src/routes-compiler/src/main/twirl/play/routes/compiler/static/forwardsRouter.scala.twirl
@@ -40,8 +40,8 @@ class Routes extends GeneratedRouter {
 
   def documentation: Seq[(String, String, String)] = List(@for((rule, index) <- rules.zipWithIndex) {
     @rule match {
-      case Route(verb, path, call, _) if path.parts.isEmpty => {(@tq@verb@tq, prefix, @tq@call@tq)}
-      case Route(verb, path, call, _) => {(@tq@verb@tq, prefix + (if(prefix.endsWith("/")) "" else "/") + @encodeStringConstant(path.toString), @tq@call@tq)}
+      case Route(verb, path, call, _, _) if path.parts.isEmpty => {(@tq@verb@tq, prefix, @tq@call@tq)}
+      case Route(verb, path, call, _, _) => {(@tq@verb@tq, prefix + (if(prefix.endsWith("/")) "" else "/") + @encodeStringConstant(path.toString), @tq@call@tq)}
       case include: Include => {@(routerIdentifier(include, index)).router.documentation}
   },}
     Nil
@@ -51,7 +51,7 @@ class Routes extends GeneratedRouter {
   }}
 
 @for(rule <- rules.zipWithIndex){@rule match {
-case (route @ Route(verb, path, call, comments), index) => {
+case (route @ Route(verb, path, call, comments, modifiers), index) => {
   @markLines(route)
   private[this] lazy val @routeIdentifier(route, index): Route.ParamsExtractor = Route("@verb.value",
     PathPattern(List(StaticPart(this.prefix)@if(path.parts.nonEmpty) {, StaticPart(this.defaultPrefix), }@path.parts.map(_.toString).mkString(", ")))
@@ -64,8 +64,9 @@ case (route @ Route(verb, path, call, comments), index) => {
       "@call.method",
       @call.parameters.filterNot(_.isEmpty).map(params => params.map("classOf[" + _.typeName + "]").mkString(", ")).map("Seq(" + _ + ")").getOrElse("Nil"),
       "@verb",
+      this.prefix + @encodeStringConstant(path.toString),
       @encodeStringConstant(comments.map(_.comment).mkString("\n")),
-      this.prefix + @encodeStringConstant(path.toString)
+      Seq(@modifiers.map(_.value).map(encodeStringConstant).mkString(", "))
     )
   )
 }
@@ -82,7 +83,7 @@ case (include @ Include(path, router), index) => {
     @markLines(include)
     case @(routerIdentifier(include, index))(handler) => handler
   }
-  case (route @ Route(_, _, _, _), index) => {
+  case (route: Route, index) => {
     @markLines(route)
     case @(routeIdentifier(route, index))(params) =>
       call@(routeBinding(route)) @ob @localNames(route)


### PR DESCRIPTION
This adds a syntax to "tag" routes to modify the behavior of that route. The tags are simply strings, but it's theoretically possible to extract the tags from the `HandlerDef` and implement more complex behavior (e.g. `key=value`).

Route modifiers are introduced using a line beginning with a `+` symbol before the route definition:

```
+ NOCSRF
POST /api/foo/bar ApiController.foobar
```
(leading/trailing spaces are optional)

Fixes #5882, by defining a new `NOCSRF` modifier that can be applied to the route (this can be configured in the CSRF config).

I decided not to use comments as suggested in #5882, since I suspect others are already using comments and did not want to interfere with custom implementations already out there. Traditionally comments should not change the behavior of your app. I'm open to suggestions on the syntax of route modifiers though.