### PR TITLE
Add missing headers

### DIFF
--- a/documentation/manual/working/commonGuide/build/code/SubProjectAssets.scala
+++ b/documentation/manual/working/commonGuide/build/code/SubProjectAssets.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package common.build
 
 package object controllers {

--- a/documentation/manual/working/commonGuide/configuration/code/Configuration.scala
+++ b/documentation/manual/working/commonGuide/configuration/code/Configuration.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 // With Play Scala
 
 object DependencyInjection {

--- a/documentation/manual/working/commonGuide/filters/code/SecurityHeaders.scala
+++ b/documentation/manual/working/commonGuide/filters/code/SecurityHeaders.scala
@@ -1,7 +1,6 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-
 package detailedtopics.configuration.securityheaders
 
 object SecurityHeaders {

--- a/documentation/manual/working/commonGuide/schedule/code/javaguide/scheduling/CodeBlockOnceTask.java
+++ b/documentation/manual/working/commonGuide/schedule/code/javaguide/scheduling/CodeBlockOnceTask.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 //###skip: 9
 package javaguide.scheduling;
 

--- a/documentation/manual/working/commonGuide/schedule/code/javaguide/scheduling/CodeBlockTask.java
+++ b/documentation/manual/working/commonGuide/schedule/code/javaguide/scheduling/CodeBlockTask.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 //###replace: package tasks;
 package javaguide.scheduling;
 

--- a/documentation/manual/working/commonGuide/schedule/code/javaguide/scheduling/MyActorTask.java
+++ b/documentation/manual/working/commonGuide/schedule/code/javaguide/scheduling/MyActorTask.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 //###replace: package tasks;
 package javaguide.scheduling;
 

--- a/documentation/manual/working/commonGuide/schedule/code/javaguide/scheduling/MyBuiltInComponentsFromContext.java
+++ b/documentation/manual/working/commonGuide/schedule/code/javaguide/scheduling/MyBuiltInComponentsFromContext.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 //###replace: package tasks;
 package javaguide.scheduling;
 

--- a/documentation/manual/working/commonGuide/schedule/code/javaguide/scheduling/TasksCustomExecutionContext.java
+++ b/documentation/manual/working/commonGuide/schedule/code/javaguide/scheduling/TasksCustomExecutionContext.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 //###replace: package tasks;
 package javaguide.scheduling;
 

--- a/documentation/manual/working/commonGuide/schedule/code/javaguide/scheduling/TasksModule.java
+++ b/documentation/manual/working/commonGuide/schedule/code/javaguide/scheduling/TasksModule.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 //###replace: package tasks;
 package javaguide.scheduling;
 

--- a/documentation/manual/working/commonGuide/schedule/code/scalaguide/scheduling/CodeBlockTask.scala
+++ b/documentation/manual/working/commonGuide/schedule/code/scalaguide/scheduling/CodeBlockTask.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package scalaguide.scheduling
 
 import javax.inject.Inject

--- a/documentation/manual/working/commonGuide/schedule/code/scalaguide/scheduling/MyActorTask.scala
+++ b/documentation/manual/working/commonGuide/schedule/code/scalaguide/scheduling/MyActorTask.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 //###replace: package tasks
 package scalaguide.scheduling
 

--- a/documentation/manual/working/commonGuide/schedule/code/scalaguide/scheduling/MyBuiltInComponentsFromContext.scala
+++ b/documentation/manual/working/commonGuide/schedule/code/scalaguide/scheduling/MyBuiltInComponentsFromContext.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 //###replace: package tasks
 package scalaguide.scheduling
 

--- a/documentation/manual/working/commonGuide/schedule/code/scalaguide/scheduling/TasksCustomExecutionContext.scala
+++ b/documentation/manual/working/commonGuide/schedule/code/scalaguide/scheduling/TasksCustomExecutionContext.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 //###replace: package tasks
 package scalaguide.scheduling
 

--- a/documentation/manual/working/commonGuide/schedule/code/scalaguide/scheduling/TasksModule.scala
+++ b/documentation/manual/working/commonGuide/schedule/code/scalaguide/scheduling/TasksModule.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 //###replace: package tasks
 package scalaguide.scheduling
 

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/websocket/HomeController.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/websocket/HomeController.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package javaguide.async.websocket;
 
 import javaguide.async.MyWebSocketActor;

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/ActionCreator.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/ActionCreator.java
@@ -1,7 +1,6 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-
 //#default
 import play.mvc.Action;
 import play.mvc.Http;

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActionCreator.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaActionCreator.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package javaguide.http;
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>

--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/full/Application.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/full/Application.java
@@ -1,7 +1,6 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-
 //#full-controller
 //###replace: package controllers;
 package javaguide.http.full;

--- a/documentation/manual/working/javaGuide/main/json/code/javaguide/json/JavaJsonCustomObjectMapperModule.java
+++ b/documentation/manual/working/javaGuide/main/json/code/javaguide/json/JavaJsonCustomObjectMapperModule.java
@@ -1,7 +1,6 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-
 package javaguide.json;
 
 import com.google.inject.AbstractModule;

--- a/documentation/manual/working/javaGuide/main/sql/code/DatabaseExecutionContext.java
+++ b/documentation/manual/working/javaGuide/main/sql/code/DatabaseExecutionContext.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package javaguide.sql;
 
 import akka.actor.ActorSystem;

--- a/documentation/manual/working/javaGuide/main/sql/code/JPARepository.java
+++ b/documentation/manual/working/javaGuide/main/sql/code/JPARepository.java
@@ -1,7 +1,6 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-
 package javaguide.sql;
 
 //#jpa-repository-api-inject

--- a/documentation/manual/working/javaGuide/main/sql/code/JavaApplicationDatabase.java
+++ b/documentation/manual/working/javaGuide/main/sql/code/JavaApplicationDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
 package javaguide.sql;
 

--- a/documentation/manual/working/javaGuide/main/sql/code/JavaNamedDatabase.java
+++ b/documentation/manual/working/javaGuide/main/sql/code/JavaNamedDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
 package javaguide.sql;
 

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/ApiRouter.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/ApiRouter.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 //#inject-sird-router
 package api
 

--- a/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
+++ b/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */

--- a/documentation/manual/working/scalaGuide/main/config/code/ScalaConfig.scala
+++ b/documentation/manual/working/scalaGuide/main/config/code/ScalaConfig.scala
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */

--- a/documentation/manual/working/scalaGuide/main/sql/code/ScalaControllerInject.scala
+++ b/documentation/manual/working/scalaGuide/main/sql/code/ScalaControllerInject.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package scalaguide.sql
 
 import javax.inject.Inject

--- a/documentation/manual/working/scalaGuide/main/sql/code/ScalaInjectNamed.scala
+++ b/documentation/manual/working/scalaGuide/main/sql/code/ScalaInjectNamed.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package scalaguide.sql
 
 import javax.inject.Inject

--- a/framework/bin/checkFileHeaders
+++ b/framework/bin/checkFileHeaders
@@ -6,4 +6,4 @@
 
 cd $FRAMEWORK
 
-build checkHeaders
+build checkHeaders test:checkHeaders

--- a/framework/src/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
+++ b/framework/src/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play
 
 import play.core.server._

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/headers/SecurityHeadersFilterSpec.scala
@@ -1,7 +1,5 @@
 /*
- *
- *  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
- *
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
 package play.filters.headers
 

--- a/framework/src/play-guice/src/test/scala/play/core/test/Fakes.scala
+++ b/framework/src/play-guice/src/test/scala/play/core/test/Fakes.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.core.test
 
 import play.api.inject.guice.GuiceInjectorBuilder

--- a/framework/src/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/HeadActionSpec.scala
@@ -1,7 +1,6 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-
 package play.it.action
 
 import akka.stream.scaladsl.Source

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaHttpHandlerSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaHttpHandlerSpec.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.it.http
 
 import play.api.Application

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/websocket/WebSocketClient.scala
@@ -1,7 +1,6 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-
 /**
  * Some elements of this were copied from:
  *

--- a/framework/src/play-integration-test/src/test/scala/play/it/routing/ServerSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/routing/ServerSpec.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.it.routing
 
 import java.util.function.Supplier

--- a/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
@@ -1,7 +1,6 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-
 package play.it.tools
 
 import java.nio.charset.StandardCharsets

--- a/framework/src/play-java-forms/src/test/java/play/data/validation/TestConstraints.java
+++ b/framework/src/play-java-forms/src/test/java/play/data/validation/TestConstraints.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.data.validation;
 
 import static java.lang.annotation.ElementType.FIELD;

--- a/framework/src/play-logback/src/test/scala/play/api/ModeSpecificLoggerSpec.scala
+++ b/framework/src/play-logback/src/test/scala/play/api/ModeSpecificLoggerSpec.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.api
 
 import org.specs2.mutable.Specification

--- a/framework/src/play-logback/src/test/scala/play/api/libs/logback/LogbackCapturingAppender.scala
+++ b/framework/src/play-logback/src/test/scala/play/api/libs/logback/LogbackCapturingAppender.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.api.libs.logback
 
 import ch.qos.logback.classic.spi.ILoggingEvent

--- a/framework/src/play-netty-server/src/test/scala/play/NettyTestServer.scala
+++ b/framework/src/play-netty-server/src/test/scala/play/NettyTestServer.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play
 
 import play.core.server._

--- a/framework/src/play-server/src/test/scala/play/core/server/ssl/ServerSSLEngineSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/ssl/ServerSSLEngineSpec.scala
@@ -1,7 +1,5 @@
 /*
- *
- *  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
- *
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
 package play.core.server.ssl
 

--- a/framework/src/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
+++ b/framework/src/play-streams/src/test/scala/play/libs/streams/AccumulatorSpec.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.libs.streams
 
 import java.util.concurrent.{

--- a/framework/src/play/src/test/scala/play/api/PlayGlobalAppSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/PlayGlobalAppSpec.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.api
 
 import org.specs2.mutable.Specification

--- a/framework/src/play/src/test/scala/play/api/libs/TemporaryFileReaperSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/TemporaryFileReaperSpec.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.api.libs
 
 import java.nio.charset.Charset

--- a/framework/src/play/src/test/scala/play/api/libs/crypto/CookieSignerSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/libs/crypto/CookieSignerSpec.scala
@@ -1,7 +1,6 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-
 package play.api.libs.crypto
 
 import org.specs2.mutable.Specification

--- a/framework/src/play/src/test/scala/play/api/mvc/MaxLengthBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/MaxLengthBodyParserSpec.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.api.mvc
 
 import akka.actor.ActorSystem

--- a/framework/src/play/src/test/scala/play/api/routing/JavaScriptReverseRouterSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/routing/JavaScriptReverseRouterSpec.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package play.api.routing
 
 import org.specs2.mutable.Specification


### PR DESCRIPTION
## Purpose

There are a number of files missing the license header. This adds the header for Scala and Java files, including the docs.