### PR TITLE
Consider SameSite when converting cookies from Java to Scala

### DIFF
--- a/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
+++ b/documentation/manual/working/javaGuide/main/http/code/javaguide/http/JavaResponse.java
@@ -109,8 +109,7 @@ public class JavaResponse extends WithApplication {
         assertThat(cookie.domain(), equalTo(".example.com"));
         assertThat(cookie.secure(), equalTo(false));
         assertThat(cookie.httpOnly(), equalTo(true));
-        assertThat(cookie.sameSite(),
-            equalTo(Optional.of(Cookie.SameSite.STRICT)));
+        assertThat(cookie.sameSite(), equalTo(Optional.of(Cookie.SameSite.STRICT)));
         removeContext();
     }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -56,8 +56,20 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
           .withCookies(new Http.Cookie("framework", "Play", 1000, "/", "example.com", false, true, null))
       }
     }) { response =>
-      response.allHeaders("Set-Cookie") must contain((s: String) => s.startsWith("bar=KitKat;"))
-      response.allHeaders("Set-Cookie") must contain((s: String) => s.startsWith("framework=Play;"))
+      response.headers("Set-Cookie") must contain((s: String) => s.startsWith("bar=KitKat;"))
+      response.headers("Set-Cookie") must contain((s: String) => s.startsWith("framework=Play;"))
+      response.body must_== "Hello world"
+    }
+
+    "add cookies with SameSite policy in Result" in makeRequest(new MockController {
+      def action = {
+        Results.ok("Hello world")
+          .withCookies(Http.Cookie.builder("bar", "KitKat").withSameSite(Http.Cookie.SameSite.LAX).build())
+          .withCookies(Http.Cookie.builder("framework", "Play").withSameSite(Http.Cookie.SameSite.STRICT).build())
+      }
+    }) { response =>
+      response.headers("Set-Cookie") must contain((s: String) => s.startsWith("bar=KitKat; SameSite=Lax"))
+      response.headers("Set-Cookie") must contain((s: String) => s.startsWith("framework=Play; SameSite=Strict"))
       response.body must_== "Hello world"
     }
 
@@ -80,7 +92,7 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
           .withCookies(new Http.Cookie("bar", "Mars", 1000, "/", "example.com", false, true, null))
       }
     }) { response =>
-      response.allHeaders("Set-Cookie") must contain((s: String) => s.startsWith("bar=Mars;"))
+      response.headers("Set-Cookie") must contain((s: String) => s.startsWith("bar=Mars;"))
       response.body must_== "Hello world"
     }
 
@@ -112,8 +124,8 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
         )
       }
     }) { response =>
-      response.allHeaders.get("Set-Cookie").get(0) must contain("bar=KitKat")
-      response.allHeaders.get("Set-Cookie").get(1) must contain("foo=1")
+      response.headers.get("Set-Cookie").get(0) must contain("bar=KitKat")
+      response.headers.get("Set-Cookie").get(1) must contain("foo=1")
       response.body must_== "Hello world"
     }
 

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -31,7 +31,8 @@ trait JavaHelpers {
   def cookieToScalaCookie(c: play.mvc.Http.Cookie): Cookie = {
     import scala.compat.java8.OptionConverters
     val optionalMaxAge = OptionConverters.toScala(Optional.ofNullable(c.maxAge))
-    Cookie(c.name, c.value, optionalMaxAge.map(_.toInt), c.path, Option(c.domain), c.secure, c.httpOnly)
+    val optionalSameSite = OptionConverters.toScala(c.sameSite()).map(_.asScala())
+    Cookie(c.name, c.value, optionalMaxAge.map(_.toInt), c.path, Option(c.domain), c.secure, c.httpOnly, optionalSameSite)
   }
 
   def cookiesToScalaCookies(cookies: java.lang.Iterable[play.mvc.Http.Cookie]): Seq[Cookie] = {


### PR DESCRIPTION
## Fixes

Fixes #7432

## Purpose

The Java to Scala cookies conversion was not considering the `SameSite` attribute.