### PR TITLE
[Bug] Fix instanceof

### DIFF
--- a/framework/src/play-java-forms/src/main/java/play/data/Form.java
+++ b/framework/src/play-java-forms/src/main/java/play/data/Form.java
@@ -478,7 +478,7 @@ public class Form<T> {
         Object globalError = null;
 
         // instances of Validatable have been validated already
-        boolean shouldTryLegacyValidateMethod = result.getTarget() != null && !result.getTarget().getClass().isInstance(Validatable.class);
+        boolean shouldTryLegacyValidateMethod = result.getTarget() != null && !(result.getTarget() instanceof Validatable);
         if (shouldTryLegacyValidateMethod) {
             try {
                 java.lang.reflect.Method v = result.getTarget().getClass().getMethod("validate");

--- a/framework/src/play-java-forms/src/test/java/play/data/LegacyUser.java
+++ b/framework/src/play-java-forms/src/test/java/play/data/LegacyUser.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.data;
+
+import play.data.validation.Constraints.Validatable;
+
+// No @Validate annotation here so we don't trigger the new validation mechanism.
+// And because Validatable is implemented as well the legacy validation mechanism
+// doesn't get triggered as well - so the validate() method here should NEVER run.
+public class LegacyUser implements Validatable<String> {
+
+    @Override
+    public String validate() {
+        return "Some global error";
+    }
+
+}

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -646,6 +646,11 @@ trait FormSpec extends Specification {
       }
     }
 
+    "not process it's legacy validate method when the Validatable interface is implemented" in {
+      val myForm = formFactory.form(classOf[LegacyUser]).bind(Map("foo" -> "foo").asJava)
+      myForm.globalErrors().size() must beEqualTo(0)
+    }
+
     "keep the declared order of constraint annotations" in {
       "return the constraints in the same order we declared them" in {
         val myForm = formFactory.form(classOf[LoginUser])


### PR DESCRIPTION
This was a mistake introduced by me.
`clazz.isInstance(obj)` actually checks if `obj` is an instance of `clazz` (and not the other way around).
So in our code correct would be: `Validatable.class.isInstance(result.getTarget())`.

However to avoid any confusion I just use the `instanceof` operator now which is much more clearer what we want to express.

I found out about this problem because I got the warnings displayed from line 487 altough I switched everything to the new validate approach.