### PR TITLE
Preserve the order of repeated params in query string

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -24,7 +24,6 @@ import play.mvc.Http.HeaderNames
 
 import scala.annotation.tailrec
 import scala.collection.immutable
-import scala.collection.immutable.Queue
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
@@ -135,7 +134,7 @@ private[server] class AkkaModelConversion(
             if (q.isEmpty) {
               map
             } else {
-              append(map.updated(q.key, map.getOrElse(q.key, Queue.empty[String]) :+ q.value), q.tail)
+              append(map.updated(q.key, map.getOrElse(q.key, Vector.empty[String]) :+ q.value), q.tail)
             }
           }
           append(Map.empty, query)

--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -127,7 +127,10 @@ private[server] class AkkaModelConversion(
           }
         }
 
-        // see https://github.com/akka/akka-http/pull/1270
+        // This method converts to a `Map`, preserving the order of the query parameters.
+        // It can be removed and replaced with `query().toMultiMap` once this Akka HTTP
+        // fix is available upstream:
+        // https://github.com/akka/akka-http/pull/1270
         private def toMultiMap(query: Uri.Query): Map[String, Seq[String]] = {
           @tailrec
           def append(map: Map[String, Seq[String]], q: Query): Map[String, Seq[String]] = {

--- a/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -6,14 +6,13 @@ package play.core.server.common
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.util.ByteString
-import io.jsonwebtoken.{ Jws, Jwts }
 import org.specs2.mutable.Specification
 import play.api.http.Status._
 import play.api.http._
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc.Results._
 import play.api.mvc._
-import play.api.mvc.request.{ DefaultRequestFactory, RemoteConnection, RequestAttrKey, RequestTarget }
+import play.api.mvc.request.{ DefaultRequestFactory, RemoteConnection, RequestTarget }
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }


### PR DESCRIPTION
## Fixes

Fixes #7567.

## Purpose

Preserves the order of repeated parameters in query string. While there is no saying in RFC3986 about how to handle repeated params, this is less surprising than having a reverse order.