### PR TITLE
Update twirl version to 1.3.3

### DIFF
--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -10,7 +10,7 @@ val Versions = new {
   val sbtDoge = "0.1.5"
   val webjarsLocatorCore = "0.32"
   val sbtHeader = "1.8.0"
-  val sbtTwirl: String = sys.props.getOrElse("twirl.version", "1.3.2")
+  val sbtTwirl: String = sys.props.getOrElse("twirl.version", "1.3.3")
   val interplay: String = sys.props.getOrElse("interplay.version", "1.3.5")
 }
 


### PR DESCRIPTION
This includes the fix for the regression in parsing `if` statements without braces: playframework/twirl#140