### PR TITLE
Remove unnecessary method declaration

### DIFF
--- a/framework/src/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSComponents.java
+++ b/framework/src/play-ahc-ws/src/main/java/play/libs/ws/ahc/AhcWSComponents.java
@@ -43,8 +43,6 @@ public interface AhcWSComponents extends WSClientComponents, ConfigurationCompon
 
     ApplicationLifecycle applicationLifecycle();
 
-    ExecutionContext executionContext();
-
     default WSClient wsClient() {
         AsyncHttpClient asyncHttpClient = new AsyncHttpClientProvider(
                 environment().asScala(),

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/components/CSRFComponents.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/components/CSRFComponents.java
@@ -60,12 +60,10 @@ public interface CSRFComponents extends ConfigurationComponents,
         );
     }
 
-    // TODO do we need this?
     default CSRFCheck csrfCheck() {
         return new CSRFCheck(csrfConfig(), csrfTokenSigner().asScala(), sessionConfiguration());
     }
 
-    // TODO do we need this?
     default CSRFAddToken csrfAddToken() {
         return new CSRFAddToken(csrfConfig(), csrfTokenSigner().asScala(), sessionConfiguration());
     }


### PR DESCRIPTION
This is a small problem I've noticed in playframework/play-java-dagger2-example#21. Basically, this method declaration is causing a conflict with the default implementation present in `AkkaComponents`.