### PR TITLE
[2.6.x]: Use ApplicationLifecycle instead of DefaultApplicationLifecycle (#7563)

### DIFF
--- a/framework/project/BuildSettings.scala
+++ b/framework/project/BuildSettings.scala
@@ -5,9 +5,11 @@ import com.typesafe.sbt.SbtScalariform._
 
 import sbt.ScriptedPlugin._
 import sbt._
-import Keys._
-import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
-import com.typesafe.tools.mima.plugin.MimaKeys.mimaPreviousArtifacts
+import Keys.{version, _}
+
+import com.typesafe.tools.mima.core._
+import com.typesafe.tools.mima.plugin.MimaKeys._
+import com.typesafe.tools.mima.plugin.MimaPlugin._
 
 import de.heikoseeberger.sbtheader.HeaderKey._
 import de.heikoseeberger.sbtheader.HeaderPattern
@@ -165,6 +167,23 @@ object BuildSettings {
         previousVersions.map(v => organization.value % moduleName.value %  v)
       }
     },
+    mimaBinaryIssueFilters ++= Seq(
+      // Changing return and parameter types from DefaultApplicationLifecycle (implementation) to ApplicationLifecycle (trait)
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.BuiltInComponents.applicationLifecycle"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.BuiltInComponentsFromContext.applicationLifecycle"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.core.server.AkkaHttpServerComponents.applicationLifecycle"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.ApplicationLoader.createContext$default$5"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.ApplicationLoader#Context.lifecycle"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.ApplicationLoader#Context.copy$default$5"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.core.ObjectMapperComponents.applicationLifecycle"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.core.server.NettyServerComponents.applicationLifecycle"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.ApplicationLoader.createContext"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.ApplicationLoader#Context.apply"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.ApplicationLoader#Context.copy"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.ApplicationLoader#Context.this"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.BuiltInComponents.applicationLifecycle"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.core.ObjectMapperComponents.applicationLifecycle")
+    ),
     unmanagedSourceDirectories in Compile <+= (sourceDirectory in Compile, scalaBinaryVersion) {
       (dir, version) => dir / s"scala-$version"
     },

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/AkkaHttpServer.scala
@@ -21,7 +21,7 @@ import akka.util.ByteString
 import com.typesafe.config.{ ConfigFactory, ConfigMemorySize }
 import play.api._
 import play.api.http.{ DefaultHttpErrorHandler, HttpConfiguration, HttpErrorHandler }
-import play.api.inject.DefaultApplicationLifecycle
+import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle }
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.api.routing.Router
@@ -406,7 +406,7 @@ trait AkkaHttpServerComponents {
   lazy val sourceMapper: Option[SourceMapper] = None
   lazy val webCommands: WebCommands = new DefaultWebCommands
   lazy val configuration: Configuration = Configuration(ConfigFactory.load())
-  lazy val applicationLifecycle: DefaultApplicationLifecycle = new DefaultApplicationLifecycle
+  lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
 
   def application: Application
 

--- a/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
+++ b/framework/src/play-guice/src/main/scala/play/api/inject/guice/GuiceApplicationLoader.scala
@@ -51,6 +51,6 @@ object GuiceApplicationLoader {
     Seq(
       bind[OptionalSourceMapper] to new OptionalSourceMapper(context.sourceMapper),
       bind[WebCommands] to context.webCommands,
-      bind[DefaultApplicationLifecycle] to context.lifecycle)
+      bind[ApplicationLifecycle] to context.lifecycle)
   }
 }

--- a/framework/src/play-java/src/main/scala/play/core/ObjectMapperModule.scala
+++ b/framework/src/play-java/src/main/scala/play/core/ObjectMapperModule.scala
@@ -38,7 +38,7 @@ class ObjectMapperProvider @Inject() (lifecycle: ApplicationLifecycle) extends P
  */
 trait ObjectMapperComponents {
 
-  def applicationLifecycle: DefaultApplicationLifecycle
+  def applicationLifecycle: ApplicationLifecycle
 
   lazy val objectMapper: ObjectMapper = new ObjectMapperProvider(applicationLifecycle).get
 }

--- a/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
+++ b/framework/src/play-jdbc-evolutions/src/main/scala/play/api/db/evolutions/Evolutions.scala
@@ -8,7 +8,7 @@ import java.nio.charset.Charset
 import java.nio.file._
 
 import play.api.db.{ DBApi, Database }
-import play.api.inject.DefaultApplicationLifecycle
+import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle }
 import play.api.libs.Codecs.sha1
 import play.api.{ Configuration, Environment, Logger, Mode, Play }
 import play.core.DefaultWebCommands
