### PR TITLE
Fix CacheApi bindings

### DIFF
--- a/framework/src/play-cache/src/main/scala/play/api/cache/SyncCacheApi.scala
+++ b/framework/src/play-cache/src/main/scala/play/api/cache/SyncCacheApi.scala
@@ -87,7 +87,7 @@ trait CacheApi {
 /**
  * A SyncCacheApi that wraps an AsyncCacheApi
  */
-class DefaultSyncCacheApi @Inject() (cacheApi: AsyncCacheApi) extends SyncCacheApi with CacheApi {
+class DefaultSyncCacheApi @Inject() (val cacheApi: AsyncCacheApi) extends SyncCacheApi with CacheApi {
 
   protected val awaitTimeout: Duration = 5.seconds
 


### PR DESCRIPTION
Make sure we bind to the named cache for all cache types, and also bind the default implementation to the default named cache.

Fixes #7401