### PR TITLE
Correctly bind form from request when using multipart form with max length

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/action/FormActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/action/FormActionSpec.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.action
+
+import akka.actor.ActorSystem
+import akka.stream.{ ActorMaterializer, Materializer }
+import play.api.data._
+import play.api.data.Forms._
+import play.api.data.format.Formats._
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.Files.TemporaryFile
+import play.api.mvc._
+import play.api.mvc.Results._
+import play.api.mvc.BodyParsers._
+import play.api.test.{ FakeRequest, PlaySpecification, WithApplication }
+
+class FormActionSpec extends PlaySpecification {
+
+  val userForm = Form(
+    mapping(
+      "name" -> of[String],
+      "email" -> of[String],
+      "age" -> of[Int]
+    )(User.apply)(User.unapply)
+  )
+
+  def application: Application = {
+
+    implicit val actorSystem = ActorSystem("form-action-spec")
+    implicit val materializer = ActorMaterializer()
+
+    GuiceApplicationBuilder()
+      .overrides(
+        play.api.inject.bind[ActorSystem].toInstance(actorSystem),
+        play.api.inject.bind[Materializer].toInstance(materializer)
+      )
+      .routes {
+        case (POST, "/multipart") => Action(parse.multipartFormData) { implicit request =>
+          val user = userForm.bindFromRequest().get
+          Ok(s"${user.name} - ${user.email}")
+        }
+        case (POST, "/multipart/max-length") => Action(parse.multipartFormData(1024)) { implicit request =>
+          val user = userForm.bindFromRequest().get
+          Ok(s"${user.name} - ${user.email}")
+        }
+        case (POST, "/multipart/wrapped-max-length") => Action(parse.maxLength(1024, parse.multipartFormData)) { implicit request =>
+          val user = userForm.bindFromRequest().get
+          Ok(s"${user.name} - ${user.email}")
+        }
+      }.build()
+  }
+
+  "Form Actions" should {
+
+    "When POSTing" in {
+
+      val multipartBody = MultipartFormData[TemporaryFile](
+        dataParts = Map(
+          "name" -> Seq("Player"),
+          "email" -> Seq("play@email.com"),
+          "age" -> Seq("10")
+        ),
+        files = Seq.empty,
+        badParts = Seq.empty
+      )
+
+      "bind all parameters for multipart request" in new WithApplication(application) {
+        val request = FakeRequest(POST, "/multipart").withMultipartFormDataBody(multipartBody)
+        contentAsString(route(app, request).get) must beEqualTo("Player - play@email.com")
+      }
+
+      "bind all parameters for multipart request with max length" in new WithApplication(application) {
+        val request = FakeRequest(POST, "/multipart/max-length").withMultipartFormDataBody(multipartBody)
+        contentAsString(route(app, request).get) must beEqualTo("Player - play@email.com")
+      }
+
+      "bind all parameters for multipart request to temporary file" in new WithApplication(application) {
+        val request = FakeRequest(POST, "/multipart/wrapped-max-length").withMultipartFormDataBody(multipartBody)
+        contentAsString(route(app, request).get) must beEqualTo("Player - play@email.com")
+      }
+    }
+  }
+}
+
+case class User(
+  name: String,
+  email: String,
+  age: Int
+)

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/MultipartFormDataParserSpec.scala
@@ -52,10 +52,10 @@ class MultipartFormDataParserSpec extends PlaySpecification {
   def checkResult(result: Either[Result, MultipartFormData[TemporaryFile]]) = {
     result must beRight.like {
       case parts =>
-        parts.dataParts.get("text1") must_== Some(Seq("the first text field"))
-        parts.dataParts.get("text2:colon") must_== Some(Seq("the second text field"))
-        parts.dataParts.get("noQuotesText1") must_== Some(Seq("text field with unquoted name"))
-        parts.dataParts.get("noQuotesText1:colon") must_== Some(Seq("text field with unquoted name and colon"))
+        parts.dataParts.get("text1") must beSome(Seq("the first text field"))
+        parts.dataParts.get("text2:colon") must beSome(Seq("the second text field"))
+        parts.dataParts.get("noQuotesText1") must beSome(Seq("text field with unquoted name"))
+        parts.dataParts.get("noQuotesText1:colon") must beSome(Seq("text field with unquoted name and colon"))
         parts.files must haveLength(2)
         parts.file("file1") must beSome.like {
           case filePart => PlayIO.readFileAsString(filePart.ref) must_== "the first file\r\n"

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -3,7 +3,7 @@
  */
 package play.api.test
 
-import java.nio.file.Path
+import java.nio.file.{ Path, Files => JFiles }
 
 import akka.actor.Cancellable
 import akka.stream.scaladsl.Source
@@ -17,8 +17,10 @@ import play.api.http._
 import play.api.i18n._
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.Files
+import play.api.libs.Files.TemporaryFile
 import play.api.libs.json.{ JsValue, Json }
 import play.api.libs.streams.Accumulator
+import play.api.mvc.MultipartFormData.FilePart
 import play.api.mvc._
 import play.mvc.Http.RequestBody
 import play.twirl.api.Content
@@ -169,6 +171,9 @@ trait Writeables {
 
   implicit def writeableOf_AnyContentAsEmpty(implicit code: Codec): Writeable[AnyContentAsEmpty.type] =
     Writeable(_ => ByteString.empty, None)
+
+  implicit def writeableOf_AnyContentAsMultipartForm(implicit codec: Codec): Writeable[AnyContentAsMultipartFormData] =
+    Writeable.writeableOf_MultipartFormData(codec, None).map(_.mfd)
 }
 
 trait DefaultAwaitTimeout {

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -82,7 +82,10 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
         case body: play.api.mvc.AnyContent if body.asJson.isDefined => FormUtils.fromJson(js = body.asJson.get).mapValues(Seq(_))
         case body: Map[_, _] => body.asInstanceOf[Map[String, Seq[String]]]
         case body: play.api.mvc.MultipartFormData[_] => body.asFormUrlEncoded
-        case body: Right[_, play.api.mvc.MultipartFormData[_]] => body.value.asFormUrlEncoded
+        case body: Either[_, play.api.mvc.MultipartFormData[_]] => body match {
+          case Right(b) => b.asFormUrlEncoded
+          case Left(_) => Map.empty[String, Seq[String]]
+        }
         case body: play.api.libs.json.JsValue => FormUtils.fromJson(js = body).mapValues(Seq(_))
         case _ => Map.empty[String, Seq[String]]
       }) ++ (if (!request.method.equalsIgnoreCase(HttpVerbs.POST) && !request.method.equalsIgnoreCase(HttpVerbs.PUT) && !request.method.equalsIgnoreCase(HttpVerbs.PATCH)) { request.queryString } else { Nil })

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -82,6 +82,7 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
         case body: play.api.mvc.AnyContent if body.asJson.isDefined => FormUtils.fromJson(js = body.asJson.get).mapValues(Seq(_))
         case body: Map[_, _] => body.asInstanceOf[Map[String, Seq[String]]]
         case body: play.api.mvc.MultipartFormData[_] => body.asFormUrlEncoded
+        case body: Right[_, play.api.mvc.MultipartFormData[_]] => body.value.asFormUrlEncoded
         case body: play.api.libs.json.JsValue => FormUtils.fromJson(js = body).mapValues(Seq(_))
         case _ => Map.empty[String, Seq[String]]
       }) ++ (if (!request.method.equalsIgnoreCase(HttpVerbs.POST) && !request.method.equalsIgnoreCase(HttpVerbs.PUT) && !request.method.equalsIgnoreCase(HttpVerbs.PATCH)) { request.queryString } else { Nil })

--- a/framework/src/play/src/main/scala/play/api/http/Writeable.scala
+++ b/framework/src/play/src/main/scala/play/api/http/Writeable.scala
@@ -137,7 +137,7 @@ trait DefaultWriteables extends LowPriorityWriteables {
             s"--$boundary\r\n${HeaderNames.CONTENT_DISPOSITION}: form-data; name=$name\r\n\r\n$value\r\n"
           }
       }.mkString("")
