### PR TITLE
Overload JavaScriptReverseRouter.create to pass host explicitly

### DIFF
--- a/framework/src/play/src/main/java/play/routing/JavaScriptReverseRouter.java
+++ b/framework/src/play/src/main/java/play/routing/JavaScriptReverseRouter.java
@@ -16,13 +16,26 @@ public class JavaScriptReverseRouter {
      *
      * @param name the router's name
      * @param ajaxMethod which asynchronous call method the user's browser will use (e.g. "jQuery.ajax")
+     * @param host the host to use for the reverse route
+     * @param routes the reverse routes for this router
+     * @return the router
+     */
+    public static JavaScript create(String name, String ajaxMethod, String host, play.api.routing.JavaScriptReverseRoute... routes) {
+        return play.api.routing.JavaScriptReverseRouter.apply(
+            name, Scala.Option(ajaxMethod), host, Scala.toSeq(routes)
+        );
+    }
+
+    /**
+     * Generates a JavaScript reverse router.
+     *
+     * @param name the router's name
+     * @param ajaxMethod which asynchronous call method the user's browser will use (e.g. "jQuery.ajax")
      * @param routes the reverse routes for this router
      * @return the router
      */
     public static JavaScript create(String name, String ajaxMethod, play.api.routing.JavaScriptReverseRoute... routes) {
-        return play.api.routing.JavaScriptReverseRouter.apply(
-            name, Scala.Option(ajaxMethod), play.mvc.Http.Context.current().request().host(), Scala.toSeq(routes)
-        );
+        return create(name, ajaxMethod, play.mvc.Http.Context.current().request().host(), routes);
     }
 
     /**


### PR DESCRIPTION
Very simple enhancement: We want to be able to pass the `host` explicitly to `JavaScriptReverseRouter.create` - right now the host is solely determined from the current Http.Context. There can be use cases where you may want to use a different host other than the one from the request or if you want to pre-render and cache stuff where an Http.Context isn't available.