### PR TITLE
Fix module in RedirectHttpsFilter

### DIFF
--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
@@ -3,11 +3,11 @@
  */
 package play.filters.https
 
-import javax.inject.{ Inject, Provider }
+import javax.inject.{ Inject, Provider, Singleton }
 
 import play.api.http.HeaderNames._
 import play.api.http.Status._
-import play.api.inject.SimpleModule
+import play.api.inject.{ SimpleModule, bind }
 import play.api.mvc._
 import play.api.{ Configuration, Environment, Mode }
 
@@ -20,6 +20,7 @@ import play.api.{ Configuration, Environment, Mode }
  * For documentation on configuring this filter, please see the Play documentation at
  * https://www.playframework.com/documentation/latest/RedirectHttpsFilter
  */
+@Singleton
 class RedirectHttpsFilter @Inject() (config: RedirectHttpsConfiguration)
     extends EssentialFilter {
 
@@ -58,6 +59,7 @@ case class RedirectHttpsConfiguration(
   hstsEnabled: Boolean = false
 )
 
+@Singleton
 class RedirectHttpsConfigurationProvider @Inject() (c: Configuration, e: Environment)
     extends Provider[RedirectHttpsConfiguration] {
   private val stsPath = "play.filters.https.strictTransportSecurity"
@@ -76,9 +78,10 @@ class RedirectHttpsConfigurationProvider @Inject() (c: Configuration, e: Environ
   }
 }
 
-class RedirectHttpsModule extends SimpleModule {
-  bind[RedirectHttpsConfiguration].toProvider[RedirectHttpsConfigurationProvider]
-}
+class RedirectHttpsModule extends SimpleModule(
+  bind[RedirectHttpsConfiguration].toProvider[RedirectHttpsConfigurationProvider],
+  bind[RedirectHttpsFilter].toSelf
+)
 
 /**
  * The Redirect to HTTPS filter components for compile time dependency injection.

--- a/framework/src/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
+++ b/framework/src/play-filters-helpers/src/test/scala/play/filters/https/RedirectHttpsFilterSpec.scala
@@ -6,10 +6,10 @@ package play.filters.https
 import javax.inject.Inject
 
 import com.typesafe.config.ConfigFactory
-import play.api._
+import play.api.{ Configuration, Environment, _ }
 import play.api.http.HttpFilters
 import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.inject.guice.{ GuiceApplicationBuilder, GuiceableModule }
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.mvc.request.RemoteConnection
@@ -100,13 +100,16 @@ class RedirectHttpsFilterSpec extends PlaySpecification {
 
   private def buildApp(config: String = "", mode: Mode = Mode.Test) = GuiceApplicationBuilder(Environment.simple(mode = mode))
     .configure(Configuration(ConfigFactory.parseString(config)))
+    .load(
+      new play.api.inject.BuiltinModule,
+      new play.api.mvc.CookiesModule,
+      new play.api.i18n.I18nModule,
+      new play.filters.https.RedirectHttpsModule)
     .appRoutes(app => {
       case ("GET", "/") =>
         val action = app.injector.instanceOf[DefaultActionBuilder]
         action(Ok(""))
-    })
-    .overrides(
-      bind[RedirectHttpsConfiguration].toProvider[RedirectHttpsConfigurationProvider],
+    }).overrides(
       bind[HttpFilters].to[TestFilters]
     ).build()
 


### PR DESCRIPTION
Fixes https://github.com/playframework/playframework/issues/7435

SimpleModule was incorrectly declared with braces instead of using a Seq in the constructor parameters, and so the bindings never took effect.  This didn't show up in the tests, because the binding was done directly instead of through the module.

Changed the tests, and made the filter and provider be @Singleton for housekeeping.