### PR TITLE
Consistent API to get headers from play.mvc.Http.RequestHeader

### DIFF
--- a/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
+++ b/framework/src/play-filters-helpers/src/main/java/play/filters/csrf/RequireCSRFCheckAction.java
@@ -109,6 +109,6 @@ public class RequireCSRFCheckAction extends Action<RequireCSRFCheck> {
         }
 
         CSRFErrorHandler handler = configurator.apply(this.configuration);
-        return handler.handle(new play.core.j.RequestHeaderImpl(request), msg);
+        return handler.handle(request.asJava(), msg);
     }
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/csrf/csrf.scala
@@ -57,7 +57,6 @@ case class CSRFConfig(
 
   import java.{ util => ju }
 
-  import play.core.j.{ RequestHeaderImpl => JRequestHeaderImpl }
   import play.mvc.Http.{ RequestHeader => JRequestHeader }
 
   import scala.compat.java8.FunctionConverters._
@@ -69,14 +68,14 @@ case class CSRFConfig(
   def withSecureCookie(isSecure: Boolean) = copy(secureCookie = isSecure)
   def withHttpOnlyCookie(isHttpOnly: Boolean) = copy(httpOnlyCookie = isHttpOnly)
   def withCreateIfNotFound(pred: ju.function.Predicate[JRequestHeader]) =
-    copy(createIfNotFound = pred.asScala.compose(new JRequestHeaderImpl(_)))
+    copy(createIfNotFound = pred.asScala.compose(_.asJava))
   def withPostBodyBuffer(bufsize: Long) = copy(postBodyBuffer = bufsize)
   def withSignTokens(signTokens: Boolean) = copy(signTokens = signTokens)
   def withMethods(checkMethod: ju.function.Predicate[String]) = copy(checkMethod = checkMethod.asScala)
   def withContentTypes(checkContentType: ju.function.Predicate[Optional[String]]) =
     copy(checkContentType = checkContentType.asScala.compose(_.asJava))
   def withShouldProtect(shouldProtect: ju.function.Predicate[JRequestHeader]) =
-    copy(shouldProtect = shouldProtect.asScala.compose(new JRequestHeaderImpl(_)))
+    copy(shouldProtect = shouldProtect.asScala.compose(_.asJava))
   def withBypassCorsTrustedOrigins(bypass: Boolean) = copy(bypassCorsTrustedOrigins = bypass)
 }
 

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/gzip/GzipFilter.scala
@@ -193,7 +193,7 @@ case class GzipFilterConfig(
   def withShouldGzip(shouldGzip: (RequestHeader, Result) => Boolean): GzipFilterConfig = copy(shouldGzip = shouldGzip)
 
   def withShouldGzip(shouldGzip: BiFunction[play.mvc.Http.RequestHeader, play.mvc.Result, Boolean]): GzipFilterConfig =
-    withShouldGzip((req: RequestHeader, res: Result) => shouldGzip.asScala(new j.RequestHeaderImpl(req), res.asJava))
+    withShouldGzip((req: RequestHeader, res: Result) => shouldGzip.asScala(req.asJava, res.asJava))
 
   def withChunkedThreshold(threshold: Int): GzipFilterConfig = copy(chunkedThreshold = threshold)
 

--- a/framework/src/play/src/main/java/play/http/DefaultHttpRequestHandler.java
+++ b/framework/src/play/src/main/java/play/http/DefaultHttpRequestHandler.java
@@ -6,7 +6,6 @@ package play.http;
 import javax.inject.Inject;
 
 import play.api.mvc.Handler;
-import play.core.j.RequestHeaderImpl;
 import play.mvc.Http.RequestHeader;
 import scala.Tuple2;
 
@@ -22,6 +21,6 @@ public class DefaultHttpRequestHandler implements HttpRequestHandler {
     @Override
     public HandlerForRequest handlerForRequest(RequestHeader request) {
         Tuple2<play.api.mvc.RequestHeader, Handler> result = underlying.handlerForRequest(request.asScala());
-        return new HandlerForRequest(new RequestHeaderImpl(result._1()), result._2());
+        return new HandlerForRequest(result._1().asJava(), result._2());
     }
 }

--- a/framework/src/play/src/main/java/play/mvc/EssentialAction.java
+++ b/framework/src/play/src/main/java/play/mvc/EssentialAction.java
@@ -8,7 +8,6 @@ import java.util.function.Function;
 import akka.util.ByteString;
 import play.api.mvc.Handler;
 import play.core.Execution;
-import play.core.j.RequestHeaderImpl;
 import play.libs.streams.Accumulator;
 import play.mvc.Http.RequestHeader;
 import scala.runtime.AbstractFunction1;
@@ -38,7 +37,7 @@ public abstract class EssentialAction
 
     @Override
     public play.api.libs.streams.Accumulator<ByteString, play.api.mvc.Result> apply(play.api.mvc.RequestHeader rh) {
-        return apply(new RequestHeaderImpl(rh))
+        return apply(rh.asJava())
             .map(Result::asScala, Execution.trampoline())
             .asScala();
     }

--- a/framework/src/play/src/main/java/play/mvc/Filter.java
+++ b/framework/src/play/src/main/java/play/mvc/Filter.java
@@ -5,7 +5,6 @@ package play.mvc;
 
 import akka.stream.Materializer;
 import play.core.j.AbstractFilter;
-import play.core.j.RequestHeaderImpl;
 import play.mvc.Http.RequestHeader;
 import scala.Function1;
 import scala.compat.java8.FutureConverters;
@@ -39,7 +38,7 @@ public abstract class Filter extends EssentialFilter {
                 return FutureConverters.toScala(
                         Filter.this.apply(
                                 (rh) -> FutureConverters.toJava(next.apply(rh.asScala())).thenApply(play.api.mvc.Result::asJava),
-                                new RequestHeaderImpl(requestHeader)
+                                requestHeader.asJava()
                         ).thenApply(Result::asScala)
                 );
             }

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -531,7 +531,7 @@ public class Http {
          * @param headerName The name of the header (case-insensitive)
          * @return <code>true</code> if the request did contain the header.
          */
-        public boolean hasHeader(String headerName) {
+        public boolean contains(String headerName) {
             return headers.containsKey(headerName);
         }
 
@@ -781,7 +781,7 @@ public class Http {
          * @return <code>true</code> if the request did contain the header.
          */
         default boolean hasHeader(String headerName) {
-            return getHeaders().hasHeader(headerName);
+            return getHeaders().contains(headerName);
         }
 
         /**

--- a/framework/src/play/src/main/java/play/mvc/Http.java
+++ b/framework/src/play/src/main/java/play/mvc/Http.java
@@ -731,6 +731,8 @@ public class Http {
 
         /**
          * Retrieve all headers.
+         *
+         * @return the request headers for this request.
          */
         Headers getHeaders();
 
@@ -1004,7 +1006,7 @@ public class Http {
                 // assume null signifies no body; RequestBody is a wrapper for the actual body content
                 headers(getHeaders().remove(HeaderNames.CONTENT_LENGTH).remove(HeaderNames.TRANSFER_ENCODING));
             } else {
-                if (!getHeader(HeaderNames.TRANSFER_ENCODING).isPresent()) {
+                if (!getHeaders().get(HeaderNames.TRANSFER_ENCODING).isPresent()) {
                     int length = body.asBytes().length();
                     header(HeaderNames.CONTENT_LENGTH, Integer.toString(length));
                 }
@@ -1387,7 +1389,7 @@ public class Http {
          * @param key the key to be used in the header
          * @return the value associated with the key, if multiple, the first, if none returns null
          *
-         * @deprecate As of release 2.6, use {@link #getHeader(String)} instead.
+         * @deprecated As of release 2.6, use {@link #getHeaders()} instead.
          */
         @Deprecated
         public String header(String key) {
@@ -1396,17 +1398,9 @@ public class Http {
 
         /**
          * @param key the key to be used in the header
-         * @return the value associated with the key, if multiple, the first, if none returns null
-         */
-        public Optional<String> getHeader(String key) {
-            return getHeaders().get(key);
-        }
-
-        /**
-         * @param key the key to be used in the header
          * @return all values (could be 0) associated with the key
          *
-         * @deprecated As of release 2.6, use {@link #getHeaderValues(String)} instead.
+         * @deprecated As of release 2.6, use {@link #getHeaders()} instead.
          */
         @Deprecated
         public String[] headers(String key) {
@@ -1424,18 +1418,10 @@ public class Http {
         }
 
         /**
-         * @return the headers
+         * @return the headers for this request builder
          */
         public Headers getHeaders() {
             return req.headers().asJava();
-        }
-
-        /**
-         * @param key the key to be used in the header
-         * @return all values (could be 0) associated with the key
-         */
-        public List<String> getHeaderValues(String key) {
-            return getHeaders().getAll(key);
         }
 
         /**
@@ -1453,6 +1439,8 @@ public class Http {
         }
 
         /**
+         * Set the headers to be used by the request builder.
+         *
          * @param headers the headers to be replaced
          * @return the builder instance
          */
@@ -1466,7 +1454,7 @@ public class Http {
          * @param values the values associated with the key
          * @return the builder instance
          *
-         * @deprecate As of release 2.6, use {@link #header(String, List)} instead.
+         * @deprecated As of release 2.6, use {@link #header(String, List)} instead.
          */
         @Deprecated
         public RequestBuilder header(String key, String[] values) {

--- a/framework/src/play/src/main/java/play/mvc/RangeResults.java
+++ b/framework/src/play/src/main/java/play/mvc/RangeResults.java
@@ -20,8 +20,7 @@ import java.util.Optional;
 public class RangeResults {
 
     private static Optional<String> rangeHeader() {
-        Http.Request request = Http.Context.current().request();
-        return Optional.ofNullable(request.getHeader(Http.HeaderNames.RANGE));
+        return Http.Context.current().request().header(Http.HeaderNames.RANGE);
     }
 
     private static Optional<String> mimeTypeFor(String fileName) {

--- a/framework/src/play/src/main/java/play/routing/Router.java
+++ b/framework/src/play/src/main/java/play/routing/Router.java
@@ -10,7 +10,6 @@ import akka.japi.JavaPartialFunction;
 import play.api.mvc.Handler;
 import play.api.routing.HandlerDef;
 import play.api.routing.SimpleRouter$;
-import play.core.j.RequestHeaderImpl;
 import play.libs.typedmap.TypedKey;
 import play.mvc.Http.RequestHeader;
 
@@ -29,7 +28,7 @@ public interface Router {
         return SimpleRouter$.MODULE$.apply(new JavaPartialFunction<play.api.mvc.RequestHeader, Handler>() {
             @Override
             public Handler apply(play.api.mvc.RequestHeader req, boolean isCheck) throws Exception {
-                Optional<Handler> handler = route(new RequestHeaderImpl(req));
+                Optional<Handler> handler = route(req.asJava());
                 if (handler.isPresent()) {
                     return handler.get();
                 } else if (isCheck) {

--- a/framework/src/play/src/main/scala/play/api/mvc/Headers.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Headers.scala
@@ -6,9 +6,9 @@ package play.api.mvc
 import java.util.Locale
 
 import play.api.http.HeaderNames
-import play.api.http.HeaderNames.CONTENT_LENGTH
-import play.api.http.HeaderNames.TRANSFER_ENCODING
 import play.core.utils.CaseInsensitiveOrdered
+
+import scala.collection.JavaConverters._
 
 import scala.collection.immutable.{ TreeMap, TreeSet }
 
@@ -112,6 +112,8 @@ class Headers(protected var _headers: Seq[(String, String)]) {
   lazy val toSimpleMap: Map[String, String] = toMap.mapValues(_.headOption.getOrElse(""))
 
   override def toString = headers.toString()
+
+  lazy val asJava: play.mvc.Http.Headers = new play.mvc.Http.Headers(this.toMap.mapValues(_.asJava).asJava)
 
 }
 

--- a/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/RequestHeader.scala
@@ -336,6 +336,7 @@ trait RequestHeader {
     method + " " + uri
   }
 
+  def asJava: play.mvc.Http.RequestHeader = new play.core.j.RequestHeaderImpl(this)
 }
 
 object RequestHeader {

--- a/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHelpers.scala
@@ -59,6 +59,13 @@ trait JavaHelpers {
     mapBuilder.result()
   }
 
+  def javaMapOfListToScalaSeqOfPairs(m: java.util.Map[String, java.util.List[String]]): Seq[(String, String)] = {
+    for {
+      (k, arr) <- m.asScala.to[Vector]
+      el <- arr.asScala
+    } yield (k, el)
+  }
+
   def javaMapOfArraysToScalaSeqOfPairs(m: java.util.Map[String, Array[String]]): Seq[(String, String)] = {
     for {
       (k, arr) <- m.asScala.to[Vector]

--- a/framework/src/play/src/main/scala/play/core/j/JavaHttpRequestHandlerAdapter.scala
+++ b/framework/src/play/src/main/scala/play/core/j/JavaHttpRequestHandlerAdapter.scala
@@ -15,7 +15,7 @@ import play.mvc.Http.{ RequestHeader => JRequestHeader }
  */
 class JavaHttpRequestHandlerAdapter @Inject() (underlying: JHttpRequestHandler) extends HttpRequestHandler {
   override def handlerForRequest(request: RequestHeader) = {
-    val handlerForRequest = underlying.handlerForRequest(new RequestHeaderImpl(request))
+    val handlerForRequest = underlying.handlerForRequest(request.asJava)
     (handlerForRequest.getRequestHeader.asScala, handlerForRequest.getHandler)
   }
 }
@@ -26,6 +26,6 @@ class JavaHttpRequestHandlerAdapter @Inject() (underlying: JHttpRequestHandler) 
 class JavaHttpRequestHandlerDelegate @Inject() (underlying: HttpRequestHandler) extends JHttpRequestHandler {
   override def handlerForRequest(requestHeader: JRequestHeader) = {
     val (newRequest, handler) = underlying.handlerForRequest(requestHeader.asScala())
-    new HandlerForRequest(new RequestHeaderImpl(newRequest), handler)
+    new HandlerForRequest(newRequest.asJava, handler)
   }
 }

--- a/framework/src/play/src/main/scala/play/core/routing/HandlerInvoker.scala
+++ b/framework/src/play/src/main/scala/play/core/routing/HandlerInvoker.scala
@@ -121,7 +121,7 @@ object HandlerInvokerFactory {
 
   private[play] def javaBodyParserToScala(parser: play.mvc.BodyParser[_]): BodyParser[RequestBody] = BodyParser { request =>
     import scala.language.existentials
-    val accumulator = parser.apply(new play.core.j.RequestHeaderImpl(request)).asScala()
+    val accumulator = parser.apply(request.asJava).asScala()
     import play.core.Execution.Implicits.trampoline
     accumulator.map { javaEither =>
       if (javaEither.left.isPresent) {
@@ -163,7 +163,7 @@ object HandlerInvokerFactory {
             val callWithContext = {
               try {
                 Context.current.set(javaContext)
-                FutureConverters.toScala(call(new j.RequestHeaderImpl(request)))
+                FutureConverters.toScala(call(request.asJava))
               } finally {
                 Context.current.remove()
               }

--- a/framework/src/play/src/test/java/play/mvc/RangeResultsTest.java
+++ b/framework/src/play/src/test/java/play/mvc/RangeResultsTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 public class RangeResultsTest {
@@ -329,6 +330,7 @@ public class RangeResultsTest {
 
     private void mockRegularRequest() {
         Http.Request request = mock(Http.Request.class);
+        when(request.header(RANGE)).thenReturn(Optional.empty());
         when(this.ctx.request()).thenReturn(request);
         
         mockRegularFileTypes();
@@ -336,7 +338,7 @@ public class RangeResultsTest {
 
     private void mockRangeRequest() {
         Http.Request request = mock(Http.Request.class);
-        when(request.getHeader(RANGE)).thenReturn("bytes=0-1");
+        when(request.header(RANGE)).thenReturn(Optional.of("bytes=0-1"));
         when(this.ctx.request()).thenReturn(request);
 
         mockRegularFileTypes();

--- a/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -19,11 +19,11 @@ class RequestHeaderSpec extends Specification {
     "convert to java" in {
       "keep all the headers" in {
         val rh = dummyRequestHeader("GET", "/", Headers(HOST -> "playframework.com"))
-        rh.asJava.getHeaders.hasHeader(HOST) must beTrue
+        rh.asJava.getHeaders.contains(HOST) must beTrue
       }
       "keep the headers accessible case insensitively" in {
         val rh = dummyRequestHeader("GET", "/", Headers(HOST -> "playframework.com"))
-        rh.asJava.getHeaders.hasHeader("host") must beTrue
+        rh.asJava.getHeaders.contains("host") must beTrue
       }
     }
 

--- a/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RequestHeaderSpec.scala
@@ -11,9 +11,21 @@ import play.api.http.HttpConfiguration
 import play.api.i18n.Lang
 import play.api.libs.typedmap.{ TypedKey, TypedMap }
 import play.api.mvc.request.{ DefaultRequestFactory, RemoteConnection, RequestTarget }
+
 class RequestHeaderSpec extends Specification {
 
   "request header" should {
+
+    "convert to java" in {
+      "keep all the headers" in {
+        val rh = dummyRequestHeader("GET", "/", Headers(HOST -> "playframework.com"))
+        rh.asJava.getHeaders.hasHeader(HOST) must beTrue
+      }
+      "keep the headers accessible case insensitively" in {
+        val rh = dummyRequestHeader("GET", "/", Headers(HOST -> "playframework.com"))
+        rh.asJava.getHeaders.hasHeader("host") must beTrue
+      }
+    }
 
     "have typed attributes" in {
       "can set and get a single attribute" in {

--- a/framework/src/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
@@ -65,6 +65,23 @@ class RequestHeaderSpec extends Specification {
           headers().hasHeader("A") must beTrue
         }
       }
+
+      "can add new headers" in {
+        val h = headers().withHeader("new", "value")
+        h.hasHeader("new") must beTrue
+        toScala(h.get("new")) must beSome("value")
+      }
+
+      "can add new headers with a list of values" in {
+        val h = headers().withHeader("new", List("v1", "v2", "v3").asJava)
+        h.getAll("new").asScala must containTheSameElementsAs(Seq("v1", "v2", "v3"))
+      }
+
+      "remove a header" in {
+        val h = headers().withHeader("to-be-removed", "value")
+        h.hasHeader("to-be-removed") must beTrue
+        h.remove("to-be-removed").hasHeader("to-be-removed") must beFalse
+      }
     }
 
     "has body" in {

--- a/framework/src/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
@@ -36,8 +36,8 @@ class RequestHeaderSpec extends Specification {
     "headers" in {
 
       "check if the header exists" in {
-        headers().hasHeader("a") must beTrue
-        headers().hasHeader("non-existend") must beFalse
+        headers().contains("a") must beTrue
+        headers().contains("non-existend") must beFalse
       }
 
       "get a single header value" in {
@@ -61,26 +61,26 @@ class RequestHeaderSpec extends Specification {
         }
 
         "when checking if the header exists" in {
-          headers().hasHeader("a") must beTrue
-          headers().hasHeader("A") must beTrue
+          headers().contains("a") must beTrue
+          headers().contains("A") must beTrue
         }
       }
 
       "can add new headers" in {
-        val h = headers().withHeader("new", "value")
-        h.hasHeader("new") must beTrue
+        val h = headers().addHeader("new", "value")
+        h.contains("new") must beTrue
         toScala(h.get("new")) must beSome("value")
       }
 
       "can add new headers with a list of values" in {
-        val h = headers().withHeader("new", List("v1", "v2", "v3").asJava)
+        val h = headers().addHeader("new", List("v1", "v2", "v3").asJava)
         h.getAll("new").asScala must containTheSameElementsAs(Seq("v1", "v2", "v3"))
       }
 
       "remove a header" in {
-        val h = headers().withHeader("to-be-removed", "value")
-        h.hasHeader("to-be-removed") must beTrue
-        h.remove("to-be-removed").hasHeader("to-be-removed") must beFalse
+        val h = headers().addHeader("to-be-removed", "value")
+        h.contains("to-be-removed") must beTrue
+        h.remove("to-be-removed").contains("to-be-removed") must beFalse
       }
     }
 

--- a/framework/src/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
+++ b/framework/src/play/src/test/scala/play/mvc/RequestHeaderSpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.mvc
+
+import org.specs2.mutable.Specification
+import play.api.http.HttpConfiguration
+import play.api.libs.typedmap.TypedMap
+import play.api.mvc.{ Headers, RequestHeader }
+import play.api.mvc.request.{ DefaultRequestFactory, RemoteConnection, RequestTarget }
+import play.mvc.Http.HeaderNames
+
+import scala.compat.java8.OptionConverters._
+import scala.collection.JavaConverters._
+
+class RequestHeaderSpec extends Specification {
+
+  private def requestHeader(headers: (String, String)*): RequestHeader = {
+    new DefaultRequestFactory(HttpConfiguration()).createRequestHeader(
+      connection = RemoteConnection("", secure = false, None),
+      method = "GET",
+      target = RequestTarget("/", "", Map.empty),
+      version = "",
+      headers = Headers(headers: _*),
+      attrs = TypedMap.empty
+    )
+  }
+
+  def headers(additionalHeaders: Map[String, java.util.List[String]] = Map.empty) = {
+    val headers = (Map("a" -> List("b1", "b2").asJava, "c" -> List("d1", "d2").asJava) ++ additionalHeaders).asJava
+    new Http.Headers(headers)
+  }
+
+  "RequestHeader" should {
+
+    "headers" in {
+
+      "check if the header exists" in {
+        headers().hasHeader("a") must beTrue
+        headers().hasHeader("non-existend") must beFalse
+      }
+
+      "get a single header value" in {
+        toScala(headers().get("a")) must beSome("b1")
+        toScala(headers().get("c")) must beSome("d1")
+      }
+
+      "get all header values" in {
+        headers().getAll("a").asScala must containTheSameElementsAs(Seq("b1", "b2"))
+        headers().getAll("c").asScala must containTheSameElementsAs(Seq("d1", "d2"))
+      }
+
+      "handle header names case insensitively" in {
+
+        "when getting the header" in {
+          toScala(headers().get("a")) must beSome("b1")
+          toScala(headers().get("c")) must beSome("d1")
+
+          toScala(headers().get("A")) must beSome("b1")
+          toScala(headers().get("C")) must beSome("d1")
+        }
+
+        "when checking if the header exists" in {
+          headers().hasHeader("a") must beTrue
+          headers().hasHeader("A") must beTrue
+        }
+      }
+    }
+
+    "has body" in {
+      "when there is a content-length greater than zero" in {
+        requestHeader(HeaderNames.CONTENT_LENGTH -> "10").asJava.hasBody must beTrue
+      }
+
+      "when there is a transfer-encoding header" in {
+        requestHeader(HeaderNames.TRANSFER_ENCODING -> "gzip").asJava.hasBody must beTrue
+      }
+    }
+
+    "has no body" in {
+      "when there is not a content-length greater than zero" in {
+        requestHeader(HeaderNames.CONTENT_LENGTH -> "0").asJava.hasBody must beFalse
+      }
+
+      "when there is not a transfer-encoding header" in {
+        requestHeader().asJava.hasBody must beFalse
+      }
+    }
+
+  }
+
+}

--- a/gravatar.py
+++ b/gravatar.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+#fetch Gravatars
+# https://code.google.com/p/gource/wiki/GravatarExample
+
+import os
+import requests
+import subprocess
+import hashlib
+
+
+def md5_hex(text):
+    m = hashlib.md5()
+    m.update(text.encode('ascii', errors='ignore'))
+    return m.hexdigest()
+
+size = 90
+output_dir = os.path.join('gource', 'gravatars')
+
+os.makedirs(output_dir)
+
+gitlog = subprocess.check_output(['git', 'log', '--pretty=format:%ae|%an'])
+authors = set(gitlog.decode('ascii', errors='ignore').splitlines())
+print(authors)
+for author in authors:
+    email, name = author.split('|')
+    output_file = os.path.join(output_dir, name.replace("/", "-") + '.png')
+    if not os.path.exists(output_file):
+        grav_url = "http://www.gravatar.com/avatar/" + md5_hex(email) + "?d=identicon&s=" + str(size)
+        print(email, name, grav_url)
+        r = requests.get(grav_url)
+        if r.ok:
+            with open(output_file, 'wb') as img:
+                img.write(r.content)


### PR DESCRIPTION
## Fixes

Fixes any leftovers of #2240.

## Purpose

This is both consistent with the Scala play.api.mvc.Headers (part of it since this Java version is not as complete as the Scala one) and also with the headers APIs in play-ws.

This Headers API can evolve later, but I kept it small now to avoid bigger changes (since we are very close to release 2.6.0).

## References

See discussion in #2240 and playframework/play-ws#101.
