### PR TITLE
Update Actor usage in docs to use AbstractActor, the main Java API since 2.5

### DIFF
--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/ConfiguredActor.java
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/ConfiguredActor.java
@@ -4,12 +4,12 @@
 package javaguide.akka;
 
 //#injected
-import akka.actor.UntypedAbstractActor;
+import akka.actor.AbstractActor;
 import com.typesafe.config.Config;
 
 import javax.inject.Inject;
 
-public class ConfiguredActor extends UntypedAbstractActor {
+public class ConfiguredActor extends AbstractActor {
 
     private Config configuration;
 
@@ -19,10 +19,12 @@ public class ConfiguredActor extends UntypedAbstractActor {
     }
 
     @Override
-    public void onReceive(Object message) throws Exception {
-        if (message instanceof ConfiguredActorProtocol.GetConfig) {
-            sender().tell(configuration.getString("my.config"), self());
-        }
+    public Receive createReceive() {
+        return receiveBuilder()
+          .match(ConfiguredActorProtocol.GetConfig.class, message -> {
+              sender().tell(configuration.getString("my.config"), self());
+          })
+          .build();
     }
 }
 //#injected

--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/ConfiguredChildActor.java
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/ConfiguredChildActor.java
@@ -4,13 +4,13 @@
 package javaguide.akka;
 
 //#injectedchild
-import akka.actor.UntypedAbstractActor;
+import akka.actor.AbstractActor;
 import com.google.inject.assistedinject.Assisted;
 import com.typesafe.config.Config;
 
 import javax.inject.Inject;
 
-public class ConfiguredChildActor extends UntypedAbstractActor {
+public class ConfiguredChildActor extends AbstractActor {
 
     private final Config configuration;
     private final String key;
@@ -22,10 +22,14 @@ public class ConfiguredChildActor extends UntypedAbstractActor {
     }
 
     @Override
-    public void onReceive(Object message) throws Exception {
-        if (message instanceof ConfiguredChildActorProtocol.GetConfig) {
-            sender().tell(configuration.getString(key), self());
-        }
+    public Receive createReceive() {
+        return receiveBuilder()
+          .match(ConfiguredChildActorProtocol.GetConfig.class, this::getConfig)
+          .build();
+    }
+
+    private void getConfig(ConfiguredChildActorProtocol.GetConfig get) {
+        sender().tell(configuration.getString(key), self());
     }
 }
 //#injectedchild

--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/HelloActor.java
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/HelloActor.java
@@ -6,13 +6,14 @@
 package javaguide.akka;
 
 import akka.actor.*;
+import akka.japi.*;
 //###replace: import actors.HelloActorProtocol.*;
 import javaguide.akka.HelloActorProtocol.*;
 
 public class HelloActor extends AbstractActor {
 
     public static Props getProps() {
-        return Props.create(() -> new HelloActor());
+        return Props.create(HelloActor.class);
     }
 
     @Override

--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/HelloActor.java
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/HelloActor.java
@@ -9,16 +9,20 @@ import akka.actor.*;
 //###replace: import actors.HelloActorProtocol.*;
 import javaguide.akka.HelloActorProtocol.*;
 
-public class HelloActor extends UntypedAbstractActor {
+public class HelloActor extends AbstractActor {
 
     public static Props getProps() {
-        return Props.create(HelloActor.class);
+        return Props.create(() -> new HelloActor());
     }
 
-    public void onReceive(Object msg) throws Exception {
-        if (msg instanceof SayHello) {
-            sender().tell("Hello, " + ((SayHello) msg).name, self());
-        }
+    @Override
+    public Receive createReceive() {
+      return receiveBuilder()
+        .match(SayHello.class, hello -> {
+            String reply = "Hello, " + hello.name;
+            sender().tell(reply, self());
+        })
+        .build();
     }
 }
 //#actor

--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/JavaAkka.java
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/JavaAkka.java
@@ -4,7 +4,7 @@
 package javaguide.akka;
 
 import akka.actor.*;
-import static akka.pattern.Patterns.ask;
+import static akka.pattern.PatternsCS.ask;
 import com.typesafe.config.*;
 import javaguide.testhelpers.MockJavaAction;
 import javaguide.testhelpers.MockJavaActionHelper;
@@ -27,10 +27,14 @@ import static play.test.Helpers.*;
 public class JavaAkka {
 
     private static volatile CountDownLatch latch;
-    public static class MyActor extends UntypedAbstractActor {
+    public static class MyActor extends AbstractActor {
         @Override
-        public void onReceive(Object msg) throws Exception {
-            latch.countDown();
+        public Receive createReceive() {
+            return receiveBuilder()
+              .matchAny(() -> {
+                  latch.countDown();
+              })
+              .build();
         }
     }
 
@@ -77,9 +81,13 @@ public class JavaAkka {
             ActorRef parent = app.injector().instanceOf(play.inject.Bindings.bind(ActorRef.class).qualifiedWith("parent-actor"));
 
             try {
-                String message = (String) FutureConverters.toJava(ask(parent, new ParentActorProtocol.GetChild("my.config"), 1000)).thenCompose(child ->
-                        FutureConverters.toJava(ask((ActorRef) child, new ConfiguredChildActorProtocol.GetConfig(), 1000))
-                ).toCompletableFuture().get(5, TimeUnit.SECONDS);
+                String message = (String) 
+                  ask(parent, new ParentActorProtocol.GetChild("my.config"), 1000)
+                    .thenApply(msg -> (ActorRef) msg)
+                    .thenCompose(child ->
+                        ask(child, new ConfiguredChildActorProtocol.GetConfig(), 1000)
+                    ).toCompletableFuture()
+                    .get(5, TimeUnit.SECONDS);
                 assertThat(message, equalTo("foo"));
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/JavaAkka.java
+++ b/documentation/manual/working/javaGuide/main/akka/code/javaguide/akka/JavaAkka.java
@@ -31,7 +31,7 @@ public class JavaAkka {
         @Override
         public Receive createReceive() {
             return receiveBuilder()
-              .matchAny(() -> {
+              .matchAny(m -> {
                   latch.countDown();
               })
               .build();

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/JavaWebSockets.java
@@ -20,14 +20,18 @@ import java.util.concurrent.CompletableFuture;
 
 public class JavaWebSockets {
 
-    public static class Actor1 extends UntypedAbstractActor {
+    public static class Actor1 extends AbstractActor {
         private final Closeable someResource;
 
         public Actor1(Closeable someResource) {
             this.someResource = someResource;
         }
 
-        public void onReceive(Object message) throws Exception {
+        @Override
+        public Receive createReceive() {
+            return receiveBuilder()
+              // match() messages here...
+              .build();
         }
 
         //#actor-post-stop
@@ -37,8 +41,12 @@ public class JavaWebSockets {
         //#actor-post-stop
     }
 
-    public static class Actor2 extends UntypedAbstractActor {
-        public void onReceive(Object message) throws Exception {
+    public static class Actor2 extends AbstractActor {
+        @Override
+        public Receive createReceive() {
+            return receiveBuilder()
+              // match() messages here
+              .build();
         }
 
         {

--- a/documentation/manual/working/javaGuide/main/async/code/javaguide/async/MyWebSocketActor.java
+++ b/documentation/manual/working/javaGuide/main/async/code/javaguide/async/MyWebSocketActor.java
@@ -6,7 +6,7 @@ package javaguide.async;
 //#actor
 import akka.actor.*;
 
-public class MyWebSocketActor extends UntypedAbstractActor {
+public class MyWebSocketActor extends AbstractActor {
 
     public static Props props(ActorRef out) {
         return Props.create(MyWebSocketActor.class, out);
@@ -18,10 +18,13 @@ public class MyWebSocketActor extends UntypedAbstractActor {
         this.out = out;
     }
 
-    public void onReceive(Object message) throws Exception {
-        if (message instanceof String) {
-            out.tell("I received your message: " + message, self());
-        }
+    @Override
+    public Receive createReceive() {
+        return receiveBuilder()
+          .match(String.class, message ->
+              out.tell("I received your message: " + message, self())
+            )
+          .build();
     }
 }
 //#actor

--- a/framework/src/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
+++ b/framework/src/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
@@ -18,7 +18,7 @@ object AkkaTestServer extends App {
     address = "127.0.0.1"
   )) {
     case GET(p"/") => Action { implicit req =>
-      Results.Ok(s"Hello world: " + req.headers.headers.toList)
+      Results.Ok(s"Hello world")
     }
   }
   println("Server (Akka HTTP) started: http://127.0.0.1:9000/ ")

--- a/framework/src/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
+++ b/framework/src/play-akka-http-server/src/test/scala/play/AkkaTestServer.scala
@@ -18,7 +18,7 @@ object AkkaTestServer extends App {
     address = "127.0.0.1"
   )) {
     case GET(p"/") => Action { implicit req =>
-      Results.Ok(s"Hello world")
+      Results.Ok(s"Hello world: " + req.headers.headers.toList)
     }
   }
   println("Server (Akka HTTP) started: http://127.0.0.1:9000/ ")

--- a/framework/src/play-guice/src/main/java/play/libs/akka/AkkaGuiceSupport.java
+++ b/framework/src/play-guice/src/main/java/play/libs/akka/AkkaGuiceSupport.java
@@ -126,7 +126,7 @@ public interface AkkaGuiceSupport {
      *   {@literal @}Override
      *   public Receive createReceive() {
      *   return receiveBuilder()
-     *     .match(CreateChildActor.class, msg -> {
+     *     .match(CreateChildActor.class, msg -&gt; {
      *       ActorRef child = injectedChild(myChildActorFactory.apply(msg.getId()));
      *       sender().send(child, self);
      *     }

--- a/framework/src/play-guice/src/main/java/play/libs/akka/AkkaGuiceSupport.java
+++ b/framework/src/play-guice/src/main/java/play/libs/akka/AkkaGuiceSupport.java
@@ -80,7 +80,7 @@ public interface AkkaGuiceSupport {
      * Let's say you have an actor that looks like this:
      *
      * <pre>
-     * public class MyChildActor extends UntypedAbstractActor {
+     * public class MyChildActor extends AbstractActor {
      *     final Database db;
      *     final String id;
      *
@@ -115,7 +115,7 @@ public interface AkkaGuiceSupport {
      * Now, when you want an actor to instantiate this as a child actor, inject `MyChildActorFactory`:
      *
      * <pre>
-     * public class MyActor extends UntypedAbstractActor implements InjectedActorSupport {
+     * public class MyActor extends AbstractActor implements InjectedActorSupport {
      *   final MyChildActorFactory myChildActorFactory;
      *
      *   {@literal @}Inject
@@ -123,11 +123,14 @@ public interface AkkaGuiceSupport {
      *       this.myChildActorFactory = myChildActorFactory;
      *   }
      *
-     *   public onReceive(Object msg) {
-     *     if (msg instanceof CreateChildActor) {
-     *       ActorRef child = injectedChild(myChildActorFactory.apply(((CreateChildActor) msg).getId()));
+     *   {@literal @}Override
+     *   public Receive createReceive() {
+     *   return receiveBuilder()
+     *     .match(CreateChildActor.class, msg -> {
+     *       ActorRef child = injectedChild(myChildActorFactory.apply(msg.getId()));
      *       sender().send(child, self);
      *     }
+     *     .build()
      *   }
      * }
      * </pre>

--- a/framework/src/play/src/main/java/play/libs/akka/InjectedActorSupport.java
+++ b/framework/src/play/src/main/java/play/libs/akka/InjectedActorSupport.java
@@ -42,7 +42,7 @@ public interface InjectedActorSupport {
     }
 
     /**
-     * Context method expected to be implemented by {@link akka.actor.UntypedAbstractActor}.
+     * Context method expected to be implemented by {@link akka.actor.AbstractActor}.
      * @return the ActorContext.
      */
     ActorContext context();


### PR DESCRIPTION
This fixes the small Javadoc error contained in PR #7547 so that it can be merged.