### PR TITLE
Fix Content-Disposition filename handling

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -275,6 +275,8 @@ private[server] class AkkaModelConversion(
     headers.flatMap {
       case (HeaderNames.SET_COOKIE, value) =>
         resultUtils.splitSetCookieHeaderValue(value).map(RawHeader(HeaderNames.SET_COOKIE, _))
+      case (HeaderNames.CONTENT_DISPOSITION, value) =>
+        RawHeader(HeaderNames.CONTENT_DISPOSITION, value) :: Nil
       case (name, value) if name != HeaderNames.TRANSFER_ENCODING =>
         HttpHeader.parse(name, value) match {
           case HttpHeader.ParsingResult.Ok(header, errors /* errors are ignored if Ok */ ) =>

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/ScalaResultsHandlingSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.it.http
 
-import java.nio.file.{ Files => JFiles }
+import java.nio.file.{ Path, Files => JFiles }
 import java.util.Locale.ENGLISH
 
 import akka.stream.scaladsl.Source
@@ -300,6 +300,30 @@ trait ScalaResultsHandlingSpec extends PlaySpecification with WsTestClient with 
 
         response.status must_== 400
         response.body must beLeft
+      }
+    }
+
+    "support UTF-8 encoded filenames in Content-Disposition headers" in {
+      val tempFile: Path = JFiles.createTempFile("ScalaResultsHandlingSpec", "txt")
+      try {
+        withServer {
+          import scala.concurrent.ExecutionContext.Implicits.global
+          implicit val mimeTypes: FileMimeTypes = new DefaultFileMimeTypes(FileMimeTypesConfiguration())
+          Results.Ok.sendFile(
+            tempFile.toFile,
+            fileName = _ => "测 试.tmp"
+          )
+        } { port =>
+          val response = BasicHttpClient.makeRequests(port)(
+            BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+          ).head
+
+          response.status must_== 200
+          response.body must beLeft("")
+          response.headers.get(CONTENT_DISPOSITION) must beSome(s"""inline; filename="? ?.tmp"; filename*=utf-8''%e6%b5%8b%20%e8%af%95.tmp""")
+        }
+      } finally {
+        tempFile.toFile.delete()
       }
     }
 

--- a/framework/src/play/src/main/java/play/mvc/StatusHeader.java
+++ b/framework/src/play/src/main/java/play/mvc/StatusHeader.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import akka.stream.javadsl.FileIO;
 import akka.stream.javadsl.Source;
@@ -23,6 +24,7 @@ import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import play.core.utils.HttpHeaderParameterEncoding;
 import play.http.HttpEntity;
 import play.libs.Json;
 import play.utils.UriEncoding;
@@ -271,10 +273,17 @@ public class StatusHeader extends Result {
 
     private Result doSendResource(Source<ByteString, ?> data, Optional<Long> contentLength,
                                   Optional<String> resourceName, boolean inline) {
+
+        // Create a Content-Disposition header
+        StringBuilder cdBuilder = new StringBuilder();
+        cdBuilder.append(inline ? "inline" : "attachment");
+        if (resourceName.isPresent()) {
+            cdBuilder.append("; ");
+            HttpHeaderParameterEncoding.encodeToBuilder("filename", resourceName.get(), cdBuilder);
+        }
         Map<String, String> headers = Collections.singletonMap(
                 Http.HeaderNames.CONTENT_DISPOSITION,
-                (inline ? "inline" : "attachment") +
-                (resourceName.isPresent() ? "; filename=\"" + resourceName.get() + "\"; filename*=utf-8''" + UriEncoding.encodePathSegment(resourceName.get(), UTF_8) : "")
+                cdBuilder.toString()
         );
 
         return new Result(status(), headers, new HttpEntity.Streamed(

--- a/framework/src/play/src/main/scala/play/api/mvc/RangeResult.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/RangeResult.scala
@@ -3,8 +3,6 @@
  */
 package play.api.mvc
 
-import java.nio.charset.StandardCharsets
-
 import akka.NotUsed
 import akka.stream.Attributes
 import akka.stream.FlowShape
@@ -20,7 +18,7 @@ import play.api.http.ContentTypes
 import play.api.http.HeaderNames._
 import play.api.http.HttpEntity
 import play.api.http.Status._
-import play.utils.UriEncoding
+import play.core.utils.HttpHeaderParameterEncoding
 
 // Long should be good enough to represent even very large files
 // considering that Long.MAX_VALUE is 9223372036854775807 which
@@ -367,7 +365,7 @@ object RangeResult {
   def ofSource(entityLength: Option[Long], source: Source[ByteString, _], rangeHeader: Option[String], fileName: Option[String], contentType: Option[String]): Result = {
     val commonHeaders = Seq(
       Some(ACCEPT_RANGES -> "bytes"),
-      fileName.map(f => CONTENT_DISPOSITION -> s"""attachment; filename="$f"; filename*=utf-8''${UriEncoding.encodePathSegment(f, StandardCharsets.UTF_8)}""")
+      fileName.map(f => CONTENT_DISPOSITION -> s"""attachment; ${HttpHeaderParameterEncoding.encode("filename", f)}""")
     ).flatten.toMap
 
     RangeSet(entityLength, rangeHeader) match {

--- a/framework/src/play/src/main/scala/play/api/mvc/Results.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Results.scala
@@ -3,7 +3,7 @@
  */
 package play.api.mvc
 
-import java.nio.charset.StandardCharsets
+import java.lang.{ StringBuilder => JStringBuilder }
 import java.nio.file.{ Files, Path }
 import java.time.format.DateTimeFormatter
 import java.time.{ ZoneOffset, ZonedDateTime }
@@ -14,8 +14,7 @@ import play.api.http.HeaderNames._
 import play.api.http.{ FileMimeTypes, _ }
 import play.api.i18n.{ Lang, MessagesApi }
 import play.api.{ Logger, Mode }
-import play.core.utils.CaseInsensitiveOrdered
-import play.utils.UriEncoding
+import play.core.utils.{ CaseInsensitiveOrdered, HttpHeaderParameterEncoding }
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.TreeMap
@@ -406,8 +405,11 @@ trait Results {
           status,
           Map(
             CONTENT_DISPOSITION -> {
-              val dispositionType = if (inline) "inline" else "attachment"
-              s"""$dispositionType; filename="$name"; filename*=utf-8''${UriEncoding.encodePathSegment(name, StandardCharsets.UTF_8)}"""
+              val builder = new JStringBuilder
+              builder.append(if (inline) "inline" else "attachment")
+              builder.append("; ")
+              HttpHeaderParameterEncoding.encodeToBuilder("filename", name, builder)
+              builder.toString
             }
           )
         ),

--- a/framework/src/play/src/main/scala/play/core/utils/HttpHeaderEncoding.scala
+++ b/framework/src/play/src/main/scala/play/core/utils/HttpHeaderEncoding.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.utils
+
+import java.lang.{ StringBuilder => JStringBuilder }
+import java.util.function.IntConsumer
+import java.util.{ BitSet => JBitSet }
+
+/**
+ * Support for rending HTTP header parameters according to RFC5987.
+ */
+private[play] object HttpHeaderParameterEncoding {
+
+  private def charSeqToBitSet(chars: Seq[Char]): JBitSet = {
+    val ints: Seq[Int] = chars.map(_.toInt)
+    val max = ints.fold(0)(Math.max(_, _))
+    assert(max <= 256) // We should only be dealing with 7 or 8 bit chars
+    val bitSet = new JBitSet(max)
+    ints.foreach(bitSet.set(_))
+    bitSet
+  }
+
+  private val AlphaNum: Seq[Char] = ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')
+
+  // From https://tools.ietf.org/html/rfc5987#section-3.2.1:
+  //
+  // attr-char     = ALPHA / DIGIT
+  // / "!" / "#" / "$" / "&" / "+" / "-" / "."
+  // / "^" / "_" / "`" / "|" / "~"
+  // ; token except ( "*" / "'" / "%" )
+  private val AttrCharPunctuation: Seq[Char] = Seq('!', '#', '$', '&', '+', '-', '.', '^', '_', '`', '|', '~')
+
+  // From https://tools.ietf.org/html/rfc2616#section-2.2
+  //
+  //   separators     = "(" | ")" | "<" | ">" | "@"
+  //                  | "," | ";" | ":" | "\" | <">
+  //                  | "/" | "[" | "]" | "?" | "="
+  //                  | "{" | "}" | SP | HT
+  //
+  // Rich: We exclude <">, "\" since they can be used for quoting/escaping and HT since it is
+  // rarely used and seems like it should be escaped.
+  private val Separators: Seq[Char] = Seq('(', ')', '<', '>', '@', ',', ';', ':', '/', '[', ']', '?', '=', '{', '}', ' ')
+
+  /**
+   * A subset of the 'qdtext' defined in https://tools.ietf.org/html/rfc2616#section-2.2. These are the
+   * characters which can be inside a 'quoted-string' parameter value. These should form a
+   * superset of the [[AttrChar]] set defined below. We exclude some characters which are technically
+   * valid, but might be problematic, e.g. "\" and "%" could be treated as escape characters by some
+   * clients. We can be conservative because we can express these characters clearly as an extended
+   * parameter.
+   */
+  private val PartialQuotedText: JBitSet = charSeqToBitSet(
+    AlphaNum ++ AttrCharPunctuation ++
+      // we include 'separators' plus some chars excluded from 'attr-char'
+      Separators ++ Seq('*', '\''))
+
+  /**
+   * The 'attr-char' values defined in https://tools.ietf.org/html/rfc5987#section-3.2.1. Should be a
+   * subset of [[PartialQuotedText]] defined above.
+   */
+  private val AttrChar: JBitSet = charSeqToBitSet(AlphaNum ++ AttrCharPunctuation)
+
+  private val PlaceholderChar: Char = '?'
+
+  /**
+   * Render a parameter name and value, handling character set issues as
+   * recommended in RFC5987.
+   *
+   * Examples:
+   * [[
+   * render("filename", "foo.txt") ==> "filename=foo.txt"
+   * render("filename", "naïve.txt") ==> "filename=na_ve.txt; filename*=utf8''na%C3%AFve.txt"
+   * ]]
+   */
+  def encode(name: String, value: String): String = {
+    val builder = new JStringBuilder
+    encodeToBuilder(name, value, builder)
+    builder.toString
+  }
+
+  /**
+   * Render a parameter name and value, handling character set issues as
+   * recommended in RFC5987.
+   *
+   * Examples:
+   * [[
+   * render("filename", "foo.txt") ==> "filename=foo.txt"
+   * render("filename", "naïve.txt") ==> "filename=na_ve.txt; filename*=utf8''na%C3%AFve.txt"
+   * ]]
+   */
+  def encodeToBuilder(name: String, value: String, builder: JStringBuilder): Unit = {
+
+    // This flag gets set if we encounter extended characters when rendering the
+    // regular parameter value.
+    var hasExtendedChars = false
+
+    // Render ASCII parameter
+    // E.g. naïve.txt --> "filename=na_ve.txt"
+
+    builder.append(name)
+    builder.append("=\"")
+
+    // Iterate over code points here, because we only want one
+    // ASCII character or placeholder per logical character. If
+    // we use the value's encoded bytes or chars then we might
+    // end up with multiple placeholders per logical character.
+    value.codePoints().forEach(new IntConsumer {
+      override def accept(codePoint: Int): Unit = {
+        // We could support a wider range of characters here by using
+        // the 'token' or 'quoted printable' encoding, however it's
+        // simpler to use the subset of characters that is also valid
+        // for extended attributes.
+        if (codePoint >= 0 && codePoint <= 255 && PartialQuotedText.get(codePoint)) {
+          builder.append(codePoint.toChar)
+        } else {
+          // Set flag because we need to render an extended parameter.
+          hasExtendedChars = true
+          // Render a placeholder instead of the unsupported character.
+          builder.append(PlaceholderChar)
+        }
+      }
+    })
+
+    builder.append('"')
+
+    // Optionally render extended, UTF-8 encoded parameter
+    // E.g. naïve.txt --> "; filename*=utf8''na%C3%AFve.txt"
+    //
+    // Renders both regular and extended parameters, as suggested by:
+    // - https://tools.ietf.org/html/rfc5987#section-4.2
+    // - https://tools.ietf.org/html/rfc6266#section-4.3 (for Content-Disposition filename parameter)
+
+    if (hasExtendedChars) {
+
+      def hexDigit(x: Int): Char = (if (x < 10) (x + '0') else (x - 10 + 'a')).toChar
+
+      // From https://tools.ietf.org/html/rfc5987#section-3.2.1:
+      //
+      // Producers MUST use either the "UTF-8" ([RFC3629]) or the "ISO-8859-1"
+      // ([ISO-8859-1]) character set.  Extension character sets (mime-
+
+      val CharacterSetName = "utf-8"
+
+      builder.append("; ")
+      builder.append(name)
+
+      builder.append("*=")
+      builder.append(CharacterSetName)
+      builder.append("''")
+
+      // From https://tools.ietf.org/html/rfc5987#section-3.2.1:
+      //
+      // Inside the value part, characters not contained in attr-char are
+      // encoded into an octet sequence using the specified character set.
+      // That octet sequence is then percent-encoded as specified in Section
+      // 2.1 of [RFC3986].
+
+      val bytes = value.getBytes(CharacterSetName)
+      for (b <- bytes) {
+        if (AttrChar.get(b & 0xFF)) {
+          builder.append(b.toChar)
+        } else {
+          builder.append('%')
+          builder.append(hexDigit((b >> 4) & 0xF))
+          builder.append(hexDigit(b & 0xF))
+        }
+      }
+    }
+  }
+
+}

--- a/framework/src/play/src/test/java/play/mvc/RangeResultsTest.java
+++ b/framework/src/play/src/test/java/play/mvc/RangeResultsTest.java
@@ -86,7 +86,7 @@ public class RangeResultsTest {
         try (InputStream stream = Files.newInputStream(path)) {
             Result result = RangeResults.ofStream(stream, path.toFile().length(), "file.txt");
             assertEquals(result.status(), PARTIAL_CONTENT);
-            assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
+            assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
         }
     }
 
@@ -97,7 +97,7 @@ public class RangeResultsTest {
             Result result = RangeResults.ofStream(stream, path.toFile().length(), "file.txt");
             assertEquals(result.status(), OK);
             assertEquals(BINARY, result.body().contentType().orElse(""));
-            assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
+            assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
         }
     }
 
@@ -118,7 +118,7 @@ public class RangeResultsTest {
             Result result = RangeResults.ofStream(stream, path.toFile().length(), "file.txt", TEXT);
             assertEquals(result.status(), PARTIAL_CONTENT);
             assertEquals(TEXT, result.body().contentType().orElse(""));
-            assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
+            assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
         }
     }
 
@@ -130,7 +130,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofPath(path);
 
         assertEquals(result.status(), PARTIAL_CONTENT);
-        assertEquals("attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"test.tmp\"", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -140,7 +140,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofPath(path);
 
         assertEquals(result.status(), OK);
-        assertEquals("attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"test.tmp\"", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -149,7 +149,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofPath(path, "file.txt");
 
         assertEquals(result.status(), PARTIAL_CONTENT);
-        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -159,7 +159,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofPath(path, "file.txt");
 
         assertEquals(result.status(), OK);
-        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -169,7 +169,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofPath(path, "测 试.tmp");
 
         assertEquals(result.status(), PARTIAL_CONTENT);
-        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"? ?.tmp\"; filename*=utf-8''%e6%b5%8b%20%e8%af%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -179,7 +179,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofPath(path, "测 试.tmp");
 
         assertEquals(result.status(), OK);
-        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"? ?.tmp\"; filename*=utf-8''%e6%b5%8b%20%e8%af%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     // -- Files
@@ -190,7 +190,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofFile(path.toFile());
 
         assertEquals(result.status(), PARTIAL_CONTENT);
-        assertEquals("attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"test.tmp\"", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -200,7 +200,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofFile(path.toFile());
 
         assertEquals(result.status(), OK);
-        assertEquals("attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"test.tmp\"", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -209,7 +209,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofFile(path.toFile(), "file.txt");
 
         assertEquals(result.status(), PARTIAL_CONTENT);
-        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -219,7 +219,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofFile(path.toFile(), "file.txt");
 
         assertEquals(result.status(), OK);
-        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -229,7 +229,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofFile(path.toFile(), "测 试.tmp");
 
         assertEquals(result.status(), PARTIAL_CONTENT);
-        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"? ?.tmp\"; filename*=utf-8''%e6%b5%8b%20%e8%af%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -239,7 +239,7 @@ public class RangeResultsTest {
         Result result = RangeResults.ofFile(path.toFile(), "测 试.tmp");
 
         assertEquals(result.status(), OK);
-        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"? ?.tmp\"; filename*=utf-8''%e6%b5%8b%20%e8%af%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     // -- Sources
@@ -275,7 +275,7 @@ public class RangeResultsTest {
 
         assertEquals(result.status(), PARTIAL_CONTENT);
         assertEquals(BINARY, result.body().contentType().orElse(""));
-        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -287,7 +287,7 @@ public class RangeResultsTest {
 
         assertEquals(result.status(), OK);
         assertEquals(BINARY, result.body().contentType().orElse(""));
-        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -300,7 +300,7 @@ public class RangeResultsTest {
 
         assertEquals(result.status(), PARTIAL_CONTENT);
         assertEquals(TEXT, result.body().contentType().orElse(""));
-        assertEquals("attachment; filename=\"file.txt\"; filename*=utf-8''file.txt", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"file.txt\"", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -312,7 +312,7 @@ public class RangeResultsTest {
 
         assertEquals(result.status(), OK);
         assertEquals(BINARY, result.body().contentType().orElse(""));
-        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"? ?.tmp\"; filename*=utf-8''%e6%b5%8b%20%e8%af%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     @Test
@@ -325,7 +325,7 @@ public class RangeResultsTest {
 
         assertEquals(result.status(), PARTIAL_CONTENT);
         assertEquals(TEXT, result.body().contentType().orElse(""));
-        assertEquals("attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
+        assertEquals("attachment; filename=\"? ?.tmp\"; filename*=utf-8''%e6%b5%8b%20%e8%af%95.tmp", result.header(CONTENT_DISPOSITION).orElse(""));
     }
 
     private void mockRegularRequest() {

--- a/framework/src/play/src/test/java/play/mvc/ResultsTest.java
+++ b/framework/src/play/src/test/java/play/mvc/ResultsTest.java
@@ -66,7 +66,7 @@ public class ResultsTest {
     this.mockRegularFileTypes();
     Result result = Results.ok().sendPath(file);
     assertEquals(result.status(), Http.Status.OK);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
   }
 
   @Test
@@ -74,7 +74,7 @@ public class ResultsTest {
     this.mockRegularFileTypes();
     Result result = Results.unauthorized().sendPath(file);
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
   }
 
   @Test
@@ -82,7 +82,7 @@ public class ResultsTest {
     this.mockRegularFileTypes();
     Result result = Results.unauthorized().sendPath(file, /*inline*/ false);
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
   }
 
   @Test
@@ -90,7 +90,7 @@ public class ResultsTest {
     this.mockRegularFileTypes();
     Result result = Results.ok().sendPath(file, /* inline */ false);
     assertEquals(result.status(), Http.Status.OK);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
   }
 
   @Test
@@ -98,7 +98,7 @@ public class ResultsTest {
     this.mockRegularFileTypes();
     Result result = Results.unauthorized().sendPath(file, "foo.bar");
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"; filename*=utf-8''foo.bar");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
   }
 
   @Test
@@ -106,7 +106,7 @@ public class ResultsTest {
     this.mockRegularFileTypes();
     Result result = Results.unauthorized().sendPath(file, true, "foo.bar");
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"; filename*=utf-8''foo.bar");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
   }
 
   @Test
@@ -114,7 +114,7 @@ public class ResultsTest {
     this.mockRegularFileTypes();
     Result result = Results.ok().sendPath(file, true, "测 试.tmp");
     assertEquals(result.status(), Http.Status.OK);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"? ?.tmp\"; filename*=utf-8''%e6%b5%8b%20%e8%af%95.tmp");
   }
 
   // -- File tests
@@ -130,7 +130,7 @@ public class ResultsTest {
     this.mockRegularFileTypes();
     Result result = Results.ok().sendFile(file.toFile());
     assertEquals(result.status(), Http.Status.OK);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
   }
 
   @Test
@@ -138,7 +138,7 @@ public class ResultsTest {
     this.mockRegularFileTypes();
     Result result = Results.unauthorized().sendFile(file.toFile());
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"test.tmp\"");
   }
 
   @Test
@@ -146,7 +146,7 @@ public class ResultsTest {
     this.mockRegularFileTypes();
     Result result = Results.unauthorized().sendFile(file.toFile(), /* inline */ false);
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
   }
 
   @Test
@@ -154,7 +154,7 @@ public class ResultsTest {
     this.mockRegularFileTypes();
     Result result = Results.ok().sendFile(file.toFile(), /* inline */ false);
     assertEquals(result.status(), Http.Status.OK);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"; filename*=utf-8''test.tmp");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "attachment; filename=\"test.tmp\"");
   }
 
   @Test
@@ -162,7 +162,7 @@ public class ResultsTest {
     this.mockRegularFileTypes();
     Result result = Results.unauthorized().sendFile(file.toFile(), "foo.bar");
     assertEquals(result.status(), Http.Status.UNAUTHORIZED);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"; filename*=utf-8''foo.bar");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
   }
 
   @Test
@@ -170,7 +170,7 @@ public class ResultsTest {
     this.mockRegularFileTypes();
     Result result = Results.ok().sendFile(file.toFile(), true, "foo.bar");
     assertEquals(result.status(), Http.Status.OK);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"; filename*=utf-8''foo.bar");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"foo.bar\"");
   }
 
   @Test
@@ -178,7 +178,7 @@ public class ResultsTest {
     this.mockRegularFileTypes();
     Result result = Results.ok().sendFile(file.toFile(), true, "测 试.tmp");
     assertEquals(result.status(), Http.Status.OK);
-    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp");
+    assertEquals(result.header(HeaderNames.CONTENT_DISPOSITION).get(), "inline; filename=\"? ?.tmp\"; filename*=utf-8''%e6%b5%8b%20%e8%af%95.tmp");
   }
 
   private void mockRegularFileTypes() {

--- a/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RangeResultSpec.scala
@@ -351,7 +351,7 @@ class RangeResultSpec extends Specification {
       val source = Source(bytes).map(b => ByteString.fromArray(Array[Byte](b)))
       val Result(ResponseHeader(_, headers, _), _, _, _, _) =
         RangeResult.ofSource(bytes.length, source, None, Some("video.mp4"), None)
-      headers must havePair("Content-Disposition" -> "attachment; filename=\"video.mp4\"; filename*=utf-8''video.mp4")
+      headers must havePair("Content-Disposition" -> "attachment; filename=\"video.mp4\"")
     }
 
     "support non-ISO-8859-1 filename in Content-Disposition header" in {
@@ -359,7 +359,7 @@ class RangeResultSpec extends Specification {
       val source = Source(bytes).map(b => ByteString.fromArray(Array[Byte](b)))
       val Result(ResponseHeader(_, headers, _), _, _, _, _) =
         RangeResult.ofSource(bytes.length, source, None, Some("测 试.tmp"), None)
-      headers must havePair("Content-Disposition" -> "attachment; filename=\"测 试.tmp\"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp")
+      headers.get("Content-Disposition") must beSome("attachment; filename=\"? ?.tmp\"; filename*=utf-8''%e6%b5%8b%20%e8%af%95.tmp")
     }
 
     "support first byte position" in {
@@ -404,7 +404,7 @@ class RangeResultSpec extends Specification {
       try {
         val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(_, _, contentType), _, _, _) =
           RangeResult.ofPath(file.toPath, None, Some("video/mp4"))
-        headers must havePair("Content-Disposition" -> "attachment; filename=\"path.mp4\"; filename*=utf-8''path.mp4")
+        headers must havePair("Content-Disposition" -> "attachment; filename=\"path.mp4\"")
         contentType must beSome("video/mp4")
       } finally {
         java.nio.file.Files.delete(file.toPath)
@@ -416,7 +416,7 @@ class RangeResultSpec extends Specification {
       try {
         val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(_, _, contentType), _, _, _) =
           RangeResult.ofFile(file, None, Some("video/mp4"))
-        headers must havePair("Content-Disposition" -> "attachment; filename=\"file.mp4\"; filename*=utf-8''file.mp4")
+        headers must havePair("Content-Disposition" -> "attachment; filename=\"file.mp4\"")
         contentType must beSome("video/mp4")
       } finally {
         java.nio.file.Files.delete(file.toPath)
@@ -429,7 +429,7 @@ class RangeResultSpec extends Specification {
       try {
         val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(_, _, contentType), _, _, _) =
           RangeResult.ofStream(inputStream, None, "file.mp4", Some("video/mp4"))
-        headers must havePair("Content-Disposition" -> "attachment; filename=\"file.mp4\"; filename*=utf-8''file.mp4")
+        headers must havePair("Content-Disposition" -> "attachment; filename=\"file.mp4\"")
         contentType must beSome("video/mp4")
       } finally {
         closeWithoutError(inputStream)
@@ -443,7 +443,7 @@ class RangeResultSpec extends Specification {
       try {
         val Result(ResponseHeader(_, headers, _), HttpEntity.Streamed(_, _, contentType), _, _, _) =
           RangeResult.ofStream(file.length(), inputStream, None, "file.mp4", Some("video/mp4"))
-        headers must havePair("Content-Disposition" -> "attachment; filename=\"file.mp4\"; filename*=utf-8''file.mp4")
+        headers must havePair("Content-Disposition" -> "attachment; filename=\"file.mp4\"")
         contentType must beSome("video/mp4")
       } finally {
         closeWithoutError(inputStream)

--- a/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/ResultsSpec.scala
@@ -194,70 +194,70 @@ class ResultsSpec extends Specification {
       val rh = Ok.sendFile(file).header
 
       (rh.status aka "status" must_== OK) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName"; filename*=utf-8''$fileName"""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
     }
 
     "support sending a file with Unauthorized status" in withFile { (file, fileName) =>
       val rh = Unauthorized.sendFile(file).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName"; filename*=utf-8''$fileName"""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
     }
 
     "support sending a file attached with Unauthorized status" in withFile { (file, fileName) =>
       val rh = Unauthorized.sendFile(file, inline = false).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName"; filename*=utf-8''$fileName"""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName""""))
     }
 
     "support sending a file with PaymentRequired status" in withFile { (file, fileName) =>
       val rh = PaymentRequired.sendFile(file).header
 
       (rh.status aka "status" must_== PAYMENT_REQUIRED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName"; filename*=utf-8''$fileName"""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
     }
 
     "support sending a file attached with PaymentRequired status" in withFile { (file, fileName) =>
       val rh = PaymentRequired.sendFile(file, inline = false).header
 
       (rh.status aka "status" must_== PAYMENT_REQUIRED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName"; filename*=utf-8''$fileName"""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName""""))
     }
 
     "support sending a file with filename" in withFile { (file, fileName) =>
       val rh = Ok.sendFile(file, fileName = _ => "测 试.tmp").header
 
       (rh.status aka "status" must_== OK) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="测 试.tmp"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp"""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="? ?.tmp"; filename*=utf-8''%e6%b5%8b%20%e8%af%95.tmp"""))
     }
 
     "support sending a path with Ok status" in withPath { (file, fileName) =>
       val rh = Ok.sendPath(file).header
 
       (rh.status aka "status" must_== OK) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName"; filename*=utf-8''$fileName"""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
     }
 
     "support sending a path with Unauthorized status" in withPath { (file, fileName) =>
       val rh = Unauthorized.sendPath(file).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName"; filename*=utf-8''$fileName"""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="$fileName""""))
     }
 
     "support sending a path attached with Unauthorized status" in withPath { (file, fileName) =>
       val rh = Unauthorized.sendPath(file, inline = false).header
 
       (rh.status aka "status" must_== UNAUTHORIZED) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName"; filename*=utf-8''$fileName"""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""attachment; filename="$fileName""""))
     }
 
     "support sending a path with filename" in withPath { (file, fileName) =>
       val rh = Ok.sendPath(file, fileName = _ => "测 试.tmp").header
 
       (rh.status aka "status" must_== OK) and
-        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="测 试.tmp"; filename*=utf-8''%E6%B5%8B%20%E8%AF%95.tmp"""))
+        (rh.headers.get(CONTENT_DISPOSITION) aka "disposition" must beSome(s"""inline; filename="? ?.tmp"; filename*=utf-8''%e6%b5%8b%20%e8%af%95.tmp"""))
     }
 
     "allow checking content length" in withPath { (file, fileName) =>

--- a/framework/src/play/src/test/scala/play/core/utils/HttpHeaderParameterEncodingSpec.scala
+++ b/framework/src/play/src/test/scala/play/core/utils/HttpHeaderParameterEncodingSpec.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.utils
+
+import org.specs2.mutable.Specification
+
+class HttpHeaderParameterEncodingSpec extends Specification {
+  "HttpHeaderParameterEncoding.encode" should {
+
+    "support RFC6266 examples" in {
+      // Examples taken from https://tools.ietf.org/html/rfc6266#section-5
+      // with some modifications.
+
+      "encode (filename, example.html) with a regular parameter only" in {
+        HttpHeaderParameterEncoding.encode("filename", "example.html") must_== "filename=\"example.html\""
+      }
+
+      "encode (filename, € rates) with both regular and extended parameters" in {
+        HttpHeaderParameterEncoding.encode("filename", "€ rates") must_== "filename=\"? rates\"; filename*=utf-8''%e2%82%ac%20rates"
+      }
+    }
+
+    "support RFC5987 example" in {
+      // Example taken from https://tools.ietf.org/html/rfc5987#section-4.2
+      // with some modifications.
+
+      "Encode (title, € exchange rates) with both regular and extended parameters" in {
+        HttpHeaderParameterEncoding.encode("title", "€ exchange rates") must_== "title=\"? exchange rates\"; title*=utf-8''%e2%82%ac%20exchange%20rates"
+      }
+    }
+
+    "support examples from http://greenbytes.de/tech/tc2231/" in {
+      // Examples taken from http://greenbytes.de/tech/tc2231/
+      // with some modifications.
+      "encode (filename, foo-ä-€.html) with both regular and extended parameters" in {
+        HttpHeaderParameterEncoding.encode("filename", "foo-ä-€.html") must_== "filename=\"foo-?-?.html\"; filename*=utf-8''foo-%c3%a4-%e2%82%ac.html"
+      }
+      "encode (filename, foo-ä.html) with both regular and extended parameters" in {
+        HttpHeaderParameterEncoding.encode("filename", "foo-ä.html") must_== "filename=\"foo-?.html\"; filename*=utf-8''foo-%c3%a4.html"
+      }
+      "encode (filename, A-%41.html) with both regular and extended parameters" in {
+        HttpHeaderParameterEncoding.encode("filename", "A-%41.html") must_== "filename=\"A-?41.html\"; filename*=utf-8''A-%2541.html"
+      }
+      "encode (filename, \\foo.html) with both regular and extended parameters" in {
+        HttpHeaderParameterEncoding.encode("filename", "\\foo.html") must_== "filename=\"?foo.html\"; filename*=utf-8''%5cfoo.html"
+      }
+      "encode (filename, Here's a semicolon;.html) with a regular parameter only" in {
+        HttpHeaderParameterEncoding.encode("filename", "Here's a semicolon;.html") must_== "filename=\"Here's a semicolon;.html\""
+      }
+    }
+
+    "support examples from https://github.com/jshttp/content-disposition" in {
+      // Examples taken from https://github.com/jshttp/content-disposition/blob/master/test/test.js
+      // with some modifications.
+      "encode (filename, планы.pdf) with both regular and extended parameters" in {
+        HttpHeaderParameterEncoding.encode("filename", "планы.pdf") must_== "filename=\"?????.pdf\"; filename*=utf-8''%d0%bf%d0%bb%d0%b0%d0%bd%d1%8b.pdf"
+      }
+      "encode (filename, £ and € rates.pdf) with both regular and extended parameters" in {
+        HttpHeaderParameterEncoding.encode("filename", "£ and € rates.pdf") must_== "filename=\"? and ? rates.pdf\"; filename*=utf-8''%c2%a3%20and%20%e2%82%ac%20rates.pdf"
+      }
+      "encode (filename, €\\'*%().pdf) with both regular and extended parameters" in {
+        HttpHeaderParameterEncoding.encode("filename", "€'*%().pdf") must_== "filename=\"?'*?().pdf\"; filename*=utf-8''%e2%82%ac%27%2a%25%28%29.pdf"
+      }
+      "encode (filename, the%20plans.pdf) with both regular and extended parameters" in {
+        HttpHeaderParameterEncoding.encode("filename", "the%20plans.pdf") must_== "filename=\"the?20plans.pdf\"; filename*=utf-8''the%2520plans.pdf"
+      }
+      "encode (filename, Here's a semicolon;.html) with a regular parameter only" in {
+        HttpHeaderParameterEncoding.encode("filename", "Here's a semicolon;.html") must_== "filename=\"Here's a semicolon;.html\""
+      }
+    }
+
+    "support misc examples" in {
+      "encode (filename, README.md) with a regular parameter only" in {
+        // Example from https://github.com/playframework/playframework/issues/7501
+        HttpHeaderParameterEncoding.encode("filename", "README.md") must_== "filename=\"README.md\""
+      }
+      "encode (filename, READM•.md) with both regular and extended parameters" in {
+        // Tested to give correct filename when downloading a file on Chrome 58
+        HttpHeaderParameterEncoding.encode("filename", "READM•.md") must_== "filename=\"READM?.md\"; filename*=utf-8''READM%e2%80%a2.md"
+      }
+      "encode (filename, test.tmp) with a regular parameter only" in {
+        // Example from https://github.com/playframework/playframework/pull/6042
+        HttpHeaderParameterEncoding.encode("filename", "test.tmp") must_== "filename=\"test.tmp\""
+      }
+      "encode (filename, video.mp4) with a regular parameter only" in {
+        // Example from https://github.com/playframework/playframework/pull/6042
+        HttpHeaderParameterEncoding.encode("filename", "video.mp4") must_== "filename=\"video.mp4\""
+      }
+      "encode (filename, 测 试.tmp) with both regular and extended parameters" in {
+        // Example from https://github.com/playframework/playframework/pull/6042
+        HttpHeaderParameterEncoding.encode("filename", "测 试.tmp") must_== "filename=\"? ?.tmp\"; filename*=utf-8''%e6%b5%8b%20%e8%af%95.tmp"
+      }
+      "encode (filename, Museum 博物馆.jpg) with both regular and extended parameters" in {
+        // Example from https://stackoverflow.com/questions/11302361/handling-filename-parameters-with-spaces-via-rfc-5987-results-in-in-filenam
+        HttpHeaderParameterEncoding.encode("filename", "Museum 博物馆.jpg") must_== "filename=\"Museum ???.jpg\"; filename*=utf-8''Museum%20%e5%8d%9a%e7%89%a9%e9%a6%86.jpg"
+      }
+    }
+
+    "handle some special cases properly" in {
+      "encode (foo, <empty>) with a regular parameter only" in {
+        HttpHeaderParameterEncoding.encode("foo", "") must_== "foo=\"\""
+      }
+      "encode (foo, <space>) with a regular parameter only" in {
+        HttpHeaderParameterEncoding.encode("foo", " ") must_== "foo=\" \""
+      }
+      "encode (foo, =) with a regular parameter only" in {
+        HttpHeaderParameterEncoding.encode("foo", "=") must_== "foo=\"=\""
+      }
+      "encode (foo, ') with a regular parameter only" in {
+        HttpHeaderParameterEncoding.encode("foo", "'") must_== "foo=\"'\""
+      }
+      "encode (foo, %) with both regular and extended parameters" in {
+        HttpHeaderParameterEncoding.encode("foo", "%") must_== "foo=\"?\"; foo*=utf-8''%25"
+      }
+      "encode (foo, \") with both regular and extended parameters" in {
+        HttpHeaderParameterEncoding.encode("foo", "\"") must_== "foo=\"?\"; foo*=utf-8''%22"
+      }
+      "encode (foo, ;) with a regular parameter only" in {
+        HttpHeaderParameterEncoding.encode("foo", ";") must_== "foo=\";\""
+      }
+      "encode (foo, 0x80) with both regular and extended parameters" in {
+        HttpHeaderParameterEncoding.encode("foo", 0x80.toChar.toString) must_== "foo=\"?\"; foo*=utf-8''%c2%80"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #7501.

1. Improve handling of extended characters in filenames, following the definition in RFC 5987.

   The previous rendering had a couple of problems. First, it rendered UTF-8 characters into the regular `filename` parameter. Second, its %-escaping of extended characters in the `filename*` parameter used the URI path-segement encoding, which doesn't escape all necessary characters.

   In addition, the new handling only renders an extended `filename*` parameter when there are special characters that need escaping.

   See:
   - https://github.com/playframework/playframework/pull/6042

2. Use a RawHeader with Akka HTTP to avoid the backend parsing and re-rendering the header. There's currently a bug with this that needs to be fixed before we can use a typed header.

   See:
   - https://github.com/akka/akka-http/issues/1240
   - https://github.com/akka/akka-http/issues/1066

Cc @jrudolph, @zhangshifeng.