### PR TITLE
Remove (duplicate) evolutions configuration from play-jdbc

### DIFF
--- a/framework/src/play-jdbc/src/main/resources/reference.conf
+++ b/framework/src/play-jdbc/src/main/resources/reference.conf
@@ -214,38 +214,4 @@ play {
       }
     }
   }
-
-  # Evolutions configuration
-  evolutions {
-
-    # Whether evolutions are enabled
-    enabled = true
-
-    # Database schema in which the generated evolution and lock tables will be saved to
-    schema = ""
-
-    # Whether evolution updates should be performed with autocommit or in a manually managed transaction
-    autocommit = true
-
-    # Whether locks should be used when apply evolutions.  If this is true, a locks table will be created, and will
-    # be used to synchronise between multiple Play instances trying to apply evolutions.  Set this to true in a multi
-    # node environment.
-    useLocks = false
-
-    # Whether evolutions should be automatically applied.  In prod mode, this will only apply ups, in dev mode, it will
-    # cause both ups and downs to be automatically applied.
-    autoApply = false
-
-    # Whether downs should be automatically applied.  This must be used in combination with autoApply, and only applies
-    # to prod mode.
-    autoApplyDowns = false
-
-    # Whether evolutions should be skipped, if the scripts are all down.
-    skipApplyDownsOnly = false
-
-    # Db specific configuration. Should be a map of db names to configuration in the same format as this.
-    db {
-
-    }
-  }
 }


### PR DESCRIPTION
The exact same configurations can be found in the `play-jdbc-evolutions` project anyway:
https://github.com/playframework/playframework/blob/master/framework/src/play-jdbc-evolutions/src/main/resources/reference.conf

For me it looks like @dotta just forgot to remove it after copying the config into it's own `reference.conf` in the (then newly created) `play-jdbc-evolutions` project in #4380.
