### PR TITLE
only warn the user if a response header is invalid #7549

### DIFF
--- a/framework/build.sbt
+++ b/framework/build.sbt
@@ -4,7 +4,8 @@
 import BuildSettings._
 import Dependencies._
 import Generators._
-import com.typesafe.tools.mima.plugin.MimaKeys.{ mimaPreviousArtifacts, mimaReportBinaryIssues }
+import com.typesafe.tools.mima.plugin.MimaKeys.{ mimaPreviousArtifacts, mimaReportBinaryIssues, mimaBinaryIssueFilters }
+import com.typesafe.tools.mima.core._
 import interplay.PlayBuildBase.autoImport._
 import sbt.Keys.parallelExecution
 import sbt.ScriptedPlugin._
@@ -97,6 +98,12 @@ import AkkaDependency._
 lazy val PlayAkkaHttpServerProject = PlayCrossBuiltProject("Play-Akka-Http-Server", "play-akka-http-server")
     .dependsOn(PlayServerProject, StreamsProject)
     .dependsOn(PlayGuiceProject % "test")
+    .settings(
+      mimaBinaryIssueFilters := Seq(
+        // class is package private[server]
+        ProblemFilters.exclude[DirectMissingMethodProblem]("play.core.server.akkahttp.AkkaModelConversion.this")
+      )
+    )
     .addAkkaModuleDependency("akka-http-core")
 
 lazy val PlayAkkaHttp2SupportProject = PlayCrossBuiltProject("Play-Akka-Http2-Support", "play-akka-http2-support")

--- a/framework/src/play-akka-http-server/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/reference.conf
@@ -39,6 +39,15 @@ play {
       # If this value is the empty string and no header was included in
       # the request, no `Server` header will be rendered at all.
       server-header = ""
+
+      # Configures the processing mode when encountering illegal characters in
+      # header value of response.
+      #
+      # Supported mode:
+      # `error`  : default mode, throw an ParsingException and terminate the processing
+      # `warn`   : ignore the illegal characters in response header value and log a warning message
+      # `ignore` : just ignore the illegal characters in response header value
+      illegal-response-header-value-processing-mode = warn
     }
   }
 

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -12,7 +12,7 @@ import akka.http.play.WebSocketHandler
 import akka.http.scaladsl.model.{ headers, _ }
 import akka.http.scaladsl.model.headers.Expect
 import akka.http.scaladsl.model.ws.UpgradeToWebSocket
-import akka.http.scaladsl.settings.ServerSettings
+import akka.http.scaladsl.settings.{ ParserSettings, ServerSettings }
 import akka.http.scaladsl.util.FastFuture._
 import akka.http.scaladsl.{ ConnectionContext, Http }
 import akka.stream.Materializer
@@ -158,7 +158,8 @@ class AkkaHttpServer(
     val configuration: Option[Configuration] = applicationProvider.get.toOption.map(_.configuration)
     val forwardedHeaderHandler = new ForwardedHeaderHandler(
       ForwardedHeaderHandler.ForwardedHeaderHandlerConfig(configuration))
-    new AkkaModelConversion(resultUtils, forwardedHeaderHandler)
+    val illegalResponseHeaderValue = ParserSettings.IllegalResponseHeaderValueProcessingMode(akkaServerConfig.get[String]("illegal-response-header-value-processing-mode"))
+    new AkkaModelConversion(resultUtils, forwardedHeaderHandler, illegalResponseHeaderValue)
   }
 
   private def handleRequest(request: HttpRequest, secure: Boolean): Future[HttpResponse] = {

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaResponseHeaderHandlingSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/AkkaResponseHeaderHandlingSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.http
+
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc._
+import play.api.test.{ PlaySpecification, Port }
+import play.it.AkkaHttpIntegrationSpecification
+
+class AkkaResponseHeaderHandlingSpec extends PlaySpecification with AkkaHttpIntegrationSpecification {
+
+  "support invalid http response headers and raise a warning" should {
+
+    def withServer[T](action: (DefaultActionBuilder, PlayBodyParsers) => EssentialAction)(block: Port => T) = {
+      val port = testServerPort
+      running(TestServer(port, GuiceApplicationBuilder().appRoutes { app =>
+        val Action = app.injector.instanceOf[DefaultActionBuilder]
+        val parse = app.injector.instanceOf[PlayBodyParsers]
+        ({ case _ => action(Action, parse) })
+      }.build())) {
+        block(port)
+      }
+    }
+
+    "correct support invalid Authorization header" in withServer((Action, _) => Action { rh =>
+      // authorization is a invalid response header
+      Results.Ok.withHeaders("Authorization" -> "invalid")
+    }) { port =>
+      val responses = BasicHttpClient.makeRequests(port, trickleFeed = Some(100L))(
+        // Second request ensures that Play switches back to its normal handler
+        BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+      )
+      responses.length must_== 1
+      responses(0).status must_== 200
+      responses(0).headers.get("Authorization") must_== Some("invalid")
+    }
+
+  }
+
+}


### PR DESCRIPTION
currently previous play versions allowed illegal response headers.
however akka-http enforces them, so we check if a response header
is renderable in responses and if not, we convert them to a RawHeader

## Fixes

Fixes #7549
