### PR TITLE
Added ByteString body parser

### DIFF
--- a/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/ByteStringBodyParserSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/parsing/ByteStringBodyParserSpec.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.http.parsing
+
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import play.api.mvc.PlayBodyParsers
+import play.api.test._
+
+class ByteStringBodyParserSpec extends PlaySpecification {
+
+  "The ByteString body parser" should {
+
+    def parsers(implicit mat: Materializer) = PlayBodyParsers()
+    def parser(implicit mat: Materializer) = parsers.byteString.apply(FakeRequest())
+
+    "parse single byte string bodies" in new WithApplication() {
+      await(parser.run(ByteString("bar"))) must beRight(ByteString("bar"))
+    }
+
+    "parse multiple chunk byte string bodies" in new WithApplication() {
+      await(parser.run(
+        Source(List(ByteString("foo"), ByteString("bar")))
+      )) must beRight(ByteString("foobar"))
+    }
+
+    "refuse to parse bodies greater than max length" in new WithApplication() {
+      val parser = parsers.byteString(4).apply(FakeRequest())
+      await(parser.run(
+        Source(List(ByteString("foo"), ByteString("bar")))
+      )) must beLeft
+    }
+  }
+}

--- a/framework/src/play/src/main/java/play/mvc/BodyParser.java
+++ b/framework/src/play/src/main/java/play/mvc/BodyParser.java
@@ -415,7 +415,10 @@ public interface BodyParser<A> {
 
         @Override
         protected final Accumulator<ByteString, F.Either<Result, A>> apply1(Http.RequestHeader request) {
-            return Accumulator.fromSink(Sink.fold(ByteString.empty(), ByteString::concat)).mapFuture(bytes -> {
+            return Accumulator.strict(
+                    maybeStrictBytes -> CompletableFuture.completedFuture(maybeStrictBytes.orElse(ByteString.empty())),
+                    Sink.fold(ByteString.empty(), ByteString::concat)
+            ).mapFuture(bytes -> {
                 try {
                     return CompletableFuture.completedFuture(F.Either.Right(parse(request, bytes)));
                 } catch (Exception e) {

--- a/framework/src/play/src/test/scala/play/api/mvc/RawBodyParserSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/mvc/RawBodyParserSpec.scala
@@ -37,6 +37,17 @@ class RawBodyParserSpec extends Specification with AfterAll {
   }
 
   "Raw Body Parser" should {
+    "parse a strict body" >> {
+      val body = ByteString("lorem ipsum")
+      // Feed a strict element rather than a singleton source, strict element triggers
+      // fast path with zero materialization.
+      Await.result(parse.raw.apply(FakeRequest()).run(body), Duration.Inf) must beRight.like {
+        case rawBuffer => rawBuffer.asBytes() must beSome.like {
+          case outBytes => outBytes mustEqual body
+        }
+      }
+    }
+
     "parse a simple body" >> {
       val body = ByteString("lorem ipsum")
 


### PR DESCRIPTION
Sometimes you just want to handle the body as a simple buffered ByteString, failing if the body is larger than the configured memory buffer limit, similar to the plain text body parser. The raw body parser doesn't fail when the buffer is exceeded, it buffers to disk, and so is more cumbersome to deal with. This adds a simple ByteString body parser.

Also added the strict Accumulator fast path to the raw body parser, so that when the body is an Akka http strict body, the zero materialization fast path will be taken. Also, the Java buffering body parser wasn't taking advantage of the strict fast path either, so I added that.  

Note that the Java body parsers already has a ByteString body parser, so there was no need to add that.

This change is only binary compatible in Scala 2.12 (it adds a new method to a trait, which isn't binary compatible in Scala 2.11 but I believe is in Scala 2.12 due to its use of default methods). If that's acceptable, it could be backported to Play 2.6.