### PR TITLE
Improvements to RedirectHttpsFilter

### DIFF
--- a/documentation/manual/working/commonGuide/filters/RedirectHttpsFilter.md
+++ b/documentation/manual/working/commonGuide/filters/RedirectHttpsFilter.md
@@ -11,25 +11,29 @@ To enable the filter, add it to `play.filters.enabled`:
 play.filters.enabled += play.filters.https.RedirectHttpsFilter
 ```
 
+By default, the redirect only happens in Prod mode. To override this, set `play.filters.https.redirectEnabled = true`.
+
 ## Determining Secure Requests
 
 The filter evaluates a request to be secure if `request.secure` is true.
 
-This logic is set by the [[trusted proxies|HTTPServer#configuring-trusted-proxies]] configured for Play's HTTP engine.  Internally, `play.core.server.common.ForwardedHeaderHandler` and `play.api.mvc.request.RemoteConnection` determine between them whether an incoming request meets the criteria to be "secure", meaning that the request has gone through HTTPS at some point.
+This logic depends on the [[trusted proxies|HTTPServer#configuring-trusted-proxies]] configured for Play's HTTP engine. Internally, `play.core.server.common.ForwardedHeaderHandler` and `play.api.mvc.request.RemoteConnection` determine between them whether an incoming request meets the criteria to be "secure", meaning that the request has gone through HTTPS at some point.
 
-A request that is not secure is redirected according to the redirect code determined through configuration.
+When the filter is enabled, any request that is not secure is redirected.
 
 ## Strict Transport Security
 
-The [Strict Transport Security](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) header is used to indicate when HTTPS should always be used, and is added to a secure request.
-
-This header is only enabled in production, since HSTS can cause problems in development by forcing the browser to always assume https://localhost:9000 for the application -- this is especially an issue when working with multiple projects.
+The [Strict Transport Security](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) header is used to indicate when HTTPS should always be used, and is added to a secure request. The HSTS header is only added if the redirect is enabled.
 
 The default is "max-age=31536000; includeSubDomains", and can be set explicitly by adding the following to `application.conf`:
 
 ```
 play.filters.https.strictTransportSecurity="max-age=31536000; includeSubDomains"
 ```
+
+It is also possible to set `play.filters.https.strictTransportSecurity = null` to disable HSTS.
+
+Note that the `Strict-Transport-Security` header tells the browser to prefer HTTPS for *all requests to that hostname*, so if you enable the filter in dev mode, the header will affect other apps being developed with that hostname (e.g. `localhost:9000`). If you want to avoid this, either use a different host for each app in development (`app1:9000`, `app2:9000`, etc.) or disable HSTS completely in dev mode.
 
 ## Redirect code
 

--- a/framework/src/play-filters-helpers/src/main/resources/reference.conf
+++ b/framework/src/play-filters-helpers/src/main/resources/reference.conf
@@ -198,11 +198,16 @@ play.filters {
     }
   }
 
-  # Redirect HTTPS configuration
+  # Configuration for redirection to HTTPS and Strict-Transport-Security
   https {
 
+    # A boolean defining whether the redirect to HTTPS is enabled.
+    # A value of null means enabled only in Prod mode, but disabled in Dev/Test.
+    redirectEnabled = null
+
     # The Strict-Transport-Security header is used to signal to browsers to always use https.
-    # This header is only enabled in production, since HSTS causes problems on localhost:9000 for development
+    # This header is added whenever the filter makes the redirect.
+    # Set to null to disable the header.
     strictTransportSecurity = "max-age=31536000; includeSubDomains"
 
     # Configures the redirect status code used if the request is not secure.
@@ -212,6 +217,8 @@ play.filters {
 
     # The HTTPS port to use in the Redirect's Location URL.
     # e.g. port = 9443 results in https://playframework.com:9443/some/url
-    port = ${?play.server.https.port}
+    port = null
+    port = ${?play.server.https.port} # default to same HTTPS port as play server
+    port = ${?https.port} # read https.port system property if provided explicitly
   }
 }

--- a/framework/src/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
+++ b/framework/src/play-filters-helpers/src/main/scala/play/filters/https/RedirectHttpsFilter.scala
@@ -10,6 +10,7 @@ import play.api.http.Status._
 import play.api.inject.{ SimpleModule, bind }
 import play.api.mvc._
 import play.api.{ Configuration, Environment, Mode }
+import play.api.Logger
 
 /**
  * A filter that redirects HTTP requests to https requests.
@@ -21,33 +22,38 @@ import play.api.{ Configuration, Environment, Mode }
  * https://www.playframework.com/documentation/latest/RedirectHttpsFilter
  */
 @Singleton
-class RedirectHttpsFilter @Inject() (config: RedirectHttpsConfiguration)
-    extends EssentialFilter {
+class RedirectHttpsFilter @Inject() (config: RedirectHttpsConfiguration) extends EssentialFilter {
+
+  import RedirectHttpsKeys._
+  import config._
+
+  private val logger = Logger(getClass)
+
+  private[this] lazy val stsHeaders = {
+    if (!redirectEnabled) Seq.empty
+    else strictTransportSecurity.toSeq.map(STRICT_TRANSPORT_SECURITY -> _)
+  }
 
   override def apply(next: EssentialAction): EssentialAction = EssentialAction { req =>
     import play.api.libs.streams.Accumulator
     import play.core.Execution.Implicits.trampoline
     if (req.secure) {
-      next(req).map { result =>
-        config.strictTransportSecurity match {
-          case Some(sts) if config.hstsEnabled =>
-            result.withHeaders(STRICT_TRANSPORT_SECURITY -> sts)
-          case other =>
-            result
-        }
-      }
+      next(req).map(_.withHeaders(stsHeaders: _*))
+    } else if (redirectEnabled) {
+      Accumulator.done(Results.Redirect(createHttpsRedirectUrl(req), redirectStatusCode))
     } else {
-      Accumulator.done(Results.Redirect(createHttpsRedirectUrl(req), config.redirectStatusCode))
+      logger.info(s"Not redirecting to HTTPS because $redirectEnabledPath flag is not set.")
+      next(req)
     }
   }
 
   protected def createHttpsRedirectUrl(req: RequestHeader): String = {
-    config.sslPort match {
-      case None =>
-        s"https://${req.domain}${req.uri}"
-
+    import req.{ domain, uri }
+    sslPort match {
+      case None | Some(443) =>
+        s"https://$domain$uri"
       case Some(port) =>
-        s"https://${req.domain}:${port}${req.uri}"
+        s"https://$domain:$port$uri"
     }
   }
 }
@@ -56,25 +62,41 @@ case class RedirectHttpsConfiguration(
   strictTransportSecurity: Option[String] = Some("max-age=31536000; includeSubDomains"),
   redirectStatusCode: Int = PERMANENT_REDIRECT,
   sslPort: Option[Int] = None, // should match up to ServerConfig.sslPort
-  hstsEnabled: Boolean = false
+  redirectEnabled: Boolean = true
 )
+
+private object RedirectHttpsKeys {
+  val stsPath = "play.filters.https.strictTransportSecurity"
+  val statusCodePath = "play.filters.https.redirectStatusCode"
+  val portPath = "play.filters.https.port"
+  val redirectEnabledPath = "play.filters.https.redirectEnabled"
+}
 
 @Singleton
 class RedirectHttpsConfigurationProvider @Inject() (c: Configuration, e: Environment)
     extends Provider[RedirectHttpsConfiguration] {
-  private val stsPath = "play.filters.https.strictTransportSecurity"
-  private val statusCodePath = "play.filters.https.redirectStatusCode"
-  private val portPath = "play.filters.https.port"
+  import RedirectHttpsKeys._
+
+  private val logger = Logger(getClass)
 
   lazy val get: RedirectHttpsConfiguration = {
-    val strictTransportSecurityMaxAge = c.get[Option[String]](stsPath)
+    val strictTransportSecurity = c.get[Option[String]](stsPath)
     val redirectStatusCode = c.get[Int](statusCodePath)
     if (!isRedirect(redirectStatusCode)) {
       throw c.reportError(statusCodePath, s"Status Code $redirectStatusCode is not a Redirect status code!")
     }
-    val port = c.getOptional[Int](portPath)
+    val port = c.get[Option[Int]](portPath)
+    val redirectEnabled = c.get[Option[Boolean]](redirectEnabledPath).getOrElse {
+      if (e.mode != Mode.Prod) {
+        logger.info(
+          s"RedirectHttpsFilter is disabled by default except in Prod mode.\n" +
+            s"See https://www.playframework.com/documentation/2.6.x/RedirectHttpsFilter"
+        )
+      }
+      e.mode == Mode.Prod
+    }
 
-    RedirectHttpsConfiguration(strictTransportSecurityMaxAge, redirectStatusCode, port, e.mode == Mode.Prod)
+    RedirectHttpsConfiguration(strictTransportSecurity, redirectStatusCode, port, redirectEnabled)
   }
 }
 
@@ -90,6 +112,8 @@ trait RedirectHttpsComponents {
   def configuration: Configuration
   def environment: Environment
 
-  lazy val redirectHttpsConfiguration: RedirectHttpsConfiguration = new RedirectHttpsConfigurationProvider(configuration, environment).get
-  lazy val redirectHttpsFilter: RedirectHttpsFilter = new RedirectHttpsFilter(redirectHttpsConfiguration)
+  lazy val redirectHttpsConfiguration: RedirectHttpsConfiguration =
+    new RedirectHttpsConfigurationProvider(configuration, environment).get
+  lazy val redirectHttpsFilter: RedirectHttpsFilter =
+    new RedirectHttpsFilter(redirectHttpsConfiguration)
 }


### PR DESCRIPTION
Fixes #7492

 - Add `play.filters.https.redirectEnabled` setting for deciding whether to enable the filter, in which case both the redirect and HSTS header are disabled. The default value of `redirectEnabled` is `null`, which only enables the filter in Prod by default.
 - If the redirect filter is disabled, this also means the HSTS header is disabled by default in dev mode, as it was before.
 - Emit a log message when the filter is disabled.
 - Update the documentation to explain these changes, as well as the issue with HSTS in dev mode.