### PR TITLE
Add docs for nocsrf and route modifiers

### DIFF
--- a/documentation/manual/working/javaGuide/main/forms/JavaCsrf.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaCsrf.md
@@ -49,6 +49,10 @@ Play provides a global CSRF filter that can be applied to all requests.  This is
 play.filters.enabled += play.filters.csrf.CsrfFilter
 ```
 
+It is also possible to disable the CSRF filter for a specific route in the routes file. To do this, add the `nocsrf` modifier tag before your route:
+
+@[nocsrf](../http/code/javaguide.http.routing.routes)
+
 ### Getting the current token
 
 The current CSRF token can be accessed using the `CSRF.getToken` method.  It takes a `RequestHeader`, which can be obtained by calling `Controllers.request()`:

--- a/documentation/manual/working/javaGuide/main/http/JavaRouting.md
+++ b/documentation/manual/working/javaGuide/main/http/JavaRouting.md
@@ -87,6 +87,10 @@ You can also define your own regular expression for a dynamic part, using the `$
 
 Just like with wildcard routes, the parameter is *not decoded by the router or encoded by the reverse router*. You're responsible for validating the input to make sure it makes sense in that context.
 
+It is also possible to apply modifiers by preceding the route with a line starting with a `+`. This can change the behavior of certain Play components. One such modifier is the "nocsrf" modifier to bypass the [[CSRF filter|JavaCsrf]]:
+
+@[nocsrf](code/javaguide.http.routing.routes)
+
 ## Call to action generator method
 
 The last part of a route definition is the call. This part must define a valid call to an action method.

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide.http.routing.routes
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide.http.routing.routes
@@ -32,3 +32,7 @@ GET   /:page                controllers.Application.show(page)
 GET   /api/list-all         controllers.Api.list(version ?= null)
 # #optional
 
+# #nocsrf
++ nocsrf
+POST  /api/new              controllers.Api.newThing()
+# #nocsrf

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/routing/controllers/Api.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/routing/controllers/Api.java
@@ -10,4 +10,8 @@ public class Api extends Controller {
     public Result list(String version) {
         return ok("version " + version);
     }
+
+    public Result newThing() {
+        return ok();
+    }
 }

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaCsrf.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaCsrf.md
@@ -49,6 +49,10 @@ Play provides a global CSRF filter that can be applied to all requests.  This is
 play.filters.enabled += play.filters.csrf.CsrfFilter
 ```
 
+It is also possible to disable the CSRF filter for a specific route in the routes file. To do this, add the `nocsrf` modifier tag before your route:
+
+@[nocsrf](../http/code/scalaguide.http.routing.routes)
+
 ### Using an implicit request
 
 All CSRF functionality assumes that a `RequestHeader` or a `Request` is available in implicit scope, and will not compile without one available. 

--- a/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
+++ b/documentation/manual/working/scalaGuide/main/http/ScalaRouting.md
@@ -50,6 +50,10 @@ You can tell the routes file to use a different router under a specific prefix b
 
 This is especially useful when combined with [[String Interpolating Routing DSL|ScalaSirdRouter]] also known as SIRD routing, or when working with [[sub projects|SBTSubProjects]] that route using several routes files.
 
+It is also possible to apply modifiers by preceding the route with a line starting with a `+`. This can change the behavior of certain Play components. One such modifier is the "nocsrf" modifier to bypass the [[CSRF filter|ScalaCsrf]]:
+
+@[nocsrf](code/scalaguide.http.routing.routes)
+
 ## The HTTP method
 
 The HTTP method can be any of the valid methods supported by HTTP (`GET`, `PATCH`, `POST`, `PUT`, `DELETE`, `HEAD`).

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
@@ -51,6 +51,7 @@ package controllers {
 
   class Api extends Controller {
     def list(version: Option[String]) = Action(Ok("version " + version))
+    def newThing = Action(parse.json) { request => Ok(request.body) }
   }
 }
 

--- a/documentation/manual/working/scalaGuide/main/http/code/scalaguide.http.routing.routes
+++ b/documentation/manual/working/scalaGuide/main/http/code/scalaguide.http.routing.routes
@@ -30,3 +30,8 @@ GET   /:page                controllers.Application.show(page)
 # The version parameter is optional. E.g. /api/list-all?version=3.0
 GET   /api/list-all         controllers.Api.list(version: Option[String])
 # #optional
+
+# #nocsrf
++ nocsrf
+POST  /api/new              controllers.Api.newThing
+# #nocsrf

--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -93,7 +93,9 @@ play.filters {
     }
 
     routeModifiers {
-      # If non empty, then requests will be checked if the route does not have this modifier
+      # If non empty, then requests will be checked if the route does not have this modifier. This is how we enable the
+      # nocsrf modifier, but you may choose to use a different modifier (such as "api") if you plan to check the
+      # modifier in your code for other purposes.
       whiteList = ["nocsrf"]
 
       # If non empty, then requests will be checked if the route contains this modifier


### PR DESCRIPTION
Adds documentation for route modifiers in general (though nocsrf is the only one we support now) and the nocsrf modifier in both the routing documentation and the CSRF documentation.

Fixes #7383.