### PR TITLE
Correct import for Joda time json Reads and Writes

### DIFF
--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -522,8 +522,8 @@ libraryDependencies += "com.typesafe.play" % "play-json-joda" % playJsonVersion
 where `playJsonVersion` is the play-json version you wish to use. Play 2.6.x should be compatible with play-json 2.6.x. Note that play-json is now a separate project (described later).
 
 ```scala
-import play.api.data.JodaWrites._
-import play.api.data.JodaReads._
+import play.api.libs.json.JodaWrites._
+import play.api.libs.json.JodaReads._
 ```
 
 ### Joda-Convert removal


### PR DESCRIPTION
## Purpose

When migrating existing play apps to `2.6.x.` that are using Joda time and following the migration guide I noticed that the suggested import does not seems to work as expected.

The associated changes add the correct import.