-      Codec.utf_8.encode(dataParts)
+      codec.encode(dataParts)
     }
 
     def filePartHeader(file: FilePart[A]) = {
@@ -146,15 +146,15 @@ trait DefaultWriteables extends LowPriorityWriteables {
       val contentType = file.contentType.map { ct =>
         s"${HeaderNames.CONTENT_TYPE}: $ct\r\n"
       }.getOrElse("")
-      Codec.utf_8.encode(s"--$boundary\r\n${HeaderNames.CONTENT_DISPOSITION}: form-data; name=$name; filename=$filename\r\n$contentType\r\n")
+      codec.encode(s"--$boundary\r\n${HeaderNames.CONTENT_DISPOSITION}: form-data; name=$name; filename=$filename\r\n$contentType\r\n")
     }
 
     Writeable[MultipartFormData[A]](
       transform = { form: MultipartFormData[A] =>
       formatDataParts(form.dataParts) ++ form.files.flatMap { file =>
         val fileBytes = aWriteable.transform(file)
-        filePartHeader(file) ++ fileBytes ++ Codec.utf_8.encode("\r\n")
-      } ++ Codec.utf_8.encode(s"--$boundary--")
+        filePartHeader(file) ++ fileBytes ++ codec.encode("\r\n")
+      } ++ codec.encode(s"--$boundary--")
     },
       contentType = Some(s"multipart/form-data; boundary=$boundary")
     )

