### PR TITLE
Avoid exception when using sqlDate

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/Forms.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Forms.scala
@@ -534,7 +534,7 @@ object Forms {
    *   Form("birthdate" -> sqlDate)
    * }}}
    */
-  val sqlDate: Mapping[java.sql.Date] = of[java.sql.Date]
+  val sqlDate: Mapping[java.sql.Date] = of[java.sql.Date](sqlDateFormat)
 
   /**
    * Constructs a simple mapping for a date field (mapped as `sql.Date type`).
@@ -548,6 +548,29 @@ object Forms {
    * @param timeZone the `java.util.TimeZone` to use for parsing and formatting
    */
   def sqlDate(pattern: String, timeZone: java.util.TimeZone = java.util.TimeZone.getDefault): Mapping[java.sql.Date] = of[java.sql.Date] as sqlDateFormat(pattern, timeZone)
+
+  /**
+   * Constructs a simple mapping for a timestamp field (mapped as `java.sql.Timestamp type`).
+   *
+   * For example:
+   * {{{
+   *   Form("birthdate" -> sqlTimestamp)
+   * }}}
+   */
+  val sqlTimestamp: Mapping[java.sql.Timestamp] = of[java.sql.Timestamp](sqlTimestampFormat)
+
+  /**
+   * Constructs a simple mapping for a Timestamp field (mapped as `java.sql.Timestamp type`).
+   *
+   * For example:
+   * {{{
+   *   Form("birthdate" -> sqlTimestamp("dd-MM-yyyy hh:mm:ss"))
+   * }}}
+   *
+   * @param pattern the date pattern, as defined in `java.text.SimpleDateFormat`
+   * @param timeZone the `java.util.TimeZone` to use for parsing and formatting
+   */
+  def sqlTimestamp(pattern: String, timeZone: java.util.TimeZone = java.util.TimeZone.getDefault): Mapping[java.sql.Timestamp] = of[java.sql.Timestamp] as sqlTimestampFormat(pattern, timeZone)
 
   /**
    * Constructs a simple mapping for an e-mail field.

--- a/framework/src/play/src/main/scala/play/api/data/format/Format.scala
+++ b/framework/src/play/src/main/scala/play/api/data/format/Format.scala
@@ -3,10 +3,8 @@
  */
 package play.api.data.format
 
-import java.text.{ DateFormat, SimpleDateFormat }
-import java.time.temporal.{ ChronoField, TemporalAccessor, TemporalField, TemporalQueries }
 import java.time._
