### PR TITLE
Session and Flash cookies respecting the sameSite configuration

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
@@ -18,28 +18,30 @@ trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecificat
 
   sequential
 
-  def appWithRedirect = GuiceApplicationBuilder().appRoutes(app => {
-    val Action = app.injector.instanceOf[DefaultActionBuilder]
-    ({
-      case ("GET", "/flash") =>
-        Action {
-          Redirect("/landing").flashing(
-            "success" -> "found"
-          )
-        }
-      case ("GET", "/set-cookie") =>
-        Action {
-          Ok.withCookies(Cookie("some-cookie", "some-value"))
-        }
-      case ("GET", "/landing") =>
-        Action {
-          Ok("ok")
-        }
-    })
-  }).build()
+  def appWithRedirect(additionalConfiguration: Map[String, String]) = GuiceApplicationBuilder()
+    .configure(additionalConfiguration)
+    .appRoutes(app => {
+      val Action = app.injector.instanceOf[DefaultActionBuilder]
+      ({
+        case ("GET", "/flash") =>
+          Action {
+            Redirect("/landing").flashing(
+              "success" -> "found"
+            )
+          }
+        case ("GET", "/set-cookie") =>
+          Action {
+            Ok.withCookies(Cookie("some-cookie", "some-value"))
+          }
+        case ("GET", "/landing") =>
+          Action {
+            Ok("ok")
+          }
+      })
+    }).build()
 