--- a/framework/src/play/src/test/resources/multipart-form-data-file.txt
+++ b/framework/src/play/src/test/resources/multipart-form-data-file.txt
@@ -1,0 +1,1 @@
+multipart-form-data-file

--- a/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
@@ -11,10 +11,13 @@ import play.api.i18n._
 import play.api.libs.json.Json
 import org.specs2.mutable.Specification
 import play.api.http.HttpConfiguration
+import play.api.libs.Files.TemporaryFile
+import play.api.mvc.MultipartFormData
 import play.core.test.FakeRequest
 
 class FormSpec extends Specification {
   "A form" should {
+
     "have an error due to a malformed email" in {
       val f5 = ScalaForms.emailForm.fillAndValidate(("john@", "John"))
       f5.errors must haveSize(1)
@@ -36,6 +39,20 @@ class FormSpec extends Specification {
       f9.errors must beEmpty
 
       ScalaForms.emailForm.fillAndValidate(("o'flynn@example.com", "O'Flynn")).errors must beEmpty
+    }
+
+    "bind params when POSTing a multipart body" in {
+      val multipartBody = MultipartFormData[TemporaryFile](
+        dataParts = Map("email" -> Seq("michael@jackson.com")),
+        files = Seq.empty,
+        badParts = Seq.empty
+      )
+
+      implicit val request = FakeRequest(method = "POST", "/").withMultipartFormDataBody(multipartBody)
+
+      val f1 = ScalaForms.updateForm.bindFromRequest()
+      f1.errors must beEmpty
+      f1.get must equalTo((Some("michael@jackson.com"), None))
     }
 
     "query params ignored when using POST" in {
@@ -339,45 +356,46 @@ class FormSpec extends Specification {
 
   "render form using java.time.LocalDate" in {
     import java.time.LocalDate
-    val dateForm = Form(("date" -> localDate))
+    val dateForm = Form("date" -> localDate)
     val data = Map("date" -> "2012-01-01")
     dateForm.bind(data).get mustEqual (LocalDate.of(2012, 1, 1))
   }
 
   "render form using java.time.LocalDate with format(15/6/2016)" in {
     import java.time.LocalDate
-    val dateForm = Form(("date" -> localDate("dd/MM/yyyy")))
+    val dateForm = Form("date" -> localDate("dd/MM/yyyy"))
     val data = Map("date" -> "15/06/2016")
     dateForm.bind(data).get mustEqual (LocalDate.of(2016, 6, 15))
   }
 
   "render form using java.time.LocalDateTime" in {
     import java.time.LocalDateTime
-    val dateForm = Form(("date" -> localDateTime))
+    val dateForm = Form("date" -> localDateTime)
     val data = Map("date" -> "2012-01-01 10:10:10")
     dateForm.bind(data).get mustEqual (LocalDateTime.of(2012, 1, 1, 10, 10, 10))
   }
 
   "render form using java.time.LocalDateTime with format(17/06/2016T17:15:33)" in {
     import java.time.LocalDateTime
-    val dateForm = Form(("date" -> localDateTime("dd/MM/yyyy HH:mm:ss")))
+    val dateForm = Form("date" -> localDateTime("dd/MM/yyyy HH:mm:ss"))
     val data = Map("date" -> "17/06/2016 10:10:10")
     dateForm.bind(data).get mustEqual (LocalDateTime.of(2016, 6, 17, 10, 10, 10))
   }
 
   "render form using java.time.LocalTime" in {
     import java.time.LocalTime
-    val dateForm = Form(("date" -> localTime))
+    val dateForm = Form("date" -> localTime)
     val data = Map("date" -> "10:10:10")
     dateForm.bind(data).get mustEqual (LocalTime.of(10, 10, 10))
   }
 
   "render form using java.time.LocalTime with format(HH-mm-ss)" in {
     import java.time.LocalTime
-    val dateForm = Form(("date" -> localTime("HH-mm-ss")))
+    val dateForm = Form("date" -> localTime("HH-mm-ss"))
     val data = Map("date" -> "10-11-12")
     dateForm.bind(data).get mustEqual (LocalTime.of(10, 11, 12))
   }
+
 }
 
 object ScalaForms {
@@ -445,8 +463,8 @@ object ScalaForms {
   )
 
   val form = Form(
-    "foo" -> Forms.text.verifying("first.digit", s => (s.headOption map { _ == '3' }) getOrElse false)
-      .transform[Int](Integer.parseInt _, _.toString).verifying("number.42", _ < 42)
+    "foo" -> Forms.text.verifying("first.digit", s => s.headOption exists { _ == '3' })
+      .transform[Int](Integer.parseInt, _.toString).verifying("number.42", _ < 42)
   )
 
   val emailForm = Form(

--- a/framework/src/play/src/test/scala/play/api/http/WriteableSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/WriteableSpec.scala
@@ -40,7 +40,7 @@ class WriteableSpec extends Specification {
 
         val writeable = Writeable.writeableOf_MultipartFormData(
           codec,
-          Writeable[FilePart[String]]((f: FilePart[String]) => codec.encode(f.ref), contentType),
+          Writeable[FilePart[String]]((f: FilePart[String]) => codec.encode(f.ref), contentType)
         )
         val transformed: ByteString = writeable.transform(multipartFormData)
 

--- a/framework/src/play/src/test/scala/play/api/http/WriteableSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/http/WriteableSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.http
+
+import java.io.File
+
+import akka.util.ByteString
+import org.specs2.mutable.Specification
+import play.api.libs.Files.TemporaryFile
+import play.api.mvc.{ Codec, MultipartFormData }
+import play.api.mvc.MultipartFormData.FilePart
+
+import play.api.libs.Files.SingletonTemporaryFileCreator._
+
+class WriteableSpec extends Specification {
+
+  "Writeable" in {
+
+    "of multipart" should {
+
+      "work for temporary files" in {
+        val multipartFormData = createMultipartFormData[TemporaryFile](create(new File("src/test/resources/multipart-form-data-file.txt").toPath))
+        val contentType = Some("text/plain")
+        val codec = Codec.utf_8
+
+        val writeable = Writeable.writeableOf_MultipartFormData(codec, contentType)
+        val transformed: ByteString = writeable.transform(multipartFormData)
+
+        transformed.utf8String must contain("Content-Disposition: form-data; name=name")
+        transformed.utf8String must contain("""Content-Disposition: form-data; name="thefile"; filename="something.text"""")
+        transformed.utf8String must contain("Content-Type: text/plain")
+        transformed.utf8String must contain("multipart-form-data-file")
+      }
+
+      "work composing with another writeable" in {
+        val multipartFormData = createMultipartFormData[String]("file part value")
+        val contentType = Some("text/plain")
+        val codec = Codec.utf_8
+
+        val writeable = Writeable.writeableOf_MultipartFormData(
+          codec,
+          Writeable[FilePart[String]]((f: FilePart[String]) => codec.encode(f.ref), contentType),
+        )
+        val transformed: ByteString = writeable.transform(multipartFormData)
+
+        transformed.utf8String must contain("Content-Disposition: form-data; name=name")
+        transformed.utf8String must contain("""Content-Disposition: form-data; name="thefile"; filename="something.text"""")
+        transformed.utf8String must contain("Content-Type: text/plain")
+        transformed.utf8String must contain("file part value")
+      }
+
+      "use multipart/form-data content-type" in {
+        val contentType = Some("text/plain")
+        val codec = Codec.utf_8
+        val writeable = Writeable.writeableOf_MultipartFormData(
+          codec,
+          Writeable[FilePart[String]]((f: FilePart[String]) => codec.encode(f.ref), contentType)
+        )
+
+        writeable.contentType must beSome.which(_.startsWith("multipart/form-data; boundary="))
+      }
+    }
+  }
+
+  def createMultipartFormData[A](ref: A): MultipartFormData[A] = {
+    MultipartFormData[A](
+      dataParts = Map(
+        "name" -> Seq("value")
+      ),
+      files = Seq(
+        FilePart[A](
+          key = "thefile",
+          filename = "something.text",
+          contentType = Some("text/plain"),
+          ref = ref
+        )
+      ),
+      badParts = Seq.empty
+    )
+  }
+}


### PR DESCRIPTION
## Fixes

Fixes #7356.

## Purpose

Correctly handles form `bindFromRequest` when using a max lengthed body parsers. Proper test was not possible without adding a `Writeable` to handle `MultipartFormData` so this PR also adds this.

## References

The `Writeable` is based on both jroper/playframework@1cb3fdb and https://goo.gl/DTgGkj.