-import java.time.format.{ DateTimeFormatter, DateTimeFormatterBuilder, ResolverStyle }
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 import play.api.data._
@@ -225,15 +223,15 @@ object Formats {
    */
   def sqlDateFormat(pattern: String, timeZone: TimeZone = TimeZone.getDefault): Formatter[java.sql.Date] = new Formatter[java.sql.Date] {
 
-    val dateFormatter = dateFormat(pattern, timeZone)
+    private val dateFormatter: Formatter[LocalDate] = localDateFormat(pattern)
 
     override val format = Some(("format.date", Seq(pattern)))
 
     def bind(key: String, data: Map[String, String]) = {
-      dateFormatter.bind(key, data).right.map(d => new java.sql.Date(d.getTime))
+      dateFormatter.bind(key, data).right.map(d => java.sql.Date.valueOf(d))
     }
 
-    def unbind(key: String, value: java.sql.Date) = dateFormatter.unbind(key, value)
+    def unbind(key: String, value: java.sql.Date) = dateFormatter.unbind(key, value.toLocalDate)
   }
 
   /**

--- a/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/FormSpec.scala
@@ -358,42 +358,82 @@ class FormSpec extends Specification {
     import java.time.LocalDate
     val dateForm = Form("date" -> localDate)
     val data = Map("date" -> "2012-01-01")
-    dateForm.bind(data).get mustEqual (LocalDate.of(2012, 1, 1))
+    dateForm.bind(data).get must beEqualTo(LocalDate.of(2012, 1, 1))
   }
 
   "render form using java.time.LocalDate with format(15/6/2016)" in {
     import java.time.LocalDate
     val dateForm = Form("date" -> localDate("dd/MM/yyyy"))
     val data = Map("date" -> "15/06/2016")
-    dateForm.bind(data).get mustEqual (LocalDate.of(2016, 6, 15))
+    dateForm.bind(data).get must beEqualTo(LocalDate.of(2016, 6, 15))
   }
 
   "render form using java.time.LocalDateTime" in {
     import java.time.LocalDateTime
     val dateForm = Form("date" -> localDateTime)
     val data = Map("date" -> "2012-01-01 10:10:10")
-    dateForm.bind(data).get mustEqual (LocalDateTime.of(2012, 1, 1, 10, 10, 10))
+    dateForm.bind(data).get must beEqualTo(LocalDateTime.of(2012, 1, 1, 10, 10, 10))
   }
 
   "render form using java.time.LocalDateTime with format(17/06/2016T17:15:33)" in {
     import java.time.LocalDateTime
     val dateForm = Form("date" -> localDateTime("dd/MM/yyyy HH:mm:ss"))
     val data = Map("date" -> "17/06/2016 10:10:10")
-    dateForm.bind(data).get mustEqual (LocalDateTime.of(2016, 6, 17, 10, 10, 10))
+    dateForm.bind(data).get must beEqualTo(LocalDateTime.of(2016, 6, 17, 10, 10, 10))
   }
 
   "render form using java.time.LocalTime" in {
     import java.time.LocalTime
     val dateForm = Form("date" -> localTime)
     val data = Map("date" -> "10:10:10")
-    dateForm.bind(data).get mustEqual (LocalTime.of(10, 10, 10))
+    dateForm.bind(data).get must beEqualTo(LocalTime.of(10, 10, 10))
   }
 
   "render form using java.time.LocalTime with format(HH-mm-ss)" in {
     import java.time.LocalTime
     val dateForm = Form("date" -> localTime("HH-mm-ss"))
     val data = Map("date" -> "10-11-12")
-    dateForm.bind(data).get mustEqual (LocalTime.of(10, 11, 12))
+    dateForm.bind(data).get must beEqualTo(LocalTime.of(10, 11, 12))
+  }
+
+  "render form using java.sql.Date" in {
+    import java.time.LocalDate
+    val dateForm = Form("date" -> sqlDate)
+    val data = Map("date" -> "2017-07-04")
+    val date = dateForm.bind(data).get.toLocalDate
+    date must beEqualTo(LocalDate.of(2017, 7, 4))
+  }
+
+  "render form using java.sql.Date with format(dd-MM-yyyy)" in {
+    import java.time.LocalDate
+    val dateForm = Form("date" -> sqlDate("dd-MM-yyyy"))
+    val data = Map("date" -> "04-07-2017")
+    val date = dateForm.bind(data).get.toLocalDate
+    date must beEqualTo(LocalDate.of(2017, 7, 4))
+  }
+
+  "render form using java.sql.Timestamp" in {
+    import java.time.LocalDateTime
+    val dateForm = Form("date" -> sqlTimestamp)
+    val data = Map("date" -> "2017-07-04 10:11:12")
+    val date = dateForm.bind(data).get.toLocalDateTime
+    date must beEqualTo(LocalDateTime.of(2017, 7, 4, 10, 11, 12))
+  }
+
+  "render form using java.sql.Date with format(dd/MM/yyyy HH-mm-ss)" in {
+    import java.time.LocalDateTime
+    val dateForm = Form("date" -> sqlTimestamp("dd/MM/yyyy HH-mm-ss"))
+    val data = Map("date" -> "04/07/2017 10-11-12")
+    val date = dateForm.bind(data).get.toLocalDateTime
+    date must beEqualTo(LocalDateTime.of(2017, 7, 4, 10, 11, 12))
+  }
+
+  "render form using java.time.Timestamp with format(17/06/2016T17:15:33)" in {
+    import java.time.LocalDateTime
+    val dateForm = Form("date" -> sqlTimestamp("dd/MM/yyyy HH:mm:ss"))
+    val data = Map("date" -> "17/06/2016 10:10:10")
+    val date = dateForm.bind(data).get.toLocalDateTime
+    date must beEqualTo(LocalDateTime.of(2016, 6, 17, 10, 10, 10))
   }
 
 }
@@ -463,7 +503,7 @@ object ScalaForms {
   )
 
   val form = Form(
-    "foo" -> Forms.text.verifying("first.digit", s => s.headOption exists { _ == '3' })
+    "foo" -> Forms.text.verifying("first.digit", s => s.headOption contains '3')
       .transform[Int](Integer.parseInt, _.toString).verifying("number.42", _ < 42)
   )
 

--- a/framework/src/play/src/test/scala/play/api/data/format/FormatSpec.scala
+++ b/framework/src/play/src/test/scala/play/api/data/format/FormatSpec.scala
@@ -3,13 +3,49 @@
  */
 package play.api.data.format
 
+import java.sql
+
 import org.specs2.mutable.Specification
-import java.util.{ UUID, Date, TimeZone }
+import java.util.{ Date, TimeZone, UUID }
 
 import play.api.data._
 import play.api.data.Forms._
 
 class FormatSpec extends Specification {
+
+  "A java.sql.Date format" should {
+    "support formatting with a pattern" in {
+      val data = Map("date" -> "04-07-2017")
+      val format = Formats.sqlDateFormat("dd-MM-yyyy")
+
+      format.bind("date", data).right.map(_.getTime) should beRight(1499137200000L)
+    }
+
+    "use yyyy-MM-dd as the default format" in {
+      val data = Map("date" -> "2017-07-04")
+      val format = Formats.sqlDateFormat
+
+      format.bind("date", data).right.map(_.getTime) should beRight(1499137200000L)
+    }
+
+    "fails when form data is using the wrong pattern" in {
+      val data = Map("date" -> "04-07-2017") // default pattern is yyyy-MM-dd, so this is wrong
+      val format = Formats.sqlDateFormat
+
+      format.bind("date", data) should beLeft
+    }
+
+    "convert raw data to form data using the given pattern" in {
+      val format = Formats.sqlDateFormat("dd-MM-yyyy")
+      format.unbind("date", new sql.Date(1499137200000L)).get("date") must beSome("04-07-2017")
+    }
+
+    "convert raw data to form data using the default pattern" in {
+      val format = Formats.sqlDateFormat
+      format.unbind("date", new sql.Date(1499137200000L)).get("date") must beSome("2017-07-04")
+    }
+  }
+
   "dateFormat" should {
     "support custom time zones" in {
       val data = Map("date" -> "00:00")


### PR DESCRIPTION
## Fixes

Fixes #7522.

## Purpose

This is using the `LocalDate` format to bind/unbind `java.sql.Date` since the conversion between these two types is straightforward and supported.