### PR TITLE
Create Akka and Netty servers from built in components

### DIFF
--- a/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaEmbeddingPlay.java
+++ b/documentation/manual/working/javaGuide/advanced/embedding/code/javaguide/advanced/embedding/JavaEmbeddingPlay.java
@@ -28,11 +28,13 @@ public class JavaEmbeddingPlay {
     @Test
     public void simple() throws Exception {
         //#simple
-        Server server = Server.forRouter((components) -> RoutingDsl.fromComponents(components)
+        Server server = Server.forRouter((components) ->
+            RoutingDsl.fromComponents(components)
                 .GET("/hello/:to").routeTo(to ->
-                        ok("Hello " + to)
+                    ok("Hello " + to)
                 )
-                .build());
+                .build()
+        );
         //#simple
 
         try {
@@ -58,9 +60,10 @@ public class JavaEmbeddingPlay {
     @Test
     public void config() throws Exception {
         //#config
-        Server server = Server.forRouter((components) -> RoutingDsl.fromComponents(components)
+        Server server = Server.forRouter((components) ->
+            RoutingDsl.fromComponents(components)
                 .GET("/hello/:to").routeTo(to ->
-                        ok("Hello " + to)
+                    ok("Hello " + to)
                 )
                 .build()
         );

--- a/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayAkkaHttp.md
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayAkkaHttp.md
@@ -1,7 +1,7 @@
 <!--- Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com> -->
 #  Embedding an Akka Http server in your application
 
-Play Akka HTTP server is also configurable as a embedded Play server. The simplest way to start an Play Akka HTTP Server is to use the [`AkkaHttpServer`](api/scala/play/core/server/AkkaHttpServer$.html) factory methods. If all you need to do is provide some straightforward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouter` method:
+Play Akka HTTP server is also configurable as a embedded Play server. The simplest way to start an Play Akka HTTP Server is to use the [`AkkaHttpServer`](api/scala/play/core/server/AkkaHttpServer$.html) factory methods. If all you need to do is provide some straightforward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouterWithComponents` method:
 
 @[simple-akka-http](code/ScalaAkkaEmbeddingPlay.scala)
 

--- a/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayNetty.md
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/ScalaEmbeddingPlayNetty.md
@@ -3,7 +3,7 @@
 
 While Play apps are most commonly used as their own container, you can also embed a Play server into your own existing application.  This can be used in conjunction with the Twirl template compiler and Play routes compiler, but these are of course not necessary, a common use case for embedding a Play application will be because you only have a few very simple routes.
 
-The simplest way to start an embedded Play server is to use the [`NettyServer`](api/scala/play/core/server/NettyServer$.html) factory methods.  If all you need to do is provide some straightforward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouter` method:
+The simplest way to start an embedded Play server is to use the [`NettyServer`](api/scala/play/core/server/NettyServer$.html) factory methods.  If all you need to do is provide some straightforward routes, you may decide to use the [[String Interpolating Routing DSL|ScalaSirdRouter]] in combination with the `fromRouterWithComponents` method:
 
 @[simple](code/ScalaNettyEmbeddingPlay.scala)
 

--- a/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaAkkaEmbeddingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaAkkaEmbeddingPlay.scala
@@ -17,9 +17,12 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
       import play.api.routing.sird._
       import play.core.server.AkkaHttpServer
 
-      val server = AkkaHttpServer.fromRouterWithComponents() { components => {
-          case GET(p"/hello/$to") => components.defaultActionBuilder {
-            Results.Ok(s"Hello $to")
+      val server = AkkaHttpServer.fromRouterWithComponents() { components =>
+        import Results._
+        import components.{ defaultActionBuilder => Action }
+        {
+          case GET(p"/hello/$to") => Action {
+            Ok(s"Hello $to")
           }
         }
       }
@@ -43,9 +46,12 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
       val server = AkkaHttpServer.fromRouterWithComponents(ServerConfig(
         port = Some(19000),
         address = "127.0.0.1"
-      )) { components => {
-          case GET(p"/hello/$to") => components.defaultActionBuilder {
-            Results.Ok(s"Hello $to")
+      )) { components =>
+        import Results._
+        import components.{ defaultActionBuilder => Action }
+        {
+          case GET(p"/hello/$to") => Action {
+            Ok(s"Hello $to")
           }
         }
       }

--- a/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaAkkaEmbeddingPlay.scala
+++ b/documentation/manual/working/scalaGuide/advanced/embedding/code/ScalaAkkaEmbeddingPlay.scala
@@ -71,8 +71,6 @@ class ScalaAkkaEmbeddingPlay extends Specification with WsTestClient {
 
       val components = new AkkaHttpServerComponents with BuiltInComponents with NoHttpFiltersComponents {
 
-        lazy val Action = defaultActionBuilder
-
         override lazy val router: Router = Router.from {
           case GET(p"/hello/$to") => Action {
             Results.Ok(s"Hello $to")

--- a/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
@@ -45,11 +45,12 @@ class GitHubClientSpec extends Specification {
   "GitHubClient" should {
     "get all repositories" in {
 
-      Server.withRouterFromComponents() { cs =>
-        import cs.{ defaultActionBuilder => Action }
+      Server.withRouterFromComponents() { components =>
+        import Results._
+        import components.{ defaultActionBuilder => Action }
         {
           case GET(p"/repositories") => Action {
-            Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
+            Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
           }
         }
       } { implicit port =>
@@ -89,11 +90,12 @@ class ScalaTestingWebServiceClients extends Specification {
       import play.api.routing.sird._
       import play.core.server.Server
 
-      Server.withRouterFromComponents() { cs =>
-        import cs.{ defaultActionBuilder => Action }
+      Server.withRouterFromComponents() { components =>
+        import Results._
+        import components.{ defaultActionBuilder => Action }
         {
           case GET(p"/repositories") => Action {
-            Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
+            Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
           }
         }
       } { implicit port =>
@@ -113,7 +115,7 @@ class ScalaTestingWebServiceClients extends Specification {
         new BuiltInComponentsFromContext(context) with HttpFiltersComponents {
           override def router: Router = Router.from {
             case GET(p"/repositories") =>
-              this.defaultActionBuilder { req =>
+              Action { req =>
                 Results.Ok.sendResource("github/repositories.json")(fileMimeTypes)
               }
           }
@@ -138,7 +140,7 @@ class ScalaTestingWebServiceClients extends Specification {
           new BuiltInComponentsFromContext(context) with HttpFiltersComponents{
             override def router: Router = Router.from {
               case GET(p"/repositories") =>
-                this.defaultActionBuilder { req =>
+                Action { req =>
                   Results.Ok.sendResource("github/repositories.json")(fileMimeTypes)
                 }
             }

--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -4,8 +4,7 @@
 import BuildSettings._
 import Dependencies._
 import Generators._
-import com.typesafe.tools.mima.plugin.MimaKeys.{ mimaPreviousArtifacts, mimaReportBinaryIssues, mimaBinaryIssueFilters }
-import com.typesafe.tools.mima.core._
+import com.typesafe.tools.mima.plugin.MimaKeys.{ mimaPreviousArtifacts, mimaReportBinaryIssues }
 import interplay.PlayBuildBase.autoImport._
 import sbt.Keys.parallelExecution
 import sbt.ScriptedPlugin._

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -198,9 +198,7 @@ object BuildSettings {
 
       // Refactoring to unify AkkaHttpServer and NettyServer fromRouter methods
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.core.server.NettyServer.fromRouter"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.core.server.AkkaHttpServer.fromRouter"),
-      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("play.api.BuiltInComponents.router"),
-      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("play.api.BuiltInComponents.httpFilters")
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.core.server.AkkaHttpServer.fromRouter")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -1,7 +1,6 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-import com.typesafe.sbt.SbtScalariform._
 import sbt.ScriptedPlugin._
 import sbt._
 import Keys.{version, _}
@@ -195,7 +194,13 @@ object BuildSettings {
       ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.akkahttp.AkkaModelConversion.this"),
 
       // Added method to PlayBodyParsers, which is a Play API not meant to be extended by end users.
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.PlayBodyParsers.byteString")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.mvc.PlayBodyParsers.byteString"),
+
+      // Refactoring to unify AkkaHttpServer and NettyServer fromRouter methods
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.core.server.NettyServer.fromRouter"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.core.server.AkkaHttpServer.fromRouter"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("play.api.BuiltInComponents.router"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("play.api.BuiltInComponents.httpFilters")
     ),
     unmanagedSourceDirectories in Compile += {
       (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -424,7 +424,7 @@ object AkkaHttpServer extends ServerFromRouter {
       application.materializer, () => Future.successful(()))
   }
 
-  override protected def createServerFromRouter(serverConf: ServerConfig = ServerConfig())(routes: ServerComponents => Router): Server = {
+  override protected def createServerFromRouter(serverConf: ServerConfig = ServerConfig())(routes: ServerComponents with BuiltInComponents => Router): Server = {
     new AkkaHttpServerComponents with BuiltInComponents with NoHttpFiltersComponents {
       override lazy val serverConfig: ServerConfig = serverConf
       override def router: Router = routes(this)

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -424,9 +424,9 @@ object AkkaHttpServer extends ServerFromRouter {
       application.materializer, () => Future.successful(()))
   }
 
-  override protected def createServerFromRouter(serverConfig: ServerConfig = ServerConfig())(routes: ServerComponents => Router): Server = {
+  override protected def createServerFromRouter(serverConf: ServerConfig = ServerConfig())(routes: ServerComponents => Router): Server = {
     new AkkaHttpServerComponents with BuiltInComponents with NoHttpFiltersComponents {
-      override lazy val serverConfig: ServerConfig = serverConfig
+      override lazy val serverConfig: ServerConfig = serverConf
       override def router: Router = routes(this)
     }.server
   }

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -422,7 +422,7 @@ object AkkaHttpServer extends ServerFromRouter {
       application.materializer, () => Future.successful(()))
   }
 
-  override def createServerFromRouter(serverConfig: ServerConfig = ServerConfig())(routes: ServerComponents => Router): Server = {
+  override protected def createServerFromRouter(serverConfig: ServerConfig = ServerConfig())(routes: ServerComponents => Router): Server = {
     new AkkaHttpServerComponents with BuiltInComponents with NoHttpFiltersComponents {
       override lazy val serverConfig: ServerConfig = serverConfig
       override def router: Router = routes(this)

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -18,17 +18,16 @@ import akka.http.scaladsl.{ ConnectionContext, Http }
 import akka.stream.Materializer
 import akka.stream.scaladsl._
 import akka.util.ByteString
-import com.typesafe.config.{ Config, ConfigFactory, ConfigMemorySize }
+import com.typesafe.config.{ Config, ConfigMemorySize }
 import play.api._
 import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
-import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle }
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.api.routing.Router
 import play.core.server.akkahttp.{ AkkaModelConversion, HttpRequestDecoder }
 import play.core.server.common.{ ReloadCache, ServerResultUtils }
 import play.core.server.ssl.ServerSSLEngine
-import play.core.{ ApplicationProvider, DefaultWebCommands, SourceMapper, WebCommands }
+import play.core.ApplicationProvider
 import play.server.SSLEngineProvider
 
 import scala.concurrent.duration._

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -391,9 +391,12 @@ class AkkaHttpServer(
  * Or from a given router using [[BuiltInComponents]]:
  *
  * {{{
- *   val server = AkkaHttpServer.fromRouterWithComponents(ServerConfig(port = Some(9002))) { components => {
- *       case GET(p"/") => components.defaultActionBuilder {
- *         Results.Ok("Hello")
+ *   val server = AkkaHttpServer.fromRouterWithComponents(ServerConfig(port = Some(9002))) { components =>
+ *     import play.api.mvc.Results._
+ *     import components.{ defaultActionBuilder => Action }
+ *     {
+ *       case GET(p"/") => Action {
+ *         Ok("Hello")
  *       }
  *     }
  *   }

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -53,7 +53,7 @@ class AkkaHttpServer(
   private val serverConfig = config.configuration.get[Configuration]("play.server")
   private val akkaServerConfig = config.configuration.get[Configuration]("play.server.akka")
 
-  def mode = config.mode
+  override def mode: Mode = config.mode
 
   // Remember that some user config may not be available in development mode due to its unusual ClassLoader.
   implicit private val system: ActorSystem = actorSystem
@@ -348,9 +348,9 @@ class AkkaHttpServer(
     httpServerBinding.orElse(httpsServerBinding).map(_.localAddress).get
   }
 
-  def httpPort = httpServerBinding.map(_.localAddress.getPort)
+  override def httpPort: Option[Int] = httpServerBinding.map(_.localAddress.getPort)
 
-  def httpsPort = httpsServerBinding.map(_.localAddress.getPort)
+  override def httpsPort: Option[Int] = httpsServerBinding.map(_.localAddress.getPort)
 
   /**
    * There is a mismatch between the Play SSL API and the Akka IO SSL API, Akka IO takes an SSL context, and
@@ -377,7 +377,31 @@ class AkkaHttpServer(
   }
 }
 
-object AkkaHttpServer {
+/**
+ * Creates an AkkaHttpServer from the given router:
+ *
+ * {{{
+ *   val server = AkkaHttpServer.fromRouter(ServerConfig(port = Some(9002))) {
+ *     case GET(p"/") => Action {
+ *       Results.Ok("Hello")
+ *     }
+ *   }
+ * }}}
+ *
+ * Or from a given router using [[BuiltInComponents]]:
+ *
+ * {{{
+ *   val server = AkkaHttpServer.fromRouterWithComponents(ServerConfig(port = Some(9002))) { components => {
+ *       case GET(p"/") => components.defaultActionBuilder {
+ *         Results.Ok("Hello")
+ *       }
+ *     }
+ *   }
+ * }}}
+ *
+ * Use this together with <a href="https://www.playframework.com/documentation/2.6.x/ScalaSirdRouter">Sird Router</a>.
+ */
+object AkkaHttpServer extends ServerFromRouter {
 
   private val logger = Logger(classOf[AkkaHttpServer])
 
@@ -398,10 +422,10 @@ object AkkaHttpServer {
       application.materializer, () => Future.successful(()))
   }
 
-  def fromRouter(config: ServerConfig = ServerConfig())(routes: PartialFunction[RequestHeader, Handler]): AkkaHttpServer = {
+  override def createServerFromRouter(serverConfig: ServerConfig = ServerConfig())(routes: ServerComponents => Router): Server = {
     new AkkaHttpServerComponents with BuiltInComponents with NoHttpFiltersComponents {
-      override lazy val serverConfig: ServerConfig = config
-      lazy val router: Router = Router.from(routes)
+      override lazy val serverConfig: ServerConfig = serverConfig
+      override def router: Router = routes(this)
     }.server
   }
 }
@@ -415,8 +439,10 @@ class AkkaHttpServerProvider extends ServerProvider {
       context.stopHook)
 }
 
-trait AkkaHttpServerComponents {
-  lazy val serverConfig: ServerConfig = ServerConfig()
+/**
+ * Components for building a simple Akka HTTP Server.
+ */
+trait AkkaHttpServerComponents extends ServerComponents {
   lazy val server: AkkaHttpServer = {
     // Start the application first
     Play.start(application)
@@ -424,16 +450,5 @@ trait AkkaHttpServerComponents {
       application.materializer, serverStopHook)
   }
 
-  lazy val environment: Environment = Environment.simple(mode = serverConfig.mode)
-  lazy val sourceMapper: Option[SourceMapper] = None
-  lazy val webCommands: WebCommands = new DefaultWebCommands
-  lazy val configuration: Configuration = Configuration(ConfigFactory.load())
-  lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
-
   def application: Application
-
-  /**
-   * Called when Server.stop is called.
-   */
-  def serverStopHook: () => Future[Unit] = () => Future.successful(())
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/BadClientHandlingSpec.scala
@@ -25,7 +25,6 @@ trait BadClientHandlingSpec extends PlaySpecification with ServerIntegrationSpec
       val port = testServerPort
 
       val app = new BuiltInComponentsFromContext(ApplicationLoader.createContext(Environment.simple())) with HttpFiltersComponents {
-        def Action = defaultActionBuilder
         def router = {
           import sird._
           Router.from {

--- a/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
@@ -325,7 +325,6 @@ object HttpBinApplication {
 
   def app = {
     new BuiltInComponentsFromContext(ApplicationLoader.createContext(Environment.simple())) with AhcWSComponents with NoHttpFiltersComponents {
-      implicit lazy val Action = defaultActionBuilder
       def router = SimpleRouter(
         PartialFunction.empty
           .orElse(getIp)

--- a/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/tools/HttpBin.scala
@@ -325,6 +325,7 @@ object HttpBinApplication {
 
   def app = {
     new BuiltInComponentsFromContext(ApplicationLoader.createContext(Environment.simple())) with AhcWSComponents with NoHttpFiltersComponents {
+      override implicit lazy val Action = defaultActionBuilder
       def router = SimpleRouter(
         PartialFunction.empty
           .orElse(getIp)

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -329,7 +329,7 @@ object NettyServer extends ServerFromRouter {
       application.materializer)
   }
 
-  override def createServerFromRouter(serverConfig: ServerConfig)(routes: (ServerComponents) => Router): Server = {
+  override protected def createServerFromRouter(serverConfig: ServerConfig)(routes: (ServerComponents) => Router): Server = {
     new NettyServerComponents with BuiltInComponents with NoHttpFiltersComponents {
       override lazy val serverConfig: ServerConfig = serverConfig
       override def router: Router = routes(this)

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -9,7 +9,7 @@ import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.{ Sink, Source }
-import com.typesafe.config.{ Config, ConfigFactory, ConfigValue }
+import com.typesafe.config.{ Config, ConfigValue }
 import com.typesafe.netty.HandlerPublisher
 import com.typesafe.netty.http.HttpStreamsServerHandler
 import io.netty.bootstrap.Bootstrap
@@ -23,8 +23,6 @@ import io.netty.handler.logging.{ LogLevel, LoggingHandler }
 import io.netty.handler.ssl.SslHandler
 import io.netty.handler.timeout.IdleStateHandler
 import play.api._
-import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle }
-import play.api.mvc.{ Handler, RequestHeader }
 import play.api.routing.Router
 import play.core._
 import play.core.server.netty._
@@ -332,9 +330,9 @@ object NettyServer extends ServerFromRouter {
       application.materializer)
   }
 
-  override protected def createServerFromRouter(serverConfig: ServerConfig)(routes: (ServerComponents) => Router): Server = {
+  override protected def createServerFromRouter(serverConf: ServerConfig)(routes: (ServerComponents) => Router): Server = {
     new NettyServerComponents with BuiltInComponents with NoHttpFiltersComponents {
-      override lazy val serverConfig: ServerConfig = serverConfig
+      override lazy val serverConfig: ServerConfig = serverConf
       override def router: Router = routes(this)
     }.server
   }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -330,7 +330,7 @@ object NettyServer extends ServerFromRouter {
       application.materializer)
   }
 
-  override protected def createServerFromRouter(serverConf: ServerConfig)(routes: (ServerComponents) => Router): Server = {
+  override protected def createServerFromRouter(serverConf: ServerConfig)(routes: ServerComponents with BuiltInComponents => Router): Server = {
     new NettyServerComponents with BuiltInComponents with NoHttpFiltersComponents {
       override lazy val serverConfig: ServerConfig = serverConf
       override def router: Router = routes(this)

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -296,9 +296,12 @@ class NettyServerProvider extends ServerProvider {
  * Or from a given router using [[BuiltInComponents]]:
  *
  * {{{
- *   val server = NettyServer.fromRouterWithComponents(ServerConfig(port = Some(9002))) { components => {
- *       case GET(p"/") => components.defaultActionBuilder {
- *         Results.Ok("Hello")
+ *   val server = NettyServer.fromRouterWithComponents(ServerConfig(port = Some(9002))) { components =>
+ *     import play.api.mvc.Results._
+ *     import components.{ defaultActionBuilder => Action }
+ *     {
+ *       case GET(p"/") => Action {
+ *         Ok("Hello")
  *       }
  *     }
  *   }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -3,7 +3,6 @@
  */
 package play.core.server
 
-import java.io.IOException
 import java.net.InetSocketAddress
 
 import akka.Done
@@ -65,7 +64,7 @@ class NettyServer(
 
   import NettyServer._
 
-  def mode = config.mode
+  override def mode: Mode = config.mode
 
   /**
    * The event loop
@@ -209,17 +208,6 @@ class NettyServer(
     }
   }
 
-  private def handleSubscriberError(error: Throwable): Unit = {
-    error match {
-      // IO exceptions happen all the time, it usually just means that the client has closed the connection before fully
-      // sending/receiving the response.
-      case e: IOException =>
-        logger.trace("Benign IO exception caught in Netty", e)
-      case e =>
-        logger.error("Exception caught in Netty", e)
-    }
-  }
-
   // Maybe the HTTP server channel
   private val httpChannel = config.port.map(bindChannel(_, secure = false))
 
@@ -271,13 +259,13 @@ class NettyServer(
     Await.result(stopHook(), Duration.Inf)
   }
 
-  override lazy val mainAddress = {
+  override lazy val mainAddress: InetSocketAddress = {
     (httpChannel orElse httpsChannel).get.localAddress().asInstanceOf[InetSocketAddress]
   }
 
-  def httpPort = httpChannel map (_.localAddress().asInstanceOf[InetSocketAddress].getPort)
+  override def httpPort: Option[Int] = httpChannel map (_.localAddress().asInstanceOf[InetSocketAddress].getPort)
 
-  def httpsPort = httpsChannel map (_.localAddress().asInstanceOf[InetSocketAddress].getPort)
+  override def httpsPort: Option[Int] = httpsChannel map (_.localAddress().asInstanceOf[InetSocketAddress].getPort)
 }
 
 /**
@@ -295,9 +283,30 @@ class NettyServerProvider extends ServerProvider {
 }
 
 /**
- * Bootstraps Play application with a NettyServer backend.
+ * Create a Netty server from the given router and server config:
+ *
+ * {{{
+ *   val server = Netty.fromRouter(ServerConfig(port = Some(9002))) {
+ *     case GET(p"/") => Action {
+ *       Results.Ok("Hello")
+ *     }
+ *   }
+ * }}}
+ *
+ * Or from a given router using [[BuiltInComponents]]:
+ *
+ * {{{
+ *   val server = NettyServer.fromRouterWithComponents(ServerConfig(port = Some(9002))) { components => {
+ *       case GET(p"/") => components.defaultActionBuilder {
+ *         Results.Ok("Hello")
+ *       }
+ *     }
+ *   }
+ * }}}
+ *
+ * Use this together with <a href="https://www.playframework.com/documentation/latest/ScalaSirdRouter">Sird Router</a>.
  */
-object NettyServer {
+object NettyServer extends ServerFromRouter {
 
   private val logger = Logger(this.getClass)
 
@@ -320,13 +329,10 @@ object NettyServer {
       application.materializer)
   }
 
-  /**
-   * Create a Netty server from the given router and server config.
-   */
-  def fromRouter(config: ServerConfig = ServerConfig())(routes: PartialFunction[RequestHeader, Handler]): NettyServer = {
+  override def createServerFromRouter(serverConfig: ServerConfig)(routes: (ServerComponents) => Router): Server = {
     new NettyServerComponents with BuiltInComponents with NoHttpFiltersComponents {
-      override lazy val serverConfig = config
-      lazy val router = Router.from(routes)
+      override lazy val serverConfig: ServerConfig = serverConfig
+      override def router: Router = routes(this)
     }.server
   }
 }
@@ -334,8 +340,7 @@ object NettyServer {
 /**
  * Cake for building a simple Netty server.
  */
-trait NettyServerComponents {
-  lazy val serverConfig: ServerConfig = ServerConfig()
+trait NettyServerComponents extends ServerComponents {
   lazy val server: NettyServer = {
     // Start the application first
     Play.start(application)
@@ -343,16 +348,5 @@ trait NettyServerComponents {
       application.materializer)
   }
 
-  lazy val environment: Environment = Environment.simple(mode = serverConfig.mode)
-  lazy val sourceMapper: Option[SourceMapper] = None
-  lazy val webCommands: WebCommands = new DefaultWebCommands
-  lazy val configuration: Configuration = Configuration(ConfigFactory.load())
-  lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
-
   def application: Application
-
-  /**
-   * Called when Server.stop is called.
-   */
-  def serverStopHook: () => Future[Unit] = () => Future.successful(())
 }

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -230,17 +230,17 @@ object Server {
 /**
  * Components to create a Server instance.
  */
-trait ServerComponents extends BuiltInComponents {
+trait ServerComponents {
 
   def server: Server
 
   lazy val serverConfig: ServerConfig = ServerConfig()
 
-  override lazy val environment: Environment = Environment.simple(mode = serverConfig.mode)
-  override lazy val sourceMapper: Option[SourceMapper] = None
-  override lazy val webCommands: WebCommands = new DefaultWebCommands
-  override lazy val configuration: Configuration = Configuration(ConfigFactory.load())
-  override lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
+  lazy val environment: Environment = Environment.simple(mode = serverConfig.mode)
+  lazy val sourceMapper: Option[SourceMapper] = None
+  lazy val webCommands: WebCommands = new DefaultWebCommands
+  lazy val configuration: Configuration = Configuration(ConfigFactory.load())
+  lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
 
   def serverStopHook: () => Future[Unit] = () => Future.successful(())
 }
@@ -250,7 +250,7 @@ trait ServerComponents extends BuiltInComponents {
  */
 private[server] trait ServerFromRouter {
 
-  protected def createServerFromRouter(serverConfig: ServerConfig = ServerConfig())(routes: ServerComponents => Router): Server
+  protected def createServerFromRouter(serverConfig: ServerConfig = ServerConfig())(routes: ServerComponents with BuiltInComponents => Router): Server
 
   /**
    * Creates a [[Server]] from the given router.

--- a/framework/src/play-server/src/main/scala/play/core/server/Server.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/Server.scala
@@ -248,12 +248,12 @@ trait ServerComponents extends BuiltInComponents {
 /**
  * Define how to create a Server from a Router.
  */
-trait ServerFromRouter {
+private[server] trait ServerFromRouter {
 
-  def createServerFromRouter(serverConfig: ServerConfig = ServerConfig())(routes: ServerComponents => Router): Server
+  protected def createServerFromRouter(serverConfig: ServerConfig = ServerConfig())(routes: ServerComponents => Router): Server
 
   /**
-   * Creates an AkkaHttpServer from the given router.
+   * Creates a [[Server]] from the given router.
    *
    * @param config the server configuration
    * @param routes the routes definitions
@@ -264,7 +264,7 @@ trait ServerFromRouter {
   }
 
   /**
-   * Creates an AkkaHttpServer from the given router, using [[ServerComponents]].
+   * Creates a [[Server]] from the given router, using [[ServerComponents]].
    *
    * @param config the server configuration
    * @param routes the routes definitions

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -263,6 +263,16 @@ trait BuiltInComponents extends I18nComponents {
   def router: Router
 
   /**
+   * Alias method to [[defaultActionBuilder]]. This just helps to keep the idiom of using `Action`
+   * when creating `Router`s using the built in components.
+   *
+   * @return the default action builder.
+   */
+  def Action: DefaultActionBuilder = defaultActionBuilder
+
+  def parse = playBodyParsers
+
+  /**
    * The runtime [[Injector]] instance provided to the [[DefaultApplication]]. This injector is set up to allow
    * existing (deprecated) legacy APIs to function. It is not set up to support injecting arbitrary Play components.
    */


### PR DESCRIPTION
## Purpose

Adds new methods to create Akka and Netty servers using components, and then avoiding deprecated methods. We have the same for Java `Server` API.

This can be backported to 2.6.x since it is just adding new APIs.

## References

See [this message from @schmitch in our gitter channel](https://gitter.im/playframework/contributors?at=594fe4438dae425031515775).
