### PR TITLE
Simplify compile-time DI Injector and add comments

### DIFF
--- a/framework/src/play-docs/src/main/scala/play/docs/DocServerStart.scala
+++ b/framework/src/play-docs/src/main/scala/play/docs/DocServerStart.scala
@@ -24,20 +24,20 @@ class DocServerStart {
   def start(projectPath: File, buildDocHandler: BuildDocHandler, translationReport: Callable[File],
     forceTranslationReport: Callable[File], port: java.lang.Integer): ReloadableServer = {
 
-    val application: Application = {
+    val components = {
       val environment = Environment(projectPath, this.getClass.getClassLoader, Mode.Test)
       val context = ApplicationLoader.createContext(environment)
-      val components = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
+      new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
         lazy val router = Router.empty
       }
-      components.application
     }
+    val application: Application = components.application
 
     Play.start(application)
 
     val applicationProvider = new ApplicationProvider {
       implicit val ec = application.actorSystem.dispatcher
-      implicit val fileMimeTypes = application.injector.instanceOf[FileMimeTypes]
+      implicit val fileMimeTypes = components.fileMimeTypes
       override def get = Success(application)
       override def handleWebCommand(request: RequestHeader) =
         buildDocHandler.maybeHandleDocRequest(request).asInstanceOf[Option[Result]].orElse(

--- a/framework/src/play/src/main/java/play/Application.java
+++ b/framework/src/play/src/main/java/play/Application.java
@@ -52,7 +52,8 @@ public interface Application {
     Config config();
 
     /**
-     * Get the injector for this application.
+     * Get the runtime injector for this application. In a runtime dependency injection based application, this can be
+     * used to obtain components as bound by the DI framework.
      *
      * @return the injector
      */

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -129,8 +129,5 @@ abstract class BuiltInComponentsFromContext(context: ApplicationLoader.Context) 
   lazy val controllerComponents: ControllerComponents = DefaultControllerComponents(
     defaultActionBuilder, playBodyParsers, messagesApi, langs, fileMimeTypes, executionContext
   )
-
-  override lazy val injector: Injector = new SimpleInjector(NewInstanceInjector) + router + cookieSigner +
-    csrfTokenSigner + httpConfiguration + tempFileCreator + messagesApi + langs + javaContextComponents + fileMimeTypes
 }
 


### PR DESCRIPTION
I cleaned up the injector instance used in `BuiltInComponents`, removing an override in `BuiltInComponentsFromContext` (which seems unnecessary) and some components I could not find usages of in our APIs. I also added Scaladoc/Javadoc to clarify how the injector is set up.