### PR TITLE
[Backport 2.6.x] Update twirl version to 1.3.3

### DIFF
--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -10,7 +10,7 @@ val Versions = new {
   val sbtDoge = "0.1.5"
   val webjarsLocatorCore = "0.32"
   val sbtHeader = "1.8.0"
-  val sbtTwirl: String = sys.props.getOrElse("twirl.version", "1.3.2")
+  val sbtTwirl: String = sys.props.getOrElse("twirl.version", "1.3.3")
   val interplay: String = sys.props.getOrElse("interplay.version", "1.3.5")
 }
 


### PR DESCRIPTION
2.6.x is protected so I can't push it directly
```
remote: error: GH006: Protected branch update failed for refs/heads/2.6.x.
remote: error: At least one approved review is required by reviewers with write access.
To github.com:playframework/playframework.git
 ! [remote rejected]     2.6.x -> 2.6.x (protected branch hook declined)
error: failed to push some refs to 'git@github.com:playframework/playframework.git'
```