### PR TITLE
[2.5.x]: Add whitesource support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,31 @@
 language: scala
-# Trusty VM has 1.8u101
-# https://github.com/travis-ci/travis-ci/issues/3259#issuecomment-243534696
 dist: trusty
 sudo: false
 group: beta
 jdk:
-  - oraclejdk8
+- oraclejdk8
 env:
-  # Define scripts here so they run concurrently
+  matrix:
   - SCRIPT=codeChecks
   - SCRIPT=test
   - SCRIPT=testSbtPlugins
   - SCRIPT=testDocumentation
   - SCRIPT=testTemplates
+  - SCRIPT=whitesource
+  global:
+    secure: "LJoRKoBXzuQwRThzokkYQ9nxy0unJeaqSumM0H/Ffz8YFmcRDCpoPiepwJJAn6JWauGmaCB/edAy9h9+0Emuffa+iyf4mUpVxZR27vYLOJ8hl9YIZ6xMNZETAZhdJPC7TmhNxTuRYWwYYdRkcqkPZapVmNZXcW+El5hmEYIel/Y="
 script:
-  # Force sbt to run on a single CPU, this limits the resources Play uses
-  - framework/bin/$SCRIPT "set concurrentRestrictions in Global += Tags.limitAll(1)"
+- framework/bin/$SCRIPT "set concurrentRestrictions in Global += Tags.limitAll(1)"
 cache:
   directories:
-    - $HOME/.ivy2/cache
+  - $HOME/.ivy2/cache
 before_cache:
-  # Ensure changes to the cache aren't persisted
-  - rm -rf $HOME/.ivy2/cache/com.typesafe.play/*
-  - rm -rf $HOME/.ivy2/cache/scala_*/sbt_*/com.typesafe.play/*
-  # Delete all ivydata files since ivy touches them on each build
-  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print0 | xargs -n10 -0 rm
+- rm -rf $HOME/.ivy2/cache/com.typesafe.play/*
+- rm -rf $HOME/.ivy2/cache/scala_*/sbt_*/com.typesafe.play/*
+- find $HOME/.ivy2/cache -name "ivydata-*.properties" -print0 | xargs -n10 -0 rm
 notifications:
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/d2c8a242a2615f659595
+    - https://webhooks.gitter.im/e/d2c8a242a2615f659595
     on_success: always
     on_failure: always

--- a/framework/bin/whitesource
+++ b/framework/bin/whitesource
@@ -1,0 +1,24 @@
+#! /bin/bash
+
+# Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+
+. "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/build"
+
+cd $FRAMEWORK
+
+echo "[info]"
+echo "[info] ---- RUNNING WHITESOURCE REPORT"
+echo "[info]"
+
+#
+# Runs only when it is not a pull request. See the page below for more details:
+# https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions
+#
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+    build 'set credentials in ThisBuild += Credentials("whitesource", "whitesourcesoftware.com", "", System.getenv("WHITESOURCE_KEY"))' whitesourceCheckPolicies whitesourceUpdate
+else
+    echo "[info]"
+    echo "[info] Runs only when it is not a pull request. See the page below for more details:"
+    echo "[info] https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions"
+    echo "[info]"
+fi

--- a/framework/project/Build.scala
+++ b/framework/project/Build.scala
@@ -655,6 +655,7 @@ object PlayBuild extends Build {
     "Play-Framework",
     file("."))
     .enablePlugins(PlayRootProject)
+    .enablePlugins(PlayWhitesourcePlugin)
     .enablePlugins(CrossPerProjectPlugin)
     .settings(playCommonSettings: _*)
     .settings(

--- a/framework/project/PlayWhitesourcePlugin.scala
+++ b/framework/project/PlayWhitesourcePlugin.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+import sbt.{ AutoPlugin, PluginTrigger, Plugins }
+
+import sbtwhitesource.WhiteSourcePlugin
+import sbtwhitesource.WhiteSourcePlugin.autoImport._
+
+/**
+ * Configures sbt-whitesource.
+ */
+object PlayWhitesourcePlugin extends AutoPlugin {
+
+  override def requires: Plugins = WhiteSourcePlugin
+
+  override def trigger: PluginTrigger = allRequirements
+
+  override lazy val projectSettings = Seq(
+    whitesourceProduct := "Lightbend Reactive Platform",
+    whitesourceAggregateProjectName := "playframework-2.5-previous",
+    whitesourceAggregateProjectToken := "5465438f-9ba6-494f-bad0-939b1b260e00"
+  )
+
+}

--- a/framework/project/plugins.sbt
+++ b/framework/project/plugins.sbt
@@ -20,6 +20,7 @@ addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.getOrElse("interplay.
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % sbtTwirlVersion)
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.8")
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.5")
 
 libraryDependencies ++= Seq(
   "org.scala-sbt" % "scripted-plugin" % sbtVersion.value,


### PR DESCRIPTION
## Purpose

Add integration with Whitesource.com. This is not using the support provided by interplay since it would require an update from interplay 1.1.1 to 1.3.6, which changes a lot of things.

## References

See [sbt-whitesource](https://github.com/typesafehub/sbt-whitesource).