### PR TITLE
Don't use JavaConversions in scala 2.12 template imports

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -165,6 +165,9 @@ object BuildSettings {
         previousVersions.map(v => organization.value % moduleName.value %  v)
       }
     },
+    unmanagedSourceDirectories in Compile <+= (sourceDirectory in Compile, scalaBinaryVersion) {
+      (dir, version) => dir / s"scala-$version"
+    },
     // Argument for setting size of permgen space or meta space for all forked processes
     Docs.apiDocsInclude := true
   )

--- a/framework/src/build-link/src/main/java/play/TemplateImports.java
+++ b/framework/src/build-link/src/main/java/play/TemplateImports.java
@@ -28,7 +28,6 @@ public class TemplateImports {
     minimalJavaImports.addAll(defaultTemplateImports);
     minimalJavaImports.add("java.lang._");
     minimalJavaImports.add("java.util._");
-    minimalJavaImports.add("scala.collection.JavaConversions._");
     minimalJavaImports.add("scala.collection.JavaConverters._");
     minimalJavaImports.add("play.core.j.PlayMagicForJava._");
     minimalJavaImports.add("play.mvc._");

--- a/framework/src/play-java/src/main/scala-2.11/play/core/j/JavaImplicitConversions.scala
+++ b/framework/src/play-java/src/main/scala-2.11/play/core/j/JavaImplicitConversions.scala
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.j
+
+import scala.collection.convert._
+
+/**
+ * Implicit conversions for use in the templates, to provide seamless interop between Java and Scala types.
+ */
+private[play] trait JavaImplicitConversions extends WrapAsJava with WrapAsScala

--- a/framework/src/play-java/src/main/scala-2.12/play/core/j/JavaImplicitConversions.scala
+++ b/framework/src/play-java/src/main/scala-2.12/play/core/j/JavaImplicitConversions.scala
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.j
+
+import scala.collection.convert._
+
+/**
+ * Implicit conversions for use in the templates, to provide seamless interop between Java and Scala types.
+ */
+private[play] trait JavaImplicitConversions extends ToScalaImplicits with ToJavaImplicits

--- a/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
+++ b/framework/src/play-java/src/main/scala/play/core/TemplateMagicForJava.scala
@@ -10,7 +10,7 @@ import play.mvc.Http
 import scala.util.control.NonFatal
 
 /** Defines a magic helper for Play templates in a Java context. */
-object PlayMagicForJava {
+object PlayMagicForJava extends JavaImplicitConversions {
 
   import scala.language.implicitConversions
   import scala.compat.java8.OptionConverters._


### PR DESCRIPTION
Fixes #7406

Since this is just for the templates, I think it's probably justified to use `ToScalaImplicits` and `ToJavaImplicits` from scala 2.12.

I decided to create a trait that's mixed into `PlayMagicForJava` since there are other implicit conversions there, but I could move to a separate object if people think it's a good idea.