-  def withClientAndServer[T](block: WSClient => T) = {
-    val app = appWithRedirect
+  def withClientAndServer[T](additionalConfiguration: Map[String, String] = Map.empty)(block: WSClient => T) = {
+    val app = appWithRedirect(additionalConfiguration)
     import app.materializer
     Server.withApplication(app) { implicit port =>
       withClient(block)
@@ -50,7 +52,7 @@ trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecificat
     response.cookies.find(_.name.exists(_ == Flash.COOKIE_NAME))
 
   "the flash cookie" should {
-    "can be set for one request" in withClientAndServer { ws =>
+    "can be set for one request" in withClientAndServer() { ws =>
       val response = await(ws.url("/flash").withFollowRedirects(follow = false).get())
       response.status must equalTo(SEE_OTHER)
       val flashCookie = readFlashCookie(response)
@@ -60,7 +62,7 @@ trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecificat
       }
     }
 
-    "be removed after a redirect" in withClientAndServer { ws =>
+    "be removed after a redirect" in withClientAndServer() { ws =>
       val response = await(ws.url("/flash").get())
       response.status must equalTo(OK)
       val flashCookie = readFlashCookie(response)
@@ -71,11 +73,11 @@ trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecificat
       }
     }
 
-    "allow the setting of additional cookies when cleaned up" in withClientAndServer { ws =>
+    "allow the setting of additional cookies when cleaned up" in withClientAndServer() { ws =>
       val response = await(ws.url("/flash").withFollowRedirects(false).get())
       val Some(flashCookie) = readFlashCookie(response)
       val response2 = await(ws.url("/set-cookie")
-        .withHeaders("Cookie" -> s"${flashCookie.name.get}=${flashCookie.value.get}")
+        .withHttpHeaders("Cookie" -> s"${flashCookie.name.get}=${flashCookie.value.get}")
         .get())
 
       readFlashCookie(response2) must beSome.like {
@@ -88,9 +90,30 @@ trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecificat
 
     }
 
-    "honor configuration for flash.secure" in Helpers.running(_.configure("play.http.flash.secure" -> true)) { _ =>
-      Flash.encodeAsCookie(Flash()).secure must beTrue
+    "honor the configuration for play.http.flash.sameSite" in {
+      "configured to lax" in withClientAndServer(Map("play.http.flash.sameSite" -> "lax")) { ws =>
+        val response = await(ws.url("/flash").withFollowRedirects(follow = false).get())
+        response.status must equalTo(SEE_OTHER)
+        response.header(SET_COOKIE) must beSome.which(_.contains("SameSite=Lax"))
+      }
+
+      "configured to strict" in withClientAndServer(Map("play.http.flash.sameSite" -> "strict")) { ws =>
+        val response = await(ws.url("/flash").withFollowRedirects(follow = false).get())
+        response.status must equalTo(SEE_OTHER)
+        response.header(SET_COOKIE) must beSome.which(_.contains("SameSite=Strict"))
+      }
     }
+
+    "honor configuration for flash.secure" in {
+      "configured to true" in Helpers.running(_.configure("play.http.flash.secure" -> true)) { _ =>
+        Flash.encodeAsCookie(Flash()).secure must beTrue
+      }
+
+      "configured to false" in Helpers.running(_.configure("play.http.flash.secure" -> false)) { _ =>
+        Flash.encodeAsCookie(Flash()).secure must beFalse
+      }
+    }
+
   }
 
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaResultsHandlingSpec.scala
@@ -13,9 +13,11 @@ import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test._
 import play.api.libs.ws.WSResponse
+import play.http.HttpEntity
 import play.it._
 import play.libs.{ Comet, EventSource, Json }
-import play.mvc.{ Http, Results }
+import play.mvc.Http.{ Cookie, Flash, Session }
+import play.mvc.{ Http, ResponseHeader, Result, Results }
 
 class NettyJavaResultsHandlingSpec extends JavaResultsHandlingSpec with NettyIntegrationSpecification
 class AkkaHttpJavaResultsHandlingSpec extends JavaResultsHandlingSpec with AkkaHttpIntegrationSpecification
@@ -25,14 +27,14 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
   sequential
 
   "Java results handling" should {
-    def makeRequest[T](controller: MockController)(block: WSResponse => T) = {
+    def makeRequest[T](controller: MockController, additionalConfig: Map[String, String] = Map.empty, followRedirects: Boolean = true)(block: WSResponse => T) = {
       implicit val port = testServerPort
-      lazy val app: Application = GuiceApplicationBuilder().routes {
+      lazy val app: Application = GuiceApplicationBuilder().configure(additionalConfig).routes {
         case _ => JAction(app, controller)
       }.build()
 
       running(TestServer(port, app)) {
-        val response = await(wsUrl("/").get())
+        val response = await(wsUrl("/").withFollowRedirects(followRedirects).get())
         block(response)
       }
     }
@@ -68,9 +70,50 @@ trait JavaResultsHandlingSpec extends PlaySpecification with WsTestClient with S
           .withCookies(Http.Cookie.builder("framework", "Play").withSameSite(Http.Cookie.SameSite.STRICT).build())
       }
     }) { response =>
-      response.headers("Set-Cookie") must contain((s: String) => s.startsWith("bar=KitKat; SameSite=Lax"))
-      response.headers("Set-Cookie") must contain((s: String) => s.startsWith("framework=Play; SameSite=Strict"))
-      response.body must_== "Hello world"
+      val cookieHeader: Seq[String] = response.headers("Set-Cookie")
+      cookieHeader(0) must contain("bar=KitKat")
+      cookieHeader(0) must contain("SameSite=Lax")
+
+      cookieHeader(1) must contain("framework=Play")
+      cookieHeader(1) must contain("SameSite=Strict")
+    }
+
+    "honor configuration for play.http.session.sameSite" in {
+      "when configured to lax" in makeRequest(new MockController {
+        def action = {
+          import scala.collection.JavaConverters._
+
+          val responseHeader = new ResponseHeader(OK, Map.empty[String, String].asJava)
+          val body = HttpEntity.fromString("Hello World", "utf-8")
+          val session = new Session(Map.empty[String, String].asJava)
+          val flash = new Flash(Map.empty[String, String].asJava)
+          val cookies = List.empty[Cookie].asJava
+
+          val result = new Result(responseHeader, body, session, flash, cookies)
+          result.session().put("bar", "KitKat")
+          result
+        }
+      }, Map("play.http.session.sameSite" -> "lax")) { response =>
+        response.header("Set-Cookie") must beSome.which(_.contains("SameSite=Lax"))
+      }
+
+      "when configured to strict" in makeRequest(new MockController {
+        def action = {
+          import scala.collection.JavaConverters._
+
+          val responseHeader = new ResponseHeader(OK, Map.empty[String, String].asJava)
+          val body = HttpEntity.fromString("Hello World", "utf-8")
+          val session = new Session(Map.empty[String, String].asJava)
+          val flash = new Flash(Map.empty[String, String].asJava)
+          val cookies = List.empty[Cookie].asJava
+
+          val result = new Result(responseHeader, body, session, flash, cookies)
+          result.session().put("bar", "KitKat")
+          result
+        }
+      }, Map("play.http.session.sameSite" -> "strict")) { response =>
+        response.header("Set-Cookie") must beSome.which(_.contains("SameSite=Strict"))
+      }
     }
 
     "handle duplicate withCookies in Result" in {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/SessionCookieSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/SessionCookieSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.http
+
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test._
+import play.api.mvc._
+import play.api.mvc.Results._
+import play.api.libs.ws.WSClient
+import play.core.server.Server
+import play.it._
+
+class NettySessionCookieSpec extends SessionCookieSpec with NettyIntegrationSpecification
+class AkkaHttpSessionCookieSpec extends SessionCookieSpec with AkkaHttpIntegrationSpecification
+
+trait SessionCookieSpec extends PlaySpecification with ServerIntegrationSpecification with WsTestClient {
+
+  sequential
+
+  def appWithActions(additionalConfiguration: Map[String, String]) = GuiceApplicationBuilder()
+    .configure(additionalConfiguration)
+    .appRoutes(app => {
+      val Action = app.injector.instanceOf[DefaultActionBuilder]
+      ({
+        case ("GET", "/session") =>
+          Action {
+            Ok.withSession("session-key" -> "session-value")
+          }
+      })
+    }).build()
+
+  def withClientAndServer[T](additionalConfiguration: Map[String, String] = Map.empty)(block: WSClient => T) = {
+    val app = appWithActions(additionalConfiguration)
+    import app.materializer
+    Server.withApplication(app) { implicit port =>
+      withClient(block)
+    }
+  }
+
+  "the session cookie" should {
+
+    "honor configuration for play.http.session.sameSite" in {
+      "configured to lax" in withClientAndServer(Map("play.http.session.sameSite" -> "lax")) { ws =>
+        val response = await(ws.url("/session").get())
+        response.status must equalTo(OK)
+        response.header(SET_COOKIE) must beSome.which(_.contains("SameSite=Lax"))
+      }
+
+      "configured to strict" in withClientAndServer(Map("play.http.session.sameSite" -> "strict")) { ws =>
+        val response = await(ws.url("/session").get())
+        response.status must equalTo(OK)
+        response.header(SET_COOKIE) must beSome.which(_.contains("SameSite=Strict"))
+      }
+    }
+
+    "honor configuration for play.http.session.secure" in {
+      "configured to true" in Helpers.running(_.configure("play.http.session.secure" -> true)) { _ =>
+        Session.encodeAsCookie(Session()).secure must beTrue
+      }
+
+      "configured to false" in Helpers.running(_.configure("play.http.session.secure" -> false)) { _ =>
+        Session.encodeAsCookie(Session()).secure must beFalse
+      }
+    }
+
+  }
+
+}

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -1337,7 +1337,7 @@ public class Http {
         public RequestBuilder cookie(Cookie cookie) {
             play.api.mvc.Cookies newCookies = JavaHelpers$.MODULE$.mergeNewCookie(
                     req.cookies(),
-                    JavaHelpers$.MODULE$.cookieToScalaCookie(cookie)
+                    cookie.asScala()
             );
             attr(new TypedKey(RequestAttrKey.Cookies()), new AssignedCell(newCookies));
             return this;
@@ -2157,6 +2157,13 @@ public class Http {
                 }
                 return Optional.empty();
             }
+        }
+
+        public play.api.mvc.Cookie asScala() {
+            OptionalInt optMaxAge = OptionalInt.of(Optional.ofNullable(maxAge()).orElse(0));
+            Optional<String> optDomain = Optional.ofNullable(domain());
+            Optional<play.api.mvc.Cookie.SameSite> optSameSite = sameSite().map(SameSite::asScala);
+            return new play.api.mvc.Cookie(name(), value(), OptionConverters.toScala(optMaxAge), path(), OptionConverters.toScala(optDomain), secure(), httpOnly(), OptionConverters.toScala(optSameSite));
         }
     }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -411,7 +411,7 @@ trait CookieBaker[T <: AnyRef] { self: CookieDataCodec =>
    */
   def encodeAsCookie(data: T): Cookie = {
     val cookie = encode(serialize(data))
-    Cookie(COOKIE_NAME, cookie, maxAge, path, domain, secure, httpOnly)
+    Cookie(COOKIE_NAME, cookie, maxAge, path, domain, secure, httpOnly, sameSite)
   }
 
   /**

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -5,7 +5,6 @@ package play.core.j
 
 import java.net.{ InetAddress, URI, URLDecoder }
 import java.security.cert.X509Certificate
-import java.util.Optional
 import java.util.concurrent.CompletionStage
 
 import play.api.http.{ DefaultFileMimeTypesProvider, FileMimeTypes, HttpConfiguration }
@@ -28,15 +27,8 @@ import scala.concurrent.Future
  */
 trait JavaHelpers {
 
-  def cookieToScalaCookie(c: play.mvc.Http.Cookie): Cookie = {
-    import scala.compat.java8.OptionConverters
-    val optionalMaxAge = OptionConverters.toScala(Optional.ofNullable(c.maxAge))
-    val optionalSameSite = OptionConverters.toScala(c.sameSite()).map(_.asScala())
-    Cookie(c.name, c.value, optionalMaxAge.map(_.toInt), c.path, Option(c.domain), c.secure, c.httpOnly, optionalSameSite)
-  }
-
   def cookiesToScalaCookies(cookies: java.lang.Iterable[play.mvc.Http.Cookie]): Seq[Cookie] = {
-    cookies.asScala.toSeq.map(cookieToScalaCookie)
+    cookies.asScala.toSeq.map(_.asScala())
   }
 
   def cookiesToJavaCookies(cookies: Cookies) = {


### PR DESCRIPTION
## Fixes 

Fixes #7440 

## Purpose

Cookies for session and flash respecting the sameSite configuration.

This adds tests and also a small refactoring to use `asScala` idiom instead of having a helper method to convert Java cookies to Scala cookies.

## References

See #7432 and #7433.
