### PR TITLE
Remove unnecessary "@Inject" twirl setting from 2.6 highlights

### DIFF
--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -102,7 +102,17 @@ First create a file `IndexTemplate.scala.html` using the `@this` syntax for the 
 @{trc.render(item)}
 ```
 
-Then define the controller by injecting the template in the constructor:
+By default all generated Scala template classes Twirl creates with the `@this` syntax within Play will automatically be annotated with `@javax.inject.Inject()`. If desired you can change this behavior in `build.sbt`:
+
+```scala
+// Add one or more annotation(s):
+TwirlKeys.constructorAnnotations += "@java.lang.Deprecated()"
+
+// Or completely replace the default one with your own annotation(s):
+TwirlKeys.constructorAnnotations := Seq("@com.google.inject.Inject()")
+```
+
+Now define the controller by injecting the template in the constructor:
 
 ```scala
 public MyController @Inject()(indexTemplate: views.html.IndexTemplate,

--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -97,7 +97,7 @@ First create a file `IndexTemplate.scala.html` using the `@this` syntax for the 
 
 ```scala
 @this(trc: TemplateRenderingComponent)
-@(item)
+@(item: Item)
 
 @{trc.render(item)}
 ```

--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -93,13 +93,7 @@ Twirl templates can now be created with a constructor annotation using `@this`. 
 
 As an example, suppose a template has a dependency on a component `TemplateRenderingComponent`, which is not used by the controller.
 
-First, add the `@Inject` annotation to Twirl in `build.sbt`:
-
-```scala
-TwirlKeys.constructorAnnotations += "@javax.inject.Inject()"
-```
-
-Then create a file `IndexTemplate.scala.html` using the `@this` syntax for the constructor. Note that the constructor must be placed **before** the `@()` syntax used for the template's parameters for the `apply` method:
+First create a file `IndexTemplate.scala.html` using the `@this` syntax for the constructor. Note that the constructor must be placed **before** the `@()` syntax used for the template's parameters for the `apply` method:
 
 ```scala
 @this(trc: TemplateRenderingComponent)
@@ -108,7 +102,7 @@ Then create a file `IndexTemplate.scala.html` using the `@this` syntax for the c
 @{trc.render(item)}
 ```
 
-And finally define the controller by injecting the template in the constructor:
+Then define the controller by injecting the template in the constructor:
 
 ```scala
 public MyController @Inject()(indexTemplate: views.html.IndexTemplate,

--- a/documentation/manual/releases/release26/Highlights26.md
+++ b/documentation/manual/releases/release26/Highlights26.md
@@ -97,7 +97,7 @@ First create a file `IndexTemplate.scala.html` using the `@this` syntax for the 
 
 ```scala
 @this(trc: TemplateRenderingComponent)
-@()
+@(item)
 
 @{trc.render(item)}
 ```


### PR DESCRIPTION
A user doesn't have to set `TwirlKeys.constructorAnnotations` by him/herself. It's done by Play already:
https://github.com/playframework/playframework/blob/2.6.0-RC1/framework/src/sbt-plugin/src/main/scala/play/sbt/PlaySettings.scala#L57

With the note users will end up annotating the generated scala class twice (checked it myself):
`class SomeView @javax.inject.Inject()@javax.inject.Inject() ...`