### PR TITLE
Encode path parameter returned from custom PathBindables

### DIFF
--- a/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
+++ b/framework/src/play/src/main/scala/play/api/mvc/Binders.scala
@@ -308,6 +308,15 @@ object JavascriptLiteral {
  */
 object QueryStringBindable {
 
+  /**
+   * A helper class for creating QueryStringBindables to map the value of a single key
+   *
+   * @param parse a function to parse the param value
+   * @param serialize a function to serialize and URL-encode the param value. Remember to encode arbitrary strings,
+   *                  for example using URLEncoder.encode.
+   * @param error a function for rendering an error message if an error occurs
+   * @tparam A the type being parsed
+   */
   class Parsing[A](parse: String => A, serialize: A => String, error: (String, Exception) => String)
       extends QueryStringBindable[A] {
 
@@ -549,8 +558,22 @@ object QueryStringBindable {
  */
 object PathBindable {
 
-  class Parsing[A](parse: String => A, serialize: A => String, error: (String, Exception) => String)(implicit codec: Codec)
+  /**
+   * A helper class for creating PathBindables to map the value of a path pattern/segment
+   *
+   * @param parse a function to parse the path value
+   * @param serialize a function to serialize the path value to a string
+   * @param error a function for rendering an error message if an error occurs
+   * @tparam A the type being parsed
+   */
+  class Parsing[A](parse: String => A, serialize: A => String, error: (String, Exception) => String)
       extends PathBindable[A] {
+
+    // added for bincompat
+    @deprecated("Use constructor without codec", "2.6.2")
+    private[mvc] def this(parse: String => A, serialize: A => String, error: (String, Exception) => String, codec: Codec) = {
+      this(parse, serialize, error)
+    }
 
     def bind(key: String, value: String): Either[String, A] = {
       try {

--- a/framework/src/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
+++ b/framework/src/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
@@ -259,10 +259,9 @@ package object templates {
       case DynamicPart(name, _, encode) =>
         route.call.parameters.getOrElse(Nil).find(_.name == name).map { param =>
           val paramName: String = paramNameOnQueryString(param.name)
-          if (encode && encodeable(param.typeName))
-            """implicitly[play.api.mvc.PathBindable[""" + param.typeName + """]].unbind("""" + paramName + """", play.core.routing.dynamicString(""" + safeKeyword(localNames.getOrElse(param.name, param.name)) + """))"""
-          else
-            """implicitly[play.api.mvc.PathBindable[""" + param.typeName + """]].unbind("""" + paramName + """", """ + safeKeyword(localNames.getOrElse(param.name, param.name)) + """)"""
+          val unbound = s"""implicitly[play.api.mvc.PathBindable[${param.typeName}]]""" +
+            s""".unbind("$paramName", ${safeKeyword(localNames.getOrElse(param.name, param.name))})"""
+          if (encode) s"play.core.routing.dynamicString($unbound)" else unbound
         }.getOrElse {
           throw new Error("missing key " + name)
         }
@@ -337,10 +336,10 @@ package object templates {
       case DynamicPart(name, _, encode) =>
         route.call.parameters.getOrElse(Nil).find(_.name == name).map { param =>
           val paramName: String = paramNameOnQueryString(param.name)
-          if (encode && encodeable(param.typeName))
-            " + (\"\"\" + implicitly[play.api.mvc.PathBindable[" + param.typeName + "]].javascriptUnbind + \"\"\")" + """("""" + paramName + """", encodeURIComponent(""" + localNames.getOrElse(param.name, param.name) + """))"""
-          else
-            " + (\"\"\" + implicitly[play.api.mvc.PathBindable[" + param.typeName + "]].javascriptUnbind + \"\"\")" + """("""" + paramName + """", """ + localNames.getOrElse(param.name, param.name) + """)"""
+          val jsUnbound =
+            "(\"\"\" + implicitly[play.api.mvc.PathBindable[" + param.typeName + "]].javascriptUnbind + \"\"\")" +
+              s"""("$paramName", ${localNames.getOrElse(param.name, param.name)})"""
+          if (encode) s" + encodeURIComponent($jsUnbound)" else s" + $jsUnbound"
         }.getOrElse {
           throw new Error("missing key " + name)
         }
@@ -412,8 +411,6 @@ package object templates {
   def encodeStringConstant(constant: String): String = {
     constant.split('$').mkString(tq, s"""$tq + "$$" + $tq""", tq)
   }
-
-  private def encodeable(paramType: String): Boolean = paramType == "String"
 
   def groupRoutesByPackage(routes: Seq[Route]): Map[String, Seq[Route]] = routes.groupBy(_.call.packageName)
   def groupRoutesByController(routes: Seq[Route]): Map[String, Seq[Route]] = routes.groupBy(_.call.controller)

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/controllers/Application.scala
@@ -6,6 +6,7 @@ package controllers
 import play.api.mvc._
 import scala.collection.JavaConverters._
 import javax.inject.Inject
+import models.UserId
 
 class Application @Inject() (c: ControllerComponents) extends AbstractController(c) {
   def index = Action {
@@ -16,6 +17,12 @@ class Application @Inject() (c: ControllerComponents) extends AbstractController
   }
   def withParam(param: String) = Action {
     Ok(param)
+  }
+  def user(userId: UserId) = Action {
+    Ok(userId.id)
+  }
+  def queryUser(userId: UserId) = Action {
+    Ok(userId.id)
   }
   def takeInt(i: Int) = Action {
     Ok(s"$i")

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/models/UserId.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/app/models/UserId.scala
@@ -1,0 +1,20 @@
+package models
+
+import java.net.URLEncoder
+
+import play.api.mvc.{ PathBindable, QueryStringBindable }
+
+object UserId {
+  implicit object pathBindable extends PathBindable.Parsing[UserId](
+    UserId.apply,
+    _.id,
+    (key: String, e: Exception) => "Cannot parse parameter %s as UserId: %s".format(key, e.getMessage)
+  )
+  implicit object queryStringBindable extends QueryStringBindable.Parsing[UserId](
+    UserId.apply,
+    userId => URLEncoder.encode(userId.id, "utf-8"),
+    (key: String, e: Exception) => "Cannot parse parameter %s as UserId: %s".format(key, e.getMessage)
+  )
+}
+
+case class UserId(id: String) extends AnyVal

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/conf/routes
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/conf/routes
@@ -8,6 +8,9 @@ GET         /with/:param            controllers.Application.withParam(param)
 
 GET         /instance               @controllers.InstanceController.index
 
+GET         /users/:userId          controllers.Application.user(userId: models.UserId)
+GET         /query-user             controllers.Application.queryUser(userId: models.UserId)
+
 GET         /escapes/$i<\d+>        controllers.Application.takeInt(i: Int)
 
 GET         /take-bool              controllers.Application.takeBool(b: Boolean)

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/tests/RouterSpec.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/injected-routes-compilation/tests/RouterSpec.scala
@@ -4,6 +4,7 @@
 package test
 
 import play.api.test._
+import models.UserId
 
 object RouterSpec extends PlaySpecification {
 
@@ -18,8 +19,26 @@ object RouterSpec extends PlaySpecification {
     }
   }
 
+  "reverse routes containing custom parameters" in {
+    "the query string" in {
+      controllers.routes.Application.queryUser(UserId("foo")).url must equalTo ("/query-user?userId=foo")
+      controllers.routes.Application.queryUser(UserId("foo/bar")).url must equalTo ("/query-user?userId=foo%2Fbar")
+      controllers.routes.Application.queryUser(UserId("foo?bar")).url must equalTo ("/query-user?userId=foo%3Fbar")
+      controllers.routes.Application.queryUser(UserId("foo%bar")).url must equalTo ("/query-user?userId=foo%25bar")
+      controllers.routes.Application.queryUser(UserId("foo&bar")).url must equalTo ("/query-user?userId=foo%26bar")
+    }
+    "the path" in {
+      controllers.routes.Application.user(UserId("foo")).url must equalTo ("/users/foo")
+      controllers.routes.Application.user(UserId("foo/bar")).url must equalTo ("/users/foo%2Fbar")
+      controllers.routes.Application.user(UserId("foo?bar")).url must equalTo ("/users/foo%3Fbar")
+      controllers.routes.Application.user(UserId("foo%bar")).url must equalTo ("/users/foo%25bar")
+      // & is not special for path segments
+      controllers.routes.Application.user(UserId("foo&bar")).url must equalTo ("/users/foo&bar")
+    }
+  }
+
   "bind boolean parameters" in {
-    "from the query string" in new WithApplication() { 
+    "from the query string" in new WithApplication() {
       val Some(result) = route(implicitApp, FakeRequest(GET, "/take-bool?b=true"))
       contentAsString(result) must equalTo ("true")
       val Some(result2) = route(implicitApp, FakeRequest(GET, "/take-bool?b=false"))

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/controllers/Application.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/controllers/Application.scala
@@ -6,6 +6,7 @@ package controllers
 import play.api.mvc._
 import javax.inject.Inject
 import scala.collection.JavaConverters._
+import models._
 
 class Application @Inject() (c: ControllerComponents) extends AbstractController(c) {
   def index = Action {
@@ -16,6 +17,12 @@ class Application @Inject() (c: ControllerComponents) extends AbstractController
   }
   def withParam(param: String) = Action {
     Ok(param)
+  }
+  def user(userId: UserId) = Action {
+    Ok(userId.id)
+  }
+  def queryUser(userId: UserId) = Action {
+    Ok(userId.id)
   }
   def takeInt(i: Int) = Action {
     Ok(s"$i")

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/models/UserId.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/app/models/UserId.scala
@@ -1,0 +1,20 @@
+package models
+
+import java.net.URLEncoder
+
+import play.api.mvc.{ PathBindable, QueryStringBindable }
+
+object UserId {
+  implicit object pathBindable extends PathBindable.Parsing[UserId](
+    UserId.apply,
+    _.id,
+    (key: String, e: Exception) => "Cannot parse parameter %s as UserId: %s".format(key, e.getMessage)
+  )
+  implicit object queryStringBindable extends QueryStringBindable.Parsing[UserId](
+    UserId.apply,
+    userId => URLEncoder.encode(userId.id, "utf-8"),
+    (key: String, e: Exception) => "Cannot parse parameter %s as UserId: %s".format(key, e.getMessage)
+  )
+}
+
+case class UserId(id: String) extends AnyVal

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/conf/routes
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/conf/routes
@@ -8,6 +8,9 @@ GET         /with/:param            controllers.Application.withParam(param)
 
 GET         /instance               @controllers.InstanceController.index
 
+GET         /users/:userId          controllers.Application.user(userId: models.UserId)
+GET         /query-user             controllers.Application.queryUser(userId: models.UserId)
+
 GET         /escapes/$i<\d+>        controllers.Application.takeInt(i: Int)
 
 GET         /take-bool              controllers.Application.takeBool(b: Boolean)

--- a/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/tests/RouterSpec.scala
+++ b/framework/src/sbt-plugin/src/sbt-test/routes-compiler-plugin/routes-compilation/tests/RouterSpec.scala
@@ -4,22 +4,41 @@
 package test
 
 import play.api.test._
+import models.UserId
 
 object RouterSpec extends PlaySpecification {
 
   "reverse routes containing boolean parameters" in {
-    "in the query string" in {
+    "the query string" in {
       controllers.routes.Application.takeBool(true).url must equalTo ("/take-bool?b=true")
       controllers.routes.Application.takeBool(false).url must equalTo ("/take-bool?b=false")
     }
-    "in the  path" in {
+    "the path" in {
       controllers.routes.Application.takeBool2(true).url must equalTo ("/take-bool-2/true")
       controllers.routes.Application.takeBool2(false).url must equalTo ("/take-bool-2/false")
     }
   }
 
+  "reverse routes containing custom parameters" in {
+    "the query string" in {
+      controllers.routes.Application.queryUser(UserId("foo")).url must equalTo ("/query-user?userId=foo")
+      controllers.routes.Application.queryUser(UserId("foo/bar")).url must equalTo ("/query-user?userId=foo%2Fbar")
+      controllers.routes.Application.queryUser(UserId("foo?bar")).url must equalTo ("/query-user?userId=foo%3Fbar")
+      controllers.routes.Application.queryUser(UserId("foo%bar")).url must equalTo ("/query-user?userId=foo%25bar")
+      controllers.routes.Application.queryUser(UserId("foo&bar")).url must equalTo ("/query-user?userId=foo%26bar")
+    }
+    "the path" in {
+      controllers.routes.Application.user(UserId("foo")).url must equalTo ("/users/foo")
+      controllers.routes.Application.user(UserId("foo/bar")).url must equalTo ("/users/foo%2Fbar")
+      controllers.routes.Application.user(UserId("foo?bar")).url must equalTo ("/users/foo%3Fbar")
+      controllers.routes.Application.user(UserId("foo%bar")).url must equalTo ("/users/foo%25bar")
+      // & is not special for path segments
+      controllers.routes.Application.user(UserId("foo&bar")).url must equalTo ("/users/foo&bar")
+    }
+  }
+
   "bind boolean parameters" in {
-    "from the query string" in new WithApplication() { 
+    "from the query string" in new WithApplication() {
       val Some(result) = route(implicitApp, FakeRequest(GET, "/take-bool?b=true"))
       contentAsString(result) must equalTo ("true")
       val Some(result2) = route(implicitApp, FakeRequest(GET, "/take-bool?b=false"))
@@ -28,7 +47,7 @@ object RouterSpec extends PlaySpecification {
       contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=1")).get) must equalTo ("true")
       contentAsString(route(implicitApp, FakeRequest(GET, "/take-bool?b=0")).get) must equalTo ("false")
     }
-    "from the path" in new WithApplication() { 
+    "from the path" in new WithApplication() {
       val Some(result) = route(implicitApp, FakeRequest(GET, "/take-bool-2/true"))
       contentAsString(result) must equalTo ("true")
       val Some(result2) = route(implicitApp, FakeRequest(GET, "/take-bool-2/false"))
@@ -41,25 +60,25 @@ object RouterSpec extends PlaySpecification {
 
   "bind int parameters from the query string as a list" in {
 
-    "from a list of numbers" in new WithApplication() { 
+    "from a list of numbers" in new WithApplication() {
       val Some(result) = route(implicitApp, FakeRequest(GET, controllers.routes.Application.takeList(List(1, 2, 3)).url))
       contentAsString(result) must equalTo("1,2,3")
     }
-    "from a list of numbers and letters" in new WithApplication() { 
+    "from a list of numbers and letters" in new WithApplication() {
       val Some(result) = route(implicitApp, FakeRequest(GET, "/take-list?x=1&x=a&x=2"))
       status(result) must equalTo(BAD_REQUEST)
     }
-    "when there is no parameter at all" in new WithApplication() { 
+    "when there is no parameter at all" in new WithApplication() {
       val Some(result) = route(implicitApp, FakeRequest(GET, "/take-list"))
       contentAsString(result) must equalTo("")
     }
-    "using the Java API" in new WithApplication() { 
+    "using the Java API" in new WithApplication() {
       val Some(result) = route(implicitApp, FakeRequest(GET, "/take-java-list?x=1&x=2&x=3"))
       contentAsString(result) must equalTo("1,2,3")
     }
   }
 
-  "URL encoding and decoding works correctly" in new WithApplication() { 
+  "URL encoding and decoding works correctly" in new WithApplication() {
     def checkDecoding(
                        dynamicEncoded: String, staticEncoded: String, queryEncoded: String,
                        dynamicDecoded: String, staticDecoded: String, queryDecoded: String) = {
@@ -101,7 +120,7 @@ object RouterSpec extends PlaySpecification {
     checkEncoding("123", "456", "789", "123", "456", "789")
   }
 
-  "allow reverse routing of routes includes" in new WithApplication() { 
+  "allow reverse routing of routes includes" in new WithApplication() {
     // Force the router to bootstrap the prefix
     implicitApp.injector.instanceOf[play.api.routing.Router]
     controllers.module.routes.ModuleController.index().url must_== "/module/index"


### PR DESCRIPTION
This fixes the inconsistency in which a `PathBindable` for a custom type does not have its result encoded properly as a path segment, even though `String` path segments are encoded properly. This also adds some Javadoc to the `Parsing` helpers with the necessary warnings.

I also removed the `implicit codec: Codec` parameter from `PathBindable.Parsing` because it was unused, and added an extra constructor for binary compatibility. This will also be source compatible unless the codec was passed explicitly, but that would not have made sense anyway since the extra parameter has no effect.

Fixes #7610 