### PR TITLE
Updated ws test example to avoid deprecated syntax

### DIFF
--- a/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
@@ -45,9 +45,10 @@ class GitHubClientSpec extends Specification {
   "GitHubClient" should {
     "get all repositories" in {
 
-      Server.withRouter() {
-        case GET(p"/repositories") => Action {
-          Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
+      Server.withRouterFromComponents() { cs => {
+          case GET(p"/repositories") => cs.defaultActionBuilder {
+            Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
+          }
         }
       } { implicit port =>
         WsTestClient.withClient { client =>
@@ -85,9 +86,10 @@ class ScalaTestingWebServiceClients extends Specification {
       import play.api.routing.sird._
       import play.core.server.Server
 
-      Server.withRouter() {
-        case GET(p"/repositories") => Action {
-          Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
+      Server.withRouterFromComponents() { cs => {
+          case GET(p"/repositories") => cs.defaultActionBuilder {
+            Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
+          }
         }
       } { implicit port =>
         //#mock-service

--- a/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
@@ -46,7 +46,7 @@ class GitHubClientSpec extends Specification {
     "get all repositories" in {
 
       Server.withRouterFromComponents() { cs =>
-        import components.{ defaultActionBuilder => Action }
+        import cs.{ defaultActionBuilder => Action }
         {
           case GET(p"/repositories") => Action {
             Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
@@ -89,7 +89,7 @@ class ScalaTestingWebServiceClients extends Specification {
       import play.core.server.Server
 
       Server.withRouterFromComponents() { cs => 
-        import components.{ defaultActionBuilder => Action }
+        import cs.{ defaultActionBuilder => Action }
         {
           case GET(p"/repositories") => Action {
             Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))

--- a/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
+++ b/documentation/manual/working/scalaGuide/main/tests/code/webservice/ScalaTestingWebServiceClients.scala
@@ -45,8 +45,10 @@ class GitHubClientSpec extends Specification {
   "GitHubClient" should {
     "get all repositories" in {
 
-      Server.withRouterFromComponents() { cs => {
-          case GET(p"/repositories") => cs.defaultActionBuilder {
+      Server.withRouterFromComponents() { cs =>
+        import components.{ defaultActionBuilder => Action }
+        {
+          case GET(p"/repositories") => Action {
             Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
           }
         }
@@ -86,8 +88,10 @@ class ScalaTestingWebServiceClients extends Specification {
       import play.api.routing.sird._
       import play.core.server.Server
 
-      Server.withRouterFromComponents() { cs => {
-          case GET(p"/repositories") => cs.defaultActionBuilder {
+      Server.withRouterFromComponents() { cs => 
+        import components.{ defaultActionBuilder => Action }
+        {
+          case GET(p"/repositories") => Action {
             Results.Ok(Json.arr(Json.obj("full_name" -> "octocat/Hello-World")))
           }
         }


### PR DESCRIPTION
The example shown on the play website leads to deprecation warnings: object Action in package mvc is deprecated (since 2.6.0): `Inject an ActionBuilder (e.g. DefaultActionBuilder) or extend BaseController/AbstractController/InjectedController`

Backport for PR #7606 
