### PR TITLE
Fix race condition creating play temp folder

### DIFF
--- a/framework/src/play/src/main/scala/play/api/libs/Files.scala
+++ b/framework/src/play/src/main/scala/play/api/libs/Files.scala
@@ -8,6 +8,7 @@ import java.lang.ref.Reference
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{ Files => JFiles, _ }
 import java.time.{ Clock, Instant }
+import java.util.concurrent.atomic.AtomicReference
 import java.util.function.Predicate
 import javax.inject.{ Inject, Provider, Singleton }
 
@@ -18,11 +19,11 @@ import org.slf4j.LoggerFactory
 import play.api.Configuration
 import play.api.inject.ApplicationLifecycle
 
+import scala.annotation.tailrec
 import scala.concurrent.Future
-import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.concurrent.duration._
 import scala.language.implicitConversions
 import scala.util.{ Failure, Try }
-import scala.concurrent.duration._
 
 /**
  * FileSystem utilities.
@@ -148,13 +149,15 @@ object Files {
     private val logger = play.api.Logger(this.getClass)
     private val frq = new FinalizableReferenceQueue()
 
+    private val TempDirectoryPrefix = "playtemp"
+
     // Much of the PhantomReference implementation is taken from
     // the Google Guava documentation example
     //
     // https://google.github.io/guava/releases/19.0/api/docs/com/google/common/base/FinalizableReferenceQueue.html
     // Keeping references ensures that the FinalizablePhantomReference itself is not garbage-collected.
     private val references = Sets.newConcurrentHashSet[Reference[TemporaryFile]]()
-    private var _playTempFolder: Option[Path] = None
+    private val _playTempFolder: AtomicReference[Option[Path]] = new AtomicReference(None)
 
     override def create(prefix: String, suffix: String): TemporaryFile = {
       JFiles.createDirectories(playTempFolder)
@@ -162,16 +165,22 @@ object Files {
       createReference(new DefaultTemporaryFile(tempFile, this))
     }
 
-    private def playTempFolder: Path = _playTempFolder match {
-      // We may need to recreate the file if it was deleted (e.g. by tmpwatch)
-      case Some(folder) if JFiles.exists(folder) =>
-        temporaryFileReaper.updateTempFolder(folder)
-        folder
-      case _ =>
-        val folder = JFiles.createTempDirectory("playtemp")
-        _playTempFolder = Some(folder)
-        temporaryFileReaper.updateTempFolder(folder)
-        folder
+    @tailrec private def playTempFolder: Path = {
+      val lastValue = _playTempFolder.get
+      val newFolder = lastValue match {
+        // We may need to recreate the file if it was deleted (e.g. by tmpwatch)
+        case Some(folder) if JFiles.exists(folder) =>
+          folder
+        case _ =>
+          JFiles.createTempDirectory(TempDirectoryPrefix)
+      }
+      if (_playTempFolder.compareAndSet(lastValue, Some(newFolder))) {
+        temporaryFileReaper.updateTempFolder(newFolder)
+        newFolder
+      } else {
+        JFiles.deleteIfExists(newFolder)
+        playTempFolder
+      }
     }
 
     override def create(path: Path): TemporaryFile = {


### PR DESCRIPTION
Fixes #7584. Uses an `AtomicReference` and retries if the value was changed while trying to update it.