### PR TITLE
Better use of AsyncCacheApi in CachedAction

### DIFF
--- a/framework/src/play-cache/src/main/java/play/cache/CachedAction.java
+++ b/framework/src/play-cache/src/main/java/play/cache/CachedAction.java
@@ -3,7 +3,6 @@
  */
 package play.cache;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import play.mvc.Action;
@@ -27,14 +26,7 @@ public class CachedAction extends Action<Cached> {
     public CompletionStage<Result> call(Context ctx) {
         final String key = configuration.key();
         final Integer duration = configuration.duration();
-        return cacheApi.<Result>get(key).thenComposeAsync(cacheResult -> {
-            if (cacheResult != null) {
-                return CompletableFuture.completedFuture(cacheResult);
-            }
-            return delegate.call(ctx).thenComposeAsync(result ->
-                    cacheApi.set(key, result, duration).thenApply(ignore -> result)
-            );
-        });
+        return cacheApi.getOrElseUpdate(key, () -> delegate.call(ctx), duration);
     }
 
 }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaActionCompositionSpec.scala
@@ -15,8 +15,6 @@ import play.mvc.{ EssentialFilter, Result, Results }
 import play.mvc.Http.Cookie
 import play.routing.{ Router => JRouter }
 
-import scala.collection.JavaConverters._
-
 class GuiceJavaActionCompositionSpec extends JavaActionCompositionSpec {
   override def makeRequest[T](controller: MockController, configuration: Map[String, AnyRef] = Map.empty)(block: WSResponse => T): T = {
     implicit val port = testServerPort
@@ -135,7 +133,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
         Results.ok(request.username())
       }
     }) { response =>
-      val setCookie = response.allHeaders.get("Set-Cookie").mkString("\n")
+      val setCookie = response.headers.get("Set-Cookie").mkString("\n")
       setCookie must contain("PLAY_SESSION=; Max-Age=-86400")
       response.body must_== "foo"
     }
@@ -146,7 +144,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
         Results.ok(request.username())
       }
     }) { response =>
-      val setCookie = response.allHeaders.get("Set-Cookie").mkString("\n")
+      val setCookie = response.headers.get("Set-Cookie").mkString("\n")
       setCookie must contain("PLAY_FLASH=; Max-Age=-86400")
       response.body must_== "foo"
     }
@@ -157,7 +155,7 @@ trait JavaActionCompositionSpec extends PlaySpecification with WsTestClient {
         Results.ok(request.username())
       }
     }) { response =>
-      val setCookie = response.allHeaders.get("Set-Cookie").mkString("\n")
+      val setCookie = response.headers.get("Set-Cookie").mkString("\n")
       setCookie must contain("foo=bar")
       response.body must_== "foo"
     }

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaCachedActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaCachedActionSpec.scala
@@ -3,7 +3,7 @@
  */
 package play.it.http
 
-import java.util.concurrent.{ CompletableFuture, TimeUnit }
+import java.util.concurrent.{ Callable, CompletableFuture, CompletionStage, TimeUnit }
 import javax.inject.{ Inject, Provider }
 
 import akka.Done
