### PR TITLE
Make sure injector uses application ClassLoader

### DIFF
--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -267,12 +267,13 @@ trait BuiltInComponents extends I18nComponents {
    * existing (deprecated) legacy APIs to function. It is not set up to support injecting arbitrary Play components.
    */
   lazy val injector: Injector = {
-    new SimpleInjector(NewInstanceInjector) +
+    val simple = new SimpleInjector(NewInstanceInjector) +
       cookieSigner + // play.api.libs.Crypto (for cookies)
       httpConfiguration + // play.api.mvc.BodyParsers trait
       tempFileCreator + // play.api.libs.TemporaryFileCreator object
       messagesApi + // play.api.i18n.Messages object
       langs // play.api.i18n.Langs object
+    new ContextClassLoaderInjector(simple, environment.classLoader)
   }
 
   lazy val playBodyParsers: PlayBodyParsers =

--- a/framework/src/play/src/main/scala/play/api/inject/Injector.scala
+++ b/framework/src/play/src/main/scala/play/api/inject/Injector.scala
@@ -109,3 +109,21 @@ class SimpleInjector(fallback: Injector, components: Map[Class[_], Any] = Map.em
     new SimpleInjector(fallback, components + (clazz -> component))
 
 }
+
+/**
+ * Wraps an existing injector, ensuring all calls have the correct context `ClassLoader` set.
+ */
+private[play] class ContextClassLoaderInjector(delegate: Injector, classLoader: ClassLoader) extends Injector {
+  override def instanceOf[T: ClassManifest]: T = withContext { delegate.instanceOf[T] }
+  override def instanceOf[T](clazz: Class[T]): T = withContext { delegate.instanceOf(clazz) }
+  override def instanceOf[T](key: BindingKey[T]): T = withContext { delegate.instanceOf(key) }
+
+  @inline
+  private def withContext[T](body: => T): T = {
+    val thread = Thread.currentThread()
+    val oldClassLoader = thread.getContextClassLoader
+    thread.setContextClassLoader(classLoader)
+    try body finally thread.setContextClassLoader(oldClassLoader)
+  }
+
+}

--- a/framework/src/play/src/test/scala/play/api/BuiltInComponentsSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/BuiltInComponentsSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api
+
+import java.io.File
+import java.net.URLClassLoader
+
+import org.specs2.mutable.Specification
+import play.api.inject.DefaultApplicationLifecycle
+import play.api.mvc.EssentialFilter
+import play.api.routing.Router
+import play.core.{ SourceMapper, WebCommands }
+
+class BuiltInComponentsSpec extends Specification {
+  "BuiltinComponents" should {
+    "use the Environment ClassLoader for runtime injection" in {
+      val classLoader = new URLClassLoader(Array())
+      val components = new BuiltInComponents {
+        override val environment: Environment = Environment(new File("."), classLoader, Mode.Test)
+        override def configuration: Configuration = Configuration.load(environment)
+        override def applicationLifecycle: DefaultApplicationLifecycle = new DefaultApplicationLifecycle
+        override def router: Router = ???
+        override def webCommands: WebCommands = ???
+        override def sourceMapper: Option[SourceMapper] = ???
+        override def httpFilters: Seq[EssentialFilter] = ???
+      }
+      components.environment.classLoader must_== classLoader
+      val constructedObject = components.injector.instanceOf[BuiltInComponentsSpec.ClassLoaderAware]
+      constructedObject.constructionClassLoader must_== classLoader
+    }
+  }
+}
+
+object BuiltInComponentsSpec {
+  class ClassLoaderAware {
+    // This is the value of the Thread's context ClassLoader at the time the object is constructed
+    val constructionClassLoader: ClassLoader = Thread.currentThread.getContextClassLoader
+  }
+}


### PR DESCRIPTION
Fixes #7535.

We need to set the thread context ClassLoader before we inject a class, because that class may itself use reflection when it initializes.

This fixes an issue where in dev mode initialization of the @Transactional annotation in dev mode fails to find the application's model classes. This is because in dev mode there are multiple ClassLoaders so we need to be careful about always using the correct ClassLoader when we load classes reflectively or call an API, such as JPA, which uses reflection internally.