### PR TITLE
Make Futures.delayed take Callable<CompletionStage<T>>

### DIFF
--- a/framework/src/play/src/main/java/play/libs/concurrent/DefaultFutures.java
+++ b/framework/src/play/src/main/java/play/libs/concurrent/DefaultFutures.java
@@ -8,6 +8,7 @@ import scala.concurrent.duration.FiniteDuration;
 
 import javax.inject.Inject;
 import java.time.Duration;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
@@ -70,38 +71,38 @@ public class DefaultFutures implements Futures {
      * Create a CompletionStage which, after a delay, will be redeemed with the result of a
      * given supplier. The supplier will be called after the delay.
      *
-     * @param stage the input completion stage that is delayed.
+     * @param callable the input completion stage that is delayed.
      * @param amount The time to wait.
      * @param unit The units to use for the amount.
      * @param <A> the type of the completion's result.
      * @return the delayed CompletionStage wrapping supplier.
      */
     @Override
-    public <A> CompletionStage<A> delayed(final CompletionStage<A> stage, long amount, TimeUnit unit) {
-        requireNonNull(stage, "Null stage");
+    public <A> CompletionStage<A> delayed(final Callable<CompletionStage<A>> callable, long amount, TimeUnit unit) {
+        requireNonNull(callable, "Null callable");
         requireNonNull(amount, "Null amount");
         requireNonNull(unit, "Null unit");
 
         FiniteDuration duration = FiniteDuration.apply(amount, unit);
-        return toJava(delegate.delayed(duration, Scala.asScalaWithFuture(() -> stage)));
+        return toJava(delegate.delayed(duration, Scala.asScalaWithFuture(callable)));
     }
 
     /**
      * Create a CompletionStage which, after a delay, will be redeemed with the result of a
      * given supplier. The supplier will be called after the delay.
      *
-     * @param stage the input completion stage that is delayed.
+     * @param callable the input completion stage that is delayed.
      * @param duration to wait.
      * @param <A> the type of the completion's result.
      * @return the delayed CompletionStage wrapping supplier.
      */
     @Override
-    public <A> CompletionStage<A> delayed(CompletionStage<A> stage, Duration duration) {
-        requireNonNull(stage, "Null stage");
+    public <A> CompletionStage<A> delayed(final Callable<CompletionStage<A>> callable, Duration duration) {
+        requireNonNull(callable, "Null callable");
         requireNonNull(duration, "Null duration");
 
         FiniteDuration finiteDuration = FiniteDuration.apply(duration.toMillis(), TimeUnit.MILLISECONDS);
-        return toJava(delegate.delayed(finiteDuration, Scala.asScalaWithFuture(() -> stage)));
+        return toJava(delegate.delayed(finiteDuration, Scala.asScalaWithFuture(callable)));
     }
 
 }

--- a/framework/src/play/src/test/java/play/libs/concurrent/FuturesTest.java
+++ b/framework/src/play/src/test/java/play/libs/concurrent/FuturesTest.java
@@ -6,7 +6,6 @@ package play.libs.concurrent;
 import akka.actor.ActorSystem;
 import org.junit.*;
 
-import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -68,7 +67,7 @@ public class FuturesTest {
         final CompletionStage<Long> stage = renderAfter(expected);
 
         Duration actual = Duration.ofMillis(stage.toCompletableFuture().get());
-        assertTrue( format("Expected duration {0} is smaller than actual duration {1}!", expected, actual), actual.compareTo(expected) > 1);
+        assertTrue( format("Expected duration {0} is smaller than actual duration {1}!", expected, actual), actual.compareTo(expected) > 0);
     }
 
     @Test
@@ -77,7 +76,7 @@ public class FuturesTest {
         final CompletionStage<Long> stage = renderAfter(Duration.ofSeconds(1));
 
         Duration actual = Duration.ofMillis(stage.toCompletableFuture().get());
-        assertTrue(format("Expected duration {0} is larger from actual duration {1}!", expected, actual), actual.compareTo(expected) < 1);
+        assertTrue(format("Expected duration {0} is larger from actual duration {1}!", expected, actual), actual.compareTo(expected) < 0);
     }
 
     private CompletionStage<Double> computePIAsynchronously() {

--- a/framework/src/play/src/test/java/play/libs/concurrent/FuturesTest.java
+++ b/framework/src/play/src/test/java/play/libs/concurrent/FuturesTest.java
@@ -6,14 +6,16 @@ package play.libs.concurrent;
 import akka.actor.ActorSystem;
 import org.junit.*;
 
+import java.text.MessageFormat;
 import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 
+import static java.text.MessageFormat.*;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class FuturesTest {
 
@@ -48,7 +50,7 @@ public class FuturesTest {
     public void failedTimeout() throws Exception {
         class MyClass {
             CompletionStage<Double> callWithTimeout() {
-                return futures.timeout(delayedFuture(), Duration.ofMillis(300));
+                return futures.timeout(delayByOneSecond(), Duration.ofMillis(300));
             }
         }
         final Double actual = new MyClass()
@@ -60,12 +62,38 @@ public class FuturesTest {
         assertThat(actual, equalTo(expected));
     }
 
-    private CompletionStage<Double> computePIAsynchronously() {
-        return CompletableFuture.completedFuture(Math.PI);
+    @Test
+    public void successfulDelay() throws Exception {
+        Duration expected = Duration.ofSeconds(3);
+        final CompletionStage<Long> stage = renderAfter(expected);
+
+        Duration actual = Duration.ofMillis(stage.toCompletableFuture().get());
+        assertTrue( format("Expected duration {0} is smaller than actual duration {1}!", expected, actual), actual.compareTo(expected) > 1);
     }
 
-    private CompletionStage<Double> delayedFuture() {
-        return futures.delayed(CompletableFuture.supplyAsync(() -> Math.PI, ForkJoinPool.commonPool()), 1, TimeUnit.SECONDS);
+    @Test
+    public void failedDelay() throws Exception {
+        Duration expected = Duration.ofSeconds(3);
+        final CompletionStage<Long> stage = renderAfter(Duration.ofSeconds(1));
+
+        Duration actual = Duration.ofMillis(stage.toCompletableFuture().get());
+        assertTrue(format("Expected duration {0} is larger from actual duration {1}!", expected, actual), actual.compareTo(expected) < 1);
+    }
+
+    private CompletionStage<Double> computePIAsynchronously() {
+        return completedFuture(Math.PI);
+    }
+
+    private CompletionStage<Double> delayByOneSecond() {
+        return futures.delayed(this::computePIAsynchronously, Duration.ofSeconds(1));
+    }
+
+    private CompletionStage<Long> renderAfter(Duration duration) {
+        long start = System.currentTimeMillis();
+        return futures.delayed(() -> {
+            long end = System.currentTimeMillis();
+            return completedFuture(end - start);
+        }, duration);
     }
 
 }


### PR DESCRIPTION
## Purpose

The `Future.delayed` method took a `CompletionStage<T>` instead of a `Callable<CompetionStage<A>>`, which meant that an active completion stage was being passed in, instead of only being executed at the time on the delay.  This was pre-existing functionality, as the previous call took a `Supplier` which had the same effect, but `Supplier` is semantically more of an idempotent operation while `Callable` indicates processing.

Also added tests, fixed documentation. and cleaned up javadoc with examples.

## References

Java version of https://github.com/playframework/playframework/pull/7380
