### PR TITLE
Updated ws test example to avoid deprecated syntax

### DIFF
--- a/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
@@ -45,11 +45,13 @@ class GitHubClientSpec extends Specification {
   "GitHubClient" should {
     "get all repositories" in {
 
-      Server.withRouter() {
-        case GET(p"/repositories") => Action {
-          Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
+      Server.withRouterFromComponents() { cs => {
+          case GET(p"/repositories") => cs.defaultActionBuilder {
+            Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
+          }
         }
       } { implicit port =>
+
         WsTestClient.withClient { client =>
           val result = Await.result(
             new GitHubClient(client, "").repositories(), 10.seconds)
@@ -85,9 +87,10 @@ class ScalaTestingWebServiceClients extends Specification {
       import play.api.routing.sird._
       import play.core.server.Server
 
-      Server.withRouter() {
-        case GET(p"/repositories") => Action {
-          Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
+      Server.withRouterFromComponents() { cs => {
+          case GET(p"/repositories") => cs.defaultActionBuilder {
+            Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
+          }
         }
       } { implicit port =>
         //#mock-service


### PR DESCRIPTION
The example shown on the play website leads to deprecation warnings: `object Action in package mvc is deprecated (since 2.6.0): Inject an ActionBuilder (e.g. DefaultActionBuilder) or extend BaseController/AbstractController/InjectedController`

This change updates the example to use the action builder in the "new style".