### PR TITLE
[doc]: Explain that updating sbt is required

### DIFF
--- a/documentation/manual/releases/release26/migration26/Migration26.md
+++ b/documentation/manual/releases/release26/migration26/Migration26.md
@@ -19,9 +19,9 @@ Where the "x" in `2.6.x` is the minor version of Play you want to use, for insta
 
 ### sbt upgrade to 0.13.15
 
-Although Play 2.6 will still work with sbt 0.13.11, we recommend upgrading to the latest sbt version, 0.13.15.  The 0.13.15 release of sbt has a number of [improvements and bug fixes](http://www.scala-sbt.org/0.13/docs/sbt-0.13-Tech-Previews.html#sbt+0.13.15) (see also the changes in [sbt 0.13.13](http://www.scala-sbt.org/0.13/docs/sbt-0.13-Tech-Previews.html#sbt+0.13.13)).
+Play 2.6 requires upgrading to the latest sbt version, 0.13.15.  The 0.13.15 release of sbt has a number of [improvements and bug fixes](http://www.scala-sbt.org/0.13/docs/sbt-0.13-Tech-Previews.html#sbt+0.13.15) (see also the changes in [sbt 0.13.13](http://www.scala-sbt.org/0.13/docs/sbt-0.13-Tech-Previews.html#sbt+0.13.13)).
 
-Update your `project/build.properties` so that it reads:
+To update, change your `project/build.properties` so that it reads:
 
 ```
 sbt.version=0.13.15


### PR DESCRIPTION
## Purpose

Explains that sbt update to 0.13.15 is required.

## References

See conversation here: https://groups.google.com/d/msgid/play-framework/CAA%3D11Hxr3YdddOguNdngkBgoA-SkchSFQYk9kzo8XycsuNXLPA%40mail.gmail.com?utm_medium=email&utm_source=footer