### PR TITLE
Deprecate sqlDateFormat with time zone

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/Forms.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Forms.scala
@@ -536,6 +536,13 @@ object Forms {
    */
   val sqlDate: Mapping[java.sql.Date] = of[java.sql.Date](sqlDateFormat)
 
+  @deprecated("Use sqlDate(pattern). SQL dates do not have time zones.", "2.6.2")
+  def sqlDate(pattern: String, timeZone: java.util.TimeZone): Mapping[java.sql.Date] = sqlDate(pattern)
+
+  // Added for bincompat
+  @deprecated("This method will be removed when sqlDate(pattern, timeZone) is removed.", "2.6.2")
+  private[data] def sqlDate$default$2: java.util.TimeZone = java.util.TimeZone.getDefault
+
   /**
    * Constructs a simple mapping for a date field (mapped as `sql.Date type`).
    *
@@ -545,9 +552,8 @@ object Forms {
    * }}}
    *
    * @param pattern the date pattern, as defined in `java.text.SimpleDateFormat`
-   * @param timeZone the `java.util.TimeZone` to use for parsing and formatting
    */
-  def sqlDate(pattern: String, timeZone: java.util.TimeZone = java.util.TimeZone.getDefault): Mapping[java.sql.Date] = of[java.sql.Date] as sqlDateFormat(pattern, timeZone)
+  def sqlDate(pattern: String): Mapping[java.sql.Date] = of[java.sql.Date] as sqlDateFormat(pattern)
 
   /**
    * Constructs a simple mapping for a timestamp field (mapped as `java.sql.Timestamp type`).

--- a/framework/src/play/src/main/scala/play/api/data/format/Format.scala
+++ b/framework/src/play/src/main/scala/play/api/data/format/Format.scala
@@ -216,13 +216,19 @@ object Formats {
    */
   implicit val dateFormat: Formatter[Date] = dateFormat("yyyy-MM-dd")
 
+  @deprecated("Use sqlDateFormat(pattern). SQL dates do not have time zones.", "2.6.2")
+  def sqlDateFormat(pattern: String, timeZone: java.util.TimeZone): Formatter[java.sql.Date] = sqlDateFormat(pattern)
+
+  // Added for bincompat
+  @deprecated("This method will be removed when sqlDateFormat(pattern, timeZone) is removed.", "2.6.2")
+  private[format] def sqlDateFormat$default$2: java.util.TimeZone = java.util.TimeZone.getDefault
+
   /**
    * Formatter for the `java.sql.Date` type.
    *
    * @param pattern a date pattern as specified in `java.time.DateTimeFormatter`.
-   * @param timeZone the `java.util.TimeZone` to use for parsing and formatting
    */
-  def sqlDateFormat(pattern: String, timeZone: TimeZone = TimeZone.getDefault): Formatter[java.sql.Date] = new Formatter[java.sql.Date] {
+  def sqlDateFormat(pattern: String): Formatter[java.sql.Date] = new Formatter[java.sql.Date] {
 
     private val dateFormatter: Formatter[LocalDate] = localDateFormat(pattern)
 


### PR DESCRIPTION
Deprecates methods producing a `java.sql.Date` that take a `java.util.TimeZone` and provides extra methods for binary compatibility.

Fixes #7590