### PR TITLE
[2.6.x]: overrides the akka-http max-content-length (#7548)

### DIFF
--- a/framework/src/play-akka-http-server/src/main/resources/reference.conf
+++ b/framework/src/play-akka-http-server/src/main/resources/reference.conf
@@ -48,6 +48,11 @@ play {
       # `warn`   : ignore the illegal characters in response header value and log a warning message
       # `ignore` : just ignore the illegal characters in response header value
       illegal-response-header-value-processing-mode = warn
+
+      # This setting is set in `akka.http.server.parsing.max-content-length`
+      # Play uses the concept of a `BodyParser` to enforce this limit, so we override it to infinite.
+      max-content-length = infinite
+
     }
   }
 


### PR DESCRIPTION
Backports #7548.