### PR TITLE
Provide better defaults for manually instantiating components

### DIFF
--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActionsComposition.scala
@@ -44,10 +44,9 @@ class ScalaActionsCompositionSpec extends Specification with Controller {
       }
       //#basic-logging
       implicit val system = ActorSystem()
-      implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
-      val eh: HttpErrorHandler =
-        new DefaultHttpErrorHandler(play.api.Environment.simple(), play.api.Configuration.empty)
-      val parse = PlayBodyParsers(ParserConfiguration(), eh, ActorMaterializer(), SingletonTemporaryFileCreator)
+      implicit val mat = ActorMaterializer()
+      implicit val ec: ExecutionContext = system.dispatcher
+      val parse = PlayBodyParsers()
       val parser = new BodyParsers.Default(parse)
       val loggingAction = new LoggingAction(parser)
 
@@ -98,10 +97,9 @@ class ScalaActionsCompositionSpec extends Specification with Controller {
       //#actions-wrapping-builder
 
       implicit val system = ActorSystem()
-      implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
-      val eh: HttpErrorHandler =
-        new DefaultHttpErrorHandler(play.api.Environment.simple(), play.api.Configuration.empty)
-      val parse = PlayBodyParsers(ParserConfiguration(), eh, ActorMaterializer(), SingletonTemporaryFileCreator)
+      implicit val mat = ActorMaterializer()
+      implicit val ec: ExecutionContext = system.dispatcher
+      val parse = PlayBodyParsers()
       val parser = new BodyParsers.Default(parse)
       val loggingAction = new LoggingAction(parser)
 
@@ -213,10 +211,9 @@ class ScalaActionsCompositionSpec extends Specification with Controller {
       }
       //#authenticated-action-builder
       implicit val system = ActorSystem()
+      implicit val mat = ActorMaterializer()
       implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
-      val eh: HttpErrorHandler =
-        new DefaultHttpErrorHandler(play.api.Environment.simple(), play.api.Configuration.empty)
-      val parser = new BodyParsers.Default(ParserConfiguration(), eh, ActorMaterializer(), SingletonTemporaryFileCreator)
+      val parser = new BodyParsers.Default()
       val userAction = new UserAction(parser)
 
       def currentUser = userAction { request =>

--- a/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
@@ -130,12 +130,10 @@ class ScalaLoggingSpec extends Specification with Mockito {
       import akka.stream.ActorMaterializer
       import play.api.http._
       import akka.stream.Materializer
-      implicit val system = ActorSystem();
-      implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
-      val eh: HttpErrorHandler =
-        new DefaultHttpErrorHandler(play.api.Environment.simple(), play.api.Configuration.empty)
-      val controller = new Application(new AccessLoggingAction(
-        new BodyParsers.Default(ParserConfiguration(), eh, ActorMaterializer(), SingletonTemporaryFileCreator)))
+      implicit val system = ActorSystem()
+      implicit val mat = ActorMaterializer()
+      implicit val ec: ExecutionContext = system.dispatcher
+      val controller = new Application(new AccessLoggingAction(new BodyParsers.Default()))
 
       controller.accessLoggingAction.accessLogger.underlyingLogger.getName must equalTo("access")
       controller.logger.underlyingLogger.getName must contain("Application")
@@ -190,13 +188,13 @@ class ScalaLoggingSpec extends Specification with Mockito {
   }
 
   //#logging-default-marker-context
-  val someMarker: org.slf4j.Marker = MarkerFactory.getMarker("SOMEMARKER")      
+  val someMarker: org.slf4j.Marker = MarkerFactory.getMarker("SOMEMARKER")
   case object SomeMarkerContext extends play.api.DefaultMarkerContext(someMarker)
   //#logging-default-marker-context
 
   "MarkerContext" should {
     "return some marker" in {
-      import play.api.Logger      
+      import play.api.Logger
       val logger: Logger = Logger("access")
 
       //#logging-marker-context
@@ -207,15 +205,15 @@ class ScalaLoggingSpec extends Specification with Mockito {
     }
 
     "logger.info with explicit marker context" in {
-      import play.api.Logger      
+      import play.api.Logger
       val logger: Logger = Logger("access")
 
       //#logging-log-info-with-explicit-markercontext
       // use a typed marker as input
       logger.info("log message with explicit marker context with case object")(SomeMarkerContext)
-      
+
       // Use a specified marker.
-      val otherMarker: Marker = MarkerFactory.getMarker("OTHER")      
+      val otherMarker: Marker = MarkerFactory.getMarker("OTHER")
       val otherMarkerContext: MarkerContext = MarkerContext(otherMarker)
       logger.info("log message with explicit marker context")(otherMarkerContext)
       //#logging-log-info-with-explicit-markercontext
@@ -224,11 +222,11 @@ class ScalaLoggingSpec extends Specification with Mockito {
     }
 
     "logger.info with implicit marker context" in {
-      import play.api.Logger      
+      import play.api.Logger
       val logger: Logger = Logger("access")
 
       //#logging-log-info-with-implicit-markercontext
-      val marker: Marker = MarkerFactory.getMarker("SOMEMARKER")      
+      val marker: Marker = MarkerFactory.getMarker("SOMEMARKER")
       implicit val mc: MarkerContext = MarkerContext(marker)
 
       // Use the implicit MarkerContext in logger.info...
@@ -239,16 +237,16 @@ class ScalaLoggingSpec extends Specification with Mockito {
     }
 
     "implicitly convert a Marker to a MarkerContext" in {
-      import play.api.Logger      
+      import play.api.Logger
       val logger: Logger = Logger("access")
 
       //#logging-log-info-with-implicit-conversion
       val mc: MarkerContext = MarkerFactory.getMarker("SOMEMARKER")
-            
-      // Use the marker that has been implicitly converted to MarkerContext      
+
+      // Use the marker that has been implicitly converted to MarkerContext
       logger.info("log message with implicit marker context")(mc)
       //#logging-log-info-with-implicit-conversion
-      
+
       success
     }
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/cors/CORSActionBuilder.scala
@@ -83,7 +83,7 @@ object CORSActionBuilder {
     tempFileCreator: TemporaryFileCreator = SingletonTemporaryFileCreator)(implicit materializer: Materializer, ec: ExecutionContext): CORSActionBuilder = {
     val eh = errorHandler
     new CORSActionBuilder {
-      override lazy val parser = new BodyParsers.Default(parserConfig, eh, materializer, tempFileCreator)
+      override lazy val parser = new BodyParsers.Default(tempFileCreator, eh, parserConfig)(materializer)
       override protected def mat: Materializer = materializer
       override protected def executionContext: ExecutionContext = ec
       override protected def corsConfig: CORSConfig = {
@@ -108,7 +108,7 @@ object CORSActionBuilder {
     tempFileCreator: TemporaryFileCreator)(implicit materializer: Materializer, ec: ExecutionContext): CORSActionBuilder = {
     val eh = errorHandler
     new CORSActionBuilder {
-      override lazy val parser = new BodyParsers.Default(parserConfig, eh, materializer, tempFileCreator)
+      override lazy val parser = new BodyParsers.Default(tempFileCreator, eh, parserConfig)(materializer)
       override protected def mat: Materializer = materializer
       override protected val executionContext: ExecutionContext = ec
       override protected val corsConfig: CORSConfig = config

--- a/framework/src/play-integration-test/src/test/scala/play/it/views/DevErrorPageSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/views/DevErrorPageSpec.scala
@@ -25,7 +25,7 @@ class DevErrorPageSpec extends PlaySpecification {
     }
 
     "show prod error page in prod mode" in {
-      val errorHandler = new DefaultHttpErrorHandler(Environment.simple(mode = Mode.Prod), Configuration.empty)
+      val errorHandler = new DefaultHttpErrorHandler()
       val result = errorHandler.onServerError(FakeRequest(), testExceptionSource)
       Helpers.contentAsString(result) must contain("Oops, an error occurred")
     }

--- a/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
+++ b/framework/src/play-test/src/main/scala/play/api/test/Helpers.scala
@@ -474,9 +474,9 @@ trait StubPlayBodyParsersFactory {
    * @param mat the input materializer.
    * @return a minimal PlayBodyParsers for unit testing.
    */
-  def stubPlayBodyParsers(mat: Materializer): PlayBodyParsers = {
+  def stubPlayBodyParsers(implicit mat: Materializer): PlayBodyParsers = {
     val errorHandler = new DefaultHttpErrorHandler(HttpErrorConfig(showDevErrors = false, None), None, None)
-    PlayBodyParsers(ParserConfiguration(), errorHandler, mat, NoTemporaryFileCreator)
+    PlayBodyParsers(NoTemporaryFileCreator, errorHandler)
   }
 
 }

--- a/framework/src/play/src/main/java/play/components/BodyParserComponents.java
+++ b/framework/src/play/src/main/java/play/components/BodyParserComponents.java
@@ -20,10 +20,10 @@ public interface BodyParserComponents extends HttpErrorHandlerComponents,
 
     default PlayBodyParsers scalaBodyParsers() {
         return PlayBodyParsers$.MODULE$.apply(
-                httpConfiguration().parser(),
+                tempFileCreator().asScala(),
                 scalaHttpErrorHandler(),
-                materializer(),
-                tempFileCreator().asScala()
+                httpConfiguration().parser(),
+                materializer()
         );
     }
 

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -275,7 +275,8 @@ trait BuiltInComponents extends I18nComponents {
       langs // play.api.i18n.Langs object
   }
 
-  lazy val playBodyParsers: PlayBodyParsers = PlayBodyParsers(httpConfiguration.parser, httpErrorHandler, materializer, tempFileCreator)
+  lazy val playBodyParsers: PlayBodyParsers =
+    PlayBodyParsers(tempFileCreator, httpErrorHandler, httpConfiguration.parser)(materializer)
   lazy val defaultBodyParser: BodyParser[AnyContent] = playBodyParsers.default
   lazy val defaultActionBuilder: DefaultActionBuilder = DefaultActionBuilder(defaultBodyParser)
 

--- a/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpErrorHandler.scala
@@ -60,7 +60,7 @@ object HttpErrorHandler {
   }
 }
 
-case class HttpErrorConfig(showDevErrors: Boolean, playEditor: Option[String])
+case class HttpErrorConfig(showDevErrors: Boolean = false, playEditor: Option[String] = None)
 
 /**
  * The default HTTP error handler.
@@ -74,9 +74,9 @@ case class HttpErrorConfig(showDevErrors: Boolean, playEditor: Option[String])
  */
 @Singleton
 class DefaultHttpErrorHandler(
-    config: HttpErrorConfig,
-    sourceMapper: Option[SourceMapper],
-    router: => Option[Router]) extends HttpErrorHandler {
+    config: HttpErrorConfig = HttpErrorConfig(),
+    sourceMapper: Option[SourceMapper] = None,
+    router: => Option[Router] = None) extends HttpErrorHandler {
 
   /**
    * @param environment The environment
@@ -85,9 +85,7 @@ class DefaultHttpErrorHandler(
    *               This is a lazy parameter, to avoid circular dependency issues, since the router may well depend on
    *               this.
    */
-  def this(environment: Environment, configuration: Configuration,
-    sourceMapper: Option[SourceMapper] = None,
-    router: => Option[Router] = None) =
+  def this(environment: Environment, configuration: Configuration, sourceMapper: Option[SourceMapper], router: => Option[Router]) =
     this(HttpErrorConfig(environment.mode != Mode.Prod, configuration.getOptional[String]("play.editor")), sourceMapper, router)
 
   @Inject
@@ -267,7 +265,10 @@ object HttpErrorHandlerExceptions {
 }
 
 /**
- * A default HTTP error handler that can be used when there's no application available
+ * A default HTTP error handler that can be used when there's no application available.
+ *
+ * Note: this HttpErrorHandler should ONLY be used in DEV or TEST. The way this displays errors to the user is
+ * generally not suitable for a production environment.
  */
 object DefaultHttpErrorHandler extends DefaultHttpErrorHandler(
   HttpErrorConfig(showDevErrors = true, playEditor = None), None, None) {

--- a/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/BodyParsers.scala
@@ -409,7 +409,14 @@ class DefaultPlayBodyParsers @Inject() (
   val temporaryFileCreator: TemporaryFileCreator) extends PlayBodyParsers
 
 object PlayBodyParsers {
-  def apply(conf: ParserConfiguration, eh: HttpErrorHandler, mat: Materializer, tfc: TemporaryFileCreator): PlayBodyParsers = {
+  /**
+   * A helper method for creating PlayBodyParsers. The default values are mainly useful in testing, and default the
+   * TemporaryFileCreator and HttpErrorHandler to singleton versions.
+   */
+  def apply(
+    tfc: TemporaryFileCreator = SingletonTemporaryFileCreator,
+    eh: HttpErrorHandler = new DefaultHttpErrorHandler(),
+    conf: ParserConfiguration = ParserConfiguration())(implicit mat: Materializer): PlayBodyParsers = {
     new DefaultPlayBodyParsers(conf, eh, mat, tfc)
   }
 }
@@ -893,8 +900,15 @@ object BodyParsers extends BodyParsers {
    * The default body parser provided by Play
    */
   class Default @Inject() (parse: PlayBodyParsers) extends BodyParser[AnyContent] {
-    def this(config: ParserConfiguration, eh: HttpErrorHandler, mat: Materializer, tfc: TemporaryFileCreator) =
-      this(PlayBodyParsers(config, eh, mat, tfc))
+    /**
+     * An alternate constructor primarily designed for unit testing. Default values are set to empty or singleton
+     * implementations where appropriate.
+     */
+    def this(
+      tfc: TemporaryFileCreator = SingletonTemporaryFileCreator,
+      eh: HttpErrorHandler = new DefaultHttpErrorHandler(),
+      config: ParserConfiguration = ParserConfiguration()
+    )(implicit mat: Materializer) = this(PlayBodyParsers(tfc, eh, config))
     override def apply(rh: RequestHeader) = parse.default(None)(rh)
   }
 

--- a/framework/src/play/src/test/scala/play/api/mvc/MaxLengthBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/MaxLengthBodyParserSpec.scala
@@ -32,9 +32,7 @@ class MaxLengthBodyParserSpec extends Specification with AfterAll {
   implicit val system = ActorSystem()
   import system.dispatcher
   implicit val mat = ActorMaterializer()
-  val tempFileCreator = SingletonTemporaryFileCreator
-  val parse = new DefaultPlayBodyParsers(
-    ParserConfiguration(), new DefaultHttpErrorHandler(Environment.simple(), Configuration.empty), mat, tempFileCreator)
+  val parse = PlayBodyParsers()
 
   override def afterAll: Unit = {
     system.terminate()

--- a/framework/src/play/src/test/scala/play/api/mvc/RawBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RawBodyParserSpec.scala
@@ -3,27 +3,24 @@
  */
 package play.api.mvc
 
-import akka.util.ByteString
-import akka.stream.scaladsl.Source
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import java.io.IOException
 
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
 import org.specs2.mutable.Specification
 import org.specs2.specification.AfterAll
-import play.api.{ Configuration, Environment }
-import play.api.http.{ DefaultHttpErrorHandler, ParserConfiguration }
-import play.api.libs.Files.SingletonTemporaryFileCreator
 import play.core.test.FakeRequest
+import play.api.http.ParserConfiguration
 
-import scala.concurrent.Future
-import scala.concurrent.Await
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration.Duration
 
 class RawBodyParserSpec extends Specification with AfterAll {
 
-  implicit val system = ActorSystem("content-types-spec")
-  implicit val materializer = ActorMaterializer()(system)
+  implicit val system = ActorSystem("raw-body-parser-spec")
+  implicit val materializer = ActorMaterializer()
 
   def afterAll(): Unit = {
     materializer.shutdown()
@@ -31,9 +28,7 @@ class RawBodyParserSpec extends Specification with AfterAll {
   }
 
   val config = ParserConfiguration()
-  val errorHandler = new DefaultHttpErrorHandler(Environment.simple(), Configuration.empty)
-  val tempFileCreator = SingletonTemporaryFileCreator
-  val parse = PlayBodyParsers(config, errorHandler, materializer, tempFileCreator)
+  val parse = PlayBodyParsers()
 
   def parse(body: ByteString, memoryThreshold: Int = config.maxMemoryBuffer, maxLength: Long = config.maxDiskBuffer)(parser: BodyParser[RawBuffer] = parse.raw(memoryThreshold, maxLength)): Either[Result, RawBuffer] = {
     val request = FakeRequest(method = "GET", "/x")

--- a/framework/src/play/src/test/scala/play/mvc/RawBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/mvc/RawBodyParserSpec.scala
@@ -12,7 +12,6 @@ import akka.util.ByteString
 import org.specs2.mutable.Specification
 import org.specs2.specification.AfterAll
 import play.api.http.{ DefaultHttpErrorHandler, ParserConfiguration }
-import play.api.libs.Files.SingletonTemporaryFileCreator
 import play.api.mvc.{ PlayBodyParsers, RawBuffer }
 import play.core.j.JavaParsers
 import play.core.test.FakeRequest
@@ -22,10 +21,9 @@ import scala.concurrent.Future
 class RawBodyParserSpec extends Specification with AfterAll {
   "Java RawBodyParserSpec" title
 
-  implicit val system = ActorSystem("content-types-spec")
-  implicit val materializer = ActorMaterializer()(system)
-  val tempFileCreator = SingletonTemporaryFileCreator
-  val parsers = PlayBodyParsers(ParserConfiguration(), DefaultHttpErrorHandler, materializer, tempFileCreator)
+  implicit val system = ActorSystem("raw-body-parser-spec")
+  implicit val materializer = ActorMaterializer()
+  val parsers = PlayBodyParsers()
 
   def afterAll(): Unit = {
     materializer.shutdown()
@@ -67,12 +65,7 @@ class RawBodyParserSpec extends Specification with AfterAll {
         implicit val system = ActorSystem()
 
         Future {
-          val scalaParser = PlayBodyParsers(
-            ParserConfiguration(),
-            new DefaultHttpErrorHandler(play.api.Environment.simple(), play.api.Configuration.empty),
-            ActorMaterializer(),
-            tempFileCreator
-          ).raw
+          val scalaParser = PlayBodyParsers().raw
           val javaParser = new BodyParser.DelegatingBodyParser[RawBuffer, RawBuffer](
             scalaParser,
             java.util.function.Function.identity[RawBuffer]) {}


### PR DESCRIPTION
The goal here is to provide sensible defaults for using Play components in a unit testing context. This is done by defaulting constructor parameters and apply methods to empty or singleton versions when possible.

I know this mainly affects the Scala API. This is much more difficult to do with the Java API due to lack of default values.

There are more components we could do this for but I wanted to get an idea of whether this makes sense before I do more.