### PR TITLE
[doc] Remove controller references

### DIFF
--- a/documentation/manual/hacking/Documentation.md
+++ b/documentation/manual/hacking/Documentation.md
@@ -60,9 +60,11 @@ For example:
 //###replace: package controllers
 package foo.bar.controllers
 
+import javax.inject.Inject
 import play.api.mvc._
 
-class HomeController extends Controller {
+class HomeController @Inject()(cc:ControllerComponents)
+ extends AbstractController(cc) {
   ...
 }
 //#controller

--- a/documentation/manual/releases/release26/migration26/MessagesMigration26.md
+++ b/documentation/manual/releases/release26/migration26/MessagesMigration26.md
@@ -276,10 +276,9 @@ For functional tests that involve configuration, the best option is to use `With
 ```scala
 
 import play.api.test.{ PlaySpecification, WithApplication }
-import play.api.mvc.Controller
 import play.api.i18n._
 
-class MessagesSpec extends PlaySpecification with Controller {
+class MessagesSpec extends PlaySpecification {
 
   sequential
 

--- a/documentation/manual/working/scalaGuide/advanced/routing/code/ApiRouter.scala
+++ b/documentation/manual/working/scalaGuide/advanced/routing/code/ApiRouter.scala
@@ -20,6 +20,6 @@ class ApiRouter @Inject()(controller: ApiController)
 }
 //#inject-sird-router
 
-class ApiController extends Controller {
+class ApiController @Inject()(cc:ControllerComponents) extends AbstractController(cc) {
   def index() = TODO
 }

--- a/documentation/manual/working/scalaGuide/main/akka/code/ScalaAkka.scala
+++ b/documentation/manual/working/scalaGuide/main/akka/code/ScalaAkka.scala
@@ -99,7 +99,9 @@ import javax.inject._
 import actors.HelloActor
 
 @Singleton
-class Application @Inject() (system: ActorSystem) extends Controller {
+class Application @Inject() (system: ActorSystem,
+                             cc:ControllerComponents)
+  extends AbstractController(cc) {
 
   val helloActor = system.actorOf(HelloActor.props, "hello-actor")
 

--- a/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
+++ b/documentation/manual/working/scalaGuide/main/async/code/ScalaWebSockets.scala
@@ -163,7 +163,7 @@ object Samples {
     import akka.actor.ActorSystem
     import akka.stream.Materializer
 
-    class Application @Inject() (implicit system: ActorSystem, mat: Materializer) extends Controller {
+    class Application @Inject()(cc:ControllerComponents) (implicit system: ActorSystem, mat: Materializer) extends AbstractController(cc) {
 
       def socket = WebSocket.accept[String, String] { request =>
         ActorFlow.actorRef { out =>
@@ -203,7 +203,7 @@ object Samples {
     import akka.actor.ActorSystem
     import akka.stream.Materializer
 
-    class Application @Inject() (implicit system: ActorSystem, mat: Materializer) extends Controller {
+    class Application @Inject() (cc:ControllerComponents)(implicit system: ActorSystem, mat: Materializer) extends AbstractController(cc) {
 
       def socket = WebSocket.acceptOrResult[String, String] { request =>
         Future.successful(request.session.get("user") match {
@@ -240,7 +240,9 @@ object Samples {
     import akka.actor.ActorSystem
     import akka.stream.Materializer
 
-    class Application @Inject() (implicit system: ActorSystem, mat: Materializer) extends Controller {
+    class Application @Inject()(cc:ControllerComponents)
+                               (implicit system: ActorSystem, mat: Materializer)
+      extends AbstractController(cc) {
 
       def socket = WebSocket.accept[JsValue, JsValue] { request =>
         ActorFlow.actorRef { out =>
@@ -290,7 +292,9 @@ object Samples {
     import akka.actor.ActorSystem
     import akka.stream.Materializer
 
-    class Application @Inject() (implicit system: ActorSystem, mat: Materializer) extends Controller {
+    class Application @Inject()(cc:ControllerComponents)
+                               (implicit system: ActorSystem, mat: Materializer)
+      extends AbstractController(cc) {
 
       def socket = WebSocket.accept[InEvent, OutEvent] { request =>
         ActorFlow.actorRef { out =>

--- a/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
+++ b/documentation/manual/working/scalaGuide/main/cache/code/ScalaCache.scala
@@ -18,7 +18,7 @@ import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
 
 @RunWith(classOf[JUnitRunner])
-class ScalaCacheSpec extends PlaySpecification with Controller {
+class ScalaCacheSpec extends AbstractController(Helpers.stubControllerComponents()) with PlaySpecification {
 
   import play.api.cache.AsyncCacheApi
   import play.api.cache.Cached
@@ -164,7 +164,7 @@ import play.api.cache._
 import play.api.mvc._
 import javax.inject.Inject
 
-class Application @Inject() (cache: AsyncCacheApi) extends Controller {
+class Application @Inject() (cache: AsyncCacheApi, cc:ControllerComponents) extends AbstractController(cc) {
 
 }
 //#inject
@@ -177,8 +177,9 @@ import play.api.mvc._
 import javax.inject.Inject
 
 class Application @Inject()(
-    @NamedCache("session-cache") sessionCache: AsyncCacheApi
-) extends Controller {
+    @NamedCache("session-cache") sessionCache: AsyncCacheApi,
+    cc: ControllerComponents
+) extends AbstractController(cc) {
 
 }
 //#qualified
@@ -189,12 +190,12 @@ package cachedaction {
 import play.api.cache.Cached
 import javax.inject.Inject
 
-class Application @Inject() (cached: Cached) extends Controller {
+class Application @Inject() (cached: Cached, cc:ControllerComponents) extends AbstractController(cc) {
 
 }
 //#cached-action-app
 
-class Application1 @Inject() (cached: Cached)(implicit ec: ExecutionContext) extends Controller {
+class Application1 @Inject() (cached: Cached, cc:ControllerComponents)(implicit ec: ExecutionContext) extends AbstractController(cc) {
   //#cached-action
   def index = cached("homePage") {
     Action {
@@ -228,7 +229,7 @@ class Application1 @Inject() (cached: Cached)(implicit ec: ExecutionContext) ext
   }
   //#cached-action-control
 }
-class Application2 @Inject() (cached: Cached) extends Controller {
+class Application2 @Inject() (cached: Cached, cc:ControllerComponents) extends AbstractController(cc) {
   //#cached-action-control-404
   def get(index: Int) = {
     val caching = cached

--- a/documentation/manual/working/scalaGuide/main/config/code/ScalaConfig.scala
+++ b/documentation/manual/working/scalaGuide/main/config/code/ScalaConfig.scala
@@ -10,11 +10,13 @@ import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import play.api.{ConfigLoader, Configuration}
 import play.api.mvc._
-import play.api.test.PlaySpecification
+import play.api.test.{Helpers, PlaySpecification}
 import java.net.URI
 
+import org.specs2.mutable.SpecificationLike
+
 @RunWith(classOf[JUnitRunner])
-class ScalaConfigSpec extends PlaySpecification with Controller {
+class ScalaConfigSpec extends AbstractController(Helpers.stubControllerComponents()) with PlaySpecification {
 
   val config: Configuration = Configuration.from(Map(
     "foo" -> "bar",

--- a/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
+++ b/documentation/manual/working/scalaGuide/main/dependencyinjection/code/CompileTimeDependencyInjection.scala
@@ -126,7 +126,7 @@ class MyComponents(context: Context)
     with HttpFiltersComponents
     with controllers.AssetsComponents {
   lazy val barRoutes = new bar.Routes(httpErrorHandler)
-  lazy val applicationController = new controllers.Application()
+  lazy val applicationController = new controllers.Application(controllerComponents)
 
   lazy val router = new Routes(httpErrorHandler, applicationController, barRoutes, assets)
 }
@@ -136,10 +136,12 @@ class MyComponents(context: Context)
 
 package controllers {
 
+  import javax.inject.Inject
+
   import play.api.http.HttpErrorHandler
   import play.api.mvc._
 
-  class Application extends Controller {
+  class Application @Inject() (cc:ControllerComponents) extends AbstractController(cc) {
     def index = Action(Ok)
     def foo = Action(Ok)
   }

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaActions.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaActions.scala
@@ -7,12 +7,13 @@ import akka.util.ByteString
 import play.api.mvc._
 import play.api.test._
 import play.api.test.Helpers._
-import org.specs2.mutable.Specification
+import org.specs2.mutable.{Specification, SpecificationLike}
 import play.api.libs.json._
+
 import scala.concurrent.Future
 import org.specs2.execute.AsResult
 
-class ScalaActionsSpec extends Specification with Controller {
+class ScalaActionsSpec extends AbstractController(Helpers.stubControllerComponents()) with SpecificationLike {
 
   "A scala action" should {
     "allow writing a simple echo action" in {
@@ -66,7 +67,7 @@ class ScalaActionsSpec extends Specification with Controller {
     }
 
     "work for a full controller class" in {
-      testAction(new full.Application().index)
+      testAction(new full.Application(Helpers.stubControllerComponents()).index)
     }
 
     "support an action with parameters" in {
@@ -177,9 +178,13 @@ package scalaguide.http.scalaactions.full {
 //#full-controller
 //###insert: package controllers
 
+import javax.inject.Inject
+
 import play.api.mvc._
 
-class Application extends Controller {
+class Application @Inject()
+(cc: ControllerComponents)
+extends AbstractController(cc) {
 
   def index = Action {
     Ok("It works!")

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaContentNegotiation.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaContentNegotiation.scala
@@ -6,16 +6,16 @@ package scalaguide.http.scalacontentnegotiation {
   import play.api.mvc._
   import play.api.test._
   import play.api.test.Helpers._
-  import org.specs2.mutable.Specification
   import play.api.libs.json._
-
   import org.junit.runner.RunWith
+  import org.specs2.mutable.SpecificationLike
   import org.specs2.runner.JUnitRunner
+
   import scala.concurrent.Future
   import org.specs2.execute.AsResult
 
   @RunWith(classOf[JUnitRunner])
-  class ScalaContentNegotiation extends Specification with Controller {
+  class ScalaContentNegotiation extends AbstractController(Helpers.stubControllerComponents()) with SpecificationLike {
 
     "A Scala Content Negotiation" should {
       "negotiate accept type" in {

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaResults.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaResults.scala
@@ -12,7 +12,7 @@ package scalaguide.http.scalaresults {
   import org.specs2.execute.AsResult
 
   @RunWith(classOf[JUnitRunner])
-  class ScalaResultsSpec extends PlaySpecification with Controller {
+  class ScalaResultsSpec extends AbstractController(Helpers.stubControllerComponents()) with PlaySpecification {
 
     "A scala result" should {
       "default result Content-Type" in {
@@ -72,7 +72,7 @@ package scalaguide.http.scalaresults {
       }
 
       "Changing the charset for text based HTTP responses" in {
-        val index = new scalaguide.http.scalaresults.full.Application().index
+        val index = new scalaguide.http.scalaresults.full.Application(Helpers.stubControllerComponents()).index
         assertAction(index)(res => testContentType(await(res), "charset=iso-8859-1"))
       }
 
@@ -105,8 +105,11 @@ package scalaguide.http.scalaresults {
   }
 
   package scalaguide.http.scalaresults.full {
+
+    import javax.inject.Inject
+
     //#full-application-set-myCustomCharset
-    class Application extends Controller {
+    class Application @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
 
       implicit val myCustomCharset = Codec.javaSupported("iso-8859-1")
 

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaRouting.scala
@@ -13,11 +13,13 @@ import play.api.routing.Router
 
 package controllers {
 
+  import javax.inject.Inject
+
   object Client {
     def findById(id: Long) = Some("showing client " + id)
   }
 
-  class Clients extends Controller {
+  class Clients @Inject()(cc:ControllerComponents) extends AbstractController(cc) {
 
     // #show-client-action
     def show(id: Long) = Action {
@@ -30,7 +32,7 @@ package controllers {
     def list() = Action(Ok("all clients"))
   }
 
-  class Application extends Controller {
+  class Application @Inject()(cc:ControllerComponents) extends AbstractController(cc)  {
     def download(name: String) = Action(Ok("download " + name))
     def homePage() = Action(Ok("home page"))
 
@@ -45,11 +47,11 @@ package controllers {
     // #show-page-action
   }
 
-  class Items extends Controller {
+  class Items @Inject()(cc:ControllerComponents) extends AbstractController(cc)  {
     def show(id: Long) = Action(Ok("showing item " + id))
   }
 
-  class Api extends Controller {
+  class Api @Inject()(cc:ControllerComponents) extends AbstractController(cc)  {
     def list(version: Option[String]) = Action(Ok("version " + version))
     def newThing = Action(parse.json) { request => Ok(request.body) }
   }
@@ -68,7 +70,10 @@ package fixed {
 }
 
 package defaultvalue.controllers {
-  class Clients extends Controller {
+
+  import javax.inject.Inject
+
+  class Clients @Inject()(cc:ControllerComponents) extends AbstractController(cc)  {
     def list(page: Int) = Action(Ok("clients page " + page))
   }
 }
@@ -81,10 +86,12 @@ package defaultcontroller.controllers {
 // ###replace: package controllers
 package reverse.controllers {
 
+import javax.inject.Inject
+
 import play.api._
 import play.api.mvc._
 
-class Application extends Controller {
+class Application @Inject()(cc:ControllerComponents) extends AbstractController(cc)  {
 
   def hello(name: String) = Action {
     Ok("Hello " + name + "!")

--- a/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
+++ b/documentation/manual/working/scalaGuide/main/http/code/ScalaSessionFlash.scala
@@ -8,12 +8,14 @@ package scalaguide.http.scalasessionflash {
   import play.api.test.Helpers._
   import org.specs2.mutable.Specification
   import org.junit.runner.RunWith
+  import org.specs2.mutable.SpecificationLike
   import org.specs2.runner.JUnitRunner
+
   import scala.concurrent.Future
   import org.specs2.execute.AsResult
 
   @RunWith(classOf[JUnitRunner])
-  class ScalaSessionFlashSpec extends Specification with Controller {
+  class ScalaSessionFlashSpec extends AbstractController(Helpers.stubControllerComponents()) with SpecificationLike {
     "A scala SessionFlash" should {
 
       "Reading a Session value" in {

--- a/documentation/manual/working/scalaGuide/main/i18n/code/ScalaI18N.scala
+++ b/documentation/manual/working/scalaGuide/main/i18n/code/ScalaI18N.scala
@@ -61,7 +61,7 @@ package scalaguide.i18n.scalai18n {
   //#i18n-support
 
   @RunWith(classOf[JUnitRunner])
-  class ScalaI18nSpec extends PlaySpecification with Controller {
+  class ScalaI18nSpec extends AbstractController(Helpers.stubControllerComponents()) with PlaySpecification {
     val conf = Configuration.reference ++ Configuration.from(Map("play.i18n.path" -> "scalaguide/i18n"))
 
     "A controller" should {

--- a/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonHttpSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/json/code/ScalaJsonHttpSpec.scala
@@ -3,12 +3,12 @@
  */
 package scalaguide.json
 
-import scala.concurrent.Future
+import javax.inject.Inject
 
+import scala.concurrent.Future
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-
 import play.api.mvc._
 import play.api.test._
 
@@ -237,7 +237,7 @@ import play.api.mvc._
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
-class HomeController extends Controller {
+class HomeController @Inject()(cc:ControllerComponents) extends AbstractController(cc)  {
 
 }
 //#controller

--- a/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
+++ b/documentation/manual/working/scalaGuide/main/logging/code/ScalaLoggingSpec.scala
@@ -108,7 +108,7 @@ class ScalaLoggingSpec extends Specification with Mockito {
         }
       }
 
-      class Application @Inject() (val accessLoggingAction: AccessLoggingAction) extends Controller {
+      class Application @Inject() (val accessLoggingAction: AccessLoggingAction, cc: ControllerComponents) extends AbstractController(cc) {
 
         val logger = Logger(this.getClass())
 
@@ -133,7 +133,7 @@ class ScalaLoggingSpec extends Specification with Mockito {
       implicit val system = ActorSystem()
       implicit val mat = ActorMaterializer()
       implicit val ec: ExecutionContext = system.dispatcher
-      val controller = new Application(new AccessLoggingAction(new BodyParsers.Default()))
+      val controller = new Application(new AccessLoggingAction(new BodyParsers.Default()), Helpers.stubControllerComponents())
 
       controller.accessLoggingAction.accessLogger.underlyingLogger.getName must equalTo("access")
       controller.logger.underlyingLogger.getName must contain("Application")

--- a/documentation/manual/working/scalaGuide/main/tests/code/controllers/HomeController.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/controllers/HomeController.scala
@@ -5,9 +5,11 @@ package scalaguide.tests
 
 package controllers
 
+import javax.inject.Inject
+
 import play.api.mvc._
 
-class HomeController extends Controller {
+class HomeController @Inject()(cc:ControllerComponents) extends AbstractController(cc) {
   def index() = Action {
     Ok("Hello Bob") as("text/plain")
   }

--- a/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/controllers/Application.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/tests/guice/controllers/Application.scala
@@ -8,7 +8,7 @@ package controllers
 import play.api.mvc._
 import javax.inject.Inject
 
-class Application @Inject() (component: Component) extends Controller {
+class Application @Inject() (component: Component, cc:ControllerComponents) extends AbstractController(cc) {
   def index() = Action {
     Ok(component.hello)
   }

--- a/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
+++ b/documentation/manual/working/scalaGuide/main/upload/code/ScalaFileUpload.scala
@@ -26,7 +26,7 @@ package scalaguide.upload.fileupload {
   import play.core.parsers.Multipart.FileInfo
 
   @RunWith(classOf[JUnitRunner])
-  class ScalaFileUploadSpec extends PlaySpecification with Controller {
+  class ScalaFileUploadSpec extends AbstractController(Helpers.stubControllerComponents()) with PlaySpecification {
     import scala.concurrent.ExecutionContext.Implicits.global
 
     "A scala file upload" should {

--- a/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/ServerIntegrationSpecification.scala
@@ -4,7 +4,7 @@
 package play.it
 
 import org.specs2.execute._
-import org.specs2.mutable.Specification
+import org.specs2.mutable.{ Specification, SpecificationLike }
 import org.specs2.specification.AroundEach
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -92,7 +92,7 @@ trait ServerIntegrationSpecification extends PendingUntilFixed with AroundEach {
 }
 
 trait NettyIntegrationSpecification extends ServerIntegrationSpecification {
-  self: Specification =>
+  self: SpecificationLike =>
   // Provide a flag to disable Netty tests
   private val runTests: Boolean = (System.getProperty("run.netty.http.tests", "true") == "true")
   skipAllIf(!runTests)
@@ -101,7 +101,7 @@ trait NettyIntegrationSpecification extends ServerIntegrationSpecification {
 }
 
 trait AkkaHttpIntegrationSpecification extends ServerIntegrationSpecification {
-  self: Specification =>
+  self: SpecificationLike =>
 
   override def integrationServerProvider: ServerProvider = AkkaHttpServer.provider
 }

--- a/framework/src/play-specs2/src/main/scala/play/api/test/PlaySpecification.scala
+++ b/framework/src/play-specs2/src/main/scala/play/api/test/PlaySpecification.scala
@@ -3,8 +3,8 @@
  */
 package play.api.test
 
-import org.specs2.mutable.Specification
-import play.api.http.{ HttpProtocol, HttpVerbs, Status, HeaderNames }
+import org.specs2.mutable.{ Specification, SpecificationLike }
+import play.api.http.{ HeaderNames, HttpProtocol, HttpVerbs, Status }
 
 /**
  * Play specs2 specification.
@@ -12,7 +12,7 @@ import play.api.http.{ HttpProtocol, HttpVerbs, Status, HeaderNames }
  * This trait excludes some of the mixins provided in the default specs2 specification that clash with Play helpers
  * methods.  It also mixes in the Play test helpers and types for convenience.
  */
-trait PlaySpecification extends Specification
+trait PlaySpecification extends SpecificationLike
     with PlayRunners
     with HeaderNames
     with Status

--- a/framework/src/play/src/main/scala/play/api/i18n/I18nSupport.scala
+++ b/framework/src/play/src/main/scala/play/api/i18n/I18nSupport.scala
@@ -12,7 +12,7 @@ import play.api.mvc._
  * {{{
  *   import play.api.i18n.Messages
  *   class MyController(val messagesApi: MessagesApi ...)
- *     extends Controller(cc) with I18nSupport {
+ *     extends AbstractController(cc) with I18nSupport {
  *     val action = Action { implicit request =>
  *       val messageFromRequest = request.messages("hello.world")
  *       Ok(s"\$messageFromRequest")

--- a/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Controller.scala
@@ -19,7 +19,7 @@ import scala.concurrent.ExecutionContext
  * useful constants.
  *
  * {{{
- *   class Controller @Inject() (action: DefaultActionBuilder, parse: PlayBodyParsers) extends ControllerHelpers {
+ *   class MyController @Inject() (action: DefaultActionBuilder, parse: PlayBodyParsers) extends ControllerHelpers {
  *     def index = action(parse.text) {
  *       Ok
  *     }


### PR DESCRIPTION
Removes the deprecated controller references from specs and from example documentation

Fixes https://github.com/playframework/playframework/issues/7390