### PR TITLE
Make sameSite=null work with session and flash

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/FlashCookieSpec.scala
@@ -91,6 +91,12 @@ trait FlashCookieSpec extends PlaySpecification with ServerIntegrationSpecificat
     }
 
     "honor the configuration for play.http.flash.sameSite" in {
+      "configured to null" in withClientAndServer(Map("play.http.flash.sameSite" -> null)) { ws =>
+        val response = await(ws.url("/flash").withFollowRedirects(follow = false).get())
+        response.status must equalTo(SEE_OTHER)
+        response.header(SET_COOKIE) must beSome.which(!_.contains("SameSite"))
+      }
+
       "configured to lax" in withClientAndServer(Map("play.http.flash.sameSite" -> "lax")) { ws =>
         val response = await(ws.url("/flash").withFollowRedirects(follow = false).get())
         response.status must equalTo(SEE_OTHER)

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/SessionCookieSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/SessionCookieSpec.scala
@@ -41,6 +41,12 @@ trait SessionCookieSpec extends PlaySpecification with ServerIntegrationSpecific
   "the session cookie" should {
 
     "honor configuration for play.http.session.sameSite" in {
+      "configured to null" in withClientAndServer(Map("play.http.session.sameSite" -> null)) { ws =>
+        val response = await(ws.url("/session").get())
+        response.status must equalTo(OK)
+        response.header(SET_COOKIE) must beSome.which(!_.contains("SameSite"))
+      }
+
       "configured to lax" in withClientAndServer(Map("play.http.session.sameSite" -> "lax")) { ws =>
         val response = await(ws.url("/session").get())
         response.status must equalTo(OK)

--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -59,7 +59,8 @@ object Cookie {
     def asJava: play.mvc.Http.Cookie.SameSite = play.mvc.Http.Cookie.SameSite.parse(value).get
   }
   object SameSite {
-    def parse(value: String): Option[SameSite] = Seq(Strict, Lax).find(_ matches value)
+    private[play] val values: Seq[SameSite] = Seq(Strict, Lax)
+    def parse(value: String): Option[SameSite] = values.find(_ matches value)
     case object Strict extends SameSite("Strict")
     case object Lax extends SameSite("Lax")
   }


### PR DESCRIPTION
Fixes #7513

I decided for backwards compatibility any string other than "strict" or "lax" will still map to no SameSite attribute, but I added a warning to encourage the use of `null` explicitly.