### PR TITLE
Added hint on how to successfully run snippets in comet docs

### DIFF
--- a/documentation/manual/working/javaGuide/main/async/JavaComet.md
+++ b/documentation/manual/working/javaGuide/main/async/JavaComet.md
@@ -43,6 +43,14 @@ The comet helper should typically be used with a `forever-iframe` technique, wit
 <iframe src="/comet"></iframe>
 ```
 
+> **Note**: add the following config to your application.conf and also ensure that you have route mappings set up in order to see the above comet in action.
+```
+play.filters.headers {
+  frameOptions = "SAMEORIGIN"
+  contentSecurityPolicy = "connect-src 'self'"
+}
+```
+
 For an example of a Comet helper, see the [Play 2.5 Clock Template](https://github.com/typesafehub/play-2.5-clock/).
 
 ## Debugging Comet

--- a/documentation/manual/working/scalaGuide/main/async/ScalaComet.md
+++ b/documentation/manual/working/scalaGuide/main/async/ScalaComet.md
@@ -43,6 +43,14 @@ The comet helper should typically be used with a `forever-iframe` technique, wit
 <iframe src="/comet"></iframe>
 ```
 
+> **Note**: add the following config to your application.conf and also ensure that you have route mappings set up in order to see the above comet in action.
+```
+play.filters.headers {
+  frameOptions = "SAMEORIGIN"
+  contentSecurityPolicy = "connect-src 'self'"
+}
+```
+
 For an example of a Comet helper, see the [Play 2.5 Clock Template](https://github.com/typesafehub/play-2.5-clock/).
 
 ## Debugging Comet


### PR DESCRIPTION
Added hint on how to successfully run the sample code snippets in the comet documentation. There was missing context on miscellaneous configuration that is needed to run the snippets. This is especially useful to someone new following through and trying out the snippets in the documentation.

