### PR TITLE
Reload server HTTP configuration when app changes

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -20,13 +20,13 @@ import akka.stream.scaladsl._
 import akka.util.ByteString
 import com.typesafe.config.{ ConfigFactory, ConfigMemorySize }
 import play.api._
-import play.api.http.{ DefaultHttpErrorHandler, HttpConfiguration, HttpErrorHandler }
+import play.api.http.{ DefaultHttpErrorHandler, HttpErrorHandler }
 import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle }
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.api.routing.Router
 import play.core.server.akkahttp.{ AkkaModelConversion, HttpRequestDecoder }
-import play.core.server.common.{ ForwardedHeaderHandler, ServerResultUtils }
+import play.core.server.common.{ ReloadCache, ServerResultUtils }
 import play.core.server.ssl.ServerSSLEngine
 import play.core.{ ApplicationProvider, DefaultWebCommands, SourceMapper, WebCommands }
 import play.server.SSLEngineProvider
@@ -142,25 +142,34 @@ class AkkaHttpServer(
   // Each request needs an id
   private val requestIDs = new java.util.concurrent.atomic.AtomicLong(0)
 
-  // TODO: We can change this to an eager val when we fully support server configuration
-  // instead of reading from the application configuration. At the moment we need to wait
-  // until we have an Application available before we can read any configuration. :(
+  /**
+   * Values that are cached based on the current application.
+   */
+  private case class ReloadCacheValues(
+    resultUtils: ServerResultUtils,
+    modelConversion: AkkaModelConversion
+  )
 
-  private lazy val resultUtils: ServerResultUtils = {
-    val httpConfiguration = applicationProvider.get match {
-      case Success(app) => HttpConfiguration.fromConfiguration(app.configuration, app.environment)
-      case Failure(_) => HttpConfiguration()
+  /**
+   * A helper to cache values that are derived from the current application.
+   */
+  private val reloadCache = new ReloadCache[ReloadCacheValues] {
+    override protected def reloadValue(tryApp: Try[Application]): ReloadCacheValues = {
+      val serverResultUtils = reloadServerResultUtils(tryApp)
+      val forwardedHeaderHandler = reloadForwardedHeaderHandler(tryApp)
+      val illegalResponseHeaderValue = ParserSettings.IllegalResponseHeaderValueProcessingMode(akkaServerConfig.get[String]("illegal-response-header-value-processing-mode"))
+      val modelConversion = new AkkaModelConversion(serverResultUtils, forwardedHeaderHandler, illegalResponseHeaderValue)
+      ReloadCacheValues(
+        resultUtils = serverResultUtils,
+        modelConversion = modelConversion
+      )
     }
-    new ServerResultUtils(httpConfiguration)
   }
 
-  private lazy val modelConversion: AkkaModelConversion = {
-    val configuration: Option[Configuration] = applicationProvider.get.toOption.map(_.configuration)
-    val forwardedHeaderHandler = new ForwardedHeaderHandler(
-      ForwardedHeaderHandler.ForwardedHeaderHandlerConfig(configuration))
-    val illegalResponseHeaderValue = ParserSettings.IllegalResponseHeaderValueProcessingMode(akkaServerConfig.get[String]("illegal-response-header-value-processing-mode"))
-    new AkkaModelConversion(resultUtils, forwardedHeaderHandler, illegalResponseHeaderValue)
-  }
+  private def resultUtils: ServerResultUtils =
+    reloadCache.cachedFrom(applicationProvider.get).resultUtils
+  private def modelConversion: AkkaModelConversion =
+    reloadCache.cachedFrom(applicationProvider.get).modelConversion
 
   private def handleRequest(request: HttpRequest, secure: Boolean): Future[HttpResponse] = {
     val remoteAddress: InetSocketAddress = remoteAddressOfRequest(request)

--- a/framework/src/play-integration-test/src/test/scala/play/it/server/ServerReloadingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/server/ServerReloadingSpec.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.server
+
+import javax.inject.{ Inject, Provider }
+
+import akka.stream.ActorMaterializer
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.concurrent.ActorSystemProvider
+import play.api.mvc.{ DefaultActionBuilder, Request, Results }
+import play.api.routing.Router
+import play.api.routing.sird._
+import play.api.test.{ PlaySpecification, WsTestClient }
+import play.api.{ Application, Configuration }
+import play.core.ApplicationProvider
+import play.core.server.{ ServerConfig, ServerProvider }
+import play.it.{ AkkaHttpIntegrationSpecification, NettyIntegrationSpecification, ServerIntegrationSpecification }
+
+import scala.concurrent.Future
+import scala.util.{ Failure, Success, Try }
+
+class NettyServerReloadingSpec extends ServerReloadingSpec with NettyIntegrationSpecification
+class AkkaServerReloadingSpec extends ServerReloadingSpec with AkkaHttpIntegrationSpecification
+
+trait ServerReloadingSpec extends PlaySpecification with WsTestClient with ServerIntegrationSpecification {
+
+  class TestApplicationProvider extends ApplicationProvider {
+    @volatile private var app: Option[Try[Application]] = None
+    def provide(newApp: Try[Application]): Unit = app = Some(newApp)
+    override def get: Try[Application] = app.get
+  }
+
+  def withApplicationProvider[A](ap: ApplicationProvider)(block: Port => A): A = {
+    val classLoader = Thread.currentThread.getContextClassLoader
+    val configuration = Configuration.load(classLoader, System.getProperties, Map.empty, allowMissingApplicationConf = true)
+    val (actorSystem, stopActorSystem) = ActorSystemProvider.start(classLoader, configuration)
+    val materializer = ActorMaterializer()(actorSystem)
+
+    val server = integrationServerProvider.createServer(ServerProvider.Context(
+      ServerConfig(port = Some(0)), ap, actorSystem, materializer, () => Future.successful(())
+    ))
+    val port: Port = server.httpPort.get
+
+    try block(port) finally {
+      server.stop()
+      stopActorSystem()
+    }
+  }
+
+  "Server reloading" should {
+
+    "update its flash cookie secret on reloading" in {
+
+      // Test for https://github.com/playframework/playframework/issues/7533
+
+      val testAppProvider = new TestApplicationProvider
+      withApplicationProvider(testAppProvider) { implicit port: Port =>
+
+        // First we make a request to the server. This tries to load the application
+        // but fails because we set our TestApplicationProvider to contain to a Failure
+        // instead of an Application. The server can't load the Application configuration
+        // yet, so it loads some default flash configuration.
+
+        {
+          testAppProvider.provide(Failure(new Exception))
+          val response = await(wsUrl("/").get())
+          response.status must_== 500
+        }
+
+        // Now we update the TestApplicationProvider with a working Application.
+        // Then we make a request to the application to check that the Server has
+        // reloaded the flash configuration properly. The FlashTestRouterProvider
+        // has the logic for setting and reading the flash value.
+
+        {
+          testAppProvider.provide(Success(GuiceApplicationBuilder()
+            .overrides(bind[Router].toProvider[ServerReloadingSpec.TestRouterProvider])
+            .build()))
+
+          val response = await(wsUrl("/setflash").withFollowRedirects(true).get())
+          response.status must_== 200
+          response.body must_== "Some(bar)"
+        }
+      }
+    }
+
+    "update its forwarding configuration on reloading" in {
+
+      val testAppProvider = new TestApplicationProvider
+      withApplicationProvider(testAppProvider) { implicit port: Port =>
+
+        // First we make a request to the server when the application
+        // cannot be loaded. This may cause the server to load the configuration.
+
+        {
+          testAppProvider.provide(Failure(new Exception))
+          val response = await(wsUrl("/getremoteaddress").get())
+          response.status must_== 500
+        }
+
+        // Now we update the TestApplicationProvider with a working Application.
+        // We check that the server uses the default forwarding configuration.
+
+        {
+          testAppProvider.provide(Success(GuiceApplicationBuilder()
+            .overrides(bind[Router].toProvider[ServerReloadingSpec.TestRouterProvider])
+            .build()))
+
+          val noHeaderResponse = await {
+            wsUrl("/getremoteaddress").get()
+          }
+          noHeaderResponse.status must_== 200
+          noHeaderResponse.body must_== "127.0.0.1"
+
+          val xForwardedHeaderResponse = await {
+            wsUrl("/getremoteaddress")
+              .withHttpHeaders("X-Forwarded-For" -> "192.0.2.43, ::1, 127.0.0.1, [::1]")
+              .get()
+          }
+          xForwardedHeaderResponse.status must_== 200
+          xForwardedHeaderResponse.body must_== "192.0.2.43"
+
+          val forwardedHeaderResponse = await {
+            wsUrl("/getremoteaddress")
+              .withHttpHeaders("Forwarded" -> "for=192.0.2.43;proto=https, for=\"[::1]\"")
+              .get()
+          }
+          forwardedHeaderResponse.status must_== 200
+          forwardedHeaderResponse.body must_== "127.0.0.1"
+
+        }
+
+        // Now we update the TestApplicationProvider with a second working Application,
+        // this time with different forwarding configuration.
+
+        {
+          testAppProvider.provide(Success(GuiceApplicationBuilder()
+            .configure("play.http.forwarded.version" -> "rfc7239")
+            .overrides(bind[Router].toProvider[ServerReloadingSpec.TestRouterProvider])
+            .build()))
+
+          val noHeaderResponse = await {
+            wsUrl("/getremoteaddress").get()
+          }
+          noHeaderResponse.status must_== 200
+          noHeaderResponse.body must_== "127.0.0.1"
+
+          val xForwardedHeaderResponse = await {
+            wsUrl("/getremoteaddress")
+              .withHttpHeaders("X-Forwarded-For" -> "192.0.2.43, ::1, 127.0.0.1, [::1]")
+              .get()
+          }
+          xForwardedHeaderResponse.status must_== 200
+          xForwardedHeaderResponse.body must_== "127.0.0.1"
+
+          val forwardedHeaderResponse = await {
+            wsUrl("/getremoteaddress")
+              .withHttpHeaders("Forwarded" -> "for=192.0.2.43;proto=https, for=\"[::1]\"")
+              .get()
+          }
+          forwardedHeaderResponse.status must_== 200
+          forwardedHeaderResponse.body must_== "192.0.2.43"
+
+        }
+
+      }
+    }
+
+  }
+}
+
+private[server] object ServerReloadingSpec {
+
+  /**
+   * The router for an application to help test server reloading.
+   */
+  class TestRouterProvider @Inject() (action: DefaultActionBuilder) extends Provider[Router] {
+    override lazy val get: Router = Router.from {
+      case GET(p"/setflash") => action {
+        Results.Redirect("/getflash").flashing("foo" -> "bar")
+      }
+      case GET(p"/getflash") => action { request: Request[_] =>
+        Results.Ok(request.flash.data.get("foo").toString)
+      }
+      case GET(p"/getremoteaddress") => action { request: Request[_] =>
+        Results.Ok(request.remoteAddress)
+      }
+    }
+  }
+}

--- a/framework/src/play-server/src/main/scala/play/core/server/common/ReloadCache.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/common/ReloadCache.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.core.server.common
+
+import play.api.Application
+import play.api.http.HttpConfiguration
+import play.utils.InlineCache
+
+import scala.util.{ Failure, Success, Try }
+
+/**
+ * Helps a `Server` to cache objects that change when an `Application` is reloaded.
+ *
+ * Subclasses should override the `reloadValue` method, which will be called
+ * when the `Application` changes, and then cached. (Caching is provided by `InlineCache`,
+ * so read its docs for the threading semantics.) Users should call
+ * `cachedValue` to get the cached value.
+ */
+private[play] abstract class ReloadCache[+T] {
+
+  private val reloadCache: Try[Application] => T = new InlineCache[Try[Application], T](reloadValue(_))
+
+  /**
+   * Get the cached `T` for the given application. If the application has changed
+   * then `reloadValue` will be called to calculate a fresh value.
+   */
+  final def cachedFrom(tryApp: Try[Application]): T = reloadCache(tryApp)
+
+  /**
+   * Calculate a fresh `T` for the given application.
+   */
+  protected def reloadValue(tryApp: Try[Application]): T
+
+  /**
+   * Helper to calculate a `ServerResultUtil`.
+   */
+  protected final def reloadServerResultUtils(tryApp: Try[Application]): ServerResultUtils = {
+    val httpConfiguration = tryApp match {
+      case Success(app) => HttpConfiguration.fromConfiguration(app.configuration, app.environment)
+      case Failure(_) => HttpConfiguration()
+    }
+    new ServerResultUtils(httpConfiguration)
+  }
+
+  /**
+   * Helper to calculate a `ForwardedHeaderHandler`.
+   */
+  protected final def reloadForwardedHeaderHandler(tryApp: Try[Application]): ForwardedHeaderHandler = {
+    val forwardedHeaderConfiguration =
+      ForwardedHeaderHandler.ForwardedHeaderHandlerConfig(tryApp.toOption.map(_.configuration))
+    new ForwardedHeaderHandler(forwardedHeaderConfiguration)
+  }
+}


### PR DESCRIPTION
Fixes #7533.

This fixes a bug that can occur in dev mode where the server and application can end up with different keys for signing and verifying cookies.

At the moment, if the application fails to start in dev mode, e.g. due to an evolutions failure or compile error, the server will load invalid default keys. The server's keys will persist even when the application is properly loaded again. This means that the server and application can end up with different keys. Since the server manages key signing, while the application manages key verification, it becomes possible in dev mode for the server to sign cookies that can't later be verified by the application.

This fix ensures that the key configuration is reloaded when the application starts again or changes, which means that the keys used for cookie signing and verification should match properly.