### PR TITLE
Add lazy rendering for CSRF token with HTTPOnly and strict body

### DIFF
--- a/documentation/manual/working/javaGuide/main/forms/JavaCsrf.md
+++ b/documentation/manual/working/javaGuide/main/forms/JavaCsrf.md
@@ -59,6 +59,8 @@ The current CSRF token can be accessed using the `CSRF.getToken` method.  It tak
 
 @[get-token](code/javaguide/forms/JavaCsrf.java)
 
+> **Note**: If the CSRF filter is installed, Play will try to avoid generating the token as long as the cookie being used is HttpOnly (meaning it cannot be accessed from JavaScript). When sending a response with a strict body, Play skips adding the token to the response unless `CSRF.getToken` has already been called. This results in a significant performance improvement for responses that don't need a CSRF token. If the cookie is not configured to be HttpOnly, Play will assume you wish to access it from JavaScript and generate it regardless.
+
 > **Note**: if you are accessing the template from a `CompletionStage` and get an `There is no HTTP Context` error, then you will need to add  [`HttpExecutionContext.current()`](api/java/play/libs/concurrent/HttpExecutionContext.html) -- see [[JavaAsync]] for details.
 
 To help in adding CSRF tokens to forms, Play provides some template helpers.  The first one adds it to the query string of the action URL:

--- a/documentation/manual/working/scalaGuide/main/forms/ScalaCsrf.md
+++ b/documentation/manual/working/scalaGuide/main/forms/ScalaCsrf.md
@@ -99,6 +99,8 @@ The current CSRF token can be accessed using the [`CSRF.getToken`](api/scala/vie
 
 @[get-token](code/ScalaCsrf.scala)
 
+> **Note**: If the CSRF filter is installed, Play will try to avoid generating the token as long as the cookie being used is HttpOnly (meaning it cannot be accessed from JavaScript). When sending a response with a strict body, Play skips adding the token to the response unless `CSRF.getToken` has already been called. This results in a significant performance improvement for responses that don't need a CSRF token. If the cookie is not configured to be HttpOnly, Play will assume you wish to access it from JavaScript and generate it regardless.
+
 If you are not using the CSRF filter, you also should inject the [`CSRFAddToken`](api/scala/play/filters/csrf/CSRFAddToken.html) and [`CSRFCheck`](api/scala/play/filters/csrf/CSRFCheck.html) action wrappers to force adding a token or a CSRF check on a specific action. Otherwise the token will not be available.
 
 @[csrf-controller](code/ScalaCsrf.scala)


### PR DESCRIPTION
A more intelligent implementation of lazy CSRF token rendering. Now we only avoid adding the token to the session/cookie if the following is true:
 - The cookie is `HTTPOnly`, meaning we know it's impossible for the browser-side JavaScript to read the token from the cookie and use it client side.
 - The body is strict, meaning we know it's impossible the body is still streaming from somewhere and `CSRF.getToken` will be called later.
 - `CSRF.getToken` has not been called on that request.