### PR TITLE
Suppress Hibernate EL warning

### DIFF
--- a/framework/src/play-logback/src/main/resources/logback-play-default.xml
+++ b/framework/src/play-logback/src/main/resources/logback-play-default.xml
@@ -20,6 +20,8 @@
   <logger name="application" level="INFO" />
 
   <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
+  <!-- https://hibernate.atlassian.net/browse/HV-1323 -->
+  <logger name="org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator" level="ERROR" />
 
   <root level="WARN">
     <appender-ref ref="ASYNCSTDOUT" />

--- a/framework/src/play-logback/src/main/resources/logback-play-dev.xml
+++ b/framework/src/play-logback/src/main/resources/logback-play-dev.xml
@@ -16,6 +16,8 @@
   <logger name="application" level="DEBUG" />
 
   <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
+  <!-- https://hibernate.atlassian.net/browse/HV-1323 -->
+  <logger name="org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator" level="ERROR" />
 
   <root level="WARN">
     <appender-ref ref="STDOUT" />

--- a/framework/src/play-logback/src/main/resources/logback-play-logSql.xml
+++ b/framework/src/play-logback/src/main/resources/logback-play-logSql.xml
@@ -30,6 +30,9 @@
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
 
+  <!-- https://hibernate.atlassian.net/browse/HV-1323 -->
+  <logger name="org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator" level="ERROR" />
+
   <logger name="org.jdbcdslog.ConnectionLogger" level="OFF"  /> <!-- Won' log connections -->
   <logger name="org.jdbcdslog.StatementLogger"  level="INFO" /> <!-- Will log all statements -->
   <logger name="org.jdbcdslog.ResultSetLogger"  level="OFF"  /> <!-- Won' log result sets -->


### PR DESCRIPTION
Hibernate gives off a spurious warning on start up when Java Forms are being used:

```
HV000184: ParameterMessageInterpolator has been chosen, EL interpolation will not be supported
```

Until https://hibernate.atlassian.net/browse/HV-1323 is fixed, we must suppress the error manually.