### PR TITLE
Add better error message to invalid JWT cookie.

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -602,12 +602,13 @@ trait JWTCookieDataCodec extends CookieDataCodec {
       case e: io.jsonwebtoken.SignatureException =>
         // Thrown when an invalid cookie signature is found -- this can be confusing to end users
         // so give a special logging message to indicate problem.
+
+        logger.warn(s"decode: cookie has invalid signature! message = ${e.getMessage}")(SecurityMarkerContext)
         val devLogger = logger.forMode(Mode.Dev)
         devLogger.info(
-          s"""decode: The JWT signature in the cookie does not match the locally computed signature with the server.
+          s"""The JWT signature in the cookie does not match the locally computed signature with the server.
              |This usually indicates the browser has a leftover cookie from another Play application,
              |so clearing cookies may resolve this error message.""".stripMargin)
-        logger.warn(s"decode: invalid JWT signature found!", e)(SecurityMarkerContext)
         Map.empty
 
       case NonFatal(e) =>

--- a/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Cookie.scala
@@ -599,6 +599,14 @@ trait JWTCookieDataCodec extends CookieDataCodec {
         logger.warn(s"decode: expired JWT found! id = $id, message = ${e.getMessage}")(SecurityMarkerContext)
         Map.empty
 
+      case e: io.jsonwebtoken.SignatureException =>
+        // io.jsonwebtoken.SignatureException: JWT signature does not match locally computed signature.
+        // JWT validity cannot be asserted and should not be trusted.
+        logger.warn(s"decode: cookie JWT signature does not match the locally computed signature " +
+          s"with the server.  This usually indicates the browser has a leftover cookie from another Play " +
+          s"application, so clearing cookies may resolve this error message.")(SecurityMarkerContext)
+        Map.empty
+
       case NonFatal(e) =>
         logger.warn(s"decode: could not decode JWT: ${e.getMessage}", e)(SecurityMarkerContext)
         Map.empty


### PR DESCRIPTION
When a user switches from one application to another application (i.e. from play-scala-secure-session-example to play-java-dagger2-example) and has JWT cookies active, the JWT cookie in the browser will not be wiped, and will not validate correctly.

This PR replaces the out of the box error message (which is not helpful) with one that details what this means exactly and how to fix it.