### PR TITLE
Fixed appender references

### DIFF
--- a/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsLogger.md
@@ -90,7 +90,7 @@ Here's an example of configuration that uses a rolling file appender, as well as
 <configuration>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${user.dir}/web/logs/application.log</file>
+        <file>${application.home:-.}/logs/application.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- Daily rollover with compression -->
             <fileNamePattern>application-log-%d{yyyy-MM-dd}.gz</fileNamePattern>
@@ -103,7 +103,7 @@ Here's an example of configuration that uses a rolling file appender, as well as
     </appender>
 
     <appender name="ACCESS_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${user.dir}/web/logs/access.log</file>
+        <file>${application.home:-.}/logs/access.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover with compression -->
             <fileNamePattern>access-log-%d{yyyy-MM-dd}.gz</fileNamePattern>
@@ -135,7 +135,7 @@ This demonstrates a few useful features:
 - It uses `RollingFileAppender` which can help manage growing log files.
 - It writes log files to a directory external to the application so they aren't affected by upgrades, etc.
 - The `FILE` appender uses an expanded message format that can be parsed by third party log analytics providers such as Sumo Logic.
-- The `access` logger is routed to a separate log file using the `ACCESS_FILE_APPENDER`.
+- The `access` logger is routed to a separate log file using the `ACCESS_FILE` appender.
 - All loggers are set to a threshold of `INFO` which is a common choice for production logging.
 
 ## Akka logging configuration


### PR DESCRIPTION
- changed the location of the `application.log` and `access.log` to the standard `logs/` location of a Play application
- fixed reference to incorrect ACCESS_FILE_APPENDER

# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