@@ -247,7 +247,7 @@ object OfflineEvolutions {
     new EvolutionsComponents {
       lazy val environment = Environment(appPath, classloader, Mode.Dev)
       lazy val configuration = Configuration.load(environment)
-      lazy val applicationLifecycle = new DefaultApplicationLifecycle
+      lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
       lazy val dbApi: DBApi = _dbApi
       lazy val webCommands = new DefaultWebCommands
     }

--- a/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
+++ b/framework/src/play-netty-server/src/main/scala/play/core/server/NettyServer.scala
@@ -24,7 +24,7 @@ import io.netty.handler.logging.{ LogLevel, LoggingHandler }
 import io.netty.handler.ssl.SslHandler
 import io.netty.handler.timeout.IdleStateHandler
 import play.api._
-import play.api.inject.DefaultApplicationLifecycle
+import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle }
 import play.api.mvc.{ Handler, RequestHeader }
 import play.api.routing.Router
 import play.core._
@@ -347,7 +347,7 @@ trait NettyServerComponents {
   lazy val sourceMapper: Option[SourceMapper] = None
   lazy val webCommands: WebCommands = new DefaultWebCommands
   lazy val configuration: Configuration = Configuration(ConfigFactory.load())
-  lazy val applicationLifecycle: DefaultApplicationLifecycle = new DefaultApplicationLifecycle
+  lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
 
   def application: Application
 

--- a/framework/src/play/src/main/scala/play/api/Application.scala
+++ b/framework/src/play/src/main/scala/play/api/Application.scala
@@ -19,7 +19,7 @@ import play.api.libs.crypto._
 import play.api.mvc._
 import play.api.mvc.request.{ DefaultRequestFactory, RequestFactory }
 import play.api.routing.Router
-import play.core.j.JavaHelpers
+import play.core.j.{ JavaContextComponents, JavaHelpers }
 import play.core.{ SourceMapper, WebCommands }
 import play.utils._
 
@@ -258,7 +258,7 @@ trait BuiltInComponents extends I18nComponents {
   def sourceMapper: Option[SourceMapper]
   def webCommands: WebCommands
   def configuration: Configuration
-  def applicationLifecycle: DefaultApplicationLifecycle
+  def applicationLifecycle: ApplicationLifecycle
 
   def router: Router
 
@@ -335,7 +335,7 @@ trait BuiltInComponents extends I18nComponents {
 
   lazy val fileMimeTypes: FileMimeTypes = new DefaultFileMimeTypesProvider(httpConfiguration.fileMimeTypes).get
 
-  lazy val javaContextComponents = JavaHelpers.createContextComponents(messagesApi, langs, fileMimeTypes, httpConfiguration)
+  lazy val javaContextComponents: JavaContextComponents = JavaHelpers.createContextComponents(messagesApi, langs, fileMimeTypes, httpConfiguration)
 }
 
 /**

--- a/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
+++ b/framework/src/play/src/main/scala/play/api/ApplicationLoader.scala
@@ -5,7 +5,7 @@ package play.api
 
 import play.core.{ DefaultWebCommands, SourceMapper, WebCommands }
 import play.utils.Reflect
-import play.api.inject.{ DefaultApplicationLifecycle, Injector, NewInstanceInjector, SimpleInjector }
+import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle, Injector, NewInstanceInjector, SimpleInjector }
 import play.api.mvc.{ ControllerComponents, DefaultControllerComponents }
 
 /**
@@ -59,7 +59,7 @@ object ApplicationLoader {
    *                             configuration used by the application, as the ApplicationLoader may, through it's own
    *                             mechanisms, modify it or completely ignore it.
    */
-  final case class Context(environment: Environment, sourceMapper: Option[SourceMapper], webCommands: WebCommands, initialConfiguration: Configuration, lifecycle: DefaultApplicationLifecycle)
+  final case class Context(environment: Environment, sourceMapper: Option[SourceMapper], webCommands: WebCommands, initialConfiguration: Configuration, lifecycle: ApplicationLifecycle)
 
   /**
    * Locate and instantiate the ApplicationLoader.
@@ -109,7 +109,7 @@ object ApplicationLoader {
     initialSettings: Map[String, AnyRef] = Map.empty[String, AnyRef],
     sourceMapper: Option[SourceMapper] = None,
     webCommands: WebCommands = new DefaultWebCommands,
-    lifecycle: DefaultApplicationLifecycle = new DefaultApplicationLifecycle()) = {
+    lifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle()) = {
     val configuration = Configuration.load(environment, initialSettings)
     Context(environment, sourceMapper, webCommands, configuration, lifecycle)
   }
@@ -124,7 +124,7 @@ abstract class BuiltInComponentsFromContext(context: ApplicationLoader.Context) 
   lazy val sourceMapper = context.sourceMapper
   lazy val webCommands = context.webCommands
   lazy val configuration = context.initialConfiguration
-  lazy val applicationLifecycle: DefaultApplicationLifecycle = context.lifecycle
+  lazy val applicationLifecycle: ApplicationLifecycle = context.lifecycle
 
   lazy val controllerComponents: ControllerComponents = DefaultControllerComponents(
     defaultActionBuilder, playBodyParsers, messagesApi, langs, fileMimeTypes, executionContext


### PR DESCRIPTION
Backports #7563.