### PR TITLE
[doc] replace instances of play.Configuration with Config

### DIFF
--- a/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
@@ -133,7 +133,7 @@ You can also disable the automatic registration of a module named `Module` in th
 
 #### Configurable bindings
 
-Sometimes you might want to read the [`com.typesafe.config.Config`](https://typesafehub.github.io/config/latest/api/com/typesafe/config/Config.html) or use a `ClassLoader` when you configure Guice bindings. You can get access to these objects by adding them to your module's constructor.
+Sometimes you might want to read the [`Config`](https://typesafehub.github.io/config/latest/api/com/typesafe/config/Config.html) or use a `ClassLoader` when you configure Guice bindings. You can get access to these objects by adding them to your module's constructor.
 
 In the example below, the `Hello` binding for each language is read from a configuration file. This allows new `Hello` bindings to be added by adding new settings in your `application.conf` file.
 

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/JavaDependencyInjection.md
@@ -133,13 +133,13 @@ You can also disable the automatic registration of a module named `Module` in th
 
 #### Configurable bindings
 
-Sometimes you might want to read the Play `Configuration` or use a `ClassLoader` when you configure Guice bindings. You can get access to these objects by adding them to your module's constructor.
+Sometimes you might want to read the [`com.typesafe.config.Config`](https://typesafehub.github.io/config/latest/api/com/typesafe/config/Config.html) or use a `ClassLoader` when you configure Guice bindings. You can get access to these objects by adding them to your module's constructor.
 
 In the example below, the `Hello` binding for each language is read from a configuration file. This allows new `Hello` bindings to be added by adding new settings in your `application.conf` file.
 
 @[dynamic-guice-module](code/javaguide/di/guice/dynamic/Module.java)
 
-> **Note:** In most cases, if you need to access `Configuration` when you create a component, you should inject the `Configuration` object into the component itself or into the component's `Provider`. Then you can read the `Configuration` when you create the component. You usually don't need to read `Configuration` when you create the bindings for the component.
+> **Note:** In most cases, if you need to access `Config` when you create a component, you should inject the `Config` object into the component itself or into the component's `Provider`. Then you can read the `Config` when you create the component. You usually don't need to read `Config` when you create the bindings for the component.
 
 #### Eager bindings
 

--- a/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/guice/dynamic/Module.java
+++ b/documentation/manual/working/javaGuide/main/dependencyinjection/code/javaguide/di/guice/dynamic/Module.java
@@ -3,31 +3,31 @@
  */
 package javaguide.di.guice.configured;
 
-import com.typesafe.config.Config;
 import javaguide.di.*;
 
 //#dynamic-guice-module
 import com.google.inject.AbstractModule;
 import com.google.inject.name.Names;
+import com.typesafe.config.Config;
 import play.Environment;
 
 public class Module extends AbstractModule {
 
     private final Environment environment;
-    private final Config configuration;
+    private final Config config;
 
     public Module(
           Environment environment,
-          Config configuration) {
+          Config config) {
         this.environment = environment;
-        this.configuration = configuration;
+        this.config = config;
     }
 
     protected void configure() {
         // Expect configuration like:
         // hello.en = "myapp.EnglishHello"
         // hello.de = "myapp.GermanHello"
-        final Config helloConf = configuration.getConfig("hello");
+        final Config helloConf = config.getConfig("hello");
         // Iterate through all the languages and bind the
         // class associated with that language. Use Play's
         // ClassLoader to load the classes.


### PR DESCRIPTION
1. There were a handful of instances where the class name `Configuration` was used.  These have been changed to `Config`.
2. In the sample code there was no import statement for `Config` so the reader couldn't easily copy this code.
3. The variable names have been changed to `config` for consistency.