### PR TITLE
overrides the akka-http max-content-length

### DIFF
--- a/framework/src/play-akka-http-server/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/reference.conf
@@ -49,16 +49,8 @@ play {
       # `ignore` : just ignore the illegal characters in response header value
       illegal-response-header-value-processing-mode = warn
 
-      # Default maximum content length which should not be exceeded by incoming request entities.
-      # Can be changed at runtime (to a higher or lower value) via the `HttpEntity::withSizeLimit` method.
-      # Note that it is not necessarily a problem to set this to a high value as all stream operations
-      # are always properly backpressured.
-      # Nevertheless you might want to apply some limit in order to prevent a single client from consuming
-      # an excessive amount of server resources.
-      #
-      # Set to `infinite` to completely disable entity length checks. (Even then you can still apply one
-      # programmatically via `withSizeLimit`.)
-      # Play has a default content-length of infinite, since body length will be set with body parsers
+      # This setting is set in `akka.http.server.parsing.max-content-length`
+      # Play uses the concept of a `BodyParser` to enforce this limit, so we override it to infinite.
       max-content-length = infinite
 
     }

--- a/framework/src/play-akka-http-server/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/reference.conf
@@ -48,6 +48,19 @@ play {
       # `warn`   : ignore the illegal characters in response header value and log a warning message
       # `ignore` : just ignore the illegal characters in response header value
       illegal-response-header-value-processing-mode = warn
+
+      # Default maximum content length which should not be exceeded by incoming request entities.
+      # Can be changed at runtime (to a higher or lower value) via the `HttpEntity::withSizeLimit` method.
+      # Note that it is not necessarily a problem to set this to a high value as all stream operations
+      # are always properly backpressured.
+      # Nevertheless you might want to apply some limit in order to prevent a single client from consuming
+      # an excessive amount of server resources.
+      #
+      # Set to `infinite` to completely disable entity length checks. (Even then you can still apply one
+      # programmatically via `withSizeLimit`.)
+      # Play has a default content-length of infinite, since body length will be set with body parsers
+      max-content-length = infinite
+
     }
   }
 

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/RequestBodyHandlingSpec.scala
@@ -116,6 +116,6 @@ trait RequestBodyHandlingSpec extends PlaySpecification with ServerIntegrationSp
       )
       responses.length must_== 1
       responses(0).status must_== 500
-    }.skipUntilNettyHttpFixed
+    }.skipUntilNettyHttpFixed // netty does not need that test, since it does not provide a built-in max-content-length
   }
 }


### PR DESCRIPTION
## Fixes

Currently this fixes a bug that all request bodies must be 8 megabyte big or they will fail since akka-http has a default max body size of 8m. currently I tought it's a good idea to actually import all settings so that users can/might fiddle with them.

**This PR should be backported, since else we do not support bodies with > 8m on akka-http**