### PR TITLE
Refactor CORSFilter to be an EssentialFilter

### DIFF
--- a/framework/src/play-filters-helpers/src/main/java/play/filters/components/CORSComponents.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/components/CORSComponents.java
@@ -3,7 +3,6 @@
  */
 package play.filters.components;
 
-import play.components.AkkaComponents;
 import play.components.ConfigurationComponents;
 import play.components.HttpErrorHandlerComponents;
 import play.filters.cors.CORSConfig;
@@ -16,9 +15,7 @@ import java.util.List;
 /**
  * Java Components for the CORS Filter.
  */
-public interface CORSComponents extends ConfigurationComponents,
-        HttpErrorHandlerComponents,
-        AkkaComponents {
+public interface CORSComponents extends ConfigurationComponents, HttpErrorHandlerComponents {
 
     default CORSConfig corsConfig() {
         return CORSConfig$.MODULE$.fromConfiguration(configuration());
@@ -32,8 +29,7 @@ public interface CORSComponents extends ConfigurationComponents,
         return new CORSFilter(
             corsConfig(),
             scalaHttpErrorHandler(),
-            Scala.asScala(corsPathPrefixes()),
-            materializer()
+            Scala.asScala(corsPathPrefixes())
         );
     }
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
@@ -9,10 +9,12 @@ import scala.collection.immutable
 import scala.concurrent.Future
 import java.net.{ URI, URISyntaxException }
 
+import akka.util.ByteString
 import play.api.LoggerLike
 import play.api.MarkerContexts.SecurityMarkerContext
 import play.api.http.{ HeaderNames, HttpErrorHandler, HttpVerbs }
-import play.api.mvc.{ RequestHeader, Result, Results }
+import play.api.libs.streams.Accumulator
+import play.api.mvc.{ EssentialAction, RequestHeader, Result, Results }
 
 /**
  * An abstraction for providing [[play.api.mvc.Action]]s and [[play.api.mvc.Filter]]s that support Cross-Origin
@@ -36,7 +38,7 @@ private[cors] trait AbstractCORSPolicy {
     immutable.HashSet(GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS)
   }
 
-  protected def filterRequest(next: RequestHeader => Future[Result], request: RequestHeader): Future[Result] = {
+  protected def filterRequest(next: EssentialAction, request: RequestHeader): Accumulator[ByteString, Result] = {
     (request.headers.get(HeaderNames.ORIGIN), request.method) match {
       case (None, _) =>
         /* http://www.w3.org/TR/cors/#resource-requests
@@ -78,8 +80,8 @@ private[cors] trait AbstractCORSPolicy {
    *
    * @see [[http://www.w3.org/TR/cors/#resource-requests Simple Cross-Origin Request, Actual Request, and Redirects]]
    */
-  private def handleCORSRequest(next: RequestHeader => Future[Result], request: RequestHeader): Future[Result] = {
-    val origin = {
+  private def handleCORSRequest(next: EssentialAction, request: RequestHeader): Accumulator[ByteString, Result] = {
+    val origin: String = {
       val originOpt = request.headers.get(HeaderNames.ORIGIN)
       assume(originOpt.isDefined, "The presence of the ORIGIN header should guaranteed at this point.")
       originOpt.get
@@ -142,20 +144,25 @@ private[cors] trait AbstractCORSPolicy {
 
       import play.core.Execution.Implicits.trampoline
 
-      val taggedRequest = request.copy(tags = request.tags + (CORSFilter.RequestTag -> origin))
+      val taggedRequest = request
+        .addAttr(CORSFilter.RequestAttr, origin)
+        .copy(tags = request.tags + (CORSFilter.RequestTag -> origin))
+
       // We must recover any errors so that we can add the headers to them to allow clients to see the result
       val result = try {
         next(taggedRequest).recoverWith {
-          case e: Throwable => errorHandler.onServerError(taggedRequest, e)
+          case e: Throwable =>
+            errorHandler.onServerError(taggedRequest, e)
         }
       } catch {
-        case e: Throwable => errorHandler.onServerError(taggedRequest, e)
+        case e: Throwable =>
+          Accumulator.done(errorHandler.onServerError(taggedRequest, e))
       }
       result.map(_.withHeaders(headerBuilder.result(): _*))
     }
   }
 
-  private def handlePreFlightCORSRequest(request: RequestHeader): Future[Result] = {
+  private def handlePreFlightCORSRequest(request: RequestHeader): Accumulator[ByteString, Result] = {
     val origin = {
       val originOpt = request.headers.get(HeaderNames.ORIGIN)
       assume(originOpt.isDefined, "The presence of the ORIGIN header should guaranteed at this point.")
@@ -288,22 +295,20 @@ private[cors] trait AbstractCORSPolicy {
                * Note: Since the list of headers can be unbounded, simply returning supported
                * headers from Access-Control-Allow-Headers can be enough.
                */
-              if (!accessControlRequestHeaders.isEmpty) {
+              if (accessControlRequestHeaders.nonEmpty) {
                 headerBuilder += HeaderNames.ACCESS_CONTROL_ALLOW_HEADERS -> accessControlRequestHeaders.mkString(",")
               }
 
-              Future.successful {
-                Results.Ok.withHeaders(headerBuilder.result(): _*)
-              }
+              Accumulator.done(Results.Ok.withHeaders(headerBuilder.result(): _*))
             }
           }
       }
     }
   }
 
-  private def handleInvalidCORSRequest(request: RequestHeader): Future[Result] = {
+  private def handleInvalidCORSRequest(request: RequestHeader): Accumulator[ByteString, Result] = {
     logger.warn(s"""Invalid CORS request;Origin=${request.headers.get(HeaderNames.ORIGIN)};Method=${request.method};${HeaderNames.ACCESS_CONTROL_REQUEST_HEADERS}=${request.headers.get(HeaderNames.ACCESS_CONTROL_REQUEST_HEADERS)}""")(SecurityMarkerContext)
-    Future.successful(Results.Forbidden)
+    Accumulator.done(Future.successful(Results.Forbidden))
   }
 
   // http://tools.ietf.org/html/rfc6454#section-7.1

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/AbstractCORSPolicy.scala
@@ -145,7 +145,7 @@ private[cors] trait AbstractCORSPolicy {
       import play.core.Execution.Implicits.trampoline
 
       val taggedRequest = request
-        .addAttr(CORSFilter.RequestAttr, origin)
+        .addAttr(CORSFilter.Attrs.Origin, origin)
         .copy(tags = request.tags + (CORSFilter.RequestTag -> origin))
 
       // We must recover any errors so that we can add the headers to them to allow clients to see the result

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
@@ -32,18 +32,7 @@ trait CORSActionBuilder extends ActionBuilder[Request, AnyContent] with Abstract
       override def apply(req: RequestHeader): Accumulator[ByteString, Result] = {
         req match {
           case r: Request[A] => Accumulator.done(block(r))
-          case _ =>
-            Accumulator.done(block(
-              new Request[A] {
-                override lazy val body: A = request.body
-                override lazy val connection: RemoteConnection = req.connection
-                override lazy val method: String = req.method
-                override lazy val version: String = req.version
-                override lazy val attrs: TypedMap = req.attrs
-                override lazy val headers: Headers = req.headers
-                override lazy val target: RequestTarget = req.target
-              }
-            ))
+          case _ => Accumulator.done(block(req.withBody(request.body)))
         }
         Accumulator.done(block(req.asInstanceOf[Request[A]]))
       }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
@@ -4,8 +4,10 @@
 package play.filters.cors
 
 import akka.stream.Materializer
+import akka.util.ByteString
 import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler, ParserConfiguration }
 import play.api.libs.Files.{ SingletonTemporaryFileCreator, TemporaryFileCreator }
+import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.api.{ Configuration, Logger }
 
@@ -19,10 +21,18 @@ import scala.concurrent.{ ExecutionContext, Future }
  */
 trait CORSActionBuilder extends ActionBuilder[Request, AnyContent] with AbstractCORSPolicy {
 
-  override protected val logger = Logger.apply(classOf[CORSActionBuilder])
+  protected def mat: Materializer
+
+  override protected val logger: Logger = Logger.apply(classOf[CORSActionBuilder])
 
   override def invokeBlock[A](request: Request[A], block: Request[A] => Future[Result]): Future[Result] = {
-    filterRequest(rh => block(Request(rh, request.body)), request)
+    val action = new EssentialAction {
+      override def apply(req: RequestHeader): Accumulator[ByteString, Result] = {
+        Accumulator.done(block(req.asInstanceOf[Request[A]]))
+      }
+    }
+
+    filterRequest(action, request).run()(mat)
   }
 }
 
@@ -64,17 +74,18 @@ object CORSActionBuilder {
     errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
     configPath: String = "play.filters.cors",
     parserConfig: ParserConfiguration = ParserConfiguration(),
-    tempFileCreator: TemporaryFileCreator = SingletonTemporaryFileCreator)(implicit mat: Materializer, ec: ExecutionContext): CORSActionBuilder = {
+    tempFileCreator: TemporaryFileCreator = SingletonTemporaryFileCreator)(implicit materializer: Materializer, ec: ExecutionContext): CORSActionBuilder = {
     val eh = errorHandler
     new CORSActionBuilder {
-      override lazy val parser = new BodyParsers.Default(parserConfig, eh, mat, tempFileCreator)
-      override protected val executionContext = ec
-      override protected def corsConfig = {
+      override lazy val parser = new BodyParsers.Default(parserConfig, eh, materializer, tempFileCreator)
+      override protected def mat: Materializer = materializer
+      override protected def executionContext: ExecutionContext = ec
+      override protected def corsConfig: CORSConfig = {
         val prototype = config.get[Configuration]("play.filters.cors")
         val corsConfig = prototype ++ config.get[Configuration](configPath)
         CORSConfig.fromUnprefixedConfiguration(corsConfig)
       }
-      override protected val errorHandler = eh
+      override protected val errorHandler: HttpErrorHandler = eh
     }
   }
 
@@ -88,13 +99,14 @@ object CORSActionBuilder {
     config: CORSConfig,
     errorHandler: HttpErrorHandler,
     parserConfig: ParserConfiguration,
-    tempFileCreator: TemporaryFileCreator)(implicit mat: Materializer, ec: ExecutionContext): CORSActionBuilder = {
+    tempFileCreator: TemporaryFileCreator)(implicit materializer: Materializer, ec: ExecutionContext): CORSActionBuilder = {
     val eh = errorHandler
     new CORSActionBuilder {
-      override lazy val parser = new BodyParsers.Default(parserConfig, eh, mat, tempFileCreator)
-      override protected val executionContext = ec
-      override protected val corsConfig = config
-      override protected val errorHandler = eh
+      override lazy val parser = new BodyParsers.Default(parserConfig, eh, materializer, tempFileCreator)
+      override protected def mat: Materializer = materializer
+      override protected val executionContext: ExecutionContext = ec
+      override protected val corsConfig: CORSConfig = config
+      override protected val errorHandler: HttpErrorHandler = eh
     }
   }
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
@@ -4,13 +4,15 @@
 package play.filters.cors
 
 import akka.stream.Materializer
+import akka.util.ByteString
 import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
 import play.core.j.{ JavaContextComponents, JavaHttpErrorHandlerAdapter }
 
 import scala.concurrent.Future
-
 import play.api.Logger
-import play.api.mvc.{ Filter, RequestHeader, Result }
+import play.api.libs.streams.Accumulator
+import play.api.libs.typedmap.TypedKey
+import play.api.mvc._
 
 /**
  * A play.api.mvc.Filter that implements Cross-Origin Resource Sharing (CORS)
@@ -39,20 +41,22 @@ import play.api.mvc.{ Filter, RequestHeader, Result }
 class CORSFilter(
     override protected val corsConfig: CORSConfig = CORSConfig(),
     override protected val errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
-    private val pathPrefixes: Seq[String] = Seq("/"))(override implicit val mat: Materializer) extends Filter with AbstractCORSPolicy {
+    private val pathPrefixes: Seq[String] = Seq("/")) extends EssentialFilter with AbstractCORSPolicy {
 
   // Java constructor
-  def this(corsConfig: CORSConfig, errorHandler: play.http.HttpErrorHandler, pathPrefixes: java.util.List[String], contextComponents: JavaContextComponents)(mat: Materializer) = {
-    this(corsConfig, new JavaHttpErrorHandlerAdapter(errorHandler, contextComponents), Seq(pathPrefixes.toArray.asInstanceOf[Array[String]]: _*))(mat)
+  def this(corsConfig: CORSConfig, errorHandler: play.http.HttpErrorHandler, pathPrefixes: java.util.List[String], contextComponents: JavaContextComponents) = {
+    this(corsConfig, new JavaHttpErrorHandlerAdapter(errorHandler, contextComponents), Seq(pathPrefixes.toArray.asInstanceOf[Array[String]]: _*))
   }
 
   override protected val logger = Logger(classOf[CORSFilter])
 
-  override def apply(f: RequestHeader => Future[Result])(request: RequestHeader): Future[Result] = {
-    if (pathPrefixes.exists(request.path.startsWith)) {
-      filterRequest(f, request)
-    } else {
-      f(request)
+  override def apply(next: EssentialAction): EssentialAction = new EssentialAction {
+    override def apply(request: RequestHeader): Accumulator[ByteString, Result] = {
+      if (pathPrefixes.exists(request.path.startsWith)) {
+        filterRequest(next, request)
+      } else {
+        next(request)
+      }
     }
   }
 }
@@ -60,6 +64,7 @@ class CORSFilter(
 object CORSFilter {
 
   val RequestTag = "CORS_REQUEST"
+  val RequestAttr: TypedKey[String] = TypedKey("CORS_REQUEST")
 
   def apply(corsConfig: CORSConfig = CORSConfig(), errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
     pathPrefixes: Seq[String] = Seq("/"))(implicit mat: Materializer) =

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSFilter.scala
@@ -64,7 +64,10 @@ class CORSFilter(
 object CORSFilter {
 
   val RequestTag = "CORS_REQUEST"
-  val RequestAttr: TypedKey[String] = TypedKey("CORS_REQUEST")
+
+  object Attrs {
+    val Origin: TypedKey[String] = TypedKey("CORS_ORIGIN")
+  }
 
   def apply(corsConfig: CORSConfig = CORSConfig(), errorHandler: HttpErrorHandler = DefaultHttpErrorHandler,
     pathPrefixes: Seq[String] = Seq("/"))(implicit mat: Materializer) =

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSModule.scala
@@ -20,11 +20,10 @@ class CORSConfigProvider @Inject() (configuration: Configuration) extends Provid
 /**
  * Provider for CORSFilter.
  */
-class CORSFilterProvider @Inject() (configuration: Configuration, errorHandler: HttpErrorHandler, corsConfig: CORSConfig,
-    materializer: Materializer) extends Provider[CORSFilter] {
+class CORSFilterProvider @Inject() (configuration: Configuration, errorHandler: HttpErrorHandler, corsConfig: CORSConfig) extends Provider[CORSFilter] {
   lazy val get = {
     val pathPrefixes = configuration.get[Seq[String]]("play.filters.cors.pathPrefixes")
-    new CORSFilter(corsConfig, errorHandler, pathPrefixes)(materializer)
+    new CORSFilter(corsConfig, errorHandler, pathPrefixes)
   }
 }
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -444,7 +444,7 @@ class CSRFActionHelper(
   }
 
   def requiresCsrfCheck(request: RequestHeader): Boolean = {
-    if (csrfConfig.bypassCorsTrustedOrigins && request.attrs.contains(CORSFilter.RequestAttr)) {
+    if (csrfConfig.bypassCorsTrustedOrigins && request.attrs.contains(CORSFilter.Attrs.Origin)) {
       filterLogger.trace("[CSRF] Bypassing check because CORSFilter request tag found")
       false
     } else {

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/CSRFActions.scala
@@ -444,7 +444,7 @@ class CSRFActionHelper(
   }
 
   def requiresCsrfCheck(request: RequestHeader): Boolean = {
-    if (csrfConfig.bypassCorsTrustedOrigins && request.tags.contains(CORSFilter.RequestTag)) {
+    if (csrfConfig.bypassCorsTrustedOrigins && request.attrs.contains(CORSFilter.RequestAttr)) {
       filterLogger.trace("[CSRF] Bypassing check because CORSFilter request tag found")
       false
     } else {

--- a/framework/src/play/src/main/scala/play/api/mvc/Action.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Action.scala
@@ -519,7 +519,7 @@ trait ActionRefiner[-R[_], +P[_]] extends ActionFunction[R, P] {
   protected def refine[A](request: R[A]): Future[Either[Result, P[A]]]
 
   final def invokeBlock[A](request: R[A], block: P[A] => Future[Result]) =
-    refine(request).flatMap(_.fold(Future.successful _, block))(executionContext)
+    refine(request).flatMap(_.fold(Future.successful, block))(executionContext)
 }
 
 /**


### PR DESCRIPTION
## Purpose

All the other built-in filters are already implemented as `EssentialFilter`s, which is more performant. This PR refactors the `CORSFilter` to be an `EssentialFilter` too.