### PR TITLE
Correct a typo in SecurityHeaders.md

### DIFF
--- a/documentation/manual/working/commonGuide/filters/SecurityHeaders.md
+++ b/documentation/manual/working/commonGuide/filters/SecurityHeaders.md
@@ -27,7 +27,7 @@ play.http.filters = "filters.MyFilters"
 
 Scaladoc is available in the [play.filters.headers](api/scala/play/filters/headers/package.html) package.
 
-The filter will set headers in the HTTP response automatically.  The settings can can be configured through the following settings in `application.conf`
+The filter will set headers in the HTTP response automatically.  The settings can be configured through the following settings in `application.conf`
 
 * `play.filters.headers.frameOptions` - sets [X-Frame-Options](https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options), "DENY" by default.
 * `play.filters.headers.xssProtection` - sets [X-XSS-Protection](https://blogs.msdn.microsoft.com/ie/2008/07/02/ie8-security-part-iv-the-xss-filter/), "1; mode=block" by default.


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you [squashed your commits]? (Optional, but makes merge messages nicer.)
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Removed duplicated `can`.

## Purpose

Correct a typo in `SecurityHeaders.md`.

## Background Context

Found a typo while reading `SecurityHeaders.md`.

## References

There are no relevant issues / PRs / mailing lists discussions.
