### PR TITLE
[2.6.x]: Preserve the order of repeated params in query string (#7573)

### DIFF
--- a/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
+++ b/framework/src/play-akka-http-server/src/main/scala/play/core/server/akkahttp/AkkaModelConversion.scala
@@ -6,6 +6,7 @@ package play.core.server.akkahttp
 import java.net.{ InetAddress, InetSocketAddress, URI }
 import java.util.Locale
 
+import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.settings.ParserSettings
@@ -21,6 +22,7 @@ import play.api.mvc.request.{ RemoteConnection, RequestTarget }
 import play.core.server.common.{ ForwardedHeaderHandler, ServerResultUtils }
 import play.mvc.Http.HeaderNames
 
+import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.control.NonFatal
@@ -117,12 +119,28 @@ private[server] class AkkaModelConversion(
 
         override lazy val queryMap: Map[String, Seq[String]] = {
           try {
-            request.uri.query().toMultiMap
+            toMultiMap(request.uri.query())
           } catch {
             case NonFatal(e) =>
               logger.warn("Failed to parse query string; returning empty map.", e)
               Map[String, Seq[String]]()
           }
+        }
+
+        // This method converts to a `Map`, preserving the order of the query parameters.
+        // It can be removed and replaced with `query().toMultiMap` once this Akka HTTP
+        // fix is available upstream:
+        // https://github.com/akka/akka-http/pull/1270
+        private def toMultiMap(query: Uri.Query): Map[String, Seq[String]] = {
+          @tailrec
+          def append(map: Map[String, Seq[String]], q: Query): Map[String, Seq[String]] = {
+            if (q.isEmpty) {
+              map
+            } else {
+              append(map.updated(q.key, map.getOrElse(q.key, Vector.empty[String]) :+ q.value), q.tail)
+            }
+          }
+          append(Map.empty, query)
         }
       },
       request.protocol.value,

--- a/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
+++ b/framework/src/play-server/src/test/scala/play/core/server/common/ServerResultUtilsSpec.scala
@@ -6,14 +6,13 @@ package play.core.server.common
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.util.ByteString
-import io.jsonwebtoken.{ Jws, Jwts }
 import org.specs2.mutable.Specification
 import play.api.http.Status._
 import play.api.http._
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc.Results._
 import play.api.mvc._
-import play.api.mvc.request.{ DefaultRequestFactory, RemoteConnection, RequestAttrKey, RequestTarget }
+import play.api.mvc.request.{ DefaultRequestFactory, RemoteConnection, RequestTarget }
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }


### PR DESCRIPTION
Backports #7573.