@@ -200,10 +200,12 @@ class TestAsyncCacheApiProvider @Inject() (lifeCycle: ApplicationLifecycle)(impl
       .expireAfterWrite(1, TimeUnit.SECONDS) // consistent with the value used in @Cached annotations above
       .build[String, Object]()
 
-    lifeCycle.addStopHook(() => {
-      cache.cleanUp()
-      cache.invalidateAll()
-      CompletableFuture.completedFuture(true)
+    lifeCycle.addStopHook(new Callable[CompletionStage[_]] {
+      override def call(): CompletionStage[_] = {
+        cache.cleanUp()
+        cache.invalidateAll()
+        CompletableFuture.completedFuture(true)
+      }
     })
 
     new TestAsyncCacheApi(cache)

--- a/framework/src/play-integration-test/src/test/scala/play/it/http/JavaCachedActionSpec.scala
+++ b/framework/src/play-integration-test/src/test/scala/play/it/http/JavaCachedActionSpec.scala
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.it.http
+
+import java.util.concurrent.{ CompletableFuture, TimeUnit }
+import javax.inject.{ Inject, Provider }
+
+import akka.Done
+import com.github.benmanes.caffeine.cache.{ Cache, Caffeine }
+import com.google.common.primitives.Primitives
+import play.api.Application
+import play.api.cache.AsyncCacheApi
+import play.api.cache.ehcache.EhCacheModule
+import play.api.inject.{ ContextClassLoaderInjector, NewInstanceInjector, SimpleInjector }
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.{ PlaySpecification, TestServer, WsTestClient }
+import play.cache.{ Cached, DefaultAsyncCacheApi }
+import play.inject.ApplicationLifecycle
+import play.mvc.Result
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.duration._
+import scala.reflect.ClassTag
+
+class JavaCachedActionSpec extends PlaySpecification with WsTestClient {
+
+  def makeRequest[T](controller: MockController)(block: Port => T): T = {
+
+    import play.api.inject.bind
+
+    implicit val port = testServerPort
+    lazy val app: Application = GuiceApplicationBuilder()
+      .disable[EhCacheModule]
+      .bindings(
+        bind[play.api.cache.AsyncCacheApi].toProvider[TestAsyncCacheApiProvider],
+        bind[play.cache.AsyncCacheApi].to[DefaultAsyncCacheApi]
+      )
+      .routes {
+        case _ => JAction(app, controller)
+      }.build()
+
+    running(TestServer(port, app)) {
+      block(port)
+    }
+  }
+
+  "Java CachedAction" should {
+
+    "when controller is annotated" in {
+
+      "cache result" in makeRequest(new CachedController()) { port =>
+        val responses = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), ""),
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        )
+
+        val first = responses.head
+        val cached = responses.last
+
+        first.status must beEqualTo(cached.status)
+        first.body must beEqualTo(cached.body)
+      }
+
+      "expire result" in makeRequest(new CachedController()) { port =>
+
+        val first = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        ).head
+
+        Thread.sleep(5.seconds.toMillis) // enough time to ensure the cache was expired
+
+        val second = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        ).head
+
+        first.status must beEqualTo(second.status)
+        first.body must not(beEqualTo(second.body))
+      }
+
+      "support using injector" in makeRequest(new CachedControllerWithInjector()) { port =>
+        val responses = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        )
+
+        responses.head.status must beEqualTo(OK)
+      }
+    }
+
+    "when action is annotated" in {
+      "cache result" in makeRequest(new MockController {
+        @Cached(key = "play.it.http.MockController.MockController.cache", duration = 1 /* second */ )
+        override def action: Result = play.mvc.Results.ok("Cached result: " + System.nanoTime())
+      }) { port =>
+        val responses = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), ""),
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        )
+
+        val first = responses.head
+        val cached = responses.last
+
+        first.status must beEqualTo(cached.status)
+        first.body must beEqualTo(cached.body)
+      }
+
+      "expire result" in makeRequest(new MockController {
+        @Cached(key = "play.it.http.MockController.MockController.cache", duration = 1 /* second */ )
+        override def action: Result = play.mvc.Results.ok("Cached result: " + System.nanoTime())
+      }) { port =>
+
+        val first = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        ).head
+
+        Thread.sleep(5.seconds.toMillis) // enough time to ensure the cache was expired
+
+        val second = BasicHttpClient.makeRequests(port)(
+          BasicRequest("GET", "/", "HTTP/1.1", Map(), "")
+        ).head
+
+        first.status must beEqualTo(second.status)
+        first.body must not(beEqualTo(second.body))
+      }
+    }
+  }
+}
+
+@Cached(key = "play.it.http.CachedController.cache", duration = 1 /* second */ )
+class CachedController extends MockController {
+  override def action: Result = {
+    play.mvc.Results.ok("Cached result: " + System.currentTimeMillis())
+  }
+}
+
+@Cached(key = "play.it.http.CachedControllerWithInjector.cache", duration = 1 /* second */ )
+class CachedControllerWithInjector extends MockController {
+  override def action: Result = {
+    injector.instanceOf(classOf[SomeComponent])
+    play.mvc.Results.ok("Cached result: " + System.currentTimeMillis())
+  }
+
+  def injector: play.inject.Injector = {
+    val thread = Thread.currentThread()
+    // injectception
+    new play.inject.DelegateInjector(
+      new ContextClassLoaderInjector(
+        new SimpleInjector(
+          fallback = NewInstanceInjector
+        ) + SomeComponent(), // register SomeComponent to SimpleInjector
+        thread.getContextClassLoader
+      )
+    )
+  }
+}
+
+case class SomeComponent()
+
+/**
+ * This is necessary to avoid EhCache shutdown problems.
+ *
+ * Using Caffeine here since it is already a dependency and it handles expiration.
+ */
+class TestAsyncCacheApi(cache: Cache[String, Object])(implicit context: ExecutionContext) extends AsyncCacheApi {
+  override def set(key: String, value: Any, expiration: Duration): Future[Done] = Future.successful {
+    cache.put(key, value.asInstanceOf[Object])
+    Done
+  }
+
+  override def remove(key: String): Future[Done] = Future {
+    cache.invalidate(key)
+    Done
+  }
+
+  override def getOrElseUpdate[A: ClassTag](key: String, expiration: Duration)(orElse: => Future[A]): Future[A] = {
+    get[A](key).flatMap {
+      case Some(value) => Future.successful(value)
+      case None => orElse.flatMap(value => set(key, value, expiration).map(_ => value))
+    }
+  }
+
+  override def get[T](key: String)(implicit ct: ClassTag[T]): Future[Option[T]] = {
+    val result = Option(cache.getIfPresent(key)).filter { v =>
+      Primitives.wrap(ct.runtimeClass).isInstance(v) ||
+        ct == ClassTag.Nothing || (ct == ClassTag.Unit && v == ((): Unit))
+    }.asInstanceOf[Option[T]]
+    Future.successful(result)
+  }
+
+  override def removeAll(): Future[Done] = Future {
+    cache.invalidateAll()
+    Done
+  }
+}
+
+class TestAsyncCacheApiProvider @Inject() (lifeCycle: ApplicationLifecycle)(implicit context: ExecutionContext) extends Provider[TestAsyncCacheApi] {
+  override def get(): TestAsyncCacheApi = {
+    val cache = Caffeine
+      .newBuilder()
+      .expireAfterWrite(1, TimeUnit.SECONDS) // consistent with the value used in @Cached annotations above
+      .build[String, Object]()
+
+    lifeCycle.addStopHook(() => {
+      cache.cleanUp()
+      cache.invalidateAll()
+      CompletableFuture.completedFuture(true)
+    })
+
+    new TestAsyncCacheApi(cache)
+  }
+}


### PR DESCRIPTION
## Fixes

Fixes #7615.

## Purpose

Instead of using get-and-set the cache, using getOrElseUpdate.

This way the execution won't happen in a ForkJoinPool thread pool, but instead it will fallback all the way down until Scala AsyncCacheApi implementation which uses the application ExecutionContext. Because of that, ContextClassLoaderInjector won't fail to change the ClassLoader for the executing thread.