### PR TITLE
Use read/write lock to minimize blocking in applicationprovider.get

### DIFF
--- a/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -147,19 +147,17 @@ object DevServerStart {
                 // http://www.dre.vanderbilt.edu/~schmidt/cs892/2017-PDFs/L5-Java-ReadWriteLocks-pt3-pt4.pdf
                 // http://blog.takipi.com/java-8-stampedlocks-vs-readwritelocks-and-synchronized/
 
-                // try an optimistic read
-                var stamp = sl.tryOptimisticRead()
-                // read the state
+                var readLock = sl.tryOptimisticRead()
                 var tryApp = lastState
-                // if a write occurred since the optimistic read, try again with a blocking read lock
-                // it will take multiple seconds for the reload to complete, so it's better to block
-                // than spin-wait here.
-                if (!sl.validate(stamp)) {
-                  stamp = sl.readLock()
+                if (!sl.validate(readLock)) {
+                  // if a write occurred since the optimistic read, try again with a blocking read lock.
+                  // it will take multiple seconds for the reload to complete, so it's better to block
+                  // than spin-wait here.
+                  readLock = sl.readLock()
                   try {
                     tryApp = lastState
                   } finally {
-                    sl.unlockRead(stamp)
+                    sl.unlockRead(readLock)
                   }
                 }
                 tryApp

--- a/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -116,54 +116,54 @@ object DevServerStart {
            * can be displayed in the user's browser. Failure is usually the result of a compilation error.
            */
           def get: Try[Application] = {
-            // Let's load the application on another thread
-            // as we are now on the Netty IO thread.
-            //
-            // Because we are on DEV mode here, it doesn't really matter
-            // but it's more coherent with the way it works in PROD mode.
-            implicit val ec = scala.concurrent.ExecutionContext.global
-            Await.result(scala.concurrent.Future {
-              // reload checks if anything has changed, and if so, returns an updated classloader.
-              // This returns a boolean and changes happen asynchronously on another thread.
-              val reloaded = buildLink.reload match {
-                case NonFatal(t) => Failure(t)
-                case cl: ClassLoader => Success(Some(cl))
-                case null => Success(None)
-              }
+            // reload checks if anything has changed, and if so, returns an updated classloader.
+            // This returns a boolean and changes happen asynchronously on another thread.
+            val reloaded = buildLink.reload match {
+              case NonFatal(t) => Failure(t)
+              case cl: ClassLoader => Success(Some(cl))
+              case null => Success(None)
+            }
 
-              // Tell the global execution context we may block this thread, so we can avoid exhaustion...
-              scala.concurrent.blocking {
-                reloaded.flatMap {
-                  case Some(projectClassloader) =>
-                    // After this point we are actively changing the state of the application, so
-                    // block until we can grab a write lock...
-                    val writeStamp = sl.writeLock()
-                    try {
-                      reload(projectClassloader)
-                    } finally {
-                      sl.unlockWrite(writeStamp)
-                    }
-                  case None =>
-                    // http://www.jfokus.se/jfokus13/preso/jf13_PhaserAndStampedLock.pdf
-                    // http://www.dre.vanderbilt.edu/~schmidt/cs892/2017-PDFs/L5-Java-ReadWriteLocks-pt3-pt4.pdf
-
-                    // try an optimistic read
-                    var stamp = sl.tryOptimisticRead()
-                    // read the state
-                    var tryApp = lastState
-                    // if a write occurred since the optimistic read, try again with a blocking read lock
-                    if (!sl.validate(stamp)) {
-                      stamp = sl.readLock()
-                      try {
-                        tryApp = lastState
-                      } finally {
-                        sl.unlockRead(stamp)
-                      }
-                    }
-                    tryApp
+            // Blocking happens in the Netty IO thread.  There is no good way to avoid this -- even
+            // in the previous implementation, there was an Await.result(Future(), Duration.Inf),
+            // so we can avoid the flow of control switch and (hopefully) make it a little faster by
+            // blocking directly.
+            reloaded.flatMap {
+              case Some(projectClassloader) =>
+                // After this point we are actively changing the state of the application, so
+                // block until we can grab a write lock...
+                val writeStamp = sl.writeLock()
+                try {
+                  reload(projectClassloader)
+                } finally {
+                  sl.unlockWrite(writeStamp)
                 }
-              }
-            }, Duration.Inf)
+              case None =>
+                // Returning an unchanged application happens frequently in dev mode, and
+                // so we want to return as fast as possible using an optimistic read:
+                //
+                // http://www.javaspecialists.eu/archive/Issue215.html
+                // http://www.jfokus.se/jfokus13/preso/jf13_PhaserAndStampedLock.pdf
+                // http://www.dre.vanderbilt.edu/~schmidt/cs892/2017-PDFs/L5-Java-ReadWriteLocks-pt3-pt4.pdf
+                // http://blog.takipi.com/java-8-stampedlocks-vs-readwritelocks-and-synchronized/
+
+                // try an optimistic read
+                var stamp = sl.tryOptimisticRead()
+                // read the state
+                var tryApp = lastState
+                // if a write occurred since the optimistic read, try again with a blocking read lock
+                // it will take multiple seconds for the reload to complete, so it's better to block
+                // than spin-wait here.
+                if (!sl.validate(stamp)) {
+                  stamp = sl.readLock()
+                  try {
+                    tryApp = lastState
+                  } finally {
+                    sl.unlockRead(stamp)
+                  }
+                }
+                tryApp
+            }
           }
 
           override def handleWebCommand(request: play.api.mvc.RequestHeader): Option[Result] = {

--- a/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
+++ b/framework/src/play-server/src/main/scala/play/core/server/DevServerStart.scala
@@ -95,6 +95,7 @@ object DevServerStart {
 
         // Create reloadable ApplicationProvider
         val appProvider = new ApplicationProvider {
+          private val sl = new java.util.concurrent.locks.StampedLock
 
           var lastState: Try[Application] = Failure(new PlayException("Not initialized", "?"))
           var lastLifecycle: Option[DefaultApplicationLifecycle] = None
@@ -111,17 +112,15 @@ object DevServerStart {
            * can be displayed in the user's browser. Failure is usually the result of a compilation error.
            */
           def get: Try[Application] = {
-
-            synchronized {
-
-              // Let's load the application on another thread
-              // as we are now on the Netty IO thread.
-              //
-              // Because we are on DEV mode here, it doesn't really matter
-              // but it's more coherent with the way it works in PROD mode.
-              implicit val ec = scala.concurrent.ExecutionContext.global
-              Await.result(scala.concurrent.Future {
-
+            // Let's load the application on another thread
+            // as we are now on the Netty IO thread.
+            //
+            // Because we are on DEV mode here, it doesn't really matter
+            // but it's more coherent with the way it works in PROD mode.
+            implicit val ec = scala.concurrent.ExecutionContext.global
+            Await.result(scala.concurrent.Future {
+              val stamp = sl.writeLock()
+              try {
                 val reloaded = buildLink.reload match {
                   case NonFatal(t) => Failure(t)
                   case cl: ClassLoader => Success(Some(cl))
@@ -129,65 +128,8 @@ object DevServerStart {
                 }
 
                 reloaded.flatMap { maybeClassLoader =>
-
                   val maybeApplication: Option[Try[Application]] = maybeClassLoader.map { projectClassloader =>
-                    try {
-
-                      if (lastState.isSuccess) {
-                        println()
-                        println(play.utils.Colors.magenta("--- (RELOAD) ---"))
-                        println()
-                      }
-
-                      val reloadable = this
-
-                      // First, stop the old application if it exists
-                      lastState.foreach(Play.stop)
-
-                      // Basically no matter if the last state was a Success, we need to
-                      // call all remaining hooks
-                      lastLifecycle.foreach(cycle => Await.result(cycle.stop(), 10.minutes))
-
-                      // Create the new environment
-                      val environment = Environment(path, projectClassloader, Mode.Dev)
-                      val sourceMapper = new SourceMapper {
-                        def sourceOf(className: String, line: Option[Int]) = {
-                          Option(buildLink.findSource(className, line.map(_.asInstanceOf[java.lang.Integer]).orNull)).flatMap {
-                            case Array(file: java.io.File, null) => Some((file, None))
-                            case Array(file: java.io.File, line: java.lang.Integer) => Some((file, Some(line)))
-                            case _ => None
-                          }
-                        }
-                      }
-
-                      val webCommands = new DefaultWebCommands
-                      currentWebCommands = Some(webCommands)
-                      val lifecycle = new DefaultApplicationLifecycle()
-                      lastLifecycle = Some(lifecycle)
-
-                      val newApplication = Threads.withContextClassLoader(projectClassloader) {
-                        val context = ApplicationLoader.createContext(environment, dirAndDevSettings, Some(sourceMapper), webCommands, lifecycle)
-                        val loader = ApplicationLoader(context)
-                        loader.load(context)
-                      }
-
-                      Play.start(newApplication)
-
-                      Success(newApplication)
-                    } catch {
-                      case e: PlayException => {
-                        lastState = Failure(e)
-                        lastState
-                      }
-                      case NonFatal(e) => {
-                        lastState = Failure(UnexpectedException(unexpected = Some(e)))
-                        lastState
-                      }
-                      case e: LinkageError => {
-                        lastState = Failure(UnexpectedException(unexpected = Some(e)))
-                        lastState
-                      }
-                    }
+                    reload(projectClassloader)
                   }
 
                   maybeApplication.flatMap(_.toOption).foreach { app =>
@@ -196,8 +138,68 @@ object DevServerStart {
 
                   maybeApplication.getOrElse(lastState)
                 }
+              } finally {
+                sl.unlockWrite(stamp)
+              }
+            }, Duration.Inf)
+          }
 
-              }, Duration.Inf)
+          def reload(projectClassloader: ClassLoader) = {
+            try {
+              if (lastState.isSuccess) {
+                println()
+                println(play.utils.Colors.magenta("--- (RELOAD) ---"))
+                println()
+              }
+
+              val reloadable = this
+
+              // First, stop the old application if it exists
+              lastState.foreach(Play.stop)
+
+              // Basically no matter if the last state was a Success, we need to
+              // call all remaining hooks
+              lastLifecycle.foreach(cycle => Await.result(cycle.stop(), 10.minutes))
+
+              // Create the new environment
+              val environment = Environment(path, projectClassloader, Mode.Dev)
+              val sourceMapper = new SourceMapper {
+                def sourceOf(className: String, line: Option[Int]) = {
+                  Option(buildLink.findSource(className, line.map(_.asInstanceOf[java.lang.Integer]).orNull)).flatMap {
+                    case Array(file: java.io.File, null) => Some((file, None))
+                    case Array(file: java.io.File, line: java.lang.Integer) => Some((file, Some(line)))
+                    case _ => None
+                  }
+                }
+              }
+
+              val webCommands = new DefaultWebCommands
+              currentWebCommands = Some(webCommands)
+              val lifecycle = new DefaultApplicationLifecycle()
+              lastLifecycle = Some(lifecycle)
+
+              val newApplication = Threads.withContextClassLoader(projectClassloader) {
+                val context = ApplicationLoader.createContext(environment, dirAndDevSettings, Some(sourceMapper), webCommands, lifecycle)
+                val loader = ApplicationLoader(context)
+                loader.load(context)
+              }
+
+              Play.start(newApplication)
+
+              Success(newApplication)
+            } catch {
+              case e: PlayException => {
+                lastState = Failure(e)
+                lastState
+              }
+              case NonFatal(e) => {
+                lastState = Failure(UnexpectedException(unexpected = Some(e)))
+                lastState
+              }
+              case e: LinkageError => {
+                lastState = Failure(UnexpectedException(unexpected = Some(e)))
+                lastState
+              }
             }
           }
 


### PR DESCRIPTION
Fixes https://github.com/playframework/playframework/issues/7614 

Switch from a synchronized block to a StampedLock.  This means that multiple threads can read the application state and it's only when a reload is happening (and there's a write lock) that other threads attempting a read will be blocked.

Tried this on https://github.com/joymufeng/play-scala-starter-example on a Dell XPS 15 9650 and running 

```
wrk -t4 -c400 -d30s http://localhost:9000/
```

with a warmed up JVM:

```
Running 30s test @ http://localhost:9000/
  4 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    15.50ms   47.74ms   1.43s    99.08%
    Req/Sec     9.03k     1.54k   11.81k    83.61%
  1074813 requests in 30.04s, 396.68MB read
Requests/sec:  35782.61
Transfer/sec:     13.21MB
```



