### PR TITLE
Remove unnecessary reference overrides for Akka HTTP server

### DIFF
--- a/framework/src/play-akka-http-server/src/main/resources/play/reference-overrides.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/play/reference-overrides.conf
@@ -11,17 +11,8 @@
 # Play's settings in their application.conf.
 
 akka {
-
   # Turn off dead letters until Akka HTTP server is stable
   log-dead-letters = off
-
-  http.server {
-    # Disable Akka-HTTP's transparent HEAD handling. so that play's HEAD handling can take action
-    transparent-head-requests = off
-
-    # doesn't work when we set .withRemoteAddressHeader(true) for some reason
-    remote-address-header = on
-  }
 
 }
 
@@ -29,9 +20,5 @@ akka {
 play.akka.dev-mode {
   akka {
     log-dead-letters = off
-    http.server {
-      transparent-head-requests = off
-      remote-address-header = on
-    }
   }
 }

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -78,9 +78,10 @@ class AkkaHttpServer(
       requestTimeoutOption.foreach(timeouts.withRequestTimeout)
       timeouts
     }
-      // Play needs Raw Request Uri's to match Netty
+      // Play needs these headers to fill in fields in its request model
       .withRawRequestUriHeader(true)
       .withRemoteAddressHeader(true)
+      // Disable Akka-HTTP's transparent HEAD handling. so that play's HEAD handling can take action
       .withTransparentHeadRequests(akkaConfig.get[Boolean]("transparent-head-requests"))
       .withServerHeader(akkaConfig.getOptional[String]("server-header").filterNot(_ == "").map(headers.Server(_)))
       .withDefaultHostHeader(headers.Host(akkaConfig.get[String]("default-host-header")))


### PR DESCRIPTION
It's better to set these programmatically than use reference-overrides.