### PR TITLE
Support multipart Content-Type in results (backport)

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -228,13 +228,10 @@ private[server] class AkkaModelConversion(
   }
 
   def parseContentType(contentType: Option[String]): ContentType = {
-    // actually play allows content types to be not spec compliant
-    // so we can't rely on the parsed content type of akka
     contentType.fold(ContentTypes.NoContentType: ContentType) { ct =>
-      MediaType.custom(ct, binary = true) match {
-        case b: MediaType.Binary => ContentType(b)
-        case _ => ContentTypes.NoContentType
-      }
+      ContentType.parse(ct).left.map { errors =>
+        throw new RuntimeException(s"Error parsing response Content-Type: <$ct>: $errors")
+      }.merge
     }
   }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/assets/AssetsSpec.scala
@@ -62,7 +62,12 @@ trait AssetsSpec extends PlaySpecification
 
       result.status must_== OK
       result.body.trim must_== "{}"
-      result.header(CONTENT_TYPE) must beSome.which(_ == "application/json; charset=utf-8")
+      result.header(CONTENT_TYPE) must (
+        // There are many valid responses, but for simplicity just hardcode the two responses that
+        // the Netty and Akka HTTP backends actually return.
+        beSome("application/json; charset=utf-8") or
+        beSome("application/json")
+      )
       result.header(ETAG) must beSome(matching(etagPattern))
       result.header(LAST_MODIFIED) must beSome
       result.header(VARY) must beNone


### PR DESCRIPTION
Backport of #7498.