### PR TITLE
Add MiMa check to travis

### DIFF
--- a/framework/bin/checkBinaryCompatibility
+++ b/framework/bin/checkBinaryCompatibility
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Checks binary compatibility
+
+. "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/build"
+
+cd $FRAMEWORK
+
+build mimaReportBinaryIssues

--- a/framework/bin/travis
+++ b/framework/bin/travis
@@ -15,7 +15,7 @@
 # we can run the tasks serially.
 set -ev
 
-declare -a TASKS=(checkCodeStyle checkFileHeaders test testSbtPlugins testDocumentation)
+declare -a TASKS=(checkCodeStyle checkFileHeaders checkBinaryCompatibility test testSbtPlugins testDocumentation)
 
 # Use travis scala version or defaults to 2.12.2 which is the `scalaVersion` configured in build.sbt
 SCALA_VERSION=${TRAVIS_SCALA_VERSION:-"2.12.2"}


### PR DESCRIPTION
This enables MiMa so future changes to 2.6.x will be checked for binary compatibility.