### PR TITLE
Use java.util.List instead of an array for Java list of filters

### DIFF
--- a/documentation/manual/working/commonGuide/filters/code/GzipEncoding.scala
+++ b/documentation/manual/working/commonGuide/filters/code/GzipEncoding.scala
@@ -45,7 +45,7 @@ class GzipEncoding extends PlaySpecification {
         implicit val mat = ActorMaterializer()(app.actorSystem)
         def Action = app.injector.instanceOf[DefaultActionBuilder]
 
-        val filter = (new CustomFilters(mat)).filters()(0)
+        val filter = (new CustomFilters(mat)).getFilters.get(0)
 
         header(CONTENT_ENCODING,
           filter(Action(Results.Ok("foo")))(gzipRequest).run()

--- a/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/gzipencoding/CustomFilters.java
+++ b/documentation/manual/working/commonGuide/filters/code/detailedtopics/configuration/gzipencoding/CustomFilters.java
@@ -12,11 +12,14 @@ import play.mvc.Http;
 import play.mvc.Result;
 
 import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.BiFunction;
 
 public class CustomFilters implements HttpFilters {
 
-    private EssentialFilter[] filters;
+    private List<EssentialFilter> filters;
 
     @Inject
     public CustomFilters(Materializer materializer) {
@@ -28,10 +31,11 @@ public class CustomFilters implements HttpFilters {
           ), materializer
         );
         //#gzip-filter
-        filters = new EssentialFilter[] { gzipFilter.asJava() };
+        filters = Collections.singletonList(gzipFilter.asJava());
     }
 
-    public EssentialFilter[] filters() {
+    @Override
+    public List<EssentialFilter> getFilters() {
         return filters;
     }
 }

--- a/documentation/manual/working/commonGuide/filters/code/javaguide/detailed/filters/Filters.java
+++ b/documentation/manual/working/commonGuide/filters/code/javaguide/detailed/filters/Filters.java
@@ -10,6 +10,7 @@ import play.http.DefaultHttpFilters;
 import play.mvc.EssentialFilter;
 
 import javax.inject.Inject;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -17,15 +18,13 @@ public class Filters extends DefaultHttpFilters {
 
     @Inject
     public Filters(EnabledFilters enabledFilters, CORSFilter corsFilter) {
-        super(combine(enabledFilters.asJava().filters(), corsFilter.asJava()));
+        super(combine(enabledFilters.asJava().getFilters(), corsFilter.asJava()));
     }
 
-    private static EssentialFilter[] combine(EssentialFilter[] filters, EssentialFilter toAppend) {
-        List<EssentialFilter> combinedFilters = Arrays.asList(filters);
+    private static List<EssentialFilter> combine(List<EssentialFilter> filters, EssentialFilter toAppend) {
+        List<EssentialFilter> combinedFilters = new ArrayList<>(filters);
         combinedFilters.add(toAppend);
-
-        EssentialFilter[] activeFilters = new EssentialFilter[combinedFilters.size()];
-        return combinedFilters.toArray(activeFilters);
+        return combinedFilters;
     }
 }
 // #filters-combine-enabled-filters

--- a/documentation/manual/working/commonGuide/filters/code/javaguide/detailed/filters/add/MyAppComponents.java
+++ b/documentation/manual/working/commonGuide/filters/code/javaguide/detailed/filters/add/MyAppComponents.java
@@ -12,7 +12,7 @@ import play.filters.components.HttpFiltersComponents;
 import play.mvc.EssentialFilter;
 import play.routing.Router;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 
 public class MyAppComponents extends BuiltInComponentsFromContext implements HttpFiltersComponents {
@@ -22,12 +22,10 @@ public class MyAppComponents extends BuiltInComponentsFromContext implements Htt
     }
 
     @Override
-    public EssentialFilter[] httpFilters() {
-        List<EssentialFilter> combinedFilters = Arrays.asList(HttpFiltersComponents.super.httpFilters());
+    public List<EssentialFilter> httpFilters() {
+        List<EssentialFilter> combinedFilters = new ArrayList<>(HttpFiltersComponents.super.httpFilters());
         combinedFilters.add(new LoggingFilter(materializer()));
-
-        EssentialFilter[] activeFilters = new EssentialFilter[combinedFilters.size()];
-        return combinedFilters.toArray(activeFilters);
+        return combinedFilters;
     }
 
     @Override

--- a/documentation/manual/working/commonGuide/filters/code/javaguide/detailed/filters/remove/MyAppComponents.java
+++ b/documentation/manual/working/commonGuide/filters/code/javaguide/detailed/filters/remove/MyAppComponents.java
@@ -10,7 +10,6 @@ import play.filters.csrf.CSRFFilter;
 import play.mvc.EssentialFilter;
 import play.routing.Router;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -22,14 +21,11 @@ public class MyAppComponents extends BuiltInComponentsFromContext implements Htt
     }
 
     @Override
-    public EssentialFilter[] httpFilters() {
-        List<EssentialFilter> filters = Arrays
-                .stream(HttpFiltersComponents.super.httpFilters())
+    public List<EssentialFilter> httpFilters() {
+        return HttpFiltersComponents.super.httpFilters()
+                .stream()
                 .filter(filter -> !filter.getClass().equals(CSRFFilter.class))
                 .collect(Collectors.toList());
-
-        EssentialFilter[] activeFilters = new EssentialFilter[filters.size()];
-        return filters.toArray(activeFilters);
     }
 
     @Override

--- a/documentation/manual/working/javaGuide/main/application/code/javaguide/application/httpfilters/Filters.java
+++ b/documentation/manual/working/javaGuide/main/application/code/javaguide/application/httpfilters/Filters.java
@@ -4,7 +4,6 @@
 package javaguide.application.httpfilters;
 
 // #filters
-import play.mvc.EssentialFilter;
 import play.http.DefaultHttpFilters;
 import play.filters.gzip.GzipFilter;
 import javax.inject.Inject;

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/components/HttpFiltersComponents.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/components/HttpFiltersComponents.java
@@ -6,6 +6,9 @@ package play.filters.components;
 import play.components.HttpComponents;
 import play.mvc.EssentialFilter;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * A compile time default filters components.
  *
@@ -36,11 +39,11 @@ public interface HttpFiltersComponents extends
         HttpComponents {
 
     @Override
-    default EssentialFilter[] httpFilters() {
-        return new EssentialFilter[] {
+    default List<EssentialFilter> httpFilters() {
+        return Arrays.asList(
             csrfFilter().asJava(),
             securityHeadersFilter().asJava(),
             allowedHostsFilter().asJava()
-        };
+        );
     }
 }

--- a/framework/src/play-filters-helpers/src/main/java/play/filters/components/NoHttpFiltersComponents.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/components/NoHttpFiltersComponents.java
@@ -6,6 +6,9 @@ package play.filters.components;
 import play.components.HttpComponents;
 import play.mvc.EssentialFilter;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Java component to mix in when no default filters should be mixed in to {@link play.BuiltInComponents}.
  *
@@ -28,7 +31,7 @@ import play.mvc.EssentialFilter;
 public interface NoHttpFiltersComponents extends HttpComponents {
 
     @Override
-    default EssentialFilter[] httpFilters() {
-        return new EssentialFilter[]{};
+    default List<EssentialFilter> httpFilters() {
+        return Collections.emptyList();
     }
 }

--- a/framework/src/play-integration-test/src/test/java/play/BuiltInComponentsFromContextTest.java
+++ b/framework/src/play-integration-test/src/test/java/play/BuiltInComponentsFromContextTest.java
@@ -60,8 +60,7 @@ public class BuiltInComponentsFromContextTest {
 
     @Test
     public void shouldProvideDefaultFilters() {
-        List<EssentialFilter> filters = Arrays.asList(this.componentsFromContext.httpFilters());
-        assertThat(filters.isEmpty(), is(false));
+        assertThat(this.componentsFromContext.httpFilters().isEmpty(), is(false));
     }
 
     @Test

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -15,6 +15,8 @@ import play.mvc.{ EssentialFilter, Result, Results }
 import play.mvc.Http.Cookie
 import play.routing.{ Router => JRouter }
 
+import scala.collection.JavaConverters._
+
 class GuiceJavaActionCompositionSpec extends JavaActionCompositionSpec {
   override def makeRequest[T](controller: MockController, configuration: Map[String, AnyRef] = Map.empty)(block: WSResponse => T): T = {
     implicit val port = testServerPort
@@ -60,7 +62,7 @@ class BuiltInComponentsJavaActionCompositionSpec extends JavaActionCompositionSp
         }.asJava
       }
 
-      override def httpFilters(): Array[EssentialFilter] = Array.empty
+      override def httpFilters(): java.util.List[EssentialFilter] = java.util.Collections.emptyList()
 
       override def actionCreator(): ActionCreator = {
         configuration.get[Option[String]]("play.http.actionCreator")

--- a/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
+++ b/framework/src/play-java-forms/src/test/scala/play/data/FormSpec.scala
@@ -47,7 +47,7 @@ class CompileTimeDependencyInjectionFormSpec extends FormSpec {
       with FormFactoryComponents {
     override def router(): Router = Router.empty()
 
-    override def httpFilters(): Array[EssentialFilter] = Array.empty
+    override def httpFilters(): java.util.List[EssentialFilter] = java.util.Collections.emptyList()
 
     override def config(): Config = {
       val javaExtraConfig = extraConfig.mapValues {

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -239,7 +239,7 @@ private[play] object JavaServerHelper {
     val context = JApplicationLoader.create(Environment.simple(mode = mode).asJava)
     val application = new JBuiltInComponentsFromContext(context) {
       override def router: JRouter = block.apply(this)
-      override def httpFilters(): Array[play.mvc.EssentialFilter] = Array.empty[play.mvc.EssentialFilter]
+      override def httpFilters(): java.util.List[play.mvc.EssentialFilter] = java.util.Collections.emptyList()
     }.application.asScala()
     Play.start(application)
     val serverConfig = ServerConfig(mode = mode, port = httpPort.map(_.intValue), sslPort = sslPort.map(_.intValue))

--- a/framework/src/play/src/main/java/play/components/HttpComponents.java
+++ b/framework/src/play/src/main/java/play/components/HttpComponents.java
@@ -8,6 +8,8 @@ import play.http.ActionCreator;
 import play.http.HttpRequestHandler;
 import play.mvc.EssentialFilter;
 
+import java.util.List;
+
 public interface HttpComponents extends HttpConfigurationComponents {
 
     ActionCreator actionCreator();
@@ -19,17 +21,16 @@ public interface HttpComponents extends HttpConfigurationComponents {
      * In most cases you will want to mixin HttpFiltersComponents and append your own filters:
      *
      * <pre>
-     * public class MyComponents extends BuiltInComponentsFromContext implements play.filters.components.HttpFiltersComponents {
+     * public class MyComponents extends BuiltInComponentsFromContext implements HttpFiltersComponents {
      *
      *   public MyComponents(ApplicationLoader.Context context) {
      *       super(context);
      *   }
      *
-     *   public EssentialFilter[] httpFilters() {
-     *       LoggingFilter loggingFilter = new LoggingFilter();
-     *       List&lt;EssentialFilter&gt; filters = Arrays.asList(httpFilters());
+     *   public List&lt;EssentialFilter&gt; httpFilters() {
+     *       List&lt;EssentialFilter&gt; filters = HttpFiltersComponents.super.httpFilters();
      *       filters.add(loggingFilter);
-     *       return filters.toArray();
+     *       return filters;
      *   }
      *
      *   // other required methods
@@ -39,18 +40,17 @@ public interface HttpComponents extends HttpConfigurationComponents {
      * If you want to filter elements out of the list, you can do the following:
      *
      * <pre>
-     * class MyComponents extends BuiltInComponentsFromContext implements play.filters.HttpFiltersComponents {
+     * class MyComponents extends BuiltInComponentsFromContext implements HttpFiltersComponents {
      *
      *   public MyComponents(ApplicationLoader.Context context) {
      *       super(context);
      *   }
      *
-     *   public EssentialFilter[] httpFilters() {
-     *     return Arrays
-     *          .stream(httpFilters())
+     *   public List&lt;EssentialFilter&gt; httpFilters() {
+     *     return httpFilters().stream()
      *          // accept only filters that are not CSRFFilter
      *          .filter(f -&gt; !f.getClass().equals(CSRFFilter.class))
-     *          .toArray();
+     *          .collect(Collectors.toList());
      *   }
      *
      *   // other required methods
@@ -60,7 +60,7 @@ public interface HttpComponents extends HttpConfigurationComponents {
      * @return an array with the http filters.
      * @see EssentialFilter
      */
-    EssentialFilter[] httpFilters();
+    List<EssentialFilter> httpFilters();
 
     JavaHandlerComponents javaHandlerComponents();
 

--- a/framework/src/play/src/main/java/play/http/DefaultHttpFilters.java
+++ b/framework/src/play/src/main/java/play/http/DefaultHttpFilters.java
@@ -4,6 +4,8 @@
 package play.http;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import play.mvc.EssentialFilter;
 
@@ -12,14 +14,18 @@ import play.mvc.EssentialFilter;
  */
 public class DefaultHttpFilters implements HttpFilters {
 
-  private final EssentialFilter[] filters;
+  private final List<EssentialFilter> filters;
 
   public DefaultHttpFilters(play.api.mvc.EssentialFilter... filters) {
-    this.filters = Arrays.stream(filters).map(f -> f.asJava()).toArray(EssentialFilter[]::new);
+    this(Arrays.asList(filters));
+  }
+
+  public DefaultHttpFilters(List<? extends play.api.mvc.EssentialFilter> filters) {
+    this.filters = filters.stream().map(f -> f.asJava()).collect(Collectors.toList());
   }
 
   @Override
-  public EssentialFilter[] filters() {
+  public List<EssentialFilter> getFilters() {
     return filters;
   }
 }

--- a/framework/src/play/src/main/java/play/http/HttpFilters.java
+++ b/framework/src/play/src/main/java/play/http/HttpFilters.java
@@ -6,6 +6,8 @@ package play.http;
 import play.api.http.JavaHttpFiltersAdapter;
 import play.mvc.EssentialFilter;
 
+import java.util.List;
+
 /**
  * Provides filters to the HttpRequestHandler.
  */
@@ -13,8 +15,18 @@ public interface HttpFilters {
 
     /**
      * @return the filters that should filter every request
+     *
+     * @deprecated as of 2.6.0. Use {@link #getFilters()} instead.
      */
-    EssentialFilter[] filters();
+    default EssentialFilter[] filters() {
+        EssentialFilter[] filters = new EssentialFilter[getFilters().size()];
+        return getFilters().toArray(filters);
+    }
+
+    /**
+     * @return the list of filters that should filter every request.
+     */
+    List<EssentialFilter> getFilters();
 
     /**
      * @return a Scala HttpFilters object

--- a/framework/src/play/src/main/scala/play/api/http/HttpFilters.scala
+++ b/framework/src/play/src/main/scala/play/api/http/HttpFilters.scala
@@ -12,6 +12,8 @@ import play.api.{ Configuration, Environment, Logger }
 import play.api.mvc.EssentialFilter
 import play.utils.Reflect
 
+import scala.collection.JavaConverters._
+
 /**
  * Provides filters to the [[play.api.http.HttpRequestHandler]].
  */
@@ -128,7 +130,7 @@ object NoHttpFilters extends NoHttpFilters
  * Adapter from the Java HttpFilters to the Scala HttpFilters interface.
  */
 class JavaHttpFiltersAdapter @Inject() (underlying: play.http.HttpFilters)
-  extends DefaultHttpFilters(underlying.filters: _*)
+  extends DefaultHttpFilters(underlying.getFilters.asScala: _*)
 
 class JavaHttpFiltersDelegate @Inject() (delegate: HttpFilters)
-  extends play.http.DefaultHttpFilters(delegate.filters: _*)
+  extends play.http.DefaultHttpFilters(delegate.filters.asJava)


### PR DESCRIPTION
## Purpose

In Java, lists are easier to manipulate (append, filter, etc) than arrays.