### PR TITLE
gzip filter can be configured via black-/whitelist in application.conf

### DIFF
--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -168,6 +168,23 @@ Please see [[the Filters page|Filters]] for more details.
 
 > **NOTE**: If you are migrating from an existing project that does not use CSRF form helpers such as `CSRF.formField`, then you may see "403 Forbidden" on PUT and POST requests, from the CSRF filter.  To check this behavior, please add `<logger name="play.filters.csrf" value="TRACE"/>` to your `logback.xml`.  Likewise, if you are running a Play application on something other than localhost, you must configure the [[AllowedHostsFilter]] to specifically allow the hostname/ip you are connecting from.
 
+### gzip filter
+
+If you have the gzip filter enabled you can now also control which responses are and aren't gzipped based on their content types via `application.conf` (instead of writing you own `Filters` class):
+
+```
+play.filters.gzip {
+    # If non empty, then a response will only be compressed if its content type is in this list.
+    whiteList = [ "text/html", "text/plain"]
+
+    # The black list is only used if the white list is empty.
+    # Compress all responses except the ones whose content type is in this list.
+    blackList = []
+}
+```
+
+Please see [[the gzip filter page|GzipEncoding]] for more details.
+
 ## JWT Cookies
 
 Play now uses [JSON Web Token](https://tools.ietf.org/html/rfc7519) (JWT) format for session and flash cookies.  This allows for a standardized signed cookie data format, cookie expiration (making replay attacks harder) and more flexibility in signing cookies.

--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -178,7 +178,7 @@ play.filters.gzip {
     contentType {
 
         # If non empty, then a response will only be compressed if its content type is in this list.
-        whiteList = [ "text/html", "text/plain"]
+        whiteList = [ "text/*", "application/javascript" ]
 
         # The black list is only used if the white list is empty.
         # Compress all responses except the ones whose content type is in this list.

--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -178,7 +178,7 @@ play.filters.gzip {
     contentType {
 
         # If non empty, then a response will only be compressed if its content type is in this list.
-        whiteList = [ "text/*", "application/javascript" ]
+        whiteList = [ "text/*", "application/javascript", "application/json" ]
 
         # The black list is only used if the white list is empty.
         # Compress all responses except the ones whose content type is in this list.

--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -174,12 +174,16 @@ If you have the gzip filter enabled you can now also control which responses are
 
 ```
 play.filters.gzip {
-    # If non empty, then a response will only be compressed if its content type is in this list.
-    whiteList = [ "text/html", "text/plain"]
 
-    # The black list is only used if the white list is empty.
-    # Compress all responses except the ones whose content type is in this list.
-    blackList = []
+    contentType {
+
+        # If non empty, then a response will only be compressed if its content type is in this list.
+        whiteList = [ "text/html", "text/plain"]
+
+        # The black list is only used if the white list is empty.
+        # Compress all responses except the ones whose content type is in this list.
+        blackList = []
+    }
 }
 ```
 

--- a/documentation/manual/working/commonGuide/filters/GzipEncoding.md
+++ b/documentation/manual/working/commonGuide/filters/GzipEncoding.md
@@ -21,12 +21,16 @@ You can control which responses are and aren't gzipped based on their content ty
 
 ```
 play.filters.gzip {
-    # If non empty, then a response will only be compressed if its content type is in this list.
-    whiteList = [ "text/html", "text/plain"]
 
-    # The black list is only used if the white list is empty.
-    # Compress all responses except the ones whose content type is in this list.
-    blackList = []
+    contentType {
+
+        # If non empty, then a response will only be compressed if its content type is in this list.
+        whiteList = [ "text/html", "text/plain"]
+
+        # The black list is only used if the white list is empty.
+        # Compress all responses except the ones whose content type is in this list.
+        blackList = []
+    }
 }
 ```
 

--- a/documentation/manual/working/commonGuide/filters/GzipEncoding.md
+++ b/documentation/manual/working/commonGuide/filters/GzipEncoding.md
@@ -25,7 +25,7 @@ play.filters.gzip {
     contentType {
 
         # If non empty, then a response will only be compressed if its content type is in this list.
-        whiteList = [ "text/html", "text/plain"]
+        whiteList = [ "text/*", "application/javascript" ]
 
         # The black list is only used if the white list is empty.
         # Compress all responses except the ones whose content type is in this list.

--- a/documentation/manual/working/commonGuide/filters/GzipEncoding.md
+++ b/documentation/manual/working/commonGuide/filters/GzipEncoding.md
@@ -25,7 +25,7 @@ play.filters.gzip {
     contentType {
 
         # If non empty, then a response will only be compressed if its content type is in this list.
-        whiteList = [ "text/*", "application/javascript" ]
+        whiteList = [ "text/*", "application/javascript", "application/json" ]
 
         # The black list is only used if the white list is empty.
         # Compress all responses except the ones whose content type is in this list.

--- a/documentation/manual/working/commonGuide/filters/GzipEncoding.md
+++ b/documentation/manual/working/commonGuide/filters/GzipEncoding.md
@@ -17,7 +17,7 @@ The gzip filter supports a small number of tuning configuration options, which c
 
 ## Controlling which responses are gzipped
 
-You can control which responses are and aren't implemented via `application.conf`:
+You can control which responses are and aren't gzipped based on their content types via `application.conf`:
 
 ```
 play.filters.gzip {
@@ -30,7 +30,7 @@ play.filters.gzip {
 }
 ```
 
-As a more flexible alternative you can use the `shouldGzip` parameter, which accepts a function of a request header and a response header to a boolean.
+As a more flexible alternative you can use the `shouldGzip` parameter of the gzip filter itself, which accepts a function of a request header and a response header to a boolean.
 
 For example, the code below only gzips HTML responses:
 

--- a/documentation/manual/working/commonGuide/filters/GzipEncoding.md
+++ b/documentation/manual/working/commonGuide/filters/GzipEncoding.md
@@ -17,7 +17,20 @@ The gzip filter supports a small number of tuning configuration options, which c
 
 ## Controlling which responses are gzipped
 
-To control which responses are and aren't implemented, use the `shouldGzip` parameter, which accepts a function of a request header and a response header to a boolean.
+You can control which responses are and aren't implemented via `application.conf`:
+
+```
+play.filters.gzip {
+    # If non empty, then a response will only be compressed if its content type is in this list.
+    whiteList = [ "text/html", "text/plain"]
+
+    # The black list is only used if the white list is empty.
+    # Compress all responses except the ones whose content type is in this list.
+    blackList = []
+}
+```
+
+As a more flexible alternative you can use the `shouldGzip` parameter, which accepts a function of a request header and a response header to a boolean.
 
 For example, the code below only gzips HTML responses:
 

--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -187,6 +187,13 @@ play.filters {
     # to chunked encoding.
     chunkedThreshold = 100k
 
+    # If non empty, then a response will only be compressed if its content type is in this list.
+    whiteList = []
+
+    # The black list is only used if the white list is empty.
+    # Compress all responses except the ones whose content type is in this list.
+    blackList = []
+
   }
 
   # Redirect HTTPS configuration

--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -187,13 +187,15 @@ play.filters {
     # to chunked encoding.
     chunkedThreshold = 100k
 
-    # If non empty, then a response will only be compressed if its content type is in this list.
-    whiteList = []
+    contentType {
 
-    # The black list is only used if the white list is empty.
-    # Compress all responses except the ones whose content type is in this list.
-    blackList = []
+        # If non empty, then a response will only be compressed if its content type is in this list.
+        whiteList = []
 
+        # The black list is only used if the white list is empty.
+        # Compress all responses except the ones whose content type is in this list.
+        blackList = []
+    }
   }
 
   # Redirect HTTPS configuration

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -209,18 +209,17 @@ object GzipFilterConfig {
       bufferSize = config.get[ConfigMemorySize]("bufferSize").toBytes.toInt,
       chunkedThreshold = config.get[ConfigMemorySize]("chunkedThreshold").toBytes.toInt,
       shouldGzip = (req, res) => {
-        val contentType = res.body.contentType.getOrElse("").toLowerCase;
+      val contentType = res.body.contentType.getOrElse("").toLowerCase;
 
-        val whiteList = config.get[Seq[String]]("whiteList").toSet
-        val blackList = config.get[Seq[String]]("blackList").toSet
+      val whiteList = config.get[Seq[String]]("whiteList").toSet
+      val blackList = config.get[Seq[String]]("blackList").toSet
 
-        if (whiteList.nonEmpty) {
-          whiteList.exists(contentType.startsWith(_))
-        } else {
-          !blackList.exists(contentType.startsWith(_))
-        }
+      if (whiteList.nonEmpty) {
+        whiteList.exists(contentType.startsWith(_))
+      } else {
+        !blackList.exists(contentType.startsWith(_))
       }
-    )
+    })
   }
 }
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -204,23 +204,22 @@ object GzipFilterConfig {
 
   def fromConfiguration(conf: Configuration) = {
     val config = conf.get[Configuration]("play.filters.gzip")
-    val whiteList = MediaRange.parse(config.get[Seq[String]]("contentType.whiteList").mkString(", "))
-    val blackList = MediaRange.parse(config.get[Seq[String]]("contentType.blackList").mkString(", "))
+    val whiteList = MediaRange.parse(config.get[Seq[String]]("contentType.whiteList").mkString(", ").toLowerCase)
+    val blackList = MediaRange.parse(config.get[Seq[String]]("contentType.blackList").mkString(", ").toLowerCase)
 
     GzipFilterConfig(
       bufferSize = config.get[ConfigMemorySize]("bufferSize").toBytes.toInt,
       chunkedThreshold = config.get[ConfigMemorySize]("chunkedThreshold").toBytes.toInt,
       shouldGzip = (req, res) => {
       res.body.contentType match {
-        case Some(ct) =>
-          MediaType.parse(ct.toLowerCase).map(mt => s"${mt.mediaType}/${mt.mediaSubType}").map(mimeType => {
-            if (whiteList.nonEmpty) {
-              whiteList.exists(_.accepts(mimeType))
-            } else {
-              blackList.forall(!_.accepts(mimeType))
-            }
-          }).getOrElse(true)
-        case None => whiteList.isEmpty
+        case Some(MediaType.parse(mt)) =>
+          val mimeType = s"${mt.mediaType}/${mt.mediaSubType}".toLowerCase
+          if (whiteList.nonEmpty) {
+            whiteList.exists(_.accepts(mimeType))
+          } else {
+            blackList.forall(!_.accepts(mimeType))
+          }
+        case _ => whiteList.isEmpty
       }
     })
   }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -207,7 +207,19 @@ object GzipFilterConfig {
 
     GzipFilterConfig(
       bufferSize = config.get[ConfigMemorySize]("bufferSize").toBytes.toInt,
-      chunkedThreshold = config.get[ConfigMemorySize]("chunkedThreshold").toBytes.toInt
+      chunkedThreshold = config.get[ConfigMemorySize]("chunkedThreshold").toBytes.toInt,
+      shouldGzip = (req, res) => {
+        val contentType = res.body.contentType.getOrElse("").toLowerCase;
+
+        val whiteList = config.get[Seq[String]]("whiteList").toSet
+        val blackList = config.get[Seq[String]]("blackList").toSet
+
+        if (whiteList.nonEmpty) {
+          whiteList.exists(contentType.startsWith(_))
+        } else {
+          !blackList.exists(contentType.startsWith(_))
+        }
+      }
     )
   }
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -211,8 +211,8 @@ object GzipFilterConfig {
       shouldGzip = (req, res) => {
       val contentType = res.body.contentType.getOrElse("").toLowerCase;
 
-      val whiteList = config.get[Seq[String]]("whiteList").toSet
-      val blackList = config.get[Seq[String]]("blackList").toSet
+      val whiteList = config.get[Seq[String]]("contentType.whiteList").toSet
+      val blackList = config.get[Seq[String]]("contentType.blackList").toSet
 
       if (whiteList.nonEmpty) {
         whiteList.exists(contentType.startsWith(_))

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -267,7 +267,7 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
 
   }
 
-  def withApplication[T](result: Result, chunkedThreshold: Int = 1024, whiteList: List[String] = List(), blackList: List[String] = List())(block: Application => T): T = {
+  def withApplication[T](result: Result, chunkedThreshold: Int = 1024, whiteList: List[String] = List.empty, blackList: List[String] = List.empty)(block: Application => T): T = {
     val application = new GuiceApplicationBuilder()
       .configure(
         "play.filters.gzip.chunkedThreshold" -> chunkedThreshold,

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -115,6 +115,10 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
       checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
     }
 
+    "gzip content type which is on the whiteList ignoring case" in withApplication(Ok("hello").as("TeXt/CsS"), whiteList = List("TExT/HtMl", "tExT/cSs")) { implicit app =>
+      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
+    }
+
     "gzip uppercase content type which is on the whiteList" in withApplication(Ok("hello").as("TEXT/CSS"), whiteList = contentTypes) { implicit app =>
       checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
     }

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -272,8 +272,8 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
       .configure(
         "play.filters.gzip.chunkedThreshold" -> chunkedThreshold,
         "play.filters.gzip.bufferSize" -> 512,
-        "play.filters.gzip.whiteList" -> whiteList,
-        "play.filters.gzip.blackList" -> blackList
+        "play.filters.gzip.contentType.whiteList" -> whiteList,
+        "play.filters.gzip.contentType.blackList" -> blackList
       ).overrides(
           bind[Result].to(result),
           bind[Router].to[ResultRouter],

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/gzip/GzipFilterSpec.scala
@@ -150,6 +150,12 @@ class GzipFilterSpec extends PlaySpecification with DataTables {
     "ignore blackList if there is a whiteList" in withApplication(Ok("hello").as("text/css; charset=utf-8"), whiteList = contentTypes, blackList = contentTypes) { implicit app =>
       checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
     }
+    "gzip 'text/html' content type when using media range 'text/*' in the whiteList" in withApplication(Ok("hello").as("text/css"), whiteList = List("text/*")) { implicit app =>
+      checkGzippedBody(makeGzipRequest(app), "hello")(app.materializer)
+    }
+    "don't gzip 'application/javascript' content type when using media range 'text/*' in the whiteList" in withApplication(Ok("hello").as("application/javascript"), whiteList = List("text/*")) { implicit app =>
+      checkNotGzipped(makeGzipRequest(app), "hello")(app.materializer)
+    }
 
     "gzip chunked responses" in withApplication(Ok.chunked(Source(List("foo", "bar")))) { implicit app =>
       val result = makeGzipRequest(app)


### PR DESCRIPTION
(I think) the gzip filter is the only play-provided  filter left which can't be configured solely via `application.conf`.

Would be great if this makes it in before 2.6 final.