### PR TITLE
Deprecate static JPA class

### DIFF
--- a/documentation/manual/releases/release26/migration26/JPAMigration26.md
+++ b/documentation/manual/releases/release26/migration26/JPAMigration26.md
@@ -9,7 +9,13 @@ The following deprecated methods have been removed in Play 2.6.
 * `play.db.jpa.JPA.bindForAsync(em)`
 * `play.db.jpa.JPA.withTransaction`
 
-Please use a `JPAApi` injected instance, or create a `JPAApi` instance with `JPA.createFor`.
+Please use a `JPAApi` injected instance as specified in [[Using play.db.jpa.JPAApi|JavaJPA#Using-play.db.jpa.JPAApi]].
+
+## Deprecated JPA Class
+
+As of 2.6.1, the `play.db.jpa.JPA` class has been deprecated, as it uses global state under the hood.  The deprecation was mistakenly left out of 2.6.0.
+
+Please use a `JPAApi` injected instance as specified in [[Using play.db.jpa.JPAApi|JavaJPA#Using-play.db.jpa.JPAApi]].
 
 ## Added Async Warning
 

--- a/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
+++ b/framework/src/play-java-jpa/src/main/java/play/db/jpa/JPA.java
@@ -6,8 +6,13 @@ package play.db.jpa;
 import javax.persistence.EntityManager;
 
 /**
- * JPA Helpers.
+ * JPA Helpers.  This is a deprecated class, and an injected JPAApi instance should be used instead.
+ *
+ * Please see <a href="https://www.playframework.com/documentation/latest/JavaJPA#Using-play.db.jpa.JPAApi">Using play.db.jpa.JPAApi</a> for more details.
+ *
+ * @deprecated Use a dependency injected JPAApi instance here, since 2.6.1
  */
+@Deprecated
 public class JPA {
 
     static JPAEntityManagerContext entityManagerContext = new JPAEntityManagerContext();


### PR DESCRIPTION
This PR deprecates the `play.db.jpa.JPA` class and points people to the JPAApi.

This should have been in 2.6.0, but there are no code changes involved, only the annotation and docs.