### PR TITLE
Consistent configuration for idleTimeout in Akka HTTP server backend

### DIFF
--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -80,8 +80,8 @@ Play 2.5.x does not have a request timeout configuration for [[Netty Server|Nett
 And you can see the default values for `akka.http.server.idle-timeout`, `akka.http.server.request-timeout` and `akka.http.server.bind-timeout` [here](http://doc.akka.io/docs/akka-http/current/scala/http/configuration.html). Play has [[its own configurations to define timeouts|SettingsAkkaHttp]], so if you start to see a number of `503 Service Unavailable`, you can change the configurations to values that are move reasonable to your application, for example:
 
 ```
-play.server.akka.http.idleTimeout = 60s
-play.server.akka.requestTimeout = 40s
+play.server.http.idleTimeout = 60s
+play.server.requestTimeout = 40s
 ```
 
 ## Scala `Mode` changes

--- a/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsAkkaHttp.md
@@ -6,7 +6,20 @@ Like the rest of Play, the Akka HTTP server backend is configured with Typesafe 
 
 @[](/confs/play-akka-http-server/reference.conf)
 
+The configurations above are specific to Akka HTTP server backend, but other more generic configurations are also available:
+ 
+@[](/confs/play-server/reference.conf)
+
 You can read more about the configuration settings in the [Akka HTTP documentation](http://doc.akka.io/docs/akka-http/current/scala/http/configuration.html).
+
+> **Note:** Akka HTTP has a number of [timeouts configurations](http://doc.akka.io/docs/akka-http/10.0.7/scala/http/common/timeouts.html#server-timeouts) that you can use to protect your application from attacks or programming mistakes. The Akka HTTP Server in Play will automatically recognize all these Akka configurations. For example, if you have `idle-timeout` and `request-timeout` configurations like below:
+>
+> ```
+> akka.http.server.idle-timeout = 20s
+> akka.http.server.request-timeout = 30s
+> ```
+>
+> They will be automatically recognized. Keep in mind that Play configurations listed above will override the Akka ones.
 
 There is also a separate configuration file for the HTTP/2 support in Akka HTTP, if you have enabled the `AkkaHttp2Support` plugin:
 

--- a/documentation/manual/working/commonGuide/configuration/SettingsNetty.md
+++ b/documentation/manual/working/commonGuide/configuration/SettingsNetty.md
@@ -3,7 +3,7 @@
 
 The Netty server backend is built on top of [Netty](http://netty.io/).
 
-> **NOTE**: The Netty server backend is not the default in 2.6.x, and so must be specifically enabled.
+> **Note**: The Netty server backend is not the default in 2.6.x, and so must be specifically enabled. See more information in [[Netty Server|NettyServer]] documentation.
 
 ## Default configuration
 
@@ -11,10 +11,13 @@ Play uses the following default configuration:
 
 @[](/confs/play-netty-server/reference.conf)
 
+The configurations above are specific to Netty server backend, but other more generic configurations are also available:
+ 
+@[](/confs/play-server/reference.conf)
+
 ## Configuring transport socket
 
-Native socket transport has higher performance and produces less garbage but is only available on Linux.
-You can configure the transport socket type in `application.conf`:
+Native socket transport has higher performance and produces less garbage but is only available on Linux. You can configure the transport socket type in `application.conf`:
 
 ```properties
 play.server {
@@ -26,5 +29,4 @@ play.server {
 
 ## Configuring channel options
 
-The available options are defined in [Netty channel option documentation](http://netty.io/4.1/api/io/netty/channel/ChannelOption.html).
-If you are using native socket transport you can set [additional options](http://netty.io/4.1/api/io/netty/channel/epoll/EpollChannelOption.html).
+The available options are defined in [Netty channel option documentation](http://netty.io/4.1/api/io/netty/channel/ChannelOption.html). If you are using native socket transport you can set [additional options](http://netty.io/4.1/api/io/netty/channel/epoll/EpollChannelOption.html).

--- a/framework/src/play-akka-http-server/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/reference.conf
@@ -13,11 +13,6 @@ play {
       # How long to wait when binding to the listening socket
       bindTimeout = 5 seconds
 
-      # The idle timeout for an open connection after which it will be closed
-      # Set to null to disable the timeout
-      https.idleTimeout = ${play.server.http.idleTimeout}
-      http.idleTimeout = ${play.server.https.idleTimeout}
-
       # How long a request takes until it times out
       requestTimeout = null
 

--- a/framework/src/play-akka-http-server/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/reference.conf
@@ -15,8 +15,8 @@ play {
 
       # The idle timeout for an open connection after which it will be closed
       # Set to null to disable the timeout
-      https.idleTimeout = 75 seconds
-      http.idleTimeout = 75 seconds
+      https.idleTimeout = ${play.server.http.idleTimeout}
+      http.idleTimeout = ${play.server.https.idleTimeout}
 
       # How long a request takes until it times out
       requestTimeout = null

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -50,8 +50,7 @@ class AkkaHttpServer(
 
   assert(config.port.isDefined || config.sslPort.isDefined, "AkkaHttpServer must be given at least one of an HTTP and an HTTPS port")
 
-  private val serverConfig = config.configuration.get[Configuration]("play.server")
-  private val akkaConfig = serverConfig.get[Configuration]("akka")
+  private val akkaConfig = config.configuration.get[Configuration]("play.server.akka")
 
   def mode = config.mode
 
@@ -69,7 +68,7 @@ class AkkaHttpServer(
     )).underlying
     val initialSettings = ServerSettings(initialConfig)
 
-    val idleTimeout = serverConfig.get[Duration](if (secure) "https.idleTimeout" else "http.idleTimeout")
+    val idleTimeout = akkaConfig.get[Duration](if (secure) "https.idleTimeout" else "http.idleTimeout")
     val requestTimeoutOption = akkaConfig.getOptional[Duration]("requestTimeout")
 
     // all akka settings that are applied to the server needs to be set here

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
@@ -21,33 +21,26 @@ import scala.concurrent.ExecutionContext.Implicits._
 import scala.util.Random
 import scala.collection.JavaConverters._
 
-class NettyIdleTimeoutSpec extends IdleTimeoutSpec with NettyIntegrationSpecification {
-  override def timeouts(httpTimeout: Duration, httpsTimeout: Duration): Map[String, String] = {
+class NettyIdleTimeoutSpec extends IdleTimeoutSpec with NettyIntegrationSpecification
+
+class AkkaIdleTimeoutSpec extends IdleTimeoutSpec with AkkaHttpIntegrationSpecification
+
+trait IdleTimeoutSpec extends PlaySpecification with ServerIntegrationSpecification {
+
+  val httpsPort = 9443
+
+  def timeouts(httpTimeout: Duration, httpsTimeout: Duration): Map[String, String] = {
+
+    def getTimeout(d: Duration) = d match {
+      case Duration.Inf => "null"
+      case Duration(t, u) => s"${u.toMillis(t)}ms"
+    }
+
     Map(
       "play.server.http.idleTimeout" -> getTimeout(httpTimeout),
       "play.server.https.idleTimeout" -> getTimeout(httpsTimeout)
     )
   }
-}
-
-class AkkaIdleTimeoutSpec extends IdleTimeoutSpec with AkkaHttpIntegrationSpecification {
-  override def timeouts(httpTimeout: Duration, httpsTimeout: Duration): Map[String, String] = {
-    Map(
-      "play.server.akka.http.idleTimeout" -> getTimeout(httpTimeout),
-      "play.server.akka.https.idleTimeout" -> getTimeout(httpsTimeout)
-    )
-  }
-}
-
-trait IdleTimeoutSpec extends PlaySpecification with ServerIntegrationSpecification {
-  val httpsPort = 9443
-
-  def getTimeout(d: Duration) = d match {
-    case Duration.Inf => "null"
-    case Duration(t, u) => s"${u.toMillis(t)}ms"
-  }
-
-  def timeouts(httpTimeout: Duration, httpsTimeout: Duration): Map[String, String]
 
   "Play's idle timeout support" should {
     def withServer[T](httpTimeout: Duration, httpsPort: Option[Int] = None, httpsTimeout: Duration = Duration.Inf)(action: EssentialAction)(block: Port => T) = {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/IdleTimeoutSpec.scala
@@ -21,25 +21,39 @@ import scala.concurrent.ExecutionContext.Implicits._
 import scala.util.Random
 import scala.collection.JavaConverters._
 
-class NettyIdleTimeoutSpec extends IdleTimeoutSpec with NettyIntegrationSpecification
+class NettyIdleTimeoutSpec extends IdleTimeoutSpec with NettyIntegrationSpecification {
+  override def timeouts(httpTimeout: Duration, httpsTimeout: Duration): Map[String, String] = {
+    Map(
+      "play.server.http.idleTimeout" -> getTimeout(httpTimeout),
+      "play.server.https.idleTimeout" -> getTimeout(httpsTimeout)
+    )
+  }
+}
 
-class AkkaIdleTimeoutSpec extends IdleTimeoutSpec with AkkaHttpIntegrationSpecification
+class AkkaIdleTimeoutSpec extends IdleTimeoutSpec with AkkaHttpIntegrationSpecification {
+  override def timeouts(httpTimeout: Duration, httpsTimeout: Duration): Map[String, String] = {
+    Map(
+      "play.server.akka.http.idleTimeout" -> getTimeout(httpTimeout),
+      "play.server.akka.https.idleTimeout" -> getTimeout(httpsTimeout)
+    )
+  }
+}
 
 trait IdleTimeoutSpec extends PlaySpecification with ServerIntegrationSpecification {
   val httpsPort = 9443
 
+  def getTimeout(d: Duration) = d match {
+    case Duration.Inf => "null"
+    case Duration(t, u) => s"${u.toMillis(t)}ms"
+  }
+
+  def timeouts(httpTimeout: Duration, httpsTimeout: Duration): Map[String, String]
+
   "Play's idle timeout support" should {
     def withServer[T](httpTimeout: Duration, httpsPort: Option[Int] = None, httpsTimeout: Duration = Duration.Inf)(action: EssentialAction)(block: Port => T) = {
       val port = testServerPort
-      def getTimeout(d: Duration) = d match {
-        case Duration.Inf => "null"
-        case Duration(t, u) => s"${u.toMillis(t)}ms"
-      }
       val props = new Properties(System.getProperties)
-      props.putAll(Map(
-        "play.server.http.idleTimeout" -> getTimeout(httpTimeout),
-        "play.server.https.idleTimeout" -> getTimeout(httpsTimeout)
-      ).asJava)
+      props.putAll(timeouts(httpTimeout, httpsTimeout).asJava)
       val serverConfig = ServerConfig(port = Some(port), sslPort = httpsPort, mode = Mode.Test, properties = props)
       running(play.api.test.TestServer(
         config = serverConfig,


### PR DESCRIPTION
## Fixes

Fixes #7172.

## Purpose

Now `play.server.akka.http.idleTimeout` is derived from `play.server.http.idleTimeout` so that we these existing options will be respected by Akka HTTP server backend. The docs were also improved to clarify these with Akka HTTP specific settings (in the namespace
`akka.http.server`).

## References

See also #7067.
